### PR TITLE
[WIP] rafactor: make `gqa_group_size` a function argument instead of template parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ flashinfer_option(FLASHINFER_TVM_SOURCE_DIR "The path to tvm for building tvm bi
 
 # The following configurations can impact the binary
 # size of the generated library
-flashinfer_option(FLASHINFER_GEN_GROUP_SIZES "Group sizes to enable" 1 4 5 6 7 8)
 flashinfer_option(FLASHINFER_GEN_PAGE_SIZES "Prefill page sizes to enable" 1 16 32)
 flashinfer_option(FLASHINFER_GEN_HEAD_DIMS "Head dims to enable" 64 128 256)
 flashinfer_option(FLASHINFER_GEN_KV_LAYOUTS "KV layouts to enable" 0 1)
@@ -80,7 +79,6 @@ if(FLASHINFER_ENABLE_BF16)
 endif(FLASHINFER_ENABLE_BF16)
 
 # generate kernel inst
-set (GROUP_SIZES ${FLASHINFER_GEN_GROUP_SIZES})
 set (PAGE_SIZES ${FLASHINFER_GEN_PAGE_SIZES})
 set (HEAD_DIMS ${FLASHINFER_GEN_HEAD_DIMS})
 set (KV_LAYOUTS ${FLASHINFER_GEN_KV_LAYOUTS})
@@ -103,7 +101,6 @@ if(FLASHINFER_ENABLE_BF16)
 endif(FLASHINFER_ENABLE_BF16)
 
 # log options
-message(STATUS "FLASHINFER_GROUP_SIZES=${GROUP_SIZES}")
 message(STATUS "FLASHINFER_PAGE_SIZES=${PAGE_SIZES}")
 message(STATUS "FLASHINFER_HEAD_DIMS=${HEAD_DIMS}")
 message(STATUS "FLASHINFER_KV_LAYOUTS=${KV_LAYOUTS}")
@@ -116,7 +113,7 @@ file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/src/generated)
 set(dispatch_inc_file ${PROJECT_SOURCE_DIR}/src/dispatch.inc)
 add_custom_command(
   OUTPUT ${dispatch_inc_file}
-  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_dispatch_inc.py --path ${PROJECT_SOURCE_DIR}/src/dispatch.inc --head_dims ${HEAD_DIMS} --page_sizes ${FLASHINFER_GEN_PAGE_SIZES} --group_sizes ${GROUP_SIZES} --kv_layouts ${KV_LAYOUTS} --pos_encoding_modes ${POS_ENCODING_MODES} --allow_fp16_qk_reductions ${ALLOW_FP16_QK_REDUCTIONS} --mask_modes ${MASK_MODES}
+  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_dispatch_inc.py --path ${PROJECT_SOURCE_DIR}/src/dispatch.inc --head_dims ${HEAD_DIMS} --page_sizes ${FLASHINFER_GEN_PAGE_SIZES} --kv_layouts ${KV_LAYOUTS} --pos_encoding_modes ${POS_ENCODING_MODES} --allow_fp16_qk_reductions ${ALLOW_FP16_QK_REDUCTIONS} --mask_modes ${MASK_MODES}
   DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_dispatch_inc.py
   COMMENT "Generating additional source file ${generated_dispatch_inc}"
   VERBATIM
@@ -124,162 +121,127 @@ add_custom_command(
 add_custom_target(dispatch_inc DEPENDS ${dispatch_inc_file})
 
 # single decode kernel inst generation
-foreach(group_size IN LISTS GROUP_SIZES)
-  foreach(head_dim IN LISTS HEAD_DIMS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        foreach(dtype IN LISTS DECODE_DTYPES)
-          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
-          add_custom_command(
-            OUTPUT ${generated_kernel_src}
-            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
-            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
-            COMMENT "Generating additional source file ${generated_kernel_src}"
-            VERBATIM
-          )
-          list(APPEND single_decode_kernels_src ${generated_kernel_src})
-        endforeach(dtype)
+foreach(head_dim IN LISTS HEAD_DIMS)
+  foreach(kv_layout IN LISTS KV_LAYOUTS)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(dtype IN LISTS DECODE_DTYPES)
+        set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+        add_custom_command(
+          OUTPUT ${generated_kernel_src}
+          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+          DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
+          COMMENT "Generating additional source file ${generated_kernel_src}"
+          VERBATIM
+        )
+        list(APPEND single_decode_kernels_src ${generated_kernel_src})
+      endforeach(dtype)
 
-        # fp8 in, fp16 out
-        foreach(dtype IN LISTS DECODE_FP8_DTYPES)
-          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
-          add_custom_command(
-            OUTPUT ${generated_kernel_src}
-            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
-            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
-            COMMENT "Generating additional source file ${generated_kernel_src}"
-            VERBATIM
-          )
-          list(APPEND single_decode_kernels_src ${generated_kernel_src})
-        endforeach(dtype)
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
-  endforeach(head_dim)
-endforeach(group_size)
+      # fp8 in, fp16 out
+      foreach(dtype IN LISTS DECODE_F8_DTYPES)
+        set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
+        add_custom_command(
+          OUTPUT ${generated_kernel_src}
+          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+          DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
+          COMMENT "Generating additional source file ${generated_kernel_src}"
+          VERBATIM
+        )
+        list(APPEND single_decode_kernels_src ${generated_kernel_src})
+      endforeach(dtype)
+    endforeach(pos_encoding_mode)
+  endforeach(kv_layout)
+endforeach(head_dim)
 
 # batch decode kernel inst generation
-foreach(group_size IN LISTS GROUP_SIZES)
-  foreach(head_dim IN LISTS HEAD_DIMS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        # paged kv-cache
-        foreach(idtype IN LISTS IDTYPES)
-          foreach(dtype IN LISTS DECODE_DTYPES)
-            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
-            add_custom_command(
-              OUTPUT ${generated_kernel_src}
-              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
-              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
-              COMMENT "Generating additional source file ${generated_kernel_src}"
-              VERBATIM
-            )
-            list(APPEND batch_decode_kernels_src ${generated_kernel_src})
-          endforeach(dtype)
-
-          # fp8 in, fp16 out
-          foreach(dtype IN LISTS DECODE_FP8_DTYPES)
-            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16_idtype_${idtype}.cu)
-            add_custom_command(
-              OUTPUT ${generated_kernel_src}
-              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
-              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
-              COMMENT "Generating additional source file ${generated_kernel_src}"
-              VERBATIM
-            )
-            list(APPEND batch_decode_kernels_src ${generated_kernel_src})
-          endforeach()
-        endforeach(idtype)
-
-        # padded kv-cache
+foreach(head_dim IN LISTS HEAD_DIMS)
+  foreach(kv_layout IN LISTS KV_LAYOUTS)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      # paged kv-cache
+      foreach(idtype IN LISTS IDTYPES)
         foreach(dtype IN LISTS DECODE_DTYPES)
-          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
-            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
           )
           list(APPEND batch_decode_kernels_src ${generated_kernel_src})
         endforeach(dtype)
 
-        # padded kv-cache, fp8 in, fp16 out
+        # fp8 in, fp16 out
         foreach(dtype IN LISTS DECODE_FP8_DTYPES)
-          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
+          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16_idtype_${idtype}.cu)
           add_custom_command(
             OUTPUT ${generated_kernel_src}
-            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
-            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
             COMMENT "Generating additional source file ${generated_kernel_src}"
             VERBATIM
           )
           list(APPEND batch_decode_kernels_src ${generated_kernel_src})
         endforeach()
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
-  endforeach(head_dim)
-endforeach(group_size)
+      endforeach(idtype)
+
+      # padded kv-cache
+      foreach(dtype IN LISTS DECODE_DTYPES)
+        set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+        add_custom_command(
+          OUTPUT ${generated_kernel_src}
+          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
+          DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
+          COMMENT "Generating additional source file ${generated_kernel_src}"
+          VERBATIM
+        )
+        list(APPEND batch_decode_kernels_src ${generated_kernel_src})
+      endforeach(dtype)
+
+      # padded kv-cache, fp8 in, fp16 out
+      foreach(dtype IN LISTS DECODE_FP8_DTYPES)
+        set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_padded_decode_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypein_${dtype}_dtypeout_f16.cu)
+        add_custom_command(
+          OUTPUT ${generated_kernel_src}
+          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py ${generated_kernel_src}
+          DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_padded_decode_inst.py
+          COMMENT "Generating additional source file ${generated_kernel_src}"
+          VERBATIM
+        )
+        list(APPEND batch_decode_kernels_src ${generated_kernel_src})
+      endforeach()
+    endforeach(pos_encoding_mode)
+  endforeach(kv_layout)
+endforeach(head_dim)
 
 add_library(decode_kernels STATIC ${single_decode_kernels_src} ${batch_decode_kernels_src})
 target_include_directories(decode_kernels PRIVATE ${FLASHINFER_INCLUDE_DIR})
 target_compile_options(decode_kernels PRIVATE -Xcompiler=-fPIC --fatbin-options -compress-all)
 
 # single prefill kernel inst generation
