### PR TITLE
Use Torch's current stream for ops

### DIFF
--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -34,6 +34,8 @@ void BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward(torch::Tensor work
   // TODO(Zihao): support dispatching to different index data types.
   CHECK_EQ(qo_indptr.scalar_type(), torch::kInt32);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  handler_.SetCUDAStream(torch_current_stream);
 
   cudaError_t status = handler_.BeginForward(
       static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
@@ -87,6 +89,7 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
   CHECK_EQ(paged_kv_indices.scalar_type(), torch::kInt32);
   CHECK_EQ(paged_kv_last_page_len.scalar_type(), torch::kInt32);
 
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
   torch::Tensor o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -114,7 +117,7 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
                     /*q_rope_position=*/nullptr, paged_kv, static_cast<c_type*>(o.data_ptr()),
                     /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr, rope_scale,
                     rope_theta,
-                    /*stream=*/nullptr);
+                    /*stream=*/torch_current_stream);
                 TORCH_CHECK(status == cudaSuccess,
                             "BatchPrefillWithPagedKVCache failed with error code ",
                             cudaGetErrorString(status));
@@ -152,6 +155,8 @@ void BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward(torch::Tensor wor
   // TODO(Zihao): support dispatching to different index data types.
   CHECK_EQ(qo_indptr.scalar_type(), torch::kInt32);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  handler_.SetCUDAStream(torch_current_stream);
 
   cudaError_t status = handler_.BeginForward(
       static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
@@ -191,6 +196,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
   CHECK_EQ(qo_indptr.scalar_type(), torch::kInt32);
   CHECK_EQ(kv_indptr.scalar_type(), torch::kInt32);
 
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
   torch::Tensor o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -213,7 +219,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
                     static_cast<c_type*>(o.data_ptr()),
                     /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr, batch_size,
                     num_kv_heads, rope_scale, rope_theta,
-                    /*stream=*/nullptr);
+                    /*stream=*/torch_current_stream);
                 TORCH_CHECK(status == cudaSuccess,
                             "BatchPrefillWithRaggedKVCache failed with error ",
                             cudaGetErrorString(status));

--- a/python/csrc/cascade.cu
+++ b/python/csrc/cascade.cu
@@ -39,6 +39,7 @@ std::vector<torch::Tensor> merge_state(torch::Tensor v_a, torch::Tensor s_a, tor
   unsigned int seq_len = v_a.size(0);
   unsigned int num_heads = v_a.size(1);
   unsigned int head_dim = v_a.size(2);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
   auto v_merged = torch::empty_like(v_a, v_a.options());
   auto s_merged = torch::empty({seq_len, num_heads}, s_a.options());
 
@@ -47,7 +48,7 @@ std::vector<torch::Tensor> merge_state(torch::Tensor v_a, torch::Tensor s_a, tor
         MergeState(static_cast<c_type*>(v_a.data_ptr()), static_cast<float*>(s_a.data_ptr()),
                    static_cast<c_type*>(v_b.data_ptr()), static_cast<float*>(s_b.data_ptr()),
                    static_cast<c_type*>(v_merged.data_ptr()),
-                   static_cast<float*>(s_merged.data_ptr()), seq_len, num_heads, head_dim);
+                   static_cast<float*>(s_merged.data_ptr()), seq_len, num_heads, head_dim, torch_current_stream);
     TORCH_CHECK(status == cudaSuccess,
                 "MergeState kernel launch failed: ", cudaGetErrorString(status));
     return true;
@@ -76,12 +77,13 @@ void merge_state_in_place(torch::Tensor v, torch::Tensor s, torch::Tensor v_othe
   unsigned int seq_len = v.size(0);
   unsigned int num_heads = v.size(1);
   unsigned int head_dim = v.size(2);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE(v.scalar_type(), c_type, [&] {
     cudaError_t status =
         MergeStateInPlace(static_cast<c_type*>(v.data_ptr()), static_cast<float*>(s.data_ptr()),
                           static_cast<c_type*>(v_other.data_ptr()),
-                          static_cast<float*>(s_other.data_ptr()), seq_len, num_heads, head_dim);
+                          static_cast<float*>(s_other.data_ptr()), seq_len, num_heads, head_dim, torch_current_stream);
     TORCH_CHECK(status == cudaSuccess,
                 "MergeStateInPlace kernel launch failed: ", cudaGetErrorString(status));
     return true;
@@ -103,6 +105,7 @@ std::vector<torch::Tensor> merge_states(torch::Tensor v, torch::Tensor s) {
   unsigned int num_heads = v.size(2);
   unsigned int head_dim = v.size(3);
   s = s.to(torch::kFloat32);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
   auto v_merged = torch::empty({seq_len, num_heads, head_dim}, v.options());
   auto s_merged = torch::empty({seq_len, num_heads}, s.options());
 
@@ -110,7 +113,7 @@ std::vector<torch::Tensor> merge_states(torch::Tensor v, torch::Tensor s) {
     cudaError_t status = MergeStates(
         static_cast<c_type*>(v.data_ptr()), static_cast<float*>(s.data_ptr()),
         static_cast<c_type*>(v_merged.data_ptr()), static_cast<float*>(s_merged.data_ptr()),
-        num_index_sets, seq_len, num_heads, head_dim);
+        num_index_sets, seq_len, num_heads, head_dim, torch_current_stream);
     TORCH_CHECK(status == cudaSuccess,
                 "MergeStates kernel launch failed: ", cudaGetErrorString(status));
     return true;

--- a/python/csrc/page.cu
+++ b/python/csrc/page.cu
@@ -65,6 +65,8 @@ void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
   CHECK_EQ(append_value.size(1), num_heads);
   CHECK_EQ(append_key.size(2), head_dim);
 
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE(kv_data.scalar_type(), c_type, [&] {
     DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {
       paged_kv_t<page_storage, KV_LAYOUT, c_type, int32_t> paged_kv(
@@ -73,7 +75,7 @@ void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
           static_cast<int32_t*>(kv_last_page_len.data_ptr()));
       cudaError_t status = AppendPagedKVCache(paged_kv, static_cast<c_type*>(append_key.data_ptr()),
                                               static_cast<c_type*>(append_value.data_ptr()),
-                                              static_cast<int32_t*>(append_indptr.data_ptr()));
+                                              static_cast<int32_t*>(append_indptr.data_ptr()), torch_current_stream);
       TORCH_CHECK(status == cudaSuccess,
                   "AppendPagedKVCache failed with error: ", cudaGetErrorString(status));
       return true;

--- a/python/csrc/pytorch_extension_utils.h
+++ b/python/csrc/pytorch_extension_utils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <torch/extension.h>
+#include <c10/cuda/CUDAStream.h>
 
 #include "generated/dispatch.inc"
 


### PR DESCRIPTION
This PR makes PyTorch ops use the current Torch stream for kernel execution. This allows compatibility with Torch CUDA Graphs and allows the user to precisely set which stream to use in Python code using the canonical PyTorch API.

Note: I believe I have found all cases where the stream should be set, but I might have missed something.