### PR TITLE
refactor: reduce binary size by making `kv_layout` an argument instead of template parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ flashinfer_option(FLASHINFER_TVM_SOURCE_DIR "The path to tvm for building tvm bi
 # The following configurations can impact the binary
 # size of the generated library
 flashinfer_option(FLASHINFER_GEN_HEAD_DIMS "Head dims to enable" 64 128 256)
-flashinfer_option(FLASHINFER_GEN_KV_LAYOUTS "KV layouts to enable" 0 1)
 flashinfer_option(FLASHINFER_GEN_LOGITS_POST_HOOKS "Logits post hooks" 0 1)
 flashinfer_option(FLASHINFER_GEN_POS_ENCODING_MODES "Pos encodings to enable" 0 1 2)
 flashinfer_option(FLASHINFER_GEN_ALLOW_FP16_QK_REDUCTIONS "QK reductions to enable" "false" "true")
@@ -81,7 +80,6 @@ endif(FLASHINFER_ENABLE_BF16)
 # generate kernel inst
 set (HEAD_DIMS ${FLASHINFER_GEN_HEAD_DIMS})
 set (LOGITS_POST_HOOKS ${FLASHINFER_GEN_LOGITS_POST_HOOKS})
-set (KV_LAYOUTS ${FLASHINFER_GEN_KV_LAYOUTS})
 set (POS_ENCODING_MODES ${FLASHINFER_GEN_POS_ENCODING_MODES})
 set (ALLOW_FP16_QK_REDUCTIONS ${FLASHINFER_GEN_ALLOW_FP16_QK_REDUCTIONS})
 set (MASK_MODES ${FLASHINFER_GEN_MASK_MODES})
@@ -102,7 +100,6 @@ endif(FLASHINFER_ENABLE_BF16)
 
 # log options
 message(STATUS "FLASHINFER_HEAD_DIMS=${HEAD_DIMS}")
-message(STATUS "FLASHINFER_KV_LAYOUTS=${KV_LAYOUTS}")
 message(STATUS "FLASHINFER_POS_ENCODING_MODES=${POS_ENCODING_MODES}")
 message(STATUS "FLASHINFER_ALLOW_FP16_QK_REDUCTIONS=${ALLOW_FP16_QK_REDUCTIONS}")
 message(STATUS "FLASHINFER_MASK_MODES=${MASK_MODES}")
@@ -112,7 +109,7 @@ file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/src/generated)
 set(dispatch_inc_file ${PROJECT_SOURCE_DIR}/src/dispatch.inc)
 add_custom_command(
   OUTPUT ${dispatch_inc_file}
-  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_dispatch_inc.py --path ${PROJECT_SOURCE_DIR}/src/dispatch.inc --head_dims ${HEAD_DIMS} --logits_post_hooks ${LOGITS_POST_HOOKS} --kv_layouts ${KV_LAYOUTS} --pos_encoding_modes ${POS_ENCODING_MODES} --allow_fp16_qk_reductions ${ALLOW_FP16_QK_REDUCTIONS} --mask_modes ${MASK_MODES}
+  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_dispatch_inc.py --path ${PROJECT_SOURCE_DIR}/src/dispatch.inc --head_dims ${HEAD_DIMS} --logits_post_hooks ${LOGITS_POST_HOOKS} --pos_encoding_modes ${POS_ENCODING_MODES} --allow_fp16_qk_reductions ${ALLOW_FP16_QK_REDUCTIONS} --mask_modes ${MASK_MODES}
   DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_dispatch_inc.py
   COMMENT "Generating additional source file ${generated_dispatch_inc}"
   VERBATIM
@@ -122,71 +119,67 @@ add_custom_target(dispatch_inc DEPENDS ${dispatch_inc_file})
 # single decode kernel inst generation
 foreach(head_dim IN LISTS HEAD_DIMS)
   foreach(logits_post_hook IN LISTS LOGITS_POST_HOOKS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        foreach(dtype IN LISTS DECODE_DTYPES)
-          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}.cu)
-          add_custom_command(
-            OUTPUT ${generated_kernel_src}
-            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
-            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
-            COMMENT "Generating additional source file ${generated_kernel_src}"
-            VERBATIM
-          )
-          list(APPEND single_decode_kernels_src ${generated_kernel_src})
-        endforeach(dtype)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(dtype IN LISTS DECODE_DTYPES)
+        set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}.cu)
+        add_custom_command(
+          OUTPUT ${generated_kernel_src}
+          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+          DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
+          COMMENT "Generating additional source file ${generated_kernel_src}"
+          VERBATIM
+        )
+        list(APPEND single_decode_kernels_src ${generated_kernel_src})
+      endforeach(dtype)
 
-        # fp8 kv-cache
-        foreach(dtype_kv IN LISTS DECODE_FP8_DTYPES)
-          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypeq_f16_dtypekv_${dtype_kv}_dtypeout_f16.cu)
-          add_custom_command(
-            OUTPUT ${generated_kernel_src}
-            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
-            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
-            COMMENT "Generating additional source file ${generated_kernel_src}"
-            VERBATIM
-          )
-          list(APPEND single_decode_kernels_src ${generated_kernel_src})
-        endforeach(dtype_kv)
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
+      # fp8 kv-cache
+      foreach(dtype_kv IN LISTS DECODE_FP8_DTYPES)
+        set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_decode_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_dtypeq_f16_dtypekv_${dtype_kv}_dtypeout_f16.cu)
+        add_custom_command(
+          OUTPUT ${generated_kernel_src}
+          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py ${generated_kernel_src}
+          DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_decode_inst.py
+          COMMENT "Generating additional source file ${generated_kernel_src}"
+          VERBATIM
+        )
+        list(APPEND single_decode_kernels_src ${generated_kernel_src})
+      endforeach(dtype_kv)
+    endforeach(pos_encoding_mode)
   endforeach(logits_post_hook)
 endforeach(head_dim)
 
 # batch decode kernel inst generation
 foreach(head_dim IN LISTS HEAD_DIMS)
   foreach(logits_post_hook IN LISTS LOGITS_POST_HOOKS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        # paged kv-cache
-        foreach(idtype IN LISTS IDTYPES)
-          foreach(dtype IN LISTS DECODE_DTYPES)
-            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
-            add_custom_command(
-              OUTPUT ${generated_kernel_src}
-              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
-              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
-              COMMENT "Generating additional source file ${generated_kernel_src}"
-              VERBATIM
-            )
-            list(APPEND batch_decode_kernels_src ${generated_kernel_src})
-          endforeach(dtype)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      # paged kv-cache
+      foreach(idtype IN LISTS IDTYPES)
+        foreach(dtype IN LISTS DECODE_DTYPES)
+          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+          add_custom_command(
+            OUTPUT ${generated_kernel_src}
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
+            COMMENT "Generating additional source file ${generated_kernel_src}"
+            VERBATIM
+          )
+          list(APPEND batch_decode_kernels_src ${generated_kernel_src})
+        endforeach(dtype)
 
-          # fp8 kv-cache
-          foreach(dtype_kv IN LISTS DECODE_FP8_DTYPES)
-            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_dtypeq_f16_dtypekv_${dtype_kv}_dtypeout_f16_idtype_${idtype}.cu)
-            add_custom_command(
-              OUTPUT ${generated_kernel_src}
-              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
-              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
-              COMMENT "Generating additional source file ${generated_kernel_src}"
-              VERBATIM
-            )
-            list(APPEND batch_decode_kernels_src ${generated_kernel_src})
-          endforeach(dtype_kv)
-        endforeach(idtype)
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
+        # fp8 kv-cache
+        foreach(dtype_kv IN LISTS DECODE_FP8_DTYPES)
+          set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_decode_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_dtypeq_f16_dtypekv_${dtype_kv}_dtypeout_f16_idtype_${idtype}.cu)
+          add_custom_command(
+            OUTPUT ${generated_kernel_src}
+            COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py ${generated_kernel_src}
+            DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_decode_inst.py
+            COMMENT "Generating additional source file ${generated_kernel_src}"
+            VERBATIM
+          )
+          list(APPEND batch_decode_kernels_src ${generated_kernel_src})
+        endforeach(dtype_kv)
+      endforeach(idtype)
+    endforeach(pos_encoding_mode)
   endforeach(logits_post_hook)
 endforeach(head_dim)
 
