### PR TITLE
[WIP][Feature] Support KV Partition for BatchPrefill kernel for Paged & Ragged KV-Cache.

### DIFF
--- a/include/flashinfer/decode.cuh
+++ b/include/flashinfer/decode.cuh
@@ -913,62 +913,68 @@ cudaError_t SingleDecodeWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut
 /*!
  * \brief Partition Paged KV-Cache into multiple chunks on KV sequence length
  * \tparam IdType A template type indicates the index data type
- * \param old_batch_size The batch size of the old Paged KV-Cache
- * \param old_page_indptr_h The host-side page indptr of the old Paged KV-Cache
- * \param old_last_page_len_h The host-side last page offset of the old Paged KV-Cache
- * \param max_num_pages_per_batch The maximum number of pages per batch
+ * \param batch_size_before_partition The batch size of the Paged KV-Cache before partition
+ * \param paged_kv_indptr_before_partition_h The host-side page indptr of the old Paged KV-Cache
+ * \param kv_last_page_len_before_partition_h The host-side last page offset of the old Paged
+ *   KV-Cache
+ * \param num_pages_per_batch The number of pages per batch
  * \param new_paged_kv_d The device-side new Paged KV-Cache
  * \param stream The cuda stream to launch the kernel
  * \return status Indicates whether CUDA calls are successful
  */
 template <typename IdType>
 cudaError_t PartitionPagedKVCacheComputeAuxiliaryInfo(
-    const uint32_t max_num_pages_per_batch, const uint32_t old_batch_size, const uint32_t page_size,
-    IdType* old_indptr_h, IdType* old_last_page_len_h, IdType* new_indptr_d,
-    IdType* new_last_page_len_d, IdType* chunk_indptr_d, IdType* batch_idx_map_d,
-    IdType* chunk_start_d, IdType* seq_lens_before_partition_d, cudaStream_t stream = nullptr) {
-  std::vector<IdType> new_page_indptr_h{0}, new_last_page_len_h, chunk_indptr_h{0}, batch_idx_map_h,
-      chunk_start_pos_h, seq_lens_before_partition_h;
+    const uint32_t num_pages_per_batch, const uint32_t batch_size_before_partition,
+    const uint32_t page_size, IdType* paged_kv_indptr_before_partition_h,
+    IdType* kv_last_page_len_before_partition_h, IdType* paged_kv_indptr_after_partition_d,
+    IdType* kv_last_page_len_after_partition_d, IdType* chunk_indptr_d, IdType* batch_idx_map_d,
+    IdType* chunk_start_pos_d, IdType* seq_lens_before_partition_d, cudaStream_t stream = nullptr) {
+  std::vector<IdType> paged_kv_indptr_after_partition_h{0}, kv_last_page_len_after_partition_h,
+      chunk_indptr_h{0}, batch_idx_map_h, chunk_start_pos_h, seq_lens_before_partition_h;
 
-  for (uint32_t batch_idx = 0; batch_idx < old_batch_size; batch_idx++) {
-    uint32_t num_chunks =
-        ceil_div(old_indptr_h[batch_idx + 1] - old_indptr_h[batch_idx], max_num_pages_per_batch);
+  for (uint32_t batch_idx = 0; batch_idx < batch_size_before_partition; batch_idx++) {
+    uint32_t num_chunks = ceil_div(paged_kv_indptr_before_partition_h[batch_idx + 1] -
+                                       paged_kv_indptr_before_partition_h[batch_idx],
+                                   num_pages_per_batch);
     chunk_indptr_h.push_back(chunk_indptr_h.back() + num_chunks);
     if (num_chunks == 0) {
-      new_page_indptr_h.push_back(old_indptr_h[batch_idx]);
-      new_last_page_len_h.push_back(0);
+      paged_kv_indptr_after_partition_h.push_back(paged_kv_indptr_before_partition_h[batch_idx]);
+      kv_last_page_len_after_partition_h.push_back(0);
       batch_idx_map_h.push_back(batch_idx);
       chunk_start_pos_h.push_back(0);
       seq_lens_before_partition_h.push_back(0);
     } else {
-      uint32_t seq_len_before_partition =
-          (old_indptr_h[batch_idx + 1] - old_indptr_h[batch_idx] - 1) * page_size +
-          old_last_page_len_h[batch_idx];
+      uint32_t seq_len_before_partition = (paged_kv_indptr_before_partition_h[batch_idx + 1] -
+                                           paged_kv_indptr_before_partition_h[batch_idx] - 1) *
+                                              page_size +
+                                          kv_last_page_len_before_partition_h[batch_idx];
       for (uint32_t j = 0; j < num_chunks; ++j) {
         bool is_last = (j + 1) == num_chunks;
-        new_page_indptr_h.push_back(min(old_indptr_h[batch_idx] + (j + 1) * max_num_pages_per_batch,
-                                        old_indptr_h[batch_idx + 1]));
-        new_last_page_len_h.push_back(is_last ? old_last_page_len_h[batch_idx] : page_size);
+        paged_kv_indptr_after_partition_h.push_back(
+            min(paged_kv_indptr_before_partition_h[batch_idx] + (j + 1) * num_pages_per_batch,
+                paged_kv_indptr_before_partition_h[batch_idx + 1]));
+        kv_last_page_len_after_partition_h.push_back(
+            is_last ? kv_last_page_len_before_partition_h[batch_idx] : page_size);
         batch_idx_map_h.push_back(batch_idx);
-        chunk_start_pos_h.push_back(j * max_num_pages_per_batch * page_size);
+        chunk_start_pos_h.push_back(j * num_pages_per_batch * page_size);
         seq_lens_before_partition_h.push_back(seq_len_before_partition);
       }
     }
   }
 
-  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(new_indptr_d, new_page_indptr_h.data(),
-                                       sizeof(IdType) * new_page_indptr_h.size(),
-                                       cudaMemcpyHostToDevice, stream));
-  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(new_last_page_len_d, new_last_page_len_h.data(),
-                                       sizeof(IdType) * new_last_page_len_h.size(),
-                                       cudaMemcpyHostToDevice, stream));
+  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(
+      paged_kv_indptr_after_partition_d, paged_kv_indptr_after_partition_h.data(),
+      sizeof(IdType) * paged_kv_indptr_after_partition_h.size(), cudaMemcpyHostToDevice, stream));
+  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(
+      kv_last_page_len_after_partition_d, kv_last_page_len_after_partition_h.data(),
+      sizeof(IdType) * kv_last_page_len_after_partition_h.size(), cudaMemcpyHostToDevice, stream));
   FLASHINFER_CUDA_CALL(cudaMemcpyAsync(chunk_indptr_d, chunk_indptr_h.data(),
                                        sizeof(IdType) * chunk_indptr_h.size(),
                                        cudaMemcpyHostToDevice, stream));
   FLASHINFER_CUDA_CALL(cudaMemcpyAsync(batch_idx_map_d, batch_idx_map_h.data(),
                                        sizeof(IdType) * batch_idx_map_h.size(),
                                        cudaMemcpyHostToDevice, stream));