-foreach(group_size IN LISTS GROUP_SIZES)
-  foreach(head_dim IN LISTS HEAD_DIMS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
-          foreach(mask_mode IN LISTS MASK_MODES)
-            foreach(dtype IN LISTS PREFILL_DTYPES)
-              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
-              add_custom_command(
-                OUTPUT ${generated_kernel_src}
-                COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
-                DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
-                COMMENT "Generating additional source file ${generated_kernel_src}"
-                VERBATIM
-              )
-              list(APPEND single_prefill_kernels_src ${generated_kernel_src})
-            endforeach(dtype)
-          endforeach(mask_mode)
-        endforeach(allow_fp16_qk_reduction)
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
-  endforeach(head_dim)
-endforeach(group_size)
+foreach(head_dim IN LISTS HEAD_DIMS)
+  foreach(kv_layout IN LISTS KV_LAYOUTS)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
+        foreach(mask_mode IN LISTS MASK_MODES)
+          foreach(dtype IN LISTS PREFILL_DTYPES)
+            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+            add_custom_command(
+              OUTPUT ${generated_kernel_src}
+              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
+              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
+              COMMENT "Generating additional source file ${generated_kernel_src}"
+              VERBATIM
+            )
+            list(APPEND single_prefill_kernels_src ${generated_kernel_src})
+          endforeach(dtype)
+        endforeach(mask_mode)
+      endforeach(allow_fp16_qk_reduction)
+    endforeach(pos_encoding_mode)
+  endforeach(kv_layout)
+endforeach(head_dim)
 
 # batch paged prefill kernel inst generation
-foreach(group_size IN LISTS GROUP_SIZES)
-  foreach(page_size IN LISTS PAGE_SIZES)
-    foreach(head_dim IN LISTS HEAD_DIMS)
-      foreach(kv_layout IN LISTS KV_LAYOUTS)
-        foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-          foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
-            foreach(mask_mode IN LISTS MASK_MODES)
-              foreach(dtype IN LISTS PREFILL_DTYPES)
-                foreach(idtype IN LISTS IDTYPES)
-                  set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_group_${group_size}_page_${page_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
-                  add_custom_command(
-                    OUTPUT ${generated_kernel_src}
-                    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
-                    DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py
-                    COMMENT "Generating additional source file ${generated_kernel_src}"
-                    VERBATIM
-                  )
-                  list(APPEND batch_paged_prefill_kernels_src ${generated_kernel_src})
-                endforeach(idtype)
-              endforeach(dtype)
-            endforeach(mask_mode)
-          endforeach(allow_fp16_qk_reduction)
-        endforeach(pos_encoding_mode)
-      endforeach(kv_layout)
-    endforeach(head_dim)
-  endforeach(page_size)
-endforeach(group_size)
-
-# batch ragged prefill kernel inst generation
-foreach(group_size IN LISTS GROUP_SIZES)
+foreach(page_size IN LISTS PAGE_SIZES)
   foreach(head_dim IN LISTS HEAD_DIMS)
     foreach(kv_layout IN LISTS KV_LAYOUTS)
       foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
@@ -287,15 +249,15 @@ foreach(group_size IN LISTS GROUP_SIZES)
           foreach(mask_mode IN LISTS MASK_MODES)
             foreach(dtype IN LISTS PREFILL_DTYPES)
               foreach(idtype IN LISTS IDTYPES)
-                set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_group_${group_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+                set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_page_${page_size}_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
                 add_custom_command(
                   OUTPUT ${generated_kernel_src}
-                  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
-                  DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py
+                  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
+                  DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py
                   COMMENT "Generating additional source file ${generated_kernel_src}"
                   VERBATIM
                 )
-                list(APPEND batch_ragged_prefill_kernels_src ${generated_kernel_src})
+                list(APPEND batch_paged_prefill_kernels_src ${generated_kernel_src})
               endforeach(idtype)
             endforeach(dtype)
           endforeach(mask_mode)
@@ -303,7 +265,32 @@ foreach(group_size IN LISTS GROUP_SIZES)
       endforeach(pos_encoding_mode)
     endforeach(kv_layout)
   endforeach(head_dim)
-endforeach(group_size)
+endforeach(page_size)
+
+# batch ragged prefill kernel inst generation
+foreach(head_dim IN LISTS HEAD_DIMS)
+  foreach(kv_layout IN LISTS KV_LAYOUTS)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
+        foreach(mask_mode IN LISTS MASK_MODES)
+          foreach(dtype IN LISTS PREFILL_DTYPES)
+            foreach(idtype IN LISTS IDTYPES)
+              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_head_${head_dim}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+              add_custom_command(
+                OUTPUT ${generated_kernel_src}
+                COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
+                DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py
+                COMMENT "Generating additional source file ${generated_kernel_src}"
+                VERBATIM
+              )
+              list(APPEND batch_ragged_prefill_kernels_src ${generated_kernel_src})
+            endforeach(idtype)
+          endforeach(dtype)
+        endforeach(mask_mode)
+      endforeach(allow_fp16_qk_reduction)
+    endforeach(pos_encoding_mode)
+  endforeach(kv_layout)
+endforeach(head_dim)
 
 add_library(prefill_kernels STATIC ${single_prefill_kernels_src} ${batch_paged_prefill_kernels_src} ${batch_ragged_prefill_kernels_src})
 target_include_directories(prefill_kernels PRIVATE ${FLASHINFER_INCLUDE_DIR})

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -22,7 +22,6 @@ set(FLASHINFER_FASTDIV_TEST ON)
 set(FLASHINFER_DISTRIBUTED ON)
 # The following configurations can impact the binary
 # size of the generated library
-set(FLASHINFER_GEN_GROUP_SIZES 1 4 6 8)
 set(FLASHINFER_GEN_PAGE_SIZES 1 16 32)
 set(FLASHINFER_GEN_HEAD_DIMS 64 128 256)
 set(FLASHINFER_GEN_KV_LAYOUTS 0 1)

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -79,10 +79,10 @@ enum class FragLayout {
  * \note The sin/cos computation is slow, especially for A100 GPUs which has low
  *   non tensor-ops flops, will optimize in the future.
  */
-template <FragLayout frag_layout, uint32_t group_size, typename T>
-__device__ __forceinline__ void frag_apply_llama_rope(T* x_first_half, T* x_second_half,
-                                                      const float* rope_freq, uint32_t offset,
-                                                      float scale = 1.f) {
+template <FragLayout frag_layout, typename T>
+__device__ __forceinline__ void k_frag_apply_llama_rope(T* x_first_half, T* x_second_half,
+                                                        const float* rope_freq,
+                                                        const uint32_t offset, float scale = 1.f) {
 #pragma unroll
   for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
     float cos, sin, tmp;
@@ -100,21 +100,52 @@ __device__ __forceinline__ void frag_apply_llama_rope(T* x_first_half, T* x_seco
       i = reg_id / 4;
       j = (reg_id % 4) / 2;
     }
-    __sincosf(float(offset + (8 / group_size) * i) * rope_freq[2 * j + reg_id % 2], &sin, &cos);
+    __sincosf(float(offset + 8 * i) * rope_freq[2 * j + reg_id % 2], &sin, &cos);
     tmp = x_first_half[reg_id];
     x_first_half[reg_id] = (tmp * cos - (float)x_second_half[reg_id] * sin) * scale;
     x_second_half[reg_id] = ((float)x_second_half[reg_id] * cos + tmp * sin) * scale;
   }
 }
 
-template <FragLayout frag_layout, uint32_t group_size, typename T, typename IdType>
-__device__ __forceinline__ void frag_apply_llama_rope_with_pos(T* x_first_half, T* x_second_half,
-                                                               const float* rope_freq,
-                                                               uint32_t offset,
-                                                               const IdType* q_offset,
-                                                               float scale = 1.f) {
-  float pos[2] = {static_cast<float>(q_offset[offset]),
-                  static_cast<float>(q_offset[offset + (8 / group_size)])};
+template <FragLayout frag_layout, typename T>
+__device__ __forceinline__ void q_frag_apply_llama_rope(T* x_first_half, T* x_second_half,
+                                                        const float* rope_freq,
+                                                        const uint32_t pre_group_division_offset,
+                                                        const uint32_t group_size,
+                                                        float scale = 1.f) {
+#pragma unroll
+  for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+    float cos, sin, tmp;
+    uint32_t i, j;
+    if constexpr (frag_layout == FragLayout::kRowMajor) {
+      // 0 1 | 4 5
+      // ---------
+      // 2 3 | 6 7
+      i = ((reg_id % 4) / 2);
+      j = (reg_id / 4);
+    } else {
+      // 0 1 | 2 3
+      // ---------
+      // 4 5 | 6 7
+      i = reg_id / 4;
+      j = (reg_id % 4) / 2;
+    }
+    __sincosf(
+        float((pre_group_division_offset + 8 * i) / group_size) * rope_freq[2 * j + reg_id % 2],
+        &sin, &cos);
+    tmp = x_first_half[reg_id];
+    x_first_half[reg_id] = (tmp * cos - (float)x_second_half[reg_id] * sin) * scale;
+    x_second_half[reg_id] = ((float)x_second_half[reg_id] * cos + tmp * sin) * scale;
+  }
+}
+
+template <FragLayout frag_layout, typename T, typename IdType>
+__device__ __forceinline__ void q_frag_apply_llama_rope_with_pos(
+    T* x_first_half, T* x_second_half, const float* rope_freq,
+    const uint32_t pre_group_division_offset, const uint32_t group_size, const IdType* q_offset,
+    float scale = 1.f) {
+  float pos[2] = {static_cast<float>(q_offset[pre_group_division_offset / group_size]),
+                  static_cast<float>(q_offset[(pre_group_division_offset + 8) / group_size])};
 #pragma unroll
   for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
     float cos, sin, tmp;
@@ -146,7 +177,6 @@ __device__ __forceinline__ void frag_apply_llama_rope_with_pos(T* x_first_half, 
  * \tparam num_frags_z The number of fragments in z dimension.
  * \tparam num_warps The number of warps in the threadblock.
  * \tparam kv_layout The layout of the input tensor.
- * \tparam group_size The number of qo heads that maps to a kv head (used in GQA).
  * \tparam T The data type of the input tensor.
  * \param smem The shared memory to store kv fragments.
  * \param gptr The global memory pointer.
@@ -282,34 +312,32 @@ __device__ __forceinline__ void init_states(float (*o_frag)[num_frags_y][8], DTy
   }
 }
 
-template <uint32_t group_size, uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeIn>
-__device__ __forceinline__ void load_q_global_smem(uint32_t q_idx_base,
+template <uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeIn>
+__device__ __forceinline__ void load_q_global_smem(uint32_t pre_group_division_offset,
                                                    const uint32_t qo_upper_bound,
                                                    DTypeIn* q_ptr_base, const uint32_t qo_n_stride,
-                                                   const uint32_t qo_h_stride, smem_t* q_smem) {
-  constexpr uint32_t rows_per_warp = 16 / (2 * group_size) * 2;
-  constexpr uint32_t aligned_group_size = 16 / rows_per_warp;
+                                                   const uint32_t qo_h_stride,
+                                                   const uint32_t group_size, smem_t* q_smem) {
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
   const uint32_t tx = threadIdx.x, ty = threadIdx.y;
   uint32_t q_smem_offset_w =
       smem_t::get_permuted_offset<channel_size_128b_in>(ty * num_frags_x * 16 + tx / 8, tx % 8);
 
-  q_idx_base += (tx / 8) / aligned_group_size;
-  q_ptr_base += ((tx / 8) / aligned_group_size) * qo_n_stride;
 #pragma unroll
   for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
 #pragma unroll
     for (uint32_t j = 0; j < 4; ++j) {
-      const uint32_t q_idx = q_idx_base + (fx * 16 + j * 4) / aligned_group_size;
-      const uint32_t group_id = (fx * 16 + j * 4 + tx / 8) % aligned_group_size;
-      DTypeIn* q_ptr = q_ptr_base + ((fx * 16 + j * 4) / aligned_group_size) * qo_n_stride +
-                       group_id * qo_h_stride;
+      const uint32_t q_idx = (pre_group_division_offset + tx / 8 + fx * 16 + j * 4) / group_size;
+      DTypeIn* q_ptr =
+          q_ptr_base +
+          ((pre_group_division_offset + tx / 8 + fx * 16 + j * 4) / group_size) * qo_n_stride +
+          ((pre_group_division_offset + tx / 8 + fx * 16 + j * 4) % group_size) * qo_h_stride;
 #pragma unroll
       for (uint32_t fyo = 0; fyo < num_frags_y / 4; ++fyo) {
         // load q fragment from gmem to smem
-        q_smem->load_128b_async<SharedMemFillMode::kFillZero>(
-            q_smem_offset_w, q_ptr, q_idx < qo_upper_bound && group_id < group_size);
+        q_smem->load_128b_async<SharedMemFillMode::kNoFill>(q_smem_offset_w, q_ptr,
+                                                            q_idx < qo_upper_bound);
         q_smem_offset_w = q_smem->advance_offset_by_column<8>(q_smem_offset_w, fyo);
         q_ptr += 8 * num_elems_per_128b<DTypeIn>();
       }
@@ -319,11 +347,11 @@ __device__ __forceinline__ void load_q_global_smem(uint32_t q_idx_base,
   }
 }
 
-template <uint32_t group_size, uint32_t num_warps, uint32_t num_frags_x, uint32_t num_frags_y,
-          typename DTypeIn>
+template <uint32_t num_warps, uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeIn>
 __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
-    const uint32_t q_idx_base, const uint32_t qo_len, const uint32_t kv_len, smem_t* q_smem,
-    uint32_t* q_smem_offset_r, float (*rope_freq)[4], const float sm_scale) {
+    const uint32_t q_pre_group_division_idx, const uint32_t qo_len, const uint32_t kv_len,
+    const uint32_t group_size, smem_t* q_smem, uint32_t* q_smem_offset_r, float (*rope_freq)[4],
+    const float sm_scale) {
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
   const uint32_t tx = threadIdx.x;
@@ -331,7 +359,6 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
   static_assert(num_frags_y % 4 == 0, "num_frags_y must be a multiple of 4");
 #pragma unroll
   for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
-    uint32_t q_idx = q_idx_base + (fx * 16 + tx / 4) / group_size;
     uint32_t q_smem_offset_r_first_half = *q_smem_offset_r;
 #pragma unroll
     for (uint32_t fyi = 0; fyi < num_frags_y / 2; ++fyi) {
@@ -339,9 +366,10 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
       uint32_t q_smem_offset_r_last_half =
           q_smem->advance_offset_by_column<num_frags_y>(q_smem_offset_r_first_half, 0);
       q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
-      frag_apply_llama_rope<FragLayout::kRowMajor, group_size, DTypeIn>(
+      q_frag_apply_llama_rope<FragLayout::kRowMajor, DTypeIn>(
           (DTypeIn*)q_frag_local[0], (DTypeIn*)q_frag_local[1], rope_freq[fyi],
-          q_idx + kv_len - qo_len, sm_scale);
+          q_pre_group_division_idx + kv_len * group_size - qo_len * group_size,
+          tx % 8 + fx * 16 + tx / 4, group_size, sm_scale);
       q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
       q_smem->stmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
       q_smem_offset_r_first_half =
@@ -352,11 +380,11 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
   *q_smem_offset_r -= num_frags_x * 16 * channel_size_128b_in;
 }
 
-template <uint32_t group_size, uint32_t num_warps, uint32_t num_frags_x, uint32_t num_frags_y,
-          typename DTypeIn, typename IdType>
+template <uint32_t num_warps, uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeIn,
+          typename IdType>
 __device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale(
-    const uint32_t q_idx_base, const IdType* q_offset, smem_t* q_smem, uint32_t* q_smem_offset_r,
-    float (*rope_freq)[4], const float sm_scale) {
+    const uint32_t q_idx_base, const IdType* q_offset, smem_t* q_smem, const uint32_t group_size,
+    uint32_t* q_smem_offset_r, float (*rope_freq)[4], const float sm_scale) {
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
   const uint32_t tx = threadIdx.x;
@@ -364,7 +392,6 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos_multiply_sm
   static_assert(num_frags_y % 4 == 0, "num_frags_y must be a multiple of 4");
 #pragma unroll
   for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
-    uint32_t q_idx = q_idx_base + (fx * 16 + tx / 4) / group_size;
     uint32_t q_smem_offset_r_first_half = *q_smem_offset_r;
 #pragma unroll
     for (uint32_t fyi = 0; fyi < num_frags_y / 2; ++fyi) {
@@ -372,9 +399,9 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos_multiply_sm
       uint32_t q_smem_offset_r_last_half =
           q_smem->advance_offset_by_column<num_frags_y>(q_smem_offset_r_first_half, 0);
       q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
-      frag_apply_llama_rope_with_pos<FragLayout::kRowMajor, group_size, DTypeIn>(
-          (DTypeIn*)q_frag_local[0], (DTypeIn*)q_frag_local[1], rope_freq[fyi], q_idx, q_offset,
-          sm_scale);
+      q_frag_apply_llama_rope_with_pos<FragLayout::kRowMajor, DTypeIn>(
+          (DTypeIn*)q_frag_local[0], (DTypeIn*)q_frag_local[1], rope_freq[fyi], q_idx_base,
+          tx % 8 + fx * 16 + tx / 4, group_size, q_offset, sm_scale);
       q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
       q_smem->stmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
       q_smem_offset_r_first_half =
@@ -433,7 +460,7 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_id
       uint32_t k_smem_offset_r_last_half =
           k_smem->advance_offset_by_column<4>(k_smem_offset_r_first_half, 0);
       k_smem->ldmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
-      frag_apply_llama_rope<FragLayout::kColMajor, 1, DTypeIn>(
+      k_frag_apply_llama_rope<FragLayout::kColMajor, 1, DTypeIn>(
           (DTypeIn*)k_frag_local[0], (DTypeIn*)k_frag_local[1], rope_freq[fyi], kv_idx);
       k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
       k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
@@ -527,10 +554,10 @@ __device__ __forceinline__ void compute_qk(smem_t* q_smem, uint32_t* q_smem_offs
   *k_smem_offset_r -= num_frags_y * 2;
 }
 
-template <uint32_t group_size, uint32_t num_frags_x, uint32_t num_frags_z, typename T>
-__device__ __forceinline__ void apply_alibi_bias(const uint32_t qo_idx_base,
+template <uint32_t num_frags_x, uint32_t num_frags_z, typename T>
+__device__ __forceinline__ void apply_alibi_bias(const uint32_t qo_pre_group_division_idx_base,
                                                  const uint32_t kv_idx_base, const int32_t q_offset,
-                                                 float (*alibi_slope)[2],
+                                                 const uint32_t group_size, float (*alibi_slope)[2],
                                                  T (*s_frag)[num_frags_z][8]) {
   const int32_t tx = threadIdx.x;
 #pragma unroll
@@ -539,8 +566,9 @@ __device__ __forceinline__ void apply_alibi_bias(const uint32_t qo_idx_base,
     for (int32_t fz = 0; fz < num_frags_z; ++fz) {
 #pragma unroll
       for (int32_t reg_id = 0; reg_id < 8; ++reg_id) {
-        const int32_t q_idx =
-                          qo_idx_base + (fx * 16 + tx / 4 + 8 * ((reg_id % 4) / 2)) / group_size,
+        const int32_t q_idx = (qo_pre_group_division_idx_base + fx * 16 + tx / 4 +
+                               8 * ((reg_id % 4) / 2)) /
+                              group_size,
                       kv_idx = kv_idx_base + fz * 16 + 2 * (tx % 4) + 8 * (reg_id / 4) + reg_id % 2;
         s_frag[fx][fz][reg_id] +=
             T(alibi_slope[fx][(reg_id % 4) / 2]) * T(kv_idx - q_idx - q_offset);
@@ -549,11 +577,12 @@ __device__ __forceinline__ void apply_alibi_bias(const uint32_t qo_idx_base,
   }
 }
 
-template <bool partition_kv, MaskMode mask_mode, uint32_t group_size, uint32_t num_warps,
-          uint32_t num_frags_x, uint32_t num_frags_y, uint32_t num_frags_z, typename DTypeQKAccum>
-__device__ __forceinline__ void mask_s(const uint32_t qo_idx_base, const uint32_t kv_idx_base,
-                                       const uint32_t qo_len, const uint32_t kv_len,
-                                       const uint32_t chunk_end, float* custom_mask,
+template <bool partition_kv, MaskMode mask_mode, uint32_t num_warps, uint32_t num_frags_x,
+          uint32_t num_frags_y, uint32_t num_frags_z, typename DTypeQKAccum>
+__device__ __forceinline__ void mask_s(const uint32_t qo_pre_group_division_idx_base,
+                                       const uint32_t kv_idx_base, const uint32_t qo_len,
+                                       const uint32_t kv_len, const uint32_t chunk_end,
+                                       const uint32_t group_size, float* custom_mask,
                                        DTypeQKAccum (*s_frag)[num_frags_z][8]) {
   const uint32_t tx = threadIdx.x;
 #pragma unroll
@@ -562,8 +591,9 @@ __device__ __forceinline__ void mask_s(const uint32_t qo_idx_base, const uint32_
     for (uint32_t fz = 0; fz < num_frags_z; ++fz) {
 #pragma unroll
       for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
-        const uint32_t q_idx =
-                           qo_idx_base + (fx * 16 + tx / 4 + 8 * ((reg_id % 4) / 2)) / group_size,
+        const uint32_t q_idx = (qo_pre_group_division_idx_base + fx * 16 + tx / 4 +
+                                8 * ((reg_id % 4) / 2)) /
+                               group_size,
                        kv_idx =
                            kv_idx_base + fz * 16 + 2 * (tx % 4) + 8 * (reg_id / 4) + reg_id % 2;
         const bool out_of_boundary =
@@ -813,14 +843,11 @@ __device__ __forceinline__ void grid_sync_mdo_states(float (*o_frag)[num_frags_y
   }
 }
 
-template <uint32_t group_size, uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeOut>
-__device__ __forceinline__ void write_o_reg_gmem(float (*o_frag)[num_frags_y][8], smem_t* o_smem,
-                                                 DTypeOut* o_ptr_base, uint32_t o_idx_base,
-                                                 const uint32_t qo_upper_bound,
-                                                 const uint32_t qo_n_stride,
-                                                 const uint32_t qo_h_stride) {
-  constexpr uint32_t rows_per_warp = 16 / (2 * group_size) * 2;
-  constexpr uint32_t aligned_group_size = 16 / rows_per_warp;
+template <uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeOut>
+__device__ __forceinline__ void write_o_reg_gmem(
+    float (*o_frag)[num_frags_y][8], smem_t* o_smem, DTypeOut* o_ptr_base,
+    uint32_t o_pre_group_division_idx_base, const uint32_t qo_upper_bound,
+    const uint32_t qo_n_stride, const uint32_t qo_h_stride, const uint32_t group_size) {
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
   const uint32_t tx = threadIdx.x, ty = threadIdx.y;
@@ -845,19 +872,19 @@ __device__ __forceinline__ void write_o_reg_gmem(float (*o_frag)[num_frags_y][8]
   uint32_t o_smem_offset_w =
       smem_t::get_permuted_offset<channel_size_128b_out>(ty * num_frags_x * 16 + tx / 8, tx % 8);
 
-  o_idx_base += (tx / 8) / aligned_group_size;
-  o_ptr_base += ((tx / 8) / group_size) * qo_n_stride;
 #pragma unroll
   for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
 #pragma unroll
     for (uint32_t j = 0; j < 4; ++j) {
-      const uint32_t o_idx = o_idx_base + (fx * 16 + j * 4) / aligned_group_size;
-      const uint32_t group_id = (fx * 16 + j * 4 + tx / 8) % aligned_group_size;
-      DTypeOut* o_ptr = o_ptr_base + ((fx * 16 + j * 4) / aligned_group_size) * qo_n_stride +
-                        group_id * qo_h_stride;
+      const uint32_t o_idx =
+          (o_pre_group_division_idx_base + tx / 8 + fx * 16 + j * 4) / group_size;
+      DTypeOut* o_ptr =
+          o_ptr_base +
+          ((o_pre_group_division_idx_base + tx / 8 + fx * 16 + j * 4) / group_size) * qo_n_stride +
+          ((o_pre_group_division_idx_base + tx / 8 + fx * 16 + j * 4) % group_size) * qo_h_stride;
 #pragma unroll
       for (uint32_t fyo = 0; fyo < num_frags_y / 4; ++fyo) {
-        if (o_idx < qo_upper_bound && group_id < group_size) {
+        if (o_idx < qo_upper_bound) {
           o_smem->store_128b(o_smem_offset_w, o_ptr);
         }
         o_ptr += 8 * num_elems_per_128b<DTypeOut>();
@@ -874,7 +901,6 @@ __device__ __forceinline__ void write_o_reg_gmem(float (*o_frag)[num_frags_y][8]
 /*!
  * \brief FlashAttention prefill CUDA kernel for a single request.
  * \tparam partition_kv Whether to split kv_len into chunks.
- * \tparam group_size The number of qo heads that maps to a kv head (used in GQA).
  * \tparam mask_mode The mask mode used in the attention operation.
  * \tparam kv_layout The layout of the input tensor.
  * \tparam pos_encoding_mode The positional encoding mode.
@@ -897,14 +923,14 @@ __device__ __forceinline__ void write_o_reg_gmem(float (*o_frag)[num_frags_y][8]
  * \param log2_rope_rcp_theta log2(1/(rope_theta)), where rope_theta is the theta
  *   used in RoPE.
  */
-template <bool partition_kv, uint32_t group_size, MaskMode mask_mode, QKVLayout kv_layout,
+template <bool partition_kv, MaskMode mask_mode, QKVLayout kv_layout,
           PosEncodingMode pos_encoding_mode, uint32_t num_frags_x, uint32_t num_frags_y,
           uint32_t num_frags_z, uint32_t num_warps, typename DTypeIn, typename DTypeQKAccum,
           typename DTypeOut>
 __global__ void SinglePrefillWithKVCacheKernel(
     DTypeIn* __restrict__ q, DTypeIn* __restrict__ k, DTypeIn* __restrict__ v,
     float* __restrict__ custom_mask, DTypeOut* __restrict__ o, void* __restrict__ tmp,
-    float* __restrict__ lse, const tensor_info_t<kv_layout, group_size, num_frags_y * 16> qkv_info,
+    float* __restrict__ lse, const tensor_info_t<kv_layout, num_frags_y * 16> qkv_info,
     float sm_scale, const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
   static_assert(sizeof(DTypeIn) == 2);
   static_assert(sizeof(DTypeOut) == 2);
@@ -913,6 +939,7 @@ __global__ void SinglePrefillWithKVCacheKernel(
   const uint32_t kv_len = qkv_info.kv_len;
   const uint32_t tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t bx = blockIdx.x, chunk_idx = blockIdx.y, kv_head_idx = blockIdx.z;
+  const uint32_t group_size = qkv_info.get_group_size();
   float alibi_slopes[num_frags_x][2];
   if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
 #pragma unroll
@@ -938,7 +965,6 @@ __global__ void SinglePrefillWithKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size >= 4 && group_size <= 8);
 
   extern __shared__ uint8_t smem[];
 
@@ -953,33 +979,34 @@ __global__ void SinglePrefillWithKVCacheKernel(
   init_states<num_frags_x, num_frags_y>(o_frag, m, d);
 
   // cooperative fetch q fragment from gmem to reg
-  const uint32_t qo_idx_base = ((bx * num_warps + ty) * num_frags_x * 16) / group_size;
+  const uint32_t qo_pre_group_division_idx_base = (bx * num_warps + ty) * num_frags_x * 16;
   const uint32_t kv_n_stride = qkv_info.get_kv_n_stride(), qo_n_stride = qkv_info.get_qo_n_stride(),
                  qo_h_stride = qkv_info.get_qo_h_stride();
   smem_t qo_smem(smem);
-  DTypeIn* q_ptr_base = q + qkv_info.get_qo_elem_offset(qo_idx_base, kv_head_idx * group_size,
+  DTypeIn* q_ptr_base = q + qkv_info.get_qo_elem_offset(0, kv_head_idx * group_size,
                                                         (tx % 8) * num_elems_per_128b<DTypeIn>());
   DTypeOut* o_ptr_base =
-      partition_kv
-          ? ((DTypeOut*)tmp) + chunk_idx * qkv_info.get_num_qo_heads() * head_dim +
-                qkv_info.get_qo_elem_offset(qo_idx_base * num_chunks, kv_head_idx * group_size,
-                                            (tx % 8) * num_elems_per_128b<DTypeOut>())
-          : o + qkv_info.get_qo_elem_offset(qo_idx_base, kv_head_idx * group_size,
-                                            (tx % 8) * num_elems_per_128b<DTypeOut>());
+      partition_kv ? ((DTypeOut*)tmp) + chunk_idx * qkv_info.get_num_qo_heads() * head_dim +
+                         qkv_info.get_qo_elem_offset(
+                             (qo_pre_group_division_idx_base / group_size) * num_chunks,
+                             kv_head_idx * group_size, (tx % 8) * num_elems_per_128b<DTypeOut>())
+                   : o + qkv_info.get_qo_elem_offset((qo_pre_group_division_idx_base / group_size),
+                                                     kv_head_idx * group_size,
+                                                     (tx % 8) * num_elems_per_128b<DTypeOut>());
   uint32_t q_smem_offset_r =
       smem_t::get_permuted_offset<channel_size_128b_in>(ty * num_frags_x * 16 + tx % 16, tx / 16);
 
-  load_q_global_smem<group_size, num_frags_x, num_frags_y>(qo_idx_base, qo_len, q_ptr_base,
-                                                           qo_n_stride, qo_h_stride, &qo_smem);
+  load_q_global_smem<num_frags_x, num_frags_y>(qo_pre_group_division_idx_base, qo_len, q_ptr_base,
+                                               qo_n_stride, qo_h_stride, group_size, &qo_smem);
 
   cp_async::commit_group();
   cp_async::wait_group<0>();
   block.sync();
 
   if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
-    q_smem_inplace_apply_rotary_multiply_sm_scale<group_size, num_warps, num_frags_x, num_frags_y,
-                                                  DTypeIn>(qo_idx_base, qo_len, kv_len, &qo_smem,
-                                                           &q_smem_offset_r, rope_freq, sm_scale);
+    q_smem_inplace_apply_rotary_multiply_sm_scale<num_warps, num_frags_x, num_frags_y, DTypeIn>(
+        qo_pre_group_division_idx_base, qo_len, kv_len, &qo_smem, &q_smem_offset_r, rope_freq,
+        sm_scale);
   } else {
     q_smem_inplace_multiply_sm_scale<num_frags_x, num_frags_y, DTypeIn>(&qo_smem, sm_scale);
   }
@@ -1037,20 +1064,20 @@ __global__ void SinglePrefillWithKVCacheKernel(
                                                                &k_smem_offset_r, s_frag);
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
-      apply_alibi_bias<group_size, num_frags_x, num_frags_z>(
-          qo_idx_base, chunk_start + iter * 16 * num_frags_z, int(kv_len) - int(qo_len),
-          alibi_slopes, s_frag);
+      apply_alibi_bias<num_frags_x, num_frags_z>(qo_pre_group_division_idx_base,
+                                                 chunk_start + iter * 16 * num_frags_z,
+                                                 int(kv_len) - int(qo_len), alibi_slopes, s_frag);
     }
     // apply mask
     if constexpr (mask_mode == MaskMode::kCustom) {
-      mask_s<partition_kv, mask_mode, group_size, num_warps, num_frags_x, num_frags_y, num_frags_z>(
-          qo_idx_base, chunk_start + iter * 16 * num_frags_z, qo_len, kv_len, chunk_end,
-          custom_mask, s_frag);
+      mask_s<partition_kv, mask_mode, num_warps, num_frags_x, num_frags_y, num_frags_z>(
+          qo_pre_group_division_idx_base, chunk_start + iter * 16 * num_frags_z, qo_len, kv_len,
+          chunk_end, group_size, custom_mask, s_frag);
     } else {
       if (iter >= mask_iteration) {
-        mask_s<partition_kv, mask_mode, group_size, num_warps, num_frags_x, num_frags_y,
-               num_frags_z>(qo_idx_base, chunk_start + iter * 16 * num_frags_z, qo_len, kv_len,
-                            chunk_end, nullptr, s_frag);
+        mask_s<partition_kv, mask_mode, num_warps, num_frags_x, num_frags_y, num_frags_z>(
+            qo_pre_group_division_idx_base, chunk_start + iter * 16 * num_frags_z, qo_len, kv_len,
+            chunk_end, group_size, nullptr, s_frag);
       }
     }
 
@@ -1082,9 +1109,10 @@ __global__ void SinglePrefillWithKVCacheKernel(
   normalize_d<num_frags_x, num_frags_y>(o_frag, d);
 
   // write back
-  write_o_reg_gmem<group_size, num_frags_x, num_frags_y>(
-      o_frag, &qo_smem, o_ptr_base, qo_idx_base, qo_len,
-      partition_kv ? qo_n_stride * num_chunks : qo_n_stride, qo_h_stride);
+  // TODO(Zihao): start from here
+  write_o_reg_gmem<num_frags_x, num_frags_y>(o_frag, &qo_smem, o_ptr_base, qo_idx_base, qo_len,
+                                             partition_kv ? qo_n_stride * num_chunks : qo_n_stride,
+                                             qo_h_stride);
 
   // write lse
   if (lse != nullptr || partition_kv) {
@@ -1121,8 +1149,8 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
     DTypeIn* __restrict__ v, IdType* __restrict__ kv_indptr, float* __restrict__ custom_mask,
     IdType* __restrict__ qk_indptr, IdType* __restrict__ q_offset,
     IdType* __restrict__ k_rope_pos_offset, DTypeOut* __restrict__ o, float* __restrict__ tmp,
-    float* __restrict__ lse, uint32_t batch_size, float sm_scale, float log2_rope_rcp_scale,
-    float log2_rope_rcp_theta) {
+    float* __restrict__ lse, uint32_t batch_size, uint32_t num_qo_heads, float sm_scale,
+    float log2_rope_rcp_scale, float log2_rope_rcp_theta) {
   static_assert(sizeof(DTypeIn) == 2);
   static_assert(sizeof(DTypeOut) == 2);
   sm_scale *= math::log2e;
@@ -1135,8 +1163,9 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
   constexpr uint32_t num_rows_per_cta = num_frags_x * num_warps * 16;
   const uint32_t qo_len = qo_indptr[request_idx + 1] - qo_indptr[request_idx],
                  kv_len = kv_indptr[request_idx + 1] - kv_indptr[request_idx];
-  const tensor_info_t<kv_layout, group_size, num_frags_y * 16> qkv_info(qo_len, kv_len,
-                                                                        num_kv_heads);
+  const tensor_info_t<kv_layout, num_frags_y * 16> qkv_info(qo_len, kv_len, num_qo_heads,
+                                                            num_kv_heads);
+  const uint32_t group_size = qkv_info.get_group_size();
   float alibi_slopes[num_frags_x][2];
   if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
 #pragma unroll
@@ -1157,7 +1186,6 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size % 4 == 0 || group_size == 6);
 
   extern __shared__ uint8_t smem[];
 
@@ -1187,8 +1215,8 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
   uint32_t q_smem_offset_r =
       smem_t::get_permuted_offset<channel_size_128b_in>(ty * num_frags_x * 16 + tx % 16, tx / 16);
 
-  load_q_global_smem<group_size, num_frags_x, num_frags_y>(qo_idx_base, qo_upper_bound, q_ptr_base,
-                                                           qo_n_stride, qo_h_stride, &qo_smem);
+  load_q_global_smem<num_frags_x, num_frags_y>(qo_idx_base, qo_upper_bound, q_ptr_base, qo_n_stride,
+                                               qo_h_stride, group_size, &qo_smem);
 
   cp_async::commit_group();
   cp_async::wait_group<0>();
@@ -1196,12 +1224,11 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
 
   if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
     if (!q_offset) {
-      q_smem_inplace_apply_rotary_multiply_sm_scale<group_size, num_warps, num_frags_x, num_frags_y,
-                                                    DTypeIn>(qo_idx_base, qo_len, kv_len, &qo_smem,
-                                                             &q_smem_offset_r, rope_freq, sm_scale);
+      q_smem_inplace_apply_rotary_multiply_sm_scale<num_warps, num_frags_x, num_frags_y, DTypeIn>(
+          qo_idx_base, qo_len, kv_len, &qo_smem, &q_smem_offset_r, rope_freq, sm_scale);
     } else {
-      q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale<group_size, num_warps, num_frags_x,
-                                                             num_frags_y, DTypeIn>(
+      q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale<num_warps, num_frags_x, num_frags_y,
+                                                             DTypeIn>(
           qo_indptr[request_idx] + qo_idx_base, q_offset, &qo_smem, &q_smem_offset_r, rope_freq,
           sm_scale);
     }
@@ -1264,8 +1291,8 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
       // TODO(Zihao): handle the case that q_offset is specified
-      apply_alibi_bias<group_size, num_frags_x, num_frags_z>(
-          qo_idx_base, iter * 16 * num_frags_z, int(kv_len) - int(qo_len), alibi_slopes, s_frag);
+      apply_alibi_bias<num_frags_x, num_frags_z>(qo_idx_base, iter * 16 * num_frags_z,
+                                                 int(kv_len) - int(qo_len), alibi_slopes, s_frag);
     }
     // apply mask
     if constexpr (mask_mode == MaskMode::kCustom) {
@@ -1306,8 +1333,8 @@ __global__ void BatchPrefillWithRaggedKVCacheKernel(
   normalize_d<num_frags_x, num_frags_y>(o_frag, d);
 
   // write back
-  write_o_reg_gmem<group_size, num_frags_x, num_frags_y>(o_frag, &qo_smem, o_ptr_base, qo_idx_base,
-                                                         qo_len, qo_n_stride, qo_h_stride);
+  write_o_reg_gmem<num_frags_x, num_frags_y>(o_frag, &qo_smem, o_ptr_base, qo_idx_base, qo_len,
+                                             qo_n_stride, qo_h_stride);
 
   // write lse
   if (lse != nullptr) {
@@ -1346,7 +1373,8 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
   auto block = cg::this_thread_block();
 
   const uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y, kv_head_idx = blockIdx.z;
-  const uint32_t num_kv_heads = gridDim.z, num_qo_heads = num_kv_heads * group_size;
+  const uint32_t num_kv_heads = gridDim.z;
+  const uint32_t group_size = num_qo_heads / num_kv_heads;
   float alibi_slopes[num_frags_x][2];
   if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
 #pragma unroll
@@ -1354,7 +1382,7 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
         const uint32_t qo_head_idx =
-            kv_head_idx * group_size + (tx / 4 + j * 8 + fx * 16) % aligned_group_size;
+            kv_head_idx * group_size + (tx / 4 + j * 8 + fx * 16) % group_size;
         alibi_slopes[fx][j] = get_alibi_slope(qo_head_idx, num_qo_heads) * math::log2e;
       }
     }
@@ -1365,8 +1393,7 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
                  kv_len = (paged_kv.indptr[request_idx + 1] - paged_kv.indptr[request_idx] - 1) *
                               paged_kv.page_size +
                           paged_kv.last_page_len[request_idx];
-  const uint32_t qo_upper_bound =
-      min(qo_len, (tile_idx + 1) * (num_rows_per_cta / aligned_group_size));
+  const uint32_t qo_upper_bound = min(qo_len, (tile_idx + 1) * (num_rows_per_cta / group_size));
 
   constexpr bool partition_kv = false;
   constexpr uint32_t head_dim = num_frags_y * 16;
@@ -1374,7 +1401,6 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   static_assert(num_frags_z * num_frags_y % num_warps == 0);
-  static_assert(group_size == 1 || group_size >= 4 && group_size <= 8);
 
   extern __shared__ uint8_t smem[];
 
@@ -1389,8 +1415,7 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
   }
   init_states<num_frags_x, num_frags_y>(o_frag, m, d);
 
-  const uint32_t qo_idx_base =
-      ((tile_idx * num_warps + ty) * num_frags_x * 16) / aligned_group_size;
+  const uint32_t qo_idx_base = ((tile_idx * num_warps + ty) * num_frags_x * 16) / group_size;
   const uint32_t qo_n_stride = get_n_stride_impl<QKVLayout::kNHD, head_dim>(num_qo_heads),
                  qo_h_stride = get_h_stride_impl<QKVLayout::kNHD, head_dim>(qo_len);
   smem_t qo_smem(smem);
@@ -1403,8 +1428,8 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
   uint32_t q_smem_offset_r =
       smem_t::get_permuted_offset<channel_size_128b_in>(ty * num_frags_x * 16 + tx % 16, tx / 16);
 
-  load_q_global_smem<group_size, num_frags_x, num_frags_y>(qo_idx_base, qo_upper_bound, q_ptr_base,
-                                                           qo_n_stride, qo_h_stride, &qo_smem);
+  load_q_global_smem<num_frags_x, num_frags_y>(qo_idx_base, qo_upper_bound, q_ptr_base, qo_n_stride,
+                                               qo_h_stride, &qo_smem);
 
   cp_async::commit_group();
   cp_async::wait_group<0>();
@@ -1412,12 +1437,11 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
 
   if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
     if (q_offset == nullptr) {
-      q_smem_inplace_apply_rotary_multiply_sm_scale<aligned_group_size, num_warps, num_frags_x,
-                                                    num_frags_y, DTypeIn>(
+      q_smem_inplace_apply_rotary_multiply_sm_scale<num_warps, num_frags_x, num_frags_y, DTypeIn>(
           qo_idx_base, qo_len, kv_len, &qo_smem, &q_smem_offset_r, rope_freq, sm_scale);
     } else {
-      q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale<aligned_group_size, num_warps,
-                                                             num_frags_x, num_frags_y, DTypeIn>(
+      q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale<num_warps, num_frags_x, num_frags_y,
+                                                             DTypeIn>(
           qo_indptr[request_idx] + qo_idx_base, q_offset, &qo_smem, &q_smem_offset_r, rope_freq,
           sm_scale);
     }
@@ -1476,8 +1500,8 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
       // TODO(Zihao): handle the case that q_offset is specified
-      apply_alibi_bias<aligned_group_size, num_frags_x, num_frags_z>(
-          qo_idx_base, iter * 16 * num_frags_z, int(kv_len) - int(qo_len), alibi_slopes, s_frag);
+      apply_alibi_bias<num_frags_x, num_frags_z>(qo_idx_base, iter * 16 * num_frags_z,
+                                                 int(kv_len) - int(qo_len), alibi_slopes, s_frag);
     }
     // apply mask
     if constexpr (mask_mode == MaskMode::kCustom) {
@@ -1521,8 +1545,8 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
   normalize_d<num_frags_x, num_frags_y>(o_frag, d);
 
   // write_back
-  write_o_reg_gmem<group_size, num_frags_x, num_frags_y>(o_frag, &qo_smem, o_ptr_base, qo_idx_base,
-                                                         qo_len, qo_n_stride, qo_h_stride);
+  write_o_reg_gmem<num_frags_x, num_frags_y>(o_frag, &qo_smem, o_ptr_base, qo_idx_base, qo_len,
+                                             qo_n_stride, qo_h_stride);
 
   // write lse
   if (lse != nullptr) {
@@ -1530,10 +1554,10 @@ __global__ void BatchPrefillWithPagedKVCacheKernel(
     for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
-        const uint32_t group_id = (tx / 4 + j * 8 + fx * 16) % aligned_group_size;
-        const uint32_t qo_head_idx = kv_head_idx * group_size + group_id;
-        const uint32_t qo_idx = qo_idx_base + (tx / 4 + j * 8 + fx * 16) / aligned_group_size;
-        if (qo_idx < qo_upper_bound && group_id < group_size) {
+        const uint32_t qo_head_idx =
+            kv_head_idx * group_size + (tx / 4 + j * 8 + fx * 16) % group_size;
+        const uint32_t qo_idx = qo_idx_base + (tx / 4 + j * 8 + fx * 16) / group_size;
+        if (qo_idx < qo_upper_bound) {
           lse[(qo_indptr[request_idx] + qo_idx) * num_qo_heads + qo_head_idx] =
               math::ptx_log2(d[fx][j]) + float(m[fx][j]);
         }
@@ -1580,119 +1604,109 @@ cudaError_t SinglePrefillWithKVCacheWorkEstimation(
       allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION,
       {DISPATCH_NUM_FRAGS_X(
           (qo_len * group_size > 64 && head_dim < 256 ? 2 : 1), num_frags_x,
-          {DISPATCH_GQA_GROUP_SIZE(
-              group_size, GROUP_SIZE,
-              {DISPATCH_MASK_MODE(
-                  mask_mode, MASK_MODE, {DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
-                    constexpr uint32_t num_frags_y = HEAD_DIM / 16;
-                    DISPATCH_POS_ENCODING_MODE(
-                        pos_encoding_mode, pos_encoding_mode,
-                        {DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {
-                          using DTypeQKAccum =
-                              typename std::conditional<ALLOW_FP16_QK_REDUCTION &&
-                                                            std::is_same<DTypeIn, half>::value,
-                                                        half, float>::type;
+          {DISPATCH_MASK_MODE(
+              mask_mode, MASK_MODE, {DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
+                constexpr uint32_t num_frags_y = HEAD_DIM / 16;
+                DISPATCH_POS_ENCODING_MODE(
+                    pos_encoding_mode, pos_encoding_mode, {DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {
+                      using DTypeQKAccum =
+                          typename std::conditional<ALLOW_FP16_QK_REDUCTION &&
+                                                        std::is_same<DTypeIn, half>::value,
+                                                    half, float>::type;
 
-                          int dev_id = 0;
-                          FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-                          int max_smem_per_sm = 0;
-                          FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
-                              &max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor,
-                              dev_id));
-                          // we expect each sm execute two threadblocks
-                          const int max_smem_per_threadblock = max_smem_per_sm / 2;
+                      int dev_id = 0;
+                      FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+                      int max_smem_per_sm = 0;
+                      FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
+                          &max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
+                      // we expect each sm execute two threadblocks
+                      const int max_smem_per_threadblock = max_smem_per_sm / 2;
 
-                          constexpr uint32_t num_warps = 4UL;
-                          const uint32_t max_num_frags_z_reg =
-                              (HEAD_DIM == 128 && num_frags_x == 2 &&
-                               pos_encoding_mode == PosEncodingMode::kRoPELlama &&
-                               !allow_fp16_qk_reduction)
-                                  ? 2
-                                  : 4;
-                          const uint32_t max_num_frags_z_smem =
-                              (max_smem_per_threadblock / (16 * head_dim * sizeof(DTypeIn)) -
-                               num_frags_x * num_warps) /
-                              2;
+                      constexpr uint32_t num_warps = 4UL;
+                      const uint32_t max_num_frags_z_reg =
+                          (HEAD_DIM == 128 && num_frags_x == 2 &&
+                           pos_encoding_mode == PosEncodingMode::kRoPELlama &&
+                           !allow_fp16_qk_reduction)
+                              ? 2
+                              : 4;
+                      const uint32_t max_num_frags_z_smem =
+                          (max_smem_per_threadblock / (16 * head_dim * sizeof(DTypeIn)) -
+                           num_frags_x * num_warps) /
+                          2;
 
-                          // control num_frags_z for maximum warp occupancy
-                          DISPATCH_NUM_FRAGS_Z(
-                              min(max_num_frags_z_smem, max_num_frags_z_reg), num_frags_z, {
-                                if constexpr (is_invalid_configuration<DTypeQKAccum>(
-                                                  num_frags_x, num_frags_y, num_frags_z,
-                                                  num_warps)) {
-                                  // Invalid configuration, skip
-                                  std::ostringstream err_msg;
-                                  err_msg << "FlashInfer Internal Error: Invalid configuration : "
-                                             "num_frags_x="
-                                          << num_frags_x << " num_frags_y=" << num_frags_y
-                                          << " num_frags_z=" << num_frags_z
-                                          << " num_warps=" << num_warps
-                                          << " please create an issue "
-                                             "(https://github.com/flashinfer-ai/flashinfer/issues)"
-                                             " and report the issue to the developers.";
-                                  throw std::invalid_argument(err_msg.str());
-                                } else {
-                                  constexpr uint32_t num_threads = num_warps * warp_size;
-                                  constexpr uint32_t num_rows_per_cta =
-                                      num_frags_x * num_warps * 16;
-                                  auto partition_kv_kernel = SinglePrefillWithKVCacheKernel<
-                                      /*partition_kv=*/true, GROUP_SIZE, MASK_MODE, KV_LAYOUT,
-                                      pos_encoding_mode, num_frags_x, num_frags_y, num_frags_z,
-                                      num_warps, DTypeIn, DTypeQKAccum, DTypeOut>;
-                                  tensor_info_t<KV_LAYOUT, GROUP_SIZE, HEAD_DIM> qkv_info(
-                                      qo_len, kv_len, num_kv_heads);
-                                  uint32_t smem_size = (num_frags_x * num_warps + num_frags_z * 2) *
-                                                       16 * head_dim * sizeof(DTypeIn);
-                                  FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
-                                      partition_kv_kernel,
-                                      cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-                                  int num_blocks_per_sm = 0;
-                                  int num_sm = 0;
-                                  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
-                                      &num_sm, cudaDevAttrMultiProcessorCount, dev_id));
-                                  FLASHINFER_CUDA_CALL(
-                                      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-                                          &num_blocks_per_sm, partition_kv_kernel, num_threads,
-                                          smem_size));
-                                  uint32_t max_num_kv_chunks =
-                                      (num_blocks_per_sm * num_sm) /
-                                      (num_kv_heads *
-                                       ceil_div(qo_len * group_size, num_rows_per_cta));
-                                  uint32_t num_chunks;
-                                  if (max_num_kv_chunks > 0) {
-                                    uint32_t chunk_size =
-                                        max(ceil_div(kv_len, max_num_kv_chunks), 256);
-                                    num_chunks = ceil_div(kv_len, chunk_size);
-                                  } else {
-                                    num_chunks = 0;
-                                  }
+                      // control num_frags_z for maximum warp occupancy
+                      DISPATCH_NUM_FRAGS_Z(
+                          min(max_num_frags_z_smem, max_num_frags_z_reg), num_frags_z, {
+                            if constexpr (is_invalid_configuration<DTypeQKAccum>(
+                                              num_frags_x, num_frags_y, num_frags_z, num_warps)) {
+                              // Invalid configuration, skip
+                              std::ostringstream err_msg;
+                              err_msg << "FlashInfer Internal Error: Invalid configuration : "
+                                         "num_frags_x="
+                                      << num_frags_x << " num_frags_y=" << num_frags_y
+                                      << " num_frags_z=" << num_frags_z
+                                      << " num_warps=" << num_warps
+                                      << " please create an issue "
+                                         "(https://github.com/flashinfer-ai/flashinfer/issues)"
+                                         " and report the issue to the developers.";
+                              throw std::invalid_argument(err_msg.str());
+                            } else {
+                              constexpr uint32_t num_threads = num_warps * warp_size;
+                              constexpr uint32_t num_rows_per_cta = num_frags_x * num_warps * 16;
+                              auto partition_kv_kernel = SinglePrefillWithKVCacheKernel<
+                                  /*partition_kv=*/true, MASK_MODE, KV_LAYOUT, pos_encoding_mode,
+                                  num_frags_x, num_frags_y, num_frags_z, num_warps, DTypeIn,
+                                  DTypeQKAccum, DTypeOut>;
+                              tensor_info_t<KV_LAYOUT, HEAD_DIM> qkv_info(
+                                  qo_len, kv_len, num_qo_heads, num_kv_heads);
+                              uint32_t smem_size = (num_frags_x * num_warps + num_frags_z * 2) *
+                                                   16 * head_dim * sizeof(DTypeIn);
+                              FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
+                                  partition_kv_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                  smem_size));
+                              int num_blocks_per_sm = 0;
+                              int num_sm = 0;
+                              FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
+                                  &num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+                              FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+                                  &num_blocks_per_sm, partition_kv_kernel, num_threads, smem_size));
+                              uint32_t max_num_kv_chunks =
+                                  (num_blocks_per_sm * num_sm) /
+                                  (num_kv_heads * ceil_div(qo_len * group_size, num_rows_per_cta));
+                              uint32_t num_chunks;
+                              if (max_num_kv_chunks > 0) {
+                                uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
+                                num_chunks = ceil_div(kv_len, chunk_size);
+                              } else {
+                                num_chunks = 0;
+                              }
 
-                                  max_grid_size = num_blocks_per_sm * num_sm;
-                                  if (num_chunks > 1) {
-                                    uint32_t grid_size =
-                                        32 * num_warps *
-                                        ceil_div(qo_len * group_size, num_rows_per_cta) *
-                                        num_chunks * num_qo_heads;
+                              max_grid_size = num_blocks_per_sm * num_sm;
+                              if (num_chunks > 1) {
+                                uint32_t grid_size =
+                                    32 * num_warps *
+                                    ceil_div(qo_len * group_size, num_rows_per_cta) * num_chunks *
+                                    num_qo_heads;
 
-                                    tmp_size = sizeof(DTypeOut) *
-                                                   (num_chunks * num_qo_heads * qo_len * head_dim) +
-                                               sizeof(float) * (num_chunks * num_qo_heads * qo_len);
-                                  } else {
-                                    tmp_size = 0;
-                                  }
-                                }
-                              })
-                        })})
-                  })})})})});
+                                tmp_size = sizeof(DTypeOut) *
+                                               (num_chunks * num_qo_heads * qo_len * head_dim) +
+                                           sizeof(float) * (num_chunks * num_qo_heads * qo_len);
+                              } else {
+                                tmp_size = 0;
+                              }
+                            }
+                          })
+                    })})
+              })})})});
   return cudaSuccess;
 }
 
-template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
-          PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename DTypeIn, typename DTypeOut>
+template <uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, PosEncodingMode pos_encoding_mode,
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* v,
                                                float* custom_mask, DTypeOut* o, float* tmp,
-                                               float* lse, uint32_t num_kv_heads, uint32_t qo_len,
+                                               float* lse, uint32_t num_qo_heads,
+                                               uint32_t num_kv_heads, uint32_t qo_len,
                                                uint32_t kv_len, float sm_scale, float rope_scale,
                                                float rope_theta, cudaStream_t stream) {
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
@@ -1705,8 +1719,9 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
     throw std::invalid_argument(err_msg.str());
   }
 
+  const uint32_t group_size = num_qo_heads / num_kv_heads;
   constexpr uint32_t num_frags_y = HEAD_DIM / 16;
-  DISPATCH_NUM_FRAGS_X((qo_len * GROUP_SIZE > 64 && HEAD_DIM < 256 ? 2 : 1), num_frags_x, {
+  DISPATCH_NUM_FRAGS_X((qo_len * group_size > 64 && HEAD_DIM < 256 ? 2 : 1), num_frags_x, {
     using DTypeQKAccum =
         typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeIn, half>::value,
                                   half, float>::type;
@@ -1744,11 +1759,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
       } else {
         constexpr uint32_t num_threads = num_warps * warp_size;
         constexpr uint32_t num_rows_per_cta = num_frags_x * num_warps * 16;
-        auto partition_kv_kernel =
-            SinglePrefillWithKVCacheKernel</*partition_kv=*/true, GROUP_SIZE, MASK_MODE, KV_LAYOUT,
-                                           pos_encoding_mode, num_frags_x, num_frags_y, num_frags_z,
-                                           num_warps, DTypeIn, DTypeQKAccum, DTypeOut>;
-        tensor_info_t<KV_LAYOUT, GROUP_SIZE, HEAD_DIM> qkv_info(qo_len, kv_len, num_kv_heads);
+        auto partition_kv_kernel = SinglePrefillWithKVCacheKernel<
+            /*partition_kv=*/true, MASK_MODE, KV_LAYOUT, pos_encoding_mode, num_frags_x,
+            num_frags_y, num_frags_z, num_warps, DTypeIn, DTypeQKAccum, DTypeOut>;
+        tensor_info_t<KV_LAYOUT, HEAD_DIM> qkv_info(qo_len, kv_len, num_qo_heads, num_kv_heads);
         uint32_t smem_size =
             (num_frags_x * num_warps + num_frags_z * 2) * 16 * HEAD_DIM * sizeof(DTypeIn);
         FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
@@ -1761,7 +1775,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
             &num_blocks_per_sm, partition_kv_kernel, num_threads, smem_size));
         uint32_t max_num_kv_chunks =
             (num_blocks_per_sm * num_sm) /
-            (num_kv_heads * ceil_div(qo_len * GROUP_SIZE, num_rows_per_cta));
+            (num_kv_heads * ceil_div(qo_len * group_size, num_rows_per_cta));
         uint32_t num_chunks;
         if (max_num_kv_chunks > 0) {
           uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
@@ -1773,8 +1787,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
         if (num_chunks <= 1 || tmp == nullptr) {
           // Enough parallelism, do not split-kv
           auto kernel = SinglePrefillWithKVCacheKernel<
-              /*partition_kv=*/false, GROUP_SIZE, MASK_MODE, KV_LAYOUT, pos_encoding_mode,
-              num_frags_x, num_frags_y, num_frags_z, num_warps, DTypeIn, DTypeQKAccum, DTypeOut>;
+              /*partition_kv=*/false, MASK_MODE, KV_LAYOUT, pos_encoding_mode, num_frags_x,
+              num_frags_y, num_frags_z, num_warps, DTypeIn, DTypeQKAccum, DTypeOut>;
           void* args[] = {(void*)&q,
                           (void*)&k,
                           (void*)&v,
@@ -1786,7 +1800,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
                           (void*)&sm_scale,
                           (void*)&log2_rope_rcp_scale,
                           (void*)&log2_rope_rcp_theta};
-          dim3 nblks(ceil_div(qo_len * GROUP_SIZE, num_rows_per_cta), 1, num_kv_heads);
+          dim3 nblks(ceil_div(qo_len * group_size, num_rows_per_cta), 1, num_kv_heads);
           dim3 nthrs(32, num_warps);
           FLASHINFER_CUDA_CALL(
               cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -1805,11 +1819,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
                           (void*)&sm_scale,
                           (void*)&log2_rope_rcp_scale,
                           (void*)&log2_rope_rcp_theta};
-          dim3 nblks(ceil_div(qo_len * GROUP_SIZE, num_rows_per_cta), num_chunks, num_kv_heads);
+          dim3 nblks(ceil_div(qo_len * group_size, num_rows_per_cta), num_chunks, num_kv_heads);
           dim3 nthrs(32, num_warps);
           FLASHINFER_CUDA_CALL(
               cudaLaunchKernel((void*)partition_kv_kernel, nblks, nthrs, args, smem_size, stream));
-          const uint32_t num_qo_heads = num_kv_heads * GROUP_SIZE;
           FLASHINFER_CUDA_CALL(MergeStates(
               (DTypeOut*)tmp,
               (float*)(((DTypeOut*)tmp) + num_chunks * qo_len * num_qo_heads * HEAD_DIM), o, lse,
@@ -1821,15 +1834,16 @@ cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* 
   return cudaSuccess;
 }
 
-template <uint32_t num_frags_x, uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
+template <uint32_t num_frags_x, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
           PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
           typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr, DTypeIn* k,
     DTypeIn* v, IdType* kv_indptr, float* custom_mask, IdType* qk_indptr, IdType* q_offset,
     IdType* k_rope_pos_offset, DTypeOut* o, float* tmp, float* lse, const uint32_t batch_size,
-    const uint32_t num_qo_tiles, const uint32_t num_kv_heads, const float sm_scale,
-    const float rope_scale, const float rope_theta, cudaStream_t stream = nullptr) {
+    const uint32_t num_qo_heads, const uint32_t num_qo_tiles, const uint32_t num_kv_heads,
+    const float sm_scale, const float rope_scale, const float rope_theta,
+    cudaStream_t stream = nullptr) {
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   constexpr uint32_t num_warps = 4;
@@ -1870,9 +1884,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
       throw std::invalid_argument(err_msg.str());
     } else {
       auto kernel =
-          BatchPrefillWithRaggedKVCacheKernel<GROUP_SIZE, MASK_MODE, KV_LAYOUT, pos_encoding_mode,
-                                              num_frags_x, num_frags_y, num_frags_z, num_warps,
-                                              DTypeIn, DTypeQKAccum, DTypeOut, IdType>;
+          BatchPrefillWithRaggedKVCacheKernel<MASK_MODE, KV_LAYOUT, pos_encoding_mode, num_frags_x,
+                                              num_frags_y, num_frags_z, num_warps, DTypeIn,
+                                              DTypeQKAccum, DTypeOut, IdType>;
       uint32_t smem_size =
           (num_frags_x * num_warps + num_frags_z * 2) * 16 * HEAD_DIM * sizeof(DTypeIn);
       FLASHINFER_CUDA_CALL(
@@ -1902,14 +1916,14 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
 }
 
 template <PageStorage page_storage, QKVLayout kv_layout, uint32_t num_frags_x, uint32_t PAGE_SIZE,
-          uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PosEncodingMode pos_encoding_mode,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut,
-          typename IdType>
+          uint32_t HEAD_DIM, PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION,
+          MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr, IdType* q_offset,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv, float* custom_mask,
-    IdType* qk_indptr, DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_tiles, float sm_scale,
-    float rope_scale, float rope_theta, cudaStream_t stream) {
+    IdType* qk_indptr, DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_heads,
+    uint32_t num_qo_tiles, float sm_scale, float rope_scale, float rope_theta,
+    cudaStream_t stream) {
   const float log2_rope_rcp_scale = -std::log2f(rope_scale);
   const float log2_rope_rcp_theta = -std::log2f(rope_theta);
   constexpr uint32_t num_warps = 4;
@@ -1952,9 +1966,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
                  " and report the issue to the developers.";
       throw std::invalid_argument(err_msg.str());
     } else {
-      auto kernel = BatchPrefillWithPagedKVCacheKernel<
-          GROUP_SIZE, PAGE_SIZE, MASK_MODE, pos_encoding_mode, num_frags_x, num_frags_y,
-          num_frags_z, num_warps, page_storage, kv_layout, DTypeIn, DTypeQKAccum, DTypeOut, IdType>;
+      auto kernel =
+          BatchPrefillWithPagedKVCacheKernel<PAGE_SIZE, MASK_MODE, pos_encoding_mode, num_frags_x,
+                                             num_frags_y, num_frags_z, num_warps, page_storage,
+                                             kv_layout, DTypeIn, DTypeQKAccum, DTypeOut, IdType>;
       uint32_t smem_size =
           (num_frags_x * num_warps + num_frags_z * 2) * 16 * HEAD_DIM * sizeof(DTypeIn);
       FLASHINFER_CUDA_CALL(

--- a/include/flashinfer/layout.cuh
+++ b/include/flashinfer/layout.cuh
@@ -62,26 +62,21 @@ __host__ __device__ __forceinline__ uint32_t get_h_stride_impl(uint32_t seq_len)
   return layout == QKVLayout::kNHD ? head_dim : seq_len * head_dim;
 }
 
-template <QKVLayout kv_layout, uint32_t group_size, uint32_t head_dim>
+template <QKVLayout kv_layout, uint32_t head_dim>
 struct tensor_info_t {
   uint32_t qo_len;
   uint32_t kv_len;
+  uint32_t num_qo_heads;
   uint32_t num_kv_heads;
   __host__ __device__ __forceinline__ tensor_info_t(uint32_t qo_len, uint32_t kv_len,
-                                                    uint32_t num_kv_heads)
-      : qo_len(qo_len), kv_len(kv_len), num_kv_heads(num_kv_heads) {}
-
-  __host__ __device__ __forceinline__ uint32_t get_num_kv_heads() const { return num_kv_heads; }
-
-  __host__ __device__ __forceinline__ uint32_t get_num_qo_heads() const {
-    return num_kv_heads * group_size;
-  }
+                                                    uint32_t num_qo_heads, uint32_t num_kv_heads)
+      : qo_len(qo_len), kv_len(kv_len), num_qo_heads(num_qo_heads), num_kv_heads(num_kv_heads) {}
 
   __host__ __device__ __forceinline__ size_t get_qo_elem_offset(uint32_t qo_idx,
                                                                 uint32_t qo_head_idx,
                                                                 uint32_t feat_idx) const {
     return get_elem_offset_impl<QKVLayout::kNHD, head_dim>(qo_idx, qo_head_idx, feat_idx, qo_len,
-                                                           get_num_qo_heads());
+                                                           num_qo_heads);
   }
 
   __host__ __device__ __forceinline__ size_t get_kv_elem_offset(uint32_t kv_idx,
@@ -91,8 +86,12 @@ struct tensor_info_t {
                                                      num_kv_heads);
   }
 
+  __host__ __device__ __forceinline__ uint32_t get_group_size() const {
+    return num_qo_heads / num_kv_heads;
+  }
+
   __host__ __device__ __forceinline__ uint32_t get_qo_n_stride() const {
-    return get_n_stride_impl<QKVLayout::kNHD, head_dim>(get_num_qo_heads());
+    return get_n_stride_impl<QKVLayout::kNHD, head_dim>(num_qo_heads);
   }
 
   __host__ __device__ __forceinline__ uint32_t get_kv_n_stride() const {

--- a/include/flashinfer/prefill_attention_decl.cuh
+++ b/include/flashinfer/prefill_attention_decl.cuh
@@ -29,43 +29,42 @@
 
 namespace flashinfer {
 
-template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
-          PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename DTypeIn, typename DTypeOut>
+template <uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, PosEncodingMode pos_encoding_mode,
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* v,
                                                float* custom_mask, DTypeOut* o, float* tmp,
-                                               float* lse, uint32_t num_kv_heads, uint32_t qo_len,
+                                               float* lse, uint32_t num_qo_heads,
+                                               uint32_t num_kv_heads, uint32_t qo_len,
                                                uint32_t kv_len, float sm_scale, float rope_scale,
                                                float rope_theta, cudaStream_t stream);
 
-template <uint32_t num_frags_x, uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
+template <uint32_t num_frags_x, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
           PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
           typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr, DTypeIn* k,
     DTypeIn* v, IdType* kv_indptr, float* custom_mask, IdType* qk_indptr, IdType* q_offset,
     IdType* k_rope_pos_offset, DTypeOut* o, float* tmp, float* lse, uint32_t batch_size,
-    uint32_t num_qo_tiles, uint32_t num_kv_heads, float sm_scale, float rope_scale,
-    float rope_theta, cudaStream_t stream = nullptr);
+    uint32_t num_qo_heads, uint32_t num_qo_tiles, uint32_t num_kv_heads, float sm_scale,
+    float rope_scale, float rope_theta, cudaStream_t stream = nullptr);
 
 template <PageStorage page_storage, QKVLayout kv_layout, uint32_t num_frags_x, uint32_t PAGE_SIZE,
-          uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PosEncodingMode pos_encoding_mode,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut,
-          typename IdType>
+          uint32_t HEAD_DIM, PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION,
+          MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(
     DTypeIn* q, IdType* request_indices, IdType* tile_indices, IdType* qo_indptr, IdType* q_offset,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv, float* custom_mask,
-    IdType* qk_indptr, DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_tiles, float sm_scale,
-    float rope_scale, float rope_theta, cudaStream_t stream);
+    IdType* qk_indptr, DTypeOut* o, float* tmp, float* lse, uint32_t num_qo_heads,
+    uint32_t num_qo_tiles, float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream);
 
-template <PageStorage page_storage, QKVLayout kv_layout, uint32_t PAGE_SIZE, uint32_t GROUP_SIZE,
-          uint32_t HEAD_DIM, PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION,
-          MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut, typename IdType>
+template <PageStorage page_storage, QKVLayout kv_layout, uint32_t PAGE_SIZE, uint32_t HEAD_DIM,
+          PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
+          typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
     BatchPrefillHandler* handler, DTypeIn* q, IdType* qo_indptr, IdType* q_offset,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv, float* custom_mask,
-    IdType* qk_indptr, DTypeOut* o, float* lse, float sm_scale, float rope_scale, float rope_theta,
-    cudaStream_t stream) {
+    IdType* qk_indptr, DTypeOut* o, float* lse, uint32_t num_qo_heads, float sm_scale,
+    float rope_scale, float rope_theta, cudaStream_t stream) {
   float* tmp = nullptr;
   IdType* request_indices = nullptr;
   IdType* tile_indices = nullptr;
@@ -85,22 +84,23 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
 
   DISPATCH_NUM_FRAGS_X(num_frags_x, NUM_FRAGS_X, {
     return BatchPrefillWithPagedKVCacheDispatched<
-        page_storage, kv_layout, NUM_FRAGS_X, PAGE_SIZE, GROUP_SIZE, HEAD_DIM, pos_encoding_mode,
+        page_storage, kv_layout, NUM_FRAGS_X, PAGE_SIZE, HEAD_DIM, pos_encoding_mode,
         ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeIn, DTypeOut, IdType>(
         q, request_indices, tile_indices, qo_indptr, q_offset, paged_kv, custom_mask, qk_indptr, o,
-        tmp, lse, num_qo_tiles, sm_scale, rope_scale, rope_theta, stream);
+        tmp, lse, num_qo_heads, num_qo_tiles, sm_scale, rope_scale, rope_theta, stream);
   });
   return cudaSuccess;
 }
 
-template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
-          PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename DTypeIn, typename DTypeOut, typename IdType>
+template <uint32_t HEAD_DIM, QKVLayout KV_LAYOUT, PosEncodingMode pos_encoding_mode,
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut,
+          typename IdType>
 cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
     BatchPrefillHandler* handler, DTypeIn* q, IdType* qo_indptr, DTypeIn* k, DTypeIn* v,
     IdType* kv_indptr, float* custom_mask, IdType* qk_indptr, IdType* q_offset,
-    IdType* k_rope_pos_offset, DTypeOut* o, float* lse, uint32_t batch_size, uint32_t num_kv_heads,
-    float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream) {
+    IdType* k_rope_pos_offset, DTypeOut* o, float* lse, uint32_t batch_size, uint32_t num_qo_heads,
+    uint32_t num_kv_heads, float sm_scale, float rope_scale, float rope_theta,
+    cudaStream_t stream) {
   float* tmp = nullptr;
   IdType* request_indices = nullptr;
   IdType* tile_indices = nullptr;
@@ -119,12 +119,12 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
   }
 
   DISPATCH_NUM_FRAGS_X(num_frags_x, NUM_FRAGS_X, {
-    return BatchPrefillWithRaggedKVCacheDispatched<NUM_FRAGS_X, GROUP_SIZE, HEAD_DIM, KV_LAYOUT,
+    return BatchPrefillWithRaggedKVCacheDispatched<NUM_FRAGS_X, HEAD_DIM, KV_LAYOUT,
                                                    pos_encoding_mode, ALLOW_FP16_QK_REDUCTION,
                                                    MASK_MODE, DTypeIn, DTypeOut, IdType>(
         q, request_indices, tile_indices, qo_indptr, k, v, kv_indptr, custom_mask, qk_indptr,
-        q_offset, k_rope_pos_offset, o, tmp, lse, batch_size, num_qo_tiles, num_kv_heads, sm_scale,
-        rope_scale, rope_theta, stream);
+        q_offset, k_rope_pos_offset, o, tmp, lse, batch_size, num_qo_heads, num_qo_tiles,
+        num_kv_heads, sm_scale, rope_scale, rope_theta, stream);
   });
   return cudaSuccess;
 }

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -112,31 +112,6 @@
     throw std::invalid_argument(err_msg.str());             \
   }
 
-#define DISPATCH_GQA_GROUP_SIZE(group_size, GROUP_SIZE, ...) \
-  if (group_size == 1) {                                     \
-    constexpr size_t GROUP_SIZE = 1;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 4) {                              \
-    constexpr size_t GROUP_SIZE = 4;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 5) {                              \
-    constexpr size_t GROUP_SIZE = 5;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 6) {                              \
-    constexpr size_t GROUP_SIZE = 6;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 7) {                              \
-    constexpr size_t GROUP_SIZE = 7;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 8) {                              \
-    constexpr size_t GROUP_SIZE = 8;                         \
-    __VA_ARGS__                                              \
-  } else {                                                   \
-    std::ostringstream err_msg;                              \
-    err_msg << "Unsupported group_size: " << group_size;     \
-    throw std::invalid_argument(err_msg.str());              \
-  }
-
 #define DISPATCH_MASK_MODE(mask_mode, MASK_MODE, ...)         \
   switch (mask_mode) {                                        \
     case MaskMode::kNone: {                                   \
@@ -288,19 +263,17 @@ std::tuple<IdType, IdType, std::vector<IdType>, std::vector<IdType>> split_qo_in
     qo_indptr_h.assign(qo_indptr, qo_indptr + batch_size + 1);
   }
 
-  const uint32_t rows_per_warp = 16 / (2 * gqa_group_size) * 2;
-  const uint32_t aligned_gqa_group_size = 16 / rows_per_warp;
   const uint32_t total_q_len = qo_indptr_h[batch_size];
-  const bool avg_len_greater_than_64 = total_q_len * aligned_gqa_group_size > 64 * batch_size;
+  const bool avg_len_greater_than_64 = total_q_len * gqa_group_size > 64 * batch_size;
   const uint32_t num_frags_x = (head_dim < 256 && avg_len_greater_than_64) ? 2 : 1;
   const uint32_t num_rows_per_cta = num_frags_x * num_warps * 16;
   uint32_t num_qo_tiles = 0;
 
   for (uint32_t i = 0; i < batch_size; ++i) {
-    for (uint32_t j = qo_indptr_h[i] * aligned_gqa_group_size;
-         j < qo_indptr_h[i + 1] * aligned_gqa_group_size; j += num_rows_per_cta) {
+    for (uint32_t j = qo_indptr_h[i] * gqa_group_size; j < qo_indptr_h[i + 1] * gqa_group_size;
+         j += num_rows_per_cta) {
       request_indices.push_back(i);
-      tile_indices.push_back((j - qo_indptr_h[i] * aligned_gqa_group_size) / num_rows_per_cta);
+      tile_indices.push_back((j - qo_indptr_h[i] * gqa_group_size) / num_rows_per_cta);
       ++num_qo_tiles;
     }
   }

--- a/python/csrc/batch_decode.cu
+++ b/python/csrc/batch_decode.cu
@@ -59,53 +59,46 @@ std::vector<torch::Tensor> batch_decode_with_padded_kv_cache(
 
   if (is_float8_tensor(q)) {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(q.scalar_type(), c_type, [&] {
-      return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_pos_encoding_mode(
-              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
-                  nv_half* tmp = nullptr;
-                  cudaError_t status =
-                      BatchDecodeWithPaddedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, KV_LAYOUT,
-                                                             POS_ENCODING_MODE, c_type, nv_half>(
-                          static_cast<c_type*>(q.data_ptr()),
-                          static_cast<c_type*>(k_padded.data_ptr()),
-                          static_cast<c_type*>(v_padded.data_ptr()),
-                          static_cast<nv_half*>(o.data_ptr()),
-                          /*tmp=*/tmp,
-                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                          batch_size, padded_kv_len, num_qo_heads, sm_scale, rope_scale, rope_theta,
-                          torch_current_stream);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPaddedKVCache failed with error code ", status);
-                  return true;
-                });
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_pos_encoding_mode(
+            PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+              return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
+                nv_half* tmp = nullptr;
+                cudaError_t status = BatchDecodeWithPaddedKVCacheDispatched<
+                    HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE, c_type, nv_half>(
+                    static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k_padded.data_ptr()),
+                    static_cast<c_type*>(v_padded.data_ptr()), static_cast<nv_half*>(o.data_ptr()),
+                    /*tmp=*/tmp,
+                    /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr, batch_size,
+                    padded_kv_len, num_qo_heads, num_kv_heads, sm_scale, rope_scale, rope_theta,
+                    torch_current_stream);
+                TORCH_CHECK(status == cudaSuccess,
+                            "BatchDecodeWithPaddedKVCache failed with error code ", status);
+                return true;
               });
-        });
+            });
       });
     });
   } else {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE(q.scalar_type(), c_type, [&] {
       c_type* tmp = nullptr;
-      return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_pos_encoding_mode(
-              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
-                  cudaError_t status = BatchDecodeWithPaddedKVCacheDispatched<
-                      GROUP_SIZE, HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE, c_type, c_type>(
-                      static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k_padded.data_ptr()),
-                      static_cast<c_type*>(v_padded.data_ptr()), static_cast<c_type*>(o.data_ptr()),
-                      /*tmp=*/tmp,
-                      /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                      batch_size, padded_kv_len, num_qo_heads, sm_scale, rope_scale, rope_theta,
-                      torch_current_stream);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPaddedKVCache failed with error code ", status);
-                  return true;
-                });
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_pos_encoding_mode(
+            PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+              return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
+                cudaError_t status = BatchDecodeWithPaddedKVCacheDispatched<
+                    HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE, c_type, c_type>(
+                    static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k_padded.data_ptr()),
+                    static_cast<c_type*>(v_padded.data_ptr()), static_cast<c_type*>(o.data_ptr()),
+                    /*tmp=*/tmp,
+                    /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr, batch_size,
+                    padded_kv_len, num_qo_heads, num_kv_heads, sm_scale, rope_scale, rope_theta,
+                    torch_current_stream);
+                TORCH_CHECK(status == cudaSuccess,
+                            "BatchDecodeWithPaddedKVCache failed with error code ", status);
+                return true;
               });
-        });
+            });
       });
     });
   }
