### PR TITLE
sampling: support min_p sampling

### DIFF
--- a/docs/api/python/sampling.rst
+++ b/docs/api/python/sampling.rst
@@ -13,6 +13,7 @@ Kernels for LLM sampling.
     sampling_from_probs
     top_p_sampling_from_probs
     top_k_sampling_from_probs
+    min_p_sampling_from_probs
     top_k_top_p_sampling_from_probs
     top_p_renorm_prob
     top_k_renorm_prob

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -33,6 +33,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sampling_from_probs", &sampling_from_probs, "Sample from probabilities");
   m.def("top_k_sampling_from_probs", &top_k_sampling_from_probs,
         "Top-k sampling from probabilities");
+  m.def("min_p_sampling_from_probs", &min_p_sampling_from_probs,
+        "Min-p sampling from probabilities");
   m.def("top_p_sampling_from_probs", &top_p_sampling_from_probs,
         "Top-p sampling from probabilities");
   m.def("top_k_top_p_sampling_from_probs", &top_k_top_p_sampling_from_probs,

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -65,6 +65,10 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
                                                      torch::Tensor uniform_samples,
                                                      unsigned int top_k, bool deterministic);
 
+std::vector<torch::Tensor> min_p_sampling_from_probs(torch::Tensor probs,
+                                                    torch::Tensor uniform_samples,
+                                                    torch::Tensor min_p, bool deterministic);
+
 std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(torch::Tensor probs,
                                                            torch::Tensor uniform_samples,
                                                            torch::Tensor top_k, torch::Tensor top_p,

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -66,8 +66,8 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
                                                      unsigned int top_k, bool deterministic);
 
 std::vector<torch::Tensor> min_p_sampling_from_probs(torch::Tensor probs,
-                                                    torch::Tensor uniform_samples,
-                                                    torch::Tensor min_p, bool deterministic);
+                                                     torch::Tensor uniform_samples,
+                                                     torch::Tensor min_p, bool deterministic);
 
 std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(torch::Tensor probs,
                                                            torch::Tensor uniform_samples,

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -213,6 +213,7 @@ def top_k_sampling_from_probs(
         probs, uniform_samples, top_k, deterministic
     )
 
+
 def min_p_sampling_from_probs(
     probs: torch.Tensor,
     uniform_samples: torch.Tensor,
@@ -281,6 +282,7 @@ def min_p_sampling_from_probs(
     return _kernels.min_p_sampling_from_probs(
         probs, uniform_samples, min_p, deterministic
     )
+
 
 def top_k_top_p_sampling_from_probs(
     probs: torch.Tensor,

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -219,7 +219,7 @@ def min_p_sampling_from_probs(
     min_p: torch.Tensor,
     deterministic: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    r"""Fused GPU kernel for min_p sampling from probabilities,
+    r"""Fused GPU kernel for `min_p sampling <https://arxiv.org/abs/2407.01082>`_ from probabilities,
 
     this operator implements GPU-based rejection sampling without explicit sorting.
 
@@ -235,7 +235,7 @@ def min_p_sampling_from_probs(
         where the first dimension is the maximum number of rounds for rejection sampling.
         Expected to be uniformly distributed in ``[0, 1)``.
     min_p: torch.Tensor
-        The threshold for min_p sampling for each request, shape ``(batch_size,)``.
+        The :math:`p_{\text{base}}` in min_p sampling for each request, shape ``(batch_size,)``.
     deterministic: bool
         Whether to use deterministic kernel implementation, default is ``True``.
 

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -213,6 +213,74 @@ def top_k_sampling_from_probs(
         probs, uniform_samples, top_k, deterministic
     )
 
+def min_p_sampling_from_probs(
+    probs: torch.Tensor,
+    uniform_samples: torch.Tensor,
+    min_p: torch.Tensor,
+    deterministic: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Fused GPU kernel for min_p sampling from probabilities,
+
+    this operator implements GPU-based rejection sampling without explicit sorting.
+
+    The multiple rounds of rejection sampling are implemented in a single CUDA kernel,
+    which is more efficient than the naive implementation that launches a series of kernels.
+
+    Parameters
+    ----------
+    probs: torch.Tensor
+        Probabilities, shape ``(batch_size, num_classes)``.
+    uniform_samples: torch.Tensor
+        The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
+        where the first dimension is the maximum number of rounds for rejection sampling.
+        Expected to be uniformly distributed in ``[0, 1)``.
+    min_p: torch.Tensor
+        The threshold for min_p sampling for each request, shape ``(batch_size,)``.
+    deterministic: bool
+        Whether to use deterministic kernel implementation, default is ``True``.
+
+    Returns
+    -------
+    samples: torch.Tensor
+        Sampled categories, shape ``(batch_size,)``.
+    success: torch.Tensor
+        Whether the sampling is successful within ``max_top_k_rounds`` rounds,
+        shape ``(batch_size,)``.
+
+    Examples
+    --------
+
+    >>> import torch
+    >>> import flashinfer
+    >>> torch.manual_seed(42)
+    <torch._C.Generator object at 0x7f8b3db06df0>
+    >>> batch_size = 4
+    >>> vocab_size = 5
+    >>> max_rounds = 3
+    >>> min_p = torch.full((batch_size,), 0.05).to(0)
+    >>> pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
+    >>> norm_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+    >>> norm_prob
+    tensor([[0.2499, 0.2592, 0.1085, 0.2718, 0.1106],
+            [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
+            [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
+            [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
+    >>> uniform_samples = torch.rand(max_rounds, batch_size).to(0)
+    >>> samples, success = flashinfer.sampling.min_p_sampling_from_probs(norm_prob, uniform_samples, min_p)
+    >>> samples
+    tensor([1, 2, 1, 4], device='cuda:0', dtype=torch.int32)
+    >>> success
+    tensor([True, True, True, True], device='cuda:0')
+
+    Notes
+    -----
+    This function expects float32 inputs, and the output is int32.
+    We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
+    implementation usually use much fewer rounds for rejection sampling because of early stopping.
+    """
+    return _kernels.min_p_sampling_from_probs(
+        probs, uniform_samples, min_p, deterministic
+    )
 
 def top_k_top_p_sampling_from_probs(
     probs: torch.Tensor,

--- a/python/tests/test_sampling.py
+++ b/python/tests/test_sampling.py
@@ -97,6 +97,39 @@ def test_top_k_sampling(batch_size, vocab_size, k):
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
+@pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 1])
+def test_min_p_sampling(batch_size, vocab_size, p):
+    torch.manual_seed(42)
+    max_min_p_trails = 32
+    pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
+    normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+    sorted_prob, indices = torch.sort(normalized_prob, descending=False)
+    # scale min-p
+    top_probs = sorted_prob[:, -1].unsqueeze(-1)
+    scaled_p = p * top_probs
+    # min-p mask
+    mask = torch.zeros(batch_size, vocab_size, dtype=torch.int32).to(0)
+    mask.scatter_add_(1, indices, (sorted_prob >= scaled_p).int())
+
+    uniform_samples = torch.empty(max_min_p_trails, batch_size, dtype=torch.float32).to(
+        0
+    )
+    min_p_tensor = torch.full((batch_size,), p).to(0)
+
+    num_trails = 1000
+    for _ in range(num_trails):
+        uniform_samples.uniform_()
+        samples, success = flashinfer.sampling.min_p_sampling_from_probs(
+            normalized_prob, uniform_samples, min_p_tensor
+        )
+        assert torch.all(success)
+        assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
+        assert torch.all(mask[torch.arange(batch_size), samples] == 1), normalized_prob[
+            torch.arange(batch_size), samples
+        ]
+
+@pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
+@pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5])
 def test_top_k_top_p_sampling(batch_size, vocab_size, p):
     if p == 0.1:

--- a/python/tests/test_sampling.py
+++ b/python/tests/test_sampling.py
@@ -97,7 +97,7 @@ def test_top_k_sampling(batch_size, vocab_size, k):
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
-@pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 1])
+@pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])
 def test_min_p_sampling(batch_size, vocab_size, p):
     torch.manual_seed(42)
     max_min_p_trails = 32
@@ -127,6 +127,7 @@ def test_min_p_sampling(batch_size, vocab_size, p):
         assert torch.all(mask[torch.arange(batch_size), samples] == 1), normalized_prob[
             torch.arange(batch_size), samples
         ]
+
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])


### PR DESCRIPTION
This PR supports min_p sampling by adding `sampling.min_p_sampling_from_probs` API.

- [x] Implement kernel
- [x] Add Tests

Ref: [Min P Sampling](https://arxiv.org/abs/2407.01082).