### PR TITLE
refactor: simplify kernel interface

### DIFF
--- a/include/flashinfer/attention/handler.cuh
+++ b/include/flashinfer/attention/handler.cuh
@@ -38,9 +38,8 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
     DTypeQ* __restrict__ q, IdType* __restrict__ q_offset,
     paged_kv_t<page_storage, kv_layout, DTypeKV, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* __restrict__ o,
-    DTypeOut* __restrict__ tmp_v, float* __restrict__ tmp_s, float* __restrict__ lse,
-    bool* __restrict__ block_valid_mask, float sm_scale, float rope_rcp_scale,
-    float rope_rcp_theta);
+    float* __restrict__ lse, bool* __restrict__ block_valid_mask, float sm_scale,
+    float rope_rcp_scale, float rope_rcp_theta);
 
 /*!
  * \brief Compute the maximum number of pages per batch and the new batch size

--- a/include/flashinfer/prefill_attention_decl.cuh
+++ b/include/flashinfer/prefill_attention_decl.cuh
@@ -32,7 +32,7 @@ template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, QKVLayout KV_LAYOU
           PosEncodingMode POS_ENCODING_MODE, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
           typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(DTypeIn* q, DTypeIn* k, DTypeIn* v,
-                                               uint8_t* custom_mask, DTypeOut* o, float* tmp,
+                                               uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp,
                                                float* lse, uint32_t num_qo_heads,
                                                uint32_t num_kv_heads, uint32_t qo_len,
                                                uint32_t kv_len, float sm_scale, float rope_scale,

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -78,7 +78,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
                                 static_cast<c_type*>(k.data_ptr()),
                                 static_cast<c_type*>(v.data_ptr()),
                                 /*custom_mask=*/nullptr, static_cast<c_type*>(o.data_ptr()),
-                                static_cast<float*>(tmp.data_ptr()),
+                                static_cast<c_type*>(tmp.data_ptr()),
                                 /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
                                 num_qo_heads, num_kv_heads, qo_len, kv_len, sm_scale, rope_scale,
                                 rope_theta, torch_current_stream);
@@ -159,7 +159,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
                           static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
                           static_cast<c_type*>(v.data_ptr()),
                           static_cast<uint8_t*>(packed_custom_mask.data_ptr()),
-                          static_cast<c_type*>(o.data_ptr()), static_cast<float*>(tmp.data_ptr()),
+                          static_cast<c_type*>(o.data_ptr()), static_cast<c_type*>(tmp.data_ptr()),
                           /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
                           num_qo_heads, num_kv_heads, qo_len, kv_len, sm_scale, rope_scale,
                           rope_theta, torch_current_stream);