@@ -138,49 +131,43 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
 
   if (is_float8_tensor(empty_data)) {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(empty_data.scalar_type(), c_type, [&] {
-      return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-            return DISPATCH_pos_encoding_mode(
-                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  cudaError_t status =
-                      handler_->BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, PageStorage::kIndices,
-                                                       KV_LAYOUT, POS_ENCODING_MODE, c_type,
-                                                       nv_half, int32_t>(
-                          static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
-                          static_cast<int32_t*>(indptr.data_ptr()),
-                          static_cast<int32_t*>(last_page_len.data_ptr()), batch_size, num_qo_heads,
-                          page_size);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPagedKVCache failed with error ",
-                              cudaGetErrorString(status));
-                  return true;
-                });
-          });
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
+          return DISPATCH_pos_encoding_mode(
+              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                cudaError_t status =
+                    handler_->BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, PageStorage::kIndices,
+                                                     KV_LAYOUT, POS_ENCODING_MODE, c_type, nv_half,
+                                                     int32_t>(
+                        static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
+                        static_cast<int32_t*>(indptr.data_ptr()),
+                        static_cast<int32_t*>(last_page_len.data_ptr()), batch_size, num_qo_heads,
+                        num_kv_heads, page_size);
+                TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",
+                            cudaGetErrorString(status));
+                return true;
+              });
         });
       });
     });
   } else {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE(empty_data.scalar_type(), c_type, [&] {
-      return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-            return DISPATCH_pos_encoding_mode(
-                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  cudaError_t status =
-                      handler_->BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, PageStorage::kIndices,
-                                                       KV_LAYOUT, POS_ENCODING_MODE, c_type, c_type,
-                                                       int32_t>(
-                          static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
-                          static_cast<int32_t*>(indptr.data_ptr()),
-                          static_cast<int32_t*>(last_page_len.data_ptr()), batch_size, num_qo_heads,
-                          page_size);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPagedKVCache failed with error ",
-                              cudaGetErrorString(status));
-                  return true;
-                });
-          });
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
+          return DISPATCH_pos_encoding_mode(
+              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                cudaError_t status =
+                    handler_->BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, PageStorage::kIndices,
+                                                     KV_LAYOUT, POS_ENCODING_MODE, c_type, c_type,
+                                                     int32_t>(
+                        static_cast<void*>(workspace_buffer.data_ptr()), workspace_size_in_bytes,
+                        static_cast<int32_t*>(indptr.data_ptr()),
+                        static_cast<int32_t*>(last_page_len.data_ptr()), batch_size, num_qo_heads,
+                        num_kv_heads, page_size);
+                TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",
+                            cudaGetErrorString(status));
+                return true;
+              });
         });
       });
     });
