### PR TITLE
3rdparty: add mscclpp dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rdparty/googletest"]
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
+[submodule "3rdparty/mscclpp"]
+	path = 3rdparty/mscclpp
+	url = https://github.com/microsoft/mscclpp.git


### PR DESCRIPTION
We use [mscclpp](https://github.com/microsoft/mscclpp) for custom distributed kernels.