### PR TITLE
feat: append attention kernels for fp8 kv-cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set (IDTYPES "i32")
 if(FLASHINFER_ENABLE_FP8)
   list(APPEND DECODE_DTYPES "e4m3" "e5m2")
   list(APPEND DECODE_FP8_DTYPES "e4m3" "e5m2")
+  list(APPEND PREFILL_FP8_DTYPES "e4m3")
 endif(FLASHINFER_ENABLE_FP8)
 
 if(FLASHINFER_ENABLE_BF16)
@@ -204,6 +205,18 @@ foreach(head_dim IN LISTS HEAD_DIMS)
             )
             list(APPEND single_prefill_kernels_src ${generated_kernel_src})
           endforeach(dtype)
+
+          foreach(dtype_kv IN LISTS PREFILL_FP8_DTYPES)
+            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypeq_f16_dtypekv_${dtype_kv}_dtypeout_f16.cu)
+            add_custom_command(
+              OUTPUT ${generated_kernel_src}
+              COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
+              DEPENDS ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py
+              COMMENT "Generating additional source file ${generated_kernel_src}"
+              VERBATIM
+            )
+            list(APPEND single_prefill_kernels_src ${generated_kernel_src})
+          endforeach(dtype_kv)
         endforeach(mask_mode)
       endforeach(allow_fp16_qk_reduction)
     endforeach(pos_encoding_mode)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ foreach(head_dim IN LISTS HEAD_DIMS)
       foreach(allow_fp16_qk_reduction IN LISTS ALLOW_FP16_QK_REDUCTIONS)
         foreach(mask_mode IN LISTS MASK_MODES)
           foreach(dtype IN LISTS PREFILL_DTYPES)
-            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}.cu)
+            set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/single_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}.cu)
             add_custom_command(
               OUTPUT ${generated_kernel_src}
               COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_single_prefill_inst.py ${generated_kernel_src}
@@ -218,7 +218,7 @@ foreach(head_dim IN LISTS HEAD_DIMS)
         foreach(mask_mode IN LISTS MASK_MODES)
           foreach(dtype IN LISTS PREFILL_DTYPES)
             foreach(idtype IN LISTS IDTYPES)
-              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_paged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
               add_custom_command(
                 OUTPUT ${generated_kernel_src}
                 COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_paged_prefill_inst.py ${generated_kernel_src}
@@ -243,7 +243,7 @@ foreach(head_dim IN LISTS HEAD_DIMS)
         foreach(mask_mode IN LISTS MASK_MODES)
           foreach(dtype IN LISTS PREFILL_DTYPES)
             foreach(idtype IN LISTS IDTYPES)
-              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypein_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
+              set(generated_kernel_src ${PROJECT_SOURCE_DIR}/src/generated/batch_ragged_prefill_head_${head_dim}_logitshook_${logits_post_hook}_posenc_${pos_encoding_mode}_fp16qkred_${allow_fp16_qk_reduction}_mask_${mask_mode}_dtypeq_${dtype}_dtypekv_${dtype}_dtypeout_${dtype}_idtype_${idtype}.cu)
               add_custom_command(
                 OUTPUT ${generated_kernel_src}
                 COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/generate_batch_ragged_prefill_inst.py ${generated_kernel_src}

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1096,9 +1096,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     }
   }
 
-  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeKV)),
-      v_smem(smem + (num_warps_x * num_frags_x + num_warps_z * num_frags_z) * 16 * head_dim *
-                        sizeof(DTypeKV));
+  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeQ)),
+      v_smem(smem + (num_warps_x * num_frags_x * sizeof(DTypeQ) + num_warps_z * num_frags_z * sizeof(DTypeKV)) * 16 * head_dim);
 
   const uint32_t num_iterations = ceil_div(
       mask_mode == MaskMode::kCausal
@@ -1386,9 +1385,9 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
            : chunk_end - chunk_start) /
       (16 * num_warps_z * num_frags_z);
 
-  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeKV)),
-      v_smem(smem + (num_warps_x * num_frags_x + num_warps_z * num_frags_z) * 16 * head_dim *
-                        sizeof(DTypeKV));
+  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeQ)),
+      v_smem(smem + (num_warps_x * num_frags_x * sizeof(DTypeQ) + num_warps_z * num_frags_z *
+                        sizeof(DTypeKV)) * 16 * head_dim);
 
   uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + 8 * (lane_idx / 16) +
@@ -1643,9 +1642,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     }
   }
 
-  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeKV)),
-      v_smem(smem + (num_warps_x * num_frags_x + num_warps_z * num_frags_z) * 16 * head_dim *
-                        sizeof(DTypeKV));
+  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeQ)),
+      v_smem(smem + (num_warps_x * num_frags_x * sizeof(DTypeQ) + num_warps_z * num_frags_z * sizeof(DTypeKV)) * 16 * head_dim);
   size_t kv_offset[num_frags_z * 4 / num_warps_x];
 
   uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -757,9 +757,9 @@ __device__ __forceinline__ void compute_sfm_v(smem_t* v_smem, uint32_t* v_smem_o
           v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag_f8);
         }
         b_frag_f8[0 + 2 * (fy % 2)] =
-            frag_layout_transform_16b_to_8b_trans(b_frag_f8[2 * (fy % 2)]);
+            frag_layout_transform_16b_to_8b_trans(b_frag_f8[0 + 2 * (fy % 2)]);
         b_frag_f8[1 + 2 * (fy % 2)] =
-            frag_layout_transform_16b_to_8b_trans(b_frag_f8[2 * (fy % 2)]);
+            frag_layout_transform_16b_to_8b_trans(b_frag_f8[1 + 2 * (fy % 2)]);
         vec_cast<DTypeQ, DTypeKV, 8>((DTypeQ*)b_frag, (DTypeKV*)(b_frag_f8 + 2 * (fy % 2)));
       } else {
         v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag);

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -33,6 +33,7 @@
 #include "../pos_enc.cuh"
 #include "../utils.cuh"
 #include "cascade.cuh"
+#include "frag_layout_swizzle.cuh"
 #include "logits_post_hook.cuh"
 #include "mask.cuh"
 #include "warp_layout.cuh"
