### PR TITLE
bugfix: Fix the behavior of decode cuda graph wrapper

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -518,18 +518,14 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
     DTypeIn* __restrict__ q, IdType* __restrict__ q_offset,
     paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* __restrict__ o,
-    DTypeOut* __restrict__ tmp, float* __restrict__ lse, float sm_scale, float rope_rcp_scale,
+    DTypeOut* __restrict__ tmp_v, float* __restrict__ tmp_s, float* __restrict__ lse,
+    bool* __restrict__ block_valid_mask, float sm_scale, float rope_rcp_scale,
     float rope_rcp_theta) {
   auto block = cg::this_thread_block();
   sm_scale *= math::log2e;
 
   constexpr uint32_t head_dim = bdx * vec_size;
   const uint32_t batch_idx = blockIdx.x;
-  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0
-      && blockIdx.x == 0 && blockIdx.y == 0) {
-    printf("%d %d\n", gridDim.x, paged_kv.batch_size);
-  }
-
   const uint32_t kv_head_idx = blockIdx.y;
   const uint32_t qo_head_idx = kv_head_idx * bdy + threadIdx.y;
   const uint32_t num_qo_heads = gridDim.y * bdy;
@@ -539,7 +535,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
                  cur_page_indptr_end = paged_kv.indptr[batch_idx + 1];
   // NOTE(Zihao): when CUDAGraph is enabled, we will launch more blocks than
   // the actual batch size, so we need to check if the current batch is valid
-  if (cur_page_indptr_begin == cur_page_indptr_end) return;
+  if (block_valid_mask && !block_valid_mask[batch_idx]) return;
   const uint32_t cur_last_page_len = paged_kv.last_page_len[batch_idx];
   const uint32_t kv_chunk_len =
       cur_page_indptr_begin != cur_page_indptr_end
@@ -587,7 +583,10 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
   // preload k/v tiles
   uint32_t stage_idx = 0;
   constexpr uint32_t vec_bits = sizeof(DTypeIn) * vec_size * 8;
-  const IdType last_indptr = paged_kv.indptr[paged_kv.batch_size];
+  // NOTE(Zihao): when CUDAGraph is disabled, gridDim.x = batch_size, otherwise,
+  // we guarantee that indptr array length is greater than or equal to batch_size + 1,
+  // so we can safely access paged_kv.indptr[batch_idx + 1]
+  const IdType last_indptr = paged_kv.indptr[gridDim.x];
 
   static_assert(num_stages_smem <= bdx);
 #pragma unroll
@@ -704,9 +703,8 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
   st.normalize();
 
   if constexpr (partition_kv) {
-    st.o.cast_store(tmp + (batch_idx * num_qo_heads + qo_head_idx) * head_dim + tx * vec_size);
-    float* tmp_lse = (float*)(tmp + paged_kv.batch_size * num_qo_heads * head_dim);
-    tmp_lse[batch_idx * num_qo_heads + qo_head_idx] = st.get_lse();
+    st.o.cast_store(tmp_v + (batch_idx * num_qo_heads + qo_head_idx) * head_dim + tx * vec_size);
+    tmp_s[batch_idx * num_qo_heads + qo_head_idx] = st.get_lse();
   } else {
     st.o.cast_store(o + (batch_idx * num_qo_heads + qo_head_idx) * head_dim + tx * vec_size);
     // write lse
@@ -850,9 +848,9 @@ template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PageStorage page_storage, QKVL
           PosEncodingMode POS_ENCODING_MODE, typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchDecodeWithPagedKVCacheDispatched(
     DTypeIn* q, IdType* q_offset, paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
-    kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp_v, float* tmp_s, float* lse,
-    std::optional<uint32_t> fixed_grid_size, float sm_scale, float rope_scale, float rope_theta,
-    cudaStream_t stream) {
+    kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp_v, float* tmp_s,
+    float* lse, bool* block_valid_mask, std::optional<uint32_t> fixed_grid_size, float sm_scale,
+    float rope_scale, float rope_theta, cudaStream_t stream) {
   const float rope_rcp_scale = 1.f / rope_scale;
   const float rope_rcp_theta = 1.f / rope_theta;
   const uint32_t num_kv_heads = paged_kv.num_heads;
@@ -890,6 +888,7 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(
                     (void*)&tmp_v,
                     (void*)&tmp_s,
                     (void*)&lse,
+                    (void*)&block_valid_mask,
                     (void*)&sm_scale,
                     (void*)&rope_rcp_scale,
                     (void*)&rope_rcp_theta};
@@ -910,6 +909,7 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(
                     (void*)&tmp_v,
                     (void*)&tmp_s,
                     (void*)&lse,
+                    (void*)&block_valid_mask,
                     (void*)&sm_scale,
                     (void*)&rope_rcp_scale,
                     (void*)&rope_rcp_theta};
@@ -918,8 +918,8 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(
     FLASHINFER_CUDA_CALL(
         cudaLaunchKernel((void*)partition_kv_kernel, nblks, nthrs, args, smem_size, stream));
     FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
-        tmp_v, tmp_s, kv_partition_info.chunk_indptr,
-        o, lse, kv_partition_info.batch_size_before_partition, num_qo_heads, HEAD_DIM, stream));
+        tmp_v, tmp_s, kv_partition_info.chunk_indptr, o, lse,
+        kv_partition_info.batch_size_before_partition, num_qo_heads, HEAD_DIM, stream));
   }
 
   return cudaSuccess;

