### PR TITLE
Update release_wheel.yml

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -73,25 +73,25 @@ jobs:
         with:
           tag_name: ${{ inputs.tag_name }}
           files: |
-            python/dist/flashinfer.*cp38.*.whl
+            python/dist/flashinfer*cp38*.whl
 
       - uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.tag_name }}
           files: |
-            python/dist/flashinfer.*cp39.*.whl
+            python/dist/flashinfer*cp39*.whl
 
       - uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.tag_name }}
           files: |
-            python/dist/flashinfer.*cp310.*.whl
+            python/dist/flashinfer*cp310*.whl
 
       - uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.tag_name }}
           files: |
-            python/dist/flashinfer.*cp311.*.whl
+            python/dist/flashinfer*cp311*.whl
 
       - uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
The github action uses [glob](https://www.npmjs.com/package/glob) to match file names, this PR changes the regex pattern to glob to match wheel names.