-  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(chunk_start_d, chunk_start_pos_h.data(),
+  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(chunk_start_pos_d, chunk_start_pos_h.data(),
                                        sizeof(IdType) * chunk_start_pos_h.size(),
                                        cudaMemcpyHostToDevice, stream));
   FLASHINFER_CUDA_CALL(cudaMemcpyAsync(
@@ -978,7 +984,7 @@ cudaError_t PartitionPagedKVCacheComputeAuxiliaryInfo(
 }
 
 /*!
- * \brief Compute the number of pages per batch and the new batch size
+ * \brief Compute the number of pages per batch and the batch size
  *   after we partition Paged KV-Cache into multiple chunks on KV sequence length
  *   dimension.
  * \tparam IdType A template type indicates the index data type
@@ -987,8 +993,8 @@ cudaError_t PartitionPagedKVCacheComputeAuxiliaryInfo(
  * \param num_pages The number of pages per request in the batch
  * \param min_num_pages_per_batch The pre-set minimum number of
  *   pages per batch, default to 1
- * \return (num_pages_per_batch, new_batch_size) The number of pages per batch and
- *   the new batch size after the partition.
+ * \return (num_pages_per_batch, batch_size_after_partition) The number of pages per batch and
+ *   the batch size after the partition.
  */
 template <typename IdType>
 std::pair<uint32_t, uint32_t> PartitionPagedKVCacheBinarySearchMinNumPagePerBatch(
@@ -998,24 +1004,24 @@ std::pair<uint32_t, uint32_t> PartitionPagedKVCacheBinarySearchMinNumPagePerBatc
   for (const IdType& elem : num_pages) {
     high = max(high, elem);
   }
-  uint32_t new_batch_size;
+  uint32_t batch_size_after_partition;
   while (low < high) {
     uint32_t mid = (low + high) / 2;
-    new_batch_size = 0;
+    batch_size_after_partition = 0;
     for (const IdType& elem : num_pages) {
-      new_batch_size += ceil_div(elem, mid);
+      batch_size_after_partition += ceil_div(elem, mid);
     }
-    if (new_batch_size * num_kv_heads > max_grid_size) {
+    if (batch_size_after_partition * num_kv_heads > max_grid_size) {
       low = mid + 1;
     } else {
       high = mid;
     }
   }
-  new_batch_size = 0;
+  batch_size_after_partition = 0;
   for (const IdType& elem : num_pages) {
-    new_batch_size += ceil_div(std::max(elem, 1), low);
+    batch_size_after_partition += ceil_div(std::max(elem, 1), low);
   }
-  return {low, new_batch_size};
+  return {low, batch_size_after_partition};
 }
 
 /*!
@@ -1026,9 +1032,8 @@ std::pair<uint32_t, uint32_t> PartitionPagedKVCacheBinarySearchMinNumPagePerBatc
  * \tparam DTypeOut A template type indicates the output data type
  * \tparam IdType A template type indicates the index data type
  * \param tmp_size The estimated temporary buffer size, return 0 if not use partition-kv kernel
- * \param max_grid_size The maximum grid size that can be used in a partiton-kv kernel
- * \param max_num_pages_per_batch The maximum number of pages per batch
- * \param new_batch_size The new batch size after the partition
+ * \param num_pages_per_batch The maximum number of pages per batch
+ * \param batch_size_after_partition The batch size after the partition
  * \param paged_kv The paged kv cache data structure
  * \param num_qo_heads A integer indicates the number of heads of query and output
  * \param rotary_mode The rotary mode
@@ -1037,8 +1042,8 @@ std::pair<uint32_t, uint32_t> PartitionPagedKVCacheBinarySearchMinNumPagePerBatc
  */
 template <PageStorage page_storage, typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchDecodeWithPagedKVCacheWorkEstimation(
-    uint32_t& tmp_size, uint32_t& max_grid_size, uint32_t& max_num_pages_per_batch,
-    uint32_t& new_batch_size, uint32_t batch_size, IdType* kv_indptr_h, const uint32_t num_qo_heads,
+    uint32_t& tmp_size, uint32_t& num_pages_per_batch, uint32_t& batch_size_after_partition,
+    uint32_t batch_size, IdType* kv_indptr_h, const uint32_t num_qo_heads,
     const uint32_t num_kv_heads, const uint32_t head_dim, const uint32_t page_size,
     const RotaryMode rotary_mode = RotaryMode::kNone, cudaStream_t stream = nullptr) {
   SWITCH_GQA_GROUP_SIZE(
@@ -1070,25 +1075,25 @@ cudaError_t BatchDecodeWithPagedKVCacheWorkEstimation(
                 cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
             FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
                 &num_blocks_per_sm, partition_kv_kernel, num_threads, smem_size));
-            max_grid_size = num_blocks_per_sm * num_sm;
+            const uint32_t max_grid_size = num_blocks_per_sm * num_sm;
             if (batch_size * num_kv_heads >= max_grid_size) {
               // do not use partition-kv kernel
               tmp_size = 0;
-              new_batch_size = batch_size;
+              batch_size_after_partition = batch_size;
             } else {
-              // compute max_num_pages_per_batch and new_batch_size
+              // compute num_pages_per_batch and batch_size_after_partition
               std::vector<IdType> num_pages(batch_size);
               for (uint32_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
                 num_pages[batch_idx] = kv_indptr_h[batch_idx + 1] - kv_indptr_h[batch_idx];
               }
-              std::tie(max_num_pages_per_batch, new_batch_size) =
+              std::tie(num_pages_per_batch, batch_size_after_partition) =
                   PartitionPagedKVCacheBinarySearchMinNumPagePerBatch(max_grid_size, num_kv_heads,
                                                                       num_pages, 128 / page_size);
-              if (new_batch_size == batch_size) {
+              if (batch_size_after_partition == batch_size) {
                 // do not use partition-kv kernel for short sequence
                 tmp_size = 0;
               } else {
-                tmp_size = num_qo_heads * new_batch_size *
+                tmp_size = num_qo_heads * batch_size_after_partition *
                            (head_dim * sizeof(DTypeOut) + 2 * sizeof(float));
               }
             }

--- a/include/flashinfer/handler.cuh
+++ b/include/flashinfer/handler.cuh
@@ -87,7 +87,7 @@ class BatchDecodeHandler {
                            uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
                            uint32_t page_size, RotaryMode rotary_mode) {
     batch_size_before_partition_ = batch_size;
-    uint32_t tmp_size, max_grid_size, max_num_pages_per_batch, new_batch_size;
+    uint32_t tmp_size, max_num_pages_per_batch, new_batch_size;
     auto work_estimation_func =
         BatchDecodeWithPagedKVCacheWorkEstimation<page_storage, DTypeIn, DTypeOut, IdType>;
 
@@ -106,8 +106,8 @@ class BatchDecodeHandler {
     }
 
     FLASHINFER_CUDA_CALL(work_estimation_func(
-        tmp_size, max_grid_size, max_num_pages_per_batch, new_batch_size, batch_size,
-        indptr_h.data(), num_qo_heads, num_kv_heads, head_dim, page_size, rotary_mode, stream_));
+        tmp_size, max_num_pages_per_batch, new_batch_size, batch_size, indptr_h.data(),
+        num_qo_heads, num_kv_heads, head_dim, page_size, rotary_mode, stream_));
     batch_size_after_partition_ = new_batch_size;
     if (tmp_size > 0) {
       FLASHINFER_CUDA_CALL(cudaMallocAsync(&float_buffer_, tmp_size, stream_));

--- a/include/flashinfer/handler.cuh
+++ b/include/flashinfer/handler.cuh
@@ -333,22 +333,13 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
     throw std::runtime_error(err_msg.str());
   }
 
-  SWITCH_NUM_FRAGS_X(
-      num_frags_x, NUM_FRAGS_X, {SWITCH_PAGE_SIZE(paged_kv.page_size, PAGE_SIZE, {
-        if constexpr (PAGE_SIZE == 0) {
-          return BatchPrefillWithPagedKVCacheFallbackDispatched<
-              page_storage, NUM_FRAGS_X, GROUP_SIZE, HEAD_DIM, ROTARY_MODE, ALLOW_FP16_QK_REDUCTION,
-              CAUSAL, DTypeIn, DTypeOut, IdType>(q, request_indices, tile_indices, qo_indptr,
-                                                 paged_kv, o, tmp, lse, num_qo_tiles, rope_scale,
-                                                 rope_theta, stream);
-        } else {
-          return BatchPrefillWithPagedKVCacheDispatched<
-              page_storage, NUM_FRAGS_X, PAGE_SIZE, GROUP_SIZE, HEAD_DIM, ROTARY_MODE,
-              ALLOW_FP16_QK_REDUCTION, CAUSAL, DTypeIn, DTypeOut, IdType>(
-              q, request_indices, tile_indices, qo_indptr, paged_kv, o, tmp, lse, num_qo_tiles,
-              rope_scale, rope_theta, stream);
-        }
-      })});
+  SWITCH_NUM_FRAGS_X(num_frags_x, NUM_FRAGS_X, {SWITCH_PAGE_SIZE(paged_kv.page_size, PAGE_SIZE, {
+                       return BatchPrefillWithPagedKVCacheDispatched<
+                           page_storage, NUM_FRAGS_X, PAGE_SIZE, GROUP_SIZE, HEAD_DIM, ROTARY_MODE,
+                           ALLOW_FP16_QK_REDUCTION, CAUSAL, DTypeIn, DTypeOut, IdType>(
+                           q, request_indices, tile_indices, qo_indptr, paged_kv, o, tmp, lse,
+                           num_qo_tiles, rope_scale, rope_theta, stream);
+                     })});
   return cudaSuccess;
 }
 

--- a/include/flashinfer/page.cuh
+++ b/include/flashinfer/page.cuh
@@ -30,6 +30,19 @@ enum class PageStorage {
 };
 
 /*!
+ * \brief The auxiliary information about qo sequence partitioning
+ */
+template <typename IdType>
+struct qo_partition_info_t {
+  IdType* request_indices;
+  IdType* tile_indices;
+
+  __host__ __device__ __forceinline__ qo_partition_info_t(IdType* request_indices,
+                                                          IdType* tile_indices)
+      : request_indices(request_indices), tile_indices(tile_indices) {}
+};
+
+/*!
  * \brief The auxiliary information about kv sequence partitioning
  */
 template <typename IdType>

--- a/include/flashinfer/page.cuh
+++ b/include/flashinfer/page.cuh
@@ -30,19 +30,6 @@ enum class PageStorage {
 };
 
 /*!
- * \brief The auxiliary information about qo sequence partitioning
- */
-template <typename IdType>
-struct qo_partition_info_t {
-  IdType* request_indices;
-  IdType* tile_indices;
-
-  __host__ __device__ __forceinline__ qo_partition_info_t(IdType* request_indices,
-                                                          IdType* tile_indices)
-      : request_indices(request_indices), tile_indices(tile_indices) {}
-};
-
-/*!
  * \brief The auxiliary information about kv sequence partitioning
  */
 template <typename IdType>

--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -1928,9 +1928,10 @@ cudaError_t BatchPrefillWithPagedKVCache(
 
   uint32_t num_frags_x, num_qo_tiles;
   std::vector<IdType> request_indices_h, tile_indices_h;
-  std::tie(num_frags_x, num_qo_tiles, request_indices_h, tile_indices_h) =
-      split_qo_indptr(qo_indptr, batch_size, group_size, stream);
-
+  SWITCH_DEVICE_PTR(qo_indptr, qo_indptr_h, batch_size + 1, stream, {
+    std::tie(num_frags_x, num_qo_tiles, request_indices_h, tile_indices_h) =
+        split_qo_indptr(qo_indptr_h, batch_size, group_size, stream);
+  });
   IdType* request_indices_d;
   IdType* tile_indices_d;
 

--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -1747,9 +1747,11 @@ cudaError_t BatchPrefillWithRaggedKVCache(
 
   uint32_t num_frags_x, num_qo_tiles;
   std::vector<IdType> request_indices_h, tile_indices_h;
-  std::tie(num_frags_x, num_qo_tiles, request_indices_h, tile_indices_h) =
-      split_qo_indptr(qo_indptr, batch_size, group_size, stream);
 
+  SWITCH_DEVICE_PTR(qo_indptr, qo_indptr_h, batch_size + 1, stream, {
+    std::tie(num_frags_x, num_qo_tiles, request_indices_h, tile_indices_h) =
+        split_qo_indptr(qo_indptr, batch_size, group_size, stream);
+  });
   IdType* request_indices_d;
   IdType* tile_indices_d;
 

--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -1750,7 +1750,7 @@ cudaError_t BatchPrefillWithRaggedKVCache(
 
   SWITCH_DEVICE_PTR(qo_indptr, qo_indptr_h, batch_size + 1, stream, {
     std::tie(num_frags_x, num_qo_tiles, request_indices_h, tile_indices_h) =
-        split_qo_indptr(qo_indptr, batch_size, group_size, stream);
+        split_qo_indptr(qo_indptr_h, batch_size, group_size, stream);
   });
   IdType* request_indices_d;
   IdType* tile_indices_d;

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -49,13 +49,13 @@
   using elem_t = std::remove_pointer_t<ptr_t>;                                                \
   if (is_device_ptr(maybe_device_ptr)) {                                                      \
     std::vector<elem_t> host_vec(length);                                                     \
-    ptr_t host_ptr = host_vec.data();                                                        \
+    ptr_t host_ptr = host_vec.data();                                                         \
     FLASHINFER_CUDA_CALL(cudaMemcpyAsync(host_ptr, maybe_device_ptr, sizeof(elem_t) * length, \
                                          cudaMemcpyDeviceToHost, stream));                    \
     FLASHINFER_CUDA_CALL(cudaStreamSynchronize(stream));                                      \
     __VA_ARGS__                                                                               \
   } else {                                                                                    \
-    ptr_t host_ptr = maybe_device_ptr;                                                       \
+    ptr_t host_ptr = maybe_device_ptr;                                                        \
     __VA_ARGS__                                                                               \
   }
 

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -44,21 +44,6 @@
   }
 #endif
 
-#define SWITCH_DEVICE_PTR(maybe_device_ptr, host_ptr, length, stream, ...)                    \
-  using ptr_t = decltype(maybe_device_ptr);                                                   \
-  using elem_t = std::remove_pointer_t<ptr_t>;                                                \
-  if (is_device_ptr(maybe_device_ptr)) {                                                      \
-    std::vector<elem_t> host_vec(length);                                                     \
-    ptr_t host_ptr = host_vec.data();                                                         \
-    FLASHINFER_CUDA_CALL(cudaMemcpyAsync(host_ptr, maybe_device_ptr, sizeof(elem_t) * length, \
-                                         cudaMemcpyDeviceToHost, stream));                    \
-    FLASHINFER_CUDA_CALL(cudaStreamSynchronize(stream));                                      \
-    __VA_ARGS__                                                                               \
-  } else {                                                                                    \
-    ptr_t host_ptr = maybe_device_ptr;                                                        \
-    __VA_ARGS__                                                                               \
-  }
-
 #define SWITCH_SPLIT_QO_INDPTR(split_qo_indptr, SPLIT_QO_INDPTR, ...) \
   if (split_qo_indptr) {                                              \
     constexpr bool SPLIT_QO_INDPTR = true;                            \

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -62,58 +62,81 @@
     __VA_ARGS__                                                                               \
   }
 
-#define SWITCH_PAGE_SIZE(page_size, PAGE_SIZE, ...) \
-  if (page_size == 1) {                             \
-    constexpr size_t PAGE_SIZE = 1;                 \
-    __VA_ARGS__                                     \
-  } else if (page_size == 8) {                      \
-    constexpr size_t PAGE_SIZE = 8;                 \
-    __VA_ARGS__                                     \
-  } else if (page_size == 16) {                     \
-    constexpr size_t PAGE_SIZE = 16;                \
-    __VA_ARGS__                                     \
-  } else if (page_size == 32) {                     \
-    constexpr size_t PAGE_SIZE = 32;                \
-    __VA_ARGS__                                     \
-  } else {                                          \
-    constexpr size_t PAGE_SIZE = 0;                 \
-    __VA_ARGS__                                     \
+#define SWITCH_PAGE_SIZE(page_size, PAGE_SIZE, ...)                                 \
+  switch (page_size) {                                                              \
+    case 1: {                                                                       \
+      constexpr size_t PAGE_SIZE = 1;                                               \
+      __VA_ARGS__                                                                   \
+      break;                                                                        \
+    }                                                                               \
+    case 8: {                                                                       \
+      constexpr size_t PAGE_SIZE = 8;                                               \
+      __VA_ARGS__                                                                   \
+      break;                                                                        \
+    }                                                                               \
+    case 16: {                                                                      \
+      constexpr size_t PAGE_SIZE = 16;                                              \
+      __VA_ARGS__                                                                   \
+      break;                                                                        \
+    }                                                                               \
+    case 32: {                                                                      \
+      constexpr size_t PAGE_SIZE = 32;                                              \
+      __VA_ARGS__                                                                   \
+      break;                                                                        \
+    }                                                                               \
+    default: {                                                                      \
+      std::ostringstream err_msg;                                                   \
+      err_msg << "Unsupported page_size for prefill/append kernels: " << page_size; \
+      throw std::invalid_argument(err_msg.str());                                   \
+    }                                                                               \
   }
 
-#define SWITCH_NUM_FRAGS_X(num_frags_x, NUM_FRAGS_X, ...)                 \
-  if (num_frags_x == 1) {                                                 \
-    constexpr size_t NUM_FRAGS_X = 1;                                     \
-    __VA_ARGS__                                                           \
-  } else if (num_frags_x == 2) {                                          \
-    constexpr size_t NUM_FRAGS_X = 2;                                     \
-    __VA_ARGS__                                                           \
-  } else {                                                                \
-    std::cerr << "Unsupported num_frags_x: " << num_frags_x << std::endl; \
+#define SWITCH_NUM_FRAGS_X(num_frags_x, NUM_FRAGS_X, ...)    \
+  switch (num_frags_x) {                                     \
+    case 1: {                                                \
+      constexpr size_t NUM_FRAGS_X = 1;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 2: {                                                \
+      constexpr size_t NUM_FRAGS_X = 2;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    default: {                                               \
+      std::ostringstream err_msg;                            \
+      err_msg << "Unsupported num_frags_x: " << num_frags_x; \
+      throw std::runtime_error(err_msg.str());               \
+    }                                                        \
   }
 
-#define SWITCH_NUM_FRAGS_Z(max_frags_z, NUM_FRAGS_Z, ...)                 \
-  if (max_frags_z == 4) {                                                 \
-    constexpr size_t NUM_FRAGS_Z = 4;                                     \
-    __VA_ARGS__                                                           \
-  } else if (max_frags_z == 2) {                                          \
-    constexpr size_t NUM_FRAGS_Z = 2;                                     \
-    __VA_ARGS__                                                           \
-  } else {                                                                \
-    std::cerr << "Unsupported max_frags_z: " << max_frags_z << std::endl; \
+#define SWITCH_NUM_FRAGS_Z(max_frags_z, NUM_FRAGS_Z, ...)  \
+  if (max_frags_z >= 4) {                                  \
+    constexpr size_t NUM_FRAGS_Z = 4;                      \
+    __VA_ARGS__                                            \
+  } else if (max_frags_z >= 2) {                           \
+    constexpr size_t NUM_FRAGS_Z = 2;                      \
+    __VA_ARGS__                                            \
+  } else {                                                 \
+    std::ostringstream err_msg;                            \
+    err_msg << "Unsupported max_frags_z: " << max_frags_z; \
+    throw std::runtime_error(err_msg.str());               \
   }
 
-#define SWITCH_GQA_GROUP_SIZE(group_size, GROUP_SIZE, ...)              \
-  if (group_size == 1) {                                                \
-    constexpr size_t GROUP_SIZE = 1;                                    \
-    __VA_ARGS__                                                         \
-  } else if (group_size == 4) {                                         \
-    constexpr size_t GROUP_SIZE = 4;                                    \
-    __VA_ARGS__                                                         \
-  } else if (group_size == 8) {                                         \
-    constexpr size_t GROUP_SIZE = 8;                                    \
-    __VA_ARGS__                                                         \
-  } else {                                                              \
-    std::cerr << "Unsupported group_size: " << group_size << std::endl; \
+#define SWITCH_GQA_GROUP_SIZE(group_size, GROUP_SIZE, ...) \
+  if (group_size == 1) {                                   \
+    constexpr size_t GROUP_SIZE = 1;                       \
+    __VA_ARGS__                                            \
+  } else if (group_size == 4) {                            \
+    constexpr size_t GROUP_SIZE = 4;                       \
+    __VA_ARGS__                                            \
+  } else if (group_size == 8) {                            \
+    constexpr size_t GROUP_SIZE = 8;                       \
+    __VA_ARGS__                                            \
+  } else {                                                 \
+    std::ostringstream err_msg;                            \
+    err_msg << "Unsupported group_size: " << group_size;   \
+    throw std::runtime_error(err_msg.str());               \
   }
 
 #define SWITCH_CAUSAL(causal, CAUSAL, ...) \

--- a/src/test_batch_prefill.cu
+++ b/src/test_batch_prefill.cu
@@ -326,7 +326,7 @@ template <typename T>
 void TestBatchPrefillKernelOneHotCorrectness(bool allow_fp16_qk_reduction) {
   for (size_t num_kv_heads : {4, 8, 32}) {
     for (size_t num_qo_heads : {32}) {
-      for (size_t page_size : {1, 7, 16}) {
+      for (size_t page_size : {1, 8, 16}) {
         for (size_t head_dim : {64, 128}) {
           for (size_t causal : {false, true}) {
             for (size_t rotary_mode : {0, 1}) {
@@ -345,7 +345,7 @@ template <typename T>
 void TestBatchPrefillKernelShortContextCorrectness(bool allow_fp16_qk_reduction) {
   for (size_t num_kv_heads : {4, 8, 32}) {
     for (size_t num_qo_heads : {32}) {
-      for (size_t page_size : {1, 7, 16}) {
+      for (size_t page_size : {1, 8, 16}) {
         for (size_t head_dim : {64, 128}) {
           for (size_t causal : {false, true}) {
             for (size_t rotary_mode : {0, 1}) {
@@ -364,7 +364,7 @@ template <typename T>
 void TestBatchPrefillKernelLongContextCorrectness(bool allow_fp16_qk_reduction) {
   for (size_t num_kv_heads : {1, 2, 8}) {
     for (size_t num_qo_heads : {8}) {
-      for (size_t page_size : {1, 7, 16}) {
+      for (size_t page_size : {1, 8, 16}) {
         for (size_t head_dim : {64, 128}) {
           for (size_t causal : {false, true}) {
             for (size_t rotary_mode : {0, 1}) {


### PR DESCRIPTION
Before this PR, FlashInfer supports KV sequence parallelism for single decode/prefill and batch decode, but not batch prefill, however, this feature is also important for batch prefill kernel. This PR implements KV partition for batch prefill kernels (on both Paged & Ragged KV-Cache).