### PR TITLE
Add group_size 7 and fix compat with Yi 1.5 34b

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -927,7 +927,7 @@ __global__ void SinglePrefillWithKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6);
+  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6 || group_size == 7);
 
   extern __shared__ uint8_t smem[];
 
@@ -1135,7 +1135,7 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6);
+  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6 || group_size == 7);
 
   extern __shared__ uint8_t smem[];
 
@@ -1341,7 +1341,7 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6);
+  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6 || group_size == 7);
 
   extern __shared__ uint8_t smem[];
 

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -122,6 +122,9 @@
   } else if (group_size == 6) {                              \
     constexpr size_t GROUP_SIZE = 6;                         \
     __VA_ARGS__                                              \
+  } else if (group_size == 7) {                              \
+    constexpr size_t GROUP_SIZE = 7;                         \
+    __VA_ARGS__                                              \
   } else if (group_size == 8) {                              \
     constexpr size_t GROUP_SIZE = 8;                         \
     __VA_ARGS__                                              \


### PR DESCRIPTION
Allow users to compile for group_size 7 and have it compatible with Yi 1.0/1.5 34B models.

Fix https://github.com/flashinfer-ai/flashinfer/issues/181

I did not modify the CI script to include group_size 7 by default as it would increase the compile time to even longer than it already is. Users that want Yi-34B compat can opt to compile only group_size 7 via env var `FLASHINFER_GROUP_SIZES` (fastest, maybe 10-15 minutes) or add 7 to the existing `1,4,6,8` for full compat with other model (super slow compile, measured in hours).

Yi 1.5 is a great model and this will help those engines (sglang) that uses flashinfer to deploy this model. 

Tests
* [x] PASS Load and run with Sglang + Yi 1.5 34B
* [ ] FAILED stability test with temp=0.7. Output contains nan/inf.  