### PR TITLE
feat: more sampling operator options

### DIFF
--- a/docs/api/python/sampling.rst
+++ b/docs/api/python/sampling.rst
@@ -14,7 +14,9 @@ Kernels for LLM sampling.
     top_p_sampling_from_probs
     top_k_sampling_from_probs
     min_p_sampling_from_probs
+    top_k_top_p_sampling_from_logits
     top_k_top_p_sampling_from_probs
     top_p_renorm_prob
     top_k_renorm_prob
+    top_k_mask_logits
     chain_speculative_sampling

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -685,7 +685,7 @@ cudaError_t ParallelSamplingFromProb(T* probs, T* uniform_samples, IdType* outpu
 
 template <typename T, typename IdType>
 cudaError_t TopKSamplingFromProb(T* probs, T* uniform_samples, IdType* output, bool* success,
-                                 T* top_k_arr, uint32_t batch_size, IdType top_k_val, uint32_t d,
+                                 T* top_k_arr, uint32_t batch_size, uint32_t top_k_val, uint32_t d,
                                  uint32_t max_top_k_rounds, bool deterministic,
                                  cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
@@ -897,7 +897,7 @@ __global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, DType* 
 
 template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE,
           typename DType, typename IdType>
-__global__ void TopKMaskLogitsKernel(DType* logits, DType* masked_logits, IdType top_k_arr,
+__global__ void TopKMaskLogitsKernel(DType* logits, DType* masked_logits, IdType* top_k_arr,
                                      uint32_t top_k_val, float eps, uint32_t d) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -34,6 +34,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Top-k and top-p sampling from probabilities");
   m.def("top_k_renorm_prob", &top_k_renorm_prob, "Renormalize probabilities by top-k mask");
   m.def("top_p_renorm_prob", &top_p_renorm_prob, "Renormalize probabilities by top-p mask");
+  m.def("top_k_mask_logits", &top_k_mask_logits, "Mask logits by top-k mask");
   m.def("chain_speculative_sampling", &chain_speculative_sampling,
         "Speculative sampling from sequence of probabilities");
   m.def("rmsnorm", &rmsnorm, "Root mean square normalization");

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -39,25 +39,33 @@ torch::Tensor sampling_from_probs(torch::Tensor probs, torch::Tensor uniform_sam
                                   bool deterministic);
 
 std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
-                                                     torch::Tensor uniform_samples, double top_p,
-                                                     bool deterministic);
+                                                     torch::Tensor uniform_samples,
+                                                     std::optional<torch::Tensor> maybe_top_p_arr,
+                                                     double top_p_val, bool deterministic);
 
 std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
                                                      torch::Tensor uniform_samples,
-                                                     unsigned int top_k, bool deterministic);
+                                                     std::optional<torch::Tensor> maybe_top_k_arr,
+                                                     unsigned int top_k_val, bool deterministic);
 
 std::vector<torch::Tensor> min_p_sampling_from_probs(torch::Tensor probs,
                                                      torch::Tensor uniform_samples,
-                                                     torch::Tensor min_p, bool deterministic);
+                                                     std::optional<torch::Tensor> maybe_min_p_arr,
+                                                     double min_p_val, bool deterministic);
 
-std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(torch::Tensor probs,
-                                                           torch::Tensor uniform_samples,
-                                                           torch::Tensor top_k, torch::Tensor top_p,
-                                                           bool deterministic);
+std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(
+    torch::Tensor probs, torch::Tensor uniform_samples,
+    std::optional<torch::Tensor> maybe_top_k_arr, double top_k_val,
+    std::optional<torch::Tensor> maybe_top_p_arr, double top_p_val, bool deterministic);
 
-torch::Tensor top_p_renorm_prob(torch::Tensor probs, double top_p, double eps);
+torch::Tensor top_p_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_p_arr,
+                                double top_p_val, double eps);
 
-torch::Tensor top_k_renorm_prob(torch::Tensor probs, unsigned int top_k, double eps);
+torch::Tensor top_k_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_k_arr,
+                                unsigned int top_k_val, double eps);
+
+torch::Tensor top_k_mask_logits(torch::Tensor logits, std::optional<torch::Tensor> maybe_top_k_arr,
+                                unsigned int top_k_val, double eps);
 
 torch::Tensor chain_speculative_sampling(torch::Tensor draft_probs, torch::Tensor draft_token_ids,
                                          torch::Tensor uniform_samples, torch::Tensor target_probs,

--- a/python/csrc/sampling.cu
+++ b/python/csrc/sampling.cu
@@ -47,8 +47,9 @@ torch::Tensor sampling_from_probs(torch::Tensor probs, torch::Tensor uniform_sam
 }
 
 std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
-                                                     torch::Tensor uniform_samples, double top_p,
-                                                     bool deterministic) {
+                                                     torch::Tensor uniform_samples,
+                                                     std::optional<torch::Tensor> maybe_top_p_arr,
+                                                     double top_p_val, bool deterministic) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
   auto device = probs.device();
@@ -59,8 +60,17 @@ std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   unsigned int max_top_p_rounds = uniform_samples.size(0);
+  bool has_top_p_arr = maybe_top_p_arr.has_value();
+  auto top_p_arr = maybe_top_p_arr.value_or(torch::empty({0}, torch::dtype(torch::kFloat32)));
+  if (has_top_p_arr) {
+    CHECK_INPUT(top_p_arr);
+    CHECK_DIM(1, top_p_arr);  // top_p_arr: (batch_size,)
+    CHECK_EQ(top_p_arr.size(0), batch_size);
+    CHECK_EQ(top_p_arr.device(), device);
+  }
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
+  top_p_arr = top_p_arr.to(torch::kFloat32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
@@ -68,8 +78,9 @@ std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
 
   cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()), top_p,
