### PR TITLE
refactor: decouple kv-cache storage

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -487,7 +487,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
     cp_async::commit_group();
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
-      DTypeKV* v_ptr = k_ptrs[j] + paged_kv.kv_offset_delta();
+      DTypeKV* v_ptr = k_ptrs[j] + paged_kv.kv_ptr_delta();
       cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
           v_smem + (((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) * head_dim +
               tx * vec_size,
@@ -554,7 +554,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(
     // load v tiles
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
-      DTypeKV* v_ptr = k_ptrs[j] + paged_kv.kv_offset_delta();
+      DTypeKV* v_ptr = k_ptrs[j] + paged_kv.kv_ptr_delta();
       cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
           v_smem + (((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) * head_dim +
               tx * vec_size,

--- a/include/flashinfer/page.cuh
+++ b/include/flashinfer/page.cuh
@@ -213,8 +213,9 @@ struct paged_kv_t {
   }
 
   __host__ __device__ __forceinline__ int64_t kv_ptr_delta() const {
-    return page_storage == PageStorage::kPointer ? num_heads * page_size * head_dim
-                                                 : int64_t(v_data) - int64_t(k_data);
+    return page_storage == PageStorage::kPointer
+               ? num_heads * page_size * head_dim
+               : (int64_t(v_data) - int64_t(k_data)) / sizeof(DType);
   }
 
   /*!

--- a/src/cpu_reference.h
+++ b/src/cpu_reference.h
@@ -180,10 +180,10 @@ void append_paged_kv_cache(paged_kv_t<PageStorage::kIndices, T, IdxType> page_cp
       for (size_t h = 0; h < num_heads; ++h) {
         std::copy(ki.begin() + (j * num_heads + h) * head_dim,
                   ki.begin() + (j * num_heads + h + 1) * head_dim,
-                  page_cpu.data + page_cpu.get_k_elem_offset(page_idx, h, entry_idx, 0));
+                  page_cpu.k_data + page_cpu.get_elem_offset(page_idx, h, entry_idx, 0));
         std::copy(vi.begin() + (j * num_heads + h) * head_dim,
                   vi.begin() + (j * num_heads + h + 1) * head_dim,
-                  page_cpu.data + page_cpu.get_v_elem_offset(page_idx, h, entry_idx, 0));
+                  page_cpu.v_data + page_cpu.get_elem_offset(page_idx, h, entry_idx, 0));
       }
     }
   }

--- a/src/test_batch_prefill.cu
+++ b/src/test_batch_prefill.cu
@@ -76,7 +76,7 @@ void _TestBatchPagedPrefillKernelOneHotCorrectness(size_t num_kv_heads, size_t n
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
   paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
-  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
+  paged_kv.v_data = paged_kv.k_data + paged_kv_cpu.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());
@@ -284,7 +284,7 @@ void _TestBatchPagedPrefillKernelShortContextCorrectness(size_t num_kv_heads, si
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
   paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
-  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
+  paged_kv.v_data = paged_kv.k_data + paged_kv_cpu.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());
@@ -405,7 +405,7 @@ void _TestBatchPagedPrefillKernelQMinMaxKVMinMaxCorrectness(
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
   paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
-  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
+  paged_kv.v_data = paged_kv.k_data + paged_kv_cpu.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());
@@ -513,7 +513,7 @@ void _TestBatchPagedPrefillKernelLongContextCorrectness(size_t num_kv_heads, siz
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
   paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
-  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
+  paged_kv.v_data = paged_kv.k_data + paged_kv_cpu.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());

--- a/src/test_batch_prefill.cu
+++ b/src/test_batch_prefill.cu
@@ -75,7 +75,8 @@ void _TestBatchPagedPrefillKernelOneHotCorrectness(size_t num_kv_heads, size_t n
 
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
-  paged_kv.data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());
@@ -282,7 +283,8 @@ void _TestBatchPagedPrefillKernelShortContextCorrectness(size_t num_kv_heads, si
 
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
-  paged_kv.data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());
@@ -402,7 +404,8 @@ void _TestBatchPagedPrefillKernelQMinMaxKVMinMaxCorrectness(
 
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
-  paged_kv.data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());
@@ -509,7 +512,8 @@ void _TestBatchPagedPrefillKernelLongContextCorrectness(size_t num_kv_heads, siz
 
   // create paged_kv object
   flashinfer::paged_kv_t<PageStorage::kIndices, T, int32_t> paged_kv = paged_kv_cpu;
-  paged_kv.data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.k_data = thrust::raw_pointer_cast(kv_data_device.data());
+  paged_kv.v_data = paged_kv.k_data + paged_kv.kv_ptr_delta();
   paged_kv.indices = thrust::raw_pointer_cast(kv_indices_device.data());
   paged_kv.indptr = thrust::raw_pointer_cast(kv_indptr_device.data());
   paged_kv.last_page_len = thrust::raw_pointer_cast(kv_last_page_len_device.data());


### PR DESCRIPTION
In our previous design, k-cache and v-cache are coupled together as a `(num_pages, 2, page_size, num_heads, head_dim)` or a `(num_pages, 2, num_heads, page_size, head_dim)` tensor.

In this PR, we decouple the k-cache and v-cache storage to enable more flexible kv-cache storage. Note that the original coupled layout is still supported, but we also supports standalone k-cache and k-cache.