### PR TITLE
feat: adding `sm_scale` field for all attention APIs

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -816,8 +816,12 @@ cudaError_t SingleDecodeWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut
                                     uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t seq_len,
                                     uint32_t head_dim, QKVLayout kv_layout = QKVLayout::kNHD,
                                     RotaryMode rotary_mode = RotaryMode::kNone,
+                                    std::optional<float> sm_scale = std::nullopt,
                                     float rope_scale = 1.f, float rope_theta = 1e4,
                                     cudaStream_t stream = nullptr) {
+  if (!sm_scale.has_value()) {
+    sm_scale = 1.f / std::sqrt(float(head_dim));
+  }
   const float sm_scale = 1.f / std::sqrt(float(head_dim));
   const float rope_rcp_scale = 1.f / rope_scale;
   const float rope_rcp_theta = 1.f / rope_theta;
@@ -865,7 +869,7 @@ cudaError_t SingleDecodeWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut
                                   (void*)&o,
                                   (void*)&tmp,
                                   (void*)&info,
-                                  (void*)&sm_scale,
+                                  (void*)&(sm_scale.value()),
                                   (void*)&rope_rcp_scale,
                                   (void*)&rope_rcp_theta,
                                   (void*)&seq_len};
@@ -1134,8 +1138,8 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(
     DTypeIn* q, IdType* q_rope_position,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp, float* lse,
+    float sm_scale,
     float rope_scale, float rope_theta, cudaStream_t stream) {
-  const float sm_scale = 1.f / std::sqrt(float(HEAD_DIM));
   const float rope_rcp_scale = 1.f / rope_scale;
   const float rope_rcp_theta = 1.f / rope_theta;
   const uint32_t num_kv_heads = paged_kv.num_heads;
@@ -1229,11 +1233,16 @@ cudaError_t BatchDecodeWithPagedKVCache(
     DTypeIn* q, IdType* q_rope_position,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp, float* lse,
-    uint32_t num_qo_heads, RotaryMode rotary_mode = RotaryMode::kNone, float rope_scale = 1.f,
+    uint32_t num_qo_heads, RotaryMode rotary_mode = RotaryMode::kNone,
+    std::optional<float> sm_scale = std::nullopt,
+    float rope_scale = 1.f,
     float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   const uint32_t num_kv_heads = paged_kv.num_heads;
   const uint32_t head_dim = paged_kv.head_dim;
   const uint32_t batch_size = paged_kv.batch_size;
+  if (!sm_scale.has_value()) {
+    sm_scale = 1.f / std::sqrt(float(head_dim));
+  }
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
@@ -1247,7 +1256,7 @@ cudaError_t BatchDecodeWithPagedKVCache(
                            return BatchDecodeWithPagedKVCacheDispatched<
                                GROUP_SIZE, HEAD_DIM, page_storage, kv_layout, ROTARY_MODE, DTypeIn,
                                DTypeOut, IdType>(q, q_rope_position, paged_kv, kv_partition_info, o,
-                                                 tmp, lse, rope_scale, rope_theta, stream);
+                                                 tmp, lse, sm_scale, rope_scale, rope_theta, stream);
                          })})});
 
   return cudaSuccess;
@@ -1258,9 +1267,9 @@ template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, RotaryMod
 cudaError_t BatchDecodeWithPaddedKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeIn* o,
                                                    DTypeOut* tmp, float* lse, uint32_t batch_size,
                                                    uint32_t padded_kv_len, uint32_t num_qo_heads,