@@ -197,77 +190,73 @@ target_compile_options(decode_kernels PRIVATE -Xcompiler=-fPIC --fatbin-options 
 # single prefill kernel inst generation
 foreach(head_dim IN LISTS HEAD_DIMS)
   foreach(logits_post_hook IN LISTS LOGITS_POST_HOOKS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
-          foreach(mask_mode IN LISTS MASK_MODES)
-            foreach(dtype IN LISTS PREFILL_DTYPES)
-              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
-              add_custom_command(
-                OUTPUT ${generated_kernel_src}
-                COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
-                DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
-                COMMENT "Generating additional source file ${generated_kernel_src}"
-                VERBATIM
-              )
-              list(APPEND single_prefill_kernels_src ${generated_kernel_src})
-            endforeach(dtype)
-          endforeach(mask_mode)
-        endforeach(allow_fp16_qk_reduction)
-      endforeach(pos_encoding_mode)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
+        foreach(mask_mode IN LISTS MASK_MODES)
+          foreach(dtype IN LISTS PREFILL_DTYPES)
+            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+            add_custom_command(
+              OUTPUT ${generated_kernel_src}
+              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
+              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
+              COMMENT "Generating additional source file ${generated_kernel_src}"
+              VERBATIM
+            )
+            list(APPEND single_prefill_kernels_src ${generated_kernel_src})
+          endforeach(dtype)
+        endforeach(mask_mode)
+      endforeach(allow_fp16_qk_reduction)
+    endforeach(pos_encoding_mode)
   endforeach(logits_post_hook)
 endforeach(head_dim)
 
 # batch paged prefill kernel inst generation
 foreach(head_dim IN LISTS HEAD_DIMS)
   foreach(logits_post_hook IN LISTS LOGITS_POST_HOOKS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
-          foreach(mask_mode IN LISTS MASK_MODES)
-            foreach(dtype IN LISTS PREFILL_DTYPES)
-              foreach(idtype IN LISTS IDTYPES)
-                set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
-                add_custom_command(
-                  OUTPUT ${generated_kernel_src}
-                  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
-                  DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py
-                  COMMENT "Generating additional source file ${generated_kernel_src}"
-                  VERBATIM
-                )
-                list(APPEND batch_paged_prefill_kernels_src ${generated_kernel_src})
-              endforeach(idtype)
-            endforeach(dtype)
-          endforeach(mask_mode)
-        endforeach(allow_fp16_qk_reduction)
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
+        foreach(mask_mode IN LISTS MASK_MODES)
+          foreach(dtype IN LISTS PREFILL_DTYPES)
+            foreach(idtype IN LISTS IDTYPES)
+              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+              add_custom_command(
+                OUTPUT ${generated_kernel_src}
+                COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
+                DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py
+                COMMENT "Generating additional source file ${generated_kernel_src}"
+                VERBATIM
+              )
+              list(APPEND batch_paged_prefill_kernels_src ${generated_kernel_src})
+            endforeach(idtype)
+          endforeach(dtype)
+        endforeach(mask_mode)
+      endforeach(allow_fp16_qk_reduction)
+    endforeach(pos_encoding_mode)
   endforeach(logits_post_hook)
 endforeach(head_dim)
 
 # batch ragged prefill kernel inst generation
 foreach(head_dim IN LISTS HEAD_DIMS)
   foreach(logits_post_hook IN LISTS LOGITS_POST_HOOKS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
-      foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
-        foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
-          foreach(mask_mode IN LISTS MASK_MODES)
-            foreach(dtype IN LISTS PREFILL_DTYPES)
-              foreach(idtype IN LISTS IDTYPES)
-                set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
-                add_custom_command(
-                  OUTPUT ${generated_kernel_src}
-                  COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
-                  DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py
-                  COMMENT "Generating additional source file ${generated_kernel_src}"
-                  VERBATIM
-                )
-                list(APPEND batch_ragged_prefill_kernels_src ${generated_kernel_src})
-              endforeach(idtype)
-            endforeach(dtype)
-          endforeach(mask_mode)
-        endforeach(allow_fp16_qk_reduction)
-      endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
+    foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
+      foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
+        foreach(mask_mode IN LISTS MASK_MODES)
+          foreach(dtype IN LISTS PREFILL_DTYPES)
+            foreach(idtype IN LISTS IDTYPES)
+              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+              add_custom_command(
+                OUTPUT ${generated_kernel_src}
+                COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}
+                DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py
+                COMMENT "Generating additional source file ${generated_kernel_src}"
+                VERBATIM
+              )
+              list(APPEND batch_ragged_prefill_kernels_src ${generated_kernel_src})
+            endforeach(idtype)
+          endforeach(dtype)
+        endforeach(mask_mode)
+      endforeach(allow_fp16_qk_reduction)
+    endforeach(pos_encoding_mode)
   endforeach(logits_post_hook)
 endforeach(head_dim)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,12 +197,11 @@ target_compile_options(decode_kernels PRIVATE -Xcompiler=-fPIC --fatbin-options 
 # single prefill kernel inst generation
 foreach(head_dim IN LISTS HEAD_DIMS)
   foreach(logits_post_hook IN LISTS LOGITS_POST_HOOKS)
-    foreach(kv_layout IN LISTS KV_LAYOUTS)
       foreach(pos_encoding_mode IN LISTS POS_ENCODING_MODES)
         foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
           foreach(mask_mode IN LISTS MASK_MODES)
             foreach(dtype IN LISTS PREFILL_DTYPES)
-              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_layout_${kv_layout}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
               add_custom_command(
                 OUTPUT ${generated_kernel_src}
                 COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
@@ -215,7 +214,6 @@ foreach(head_dim IN LISTS HEAD_DIMS)
           endforeach(mask_mode)
         endforeach(allow_fp16_qk_reduction)
       endforeach(pos_encoding_mode)
-    endforeach(kv_layout)
   endforeach(logits_post_hook)
 endforeach(head_dim)
 

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -184,7 +184,6 @@ __device__ __forceinline__ void sync_state(state_t<vec_size>& st, float* smem, f
 /*!
  * \brief FlashAttention decoding cuda kernel with kv-cache for a single request
  * \tparam logits_post_hook The logits post hook used in the kernel
- * \tparam kv_layout The layout of k/v matrices (NHD or HND)
  * \tparam partition_kv Whether to partition kv-cache on sequence length dimension or not
  * \tparam pos_encoding_mode The positional encoding mode
  * \tparam vec_size A template integer indicates the vector size
@@ -207,14 +206,12 @@ __device__ __forceinline__ void sync_state(state_t<vec_size>& st, float* smem, f
  *   of "theta" used in RoPE (Rotary Positional Embeddings)
  * \param kv_chunk_size A integer indicates the kv-chunk size
  */
-template <LogitsPostHook logits_post_hook, QKVLayout kv_layout, bool partition_kv,
-          PosEncodingMode pos_encoding_mode, uint32_t num_stages_smem, uint32_t tile_size_per_bdx,
-          uint32_t vec_size, uint32_t bdx, uint32_t bdy, uint32_t bdz, typename DTypeQ,
-          typename DTypeKV, typename DTypeOut>
+template <LogitsPostHook logits_post_hook, bool partition_kv, PosEncodingMode pos_encoding_mode,
+          uint32_t num_stages_smem, uint32_t tile_size_per_bdx, uint32_t vec_size, uint32_t bdx,
+          uint32_t bdy, uint32_t bdz, typename DTypeQ, typename DTypeKV, typename DTypeOut>
 __global__ void SingleDecodeWithKVCacheKernel(DTypeQ* __restrict__ q, DTypeKV* __restrict__ k,
                                               DTypeKV* __restrict__ v, DTypeOut* __restrict__ o,
-                                              float* __restrict__ lse,
-                                              tensor_info_t info,
+                                              float* __restrict__ lse, tensor_info_t info,
                                               float logits_soft_cap, float sm_scale,
                                               float rope_rcp_scale, float rope_rcp_theta,
                                               uint32_t kv_chunk_size) {
@@ -386,11 +383,11 @@ __global__ void SingleDecodeWithKVCacheKernel(DTypeQ* __restrict__ q, DTypeKV* _
  */
 template <LogitsPostHook logits_post_hook, bool partition_kv, PosEncodingMode pos_encoding_mode,
           uint32_t num_stages_smem, uint32_t tile_size_per_bdx, uint32_t vec_size, uint32_t bdx,
-          uint32_t bdy, uint32_t bdz, PageStorage page_storage, QKVLayout kv_layout,
-          typename DTypeQ, typename DTypeKV, typename DTypeOut, typename IdType>
+          uint32_t bdy, uint32_t bdz, PageStorage page_storage, typename DTypeQ, typename DTypeKV,
+          typename DTypeOut, typename IdType>
 __global__ void BatchDecodeWithPagedKVCacheKernel(
     DTypeQ* __restrict__ q, IdType* __restrict__ q_offset,
-    paged_kv_t<page_storage, kv_layout, DTypeKV, IdType> paged_kv,
+    paged_kv_t<page_storage, DTypeKV, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* __restrict__ o,
     float* __restrict__ lse, bool* __restrict__ block_valid_mask, float logits_soft_cap,
     float sm_scale, float rope_rcp_scale, float rope_rcp_theta) {
@@ -619,20 +616,19 @@ constexpr uint32_t get_heuristic_num_threads(uint32_t group_size, uint32_t sizeo
  * \param num_kv_heads A integer indicates the number of heads of key and value
  * \param seq_len A integer indicates the sequence length
  * \param head_dim A integer indicates the head dimension
- * \param kv_layout The layout of q/k/v matrices
  * \param pos_encoding_mode The positional encoding mode
  * \param rope_scale The scaling factor used in RoPE Interpolation
  * \param rope_theta The theta used in RoPE
  * \param stream The cuda stream to launch the kernel
  * \return status Indicates whether CUDA calls are successful
  */
-template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, QKVLayout KV_LAYOUT,
-          PosEncodingMode POS_ENCODING_MODE, typename DTypeQ, typename DTypeKV, typename DTypeOut>
+template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode POS_ENCODING_MODE,
+          typename DTypeQ, typename DTypeKV, typename DTypeOut>
 cudaError_t SingleDecodeWithKVCacheDispatched(DTypeQ* q, DTypeKV* k, DTypeKV* v, DTypeOut* o,
                                               DTypeOut* tmp, uint32_t num_qo_heads,
                                               uint32_t num_kv_heads, uint32_t seq_len,
-                                              float logits_soft_cap, float sm_scale,
-                                              float rope_scale, float rope_theta,
+                                              QKVLayout kv_layout, float logits_soft_cap,
+                                              float sm_scale, float rope_scale, float rope_theta,
                                               cudaStream_t stream) {
   const float rope_rcp_scale = 1.f / rope_scale;
   const float rope_rcp_theta = 1.f / rope_theta;
@@ -645,7 +641,7 @@ cudaError_t SingleDecodeWithKVCacheDispatched(DTypeQ* q, DTypeKV* k, DTypeKV* v,
     constexpr uint32_t num_threads =
         std::max(get_heuristic_num_threads(GROUP_SIZE, sizeof(DTypeKV)), bdx * bdy);
     constexpr uint32_t bdz = num_threads / (bdx * bdy);
-    tensor_info_t info(1, seq_len, num_qo_heads, num_kv_heads, KV_LAYOUT, HEAD_DIM);
+    tensor_info_t info(1, seq_len, num_qo_heads, num_kv_heads, kv_layout, HEAD_DIM);
     constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 8U) : 1U;
     const uint32_t smem_size =
         2U * num_stages_smem * bdy * tile_size_per_bdx * bdz * HEAD_DIM * sizeof(DTypeKV) +
@@ -653,9 +649,9 @@ cudaError_t SingleDecodeWithKVCacheDispatched(DTypeQ* q, DTypeKV* k, DTypeKV* v,
     if (seq_len <= 256 || tmp == nullptr) {
       // no need to use partition-kv kernel
       auto kernel =
-          SingleDecodeWithKVCacheKernel<LOGITS_POST_HOOK, KV_LAYOUT, /*partition_kv=*/false,
-                                        POS_ENCODING_MODE, num_stages_smem, tile_size_per_bdx,
-                                        vec_size, bdx, bdy, bdz, DTypeQ, DTypeKV, DTypeOut>;
+          SingleDecodeWithKVCacheKernel<LOGITS_POST_HOOK, /*partition_kv=*/false, POS_ENCODING_MODE,
+                                        num_stages_smem, tile_size_per_bdx, vec_size, bdx, bdy, bdz,
+                                        DTypeQ, DTypeKV, DTypeOut>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
@@ -677,9 +673,9 @@ cudaError_t SingleDecodeWithKVCacheDispatched(DTypeQ* q, DTypeKV* k, DTypeKV* v,
     } else {
       // use partition-kv kernel
       auto kernel =
-          SingleDecodeWithKVCacheKernel<LOGITS_POST_HOOK, KV_LAYOUT, /*partition_kv=*/true,
-                                        POS_ENCODING_MODE, num_stages_smem, tile_size_per_bdx,
-                                        vec_size, bdx, bdy, bdz, DTypeQ, DTypeKV, DTypeOut>;
+          SingleDecodeWithKVCacheKernel<LOGITS_POST_HOOK, /*partition_kv=*/true, POS_ENCODING_MODE,
+                                        num_stages_smem, tile_size_per_bdx, vec_size, bdx, bdy, bdz,
+                                        DTypeQ, DTypeKV, DTypeOut>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
@@ -722,10 +718,10 @@ cudaError_t SingleDecodeWithKVCacheDispatched(DTypeQ* q, DTypeKV* k, DTypeKV* v,
 }
 
 template <uint32_t HEAD_DIM, PageStorage page_storage, LogitsPostHook LOGITS_POST_HOOK,
-          QKVLayout kv_layout, PosEncodingMode POS_ENCODING_MODE, typename DTypeQ, typename DTypeKV,
-          typename DTypeOut, typename IdType>
+          PosEncodingMode POS_ENCODING_MODE, typename DTypeQ, typename DTypeKV, typename DTypeOut,
+          typename IdType>
 cudaError_t BatchDecodeWithPagedKVCacheDispatched(
-    DTypeQ* q, IdType* q_offset, paged_kv_t<page_storage, kv_layout, DTypeKV, IdType> paged_kv,
+    DTypeQ* q, IdType* q_offset, paged_kv_t<page_storage, DTypeKV, IdType> paged_kv,
     kv_partition_info_t<IdType> kv_partition_info, DTypeOut* o, DTypeOut* tmp_v, float* tmp_s,
     float* lse, bool* block_valid_mask, uint32_t padded_batch_size, uint32_t num_qo_heads,
     float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
@@ -754,8 +750,8 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(
       auto kernel =
           BatchDecodeWithPagedKVCacheKernel<LOGITS_POST_HOOK, /*partition_kv=*/false,
                                             POS_ENCODING_MODE, num_stages_smem, tile_size_per_bdx,
-                                            vec_size, bdx, bdy, bdz, page_storage, kv_layout,
-                                            DTypeQ, DTypeKV, DTypeOut, IdType>;
+                                            vec_size, bdx, bdy, bdz, page_storage, DTypeQ, DTypeKV,
+                                            DTypeOut, IdType>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
       void* args[] = {(void*)&q,
@@ -775,8 +771,8 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(
       auto partition_kv_kernel =
           BatchDecodeWithPagedKVCacheKernel<LOGITS_POST_HOOK, /*partition_kv=*/true,
                                             POS_ENCODING_MODE, num_stages_smem, tile_size_per_bdx,
-                                            vec_size, bdx, bdy, bdz, page_storage, kv_layout,
-                                            DTypeQ, DTypeKV, DTypeOut, IdType>;
+                                            vec_size, bdx, bdy, bdz, page_storage, DTypeQ, DTypeKV,
+                                            DTypeOut, IdType>;
       FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
           partition_kv_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
       void* args[] = {(void*)&q,

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -214,7 +214,7 @@ template <LogitsPostHook logits_post_hook, QKVLayout kv_layout, bool partition_k
 __global__ void SingleDecodeWithKVCacheKernel(DTypeQ* __restrict__ q, DTypeKV* __restrict__ k,
                                               DTypeKV* __restrict__ v, DTypeOut* __restrict__ o,
                                               float* __restrict__ lse,
-                                              tensor_info_t<kv_layout, bdx * vec_size> info,
+                                              tensor_info_t info,
                                               float logits_soft_cap, float sm_scale,
                                               float rope_rcp_scale, float rope_rcp_theta,
                                               uint32_t kv_chunk_size) {
@@ -645,7 +645,7 @@ cudaError_t SingleDecodeWithKVCacheDispatched(DTypeQ* q, DTypeKV* k, DTypeKV* v,
     constexpr uint32_t num_threads =
         std::max(get_heuristic_num_threads(GROUP_SIZE, sizeof(DTypeKV)), bdx * bdy);
     constexpr uint32_t bdz = num_threads / (bdx * bdy);
-    tensor_info_t<KV_LAYOUT, HEAD_DIM> info(1, seq_len, num_qo_heads, num_kv_heads);
+    tensor_info_t info(1, seq_len, num_qo_heads, num_kv_heads, KV_LAYOUT, HEAD_DIM);
     constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 8U) : 1U;
     const uint32_t smem_size =
         2U * num_stages_smem * bdy * tile_size_per_bdx * bdz * HEAD_DIM * sizeof(DTypeKV) +

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1803,10 +1803,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
     constexpr uint32_t num_warps_x = get_num_warps_x<WARP_LAYOUT>();
     constexpr uint32_t num_warps_z = get_num_warps_z<WARP_LAYOUT>();
     const uint32_t max_num_frags_z_reg =
-        (HEAD_DIM == 128 && num_frags_x == 2 && pos_encoding_mode == PosEncodingMode::kRoPELlama &&
+        (HEAD_DIM >= 128 && num_frags_x == 2 && pos_encoding_mode == PosEncodingMode::kRoPELlama &&
          !ALLOW_FP16_QK_REDUCTION)
             ? 2
-            : 4;
+            : (8 / num_frags_x);
     const uint32_t max_num_frags_z_smem =
         (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeIn)) - num_frags_x * num_warps_x) /
         (2 * num_warps_z);
@@ -1946,10 +1946,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
   const int max_smem_per_threadblock = max_smem_per_sm / 2;
 
   const uint32_t max_num_frags_z_reg =
-      (HEAD_DIM == 128 && num_frags_x == 2 && pos_encoding_mode == PosEncodingMode::kRoPELlama &&
+      (HEAD_DIM >= 128 && num_frags_x == 2 && pos_encoding_mode == PosEncodingMode::kRoPELlama &&
        !ALLOW_FP16_QK_REDUCTION)
           ? 2
-          : 4;
+          : (8 / num_frags_x);
   const uint32_t max_num_frags_z_smem =
       (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeIn)) - num_frags_x * num_warps_x) /
       (2 * num_warps_z);
@@ -2086,10 +2086,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
   const int max_smem_per_threadblock = max_smem_per_sm / 2;
 
   const uint32_t max_num_frags_z_reg =
-      (HEAD_DIM == 128 && num_frags_x == 2 && pos_encoding_mode == PosEncodingMode::kRoPELlama &&
+      (HEAD_DIM >= 128 && num_frags_x == 2 && pos_encoding_mode == PosEncodingMode::kRoPELlama &&
        !ALLOW_FP16_QK_REDUCTION)
           ? 2
-          : 4;
+          : (8 / num_frags_x);
   const uint32_t max_num_frags_z_smem =
       (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeIn)) - num_frags_x * num_warps_x) /
       (2 * num_warps_z);

--- a/include/flashinfer/layout.cuh
+++ b/include/flashinfer/layout.cuh
@@ -30,80 +30,58 @@ enum class QKVLayout {
   kHND = 1U,
 };
 
-template <QKVLayout layout>
 __host__ __device__ __forceinline__ size_t get_elem_offset_impl(size_t elem_idx, size_t head_idx,
-                                                                size_t feat_idx, size_t seq_len,
-                                                                size_t num_heads, size_t head_dim) {
-  if constexpr (layout == QKVLayout::kHND) {
-    return (head_idx * seq_len + elem_idx) * head_dim + feat_idx;
-  } else {
-    return (elem_idx * num_heads + head_idx) * head_dim + feat_idx;
-  }
+                                                                size_t feat_idx, size_t stride_n,
+                                                                size_t stride_h) {
+  return elem_idx * stride_n + head_idx * stride_h + feat_idx;
 }
 
-template <QKVLayout layout, size_t head_dim>
-__host__ __device__ __forceinline__ size_t get_elem_offset_impl(size_t elem_idx, size_t head_idx,
-                                                                size_t feat_idx, size_t seq_len,
-                                                                size_t num_heads) {
-  if constexpr (layout == QKVLayout::kHND) {
-    return (head_idx * seq_len + elem_idx) * head_dim + feat_idx;
-  } else {
-    return (elem_idx * num_heads + head_idx) * head_dim + feat_idx;
-  }
-}
-
-template <QKVLayout layout, uint32_t head_dim>
-__host__ __device__ __forceinline__ uint32_t get_n_stride_impl(uint32_t num_heads) {
-  return layout == QKVLayout::kHND ? head_dim : num_heads * head_dim;
-}
-
-template <QKVLayout layout, uint32_t head_dim>
-__host__ __device__ __forceinline__ uint32_t get_h_stride_impl(uint32_t seq_len) {
-  return layout == QKVLayout::kNHD ? head_dim : seq_len * head_dim;
-}
-
-template <QKVLayout kv_layout, uint32_t head_dim>
 struct tensor_info_t {
   uint32_t qo_len;
   uint32_t kv_len;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
+  uint32_t qo_stride_n;
+  uint32_t qo_stride_h;
+  uint32_t kv_stride_n;
+  uint32_t kv_stride_h;
   __host__ __device__ __forceinline__ tensor_info_t(uint32_t qo_len, uint32_t kv_len,
-                                                    uint32_t num_qo_heads, uint32_t num_kv_heads)
-      : qo_len(qo_len), kv_len(kv_len), num_qo_heads(num_qo_heads), num_kv_heads(num_kv_heads) {}
+                                                    uint32_t num_qo_heads, uint32_t num_kv_heads,
+                                                    uint32_t qo_stride_n, uint32_t qo_stride_h,
+                                                    uint32_t kv_stride_n, uint32_t kv_stride_h)
+      : qo_len(qo_len),
+        kv_len(kv_len),
+        num_qo_heads(num_qo_heads),
+        num_kv_heads(num_kv_heads),
+        qo_stride_n(qo_stride_n),
+        qo_stride_h(qo_stride_h),
+        kv_stride_n(kv_stride_n),
+        kv_stride_h(kv_stride_h) {}
+
+  __host__ __device__ __forceinline__ tensor_info_t(uint32_t qo_len, uint32_t kv_len,
+                                                    uint32_t num_qo_heads, uint32_t num_kv_heads,
+                                                    QKVLayout kv_layout, uint32_t head_dim)
+      : qo_len(qo_len), kv_len(kv_len), num_qo_heads(num_qo_heads), num_kv_heads(num_kv_heads) {
+    qo_stride_n = num_qo_heads * head_dim;
+    qo_stride_h = head_dim;
+    kv_stride_n = (kv_layout == QKVLayout::kNHD) ? num_kv_heads * head_dim : head_dim;
+    kv_stride_h = (kv_layout == QKVLayout::kNHD) ? head_dim : kv_len * head_dim;
+  }
 
   __host__ __device__ __forceinline__ size_t get_qo_elem_offset(uint32_t qo_idx,
                                                                 uint32_t qo_head_idx,
                                                                 uint32_t feat_idx) const {
-    return get_elem_offset_impl<QKVLayout::kNHD, head_dim>(qo_idx, qo_head_idx, feat_idx, qo_len,
-                                                           num_qo_heads);
+    return get_elem_offset_impl(qo_idx, qo_head_idx, feat_idx, qo_stride_n, qo_stride_h);
   }
 
   __host__ __device__ __forceinline__ size_t get_kv_elem_offset(uint32_t kv_idx,
                                                                 uint32_t kv_head_idx,
                                                                 uint32_t feat_idx) const {
-    return get_elem_offset_impl<kv_layout, head_dim>(kv_idx, kv_head_idx, feat_idx, kv_len,
-                                                     num_kv_heads);
+    return get_elem_offset_impl(kv_idx, kv_head_idx, feat_idx, kv_stride_n, kv_stride_h);
   }
 
   __host__ __device__ __forceinline__ uint32_t get_group_size() const {
     return num_qo_heads / num_kv_heads;
-  }
-
-  __host__ __device__ __forceinline__ uint32_t get_qo_n_stride() const {
-    return get_n_stride_impl<QKVLayout::kNHD, head_dim>(num_qo_heads);
-  }
-
-  __host__ __device__ __forceinline__ uint32_t get_kv_n_stride() const {
-    return get_n_stride_impl<kv_layout, head_dim>(num_kv_heads);
-  }
-
-  __host__ __device__ __forceinline__ uint32_t get_qo_h_stride() const {
-    return get_h_stride_impl<QKVLayout::kNHD, head_dim>(qo_len);
-  }
-
-  __host__ __device__ __forceinline__ uint32_t get_kv_h_stride() const {
-    return get_h_stride_impl<kv_layout, head_dim>(kv_len);
   }
 };
 

--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -120,8 +120,8 @@ __global__ void BatchQKApplyRotaryInPlaceKernel(DType* __restrict__ q, DType* __
       vec_t<float, vec_size> q_vec;
       if (i * bdy + ty < seq_len) {
         DType* q_ptr =
-            q + get_elem_offset_impl<QKVLayout::kNHD, head_dim>(
-                    indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0, seq_len, num_qo_heads);
+            q + get_elem_offset_impl(
+                    indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0, seq_len, num_qo_heads, num_qo_heads * head_dim, head_dim);
         q_vec = vec_apply_llama_rope<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
         q_vec.cast_store(q_ptr + tx * vec_size);
       }
@@ -137,8 +137,8 @@ __global__ void BatchQKApplyRotaryInPlaceKernel(DType* __restrict__ q, DType* __
       vec_t<float, vec_size> k_vec;
       if (i * bdy + ty < seq_len) {
         DType* k_ptr =
-            k + get_elem_offset_impl<QKVLayout::kNHD, head_dim>(
-                    indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0, seq_len, num_kv_heads);
+            k + get_elem_offset_impl(
+                    indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0, seq_len, num_kv_heads, num_kv_heads * head_dim, head_dim);
         k_vec = vec_apply_llama_rope<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
         k_vec.cast_store(k_ptr + tx * vec_size);
       }

--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -119,9 +119,8 @@ __global__ void BatchQKApplyRotaryInPlaceKernel(DType* __restrict__ q, DType* __
     for (uint32_t i = 0; i < (seq_len + bdy - 1) / bdy; ++i) {
       vec_t<float, vec_size> q_vec;
       if (i * bdy + ty < seq_len) {
-        DType* q_ptr =
-            q + get_elem_offset_impl(
-                    indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0, seq_len, num_qo_heads, num_qo_heads * head_dim, head_dim);
+        DType* q_ptr = q + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0,
+                                                num_qo_heads * head_dim, head_dim);
         q_vec = vec_apply_llama_rope<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
         q_vec.cast_store(q_ptr + tx * vec_size);
       }
@@ -136,9 +135,8 @@ __global__ void BatchQKApplyRotaryInPlaceKernel(DType* __restrict__ q, DType* __
     for (uint32_t i = 0; i < (seq_len + bdy - 1) / bdy; ++i) {
       vec_t<float, vec_size> k_vec;
       if (i * bdy + ty < seq_len) {
-        DType* k_ptr =
-            k + get_elem_offset_impl(
-                    indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0, seq_len, num_kv_heads, num_kv_heads * head_dim, head_dim);
+        DType* k_ptr = k + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0,
+                                                num_kv_heads * head_dim, head_dim);
         k_vec = vec_apply_llama_rope<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
         k_vec.cast_store(k_ptr + tx * vec_size);
       }

--- a/include/flashinfer/prefill_attention_decl.cuh
+++ b/include/flashinfer/prefill_attention_decl.cuh
@@ -29,12 +29,13 @@
 
 namespace flashinfer {
 
-template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, QKVLayout KV_LAYOUT,
+template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK,
           PosEncodingMode POS_ENCODING_MODE, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
           typename DTypeIn, typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(
     DTypeIn* q, DTypeIn* k, DTypeIn* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp,
     float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
+    QKVLayout kv_layout,
     float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream);
 
 template <WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK,

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -146,25 +146,6 @@
     throw std::invalid_argument(err_msg.str());                                 \
   }
 
-#define DISPATCH_LAYOUT(layout, LAYOUT, ...)            \
-  switch (layout) {                                     \
-    case QKVLayout::kNHD: {                             \
-      constexpr QKVLayout LAYOUT = QKVLayout::kNHD;     \
-      __VA_ARGS__                                       \
-      break;                                            \
-    }                                                   \
-    case QKVLayout::kHND: {                             \
-      constexpr QKVLayout LAYOUT = QKVLayout::kHND;     \
-      __VA_ARGS__                                       \
-      break;                                            \
-    }                                                   \
-    default: {                                          \
-      std::ostringstream err_msg;                       \
-      err_msg << "Unsupported layout: " << int(layout); \
-      throw std::invalid_argument(err_msg.str());       \
-    }                                                   \
-  }
-
 #define DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, ...)     \
   switch (head_dim) {                                  \
     case 64: {                                         \

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -120,38 +120,35 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::Forward(
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-      return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-        paged_kv_t<PageStorage::kIndices, KV_LAYOUT, c_type, int32_t> paged_kv(
-            num_kv_heads, page_size, head_dim, batch_size,
-            static_cast<c_type*>(paged_kv_data.data_ptr()),
-            static_cast<int32_t*>(paged_kv_indices.data_ptr()),
-            static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
-            static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
-            return DISPATCH_allow_fp16_qk_reduction(
-                allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
-                  return DISPATCH_pos_encoding_mode(
-                      PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                        cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
-                            PageStorage::kIndices, HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT,
-                            POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type,
-                            int32_t>(
-                            handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                            static_cast<int32_t*>(qo_indptr.data_ptr()),
-                            /*q_offset=*/nullptr, paged_kv,
-                            /*custom_mask=*/nullptr,
-                            /*qk_indptr=*/nullptr, static_cast<c_type*>(o.data_ptr()),
-                            /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                            num_qo_heads, logits_soft_cap, sm_scale, rope_scale, rope_theta,
-                            /*stream=*/torch_current_stream);
-                        TORCH_CHECK(status == cudaSuccess,
-                                    "BatchPrefillWithPagedKVCache failed with error code ",
-                                    cudaGetErrorString(status));
-                        return true;
-                      });
-                });
-          });
+      paged_kv_t<PageStorage::kIndices, c_type, int32_t> paged_kv(
+          num_kv_heads, page_size, head_dim, batch_size, kv_layout_,
+          static_cast<c_type*>(paged_kv_data.data_ptr()),
+          static_cast<int32_t*>(paged_kv_indices.data_ptr()),
+          static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
+          static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
+          return DISPATCH_allow_fp16_qk_reduction(
+              allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
+                return DISPATCH_pos_encoding_mode(
+                    PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                      cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
+                          PageStorage::kIndices, HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE,
+                          ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
+                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                          static_cast<int32_t*>(qo_indptr.data_ptr()),
+                          /*q_offset=*/nullptr, paged_kv,
+                          /*custom_mask=*/nullptr,
+                          /*qk_indptr=*/nullptr, static_cast<c_type*>(o.data_ptr()),
+                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                          num_qo_heads, logits_soft_cap, sm_scale, rope_scale, rope_theta,
+                          /*stream=*/torch_current_stream);
+                      TORCH_CHECK(status == cudaSuccess,
+                                  "BatchPrefillWithPagedKVCache failed with error code ",
+                                  cudaGetErrorString(status));
+                      return true;
+                    });
+              });
         });
       });
     });
@@ -235,38 +232,35 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCachePyTorchWrapper::ForwardCu
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-      return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-        paged_kv_t<PageStorage::kIndices, KV_LAYOUT, c_type, int32_t> paged_kv(
-            num_kv_heads, page_size, head_dim, batch_size,
-            static_cast<c_type*>(paged_kv_data.data_ptr()),
-            static_cast<int32_t*>(paged_kv_indices.data_ptr()),
-            static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
-            static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
-        return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
-          return DISPATCH_allow_fp16_qk_reduction(
-              allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
-                return DISPATCH_pos_encoding_mode(
-                    PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                      cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
-                          PageStorage::kIndices, HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT,
-                          POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type,
-                          int32_t>(
-                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                          static_cast<int32_t*>(qo_indptr.data_ptr()),
-                          /*q_offset=*/nullptr, paged_kv,
-                          static_cast<uint8_t*>(custom_mask.data_ptr()),
-                          static_cast<int32_t*>(qk_indptr.data_ptr()),
-                          static_cast<c_type*>(o.data_ptr()),
-                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                          num_qo_heads, logits_soft_cap, sm_scale, rope_scale, rope_theta,
-                          /*stream=*/torch_current_stream);
-                      TORCH_CHECK(status == cudaSuccess,
-                                  "BatchPrefillWithPagedKVCache failed with error code ",
-                                  cudaGetErrorString(status));
-                      return true;
-                    });
-              });
-        });
+      paged_kv_t<PageStorage::kIndices, c_type, int32_t> paged_kv(
+          num_kv_heads, page_size, head_dim, batch_size, kv_layout_,
+          static_cast<c_type*>(paged_kv_data.data_ptr()),
+          static_cast<int32_t*>(paged_kv_indices.data_ptr()),
+          static_cast<int32_t*>(paged_kv_indptr.data_ptr()),
+          static_cast<int32_t*>(paged_kv_last_page_len.data_ptr()));
+      return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
+        return DISPATCH_allow_fp16_qk_reduction(
+            allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
+              return DISPATCH_pos_encoding_mode(
+                  PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                    cudaError_t status = BatchPrefillWithPagedKVCacheWrapperDispatched<
+                        PageStorage::kIndices, HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE,
+                        ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
+                        handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                        static_cast<int32_t*>(qo_indptr.data_ptr()),
+                        /*q_offset=*/nullptr, paged_kv,
+                        static_cast<uint8_t*>(custom_mask.data_ptr()),
+                        static_cast<int32_t*>(qk_indptr.data_ptr()),
+                        static_cast<c_type*>(o.data_ptr()),
+                        /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                        num_qo_heads, logits_soft_cap, sm_scale, rope_scale, rope_theta,
+                        /*stream=*/torch_current_stream);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchPrefillWithPagedKVCache failed with error code ",
+                                cudaGetErrorString(status));
+                    return true;
+                  });
+            });
       });
     });
   });