@@ -171,7 +172,7 @@ __device__ __forceinline__ void produce_kv(smem_t smem, uint32_t* smem_offset, T
                                            const uint32_t kv_len) {
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t num_warps = num_warps_x * num_warps_z;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<T>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<T>();
   const uint32_t warp_idx = get_warp_idx<num_warps_x, num_warps_z>(), lane_idx = threadIdx.x;
   uint32_t kv_idx = kv_idx_base + warp_idx * 4 + lane_idx / 8;
   // NOTE(Zihao): num_frags_z * 4 / num_warps_x = num_warps_z * num_frags_z * 4 / num_warps
@@ -179,17 +180,17 @@ __device__ __forceinline__ void produce_kv(smem_t smem, uint32_t* smem_offset, T
 #pragma unroll
   for (uint32_t i = 0; i < num_frags_z * 4 / num_warps_x; ++i) {
 #pragma unroll
-    for (uint32_t j = 0; j < num_frags_y / 4; ++j) {
+    for (uint32_t j = 0; j < num_frags_y / (8 / sizeof(T)); ++j) {
       smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
       *smem_offset = smem.advance_offset_by_column<8>(*smem_offset, j);
       *gptr += 8 * num_elems_per_128b<T>();
     }
     kv_idx += num_warps * 4;
-    *smem_offset = smem.advance_offset_by_row<num_warps * 4, channel_size_128b_in>(*smem_offset) -
-                   2 * num_frags_y;
-    *gptr += num_warps * 4 * kv_stride_n - 2 * num_frags_y * num_elems_per_128b<T>();
+    *smem_offset = smem.advance_offset_by_row<num_warps * 4, channel_size_128b_kv>(*smem_offset) -
+                   sizeof(T) * num_frags_y;
+    *gptr += num_warps * 4 * kv_stride_n - sizeof(T) * num_frags_y * num_elems_per_128b<T>();
   }
-  *smem_offset -= num_warps_z * num_frags_z * 16 * channel_size_128b_in;
+  *smem_offset -= num_warps_z * num_frags_z * 16 * channel_size_128b_kv;
 }
 
 template <bool produce_v, uint32_t num_warps_x, uint32_t num_warps_z, uint32_t num_frags_y,
@@ -202,7 +203,7 @@ __device__ __forceinline__ void page_produce_kv(smem_t smem, uint32_t* smem_offs
       produce_v ? SharedMemFillMode::kFillZero : SharedMemFillMode::kNoFill;
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t num_warps = num_warps_x * num_warps_z;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DType>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DType>();
   const uint32_t warp_idx = get_warp_idx<num_warps_x, num_warps_z>(), lane_idx = threadIdx.x;
   uint32_t kv_idx = kv_idx_base + warp_idx * 4 + lane_idx / 8;
   // NOTE(Zihao): num_frags_z * 4 / num_warps_x = num_warps_z * num_frags_z * 4 / num_warps
@@ -211,16 +212,16 @@ __device__ __forceinline__ void page_produce_kv(smem_t smem, uint32_t* smem_offs
   for (uint32_t i = 0; i < num_frags_z * 4 / num_warps_x; ++i) {
     DType* gptr = produce_v ? paged_kv.v_data + kv_offset[i] : paged_kv.k_data + kv_offset[i];
 #pragma unroll
-    for (uint32_t j = 0; j < num_frags_y / 4; ++j) {
+    for (uint32_t j = 0; j < num_frags_y / (8 / sizeof(DType)); ++j) {
       smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
       *smem_offset = smem.advance_offset_by_column<8>(*smem_offset, j);
       gptr += 8 * num_elems_per_128b<DType>();
     }
     kv_idx += num_warps * 4;
-    *smem_offset = smem.advance_offset_by_row<num_warps * 4, channel_size_128b_in>(*smem_offset) -
-                   2 * num_frags_y;
+    *smem_offset = smem.advance_offset_by_row<num_warps * 4, channel_size_128b_kv>(*smem_offset) -
+                   sizeof(DType) * num_frags_y;
   }
-  *smem_offset -= num_warps_z * num_frags_z * 16 * channel_size_128b_in;
+  *smem_offset -= num_warps_z * num_frags_z * 16 * channel_size_128b_kv;
 }
 
 template <uint32_t num_frags_y>
@@ -266,18 +267,18 @@ __device__ __forceinline__ void init_states(float (*o_frag)[num_frags_y][8], DTy
 }
 
 template <uint32_t num_warps_x, uint32_t num_warps_z, uint32_t num_frags_x, uint32_t num_frags_y,
-          typename DTypeIn>
+          typename DTypeQ>
 __device__ __forceinline__ void load_q_global_smem(uint32_t packed_offset,
                                                    const uint32_t qo_upper_bound,
-                                                   DTypeIn* q_ptr_base, const uint32_t q_stride_n,
+                                                   DTypeQ* q_ptr_base, const uint32_t q_stride_n,
                                                    const uint32_t q_stride_h,
                                                    const uint_fastdiv group_size, smem_t* q_smem) {
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
   const uint32_t lane_idx = threadIdx.x, warp_idx_x = get_warp_idx_x<num_warps_x, num_warps_z>();
 
   if (get_warp_idx_z<num_warps_x, num_warps_z>() == 0) {
-    uint32_t q_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_in>(
+    uint32_t q_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_q>(
         warp_idx_x * num_frags_x * 16 + lane_idx / 8, lane_idx % 8);
 
 #pragma unroll
@@ -287,16 +288,16 @@ __device__ __forceinline__ void load_q_global_smem(uint32_t packed_offset,
         uint32_t q, r;
         group_size.divmod(packed_offset + lane_idx / 8 + fx * 16 + j * 4, q, r);
         const uint32_t q_idx = q;
-        DTypeIn* q_ptr = q_ptr_base + q * q_stride_n + r * q_stride_h;
+        DTypeQ* q_ptr = q_ptr_base + q * q_stride_n + r * q_stride_h;
 #pragma unroll
         for (uint32_t fyo = 0; fyo < num_frags_y / 4; ++fyo) {
           // load q fragment from gmem to smem
           q_smem->load_128b_async<SharedMemFillMode::kNoFill>(q_smem_offset_w, q_ptr,
                                                               q_idx < qo_upper_bound);
           q_smem_offset_w = q_smem->advance_offset_by_column<8>(q_smem_offset_w, fyo);
-          q_ptr += 8 * num_elems_per_128b<DTypeIn>();
+          q_ptr += 8 * num_elems_per_128b<DTypeQ>();
         }
-        q_smem_offset_w = q_smem->advance_offset_by_row<4, channel_size_128b_in>(q_smem_offset_w) -
+        q_smem_offset_w = q_smem->advance_offset_by_row<4, channel_size_128b_q>(q_smem_offset_w) -
                           2 * num_frags_y;
       }
     }
@@ -304,14 +305,14 @@ __device__ __forceinline__ void load_q_global_smem(uint32_t packed_offset,
 }
 
 template <uint32_t num_warps_x, uint32_t num_warps_z, uint32_t num_frags_x, uint32_t num_frags_y,
-          typename DTypeIn>
+          typename DTypeQ>
 __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
     const uint32_t q_packed_idx, const uint32_t qo_len, const uint32_t kv_len,
     const uint_fastdiv group_size, smem_t* q_smem, uint32_t* q_smem_offset_r, float (*rope_freq)[4],
     const float sm_scale) {
   if (get_warp_idx_z<num_warps_x, num_warps_z>() == 0) {
     constexpr uint32_t head_dim = num_frags_y * 16;
-    constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+    constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
     const uint32_t lane_idx = threadIdx.x;
     uint32_t q_frag_local[2][4];
     static_assert(num_frags_y % 4 == 0, "num_frags_y must be a multiple of 4");
@@ -324,8 +325,8 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
         uint32_t q_smem_offset_r_last_half =
             q_smem->advance_offset_by_column<num_frags_y>(q_smem_offset_r_first_half, 0);
         q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
-        q_frag_apply_llama_rope<DTypeIn>(
-            (DTypeIn*)q_frag_local[0], (DTypeIn*)q_frag_local[1], rope_freq[fyi],
+        q_frag_apply_llama_rope<DTypeQ>(
+            (DTypeQ*)q_frag_local[0], (DTypeQ*)q_frag_local[1], rope_freq[fyi],
             q_packed_idx + kv_len * group_size - qo_len * group_size + fx * 16 + lane_idx / 4,
             group_size, sm_scale);
         q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
@@ -333,21 +334,21 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_multiply_sm_scale(
         q_smem_offset_r_first_half =
             q_smem->advance_offset_by_column<2>(q_smem_offset_r_first_half, fyi);
       }
-      *q_smem_offset_r += 16 * channel_size_128b_in;
+      *q_smem_offset_r += 16 * channel_size_128b_q;
     }
-    *q_smem_offset_r -= num_frags_x * 16 * channel_size_128b_in;
+    *q_smem_offset_r -= num_frags_x * 16 * channel_size_128b_q;
   }
 }
 
 template <uint32_t num_warps_x, uint32_t num_warps_z, uint32_t num_frags_x, uint32_t num_frags_y,
-          typename DTypeIn, typename IdType>
+          typename DTypeQ, typename IdType>
 __device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale(
     const uint32_t q_packed_idx_base, const IdType* q_offset, smem_t* q_smem,
     const uint_fastdiv group_size, uint32_t* q_smem_offset_r, float (*rope_freq)[4],
     const float sm_scale) {
   if (get_warp_idx_z<num_warps_x, num_warps_z>() == 0) {
     constexpr uint32_t head_dim = num_frags_y * 16;
-    constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+    constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
     const uint32_t lane_idx = threadIdx.x;
     uint32_t q_frag_local[2][4];
     static_assert(num_frags_y % 4 == 0, "num_frags_y must be a multiple of 4");
@@ -360,48 +361,48 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos_multiply_sm
         uint32_t q_smem_offset_r_last_half =
             q_smem->advance_offset_by_column<num_frags_y>(q_smem_offset_r_first_half, 0);
         q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
-        q_frag_apply_llama_rope_with_pos<DTypeIn>(
-            (DTypeIn*)q_frag_local[0], (DTypeIn*)q_frag_local[1], rope_freq[fyi],
+        q_frag_apply_llama_rope_with_pos<DTypeQ>(
+            (DTypeQ*)q_frag_local[0], (DTypeQ*)q_frag_local[1], rope_freq[fyi],
             q_packed_idx_base + fx * 16 + lane_idx / 4, group_size, q_offset, sm_scale);
         q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
         q_smem->stmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
         q_smem_offset_r_first_half =
             q_smem->advance_offset_by_column<2>(q_smem_offset_r_first_half, fyi);
       }
-      *q_smem_offset_r += 16 * channel_size_128b_in;
+      *q_smem_offset_r += 16 * channel_size_128b_q;
     }
-    *q_smem_offset_r -= num_frags_x * 16 * channel_size_128b_in;
+    *q_smem_offset_r -= num_frags_x * 16 * channel_size_128b_q;
   }
 }
 
 template <uint32_t num_warps_x, uint32_t num_warps_z, uint32_t num_frags_x, uint32_t num_frags_y,
-          typename DTypeIn>
+          typename DTypeQ>
 __device__ __forceinline__ void q_smem_inplace_multiply_sm_scale(smem_t* q_smem,
                                                                  const float sm_scale) {
   const uint32_t warp_idx = get_warp_idx<num_warps_x, num_warps_z>(), lane_idx = threadIdx.x;
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
   constexpr uint32_t num_warps = num_warps_x * num_warps_z;
 #pragma unroll
   for (uint32_t i = 0; i < num_frags_x * head_dim / (num_warps_z * 16); ++i) {
-    vec_t<DTypeIn, 8> tmp;
-    tmp.load((DTypeIn*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
+    vec_t<DTypeQ, 8> tmp;
+    tmp.load((DTypeQ*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
 #pragma unroll
     for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
       tmp[reg_id] *= sm_scale;
     }
-    tmp.store((DTypeIn*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
+    tmp.store((DTypeQ*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
   }
 }
 
 template <uint32_t num_warps_x, uint32_t num_warps_z, uint32_t num_frags_y, uint32_t num_frags_z,
-          typename DTypeIn>
+          typename DTypeKV>
 __device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_idx_base,
                                                             smem_t* k_smem,
                                                             uint32_t* k_smem_offset_r,
                                                             float (*rope_freq)[4]) {
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
   uint32_t k_frag_local[2][4];
   const uint32_t lane_idx = threadIdx.x;
   if constexpr (num_frags_y == 4 && num_warps_x == 4) {
@@ -417,7 +418,7 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_id
                   "when num_frags_y == 4, num_frags_z must be a multiple of 2");
     uint32_t kv_idx = kv_idx_base + (warp_idx / 2) * 16 + lane_idx / 4;
     *k_smem_offset_r =
-        (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) + (warp_idx / 2) * 16 * channel_size_128b_in;
+        (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) + (warp_idx / 2) * 16 * channel_size_128b_kv;
 #pragma unroll
     for (uint32_t i = 0; i < num_frags_z / 2; ++i) {
       // uint32_t fz = warp_idx / 2 + i * 2;
@@ -427,15 +428,15 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_id
       uint32_t k_smem_offset_r_last_half =
           k_smem->advance_offset_by_column<4>(k_smem_offset_r_first_half, 0);
       k_smem->ldmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
-      k_frag_apply_llama_rope<DTypeIn>((DTypeIn*)k_frag_local[0], (DTypeIn*)k_frag_local[1],
+      k_frag_apply_llama_rope<DTypeKV>((DTypeKV*)k_frag_local[0], (DTypeKV*)k_frag_local[1],
                                        rope_freq[fyi], kv_idx);
       k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
       k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
-      *k_smem_offset_r += 32 * channel_size_128b_in;
+      *k_smem_offset_r += 32 * channel_size_128b_kv;
       kv_idx += 32;
     }
     *k_smem_offset_r = (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) -
-                       ((warp_idx / 2) + num_frags_z) * 16 * channel_size_128b_in;
+                       ((warp_idx / 2) + num_frags_z) * 16 * channel_size_128b_kv;
   } else {
     const uint32_t warp_idx_x = get_warp_idx_x<num_warps_x, num_warps_z>(),
                    warp_idx_z = get_warp_idx_z<num_warps_x, num_warps_z>();
@@ -458,29 +459,30 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_id
         uint32_t k_smem_offset_r_last_half =
             k_smem->advance_offset_by_column<num_frags_y>(k_smem_offset_r_first_half, 0);
         k_smem->ldmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
-        k_frag_apply_llama_rope<DTypeIn>((DTypeIn*)k_frag_local[0], (DTypeIn*)k_frag_local[1],
+        k_frag_apply_llama_rope<DTypeKV>((DTypeKV*)k_frag_local[0], (DTypeKV*)k_frag_local[1],
                                          rope_freq[fyi], kv_idx);
         k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
         k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
         k_smem_offset_r_first_half =
             k_smem->advance_offset_by_column<2 * num_warps_x>(k_smem_offset_r_first_half, fyi);
       }
-      *k_smem_offset_r += 16 * channel_size_128b_in;
+      *k_smem_offset_r += 16 * channel_size_128b_kv;
       kv_idx += 16;
     }
     *k_smem_offset_r =
-        (*k_smem_offset_r ^ (0x2 * warp_idx_x)) - num_frags_z * 16 * channel_size_128b_in;
+        (*k_smem_offset_r ^ (0x2 * warp_idx_x)) - num_frags_z * 16 * channel_size_128b_kv;
   }
 }
 
 template <LogitsPostHook logits_post_hook, uint32_t num_frags_x, uint32_t num_frags_y,
-          uint32_t num_frags_z, typename DTypeIn, typename DTypeQKAccum>
+          uint32_t num_frags_z, typename DTypeQ, typename DTypeKV, typename DTypeQKAccum>
 __device__ __forceinline__ void compute_qk(smem_t* q_smem, uint32_t* q_smem_offset_r,
                                            smem_t* k_smem, uint32_t* k_smem_offset_r,
                                            DTypeQKAccum (*s_frag)[num_frags_z][8],
                                            const float soft_cap) {
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
   uint32_t a_frag[num_frags_x][4], b_frag[4];
   // compute q*k^T
 #pragma unroll
@@ -488,24 +490,33 @@ __device__ __forceinline__ void compute_qk(smem_t* q_smem, uint32_t* q_smem_offs
 #pragma unroll
     for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
       q_smem->ldmatrix_m8n8x4(*q_smem_offset_r, a_frag[fx]);
-      *q_smem_offset_r = q_smem->advance_offset_by_row<16, channel_size_128b_in>(*q_smem_offset_r);
+      *q_smem_offset_r = q_smem->advance_offset_by_row<16, channel_size_128b_q>(*q_smem_offset_r);
     }
 
     *q_smem_offset_r = q_smem->advance_offset_by_column<2>(*q_smem_offset_r, fy) -
-                       num_frags_x * 16 * channel_size_128b_in;
+                       num_frags_x * 16 * channel_size_128b_q;
 
 #pragma unroll
     for (uint32_t fz = 0; fz < num_frags_z; ++fz) {
-      k_smem->ldmatrix_m8n8x4(*k_smem_offset_r, b_frag);
-      *k_smem_offset_r = k_smem->advance_offset_by_row<16, channel_size_128b_in>(*k_smem_offset_r);
+      if constexpr (sizeof(DTypeKV) == 1) {
+        uint32_t b_frag_f8[2];
+        k_smem->ldmatrix_m8n8x2(*k_smem_offset_r, b_frag_f8);
+        b_frag_f8[0] = frag_layout_transform_16b_to_8b(b_frag_f8[0]);
+        b_frag_f8[1] = frag_layout_transform_16b_to_8b(b_frag_f8[1]);
+        vec_cast<8>((DTypeKV*)b_frag_f8, (DTypeQ*)b_frag);
+      } else {
+        k_smem->ldmatrix_m8n8x4(*k_smem_offset_r, b_frag);
+      }
+      *k_smem_offset_r = k_smem->advance_offset_by_row<16, channel_size_128b_kv>(*k_smem_offset_r);
+
 #pragma unroll
       for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
         if constexpr (std::is_same<DTypeQKAccum, float>::value) {
           if (fy == 0) {
-            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeIn, MMAMode::kInit>(s_frag[fx][fz],
-                                                                               a_frag[fx], b_frag);
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ, MMAMode::kInit>(s_frag[fx][fz],
+                                                                              a_frag[fx], b_frag);
           } else {
-            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeIn>(s_frag[fx][fz], a_frag[fx], b_frag);
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(s_frag[fx][fz], a_frag[fx], b_frag);
           }
         } else if (std::is_same<DTypeQKAccum, half>::value) {
           if (fy == 0) {
@@ -518,11 +529,11 @@ __device__ __forceinline__ void compute_qk(smem_t* q_smem, uint32_t* q_smem_offs
         }
       }
     }
-    *k_smem_offset_r = k_smem->advance_offset_by_column<2>(*k_smem_offset_r, fy) -
-                       num_frags_z * 16 * channel_size_128b_in;
+    *k_smem_offset_r = k_smem->advance_offset_by_column<sizeof(DTypeKV)>(*k_smem_offset_r, fy) -
+                       num_frags_z * 16 * channel_size_128b_kv;
   }
   *q_smem_offset_r -= num_frags_y * 2;
-  *k_smem_offset_r -= num_frags_y * 2;
+  *k_smem_offset_r -= num_frags_y * sizeof(DTypeKV);
 
   if constexpr (std::is_same<DTypeQKAccum, float>::value) {
 #pragma unroll
@@ -690,21 +701,21 @@ __device__ __forceinline__ void update_mdo_states(DTypeQKAccum (*s_frag)[num_fra
   }
 }
 
-template <uint32_t num_frags_x, uint32_t num_frags_y, uint32_t num_frags_z, typename DTypeIn,
-          typename DTypeQKAccum>
+template <uint32_t num_frags_x, uint32_t num_frags_y, uint32_t num_frags_z, typename DTypeQ,
+          typename DTypeKV, typename DTypeQKAccum>
 __device__ __forceinline__ void compute_sfm_v(smem_t* v_smem, uint32_t* v_smem_offset_r,
                                               DTypeQKAccum (*s_frag)[num_frags_z][8],
                                               float (*o_frag)[num_frags_y][8], float (*d)[2]) {
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
 
-  DTypeIn s_frag_f16[num_frags_x][num_frags_z][8];
+  DTypeQ s_frag_f16[num_frags_x][num_frags_z][8];
   if constexpr (std::is_same<DTypeQKAccum, float>::value) {
 #pragma unroll
     for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
 #pragma unroll
       for (uint32_t fz = 0; fz < num_frags_z; ++fz) {
-        vec_cast<DTypeIn, float, 8>(s_frag_f16[fx][fz], s_frag[fx][fz]);
+        vec_cast<DTypeQ, float, 8>(s_frag_f16[fx][fz], s_frag[fx][fz]);
       }
     }
   }
@@ -726,23 +737,31 @@ __device__ __forceinline__ void compute_sfm_v(smem_t* v_smem, uint32_t* v_smem_o
 #pragma unroll
     for (uint32_t fy = 0; fy < num_frags_y; ++fy) {
       uint32_t b_frag[4];
-      v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag);
+      if constexpr (sizeof(DTypeKV) == 1) {
+        uint32_t b_frag_f8[2];
+        v_smem->ldmatrix_m8n8x2_trans(*v_smem_offset_r, b_frag_f8);
+        b_frag_f8[0] = frag_layout_transform_16b_to_8b_trans(b_frag_f8[0]);
+        b_frag_f8[1] = frag_layout_transform_16b_to_8b_trans(b_frag_f8[1]);
+        vec_cast<8>((DTypeKV*)b_frag_f8, (DTypeQ*)b_frag);
+      } else {
+        v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag);
+      }
 #pragma unroll
       for (uint32_t fx = 0; fx < num_frags_x; ++fx) {
         if constexpr (std::is_same<DTypeQKAccum, float>::value) {
-          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeIn>(
+          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
               o_frag[fx][fy], (uint32_t*)(s_frag_f16[fx][fz]), b_frag);
         } else {
-          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeIn>(o_frag[fx][fy],
-                                                             (uint32_t*)s_frag[fx][fz], b_frag);
+          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(o_frag[fx][fy],
+                                                            (uint32_t*)s_frag[fx][fz], b_frag);
         }
       }
-      *v_smem_offset_r = v_smem->advance_offset_by_column<2>(*v_smem_offset_r, fy);
+      *v_smem_offset_r = v_smem->advance_offset_by_column<sizeof(DTypeKV)>(*v_smem_offset_r, fy);
     }
-    *v_smem_offset_r =
-        v_smem->advance_offset_by_row<16, channel_size_128b_in>(*v_smem_offset_r) - 2 * num_frags_y;
+    *v_smem_offset_r = v_smem->advance_offset_by_row<16, channel_size_128b_kv>(*v_smem_offset_r) -
+                       sizeof(DTypeKV) * num_frags_y;
   }
-  *v_smem_offset_r -= 16 * num_frags_z * channel_size_128b_in;
+  *v_smem_offset_r -= 16 * num_frags_z * channel_size_128b_kv;
 }
 
 template <uint32_t num_frags_x, uint32_t num_frags_y, typename DTypeQKAccum>
@@ -942,7 +961,8 @@ __device__ __forceinline__ void write_o_reg_gmem(
  * \tparam num_frags_y The number of fragments in y dimension.
  * \tparam num_frags_z The number of fragments in z dimension.
  * \tparam num_warps The number of warps in the threadblock.
- * \tparam DTypeIn The data type of the input tensor.
+ * \tparam DTypeQ The data type of the query tensor.
+ * \tparam DTypeKV The data type of the key/value tensor.
  * \tparam DTypeOut The data type of the output tensor.
  * \param q The query tensor.
  * \param k The key tensor.
@@ -959,17 +979,17 @@ __device__ __forceinline__ void write_o_reg_gmem(
  */
 template <LogitsPostHook logits_post_hook, bool partition_kv, MaskMode mask_mode,
           PosEncodingMode pos_encoding_mode, uint32_t num_frags_x, uint32_t num_frags_y,
-          uint32_t num_frags_z, uint32_t num_warps_x, uint32_t num_warps_z, typename DTypeIn,
+          uint32_t num_frags_z, uint32_t num_warps_x, uint32_t num_warps_z, typename DTypeQ,
           typename DTypeQKAccum, typename DTypeOut>
 __global__
 __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVCacheKernel(
-    DTypeIn* __restrict__ q, DTypeIn* __restrict__ k, DTypeIn* __restrict__ v,
+    DTypeQ* __restrict__ q, DTypeKV* __restrict__ k, DTypeKV* __restrict__ v,
     uint8_t* __restrict__ custom_mask, DTypeOut* __restrict__ o, float* __restrict__ lse,
     const uint32_t qo_len, const uint32_t kv_len, const uint_fastdiv group_size,
     const uint32_t q_stride_n, const uint32_t q_stride_h, const uint32_t kv_stride_n,
     const uint32_t kv_stride_h, const int32_t maybe_window_left, const float logits_soft_cap,
     float sm_scale, const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
-  static_assert(sizeof(DTypeIn) == 2);
+  static_assert(sizeof(DTypeQ) == 2);
   static_assert(sizeof(DTypeOut) == 2);
   sm_scale *=
       (logits_post_hook == LogitsPostHook::kNone ? math::log2e : math::ptx_rcp(logits_soft_cap));
@@ -989,7 +1009,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
   const uint32_t window_left = (maybe_window_left >= 0) ? maybe_window_left : kv_len;
 
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
+  // constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   extern __shared__ uint8_t smem[];
@@ -1008,9 +1029,9 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
   const uint32_t qo_packed_idx_base =
       (bx * num_warps_x + get_warp_idx_x<num_warps_x, num_warps_z>()) * num_frags_x * 16;
   smem_t qo_smem(smem);
-  DTypeIn* q_ptr_base =
+  DTypeQ* q_ptr_base =
       q + qkv_info.get_q_elem_offset(0, kv_head_idx * group_size,
-                                     (lane_idx % 8) * num_elems_per_128b<DTypeIn>());
+                                     (lane_idx % 8) * num_elems_per_128b<DTypeQ>());
   DTypeOut* o_ptr_base =
       partition_kv
           ? o + chunk_idx * num_qo_heads * head_dim +
@@ -1018,7 +1039,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
                                            (lane_idx % 8) * num_elems_per_128b<DTypeOut>())
           : o + qkv_info.get_o_elem_offset(0, kv_head_idx * group_size,
                                            (lane_idx % 8) * num_elems_per_128b<DTypeOut>());
-  uint32_t q_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+  uint32_t q_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_q>(
       get_warp_idx_x<num_warps_x, num_warps_z>() * num_frags_x * 16 + lane_idx % 16, lane_idx / 16);
 
   load_q_global_smem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
@@ -1030,11 +1051,11 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
 
   if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
     q_smem_inplace_apply_rotary_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x,
-                                                  num_frags_y, DTypeIn>(
+                                                  num_frags_y, DTypeQ>(
         qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq,
         sm_scale);
   } else {
-    q_smem_inplace_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x, num_frags_y, DTypeIn>(
+    q_smem_inplace_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x, num_frags_y, DTypeQ>(
         &qo_smem, sm_scale);
   }
 
@@ -1051,9 +1072,9 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     }
   }
 
-  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeIn)),
+  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeKV)),
       v_smem(smem + (num_warps_x * num_frags_x + num_warps_z * num_frags_z) * 16 * head_dim *
-                        sizeof(DTypeIn));
+                        sizeof(DTypeKV));
 
   const uint32_t num_iterations = ceil_div(
       mask_mode == MaskMode::kCausal
@@ -1076,20 +1097,20 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
            : (chunk_end - chunk_start)) /
       (16 * num_warps_z * num_frags_z);
 
-  DTypeIn* k_ptr =
+  DTypeKV* k_ptr =
       k + qkv_info.get_kv_elem_offset(chunk_start + warp_idx * 4 + lane_idx / 8, kv_head_idx,
-                                      (lane_idx % 8) * num_elems_per_128b<DTypeIn>());
-  DTypeIn* v_ptr =
+                                      (lane_idx % 8) * num_elems_per_128b<DTypeKV>());
+  DTypeKV* v_ptr =
       v + qkv_info.get_kv_elem_offset(chunk_start + warp_idx * 4 + lane_idx / 8, kv_head_idx,
-                                      (lane_idx % 8) * num_elems_per_128b<DTypeIn>());
-  uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+                                      (lane_idx % 8) * num_elems_per_128b<DTypeKV>());
+  uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + 8 * (lane_idx / 16) +
                    lane_idx % 8,
                (lane_idx % 16) / 8),