+                                                   float sm_scale,
                                                    float rope_scale, float rope_theta,
                                                    cudaStream_t stream) {
-  const float sm_scale = 1.f / std::sqrt(float(HEAD_DIM));
   const float rope_rcp_scale = 1.f / rope_scale;
   const float rope_rcp_theta = 1.f / rope_theta;
   const uint32_t num_kv_heads = num_qo_heads / GROUP_SIZE;
@@ -1301,7 +1310,11 @@ cudaError_t BatchDecodeWithPaddedKVCache(
     DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeIn* o, DTypeOut* tmp, float* lse, uint32_t batch_size,
     uint32_t padded_kv_len, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
     QKVLayout kv_layout = QKVLayout::kNHD, RotaryMode rotary_mode = RotaryMode::kNone,
+    std::optional<float> sm_scale = std::nullopt,
     float rope_scale = 1.f, float rope_theta = 1e4, cudaStream_t stream = nullptr) {
+  if (!sm_scale.has_value()) {
+    sm_scale = 1.f / std::sqrt(float(head_dim));
+  }
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " is not a multiple of num_kv_heads "
@@ -1317,7 +1330,9 @@ cudaError_t BatchDecodeWithPaddedKVCache(
               rotary_mode, ROTARY_MODE, {DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {
                 return BatchDecodeWithPaddedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, KV_LAYOUT,
                                                               ROTARY_MODE, DTypeIn, DTypeOut>(
-                    q, k, v, o, tmp, lse, batch_size, padded_kv_len, num_qo_heads, rope_scale,
+                    q, k, v, o, tmp, lse, batch_size, padded_kv_len, num_qo_heads,
+                    sm_scale,
+                    rope_scale,
                     rope_theta, stream);
               })})})});
   return cudaSuccess;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -23,6 +23,7 @@
 #endif
 #include <cuda_runtime.h>
 
+#include <optional>
 #include <tuple>
 
 #include "../cp_async.cuh"
@@ -1563,10 +1564,9 @@ template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, RotaryMod
           bool ALLOW_FP16_QK_REDUCTION, bool CAUSAL, typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o,
                                                float* tmp, float* lse, uint32_t num_kv_heads,
-                                               uint32_t qo_len, uint32_t kv_len,
-                                               float sm_scale,
-                                               float rope_scale,
-                                               float rope_theta, cudaStream_t stream) {
+                                               uint32_t qo_len, uint32_t kv_len, float sm_scale,
+                                               float rope_scale, float rope_theta,
+                                               cudaStream_t stream) {
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   if (kv_len < qo_len && CAUSAL) {
@@ -1715,19 +1715,14 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
  * \return status Indicates whether CUDA calls are successful
  */
 template <typename DTypeIn, typename DTypeOut>
-cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o, float* tmp,
-                                     float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads,
-                                     uint32_t qo_len, uint32_t kv_len, uint32_t head_dim,
-                                     bool causal = true, QKVLayout kv_layout = QKVLayout::kNHD,
-                                     RotaryMode rotary_mode = RotaryMode::kNone,
-                                     bool allow_fp16_qk_reduction = false,
-                                     std::optional<float> sm_scale = std::nullopt,
-                                     float rope_scale = 1.f,
-                                     float rope_theta = 1e4, cudaStream_t stream = nullptr) {
+cudaError_t SinglePrefillWithKVCache(
+    DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_heads,
+    uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len, uint32_t head_dim, bool causal = true,
+    QKVLayout kv_layout = QKVLayout::kNHD, RotaryMode rotary_mode = RotaryMode::kNone,
+    bool allow_fp16_qk_reduction = false, std::optional<float> maybe_sm_scale = std::nullopt,
+    float rope_scale = 1.f, float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   const uint32_t group_size = num_qo_heads / num_kv_heads;
-  if (!sm_scale.has_value()) {
-    sm_scale = 1.f / std::sqrt(float(head_dim));
-  }
+  const float sm_scale = maybe_sm_scale.value_or(1.f / std::sqrt(float(head_dim)));
   DISPATCH_ALLOW_FP16_QK_REDUCTION(
       allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION,
       {DISPATCH_GQA_GROUP_SIZE(
@@ -1740,9 +1735,9 @@ cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOu
                       rotary_mode, ROTARY_MODE, {DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {
                         SinglePrefillWithKVCacheDispatched<GROUP_SIZE, HEAD_DIM, KV_LAYOUT,
                                                            ROTARY_MODE, ALLOW_FP16_QK_REDUCTION,
-                                                           CAUSAL>(q, k, v, o, tmp, lse,
-                                                                   num_kv_heads, qo_len, kv_len,
-                                                                   sm_scale, rope_scale, rope_theta, stream);
+                                                           CAUSAL>(
+                            q, k, v, o, tmp, lse, num_kv_heads, qo_len, kv_len, sm_scale,
+                            rope_scale, rope_theta, stream);
                       })})})})})});
   return cudaSuccess;
 }
@@ -1754,8 +1749,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr, DTypeIn* k,
     DTypeIn* v, IdType* kv_indptr, IdType* q_rope_position, IdType* k_rope_pos_offset, DTypeOut* o,
     float* tmp, float* lse, const uint32_t batch_size, const uint32_t num_qo_tiles,