@@ -244,60 +231,56 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCachePyTorchWrapper::Forward(
   if (is_float8_tensor(q)) {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(q.scalar_type(), c_type, [&] {
       return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-        return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-          return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-            return DISPATCH_pos_encoding_mode(
-                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  paged_kv_t<PageStorage::kIndices, KV_LAYOUT, c_type, int32_t> paged_kv(
-                      num_kv_heads, page_size, head_dim, batch_size,
-                      static_cast<c_type*>(paged_kv_data.data_ptr()),
-                      static_cast<int32_t*>(paged_kv_indices.data_ptr()),
-                      static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
-                      static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
-                  cudaError_t status = BatchDecodeWithPagedKVCacheWrapperDispatched<
-                      PageStorage::kIndices, KV_LAYOUT, GROUP_SIZE, HEAD_DIM, POS_ENCODING_MODE,
-                      c_type, nv_half, int32_t>(
-                      handler_.get(), static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr,
-                      paged_kv, static_cast<nv_half*>(o.data_ptr()),
-                      /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
-                      sm_scale, rope_scale, rope_theta,
-                      /*stream=*/torch_current_stream);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPagedKVCache failed with error ",
-                              cudaGetErrorString(status));
-                  return true;
-                });
-          });
+        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+          return DISPATCH_pos_encoding_mode(
+              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                paged_kv_t<PageStorage::kIndices, KV_LAYOUT, c_type, int32_t> paged_kv(
+                    num_kv_heads, page_size, head_dim, batch_size,
+                    static_cast<c_type*>(paged_kv_data.data_ptr()),
+                    static_cast<int32_t*>(paged_kv_indices.data_ptr()),
+                    static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
+                    static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
+                cudaError_t status =
+                    BatchDecodeWithPagedKVCacheWrapperDispatched<PageStorage::kIndices, KV_LAYOUT,
+                                                                 HEAD_DIM, POS_ENCODING_MODE,
+                                                                 c_type, nv_half, int32_t>(
+                        handler_.get(), static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr,
+                        paged_kv, static_cast<nv_half*>(o.data_ptr()),
+                        /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
+                        num_qo_heads, sm_scale, rope_scale, rope_theta,
+                        /*stream=*/torch_current_stream);
+                TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",
+                            cudaGetErrorString(status));
+                return true;
+              });
         });
       });
     });
   } else {
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE(q.scalar_type(), c_type, [&] {
       return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-        return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-          return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-            return DISPATCH_pos_encoding_mode(
-                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  paged_kv_t<PageStorage::kIndices, KV_LAYOUT, c_type, int32_t> paged_kv(
-                      num_kv_heads, page_size, head_dim, batch_size,
-                      static_cast<c_type*>(paged_kv_data.data_ptr()),
-                      static_cast<int32_t*>(paged_kv_indices.data_ptr()),
-                      static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
-                      static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
-                  cudaError_t status = BatchDecodeWithPagedKVCacheWrapperDispatched<
-                      PageStorage::kIndices, KV_LAYOUT, GROUP_SIZE, HEAD_DIM, POS_ENCODING_MODE,
-                      c_type, c_type, int32_t>(
-                      handler_.get(), static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr,
-                      paged_kv, static_cast<c_type*>(o.data_ptr()),
-                      /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
-                      sm_scale, rope_scale, rope_theta,
-                      /*stream=*/torch_current_stream);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "BatchDecodeWithPagedKVCache failed with error ",
-                              cudaGetErrorString(status));
-                  return true;
-                });
-          });
+        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+          return DISPATCH_pos_encoding_mode(
+              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                paged_kv_t<PageStorage::kIndices, KV_LAYOUT, c_type, int32_t> paged_kv(
+                    num_kv_heads, page_size, head_dim, batch_size,
+                    static_cast<c_type*>(paged_kv_data.data_ptr()),
+                    static_cast<int32_t*>(paged_kv_indices.data_ptr()),
+                    static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
+                    static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
+                cudaError_t status =
+                    BatchDecodeWithPagedKVCacheWrapperDispatched<PageStorage::kIndices, KV_LAYOUT,
+                                                                 HEAD_DIM, POS_ENCODING_MODE,
+                                                                 c_type, c_type, int32_t>(
+                        handler_.get(), static_cast<c_type*>(q.data_ptr()), /*q_offset=*/nullptr,
+                        paged_kv, static_cast<c_type*>(o.data_ptr()),
+                        /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
+                        num_qo_heads, sm_scale, rope_scale, rope_theta,
+                        /*stream=*/torch_current_stream);
+                TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",
+                            cudaGetErrorString(status));
+                return true;
+              });
         });
       });
     });

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -110,34 +110,32 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
           static_cast<int32_t*>(paged_kv_indices.data_ptr()),
           static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
           static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
