### PR TITLE
bugfix: check gpu id in PyTorch APIs and use input tensor's gpu default stream

### DIFF
--- a/python/csrc/batch_decode.cu
+++ b/python/csrc/batch_decode.cu
@@ -37,7 +37,7 @@ void BatchDecodeWithPagedKVCachePyTorchWrapper::BeginForward(
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
   auto device = workspace_buffer.device();
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   handler_->SetCUDAStream(torch_current_stream);
   indptr = indptr.to(torch::kCPU);
   last_page_len = last_page_len.to(torch::kCPU);
@@ -150,7 +150,7 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCachePyTorchWrapper::Forward(
   CHECK_EQ(paged_kv_last_page_len.scalar_type(), torch::kInt32);
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   torch::Tensor o = torch::empty_like(q);
   torch::Tensor lse;
   if (return_lse) {

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -35,7 +35,7 @@ void BatchPrefillWithPagedKVCachePyTorchWrapper::BeginForward(
   paged_kv_indptr = paged_kv_indptr.to(torch::kCPU).to(torch::kInt32);
   auto device = workspace_buffer.device();
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   handler_->SetCUDAStream(torch_current_stream);
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(empty_q_data.scalar_type(), q_type, [&] {
@@ -107,7 +107,7 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
   paged_kv_indices = paged_kv_indices.to(torch::kInt32);
   paged_kv_last_page_len = paged_kv_last_page_len.to(torch::kInt32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   torch::Tensor o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -222,7 +222,7 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::ForwardCu
   paged_kv_last_page_len = paged_kv_last_page_len.to(torch::kInt32);
   qk_indptr = qk_indptr.to(torch::kInt32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   torch::Tensor o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -292,7 +292,7 @@ void BatchPrefillWithRaggedKVCachePyTorchWrapper::BeginForward(
   kv_indptr = kv_indptr.to(torch::kCPU).to(torch::kInt32);
   size_t workspace_size_in_bytes = workspace_buffer.size(0) * workspace_buffer.element_size();
   auto device = workspace_buffer.device();
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   handler_->SetCUDAStream(torch_current_stream);
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(empty_q_data.scalar_type(), q_type, [&] {
@@ -350,7 +350,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
   qo_indptr = qo_indptr.to(torch::kInt32);
   kv_indptr = kv_indptr.to(torch::kInt32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   torch::Tensor o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -448,7 +448,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::ForwardC
   kv_indptr = kv_indptr.to(torch::kInt32);
   qk_indptr = qk_indptr.to(torch::kInt32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   torch::Tensor o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {

--- a/python/csrc/cascade.cu
+++ b/python/csrc/cascade.cu
@@ -43,7 +43,7 @@ std::vector<torch::Tensor> merge_state(torch::Tensor v_a, torch::Tensor s_a, tor
   unsigned int seq_len = v_a.size(0);
   unsigned int num_heads = v_a.size(1);
   unsigned int head_dim = v_a.size(2);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto v_merged = torch::empty_like(v_a, v_a.options());
   auto s_merged = torch::empty({seq_len, num_heads}, s_a.options());
 
@@ -85,7 +85,7 @@ void merge_state_in_place(torch::Tensor v, torch::Tensor s, torch::Tensor v_othe
   unsigned int seq_len = v.size(0);
   unsigned int num_heads = v.size(1);
   unsigned int head_dim = v.size(2);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(v.scalar_type(), c_type, [&] {
     cudaError_t status = MergeStateInPlace(
@@ -115,7 +115,7 @@ std::vector<torch::Tensor> merge_states(torch::Tensor v, torch::Tensor s) {
   unsigned int num_heads = v.size(2);
   unsigned int head_dim = v.size(3);
   s = s.to(torch::kFloat32);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto v_merged = torch::empty({seq_len, num_heads, head_dim}, v.options());
   auto s_merged = torch::empty({seq_len, num_heads}, s.options());
 

--- a/python/csrc/cascade.cu
+++ b/python/csrc/cascade.cu
@@ -85,7 +85,7 @@ void merge_state_in_place(torch::Tensor v, torch::Tensor s, torch::Tensor v_othe
   unsigned int seq_len = v.size(0);
   unsigned int num_heads = v.size(1);
   unsigned int head_dim = v.size(2);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(v);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(v.scalar_type(), c_type, [&] {
     cudaError_t status = MergeStateInPlace(

--- a/python/csrc/cascade.cu
+++ b/python/csrc/cascade.cu
@@ -26,6 +26,10 @@ std::vector<torch::Tensor> merge_state(torch::Tensor v_a, torch::Tensor s_a, tor
   CHECK_INPUT(s_a);
   CHECK_INPUT(v_b);
   CHECK_INPUT(s_b);
+  auto device = v_a.device();
+  CHECK_EQ(s_a.device(), device);
+  CHECK_EQ(v_b.device(), device);
+  CHECK_EQ(s_b.device(), device);
   CHECK_DIM(3, v_a);
   CHECK_DIM(2, s_a);
   CHECK_DIM(3, v_b);
@@ -39,7 +43,7 @@ std::vector<torch::Tensor> merge_state(torch::Tensor v_a, torch::Tensor s_a, tor
   unsigned int seq_len = v_a.size(0);
   unsigned int num_heads = v_a.size(1);
   unsigned int head_dim = v_a.size(2);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto v_merged = torch::empty_like(v_a, v_a.options());
   auto s_merged = torch::empty({seq_len, num_heads}, s_a.options());
 
@@ -64,6 +68,10 @@ void merge_state_in_place(torch::Tensor v, torch::Tensor s, torch::Tensor v_othe
   CHECK_INPUT(s);
   CHECK_INPUT(v_other);
   CHECK_INPUT(s_other);
+  auto device = v.device();
+  CHECK_EQ(s.device(), device);
+  CHECK_EQ(v_other.device(), device);
+  CHECK_EQ(s_other.device(), device);
   CHECK_DIM(3, v);
   CHECK_DIM(2, s);
   CHECK_DIM(3, v_other);
@@ -77,7 +85,7 @@ void merge_state_in_place(torch::Tensor v, torch::Tensor s, torch::Tensor v_othe
   unsigned int seq_len = v.size(0);
   unsigned int num_heads = v.size(1);
   unsigned int head_dim = v.size(2);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(v);
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(v.scalar_type(), c_type, [&] {
     cudaError_t status = MergeStateInPlace(
@@ -95,6 +103,8 @@ void merge_state_in_place(torch::Tensor v, torch::Tensor s, torch::Tensor v_othe
 std::vector<torch::Tensor> merge_states(torch::Tensor v, torch::Tensor s) {
   CHECK_INPUT(v);
   CHECK_INPUT(s);
+  auto device = v.device();
+  CHECK_EQ(s.device(), device);
   CHECK_DIM(4, v);
   CHECK_DIM(3, s);
   CHECK_EQ(v.size(0), s.size(0));
@@ -105,7 +115,7 @@ std::vector<torch::Tensor> merge_states(torch::Tensor v, torch::Tensor s) {
   unsigned int num_heads = v.size(2);
   unsigned int head_dim = v.size(3);
   s = s.to(torch::kFloat32);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto v_merged = torch::empty({seq_len, num_heads, head_dim}, v.options());
   auto s_merged = torch::empty({seq_len, num_heads}, s.options());
 

--- a/python/csrc/group_gemm.cu
+++ b/python/csrc/group_gemm.cu
@@ -45,7 +45,7 @@ torch::Tensor CutlassSegmentGEMMPyTorchWrapper::Forward(torch::Tensor seg_indptr
   int64_t d_in = weight_column_major ? weight.size(2) : weight.size(1);
   CHECK_EQ(x.size(1), d_in);
   auto y = torch::zeros({cumulative_batch_size, d_out}, x.options());
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   seg_indptr = seg_indptr.to(torch::kInt64);
 
   bool weight_indices_defined = weight_indices.numel() > 0;

--- a/python/csrc/group_gemm.cu
+++ b/python/csrc/group_gemm.cu
@@ -31,12 +31,12 @@ torch::Tensor CutlassSegmentGEMMPyTorchWrapper::Forward(torch::Tensor seg_indptr
                                                         unsigned int batch_size,
                                                         bool weight_column_major) {
   // TODO(Zihao): Add more checks here
-  CHECK_CUDA(seg_indptr);
-  CHECK_CUDA(x);
-  CHECK_CUDA(weight);
+  CHECK_INPUT(seg_indptr);
+  CHECK_INPUT(x);
+  CHECK_INPUT(weight);
   auto device = x.device();
   CHECK_EQ(seg_indptr.device(), device);
-  CHECK_EQ(weight_indices.device(), device);
+  CHECK_EQ(weight.device(), device);
   CHECK_DIM(2, x);       // x: [sum(m_i), d_in]
   CHECK_DIM(3, weight);  // weight: [num_weights, d_out, d_in] if weight_column_major, [num_weights,
                          // d_in, d_out] otherwise
@@ -50,7 +50,7 @@ torch::Tensor CutlassSegmentGEMMPyTorchWrapper::Forward(torch::Tensor seg_indptr
 
   bool weight_indices_defined = weight_indices.numel() > 0;
   if (weight_indices_defined) {
-    CHECK_CUDA(weight_indices);
+    CHECK_INPUT(weight_indices);
     CHECK_EQ(weight_indices.device(), device);
     weight_indices = weight_indices.to(torch::kInt64);
   }

--- a/python/csrc/norm.cu
+++ b/python/csrc/norm.cu
@@ -31,7 +31,7 @@ torch::Tensor rmsnorm(torch::Tensor x, torch::Tensor w, double eps) {
   unsigned int batch_size = x.size(0);
   unsigned int hidden_size = x.size(1);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto y = torch::empty_like(x);
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(x.scalar_type(), c_type, [&] {
     cudaError_t status = norm::RMSNorm(

--- a/python/csrc/norm.cu
+++ b/python/csrc/norm.cu
@@ -23,13 +23,15 @@ using namespace flashinfer;
 torch::Tensor rmsnorm(torch::Tensor x, torch::Tensor w, double eps) {
   CHECK_INPUT(x);
   CHECK_INPUT(w);
+  auto device = x.device();
+  CHECK_EQ(w.device(), device);
   CHECK_DIM(2, x);  // x: (batch_size, hidden_size)
   CHECK_DIM(1, w);  // w: (hidden_size)
   CHECK_EQ(x.size(1), w.size(0));
   unsigned int batch_size = x.size(0);
   unsigned int hidden_size = x.size(1);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto y = torch::empty_like(x);
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(x.scalar_type(), c_type, [&] {
     cudaError_t status = norm::RMSNorm(

--- a/python/csrc/page.cu
+++ b/python/csrc/page.cu
@@ -45,6 +45,13 @@ void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
   CHECK_EQ(kv_indptr.scalar_type(), torch::kInt32);
   CHECK_EQ(kv_indices.scalar_type(), torch::kInt32);
   CHECK_EQ(kv_last_page_len.scalar_type(), torch::kInt32);
+  auto device = append_indptr.device();
+  CHECK_EQ(append_key.device(), device);
+  CHECK_EQ(append_value.device(), device);
+  CHECK_EQ(kv_data.device(), device);
+  CHECK_EQ(kv_indices.device(), device);
+  CHECK_EQ(kv_indptr.device(), device);
+  CHECK_EQ(kv_last_page_len.device(), device);
 
   constexpr PageStorage page_storage = PageStorage::kIndices;
   QKVLayout kv_layout = QKVLayout(layout);
@@ -65,7 +72,7 @@ void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
   CHECK_EQ(append_value.size(1), num_heads);
   CHECK_EQ(append_key.size(2), head_dim);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE(kv_data.scalar_type(), c_type, [&] {
     DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {

--- a/python/csrc/page.cu
+++ b/python/csrc/page.cu
@@ -72,7 +72,7 @@ void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
   CHECK_EQ(append_value.size(1), num_heads);
   CHECK_EQ(append_key.size(2), head_dim);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE(kv_data.scalar_type(), c_type, [&] {
     DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {

--- a/python/csrc/quantization.cu
+++ b/python/csrc/quantization.cu
@@ -25,7 +25,7 @@ torch::Tensor packbits(torch::Tensor x, const std::string& bitorder) {
   auto device = x.device();
   TORCH_CHECK(bitorder == "big" || bitorder == "little", "bitorder must be 'big' or 'little'");
   x = x.to(torch::kBool);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
 
   int64_t num_elements = x.numel();
   int64_t num_output_elements = (num_elements + 7) / 8;
@@ -63,6 +63,6 @@ torch::Tensor segment_packbits(torch::Tensor x, torch::Tensor input_indptr,
       static_cast<int32_t*>(input_indptr.data_ptr()),
       static_cast<int32_t*>(output_indptr.data_ptr()), batch_size,
       bitorder == "big" ? quantization::BitOrder::kBig : quantization::BitOrder::kLittle,
-      c10::cuda::getCurrentCUDAStream(device));
+      c10::cuda::getCurrentCUDAStream(device.index()));
   return y;
 }

--- a/python/csrc/quantization.cu
+++ b/python/csrc/quantization.cu
@@ -22,9 +22,10 @@ using namespace flashinfer;
 
 torch::Tensor packbits(torch::Tensor x, const std::string& bitorder) {
   CHECK_INPUT(x);
+  auto device = x.device();
   TORCH_CHECK(bitorder == "big" || bitorder == "little", "bitorder must be 'big' or 'little'");
   x = x.to(torch::kBool);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
 
   int64_t num_elements = x.numel();
   int64_t num_output_elements = (num_elements + 7) / 8;
@@ -46,6 +47,9 @@ torch::Tensor segment_packbits(torch::Tensor x, torch::Tensor input_indptr,
   CHECK_INPUT(x);
   CHECK_INPUT(input_indptr);
   CHECK_INPUT(output_indptr);
+  auto device = x.device();
+  CHECK_EQ(input_indptr.device(), device);
+  CHECK_EQ(output_indptr.device(), device);
   TORCH_CHECK(bitorder == "big" || bitorder == "little", "bitorder must be 'big' or 'little'");
   unsigned int batch_size = input_indptr.size(0) - 1;
   CHECK_EQ(output_indptr.size(0), batch_size + 1);
@@ -59,6 +63,6 @@ torch::Tensor segment_packbits(torch::Tensor x, torch::Tensor input_indptr,
       static_cast<int32_t*>(input_indptr.data_ptr()),
       static_cast<int32_t*>(output_indptr.data_ptr()), batch_size,
       bitorder == "big" ? quantization::BitOrder::kBig : quantization::BitOrder::kLittle,
-      c10::cuda::getCurrentCUDAStream());
+      c10::cuda::getCurrentCUDAStream(device));
   return y;
 }

--- a/python/csrc/sampling.cu
+++ b/python/csrc/sampling.cu
@@ -33,7 +33,7 @@ torch::Tensor sampling_from_probs(torch::Tensor probs, torch::Tensor uniform_sam
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
 
   cudaError_t status = sampling::SamplingFromProb(
@@ -59,7 +59,7 @@ std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
   auto success = torch::empty({batch_size}, torch::dtype(torch::kBool).device(device));
 
@@ -89,7 +89,7 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
   auto success = torch::empty({batch_size}, torch::dtype(torch::kBool).device(device));
 
@@ -111,7 +111,7 @@ torch::Tensor top_p_renorm_prob(torch::Tensor probs, double top_p, double eps) {
   unsigned int vocab_size = probs.size(1);
   probs = probs.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto renorm_probs =
       torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
 
@@ -131,7 +131,7 @@ torch::Tensor top_k_renorm_prob(torch::Tensor probs, unsigned int top_k, double 
   unsigned int vocab_size = probs.size(1);
   probs = probs.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto renorm_probs =
       torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
 
@@ -174,7 +174,7 @@ torch::Tensor chain_speculative_sampling(torch::Tensor draft_probs, torch::Tenso
   uniform_samples = uniform_samples.to(torch::kFloat32);
   target_probs = target_probs.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto output_token_ids = torch::empty({batch_size, num_speculate_tokens + 1},
                                        torch::dtype(torch::kInt32).device(device));
 

--- a/python/csrc/sampling.cu
+++ b/python/csrc/sampling.cu
@@ -23,6 +23,8 @@ using namespace flashinfer;
 torch::Tensor sampling_from_probs(torch::Tensor probs, torch::Tensor uniform_samples) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
+  auto device = probs.device();
+  CHECK_EQ(uniform_samples.device(), device);
   CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
   CHECK_DIM(1, uniform_samples);  // uniform_samples: (batch_size)
   CHECK_EQ(probs.size(0), uniform_samples.size(0));
@@ -31,8 +33,8 @@ torch::Tensor sampling_from_probs(torch::Tensor probs, torch::Tensor uniform_sam
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(probs.device()));
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
 
   cudaError_t status = sampling::SamplingFromProb(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
@@ -46,6 +48,8 @@ std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
                                                      torch::Tensor uniform_samples, double top_p) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
+  auto device = probs.device();
+  CHECK_EQ(uniform_samples.device(), device);
   CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
   CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_top_p_rounds, batch_size)
   CHECK_EQ(probs.size(0), uniform_samples.size(1));
@@ -55,9 +59,9 @@ std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(probs.device()));
-  auto success = torch::empty({batch_size}, torch::dtype(torch::kBool).device(probs.device()));
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
+  auto success = torch::empty({batch_size}, torch::dtype(torch::kBool).device(device));
 
   cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
@@ -74,6 +78,8 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
                                                      unsigned int top_k) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
+  auto device = probs.device();
+  CHECK_EQ(uniform_samples.device(), device);
   CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
   CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_top_k_rounds, batch_size)
   CHECK_EQ(probs.size(0), uniform_samples.size(1));
@@ -83,9 +89,9 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(probs.device()));
-  auto success = torch::empty({batch_size}, torch::dtype(torch::kBool).device(probs.device()));
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
+  auto success = torch::empty({batch_size}, torch::dtype(torch::kBool).device(device));
 
   cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
@@ -99,14 +105,15 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
 
 torch::Tensor top_p_renorm_prob(torch::Tensor probs, double top_p, double eps) {
   CHECK_INPUT(probs);
+  auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   probs = probs.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto renorm_probs =
-      torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(probs.device()));
+      torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
 
   cudaError_t status = sampling::TopPRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()), top_p,
@@ -118,14 +125,15 @@ torch::Tensor top_p_renorm_prob(torch::Tensor probs, double top_p, double eps) {
 
 torch::Tensor top_k_renorm_prob(torch::Tensor probs, unsigned int top_k, double eps) {
   CHECK_INPUT(probs);
+  auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   probs = probs.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto renorm_probs =
-      torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(probs.device()));
+      torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
 
   cudaError_t status = sampling::TopKRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()), top_k,
@@ -143,6 +151,10 @@ torch::Tensor chain_speculative_sampling(torch::Tensor draft_probs, torch::Tenso
   CHECK_INPUT(draft_token_ids);
   CHECK_INPUT(uniform_samples);
   CHECK_INPUT(target_probs);
+  auto device = draft_probs.device();
+  CHECK_EQ(draft_token_ids.device(), device);
+  CHECK_EQ(uniform_samples.device(), device);
+  CHECK_EQ(target_probs.device(), device);
   CHECK_DIM(3, draft_probs);      // draft_probs: (batch_size, num_speculate_tokens, vocab_size)
   CHECK_DIM(2, draft_token_ids);  // draft_token_ids: (batch_size, num_speculate_tokens)
   CHECK_DIM(2, uniform_samples);  // uniform_samples: (batch_size, num_speculate_tokens + 1)
@@ -162,10 +174,9 @@ torch::Tensor chain_speculative_sampling(torch::Tensor draft_probs, torch::Tenso
   uniform_samples = uniform_samples.to(torch::kFloat32);
   target_probs = target_probs.to(torch::kFloat32);
 
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
-  auto output_token_ids =
-      torch::empty({batch_size, num_speculate_tokens + 1},
-                   torch::dtype(torch::kInt32).device(draft_token_ids.device()));
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  auto output_token_ids = torch::empty({batch_size, num_speculate_tokens + 1},
+                                       torch::dtype(torch::kInt32).device(device));
 
   cudaError_t status = sampling::ChainSpeculativeSampling<float, int>(
       static_cast<float*>(draft_probs.data_ptr()), static_cast<int*>(draft_token_ids.data_ptr()),

--- a/python/csrc/single_decode.cu
+++ b/python/csrc/single_decode.cu
@@ -50,7 +50,7 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
     kv_len = k.size(1);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto o = torch::empty_like(q);
 
   TORCH_CHECK(logits_soft_cap >= 0.f, "logits_soft_cap must be non-negative");

--- a/python/csrc/single_decode.cu
+++ b/python/csrc/single_decode.cu
@@ -27,6 +27,11 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
   CHECK_INPUT(q);
   CHECK_INPUT(k);
   CHECK_INPUT(v);
+  CHECK_INPUT(tmp);
+  auto device = q.device();
+  CHECK_EQ(k.device(), device);
+  CHECK_EQ(v.device(), device);
+  CHECK_EQ(tmp.device(), device);
   CHECK_DIM(2, q);
   CHECK_DIM(3, k);
   CHECK_DIM(3, v);
@@ -45,7 +50,7 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
     kv_len = k.size(1);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto o = torch::empty_like(q);
 
   TORCH_CHECK(logits_soft_cap >= 0.f, "logits_soft_cap must be non-negative");

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -27,6 +27,11 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
   CHECK_INPUT(q);
   CHECK_INPUT(k);
   CHECK_INPUT(v);
+  CHECK_INPUT(tmp);
+  auto device = q.device();
+  CHECK_EQ(k.device(), device);
+  CHECK_EQ(v.device(), device);
+  CHECK_EQ(tmp.device(), device);
   CHECK_DIM(3, q);
   CHECK_DIM(3, k);
   CHECK_DIM(3, v);
@@ -47,7 +52,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
     num_kv_heads = k.size(0);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -108,6 +113,10 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
   CHECK_INPUT(k);
   CHECK_INPUT(v);
   CHECK_INPUT(packed_custom_mask);
+  auto device = q.device();
+  CHECK_EQ(k.device(), device);
+  CHECK_EQ(v.device(), device);
+  CHECK_EQ(packed_custom_mask.device(), device);
   CHECK_DIM(3, q);
   CHECK_DIM(3, k);
   CHECK_DIM(3, v);
@@ -130,7 +139,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
     num_kv_heads = k.size(0);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
   auto o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -52,7 +52,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
     num_kv_heads = k.size(0);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {
@@ -139,7 +139,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
     num_kv_heads = k.size(0);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device);
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto o = torch::empty_like(q, q.options());
   torch::Tensor lse = torch::empty({0});
   if (return_lse) {


### PR DESCRIPTION
This PR fixes #349  by using the default stream of input tensors' device instead of the default stream of default device (which might be different to input tensors' device). This PR also adds sanity check on input tensors device id (all input tensors must be on the same GPU).