### PR TITLE
[CMake][Bugfix] Set default value for FLASHINFER_GEN_MASK_MODES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ flashinfer_option(FLASHINFER_GEN_KV_LAYOUTS "KV layouts to enable" 0 1)
 flashinfer_option(FLASHINFER_GEN_LOGITS_POST_HOOKS "Logits post hooks" 0 1)
 flashinfer_option(FLASHINFER_GEN_POS_ENCODING_MODES "Pos encodings to enable" 0 1 2)
 flashinfer_option(FLASHINFER_GEN_ALLOW_FP16_QK_REDUCTIONS "QK reductions to enable" "false" "true")
-flashinfer_option(FLASHINFER_GEN_CASUALS "Casual modes to enable" "false" "true")
+flashinfer_option(FLASHINFER_GEN_MASK_MODES "Mask modes to enable" 0 1 2)
 
 if(DEFINED FLASHINFER_CUDA_ARCHITECTURES)
   message(STATUS "CMAKE_CUDA_ARCHITECTURES set to ${FLASHINFER_CUDA_ARCHITECTURES}.")


### PR DESCRIPTION
This commit resolves a build-time error with the following message:

```
CMake Error at 3rdparty/flashinfer/CMakeLists.txt:313 (add_library):
  No SOURCES given to target: prefill_kernels
```

This occurred after https://github.com/flashinfer-ai/flashinfer/pull/266, which replaces the `FLASHINFER_GEN_CASUALS` option with `FLASHINFER_GEN_MASK_MODES`. However, the definition of `flashinfer_option(FLASHINFER_GEN_CASUALS ... )` was not replaced.  As a result, loop over the empty `MASK_MODES` does not produce any kernels that should be compiled.

This commit updates the `flashinfer_option(FLASH_GEN_CASUALS ...)` line to instead define `FLASH_GEN_MASK_MODES`, using the same default value as `config.cmake`.