@@ -370,26 +364,24 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
               return DISPATCH_pos_encoding_mode(
                   PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
                     return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-                      return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-                        cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
-                            HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT, POS_ENCODING_MODE,
-                            ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
-                            handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                            static_cast<int32_t*>(qo_indptr.data_ptr()),
-                            static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
-                            static_cast<int32_t*>(kv_indptr.data_ptr()),
-                            /*custom_mask=*/nullptr, /*qk_indptr=*/nullptr,
-                            /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
-                            static_cast<c_type*>(o.data_ptr()),
-                            /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                            num_qo_heads, num_kv_heads, logits_soft_cap, sm_scale, rope_scale,
-                            rope_theta,
-                            /*stream=*/torch_current_stream);
-                        TORCH_CHECK(status == cudaSuccess,
-                                    "BatchPrefillWithRaggedKVCache failed with error ",
-                                    cudaGetErrorString(status));
-                        return true;
-                      });
+                      cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
+                          HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION,
+                          MASK_MODE, c_type, c_type, int32_t>(
+                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                          static_cast<int32_t*>(qo_indptr.data_ptr()),
+                          static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
+                          static_cast<int32_t*>(kv_indptr.data_ptr()),
+                          /*custom_mask=*/nullptr, /*qk_indptr=*/nullptr,
+                          /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
+                          static_cast<c_type*>(o.data_ptr()),
+                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                          num_qo_heads, num_kv_heads, kv_layout_, logits_soft_cap, sm_scale,
+                          rope_scale, rope_theta,
+                          /*stream=*/torch_current_stream);
+                      TORCH_CHECK(status == cudaSuccess,
+                                  "BatchPrefillWithRaggedKVCache failed with error ",
+                                  cudaGetErrorString(status));
+                      return true;
                     });
                   });
             });
