### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ else()
   endif()
 endif()
 
+find_package(Python3 REQUIRED)
+if(NOT Python3_FOUND)
+  message(FATAL_ERROR "Python3 not found.")
+endif()
+
 # NOTE: do not modify this file to change option values.
 # You can create a config.cmake at build folder
 # and add set(OPTION VALUE) to override these build options.
@@ -90,7 +95,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -103,7 +108,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -126,7 +131,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
             set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
             add_custom_command(
               OUTPUT ${generated_kernel_src}
-              COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
               DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
               COMMENT "Generating additional source file ${generated_kernel_src}"
               VERBATIM
@@ -139,7 +144,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
             set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16_idtype_${idtype}.cu)
             add_custom_command(
               OUTPUT ${generated_kernel_src}
-              COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
               DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
               COMMENT "Generating additional source file ${generated_kernel_src}"
               VERBATIM
@@ -153,7 +158,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -166,7 +171,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -193,7 +198,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
               set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_causal_${causal}_dtypein_${dtype}_dtypeout_${dtype}.cu)
               add_custom_command(
                 OUTPUT ${generated_kernel_src}
-                COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
+                COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
                 DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
                 COMMENT "Generating additional source file ${generated_kernel_src}"
                 VERBATIM
@@ -219,7 +224,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
                 set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_causal_${causal}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
                 add_custom_command(
                   OUTPUT ${generated_kernel_src}
-                  COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
+                  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
                   DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py
                   COMMENT "Generating additional source file ${generated_kernel_src}"
                   VERBATIM
@@ -246,7 +251,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
                 set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_causal_${causal}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
                 add_custom_command(
                   OUTPUT ${generated_kernel_src}
-                  COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
+                  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
                   DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py
                   COMMENT "Generating additional source file ${generated_kernel_src}"
                   VERBATIM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -103,7 +103,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -126,7 +126,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
             set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
             add_custom_command(
               OUTPUT ${generated_kernel_src}
-              COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+              COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
               DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
               COMMENT "Generating additional source file ${generated_kernel_src}"
               VERBATIM
@@ -139,7 +139,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
             set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16_idtype_${idtype}.cu)
             add_custom_command(
               OUTPUT ${generated_kernel_src}
-              COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+              COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
               DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
               COMMENT "Generating additional source file ${generated_kernel_src}"
               VERBATIM
@@ -153,7 +153,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
+            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -166,7 +166,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
           set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
+            COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
             DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
@@ -193,7 +193,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
               set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_causal_${causal}_dtypein_${dtype}_dtypeout_${dtype}.cu)
               add_custom_command(
                 OUTPUT ${generated_kernel_src}
-                COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
+                COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
                 DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
                 COMMENT "Generating additional source file ${generated_kernel_src}"
                 VERBATIM
@@ -219,7 +219,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
                 set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_causal_${causal}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
                 add_custom_command(
                   OUTPUT ${generated_kernel_src}
-                  COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
+                  COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
                   DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py
                   COMMENT "Generating additional source file ${generated_kernel_src}"
                   VERBATIM
@@ -246,7 +246,7 @@ foreach(group_size IN LISTS GROUP_SIZES)
                 set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_causal_${causal}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
                 add_custom_command(
                   OUTPUT ${generated_kernel_src}
-                  COMMAND python ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
+                  COMMAND python3 ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
                   DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py
                   COMMENT "Generating additional source file ${generated_kernel_src}"
                   VERBATIM


### PR DESCRIPTION
Update `COMMAND python` to `COMMAND python3` to ensure that build uses python 3.X rather than defaulting to python 2.X in case python is not installed in the build environment.
Main errors when using python 2.X:
1. f-strings are not supported which results in syntax error
2. Pathlib was introduced in python 3.4+ and results in module not found error in lower versions

cc @MasterJH5574 