### PR TITLE
[Decode] KV cache split pre-process update

### DIFF
--- a/include/flashinfer/decode.cuh
+++ b/include/flashinfer/decode.cuh
@@ -973,6 +973,14 @@ cudaError_t BatchDecodeWithPagedKVCacheWorkEstimation(
   const uint32_t head_dim = paged_kv.head_dim;
   const uint32_t batch_size = paged_kv.batch_size;
   const uint32_t num_kv_heads = paged_kv.num_heads;
+
+  // Only apply for batch size over 2 at this moment.
+  if (batch_size >= 2) {
+    tmp_size = 0;
+    new_batch_size = batch_size;
+    return cudaSuccess;
+  }
+
   SWITCH_GQA_GROUP_SIZE(
       num_qo_heads / num_kv_heads, GROUP_SIZE,
       {SWITCH_HEAD_DIM(
@@ -1012,16 +1020,15 @@ cudaError_t BatchDecodeWithPagedKVCacheWorkEstimation(
                 } else {
                   // compute max_num_pages_per_batch and new_batch_size
                   std::vector<IdType> page_indptr_h(batch_size + 1), num_pages(batch_size);
-                  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(page_indptr_h.data(), paged_kv.indptr,
-                                                       sizeof(IdType) * (batch_size + 1),
-                                                       cudaMemcpyDeviceToHost, stream));
-                  FLASHINFER_CUDA_CALL(cudaStreamSynchronize(stream));
+                  FLASHINFER_CUDA_CALL(cudaMemcpy(page_indptr_h.data(), paged_kv.indptr,
+                                                  sizeof(IdType) * (batch_size + 1),
+                                                  cudaMemcpyDeviceToHost));
                   for (uint32_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
                     num_pages[batch_idx] = page_indptr_h[batch_idx + 1] - page_indptr_h[batch_idx];
                   }
                   std::tie(max_num_pages_per_batch, new_batch_size) =
                       SplitPagedKVCacheBinarySearchMinNumPagePerBatch(
-                          max_grid_size, num_kv_heads, num_pages, 128 / paged_kv.page_size);
+                          max_grid_size, num_kv_heads, num_pages, 512 / paged_kv.page_size);
                   if (new_batch_size == batch_size) {
                     // do not use cooperative kernel for short sequence
                     tmp_size = 0;

--- a/include/flashinfer/wrapper.cuh
+++ b/include/flashinfer/wrapper.cuh
@@ -43,44 +43,6 @@ void hash_combine(std::size_t& seed, const T& v) {
 template <typename DTypeIn, typename DTypeOut, typename IdType>
 class BatchDecodeBufferManager {
  public:
-  struct Key {
-    uint32_t num_qo_heads;
-    uint32_t num_kv_heads;
-    uint32_t page_size;
-    uint32_t head_dim;
-    uint32_t batch_size;
-    IdType* indptr;
-    IdType* indices;
-    IdType* last_page_offset;
-    RotaryMode rotary_mode;
-  };
-
-  struct KeyHasher {
-    uint64_t operator()(const Key& key) const {
-      uint64_t seed(1111);
-      hash_combine(seed, key.num_qo_heads);
-      hash_combine(seed, key.num_kv_heads);
-      hash_combine(seed, key.page_size);
-      hash_combine(seed, key.head_dim);
-      hash_combine(seed, key.batch_size);
-      hash_combine(seed, key.indptr);
-      hash_combine(seed, key.indices);
-      hash_combine(seed, key.last_page_offset);
-      hash_combine(seed, uint32_t(key.rotary_mode));
-      return seed;
-    }
-  };
-
-  struct KeyEqualFn {
-    bool operator()(const Key& lhs, const Key& rhs) const {
-      return lhs.num_qo_heads == rhs.num_qo_heads && lhs.num_kv_heads == rhs.num_kv_heads &&
-             lhs.page_size == rhs.page_size && lhs.head_dim == rhs.head_dim &&
-             lhs.batch_size == rhs.batch_size && lhs.indptr == rhs.indptr &&
-             lhs.indices == rhs.indices && lhs.last_page_offset == rhs.last_page_offset &&
-             lhs.rotary_mode == rhs.rotary_mode;
-    }
-  };
-
   struct Value {
     uint32_t new_batch_size;
     float* float_buffer;
@@ -128,60 +90,48 @@ class BatchDecodeBufferManager {
     }
   };
 
-  uint32_t GetAllocatedBufferSize() const { return allocated_buffer_size_; }
-
   Value Get(const paged_kv_t<DTypeIn, IdType>& paged_kv, uint32_t num_qo_heads,
             RotaryMode rotary_mode) {
-    Key key{num_qo_heads,      paged_kv.num_heads,        paged_kv.page_size,
-            paged_kv.head_dim, paged_kv.batch_size,       paged_kv.indptr,
-            paged_kv.indices,  paged_kv.last_page_offset, rotary_mode};
-    Value value;
-    if (cached_tmp_buffer_.find(key) == cached_tmp_buffer_.end()) {
+    if (paged_kv.layer_idx == 0) {
+      FreeValue();
       uint32_t tmp_size, max_grid_size, max_num_pages_per_batch, new_batch_size;
       BatchDecodeWithPagedKVCacheWorkEstimation<DTypeIn, DTypeOut, IdType>(
           tmp_size, max_grid_size, max_num_pages_per_batch, new_batch_size, paged_kv, num_qo_heads,
           rotary_mode, stream_);
-      value.new_batch_size = new_batch_size;
+      value_.new_batch_size = new_batch_size;
       if (tmp_size > 0) {
-        cudaMallocAsync(&value.float_buffer, sizeof(float) * tmp_size, stream_);
-        cudaMallocAsync(&value.int_buffer, sizeof(IdType) * (6 * new_batch_size + 2), stream_);
-        allocated_buffer_size_ +=
-            sizeof(float) * tmp_size + sizeof(IdType) * (6 * new_batch_size + 2);
+        cudaMallocAsync(&value_.float_buffer, sizeof(float) * tmp_size, stream_);
+        cudaMallocAsync(&value_.int_buffer, sizeof(IdType) * (6 * new_batch_size + 2), stream_);
         SplitPagedCacheKVComputeAuxiliaryInfo(
-            max_num_pages_per_batch, paged_kv, value.new_indptr(), value.new_last_page_offset(),
-            value.cooperative_indptr(), value.batch_idx_map(), value.chunk_start(),
-            value.seq_lens_before_split(), stream_);
+            max_num_pages_per_batch, paged_kv, value_.new_indptr(), value_.new_last_page_offset(),
+            value_.cooperative_indptr(), value_.batch_idx_map(), value_.chunk_start(),
+            value_.seq_lens_before_split(), stream_);
       }
-      cached_tmp_buffer_[key] = value;
-      return value;
-    } else {
-      return cached_tmp_buffer_[key];
     }
+    return value_;
   }
 
-  void ClearCache() {
-    allocated_buffer_size_ = 0U;
-    for (const auto& [k, v] : cached_tmp_buffer_) {
-      if (v.float_buffer != nullptr) {
-        cudaFreeAsync(v.float_buffer, stream_);
-      }
-      if (v.int_buffer != nullptr) {
-        cudaFreeAsync(v.int_buffer, stream_);
-      }
+  void FreeValue() {
+    value_.new_batch_size = 0;
+    if (value_.float_buffer != nullptr) {
+      cudaFreeAsync(value_.float_buffer, stream_);
+      value_.float_buffer = nullptr;
     }
-    cached_tmp_buffer_.clear();
+    if (value_.int_buffer != nullptr) {
+      cudaFreeAsync(value_.int_buffer, stream_);
+      value_.int_buffer = nullptr;
+    }
   }
 
   cudaStream_t GetCUDAStream() const { return stream_; }
 
   void SetCUDAStream(cudaStream_t stream) { stream_ = stream; }
 
-  BatchDecodeBufferManager() : allocated_buffer_size_(0U), cached_tmp_buffer_{}, stream_(nullptr) {}
-  ~BatchDecodeBufferManager() { ClearCache(); }
+  BatchDecodeBufferManager() : stream_(nullptr) {}
+  ~BatchDecodeBufferManager() { FreeValue(); }
 
  private:
-  uint32_t allocated_buffer_size_;
-  std::unordered_map<Key, Value, KeyHasher, KeyEqualFn> cached_tmp_buffer_;
+  Value value_;
   cudaStream_t stream_;
 };
 


### PR DESCRIPTION
This PR applies the following changes to the KV cache split:
- removed the map structure for temporary array cache,
- changed cudaMallocAsync to cudaMalloc in the split work estimation, as we noticed that the asynchronous malloc takes huge amount of time on 4090.
- only apply KV cache split when batch size is no more than 2. This might be adjusted further based on more evaluation.