-      batch_size, vocab_size, max_top_p_rounds, deterministic, torch_current_stream);
+      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()),
+      has_top_p_arr ? static_cast<float*>(top_p_arr.data_ptr()) : nullptr, batch_size, top_p_val,
+      vocab_size, max_top_p_rounds, deterministic, torch_current_stream);
   TORCH_CHECK(status == cudaSuccess, "TopPSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 
@@ -78,7 +89,8 @@ std::vector<torch::Tensor> top_p_sampling_from_probs(torch::Tensor probs,
 
 std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
                                                      torch::Tensor uniform_samples,
-                                                     unsigned int top_k, bool deterministic) {
+                                                     std::optional<torch::Tensor> maybe_top_k_arr,
+                                                     unsigned int top_k_val, bool deterministic) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
   auto device = probs.device();
@@ -89,8 +101,17 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   unsigned int max_top_k_rounds = uniform_samples.size(0);
+  bool has_top_k_arr = maybe_top_k_arr.has_value();
+  auto top_k_arr = maybe_top_k_arr.value_or(torch::empty({0}, torch::dtype(torch::kInt32)));
+  if (has_top_k_arr) {
+    CHECK_INPUT(top_k_arr);
+    CHECK_DIM(1, top_k_arr);  // top_k_arr: (batch_size,)
+    CHECK_EQ(top_k_arr.size(0), batch_size);
+    CHECK_EQ(top_k_arr.device(), device);
+  }
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
+  top_k_arr = top_k_arr.to(torch::kInt32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
@@ -98,8 +119,9 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
 
   cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()), top_k,
-      batch_size, vocab_size, max_top_k_rounds, deterministic, torch_current_stream);
+      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()),
+      has_top_k_arr ? static_cast<float*>(top_k_arr.data_ptr()) : nullptr, batch_size, top_k_val,
+      vocab_size, max_top_k_rounds, deterministic, torch_current_stream);
   TORCH_CHECK(status == cudaSuccess, "TopKSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 
@@ -108,21 +130,28 @@ std::vector<torch::Tensor> top_k_sampling_from_probs(torch::Tensor probs,
 
 std::vector<torch::Tensor> min_p_sampling_from_probs(torch::Tensor probs,
                                                      torch::Tensor uniform_samples,
-                                                     torch::Tensor min_p, bool deterministic) {
+                                                     std::optional<torch::Tensor> maybe_min_p_arr,
+                                                     double min_p_val, bool deterministic) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
-  CHECK_INPUT(min_p);
   auto device = probs.device();
   CHECK_EQ(uniform_samples.device(), device);
-  CHECK_EQ(min_p.device(), device);
   CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
   CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_rounds, batch_size)
-  CHECK_DIM(1, min_p);            // min_p: (batch_size,)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   unsigned int max_rounds = uniform_samples.size(0);
   CHECK_EQ(uniform_samples.size(1), batch_size);
-  CHECK_EQ(min_p.size(0), batch_size);
+  bool has_min_p_arr = maybe_min_p_arr.has_value();
+  auto min_p_arr = maybe_min_p_arr.value_or(torch::empty({0}, torch::dtype(torch::kFloat32)));
+  if (has_min_p_arr) {
+    CHECK_INPUT(min_p_arr);
+    CHECK_DIM(1, min_p_arr);  // min_p_arr: (batch_size,)
+    CHECK_EQ(min_p_arr.size(0), batch_size);
+    CHECK_EQ(min_p_arr.device(), device);
+  }
+  min_p_arr = min_p_arr.to(torch::kFloat32);
+
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
   min_p = min_p.to(torch::kFloat32);
@@ -133,41 +162,49 @@ std::vector<torch::Tensor> min_p_sampling_from_probs(torch::Tensor probs,
 
   cudaError_t status = sampling::MinPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<float*>(min_p.data_ptr()), static_cast<int*>(samples.data_ptr()),
-      static_cast<bool*>(success.data_ptr()), batch_size, vocab_size, max_rounds, deterministic,
-      torch_current_stream);
+      has_min_p_arr ? static_cast<float*>(min_p_arr.data_ptr()) : nullptr,
+      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()), batch_size,
+      min_p_val, vocab_size, max_rounds, deterministic, torch_current_stream);
   TORCH_CHECK(status == cudaSuccess, "MinPSamplingFromProb failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 
   return {samples, success};
 }
 
-std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(torch::Tensor probs,
-                                                           torch::Tensor uniform_samples,
-                                                           torch::Tensor top_k, torch::Tensor top_p,
-                                                           bool deterministic) {
+std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(
+    torch::Tensor probs, torch::Tensor uniform_samples,
+    std::optional<torch::Tensor> maybe_top_k_arr, double top_k_val,
+    std::optional<torch::Tensor> maybe_top_p_arr, double top_p_val, bool deterministic) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
-  CHECK_INPUT(top_k);
-  CHECK_INPUT(top_p);
   auto device = probs.device();
   CHECK_EQ(uniform_samples.device(), device);
-  CHECK_EQ(top_k.device(), device);
-  CHECK_EQ(top_p.device(), device);
   CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
   CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_rounds, batch_size)
-  CHECK_DIM(1, top_k);            // top_k: (batch_size,)
-  CHECK_DIM(1, top_p);            // top_p: (batch_size,)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   unsigned int max_rounds = uniform_samples.size(0);
   CHECK_EQ(uniform_samples.size(1), batch_size);
-  CHECK_EQ(top_k.size(0), batch_size);
-  CHECK_EQ(top_p.size(0), batch_size);
+  bool has_top_k_arr = maybe_top_k_arr.has_value();
+  auto top_k_arr = maybe_top_k_arr.value_or(torch::empty({0}, torch::dtype(torch::kInt32)));
+  if (has_top_k_arr) {
+    CHECK_INPUT(top_k_arr);
+    CHECK_DIM(1, top_k_arr);  // top_k_arr: (batch_size,)
+    CHECK_EQ(top_k_arr.size(0), batch_size);
+    CHECK_EQ(top_k_arr.device(), device);
+  }
+  top_k_arr = top_k_arr.to(torch::kInt32);
+  bool has_top_p_arr = maybe_top_p_arr.has_value();
+  auto top_p_arr = maybe_top_p_arr.value_or(torch::empty({0}, torch::dtype(torch::kFloat32)));
+  if (has_top_p_arr) {
+    CHECK_INPUT(top_p_arr);
+    CHECK_DIM(1, top_p_arr);  // top_p_arr: (batch_size,)
+    CHECK_EQ(top_p_arr.size(0), batch_size);
+    CHECK_EQ(top_p_arr.device(), device);
+  }
+  top_p_arr = top_p_arr.to(torch::kFloat32);
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
-  top_k = top_k.to(torch::kInt32);
-  top_p = top_p.to(torch::kFloat32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));
@@ -175,21 +212,32 @@ std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(torch::Tensor probs,
 
   cudaError_t status = sampling::TopKTopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(top_k.data_ptr()), static_cast<float*>(top_p.data_ptr()),
+      has_top_k_arr ? static_cast<int*>(top_k_arr.data_ptr()) : nullptr,
+      has_top_p_arr ? static_cast<float*>(top_p_arr.data_ptr()) : nullptr,
       static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()), batch_size,