-           v_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+           v_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + lane_idx % 16,
                lane_idx / 16),
-           kv_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_in>(
+           kv_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_kv>(
                warp_idx * 4 + lane_idx / 8, lane_idx % 8);
   produce_kv<SharedMemFillMode::kNoFill, num_warps_x, num_warps_z, num_frags_y, num_frags_z>(
       k_smem, &kv_smem_offset_w, &k_ptr, kv_stride_n, chunk_start, chunk_end);
@@ -1104,14 +1125,14 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     block.sync();
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
-      k_smem_inplace_apply_rotary<num_warps_x, num_warps_z, num_frags_y, num_frags_z, DTypeIn>(
+      k_smem_inplace_apply_rotary<num_warps_x, num_warps_z, num_frags_y, num_frags_z, DTypeKV>(
           chunk_start + iter * 16 * num_warps_z * num_frags_z, &k_smem, &k_smem_offset_r,
           rope_freq);
       block.sync();
     }
 
     // compute attention score
-    compute_qk<logits_post_hook, num_frags_x, num_frags_y, num_frags_z, DTypeIn>(
+    compute_qk<logits_post_hook, num_frags_x, num_frags_y, num_frags_z, DTypeQ, DTypeKV>(
         &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag, logits_soft_cap);
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
@@ -1150,8 +1171,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     block.sync();
 
     // compute sfm*v
-    compute_sfm_v<num_frags_x, num_frags_y, num_frags_z, DTypeIn>(&v_smem, &v_smem_offset_r, s_frag,
-                                                                  o_frag, d);
+    compute_sfm_v<num_frags_x, num_frags_y, num_frags_z, DTypeQ, DTypeKV>(&v_smem, &v_smem_offset_r,
+                                                                          s_frag, o_frag, d);
 
     block.sync();
     produce_kv<SharedMemFillMode::kFillZero, num_warps_x, num_warps_z, num_frags_y, num_frags_z>(
@@ -1202,13 +1223,13 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
 
 template <bool partition_kv, LogitsPostHook logits_post_hook, MaskMode mask_mode,
           PosEncodingMode pos_encoding_mode, uint32_t num_frags_x, uint32_t num_frags_y,
-          uint32_t num_frags_z, uint32_t num_warps_x, uint32_t num_warps_z, typename DTypeIn,
-          typename DTypeQKAccum, typename DTypeOut, typename IdType>
+          uint32_t num_frags_z, uint32_t num_warps_x, uint32_t num_warps_z, typename DTypeQ,
+          typename DTypeKV, typename DTypeQKAccum, typename DTypeOut, typename IdType>
 __global__
 __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRaggedKVCacheKernel(
-    DTypeIn* __restrict__ q, IdType* __restrict__ request_indices,
+    DTypeQ* __restrict__ q, IdType* __restrict__ request_indices,
     IdType* __restrict__ q_tile_indices, IdType* __restrict__ kv_tile_indices,
-    IdType* __restrict__ q_indptr, DTypeIn* __restrict__ k, DTypeIn* __restrict__ v,
+    IdType* __restrict__ q_indptr, DTypeKV* __restrict__ k, DTypeKV* __restrict__ v,
     IdType* __restrict__ kv_indptr, uint8_t* __restrict__ custom_mask,
     IdType* __restrict__ qk_indptr, IdType* __restrict__ q_offset,
     IdType* __restrict__ k_rope_pos_offset, IdType* __restrict__ o_indptr, DTypeOut* __restrict__ o,
@@ -1217,7 +1238,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     const uint32_t q_stride_n, const uint32_t q_stride_h, const uint32_t kv_stride_n,
     const uint32_t kv_stride_h, const int32_t maybe_window_left, const float logits_soft_cap,
     float sm_scale, const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
-  static_assert(sizeof(DTypeIn) == 2);
+  static_assert(sizeof(DTypeQ) == 2);
   static_assert(sizeof(DTypeOut) == 2);
   sm_scale *=
       (logits_post_hook == LogitsPostHook::kNone ? math::log2e : math::ptx_rcp(logits_soft_cap));
@@ -1246,7 +1267,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
   const uint32_t qo_upper_bound =
       min(qo_len, ceil_div((qo_tile_idx + 1) * num_rows_per_cta, group_size));
 
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   extern __shared__ uint8_t smem[];
@@ -1266,11 +1288,11 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
       (qo_tile_idx * num_warps_x + get_warp_idx_x<num_warps_x, num_warps_z>()) * num_frags_x * 16;
   smem_t qo_smem(smem);
 
-  DTypeIn* q_ptr_base =
+  DTypeQ* q_ptr_base =
       q + qkv_info.get_q_elem_offset(q_indptr[request_idx], kv_head_idx * group_size,
-                                     (lane_idx % 8) * num_elems_per_128b<DTypeIn>());
+                                     (lane_idx % 8) * num_elems_per_128b<DTypeQ>());
 
-  DTypeIn* o_ptr_base =
+  DTypeOut* o_ptr_base =
       partition_kv
           ? o + kv_tile_idx * num_qo_heads * head_dim +
                 qkv_info.get_o_elem_offset(o_indptr[request_idx], kv_head_idx * group_size,
@@ -1278,7 +1300,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
           : o + qkv_info.get_o_elem_offset(o_indptr[request_idx], kv_head_idx * group_size,
                                            (lane_idx % 8) * num_elems_per_128b<DTypeOut>());
 
-  uint32_t q_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+  uint32_t q_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_q>(
       get_warp_idx_x<num_warps_x, num_warps_z>() * num_frags_x * 16 + lane_idx % 16, lane_idx / 16);
 
   load_q_global_smem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
@@ -1291,17 +1313,17 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
   if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
     if (!q_offset) {
       q_smem_inplace_apply_rotary_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x,
-                                                    num_frags_y, DTypeIn>(
+                                                    num_frags_y, DTypeQ>(
           qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq,
           sm_scale);
     } else {
       q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x,
-                                                             num_frags_y, DTypeIn>(
+                                                             num_frags_y, DTypeQ>(
           qo_packed_idx_base, q_offset + q_indptr[request_idx], &qo_smem, group_size,
           &q_smem_offset_r, rope_freq, sm_scale);
     }
   } else {
-    q_smem_inplace_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x, num_frags_y, DTypeIn>(
+    q_smem_inplace_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x, num_frags_y, DTypeQ>(
         &qo_smem, sm_scale);
   }
 
@@ -1340,26 +1362,26 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
            : chunk_end - chunk_start) /
       (16 * num_warps_z * num_frags_z);
 
-  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeIn)),
+  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeKV)),
       v_smem(smem + (num_warps_x * num_frags_x + num_warps_z * num_frags_z) * 16 * head_dim *
-                        sizeof(DTypeIn));
+                        sizeof(DTypeKV));
 
-  uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+  uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + 8 * (lane_idx / 16) +
                    lane_idx % 8,
                (lane_idx % 16) / 8),
-           v_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+           v_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + lane_idx % 16,
                lane_idx / 16),