-    const uint32_t num_kv_heads, const float sm_scale, const float rope_scale, const float rope_theta,
-    cudaStream_t stream = nullptr) {
+    const uint32_t num_kv_heads, const float sm_scale, const float rope_scale,
+    const float rope_theta, cudaStream_t stream = nullptr) {
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   constexpr uint32_t num_warps = 4;
@@ -1831,12 +1826,10 @@ cudaError_t BatchPrefillWithRaggedKVCache(
     const uint32_t batch_size, const uint32_t num_qo_heads, const uint32_t num_kv_heads,
     const uint32_t head_dim, bool causal = true, QKVLayout kv_layout = QKVLayout::kNHD,
     RotaryMode rotary_mode = RotaryMode::kNone, bool allow_fp16_qk_reduction = false,
-    std::optional<float> sm_scale = std::nullopt,
-    const float rope_scale = 1.f, const float rope_theta = 1e4, cudaStream_t stream = nullptr) {
+    std::optional<float> maybe_sm_scale = std::nullopt, const float rope_scale = 1.f,
+    const float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   const uint32_t group_size = num_qo_heads / num_kv_heads;
-  if (!sm_scale.has_value()) {
-    sm_scale = 1.f / std::sqrt(float(head_dim));
-  }
+  const float sm_scale = maybe_sm_scale.value_or(1.f / std::sqrt(float(head_dim)));
 
   uint32_t num_frags_x, num_qo_tiles;
   std::vector<IdType> request_indices_h, tile_indices_h;
@@ -1874,7 +1867,8 @@ cudaError_t BatchPrefillWithRaggedKVCache(
                                 ALLOW_FP16_QK_REDUCTION, CAUSAL, DTypeIn, DTypeOut, IdType>(
                                 q, request_indices_d, tile_indices_d, qo_indptr, k, v, kv_indptr,
                                 q_rope_position, k_rope_pos_offset, o, tmp, lse, batch_size,
-                                num_qo_tiles, num_kv_heads, sm_scale, rope_scale, rope_theta, stream);
+                                num_qo_tiles, num_kv_heads, sm_scale, rope_scale, rope_theta,
+                                stream);
                           })})})})})})});
 
   FLASHINFER_CUDA_CALL(cudaFreeAsync(request_indices_d, stream));
@@ -1911,16 +1905,13 @@ cudaError_t BatchPrefillWithPagedKVCacheFallbackDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr,
     IdType* q_rope_position, paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
     DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_tiles,
-    std::optional<float> sm_scale = std::nullopt,
-    float rope_scale = 1.f,
+    std::optional<float> maybe_sm_scale = std::nullopt, float rope_scale = 1.f,
     float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   constexpr QKVLayout KV_LAYOUT = QKVLayout::kNHD;
   const uint32_t num_kv_heads = paged_kv.num_heads;
   const uint32_t head_dim = paged_kv.head_dim;
   const uint32_t batch_size = paged_kv.batch_size;
-  if (!sm_scale.has_value()) {
-    sm_scale = 1.f / std::sqrt(float(head_dim));
-  }
+  const float sm_scale = maybe_sm_scale.value_or(1.f / std::sqrt(float(head_dim)));
 
   std::vector<IdType> kv_indptr_h(paged_kv.batch_size + 1);
 
@@ -1943,8 +1934,8 @@ cudaError_t BatchPrefillWithPagedKVCacheFallbackDispatched(
                                           ALLOW_FP16_QK_REDUCTION, CAUSAL, DTypeIn, DTypeOut,
                                           IdType>(
       q, request_indices, tile_indices, qo_indptr, keys, values, kv_indptr, q_rope_position,
-      paged_kv.rope_pos_offset, o, tmp, lse, batch_size, num_qo_tiles, num_kv_heads, sm_scale, rope_scale,
-      rope_theta, stream);
+      paged_kv.rope_pos_offset, o, tmp, lse, batch_size, num_qo_tiles, num_kv_heads, sm_scale,
+      rope_scale, rope_theta, stream);
 
   FLASHINFER_CUDA_CALL(cudaFreeAsync(keys, stream));
   FLASHINFER_CUDA_CALL(cudaFreeAsync(values, stream));
@@ -1960,9 +1951,8 @@ template <PageStorage page_storage, QKVLayout kv_layout, uint32_t num_frags_x, u
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr,
     IdType* q_rope_position, paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
