### PR TITLE
perf: initial cuda graph support

### DIFF
--- a/docs/api/python/decode.rst
+++ b/docs/api/python/decode.rst
@@ -24,3 +24,6 @@ Batch Decoding
 
 .. autoclass:: BatchDecodeWithPagedKVCacheWrapper
     :members:
+
+.. autoclass:: CUDAGraphDecodeWithPagedKVCacheWrapper
+    :members:

--- a/include/flashinfer/attention/handler.cuh
+++ b/include/flashinfer/attention/handler.cuh
@@ -476,13 +476,10 @@ class CUDAGraphBatchDecodeHandler : public BatchDecodeHandler {
                            dev_id);
     max_batch_size_after_partition_ =
         std::max<size_t>(max_thread_blocks_per_sm * num_sm, max_batch_size);
+    std::cout << max_thread_blocks_per_sm * num_sm << " " << max_batch_size << std::endl;
     size_t max_workspace_size_in_bytes =
         6 * (sizeof(uint64_t) * (max_batch_size_after_partition_ + 1) + 16);
     cudaMallocHost(&page_locked_buffer_, max_workspace_size_in_bytes);
-  }
-  ~CUDAGraphBatchDecodeHandler() {
-    EndForward();
-    cudaFreeHost(page_locked_buffer_);
   }
   bool IsCUDAGraphMode() const override { return true; }
 

--- a/include/flashinfer/attention/handler.cuh
+++ b/include/flashinfer/attention/handler.cuh
@@ -17,6 +17,7 @@
 #define FLASHINFER_HANDLER_CUH_
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -101,7 +102,7 @@ template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PageStorage page_storage, QKVL
 cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatched(
     uint32_t& tmp_size, uint32_t& max_grid_size, uint32_t& max_num_pages_per_batch,
     uint32_t& new_batch_size, uint32_t batch_size, IdType* kv_indptr, const uint32_t num_qo_heads,
-    const uint32_t page_size, cudaStream_t stream) {
+    const uint32_t page_size, bool enable_cuda_graph, cudaStream_t stream) {
   constexpr uint32_t vec_size = std::max(16UL / sizeof(DTypeIn), HEAD_DIM / 32UL);
   constexpr uint32_t num_stages_smem = 2U;
   constexpr uint32_t bdx = HEAD_DIM / vec_size;
@@ -126,8 +127,10 @@ cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatched(
   FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
       &num_blocks_per_sm, partition_kv_kernel, num_threads, smem_size));
   max_grid_size = num_blocks_per_sm * num_sm;