-      return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
-            return DISPATCH_allow_fp16_qk_reduction(
-                allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
-                  return DISPATCH_pos_encoding_mode(
-                      PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                        return DISPATCH_page_size(page_size, PAGE_SIZE, [&] {
-                          cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
-                              PageStorage::kIndices, KV_LAYOUT, PAGE_SIZE, GROUP_SIZE, HEAD_DIM,
-                              POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type,
-                              int32_t>(
-                              handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                              static_cast<int32_t*>(qo_indptr.data_ptr()),
-                              /*q_offset=*/nullptr, paged_kv,
-                              /*custom_mask=*/nullptr,
-                              /*qk_indptr=*/nullptr, static_cast<c_type*>(o.data_ptr()),
-                              /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                              sm_scale, rope_scale, rope_theta,
-                              /*stream=*/torch_current_stream);
-                          TORCH_CHECK(status == cudaSuccess,
-                                      "BatchPrefillWithPagedKVCache failed with error code ",
-                                      cudaGetErrorString(status));
-                          return true;
-                        });
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
+          return DISPATCH_allow_fp16_qk_reduction(
+              allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
+                return DISPATCH_pos_encoding_mode(
+                    PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                      return DISPATCH_page_size(page_size, PAGE_SIZE, [&] {
+                        cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
+                            PageStorage::kIndices, KV_LAYOUT, PAGE_SIZE, HEAD_DIM,
+                            POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type,
+                            int32_t>(
+                            handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                            static_cast<int32_t*>(qo_indptr.data_ptr()),
+                            /*q_offset=*/nullptr, paged_kv,
+                            /*custom_mask=*/nullptr,
+                            /*qk_indptr=*/nullptr, static_cast<c_type*>(o.data_ptr()),
+                            /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                            num_qo_heads, sm_scale, rope_scale, rope_theta,
+                            /*stream=*/torch_current_stream);
+                        TORCH_CHECK(status == cudaSuccess,
+                                    "BatchPrefillWithPagedKVCache failed with error code ",
+                                    cudaGetErrorString(status));
+                        return true;
                       });
-                });
-          });
+                    });
+              });
         });
       });
     });
