### PR TITLE
Fix compile/assert on group_size

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1141,7 +1141,7 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6);
+  static_assert(group_size == 1 || group_size >= 4 && group_size <= 8);
 
   extern __shared__ uint8_t smem[];
 


### PR DESCRIPTION
Fix compile.  Could not compile without the change. 

* [x] PASS compile
* [x] Inference Test with group_size 7 (Yi-1.5 34B) 
* [x] Inference Test with group_size ? (Command-r 30B)