-  if (batch_size * num_kv_heads >= max_grid_size) {
+  if (batch_size * num_kv_heads >= max_grid_size && !enable_cuda_graph) {
     // do not use partition-kv kernel
+    // TODO(Zihao): if enable_cuda_graph, we should always use partition-kv kernel
+    // so that only one kernel will be captured in the graph.
     tmp_size = 0;
     new_batch_size = batch_size;
   } else {
@@ -299,7 +302,8 @@ class BatchDecodeHandler {
                                                             DTypeOut, IdType>;
     FLASHINFER_CUDA_CALL(work_estimation_func(tmp_size, max_grid_size, max_num_pages_per_batch,
                                               new_batch_size, batch_size, indptr, num_qo_heads,
-                                              page_size, stream_));
+                                              page_size,
+                                              /*enable_cuda_graph=*/false, stream_));
     batch_size_after_partition_ = new_batch_size;
     if (tmp_size > 0) {
       AlignedAlloactor allocator(buffer, workspace_size_in_bytes);
@@ -386,7 +390,9 @@ class BatchDecodeHandler {
     cudaFreeHost(page_locked_buffer_);
   }
 
- private:
+  virtual bool IsCUDAGraphMode() const { return false; }
+
+ protected:
   uint32_t batch_size_before_partition_;
   uint32_t batch_size_after_partition_;
   void* page_locked_buffer_;
@@ -401,12 +407,88 @@ class BatchDecodeHandler {
   cudaStream_t stream_;
 };
 
-// class CUDAGraphBatchDecodeHandler: public BatchDecodeHandler {
-//  public:
-//   BatchDecodeHandler(size_t max_workspace_size_in_bytes = 64 * 1024 * 1024) {
+class CUDAGraphBatchDecodeHandler : public BatchDecodeHandler {
+ public:
+  template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PageStorage page_storage, QKVLayout kv_layout,
+            PosEncodingMode POS_ENCODING_MODE, typename DTypeIn, typename DTypeOut, typename IdType>
+  cudaError_t CUDAGraphBeginForwardDispatched(void* buffer, size_t workspace_size_in_bytes,
+                                              IdType* indptr, IdType* last_page_len,
+                                              uint32_t batch_size, uint32_t num_qo_heads,
+                                              uint32_t page_size) {
+    batch_size_before_partition_ = batch_size;
+    uint32_t tmp_size, max_grid_size, max_num_pages_per_batch, new_batch_size;
+    auto work_estimation_func =
+        BatchDecodeWithPagedKVCacheWorkEstimationDispatched<GROUP_SIZE, HEAD_DIM, page_storage,
+                                                            kv_layout, POS_ENCODING_MODE, DTypeIn,
+                                                            DTypeOut, IdType>;
+    FLASHINFER_CUDA_CALL(work_estimation_func(tmp_size, max_grid_size, max_num_pages_per_batch,
+                                              new_batch_size, batch_size, indptr, num_qo_heads,
+                                              page_size,
+                                              /*enable_cuda_graph=*/true, stream_));
+    // NOTE(Zihao): max_batch_size_after_partition_ is determined in handler initialization.
+    // the value should not be changed during the lifetime of the handler.
+    // So it should be compatible with CUDAGraph which requires fixed pointer.
+    batch_size_after_partition_ = new_batch_size;
+    size_t max_tmp_size = num_qo_heads * max_batch_size_after_partition_ *
+                          (HEAD_DIM * sizeof(DTypeOut) + 2 * sizeof(float));
+    AlignedAlloactor allocator(buffer, workspace_size_in_bytes);
+    float_buffer_ = allocator.aligned_alloc<void*>(max_tmp_size, 16);
+    new_indptr_ =
+        allocator.aligned_alloc<void*>((max_batch_size_after_partition_ + 1) * sizeof(IdType), 16);
 
-//   }
-// }
+    void* new_indptr_h_ = page_locked_buffer_;
+    new_last_page_len_ =
+        allocator.aligned_alloc<void*>(max_batch_size_after_partition_ * sizeof(IdType), 16);
+    void* new_last_page_len_h_ =
+        (char*)page_locked_buffer_ + ((char*)new_last_page_len_ - (char*)new_indptr_);
+    chunk_indptr_ =
+        allocator.aligned_alloc<void*>((max_batch_size_after_partition_ + 1) * sizeof(IdType), 16);
+    void* chunk_indptr_h_ =
+        (char*)page_locked_buffer_ + ((char*)chunk_indptr_ - (char*)new_indptr_);
+    batch_idx_map_ =
+        allocator.aligned_alloc<void*>(max_batch_size_after_partition_ * sizeof(IdType), 16);
+    void* batch_idx_map_h_ =
+        (char*)page_locked_buffer_ + ((char*)batch_idx_map_ - (char*)new_indptr_);
+    chunk_start_pos_ =
+        allocator.aligned_alloc<void*>(max_batch_size_after_partition_ * sizeof(IdType), 16);
+    void* chunk_start_pos_h_ =
+        (char*)page_locked_buffer_ + ((char*)chunk_start_pos_ - (char*)new_indptr_);
+    seq_lengths_before_partition_ =
+        allocator.aligned_alloc<void*>(max_batch_size_after_partition_ * sizeof(IdType), 16);
+    void* seq_lengths_before_partition_h_ =
+        (char*)page_locked_buffer_ + ((char*)seq_lengths_before_partition_ - (char*)new_indptr_);
+
+    size_t num_bytes_to_copy = (char*)allocator.ptr - (char*)new_indptr_;
+    FLASHINFER_CUDA_CALL(PartitionPagedKVCacheComputeAuxiliaryInfo(
+        max_num_pages_per_batch, batch_size, page_size, indptr, last_page_len,
+        (IdType*)new_indptr_h_, (IdType*)new_last_page_len_h_, (IdType*)chunk_indptr_h_,
+        (IdType*)batch_idx_map_h_, (IdType*)chunk_start_pos_h_,
+        (IdType*)seq_lengths_before_partition_h_, new_indptr_, page_locked_buffer_,
+        num_bytes_to_copy, stream_));
+    forward_started_ = true;
+    return cudaSuccess;
+  }
+  CUDAGraphBatchDecodeHandler(size_t max_batch_size) {
+    int dev_id = 0, num_sm = 0, max_thread_blocks_per_sm = 0;
+    cudaGetDevice(&dev_id);
+    cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id);
+    cudaDeviceGetAttribute(&max_thread_blocks_per_sm, cudaDevAttrMaxBlocksPerMultiprocessor,
+                           dev_id);
+    max_batch_size_after_partition_ =
+        std::max<size_t>(max_thread_blocks_per_sm * num_sm, max_batch_size);
+    size_t max_workspace_size_in_bytes =
+        6 * (sizeof(uint64_t) * (max_batch_size_after_partition_ + 1) + 16);
+    cudaMallocHost(&page_locked_buffer_, max_workspace_size_in_bytes);
+  }
+  ~CUDAGraphBatchDecodeHandler() {
+    EndForward();
+    cudaFreeHost(page_locked_buffer_);
+  }
+  bool IsCUDAGraphMode() const override { return true; }
+
+ private:
+  uint32_t max_batch_size_after_partition_;
+};
 
 class BatchPrefillHandler {
  public:

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -282,8 +282,8 @@ std::tuple<IdType, IdType, std::vector<IdType>, std::vector<IdType>> split_qo_in
   uint32_t num_qo_tiles = 0;
 
   for (uint32_t i = 0; i < batch_size; ++i) {
-    for (uint32_t j = qo_indptr_h[i] * aligned_gqa_group_size; j < qo_indptr_h[i + 1] * aligned_gqa_group_size;
-         j += num_rows_per_cta) {
+    for (uint32_t j = qo_indptr_h[i] * aligned_gqa_group_size;
+         j < qo_indptr_h[i + 1] * aligned_gqa_group_size; j += num_rows_per_cta) {
       request_indices.push_back(i);
       tile_indices.push_back((j - qo_indptr_h[i] * aligned_gqa_group_size) / num_rows_per_cta);
       ++num_qo_tiles;

--- a/python/csrc/batch_decode.cu
+++ b/python/csrc/batch_decode.cu
@@ -187,6 +187,11 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
 
 void BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
 
+void BatchDecodeWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
+  unsigned int max_workspace_size_in_bytes) {
+  handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
+}
+
 std::vector<torch::Tensor> BatchDecodeWithPagedKVCachePyTorchWrapper::Forward(
     torch::Tensor q, torch::Tensor paged_kv_data, torch::Tensor paged_kv_indptr,
     torch::Tensor paged_kv_indices, torch::Tensor paged_kv_last_page_len,

--- a/python/csrc/batch_decode.cu
+++ b/python/csrc/batch_decode.cu
@@ -188,7 +188,7 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
 void BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
 
 void BatchDecodeWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
-  unsigned int max_workspace_size_in_bytes) {
+    unsigned int max_workspace_size_in_bytes) {
   handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
 }
 

--- a/python/csrc/batch_decode.cu
+++ b/python/csrc/batch_decode.cu
@@ -132,7 +132,7 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  handler_.SetCUDAStream(torch_current_stream);
+  handler_ptr_->SetCUDAStream(torch_current_stream);
 
   if (is_float8_tensor(empty_data)) {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(empty_data.scalar_type(), c_type, [&] {
@@ -141,17 +141,32 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
           return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
             return DISPATCH_pos_encoding_mode(
                 PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  cudaError_t status =
-                      handler_.BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, PageStorage::kIndices,
-                                                      KV_LAYOUT, POS_ENCODING_MODE, c_type, nv_half,
-                                                      int32_t>(
-                          static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
-                          static_cast<int32_t*>(indptr.data_ptr()),
-                          static_cast<int32_t*>(last_page_len.data_ptr()), batch_size, num_qo_heads,
-                          page_size);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPagedKVCache failed with error ",
-                              cudaGetErrorString(status));
+                  if (handler_ptr_->IsCUDAGraphMode()) {
+                    // NOTE(Zihao): use runtime dispatch because template function is not virtual
+                    auto cuda_graph_handler_ptr_ =
+                        dynamic_cast<CUDAGraphBatchDecodeHandler*>(handler_ptr_.get());
+                    cudaError_t status = cuda_graph_handler_ptr_->CUDAGraphBeginForwardDispatched<
+                        GROUP_SIZE, HEAD_DIM, PageStorage::kIndices, KV_LAYOUT, POS_ENCODING_MODE,
+                        c_type, nv_half, int32_t>(static_cast<void*>(workspace_buffer.data_ptr()),
+                                                  workspace_size_in_bytes,
+                                                  static_cast<int32_t*>(indptr.data_ptr()),
+                                                  static_cast<int32_t*>(last_page_len.data_ptr()),
+                                                  batch_size, num_qo_heads, page_size);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchDecodeWithPagedKVCache (CUDAGraph Mode) failed with error ",
+                                cudaGetErrorString(status));
+                  } else {
+                    cudaError_t status = handler_ptr_->BeginForwardDispatched<
+                        GROUP_SIZE, HEAD_DIM, PageStorage::kIndices, KV_LAYOUT, POS_ENCODING_MODE,
+                        c_type, nv_half, int32_t>(static_cast<void*>(workspace_buffer.data_ptr()),
+                                                  workspace_size_in_bytes,
+                                                  static_cast<int32_t*>(indptr.data_ptr()),
+                                                  static_cast<int32_t*>(last_page_len.data_ptr()),
+                                                  batch_size, num_qo_heads, page_size);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchDecodeWithPagedKVCache failed with error ",
+                                cudaGetErrorString(status));
+                  }
                   return true;
                 });
           });
@@ -165,17 +180,32 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
           return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
             return DISPATCH_pos_encoding_mode(
                 PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  cudaError_t status =
-                      handler_.BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, PageStorage::kIndices,
-                                                      KV_LAYOUT, POS_ENCODING_MODE, c_type, c_type,
-                                                      int32_t>(
-                          static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
-                          static_cast<int32_t*>(indptr.data_ptr()),
-                          static_cast<int32_t*>(last_page_len.data_ptr()), batch_size, num_qo_heads,
-                          page_size);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPagedKVCache failed with error ",
-                              cudaGetErrorString(status));
+                  if (handler_ptr_->IsCUDAGraphMode()) {
+                    // NOTE(Zihao): use runtime dispatch because template function is not virtual
+                    auto cuda_graph_handler_ptr_ =
+                        dynamic_cast<CUDAGraphBatchDecodeHandler*>(handler_ptr_.get());
+                    auto status = cuda_graph_handler_ptr_->CUDAGraphBeginForwardDispatched<
+                        GROUP_SIZE, HEAD_DIM, PageStorage::kIndices, KV_LAYOUT, POS_ENCODING_MODE,
+                        c_type, c_type, int32_t>(static_cast<void*>(workspace_buffer.data_ptr()),
+                                                 workspace_size_in_bytes,
+                                                 static_cast<int32_t*>(indptr.data_ptr()),
+                                                 static_cast<int32_t*>(last_page_len.data_ptr()),
+                                                 batch_size, num_qo_heads, page_size);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchDecodeWithPagedKVCache (CUDAGraph Mode) failed with error ",
+                                cudaGetErrorString(status));
+                  } else {
+                    cudaError_t status = handler_ptr_->BeginForwardDispatched<
+                        GROUP_SIZE, HEAD_DIM, PageStorage::kIndices, KV_LAYOUT, POS_ENCODING_MODE,
+                        c_type, c_type, int32_t>(static_cast<void*>(workspace_buffer.data_ptr()),
+                                                 workspace_size_in_bytes,
+                                                 static_cast<int32_t*>(indptr.data_ptr()),
+                                                 static_cast<int32_t*>(last_page_len.data_ptr()),
+                                                 batch_size, num_qo_heads, page_size);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchDecodeWithPagedKVCache failed with error ",
+                                cudaGetErrorString(status));
+                  }
                   return true;
                 });
           });