@@ -217,34 +215,31 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::ForwardCu
           static_cast<int32_t*>(paged_kv_indices.data_ptr()),
           static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
           static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
-      return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_allow_fp16_qk_reduction(
-              allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
-                return DISPATCH_pos_encoding_mode(
-                    PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                      return DISPATCH_page_size(page_size, PAGE_SIZE, [&] {
-                        cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
-                            PageStorage::kIndices, KV_LAYOUT, PAGE_SIZE, GROUP_SIZE, HEAD_DIM,
-                            POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type,
-                            int32_t>(
-                            handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                            static_cast<int32_t*>(qo_indptr.data_ptr()),
-                            /*q_offset=*/nullptr, paged_kv,
-                            static_cast<float*>(custom_mask.data_ptr()),
-                            static_cast<int32_t*>(qk_indptr.data_ptr()),
-                            static_cast<c_type*>(o.data_ptr()),
-                            /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                            sm_scale, rope_scale, rope_theta,
-                            /*stream=*/torch_current_stream);
-                        TORCH_CHECK(status == cudaSuccess,
-                                    "BatchPrefillWithPagedKVCache failed with error code ",
-                                    cudaGetErrorString(status));
-                        return true;
-                      });
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_allow_fp16_qk_reduction(
+            allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
+              return DISPATCH_pos_encoding_mode(
+                  PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                    return DISPATCH_page_size(page_size, PAGE_SIZE, [&] {
+                      cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
+                          PageStorage::kIndices, KV_LAYOUT, PAGE_SIZE, HEAD_DIM, POS_ENCODING_MODE,
+                          ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
+                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                          static_cast<int32_t*>(qo_indptr.data_ptr()),
+                          /*q_offset=*/nullptr, paged_kv,
+                          static_cast<float*>(custom_mask.data_ptr()),
+                          static_cast<int32_t*>(qk_indptr.data_ptr()),
+                          static_cast<c_type*>(o.data_ptr()),
+                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                          num_qo_heads, sm_scale, rope_scale, rope_theta,
+                          /*stream=*/torch_current_stream);
+                      TORCH_CHECK(status == cudaSuccess,
+                                  "BatchPrefillWithPagedKVCache failed with error code ",
+                                  cudaGetErrorString(status));
+                      return true;
                     });
-              });
-        });
+                  });
+            });
       });
     });
   });
