### PR TITLE
ci: add pytorch 2.3 to matrix

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11"]
         cuda: ["11.8", "12.1"]
-        torch: ["2.1", "2.2"]
+        torch: ["2.1", "2.2", "2.3"]
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Release pytorch 2.3 version in next release.