### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ cd flashinfer/python
 pip install -e .
 ```
 
+when building and testing on A100:
+```bash
+git clone https://github.com/flashinfer-ai/flashinfer.git --recursive
+cd flashinfer/python
+# workaround for undefined symbol `__gmon_start__' on A100
+export TORCH_CUDA_ARCH_LIST=8.0
+pip install -e .
+```
+
 ### Trying it out
 
 Below is a minimal example of using FlashInfer's single-request decode/append/prefill attention kernels:

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ cd flashinfer/python
 pip install -e .
 ```
 
-when building and testing on A100:
+to reduce binary size during build and testing:
 ```bash
 git clone https://github.com/flashinfer-ai/flashinfer.git --recursive
 cd flashinfer/python
-# workaround for undefined symbol `__gmon_start__' on A100
+# ref https://pytorch.org/docs/stable/generated/torch.cuda.get_device_capability.html#torch.cuda.get_device_capability
 export TORCH_CUDA_ARCH_LIST=8.0
 pip install -e .
 ```


### PR DESCRIPTION
fix cc @yzh119 

```
 /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/crti.o: in function `_init':
    (.init+0xb): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against undefined symbol `__gmon_start__'
    /flashinfer/python/build/temp.linux-x86_64-cpython-310/csrc/batch_decode.o: in function `__cudaUnregisterBinaryUtil()':
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x1d7): relocation truncated to fit: R_X86_64_PC32 against `.bss'
    /flashinfer/python/build/temp.linux-x86_64-cpython-310/csrc/batch_decode.o: in function `std::string::_Rep::_M_dispose(std::allocator<char> const&) [clone .part.0]':
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x1e3): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `__libc_single_threaded@@GLIBC_2.32' defined in .bss section in /lib/x86_64-linux-gnu/libc.so.6
    /flashinfer/python/build/temp.linux-x86_64-cpython-310/csrc/batch_decode.o: in function `std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*) [clone .constprop.0]':
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x237): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `std::cerr@@GLIBCXX_3.4' defined in .bss section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x25b): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `std::cerr@@GLIBCXX_3.4' defined in .bss section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    /flashinfer/python/build/temp.linux-x86_64-cpython-310/csrc/batch_decode.o: in function `void* flashinfer::AlignedAllocator::aligned_alloc<void>(unsigned long, unsigned long, std::string) [clone .constprop.0]':
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x30a): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `vtable for std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >@@GLIBCXX_3.4' defined in .data.rel.ro section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x324): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `vtable for std::basic_streambuf<char, std::char_traits<char> >@@GLIBCXX_3.4' defined in .data.rel.ro section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x3cf): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `vtable for std::basic_ios<char, std::char_traits<char> >@@GLIBCXX_3.4' defined in .data.rel.ro section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x402): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `VTT for std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >@@GLIBCXX_3.4' defined in .data.rel.ro section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x46e): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against symbol `vtable for std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >@@GLIBCXX_3.4' defined in .data.rel.ro section in /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
    tmpxft_00000886_00000000-6_batch_decode.cudafe1.cpp:(.text+0x48c): additional relocation overflows omitted from the output
    build/lib.linux-x86_64-cpython-310/flashinfer/_kernels.cpython-310-x86_64-linux-gnu.so: PC-relative offset overflow in PLT entry for `PyDict_DelItemString'
    collect2: error: ld returned 1 exit status
    error: command '/usr/bin/x86_64-linux-gnu-g++' failed with exit code 1
    [end of output]
```