### PR TITLE
[CMake] Add positional independent code (PIC) option to kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ endforeach(group_size)
 
 add_library(decode_kernels STATIC ${single_decode_kernels_src} ${batch_decode_kernels_src})
 target_include_directories(decode_kernels PRIVATE ${FLASHINFER_INCLUDE_DIR})
+target_compile_options(decode_kernels PRIVATE -Xcompiler=-fPIC --fatbin-options -compress-all)
 
 # single prefill kernel inst generation
 foreach(group_size IN LISTS GROUP_SIZES)
@@ -262,6 +263,7 @@ endforeach(group_size)
 
 add_library(prefill_kernels STATIC ${single_prefill_kernels_src} ${batch_paged_prefill_kernels_src} ${batch_ragged_prefill_kernels_src})
 target_include_directories(prefill_kernels PRIVATE ${FLASHINFER_INCLUDE_DIR})
+target_compile_options(prefill_kernels PRIVATE -Xcompiler=-fPIC --fatbin-options -compress-all)
 
 if (FLASHINFER_DECODE)
   message(STATUS "Compile single decode kernel benchmarks.")

--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -18,6 +18,9 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#ifdef FLASHINFER_ENABLE_FP8
+#include <cuda_fp8.h>
+#endif
 #include <cuda_runtime.h>
 
 #include <type_traits>
@@ -127,6 +130,7 @@ __device__ __forceinline__ void stmatrix_m8n8x4(uint32_t* R, T* smem_ptr) {
 #endif
 }
 
+#ifdef FLASHINFER_ENABLE_FP8
 /*!
  * \brief Wrapper of two mma m16n8k32 instructions for row major and column major f8 matrix
  *   multiplication, accumulated in f32.
@@ -227,6 +231,7 @@ __device__ __forceinline__ void mma_sync_m16n16k32_row_col_f8f8f32(float* C, uin
       "fp8 mma instruction is only available for sm89, PTX 8.4+ and CUDA 12.4+");
 #endif
 }
+#endif
 
 /*!
  * \brief Wrapper of two mma m16n8k16 instructions for row major and column major f16 matrix
@@ -395,6 +400,7 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, u
 #endif
 }
 
+#ifdef FLASHINFER_ENABLE_FP8
 /*!
  * \brief Use mma instructions to compute rowsum.
  */
@@ -435,6 +441,7 @@ __device__ __forceinline__ void rowsum_f8f8f32(float* d, DType* s) {
       "fp8 mma instruction is only available for sm89, PTX 8.4+ and CUDA 12.4+");
 #endif
 }
+#endif
 
 /*!
  * \brief Use mma instructions to compute rowsum.


### PR DESCRIPTION
This PR adds the `-fPIC` option to prefill/decode kernels for packaging.