--- a/include/flashinfer/attention/handler.cuh
+++ b/include/flashinfer/attention/handler.cuh
@@ -271,7 +271,7 @@ class BatchDecodeHandler {
     return (IdType*)seq_lengths_before_partition_;
   }
 
-  const uint32_t GetFixedGridSize() const { return fixed_grid_size_; }
+  uint32_t GetFixedGridSize() const { return fixed_grid_size_; }
 
   template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PageStorage page_storage, QKVLayout kv_layout,
             PosEncodingMode POS_ENCODING_MODE, typename DTypeIn, typename DTypeOut, typename IdType>

--- a/include/flashinfer/decode_attention_decl.cuh
+++ b/include/flashinfer/decode_attention_decl.cuh
@@ -39,9 +39,9 @@ template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, PageStorage page_storage, QKVL
           PosEncodingMode POS_ENCODING_MODE, typename DTypeIn, typename DTypeOut, typename IdType>
 cudaError_t BatchDecodeWithPagedKVCacheDispatched(
     DTypeIn* q, IdType* q_offset, paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
-    kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp_v, float* tmp_s, float* lse,
-    std::optional<uint32_t> fixed_grid_size, float sm_scale, float rope_scale, float rope_theta,
-    cudaStream_t stream);
+    kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp_v, float* tmp_s,
+    float* lse, bool* block_valid_mask, std::optional<uint32_t> fixed_grid_size, float sm_scale,
+    float rope_scale, float rope_theta, cudaStream_t stream);
 
 template <uint32_t GROUP_SIZE, uint32_t HEAD_DIM, QKVLayout KV_LAYOUT,
           PosEncodingMode POS_ENCODING_MODE, typename DTypeIn, typename DTypeOut>
