### PR TITLE
perf: use cub's native BlockLoad/BlockStore for sampling kernels

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -218,40 +218,6 @@
     }                                                                            \
   }
 
-#define DISPATCH_ALIGNED_VEC_SIZE(aligned_vec_size, ALIGNED_VEC_SIZE, ...) \
-  switch (aligned_vec_size) {                                              \
-    case 16: {                                                             \
-      constexpr size_t ALIGNED_VEC_SIZE = 16;                              \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    case 8: {                                                              \
-      constexpr size_t ALIGNED_VEC_SIZE = 8;                               \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    case 4: {                                                              \
-      constexpr size_t ALIGNED_VEC_SIZE = 4;                               \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    case 2: {                                                              \
-      constexpr size_t ALIGNED_VEC_SIZE = 2;                               \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    case 1: {                                                              \
-      constexpr size_t ALIGNED_VEC_SIZE = 1;                               \
-      __VA_ARGS__                                                          \
-      break;                                                               \
-    }                                                                      \
-    default: {                                                             \
-      std::ostringstream err_msg;                                          \
-      err_msg << "Unsupported aligned_vec_size: " << aligned_vec_size;     \
-      throw std::invalid_argument(err_msg.str());                          \
-    }                                                                      \
-  }
-
 namespace flashinfer {
 
 inline bool is_device_ptr(const void* ptr) {


### PR DESCRIPTION
Faster for odd hidden dimensions.
Slower for hidden dimension divisible by 4.

Maybe we should use a mixture of BlockLoad/BlockStore and current solution.