### PR TITLE
feat: add `use_tensor_cores` option to decode kernels to accelerate GQA

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -91,23 +91,8 @@
   if (group_size == 1) {                                     \
     constexpr size_t GROUP_SIZE = 1;                         \
     __VA_ARGS__                                              \
-  } else if (group_size == 2) {                              \
-    constexpr size_t GROUP_SIZE = 2;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 3) {                              \
-    constexpr size_t GROUP_SIZE = 3;                         \
-    __VA_ARGS__                                              \
   } else if (group_size == 4) {                              \
     constexpr size_t GROUP_SIZE = 4;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 5) {                              \
-    constexpr size_t GROUP_SIZE = 5;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 6) {                              \
-    constexpr size_t GROUP_SIZE = 6;                         \
-    __VA_ARGS__                                              \
-  } else if (group_size == 7) {                              \
-    constexpr size_t GROUP_SIZE = 7;                         \
     __VA_ARGS__                                              \
   } else if (group_size == 8) {                              \
     constexpr size_t GROUP_SIZE = 8;                         \

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -38,16 +38,14 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
   unsigned int head_dim = q.size(2);
   unsigned int kv_len, qo_len, num_kv_heads, num_qo_heads;
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
+  qo_len = q.size(0);
+  num_qo_heads = q.size(1);
   if (kv_layout == QKVLayout::kNHD) {
     kv_len = k.size(0);
-    qo_len = q.size(0);
     num_kv_heads = k.size(1);
-    num_qo_heads = q.size(1);
   } else {
     kv_len = k.size(1);
-    qo_len = q.size(1);
     num_kv_heads = k.size(0);
-    num_qo_heads = q.size(0);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
@@ -122,16 +120,14 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
   unsigned int head_dim = q.size(2);
   unsigned int kv_len, qo_len, num_kv_heads, num_qo_heads;
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
+  qo_len = q.size(0);
+  num_qo_heads = q.size(1);
   if (kv_layout == QKVLayout::kNHD) {
     kv_len = k.size(0);
-    qo_len = q.size(0);
     num_kv_heads = k.size(1);
-    num_qo_heads = q.size(1);
   } else {
     kv_len = k.size(1);
-    qo_len = q.size(1);
     num_kv_heads = k.size(0);
-    num_qo_heads = q.size(0);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();

--- a/python/flashinfer/cascade.py
+++ b/python/flashinfer/cascade.py
@@ -307,8 +307,8 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
     >>> head_dim = 128
     >>> max_num_pages = 128
     >>> page_size = 16
-    >>> # allocate 16MB workspace buffer
-    >>> workspace_buffer = torch.empty(16 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    >>> # allocate 128MB workspace buffer
+    >>> workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
     >>> wrapper = flashinfer.BatchDecodeWithSharedPrefixPagedKVCacheWrapper(
     ...     workspace_buffer, "NHD"
     ... )
@@ -540,8 +540,8 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
     >>> head_dim = 128
     >>> max_num_pages = 128
     >>> page_size = 16
-    >>> # allocate 16MB workspace buffer
-    >>> workspace_buffer = torch.empty(16 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    >>> # allocate 128MB workspace buffer
+    >>> workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
     >>> prefill_wrapper = flashinfer.BatchPrefillWithSharedPrefixPagedKVCacheWrapper(
     ...     workspace_buffer, "NHD"
     ... )
@@ -617,7 +617,7 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
         ----------
         workspace_buffer : torch.Tensor
             The user reserved workspace buffer used to store auxiliary data structures,
-            recommended size is 16MB, the device of the workspace buffer should be the
+            recommended size is 128MB, the device of the workspace buffer should be the
             same as the device of the input tensors.
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.

--- a/python/tests/test_tensor_cores_decode.py
+++ b/python/tests/test_tensor_cores_decode.py
@@ -1,0 +1,256 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy
+import pytest
+import torch
+
+import flashinfer
+
+
+@pytest.mark.parametrize("kv_len", [54, 128, 999, 32789])
+@pytest.mark.parametrize("num_kv_heads", [4, 8])
+@pytest.mark.parametrize("group_size", [1, 4, 8])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
+def test_single_decode_tensor_cores(
+    kv_len: int,
+    num_kv_heads: int,
+    group_size: int,
+    head_dim: int,
+    kv_layout: str,
+    pos_encoding_mode: str,
+):
+    num_qo_heads = num_kv_heads * group_size
+    q = torch.randn(num_qo_heads, head_dim).to(0).half()
+    k = (
+        torch.randn(num_kv_heads, kv_len, head_dim).to(0).half()
+        if kv_layout == "HND"
+        else torch.randn(kv_len, num_kv_heads, head_dim).to(0).half()
+    )
+    v = (
+        torch.randn(num_kv_heads, kv_len, head_dim).to(0).half()
+        if kv_layout == "HND"
+        else torch.randn(kv_len, num_kv_heads, head_dim).to(0).half()
+    )
+
+    o = flashinfer.single_decode_with_kv_cache(
+        q, k, v, kv_layout, pos_encoding_mode, use_tensor_cores=False
+    )
+    o_tensor_cores = flashinfer.single_decode_with_kv_cache(
+        q, k, v, kv_layout, pos_encoding_mode, use_tensor_cores=True
+    )
+
+    numpy.testing.assert_allclose(
+        o.cpu().numpy(), o_tensor_cores.cpu().numpy(), rtol=1e-3, atol=1e-3
+    )
+
+
+@pytest.mark.parametrize("batch_size", [12, 17])
+@pytest.mark.parametrize("kv_len", [54, 97, 512])
+@pytest.mark.parametrize("page_size", [1, 8, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("group_size", [1, 4, 8])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
+def test_batch_decode_tensor_cores(
+    batch_size: int,
+    kv_len: int,
+    page_size: int,
+    num_kv_heads: int,
+    group_size: int,
+    head_dim: int,
+    kv_layout: str,
+    pos_encoding_mode: str,
+):
+    num_qo_heads = num_kv_heads * group_size
+    q = torch.randn(batch_size, num_qo_heads, head_dim).to(0).to(torch.float16)
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = (
+        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0) / 10
+        if kv_layout == "HND"
+        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim).to(0)
+        / 10
+    ).to(torch.float16)
+    kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * num_pages_per_seq
+    kv_indices = torch.arange(0, total_num_pages).to(0).int()
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    ).to(0)
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
+    wrapper.begin_forward(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        "NONE",
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    o = wrapper.forward(q, kv_data, pos_encoding_mode=pos_encoding_mode)
+
+    wrapper_tensor_cores = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout, use_tensor_cores=True
+    )
+    wrapper_tensor_cores.begin_forward(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        "NONE",
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    o_tensor_cores = wrapper_tensor_cores.forward(
+        q, kv_data, pos_encoding_mode=pos_encoding_mode
+    )
+
+    numpy.testing.assert_allclose(
+        o.cpu().numpy(), o_tensor_cores.cpu().numpy(), rtol=1e-3, atol=1e-3
+    )
+
+
+@pytest.mark.parametrize("batch_size", [12, 17])
+@pytest.mark.parametrize("kv_len", [54, 97, 512])
+@pytest.mark.parametrize("page_size", [1, 8, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("group_size", [1, 4, 8])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
+def test_batch_decode_tensor_cores_cuda_graph(
+    batch_size: int,
+    kv_len: int,
+    page_size: int,
+    num_kv_heads: int,
+    group_size: int,
+    head_dim: int,
+    kv_layout: str,
+    pos_encoding_mode: str,
+):
+    num_qo_heads = num_kv_heads * group_size
+    q = torch.randn(batch_size, num_qo_heads, head_dim).to(0).to(torch.float16)
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = (
+        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0) / 10
+        if kv_layout == "HND"
+        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim).to(0)
+        / 10
+    ).to(torch.float16)
+    kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * num_pages_per_seq
+    kv_indices = torch.arange(0, total_num_pages).to(0).int()
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    ).to(0)
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
+
+    # cuda cores wrapper
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout,
+        enable_cuda_graph=True,
+        paged_kv_indptr_buffer=kv_indptr,
+        paged_kv_indices_buffer=kv_indices,
+        paged_kv_last_page_len_buffer=kv_last_page_len,
+    )
+    wrapper.begin_forward(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        "NONE",
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    # warmup
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            o = wrapper.forward(q, kv_data, pos_encoding_mode=pos_encoding_mode)
+    torch.cuda.current_stream().wait_stream(s)
+
+    # capture
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        o = wrapper.forward(q, kv_data, pos_encoding_mode=pos_encoding_mode)
+    wrapper.end_forward()
+
+    # replay
+    g.replay()
+
+    # cuda cores wrapper
+    wrapper_tensor_cores = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout,
+        enable_cuda_graph=True,
+        use_tensor_cores=True,
+        paged_kv_indptr_buffer=kv_indptr,
+        paged_kv_indices_buffer=kv_indices,
+        paged_kv_last_page_len_buffer=kv_last_page_len,
+    )
+    wrapper_tensor_cores.begin_forward(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        "NONE",
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    # warmup
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            o_tensor_cores = wrapper_tensor_cores.forward(
+                q, kv_data, pos_encoding_mode=pos_encoding_mode
+            )
+    torch.cuda.current_stream().wait_stream(s)
+
+    # capture
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        o_tensor_cores = wrapper_tensor_cores.forward(
+            q, kv_data, pos_encoding_mode=pos_encoding_mode
+        )
+    wrapper_tensor_cores.end_forward()
+
+    # replay
+    g.replay()
+
+    numpy.testing.assert_allclose(
+        o.cpu().numpy(), o_tensor_cores.cpu().numpy(), rtol=1e-3, atol=1e-3
+    )


### PR DESCRIPTION
The tensor-cores accelerated GQA in our [blog post](https://flashinfer.ai/2024/02/02/introduce-flashinfer.html) was not enabled by default (user need to use Prefill kernels/wrappers for decode to get such acceleration).

In this PR we add an option `use_tensor_cores` to decode operators/wrappers, and user can select whether to use `tensor_cores` for acceleration depending on use cases.

Not that our prefill kernels are compiled for all possible group sizes (#301 ), but decode kernels are not. So if user wants to use general group size, it's encouraged to set `use_tensor_cores=True`.