### PR TITLE
[Bugfix] Fix the lse computation for batch decode kernel

### DIFF
--- a/include/flashinfer/decode.cuh
+++ b/include/flashinfer/decode.cuh
@@ -732,15 +732,18 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
       st_global.o.cast_store(
           o + (paged_kv.batch_idx_map()[batch_idx] * num_qo_heads + qo_head_idx) * head_dim +
           tx * vec_size);
+      // write lse
+      if (lse != nullptr) {
+        lse[batch_idx * num_qo_heads + qo_head_idx] = st_global.get_lse();
+      }
     }
   } else {
     st.normalize();
     st.o.cast_store(o + (batch_idx * num_qo_heads + qo_head_idx) * head_dim + tx * vec_size);
-  }
-
-  // write lse
-  if (lse != nullptr) {
-    lse[batch_idx * num_qo_heads + qo_head_idx] = st.get_lse();
+    // write lse
+    if (lse != nullptr) {
+      lse[batch_idx * num_qo_heads + qo_head_idx] = st.get_lse();
+    }
   }
 }
 


### PR DESCRIPTION
The lse returned by `BatchDecodeWithPagedKVCacheKernel` is wrong if Paged-KV is splitted.