@@ -185,11 +215,11 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
   }
 }
 
-void BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
+void BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward() { handler_ptr_->EndForward(); }
 
 void BatchDecodeWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
     unsigned int max_workspace_size_in_bytes) {
-  handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
+  handler_ptr_->UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
 }
 
 std::vector<torch::Tensor> BatchDecodeWithPagedKVCachePyTorchWrapper::Forward(
@@ -254,8 +284,8 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCachePyTorchWrapper::Forward(
                   cudaError_t status = BatchDecodeWithPagedKVCacheWrapperDispatched<
                       PageStorage::kIndices, KV_LAYOUT, GROUP_SIZE, HEAD_DIM, POS_ENCODING_MODE,
                       c_type, nv_half, int32_t>(
-                      &handler_, static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr, paged_kv,
-                      static_cast<nv_half*>(o.data_ptr()),
+                      handler_ptr_.get(), static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr,
+                      paged_kv, static_cast<nv_half*>(o.data_ptr()),
                       /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
                       sm_scale, rope_scale, rope_theta,
                       /*stream=*/torch_current_stream);
@@ -284,8 +314,8 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCachePyTorchWrapper::Forward(
                   cudaError_t status = BatchDecodeWithPagedKVCacheWrapperDispatched<
                       PageStorage::kIndices, KV_LAYOUT, GROUP_SIZE, HEAD_DIM, POS_ENCODING_MODE,
                       c_type, c_type, int32_t>(
-                      &handler_, static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr, paged_kv,
-                      static_cast<c_type*>(o.data_ptr()),
+                      handler_ptr_.get(), static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr,
+                      paged_kv, static_cast<c_type*>(o.data_ptr()),
                       /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
                       sm_scale, rope_scale, rope_theta,
                       /*stream=*/torch_current_stream);

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -46,6 +46,11 @@ void BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward(
 
 void BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
 
+void BatchPrefillWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
+  unsigned int max_workspace_size_in_bytes) {
+  handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
+}
+
 std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
     torch::Tensor q, torch::Tensor qo_indptr, torch::Tensor paged_kv_data,
     torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
@@ -168,6 +173,11 @@ void BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward(
 }
 
 void BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
+
+void BatchPrefillWithRaggedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
+  unsigned int max_workspace_size_in_bytes) {
+  handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
+}
 
 std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
     torch::Tensor q, torch::Tensor qo_indptr, torch::Tensor k, torch::Tensor v,

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -47,7 +47,7 @@ void BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward(
 void BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
 
 void BatchPrefillWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
-  unsigned int max_workspace_size_in_bytes) {
+    unsigned int max_workspace_size_in_bytes) {
   handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
 }
 
@@ -175,7 +175,7 @@ void BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward(
 void BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
 
 void BatchPrefillWithRaggedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
-  unsigned int max_workspace_size_in_bytes) {
+    unsigned int max_workspace_size_in_bytes) {
   handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
 }
 

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -34,21 +34,21 @@ void BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward(
   CHECK_EQ(qo_indptr.scalar_type(), torch::kInt32);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  handler_.SetCUDAStream(torch_current_stream);
+  handler_->SetCUDAStream(torch_current_stream);
 
   cudaError_t status =
-      handler_.BeginForward(static_cast<void*>(workspace_buffer.data_ptr()),
+      handler_->BeginForward(static_cast<void*>(workspace_buffer.data_ptr()),
                             workspace_size_in_bytes, static_cast<int32_t*>(qo_indptr.data_ptr()),
                             batch_size, num_qo_heads, num_kv_heads, head_dim);
   TORCH_CHECK(status == cudaSuccess, "BatchPrefillWithPagedKVCache failed with error ",
               cudaGetErrorString(status));
 }
 
-void BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
+void BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward() { handler_->EndForward(); }
 
 void BatchPrefillWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
     unsigned int max_workspace_size_in_bytes) {
-  handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
+  handler_->UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
 }
 
 std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
@@ -122,7 +122,7 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
                               PageStorage::kIndices, KV_LAYOUT, PAGE_SIZE, GROUP_SIZE, HEAD_DIM,
                               POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, CAUSAL, c_type, c_type,
                               int32_t>(
-                              &handler_, static_cast<c_type*>(q.data_ptr()),
+                              handler_.get(), static_cast<c_type*>(q.data_ptr()),
                               static_cast<int32_t*>(qo_indptr.data_ptr()),
                               /*q_offset=*/nullptr, paged_kv, static_cast<c_type*>(o.data_ptr()),
                               /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
@@ -162,21 +162,21 @@ void BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward(
   CHECK_EQ(qo_indptr.scalar_type(), torch::kInt32);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  handler_.SetCUDAStream(torch_current_stream);
+  handler_->SetCUDAStream(torch_current_stream);
 
   cudaError_t status =
-      handler_.BeginForward(static_cast<void*>(workspace_buffer.data_ptr()),
+      handler_->BeginForward(static_cast<void*>(workspace_buffer.data_ptr()),
                             workspace_size_in_bytes, static_cast<int32_t*>(qo_indptr.data_ptr()),
                             batch_size, num_qo_heads, num_kv_heads, head_dim);
   TORCH_CHECK(status == cudaSuccess, "BatchPrefillWithPagedKVCache failed with error ",
               cudaGetErrorString(status));
 }
 
-void BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward() { handler_.EndForward(); }
+void BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward() { handler_->EndForward(); }
 
 void BatchPrefillWithRaggedKVCachePyTorchWrapper::UpdatePageLockedBufferSize(
     unsigned int max_workspace_size_in_bytes) {
-  handler_.UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
+  handler_->UpdatePageLockedBufferSize(max_workspace_size_in_bytes);
 }
 
 std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
@@ -228,7 +228,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
                         cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
                             GROUP_SIZE, HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE,
                             ALLOW_FP16_QK_REDUCTION, CAUSAL, c_type, c_type, int32_t>(
-                            &handler_, static_cast<c_type*>(q.data_ptr()),
+                            handler_.get(), static_cast<c_type*>(q.data_ptr()),
                             static_cast<int32_t*>(qo_indptr.data_ptr()),
                             static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
                             static_cast<int32_t*>(kv_indptr.data_ptr()),

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -37,7 +37,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("rmsnorm", &rmsnorm, "Root mean square normalization");
   py::class_<BatchDecodeWithPagedKVCachePyTorchWrapper>(m,
                                                         "BatchDecodeWithPagedKVCachePyTorchWrapper")
-      .def(py::init<unsigned int>())
+      .def(py::init<unsigned int, unsigned int>())
       .def("begin_forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward)
       .def("update_page_locked_buffer_size",
@@ -45,7 +45,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithPagedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithPagedKVCachePyTorchWrapper")
-      .def(py::init<unsigned int>())
+      .def(py::init<unsigned int, unsigned int>())
       .def("begin_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward)
       .def("update_page_locked_buffer_size",
@@ -53,7 +53,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithRaggedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithRaggedKVCachePyTorchWrapper")
-      .def(py::init<unsigned int>())
+      .def(py::init<unsigned int, unsigned int>())
       .def("begin_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward)
       .def("update_page_locked_buffer_size",

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -43,6 +43,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("update_page_locked_buffer_size",
            &BatchDecodeWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize)
       .def("forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::Forward);
+  py::class_<CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper>(
+      m, "CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper")
+      .def(py::init<unsigned int, unsigned int>())
+      .def("begin_forward", &CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward)
+      .def("end_forward", &CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper::EndForward)
+      .def("update_page_locked_buffer_size",
+           &CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize)
+      .def("forward", &CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithPagedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithPagedKVCachePyTorchWrapper")
       .def(py::init<unsigned int, unsigned int>())

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -40,17 +40,23 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def(py::init<unsigned int>())
       .def("begin_forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward)
+      .def("update_page_locked_buffer_size",
+           &BatchDecodeWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize)
       .def("forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithPagedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithPagedKVCachePyTorchWrapper")
       .def(py::init<unsigned int>())
       .def("begin_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward)
+      .def("update_page_locked_buffer_size",
+           &BatchPrefillWithPagedKVCachePyTorchWrapper::UpdatePageLockedBufferSize)
       .def("forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithRaggedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithRaggedKVCachePyTorchWrapper")
       .def(py::init<unsigned int>())
       .def("begin_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward)
+      .def("update_page_locked_buffer_size",
+           &BatchPrefillWithRaggedKVCachePyTorchWrapper::UpdatePageLockedBufferSize)
       .def("forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward);
 }

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -79,15 +79,15 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
                                      float rope_scale, float rope_theta, bool return_lse);
   BatchDecodeWithPagedKVCachePyTorchWrapper(
       std::shared_ptr<flashinfer::BatchDecodeHandler> handler_ptr, flashinfer::QKVLayout kv_layout)
-      : handler_ptr_(handler_ptr), kv_layout_(kv_layout) {}
+      : handler_(handler_ptr), kv_layout_(kv_layout) {}
   BatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout,
                                             unsigned int max_workspace_size_in_bytes)
       : kv_layout_(flashinfer::QKVLayout(layout)),
-        handler_ptr_(
+        handler_(
             std::make_shared<flashinfer::BatchDecodeHandler>(max_workspace_size_in_bytes)) {}
 
  protected:
-  std::shared_ptr<flashinfer::BatchDecodeHandler> handler_ptr_;
+  std::shared_ptr<flashinfer::BatchDecodeHandler> handler_;
   flashinfer::QKVLayout kv_layout_;
 };
 
@@ -118,10 +118,10 @@ class BatchPrefillWithPagedKVCachePyTorchWrapper {
   BatchPrefillWithPagedKVCachePyTorchWrapper(unsigned int layout,
                                              unsigned int max_workspace_size_in_bytes)
       : kv_layout_(flashinfer::QKVLayout(layout)),
-        handler_(flashinfer::BatchPrefillHandler(max_workspace_size_in_bytes)) {}
+        handler_(std::make_shared<flashinfer::BatchPrefillHandler>(max_workspace_size_in_bytes)) {}
 
  private:
-  flashinfer::BatchPrefillHandler handler_;
+  std::shared_ptr<flashinfer::BatchPrefillHandler> handler_;
   flashinfer::QKVLayout kv_layout_;
 };
 
@@ -140,9 +140,9 @@ class BatchPrefillWithRaggedKVCachePyTorchWrapper {
   BatchPrefillWithRaggedKVCachePyTorchWrapper(unsigned int layout,
                                               unsigned int max_workspace_size_in_bytes)
       : kv_layout_(flashinfer::QKVLayout(layout)),
-        handler_(flashinfer::BatchPrefillHandler(max_workspace_size_in_bytes)) {}
+        handler_(std::make_shared<flashinfer::BatchPrefillHandler>(max_workspace_size_in_bytes)) {}
 
  private:
-  flashinfer::BatchPrefillHandler handler_;
+  std::shared_ptr<flashinfer::BatchPrefillHandler> handler_;
   flashinfer::QKVLayout kv_layout_;
 };

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -76,8 +76,10 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
                                      torch::Tensor paged_kv_last_page_len,
                                      unsigned int pos_encoding_mode, float sm_scale,
                                      float rope_scale, float rope_theta, bool return_lse);
-  BatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout)
-      : kv_layout_(flashinfer::QKVLayout(layout)) {}
+  BatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout,
+                                            unsigned int max_workspace_buffer_size_in_bytes)
+      : kv_layout_(flashinfer::QKVLayout(layout)),
+        handler_(flashinfer::BatchDecodeHandler(max_workspace_buffer_size_in_bytes)) {}
 
  private:
   flashinfer::BatchDecodeHandler handler_;
@@ -123,8 +125,10 @@ class BatchPrefillWithPagedKVCachePyTorchWrapper {
                                      unsigned int pos_encoding_mode, bool allow_fp16_qk_reduction,
                                      float sm_scale, float rope_scale, float rope_theta,
                                      bool return_lse);
-  BatchPrefillWithPagedKVCachePyTorchWrapper(unsigned int layout)
-      : kv_layout_(flashinfer::QKVLayout(layout)) {}
+  BatchPrefillWithPagedKVCachePyTorchWrapper(unsigned int layout,
+                                             unsigned int max_workspace_buffer_size_in_bytes)
+      : kv_layout_(flashinfer::QKVLayout(layout)),
+        handler_(flashinfer::BatchPrefillHandler(max_workspace_buffer_size_in_bytes)) {}
 
  private:
   flashinfer::BatchPrefillHandler handler_;
@@ -143,8 +147,10 @@ class BatchPrefillWithRaggedKVCachePyTorchWrapper {
                                      unsigned int pos_encoding_mode, bool allow_fp16_qk_reduction,
                                      float sm_scale, float rope_scale, float rope_theta,
                                      bool return_lse);
-  BatchPrefillWithRaggedKVCachePyTorchWrapper(unsigned int layout)
-      : kv_layout_(flashinfer::QKVLayout(layout)) {}
+  BatchPrefillWithRaggedKVCachePyTorchWrapper(unsigned int layout,
+                                              unsigned int max_workspace_buffer_size_in_bytes)
+      : kv_layout_(flashinfer::QKVLayout(layout)),
+        handler_(flashinfer::BatchPrefillHandler(max_workspace_buffer_size_in_bytes)) {}
 
  private:
   flashinfer::BatchPrefillHandler handler_;

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -70,6 +70,7 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
                     unsigned int num_kv_heads, unsigned int head_dim, unsigned int page_size,
                     unsigned int pos_encoding_mode, torch::Tensor empty_data);
   void EndForward();
+  void UpdatePageLockedBufferSize(uint32_t max_workspace_size_in_bytes);
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor paged_kv_data,
                                      torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
                                      torch::Tensor paged_kv_last_page_len,
@@ -83,12 +84,38 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
   flashinfer::QKVLayout kv_layout_;
 };
 
+// class CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper {
+//  public:
+//   static CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper Create(unsigned int layout) {
+//     return CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper(layout);
+//   }
+//   void BeginForward(torch::Tensor workspace_buffer, torch::Tensor indptr_host,
+//                     torch::Tensor last_page_len_host, unsigned int batch_size, unsigned int
+//                     num_qo_heads, unsigned int num_kv_heads, unsigned int head_dim, unsigned int
+//                     page_size, unsigned int pos_encoding_mode, torch::Tensor empty_data);
+//   void EndForward();
+//   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor paged_kv_data,
+//                                      torch::Tensor paged_kv_indptr_buf, torch::Tensor
+//                                      paged_kv_indices_buf, torch::Tensor
+//                                      paged_kv_last_page_len_buf, unsigned int batch_size,
+//                                      unsigned int nnz_pages,
+//                                      unsigned int pos_encoding_mode, float sm_scale,
+//                                      float rope_scale, float rope_theta, bool return_lse);
+
+//  private:
+//   CUDAGraphBatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout)
+//       : kv_layout_(flashinfer::QKVLayout(layout)) {}
+//   flashinfer::CUDAGraphBatchDecodeHandler handler_;
+//   flashinfer::QKVLayout kv_layout_;
+// };
+
 class BatchPrefillWithPagedKVCachePyTorchWrapper {
  public:
   void BeginForward(torch::Tensor workspace_buffer, torch::Tensor qo_indptr,
                     unsigned int batch_size, unsigned int num_qo_heads, unsigned int num_kv_heads,
                     unsigned int head_dim);
   void EndForward();
+  void UpdatePageLockedBufferSize(uint32_t max_workspace_size_in_bytes);
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor qo_indptr,
                                      torch::Tensor paged_kv_data, torch::Tensor paged_kv_indptr,
                                      torch::Tensor paged_kv_indices,
@@ -110,6 +137,7 @@ class BatchPrefillWithRaggedKVCachePyTorchWrapper {
                     unsigned int batch_size, unsigned int num_qo_heads, unsigned int num_kv_heads,
                     unsigned int head_dim);
   void EndForward();
+  void UpdatePageLockedBufferSize(uint32_t max_workspace_size_in_bytes);
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor qo_indptr, torch::Tensor k,
                                      torch::Tensor v, torch::Tensor kv_indptr, bool causal,
                                      unsigned int pos_encoding_mode, bool allow_fp16_qk_reduction,

--- a/python/flashinfer/__init__.py
+++ b/python/flashinfer/__init__.py
@@ -19,6 +19,7 @@ from .decode import (
     batch_decode_with_padded_kv_cache,
     batch_decode_with_padded_kv_cache_return_lse,
     BatchDecodeWithPagedKVCacheWrapper,
+    CUDAGraphBatchDecodeWithPagedKVCacheWrapper,
 )
 from .prefill import (
     single_prefill_with_kv_cache,

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -405,7 +405,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchDecodeWithPagedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
+            TensorLayout[kv_layout].value,
+            workspace_buffer.numel() * workspace_buffer.element_size(),
         )
         self._paged_kv_indptr = None
         self._paged_kv_indices = None
@@ -639,12 +640,14 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper:
     # TODO(Zihao): update documentation
     """
 
-    def __init__(self,
+    def __init__(
+        self,
         workspace_buffer: torch.Tensor,
         indptr_buffer,
         indices_buffer,
         last_page_len_buffer,
-        kv_layout: str = "NHD"):
+        kv_layout: str = "NHD",
+    ):
         r"""Constructor of :class:`BatchDecodeWithPagedKVCacheWrapper`.
 
         Parameters
@@ -660,7 +663,8 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchDecodeWithPagedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
+            TensorLayout[kv_layout].value,
+            workspace_buffer.numel() * workspace_buffer.element_size(),
         )
         self._paged_kv_indptr_buf = indptr_buffer
         self._paged_kv_indices_buf = indices_buffer
@@ -889,4 +893,3 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper:
             rope_theta,
             True,
         )
-

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -405,7 +405,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchDecodeWithPagedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value
+            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
         )
         self._paged_kv_indptr = None
         self._paged_kv_indices = None
@@ -628,3 +628,265 @@ class BatchDecodeWithPagedKVCacheWrapper:
             rope_theta,
             True,
         )
+
+
+class CUDAGraphBatchDecodeWithPagedKVCacheWrapper:
+    r"""Wrapper class for decode attention with paged kv-cache (first proposed in
+    `vLLM <https://arxiv.org/abs/2309.06180>`_) for batch of requests. Compatible
+    with CUDA Graph.
+
+    Check :ref:`our tutorial<page-layout>` for page table layout.
+    # TODO(Zihao): update documentation
+    """
+
+    def __init__(self,
+        workspace_buffer: torch.Tensor,
+        indptr_buffer,
+        indices_buffer,
+        last_page_len_buffer,
+        kv_layout: str = "NHD"):
+        r"""Constructor of :class:`BatchDecodeWithPagedKVCacheWrapper`.
+
+        Parameters
+        ----------
+        workspace_buffer : torch.Tensor
+            The user reserved workspace buffer used to store auxiliary data structures,
+            recommended size is 16MB, the device of the workspace buffer should be the
+            same as the device of the input tensors.
+        kv_layout : str
+            The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
+        """
+        check_kv_layout(kv_layout)
+        self._kv_layout = kv_layout
+        self._workspace_buffer = workspace_buffer
+        self._wrapper = _kernels.BatchDecodeWithPagedKVCachePyTorchWrapper(
+            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
+        )
+        self._paged_kv_indptr_buf = indptr_buffer
+        self._paged_kv_indices_buf = indices_buffer
+        self._paged_kv_last_page_len_buf = last_page_len_buffer
+        self._batch_size = 0
+        self._nnz_pages = 0
+
+    def reset_workspace_buffer(self, new_workspace_buffer: torch.Tensor):
+        r"""Reset the workspace buffer.
+
+        Parameters
+        ----------
+        new_workspace_buffer : torch.Tensor
+            The new workspace buffer, the device of the new workspace buffer should
+            be the same as the device of the input tensors.
+        """
+        self._workspace_buffer = new_workspace_buffer
+
+    def begin_forward(
+        self,
+        indptr_host: torch.Tensor,
+        indices_host: torch.Tensor,
+        last_page_len_host: torch.Tensor,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        page_size: int,
+        pos_encoding_mode: str = "NONE",
+        data_type: Union[str, torch.dtype] = "float16",
+    ):
+        r"""Create auxiliary data structures for batch decode for multiple forward calls
+        within the same decode step.
+
+        Parameters
+        ----------
+        indptr : torch.Tensor
+            The indptr of the paged kv cache, shape: ``[batch_size + 1]``
+        indices : torch.Tensor
+            The page indices of the paged kv cache, shape: ``[qo_indptr[-1]]``
+        last_page_len : torch.Tensor
+            The number of entries in the last page of each request in the paged kv
+            cache, shape: ``[batch_size]``
+        num_qo_heads : int
+            The number of query/output heads
+        num_kv_heads : int
+            The number of key/value heads
+        head_dim : int
+            The dimension of the heads
+        page_size : int
+            The page size of the paged kv cache
+        pos_encoding_mode : str
+            Whether to apply RoPE on-the-fly inside attention kernels, could be
+            ``NONE``/``ROPE_LLAMA`` (LLAMA style rotary embedding) /``ALIBI``.
+        data_type : Union[str, torch.dtype]
+            The data type of the paged kv cache
+
+        Note
+        ----
+        The :meth:`begin_forward` method should be called before any :meth:`forward` or
+        :meth:`forward_return_lse` calls, auxiliary data structures will be created
+        during this call and cached for multiple forward calls.
+
+        The ``num_qo_heads`` must be a multiple of ``num_kv_heads``. If ``num_qo_heads``
+        is not equal to ``num_kv_heads``, the function will use
+        `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
+        """
+        self._paged_kv_indptr_buf[len(indptr_host)] = indptr_host
+        self._paged_kv_indices_buf[len(indices_host)] = indices_host
+        self._paged_kv_last_page_len_buf[len(last_page_len_host)] = last_page_len_host
+
+        self._batch_size = len(indptr_host) - 1
+        self._nnz_pages = len(indices_host)
+
+        batch_size = len(indptr_host) - 1
+        # NOTE(Zihao): the following tensor acts as placeholder to pass dtype info
+        empty_data = torch.empty(
+            0,
+            dtype=(
+                getattr(torch, data_type) if isinstance(data_type, str) else data_type
+            ),
+        )
+        self._wrapper.begin_forward(
+            self._workspace_buffer,
+            indptr_host,
+            last_page_len_host,
+            batch_size,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            PosEncodingMode[pos_encoding_mode].value,
+            empty_data,
+        )
+
+    def end_forward(self):
+        r"""Clear auxiliary data structures created by :meth:`begin_forward`."""
+        self._wrapper.end_forward()
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        paged_kv_data: torch.Tensor,
+        pos_encoding_mode: str = "NONE",
+        sm_scale: Optional[float] = None,
+        rope_scale: Optional[float] = None,
+        rope_theta: Optional[float] = None,
+    ):
+        r"""Compute batch decode attention between query and paged kv cache.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            The query tensor, shape: ``[batch_size, num_qo_heads, head_dim]``
+        paged_kv_data : torch.Tensor
+            A 5-D tensor of the reserved paged kv-cache data, shape:
+            ``[max_num_pages, 2, page_size, num_kv_heads, head_dim]`` if
+            :attr:`kv_layout` is ``NHD``, or
+            ``[max_num_pages, 2, num_kv_heads, page_size, head_dim]`` if
+            :attr:`kv_layout` is ``HND``.
+        pos_encoding_mode : str
+            Whether to apply RoPE on-the-fly inside attention kernels, could be
+            ``NONE``/``ROPE_LLAMA`` (LLAMA style rotary embedding) /``ALIBI``.
+        sm_scale : Optional[float]
+            The scale of softmax, if not provided, will be set to ``1 / sqrt(head_dim)``.
+        rope_scale : Optional[float]
+            The scale used in RoPE interpolation, if not provided, will be set to
+            ``1.0``.
+        rope_theta : Optional[float]
+            The theta used in RoPE, if not provided, will be set to ``1e4``.
+
+        Returns
+        -------
+        torch.Tensor
+            The attention output, shape: ``[batch_size, num_qo_heads, head_dim]``.
+        """
+        check_pos_encoding_mode(pos_encoding_mode)
+        if sm_scale is None:
+            head_dim = q.shape[-1]
+            sm_scale = 1.0 / math.sqrt(head_dim)
+        if rope_scale is None:
+            rope_scale = 1.0
+        if rope_theta is None:
+            rope_theta = 1e4
+
+        paged_kv_data = expand_5d(paged_kv_data, self._kv_layout)
+        return self._wrapper.forward(
+            q,
+            paged_kv_data,
+            self._paged_kv_indptr_buf,
+            self._paged_kv_indices_buf,
+            self._paged_kv_last_page_len_buf,
+            self._batch_size,
+            self._nnz_pages,
+            PosEncodingMode[pos_encoding_mode].value,
+            sm_scale,
+            rope_scale,
+            rope_theta,
+            False,
+        )[0]
+
+    def forward_return_lse(
+        self,
+        q: torch.Tensor,
+        paged_kv_data: torch.Tensor,
+        pos_encoding_mode: str = "NONE",
+        sm_scale: Optional[float] = None,
+        rope_scale: Optional[float] = None,
+        rope_theta: Optional[float] = None,
+    ):
+        r"""Compute batch decode attention with paged kv cache, return attention output
+        and logsumexp of attention scores.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            The query tensor, shape: ``[batch_size, num_qo_heads, head_dim]``
+        paged_kv_data : torch.Tensor
+            A 5-D tensor of the reserved paged kv-cache data, shape:
+            ``[max_num_pages, 2, page_size, num_kv_heads, head_dim]`` if
+            :attr:`kv_layout` is ``NHD``, or
+            ``[max_num_pages, 2, num_kv_heads, page_size, head_dim]`` if
+            :attr:`kv_layout` is ``HND``.
+        pos_encoding_mode : str
+            Whether to apply RoPE on-the-fly inside attention kernels, could be
+            ``NONE``/``ROPE_LLAMA`` (LLAMA style rotary embedding) /``ALIBI``.
+        sm_scale : Optional[float]
+            The scale of softmax, if not provided, will be set to ``1 / sqrt(head_dim)``.
+        rope_scale : Optional[float]
+            The scale used in RoPE interpolation, if not provided, will be set to
+            ``1.0``.
+        rope_theta : Optional[float]
+            The theta used in RoPE, if not provided, will be set to ``1e4``.
+
+        Returns
+        -------
+        V : torch.Tensor
+            The attention output, shape: ``[batch_size, num_qo_heads, head_dim]``.
+        S : torch.Tensor
+            The logsumexp of attention scores, Shape: ``[batch_size, num_qo_heads]``.
+
+        Notes
+        -----
+        Please refer to the :ref:`tutorial <recursive-attention>` for a detailed
+        explanation of the log-sum-exp function and attention states.
+        """
+        check_pos_encoding_mode(pos_encoding_mode)
+        if sm_scale is None:
+            head_dim = q.shape[-1]
+            sm_scale = 1.0 / math.sqrt(head_dim)
+        if rope_scale is None:
+            rope_scale = 1.0
+        if rope_theta is None:
+            rope_theta = 1e4
+        paged_kv_data = expand_5d(paged_kv_data, self._kv_layout)
+        return self._wrapper.forward(
+            q,
+            paged_kv_data,
+            self._paged_kv_indptr_buf,
+            self._paged_kv_indices_buf,
+            self._paged_kv_last_page_len_buf,
+            self._batch_size,
+            self._nnz_pages,
+            PosEncodingMode[pos_encoding_mode].value,
+            sm_scale,
+            rope_scale,
+            rope_theta,
+            True,
+        )
+

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -353,7 +353,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchPrefillWithPagedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
+            TensorLayout[kv_layout].value,
+            workspace_buffer.numel() * workspace_buffer.element_size(),
         )
         self._qo_indptr = None
         self._paged_kv_indptr = None
@@ -666,7 +667,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchPrefillWithRaggedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
+            TensorLayout[kv_layout].value,
+            workspace_buffer.numel() * workspace_buffer.element_size(),
         )
         self._qo_indptr = None
         self._kv_indptr = None

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -353,7 +353,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchPrefillWithPagedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value
+            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
         )
         self._qo_indptr = None
         self._paged_kv_indptr = None
@@ -666,7 +666,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchPrefillWithRaggedKVCachePyTorchWrapper(
-            TensorLayout[kv_layout].value
+            TensorLayout[kv_layout].value, workspace_buffer.numel() * workspace_buffer.element_size()
         )
         self._qo_indptr = None
         self._kv_indptr = None

--- a/python/setup.py
+++ b/python/setup.py
@@ -63,15 +63,15 @@ def get_instantiation_cu() -> List[str]:
     prefix = "csrc/generated"
     (root / prefix).mkdir(parents=True, exist_ok=True)
 
-    group_sizes = os.environ.get("FLASHINFER_GROUP_SIZES", "1").split(",")
-    page_sizes = os.environ.get("FLASHINFER_PAGE_SIZES", "1,16").split(",")
-    head_dims = os.environ.get("FLASHINFER_HEAD_DIMS", "128").split(",")
+    group_sizes = os.environ.get("FLASHINFER_GROUP_SIZES", "1,4,6,8").split(",")
+    page_sizes = os.environ.get("FLASHINFER_PAGE_SIZES", "1,16,32").split(",")
+    head_dims = os.environ.get("FLASHINFER_HEAD_DIMS", "64,128,256").split(",")
     kv_layouts = os.environ.get("FLASHINFER_KV_LAYOUTS", "0,1").split(",")
-    pos_encoding_modes = os.environ.get("FLASHINFER_POS_ENCODING_MODES", "0,1").split(
+    pos_encoding_modes = os.environ.get("FLASHINFER_POS_ENCODING_MODES", "0,1,2").split(
         ","
     )
     allow_fp16_qk_reduction_options = os.environ.get(
-        "FLASHINFER_ALLOW_FP16_QK_REDUCTION_OPTIONS", "0"
+        "FLASHINFER_ALLOW_FP16_QK_REDUCTION_OPTIONS", "0,1"
     ).split(",")
     causal_options = os.environ.get("FLASHINFER_CAUSAL_OPTIONS", "0,1").split(",")
     # dispatch.inc

--- a/python/setup.py
+++ b/python/setup.py
@@ -63,15 +63,15 @@ def get_instantiation_cu() -> List[str]:
     prefix = "csrc/generated"
     (root / prefix).mkdir(parents=True, exist_ok=True)
 
-    group_sizes = os.environ.get("FLASHINFER_GROUP_SIZES", "1,4,6,8").split(",")
-    page_sizes = os.environ.get("FLASHINFER_PAGE_SIZES", "1,16,32").split(",")
-    head_dims = os.environ.get("FLASHINFER_HEAD_DIMS", "64,128,256").split(",")
+    group_sizes = os.environ.get("FLASHINFER_GROUP_SIZES", "1").split(",")
+    page_sizes = os.environ.get("FLASHINFER_PAGE_SIZES", "1,16").split(",")
+    head_dims = os.environ.get("FLASHINFER_HEAD_DIMS", "128").split(",")
     kv_layouts = os.environ.get("FLASHINFER_KV_LAYOUTS", "0,1").split(",")
-    pos_encoding_modes = os.environ.get("FLASHINFER_POS_ENCODING_MODES", "0,1,2").split(
+    pos_encoding_modes = os.environ.get("FLASHINFER_POS_ENCODING_MODES", "0,1").split(
         ","
     )
     allow_fp16_qk_reduction_options = os.environ.get(
-        "FLASHINFER_ALLOW_FP16_QK_REDUCTION_OPTIONS", "0,1"
+        "FLASHINFER_ALLOW_FP16_QK_REDUCTION_OPTIONS", "0"
     ).split(",")
     causal_options = os.environ.get("FLASHINFER_CAUSAL_OPTIONS", "0,1").split(",")
     # dispatch.inc

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -72,10 +72,7 @@ def test_batch_decode_with_paged_kv_cache(
         "NONE",
         dtype,
     )
-    print("wow")
     o = wrapper.forward(q, kv_data.to(dtype), pos_encoding_mode=pos_encoding_mode)
-    print("hmmm")
-    print(o)
 
     for i in range(batch_size):
         perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
@@ -111,11 +108,9 @@ def test_batch_decode_with_paged_kv_cache(
             ],
             dim=0,
         ).to(dtype)
-        print('ahhhh')
         o_ref_i = flashinfer.single_decode_with_kv_cache(
             qi, ki, vi, pos_encoding_mode=pos_encoding_mode
         )
-        print('okkk')
         o_i_np = o[i].cpu().numpy()
         o_ref_i_np = o_ref_i.cpu().numpy()
         numpy.testing.assert_allclose(o_i_np, o_ref_i_np, rtol=1e-3, atol=1e-3)

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -23,7 +23,6 @@ import flashinfer
 
 @pytest.mark.parametrize("batch_size", [12, 17])
 @pytest.mark.parametrize("kv_len", [54, 97])
-@pytest.mark.parametrize("qo_len", [37, 17])
 @pytest.mark.parametrize("page_size", [1, 8, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])
@@ -36,7 +35,6 @@ import flashinfer
 def test_batch_decode_with_paged_kv_cache(
     batch_size,
     kv_len,
-    qo_len,
     page_size,
     num_kv_heads,
     num_qo_heads,
@@ -116,10 +114,151 @@ def test_batch_decode_with_paged_kv_cache(
         numpy.testing.assert_allclose(o_i_np, o_ref_i_np, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("batch_size", [12, 17])
+@pytest.mark.parametrize("kv_len", [54, 97])
+@pytest.mark.parametrize("page_size", [1, 8, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.float8_e4m3fn, torch.float8_e5m2]
+)
+def test_cuda_graph_batch_decode_with_paged_kv_cache(
+    batch_size,
+    kv_len,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    kv_layout,
+    pos_encoding_mode,
+    dtype,
+):
+    q = torch.randn(batch_size, num_qo_heads, head_dim).to(0).to(dtype)
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = (
+        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0)
+        if kv_layout == "HND"
+        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim).to(0)
+    )
+    kv_indptr_host_warmup = torch.arange(0, batch_size + 1).int()
+    kv_indices_host_warmup = torch.arange(0, batch_size).int()
+    kv_last_page_len_host_warmup = torch.full(
+        (batch_size,), page_size, dtype=torch.int32
+    )
+
+    kv_indptr_host = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
+    kv_indices_host = torch.arange(0, total_num_pages).int()
+    kv_last_page_len_host = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    )
+
+    kv_indptr_device_buffer = torch.empty(batch_size + 1).int().to(0)
+    kv_indices_device_buffer = torch.empty(total_num_pages).int().to(0)
+    kv_last_page_device_buffer = torch.empty(batch_size).int().to(0)
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(0)
+    wrapper = flashinfer.CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_indptr_device_buffer,
+        kv_indices_device_buffer,
+        kv_last_page_device_buffer,
+        kv_layout,
+    )
+    wrapper.begin_forward(
+        kv_indptr_host_warmup,
+        kv_indices_host_warmup,
+        kv_last_page_len_host_warmup,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        "NONE",
+        dtype,
+    )
+    # warmup
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            o = wrapper.forward(
+                q, kv_data.to(dtype), pos_encoding_mode=pos_encoding_mode
+            )
+    torch.cuda.current_stream().wait_stream(s)
+    # capture
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        o = wrapper.forward(q, kv_data.to(dtype), pos_encoding_mode=pos_encoding_mode)
+
+    wrapper.begin_forward(
+        kv_indptr_host,
+        kv_indices_host,
+        kv_last_page_len_host,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        "NONE",
+        dtype,
+    )
+    g.replay()
+
+    # compute ground truth and compare
+    kv_indptr = kv_indptr_host.to(0)
+    kv_indices = kv_indices_host.to(0)
+    kv_last_page_len = kv_last_page_len_host.to(0)
+    for i in range(batch_size):
+        perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
+        perm_dims_last = [1, 0, 2] if kv_layout == "HND" else [0, 1, 2]
+        qi = q[i]
+        ki = torch.cat(
+            [
+                kv_data[kv_indptr[i] : kv_indptr[i + 1] - 1, 0]
+                .permute(*perm_dims)
+                .reshape(-1, num_kv_heads, head_dim),
+                (
+                    kv_data[kv_indptr[i + 1] - 1, 0, :, : kv_last_page_len[i]]
+                    if kv_layout == "HND"
+                    else kv_data[kv_indptr[i + 1] - 1, 0, : kv_last_page_len[i], :]
+                )
+                .permute(*perm_dims_last)
+                .reshape(-1, num_kv_heads, head_dim),
+            ],
+            dim=0,
+        ).to(dtype)
+        vi = torch.cat(
+            [
+                kv_data[kv_indptr[i] : kv_indptr[i + 1] - 1, 1]
+                .permute(*perm_dims)
+                .reshape(-1, num_kv_heads, head_dim),
+                (
+                    kv_data[kv_indptr[i + 1] - 1, 1, :, : kv_last_page_len[i]]
+                    if kv_layout == "HND"
+                    else kv_data[kv_indptr[i + 1] - 1, 1, : kv_last_page_len[i], :]
+                )
+                .permute(*perm_dims_last)
+                .reshape(-1, num_kv_heads, head_dim),
+            ],
+            dim=0,
+        ).to(dtype)
+        o_ref_i = flashinfer.single_decode_with_kv_cache(
+            qi, ki, vi, pos_encoding_mode=pos_encoding_mode
+        )
+        o_i_np = o[i].cpu().numpy()
+        o_ref_i_np = o_ref_i.cpu().numpy()
+        numpy.testing.assert_allclose(o_i_np, o_ref_i_np, rtol=1e-3, atol=1e-3)
+
+
 if __name__ == "__main__":
     test_batch_decode_with_paged_kv_cache(
-        12, 54, 37, 8, 8, 8, 128, "HND", "NONE", torch.float16
+        12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16
     )
     test_batch_decode_with_paged_kv_cache(
-        12, 54, 37, 1, 8, 8, 128, "HND", "NONE", torch.float8_e5m2
+        12, 54, 1, 8, 8, 128, "HND", "NONE", torch.float8_e5m2
+    )
+    test_cuda_graph_batch_decode_with_paged_kv_cache(
+        12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16
     )

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -72,7 +72,10 @@ def test_batch_decode_with_paged_kv_cache(
         "NONE",
         dtype,
     )
+    print("wow")
     o = wrapper.forward(q, kv_data.to(dtype), pos_encoding_mode=pos_encoding_mode)
+    print("hmmm")
+    print(o)
 
     for i in range(batch_size):
         perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
@@ -108,9 +111,11 @@ def test_batch_decode_with_paged_kv_cache(
             ],
             dim=0,
         ).to(dtype)
+        print('ahhhh')
         o_ref_i = flashinfer.single_decode_with_kv_cache(
             qi, ki, vi, pos_encoding_mode=pos_encoding_mode
         )
+        print('okkk')
         o_i_np = o[i].cpu().numpy()
         o_ref_i_np = o_ref_i.cpu().numpy()
         numpy.testing.assert_allclose(o_i_np, o_ref_i_np, rtol=1e-3, atol=1e-3)

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -160,7 +160,7 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
     kv_indices_device_buffer = torch.empty(total_num_pages).int().to(0)
     kv_last_page_device_buffer = torch.empty(batch_size).int().to(0)
 
-    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(0)
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
     wrapper = flashinfer.CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
         workspace_buffer,
         kv_indptr_device_buffer,


### PR DESCRIPTION
As requested in #187 , this PR adds initial support of `CUDAGraph` compatibility of flashinfer batch decode attention kernels. This PR is the first step towards full CUDAGraph support and we will implement CUDAGraph compatible prefill operators in later PRs.

# Proposed APIs
We add another wrapper `CUDAGraphBatchDecodeWithPagedKVCacheWrapper`, and user need to pre-allocation page data structure buffers to initialize this wrapper class. Once initiated, these buffers are pinned on GPUs in the life cycle of the wrapper class.

The behavior of `CUDAGraphBatchDecodeWithPagedKVCacheWrapper` is a little bit different from `BatchDecodeWithPagedKVCacheWrapper`'s: we will only run a fixed set of kernels in CUDAGraph mode, no matter what the input shape is (the original implementation will dispatch to different kernels according to different input shapes).

This PR also fix the address of all kernel input pointers to accomodate the constraint of CUDAGraph capturing.

# Examples
See `test_cuda_graph_batch_decode_with_paged_kv_cache` in unittests.
`begin_forward` functions should not be captured as some of the operators are not allowed to be captured.

cc @AgrawalAmey  @LiuXiaoxuanPKU  @comaniac

