### PR TITLE
[Feature] Support variable length merge states

### DIFF
--- a/include/flashinfer/cascade.cuh
+++ b/include/flashinfer/cascade.cuh
@@ -280,7 +280,6 @@ __global__ void VariableLengthMergeStatesKernel(DTypeIn* __restrict__ V, float* 
                                                 IdType* indptr, DTypeOut* __restrict__ v_merged,
                                                 float* __restrict__ s_merged, uint32_t num_heads) {
   uint32_t tx = threadIdx.x, ty = threadIdx.y;
-  uint32_t seq_len = gridDim.x;
   uint32_t pos = blockIdx.x;
   uint32_t head_idx = blockIdx.y;
   state_t<vec_size> st;

--- a/include/flashinfer/cascade.cuh
+++ b/include/flashinfer/cascade.cuh
@@ -137,8 +137,8 @@ __device__ __forceinline__ void threadblock_sync_state(state_t<vec_size>& st, DT
  * \param vec_size The vector size used in the kernel.
  * \tparam DTypeIn The data type of v.
  * \tparam DTypeOut The data type of v_merged.
- * \param v The partial v of index sets. (num_index_sets, n, h, d)
- * \param s The logsumexp value of index sets. (num_index_sets, n, h)
+ * \param v The partial v of index sets. (n, num_index_sets, h, d)
+ * \param s The logsumexp value of index sets. (n, num_index_sets, h)
  * \param v_merged The merged v of index sets union. (n, h, d)
  * \param s_merged The merged logsumexp value of index sets union. (n, h)
  * \param num_heads The number of heads of v.
@@ -175,14 +175,14 @@ __global__ void MergeStatesKernel(DTypeIn* __restrict__ V, float* __restrict__ S
 /*!
  * \brief The CUDA kernel that merges self-attention states of a list of index sets,
  *   accelerated for larget number of index sets.
- * \param vec_size The vector size used in the kernel.
- * \param bdx The blockDim.x used in the kernel.
- * \param bdy The blockDim.y used in the kernel.
- * \param num_smem_stages The number of stages of shared memory used in the kernel.
+ * \tparam vec_size The vector size used in the kernel.
+ * \tparam bdx The blockDim.x used in the kernel.
+ * \tparam bdy The blockDim.y used in the kernel.
+ * \tparam num_smem_stages The number of stages of shared memory used in the kernel.
  * \tparam DTypeIn The data type of v.
  * \tparam DTypeOut The data type of v_merged.
- * \param v The partial v of index sets. (num_index_sets, n, h, d)
- * \param s The logsumexp value of index sets. (num_index_sets, n, h)
+ * \param V The partial v of index sets. (n, num_index_sets, h, d)
+ * \param S The logsumexp value of index sets. (n, num_index_sets, h)
  * \param v_merged The merged v of index sets union. (n, h, d)
  * \param s_merged The merged logsumexp value of index sets union. (n, h)
  * \param num_heads The number of heads of v.
@@ -196,9 +196,9 @@ __global__ void MergeStatesLargeNumIndexSetsKernel(DTypeIn* __restrict__ V, floa
                                                    float* __restrict__ s_merged,
                                                    uint32_t num_index_sets, uint32_t num_heads) {
   uint32_t tx = threadIdx.x, ty = threadIdx.y;
-  uint32_t seq_len = gridDim.y;
-  uint32_t pos = blockIdx.y;
-  uint32_t head_idx = blockIdx.x;
+  uint32_t seq_len = gridDim.x;
+  uint32_t pos = blockIdx.x;
+  uint32_t head_idx = blockIdx.y;
   state_t<vec_size> st;
   constexpr uint32_t vec_bits = sizeof(DTypeIn) * vec_size * 8;
   constexpr uint32_t head_dim = vec_size * bdx;
@@ -211,7 +211,8 @@ __global__ void MergeStatesLargeNumIndexSetsKernel(DTypeIn* __restrict__ V, floa
   for (uint32_t iter = 0; iter < num_smem_stages; ++iter) {
     cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
         v_smem + (iter * bdy + ty) * head_dim + tx * vec_size,
-        V + (((iter * bdy + ty) * seq_len + pos) * num_heads + head_idx) * head_dim + tx * vec_size,
+        V + ((pos * num_index_sets + (iter * bdy + ty)) * num_heads + head_idx) * head_dim +
+            tx * vec_size,
         (iter * bdy + ty) < num_index_sets);
     cp_async::commit_group();
   }
@@ -220,7 +221,7 @@ __global__ void MergeStatesLargeNumIndexSetsKernel(DTypeIn* __restrict__ V, floa
     if (iter % bdx == 0) {
       s_smem[ty * bdx + tx] =
           iter * bdy + (ty * bdx + tx) < num_index_sets
-              ? S[((iter * bdy + ty * bdx + tx) * seq_len + pos) * num_heads + head_idx]
+              ? S[(pos * num_index_sets + (iter * bdy + ty * bdx + tx)) * num_heads + head_idx]
               : 0.f;
       __syncthreads();
     }
@@ -232,7 +233,92 @@ __global__ void MergeStatesLargeNumIndexSetsKernel(DTypeIn* __restrict__ V, floa
     cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
         v_smem + ((iter % num_smem_stages) * bdy + ty) * head_dim + tx * vec_size,
         V +
-            ((((iter + num_smem_stages) * bdy + ty) * seq_len + pos) * num_heads + head_idx) *
+            ((pos * num_index_sets + ((iter + num_smem_stages) * bdy + ty)) * num_heads +
+             head_idx) *
+                head_dim +
+            tx * vec_size,
+        (iter + num_smem_stages) * bdy + ty < num_index_sets);
+    cp_async::commit_group();
+    if (iter * bdy + ty < num_index_sets) {
+      float s = s_smem[(iter % bdx) * bdy + ty];
+      st.merge(v, s, 1);
+    }
+  }
+  cp_async::wait_group<0>();
+  __syncthreads();
+
+  st.normalize();
+  threadblock_sync_state<bdx, bdy, vec_size>(st, v_smem, s_smem);
+  st.normalize();
+
+  st.o.cast_store(v_merged + (pos * num_heads + head_idx) * head_dim + tx * vec_size);
+  if (s_merged != nullptr) {
+    s_merged[pos * num_heads + head_idx] = st.get_lse();
+  }
+}
+
+/*!
+ * \brief The CUDA kernel to merge self-attention states of multiple index sets, the number of index
+ *   sets at each position might vary.
+ * \tparam vec_size The vector size used in the kernel.
+ * \tparam bdx The blockDim.x used in the kernel.
+ * \tparam bdy The blockDim.y used in the kernel.
+ * \tparam num_smem_stages The number of stages of shared memory used in the kernel.
+ * \tparam DTypeIn The data type of v.
+ * \tparam DTypeOut The data type of v_merged.
+ * \param V The partial v of index sets. (nnz, h, d)
+ * \param S The logsumexp value of index sets. (nnz, n, h)
+ * \param indptr The start offsets of each position in the variable length array.
+ * \param v_merged The merged v of index sets union. (n, h, d)
+ * \param s_merged The merged logsumexp value of index sets union. (n, h)
+ * \param num_heads The number of heads of v.
+ * \param head_dim The dimension of each head.
+ * \note s are logsumexp values with base 2.
+ */
+template <uint32_t vec_size, uint32_t bdx, uint32_t bdy, uint32_t num_smem_stages, typename DTypeIn,
+          typename DTypeOut, typename IdType>
+__global__ void VariableLengthMergeStatesKernel(DTypeIn* __restrict__ V, float* __restrict__ S,
+                                                IdType* indptr, DTypeOut* __restrict__ v_merged,
+                                                float* __restrict__ s_merged, uint32_t num_heads) {
+  uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  uint32_t seq_len = gridDim.x;
+  uint32_t pos = blockIdx.x;
+  uint32_t head_idx = blockIdx.y;
+  state_t<vec_size> st;
+  constexpr uint32_t vec_bits = sizeof(DTypeIn) * vec_size * 8;
+  constexpr uint32_t head_dim = vec_size * bdx;
+
+  extern __shared__ uint8_t smem[];
+  DTypeIn* v_smem = (DTypeIn*)smem;
+  float* s_smem = (float*)(smem + num_smem_stages * bdy * head_dim * sizeof(DTypeIn));
+  const uint32_t num_index_sets = indptr[pos + 1] - indptr[pos];
+
+#pragma unroll
+  for (uint32_t iter = 0; iter < num_smem_stages; ++iter) {
+    cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
+        v_smem + (iter * bdy + ty) * head_dim + tx * vec_size,
+        V + ((indptr[pos] + (iter * bdy + ty)) * num_heads + head_idx) * head_dim + tx * vec_size,
+        (iter * bdy + ty) < num_index_sets);
+    cp_async::commit_group();
+  }
+#pragma unroll 4
+  for (uint32_t iter = 0; iter < ceil_div(num_index_sets, bdy); ++iter) {
+    if (iter % bdx == 0) {
+      s_smem[ty * bdx + tx] =
+          iter * bdy + (ty * bdx + tx) < num_index_sets
+              ? S[(indptr[pos] + (iter * bdy + ty * bdx + tx)) * num_heads + head_idx]
+              : 0.f;
+      __syncthreads();
+    }
+    cp_async::wait_group<num_smem_stages - 1>();
+    __syncthreads();
+    vec_t<float, vec_size> v;
+    v.cast_load(v_smem + ((iter % num_smem_stages) * bdy + ty) * head_dim + tx * vec_size);
+    __syncthreads();
+    cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
+        v_smem + ((iter % num_smem_stages) * bdy + ty) * head_dim + tx * vec_size,
+        V +
+            ((indptr[pos] + ((iter + num_smem_stages) * bdy + ty)) * num_heads + head_idx) *
                 head_dim +
             tx * vec_size,
         (iter + num_smem_stages) * bdy + ty < num_index_sets);
@@ -346,7 +432,7 @@ cudaError_t MergeStates(DTypeIn* v, float* s, DTypeOut* v_merged, float* s_merge
     if (num_index_sets > 2 * (128 / bdx)) {
       constexpr uint32_t num_threads = 128;
       constexpr uint32_t bdy = num_threads / bdx;
-      dim3 nblks(num_heads, seq_len);
+      dim3 nblks(seq_len, num_heads);
       dim3 nthrs(bdx, bdy);
       constexpr uint32_t num_smem_stages = 4;
       auto kernel = MergeStatesLargeNumIndexSetsKernel<vec_size, bdx, bdy, num_smem_stages, DTypeIn,
@@ -366,6 +452,26 @@ cudaError_t MergeStates(DTypeIn* v, float* s, DTypeOut* v_merged, float* s_merge
       FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
     }
   });
+  return cudaSuccess;
+}
+
+template <typename DTypeIn, typename DTypeOut, typename IdType>
+cudaError_t VariableLengthMergeStates(DTypeIn* v, float* s, IdType* indptr, DTypeOut* v_merged,
+                                      float* s_merged, uint32_t seq_len, uint32_t num_heads,
+                                      uint32_t head_dim, cudaStream_t stream = nullptr) {
+  SWITCH_HEAD_DIM(head_dim, HEAD_DIM, {
+    constexpr uint32_t vec_size = std::max(16U / sizeof(DTypeIn), HEAD_DIM / 32U);
+    constexpr uint32_t bdy = num_threads / bdx;
+    dim3 nblks(seq_len, num_heads);
+    dim3 nthrs(bdx, bdy);
+    constexpr uint32_t num_smem_stages = 4;
+    auto kernel = VariableLengthMergeStatesKernel<vec_size, bdx, bdy, num_smem_stages, DTypeIn,
+                                                  DTypeOut, IdType>;
+    void* args[] = {&v, &s, &indptr, &v_merged, &s_merged, &num_heads};
+    uint32_t smem_size = FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+  })
   return cudaSuccess;
 }
 

--- a/python/csrc/cascade.cu
+++ b/python/csrc/cascade.cu
@@ -65,8 +65,8 @@ std::vector<torch::Tensor> merge_states(torch::Tensor v, torch::Tensor s) {
   CHECK_EQ(v.size(0), s.size(0));
   CHECK_EQ(v.size(1), s.size(1));
   CHECK_EQ(v.size(2), s.size(2));
-  unsigned int num_index_sets = v.size(0);
-  unsigned int seq_len = v.size(1);
+  unsigned int seq_len = v.size(0);
+  unsigned int num_index_sets = v.size(1);
   unsigned int num_heads = v.size(2);
   unsigned int head_dim = v.size(3);
   s = s.to(torch::kFloat32);

--- a/python/flashinfer/ops/__init__.py
+++ b/python/flashinfer/ops/__init__.py
@@ -265,10 +265,10 @@ def merge_states(v: torch.Tensor, s: torch.Tensor):
     ----------
     v : torch.Tensor
         The attention output from the KV segments.
-        Shape: [num_kv_segments, seq_len, num_heads, head_dim]
+        Shape: [seq_len, num_kv_segments, num_heads, head_dim]
     s : torch.Tensor
         The logsumexp value from the KV segments.
-        Shape: [num_kv_segments, seq_len, num_heads]
+        Shape: [seq_len, num_kv_segments, num_heads]
 
     Returns
     -------

--- a/src/test_cascade.cu
+++ b/src/test_cascade.cu
@@ -525,18 +525,18 @@ void TestTwoLevelSinglePrefixCascadeAppendCorrectness() {
   }
 }
 
-// TEST(FlashInferCorrectnessTest, MergeKernelCorrectnessTestFP16) {
-//   TestMergeKernelCorrectness<half>();
-// }
+TEST(FlashInferCorrectnessTest, MergeKernelCorrectnessTestFP16) {
+  TestMergeKernelCorrectness<half>();
+}
 
 TEST(FlashInferCorrectnessTest, VariableLengthMergeKernelCorrectnessTestFP16) {
   TestVariableLengthMergeKernelCorrectness<half>();
 }
 
-// TEST(FlashInferCorrectnessTest, TwoLevelSinglePrefixCascadeDecodeTestFP16) {
-//   TestTwoLevelSinglePrefixCascadeDecodeCorrectness<half>();
-// }
+TEST(FlashInferCorrectnessTest, TwoLevelSinglePrefixCascadeDecodeTestFP16) {
+  TestTwoLevelSinglePrefixCascadeDecodeCorrectness<half>();
+}
 
-// TEST(FlashInferCorrectnessTest, TwoLevelSinglePrefixCascadeAppendTestFP16) {
-//   TestTwoLevelSinglePrefixCascadeAppendCorrectness<half>();
-// }
+TEST(FlashInferCorrectnessTest, TwoLevelSinglePrefixCascadeAppendTestFP16) {
+  TestTwoLevelSinglePrefixCascadeAppendCorrectness<half>();
+}

--- a/src/test_cascade.cu
+++ b/src/test_cascade.cu
@@ -32,22 +32,21 @@ bool is_prime(int x) {
 }
 
 template <typename T>
-void _TestMergeKernelCorrectness(size_t num_index_sets, size_t batch_size, size_t num_heads,
+void _TestMergeKernelCorrectness(size_t num_index_sets, size_t seq_len, size_t num_heads,
                                  size_t head_dim, bool sparse_s) {
   EXPECT_GT(num_index_sets, 1) << "num_index_sets must be greater than 1";
-  std::vector<T> V_host(num_index_sets * batch_size * num_heads * head_dim);
-  std::vector<float> V_host_f32(num_index_sets * batch_size * num_heads * head_dim);
-  std::vector<float> S_host(num_index_sets * batch_size * num_heads);
+  std::vector<T> V_host(seq_len * num_index_sets * num_heads * head_dim);
+  std::vector<float> V_host_trans_f32(num_index_sets * seq_len * num_heads * head_dim);
+  std::vector<float> S_host(seq_len * num_index_sets * num_heads);
+  std::vector<float> S_host_trans(num_index_sets * seq_len * num_heads);
 
   utils::vec_normal_(V_host);
-  std::transform(V_host.begin(), V_host.end(), V_host_f32.begin(),
-                 [](T x) { return static_cast<float>(x); });
   if (sparse_s) {
     for (uint32_t i = 0; i < num_index_sets; ++i) {
       float fill_val = is_prime(i) ? 10 : -10;
-      for (uint32_t j = 0; j < batch_size; ++j) {
+      for (uint32_t j = 0; j < seq_len; ++j) {
         for (uint32_t k = 0; k < num_heads; ++k) {
-          S_host[i * batch_size * num_heads + j * num_heads + k] = fill_val;
+          S_host[(j * num_index_sets + i) * num_heads + k] = fill_val;
         }
       }
     }
@@ -55,58 +54,71 @@ void _TestMergeKernelCorrectness(size_t num_index_sets, size_t batch_size, size_
     utils::vec_uniform_(S_host, -10, 10);
   }
 
-  thrust::device_vector<T> V_device(V_host);
-  thrust::device_vector<float> V_device_f32(V_host_f32);
-  thrust::device_vector<float> S_device(S_host);
+  for (uint32_t i = 0; i < num_index_sets; ++i) {
+    for (uint32_t j = 0; j < seq_len; ++j) {
+      std::transform(V_host.begin() + (j * num_index_sets + i) * num_heads * head_dim,
+                     V_host.begin() + (j * num_index_sets + i + 1) * num_heads * head_dim,
+                     V_host_trans_f32.begin() + (i * seq_len + j) * num_heads * head_dim,
+                     [](T x) { return static_cast<float>(x); });
+      std::copy(S_host.begin() + (j * num_index_sets + i) * num_heads,
+                S_host.begin() + (j * num_index_sets + i + 1) * num_heads,
+                S_host_trans.begin() + (i * seq_len + j) * num_heads);
+    }
+  }
 
-  thrust::device_vector<float> V_merged_0_device(batch_size * num_heads * head_dim);
-  thrust::device_vector<float> S_merged_0_device(batch_size * num_heads);
-  thrust::device_vector<T> V_merged_1_device(batch_size * num_heads * head_dim);
-  thrust::device_vector<float> S_merged_1_device(batch_size * num_heads);
+  thrust::device_vector<T> V_device(V_host);
+  thrust::device_vector<float> V_device_trans_f32(V_host_trans_f32);
+  thrust::device_vector<float> S_device(S_host);
+  thrust::device_vector<float> S_device_trans(S_host_trans);
+
+  thrust::device_vector<float> V_merged_0_device(seq_len * num_heads * head_dim);
+  thrust::device_vector<float> S_merged_0_device(seq_len * num_heads);
+  thrust::device_vector<T> V_merged_1_device(seq_len * num_heads * head_dim);
+  thrust::device_vector<float> S_merged_1_device(seq_len * num_heads);
 
   // Method 0: use MergeState
-  MergeState(thrust::raw_pointer_cast(V_device_f32.data()),
-             thrust::raw_pointer_cast(S_device.data()),
-             thrust::raw_pointer_cast(V_device_f32.data() + batch_size * num_heads * head_dim),
-             thrust::raw_pointer_cast(S_device.data() + batch_size * num_heads),
+  MergeState(thrust::raw_pointer_cast(V_device_trans_f32.data()),
+             thrust::raw_pointer_cast(S_device_trans.data()),
+             thrust::raw_pointer_cast(V_device_trans_f32.data() + seq_len * num_heads * head_dim),
+             thrust::raw_pointer_cast(S_device_trans.data() + seq_len * num_heads),
              thrust::raw_pointer_cast(V_merged_0_device.data()),
-             thrust::raw_pointer_cast(S_merged_0_device.data()), batch_size, num_heads, head_dim);
+             thrust::raw_pointer_cast(S_merged_0_device.data()), seq_len, num_heads, head_dim);
   for (uint i = 2; i < num_index_sets; ++i) {
     MergeStateInPlace(
         thrust::raw_pointer_cast(V_merged_0_device.data()),
         thrust::raw_pointer_cast(S_merged_0_device.data()),
-        thrust::raw_pointer_cast(V_device_f32.data() + i * batch_size * num_heads * head_dim),
-        thrust::raw_pointer_cast(S_device.data() + i * batch_size * num_heads), batch_size,
+        thrust::raw_pointer_cast(V_device_trans_f32.data() + i * seq_len * num_heads * head_dim),
+        thrust::raw_pointer_cast(S_device_trans.data() + i * seq_len * num_heads), seq_len,
         num_heads, head_dim);
   }
 
   // Method 1: use MergeStates
   MergeStates(thrust::raw_pointer_cast(V_device.data()), thrust::raw_pointer_cast(S_device.data()),
               thrust::raw_pointer_cast(V_merged_1_device.data()),
-              thrust::raw_pointer_cast(S_merged_1_device.data()), num_index_sets, batch_size,
+              thrust::raw_pointer_cast(S_merged_1_device.data()), num_index_sets, seq_len,
               num_heads, head_dim);
 
   thrust::host_vector<float> V_merged_0_host(V_merged_0_device);
   thrust::host_vector<T> V_merged_1_host(V_merged_1_device);
   thrust::host_vector<float> S_merged_0_host(S_merged_0_device), S_merged_1_host(S_merged_1_device);
   size_t num_V_result_errors_atol_1e_3_rtol_1e_3 = 0, num_S_result_errors_atol_1e_3_rtol_1e_3 = 0;
-  for (size_t i = 0; i < batch_size * num_heads * head_dim; ++i) {
+  for (size_t i = 0; i < seq_len * num_heads * head_dim; ++i) {
     EXPECT_FALSE(std::isnan(float(V_merged_0_host[i]))) << "V_merged_0_host[" << i << "] is nan";
     EXPECT_FALSE(std::isnan(float(V_merged_1_host[i]))) << "V_merged_1_host[" << i << "] is nan";
     num_V_result_errors_atol_1e_3_rtol_1e_3 +=
         (!utils::isclose(float(V_merged_0_host[i]), float(V_merged_1_host[i]), 1e-3, 1e-3));
   }
-  for (size_t i = 0; i < batch_size * num_heads; ++i) {
+  for (size_t i = 0; i < seq_len * num_heads; ++i) {
     EXPECT_FALSE(std::isnan(float(S_merged_0_host[i]))) << "S_merged_0_host[" << i << "] is nan";
     EXPECT_FALSE(std::isnan(float(S_merged_1_host[i]))) << "S_merged_1_host[" << i << "] is nan";
     num_S_result_errors_atol_1e_3_rtol_1e_3 +=
         (!utils::isclose(float(S_merged_0_host[i]), float(S_merged_1_host[i]), 1e-3, 1e-3));
   }
   float V_result_accuracy =
-      1.0 - float(num_V_result_errors_atol_1e_3_rtol_1e_3) / (batch_size * num_heads * head_dim);
+      1.0 - float(num_V_result_errors_atol_1e_3_rtol_1e_3) / (seq_len * num_heads * head_dim);
   float S_result_accuracy =
-      1.0 - float(num_S_result_errors_atol_1e_3_rtol_1e_3) / (batch_size * num_heads);
-  std::cout << "num_index_setes=" << num_index_sets << ", batch_size=" << batch_size
+      1.0 - float(num_S_result_errors_atol_1e_3_rtol_1e_3) / (seq_len * num_heads);
+  std::cout << "num_index_sets=" << num_index_sets << ", seq_len=" << seq_len
             << ", num_heads=" << num_heads << ", head_dim=" << head_dim << ", sparse_s=" << sparse_s
             << ", V accuracy (atol=1e-3, rtol=1e-3)=" << V_result_accuracy
             << ", S accuracy (atol=1e-3, rtol=1e-3)=" << S_result_accuracy << std::endl;
@@ -115,15 +127,14 @@ void _TestMergeKernelCorrectness(size_t num_index_sets, size_t batch_size, size_
 }
 
 template <typename T>
-void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
-                                                       size_t shared_prefix_length,
+void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t seq_len, size_t shared_prefix_length,
                                                        size_t unique_kv_length, size_t num_qo_heads,
                                                        size_t num_kv_heads, size_t head_dim) {
   constexpr uint32_t page_size = 16;
   std::vector<std::vector<T>> testcase_float_data;
   std::vector<std::vector<int32_t>> testcase_int_data;
   std::tie(testcase_float_data, testcase_int_data) = utils::create_shared_prefix_testcase_data<T>(
-      batch_size, shared_prefix_length, unique_kv_length,
+      seq_len, shared_prefix_length, unique_kv_length,
       /*qo_append_length=*/1, num_qo_heads, num_kv_heads, head_dim, page_size);
 
   std::vector<T> q_h = std::move(testcase_float_data[0]),
@@ -140,8 +151,8 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
 
   thrust::device_vector<T> shared_k_d(shared_k_h), shared_v_d(shared_v_h), kv_data_d(kv_data_h),
       q_d(q_h), o_baseline_d(q_h.size()), o_cascade_0_d(q_h.size()), o_cascade_1_d(q_h.size());
-  thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024), lse_cascade_0_d(batch_size * num_qo_heads),
-      lse_cascade_1_d(batch_size * num_qo_heads);
+  thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024), lse_cascade_0_d(seq_len * num_qo_heads),
+      lse_cascade_1_d(seq_len * num_qo_heads);
 
   thrust::device_vector<int32_t> kv_indptr_combined_d(kv_indptr_combined_h),
       kv_indptr_unique_d(kv_indptr_unique_h), kv_indices_combined_d(kv_indices_combined_h),
@@ -152,13 +163,13 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
   constexpr PageStorage page_storage = PageStorage::kIndices;
 
   paged_kv_t<page_storage, T, int32_t> paged_kv_baseline_d(
-      num_kv_heads, page_size, head_dim, batch_size, thrust::raw_pointer_cast(kv_data_d.data()),
+      num_kv_heads, page_size, head_dim, seq_len, thrust::raw_pointer_cast(kv_data_d.data()),
       thrust::raw_pointer_cast(kv_indices_combined_d.data()),
       thrust::raw_pointer_cast(kv_indptr_combined_d.data()),
       thrust::raw_pointer_cast(kv_last_page_len_combined_d.data()));
 
   paged_kv_t<page_storage, T, int32_t> paged_kv_casacde_d(
-      num_kv_heads, page_size, head_dim, batch_size, thrust::raw_pointer_cast(kv_data_d.data()),
+      num_kv_heads, page_size, head_dim, seq_len, thrust::raw_pointer_cast(kv_data_d.data()),
       thrust::raw_pointer_cast(kv_indices_unique_d.data()),
       thrust::raw_pointer_cast(kv_indptr_unique_d.data()),
       thrust::raw_pointer_cast(kv_last_page_len_unique_d.data()));
@@ -166,11 +177,11 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
   BatchDecodeHandler baseline_handler, cascade_handler;
 
   baseline_handler.BeginForward<page_storage, T, T, int32_t>(
-      kv_indptr_combined_h.data(), kv_last_page_len_combined_h.data(), batch_size, num_qo_heads,
+      kv_indptr_combined_h.data(), kv_last_page_len_combined_h.data(), seq_len, num_qo_heads,
       num_kv_heads, head_dim, page_size, RotaryMode::kNone);
 
   cascade_handler.BeginForward<page_storage, T, T, int32_t>(
-      kv_indptr_unique_h.data(), kv_last_page_len_unique_h.data(), batch_size, num_qo_heads,
+      kv_indptr_unique_h.data(), kv_last_page_len_unique_h.data(), seq_len, num_qo_heads,
       num_kv_heads, head_dim, page_size, RotaryMode::kNone);
 
   // Compute result using baseline implementation
@@ -187,7 +198,7 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
       thrust::raw_pointer_cast(q_d.data()), thrust::raw_pointer_cast(shared_k_d.data()),
       thrust::raw_pointer_cast(shared_v_d.data()), thrust::raw_pointer_cast(o_cascade_0_d.data()),
       thrust::raw_pointer_cast(tmp_0_d.data()), thrust::raw_pointer_cast(lse_cascade_0_d.data()),
-      num_qo_heads, num_kv_heads, /*qo_len=*/batch_size, /*kv_len=*/shared_prefix_length, head_dim,
+      num_qo_heads, num_kv_heads, /*qo_len=*/seq_len, /*kv_len=*/shared_prefix_length, head_dim,
       /*causal=*/false, /*layout=*/QKVLayout::kNHD,
       /*rotary_mode=*/RotaryMode::kNone, /*allow_fp16_qk_reduction=*/false);
 
@@ -205,7 +216,7 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
   status = MergeStateInPlace(thrust::raw_pointer_cast(o_cascade_0_d.data()),
                              thrust::raw_pointer_cast(lse_cascade_0_d.data()),
                              thrust::raw_pointer_cast(o_cascade_1_d.data()),
-                             thrust::raw_pointer_cast(lse_cascade_1_d.data()), batch_size,
+                             thrust::raw_pointer_cast(lse_cascade_1_d.data()), seq_len,
                              num_qo_heads, head_dim);
 
   EXPECT_EQ(status, cudaSuccess) << "Cascade implementation merge failed with error: "
@@ -221,7 +232,7 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
   }
   float result_accuracy =
       1. - float(num_result_errors_atol_1e_3_rtol_1e_3) / float(o_baseline_h.size());
-  std::cout << "batch_size=" << batch_size << ", shared_prefix_length=" << shared_prefix_length
+  std::cout << "seq_len=" << seq_len << ", shared_prefix_length=" << shared_prefix_length
             << ", unique_kv_length=" << unique_kv_length << ", num_qo_heads=" << num_qo_heads
             << ", num_kv_heads=" << num_kv_heads << ", head_dim=" << head_dim
             << ", result_accuracy (atol=1e-3, rtol=1e-3)=" << result_accuracy << std::endl;
@@ -229,8 +240,7 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
 }
 
 template <typename T>
-void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
-                                                       size_t shared_prefix_length,
+void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t seq_len, size_t shared_prefix_length,
                                                        size_t unique_kv_length,
                                                        size_t qo_append_length, size_t num_qo_heads,
                                                        size_t num_kv_heads, size_t head_dim) {
@@ -239,8 +249,8 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
   std::vector<std::vector<T>> testcase_float_data;
   std::vector<std::vector<int32_t>> testcase_int_data;
   std::tie(testcase_float_data, testcase_int_data) = utils::create_shared_prefix_testcase_data<T>(
-      batch_size, shared_prefix_length, unique_kv_length, qo_append_length, num_qo_heads,
-      num_kv_heads, head_dim, page_size);
+      seq_len, shared_prefix_length, unique_kv_length, qo_append_length, num_qo_heads, num_kv_heads,
+      head_dim, page_size);
 
   std::vector<T> q_h = std::move(testcase_float_data[0]),
                  shared_k_h = std::move(testcase_float_data[1]),
@@ -258,8 +268,8 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
   thrust::device_vector<T> shared_k_d(shared_k_h), shared_v_d(shared_v_h), kv_data_d(kv_data_h),
       q_d(q_h), o_baseline_d(q_h.size()), o_cascade_0_d(q_h.size()), o_cascade_1_d(q_h.size());
   thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024),
-      lse_cascade_0_d((batch_size * qo_append_length) * num_qo_heads),
-      lse_cascade_1_d((batch_size * qo_append_length) * num_qo_heads);
+      lse_cascade_0_d((seq_len * qo_append_length) * num_qo_heads),
+      lse_cascade_1_d((seq_len * qo_append_length) * num_qo_heads);
 
   thrust::device_vector<int32_t> qo_indptr_d(qo_indptr_h),
       kv_indptr_combined_d(kv_indptr_combined_h), kv_indptr_unique_d(kv_indptr_unique_h),
@@ -270,20 +280,20 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
   constexpr PageStorage page_storage = PageStorage::kIndices;
 
   paged_kv_t<page_storage, T, int32_t> paged_kv_baseline_d(
-      num_kv_heads, page_size, head_dim, batch_size, thrust::raw_pointer_cast(kv_data_d.data()),
+      num_kv_heads, page_size, head_dim, seq_len, thrust::raw_pointer_cast(kv_data_d.data()),
       thrust::raw_pointer_cast(kv_indices_combined_d.data()),
       thrust::raw_pointer_cast(kv_indptr_combined_d.data()),
       thrust::raw_pointer_cast(kv_last_page_len_combined_d.data()));
 
   paged_kv_t<page_storage, T, int32_t> paged_kv_casacde_d(
-      num_kv_heads, page_size, head_dim, batch_size, thrust::raw_pointer_cast(kv_data_d.data()),
+      num_kv_heads, page_size, head_dim, seq_len, thrust::raw_pointer_cast(kv_data_d.data()),
       thrust::raw_pointer_cast(kv_indices_unique_d.data()),
       thrust::raw_pointer_cast(kv_indptr_unique_d.data()),
       thrust::raw_pointer_cast(kv_last_page_len_unique_d.data()));
 
   BatchPrefillHandler baseline_handler, cascade_handler;
-  baseline_handler.BeginForward(qo_indptr_h.data(), batch_size, num_qo_heads, num_kv_heads);
-  cascade_handler.BeginForward(qo_indptr_h.data(), batch_size, num_qo_heads, num_kv_heads);
+  baseline_handler.BeginForward(qo_indptr_h.data(), seq_len, num_qo_heads, num_kv_heads);
+  cascade_handler.BeginForward(qo_indptr_h.data(), seq_len, num_qo_heads, num_kv_heads);
 
   cudaError_t status = BatchPrefillWithPagedKVCacheWrapper<page_storage, T, T, int32_t>(
       &baseline_handler, thrust::raw_pointer_cast(q_d.data()),
@@ -299,7 +309,7 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
       thrust::raw_pointer_cast(q_d.data()), thrust::raw_pointer_cast(shared_k_d.data()),
       thrust::raw_pointer_cast(shared_v_d.data()), thrust::raw_pointer_cast(o_cascade_0_d.data()),
       thrust::raw_pointer_cast(tmp_0_d.data()), thrust::raw_pointer_cast(lse_cascade_0_d.data()),
-      num_qo_heads, num_kv_heads, /*qo_len=*/batch_size * qo_append_length,
+      num_qo_heads, num_kv_heads, /*qo_len=*/seq_len * qo_append_length,
       /*kv_len=*/shared_prefix_length, head_dim,
       /*causal=*/false, /*layout=*/QKVLayout::kNHD,
       /*rotary_mode=*/RotaryMode::kNone, /*allow_fp16_qk_reduction=*/false);
@@ -322,7 +332,7 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
                              thrust::raw_pointer_cast(lse_cascade_0_d.data()),
                              thrust::raw_pointer_cast(o_cascade_1_d.data()),
                              thrust::raw_pointer_cast(lse_cascade_1_d.data()),
-                             batch_size * qo_append_length, num_qo_heads, head_dim);
+                             seq_len * qo_append_length, num_qo_heads, head_dim);
   EXPECT_EQ(status, cudaSuccess) << "Cascade implementation merge failed with error: "
                                  << cudaGetErrorString(status);
 
