### PR TITLE
ci: remove multi-threading in nvcc compile flags

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -394,8 +394,6 @@ if __name__ == "__main__":
                 "nvcc": [
                     "-O3",
                     "-std=c++17",
-                    "--threads",
-                    "8",
                     "-Xfatbin",
                     "-compress-all",
                 ],


### PR DESCRIPTION
We already created lots of process and there is no need to use multi-threading to accelerate compilation.