### PR TITLE
ci: remove redundant `NUM_FRAGS_Z`

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -75,9 +75,6 @@
   if (max_frags_z >= 8) {                                   \
     constexpr size_t NUM_FRAGS_Z = 8;                       \
     __VA_ARGS__                                             \
-  } else if (max_frags_z >= 6) {                            \
-    constexpr size_t NUM_FRAGS_Z = 6;                       \
-    __VA_ARGS__                                             \
   } else if (max_frags_z >= 4) {                            \
     constexpr size_t NUM_FRAGS_Z = 4;                       \
     __VA_ARGS__                                             \

--- a/python/setup.py
+++ b/python/setup.py
@@ -357,10 +357,6 @@ if __name__ == "__main__":
                     "1",
                     "-Xfatbin",
                     "-compress-all",
-                    "-Xcompiler",
-                    "-mcmodel=medium",
-                    "-Xcompiler",
-                    '"-Wl,--no-relax"',
                 ],
             },
         )


### PR DESCRIPTION
Do not compile `NUM_FRAGS_Z=6` to reduce wheel size.
Also revert #341 as they don't make effect.