### PR TITLE
feat: support non-contiguous (packed) input for prefill kernels

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -246,11 +246,11 @@ __global__ void SingleDecodeWithKVCacheKernel(DTypeQ* __restrict__ q, DTypeKV* _
                        float(2 * ((tx * vec_size + i) % (head_dim / 2))) / float(head_dim));
     }
     // apply rotary embedding to q matrix
-    q_vec = vec_apply_llama_rope<vec_size, bdx>(q + info.get_qo_elem_offset(0, qo_head_idx, 0),
-                                                freq, seq_len - 1);
+    q_vec = vec_apply_llama_rope<vec_size, bdx>(q + info.get_q_elem_offset(0, qo_head_idx, 0), freq,
+                                                seq_len - 1);
   } else {
     // do not apply rotary embedding to q matrix
-    q_vec.cast_load(q + info.get_qo_elem_offset(0, qo_head_idx, tx * vec_size));
+    q_vec.cast_load(q + info.get_q_elem_offset(0, qo_head_idx, tx * vec_size));
   }
   // multiple q_vec by sm_scale
 #pragma unroll

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1171,7 +1171,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
   // write back
   write_o_reg_gmem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
       o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
-      partition_kv ? q_stride_n * num_chunks : q_stride_n, q_stride_h, group_size);
+      /*o_stride_n=*/partition_kv ? num_qo_heads * head_dim * num_chunks : num_qo_heads * head_dim,
+      /*o_stride_h=*/head_dim, group_size);
 
   // write lse
   if (lse != nullptr || partition_kv) {
@@ -1438,7 +1439,9 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
   // write back
   write_o_reg_gmem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
       o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
-      partition_kv ? q_stride_n * num_kv_chunks : q_stride_n, q_stride_h, group_size);
+      /*o_stride_n=*/
+          partition_kv ? num_qo_heads * head_dim * num_kv_chunks : num_qo_heads * head_dim,
+      /*o_stride_h=*/head_dim, group_size);
 
   // write lse
   if (lse != nullptr) {
@@ -1728,7 +1731,9 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
   // write_back
   write_o_reg_gmem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
       o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
-      partition_kv ? q_stride_n * num_kv_chunks : q_stride_n, q_stride_h, group_size);
+      /*o_stride_n=*/
+          partition_kv ? num_qo_heads * head_dim * num_kv_chunks : num_qo_heads * head_dim,
+      /*o_stride_h=*/head_dim, group_size);
 
   // write lse
   if (lse != nullptr) {

--- a/include/flashinfer/layout.cuh
+++ b/include/flashinfer/layout.cuh
@@ -83,8 +83,6 @@ struct tensor_info_t {
     q_stride_h = head_dim;
     kv_stride_n = (kv_layout == QKVLayout::kNHD) ? num_kv_heads * head_dim : head_dim;
     kv_stride_h = (kv_layout == QKVLayout::kNHD) ? head_dim : kv_len * head_dim;
-    // std::tie(q_stride_n, q_stride_h, kv_stride_n, kv_stride_h) =
-    //     get_qkv_strides(kv_layout, kv_len, num_qo_heads, num_kv_heads, head_dim);
   }
 
   __host__ __device__ __forceinline__ size_t get_q_elem_offset(uint32_t qo_idx,

--- a/include/flashinfer/layout.cuh
+++ b/include/flashinfer/layout.cuh
@@ -17,6 +17,7 @@
 #define FLASHINFER_LAYOUT_CUH_
 
 #include <string>
+#include <tuple>
 
 namespace flashinfer {
 
@@ -36,42 +37,66 @@ __host__ __device__ __forceinline__ size_t get_elem_offset_impl(size_t elem_idx,
   return elem_idx * stride_n + head_idx * stride_h + feat_idx;
 }
 
+__host__ __forceinline__ auto get_qkv_strides(QKVLayout kv_layout, uint32_t kv_len,
+                                              uint32_t num_qo_heads, uint32_t num_kv_heads,
+                                              uint32_t head_dim) {
+  const uint32_t q_stride_n = num_qo_heads * head_dim, q_stride_h = head_dim,
+                 kv_stride_n = (kv_layout == QKVLayout::kNHD) ? num_kv_heads * head_dim : head_dim,
+                 kv_stride_h = (kv_layout == QKVLayout::kNHD) ? head_dim : kv_len * head_dim;
+  return std::make_tuple(q_stride_n, q_stride_h, kv_stride_n, kv_stride_h);
+}
+
 struct tensor_info_t {
   uint32_t qo_len;
   uint32_t kv_len;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
-  uint32_t qo_stride_n;
-  uint32_t qo_stride_h;
+  uint32_t q_stride_n;
+  uint32_t q_stride_h;
   uint32_t kv_stride_n;
   uint32_t kv_stride_h;
+  uint32_t head_dim;
   __host__ __device__ __forceinline__ tensor_info_t(uint32_t qo_len, uint32_t kv_len,
                                                     uint32_t num_qo_heads, uint32_t num_kv_heads,
-                                                    uint32_t qo_stride_n, uint32_t qo_stride_h,
-                                                    uint32_t kv_stride_n, uint32_t kv_stride_h)
+                                                    uint32_t q_stride_n, uint32_t q_stride_h,
+                                                    uint32_t kv_stride_n, uint32_t kv_stride_h,
+                                                    uint32_t head_dim)
       : qo_len(qo_len),
         kv_len(kv_len),
         num_qo_heads(num_qo_heads),
         num_kv_heads(num_kv_heads),
-        qo_stride_n(qo_stride_n),
-        qo_stride_h(qo_stride_h),
+        q_stride_n(q_stride_n),
+        q_stride_h(q_stride_h),
         kv_stride_n(kv_stride_n),
-        kv_stride_h(kv_stride_h) {}
+        kv_stride_h(kv_stride_h),
+        head_dim(head_dim) {}
 
   __host__ __device__ __forceinline__ tensor_info_t(uint32_t qo_len, uint32_t kv_len,
                                                     uint32_t num_qo_heads, uint32_t num_kv_heads,
                                                     QKVLayout kv_layout, uint32_t head_dim)
-      : qo_len(qo_len), kv_len(kv_len), num_qo_heads(num_qo_heads), num_kv_heads(num_kv_heads) {
-    qo_stride_n = num_qo_heads * head_dim;
-    qo_stride_h = head_dim;
+      : qo_len(qo_len),
+        kv_len(kv_len),
+        num_qo_heads(num_qo_heads),
+        num_kv_heads(num_kv_heads),
+        head_dim(head_dim) {
+    q_stride_n = num_qo_heads * head_dim;
+    q_stride_h = head_dim;
     kv_stride_n = (kv_layout == QKVLayout::kNHD) ? num_kv_heads * head_dim : head_dim;
     kv_stride_h = (kv_layout == QKVLayout::kNHD) ? head_dim : kv_len * head_dim;
+    // std::tie(q_stride_n, q_stride_h, kv_stride_n, kv_stride_h) =
+    //     get_qkv_strides(kv_layout, kv_len, num_qo_heads, num_kv_heads, head_dim);
   }
 
-  __host__ __device__ __forceinline__ size_t get_qo_elem_offset(uint32_t qo_idx,
-                                                                uint32_t qo_head_idx,
-                                                                uint32_t feat_idx) const {
-    return get_elem_offset_impl(qo_idx, qo_head_idx, feat_idx, qo_stride_n, qo_stride_h);
+  __host__ __device__ __forceinline__ size_t get_q_elem_offset(uint32_t qo_idx,
+                                                               uint32_t qo_head_idx,
+                                                               uint32_t feat_idx) const {
+    return get_elem_offset_impl(qo_idx, qo_head_idx, feat_idx, q_stride_n, q_stride_h);
+  }
+
+  __host__ __device__ __forceinline__ size_t get_o_elem_offset(uint32_t qo_idx,
+                                                               uint32_t qo_head_idx,
+                                                               uint32_t feat_idx) const {
+    return get_elem_offset_impl(qo_idx, qo_head_idx, feat_idx, num_qo_heads * head_dim, head_dim);
   }
 
   __host__ __device__ __forceinline__ size_t get_kv_elem_offset(uint32_t kv_idx,

--- a/include/flashinfer/prefill_attention_decl.cuh
+++ b/include/flashinfer/prefill_attention_decl.cuh
@@ -34,8 +34,8 @@ template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode PO
 cudaError_t SinglePrefillWithKVCacheDispatched(
     DTypeIn* q, DTypeIn* k, DTypeIn* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp,
     float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
-    QKVLayout kv_layout, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
-    cudaStream_t stream);
+    uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n, uint32_t kv_stride_h,
+    float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream);
 
 template <WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK,
           PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
@@ -46,8 +46,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
     IdType* qk_indptr, IdType* q_offset, IdType* k_rope_pos_offset, IdType* o_indptr, DTypeOut* o,
     DTypeOut* tmp_v, float* tmp_s, float* lse, IdType* merge_indptr, bool* block_valid_mask,
     IdType* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
-    uint32_t padded_batch_size, uint32_t num_kv_heads, QKVLayout layout, float logits_soft_cap,
-    float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream = nullptr);
+    uint32_t padded_batch_size, uint32_t num_kv_heads, uint32_t q_stride_n, uint32_t q_stride_h,
+    uint32_t kv_stride_n, uint32_t kv_stride_h, float logits_soft_cap, float sm_scale,
+    float rope_scale, float rope_theta, cudaStream_t stream = nullptr);
 
 template <PageStorage page_storage, WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM,
           LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode pos_encoding_mode,
@@ -117,8 +118,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
     BatchPrefillHandler* handler, DTypeIn* q, IdType* q_indptr, DTypeIn* k, DTypeIn* v,
     IdType* kv_indptr, uint8_t* custom_mask, IdType* qk_indptr, IdType* q_offset,
     IdType* k_rope_pos_offset, DTypeOut* o, float* lse, uint32_t num_qo_heads,
-    uint32_t num_kv_heads, QKVLayout kv_layout, float logits_soft_cap, float sm_scale,
-    float rope_scale, float rope_theta, cudaStream_t stream) {
+    uint32_t num_kv_heads, uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n,
+    uint32_t kv_stride_h, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
+    cudaStream_t stream) {
   DTypeOut* tmp_v = nullptr;
   float* tmp_s = nullptr;
   IdType *request_indices = nullptr, *qo_tile_indices = nullptr, *kv_tile_indices = nullptr,
@@ -154,8 +156,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
         q, request_indices, qo_tile_indices, kv_tile_indices, q_indptr, k, v, kv_indptr,
         custom_mask, qk_indptr, q_offset, k_rope_pos_offset, o_indptr, o, tmp_v, tmp_s, lse,
         merge_indptr, block_valid_mask, kv_chunk_size_ptr, total_num_rows, num_qo_heads,
-        padded_batch_size, num_kv_heads, kv_layout, logits_soft_cap, sm_scale, rope_scale,
-        rope_theta, stream);
+        padded_batch_size, num_kv_heads, q_stride_n, q_stride_h, kv_stride_n, kv_stride_h,
+        logits_soft_cap, sm_scale, rope_scale, rope_theta, stream);
   });
   return cudaSuccess;
 }

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -422,7 +422,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::Forward(
   CHECK_EQ(k.size(2), v.size(2));
   CHECK_EQ(k.size(2), head_dim);
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  const uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
+  uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
   if (kv_layout_ == QKVLayout::kNHD) {
     kv_stride_n = k.stride(0);
     kv_stride_h = k.stride(1);
@@ -528,7 +528,7 @@ std::vector<torch::Tensor> BatchPrefillWithRaggedKVCachePyTorchWrapper::ForwardC
   CHECK_EQ(k.size(2), v.size(2));
   CHECK_EQ(k.size(2), head_dim);
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
-  const uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
+  uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
   if (kv_layout_ == QKVLayout::kNHD) {
     kv_stride_n = k.stride(0);
     kv_stride_h = k.stride(1);

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -24,9 +24,9 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
     torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor tmp, bool causal,
     unsigned int layout, unsigned int pos_encoding_mode, bool allow_fp16_qk_reduction,
     float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta, bool return_lse) {
-  CHECK_INPUT(q);
-  CHECK_INPUT(k);
-  CHECK_INPUT(v);
+  CHECK_CUDA(q);
+  CHECK_CUDA(k);
+  CHECK_CUDA(v);
   CHECK_INPUT(tmp);
   auto device = q.device();
   CHECK_EQ(k.device(), device);
@@ -36,6 +36,9 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
   CHECK_DIM(3, k);
   CHECK_DIM(3, v);
   CHECK_SHAPE(k, v);
+  CHECK_EQ(q.stride(2), 1);
+  CHECK_EQ(k.stride(2), 1);
+  CHECK_EQ(v.stride(2), 1);
   CHECK_EQ(q.size(2), k.size(2));
   CHECK_EQ(q.scalar_type(), k.scalar_type());
   CHECK_EQ(q.scalar_type(), v.scalar_type());
@@ -44,12 +47,17 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
   qo_len = q.size(0);
   num_qo_heads = q.size(1);
+  const uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
   if (kv_layout == QKVLayout::kNHD) {
     kv_len = k.size(0);
     num_kv_heads = k.size(1);
-  } else {
+    kv_stride_n = k.stride(0);
+    kv_stride_h = k.stride(1);
+  } else {  // QKVLayout::kHND
     kv_len = k.size(1);
     num_kv_heads = k.size(0);
+    kv_stride_h = k.stride(0);
+    kv_stride_n = k.stride(1);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
@@ -72,16 +80,19 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
               allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, [&] {
                 return DISPATCH_pos_encoding_mode(
                     PosEncodingMode(pos_encoding_mode), POS_ENCODING_MODE, [&] {
-                      cudaError_t status = SinglePrefillWithKVCacheDispatched<
-                          HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION,
-                          MASK_MODE>(
-                          static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
-                          static_cast<c_type*>(v.data_ptr()),
-                          /*custom_mask=*/nullptr, static_cast<c_type*>(o.data_ptr()),
-                          static_cast<c_type*>(tmp.data_ptr()),
-                          /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                          num_qo_heads, num_kv_heads, qo_len, kv_len, kv_layout, logits_soft_cap,
-                          sm_scale, rope_scale, rope_theta, torch_current_stream);
+                      cudaError_t status =
+                          SinglePrefillWithKVCacheDispatched<HEAD_DIM, LOGITS_POST_HOOK,
+                                                             POS_ENCODING_MODE,
+                                                             ALLOW_FP16_QK_REDUCTION, MASK_MODE>(
+                              static_cast<c_type*>(q.data_ptr()),
+                              static_cast<c_type*>(k.data_ptr()),
+                              static_cast<c_type*>(v.data_ptr()),
+                              /*custom_mask=*/nullptr, static_cast<c_type*>(o.data_ptr()),
+                              static_cast<c_type*>(tmp.data_ptr()),
+                              /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
+                              num_qo_heads, num_kv_heads, qo_len, kv_len, q_stride_n, q_stride_h,
+                              kv_stride_n, kv_stride_h, logits_soft_cap, sm_scale, rope_scale,
+                              rope_theta, torch_current_stream);
                       TORCH_CHECK(status == cudaSuccess,
                                   "SinglePrefillWithKVCache kernel launch failed, error: " +
                                       std::string(cudaGetErrorString(status)));
@@ -105,9 +116,9 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
     torch::Tensor tmp, unsigned int layout, unsigned int pos_encoding_mode,
     bool allow_fp16_qk_reduction, float logits_soft_cap, float sm_scale, float rope_scale,
     float rope_theta, bool return_lse) {
-  CHECK_INPUT(q);
-  CHECK_INPUT(k);
-  CHECK_INPUT(v);
+  CHECK_CUDA(q);
+  CHECK_CUDA(k);
+  CHECK_CUDA(v);
   CHECK_INPUT(packed_custom_mask);
   auto device = q.device();
   CHECK_EQ(k.device(), device);
@@ -118,6 +129,9 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
   CHECK_DIM(3, v);
   CHECK_DIM(1, packed_custom_mask);
   CHECK_SHAPE(k, v);
+  CHECK_EQ(q.stride(2), 1);
+  CHECK_EQ(k.stride(2), 1);
+  CHECK_EQ(v.stride(2), 1);
   CHECK_EQ(q.size(2), k.size(2));
   // packed_custom_mask must be uint8
   TORCH_CHECK(packed_custom_mask.scalar_type() == torch::kUInt8,
@@ -127,12 +141,17 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
   qo_len = q.size(0);
   num_qo_heads = q.size(1);
+  const uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
   if (kv_layout == QKVLayout::kNHD) {
     kv_len = k.size(0);
     num_kv_heads = k.size(1);
+    kv_stride_n = k.stride(0);
+    kv_stride_h = k.stride(1);
   } else {
     kv_len = k.size(1);
     num_kv_heads = k.size(0);
+    kv_stride_h = k.stride(0);
+    kv_stride_n = k.stride(1);
   }
   CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads);
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
@@ -164,8 +183,9 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
                             static_cast<c_type*>(o.data_ptr()),
                             static_cast<c_type*>(tmp.data_ptr()),
                             /*lse=*/return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr,
-                            num_qo_heads, num_kv_heads, qo_len, kv_len, kv_layout, logits_soft_cap,
-                            sm_scale, rope_scale, rope_theta, torch_current_stream);
+                            num_qo_heads, num_kv_heads, qo_len, kv_len, q_stride_n, q_stride_h,
+                            kv_stride_n, kv_stride_h, logits_soft_cap, sm_scale, rope_scale,
+                            rope_theta, torch_current_stream);
                     TORCH_CHECK(status == cudaSuccess,
                                 "SinglePrefillWithKVCache kernel launch failed, error: " +
                                     std::string(cudaGetErrorString(status)));

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -47,7 +47,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
   qo_len = q.size(0);
   num_qo_heads = q.size(1);
-  const uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
+  uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
   if (kv_layout == QKVLayout::kNHD) {
     kv_len = k.size(0);
     num_kv_heads = k.size(1);
@@ -141,7 +141,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
   qo_len = q.size(0);
   num_qo_heads = q.size(1);
-  const uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
+  uint32_t q_stride_n = q.stride(0), q_stride_h = q.stride(1), kv_stride_n, kv_stride_h;
   if (kv_layout == QKVLayout::kNHD) {
     kv_len = k.size(0);
     num_kv_heads = k.size(1);

--- a/python/csrc/single_prefill.cu
+++ b/python/csrc/single_prefill.cu
@@ -71,7 +71,7 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache(
   TORCH_CHECK(logits_soft_cap >= 0.f, "logits_soft_cap must be non-negative");
   const LogitsPostHook logits_post_hook =
       logits_soft_cap > 0.f ? LogitsPostHook::kSoftCap : LogitsPostHook::kNone;
-
+  
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     return DISPATCH_head_dim(head_dim, HEAD_DIM, [&] {
       return DISPATCH_mask_mode(mask_mode, MASK_MODE, [&] {

--- a/python/generate_batch_ragged_prefill_inst.py
+++ b/python/generate_batch_ragged_prefill_inst.py
@@ -46,8 +46,8 @@ def get_cu_file_str(
     uint8_t* custom_mask, {idtype}* qk_indptr, {idtype}* q_offset, {idtype}* k_rope_pos_offset,
     {idtype}* o_indptr, {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse, {idtype}* merge_indptr,
     bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
-    uint32_t padded_batch_size, uint32_t num_kv_heads, QKVLayout kv_layout,
-    float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
+    uint32_t padded_batch_size, uint32_t num_kv_heads, uint32_t q_stride_n, uint32_t q_stride_h,
+    uint32_t kv_stride_n, uint32_t kv_stride_h, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
     cudaStream_t stream);
         """.format(
                 warp_layout=warp_layout_literal[warp_layout],

--- a/python/generate_single_prefill_inst.py
+++ b/python/generate_single_prefill_inst.py
@@ -42,8 +42,8 @@ namespace flashinfer {{
 template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
     {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, uint8_t* custom_mask, {dtype_out}* o,
     {dtype_out}* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
-    QKVLayout kv_layout, float logits_soft_cap, float sm_scale, float rope_scale,
-    float rope_theta, cudaStream_t stream);
+    uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n, uint32_t kv_stride_h,
+    float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream);
 
 }}
     """.format(

--- a/python/tests/test_non_contiguous_prefill.py
+++ b/python/tests/test_non_contiguous_prefill.py
@@ -60,7 +60,7 @@ def test_single_prefill_packed_input(
 @pytest.mark.parametrize("batch_size", [1, 19, 99])
 @pytest.mark.parametrize("seq_len", [1, 7, 127, 257])
 @pytest.mark.parametrize("num_kv_heads", [1, 4, 8])
-@pytest.mark.parametrize("num_qo_heads", [4, 8, 32])
+@pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("causal", [True, False])
 def test_batch_ragged_prefill_packed_input(
@@ -88,7 +88,7 @@ def test_batch_ragged_prefill_packed_input(
     kv_indptr = qo_indptr
 
     workspace_buffer = torch.empty(
-        (128 * 1024 * 1024,), dtype=torch.uint8, device="cuda:0"
+        (256 * 1024 * 1024,), dtype=torch.uint8, device="cuda:0"
     )
     wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace_buffer)
     wrapper.begin_forward(

--- a/python/tests/test_non_contiguous_prefill.py
+++ b/python/tests/test_non_contiguous_prefill.py
@@ -1,0 +1,113 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy
+import pytest
+import torch
+
+import flashinfer
+
+
+@pytest.mark.parametrize("seq_len", [1, 7, 127, 999, 3579])
+@pytest.mark.parametrize("num_kv_heads", [1, 4, 8])
+@pytest.mark.parametrize("num_qo_heads", [4, 8, 32])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("causal", [True, False])
+def test_single_prefill_packed_input(
+    seq_len, num_kv_heads, num_qo_heads, head_dim, causal
+):
+    if num_qo_heads % num_kv_heads != 0:
+        pytest.skip("num_qo_heads must be a multiple of num_kv_heads")
+    qkv_packed = torch.randn(
+        seq_len,
+        (num_qo_heads + 2 * num_kv_heads) * head_dim,
+        dtype=torch.float16,
+        device="cuda:0",
+    )
+    q = qkv_packed[:, : num_qo_heads * head_dim].reshape(
+        seq_len, num_qo_heads, head_dim
+    )
+    k = qkv_packed[
+        :, num_qo_heads * head_dim : (num_qo_heads + num_kv_heads) * head_dim
+    ].reshape(seq_len, num_kv_heads, head_dim)
+    v = qkv_packed[:, (num_qo_heads + num_kv_heads) * head_dim :].reshape(
+        seq_len, num_kv_heads, head_dim
+    )
+
+    o_packed = flashinfer.single_prefill_with_kv_cache(q, k, v, causal=causal)
+    o_contiguous = flashinfer.single_prefill_with_kv_cache(
+        q.contiguous(), k.contiguous(), v.contiguous(), causal=causal
+    )
+
+    numpy.testing.assert_allclose(
+        o_packed.cpu(), o_contiguous.cpu(), rtol=1e-3, atol=1e-3
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 19, 99])
+@pytest.mark.parametrize("seq_len", [1, 7, 127, 257])
+@pytest.mark.parametrize("num_kv_heads", [1, 4, 8])
+@pytest.mark.parametrize("num_qo_heads", [4, 8, 32])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("causal", [True, False])
+def test_batch_ragged_prefill_packed_input(
+    batch_size, seq_len, num_kv_heads, num_qo_heads, head_dim, causal
+):
+    if num_qo_heads % num_kv_heads != 0:
+        pytest.skip("num_qo_heads must be a multiple of num_kv_heads")
+    nnz = batch_size * seq_len
+    qkv_packed = torch.randn(
+        nnz,
+        (num_qo_heads + 2 * num_kv_heads) * head_dim,
+        dtype=torch.float16,
+        device="cuda:0",
+    )
+    q = qkv_packed[:, : num_qo_heads * head_dim].reshape(nnz, num_qo_heads, head_dim)
+    k = qkv_packed[
+        :, num_qo_heads * head_dim : (num_qo_heads + num_kv_heads) * head_dim
+    ].reshape(nnz, num_kv_heads, head_dim)
+    v = qkv_packed[:, (num_qo_heads + num_kv_heads) * head_dim :].reshape(
+        nnz, num_kv_heads, head_dim
+    )
+    qo_indptr = torch.tensor(
+        [i * seq_len for i in range(batch_size + 1)], dtype=torch.int32, device="cuda:0"
+    )
+    kv_indptr = qo_indptr
+
+    workspace_buffer = torch.empty(
+        (128 * 1024 * 1024,), dtype=torch.uint8, device="cuda:0"
+    )
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace_buffer)
+    wrapper.begin_forward(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+    )
+    o_packed = wrapper.forward(q, k, v, causal=causal)
+    o_contiguous = wrapper.forward(
+        q.contiguous(), k.contiguous(), v.contiguous(), causal=causal
+    )
+
+    numpy.testing.assert_allclose(
+        o_packed.cpu(), o_contiguous.cpu(), rtol=1e-3, atol=1e-3
+    )
+
+
+if __name__ == "__main__":
+    test_single_prefill_packed_input(127, 4, 4, 64, True)
+    test_batch_ragged_prefill_packed_input(37, 127, 4, 4, 64, True)

--- a/src/cpu_reference.h
+++ b/src/cpu_reference.h
@@ -94,7 +94,7 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_q>& q, const std::vect
         float max_val = -5e4;
         if (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
           q_rotary_local = std::move(cpu_reference::apply_llama_rope(
-              q.data() + info.get_qo_elem_offset(q_idx, qo_head_idx, 0), head_dim,
+              q.data() + info.get_q_elem_offset(q_idx, qo_head_idx, 0), head_dim,
               q_idx + kv_len - qo_len, rope_scale, rope_theta));
         }
         for (size_t kv_idx = 0; kv_idx < kv_len; ++kv_idx) {
@@ -102,7 +102,7 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_q>& q, const std::vect
           switch (pos_encoding_mode) {
             case PosEncodingMode::kNone: {
               for (size_t feat_idx = 0; feat_idx < head_dim; ++feat_idx) {
-                att[kv_idx] += float(q[info.get_qo_elem_offset(q_idx, qo_head_idx, feat_idx)]) *
+                att[kv_idx] += float(q[info.get_q_elem_offset(q_idx, qo_head_idx, feat_idx)]) *
                                float(k[info.get_kv_elem_offset(kv_idx, kv_head_idx, feat_idx)]) *
                                sm_scale;
               }
@@ -147,7 +147,7 @@ std::vector<dtype_out> single_mha(const std::vector<dtype_q>& q, const std::vect
             o_float +=
                 att[kv_idx] * float(v[info.get_kv_elem_offset(kv_idx, kv_head_idx, feat_idx)]);
           }
-          o[info.get_qo_elem_offset(q_idx, qo_head_idx, feat_idx)] = dtype_out(o_float);
+          o[info.get_o_elem_offset(q_idx, qo_head_idx, feat_idx)] = dtype_out(o_float);
         }
       }
     }


### PR DESCRIPTION
This PR implements #311 , after this PR, we support packed qkv input without explictly convert make the input contiguous:
```python
packed_qkv = W_qkv(x) # (nnz, (num_qo_heads + 2 * num_kv_heads) * head_dim)
q = packed_qkv[..., : num_qo_heads * head_dim].reshape(-1, num_qo_heads, head_dim)
k = packed_qkv[..., num_qo_heads * head_dim: (num_qo_heads + num_kv_heads) * head_dim].reshape(-1, num_kv_heads, head_dim)
v = packed_qkv[..., (num_qo_heads + num_kv_heads) * head_dim:].reshape(-1, num_kv_heads, head_dim)
apply_rope_inplace(q, k, indptr, offsets)
ragged_prefill_wrapper.forward(q, k, v)
```

Before this PR, we need to make `q`/`k`/`v` contiguous before we launch the attention kernel, which incurs some overhead.

I observe slight (<1%) performance degration after this PR for non-packed input, which is acceptable IMO.