-           kv_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_in>(
+           kv_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_kv>(
                warp_idx * 4 + lane_idx / 8, lane_idx % 8);
 
-  DTypeIn* k_ptr = k + qkv_info.get_kv_elem_offset(
+  DTypeKV* k_ptr = k + qkv_info.get_kv_elem_offset(
                            kv_indptr[request_idx] + chunk_start + warp_idx * 4 + lane_idx / 8,
-                           kv_head_idx, (lane_idx % 8) * num_elems_per_128b<DTypeIn>());
-  DTypeIn* v_ptr = v + qkv_info.get_kv_elem_offset(
+                           kv_head_idx, (lane_idx % 8) * num_elems_per_128b<DTypeKV>());
+  DTypeKV* v_ptr = v + qkv_info.get_kv_elem_offset(
                            kv_indptr[request_idx] + chunk_start + warp_idx * 4 + lane_idx / 8,
-                           kv_head_idx, (lane_idx % 8) * num_elems_per_128b<DTypeIn>());
+                           kv_head_idx, (lane_idx % 8) * num_elems_per_128b<DTypeKV>());
 
   produce_kv<SharedMemFillMode::kNoFill, num_warps_x, num_warps_z, num_frags_y, num_frags_z>(
       k_smem, &kv_smem_offset_w, &k_ptr, kv_stride_n, chunk_start, chunk_end);
@@ -1374,7 +1396,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     block.sync();
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
-      k_smem_inplace_apply_rotary<num_warps_x, num_warps_z, num_frags_y, num_frags_z, DTypeIn>(
+      k_smem_inplace_apply_rotary<num_warps_x, num_warps_z, num_frags_y, num_frags_z, DTypeKV>(
           (k_rope_pos_offset == nullptr ? 0 : k_rope_pos_offset[request_idx]) + chunk_start +
               iter * 16 * num_warps_z * num_frags_z,
           &k_smem, &k_smem_offset_r, rope_freq);
@@ -1382,7 +1404,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     }
 
     // compute attention score
-    compute_qk<logits_post_hook, num_frags_x, num_frags_y, num_frags_z, DTypeIn>(
+    compute_qk<logits_post_hook, num_frags_x, num_frags_y, num_frags_z, DTypeQ, DTypeKV>(
         &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag, logits_soft_cap);
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
@@ -1423,8 +1445,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     block.sync();
 
     // compute sfm*v
-    compute_sfm_v<num_frags_x, num_frags_y, num_frags_z, DTypeIn>(&v_smem, &v_smem_offset_r, s_frag,
-                                                                  o_frag, d);
+    compute_sfm_v<num_frags_x, num_frags_y, num_frags_z, DTypeQ, DTypeKV>(&v_smem, &v_smem_offset_r,
+                                                                          s_frag, o_frag, d);
 
     block.sync();
     produce_kv<SharedMemFillMode::kFillZero, num_warps_x, num_warps_z, num_frags_y, num_frags_z>(
@@ -1480,20 +1502,20 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
 template <bool partition_kv, LogitsPostHook logits_post_hook, MaskMode mask_mode,
           PosEncodingMode pos_encoding_mode, uint32_t num_frags_x, uint32_t num_frags_y,
           uint32_t num_frags_z, uint32_t num_warps_x, uint32_t num_warps_z,
-          PageStorage page_storage, typename DTypeIn, typename DTypeQKAccum, typename DTypeOut,
-          typename IdType>
+          PageStorage page_storage, typename DTypeQ, typename DTypeKV, typename DTypeQKAccum,
+          typename DTypeOut, typename IdType>
 __global__
 __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPagedKVCacheKernel(
     IdType* __restrict__ request_indices, IdType* __restrict__ q_tile_indices,
-    IdType* __restrict__ kv_tile_indices, DTypeIn* __restrict__ q,
-    paged_kv_t<page_storage, DTypeIn, IdType> paged_kv, IdType* __restrict__ q_indptr,
+    IdType* __restrict__ kv_tile_indices, DTypeQ* __restrict__ q,
+    paged_kv_t<page_storage, DTypeKV, IdType> paged_kv, IdType* __restrict__ q_indptr,
     uint8_t* __restrict__ custom_mask, IdType* __restrict__ qk_indptr,
     IdType* __restrict__ q_offset, IdType* __restrict__ o_indptr, DTypeOut* __restrict__ o,
     float* __restrict__ lse, bool* __restrict__ block_valid_mask,
     IdType* __restrict__ kv_chunk_size_ptr, const uint_fastdiv group_size,
     int32_t maybe_window_left, const float logits_soft_cap, float sm_scale,
     const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
-  static_assert(sizeof(DTypeIn) == 2);
+  static_assert(sizeof(DTypeQ) == 2);
   static_assert(sizeof(DTypeOut) == 2);
   sm_scale *=
       (logits_post_hook == LogitsPostHook::kNone ? math::log2e : math::ptx_rcp(logits_soft_cap));
@@ -1525,7 +1547,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
       min(qo_len, ceil_div((qo_tile_idx + 1) * num_rows_per_cta, group_size));
 
   constexpr uint32_t head_dim = num_frags_y * 16;
-  constexpr uint32_t channel_size_128b_in = head_dim / num_elems_per_128b<DTypeIn>();
+  constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   extern __shared__ uint8_t smem[];
@@ -1545,10 +1568,10 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
       (qo_tile_idx * num_warps_x + get_warp_idx_x<num_warps_x, num_warps_z>()) * num_frags_x * 16;
   const uint32_t q_stride_n = num_qo_heads * head_dim, q_stride_h = head_dim;
   smem_t qo_smem(smem);
-  DTypeIn* q_ptr_base = q + get_elem_offset_impl(q_indptr[request_idx], kv_head_idx * group_size,
-                                                 (lane_idx % 8) * num_elems_per_128b<DTypeIn>(),
-                                                 q_stride_n, q_stride_h);
-  DTypeIn* o_ptr_base =
+  DTypeQ* q_ptr_base = q + get_elem_offset_impl(q_indptr[request_idx], kv_head_idx * group_size,
+                                                (lane_idx % 8) * num_elems_per_128b<DTypeQ>(),
+                                                q_stride_n, q_stride_h);
+  DTypeOut* o_ptr_base =
       partition_kv ? o + kv_tile_idx * num_qo_heads * head_dim +
                          get_elem_offset_impl(o_indptr[request_idx], kv_head_idx * group_size,
                                               (lane_idx % 8) * num_elems_per_128b<DTypeOut>(),
@@ -1556,7 +1579,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
                    : o + get_elem_offset_impl(o_indptr[request_idx], kv_head_idx * group_size,
                                               (lane_idx % 8) * num_elems_per_128b<DTypeOut>(),
                                               num_qo_heads * head_dim, head_dim);
-  uint32_t q_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+  uint32_t q_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_q>(
       get_warp_idx_x<num_warps_x, num_warps_z>() * num_frags_x * 16 + lane_idx % 16, lane_idx / 16);
 
   load_q_global_smem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
@@ -1569,17 +1592,17 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
   if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
     if (q_offset == nullptr) {
       q_smem_inplace_apply_rotary_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x,
-                                                    num_frags_y, DTypeIn>(
+                                                    num_frags_y, DTypeQ>(
           qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq,
           sm_scale);
     } else {
       q_smem_inplace_apply_rotary_with_pos_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x,
-                                                             num_frags_y, DTypeIn>(
+                                                             num_frags_y, DTypeQ>(
           qo_packed_idx_base, q_offset + q_indptr[request_idx], &qo_smem, group_size,
           &q_smem_offset_r, rope_freq, sm_scale);
     }
   } else {
-    q_smem_inplace_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x, num_frags_y, DTypeIn>(
+    q_smem_inplace_multiply_sm_scale<num_warps_x, num_warps_z, num_frags_x, num_frags_y, DTypeQ>(
         &qo_smem, sm_scale);
   }
 
@@ -1596,19 +1619,19 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     }
   }
 
-  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeIn)),
+  smem_t k_smem(smem + (num_warps_x * num_frags_x) * 16 * head_dim * sizeof(DTypeKV)),
       v_smem(smem + (num_warps_x * num_frags_x + num_warps_z * num_frags_z) * 16 * head_dim *
-                        sizeof(DTypeIn));
+                        sizeof(DTypeKV));
   size_t kv_offset[num_frags_z * 4 / num_warps_x];
 
-  uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+  uint32_t k_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + 8 * (lane_idx / 16) +
                    lane_idx % 8,
                (lane_idx % 16) / 8),
-           v_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_in>(
+           v_smem_offset_r = smem_t::get_permuted_offset<channel_size_128b_kv>(
                get_warp_idx_z<num_warps_x, num_warps_z>() * num_frags_z * 16 + lane_idx % 16,
                lane_idx / 16),
-           kv_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_in>(
+           kv_smem_offset_w = smem_t::get_permuted_offset<channel_size_128b_kv>(
                warp_idx * 4 + lane_idx / 8, lane_idx % 8);
   const IdType last_indptr = paged_kv.indptr[paged_kv.batch_size];
 
@@ -1622,7 +1645,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     kv_offset[i] =
         page_iter < last_indptr
             ? paged_kv.get_elem_offset(__ldg(paged_kv.indices + page_iter), kv_head_idx, entry_idx,
-                                       (lane_idx % 8) * num_elems_per_128b<DTypeIn>())
+                                       (lane_idx % 8) * num_elems_per_128b<DTypeKV>())
             : 0;
   }
   page_produce_kv<false, num_warps_x, num_warps_z, num_frags_y, num_frags_z>(
@@ -1666,14 +1689,14 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
       kv_offset[i] =
           page_iter < last_indptr
               ? paged_kv.get_elem_offset(__ldg(paged_kv.indices + page_iter), kv_head_idx,
-                                         entry_idx, (lane_idx % 8) * num_elems_per_128b<DTypeIn>())
+                                         entry_idx, (lane_idx % 8) * num_elems_per_128b<DTypeKV>())
               : 0;
     }
     cp_async::wait_group<1>();
     block.sync();
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kRoPELlama) {
-      k_smem_inplace_apply_rotary<num_warps_x, num_warps_z, num_frags_y, num_frags_z, DTypeIn>(
+      k_smem_inplace_apply_rotary<num_warps_x, num_warps_z, num_frags_y, num_frags_z, DTypeKV>(
           (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[request_idx]) +
               chunk_start + iter * 16 * num_warps_z * num_frags_z,
           &k_smem, &k_smem_offset_r, rope_freq);
@@ -1681,7 +1704,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     }
 
     // compute attention score
-    compute_qk<logits_post_hook, num_frags_x, num_frags_y, num_frags_z, DTypeIn>(
+    compute_qk<logits_post_hook, num_frags_x, num_frags_y, num_frags_z, DTypeQ, DTypeKV>(
         &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag, logits_soft_cap);
 
     if constexpr (pos_encoding_mode == PosEncodingMode::kALiBi) {
@@ -1722,8 +1745,8 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     block.sync();
 
     // compute sfm*v
-    compute_sfm_v<num_frags_x, num_frags_y, num_frags_z, DTypeIn>(&v_smem, &v_smem_offset_r, s_frag,
-                                                                  o_frag, d);
+    compute_sfm_v<num_frags_x, num_frags_y, num_frags_z, DTypeQ, DTypeKV>(&v_smem, &v_smem_offset_r,
+                                                                          s_frag, o_frag, d);
 
     block.sync();
     page_produce_kv<true, num_warps_x, num_warps_z, num_frags_y, num_frags_z>(
@@ -1777,10 +1800,11 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
 }
 
 template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode pos_encoding_mode,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut>
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeQ, typename DTypeKV,
+          typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(
-    DTypeIn* q, DTypeIn* k, DTypeIn* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp,
-    float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
+    DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp, float* lse,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
     uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n, uint32_t kv_stride_h,
     int32_t window_left, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
     cudaStream_t stream) {
@@ -1812,7 +1836,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
   DISPATCH_WARP_LAYOUT(warp_layout, WARP_LAYOUT, {
     constexpr uint32_t num_frags_x = get_num_frags_x<WARP_LAYOUT>();
     using DTypeQKAccum =
-        typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeIn, half>::value,
+        typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeQ, half>::value,
                                   half, float>::type;
 
     int dev_id = 0;
@@ -1821,7 +1845,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
     FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
         &max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
     // we expect each sm execute two threadblocks
-    const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM * sizeof(DTypeIn) * 16) ? 2 : 1;
+    // TODO(Zihao): fix the following computation
+    const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM * sizeof(DTypeQ) * 16) ? 2 : 1;
     const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
 
     constexpr uint32_t num_warps_x = get_num_warps_x<WARP_LAYOUT>();
@@ -1831,8 +1856,9 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
          !ALLOW_FP16_QK_REDUCTION)
             ? 2
             : (8 / num_frags_x);
+    // TODO(Zihao): fix the following computation
     const uint32_t max_num_frags_z_smem =
-        (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeIn)) - num_frags_x * num_warps_x) /
+        (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeQ)) - num_frags_x * num_warps_x) /
         (2 * num_warps_z);
 
     // control num_frags_z for maximum warp occupancy
