### PR TITLE
ci: add torch 12.4 to the matrix configuration

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -26,8 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11"]
-        cuda: ["11.8", "12.1"]
-        torch: ["2.1", "2.2", "2.3"]
+        cuda: ["11.8", "12.1", "12.4"]
+        torch: ["2.2", "2.3", "2.4"]
+        exclude: # for cuda 12.4, we only support torch 2.4+
+          - cuda: "12.4"
+            torch: "2.2"
+          - cuda: "12.4"
+            torch: "2.3"
+
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Remove torch 2.1 (we will not support torch 2.1 from v0.1.2 on).
- Add pytorch 2.4
- Add cuda 12.4 (for torch 2.4+)