### PR TITLE
Tweak `FLASHINFER_INLINE` into a device-only specifier

### DIFF
--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -27,7 +27,7 @@
 
 namespace flashinfer {
 
-#define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__ __host__
+#define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
 
 template <typename float_t, size_t vec_size>
 struct vec_t {


### PR DESCRIPTION
This prevents host-side warnings such as: `ignoring #pragma unroll` or `dereferencing type-punned pointer will break strict-aliasing rules`.