### PR TITLE
ci/cd: add python 3.12

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         cuda: ["11.8", "12.1", "12.4"]
         torch: ["2.2", "2.3", "2.4"]
         exclude: # for cuda 12.4, we only support torch 2.4+


### PR DESCRIPTION
Per requested in https://github.com/sgl-project/sglang/issues/849, we should build python 3.12 wheels starting from the next version.