--- a/python/generate_single_prefill_inst.py
+++ b/python/generate_single_prefill_inst.py
@@ -43,7 +43,7 @@ namespace flashinfer {{
 
 template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, uint8_t* custom_mask, {dtype_out}* o,
-    float* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
+    {dtype_out}* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
     float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 

--- a/src/bench_cascade.cu
+++ b/src/bench_cascade.cu
@@ -96,8 +96,9 @@ void bench_two_level_single_prefix_cascade_decode(nvbench::state& state) {
   if (use_cascade) {
     thrust::device_vector<T> shared_k_d(shared_k_h), shared_v_d(shared_v_h),
         o_cascade_0_d(q_h.size()), o_cascade_1_d(q_h.size());
-    thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024),
-        lse_cascade_0_d(batch_size * num_qo_heads), lse_cascade_1_d(batch_size * num_qo_heads);
+    thrust::device_vector<T> tmp_0_d(16 * 1024 * 1024);
+    thrust::device_vector<float> lse_cascade_0_d(batch_size * num_qo_heads),
+        lse_cascade_1_d(batch_size * num_qo_heads);
     thrust::device_vector<int32_t> kv_indptr_unique_d(kv_indptr_unique_h),
         kv_indices_unique_d(kv_indices_unique_h),
         kv_last_page_len_unique_d(kv_last_page_len_unique_h);
@@ -231,8 +232,8 @@ void bench_two_level_single_prefix_cascade_append(nvbench::state& state) {
   if (use_cascade) {
     thrust::device_vector<T> shared_k_d(shared_k_h), shared_v_d(shared_v_h),
         o_cascade_0_d(q_h.size()), o_cascade_1_d(q_h.size());
-    thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024),
-        lse_cascade_0_d((batch_size * qo_append_length) * num_qo_heads),
+    thrust::device_vector<T> tmp_0_d(8 * 1024 * 1024);
+    thrust::device_vector<float> lse_cascade_0_d((batch_size * qo_append_length) * num_qo_heads),
         lse_cascade_1_d((batch_size * qo_append_length) * num_qo_heads);
     thrust::device_vector<int32_t> kv_indptr_unique_d(kv_indptr_unique_h),
         kv_indices_unique_d(kv_indices_unique_h),

--- a/src/bench_single_decode.cu
+++ b/src/bench_single_decode.cu
@@ -76,7 +76,7 @@ void bench_flashinfer_single_decode_with_prefill(nvbench::state& state) {
   thrust::device_vector<dtype_in> K(seq_len * num_kv_heads * head_dim);
   thrust::device_vector<dtype_in> V(seq_len * num_kv_heads * head_dim);
   thrust::device_vector<dtype_out> O(num_qo_heads * head_dim);
-  thrust::device_vector<float> tmp(8 * 1024 * 1024);
+  thrust::device_vector<dtype_out> tmp(16 * 1024 * 1024);
 
   // Provide throughput information:
   state.add_global_memory_reads<dtype_in>(

--- a/src/bench_single_prefill.cu
+++ b/src/bench_single_prefill.cu
@@ -50,7 +50,7 @@ void bench_flashinfer_single_prefill(nvbench::state& state) {
   thrust::device_vector<dtype_in> V(kv_len * num_kv_heads * head_dim);
   thrust::device_vector<uint8_t> mask(ceil_div(qo_len * kv_len, 8));
   thrust::device_vector<dtype_out> O(qo_len * num_qo_heads * head_dim);
-  thrust::device_vector<float> tmp(8 * 1024 * 1024);
+  thrust::device_vector<dtype_out> tmp(16 * 1024 * 1024);
 
   // Provide throughput information:
   state.add_global_memory_reads<dtype_in>(

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -25,8 +25,8 @@ namespace flashinfer {
 
 template <typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheCustomMask(
-    DTypeIn* q, DTypeIn* k, DTypeIn* v, uint8_t* custom_mask, DTypeOut* o, float* tmp, float* lse,
-    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
+    DTypeIn* q, DTypeIn* k, DTypeIn* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp,
+    float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
     uint32_t head_dim, QKVLayout kv_layout = QKVLayout::kNHD,
     PosEncodingMode pos_encoding_mode = PosEncodingMode::kNone,
     bool allow_fp16_qk_reduction = false, std::optional<float> maybe_sm_scale = std::nullopt,
@@ -72,7 +72,7 @@ cudaError_t SinglePrefillWithKVCacheCustomMask(
  * \return status Indicates whether CUDA calls are successful
  */
 template <typename DTypeIn, typename DTypeOut>
-cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o, float* tmp,
+cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o, DTypeOut* tmp,
                                      float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads,
                                      uint32_t qo_len, uint32_t kv_len, uint32_t head_dim,
                                      bool causal = true, QKVLayout kv_layout = QKVLayout::kNHD,

--- a/src/test_cascade.cu
+++ b/src/test_cascade.cu
@@ -254,7 +254,8 @@ void _TestTwoLevelSinglePrefixCascadeDecodeCorrectness(size_t batch_size,
 
   thrust::device_vector<T> shared_k_d(shared_k_h), shared_v_d(shared_v_h), kv_data_d(kv_data_h),
       q_d(q_h), o_baseline_d(q_h.size()), o_cascade_0_d(q_h.size()), o_cascade_1_d(q_h.size());
-  thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024), lse_cascade_0_d(batch_size * num_qo_heads),
+  thrust::device_vector<T> tmp_0_d(16 * 1024 * 1024);
+  thrust::device_vector<float> lse_cascade_0_d(batch_size * num_qo_heads),
       lse_cascade_1_d(batch_size * num_qo_heads);
 
   thrust::device_vector<int32_t> kv_indptr_combined_d(kv_indptr_combined_h),
@@ -379,8 +380,8 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
 
   thrust::device_vector<T> shared_k_d(shared_k_h), shared_v_d(shared_v_h), kv_data_d(kv_data_h),
       q_d(q_h), o_baseline_d(q_h.size()), o_cascade_0_d(q_h.size()), o_cascade_1_d(q_h.size());
-  thrust::device_vector<float> tmp_0_d(8 * 1024 * 1024),
-      lse_cascade_0_d((batch_size * qo_append_length) * num_qo_heads),
+  thrust::device_vector<T> tmp_0_d(16 * 1024 * 1024);
+  thrust::device_vector<float> lse_cascade_0_d((batch_size * qo_append_length) * num_qo_heads),
       lse_cascade_1_d((batch_size * qo_append_length) * num_qo_heads);
 
   thrust::device_vector<int32_t> qo_indptr_d(qo_indptr_h),

--- a/src/test_single_prefill.cu
+++ b/src/test_single_prefill.cu
@@ -41,7 +41,7 @@ void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t nu
   thrust::device_vector<DTypeIn> k_d(k);
   thrust::device_vector<DTypeIn> v_d(v);
   thrust::device_vector<DTypeOut> o_d(o);
-  thrust::device_vector<float> tmp_d(4 * 1024 * 1024);
+  thrust::device_vector<DTypeOut> tmp_d(16 * 1024 * 1024);
 
   cudaError_t status = flashinfer::SinglePrefillWithKVCache<DTypeIn, DTypeOut>(
       thrust::raw_pointer_cast(q_d.data()), thrust::raw_pointer_cast(k_d.data()),

--- a/src/tvm_wrapper.cu
+++ b/src/tvm_wrapper.cu
@@ -90,7 +90,7 @@ int _FlashInferSinglePrefillWithKVCache(DLTensor* q, DLTensor* k, DLTensor* v, D
       q->dtype, dtype_in, {DISPATCH_TVM_CUDA_DTYPE(o->dtype, dtype_out, {
         cudaError_t status = SinglePrefillWithKVCache(
             (dtype_in*)q->data, (dtype_in*)k->data, (dtype_in*)v->data, (dtype_out*)o->data,
-            (float*)tmp->data, /*lse=*/nullptr, num_qo_heads, num_kv_heads, qo_len, kv_len,
+            (dtype_out*)tmp->data, /*lse=*/nullptr, num_qo_heads, num_kv_heads, qo_len, kv_len,
             head_dim, causal, QKVLayout(kv_layout), PosEncodingMode(pos_encoding_mode),
             allow_fp16_qk_reduction, std::nullopt, rope_scale, rope_theta, 0);
         if (status != cudaSuccess) {


### PR DESCRIPTION
We don't need to separate between `tmp_v`/`o` and `tmp_s`/`lse` in kernel arguments 