-    DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_tiles, float rope_scale, float rope_theta,
-    cudaStream_t stream) {
-  const float sm_scale = 1.f / std::sqrt(float(paged_kv.head_dim));
+    DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_tiles, float sm_scale, float rope_scale,
+    float rope_theta, cudaStream_t stream) {
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   constexpr uint32_t num_warps = 4;
@@ -2036,11 +2026,13 @@ cudaError_t BatchPrefillWithPagedKVCache(
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv, DTypeOut* o, float* tmp,
     float* lse, uint32_t num_qo_heads, bool causal = true,
     RotaryMode rotary_mode = RotaryMode::kNone, bool allow_fp16_qk_reduction = false,
-    float rope_scale = 1.f, float rope_theta = 1e4, cudaStream_t stream = nullptr) {
+    std::optional<float> maybe_sm_scale = std::nullopt, float rope_scale = 1.f,
+    float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   const uint32_t num_kv_heads = paged_kv.num_heads;
   const uint32_t head_dim = paged_kv.head_dim;
   const uint32_t batch_size = paged_kv.batch_size;
   const uint32_t group_size = num_qo_heads / num_kv_heads;
+  const float sm_scale = maybe_sm_scale.value_or(1.f / std::sqrt(float(head_dim)));
 
   uint32_t num_frags_x, num_qo_tiles;
   std::vector<IdType> request_indices_h, tile_indices_h;
@@ -2082,8 +2074,8 @@ cudaError_t BatchPrefillWithPagedKVCache(
                                       ROTARY_MODE, ALLOW_FP16_QK_REDUCTION, CAUSAL, DTypeIn,
                                       DTypeOut, IdType>(q, request_indices_d, tile_indices_d,
                                                         qo_indptr, q_rope_position, paged_kv, o,
-                                                        tmp, lse, num_qo_tiles, rope_scale,
-                                                        rope_theta, stream);
+                                                        tmp, lse, num_qo_tiles, sm_scale,
+                                                        rope_scale, rope_theta, stream);
                                 } else {
                                   return BatchPrefillWithPagedKVCacheDispatched<
                                       page_storage, kv_layout, NUM_FRAGS_X, PAGE_SIZE, GROUP_SIZE,
@@ -2091,7 +2083,7 @@ cudaError_t BatchPrefillWithPagedKVCache(
                                       DTypeIn, DTypeOut, IdType>(
                                       q, request_indices_d, tile_indices_d, qo_indptr,
                                       q_rope_position, paged_kv, o, tmp, lse, num_qo_tiles,
-                                      rope_scale, rope_theta, stream);
+                                      sm_scale, rope_scale, rope_theta, stream);
                                 }
                               })
 

--- a/python/csrc/flashinfer_decl.h
+++ b/python/csrc/flashinfer_decl.h
@@ -26,7 +26,8 @@
       CAUSAL, T, T, int32_t>(BatchPrefillHandler * handler, T* q, int32_t* qo_indptr,              \
                              int32_t* q_rope_position,                                             \
                              paged_kv_t<PageStorage::kIndices, LAYOUT, T, int32_t> paged_kv, T* o, \
-                             float* lse, float rope_scale, float rope_theta, cudaStream_t stream); \
+                             float* lse, float sm_scale, float rope_scale, float rope_theta,       \
+                             cudaStream_t stream);                                                 \
   }
 
 #define INST_BatchPrefillRaggedWrapper(T, GROUP_SIZE, HEAD_DIM, CAUSAL, ALLOW_FP16_QK_REDUCTION,   \
@@ -36,16 +37,17 @@
       GROUP_SIZE, HEAD_DIM, LAYOUT, ROTARY_MODE, ALLOW_FP16_QK_REDUCTION, CAUSAL, T, T, int32_t>(  \
       BatchPrefillHandler * handler, T* q, int32_t* qo_indptr, T* k, T* v, int32_t* kv_indptr,     \
       int32_t* q_rope_position, int32_t* k_rope_pos_offset, T* o, float* lse, uint32_t batch_size, \
-      uint32_t num_kv_heads, float rope_scale, float rope_theta, cudaStream_t stream);             \
+      uint32_t num_kv_heads, float sm_scale, float rope_scale, float rope_theta,                   \
+      cudaStream_t stream);                                                                        \
   }
 
