### PR TITLE
[FIX] stmatrix asm output operand

### DIFF
--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -96,7 +96,7 @@ __device__ __forceinline__ void stmatrix_m8n8x4(uint32_t* R, T* smem_ptr) {
 #ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
   uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
   asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
-               : "r"(smem_int_ptr), "r"(R[0]), "r"(R[1]), "r"(R[2]), "r"(R[3]));
+               : : "r"(smem_int_ptr), "r"(R[0]), "r"(R[1]), "r"(R[2]), "r"(R[3]));
 #else
   // Fallback implementation, slower than PTX instruction
   const uint32_t tx = threadIdx.x;


### PR DESCRIPTION
`stmatrix` output operand missing. Fix it by adding a ':'.