### PR TITLE
bugfix: Fix release wheel script and remove uninstantiated branches in dispatch

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -73,7 +73,30 @@ jobs:
         with:
           tag_name: ${{ inputs.tag_name }}
           files: |
-            python/dist/flashinfer-*.whl
+            python/dist/flashinfer.*cp38.*.whl
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
+            python/dist/flashinfer.*cp39.*.whl
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
+            python/dist/flashinfer.*cp310.*.whl
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
+            python/dist/flashinfer.*cp311.*.whl
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
             python/dist/flashinfer-*.tar.gz
 
       - name: Clone wheel index

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -67,9 +67,6 @@
   if (page_size == 1) {                                \
     constexpr size_t PAGE_SIZE = 1;                    \
     __VA_ARGS__                                        \
-  } else if (page_size == 8) {                         \
-    constexpr size_t PAGE_SIZE = 8;                    \
-    __VA_ARGS__                                        \
   } else if (page_size == 16) {                        \
     constexpr size_t PAGE_SIZE = 16;                   \
     __VA_ARGS__                                        \

--- a/python/setup.py
+++ b/python/setup.py
@@ -349,6 +349,7 @@ def remove_unwanted_pytorch_nvcc_flags():
         except ValueError:
             pass
 
+
 class NinjaBuildExtension(torch_cpp_ext.BuildExtension):
     def __init__(self, *args, **kwargs) -> None:
         # do not override env MAX_JOBS if already exists
@@ -357,6 +358,7 @@ class NinjaBuildExtension(torch_cpp_ext.BuildExtension):
             os.environ["MAX_JOBS"] = str(max_num_jobs_cores)
 
         super().__init__(*args, **kwargs)
+
 
 if __name__ == "__main__":
     remove_unwanted_pytorch_nvcc_flags()
@@ -380,7 +382,14 @@ if __name__ == "__main__":
             ],
             extra_compile_args={
                 "cxx": ["-O3"],
-                "nvcc": ["-O3", "-std=c++17", "--threads", "8", "-Xfatbin", "-compress-all"],
+                "nvcc": [
+                    "-O3",
+                    "-std=c++17",
+                    "--threads",
+                    "8",
+                    "-Xfatbin",
+                    "-compress-all",
+                ],
             },
         )
     )


### PR DESCRIPTION
The release action [failed](https://github.com/flashinfer-ai/flashinfer/actions/runs/8227731974/job/22501369048) because [action-gh-release](https://github.com/softprops/action-gh-release) action do not support uploading multiple large files at a time: https://github.com/softprops/action-gh-release/issues/353

This PR changes the behavior of release job to upload artifacts in multiple batches.

Also, https://github.com/flashinfer-ai/flashinfer/pull/172 removes the instantiation of page prefill kernels for `page_size=8`, this PR fixes the behavior of `DISPATCH_PAGE_SIZE` by removing corresponding branches.