-#define INST_SinglePrefill(T, GROUP_SIZE, HEAD_DIM, CAUSAL, ALLOW_FP16_QK_REDUCTION, LAYOUT,   \
-                           ROTARY_MODE)                                                        \
-  namespace flashinfer {                                                                       \
-  template cudaError_t SinglePrefillWithKVCacheDispatched<                                     \
-      GROUP_SIZE, HEAD_DIM, LAYOUT, ROTARY_MODE, ALLOW_FP16_QK_REDUCTION, CAUSAL, T, T>(       \
-      T * q, T* k, T* v, T* o, float* tmp, float* lse, uint32_t num_kv_heads, uint32_t qo_len, \
-      uint32_t kv_len, float rope_scale, float rope_theta, cudaStream_t stream);               \
+#define INST_SinglePrefill(T, GROUP_SIZE, HEAD_DIM, CAUSAL, ALLOW_FP16_QK_REDUCTION, LAYOUT,     \
+                           ROTARY_MODE)                                                          \
+  namespace flashinfer {                                                                         \
+  template cudaError_t SinglePrefillWithKVCacheDispatched<                                       \
+      GROUP_SIZE, HEAD_DIM, LAYOUT, ROTARY_MODE, ALLOW_FP16_QK_REDUCTION, CAUSAL, T, T>(         \
+      T * q, T* k, T* v, T* o, float* tmp, float* lse, uint32_t num_kv_heads, uint32_t qo_len,   \
+      uint32_t kv_len, float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream); \
   }
 
 namespace flashinfer {
@@ -58,8 +60,8 @@ template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, RotaryMod
 cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
     BatchPrefillHandler* handler, DTypeIn* q, IdType* qo_indptr, DTypeIn* k, DTypeIn* v,
     IdType* kv_indptr, IdType* q_rope_position, IdType* k_rope_pos_offset, DTypeOut* o, float* lse,
-    const uint32_t batch_size, const uint32_t num_kv_heads, const float rope_scale,
-    const float rope_theta, cudaStream_t stream);
+    const uint32_t batch_size, const uint32_t num_kv_heads, const float sm_scale,
+    const float rope_scale, const float rope_theta, cudaStream_t stream);
 
 template <PageStorage page_storage, QKVLayout kv_layout, uint32_t GROUP_SIZE, uint32_t HEAD_DIM,
           RotaryMode ROTARY_MODE, bool ALLOW_FP16_QK_REDUCTION, bool CAUSAL, typename DTypeIn,
@@ -67,13 +69,14 @@ template <PageStorage page_storage, QKVLayout kv_layout, uint32_t GROUP_SIZE, ui
 cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
     BatchPrefillHandler* handler, DTypeIn* q, IdType* qo_indptr, IdType* q_rope_position,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv, DTypeOut* o, float* lse,
-    float rope_scale, float rope_theta, cudaStream_t stream);
+    float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream);
 
 template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, RotaryMode ROTARY_MODE,
           bool ALLOW_FP16_QK_REDUCTION, bool CAUSAL, typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o,
                                                float* tmp, float* lse, uint32_t num_kv_heads,
-                                               uint32_t qo_len, uint32_t kv_len, float rope_scale,
-                                               float rope_theta, cudaStream_t stream);
+                                               uint32_t qo_len, uint32_t kv_len, float sm_scale,
+                                               float rope_scale, float rope_theta,
+                                               cudaStream_t stream);
 
 }  // namespace flashinfer

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -31,8 +31,8 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
 
 std::vector<torch::Tensor> single_prefill_with_kv_cache(
     torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor tmp, bool causal,
-    unsigned int layout, unsigned int rotary_mode, bool allow_fp16_qk_reduction, float sm_scale, float rope_scale,
-    float rope_theta, bool return_lse);
+    unsigned int layout, unsigned int rotary_mode, bool allow_fp16_qk_reduction, float sm_scale,
+    float rope_scale, float rope_theta, bool return_lse);
 
 void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
                            torch::Tensor append_indptr, torch::Tensor kv_data,
@@ -64,8 +64,8 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor paged_kv_data,
                                      torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
                                      torch::Tensor paged_kv_last_page_len, unsigned int rotary_mode,
-                                     float sm_scale,
-                                     float rope_scale, float rope_theta, bool return_lse);
+                                     float sm_scale, float rope_scale, float rope_theta,
+                                     bool return_lse);
 
  private:
   BatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout)