@@ -467,27 +459,25 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::ForwardC
             return DISPATCH_pos_encoding_mode(
                 PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
                   return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-                    return DISPATCH_kv_layout(kv_layout_, KV_LAYOUT, [&] {
-                      cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
-                          HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT, POS_ENCODING_MODE,
-                          ALLOW_FP16_QK_REDUCTION, MASK_MODE, c_type, c_type, int32_t>(
-                          handler_.get(), static_cast<c_type*>(q.data_ptr()),
-                          static_cast<int32_t*>(qo_indptr.data_ptr()),
-                          static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
-                          static_cast<int32_t*>(kv_indptr.data_ptr()),
-                          static_cast<uint8_t*>(custom_mask.data_ptr()),
-                          static_cast<int32_t*>(qk_indptr.data_ptr()),
-                          /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
-                          static_cast<c_type*>(o.data_ptr()),
-                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                          num_qo_heads, num_kv_heads, logits_soft_cap, sm_scale, rope_scale,
-                          rope_theta,
-                          /*stream=*/torch_current_stream);
-                      TORCH_CHECK(status == cudaSuccess,
-                                  "BatchPrefillWithRaggedKVCache failed with error ",
-                                  cudaGetErrorString(status));
-                      return true;
-                    });
+                    cudaError_t status = BatchPrefillWithRaggedKVCacheWrapperDispatched<
+                        HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION,
+                        MASK_MODE, c_type, c_type, int32_t>(
+                        handler_.get(), static_cast<c_type*>(q.data_ptr()),
+                        static_cast<int32_t*>(qo_indptr.data_ptr()),
+                        static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(v.data_ptr()),
+                        static_cast<int32_t*>(kv_indptr.data_ptr()),
+                        static_cast<uint8_t*>(custom_mask.data_ptr()),
+                        static_cast<int32_t*>(qk_indptr.data_ptr()),
+                        /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
+                        static_cast<c_type*>(o.data_ptr()),
+                        /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                        num_qo_heads, num_kv_heads, kv_layout_, logits_soft_cap, sm_scale,
+                        rope_scale, rope_theta,
+                        /*stream=*/torch_current_stream);
+                    TORCH_CHECK(status == cudaSuccess,
+                                "BatchPrefillWithRaggedKVCache failed with error ",
+                                cudaGetErrorString(status));
+                    return true;
                   });
                 });
           });