-      vocab_size, max_rounds, deterministic, torch_current_stream);
+      top_k_val, top_p_val, vocab_size, max_rounds, deterministic, torch_current_stream);
   TORCH_CHECK(status == cudaSuccess, "TopKTopPSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 
   return {samples, success};
 }
 
-torch::Tensor top_p_renorm_prob(torch::Tensor probs, double top_p, double eps) {
+torch::Tensor top_p_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_p_arr,
+                                double top_p_val, double eps) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
+  bool has_top_p_arr = maybe_top_p_arr.has_value();
+  auto top_p_arr = maybe_top_p_arr.value_or(torch::empty({0}, torch::dtype(torch::kFloat32)));
+  if (has_top_p_arr) {
+    CHECK_INPUT(top_p_arr);
+    CHECK_DIM(1, top_p_arr);  // top_p_arr: (batch_size,)
+    CHECK_EQ(top_p_arr.size(0), batch_size);
+    CHECK_EQ(top_p_arr.device(), device);
+  }
+  top_p_arr = top_p_arr.to(torch::kFloat32);
   probs = probs.to(torch::kFloat32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
@@ -197,19 +245,30 @@ torch::Tensor top_p_renorm_prob(torch::Tensor probs, double top_p, double eps) {
       torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
 
   cudaError_t status = sampling::TopPRenormProb<float>(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()), top_p,
-      eps, batch_size, vocab_size, torch_current_stream);
+      static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
+      has_top_p_arr ? static_cast<float*>(top_p_arr.data_ptr()) : nullptr, eps, batch_size,
+      top_p_val, vocab_size, torch_current_stream);
   TORCH_CHECK(status == cudaSuccess,
               "TopPRenormProb failed with error code " + std::string(cudaGetErrorString(status)));
   return renorm_probs;
 }
 
-torch::Tensor top_k_renorm_prob(torch::Tensor probs, unsigned int top_k, double eps) {
+torch::Tensor top_k_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_k_arr,
+                                unsigned int top_k_val, double eps) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
+  bool has_top_k_arr = maybe_top_k_arr.has_value();
+  auto top_k_arr = maybe_top_k_arr.value_or(torch::empty({0}, torch::dtype(torch::kInt32)));
+  if (has_top_k_arr) {
+    CHECK_INPUT(top_k_arr);
+    CHECK_DIM(1, top_k_arr);  // top_k_arr: (batch_size,)
+    CHECK_EQ(top_k_arr.size(0), batch_size);
+    CHECK_EQ(top_k_arr.device(), device);
+  }
+  top_k_arr = top_k_arr.to(torch::kInt32);
   probs = probs.to(torch::kFloat32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
@@ -217,12 +276,45 @@ torch::Tensor top_k_renorm_prob(torch::Tensor probs, unsigned int top_k, double 
       torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
 
   cudaError_t status = sampling::TopKRenormProb<float>(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()), top_k,
-      eps, batch_size, vocab_size, torch_current_stream);
+      static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
+      has_top_k_arr ? static_cast<int*>(top_k_arr.data_ptr()) : nullptr, eps, batch_size, top_k_val,
+      vocab_size, torch_current_stream);
 
   TORCH_CHECK(status == cudaSuccess,
               "TopKRenormProb failed with error code " + std::string(cudaGetErrorString(status)));
   return renorm_probs;
