### PR TITLE
[Hotfix] Fix the behavior of `FLASHINFER_CUDA_ARCHITECTURES` flag in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,18 +24,13 @@ flashinfer_option(FLASHINFER_DECODE "Whether to compile decode kernel tests/benc
 flashinfer_option(FLASHINFER_PAGE "Whether to compile page kernel tests/benchmarks or not." ON)
 flashinfer_option(FLASHINFER_TVM_BINDING "Whether to compile tvm binding or not." OFF)
 flashinfer_option(FLASHINFER_TVM_HOME "The path to tvm for building tvm binding." "")
-# "native" is a special value for CMAKE_CUDA_ARCHITECTURES which means use the architectures of the host's GPU.
-# it's new in CMake 3.24, if you are using an older of CMake or you want to use a different value, you can
-# set its value through config.cmake or -DCMAKE_CUDA_ARCHITECTURES=... through command-line.
-# Supported CUDA architctures include 80;86;89;90
-flashinfer_option(FLASHINFER_CUDA_ARCHITECTURES "CUDA architectures of tests/benchmarks" native)
 
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES ${FLASHINFER_CUDA_ARCHITECTURES})
+if(DEFINED FLASHINFER_CUDA_ARCHITECTURES)
   message(STATUS "CMAKE_CUDA_ARCHITECTURES set to ${FLASHINFER_CUDA_ARCHITECTURES}.")
-else(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  message(STATUS "External CMAKE_CUDA_ARCHITECTURES exists. Ignore FLASHINFER_CUDA_ARCHITECTURES.")
-endif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES ${FLASHINFER_CUDA_ARCHITECTURES})
+else(DEFINED FLASHINFER_CUDA_ARCHITECTURES)
+  message(STATUS "CMAKE_CUDA_ARCHITECTURES is ${CMAKE_CUDA_ARCHITECTURES}")
+endif(DEFINED FLASHINFER_CUDA_ARCHITECTURES)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 if(FLASHINFER_PREFILL OR FLASHINFER_DECODE OR FLASHINFER_PAGE)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -8,6 +8,10 @@ set(FLASHINFER_PREFILL ON)
 set(FLASHINFER_DECODE ON)
 # Whether to compile page kernel tests/benchmarks or not.
 set(FLASHINFER_PAGE ON)
-# Set target cuda architectures for tests/benchmarks, defaults to native (which is new in CMake 3.24, you can configure it manually if you are using older CMake).
-# Example: "80;86;90;90"
+# Set target cuda architectures for tests/benchmarks, defaults to native.
+# "native" is a special value for CMAKE_CUDA_ARCHITECTURES which means use the architectures of the host's GPU.
+# it's new in CMake 3.24, if you are using an older of CMake or you want to use a different value, you can
+# set its value here. Supported CUDA architctures include 80;86;89;90
+# Example:
+# set(FLASHINFER_CUDA_ARCHITECTURES 80)
 set(FLASHINFER_CUDA_ARCHITECTURES native)


### PR DESCRIPTION
Followup of #42 , we remove the default value of `FLASHINFER_CUDA_ARCHITECTURES`, now it must be specified by user (either by setting the value in `config.cmake` or calling `cmake` via `cmake .. -DFLASHINFER_CUDA_ARCHITECTURES=xx`). We also change behavior of `FLASHINFER_CUDA_ARCHITECTURES` is
1. if `FLASHINFER_CUDA_ARCHITECTURES` is defined, override `CMAKE_CUDA_ARCHITECTURES` with `FLASHINFER_CUDA_ARCHITECTURES`.
1. if the `FLASHINFER_CUDA_ARCHITECTURES` is not defined (e.g. externally), use `CMAKE_CUDA_ARCHITECTURES` (e.g. defined externally).

cc @MasterJH5574 