### PR TITLE
ci: update release please github action

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
https://github.com/google-github-actions/release-please-action is deprecated, this PR replace it with the new action https://github.com/googleapis/release-please-action that is under maintenance.