### PR TITLE
bugfix: fix the potential issue of sampling kernels

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -30,16 +30,6 @@ namespace sampling {
 
 using namespace cub;
 
-/*!
- * \note (Zihao): We choose the BLOCK_SCAN_WARP_SCANS algorithm because we found
- * this is the only algorithm that guarantee the monotonicity of the inclusive
- * sum. This is important for the sampling algorithm to work correctly.
- *
- * In sampling, there might be lots of small probabilities, for the other two
- * algorithms, the sum(prob[0:i]) might be smaller than the sum(prob[0:i-1]) due to
- * the different order of floating point addition. This will cause the sampling
- * algorithm to fail.
- */
 constexpr BlockScanAlgorithm SCAN_ALGO = BLOCK_SCAN_WARP_SCANS;
 constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
 


### PR DESCRIPTION
In #225  we use `BLOCK_SCAN_WARP_SCANS` to make sure prefix sum result is monotonic, however, we found there are still cases that InclusiveSum with `BLOCK_SCAN_WARP_SCANS` algorithm still do not return monotonic output.

In this PR, we fix the behavior in another way: apply prefix sum on a pair `(value, greater_than_0)` instead of only `value`, and write `i` to output only when `value[i] > u && value[i - 1] <= u` and `prob[i] > 0`. If there are multiple `i` that satisfy this condition (because of the floating point numerical issues), we select the smallest `i`.