### PR TITLE
ci: use python3 for release wheel workflow

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -105,7 +105,7 @@ jobs:
           WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
 
       - name: Update wheel index
-        shell: python
+        shell: python3
         run: |
           import hashlib
           import pathlib


### PR DESCRIPTION
To fix the error: https://github.com/flashinfer-ai/flashinfer/actions/runs/9594555333/job/26475097423