### PR TITLE
Fix a bug related to causal mask

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -619,7 +619,7 @@ __device__ __forceinline__ void mask_s(const uint32_t qo_packed_idx_base,
                                 reg_id % 2;
         const bool out_of_boundary =
             (mask_mode == MaskMode::kCausal
-                 ? (kv_idx > kv_len + q_idx - qo_len || (partition_kv && kv_idx >= chunk_end))
+                 ? (kv_idx >= kv_len + q_idx - qo_len || (partition_kv && kv_idx >= chunk_end))
                  : kv_idx >= chunk_end);
         s_frag[fx][fz][reg_id] =
             (out_of_boundary ||

--- a/src/cpu_reference.h
+++ b/src/cpu_reference.h
@@ -125,7 +125,7 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_q>& q, const std::vect
               }
             }
             // apply mask
-            if (causal && kv_idx > kv_len + q_idx - qo_len) {
+            if (causal && kv_idx >= kv_len + q_idx - qo_len) {
               att[kv_idx] = -5e4;
             }
             max_val = std::max(max_val, att[kv_idx]);


### PR DESCRIPTION
For example, case (qo_len=2, kv_len=3) should have a causal mask as (`kv_idx >= kv_len + q_idx - qo_len`):
```math
\begin{pmatrix}
0 & -\infty & -\infty\\ 
0 & 0 & -\infty
\end{pmatrix}
```
The causal mask by `include/flashinfer/attention/prefill.cuh` and `src/cpu_reference.h` (`kv_idx > kv_len + q_idx - qo_len`):
```math
\begin{pmatrix}
0 & 0 & -\infty\\ 
0 & 0 & 0
\end{pmatrix}
```