@@ -1850,11 +1876,14 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
       } else {
         constexpr uint32_t num_threads = (num_warps_x * num_warps_z) * warp_size;
         constexpr uint32_t num_rows_per_cta = num_frags_x * num_warps_x * 16;
-        auto partition_kv_kernel = SinglePrefillWithKVCacheKernel<
-            LOGITS_POST_HOOK, /*partition_kv=*/true, MASK_MODE, pos_encoding_mode, num_frags_x,
-            num_frags_y, num_frags_z, num_warps_x, num_warps_z, DTypeIn, DTypeQKAccum, DTypeOut>;
+        auto partition_kv_kernel =
+            SinglePrefillWithKVCacheKernel<LOGITS_POST_HOOK, /*partition_kv=*/true, MASK_MODE,
+                                           pos_encoding_mode, num_frags_x, num_frags_y, num_frags_z,
+                                           num_warps_x, num_warps_z, DTypeQ, DTypeKV, DTypeQKAccum,
+                                           DTypeOut>;
+        // TODO(Zihao): fix the following computation
         uint32_t smem_size = (num_frags_x * num_warps_x + num_frags_z * num_warps_z * 2) * 16 *
-                             HEAD_DIM * sizeof(DTypeIn);
+                             HEAD_DIM * sizeof(DTypeQ);
         FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
             partition_kv_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
         int num_blocks_per_sm = 0;
@@ -1876,9 +1905,11 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
 
         if (num_chunks <= 1 || tmp == nullptr) {
           // Enough parallelism, do not split-kv
-          auto kernel = SinglePrefillWithKVCacheKernel<
-              LOGITS_POST_HOOK, /*partition_kv=*/false, MASK_MODE, pos_encoding_mode, num_frags_x,
-              num_frags_y, num_frags_z, num_warps_x, num_warps_z, DTypeIn, DTypeQKAccum, DTypeOut>;
+          auto kernel =
+              SinglePrefillWithKVCacheKernel<LOGITS_POST_HOOK, /*partition_kv=*/false, MASK_MODE,
+                                             pos_encoding_mode, num_frags_x, num_frags_y,
+                                             num_frags_z, num_warps_x, num_warps_z, DTypeQ, DTypeKV,
+                                             DTypeQKAccum, DTypeOut>;
           void* args[] = {(void*)&q,
                           (void*)&k,
                           (void*)&v,
@@ -1939,10 +1970,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(
 
 template <WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK,
           PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename DTypeIn, typename DTypeOut, typename IdType>
+          typename DTypeQ, typename DTypeKV, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
-    DTypeIn* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
-    IdType* q_indptr, DTypeIn* k, DTypeIn* v, IdType* kv_indptr, uint8_t* custom_mask,
+    DTypeQ* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
+    IdType* q_indptr, DTypeKV* k, DTypeKV* v, IdType* kv_indptr, uint8_t* custom_mask,
     IdType* qk_indptr, IdType* q_offset, IdType* k_rope_pos_offset, IdType* o_indptr, DTypeOut* o,
     DTypeOut* tmp_v, float* tmp_s, float* lse, IdType* merge_indptr, bool* block_valid_mask,
     IdType* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
@@ -1967,7 +1998,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
   dim3 nthrs(32, num_warps_x, num_warps_z);
   constexpr uint32_t num_frags_y = HEAD_DIM / 16;
   using DTypeQKAccum =
-      typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeIn, half>::value, half,
+      typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeQ, half>::value, half,
                                 float>::type;
 
   int dev_id = 0;
@@ -1976,7 +2007,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
   FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm,
                                               cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
   // we expect each sm execute two threadblocks
-  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM * sizeof(DTypeIn) * 16) ? 2 : 1;
+  // TODO(Zihao): fix the following computation
+  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM * sizeof(DTypeQ) * 16) ? 2 : 1;
   const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
 
   const uint32_t max_num_frags_z_reg =
@@ -1984,8 +2016,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
        !ALLOW_FP16_QK_REDUCTION)
           ? 2
           : (8 / num_frags_x);
+  // TODO(Zihao): fix the following computation
   const uint32_t max_num_frags_z_smem =
-      (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeIn)) - num_frags_x * num_warps_x) /
+      (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeQ)) - num_frags_x * num_warps_x) /
       (2 * num_warps_z);
 
   DISPATCH_NUM_FRAGS_Z(min(max_num_frags_z_smem, max_num_frags_z_reg), num_frags_z, {
@@ -2000,14 +2033,15 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
                  " and report the issue to the developers.";
       throw std::invalid_argument(err_msg.str());
     } else {
+      // TODO(Zihao): fix the following computation
       uint32_t smem_size = (num_frags_x * num_warps_x + num_frags_z * num_warps_z * 2) * 16 *
-                           HEAD_DIM * sizeof(DTypeIn);
+                           HEAD_DIM * sizeof(DTypeQ);
       if (tmp_v == nullptr) {
         // do not partition kv
         auto kernel = BatchPrefillWithRaggedKVCacheKernel<
             /*partition_kv=*/false, LOGITS_POST_HOOK, MASK_MODE, pos_encoding_mode, num_frags_x,
-            num_frags_y, num_frags_z, num_warps_x, num_warps_z, DTypeIn, DTypeQKAccum, DTypeOut,
-            IdType>;
+            num_frags_y, num_frags_z, num_warps_x, num_warps_z, DTypeQ, DTypeKV, DTypeQKAccum,
+            DTypeOut, IdType>;
         FLASHINFER_CUDA_CALL(
             cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
         void* args[] = {(void*)&q,
@@ -2043,8 +2077,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
         // partition kv
         auto kernel = BatchPrefillWithRaggedKVCacheKernel<
             /*partition_kv=*/true, LOGITS_POST_HOOK, MASK_MODE, pos_encoding_mode, num_frags_x,
-            num_frags_y, num_frags_z, num_warps_x, num_warps_z, DTypeIn, DTypeQKAccum, DTypeOut,
-            IdType>;
+            num_frags_y, num_frags_z, num_warps_x, num_warps_z, DTypeQ, DTypeKV, DTypeQKAccum,
+            DTypeOut, IdType>;
         FLASHINFER_CUDA_CALL(
             cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
         void* args[] = {(void*)&q,
@@ -2086,11 +2120,11 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
 
 template <PageStorage page_storage, WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM,
           LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode pos_encoding_mode,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut,
-          typename IdType>
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeQ, typename DTypeKV,
+          typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(
-    DTypeIn* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
-    IdType* q_indptr, IdType* q_offset, paged_kv_t<page_storage, DTypeIn, IdType> paged_kv,
+    DTypeQ* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
+    IdType* q_indptr, IdType* q_offset, paged_kv_t<page_storage, DTypeKV, IdType> paged_kv,
     uint8_t* custom_mask, IdType* qk_indptr, IdType* o_indptr, DTypeOut* o, DTypeOut* tmp_v,
     float* tmp_s, float* lse, IdType* merge_indptr, bool* block_valid_mask,
     IdType* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
@@ -2116,7 +2150,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
 
   constexpr uint32_t num_frags_y = HEAD_DIM / 16;
   using DTypeQKAccum =
-      typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeIn, half>::value, half,
+      typename std::conditional<ALLOW_FP16_QK_REDUCTION && std::is_same<DTypeQ, half>::value, half,
                                 float>::type;
 
   int dev_id = 0;
@@ -2125,7 +2159,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
   FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm,
                                               cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
   // we expect each sm execute two threadblocks
-  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM * sizeof(DTypeIn) * 16) ? 2 : 1;
+  // TODO(Zihao): fix the following computation
+  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM * sizeof(DTypeQ) * 16) ? 2 : 1;
   const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
 
   const uint32_t max_num_frags_z_reg =
@@ -2133,8 +2168,9 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
        !ALLOW_FP16_QK_REDUCTION)
           ? 2
           : (8 / num_frags_x);
+  // TODO(Zihao): fix the following computation
   const uint32_t max_num_frags_z_smem =
-      (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeIn)) - num_frags_x * num_warps_x) /
+      (max_smem_per_threadblock / (16 * HEAD_DIM * sizeof(DTypeQ)) - num_frags_x * num_warps_x) /
       (2 * num_warps_z);
 
   DISPATCH_NUM_FRAGS_Z(min(max_num_frags_z_smem, max_num_frags_z_reg), num_frags_z, {
@@ -2149,15 +2185,16 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
                  " and report the issue to the developers.";
       throw std::invalid_argument(err_msg.str());
     } else {
+      // TODO(Zihao): fix the following computation
       uint32_t smem_size = (num_frags_x * num_warps_x + num_frags_z * num_warps_z * 2) * 16 *
-                           HEAD_DIM * sizeof(DTypeIn);
+                           HEAD_DIM * sizeof(DTypeQ);
 
       if (tmp_v == nullptr) {
         // do not partition kv
         auto kernel = BatchPrefillWithPagedKVCacheKernel<
             /*partition_kv=*/false, LOGITS_POST_HOOK, MASK_MODE, pos_encoding_mode, num_frags_x,
-            num_frags_y, num_frags_z, num_warps_x, num_warps_z, page_storage, DTypeIn, DTypeQKAccum,
-            DTypeOut, IdType>;
+            num_frags_y, num_frags_z, num_warps_x, num_warps_z, page_storage, DTypeQ, DTypeKV,
+            DTypeQKAccum, DTypeOut, IdType>;
 
         FLASHINFER_CUDA_CALL(
             cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -2186,8 +2223,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
       } else {
         auto kernel = BatchPrefillWithPagedKVCacheKernel<
             /*partition_kv=*/true, LOGITS_POST_HOOK, MASK_MODE, pos_encoding_mode, num_frags_x,
-            num_frags_y, num_frags_z, num_warps_x, num_warps_z, page_storage, DTypeIn, DTypeQKAccum,
-            DTypeOut, IdType>;
+            num_frags_y, num_frags_z, num_warps_x, num_warps_z, page_storage, DTypeQ, DTypeKV,
+            DTypeQKAccum, DTypeOut, IdType>;
 
         FLASHINFER_CUDA_CALL(
             cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -32,8 +32,8 @@
 #include "../permuted_smem.cuh"
 #include "../pos_enc.cuh"
 #include "../utils.cuh"
+#include "../frag_layout_swizzle.cuh"
 #include "cascade.cuh"
-#include "frag_layout_swizzle.cuh"
 #include "logits_post_hook.cuh"
 #include "mask.cuh"
 #include "warp_layout.cuh"
@@ -980,7 +980,7 @@ __device__ __forceinline__ void write_o_reg_gmem(
 template <LogitsPostHook logits_post_hook, bool partition_kv, MaskMode mask_mode,
           PosEncodingMode pos_encoding_mode, uint32_t num_frags_x, uint32_t num_frags_y,
           uint32_t num_frags_z, uint32_t num_warps_x, uint32_t num_warps_z, typename DTypeQ,
-          typename DTypeQKAccum, typename DTypeOut>
+          typename DTypeKV, typename DTypeQKAccum, typename DTypeOut>
 __global__
 __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVCacheKernel(
     DTypeQ* __restrict__ q, DTypeKV* __restrict__ k, DTypeKV* __restrict__ v,
@@ -1010,7 +1010,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
 
   constexpr uint32_t head_dim = num_frags_y * 16;
   constexpr uint32_t channel_size_128b_q = head_dim / num_elems_per_128b<DTypeQ>();
-  // constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
+  constexpr uint32_t channel_size_128b_kv = head_dim / num_elems_per_128b<DTypeKV>();
   constexpr uint32_t channel_size_128b_out = head_dim / num_elems_per_128b<DTypeOut>();
 
   extern __shared__ uint8_t smem[];

--- a/include/flashinfer/frag_layout_swizzle.cuh
+++ b/include/flashinfer/frag_layout_swizzle.cuh
@@ -17,6 +17,7 @@
 #define FLASHINFER_FRAG_LAYOUT_SWIZZLE_CUH_
 
 #include <cuda_runtime.h>
+#include <cstdint>
 
 __device__ __forceinline__ uint32_t frag_layout_transform_16b_to_8b(uint32_t x) {
   uint32_t tmp = __shfl_xor_sync(0xffffffff, x, 0x1);
@@ -35,6 +36,16 @@ __device__ __forceinline__ uint32_t frag_layout_transform_16b_to_8b_trans(uint32
   tmp = __shfl_xor_sync(0xffffffff, x, 0x10);
   x = __byte_perm(x, tmp, ((threadIdx.x & 0x10) == 0) ? 0x3276 : 0x5410);
   return x;
+}
+
+__device__ __forceinline__ void bfly_exch(uint32_t& a, uint32_t& b) {
+  uint32_t tmp = __byte_perm(a, b, 0x5410);
+  uint32_t tmp2 = __byte_perm(a, b, 0x7632);
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    printf("%x %x %x %x\n", a, b, tmp, tmp2);
+  }
+  a = tmp;
+  b = tmp2;
 }
 
 #endif  // FLASHINFER_FRAG_LAYOUT_SWIZZLE_CUH_

--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -81,6 +81,44 @@ __device__ __forceinline__ void ldmatrix_m8n8x4(uint32_t* R, T* smem_ptr) {
 }
 
 /*!
+ * \brief Wrapper of PTX ldmatrix m8n8.x4 instruction, loads data from shared memory
+ *   to fragment
+ * \tparam T data type of the fragment
+ * \param R pointer to the fragment
+ * \param smem_ptr pointer to the shared memory
+ */
+template <typename T>
+__device__ __forceinline__ void ldmatrix_m8n8x4_left_half(uint32_t* R, T* smem_ptr) {
+#ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
+  uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, _, %1, _}, [%2];\n"
+               : "=r"(R[0]), "=r"(R[1])
+               : "r"(smem_int_ptr));
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for ldmatrix instruction");
+#endif
+}
+
+/*!
+ * \brief Wrapper of PTX ldmatrix m8n8.x4 instruction, loads data from shared memory
+ *   to fragment
+ * \tparam T data type of the fragment
+ * \param R pointer to the fragment
+ * \param smem_ptr pointer to the shared memory
+ */
+template <typename T>
+__device__ __forceinline__ void ldmatrix_m8n8x4_right_half(uint32_t* R, T* smem_ptr) {
+#ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
+  uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {_, %0, _, %1}, [%2];\n"
+               : "=r"(R[0]), "=r"(R[1])
+               : "r"(smem_int_ptr));
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for ldmatrix instruction");
+#endif
+}
+
+/*!
  * \brief Wrapper of PTX ldmatrix m8n8.x4 transposed instruction, loads data from
  *   shared memory to fragment and transposes the fragment
  * \tparam T data type of the fragment
@@ -100,17 +138,17 @@ __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t* R, T* smem_ptr) 
 }
 
 /*!
- * \brief Wrapper of PTX ldmatrix m8n8.x2 instruction, loads data from shared memory
- *   to fragment
+ * \brief Wrapper of PTX ldmatrix m8n8.x4 transposed instruction, loads data from
+ *   shared memory to fragment and transposes the fragment
  * \tparam T data type of the fragment
  * \param R pointer to the fragment
  * \param smem_ptr pointer to the shared memory
  */
 template <typename T>
-__device__ __forceinline__ void ldmatrix_m8n8x2(uint32_t* R, T* smem_ptr) {
+__device__ __forceinline__ void ldmatrix_m8n8x4_trans_left_half(uint32_t* R, T* smem_ptr) {
 #ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
   uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
-  asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+  asm volatile("ldmatrix.sync.aligned.trans.m8n8.x4.shared.b16 {%0, %1, _, _}, [%2];\n"
                : "=r"(R[0]), "=r"(R[1])
                : "r"(smem_int_ptr));
 #else
@@ -119,17 +157,17 @@ __device__ __forceinline__ void ldmatrix_m8n8x2(uint32_t* R, T* smem_ptr) {
 }
 
 /*!
- * \brief Wrapper of PTX ldmatrix m8n8.x2 transposed instruction, loads data from
+ * \brief Wrapper of PTX ldmatrix m8n8.x4 transposed instruction, loads data from
  *   shared memory to fragment and transposes the fragment
  * \tparam T data type of the fragment
  * \param R pointer to the fragment
  * \param smem_ptr pointer to the shared memory
  */
 template <typename T>
-__device__ __forceinline__ void ldmatrix_m8n8x2_trans(uint32_t* R, T* smem_ptr) {
+__device__ __forceinline__ void ldmatrix_m8n8x4_trans_right_half(uint32_t* R, T* smem_ptr) {
 #ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
   uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
-  asm volatile("ldmatrix.sync.aligned.trans.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+  asm volatile("ldmatrix.sync.aligned.trans.m8n8.x4.shared.b16 {_, _, %0, %1}, [%2];\n"
                : "=r"(R[0]), "=r"(R[1])
                : "r"(smem_int_ptr));
 #else

--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -100,6 +100,44 @@ __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t* R, T* smem_ptr) 
 }
 
 /*!
+ * \brief Wrapper of PTX ldmatrix m8n8.x2 instruction, loads data from shared memory
+ *   to fragment
+ * \tparam T data type of the fragment
+ * \param R pointer to the fragment
+ * \param smem_ptr pointer to the shared memory
+ */
+template <typename T>
+__device__ __forceinline__ void ldmatrix_m8n8x2(uint32_t* R, T* smem_ptr) {
+#ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
+  uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+               : "=r"(R[0]), "=r"(R[1])
+               : "r"(smem_int_ptr));
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for ldmatrix instruction");
+#endif
+}
+
+/*!
+ * \brief Wrapper of PTX ldmatrix m8n8.x2 transposed instruction, loads data from
+ *   shared memory to fragment and transposes the fragment
+ * \tparam T data type of the fragment
+ * \param R pointer to the fragment
+ * \param smem_ptr pointer to the shared memory
+ */
+template <typename T>
+__device__ __forceinline__ void ldmatrix_m8n8x2_trans(uint32_t* R, T* smem_ptr) {
+#ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
+  uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.trans.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+               : "=r"(R[0]), "=r"(R[1])
+               : "r"(smem_int_ptr));
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for ldmatrix instruction");
+#endif
+}
+
+/*!
  * \brief Wrapper of PTX stmatrix m8n8.x4 instruction, stores data from fragment
  *   to shared memory
  * \tparam T data type of the fragment

--- a/include/flashinfer/permuted_smem.cuh
+++ b/include/flashinfer/permuted_smem.cuh
@@ -95,9 +95,19 @@ struct smem_t {
     mma::stmatrix_m8n8x4(R, smem_ptr);
   }
 
+  __device__ __forceinline__ void ldmatrix_m8n8x2(uint32_t offset, uint32_t* R) {
+    b128_t* smem_ptr = base + offset;
+    mma::ldmatrix_m8n8x2(R, smem_ptr);
+  }
+
   __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t offset, uint32_t* R) {
     b128_t* smem_ptr = base + offset;
     mma::ldmatrix_m8n8x4_trans(R, smem_ptr);
+  }
+
+  __device__ __forceinline__ void ldmatrix_m8n8x2_trans(uint32_t offset, uint32_t* R) {
+    b128_t* smem_ptr = base + offset;
+    mma::ldmatrix_m8n8x2_trans(R, smem_ptr);
   }
 
   template <cp_async::SharedMemFillMode fill_mode, typename T>

--- a/include/flashinfer/permuted_smem.cuh
+++ b/include/flashinfer/permuted_smem.cuh
@@ -90,14 +90,19 @@ struct smem_t {
     mma::ldmatrix_m8n8x4(R, smem_ptr);
   }
 
+  __device__ __forceinline__ void ldmatrix_m8n8x4_left_half(uint32_t offset, uint32_t* R) {
+    b128_t* smem_ptr = base + offset;
+    mma::ldmatrix_m8n8x4_left_half(R, smem_ptr);
+  }
+
+  __device__ __forceinline__ void ldmatrix_m8n8x4_right_half(uint32_t offset, uint32_t* R) {
+    b128_t* smem_ptr = base + offset;
+    mma::ldmatrix_m8n8x4_right_half(R, smem_ptr);
+  }
+
   __device__ __forceinline__ void stmatrix_m8n8x4(uint32_t offset, uint32_t* R) {
     b128_t* smem_ptr = base + offset;
     mma::stmatrix_m8n8x4(R, smem_ptr);
-  }
-
-  __device__ __forceinline__ void ldmatrix_m8n8x2(uint32_t offset, uint32_t* R) {
-    b128_t* smem_ptr = base + offset;
-    mma::ldmatrix_m8n8x2(R, smem_ptr);
   }
 
   __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t offset, uint32_t* R) {
@@ -105,9 +110,14 @@ struct smem_t {
     mma::ldmatrix_m8n8x4_trans(R, smem_ptr);
   }
 
-  __device__ __forceinline__ void ldmatrix_m8n8x2_trans(uint32_t offset, uint32_t* R) {
+  __device__ __forceinline__ void ldmatrix_m8n8x4_trans_left_half(uint32_t offset, uint32_t* R) {
     b128_t* smem_ptr = base + offset;
-    mma::ldmatrix_m8n8x2_trans(R, smem_ptr);
+    mma::ldmatrix_m8n8x4_trans_left_half(R, smem_ptr);
+  }
+
+  __device__ __forceinline__ void ldmatrix_m8n8x4_trans_right_half(uint32_t offset, uint32_t* R) {
+    b128_t* smem_ptr = base + offset;
+    mma::ldmatrix_m8n8x4_trans_right_half(R, smem_ptr);
   }
 
   template <cp_async::SharedMemFillMode fill_mode, typename T>

--- a/include/flashinfer/prefill_attention_decl.cuh
+++ b/include/flashinfer/prefill_attention_decl.cuh
@@ -30,20 +30,21 @@
 namespace flashinfer {
 
 template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode POS_ENCODING_MODE,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut>
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeQ, typename DTypeKV,
+          typename DTypeOut>
 cudaError_t SinglePrefillWithKVCacheDispatched(
-    DTypeIn* q, DTypeIn* k, DTypeIn* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp,
-    float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
+    DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* custom_mask, DTypeOut* o, DTypeOut* tmp, float* lse,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
     uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n, uint32_t kv_stride_h,
     int32_t window_left, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
     cudaStream_t stream);
 
 template <WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK,
           PosEncodingMode pos_encoding_mode, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename DTypeIn, typename DTypeOut, typename IdType>
+          typename DTypeQ, typename DTypeKV, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
-    DTypeIn* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
-    IdType* q_indptr, DTypeIn* k, DTypeIn* v, IdType* kv_indptr, uint8_t* custom_mask,
+    DTypeQ* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
+    IdType* q_indptr, DTypeKV* k, DTypeKV* v, IdType* kv_indptr, uint8_t* custom_mask,
     IdType* qk_indptr, IdType* q_offset, IdType* k_rope_pos_offset, IdType* o_indptr, DTypeOut* o,
     DTypeOut* tmp_v, float* tmp_s, float* lse, IdType* merge_indptr, bool* block_valid_mask,
     IdType* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
@@ -53,11 +54,11 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
 
 template <PageStorage page_storage, WarpLayout WARP_LAYOUT, uint32_t HEAD_DIM,
           LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode pos_encoding_mode,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut,
-          typename IdType>
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeQ, typename DTypeKV,
+          typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(
-    DTypeIn* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
-    IdType* q_indptr, IdType* q_offset, paged_kv_t<page_storage, DTypeIn, IdType> paged_kv,
+    DTypeQ* q, IdType* request_indices, IdType* q_tile_indices, IdType* kv_tile_indices,
+    IdType* q_indptr, IdType* q_offset, paged_kv_t<page_storage, DTypeKV, IdType> paged_kv,
     uint8_t* custom_mask, IdType* qk_indptr, IdType* o_indptr, DTypeOut* o, DTypeOut* tmp_v,
     float* tmp_s, float* lse, IdType* merge_indptr, bool* block_valid_mask,
     IdType* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
@@ -66,10 +67,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(
 
 template <PageStorage PAGE_STORAGE, uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK,
           PosEncodingMode POS_ENCODING_MODE, bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename DTypeIn, typename DTypeOut, typename IdType>
+          typename DTypeQ, typename DTypeKV, typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
-    BatchPrefillHandler* handler, DTypeIn* q, IdType* q_indptr, IdType* q_offset,
-    paged_kv_t<PAGE_STORAGE, DTypeIn, IdType> paged_kv, uint8_t* custom_mask, IdType* qk_indptr,
+    BatchPrefillHandler* handler, DTypeQ* q, IdType* q_indptr, IdType* q_offset,
+    paged_kv_t<PAGE_STORAGE, DTypeKV, IdType> paged_kv, uint8_t* custom_mask, IdType* qk_indptr,
     DTypeOut* o, float* lse, uint32_t num_qo_heads, int32_t window_left, float logits_soft_cap,
     float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream) {
   DTypeOut* tmp_v = nullptr;
@@ -103,7 +104,7 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
   DISPATCH_WARP_LAYOUT(warp_layout, WARP_LAYOUT, {
     return BatchPrefillWithPagedKVCacheDispatched<
         PAGE_STORAGE, WARP_LAYOUT, HEAD_DIM, LOGITS_POST_HOOK, POS_ENCODING_MODE,
-        ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeIn, DTypeOut, IdType>(
+        ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeQ, DTypeKV, DTypeOut, IdType>(
         q, request_indices, qo_tile_indices, kv_tile_indices, q_indptr, q_offset, paged_kv,
         custom_mask, qk_indptr, o_indptr, o, tmp_v, tmp_s, lse, merge_indptr, block_valid_mask,
         kv_chunk_size_ptr, total_num_rows, num_qo_heads, padded_batch_size, window_left,
@@ -113,10 +114,10 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapperDispatched(
 }
 
 template <uint32_t HEAD_DIM, LogitsPostHook LOGITS_POST_HOOK, PosEncodingMode POS_ENCODING_MODE,
-          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeIn, typename DTypeOut,
-          typename IdType>
+          bool ALLOW_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename DTypeQ, typename DTypeKV,
+          typename DTypeOut, typename IdType>
 cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
-    BatchPrefillHandler* handler, DTypeIn* q, IdType* q_indptr, DTypeIn* k, DTypeIn* v,
+    BatchPrefillHandler* handler, DTypeQ* q, IdType* q_indptr, DTypeKV* k, DTypeKV* v,
     IdType* kv_indptr, uint8_t* custom_mask, IdType* qk_indptr, IdType* q_offset,
     IdType* k_rope_pos_offset, DTypeOut* o, float* lse, uint32_t num_qo_heads,
     uint32_t num_kv_heads, uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n,
@@ -153,7 +154,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapperDispatched(
   DISPATCH_WARP_LAYOUT(warp_layout, WARP_LAYOUT, {
     return BatchPrefillWithRaggedKVCacheDispatched<WARP_LAYOUT, HEAD_DIM, LOGITS_POST_HOOK,
                                                    POS_ENCODING_MODE, ALLOW_FP16_QK_REDUCTION,
-                                                   MASK_MODE, DTypeIn, DTypeOut, IdType>(
+                                                   MASK_MODE, DTypeQ, DTypeKV, DTypeOut, IdType>(
         q, request_indices, qo_tile_indices, kv_tile_indices, q_indptr, k, v, kv_indptr,
         custom_mask, qk_indptr, q_offset, k_rope_pos_offset, o_indptr, o, tmp_v, tmp_s, lse,
         merge_indptr, block_valid_mask, kv_chunk_size_ptr, total_num_rows, num_qo_heads,

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -1050,7 +1050,7 @@ template <typename dst_t, typename src_t, size_t vec_size>
 FLASHINFER_INLINE void vec_cast(dst_t* dst, const src_t* src) {
 #pragma unroll
   for (size_t i = 0; i < vec_size; ++i) {
-    dst[i] = src[i];
+    dst[i] = (dst_t)src[i];
   }
 }
 

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -1070,6 +1070,64 @@ FLASHINFER_INLINE void vec_cast<half, float>(half* dst, const float* src) {
   }
 }
 
+#if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 890))
+template <size_t vec_size>
+FLASHINFER_INLINE void vec_cast<__nv_fp8_e4m3, half>(__nv_fp8_e4m3* dst, const half* src) {
+  if constexpr (vec_size == 1) {
+    dst[0] = __nv_fp8_e4m3(src[0]);
+  } else {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;"
+                   : "=h"(*(__nv_fp8x2_e4m3*)&dst[i * 2])
+                   : "r"(*(half2*)&src[i * 2]));
+    }
+  }
+}
+
+template <size_t vec_size>
+FLASHINFER_INLINE void vec_cast<__nv_fp8_e5m2, half>(__nv_fp8_e5m2* dst, const half* src) {
+  if constexpr (vec_size == 1) {
+    dst[0] = __nv_fp8_e5m2(src[0]);
+  } else {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      asm volatile("cvt.rn.satfinite.e5m2x2.f16x2 %0, %1;"
+                   : "=h"(*(__nv_fp8x2_e5m2*)&dst[i * 2])
+                   : "r"(*(half2*)&src[i * 2]));
+    }
+  }
+}
+
+template <size_t vec_size>
+FLASHINFER_INLINE void vec_cast<half, __nv_fp8_e4m3>(half* dst, const __nv_fp8_e4m3* src) {
+  if constexpr (vec_size == 1) {
+    dst[0] = half(src[0]);
+  } else {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;"
+                   : "=h"(*(half2*)&dst[i * 2])
+                   : "r"(*(__nv_fp8x2_e4m3*)&src[i * 2]));
+    }
+  }
+}
+
+template <size_t vec_size>
+FLASHINFER_INLINE void vec_cast<half, __nv_fp8_e5m2>(half* dst, const __nv_fp8_e5m2* src) {
+  if constexpr (vec_size == 1) {
+    dst[0] = half(src[0]);
+  } else {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      asm volatile("cvt.rn.f16x2.e5m2x2 %0, %1;"
+                   : "=h"(*(half2*)&dst[i * 2])
+                   : "r"(*(__nv_fp8x2_e5m2*)&src[i * 2]));
+    }
+  }
+}
+#endif
+
 #ifdef FLASHINFER_ENABLE_BF16
 template <size_t vec_size>
 FLASHINFER_INLINE void vec_cast<float, nv_bfloat16>(float* dst, const nv_bfloat16* src) {

--- a/python/generate_batch_paged_prefill_inst.py
+++ b/python/generate_batch_paged_prefill_inst.py
@@ -34,17 +34,18 @@ def get_cu_file_str(
     pos_encoding_mode,
     allow_fp16_qk_reduction,
     mask_mode,
-    dtype_in,
+    dtype_q,
+    dtype_kv,
     dtype_out,
     idtype,
 ):
     warp_layout_choice = [0, 1, 2]
     insts = "\n".join(
         [
-            """template cudaError_t BatchPrefillWithPagedKVCacheDispatched<page_storage, {warp_layout}, {head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}, {idtype}>(
-    {dtype_in}* q, {idtype}* request_indices, {idtype}* q_tile_indices, {idtype}* kv_tile_indices,
+            """template cudaError_t BatchPrefillWithPagedKVCacheDispatched<page_storage, {warp_layout}, {head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_q}, {dtype_kv}, {dtype_out}, {idtype}>(
+    {dtype_q}* q, {idtype}* request_indices, {idtype}* q_tile_indices, {idtype}* kv_tile_indices,
     {idtype}* q_indptr, {idtype}* q_offset,
-    paged_kv_t<page_storage, {dtype_in}, {idtype}> paged_kv, uint8_t* custom_mask,
+    paged_kv_t<page_storage, {dtype_kv}, {idtype}> paged_kv, uint8_t* custom_mask,
     {idtype}* qk_indptr, {idtype}* o_indptr, {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse,
     {idtype}* merge_indptr, bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, uint32_t max_num_rows,
     uint32_t num_qo_heads, uint32_t padded_batch_size, int32_t window_left,
@@ -56,7 +57,8 @@ def get_cu_file_str(
                 pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
                 allow_fp16_qk_reduction=allow_fp16_qk_reduction,
                 mask_mode=mask_mode_literal[int(mask_mode)],
-                dtype_in=dtype_literal[dtype_in],
+                dtype_q=dtype_literal[dtype_q],
+                dtype_kv=dtype_literal[dtype_kv],
                 dtype_out=dtype_literal[dtype_out],
                 idtype=idtype_literal[idtype],
             )
@@ -79,7 +81,7 @@ constexpr PageStorage page_storage = PageStorage::kIndices;
 if __name__ == "__main__":
     pattern = (
         r"batch_paged_prefill_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
-        r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)_idtype_([a-z0-9]+)\.cu"
+        r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypeq_([a-z0-9]+)_dtypekv_([a-z0-9]+)_dtypeout_([a-z0-9]+)_idtype_([a-z0-9]+)\.cu"
     )
     compiled_pattern = re.compile(pattern)
     path = Path(sys.argv[1])

--- a/python/generate_batch_ragged_prefill_inst.py
+++ b/python/generate_batch_ragged_prefill_inst.py
@@ -33,16 +33,17 @@ def get_cu_file_str(
     pos_encoding_mode,
     allow_fp16_qk_reduction,
     mask_mode,
-    dtype_in,
+    dtype_q,
+    dtype_kv,
     dtype_out,
     idtype,
 ):
     warp_layout_choice = [0, 1, 2]
     insts = "\n".join(
         [
-            """template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{warp_layout}, {head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}, {idtype}>(
-    {dtype_in}* q, {idtype}* request_indices, {idtype}* q_tile_indices, {idtype}* kv_tile_indices,
-    {idtype}* q_indptr, {dtype_in}* k, {dtype_in}* v, {idtype}* kv_indptr,
+            """template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{warp_layout}, {head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_q}, {dtype_kv}, {dtype_out}, {idtype}>(
+    {dtype_q}* q, {idtype}* request_indices, {idtype}* q_tile_indices, {idtype}* kv_tile_indices,
+    {idtype}* q_indptr, {dtype_kv}* k, {dtype_kv}* v, {idtype}* kv_indptr,
     uint8_t* custom_mask, {idtype}* qk_indptr, {idtype}* q_offset, {idtype}* k_rope_pos_offset,
     {idtype}* o_indptr, {dtype_out}* o, {dtype_out}* tmp_v, float* tmp_s, float* lse, {idtype}* merge_indptr,
     bool* block_valid_mask, {idtype}* kv_chunk_size_ptr, uint32_t total_num_rows, uint32_t num_qo_heads,
@@ -57,7 +58,8 @@ def get_cu_file_str(
                 pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
                 allow_fp16_qk_reduction=allow_fp16_qk_reduction,
                 mask_mode=mask_mode_literal[int(mask_mode)],
-                dtype_in=dtype_literal[dtype_in],
+                dtype_q=dtype_literal[dtype_q],
+                dtype_kv=dtype_literal[dtype_kv],
                 dtype_out=dtype_literal[dtype_out],
                 idtype=idtype_literal[idtype],
             )
@@ -79,7 +81,7 @@ namespace flashinfer {{
 if __name__ == "__main__":
     pattern = (
         r"batch_ragged_prefill_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
-        r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)_idtype_([a-z0-9]+)\.cu"
+        r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypeq_([a-z0-9]+)_dtypekv_([a-z0-9]+)_dtypeout_([a-z0-9]+)_idtype_([a-z0-9]+)\.cu"
     )
     compiled_pattern = re.compile(pattern)
     path = Path(sys.argv[1])

--- a/python/generate_single_prefill_inst.py
+++ b/python/generate_single_prefill_inst.py
@@ -31,7 +31,8 @@ def get_cu_file_str(
     pos_encoding_mode,
     allow_fp16_qk_reduction,
     mask_mode,
-    dtype_in,
+    dtype_q,
+    dtype_kv,
     dtype_out,
 ):
 
@@ -39,8 +40,8 @@ def get_cu_file_str(
 
 namespace flashinfer {{
 
-template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_in}, {dtype_out}>(
-    {dtype_in}* q, {dtype_in}* k, {dtype_in}* v, uint8_t* custom_mask, {dtype_out}* o,
+template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook}, {pos_encoding_mode}, {allow_fp16_qk_reduction}, {mask_mode}, {dtype_q}, {dtype_kv}, {dtype_out}>(
+    {dtype_q}* q, {dtype_kv}* k, {dtype_kv}* v, uint8_t* custom_mask, {dtype_out}* o,
     {dtype_out}* tmp, float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len, uint32_t kv_len,
     uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n, uint32_t kv_stride_h, int32_t window_left,
     float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta, cudaStream_t stream);
@@ -52,7 +53,8 @@ template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         allow_fp16_qk_reduction=allow_fp16_qk_reduction,
         mask_mode=mask_mode_literal[int(mask_mode)],
-        dtype_in=dtype_literal[dtype_in],
+        dtype_q=dtype_literal[dtype_q],
+        dtype_kv=dtype_literal[dtype_kv],
         dtype_out=dtype_literal[dtype_out],
     )
     return content
@@ -61,7 +63,7 @@ template cudaError_t SinglePrefillWithKVCacheDispatched<{head_dim}, {logits_hook
 if __name__ == "__main__":
     pattern = (
         r"single_prefill_head_([0-9]+)_logitshook_([0-9]+)_posenc_([0-9]+)_"
-        r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypein_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
+        r"fp16qkred_([a-z]+)_mask_([0-9]+)_dtypeq_([a-z0-9]+)_dtypekv_([a-z0-9]+)_dtypeout_([a-z0-9]+)\.cu"
     )
 
     compiled_pattern = re.compile(pattern)

--- a/python/setup.py
+++ b/python/setup.py
@@ -169,18 +169,20 @@ def get_instantiation_cu() -> List[str]:
         mask_modes,
     ):
         for dtype in prefill_dtypes:
-            fname = f"single_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}.cu"
-            files.append(prefix + "/" + fname)
-            content = generate_single_prefill_inst.get_cu_file_str(
-                head_dim,
-                logits_hook,
-                pos_encoding_mode,
-                allow_fp16_qk_reduction,
-                mask_mode,
-                dtype,
-                dtype,
-            )
-            write_if_different(root / prefix / fname, content)
+            for dtype_kv in fp8_dtypes:
+                fname = f"single_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypeq_{dtype}_dtypekv_{dtype_kv}_dtypeout_{dtype}.cu"
+                files.append(prefix + "/" + fname)
+                content = generate_single_prefill_inst.get_cu_file_str(
+                    head_dim,
+                    logits_hook,
+                    pos_encoding_mode,
+                    allow_fp16_qk_reduction,
+                    mask_mode,
+                    dtype, # dtype_q
+                    dtype_kv, # dtype_kv
+                    dtype, # dtype_out
+                )
+                write_if_different(root / prefix / fname, content)
 
     # batch paged prefill files
     for (
@@ -199,19 +201,21 @@ def get_instantiation_cu() -> List[str]:
         idtypes,
     ):
         for dtype in prefill_dtypes:
-            fname = f"batch_paged_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}_idtype_{idtype}.cu"
-            files.append(prefix + "/" + fname)
-            content = generate_batch_paged_prefill_inst.get_cu_file_str(
-                head_dim,
-                logits_hook,
-                pos_encoding_mode,
-                allow_fp16_qk_reduction,
-                mask_mode,
-                dtype,
-                dtype,
-                idtype,
-            )
-            write_if_different(root / prefix / fname, content)
+            for dtype_kv in fp8_dtypes:
+                fname = f"batch_paged_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypeq_{dtype}_dtypekv_{dtype_kv}_dtypeout_{dtype}_idtype_{idtype}.cu"
+                files.append(prefix + "/" + fname)
+                content = generate_batch_paged_prefill_inst.get_cu_file_str(
+                    head_dim,
+                    logits_hook,
+                    pos_encoding_mode,
+                    allow_fp16_qk_reduction,
+                    mask_mode,
+                    dtype, # dtype_q
+                    dtype_kv, # dtype_kv
+                    dtype, # dtype_out
+                    idtype,
+                )
+                write_if_different(root / prefix / fname, content)
 
     # batch ragged prefill files
     for (
@@ -230,19 +234,21 @@ def get_instantiation_cu() -> List[str]:
         idtypes,
     ):
         for dtype in prefill_dtypes:
-            fname = f"batch_ragged_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypein_{dtype}_dtypeout_{dtype}_idtype_{idtype}.cu"
-            files.append(prefix + "/" + fname)
-            content = generate_batch_ragged_prefill_inst.get_cu_file_str(
-                head_dim,
-                logits_hook,
-                pos_encoding_mode,
-                allow_fp16_qk_reduction,
-                mask_mode,
-                dtype,
-                dtype,
-                idtype,
-            )
-            write_if_different(root / prefix / fname, content)
+            for dtype_kv in fp8_dtypes:
+                fname = f"batch_ragged_prefill_head_{head_dim}_logitshook_{logits_hook}_posenc_{pos_encoding_mode}_fp16qkred_{allow_fp16_qk_reduction}_mask_{mask_mode}_dtypeq_{dtype}_dtypekv_{dtype_kv}_dtypeout_{dtype}_idtype_{idtype}.cu"
+                files.append(prefix + "/" + fname)
+                content = generate_batch_ragged_prefill_inst.get_cu_file_str(
+                    head_dim,
+                    logits_hook,
+                    pos_encoding_mode,
+                    allow_fp16_qk_reduction,
+                    mask_mode,
+                    dtype, # dtype_q
+                    dtype_kv, # dtype_kv
+                    dtype, # dtype_out
+                    idtype,
+                )
+                write_if_different(root / prefix / fname, content)
 
     return files
 

--- a/src/bench_single_prefill.cu
+++ b/src/bench_single_prefill.cu
@@ -24,6 +24,68 @@ using flashinfer::QKVLayout;
 
 inline uint32_t ceil_div(uint32_t a, uint32_t b) { return (a + b - 1) / b; }
 
+template <bool append>
+void bench_flashinfer_single_prefill_fp8(nvbench::state& state) {
+  size_t kv_len = state.get_int64("kv_len");
+  size_t qo_len = kv_len;
+  if (append) {
+    qo_len = state.get_int64("qo_len");
+    if (qo_len > kv_len) {
+      state.skip("qo_len > kv_len");
+    }
+  }
+  size_t num_qo_heads = state.get_int64("num_qo_heads");
+  size_t num_kv_heads = state.get_int64("num_kv_heads");
+  size_t head_dim = state.get_int64("head_dim");
+  size_t pos_encoding_mode = state.get_int64("pos_encoding_mode");
+  size_t kv_layout = state.get_int64("kv_layout");
+  bool causal = state.get_int64("causal");
+  bool cooperative = state.get_int64("cooperative");
+  bool allow_fp16_qk_reduction = state.get_int64("allow_fp16_qk_reduction");
+  // Allocate input data:
+  thrust::device_vector<half> Q(qo_len * num_qo_heads * head_dim);
+  thrust::device_vector<__nv_fp8_e4m3> K(kv_len * num_kv_heads * head_dim);
+  thrust::device_vector<__nv_fp8_e4m3> V(kv_len * num_kv_heads * head_dim);
+  thrust::device_vector<half> O(qo_len * num_qo_heads * head_dim);
+  thrust::device_vector<half> tmp(16 * 1024 * 1024);
+
+  // Provide throughput information:
+  state.add_global_memory_reads<uint8_t>(
+      (qo_len * num_qo_heads * sizeof(half) + 2 * kv_len * num_kv_heads) * head_dim, "Read");
+  state.add_global_memory_writes<half>(qo_len * num_qo_heads * head_dim, "Write");
+
+  state.exec(nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
+    timer.start();
+    cudaError_t status;
+    status = flashinfer::SinglePrefillWithKVCache<half, __nv_fp8_e4m3, half>(
+        thrust::raw_pointer_cast(Q.data()), thrust::raw_pointer_cast(K.data()),
+        thrust::raw_pointer_cast(V.data()), thrust::raw_pointer_cast(O.data()),
+        /*tmp=*/cooperative ? thrust::raw_pointer_cast(tmp.data()) : nullptr,
+        /*lse=*/nullptr, num_qo_heads, num_kv_heads, qo_len, kv_len, head_dim, causal,
+        QKVLayout(kv_layout), PosEncodingMode(pos_encoding_mode), allow_fp16_qk_reduction,
+        /*maybe_sm_scale=*/std::nullopt,
+        /*rope_scale=*/1.f,
+        /*rope_theta=*/1e4, launch.get_stream());
+    if (status != cudaSuccess) {
+      state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));
+    }
+    timer.stop();
+  });
+
+  const auto measured_mean = static_cast<nvbench::float32_t>(
+      state.get_summary("nv/cold/time/gpu/mean").get_float64("value"));
+  auto& summ = state.add_summary("nv/tflops");
+  summ.set_string("description", "Achieved TFlops/s");
+  summ.set_string("name", "TFlops/s");
+  float tflops;
+  if (causal) {
+    tflops = qo_len * (2 * kv_len - qo_len) * 2 * num_qo_heads * head_dim / measured_mean / 1e12;
+  } else {
+    tflops = qo_len * kv_len * 4 * num_qo_heads * head_dim / measured_mean / 1e12;
+  }
+  summ.set_float64("value", tflops);
+}
+
 template <typename dtype_in, typename dtype_out, bool append>
 void bench_flashinfer_single_prefill(nvbench::state& state) {
   size_t kv_len = state.get_int64("kv_len");
@@ -71,7 +133,7 @@ void bench_flashinfer_single_prefill(nvbench::state& state) {
           /*rope_scale=*/1.f,
           /*rope_theta=*/1e4, launch.get_stream());
     } else {
-      status = flashinfer::SinglePrefillWithKVCache<dtype_in, dtype_out>(
+      status = flashinfer::SinglePrefillWithKVCache<dtype_in, dtype_in, dtype_out>(
           thrust::raw_pointer_cast(Q.data()), thrust::raw_pointer_cast(K.data()),
           thrust::raw_pointer_cast(V.data()), thrust::raw_pointer_cast(O.data()),
           /*tmp=*/cooperative ? thrust::raw_pointer_cast(tmp.data()) : nullptr,
@@ -119,6 +181,20 @@ void bench_flashinfer_single_prefill(nvbench::state& state) {
       .add_int64_axis("allow_fp16_qk_reduction", {0, 1})                                    \
       .add_int64_axis("custom_mask", {0})                                                   \
       .add_int64_axis("cooperative", {1})
+
+auto bench_flashinfer_single_prefill_fp8_kv = bench_flashinfer_single_prefill_fp8<false>;
+NVBENCH_BENCH(bench_flashinfer_single_prefill_fp8_kv)
+    .set_name(("bench_flashinfer_single_prefill_fp8_kv"))
+    .add_int64_axis("kv_len", {32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536})
+    .add_int64_axis("num_qo_heads", {32})
+    .add_int64_axis("num_kv_heads", {32})
+    .add_int64_axis("head_dim", {128})
+    .add_int64_axis("causal", {0, 1})
+    .add_int64_axis("kv_layout", {0, 1})
+    .add_int64_axis("pos_encoding_mode", {0, 1})
+    .add_int64_axis("allow_fp16_qk_reduction", {0, 1})
+    .add_int64_axis("custom_mask", {0})
+    .add_int64_axis("cooperative", {1});
 
 #define BENCH_FLASHINFER_APPEND_PREFILL(dtype_in, dtype_out)                                  \
   auto bench_flashinfer_single_append_prefill_##dtype_in##_##dtype_out##_ =                   \

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -127,7 +127,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheWrapper(
               {DISPATCH_allow_fp16_qk_reduction(allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, {
                 return BatchPrefillWithRaggedKVCacheWrapperDispatched<
                     HEAD_DIM, LogitsPostHook::kNone, pos_encoding_mode, ALLOW_FP16_QK_REDUCTION,
-                    MASK_MODE, DTypeIn, DTypeOut, IdType>(
+                    MASK_MODE, DTypeIn, DTypeIn, DTypeOut, IdType>(
                     handler, q, qo_indptr, k, v, kv_indptr, /*custom_mask=*/nullptr,
                     /*qk_indptr=*/nullptr, q_offset, k_rope_pos_offset, o, lse, num_qo_heads,
                     num_kv_heads, qo_stride_n, qo_stride_h, kv_stride_n, kv_stride_h,
@@ -158,7 +158,7 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapper(
               {DISPATCH_allow_fp16_qk_reduction(allow_fp16_qk_reduction, ALLOW_FP16_QK_REDUCTION, {
                 return BatchPrefillWithPagedKVCacheWrapperDispatched<
                     PAGE_STORAGE, HEAD_DIM, LogitsPostHook::kNone, POS_ENCODING_MODE,
-                    ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeIn, DTypeOut, IdType>(
+                    ALLOW_FP16_QK_REDUCTION, MASK_MODE, DTypeIn, DTypeIn, DTypeOut, IdType>(
                     handler, q, qo_indptr, q_offset, paged_kv,
                     /*custom_mask=*/nullptr,
                     /*qk_indptr=*/nullptr, o, lse, num_qo_heads, /*window_left=*/-1,

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -73,8 +73,8 @@ cudaError_t SinglePrefillWithKVCacheCustomMask(
  * \param stream The cuda stream to execute the kernel on.
  * \return status Indicates whether CUDA calls are successful
  */
-template <typename DTypeIn, typename DTypeOut>
-cudaError_t SinglePrefillWithKVCache(DTypeIn* q, DTypeIn* k, DTypeIn* v, DTypeOut* o, DTypeOut* tmp,
+template <typename DTypeQ, typename DTypeKV, typename DTypeOut>
+cudaError_t SinglePrefillWithKVCache(DTypeQ* q, DTypeKV* k, DTypeKV* v, DTypeOut* o, DTypeOut* tmp,
                                      float* lse, uint32_t num_qo_heads, uint32_t num_kv_heads,
                                      uint32_t qo_len, uint32_t kv_len, uint32_t head_dim,
                                      bool causal = true, QKVLayout kv_layout = QKVLayout::kNHD,

--- a/src/test_single_prefill.cu
+++ b/src/test_single_prefill.cu
@@ -43,7 +43,7 @@ void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t nu
   thrust::device_vector<DTypeOut> o_d(o);
   thrust::device_vector<DTypeOut> tmp_d(16 * 1024 * 1024);
 
-  cudaError_t status = flashinfer::SinglePrefillWithKVCache<DTypeIn, DTypeOut>(
+  cudaError_t status = flashinfer::SinglePrefillWithKVCache<DTypeIn, DTypeIn, DTypeOut>(
       thrust::raw_pointer_cast(q_d.data()), thrust::raw_pointer_cast(k_d.data()),
       thrust::raw_pointer_cast(v_d.data()), thrust::raw_pointer_cast(o_d.data()),
       thrust::raw_pointer_cast(tmp_d.data()),

--- a/src/test_single_prefill.cu
+++ b/src/test_single_prefill.cu
@@ -21,15 +21,15 @@
 
 using namespace flashinfer;
 
-template <typename DTypeIn, typename DTypeOut>
+template <typename DTypeQ, typename DTypeKV, typename DTypeOut>
 void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t num_qo_heads,
                                          size_t num_kv_heads, size_t head_dim, bool causal,
                                          QKVLayout kv_layout, PosEncodingMode pos_encoding_mode,
                                          bool allow_fp16_qk_reduction, float rtol = 1e-3,
                                          float atol = 1e-3) {
-  std::vector<DTypeIn> q(qo_len * num_qo_heads * head_dim);
-  std::vector<DTypeIn> k(kv_len * num_kv_heads * head_dim);
-  std::vector<DTypeIn> v(kv_len * num_kv_heads * head_dim);
+  std::vector<DTypeQ> q(qo_len * num_qo_heads * head_dim);
+  std::vector<DTypeKV> k(kv_len * num_kv_heads * head_dim);
+  std::vector<DTypeKV> v(kv_len * num_kv_heads * head_dim);
   std::vector<DTypeOut> o(qo_len * num_qo_heads * head_dim);
 
   utils::vec_normal_(q);
@@ -37,13 +37,13 @@ void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t nu
   utils::vec_normal_(v);
   utils::vec_zero_(o);
 
-  thrust::device_vector<DTypeIn> q_d(q);
-  thrust::device_vector<DTypeIn> k_d(k);
-  thrust::device_vector<DTypeIn> v_d(v);
+  thrust::device_vector<DTypeQ> q_d(q);
+  thrust::device_vector<DTypeKV> k_d(k);
+  thrust::device_vector<DTypeKV> v_d(v);
   thrust::device_vector<DTypeOut> o_d(o);
   thrust::device_vector<DTypeOut> tmp_d(16 * 1024 * 1024);
 
-  cudaError_t status = flashinfer::SinglePrefillWithKVCache<DTypeIn, DTypeIn, DTypeOut>(
+  cudaError_t status = flashinfer::SinglePrefillWithKVCache<DTypeQ, DTypeKV, DTypeOut>(
       thrust::raw_pointer_cast(q_d.data()), thrust::raw_pointer_cast(k_d.data()),
       thrust::raw_pointer_cast(v_d.data()), thrust::raw_pointer_cast(o_d.data()),
       thrust::raw_pointer_cast(tmp_d.data()),
@@ -54,7 +54,7 @@ void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t nu
                                  << cudaGetErrorString(status);
 
   thrust::host_vector<DTypeOut> o_h(o_d);
-  std::vector<DTypeOut> o_ref = cpu_reference::single_mha<DTypeIn, DTypeIn, DTypeOut>(
+  std::vector<DTypeOut> o_ref = cpu_reference::single_mha<DTypeQ, DTypeKV, DTypeOut>(
       q, k, v, qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, causal, kv_layout,
       pos_encoding_mode);
   size_t num_results_error_atol = 0;
@@ -86,7 +86,7 @@ void TestSinglePrefillKernelLongContextCorrectness(bool allow_fp16_qk_reduction)
           for (bool causal : {false, true}) {
             for (size_t pos_encoding_mode : {0, 1}) {
               for (size_t kv_layout : {0, 1}) {
-                _TestSinglePrefillKernelCorrectness<DTypeIn, DTypeOut>(
+                _TestSinglePrefillKernelCorrectness<DTypeIn, DTypeIn, DTypeOut>(
                     qo_len, kv_len, num_heads, num_heads, head_dim, causal, QKVLayout(kv_layout),
                     PosEncodingMode(pos_encoding_mode), allow_fp16_qk_reduction);
               }
@@ -109,7 +109,31 @@ void TestSinglePrefillKernelShortContextCorrectness(bool allow_fp16_qk_reduction
           for (bool causal : {false, true}) {
             for (size_t pos_encoding_mode : {0, 1}) {
               for (size_t kv_layout : {0, 1}) {
-                _TestSinglePrefillKernelCorrectness<DTypeIn, DTypeOut>(
+                _TestSinglePrefillKernelCorrectness<DTypeIn, DTypeIn, DTypeOut>(
+                    qkv_len, qkv_len, num_qo_heads, num_kv_heads, head_dim, causal,
+                    QKVLayout(kv_layout), PosEncodingMode(pos_encoding_mode),
+                    allow_fp16_qk_reduction, rtol, atol);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename DTypeKV>
+void TestSinglePrefillFP8KernelShortContextCorrectness(bool allow_fp16_qk_reduction) {
+  float rtol = 1e-3;
+  float atol = 1e-3;
+  for (size_t qkv_len : {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}) {
+    for (size_t num_qo_heads : {32}) {
+      for (size_t num_kv_heads : {4, 8, 32}) {
+        for (size_t head_dim : {128, 256}) {
+          for (bool causal : {false, true}) {
+            for (size_t pos_encoding_mode : {0}) {
+              for (size_t kv_layout : {0, 1}) {
+                _TestSinglePrefillKernelCorrectness<half, DTypeKV, half>(
                     qkv_len, qkv_len, num_qo_heads, num_kv_heads, head_dim, causal,
                     QKVLayout(kv_layout), PosEncodingMode(pos_encoding_mode),
                     allow_fp16_qk_reduction, rtol, atol);
@@ -131,7 +155,7 @@ void TestSinglePrefillKernelCorrectness(bool allow_fp16_qk_reduction) {
           for (bool causal : {false, true}) {
             for (size_t pos_encoding_mode : {0, 1}) {
               for (size_t kv_layout : {0, 1}) {
-                _TestSinglePrefillKernelCorrectness<DTypeIn, DTypeOut>(
+                _TestSinglePrefillKernelCorrectness<DTypeIn, DTypeIn, DTypeOut>(
                     qo_len, kv_len, num_heads, num_heads, head_dim, causal, QKVLayout(kv_layout),
                     PosEncodingMode(pos_encoding_mode), allow_fp16_qk_reduction);
               }
@@ -176,5 +200,11 @@ TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelShortContextCorrectnessBF
 }
 TEST(FlashInferCorrectnessTest, SinglePrefillKernelCorrectnessTestBF16) {
   TestSinglePrefillKernelCorrectness<nv_bfloat16, nv_bfloat16>(false);
+}
+#endif
+
+#ifdef FLASHINFER_ENABLE_FP8
+TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelShortContextCorrectnessE4M3) {
+  TestSinglePrefillFP8KernelShortContextCorrectness<__nv_fp8_e4m3>(false);
 }
 #endif


### PR DESCRIPTION
This implementation do not rely on fp8 tensor cores, but uses fp16 tensor cores instead, the fp8 kv-cache will be dequantized on the fly.

sm_89 and sm_90 append attention kernels will be available in later PRs.