### PR TITLE
ci: fix setuptools version

### DIFF
--- a/scripts/run-ci-build-wheel.sh
+++ b/scripts/run-ci-build-wheel.sh
@@ -36,7 +36,7 @@ echo "::endgroup::"
 
 echo "::group::Install build system"
 pip install ninja numpy
-pip install --upgrade setuptools wheel build
+pip install --upgrade setuptools==69.5.1 wheel build
 echo "::endgroup::"
 
 


### PR DESCRIPTION
We met the following error when running the building scripts:
```
   File "/tmp/home/.local/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 28, in <module>
      from pkg_resources import packaging  # type: ignore[attr-defined]
  ImportError: cannot import name 'packaging' from 'pkg_resources' (/tmp/home/.local/lib/python3.10/site-packages/pkg_resources/__init__.py)
```

Let's follow [this](https://stackoverflow.com/questions/78604018/importerror-cannot-import-name-packaging-from-pkg-resources-when-trying-to) and see whether it works or not.