### PR TITLE
[Performance] Cooperative prefill parameter tweak

### DIFF
--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -1378,7 +1378,7 @@ cudaError_t SinglePrefillWithKVCacheWorkEstimation(
                                     min((num_blocks_per_sm * num_sm) /
                                             (num_kv_heads *
                                              ceil_div(qo_len * group_size, num_rows_per_cta)),
-                                        kv_len / 1024);
+                                        kv_len / 2048);
 
                                 max_grid_size = num_blocks_per_sm * num_sm;
                                 if (num_chunks > 1) {
@@ -1458,7 +1458,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
       uint32_t num_chunks =
           min((num_blocks_per_sm * num_sm) /
                   (num_kv_heads * ceil_div(qo_len * GROUP_SIZE, num_rows_per_cta)),
-              kv_len / 1024);
+              kv_len / 2048);
 
       if (num_chunks <= 1 || tmp == nullptr) {
         // Enough parallelism, do not use cooperative


### PR DESCRIPTION
Note that prefill kernel's synchronization overhead is larger than decode's. A naive linear model might not be optimal is finding the best chunk size. We should create an analytical cost model in the future.