### PR TITLE
feat: customize `logits_soft_cap` value

### DIFF
--- a/include/flashinfer/attention/handler.cuh
+++ b/include/flashinfer/attention/handler.cuh
@@ -42,8 +42,8 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
     DTypeQ* __restrict__ q, IdType* __restrict__ q_offset,
     paged_kv_t<page_storage, kv_layout, DTypeKV, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* __restrict__ o,
-    float* __restrict__ lse, bool* __restrict__ block_valid_mask, float sm_scale,
-    float rope_rcp_scale, float rope_rcp_theta);
+    float* __restrict__ lse, bool* __restrict__ block_valid_mask, float logits_soft_cap,
+    float sm_scale, float rope_rcp_scale, float rope_rcp_theta);
 
 /*!
  * \brief Compute the maximum number of pages per batch and the new batch size

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -133,6 +133,19 @@
     }                                                         \
   }
 
+#define DISPATCH_LOGITS_POST_HOOK(logits_soft_cap, LOGITS_POST_HOOK, ...)       \
+  if (logits_soft_cap > 0.f) {                                                  \
+    constexpr LogitsPostHook LOGITS_POST_HOOK = LogitsPostHook::kSoftCap;       \
+    __VA_ARGS__                                                                 \
+  } else if (logits_soft_cap == 0.f) {                                          \
+    constexpr LogitsPostHook LOGITS_POST_HOOK = LogitsPostHook::kNone;          \
+    __VA_ARGS__                                                                 \
+  } else {                                                                      \
+    std::ostringstream err_msg;                                                 \
+    err_msg << "Invalid logits_soft_cap (should be >= 0): " << logits_soft_cap; \
+    throw std::invalid_argument(err_msg.str());                                 \
+  }
+
 #define DISPATCH_LAYOUT(layout, LAYOUT, ...)            \
   switch (layout) {                                     \
     case QKVLayout::kNHD: {                             \

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -142,6 +142,8 @@ def single_decode_with_kv_cache(
     check_pos_encoding_mode(pos_encoding_mode)
     check_kv_layout(kv_layout)
     tmp = _get_cache_buf("single_decode_with_kv_cache_tmp", 32 * 1024 * 1024, q.device)
+    if logits_soft_cap is None:
+        logits_soft_cap = 0.0
     if sm_scale is None:
         head_dim = q.shape[-1]
         sm_scale = 1.0 / math.sqrt(head_dim)
@@ -282,6 +284,8 @@ def batch_decode_with_padded_kv_cache(
     not equal to ``num_kv_heads``, the function will use
     `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
     """
+    if logits_soft_cap is None:
+        logits_soft_cap = 0.0
     if sm_scale is None:
         head_dim = q.shape[-1]
         sm_scale = 1.0 / math.sqrt(head_dim)
@@ -403,6 +407,8 @@ def batch_decode_with_padded_kv_cache_return_lse(
     not equal to ``num_kv_heads``, the function will use
     `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
     """
+    if logits_soft_cap is None:
+        logits_soft_cap = 0.0
     if sm_scale is None:
         head_dim = q.shape[-1]
         sm_scale = 1.0 / math.sqrt(head_dim)
@@ -675,6 +681,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
         """
         batch_size = len(last_page_len)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
 
         if self.is_cuda_graph_enabled:
             if batch_size != self._fixed_batch_size:
@@ -821,6 +829,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             The attention output, shape: ``[batch_size, num_qo_heads, head_dim]``.
         """
         check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
         if sm_scale is None:
             head_dim = q.shape[-1]
             sm_scale = 1.0 / math.sqrt(head_dim)
@@ -933,6 +943,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         explanation of the log-sum-exp function and attention states.
         """
         check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
         if sm_scale is None:
             head_dim = q.shape[-1]
             sm_scale = 1.0 / math.sqrt(head_dim)

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -870,8 +870,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 self._paged_kv_indices_buf,
                 self._paged_kv_last_page_len_buf,
                 PosEncodingMode[pos_encoding_mode].value,
-                sm_scale,
                 logits_soft_cap,
+                sm_scale,
                 rope_scale,
                 rope_theta,
                 False,  # return_lse

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -168,6 +168,8 @@ def single_prefill_with_kv_cache(
     check_pos_encoding_mode(pos_encoding_mode)
     check_kv_layout(kv_layout)
     tmp = _get_cache_buf("single_prefill_with_kv_cache_tmp", 32 * 1024 * 1024, q.device)
+    if logits_soft_cap is None:
+        logits_soft_cap = 0.0
     if sm_scale is None:
         sm_scale = 1.0 / math.sqrt(q.size(-1))
     if rope_scale is None:
@@ -337,6 +339,8 @@ def single_prefill_with_kv_cache_return_lse(
     tmp = _get_cache_buf(
         "single_prefill_with_kv_cache_return_lse_tmp", 8 * 1024 * 1024, q.device
     )
+    if logits_soft_cap is None:
+        logits_soft_cap = 0.0
     if sm_scale is None:
         sm_scale = 1.0 / math.sqrt(q.size(-1))
     if rope_scale is None:
@@ -850,6 +854,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             The attention output, shape: ``[qo_indptr[-1], num_qo_heads, head_dim]``.
         """
         check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
         if rope_scale is None:
@@ -958,6 +964,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             ``[qo_indptr[-1], num_qo_heads, head_dim]``.
         """
         check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
         if rope_scale is None:
@@ -1392,6 +1400,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             The attention output, shape: ``[qo_indptr[-1], num_qo_heads, head_dim]``.
         """
         check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
         if rope_scale is None:
@@ -1497,6 +1507,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             ``[qo_indptr[-1], num_qo_heads, head_dim]``.
         """
         check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
         if rope_scale is None:

--- a/python/generate_batch_padded_decode_inst.py
+++ b/python/generate_batch_padded_decode_inst.py
@@ -42,7 +42,7 @@ template cudaError_t BatchDecodeWithPaddedKVCacheDispatched<{head_dim}, {logits_
     {dtype_q}* q, {dtype_kv}* k, {dtype_kv}* v,
     {dtype_out}* o, {dtype_out}* tmp, float* lse,
     uint32_t batch_size, uint32_t padded_kv_len, uint32_t num_qo_heads, uint32_t num_kv_heads,
-    float sm_scale, float rope_scale,
+    float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}

--- a/python/generate_batch_paged_decode_inst.py
+++ b/python/generate_batch_paged_decode_inst.py
@@ -48,7 +48,7 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{head_dim}, page_stor
     kv_partition_info_t<{idtype}> kv_partition_info,
     {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
     bool* block_valid_mask, uint32_t padded_batch_size, uint32_t num_qo_heads,
-    float sm_scale, float rope_scale,
+    float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}

--- a/python/generate_batch_paged_prefill_inst.py
+++ b/python/generate_batch_paged_prefill_inst.py
@@ -49,8 +49,8 @@ def get_cu_file_str(
     paged_kv_t<page_storage, {kv_layout}, {dtype_in}, {idtype}> paged_kv, uint8_t* custom_mask,
     {idtype}* qk_indptr, {idtype}* o_indptr, {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
     {idtype}* merge_indptr, bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, uint32_t max_num_rows,
-    uint32_t num_qo_heads, uint32_t padded_batch_size, float sm_scale, float rope_scale, float rope_theta,
-    cudaStream_t stream);
+    uint32_t num_qo_heads, uint32_t padded_batch_size, float logits_soft_cap, float sm_scale, float rope_scale,
+    float rope_theta, cudaStream_t stream);
     """.format(
                 logits_hook=logits_hook_literal[int(logits_hook)],
                 kv_layout=kv_layout_literal[int(kv_layout)],

--- a/python/generate_batch_ragged_prefill_inst.py
+++ b/python/generate_batch_ragged_prefill_inst.py
@@ -47,9 +47,9 @@ def get_cu_file_str(
     {idtype}* q_indptr, {dtype_in}* k, {dtype_in}* v, {idtype}* kv_indptr,
     uint8_t* custom_mask, {idtype}* qk_indptr, {idtype}* q_offset, {idtype}* k_rope_pos_offset,
     {idtype}* o_indptr, {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse, {idtype}* merge_indptr,
-    bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, const uint32_t total_num_rows, const uint32_t num_qo_heads,
-    const uint32_t padded_batch_size, const uint32_t num_kv_heads,
-    const float sm_scale, const float rope_scale, const float rope_theta,
+    bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
+    uint32_t padded_batch_size, uint32_t num_kv_heads,
+    float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
     cudaStream_t stream);
         """.format(
                 warp_layout=warp_layout_literal[warp_layout],

--- a/python/generate_single_decode_inst.py
+++ b/python/generate_single_decode_inst.py
@@ -41,7 +41,7 @@ namespace flashinfer {{
 template cudaError_t SingleDecodeWithKVCacheDispatched<{head_dim}, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {dtype_q}, {dtype_kv}, {dtype_out}>(
     {dtype_q}* q, {dtype_kv}* k, {dtype_kv}* v, {dtype_out}* o,
     {dtype_out}* tmp, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t seq_len,
-    float sm_scale, float rope_scale,
+    float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}

--- a/python/generate_single_prefill_inst.py
+++ b/python/generate_single_prefill_inst.py
@@ -44,7 +44,7 @@ namespace flashinfer {{
 template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, uint8_t* custom_mask, {dtype_out}* o,
     {dtype_out}* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
-    float sm_scale, float rope_scale,
+    float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}

--- a/python/literal_map.py
+++ b/python/literal_map.py
@@ -22,7 +22,7 @@ mask_mode_literal = {
 
 logits_hook_literal = {
     0: "LogitsPostHook::kNone",
-    1: "LogitsPostHook::kCap30",
+    1: "LogitsPostHook::kSoftCap",
 }
 
 warp_layout_literal = {

--- a/python/tests/test_logits_cap.py
+++ b/python/tests/test_logits_cap.py
@@ -21,12 +21,12 @@ import pytest
 import flashinfer
 
 
-def attention_logits_cap_torch(q, k, v):
+def attention_logits_soft_cap_torch(q, k, v, soft_cap):
     q_len, num_heads, head_dim = q.shape
     kv_len = k.shape[0]
     scores = torch.einsum("qhd,khd->qkh", q.float(), k.float())
     scores *= 1.0 / math.sqrt(head_dim)
-    scores = 30 * torch.tanh(scores / 30)
+    scores = soft_cap * torch.tanh(scores / soft_cap)
     attn = torch.softmax(scores, dim=1)
     return torch.einsum("ovh,vhd->ohd", attn, v.float()).to(q)
 
@@ -34,17 +34,19 @@ def attention_logits_cap_torch(q, k, v):
 @pytest.mark.parametrize("seq_len", [1, 9, 81, 729, 33001])
 @pytest.mark.parametrize("num_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [128, 256])
-def test_single_decode_logits_cap(
+@pytest.mark.parametrize("soft_cap", [30.0, 50.0])
+def test_single_decode_logits_soft_cap(
     seq_len,
     num_heads,
     head_dim,
+    soft_cap,
 ):
     q = torch.randn(num_heads, head_dim).to(0).half()
     k = torch.randn(seq_len, num_heads, head_dim).to(0).half()
     v = torch.randn(seq_len, num_heads, head_dim).to(0).half()
 
-    o = flashinfer.single_decode_with_kv_cache(q, k, v, logits_cap=True)
-    o_ref = attention_logits_cap_torch(q.unsqueeze(0), k, v).squeeze(0)
+    o = flashinfer.single_decode_with_kv_cache(q, k, v, logits_soft_cap=soft_cap)
+    o_ref = attention_logits_soft_cap_torch(q.unsqueeze(0), k, v, soft_cap).squeeze(0)
     numpy.testing.assert_allclose(
         o.cpu().numpy(), o_ref.cpu().numpy(), rtol=1e-3, atol=1e-3
     )
@@ -54,23 +56,25 @@ def test_single_decode_logits_cap(
 @pytest.mark.parametrize("kv_len", [1, 17, 81, 987, 31111])
 @pytest.mark.parametrize("num_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [128, 256])
-def test_single_prefill_logits_cap(
+@pytest.mark.parametrize("soft_cap", [30.0, 50.0])
+def test_single_prefill_logits_soft_cap(
     q_len,
     kv_len,
     num_heads,
     head_dim,
+    soft_cap,
 ):
     q = torch.randn(q_len, num_heads, head_dim).to(0).half()
     k = torch.randn(kv_len, num_heads, head_dim).to(0).half()
     v = torch.randn(kv_len, num_heads, head_dim).to(0).half()
 
-    o = flashinfer.single_prefill_with_kv_cache(q, k, v, logits_cap=True)
-    o_ref = attention_logits_cap_torch(q, k, v)
+    o = flashinfer.single_prefill_with_kv_cache(q, k, v, logits_soft_cap=soft_cap)
+    o_ref = attention_logits_soft_cap_torch(q, k, v, soft_cap)
     numpy.testing.assert_allclose(
         o.cpu().numpy(), o_ref.cpu().numpy(), rtol=1e-2, atol=1e-2
     )
 
 
 if __name__ == "__main__":
-    test_single_decode_logits_cap(9, 32, 128)
-    test_single_prefill_logits_cap(1, 64, 1, 128)
+    test_single_decode_logits_soft_cap(9, 32, 128, 30.0)
+    test_single_prefill_logits_soft_cap(1, 64, 1, 128, 30.0)


### PR DESCRIPTION
This PR supports customized logits soft cap values. Different models might use different logits soft cap values (e.g. Grok-1 uses 30 and Gemma-2 uses 50).