### PR TITLE
[Refactor] Use `std::runtime_error` instead of `abort()`

### DIFF
--- a/include/flashinfer/decode.cuh
+++ b/include/flashinfer/decode.cuh
@@ -811,9 +811,10 @@ cudaError_t SingleDecodeWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut
   const float rope_rcp_scale = 1.f / rope_scale;
   const float rope_rcp_theta = 1.f / rope_theta;
   if (num_qo_heads % num_kv_heads != 0) {
-    std::cerr << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
-              << num_kv_heads << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
+            << num_kv_heads;
+    throw std::invalid_argument(err_msg.str());
   }
 
   SWITCH_GQA_GROUP_SIZE(
@@ -881,9 +882,10 @@ cudaError_t SingleDecodeWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut
                   uint32_t num_chunks = ceil_div(seq_len, kv_chunk_size);
                   dim3 nblks = dim3(num_chunks, num_kv_heads);
                   if (nblks.x == 0 || nblks.y == 0) {
-                    std::cerr << "Invalid kernel configuration: nblks=(" << nblks.x << ","
-                              << nblks.y << ")" << std::endl;
-                    abort();
+                    std::ostringstream err_msg;
+                    err_msg << "Invalid kernel configuration: nblks=(" << nblks.x << "," << nblks.y
+                            << ")";
+                    throw std::runtime_error(err_msg.str());
                   }
                   dim3 nthrs = dim3(bdx, bdy, bdz);
                   void* args[] = {(void*)&q,
@@ -1216,9 +1218,10 @@ cudaError_t BatchDecodeWithPagedKVCache(DTypeIn* q,
   const uint32_t head_dim = paged_kv.head_dim;
   const uint32_t batch_size = paged_kv.batch_size;
   if (num_qo_heads % num_kv_heads != 0) {
-    std::cerr << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
-              << num_kv_heads << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
+            << num_kv_heads;
+    throw std::invalid_argument(err_msg.str());
   }
 
   SWITCH_GQA_GROUP_SIZE(
@@ -1283,9 +1286,10 @@ cudaError_t BatchDecodeWithPaddedKVCache(
     QKVLayout layout = QKVLayout::kNHD, RotaryMode rotary_mode = RotaryMode::kNone,
     float rope_scale = 1.f, float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   if (num_qo_heads % num_kv_heads != 0) {
-    std::cerr << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
-              << num_kv_heads << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
+            << num_kv_heads << std::endl;
+    throw std::invalid_argument(err_msg.str());
   }
 
   SWITCH_GQA_GROUP_SIZE(

--- a/include/flashinfer/decode.cuh
+++ b/include/flashinfer/decode.cuh
@@ -1288,7 +1288,7 @@ cudaError_t BatchDecodeWithPaddedKVCache(
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
-            << num_kv_heads << std::endl;
+            << num_kv_heads;
     throw std::invalid_argument(err_msg.str());
   }
 

--- a/include/flashinfer/handler.cuh
+++ b/include/flashinfer/handler.cuh
@@ -173,8 +173,10 @@ class BatchPrefillHandler {
   cudaError_t BeginForward(IdType* qo_indptr, uint32_t batch_size, uint32_t num_qo_heads,
                            uint32_t num_kv_heads) {
     if (num_qo_heads % num_kv_heads != 0) {
-      std::cerr << "num_qo_heads should be divisible by num_kv_heads" << std::endl;
-      abort();
+      std::ostringstream err_msg;
+      err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
+              << num_kv_heads;
+      throw std::invalid_argument(err_msg.str());
     }
     uint32_t gqa_group_size = num_qo_heads / num_kv_heads;
     std::vector<IdType> request_indices_h, tile_indices_h;
@@ -271,10 +273,10 @@ cudaError_t BatchDecodeWithPagedKVCacheWrapper(BatchDecodeHandler* handler, DTyp
       kv_partition_info.seq_lens_before_partition = handler->GetSeqLengthsBeforePartition<IdType>();
     }
   } else {
-    std::cerr << "Please call BatchDecodeHandler's BeginForward() before calling "
-                 "BatchDecodeWithPagedKVCacheWrapper()"
-              << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "Please call BatchDecodeHandler's BeginForward() before calling "
+               "BatchDecodeWithPagedKVCacheWrapper()";
+    throw std::runtime_error(err_msg.str());
   }
   return BatchDecodeWithPagedKVCache<page_storage, DTypeIn, DTypeOut, IdType>(
       q, new_paged_kv, kv_partition_info, o, tmp, lse, num_qo_heads, rotary_mode, rope_scale,
@@ -300,10 +302,10 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
     num_frags_x = handler->GetNumFragsX();
     num_qo_tiles = handler->GetNumQOTiles();
   } else {
-    std::cerr << "Please call BatchPrefillHandler's BeginForward() before calling "
-                 "BatchPrefillWithPagedKVCacheWrapper()"
-              << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "Please call BatchPrefillHandler's BeginForward() before calling "
+               "BatchPrefillWithPagedKVCacheWrapper()";
+    throw std::runtime_error(err_msg.str());
   }
 
   SWITCH_NUM_FRAGS_X(
@@ -371,10 +373,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
     num_frags_x = handler->GetNumFragsX();
     num_qo_tiles = handler->GetNumQOTiles();
   } else {
-    std::cerr << "Please call BatchPrefillHandler's BeginForward() before calling "
-                 "BatchPrefillWithRaggedKVWrapperCache()"
-              << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "Please call BatchPrefillHandler's BeginForward() before calling "
+               "BatchPrefillWithRaggedKVWrapperCache()";
+    throw std::runtime_error(err_msg.str());
   }
 
   SWITCH_NUM_FRAGS_X(num_frags_x, NUM_FRAGS_X, {

--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -1320,8 +1320,9 @@ cudaError_t SinglePrefillWithKVCacheWorkEstimation(
     QKVLayout layout = QKVLayout::kNHD, RotaryMode rotary_mode = RotaryMode::kNone,
     bool allow_fp16_qk_reduction = false, cudaStream_t stream = nullptr) {
   if (kv_len < qo_len && causal) {
-    std::cerr << "When causal is true, kv_len must be greater than or equal to qo_len" << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "When causal is true, kv_len must be greater than or equal to qo_len" << std::endl;
+    throw std::invalid_argument(err_msg.str());
   }
   const uint32_t group_size = num_qo_heads / num_kv_heads;
 
@@ -1420,8 +1421,9 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   if (kv_len < qo_len && CAUSAL) {
-    std::cerr << "When causal is true, kv_len must be greater than or equal to qo_len" << std::endl;
-    abort();
+    std::ostringstream err_msg;
+    err_msg << "When causal is true, kv_len must be greater than or equal to qo_len" << std::endl;
+    throw std::invalid_argument(err_msg.str());
   }
 
   constexpr uint32_t num_frags_y = HEAD_DIM / 16;

--- a/include/flashinfer/prefill.cuh
+++ b/include/flashinfer/prefill.cuh
@@ -1321,7 +1321,8 @@ cudaError_t SinglePrefillWithKVCacheWorkEstimation(
     bool allow_fp16_qk_reduction = false, cudaStream_t stream = nullptr) {
   if (kv_len < qo_len && causal) {
     std::ostringstream err_msg;
-    err_msg << "When causal is true, kv_len must be greater than or equal to qo_len" << std::endl;
+    err_msg << "When causal is true, kv_len must be greater than or equal to qo_len, "
+            << "got kv_len " << kv_len << " and qo_len " << qo_len;
     throw std::invalid_argument(err_msg.str());
   }
   const uint32_t group_size = num_qo_heads / num_kv_heads;
@@ -1422,7 +1423,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   if (kv_len < qo_len && CAUSAL) {
     std::ostringstream err_msg;
-    err_msg << "When causal is true, kv_len must be greater than or equal to qo_len" << std::endl;
+    err_msg << "When causal is true, kv_len must be greater than or equal to qo_len, got kv_len"
+            << kv_len << " and qo_len " << qo_len;
     throw std::invalid_argument(err_msg.str());
   }
 

--- a/include/flashinfer/rope.cuh
+++ b/include/flashinfer/rope.cuh
@@ -50,24 +50,6 @@ inline std::string RotaryModeToString(const RotaryMode& rotary_mode) {
   }
 }
 
-#define SWITCH_ROTARY_MODE(rotary_mode, ROTARY_MODE, ...)                        \
-  switch (rotary_mode) {                                                         \
-    case RotaryMode::kNone: {                                                    \
-      constexpr RotaryMode ROTARY_MODE = RotaryMode::kNone;                      \
-      __VA_ARGS__                                                                \
-      break;                                                                     \
-    }                                                                            \
-    case RotaryMode::kLlama: {                                                   \
-      constexpr RotaryMode ROTARY_MODE = RotaryMode::kLlama;                     \
-      __VA_ARGS__                                                                \
-      break;                                                                     \
-    }                                                                            \
-    default: {                                                                   \
-      std::cerr << "Unsupported rotary_mode: " << int(rotary_mode) << std::endl; \
-      abort();                                                                   \
-    }                                                                            \
-  }
-
 /*!
  * \brief Apply RoPE (Rotary Positional Embeddings) to x[0: head_dim],
  *   return thread-local vector

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -18,6 +18,8 @@
 #include <cuda_runtime.h>
 
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
@@ -113,81 +115,85 @@
     __VA_ARGS__                            \
   }
 
-#define SWITCH_LAYOUT(layout, LAYOUT, ...)                                 \
-  switch (layout) {                                                        \
-    case QKVLayout::kNHD: {                                                \
-      constexpr QKVLayout LAYOUT = QKVLayout::kNHD;                        \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    case QKVLayout::kHND: {                                                \
-      constexpr QKVLayout LAYOUT = QKVLayout::kHND;                        \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    default: {                                                             \
-      std::cerr << "Unsupported qkv_layout: " << int(layout) << std::endl; \
-      abort();                                                             \
-    }                                                                      \
+#define SWITCH_LAYOUT(layout, LAYOUT, ...)                  \
+  switch (layout) {                                         \
+    case QKVLayout::kNHD: {                                 \
+      constexpr QKVLayout LAYOUT = QKVLayout::kNHD;         \
+      __VA_ARGS__                                           \
+      break;                                                \
+    }                                                       \
+    case QKVLayout::kHND: {                                 \
+      constexpr QKVLayout LAYOUT = QKVLayout::kHND;         \
+      __VA_ARGS__                                           \
+      break;                                                \
+    }                                                       \
+    default: {                                              \
+      std::ostringstream err_msg;                           \
+      err_msg << "Unsupported qkv_layout: " << int(layout); \
+      throw std::invalid_argument(err_msg.str());           \
+    }                                                       \
   }
 
-#define SWITCH_HEAD_DIM(head_dim, HEAD_DIM, ...)                      \
-  switch (head_dim) {                                                 \
-    case 64: {                                                        \
-      constexpr size_t HEAD_DIM = 64;                                 \
-      __VA_ARGS__                                                     \
-      break;                                                          \
-    }                                                                 \
-    case 128: {                                                       \
-      constexpr size_t HEAD_DIM = 128;                                \
-      __VA_ARGS__                                                     \
-      break;                                                          \
-    }                                                                 \
-    case 256: {                                                       \
-      constexpr size_t HEAD_DIM = 256;                                \
-      __VA_ARGS__                                                     \
-      break;                                                          \
-    }                                                                 \
-    default: {                                                        \
-      std::cerr << "Unsupported head_dim: " << head_dim << std::endl; \
-      abort();                                                        \
-    }                                                                 \
+#define SWITCH_HEAD_DIM(head_dim, HEAD_DIM, ...)       \
+  switch (head_dim) {                                  \
+    case 64: {                                         \
+      constexpr size_t HEAD_DIM = 64;                  \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 128: {                                        \
+      constexpr size_t HEAD_DIM = 128;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 256: {                                        \
+      constexpr size_t HEAD_DIM = 256;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    default: {                                         \
+      std::ostringstream err_msg;                      \
+      err_msg << "Unsupported head_dim: " << head_dim; \
+      throw std::invalid_argument(err_msg.str());      \
+    }                                                  \
   }
 
-#define SWITCH_HEAD_DIM_PREFILL(head_dim, HEAD_DIM, ...)              \
-  switch (head_dim) {                                                 \
-    case 64: {                                                        \
-      constexpr size_t HEAD_DIM = 64;                                 \
-      __VA_ARGS__                                                     \
-      break;                                                          \
-    }                                                                 \
-    case 128: {                                                       \
-      constexpr size_t HEAD_DIM = 128;                                \
-      __VA_ARGS__                                                     \
-      break;                                                          \
-    }                                                                 \
-    default: {                                                        \
-      std::cerr << "Unsupported head_dim: " << head_dim << std::endl; \
-      abort();                                                        \
-    }                                                                 \
+#define SWITCH_HEAD_DIM_PREFILL(head_dim, HEAD_DIM, ...) \
+  switch (head_dim) {                                    \
+    case 64: {                                           \
+      constexpr size_t HEAD_DIM = 64;                    \
+      __VA_ARGS__                                        \
+      break;                                             \
+    }                                                    \
+    case 128: {                                          \
+      constexpr size_t HEAD_DIM = 128;                   \
+      __VA_ARGS__                                        \
+      break;                                             \
+    }                                                    \
+    default: {                                           \
+      std::ostringstream err_msg;                        \
+      err_msg << "Unsupported head_dim: " << head_dim;   \
+      throw std::invalid_argument(err_msg.str());        \
+    }                                                    \
   }
 
-#define SWITCH_ROTARY_MODE(rotary_mode, ROTARY_MODE, ...)                        \
-  switch (rotary_mode) {                                                         \
-    case RotaryMode::kNone: {                                                    \
-      constexpr RotaryMode ROTARY_MODE = RotaryMode::kNone;                      \
-      __VA_ARGS__                                                                \
-      break;                                                                     \
-    }                                                                            \
-    case RotaryMode::kLlama: {                                                   \
-      constexpr RotaryMode ROTARY_MODE = RotaryMode::kLlama;                     \
-      __VA_ARGS__                                                                \
-      break;                                                                     \
-    }                                                                            \
-    default: {                                                                   \
-      std::cerr << "Unsupported rotary_mode: " << int(rotary_mode) << std::endl; \
-      abort();                                                                   \
-    }                                                                            \
+#define SWITCH_ROTARY_MODE(rotary_mode, ROTARY_MODE, ...)         \
+  switch (rotary_mode) {                                          \
+    case RotaryMode::kNone: {                                     \
+      constexpr RotaryMode ROTARY_MODE = RotaryMode::kNone;       \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case RotaryMode::kLlama: {                                    \
+      constexpr RotaryMode ROTARY_MODE = RotaryMode::kLlama;      \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    default: {                                                    \
+      std::ostringstream err_msg;                                 \
+      err_msg << "Unsupported rotary_mode: " << int(rotary_mode); \
+      throw std::invalid_argument(err_msg.str());                 \
+    }                                                             \
   }
 
 namespace flashinfer {

--- a/src/bench_cascade.cu
+++ b/src/bench_cascade.cu
@@ -308,13 +308,13 @@ void bench_two_level_single_prefix_cascade_append(nvbench::state& state) {
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
-#define BENCH_FLASHINFER_MERGE_KERNELS(T)                               \
-  auto bench_flashinfer_merge_states_##T##_ = bench_merge_states<T>;    \
-  NVBENCH_BENCH(bench_flashinfer_merge_states_##T##_)                   \
-      .set_name("flashinfer_merge_states_" STR(T))                      \
-      .add_int64_axis("num_index_sets", {2, 16, 64, 128, 256})          \
-      .add_int64_axis("seq_len", {1, 2, 4, 8, 16, 32, 64, 128, 256})    \
-      .add_int64_axis("num_heads", {32})                                \
+#define BENCH_FLASHINFER_MERGE_KERNELS(T)                            \
+  auto bench_flashinfer_merge_states_##T##_ = bench_merge_states<T>; \
+  NVBENCH_BENCH(bench_flashinfer_merge_states_##T##_)                \
+      .set_name("flashinfer_merge_states_" STR(T))                   \
+      .add_int64_axis("num_index_sets", {2, 16, 64, 128, 256})       \
+      .add_int64_axis("seq_len", {1, 2, 4, 8, 16, 32, 64, 128, 256}) \
+      .add_int64_axis("num_heads", {32})                             \
       .add_int64_axis("head_dim", {128})
 
 #define BENCH_FLASHINFER_TWO_LEVEL_SINGLE_PREFIX_CASCADE_DECODE_KERNELS(T)      \

--- a/src/cpu_reference.h
+++ b/src/cpu_reference.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <flashinfer.cuh>
+#include <stdexcept>
 
 #include "utils.h"
 
@@ -93,8 +94,9 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_in>& q, const std::vec
                       break;
                     }
                     default: {
-                      std::cerr << "Unsupported rotary mode." << std::endl;
-                      abort();
+                      std::ostringstream err_msg;
+                      err_msg << "Unsupported rotary mode.";
+                      throw std::invalid_argument(err_msg.str());
                     }
                   }
                   // apply mask


### PR DESCRIPTION
Before this PR,  we directly abort the program for runtime errors which is not desired behavior for a header-only library. This PR converts all `abort()` call to C++ `std::runtime_error` exceptions, so that we can catch them in different applications that imports flashinfer header files.