@@ -327,35 +322,33 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
   MaskMode mask_mode = causal ? MaskMode::kCausal : MaskMode::kNone;
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE(q.scalar_type(), c_type, [&] {
-    return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-        return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
-          return DISPATCH_allow_fp16_qk_reduction(
-              allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
-                return DISPATCH_pos_encoding_mode(
-                    PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                      return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-                        cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
-                            GROUP_SIZE, HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE,
-                            ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
-                            handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                            static_cast<int32_t*>(qo_indptr.data_ptr()),
-                            static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
-                            static_cast<int32_t*>(kv_indptr.data_ptr()),
-                            /*custom_mask=*/nullptr, /*qk_indptr=*/nullptr,
-                            /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
-                            static_cast<c_type*>(o.data_ptr()),
-                            /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                            batch_size, num_kv_heads, sm_scale, rope_scale, rope_theta,
-                            /*stream=*/torch_current_stream);
-                        TORCH_CHECK(status == cudaSuccess,
-                                    "BatchPrefillWithRaggedKVCache failed with error ",
-                                    cudaGetErrorString(status));
-                        return true;
-                      });
+    return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+      return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
+        return DISPATCH_allow_fp16_qk_reduction(
+            allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
+              return DISPATCH_pos_encoding_mode(
+                  PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                    return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
+                      cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
+                          HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION,
+                          MASK_MODE, c_type, c_type, int32_t>(
+                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                          static_cast<int32_t*>(qo_indptr.data_ptr()),
+                          static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
+                          static_cast<int32_t*>(kv_indptr.data_ptr()),
+                          /*custom_mask=*/nullptr, /*qk_indptr=*/nullptr,
+                          /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
+                          static_cast<c_type*>(o.data_ptr()),
+                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                          batch_size, num_qo_heads, num_kv_heads, sm_scale, rope_scale, rope_theta,
+                          /*stream=*/torch_current_stream);
+                      TORCH_CHECK(status == cudaSuccess,
+                                  "BatchPrefillWithRaggedKVCache failed with error ",
+                                  cudaGetErrorString(status));
+                      return true;
                     });
-              });
-        });
+                  });
+            });
       });
     });
   });
@@ -414,35 +407,33 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::ForwardC
 
   constexpr MaskMode MASK_MODE = MaskMode::kCustom;
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE(q.scalar_type(), c_type, [&] {
-    return DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, [&] {
-      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-        return DISPATCH_allow_fp16_qk_reduction(
-            allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
-              return DISPATCH_pos_encoding_mode(
-                  PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                    return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-                      cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
-                          GROUP_SIZE, HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE,
-                          ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
-                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                          static_cast<int32_t*>(qo_indptr.data_ptr()),
-                          static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
-                          static_cast<int32_t*>(kv_indptr.data_ptr()),
-                          static_cast<float*>(custom_mask.data_ptr()),
-                          static_cast<int32_t*>(qk_indptr.data_ptr()),
-                          /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
-                          static_cast<c_type*>(o.data_ptr()),
-                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                          batch_size, num_kv_heads, sm_scale, rope_scale, rope_theta,
-                          /*stream=*/torch_current_stream);
-                      TORCH_CHECK(status == cudaSuccess,
-                                  "BatchPrefillWithRaggedKVCache failed with error ",
-                                  cudaGetErrorString(status));
-                      return true;
-                    });
+    return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+      return DISPATCH_allow_fp16_qk_reduction(
+          allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
+            return DISPATCH_pos_encoding_mode(
+                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                  return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
+                    cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
+                        HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE,
+                        c_type, c_type, int32_t>(
+                        handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                        static_cast<int32_t*>(qo_indptr.data_ptr()),
+                        static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
+                        static_cast<int32_t*>(kv_indptr.data_ptr()),
+                        static_cast<float*>(custom_mask.data_ptr()),
+                        static_cast<int32_t*>(qk_indptr.data_ptr()),
+                        /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
+                        static_cast<c_type*>(o.data_ptr()),
+                        /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                        batch_size, num_qo_heads, num_kv_heads, sm_scale, rope_scale, rope_theta,
+                        /*stream=*/torch_current_stream);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchPrefillWithRaggedKVCache failed with error ",
+                                cudaGetErrorString(status));
+                    return true;
                   });
-            });
-      });
+                });
+          });
     });
   });
 

--- a/python/csrc/pytorch_extension_utils.h
+++ b/python/csrc/pytorch_extension_utils.h
@@ -114,9 +114,6 @@ using namespace flashinfer;
     return __VA_ARGS__();                        \
   }
 
-#define DISPATCH_group_size(expr, const_expr, ...) \
-  _DISPATCH_SWITCH("group_size", expr, _DISPATCH_CASES_group_size(const_expr, __VA_ARGS__))
-
 #define DISPATCH_page_size(expr, const_expr, ...) \
   _DISPATCH_SWITCH("page size", expr, _DISPATCH_CASES_page_size(const_expr, __VA_ARGS__))
 

