### PR TITLE
[CI] Remove py3.12 from the matrix

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11"]
         cuda: ["11.8", "12.1"]
     runs-on: [self-hosted]
     steps:


### PR DESCRIPTION
PyTorch wheels for py312 is not ready yet, we should follow PyTorch's version.