+}
+
+torch::Tensor top_k_mask_logits(torch::Tensor logits, std::optional<torch::Tensor> maybe_top_k_arr,
+                                unsigned int top_k_val, double eps) {
+  CHECK_INPUT(logits);
+  auto device = logits.device();
+  CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
+  unsigned int batch_size = logits.size(0);
+  unsigned int vocab_size = logits.size(1);
+  bool has_top_k_arr = maybe_top_k_arr.has_value();
+  auto top_k_arr = maybe_top_k_arr.value_or(torch::empty({0}, torch::dtype(torch::kInt32)));
+  if (has_top_k_arr) {
+    CHECK_INPUT(top_k_arr);
+    CHECK_DIM(1, top_k_arr);  // top_k_arr: (batch_size,)
+    CHECK_EQ(top_k_arr.size(0), batch_size);
+    CHECK_EQ(top_k_arr.device(), device);
+  }
+  top_k_arr = top_k_arr.to(torch::kInt32);
+  probs = probs.to(torch::kFloat32);
+
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
+  auto mask_logits =
+      torch::empty({batch_size, vocab_size}, torch::dtype(torch::kFloat32).device(device));
+
+  cudaError_t status = sampling::TopKMaskLogits<float>(
+      static_cast<float*>(logits.data_ptr()), static_cast<float*>(mask_logits.data_ptr()),
+      has_top_k_arr ? static_cast<int*>(top_k_arr.data_ptr()) : nullptr, eps, batch_size, top_k_val,
+      vocab_size, torch_current_stream);
+
+  TORCH_CHECK(status == cudaSuccess,
+              "TopKMaskLogits failed with error code " + std::string(cudaGetErrorString(status)));
+  return mask_logits;
 }
 
 torch::Tensor chain_speculative_sampling(torch::Tensor draft_probs, torch::Tensor draft_token_ids,

--- a/python/csrc/sampling.cu
+++ b/python/csrc/sampling.cu
@@ -301,7 +301,7 @@ torch::Tensor top_k_mask_logits(torch::Tensor logits, std::optional<torch::Tenso
     CHECK_EQ(top_k_arr.device(), device);
   }
   top_k_arr = top_k_arr.to(torch::kInt32);
-  probs = probs.to(torch::kFloat32);
+  logits = logits.to(torch::kFloat32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto mask_logits =

--- a/python/csrc/sampling.cu
+++ b/python/csrc/sampling.cu
@@ -151,10 +151,8 @@ std::vector<torch::Tensor> min_p_sampling_from_probs(torch::Tensor probs,
     CHECK_EQ(min_p_arr.device(), device);
   }
   min_p_arr = min_p_arr.to(torch::kFloat32);
-
   probs = probs.to(torch::kFloat32);
   uniform_samples = uniform_samples.to(torch::kFloat32);
-  min_p = min_p.to(torch::kFloat32);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   auto samples = torch::empty({batch_size}, torch::dtype(torch::kInt32).device(device));

--- a/python/flashinfer/__init__.py
+++ b/python/flashinfer/__init__.py
@@ -14,26 +14,46 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .cascade import (BatchDecodeWithSharedPrefixPagedKVCacheWrapper,
-                      BatchPrefillWithSharedPrefixPagedKVCacheWrapper,
-                      merge_state, merge_state_in_place, merge_states)
-from .decode import (BatchDecodeWithPagedKVCacheWrapper,
-                     CUDAGraphBatchDecodeWithPagedKVCacheWrapper,
-                     single_decode_with_kv_cache)
+from .cascade import (
+    BatchDecodeWithSharedPrefixPagedKVCacheWrapper,
+    BatchPrefillWithSharedPrefixPagedKVCacheWrapper,
+    merge_state,
+    merge_state_in_place,
+    merge_states,
+)
+from .decode import (
+    BatchDecodeWithPagedKVCacheWrapper,
+    CUDAGraphBatchDecodeWithPagedKVCacheWrapper,
+    single_decode_with_kv_cache,
+)
 from .group_gemm import SegmentGEMMWrapper
 from .norm import fused_add_rmsnorm, rmsnorm
 from .page import append_paged_kv_cache
-from .prefill import (BatchPrefillWithPagedKVCacheWrapper,
-                      BatchPrefillWithRaggedKVCacheWrapper,
-                      single_prefill_with_kv_cache,
-                      single_prefill_with_kv_cache_return_lse)
+from .prefill import (
+    BatchPrefillWithPagedKVCacheWrapper,
+    BatchPrefillWithRaggedKVCacheWrapper,
+    single_prefill_with_kv_cache,
+    single_prefill_with_kv_cache_return_lse,
+)
 from .quantization import packbits, segment_packbits
-from .rope import (apply_llama31_rope, apply_llama31_rope_inplace, apply_rope,
-                   apply_rope_inplace)
-from .sampling import (chain_speculative_sampling, sampling_from_probs,
-                       top_k_renorm_prob, top_k_sampling_from_probs,
-                       top_k_top_p_sampling_from_probs, top_p_renorm_prob,
-                       top_p_sampling_from_probs)
+from .rope import (
+    apply_llama31_rope,
+    apply_llama31_rope_inplace,
+    apply_rope,
+    apply_rope_inplace,
+)
+from .sampling import (
+    chain_speculative_sampling,
+    sampling_from_probs,
+    top_k_renorm_prob,
+    top_k_mask_logits,
+    top_k_sampling_from_probs,
+    top_k_top_p_sampling_from_probs,
+    top_k_top_p_sampling_from_logits,
+    top_p_renorm_prob,
+    top_p_sampling_from_probs,
+    min_p_sampling_from_probs,
+)
 from .sparse import BlockSparseAttentionWrapper
 
 try:

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -293,7 +293,7 @@ def min_p_sampling_from_probs(
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
     return _kernels.min_p_sampling_from_probs(
-        probs, uniform_samples, _to_tensor_scalar_tuple(min_p), deterministic
+        probs, uniform_samples, *_to_tensor_scalar_tuple(min_p), deterministic
     )
 
 
@@ -511,7 +511,7 @@ def top_p_renorm_prob(
     This combination of ``top_p_renorm_prob`` and ``sampling_from_probs`` should be equivalent to
     ``top_p_sampling_from_probs``.
     """
-    return _kernels.top_p_renorm_prob(probs, _to_tensor_scalar_tuple(top_p), eps)
+    return _kernels.top_p_renorm_prob(probs, *_to_tensor_scalar_tuple(top_p), eps)
 
 
 def top_k_renorm_prob(
@@ -542,7 +542,7 @@ def top_k_renorm_prob(
     This combination of ``top_k_renorm_prob`` and ``sampling_from_probs`` should be equivalent to
     ``top_k_sampling_from_probs``.
     """
-    return _kernels.top_k_renorm_prob(probs, _to_tensor_scalar_tuple(top_k), eps)
+    return _kernels.top_k_renorm_prob(probs, *_to_tensor_scalar_tuple(top_k), eps)
 
 
 def top_k_mask_logits(
@@ -572,7 +572,7 @@ def top_k_mask_logits(
     ----
     The combination of ``top_k_mask_logits`` and ``softmax`` should be equivalent to ``top_k_renorm_prob``.
     """
-    return _kernels.top_k_mask_logits(logits, _to_tensor_scalar_tuple(top_k), eps)
+    return _kernels.top_k_mask_logits(logits, *_to_tensor_scalar_tuple(top_k), eps)
 
 
 def chain_speculative_sampling(

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -297,6 +297,99 @@ def min_p_sampling_from_probs(
     )
 
 
+def top_k_top_p_sampling_from_logits(
+    probs: torch.Tensor,
+    uniform_samples: torch.Tensor,
+    top_k: Union[torch.Tensor, int],
+    top_p: Union[torch.Tensor, float],
+    filter_apply_order: str = "top_k_first",
+    deterministic: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Fused GPU kernel for top-k and top-p sampling from pre-softmax logits,
+
+    this operator implements GPU-based rejection sampling without explicit sorting.
+
+    The multiple rounds of rejection sampling are implemented in a single CUDA kernel,
+    which is more efficient than the naive implementation that launches a series of kernels.
+
+    Parameters
+    ----------
+    logits: torch.Tensor
+        Pre-softmax logits, shape ``(batch_size, num_classes)``.
+    uniform_samples: torch.Tensor
+        The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
+        where the first dimension is the maximum number of rounds for rejection sampling.
+        Expected to be uniformly distributed in ``[0, 1)``.
+    top_k: Union[torch.Tensor, int]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+    top_p: Union[torch.Tensor, float]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+    filter_apply_order: str
+        The order of applying top-k and top-p sampling, should be either ``"top_k_first"`` or ``"joint"``.
+        If ``"top_k_first"``, we first apply top-k filter, then apply top-p sampling on the top-k results.
+        If ``"joint"``, we apply top-k and top-p filter simultaneously in each round.
+    deterministic: bool
+        Whether to use deterministic kernel implementation, default is ``True``.
+
+    Returns
+    -------
+    samples: torch.Tensor
+        Sampled categories, shape ``(batch_size,)``.
+    success: torch.Tensor
+        Whether the sampling is successful within ``max_top_k_rounds`` rounds,
+        shape ``(batch_size,)``.
+
+    Examples
+    --------
+
+    >>> import torch
+    >>> import flashinfer
+    >>> torch.manual_seed(42)
+    >>> batch_size = 4
+    >>> vocab_size = 5
+    >>> max_rounds = 3
+    >>> top_p = torch.full((batch_size,), 0.2).to(0)
+    >>> top_k = torch.full((batch_size,), 2).to(0)
+    >>> logits = torch.randn(batch_size, vocab_size).to(0)
+    >>> logits
+    tensor([[0.2499, 0.2592, 0.1085, 0.2718, 0.1106],
+            [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
+            [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
+            [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
+    >>> uniform_samples = torch.rand(max_rounds, batch_size).to(0)
+    >>> samples, success = flashinfer.sampling.top_k_top_p_sampling_from_logits(logits, uniform_samples, top_k, top_p)
+    >>> samples
+    tensor([3, 3, 0, 1], device='cuda:0', dtype=torch.int32)
+    >>> success
+    tensor([True, True, True, True], device='cuda:0')
+
+    Notes
+    -----
+    This function expects float32 inputs, and the output is int32.
+    We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
+    implementation usually use much fewer rounds for rejection sampling because of early stopping.
+    """
+    if filter_apply_order == "top_k_first":
+        masked_logits = top_k_mask_logits(probs, top_k)
+        probs = torch.softmax(masked_logits, dim=-1)
+        return top_p_sampling_from_probs(probs, uniform_samples, top_p, deterministic)
+    elif filter_apply_order == "joint":
+        probs = torch.softmax(probs, dim=-1)
+        return _kernels.top_k_top_p_sampling_from_probs(
+            probs,
+            uniform_samples,
+            *_to_tensor_scalar_tuple(top_k),
+            *_to_tensor_scalar_tuple(top_p),
+            deterministic,
+        )
+    else:
+        raise ValueError(f"Invalid filter_apply_order: {filter_apply_order}")
+
+
 def top_k_top_p_sampling_from_probs(
     probs: torch.Tensor,
     uniform_samples: torch.Tensor,
@@ -375,9 +468,10 @@ def top_k_top_p_sampling_from_probs(
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
     if filter_apply_order == "top_k_first":
-        masked_logits = top_k_mask_logits(probs, top_k)
-        probs = torch.softmax(masked_logits, dim=-1)
-        return top_p_sampling_from_probs(probs, uniform_samples, top_p, deterministic)
+        renorm_probs = top_k_renorm_prob(probs, top_k)
+        return top_p_sampling_from_probs(
+            renorm_probs, uniform_samples, top_p, deterministic
+        )
     elif filter_apply_order == "joint":
         return _kernels.top_k_top_p_sampling_from_probs(
             probs,

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import torch
-from typing import Tuple
+from typing import Tuple, Union
 
 # mypy: disable-error-code="attr-defined"
 try:
@@ -29,6 +29,13 @@ except ImportError as e:
         logging.warning("Kernels are not loaded in documentation build mode.")
     else:
         raise e
+
+
+def _to_tensor_scalar_tuple(x):
+    if isinstance(x, torch.Tensor):
+        return (x, 0)
+    else:
+        return (None, x)
 
 
 def sampling_from_probs(
@@ -81,7 +88,7 @@ def sampling_from_probs(
 def top_p_sampling_from_probs(
     probs: torch.Tensor,
     uniform_samples: torch.Tensor,
-    top_p: float,
+    top_p: Union[torch.Tensor, float],
     deterministic: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Fused GPU kernel for top-p sampling (nucleus sampling) from probabilities,
@@ -98,8 +105,10 @@ def top_p_sampling_from_probs(
         The uniform samples used as needle for sampling, shape ``(max_top_p_rounds, batch_size,)``,
         where the first dimension is the maximum number of rounds for rejection sampling.
         Expected to be uniformly distributed in ``[0, 1)``.
-    top_p: float
-        The threshold for top-p sampling.
+    top_p: Union[torch.Tensor, float]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
     deterministic: bool
         Whether to use deterministic kernel implementation, default is ``True``.
 
@@ -142,14 +151,14 @@ def top_p_sampling_from_probs(
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
     return _kernels.top_p_sampling_from_probs(
-        probs, uniform_samples, top_p, deterministic
+        probs, uniform_samples, *_to_tensor_scalar_tuple(top_p), deterministic
     )
 
 
 def top_k_sampling_from_probs(
     probs: torch.Tensor,
     uniform_samples: torch.Tensor,
-    top_k: int,
+    top_k: Union[torch.Tensor, int],
     deterministic: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Fused GPU kernel for top-k sampling from probabilities,
@@ -166,8 +175,10 @@ def top_k_sampling_from_probs(
         The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
         where the first dimension is the maximum number of rounds for rejection sampling.
         Expected to be uniformly distributed in ``[0, 1)``.
-    top_k: int
-        The k in "top-k".
+    top_k: Union[torch.Tensor, int]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
     deterministic: bool
         Whether to use deterministic kernel implementation, default is ``True``.
 
@@ -210,14 +221,14 @@ def top_k_sampling_from_probs(
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
     return _kernels.top_k_sampling_from_probs(
-        probs, uniform_samples, top_k, deterministic
+        probs, uniform_samples, *_to_tensor_scalar_tuple(top_k), deterministic
     )
 
 
 def min_p_sampling_from_probs(
     probs: torch.Tensor,
     uniform_samples: torch.Tensor,
-    min_p: torch.Tensor,
+    min_p: Union[torch.Tensor, float],
     deterministic: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Fused GPU kernel for `min_p sampling <https://arxiv.org/abs/2407.01082>`_ from probabilities,
@@ -236,7 +247,9 @@ def min_p_sampling_from_probs(
         where the first dimension is the maximum number of rounds for rejection sampling.
         Expected to be uniformly distributed in ``[0, 1)``.
     min_p: torch.Tensor
-        The :math:`p_{\text{base}}` in min_p sampling for each request, shape ``(batch_size,)``.
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for min-p sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
     deterministic: bool
         Whether to use deterministic kernel implementation, default is ``True``.
 
@@ -280,18 +293,19 @@ def min_p_sampling_from_probs(
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
     return _kernels.min_p_sampling_from_probs(
-        probs, uniform_samples, min_p, deterministic
+        probs, uniform_samples, _to_tensor_scalar_tuple(min_p), deterministic
     )
 
 
 def top_k_top_p_sampling_from_probs(
     probs: torch.Tensor,
     uniform_samples: torch.Tensor,
-    top_k: torch.Tensor,
-    top_p: torch.Tensor,
+    top_k: Union[torch.Tensor, int],
+    top_p: Union[torch.Tensor, float],
+    filter_apply_order: str = "top_k_first",
     deterministic: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    r"""Fused GPU kernel for joint top-k and top-p sampling from probabilities,
+    r"""Fused GPU kernel for top-k and top-p sampling from probabilities,
 
     this operator implements GPU-based rejection sampling without explicit sorting.
 
@@ -306,10 +320,18 @@ def top_k_top_p_sampling_from_probs(
         The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
         where the first dimension is the maximum number of rounds for rejection sampling.
         Expected to be uniformly distributed in ``[0, 1)``.
-    top_k: torch.Tensor
-        The k in "top-k" for each request, shape ``(batch_size,)``.
-    top_p: torch.Tensor
-        The threshold for top-p sampling for each request, shape ``(batch_size,)``.
+    top_k: Union[torch.Tensor, int]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+    top_p: Union[torch.Tensor, float]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+    filter_apply_order: str
+        The order of applying top-k and top-p sampling, should be either ``"top_k_first"`` or ``"joint"``.
+        If ``"top_k_first"``, we first apply top-k filter, then apply top-p sampling on the top-k results.
+        If ``"joint"``, we apply top-k and top-p filter simultaneously in each round.
     deterministic: bool
         Whether to use deterministic kernel implementation, default is ``True``.
 
@@ -352,13 +374,24 @@ def top_k_top_p_sampling_from_probs(
     We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
-    return _kernels.top_k_top_p_sampling_from_probs(
-        probs, uniform_samples, top_k, top_p, deterministic
-    )
+    if filter_apply_order == "top_k_first":
+        masked_logits = top_k_mask_logits(probs, top_k)
+        probs = torch.softmax(masked_logits, dim=-1)
+        return top_p_sampling_from_probs(probs, uniform_samples, top_p, deterministic)
+    elif filter_apply_order == "joint":
+        return _kernels.top_k_top_p_sampling_from_probs(
+            probs,
+            uniform_samples,
+            *_to_tensor_scalar_tuple(top_k),
+            *_to_tensor_scalar_tuple(top_p),
+            deterministic,
+        )
+    else:
+        raise ValueError(f"Invalid filter_apply_order: {filter_apply_order}")
 
 
 def top_p_renorm_prob(
-    probs: torch.Tensor, top_p: float, eps: float = 1e-5
+    probs: torch.Tensor, top_p: Union[torch.Tensor, float], eps: float = 1e-5
 ) -> torch.Tensor:
     r"""Fused GPU kernel for renormalizing probabilities by top-p thresholding.
 
@@ -366,8 +399,11 @@ def top_p_renorm_prob(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    top_p: float
-        The threshold for re-normalizing probabilities, should be in ``(0, 1)``.
+    top_p: Union[torch.Tensor, float]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-p threshold for for
+        re-normalizing probabilities, should be in ``(0, 1)``.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
         We mask out the probabilities less than `threshold` where the cumulative sum
         of ``probs[probs >= threshold]`` is `top_p`, and renormalize the probabilities.
     eps: float
@@ -381,11 +417,11 @@ def top_p_renorm_prob(
     This combination of ``top_p_renorm_prob`` and ``sampling_from_probs`` should be equivalent to
     ``top_p_sampling_from_probs``.
     """
-    return _kernels.top_p_renorm_prob(probs, top_p, eps)
+    return _kernels.top_p_renorm_prob(probs, _to_tensor_scalar_tuple(top_p), eps)
 
 
 def top_k_renorm_prob(
-    probs: torch.Tensor, top_k: int, eps: float = 1e-5
+    probs: torch.Tensor, top_k: Union[torch.Tensor, int], eps: float = 1e-5
 ) -> torch.Tensor:
     r"""Fused GPU kernel for renormalizing probabilities by top-k thresholding.
 
@@ -393,8 +429,11 @@ def top_k_renorm_prob(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    top_k: int
-        The threshold for re-normalizing probabilities, should be in ``(0, num_classes)``.
+    top_k: Union[torch.Tensor, int]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-k threshold for for
+        for re-normalizing probabilities, should be in ``(0, num_classes)``.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
         We keep the top-k probabilities, set the rest to zero, and renormalize the probabilities.
     eps: float
         The epsilon value for numerical stability.
@@ -409,7 +448,37 @@ def top_k_renorm_prob(
     This combination of ``top_k_renorm_prob`` and ``sampling_from_probs`` should be equivalent to
     ``top_k_sampling_from_probs``.
     """
-    return _kernels.top_k_renorm_prob(probs, top_k, eps)
+    return _kernels.top_k_renorm_prob(probs, _to_tensor_scalar_tuple(top_k), eps)
+
+
+def top_k_mask_logits(
+    logits: torch.Tensor, top_k: Union[torch.Tensor, int], eps: float = 1e-5
+) -> torch.Tensor:
+    r"""Fused GPU kernel for masking logits by top-k thresholding.
+
+    Parameters
+    ----------
+    logits: torch.Tensor
+        Logits before softmax, shape ``(batch_size, num_classes)``.
+    top_k: Union[torch.Tensor, int]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-k threshold for for
+        for masking logits, should be in ``(0, num_classes)``.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+        We keep the top-k logits, set the rest to negative infinity.
+    eps: float
+        The epsilon value for numerical stability.
+
+    Returns
+    -------
+    masked_logits: torch.Tensor
+        Masked logits, shape ``(batch_size, num_classes)``.
+
+    Note
+    ----
+    The combination of ``top_k_mask_logits`` and ``softmax`` should be equivalent to ``top_k_renorm_prob``.
+    """
+    return _kernels.top_k_mask_logits(logits, _to_tensor_scalar_tuple(top_k), eps)
 
 
 def chain_speculative_sampling(

--- a/python/tests/test_sampling.py
+++ b/python/tests/test_sampling.py
@@ -132,7 +132,8 @@ def test_min_p_sampling(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5])
-def test_top_k_top_p_sampling(batch_size, vocab_size, p):
+def test_top_k_top_p_joint_sampling_from_probs(batch_size, vocab_size, p):
+    torch.manual_seed(42)
     if p == 0.1:
         k = int(vocab_size * 0.5)
     elif p == 0.5:
@@ -164,13 +165,66 @@ def test_top_k_top_p_sampling(batch_size, vocab_size, p):
     for _ in range(num_trails):
         uniform_samples.uniform_()
         samples, success = flashinfer.sampling.top_k_top_p_sampling_from_probs(
-            normalized_prob, uniform_samples, top_k_tensor, top_p_tensor, filter_apply_order="joint"
+            normalized_prob,
+            uniform_samples,
+            top_k_tensor,
+            top_p_tensor,
+            filter_apply_order="joint",
         )
         assert torch.all(success)
         assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
         assert torch.all(mask[torch.arange(batch_size), samples] == 1), normalized_prob[
             torch.arange(batch_size), samples
         ]
+
+
+@pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
+@pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
+@pytest.mark.parametrize("k", [100])
+@pytest.mark.parametrize("p", [0.1, 0.5])
+def test_top_k_top_p_sampling_from_probs_logits_alignment(batch_size, vocab_size, k, p):
+    torch.manual_seed(42)
+    logits = torch.randn(batch_size, vocab_size).to(0) * 5
+    uniform_samples = torch.empty(32, batch_size).to(0)
+    samples, success = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+        logits, uniform_samples, k, p, filter_apply_order="top_k_first"
+    )
+    samples_ref, success_ref = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+        torch.softmax(logits, dim=-1),
+        uniform_samples,
+        k,
+        p,
+        filter_apply_order="top_k_first",
+    )
+    assert torch.all(samples == samples_ref)
+    assert torch.all(success)
+    assert torch.all(success_ref)
+
+
+@pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
+@pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
+@pytest.mark.parametrize("p", [0.1, 0.5])
+def test_top_k_top_p_joint_sampling_from_logits(batch_size, vocab_size, p):
+    torch.manual_seed(42)
+    logits = torch.rand(batch_size, vocab_size).to(0) * 5
+    uniform_samples = torch.empty(32, batch_size).to(0)
+    if p == 0.1:
+        k = int(vocab_size * 0.5)
+    elif p == 0.5:
+        k = int(vocab_size * 0.1)
+    else:
+        raise ValueError("p not recognized")
+
+    samples, success = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+        logits, uniform_samples, k, p, filter_apply_order="joint"
+    )
+
+    samples_ref, success_ref = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+        torch.softmax(logits, dim=-1), uniform_samples, k, p, filter_apply_order="joint"
+    )
+    assert torch.all(samples == samples_ref)
+    assert torch.all(success)
+    assert torch.all(success_ref)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
@@ -226,25 +280,25 @@ def test_top_k_renorm_prob(batch_size, vocab_size, k):
     )
 
 
-# @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
-# @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
-# @pytest.mark.parametrize("k", [10, 100, 500])
-# def test_top_k_mask_logits(batch_size, vocab_size, k):
-#     if k > vocab_size:
-#         pytest.skip("k should be less than vocab_size")
-#     torch.manual_seed(42)
-#     logits = torch.randn(batch_size, vocab_size).to(0)
-#     probs = torch.softmax(logits, dim=-1)
-#     masked_logits = flashinfer.sampling.top_k_mask_logits(logits, k, eps=1e-3)
-#     renormed_probs = torch.softmax(masked_logits, dim=-1)
-#     renormed_probs_ref = flashinfer.sampling.top_k_renorm_prob(probs, k, eps=1e-8)
+@pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
+@pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
+@pytest.mark.parametrize("k", [10, 100, 500])
+def test_top_k_mask_logits(batch_size, vocab_size, k):
+    if k > vocab_size:
+        pytest.skip("k should be less than vocab_size")
+    torch.manual_seed(42)
+    logits = torch.randn(batch_size, vocab_size).to(0) * 5
+    probs = torch.softmax(logits, dim=-1)
+    masked_logits = flashinfer.sampling.top_k_mask_logits(logits, k)
+    renormed_probs = torch.softmax(masked_logits, dim=-1)
+    renormed_probs_ref = flashinfer.sampling.top_k_renorm_prob(probs, k, 1e-8)
 
-#     numpy.testing.assert_allclose(
-#         renormed_probs.cpu().numpy(),
-#         renormed_probs_ref.cpu().numpy(),
-#         rtol=1e-3,
-#         atol=1e-3,
-#     )
+    numpy.testing.assert_allclose(
+        renormed_probs.cpu().numpy(),
+        renormed_probs_ref.cpu().numpy(),
+        rtol=1e-3,
+        atol=1e-3,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
@@ -307,11 +361,11 @@ def test_chain_speculative_sampling(
 
 
 if __name__ == "__main__":
-    # test_sampling(1, 111)
-    # test_top_p_sampling(3, 111, 0.9)
-    # test_top_k_sampling(3, 111, 10)
-    # test_top_p_renorm_prob(3, 111, 0.9)
-    # test_top_k_renorm_prob(3, 111, 10)
-    test_top_k_mask_logits(3, 111, 10)
-    # test_chain_speculative_sampling(3, 111, 3, False)
-    # test_chain_speculative_sampling(3, 111, 3, True)
+    test_sampling(1, 111)
+    test_top_p_sampling(3, 111, 0.9)
+    test_top_k_sampling(3, 111, 10)
+    test_top_p_renorm_prob(3, 111, 0.9)
+    test_top_k_renorm_prob(3, 111, 10)
+    test_top_k_mask_logits(99, 989, 10)
+    test_chain_speculative_sampling(3, 111, 3, False)
+    test_chain_speculative_sampling(3, 111, 3, True)

--- a/python/tests/test_sampling.py
+++ b/python/tests/test_sampling.py
@@ -164,7 +164,7 @@ def test_top_k_top_p_sampling(batch_size, vocab_size, p):
     for _ in range(num_trails):
         uniform_samples.uniform_()
         samples, success = flashinfer.sampling.top_k_top_p_sampling_from_probs(
-            normalized_prob, uniform_samples, top_k_tensor, top_p_tensor
+            normalized_prob, uniform_samples, top_k_tensor, top_p_tensor, filter_apply_order="joint"
         )
         assert torch.all(success)
         assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
@@ -224,6 +224,27 @@ def test_top_k_renorm_prob(batch_size, vocab_size, k):
         rtol=1e-3,
         atol=1e-3,
     )
+
+
+# @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
+# @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
+# @pytest.mark.parametrize("k", [10, 100, 500])
+# def test_top_k_mask_logits(batch_size, vocab_size, k):
+#     if k > vocab_size:
+#         pytest.skip("k should be less than vocab_size")
+#     torch.manual_seed(42)
+#     logits = torch.randn(batch_size, vocab_size).to(0)
+#     probs = torch.softmax(logits, dim=-1)
+#     masked_logits = flashinfer.sampling.top_k_mask_logits(logits, k, eps=1e-3)
+#     renormed_probs = torch.softmax(masked_logits, dim=-1)
+#     renormed_probs_ref = flashinfer.sampling.top_k_renorm_prob(probs, k, eps=1e-8)
+
+#     numpy.testing.assert_allclose(
+#         renormed_probs.cpu().numpy(),
+#         renormed_probs_ref.cpu().numpy(),
+#         rtol=1e-3,
+#         atol=1e-3,
+#     )
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
@@ -286,10 +307,11 @@ def test_chain_speculative_sampling(
 
 
 if __name__ == "__main__":
-    test_sampling(1, 111)
-    test_top_p_sampling(3, 111, 0.9)
-    test_top_k_sampling(3, 111, 10)
-    test_top_p_renorm_prob(3, 111, 0.9)
-    test_top_k_renorm_prob(3, 111, 10)
-    test_chain_speculative_sampling(3, 111, 3, False)
-    test_chain_speculative_sampling(3, 111, 3, True)
+    # test_sampling(1, 111)
+    # test_top_p_sampling(3, 111, 0.9)
+    # test_top_k_sampling(3, 111, 10)
+    # test_top_p_renorm_prob(3, 111, 0.9)
+    # test_top_k_renorm_prob(3, 111, 10)
+    test_top_k_mask_logits(3, 111, 10)
+    # test_chain_speculative_sampling(3, 111, 3, False)
+    # test_chain_speculative_sampling(3, 111, 3, True)

--- a/src/bench_sampling.cu
+++ b/src/bench_sampling.cu
@@ -101,8 +101,8 @@ void bench_top_p_sampling_with_probability(nvbench::state& state) {
     cudaError_t status = sampling::TopPSamplingFromProb<T, int32_t>(
         thrust::raw_pointer_cast(probs_d.data()),
         thrust::raw_pointer_cast(uniform_samples_d.data()),
-        thrust::raw_pointer_cast(output_d.data()), thrust::raw_pointer_cast(success_d.data()), p,
-        batch_size, vocab_size, max_top_p_rounds, deterministic);
+        thrust::raw_pointer_cast(output_d.data()), thrust::raw_pointer_cast(success_d.data()),
+        /*top_p_arr=*/nullptr, batch_size, p, vocab_size, max_top_p_rounds, deterministic);
     timer.stop();
     if (status != cudaSuccess) {
       state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));
@@ -147,8 +147,8 @@ void bench_top_k_sampling_with_probability(nvbench::state& state) {
     cudaError_t status = sampling::TopKSamplingFromProb<T, int32_t>(
         thrust::raw_pointer_cast(probs_d.data()),
         thrust::raw_pointer_cast(uniform_samples_d.data()),
-        thrust::raw_pointer_cast(output_d.data()), thrust::raw_pointer_cast(success_d.data()), k,
-        batch_size, vocab_size, max_top_k_rounds, deterministic);
+        thrust::raw_pointer_cast(output_d.data()), thrust::raw_pointer_cast(success_d.data()),
+        /*top_k_arr=*/nullptr, batch_size, k, vocab_size, max_top_k_rounds, deterministic);
     timer.stop();
     if (status != cudaSuccess) {
       state.skip("CUDA error: " + std::string(cudaGetErrorString(status)));

--- a/src/test_sampling.cu
+++ b/src/test_sampling.cu
@@ -61,7 +61,7 @@ void _TestTopKSamplingFromProb(size_t batch_size, uint32_t k, size_t vocab_size)
         thrust::raw_pointer_cast(probs_d.data()),
         thrust::raw_pointer_cast(uniform_samples_d.data()),
         thrust::raw_pointer_cast(sampled_ids_d.data()), thrust::raw_pointer_cast(success_d.data()),
-        k, batch_size, vocab_size, max_top_p_rounds, /*deterministic=*/true);
+        /*top_k_arr=*/nullptr, batch_size, k, vocab_size, max_top_p_rounds, /*deterministic=*/true);
 
     EXPECT_EQ(status, cudaSuccess) << "TopKSamplingFromProb kernel launch failed, error message: "
                                    << cudaGetErrorString(status);
@@ -126,7 +126,7 @@ void _TestTopPSamplingFromProb(size_t batch_size, uint32_t k, size_t vocab_size)
         thrust::raw_pointer_cast(probs_d.data()),
         thrust::raw_pointer_cast(uniform_samples_d.data()),
         thrust::raw_pointer_cast(sampled_ids_d.data()), thrust::raw_pointer_cast(success_d.data()),
-        p, batch_size, vocab_size, max_top_p_rounds, /*deterministic=*/true);
+        /*top_p_arr=*/nullptr, batch_size, p, vocab_size, max_top_p_rounds, /*deterministic=*/true);
 
     EXPECT_EQ(status, cudaSuccess) << "TopPSamplingFromProb kernel launch failed, error message: "
                                    << cudaGetErrorString(status);

--- a/src/test_single_prefill.cu
+++ b/src/test_single_prefill.cu
@@ -36,7 +36,8 @@ void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t nu
 
   utils::vec_normal_(q);
   utils::vec_normal_(k);
-  utils::vec_normal_(v);
+  // utils::vec_normal_(v);
+  utils::vec_fill_(v, DTypeKV(1.0));
   utils::vec_zero_(o);
 
   thrust::device_vector<DTypeQ> q_d(q);

--- a/src/test_single_prefill.cu
+++ b/src/test_single_prefill.cu
@@ -36,8 +36,7 @@ void _TestSinglePrefillKernelCorrectness(size_t qo_len, size_t kv_len, size_t nu
 
   utils::vec_normal_(q);
   utils::vec_normal_(k);
-  // utils::vec_normal_(v);
-  utils::vec_fill_(v, DTypeKV(1.0));
+  utils::vec_normal_(v);
   utils::vec_zero_(o);
 
   thrust::device_vector<DTypeQ> q_d(q);


### PR DESCRIPTION
1. implement the first top-k then top-p sampling to align with vllm and huggingface's behavior https://github.com/vllm-project/vllm/pull/7137#issuecomment-2275167700
2. add options of using a scalar/tensor for top-p/top-k thresholds for all sampling operators.