### PR TITLE
perf: faster fp8->fp16 dequantization for pre sm_90 arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ flashinfer_option(FLASHINFER_CASCADE "Whether to compile cascade kernel tests/be
 flashinfer_option(FLASHINFER_SAMPLING "Whether to compile sampling kernel tests/benchmarks or not." OFF)
 flashinfer_option(FLASHINFER_NORM "Whether to compile normalization kernel tests/benchmarks or not." OFF)
 flashinfer_option(FLASHINFER_DISTRIBUTED "Whether to compile distributed kernel tests/benchmarks or not." OFF)
+flashinfer_option(FLASHINFER_FASTDIV_TEST "Whether to compile fastdiv kernel tests or not." OFF)
+flashinfer_option(FLASHINFER_FASTDEQAUNT_TEST "Whether to compile fast dequant kernel tests or not." OFF)
 flashinfer_option(FLASHINFER_TVM_BINDING "Whether to compile tvm binding or not." OFF)
 flashinfer_option(FLASHINFER_TVM_SOURCE_DIR "The path to tvm for building tvm binding." "")
 
@@ -476,6 +478,17 @@ if(FLASHINFER_FASTDIV_TEST)
   target_include_directories(test_fastdiv PRIVATE ${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
   target_link_libraries(test_fastdiv PRIVATE gtest gtest_main)
 endif(FLASHINFER_FASTDIV_TEST)
+
+if(FLASHINFER_FASTDEQUANT_TEST)
+  message(STATUS "Compile fast dequant test.")
+  file(GLOB_RECURSE TEST_FAST_DEQUANT_SRCS ${PROJECT_SOURCE_DIR}/src/test_fast_dequant.cu)
+  add_executable(test_fast_dequant ${TEST_FAST_DEQUANT_SRCS})
+  target_include_directories(test_fast_dequant PRIVATE ${FLASHINFER_INCLUDE_DIR})
+  target_include_directories(test_fast_dequant PRIVATE ${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+  target_link_libraries(test_fast_dequant PRIVATE gtest gtest_main)
+endif(FLASHINFER_FASTDIV_TEST)
+
+
 
 if (FLASHINFER_DISTRIBUTED)
   find_package(MPI REQUIRED)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -18,6 +18,8 @@ set(FLASHINFER_SAMPLING ON)
 set(FLASHINFER_NORMALIZATION ON)
 # Whether to compile fastdiv tests
 set(FLASHINFER_FASTDIV_TEST ON)
+# Whether to compile fastdequant tests
+set(FLASHINFER_FASTDEQUANT_TEST ON)
 # Whether to compile distributed tests
 set(FLASHINFER_DISTRIBUTED ON)
 # The following configurations can impact the binary

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -124,21 +124,20 @@ __device__ void marlin_dequant_f8f16x4(uint32_t* input, uint2* output) {
   int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
   int Out2 = ((q << 8) & 0x80008000) | (((q << 8) & MASK) >> RIGHT_SHIFT);
 
-  // Construct and apply exponent bias
   constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
-
+  // Construct and apply exponent bias
   if (std::is_same<fp16_dtype, half>::value) {
     const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
 
     // Convert to half2 and apply bias
-    // Note: reverse indexing is intentional because weights are permuted
     *(half2*)&(output->x) = __hmul2(*reinterpret_cast<const half2*>(&Out1), bias_reg);
     *(half2*)&(output->y) = __hmul2(*reinterpret_cast<const half2*>(&Out2), bias_reg);
   } else {
-    const nv_bfloat162 bias_reg = __float2bfloat162_rn(float(1 << BIAS_OFFSET));
+    constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+    const nv_bfloat162 bias_reg =
+        __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
 
     // Convert to bfloat162 and apply bias
-    // Note: reverse indexing is intentional because weights are permuted
     *(nv_bfloat162*)&(output->x) = __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out1), bias_reg);
     *(nv_bfloat162*)&(output->y) = __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out2), bias_reg);
   }

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -75,7 +75,7 @@ struct vec_cast<half, float> {
 };
 
 template <typename T>
-constexpr int get_exponent_bits() {
+constexpr FLASHINFER_INLINE int get_exponent_bits() {
   if constexpr (std::is_same<T, __nv_fp8_e4m3>::value) {
     return 4;
   } else if constexpr (std::is_same<T, __nv_fp8_e5m2>::value) {
@@ -88,7 +88,7 @@ constexpr int get_exponent_bits() {
 }
 
 template <typename T>
-constexpr int get_mantissa_bits() {
+constexpr FLASHINFER_INLINE int get_mantissa_bits() {
   if constexpr (std::is_same<T, __nv_fp8_e4m3>::value) {
     return 3;
   } else if constexpr (std::is_same<T, __nv_fp8_e5m2>::value) {

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -25,9 +25,9 @@
 
 namespace flashinfer {
 
-// #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
-// #define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
-// #endif
+#if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
+#define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+#endif
 
 #define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
 

--- a/src/test_fast_dequant.cu
+++ b/src/test_fast_dequant.cu
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <thrust/detail/raw_pointer_cast.h>
+
+#include <bitset>
+#include <flashinfer/vec_dtypes.cuh>
+
+#include "utils.h"
+
+using namespace flashinfer;
+
+template <typename dtype_f8, typename dtype_f16>
+__global__ void test_fast_f8_f16_dequant(dtype_f8* f8, dtype_f16* f16) {
+  size_t global_tidx = blockIdx.x * blockDim.x + threadIdx.x;
+  vec_cast<dtype_f16, dtype_f8>::cast<8>(f16 + global_tidx * 8, f8 + global_tidx * 8);
+}
+
+template <typename dtype_f8, typename dtype_f16>
+void TestFastDequant() {
+  std::vector<dtype_f8> f8_h(1024);
+  utils::vec_normal_(f8_h);
+  std::vector<dtype_f16> f16_h_ref(1024);
+  for (uint32_t i = 0; i < 1024; ++i) {
+    f16_h_ref[i] = static_cast<dtype_f16>(f8_h[i]);
+  }
+
+  thrust::device_vector<dtype_f8> f8_d(f8_h);
+  thrust::device_vector<dtype_f16> f16_d(1024);
+
+  test_fast_f8_f16_dequant<dtype_f8, dtype_f16>
+      <<<1, 128>>>(thrust::raw_pointer_cast(f8_d.data()), thrust::raw_pointer_cast(f16_d.data()));
+
+  cudaError_t err = cudaGetLastError();
+  EXPECT_EQ(err, cudaSuccess);
+
+  thrust::host_vector<dtype_f16> f16_h(f16_d);
+  for (uint32_t i = 0; i < 1024; ++i) {
+    if (f16_h[i] != f16_h_ref[i]) {
+      printf("mismatch at i=%d: out=%x ref=%x\n", i, *(uint16_t*)(f16_h.data() + i),
+             *(uint16_t*)(f16_h_ref.data() + i));
+    }
+    EXPECT_EQ(f16_h[i], f16_h_ref[i]);
+  }
+}
+
+TEST(FlashInferCorrectnessTest, TestFastDequantCorrectnessE4M3ToFloat16) {
+  TestFastDequant<__nv_fp8_e4m3, half>();
+}
+TEST(FlashInferCorrectnessTest, TestFastDequantCorrectnessE5M2ToFloat16) {
+  TestFastDequant<__nv_fp8_e5m2, half>();
+}
+TEST(FlashInferCorrectnessTest, TestFastDequantCorrectnessE4M3ToBFloat16) {
+  TestFastDequant<__nv_fp8_e4m3, __nv_bfloat16>();
+}
+TEST(FlashInferCorrectnessTest, TestFastDequantCorrectnessE5M2ToBFloat16) {
+  TestFastDequant<__nv_fp8_e5m2, __nv_bfloat16>();
+}


### PR DESCRIPTION
hardware fp8->fp16 fast conversion instruction is not available for sm_80 & sm_89, which makes #420 slow for these architectures.

this pr uses marlin's fast fp8->fp16x4 conversion algorithm (copied from vllm project) to accelerate such cases.

Co-authored-by: Antoni Baum <antoni@anyscale.com>
Co-authored-by: Cody Yu <cody@anyscale.com>