### PR TITLE
[Bugfix] Fix the frag_b constant for mma rowsum of b16 input data type

### DIFF
--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -315,8 +315,8 @@ __device__ __forceinline__ void rowsum_f16f16f32(float* d, DType* s) {
         "{%8,  0.,  %9,  0.};\n"
         "}\n"
         : "=f"(d[0]), "=f"(d[1])
-        : "r"(s_u32[0]), "r"(s_u32[1]), "r"(s_u32[2]), "r"(s_u32[3]), "r"(1006648320),
-          "r"(1006648320), "f"(d[0]), "f"(d[1]));
+        : "r"(s_u32[0]), "r"(s_u32[1]), "r"(s_u32[2]), "r"(s_u32[3]), "r"(1065369472),
+          "r"(1065369472), "f"(d[0]), "f"(d[1]));
   }
 #else
 #error "Unsupported CUDA architecture for mma instruction"


### PR DESCRIPTION
We mistakenly fill the same constant value in `frag_b` of mma rowsum function for both bf16 and fp16. However, we should use different values because 1's binary representation in bf16 & fp16 is not the same.

```python
>>> import torch
>>> x = torch.ones(2).half()
>>> x.view(dtype=torch.int32)
tensor([1006648320], dtype=torch.int32)
>>> x = torch.ones(2).bfloat16()
>>> x.view(dtype=torch.int32)
tensor([1065369472], dtype=torch.int32)
```