@@ -88,8 +88,8 @@ class BatchPrefillWithPagedKVCachePyTorchWrapper {
                                      torch::Tensor paged_kv_indices,
                                      torch::Tensor paged_kv_last_page_len, bool causal,
                                      unsigned int rotary_mode, bool allow_fp16_qk_reduction,
-                                     float sm_scale,
-                                     float rope_scale, float rope_theta, bool return_lse);
+                                     float sm_scale, float rope_scale, float rope_theta,
+                                     bool return_lse);
 
  private:
   BatchPrefillWithPagedKVCachePyTorchWrapper(unsigned int layout)
@@ -110,8 +110,8 @@ class BatchPrefillWithRaggedKVCachePyTorchWrapper {
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor qo_indptr, torch::Tensor k,
                                      torch::Tensor v, torch::Tensor kv_indptr, bool causal,
                                      unsigned int rotary_mode, bool allow_fp16_qk_reduction,
-                                     float sm_scale,
-                                     float rope_scale, float rope_theta, bool return_lse);
+                                     float sm_scale, float rope_scale, float rope_theta,
+                                     bool return_lse);
 
  private:
   BatchPrefillWithRaggedKVCachePyTorchWrapper(unsigned int layout)

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -31,7 +31,7 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
 
 std::vector<torch::Tensor> single_prefill_with_kv_cache(
     torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor tmp, bool causal,
-    unsigned int layout, unsigned int rotary_mode, bool allow_fp16_qk_reduction, float rope_scale,
+    unsigned int layout, unsigned int rotary_mode, bool allow_fp16_qk_reduction, float sm_scale, float rope_scale,
     float rope_theta, bool return_lse);
 
 void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
@@ -64,6 +64,7 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor paged_kv_data,
                                      torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
                                      torch::Tensor paged_kv_last_page_len, unsigned int rotary_mode,
+                                     float sm_scale,
                                      float rope_scale, float rope_theta, bool return_lse);
 
  private:
@@ -87,6 +88,7 @@ class BatchPrefillWithPagedKVCachePyTorchWrapper {
                                      torch::Tensor paged_kv_indices,
                                      torch::Tensor paged_kv_last_page_len, bool causal,
                                      unsigned int rotary_mode, bool allow_fp16_qk_reduction,
+                                     float sm_scale,
                                      float rope_scale, float rope_theta, bool return_lse);
 
  private:
@@ -108,6 +110,7 @@ class BatchPrefillWithRaggedKVCachePyTorchWrapper {
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor qo_indptr, torch::Tensor k,
                                      torch::Tensor v, torch::Tensor kv_indptr, bool causal,
                                      unsigned int rotary_mode, bool allow_fp16_qk_reduction,
+                                     float sm_scale,
                                      float rope_scale, float rope_theta, bool return_lse);
 
  private:

--- a/python/flashinfer/cascade.py
+++ b/python/flashinfer/cascade.py
@@ -272,6 +272,7 @@ def batch_decode_with_shared_prefix_padded_kv_cache(
         rotary_mode="NONE",
         kv_layout=kv_layout,
         allow_fp16_qk_reduction=allow_fp16_qk_reduction,
+        sm_scale=sm_scale,
         rope_scale=rope_scale,
         rope_theta=rope_theta,
     )
@@ -458,6 +459,7 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
         v_shared: torch.Tensor,
         unique_kv_data: torch.Tensor,
         allow_fp16_qk_reduction=False,
+        sm_scale: Optional[float] = None,
         rope_scale: Optional[float] = None,
         rope_theta: Optional[float] = None,
     ):
@@ -488,6 +490,8 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
         allow_fp16_qk_reduction : bool
             Whether to use f16 for qk reduction (faster at the cost of slight precision
             loss).
+        sm_scale : Optional[float]
+            The scale of softmax, if not provided, will be set to ``1 / sqrt(head_dim)``.
         rope_scale : Optional[float]
             The scale used in RoPE interpolation, if not provided, will be set to
             ``1.0``.
@@ -507,6 +511,7 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
             rotary_mode="NONE",
             kv_layout=self._kv_layout,
             allow_fp16_qk_reduction=allow_fp16_qk_reduction,
+            sm_scale=sm_scale,
             rope_scale=rope_scale,
             rope_theta=rope_theta,
         )
