### PR TITLE
ci: py38 wheels

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         cuda: ["11.8", "12.1"]
         torch: ["2.1", "2.2"]
     runs-on: [self-hosted]


### PR DESCRIPTION
According to #129 , we should release py38 wheels as well.