@@ -59,8 +59,8 @@ cudaError_t BatchDecodeWithPagedKVCacheWrapperDispatched(
     float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream) {
   paged_kv_t<page_storage, KV_LAYOUT, DTypeIn, IdType> new_paged_kv = paged_kv;
   kv_partition_info_t<IdType> kv_partition_info;
-  DTypeOut* tmp_v = handler->GetTempFloatVBuffer<DTypeOut>();
-  float* tmp_s = handler->GetTempFloatSBuffer<float>();
+  DTypeOut* tmp_v = handler->GetTempV<DTypeOut>();
+  float* tmp_s = handler->GetTempS<float>();
 
   if (handler->IsForwardStarted()) {
     if (tmp_v != nullptr) {
@@ -84,6 +84,7 @@ cudaError_t BatchDecodeWithPagedKVCacheWrapperDispatched(
   return BatchDecodeWithPagedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, page_storage, KV_LAYOUT,
                                                POS_ENCODING_MODE, DTypeIn, DTypeOut, IdType>(
       q, q_offset, new_paged_kv, kv_partition_info, o, tmp_v, tmp_s, lse,
+      handler->GetBlockValidMask(),
       (handler->IsCUDAGraphEnabled() ? std::optional<uint32_t>(handler->GetFixedGridSize())
                                      : std::nullopt),
       sm_scale, rope_scale, rope_theta, stream);

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -53,7 +53,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithPagedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithPagedKVCachePyTorchWrapper")
-      .def(py::init<bool, unsigned int>())
+      .def(py::init<unsigned int, bool>())
       .def("begin_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward)
       .def("is_cuda_graph_enabled", &BatchPrefillWithPagedKVCachePyTorchWrapper::IsCUDAGraphEnabled)
@@ -63,7 +63,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("forward_custom_mask", &BatchPrefillWithPagedKVCachePyTorchWrapper::ForwardCustomMask);
   py::class_<BatchPrefillWithRaggedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithRaggedKVCachePyTorchWrapper")
-      .def(py::init<bool, unsigned int>())
+      .def(py::init<unsigned int, bool>())
       .def("begin_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward)
       .def("is_cuda_graph_enabled",

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -44,7 +44,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("rmsnorm", &rmsnorm, "Root mean square normalization");
   py::class_<BatchDecodeWithPagedKVCachePyTorchWrapper>(m,
                                                         "BatchDecodeWithPagedKVCachePyTorchWrapper")
-      .def(py::init<unsigned int, unsigned int, unsigned int, bool>())
+      .def(py::init<unsigned int, bool, unsigned int>())
       .def("begin_forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::EndForward)
       .def("is_cuda_graph_enabled", &BatchDecodeWithPagedKVCachePyTorchWrapper::IsCUDAGraphEnabled)
@@ -53,7 +53,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("forward", &BatchDecodeWithPagedKVCachePyTorchWrapper::Forward);
   py::class_<BatchPrefillWithPagedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithPagedKVCachePyTorchWrapper")
-      .def(py::init<unsigned int, unsigned int, bool>())
+      .def(py::init<bool, unsigned int>())
       .def("begin_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithPagedKVCachePyTorchWrapper::EndForward)
       .def("is_cuda_graph_enabled", &BatchPrefillWithPagedKVCachePyTorchWrapper::IsCUDAGraphEnabled)
@@ -63,7 +63,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("forward_custom_mask", &BatchPrefillWithPagedKVCachePyTorchWrapper::ForwardCustomMask);
   py::class_<BatchPrefillWithRaggedKVCachePyTorchWrapper>(
       m, "BatchPrefillWithRaggedKVCachePyTorchWrapper")
-      .def(py::init<unsigned int, unsigned int, bool>())
+      .def(py::init<bool, unsigned int>())
       .def("begin_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward)
       .def("end_forward", &BatchPrefillWithRaggedKVCachePyTorchWrapper::EndForward)
       .def("is_cuda_graph_enabled",

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -89,12 +89,11 @@ class BatchDecodeWithPagedKVCachePyTorchWrapper {
   BatchDecodeWithPagedKVCachePyTorchWrapper(
       std::shared_ptr<flashinfer::BatchDecodeHandler> handler_ptr, flashinfer::QKVLayout kv_layout)
       : handler_(handler_ptr), kv_layout_(kv_layout) {}
-  BatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout,
-                                            unsigned int max_workspace_size_in_bytes,
-                                            unsigned int max_batch_size, bool enable_cuda_graph)
+  BatchDecodeWithPagedKVCachePyTorchWrapper(unsigned int layout, bool enable_cuda_graph,
+                                            unsigned int fixed_batch_size)
       : kv_layout_(flashinfer::QKVLayout(layout)),
-        handler_(std::make_shared<flashinfer::BatchDecodeHandler>(
-            max_workspace_size_in_bytes, max_batch_size, enable_cuda_graph)) {}
+        handler_(std::make_shared<flashinfer::BatchDecodeHandler>(enable_cuda_graph,
+                                                                  fixed_batch_size)) {}
 
  protected:
   std::shared_ptr<flashinfer::BatchDecodeHandler> handler_;
@@ -122,12 +121,9 @@ class BatchPrefillWithPagedKVCachePyTorchWrapper {
       torch::Tensor paged_kv_last_page_len, torch::Tensor custom_mask, torch::Tensor qk_indptr,
       unsigned int pos_encoding_mode, bool allow_fp16_qk_reduction, float sm_scale,
       float rope_scale, float rope_theta, bool return_lse);
-  BatchPrefillWithPagedKVCachePyTorchWrapper(unsigned int layout,
-                                             unsigned int max_workspace_size_in_bytes,
-                                             bool enable_cuda_graph)
+  BatchPrefillWithPagedKVCachePyTorchWrapper(unsigned int layout, bool enable_cuda_graph)
       : kv_layout_(flashinfer::QKVLayout(layout)),
-        handler_(std::make_shared<flashinfer::BatchPrefillHandler>(max_workspace_size_in_bytes,
-                                                                   enable_cuda_graph)) {}
+        handler_(std::make_shared<flashinfer::BatchPrefillHandler>(enable_cuda_graph)) {}
 
  private:
   std::shared_ptr<flashinfer::BatchPrefillHandler> handler_;
@@ -154,12 +150,9 @@ class BatchPrefillWithRaggedKVCachePyTorchWrapper {
                                                unsigned int pos_encoding_mode,
                                                bool allow_fp16_qk_reduction, float sm_scale,
                                                float rope_scale, float rope_theta, bool return_lse);
-  BatchPrefillWithRaggedKVCachePyTorchWrapper(unsigned int layout,
-                                              unsigned int max_workspace_size_in_bytes,
-                                              bool enable_cuda_graph)
+  BatchPrefillWithRaggedKVCachePyTorchWrapper(unsigned int layout, bool enable_cuda_graph)
       : kv_layout_(flashinfer::QKVLayout(layout)),
-        handler_(std::make_shared<flashinfer::BatchPrefillHandler>(max_workspace_size_in_bytes,
-                                                                   enable_cuda_graph)) {}
+        handler_(std::make_shared<flashinfer::BatchPrefillHandler>(enable_cuda_graph)) {}
 
  private:
   std::shared_ptr<flashinfer::BatchPrefillHandler> handler_;

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -463,9 +463,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             auxiliary data structures will be stored in the provided buffers.
 
         indptr_buffer : Optional[torch.Tensor]
-            The user reserved buffer on GPU to store the indptr of the paged kv cache, should
-            be large enough to store the indptr of maximum batch size (``[max_batch_size + 1]``)
-            during the lifecycle of this wrapper.
+            The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
+            of the buffer should be ``[batch_size + 1]``.
             Only needed when ``enable_cuda_graph`` is ``True``.
 
         indices_buffer : Optional[torch.Tensor]
@@ -475,21 +474,27 @@ class BatchDecodeWithPagedKVCacheWrapper:
             Only needed when ``enable_cuda_graph`` is ``True``.
 
         last_page_len_buffer : Optional[torch.Tensor]
-            The user reserved buffer on GPU to store the number of entries in the last page,
-            should be large enough to store the maximum batch size (``[max_batch_size]``)
-            during the lifecycle of this wrapper.
+            The user reserved buffer on GPU to store the number of entries in the last page, the
+            size of the buffer should be ``[batch_size]``.
             Only needed when ``enable_cuda_graph`` is ``True``.
         """
         check_kv_layout(kv_layout)
         self._kv_layout = kv_layout
         self._workspace_buffer = workspace_buffer
-        # NOTE(Zihao): max_batch_size will only be used in cudagraph mode
-        max_batch_size = len(paged_kv_last_page_len_buffer) if enable_cuda_graph else 0
+        # NOTE(Zihao): fixed_batch_size will only be used in cudagraph mode
+        if enable_cuda_graph:
+            self._fixed_batch_size = len(paged_kv_last_page_len_buffer)
+            if len(paged_kv_indptr_buffer) != self._fixed_batch_size + 1:
+                raise ValueError(
+                    "The size of paged_kv_indptr_buffer should be batch_size + 1"
+                )
+        else:
+            self._fixed_batch_size = 0
+
         self._wrapper = _kernels.BatchDecodeWithPagedKVCachePyTorchWrapper(
             TensorLayout[kv_layout].value,
-            workspace_buffer.numel() * workspace_buffer.element_size(),
-            max_batch_size,
             enable_cuda_graph,
+            self._fixed_batch_size,
         )
         if enable_cuda_graph:
             if not torch.is_tensor(paged_kv_indptr_buffer):
@@ -575,16 +580,34 @@ class BatchDecodeWithPagedKVCacheWrapper:
         is not equal to ``num_kv_heads``, the function will use
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
         """
+        batch_size = len(last_page_len)
+        if len(indptr) != batch_size + 1:
+            raise ValueError(
+                "The size of indptr ({}) should be size of last_page_len ({}) + 1".format(
+                    len(indptr), batch_size
+                )
+            )
+
         if self.is_cuda_graph_enabled:
-            self._paged_kv_indptr_buf[: len(indptr)] = indptr
+            if batch_size != self._fixed_batch_size:
+                raise ValueError(
+                    "The batch size should be fixed in cudagraph mode, the runtime batch size {} "
+                    " mismatches the batch size set during initialization {}".format(
+                        batch_size, self._fixed_batch_size
+                    )
+                )
+            if len(indices) > len(self._paged_kv_indices_buf):
+                raise ValueError(
+                    "The size of indices should be less than or equal to the allocated buffer"
+                )
+            self._paged_kv_indptr_buf[: self._fixed_batch_size + 1] = indptr
             self._paged_kv_indices_buf[: len(indices)] = indices
-            self._paged_kv_last_page_len_buf[: len(last_page_len)] = last_page_len
+            self._paged_kv_last_page_len_buf[: self._fixed_batch_size] = last_page_len
         else:
             self._paged_kv_indptr_buf = indptr
             self._paged_kv_indices_buf = indices
             self._paged_kv_last_page_len_buf = last_page_len
 
-        batch_size = len(indptr) - 1
         # NOTE(Zihao): the following tensor acts as placeholder to pass dtype info
         empty_data = torch.empty(
             0,

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -542,7 +542,6 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchPrefillWithPagedKVCachePyTorchWrapper(
             TensorLayout[kv_layout].value,
-            workspace_buffer.numel() * workspace_buffer.element_size(),
             enable_cuda_graph,
         )
         if enable_cuda_graph:
@@ -1055,7 +1054,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._workspace_buffer = workspace_buffer
         self._wrapper = _kernels.BatchPrefillWithRaggedKVCachePyTorchWrapper(
             TensorLayout[kv_layout].value,
-            workspace_buffer.numel() * workspace_buffer.element_size(),
             enable_cuda_graph,
         )
         if enable_cuda_graph:

--- a/python/generate_batch_paged_decode_inst.py
+++ b/python/generate_batch_paged_decode_inst.py
@@ -39,6 +39,7 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{group_size}, {head_d
     paged_kv_t<page_storage, {kv_layout}, {dtype_in}, {idtype}> paged_kv,
     kv_partition_info_t<{idtype}> kv_partition_info,
     {dtype_out}* o, {dtype_out}* tmp, float* lse,
+    std::optional<uint32_t> fixed_grid_size,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 

--- a/python/generate_batch_paged_decode_inst.py
+++ b/python/generate_batch_paged_decode_inst.py
@@ -38,7 +38,7 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{group_size}, {head_d
     {dtype_in}* q, {idtype}* q_offset,
     paged_kv_t<page_storage, {kv_layout}, {dtype_in}, {idtype}> paged_kv,
     kv_partition_info_t<{idtype}> kv_partition_info,
-    {dtype_out}* o, {dtype_out}* tmp, float* lse,
+    {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
     std::optional<uint32_t> fixed_grid_size,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);

--- a/python/generate_batch_paged_decode_inst.py
+++ b/python/generate_batch_paged_decode_inst.py
@@ -39,6 +39,7 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{group_size}, {head_d
     paged_kv_t<page_storage, {kv_layout}, {dtype_in}, {idtype}> paged_kv,
     kv_partition_info_t<{idtype}> kv_partition_info,
     {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
+    bool* block_valid_mask,
     std::optional<uint32_t> fixed_grid_size,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -152,9 +152,9 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
     )
 
     # NOTE(Zihao): allocate more space than needed for testing
-    kv_indptr_device_buffer = torch.empty(batch_size + 11).int().to(0)
-    kv_indices_device_buffer = torch.empty(total_num_pages + 10).int().to(0)
-    kv_last_page_device_buffer = torch.empty(batch_size + 10).int().to(0)
+    kv_indptr_device_buffer = torch.empty(batch_size + 1).int().to(0)
+    kv_indices_device_buffer = torch.empty(total_num_pages).int().to(0)
+    kv_last_page_device_buffer = torch.empty(batch_size).int().to(0)
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
     wrapper = flashinfer.CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
@@ -275,12 +275,18 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
 
 
 if __name__ == "__main__":
-    # test_batch_decode_with_paged_kv_cache(
-    #     12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16
-    # )
-    # test_batch_decode_with_paged_kv_cache(
-    #     12, 54, 1, 8, 8, 128, "HND", "NONE", torch.float8_e5m2
-    # )
+    test_batch_decode_with_paged_kv_cache(
+        256, 54, 8, 8, 8, 128, "NHD", "NONE", torch.float16
+    )
+    test_batch_decode_with_paged_kv_cache(
+        12, 2048, 8, 8, 8, 128, "NHD", "NONE", torch.float16
+    )
+    test_batch_decode_with_paged_kv_cache(
+        12, 54, 1, 8, 8, 128, "HND", "NONE", torch.float8_e5m2
+    )
     test_cuda_graph_batch_decode_with_paged_kv_cache(
         12, 2048, 8, 8, 8, 128, "NHD", "NONE", torch.float16
+    )
+    test_cuda_graph_batch_decode_with_paged_kv_cache(
+        128, 54, 8, 8, 8, 128, "NHD", "NONE", torch.float16
     )

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -22,7 +22,7 @@ import flashinfer
 
 
 @pytest.mark.parametrize("batch_size", [12, 17])
-@pytest.mark.parametrize("kv_len", [54, 97])
+@pytest.mark.parametrize("kv_len", [54, 97, 512])
 @pytest.mark.parametrize("page_size", [1, 8, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -115,7 +115,7 @@ def test_batch_decode_with_paged_kv_cache(
 
 
 @pytest.mark.parametrize("batch_size", [12, 17])
-@pytest.mark.parametrize("kv_len", [54, 97])
+@pytest.mark.parametrize("kv_len", [54, 2048])
 @pytest.mark.parametrize("page_size", [1, 8, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])
@@ -144,16 +144,11 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
         if kv_layout == "HND"
         else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim).to(0)
     )
+    kv_data_dtype = kv_data.to(dtype)
     kv_indptr_host_warmup = torch.arange(0, batch_size + 1).int()
     kv_indices_host_warmup = torch.arange(0, batch_size).int()
     kv_last_page_len_host_warmup = torch.full(
         (batch_size,), page_size, dtype=torch.int32
-    )
-
-    kv_indptr_host = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
-    kv_indices_host = torch.arange(0, total_num_pages).int()
-    kv_last_page_len_host = torch.full(
-        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
     )
 
     # NOTE(Zihao): allocate more space than needed for testing
@@ -185,16 +180,41 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
     s.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(s):
         for _ in range(3):
-            o = wrapper.forward(
-                q, kv_data.to(dtype), pos_encoding_mode=pos_encoding_mode
-            )
+            o = wrapper.forward(q, kv_data_dtype, pos_encoding_mode=pos_encoding_mode)
     torch.cuda.current_stream().wait_stream(s)
+
     # capture
     g = torch.cuda.CUDAGraph()
     with torch.cuda.graph(g):
-        o = wrapper.forward(q, kv_data.to(dtype), pos_encoding_mode=pos_encoding_mode)
+        o = wrapper.forward(q, kv_data_dtype, pos_encoding_mode=pos_encoding_mode)
     wrapper.end_forward()
-    # replay
+
+    # replay multiple times
+    for i in range(1, min(4, num_pages_per_seq)):
+        kv_indptr_host = torch.arange(0, batch_size + 1).int() * i
+        kv_indices_host = torch.arange(0, i * batch_size).int()
+        kv_last_page_len_host = torch.full((batch_size,), page_size, dtype=torch.int32)
+
+        wrapper.begin_forward(
+            kv_indptr_host,
+            kv_indices_host,
+            kv_last_page_len_host,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            "NONE",
+            dtype,
+        )
+        g.replay()
+
+    # replay again
+    kv_indptr_host = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
+    kv_indices_host = torch.arange(0, total_num_pages).int()
+    kv_last_page_len_host = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    )
+
     wrapper.begin_forward(
         kv_indptr_host,
         kv_indices_host,
@@ -255,12 +275,12 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
 
 
 if __name__ == "__main__":
-    test_batch_decode_with_paged_kv_cache(
-        12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16
-    )
-    test_batch_decode_with_paged_kv_cache(
-        12, 54, 1, 8, 8, 128, "HND", "NONE", torch.float8_e5m2
-    )
+    # test_batch_decode_with_paged_kv_cache(
+    #     12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16
+    # )
+    # test_batch_decode_with_paged_kv_cache(
+    #     12, 54, 1, 8, 8, 128, "HND", "NONE", torch.float8_e5m2
+    # )
     test_cuda_graph_batch_decode_with_paged_kv_cache(
-        12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16
+        12, 2048, 8, 8, 8, 128, "NHD", "NONE", torch.float16
     )

--- a/python/tests/test_batch_prefill_kernels.py
+++ b/python/tests/test_batch_prefill_kernels.py
@@ -31,7 +31,7 @@ import flashinfer
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
-@pytest.mark.parametrize("enable_cuda_graph", [True])
+@pytest.mark.parametrize("enable_cuda_graph", [False, True])
 def test_batch_prefill_with_paged_kv_cache(
     batch_size,
     kv_len,

--- a/python/tests/test_batch_prefill_kernels.py
+++ b/python/tests/test_batch_prefill_kernels.py
@@ -31,7 +31,7 @@ import flashinfer
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
-@pytest.mark.parametrize("enable_cuda_graph", [False, True])
+@pytest.mark.parametrize("enable_cuda_graph", [True])
 def test_batch_prefill_with_paged_kv_cache(
     batch_size,
     kv_len,
@@ -114,17 +114,22 @@ def test_batch_prefill_with_paged_kv_cache(
             head_dim,
             page_size,
         )
+
         # warmup
         s = torch.cuda.Stream()
         s.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(s):
             for _ in range(3):
-                o = wrapper.forward(q, kv_data, pos_encoding_mode=pos_encoding_mode)
+                o = wrapper.forward(
+                    q, kv_data, causal=causal, pos_encoding_mode=pos_encoding_mode
+                )
         torch.cuda.current_stream().wait_stream(s)
         # capture
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
-            o = wrapper.forward(q, kv_data, pos_encoding_mode=pos_encoding_mode)
+            o = wrapper.forward(
+                q, kv_data, causal=causal, pos_encoding_mode=pos_encoding_mode
+            )
         wrapper.end_forward()
 
         wrapper.begin_forward(
@@ -259,8 +264,8 @@ def test_batch_prefill_with_paged_kv_cache_custom_mask(
         kv_last_page_len,
         num_qo_heads,
         num_kv_heads,
-        page_size,
         head_dim,
+        page_size,
     )
     o_causal = wrapper.forward(
         q, kv_data, causal=True, pos_encoding_mode=pos_encoding_mode

--- a/src/bench_batch_decode.cu
+++ b/src/bench_batch_decode.cu
@@ -91,7 +91,8 @@ void bench_flashinfer_batch_decode(nvbench::state& state) {
       cudaError_t status =
           BatchDecodeWithPagedKVCache<PageStorage::kIndices, kv_layout, T, T, int32_t>(
               thrust::raw_pointer_cast(q.data()), /*q_offset=*/nullptr, paged_kv,
-              kv_partition_info_t<int32_t>(), thrust::raw_pointer_cast(o.data()), nullptr,
+              kv_partition_info_t<int32_t>(), thrust::raw_pointer_cast(o.data()), /*tmp_v=*/nullptr,
+              /*tmp_s=*/nullptr,
               /*lse=*/nullptr, num_qo_heads, pos_encoding_mode);
       if (status != cudaSuccess) {
         state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -15,6 +15,7 @@
  */
 #include <flashinfer/decode_attention_decl.cuh>
 #include <flashinfer/prefill_attention_decl.cuh>
+#include <optional>
 
 #include "utils.h"
 
@@ -232,8 +233,8 @@ cudaError_t BatchDecodeWithPagedKVCache(
             return BatchDecodeWithPagedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, page_storage,
                                                          kv_layout, POS_ENCODING_MODE, DTypeIn,
                                                          DTypeOut, IdType>(
-                q, q_offset, paged_kv, kv_partition_info, o, tmp, lse, sm_scale, rope_scale,
-                rope_theta, stream);
+                q, q_offset, paged_kv, kv_partition_info, o, tmp, lse, std::nullopt, sm_scale,
+                rope_scale, rope_theta, stream);
           })})});
 
   return cudaSuccess;

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -211,8 +211,8 @@ template <PageStorage page_storage, QKVLayout kv_layout, typename DTypeIn, typen
           typename IdType>
 cudaError_t BatchDecodeWithPagedKVCache(
     DTypeIn* q, IdType* q_offset, paged_kv_t<page_storage, kv_layout, DTypeIn, IdType> paged_kv,
-    kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp, float* lse,
-    uint32_t num_qo_heads, PosEncodingMode pos_encoding_mode = PosEncodingMode::kNone,
+    kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp_v, float* tmp_s,
+    float* lse, uint32_t num_qo_heads, PosEncodingMode pos_encoding_mode = PosEncodingMode::kNone,
     std::optional<float> maybe_sm_scale = std::nullopt, float rope_scale = 1.f,
     float rope_theta = 1e4, cudaStream_t stream = nullptr) {
   const uint32_t num_kv_heads = paged_kv.num_heads;
@@ -233,9 +233,9 @@ cudaError_t BatchDecodeWithPagedKVCache(
             return BatchDecodeWithPagedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, page_storage,
                                                          kv_layout, POS_ENCODING_MODE, DTypeIn,
                                                          DTypeOut, IdType>(
-                q, q_offset, paged_kv, kv_partition_info, o, tmp,
-                (float*)tmp + batch_size * num_qo_heads * head_dim, lse, std::nullopt, sm_scale,
-                rope_scale, rope_theta, stream);
+                q, q_offset, paged_kv, kv_partition_info, o, tmp_v, tmp_s, lse,
+                /*block_valid_mask=*/nullptr, std::nullopt, sm_scale, rope_scale, rope_theta,
+                stream);
           })})});
 
   return cudaSuccess;

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -233,7 +233,9 @@ cudaError_t BatchDecodeWithPagedKVCache(
             return BatchDecodeWithPagedKVCacheDispatched<GROUP_SIZE, HEAD_DIM, page_storage,
                                                          kv_layout, POS_ENCODING_MODE, DTypeIn,
                                                          DTypeOut, IdType>(
-                q, q_offset, paged_kv, kv_partition_info, o, tmp, lse, std::nullopt, sm_scale,
+                q, q_offset, paged_kv, kv_partition_info, o, tmp,
+                (float*)tmp + batch_size * num_qo_heads * head_dim,
+                lse, std::nullopt, sm_scale,
                 rope_scale, rope_theta, stream);
           })})});
 

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -234,8 +234,7 @@ cudaError_t BatchDecodeWithPagedKVCache(
                                                          kv_layout, POS_ENCODING_MODE, DTypeIn,
                                                          DTypeOut, IdType>(
                 q, q_offset, paged_kv, kv_partition_info, o, tmp,
-                (float*)tmp + batch_size * num_qo_heads * head_dim,
-                lse, std::nullopt, sm_scale,
+                (float*)tmp + batch_size * num_qo_heads * head_dim, lse, std::nullopt, sm_scale,
                 rope_scale, rope_theta, stream);
           })})});
 

--- a/src/test_batch_decode.cu
+++ b/src/test_batch_decode.cu
@@ -111,7 +111,7 @@ void _TestBatchDecodingKernelCorrectness(size_t page_size, size_t batch_size, si
         flashinfer::BatchDecodeWithPagedKVCache<PageStorage::kIndices, kv_layout, T, T, int32_t>(
             thrust::raw_pointer_cast(q_device.data()), /*q_offset=*/nullptr, paged_kv,
             kv_partition_info_t<int32_t>(), thrust::raw_pointer_cast(o_device.data()),
-            /*tmp=*/nullptr, /*lse=*/nullptr, num_qo_heads, pos_encoding_mode);
+            /*tmp_v=*/nullptr, /*tmp_s=*/nullptr, /*lse=*/nullptr, num_qo_heads, pos_encoding_mode);
     EXPECT_EQ(status, cudaSuccess) << "CUDA error: " + std::string(cudaGetErrorString(status));
   } else {
     cudaError_t status = flashinfer::BatchDecodeWithPagedKVCacheWrapper<PageStorage::kIndices,


### PR DESCRIPTION
In this PR, we fixed the grid size of the kernels launched by a decode cuda graph wrapper:
* We always launch a kernel with fixed grid size (should be an upperbound of effective grid size)
* Early stop for threadblocks that is out of bound.