@@ -514,6 +519,7 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
             q,
             unique_kv_data,
             rotary_mode="NONE",
+            sm_scale=sm_scale,
             rope_scale=rope_scale,
             rope_theta=rope_theta,
         )
@@ -698,6 +704,7 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
         unique_kv_data: torch.Tensor,
         causal: bool = True,
         allow_fp16_qk_reduction: bool = False,
+        sm_scale: Optional[float] = None,
         rope_scale: Optional[float] = None,
         rope_theta: Optional[float] = None,
     ):
@@ -730,6 +737,8 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
         allow_fp16_qk_reduction : bool
             Whether to use f16 for qk reduction (faster at the cost of slight precision
             loss).
+        sm_scale : Optional[float]
+            The scale of softmax, if not provided, will be set to ``1 / sqrt(head_dim)``.
         rope_scale : Optional[float]
             The scale used in RoPE interpolation, if not provided, will be set to
             ``1.0``.
@@ -749,6 +758,7 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
             rotary_mode="NONE",
             kv_layout=self._kv_layout,
             allow_fp16_qk_reduction=allow_fp16_qk_reduction,
+            sm_scale=sm_scale,
             rope_scale=rope_scale,
             rope_theta=rope_theta,
         )
@@ -758,6 +768,7 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
             causal=causal,
             rotary_mode="NONE",
             allow_fp16_qk_reduction=allow_fp16_qk_reduction,
+            sm_scale=sm_scale,
             rope_scale=rope_scale,
             rope_theta=rope_theta,
         )

--- a/src/bench_single_decode.cu
+++ b/src/bench_single_decode.cu
@@ -49,8 +49,10 @@ void bench_flashinfer_single_decode(nvbench::state& state) {
         thrust::raw_pointer_cast(Q.data()), thrust::raw_pointer_cast(K.data()),
         thrust::raw_pointer_cast(V.data()), thrust::raw_pointer_cast(O.data()),
         cooperative ? thrust::raw_pointer_cast(tmp.data()) : nullptr, num_qo_heads, num_kv_heads,
-        seq_len, head_dim, QKVLayout(kv_layout), RotaryMode(rotary_mode), 1.f, 1e4,
-        launch.get_stream());
+        seq_len, head_dim, QKVLayout(kv_layout), RotaryMode(rotary_mode),
+        /*maybe_sm_scale=*/std::nullopt,
+        /*rope_scale=*/1.f,
+        /*rope_theta=*/1e4, launch.get_stream());
     if (status != cudaSuccess) {
       state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));
     }
@@ -91,7 +93,10 @@ void bench_flashinfer_single_decode_with_prefill(nvbench::state& state) {
         /*qo_len=*/1,
         /*kv_len=*/seq_len, head_dim,
         /*causal=*/false, QKVLayout(kv_layout), RotaryMode(rotary_mode),
-        /*allow_fp16_qk_reduction=*/false, 1.f, 1e4, launch.get_stream());
+        /*allow_fp16_qk_reduction=*/false,
+        /*maybe_sm_scale=*/std::nullopt,
+        /*rope_scale=*/1.f,
+        /*rope_theta=*/1e4, launch.get_stream());
     if (status != cudaSuccess) {
       state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));
     }

--- a/src/bench_single_prefill.cu
+++ b/src/bench_single_prefill.cu
@@ -58,8 +58,10 @@ void bench_flashinfer_single_prefill(nvbench::state& state) {
         thrust::raw_pointer_cast(V.data()), thrust::raw_pointer_cast(O.data()),
         /*tmp=*/cooperative ? thrust::raw_pointer_cast(tmp.data()) : nullptr,
         /*lse=*/nullptr, num_qo_heads, num_kv_heads, qo_len, kv_len, head_dim, causal,
-        QKVLayout(kv_layout), RotaryMode(rotary_mode), allow_fp16_qk_reduction, 1.f, 1e4,
-        launch.get_stream());
+        QKVLayout(kv_layout), RotaryMode(rotary_mode), allow_fp16_qk_reduction,
+        /*maybe_sm_scale=*/std::nullopt,
+        /*rope_scale=*/1.f,
+        /*rope_theta=*/1e4, launch.get_stream());
     if (status != cudaSuccess) {
       state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));
     }


### PR DESCRIPTION
Some of our attention APIs have this field and some don't, this PR add `sm_scale` field for all attention APIs to make them consistent.