--- a/python/csrc/page.cu
+++ b/python/csrc/page.cu
@@ -75,19 +75,18 @@ void append_paged_kv_cache(torch::Tensor append_key, torch::Tensor append_value,
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE(kv_data.scalar_type(), c_type, [&] {
-    DISPATCH_LAYOUT(kv_layout, KV_LAYOUT, {
-      paged_kv_t<page_storage, KV_LAYOUT, c_type, int32_t> paged_kv(
-          num_heads, page_size, head_dim, batch_size, static_cast<c_type*>(kv_data.data_ptr()),
-          static_cast<int32_t*>(kv_indices.data_ptr()), static_cast<int32_t*>(kv_indptr.data_ptr()),
-          static_cast<int32_t*>(kv_last_page_len.data_ptr()));
-      cudaError_t status =
-          AppendPagedKVCache(paged_kv, static_cast<c_type*>(append_key.data_ptr()),
-                             static_cast<c_type*>(append_value.data_ptr()),
-                             static_cast<int32_t*>(append_indptr.data_ptr()), torch_current_stream);
-      TORCH_CHECK(status == cudaSuccess,
-                  "AppendPagedKVCache failed with error: ", cudaGetErrorString(status));
-      return true;
-    });
+    paged_kv_t<page_storage, c_type, int32_t> paged_kv(
+        num_heads, page_size, head_dim, batch_size, kv_layout,
+        static_cast<c_type*>(kv_data.data_ptr()), static_cast<int32_t*>(kv_indices.data_ptr()),
+        static_cast<int32_t*>(kv_indptr.data_ptr()),
+        static_cast<int32_t*>(kv_last_page_len.data_ptr()));
+    cudaError_t status =
+        AppendPagedKVCache(paged_kv, static_cast<c_type*>(append_key.data_ptr()),
+                           static_cast<c_type*>(append_value.data_ptr()),
+                           static_cast<int32_t*>(append_indptr.data_ptr()), torch_current_stream);
+    TORCH_CHECK(status == cudaSuccess,
+                "AppendPagedKVCache failed with error: ", cudaGetErrorString(status));
+    return true;
   });
 
   TORCH_CHECK(success, "AppendPagedKVCache failed to dispatch with dtype ", kv_data.scalar_type());

--- a/python/csrc/pytorch_extension_utils.h
+++ b/python/csrc/pytorch_extension_utils.h
@@ -203,9 +203,6 @@ using namespace flashinfer;
   _DISPATCH_SWITCH("logits post hook", expr,             \
                    _DISPATCH_CASES_logits_post_hook(const_expr, __VA_ARGS__))
 
-#define DISPATCH_kv_layout(expr, const_expr, ...) \
-  _DISPATCH_SWITCH("kv layout", expr, _DISPATCH_CASES_kv_layout(const_expr, __VA_ARGS__))
-
 #define DISPATCH_pos_encoding_mode(expr, const_expr, ...) \
   _DISPATCH_SWITCH("positional encoding mode", expr,      \
                    _DISPATCH_CASES_pos_encoding_mode(const_expr, __VA_ARGS__))

--- a/python/csrc/single_decode.cu
+++ b/python/csrc/single_decode.cu
@@ -64,21 +64,20 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE(q_scalar_type, qkv_type, [&] {
       return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
         return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-          return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
-            return DISPATCH_pos_encoding_mode(
-                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                  cudaError_t status = SingleDecodeWithKVCacheDispatched<
-                      HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT, POS_ENCODING_MODE>(
-                      static_cast<qkv_type*>(q.data_ptr()), static_cast<qkv_type*>(k.data_ptr()),
-                      static_cast<qkv_type*>(v.data_ptr()), static_cast<qkv_type*>(o.data_ptr()),
-                      static_cast<qkv_type*>(tmp.data_ptr()), num_qo_heads, num_kv_heads, kv_len,
-                      logits_soft_cap, sm_scale, rope_scale, rope_theta, torch_current_stream);
-                  TORCH_CHECK(status == cudaSuccess,
-                              "SingleDecodeWithKVCache kernel launch failed, error: " +
-                                  std::string(cudaGetErrorString(status)));
-                  return true;
-                });
-          });
+          return DISPATCH_pos_encoding_mode(
+              PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                cudaError_t status = SingleDecodeWithKVCacheDispatched<HEAD_DIM, LOGITS_POST_HOOK,
+                                                                       POS_ENCODING_MODE>(
+                    static_cast<qkv_type*>(q.data_ptr()), static_cast<qkv_type*>(k.data_ptr()),
+                    static_cast<qkv_type*>(v.data_ptr()), static_cast<qkv_type*>(o.data_ptr()),
+                    static_cast<qkv_type*>(tmp.data_ptr()), num_qo_heads, num_kv_heads, kv_len,
+                    kv_layout, logits_soft_cap, sm_scale, rope_scale, rope_theta,
+                    torch_current_stream);
+                TORCH_CHECK(status == cudaSuccess,
+                            "SingleDecodeWithKVCache kernel launch failed, error: " +
+                                std::string(cudaGetErrorString(status)));
+                return true;
+              });
         });
       });
     });
