### PR TITLE
[CMake] Reading TVM_HOME from build args or environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ flashinfer_option(FLASHINFER_PREFILL "Whether to compile prefill kernel tests/be
 flashinfer_option(FLASHINFER_DECODE "Whether to compile decode kernel tests/benchmarks or not." ON)
 flashinfer_option(FLASHINFER_PAGE "Whether to compile page kernel tests/benchmarks or not." ON)
 flashinfer_option(FLASHINFER_TVM_BINDING "Whether to compile tvm binding or not." OFF)
+flashinfer_option(FLASHINFER_TVM_HOME "The path to tvm for building tvm binding." "")
 # "native" is a special value for CMAKE_CUDA_ARCHITECTURES which means use the architectures of the host's GPU.
 # it's new in CMake 3.24, if you are using an older of CMake or you want to use a different value, you can
 # set its value through config.cmake or -DCMAKE_CUDA_ARCHITECTURES=... through command-line.
@@ -110,12 +111,21 @@ endif(FLASHINFER_PAGE)
 
 if(FLASHINFER_TVM_BINDING)
   message(STATUS "Compile tvm binding.")
+  if(NOT FLASHINFER_TVM_HOME STREQUAL "")
+    set(TVM_HOME_SET ${FLASHINFER_TVM_HOME})
+  elseif(DEFINED ENV{TVM_HOME})
+    set(TVM_HOME_SET $ENV{TVM_HOME})
+  else()
+    message(FATAL_ERROR "Error: Cannot find TVM. Please set the path to TVM by 1) adding `-DFLASHINFER_TVM_HOME=path/to/tvm` in the cmake command, or 2) setting the environment variable `TVM_HOME` to the tvm path.")
+  endif()
+  message(STATUS "FlashInfer uses TVM home ${TVM_HOME_SET}.")
+
   file(GLOB_RECURSE TVM_BINDING_SRCS ${PROJECT_SOURCE_DIR}/src/tvm_wrapper.cu)
   add_library(flashinfer_tvm OBJECT ${TVM_BINDING_SRCS})
   target_compile_definitions(flashinfer_tvm PRIVATE -DDMLC_USE_LOGGING_LIBRARY=\<tvm/runtime/logging.h\>)
   target_include_directories(flashinfer_tvm PRIVATE ${FLASHINFER_INCLUDE_DIR})
-  target_include_directories(flashinfer_tvm PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/tvm/include)
-  target_include_directories(flashinfer_tvm PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/tvm/3rdparty/dlpack/include)
-  target_include_directories(flashinfer_tvm PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/tvm/3rdparty/dmlc-core/include)
+  target_include_directories(flashinfer_tvm PRIVATE ${TVM_HOME_SET}/include)
+  target_include_directories(flashinfer_tvm PRIVATE ${TVM_HOME_SET}/3rdparty/dlpack/include)
+  target_include_directories(flashinfer_tvm PRIVATE ${TVM_HOME_SET}/3rdparty/dmlc-core/include)
   target_compile_options(flashinfer_tvm PRIVATE -Xcompiler=-fPIC)
 endif(FLASHINFER_TVM_BINDING)


### PR DESCRIPTION
This PR updates the CMakeLists to properly get the TVM_HOME after TVM being removed from the 3rdparty.