### PR TITLE
ci: update release wheel yaml

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -59,7 +59,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -107,15 +107,22 @@ jobs:
       - name: Update wheel index
         shell: python
         run: |
-          import pathlib
           import hashlib
+          import pathlib
           import re
           for path in sorted(pathlib.Path("python/dist").glob("*.whl")):
             with open(path, "rb") as f:
               sha256 = hashlib.sha256(f.read()).hexdigest()
-            ver, cu, torch = re.findall(r"flashinfer-([0-9.]+)\+cu(\d+)torch([0-9.]+)-", path.name)[0]
-            with open(f"flashinfer-whl/cu{cu}/torch{torch}/flashinfer/index.html", "a") as f:
-              f.write(f'<a href="https://github.com/flashinfer-ai/flashinfer/releases/download/v{ver}/{path.name}#sha256={sha256}">{path.name}</a><br>\n')
+            ver, cu, torch = re.findall(
+              r"flashinfer-([0-9.]+)\+cu(\d+)torch([0-9.]+)-", path.name
+            )[0]
+            index_dir = pathlib.Path(f"flashinfer-whl/cu{cu}/torch{torch}/flashinfer")
+            index_dir.mkdir(exist_ok=True)
+            index_path = index_dir / "index.html"
+            with index_path.open("a") as f:
+              f.write(
+                f'<a href="https://github.com/flashinfer-ai/flashinfer/releases/download/v{ver}/{path.name}#sha256={sha256}">{path.name}</a><br>\n'
+              )
 
       - name: Push wheel index
         run: |


### PR DESCRIPTION
Run it on self-hosted runner because default github runner do not have enough disk space.
Fix the python scripts that updates wheel index so that it can mkdir when directory not exists.