### PR TITLE
fix: version naming issue

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         python: ["3.9", "3.10", "3.11"]
         cuda: ["11.8", "12.1"]
-        torch: ["2.1.0", "2.2.0"]
+        torch: ["2.1", "2.2"]
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v4

--- a/scripts/run-ci-build-wheel.sh
+++ b/scripts/run-ci-build-wheel.sh
@@ -24,6 +24,8 @@ mkdir -p $HOME
 export PATH="$HOME/.local/bin:$PATH"
 CUDA_MAJOR="${FLASHINFER_CI_CUDA_VERSION%.*}"
 CUDA_MINOR="${FLASHINFER_CI_CUDA_VERSION#*.}"
+TORCH_MAJOR="${FLASHINFER_CI_TORCH_VERSION%.*}"
+TORCH_MINOR="${FLASHINFER_CI_TORCH_VERSION#*.}"
 PYVER="${FLASHINFER_CI_PYTHON_VERSION//./}"
 export PATH="/opt/python/cp${PYVER}-cp${PYVER}/bin:$PATH"
 
@@ -40,7 +42,7 @@ echo "::endgroup::"
 
 echo "::group::Build wheel for FlashInfer"
 cd "$PROJECT_ROOT/python"
-MAX_JOBS=32 FLASHINFER_BUILD_VERSION="${FLASHINFER_BUILD_VERSION}+cu${CUDA_MAJOR}${CUDA_MINOR}+torch${FLASHINFER_CI_TORCH_VERSION}" python -m build --no-isolation
+MAX_JOBS=32 FLASHINFER_BUILD_VERSION="${FLASHINFER_BUILD_VERSION}+cu${CUDA_MAJOR}${CUDA_MINOR}+torch${TORCH_MAJOR}${TORCH_MINOR}" python -m build --no-isolation
 rm -f dist/*.tar.gz
 python -m build --no-isolation --sdist
 echo "::endgroup::"


### PR DESCRIPTION
Previous package naming convention cannot be recognized by packaging tools:
```
setuptools.extern.packaging.version.InvalidVersion: Invalid version: '0.0.2+cu118+torch2.1.0'
```