### PR TITLE
Compile more GQA group sizes

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -89,6 +89,9 @@
   if (group_size == 1) {                                                \
     constexpr size_t GROUP_SIZE = 1;                                    \
     __VA_ARGS__                                                         \
+  } else if (group_size == 4) {                                         \
+    constexpr size_t GROUP_SIZE = 4;                                    \
+    __VA_ARGS__                                                         \
   } else if (group_size == 8) {                                         \
     constexpr size_t GROUP_SIZE = 8;                                    \
     __VA_ARGS__                                                         \


### PR DESCRIPTION
Mistral uses 4 and current we only compile 1 and 8.