@@ -336,7 +346,7 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
   }
   float result_accuracy =
       1. - float(num_result_errors_atol_1e_3_rtol_1e_3) / float(o_baseline_h.size());
-  std::cout << "batch_size=" << batch_size << ", shared_prefix_length=" << shared_prefix_length
+  std::cout << "seq_len=" << seq_len << ", shared_prefix_length=" << shared_prefix_length
             << ", unique_kv_length=" << unique_kv_length
             << ", qo_append_length=" << qo_append_length << ", num_qo_heads=" << num_qo_heads
             << ", num_kv_heads=" << num_kv_heads << ", head_dim=" << head_dim
@@ -347,12 +357,11 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
 template <typename T>
 void TestMergeKernelCorrectness() {
   for (size_t num_index_sets : {2, 9, 81, 513}) {
-    for (size_t batch_size : {4, 16}) {
+    for (size_t seq_len : {4, 16}) {
       for (size_t num_heads : {1, 21, 32}) {
         for (size_t head_dim : {64, 128, 256}) {
           for (bool sparse_s : {false, true}) {
-            _TestMergeKernelCorrectness<T>(num_index_sets, batch_size, num_heads, head_dim,
-                                           sparse_s);
+            _TestMergeKernelCorrectness<T>(num_index_sets, seq_len, num_heads, head_dim, sparse_s);
           }
         }
       }
@@ -362,13 +371,13 @@ void TestMergeKernelCorrectness() {
 
 template <typename T>
 void TestTwoLevelSinglePrefixCascadeDecodeCorrectness() {
-  for (size_t batch_size : {1, 8, 16, 64, 128}) {
+  for (size_t seq_len : {1, 8, 16, 64, 128}) {
     for (size_t shared_prefix_length : {1024, 2048, 8192, 32768}) {
       for (size_t unique_kv_length : {128, 256, 512, 1024}) {
         for (size_t num_qo_heads : {32}) {
           for (size_t num_kv_heads : {32}) {
             for (size_t head_dim : {128}) {
-              _TestTwoLevelSinglePrefixCascadeDecodeCorrectness<T>(batch_size, shared_prefix_length,
+              _TestTwoLevelSinglePrefixCascadeDecodeCorrectness<T>(seq_len, shared_prefix_length,
                                                                    unique_kv_length, num_qo_heads,
                                                                    num_kv_heads, head_dim);
             }
@@ -381,7 +390,7 @@ void TestTwoLevelSinglePrefixCascadeDecodeCorrectness() {
 
 template <typename T>
 void TestTwoLevelSinglePrefixCascadeAppendCorrectness() {
-  for (size_t batch_size : {1, 8, 16, 64, 128}) {
+  for (size_t seq_len : {1, 8, 16, 64, 128}) {
     for (size_t shared_prefix_length : {1024, 2048, 8192, 32768}) {
       for (size_t unique_kv_length : {128, 256, 512, 1024}) {
         for (size_t qo_append_length : {128}) {
@@ -389,8 +398,8 @@ void TestTwoLevelSinglePrefixCascadeAppendCorrectness() {
             for (size_t num_kv_heads : {32}) {
               for (size_t head_dim : {128}) {
                 _TestTwoLevelSinglePrefixCascadeAppendCorrectness<T>(
-                    batch_size, shared_prefix_length, unique_kv_length, qo_append_length,
-                    num_qo_heads, num_kv_heads, head_dim);
+                    seq_len, shared_prefix_length, unique_kv_length, qo_append_length, num_qo_heads,
+                    num_kv_heads, head_dim);
               }
             }
           }


### PR DESCRIPTION
Also, reorder the input dimension of `MergeStates` to be consistent with variable length version.