@@ -87,23 +86,20 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
       return DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(kv_scalar_type, kv_type, [&] {
         return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
           return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-            return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
-              return DISPATCH_pos_encoding_mode(
-                  PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                    cudaError_t status =
-                        SingleDecodeWithKVCacheDispatched<HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT,
-                                                          POS_ENCODING_MODE>(
-                            static_cast<q_type*>(q.data_ptr()), static_cast<kv_type*>(k.data_ptr()),
-                            static_cast<kv_type*>(v.data_ptr()), static_cast<q_type*>(o.data_ptr()),
-                            static_cast<q_type*>(tmp.data_ptr()), num_qo_heads, num_kv_heads,
-                            kv_len, logits_soft_cap, sm_scale, rope_scale, rope_theta,
-                            torch_current_stream);
-                    TORCH_CHECK(status == cudaSuccess,
-                                "SingleDecodeWithKVCache kernel launch failed, error: " +
-                                    std::string(cudaGetErrorString(status)));
-                    return true;
-                  });
-            });
+            return DISPATCH_pos_encoding_mode(
+                PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
+                  cudaError_t status = SingleDecodeWithKVCacheDispatched<HEAD_DIM, LOGITS_POST_HOOK,
+                                                                         POS_ENCODING_MODE>(
+                      static_cast<q_type*>(q.data_ptr()), static_cast<kv_type*>(k.data_ptr()),
+                      static_cast<kv_type*>(v.data_ptr()), static_cast<q_type*>(o.data_ptr()),
+                      static_cast<q_type*>(tmp.data_ptr()), num_qo_heads, num_kv_heads, kv_len,
+                      kv_layout, logits_soft_cap, sm_scale, rope_scale, rope_theta,
+                      torch_current_stream);
+                  TORCH_CHECK(status == cudaSuccess,
+                              "SingleDecodeWithKVCache kernel launch failed, error: " +
+                                  std::string(cudaGetErrorString(status)));
+                  return true;
+                });
           });
         });
       });

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -68,14 +68,13 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
     return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
       return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {
         return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-          return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
             return DISPATCH_allow_fp16_qk_reduction(
                 allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
                   return DISPATCH_pos_encoding_mode(
                       PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
                         cudaError_t status =
                             SinglePrefillWithKVCacheDispatched<HEAD_DIM, LOGITS_POST_HOOK,
-                                                               KV_LAYOUT, POS_ENCODING_MODE,
+                                                               POS_ENCODING_MODE,
                                                                ALLOW_FP16_QK_REDUCTION, MASK_MODE>(
                                 static_cast<c_type*>(q.data_ptr()),
                                 static_cast<c_type*>(k.data_ptr()),
@@ -83,7 +82,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
                                 /*custom_mask=*/nullptr, static_cast<c_type*>(o.data_ptr()),
                                 static_cast<c_type*>(tmp.data_ptr()),
                                 /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                                num_qo_heads, num_kv_heads, qo_len, kv_len, logits_soft_cap,
+                                num_qo_heads, num_kv_heads, qo_len, kv_len, kv_layout, logits_soft_cap,
                                 sm_scale, rope_scale, rope_theta, torch_current_stream);
                         TORCH_CHECK(status == cudaSuccess,
                                     "SinglePrefillWithKVCache kernel launch failed, error: " +
@@ -92,7 +91,6 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
                       });
                 });
           });
-        });
       });
     });
   });
@@ -154,20 +152,19 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
       return DISPATCH_logits_post_hook(logits_post_hook, LOGITS_POST_HOOK, [&] {
-        return DISPATCH_kv_layout(kv_layout, KV_LAYOUT, [&] {
           return DISPATCH_allow_fp16_qk_reduction(
               allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
                 return DISPATCH_pos_encoding_mode(
                     PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
                       cudaError_t status = SinglePrefillWithKVCacheDispatched<
-                          HEAD_DIM, LOGITS_POST_HOOK, KV_LAYOUT, POS_ENCODING_MODE,
+                          HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE,
                           ALLOW_FP16_QK_REDUCTION, MASK_MODE>(
                           static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
                           static_cast<c_type*>(v.data_ptr()),
                           static_cast<uint8_t*>(packed_custom_mask.data_ptr()),
                           static_cast<c_type*>(o.data_ptr()), static_cast<c_type*>(tmp.data_ptr()),
                           /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                          num_qo_heads, num_kv_heads, qo_len, kv_len, logits_soft_cap, sm_scale,
+                          num_qo_heads, num_kv_heads, qo_len, kv_len, kv_layout, logits_soft_cap, sm_scale,
                           rope_scale, rope_theta, torch_current_stream);
                       TORCH_CHECK(status == cudaSuccess,
                                   "SinglePrefillWithKVCache kernel launch failed, error: " +
@@ -176,7 +173,6 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
                     });
               });
         });
-      });
     });
   });
 

