### PR TITLE
[Bugfix] Store LSE when split_kv is activated

### DIFF
--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -914,7 +914,7 @@ __global__ void SinglePrefillWithKVCacheKernel(
                                                          qo_len, qo_n_stride, qo_h_stride);
 
   // write lse
-  if (lse != nullptr) {
+  if (lse != nullptr || split_kv) {
 #pragma unroll
     for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
 #pragma unroll


### PR DESCRIPTION
#48 is buggy when `lse` is nullptr, we should always store LSE when `split_kv` is true because the merge kernel needs it, whatever `lse` is.