--- a/python/generate_batch_padded_decode_inst.py
+++ b/python/generate_batch_padded_decode_inst.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 
 def get_cu_file_str(
-    group_size,
     head_dim,
     kv_layout,
     pos_encoding_mode,
@@ -36,17 +35,18 @@ def get_cu_file_str(
 
 namespace flashinfer {{
 
-template cudaError_t BatchDecodeWithPaddedKVCacheDispatched<{group_size}, {head_dim}, {kv_layout}, {pos_encoding_mode}, {dtype_in}, {dtype_out}>(
+template cudaError_t BatchDecodeWithPaddedKVCacheDispatched<{head_dim}, {kv_layout}, {pos_encoding_mode}, {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v,
     {dtype_out}* o, {dtype_out}* tmp, float* lse,
-    uint32_t batch_size, uint32_t padded_kv_len, uint32_t num_qo_heads,
+    uint32_t batch_size, uint32_t padded_kv_len,
+    uint32_t num_qo_heads,
+    uint32_t num_kv_heads,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}
     """.format(
         kv_layout=kv_layout_literal[int(kv_layout)],
-        group_size=group_size,
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_in=dtype_literal[dtype_in],
@@ -57,7 +57,7 @@ template cudaError_t BatchDecodeWithPaddedKVCacheDispatched<{group_size}, {head_
 
 if __name__ == "__main__":
     pattern = (
-        r"batch_padded_decode_group_([0-9]+)_head_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"batch_padded_decode_head_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
         r"dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
     )
 

--- a/python/generate_dispatch_inc.py
+++ b/python/generate_dispatch_inc.py
@@ -36,17 +36,6 @@ def get_dispatch_inc_str(args: argparse.Namespace) -> str:
 {dispatch_head_dims_entries}
 // EOL
 """
-    # group sizes
-    dispatch_group_sizes_entries = "\n".join(
-        [
-            "  _DISPATCH_CASE({}, case_var, __VA_ARGS__) \\".format(_)
-            for _ in args.group_sizes
-        ]
-    )
-    dispatch_group_sizes_str = f"""#define _DISPATCH_CASES_group_size(case_var, ...)         \\
-{dispatch_group_sizes_entries}
-// EOL
-"""
     # page sizes
     dispatch_page_sizes_entries = "\n".join(
         [
@@ -112,7 +101,6 @@ def get_dispatch_inc_str(args: argparse.Namespace) -> str:
     return "\n".join(
         [
             dispatch_head_dims_str,
-            dispatch_group_sizes_str,
             dispatch_page_sizes_str,
             dispatch_kv_layouts_str,
             dispatch_pos_encoding_modes_str,
@@ -136,9 +124,6 @@ if __name__ == "__main__":
         required=True,
         nargs="+",
         help="Prefill attention page sizes",
-    )
-    parser.add_argument(
-        "--group_sizes", type=int, required=True, nargs="+", help="Group sizes"
     )
     parser.add_argument(
         "--kv_layouts", type=int, required=True, nargs="+", help="KV layouts"

--- a/python/generate_single_decode_inst.py
+++ b/python/generate_single_decode_inst.py
@@ -20,23 +20,20 @@ from literal_map import kv_layout_literal, pos_encoding_mode_literal, dtype_lite
 from pathlib import Path
 
 
-def get_cu_file_str(
-    group_size, head_dim, kv_layout, pos_encoding_mode, dtype_in, dtype_out
-):
+def get_cu_file_str(head_dim, kv_layout, pos_encoding_mode, dtype_in, dtype_out):
     content = """#include <flashinfer/attention_impl.cuh>
 
 namespace flashinfer {{
 
-template cudaError_t SingleDecodeWithKVCacheDispatched<{group_size}, {head_dim}, {kv_layout}, {pos_encoding_mode}, {dtype_in}, {dtype_out}>(
+template cudaError_t SingleDecodeWithKVCacheDispatched<{head_dim}, {kv_layout}, {pos_encoding_mode}, {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, {dtype_out}* o,
-    {dtype_out}* tmp, uint32_t num_kv_heads, uint32_t seq_len,
+    {dtype_out}* tmp, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t seq_len,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}
     """.format(
         kv_layout=kv_layout_literal[int(kv_layout)],
-        group_size=group_size,
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_in=dtype_literal[dtype_in],
@@ -47,7 +44,7 @@ template cudaError_t SingleDecodeWithKVCacheDispatched<{group_size}, {head_dim},
 
 if __name__ == "__main__":
     pattern = (
-        r"single_decode_group_([0-9]+)_head_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"single_decode_head_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
         r"dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
     )
 

--- a/python/generate_single_prefill_inst.py
+++ b/python/generate_single_prefill_inst.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 
 def get_cu_file_str(
-    group_size,
     head_dim,
     kv_layout,
     pos_encoding_mode,
@@ -40,16 +39,15 @@ def get_cu_file_str(
 
 namespace flashinfer {{
 
-template cudaError_t SinglePrefillWithKVCacheDispatched<{group_size}, {head_dim}, {kv_layout}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
+template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {kv_layout}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode},  {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, float* custom_mask, {dtype_out}* o,
-    float* tmp, float* lse, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
+    float* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}
     """.format(
         kv_layout=kv_layout_literal[int(kv_layout)],
-        group_size=group_size,
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         allow_fp16_qk_reduction=allow_fp16_qk_reduction,
@@ -62,7 +60,7 @@ template cudaError_t SinglePrefillWithKVCacheDispatched<{group_size}, {head_dim}
 
 if __name__ == "__main__":
     pattern = (
-        r"single_prefill_group_([0-9]+)_head_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"single_prefill_head_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
         r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
     )
 

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -60,21 +60,17 @@ cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOu
   const MaskMode mask_mode = causal ? MaskMode::kCausal : MaskMode::kNone;
   DISPATCH_allow_fp16_qk_reduction(
       allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION,
-      {DISPATCH_group_size(
-          group_size, GROUP_SIZE,
-          {DISPATCH_mask_mode(
-              mask_mode, MASK_MODE,
-              {DISPATCH_head_dim(head_dim, HEAD_DIM,
-                                 {DISPATCH_pos_encoding_mode(
-                                     pos_encoding_mode, POS_ENCODING_MODE,
-                                     {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
-                                       return SinglePrefillWithKVCacheDispatched<
-                                           GROUP_SIZE, HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE,
-                                           ALLOW_FP16_QK_REDUCTION, MASK_MODE>(
-                                           q, k, v, /*custom_mask=*/nullptr, o, tmp, lse,
-                                           num_kv_heads, qo_len, kv_len, sm_scale, rope_scale,
-                                           rope_theta, stream);
-                                     })})})})})});
+      {DISPATCH_mask_mode(
+          mask_mode, MASK_MODE,
+          {DISPATCH_head_dim(
+              head_dim, HEAD_DIM,
+              {DISPATCH_pos_encoding_mode(
+                  pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
+                    return SinglePrefillWithKVCacheDispatched<
+                        HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE>(
+                        q, k, v, /*custom_mask=*/nullptr, o, tmp, lse, num_qo_heads, num_kv_heads,
+                        qo_len, kv_len, sm_scale, rope_scale, rope_theta, stream);
+                  })})})})});
   return cudaSuccess;
 }
 
@@ -91,23 +87,21 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapper(
   const MaskMode mask_mode = causal ? MaskMode::kCausal : MaskMode::kNone;
   DISPATCH_kv_layout(
       kv_layout, KV_LAYOUT,
-      {DISPATCH_group_size(
-          num_qo_heads / num_kv_heads, GROUP_SIZE,
-          {DISPATCH_head_dim(
-              head_dim, HEAD_DIM,
-              {DISPATCH_mask_mode(
-                  mask_mode, MASK_MODE,
-                  {DISPATCH_pos_encoding_mode(
-                      pos_encoding_mode, pos_encoding_mode,
-                      {DISPATCH_allow_fp16_qk_reduction(
-                          allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, {
-                            return BatchPrefillWithRaggedKVCacheWrapperDispatched<
-                                GROUP_SIZE, HEAD_DIM, KV_LAYOUT, pos_encoding_mode,
-                                ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeIn, DTypeOut, IdType>(
-                                handler, q, qo_indptr, k, v, kv_indptr, /*custom_mask=*/nullptr,
-                                /*qk_indptr=*/nullptr, q_offset, k_rope_pos_offset, o, lse,
-                                batch_size, num_kv_heads, sm_scale, rope_scale, rope_theta, stream);
-                          })})})})})});
+      {DISPATCH_head_dim(
+          head_dim, HEAD_DIM,
+          {DISPATCH_mask_mode(
+              mask_mode, MASK_MODE,
+              {DISPATCH_pos_encoding_mode(
+                  pos_encoding_mode, pos_encoding_mode,
+                  {DISPATCH_allow_fp16_qk_reduction(
+                      allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, {
+                        return BatchPrefillWithRaggedKVCacheWrapperDispatched<
+                            HEAD_DIM, KV_LAYOUT, pos_encoding_mode, ALLOW_FP16_QK_REDUCTION,
+                            MASK_MODE, DTypeIn, DTypeOut, IdType>(
+                            handler, q, qo_indptr, k, v, kv_indptr, /*custom_mask=*/nullptr,
+                            /*qk_indptr=*/nullptr, q_offset, k_rope_pos_offset, o, lse, batch_size,
+                            num_qo_heads, num_kv_heads, sm_scale, rope_scale, rope_theta, stream);
+                      })})})})});
   return cudaSuccess;
 }
 
@@ -124,24 +118,22 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapper(
   const uint32_t num_kv_heads = paged_kv.num_heads;
   const uint32_t head_dim = paged_kv.head_dim;
   const MaskMode mask_mode = causal ? MaskMode::kCausal : MaskMode::kNone;
-  DISPATCH_group_size(
-      num_qo_heads / num_kv_heads, GROUP_SIZE,
-      {DISPATCH_head_dim(
-          head_dim, HEAD_DIM,
-          {DISPATCH_mask_mode(mask_mode, MASK_MODE,
-                              {DISPATCH_pos_encoding_mode(
-                                  pos_encoding_mode, pos_encoding_mode,
-                                  {DISPATCH_allow_fp16_qk_reduction(
-                                      allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION,
-                                      {DISPATCH_page_size(paged_kv.page_size, PAGE_SIZE, {
-                                        return BatchPrefillWithPagedKVCacheWrapperDispatched<
-                                            page_storage, kv_layout, PAGE_SIZE, GROUP_SIZE,
-                                            HEAD_DIM, pos_encoding_mode, ALLOW_FP16_QK_REDUCTION,
-                                            MASK_MODE, DTypeIn, DTypeOut, IdType>(
-                                            handler, q, qo_indptr, q_offset, paged_kv,
-                                            /*custom_mask=*/nullptr, /*qk_indptr=*/nullptr, o, lse,
-                                            sm_scale, rope_scale, rope_theta, stream);
-                                      })})})})})});
+  DISPATCH_head_dim(
+      head_dim, HEAD_DIM,
+      {DISPATCH_mask_mode(
+          mask_mode, MASK_MODE,
+          {DISPATCH_pos_encoding_mode(
+              pos_encoding_mode, pos_encoding_mode,
+              {DISPATCH_allow_fp16_qk_reduction(
+                  allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION,
+                  {DISPATCH_page_size(paged_kv.page_size, PAGE_SIZE, {
+                    return BatchPrefillWithPagedKVCacheWrapperDispatched<
+                        page_storage, kv_layout, PAGE_SIZE, HEAD_DIM, pos_encoding_mode,
+                        ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeIn, DTypeOut, IdType>(
+                        handler, q, qo_indptr, q_offset, paged_kv,
+                        /*custom_mask=*/nullptr, /*qk_indptr=*/nullptr, o, lse, num_qo_heads,
+                        sm_scale, rope_scale, rope_theta, stream);
+                  })})})})});
   return cudaSuccess;
 }
 
@@ -161,17 +153,14 @@ cudaError_t SingleDecodeWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut
     throw std::invalid_argument(err_msg.str());
   }
 
-  DISPATCH_group_size(
-      num_qo_heads / num_kv_heads, GROUP_SIZE,
-      {DISPATCH_head_dim(
-          head_dim, HEAD_DIM,
-          {DISPATCH_pos_encoding_mode(
-              pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
-                SingleDecodeWithKVCacheDispatched<GROUP_SIZE, HEAD_DIM, KV_LAYOUT,
-                                                  POS_ENCODING_MODE>(q, k, v, o, tmp, num_kv_heads,
-                                                                     seq_len, sm_scale, rope_scale,
-                                                                     rope_theta, stream);
-              })})})});
+  DISPATCH_head_dim(
+      head_dim, HEAD_DIM,
+      {DISPATCH_pos_encoding_mode(
+          pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
+            SingleDecodeWithKVCacheDispatched<HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE>(
+                q, k, v, o, tmp, num_qo_heads, num_kv_heads, seq_len, sm_scale, rope_scale,
+                rope_theta, stream);
+          })})});
   return cudaSuccess;
 }
 
@@ -193,17 +182,15 @@ cudaError_t BatchDecodeWithPaddedKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTy
     throw std::invalid_argument(err_msg.str());
   }
 
-  DISPATCH_group_size(
-      num_qo_heads / num_kv_heads, GROUP_SIZE,
-      {DISPATCH_head_dim(
-          head_dim, HEAD_DIM,
-          {DISPATCH_pos_encoding_mode(
-              pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
-                return BatchDecodeWithPaddedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, KV_LAYOUT,
-                                                              POS_ENCODING_MODE, DTypeIn, DTypeOut>(
-                    q, k, v, o, tmp, lse, batch_size, padded_kv_len, num_qo_heads, sm_scale,
-                    rope_scale, rope_theta, stream);
-              })})})});
+  DISPATCH_head_dim(
+      head_dim, HEAD_DIM,
+      {DISPATCH_pos_encoding_mode(
+          pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
+            return BatchDecodeWithPaddedKVCacheDispatched<HEAD_DIM, KV_LAYOUT, POS_ENCODING_MODE,
+                                                          DTypeIn, DTypeOut>(
+                q, k, v, o, tmp, lse, batch_size, padded_kv_len, num_qo_heads, num_kv_heads,
+                sm_scale, rope_scale, rope_theta, stream);
+          })})});
   return cudaSuccess;
 }
 
@@ -226,18 +213,14 @@ cudaError_t BatchDecodeWithPagedKVCacheNoSplitKV(
     throw std::invalid_argument(err_msg.str());
   }
 
-  DISPATCH_group_size(
-      num_qo_heads / num_kv_heads, GROUP_SIZE,
-      {DISPATCH_head_dim(
-          head_dim, HEAD_DIM, {DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
-            return BatchDecodeWithPagedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, page_storage,
-                                                         kv_layout, POS_ENCODING_MODE, DTypeIn,
-                                                         DTypeOut, IdType>(
-                q, q_offset, paged_kv, kv_partition_info, o, /*tmp_v=*/nullptr, /*tmp_s=*/nullptr,
-                lse,
-                /*block_valid_mask=*/nullptr, /*padded_batch_size=*/paged_kv.batch_size, sm_scale,
-                rope_scale, rope_theta, stream);
-          })})});
+  DISPATCH_head_dim(
+      head_dim, HEAD_DIM, {DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
+        return BatchDecodeWithPagedKVCacheDispatched<HEAD_DIM, page_storage, kv_layout,
+                                                     POS_ENCODING_MODE, DTypeIn, DTypeOut, IdType>(
+            q, q_offset, paged_kv, kv_partition_info, o, /*tmp_v=*/nullptr, /*tmp_s=*/nullptr, lse,
+            /*block_valid_mask=*/nullptr, /*padded_batch_size=*/paged_kv.batch_size, num_qo_heads,
+            sm_scale, rope_scale, rope_theta, stream);
+      })});
 
   return cudaSuccess;
 }
@@ -280,16 +263,14 @@ cudaError_t BatchDecodeWithPagedKVCacheWrapper(
     throw std::invalid_argument(err_msg.str());
   }
 
-  DISPATCH_group_size(
-      num_qo_heads / num_kv_heads, GROUP_SIZE,
-      {DISPATCH_head_dim(
-          paged_kv.head_dim, HEAD_DIM,
-          {DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
-            return BatchDecodeWithPagedKVCacheWrapperDispatched<page_storage, KV_LAYOUT, GROUP_SIZE,
-                                                                HEAD_DIM, POS_ENCODING_MODE,
-                                                                DTypeIn, DTypeOut, IdType>(
-                handler, q, q_offset, paged_kv, o, lse, sm_scale, rope_scale, rope_theta, stream);
-          })})});
+  DISPATCH_head_dim(
+      paged_kv.head_dim, HEAD_DIM,
+      {DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
+        return BatchDecodeWithPagedKVCacheWrapperDispatched<
+            page_storage, KV_LAYOUT, HEAD_DIM, POS_ENCODING_MODE, DTypeIn, DTypeOut, IdType>(
+            handler, q, q_offset, paged_kv, o, lse, num_qo_heads, sm_scale, rope_scale, rope_theta,
+            stream);
+      })});
   return cudaSuccess;
 }
 
@@ -307,14 +288,12 @@ cudaError_t BatchDecodeHandlerBeginForward(BatchDecodeHandler* handler, void* bu
             << num_kv_heads;
     throw std::invalid_argument(err_msg.str());
   }
-  DISPATCH_group_size(num_qo_heads / num_kv_heads, GROUP_SIZE, {
-    DISPATCH_head_dim(head_dim, HEAD_DIM, {
-      DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
-        return handler->BeginForwardDispatched<GROUP_SIZE, HEAD_DIM, page_storage, kv_layout,
-                                               POS_ENCODING_MODE, DTypeIn, DTypeOut, IdType>(
-            buffer, workspace_size_in_bytes, indptr, last_page_len, batch_size, num_qo_heads,
-            page_size);
-      });
+  DISPATCH_head_dim(head_dim, HEAD_DIM, {
+    DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
+      return handler->BeginForwardDispatched<HEAD_DIM, page_storage, kv_layout, POS_ENCODING_MODE,
+                                             DTypeIn, DTypeOut, IdType>(
+          buffer, workspace_size_in_bytes, indptr, last_page_len, batch_size, num_qo_heads,
+          num_kv_heads, page_size);
     });
   });
 }

--- a/src/test_batch_prefill.cu
+++ b/src/test_batch_prefill.cu
@@ -487,8 +487,7 @@ void TestBatchPagedPrefillKernelShortContextCorrectness(bool allow_fp16_qk_reduc
 template <typename T>
 void TestBatchPagedPrefillKernelLongContextCorrectness(bool allow_fp16_qk_reduction) {
   for (size_t num_kv_heads : {1, 2, 8}) {
-    for (size_t group_size : {1, 4, 5, 6, 7, 8}) {
-      size_t num_qo_heads = num_kv_heads * group_size;
+    for (size_t num_qo_heads : {8}) {
       for (size_t page_size : {1, 8, 16}) {
         for (size_t head_dim : {64, 128, 256}) {
           for (size_t causal : {false, true}) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -48,9 +48,6 @@
     break;                                       \
   }
 
-#define DISPATCH_group_size(expr, const_expr, ...) \
-  _DISPATCH_SWITCH("group_size", expr, _DISPATCH_CASES_group_size(const_expr, __VA_ARGS__))
-
 #define DISPATCH_page_size(expr, const_expr, ...) \
   _DISPATCH_SWITCH("page size", expr, _DISPATCH_CASES_page_size(const_expr, __VA_ARGS__))
 


### PR DESCRIPTION
Our previous implementation treats `gqa_group_size` as a template parameter.
We also have an implicit assumption that 8 should be divisible by `gqa_group_size`, this is not documented and cause lots of confusion for developers.

#223 could be a workaround but this would quickly increase the binary size of this library if we keep adding more and more gqa group sizes.

This PR refactors the code so that `gqa_group_size` becomes a runtime function argument, and we don't need to compile one kernel for each of them. This would be bring very slight performance degradation to `gqa_group_size=1` but should work good in general. This PR also removes the requirement that "8 should be divisible by `gqa_group_size`", so that any gqa group size should be supported.

This PR should resolve #142 #181 #246 #254 #258 and so on.

Still working in progress, estimated finish time: <del> May 27th at noon (PST time). </del> <del>May 30th</del> June 3rd.