--- a/python/generate_batch_paged_decode_inst.py
+++ b/python/generate_batch_paged_decode_inst.py
@@ -17,7 +17,6 @@ limitations under the License.
 import sys
 import re
 from literal_map import (
-    kv_layout_literal,
     pos_encoding_mode_literal,
     dtype_literal,
     idtype_literal,
@@ -29,7 +28,6 @@ from pathlib import Path
 def get_cu_file_str(
     head_dim,
     logits_hook,
-    kv_layout,
     pos_encoding_mode,
     dtype_q,
     dtype_kv,
@@ -42,9 +40,9 @@ namespace flashinfer {{
 
 constexpr PageStorage page_storage = PageStorage::kIndices;
 
-template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{head_dim}, page_storage, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {dtype_q}, {dtype_kv}, {dtype_out}, {idtype}>(
+template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{head_dim}, page_storage, {logits_hook}, {pos_encoding_mode}, {dtype_q}, {dtype_kv}, {dtype_out}, {idtype}>(
     {dtype_q}* q, {idtype}* q_offset,
-    paged_kv_t<page_storage, {kv_layout}, {dtype_kv}, {idtype}> paged_kv,
+    paged_kv_t<page_storage, {dtype_kv}, {idtype}> paged_kv,
     kv_partition_info_t<{idtype}> kv_partition_info,
     {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
     bool* block_valid_mask, uint32_t padded_batch_size, uint32_t num_qo_heads,
@@ -54,7 +52,6 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{head_dim}, page_stor
 }}
     """.format(
         logits_hook=logits_hook_literal[int(logits_hook)],
-        kv_layout=kv_layout_literal[int(kv_layout)],
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_q=dtype_literal[dtype_q],
@@ -67,7 +64,7 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatched<{head_dim}, page_stor
 
 if __name__ == "__main__":
     pattern = (
-        r"batch_paged_decode_head_([0-9]+)_logitshook_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"batch_paged_decode_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
         r"dtypeq_([a-z0-9]+)_dtypekv_([a-z0-9]+)_dtypeout_([a-z0-9]+)_idtype_([a-z0-9]+)\.cu"
     )
 

--- a/python/generate_batch_paged_prefill_inst.py
+++ b/python/generate_batch_paged_prefill_inst.py
@@ -19,7 +19,6 @@ import re
 import itertools
 from literal_map import (
     mask_mode_literal,
-    kv_layout_literal,
     pos_encoding_mode_literal,
     warp_layout_literal,
     dtype_literal,
@@ -32,7 +31,6 @@ from pathlib import Path
 def get_cu_file_str(
     head_dim,
     logits_hook,
-    kv_layout,
     pos_encoding_mode,
     allow_fp16_qk_reduction,
     mask_mode,
@@ -43,17 +41,16 @@ def get_cu_file_str(
     warp_layout_choice = [0, 1, 2]
     insts = "\n".join(
         [
-            """template cudaError_t BatchPrefillWithPagedKVCacheDispatched<page_storage, {warp_layout}, {head_dim}, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}, {idtype}>(
+            """template cudaError_t BatchPrefillWithPagedKVCacheDispatched<page_storage, {warp_layout}, {head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}, {idtype}>(
     {dtype_in}* q, {idtype}* request_indices, {idtype}* q_tile_indices, {idtype}* kv_tile_indices,
     {idtype}* q_indptr, {idtype}* q_offset,
-    paged_kv_t<page_storage, {kv_layout}, {dtype_in}, {idtype}> paged_kv, uint8_t* custom_mask,
+    paged_kv_t<page_storage, {dtype_in}, {idtype}> paged_kv, uint8_t* custom_mask,
     {idtype}* qk_indptr, {idtype}* o_indptr, {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
     {idtype}* merge_indptr, bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, uint32_t max_num_rows,
     uint32_t num_qo_heads, uint32_t padded_batch_size, float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
     """.format(
                 logits_hook=logits_hook_literal[int(logits_hook)],
-                kv_layout=kv_layout_literal[int(kv_layout)],
                 warp_layout=warp_layout_literal[warp_layout],
                 head_dim=head_dim,
                 pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
@@ -81,7 +78,7 @@ constexpr PageStorage page_storage = PageStorage::kIndices;
 
 if __name__ == "__main__":
     pattern = (
-        r"batch_paged_prefill_head_([0-9]+)_logitshook_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"batch_paged_prefill_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
         r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)_idtype_([a-z0-9]+)\.cu"
     )
     compiled_pattern = re.compile(pattern)

--- a/python/generate_dispatch_inc.py
+++ b/python/generate_dispatch_inc.py
@@ -17,7 +17,6 @@ limitations under the License.
 import argparse
 from pathlib import Path
 from literal_map import (
-    kv_layout_literal,
     pos_encoding_mode_literal,
     bool_literal,
     mask_mode_literal,
@@ -48,19 +47,6 @@ def get_dispatch_inc_str(args: argparse.Namespace) -> str:
     )
     dispatch_logits_post_hooks_str = f"""#define _DISPATCH_CASES_logits_post_hook(case_var, ...)         \\
 {dispatch_logits_post_hooks_entries}
-// EOL
-"""
-    # kv layouts
-    dispatch_kv_layouts_entries = "\n".join(
-        [
-            "  _DISPATCH_CASE({}, case_var, __VA_ARGS__) \\".format(
-                kv_layout_literal[_]
-            )
-            for _ in args.kv_layouts
-        ]
-    )
-    dispatch_kv_layouts_str = f"""#define _DISPATCH_CASES_kv_layout(case_var, ...)         \\
-{dispatch_kv_layouts_entries}
 // EOL
 """
     # positional encoding modes
@@ -105,7 +91,6 @@ def get_dispatch_inc_str(args: argparse.Namespace) -> str:
         [
             dispatch_head_dims_str,
             dispatch_logits_post_hooks_str,
-            dispatch_kv_layouts_str,
             dispatch_pos_encoding_modes_str,
             dispatch_allow_fp16_qk_reductions_str,
             dispatch_mask_mode_str,
@@ -127,9 +112,6 @@ if __name__ == "__main__":
         required=True,
         nargs="+",
         help="Logit post hooks",
-    )
-    parser.add_argument(
-        "--kv_layouts", type=int, required=True, nargs="+", help="KV layouts"
     )
     parser.add_argument(
         "--pos_encoding_modes",

--- a/python/generate_single_decode_inst.py
+++ b/python/generate_single_decode_inst.py
@@ -17,7 +17,6 @@ limitations under the License.
 import sys
 import re
 from literal_map import (
-    kv_layout_literal,
     pos_encoding_mode_literal,
     dtype_literal,
     logits_hook_literal,
@@ -28,7 +27,6 @@ from pathlib import Path
 def get_cu_file_str(
     head_dim,
     logits_hook,
-    kv_layout,
     pos_encoding_mode,
     dtype_q,
     dtype_kv,
@@ -38,16 +36,15 @@ def get_cu_file_str(
 
 namespace flashinfer {{
 
-template cudaError_t SingleDecodeWithKVCacheDispatched<{head_dim}, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {dtype_q}, {dtype_kv}, {dtype_out}>(
+template cudaError_t SingleDecodeWithKVCacheDispatched<{head_dim}, {logits_hook}, {pos_encoding_mode}, {dtype_q}, {dtype_kv}, {dtype_out}>(
     {dtype_q}* q, {dtype_kv}* k, {dtype_kv}* v, {dtype_out}* o,
     {dtype_out}* tmp, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t seq_len,
-    float logits_soft_cap, float sm_scale, float rope_scale,
+    QKVLayout kv_layout, float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}
     """.format(
         logits_hook=logits_hook_literal[int(logits_hook)],
-        kv_layout=kv_layout_literal[int(kv_layout)],
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_q=dtype_literal[dtype_q],
@@ -59,7 +56,7 @@ template cudaError_t SingleDecodeWithKVCacheDispatched<{head_dim}, {logits_hook}
 
 if __name__ == "__main__":
     pattern = (
-        r"single_decode_head_([0-9]+)_logitshook_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"single_decode_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
         r"dtypeq_([a-z0-9]+)_dtypekv_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
     )
 

--- a/python/generate_single_prefill_inst.py
+++ b/python/generate_single_prefill_inst.py
@@ -17,7 +17,6 @@ limitations under the License.
 import sys
 import re
 from literal_map import (
-    kv_layout_literal,
     pos_encoding_mode_literal,
     dtype_literal,
     mask_mode_literal,
@@ -29,7 +28,6 @@ from pathlib import Path
 def get_cu_file_str(
     head_dim,
     logits_hook,
-    kv_layout,
     pos_encoding_mode,
     allow_fp16_qk_reduction,
     mask_mode,
@@ -41,16 +39,15 @@ def get_cu_file_str(
 
 namespace flashinfer {{
 
-template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {kv_layout}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
+template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, uint8_t* custom_mask, {dtype_out}* o,
     {dtype_out}* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
-    float logits_soft_cap, float sm_scale, float rope_scale,
+    QKVLayout kv_layout, float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, cudaStream_t stream);
 
 }}
     """.format(
         logits_hook=logits_hook_literal[int(logits_hook)],
-        kv_layout=kv_layout_literal[int(kv_layout)],
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         allow_fp16_qk_reduction=allow_fp16_qk_reduction,
@@ -63,7 +60,7 @@ template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook
 
 if __name__ == "__main__":
     pattern = (
-        r"single_prefill_head_([0-9]+)_logitshook_([0-9]+)_layout_([0-9]+)_posenc_([0-9]+)_"
+        r"single_prefill_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
         r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
     )
 

--- a/python/literal_map.py
+++ b/python/literal_map.py
@@ -31,11 +31,6 @@ warp_layout_literal = {
     2: "WarpLayout::k1x4x1",
 }
 
-kv_layout_literal = {
-    0: "QKVLayout::kNHD",
-    1: "QKVLayout::kHND",
-}
-
 pos_encoding_mode_literal = {
     0: "PosEncodingMode::kNone",
     1: "PosEncodingMode::kRoPELlama",

--- a/python/setup.py
+++ b/python/setup.py
@@ -65,7 +65,6 @@ def get_instantiation_cu() -> List[str]:
 
     logits_hooks = os.environ.get("FLASHINFER_LOGITS_POST_HOOKS", "0,1").split(",")
     head_dims = os.environ.get("FLASHINFER_HEAD_DIMS", "64,128,256").split(",")
-    kv_layouts = os.environ.get("FLASHINFER_KV_LAYOUTS", "0,1").split(",")
     pos_encoding_modes = os.environ.get("FLASHINFER_POS_ENCODING_MODES", "0,1,2").split(
         ","
     )
@@ -81,7 +80,6 @@ def get_instantiation_cu() -> List[str]:
             argparse.Namespace(
                 head_dims=map(int, head_dims),
                 logits_post_hooks=map(int, logits_hooks),
-                kv_layouts=map(int, kv_layouts),
                 pos_encoding_modes=map(int, pos_encoding_modes),
                 allow_fp16_qk_reductions=map(int, allow_fp16_qk_reduction_options),
                 mask_modes=map(int, mask_modes),
@@ -106,24 +104,21 @@ def get_instantiation_cu() -> List[str]:
     for (
         head_dim,
         logits_hook,
-        kv_layout,
         pos_encoding_mode,
     ) in itertools.product(
         head_dims,
         logits_hooks,
-        kv_layouts,
         pos_encoding_modes,
     ):
         for dtype_q, dtype_kv in list(zip(decode_dtypes, decode_dtypes)) + list(
             itertools.product(fp16_dtypes, fp8_dtypes)
         ):
             dtype_out = dtype_q
-            fname = f"single_decode_head_{head_dim}_logitshook_{logits_hook}_layout_{kv_layout}_posenc_{pos_encoding_mode}_dtypeq_{dtype_q}_dtypekv_{dtype_kv}_dtypeout_{dtype_out}.cu"
+            fname = f"single_decode_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_dtypeq_{dtype_q}_dtypekv_{dtype_kv}_dtypeout_{dtype_out}.cu"
             files.append(prefix + "/" + fname)
             content = generate_single_decode_inst.get_cu_file_str(
                 head_dim,
                 logits_hook,
-                kv_layout,
                 pos_encoding_mode,
                 dtype_q,
                 dtype_kv,
@@ -135,12 +130,10 @@ def get_instantiation_cu() -> List[str]:
     for (
         head_dim,
         logits_hook,
-        kv_layout,
         pos_encoding_mode,
     ) in itertools.product(
         head_dims,
         logits_hooks,
-        kv_layouts,
         pos_encoding_modes,
     ):
         for idtype in idtypes:
@@ -148,12 +141,11 @@ def get_instantiation_cu() -> List[str]:
                 itertools.product(fp16_dtypes, fp8_dtypes)
             ):
                 dtype_out = dtype_q
-                fname = f"batch_paged_decode_head_{head_dim}_logitshook_{logits_hook}_layout_{kv_layout}_posenc_{pos_encoding_mode}_dtypeq_{dtype_q}_dtypekv_{dtype_kv}_dtypeout_{dtype_out}_idtype_{idtype}.cu"
+                fname = f"batch_paged_decode_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_dtypeq_{dtype_q}_dtypekv_{dtype_kv}_dtypeout_{dtype_out}_idtype_{idtype}.cu"
                 files.append(prefix + "/" + fname)
                 content = generate_batch_paged_decode_inst.get_cu_file_str(
                     head_dim,
                     logits_hook,
-                    kv_layout,
                     pos_encoding_mode,
                     dtype_q,
                     dtype_kv,
@@ -166,25 +158,22 @@ def get_instantiation_cu() -> List[str]:
     for (
         head_dim,
         logits_hook,
-        kv_layout,
         pos_encoding_mode,
         allow_fp16_qk_reduction,
         mask_mode,
     ) in itertools.product(
         head_dims,
         logits_hooks,
-        kv_layouts,
         pos_encoding_modes,
         allow_fp16_qk_reduction_options,
         mask_modes,
     ):
         for dtype in prefill_dtypes:
-            fname = f"single_prefill_head_{head_dim}_logitshook_{logits_hook}_layout_{kv_layout}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}.cu"
+            fname = f"single_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}.cu"
             files.append(prefix + "/" + fname)
             content = generate_single_prefill_inst.get_cu_file_str(
                 head_dim,
                 logits_hook,
-                kv_layout,
                 pos_encoding_mode,
                 allow_fp16_qk_reduction,
                 mask_mode,
@@ -197,7 +186,6 @@ def get_instantiation_cu() -> List[str]:
     for (
         head_dim,
         logits_hook,
-        kv_layout,
         pos_encoding_mode,
         allow_fp16_qk_reduction,
         mask_mode,
@@ -205,19 +193,17 @@ def get_instantiation_cu() -> List[str]:
     ) in itertools.product(
         head_dims,
         logits_hooks,
-        kv_layouts,
         pos_encoding_modes,
         allow_fp16_qk_reduction_options,
         mask_modes,
         idtypes,
     ):
         for dtype in prefill_dtypes:
-            fname = f"batch_paged_prefill_head_{head_dim}_logitshook_{logits_hook}_layout_{kv_layout}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}_idtype_{idtype}.cu"
+            fname = f"batch_paged_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}_idtype_{idtype}.cu"
             files.append(prefix + "/" + fname)
             content = generate_batch_paged_prefill_inst.get_cu_file_str(
                 head_dim,
                 logits_hook,
-                kv_layout,
                 pos_encoding_mode,
                 allow_fp16_qk_reduction,
                 mask_mode,
@@ -231,7 +217,6 @@ def get_instantiation_cu() -> List[str]:
     for (
         head_dim,
         logits_hook,
-        kv_layout,
         pos_encoding_mode,
         allow_fp16_qk_reduction,
         mask_mode,
@@ -239,19 +224,17 @@ def get_instantiation_cu() -> List[str]:
     ) in itertools.product(
         head_dims,
         logits_hooks,
-        kv_layouts,
         pos_encoding_modes,
         allow_fp16_qk_reduction_options,
         mask_modes,
         idtypes,
     ):
         for dtype in prefill_dtypes:
-            fname = f"batch_ragged_prefill_head_{head_dim}_logitshook_{logits_hook}_layout_{kv_layout}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}_idtype_{idtype}.cu"
+            fname = f"batch_ragged_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}_idtype_{idtype}.cu"
             files.append(prefix + "/" + fname)
             content = generate_batch_ragged_prefill_inst.get_cu_file_str(
                 head_dim,
                 logits_hook,
-                kv_layout,
                 pos_encoding_mode,
                 allow_fp16_qk_reduction,
                 mask_mode,

--- a/python/tests/test_decode_prefill_lse.py
+++ b/python/tests/test_decode_prefill_lse.py
@@ -64,9 +64,7 @@ def test_mlc_failed_case():
         data_type=torch.float16,
         q_data_type=torch.float16,
     )
-    o_1_tc, lse_1_tc = wrapper_tensor_cores.forward_return_lse(
-        q, kv_data
-    )
+    o_1_tc, lse_1_tc = wrapper_tensor_cores.forward_return_lse(q, kv_data)
 
     np.testing.assert_allclose(
         lse_1.cpu().numpy(), lse_1_tc.cpu().numpy(), rtol=1e-3, atol=1e-3
@@ -74,6 +72,7 @@ def test_mlc_failed_case():
     np.testing.assert_allclose(
         o_1.cpu().numpy(), o_1_tc.cpu().numpy(), rtol=1e-3, atol=1e-3
     )
+
 
 if __name__ == "__main__":
     test_mlc_failed_case()

--- a/src/cpu_reference.h
+++ b/src/cpu_reference.h
@@ -86,79 +86,77 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_q>& q, const std::vect
   std::vector<float> att(kv_len);
   std::vector<float> q_rotary_local(head_dim);
   std::vector<float> k_rotary_local(head_dim);
-  DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
-    DISPATCH_head_dim(head_dim, HEAD_DIM, {
-      tensor_info_t info(qo_len, kv_len, num_qo_heads, num_kv_heads, KV_LAYOUT, HEAD_DIM);
-      for (size_t qo_head_idx = 0; qo_head_idx < num_qo_heads; ++qo_head_idx) {
-        const size_t kv_head_idx = qo_head_idx / info.get_group_size();
-        for (size_t q_idx = 0; q_idx < qo_len; ++q_idx) {
-          float max_val = -5e4;
-          if (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
-            q_rotary_local = std::move(cpu_reference::apply_llama_rope(
-                q.data() + info.get_qo_elem_offset(q_idx, qo_head_idx, 0), head_dim,
-                q_idx + kv_len - qo_len, rope_scale, rope_theta));
-          }
-          for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
-            att[kv_idx] = 0.;
-            switch (pos_encoding_mode) {
-              case PosEncodingMode::kNone: {
-                for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
-                  att[kv_idx] += float(q[info.get_qo_elem_offset(q_idx, qo_head_idx, feat_idx)]) *
-                                 float(k[info.get_kv_elem_offset(kv_idx, kv_head_idx, feat_idx)]) *
-                                 sm_scale;
-                }
-                break;
+  DISPATCH_head_dim(head_dim, HEAD_DIM, {
+    tensor_info_t info(qo_len, kv_len, num_qo_heads, num_kv_heads, kv_layout, HEAD_DIM);
+    for (size_t qo_head_idx = 0; qo_head_idx < num_qo_heads; ++qo_head_idx) {
+      const size_t kv_head_idx = qo_head_idx / info.get_group_size();
+      for (size_t q_idx = 0; q_idx < qo_len; ++q_idx) {
+        float max_val = -5e4;
+        if (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
+          q_rotary_local = std::move(cpu_reference::apply_llama_rope(
+              q.data() + info.get_qo_elem_offset(q_idx, qo_head_idx, 0), head_dim,
+              q_idx + kv_len - qo_len, rope_scale, rope_theta));
+        }
+        for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
+          att[kv_idx] = 0.;
+          switch (pos_encoding_mode) {
+            case PosEncodingMode::kNone: {
+              for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
+                att[kv_idx] += float(q[info.get_qo_elem_offset(q_idx, qo_head_idx, feat_idx)]) *
+                               float(k[info.get_kv_elem_offset(kv_idx, kv_head_idx, feat_idx)]) *
+                               sm_scale;
               }
-              case PosEncodingMode::kRoPELlama: {
-                k_rotary_local = std::move(cpu_reference::apply_llama_rope(
-                    k.data() + info.get_kv_elem_offset(kv_idx, kv_head_idx, 0), head_dim, kv_idx,
-                    rope_scale, rope_theta));
-                for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
-                  att[kv_idx] += q_rotary_local[feat_idx] * k_rotary_local[feat_idx] * sm_scale;
-                }
-                break;
-              }
-              default: {
-                std::ostringstream err_msg;
-                err_msg << "Unsupported rotary mode.";
-                throw std::invalid_argument(err_msg.str());
-              }
+              break;
             }
-            // apply mask
-            if (causal && kv_idx > kv_len + q_idx - qo_len) {
-              att[kv_idx] = -5e4;
+            case PosEncodingMode::kRoPELlama: {
+              k_rotary_local = std::move(cpu_reference::apply_llama_rope(
+                  k.data() + info.get_kv_elem_offset(kv_idx, kv_head_idx, 0), head_dim, kv_idx,
+                  rope_scale, rope_theta));
+              for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
+                att[kv_idx] += q_rotary_local[feat_idx] * k_rotary_local[feat_idx] * sm_scale;
+              }
+              break;
             }
-            max_val = std::max(max_val, att[kv_idx]);
+            default: {
+              std::ostringstream err_msg;
+              err_msg << "Unsupported rotary mode.";
+              throw std::invalid_argument(err_msg.str());
+            }
           }
-          // exp minus max
-          float denom = 0;
-          for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
-            att[kv_idx] = std::exp(att[kv_idx] - max_val);
-            denom += att[kv_idx];
+          // apply mask
+          if (causal && kv_idx > kv_len + q_idx - qo_len) {
+            att[kv_idx] = -5e4;
           }
+          max_val = std::max(max_val, att[kv_idx]);
+        }
+        // exp minus max
+        float denom = 0;
+        for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
+          att[kv_idx] = std::exp(att[kv_idx] - max_val);
+          denom += att[kv_idx];
+        }
 
-          // divide by denom
-          for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
-            att[kv_idx] /= denom;
-          }
+        // divide by denom
+        for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
+          att[kv_idx] /= denom;
+        }
 
-          for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
-            float o_float = 0.;
-            for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
-              o_float +=
-                  att[kv_idx] * float(v[info.get_kv_elem_offset(kv_idx, kv_head_idx, feat_idx)]);
-            }
-            o[info.get_qo_elem_offset(q_idx, qo_head_idx, feat_idx)] = dtype_out(o_float);
+        for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
+          float o_float = 0.;
+          for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
+            o_float +=
+                att[kv_idx] * float(v[info.get_kv_elem_offset(kv_idx, kv_head_idx, feat_idx)]);
           }
+          o[info.get_qo_elem_offset(q_idx, qo_head_idx, feat_idx)] = dtype_out(o_float);
         }
       }
-    });
+    }
   });
   return std::move(o);
 }
 
-template <QKVLayout kv_layout, typename T, typename IdxType>
-void append_paged_kv_cache(paged_kv_t<PageStorage::kIndices, kv_layout, T, IdxType> page_cpu,
+template <typename T, typename IdxType>
+void append_paged_kv_cache(paged_kv_t<PageStorage::kIndices, T, IdxType> page_cpu,
                            const std::vector<std::vector<T>>& keys,
                            const std::vector<std::vector<T>>& values,
                            const std::vector<IdxType>& append_indptr) {

--- a/src/cpu_reference.h
+++ b/src/cpu_reference.h
@@ -88,7 +88,7 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_q>& q, const std::vect
   std::vector<float> k_rotary_local(head_dim);
   DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
     DISPATCH_head_dim(head_dim, HEAD_DIM, {
-      tensor_info_t<KV_LAYOUT, HEAD_DIM> info(qo_len, kv_len, num_qo_heads, num_kv_heads);
+      tensor_info_t info(qo_len, kv_len, num_qo_heads, num_kv_heads, KV_LAYOUT, HEAD_DIM);
       for (size_t qo_head_idx = 0; qo_head_idx < num_qo_heads; ++qo_head_idx) {
         const size_t kv_head_idx = qo_head_idx / info.get_group_size();
         for (size_t q_idx = 0; q_idx < qo_len; ++q_idx) {

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -37,13 +37,14 @@ cudaError_t SinglePrefillWithKVCacheCustomMask(
       {DISPATCH_head_dim(
           head_dim, HEAD_DIM,
           {DISPATCH_pos_encoding_mode(
-              pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
+              pos_encoding_mode, POS_ENCODING_MODE, {
                 return SinglePrefillWithKVCacheDispatched<
-                    HEAD_DIM, LogitsPostHook::kNone, KV_LAYOUT, POS_ENCODING_MODE,
+                    HEAD_DIM, LogitsPostHook::kNone, POS_ENCODING_MODE,
                     ALLOW_FP16_QK_REDUCTION, MaskMode::kCustom>(
                     q, k, v, custom_mask, o, tmp, lse, num_qo_heads, num_kv_heads, qo_len, kv_len,
+                    kv_layout,
                     /*logits_soft_cap*/ 0.f, sm_scale, rope_scale, rope_theta, stream);
-              })})})});
+              })})});
   return cudaSuccess;
 }
 
@@ -90,14 +91,14 @@ cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOu
           {DISPATCH_head_dim(
               head_dim, HEAD_DIM,
               {DISPATCH_pos_encoding_mode(
-                  pos_encoding_mode, POS_ENCODING_MODE, {DISPATCH_kv_layout(kv_layout, KV_LAYOUT, {
+                  pos_encoding_mode, POS_ENCODING_MODE, {
                     return SinglePrefillWithKVCacheDispatched<HEAD_DIM, LogitsPostHook::kNone,
-                                                              KV_LAYOUT, POS_ENCODING_MODE,
+                                                              POS_ENCODING_MODE,
                                                               ALLOW_FP16_QK_REDUCTION, MASK_MODE>(
                         q, k, v, /*custom_mask=*/nullptr, o, tmp, lse, num_qo_heads, num_kv_heads,
-                        qo_len, kv_len, /*logits_soft_cap=*/0.f, sm_scale, rope_scale, rope_theta,
+                        qo_len, kv_len, kv_layout, /*logits_soft_cap=*/0.f, sm_scale, rope_scale, rope_theta,
                         stream);
-                  })})})})});
+                  })})})});
   return cudaSuccess;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -54,9 +54,6 @@
 #define DISPATCH_head_dim(expr, const_expr, ...) \
   _DISPATCH_SWITCH("head_dim", expr, _DISPATCH_CASES_head_dim(const_expr, __VA_ARGS__))
 
-#define DISPATCH_kv_layout(expr, const_expr, ...) \
-  _DISPATCH_SWITCH("kv layout", expr, _DISPATCH_CASES_kv_layout(const_expr, __VA_ARGS__))
-
 #define DISPATCH_pos_encoding_mode(expr, const_expr, ...) \
   _DISPATCH_SWITCH("positional encoding mode", expr,      \
                    _DISPATCH_CASES_pos_encoding_mode(const_expr, __VA_ARGS__))


### PR DESCRIPTION
This PR reduces binary size by half, by moving `kv_layout` from template parameter to input argument.

This PR also adds `stride_n` and `stride_h` fields to `tensor_info_t` and `paged_kv_t`, thus making it possible to support non-contiguous inputs (#311 ), however, I'll leave it for another PR.