### PR TITLE
feat: decouple float and int workspace buffer

### DIFF
--- a/python/csrc/activation.cu
+++ b/python/csrc/activation.cu
@@ -51,8 +51,7 @@ void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input) {
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
     dim3 block(std::min(d / vec_size, 1024U));
-    flashinfer::activation::act_and_mul_kernel<c_type,
-                                               flashinfer::activation::gelu_tanh_kernel>
+    flashinfer::activation::act_and_mul_kernel<c_type, flashinfer::activation::gelu_tanh_kernel>
         <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()),
                                      static_cast<c_type*>(input.data_ptr()), d);
 

--- a/python/csrc/flashinfer_ops_decode.h
+++ b/python/csrc/flashinfer_ops_decode.h
@@ -28,13 +28,13 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
 
 class BatchDecodeWithPagedKVCachePyTorchWrapper {
  public:
-  void BeginForward(torch::Tensor workspace_buffer, torch::Tensor indptr,
-                    torch::Tensor last_page_len, unsigned int batch_size, unsigned int num_qo_heads,
-                    unsigned int num_kv_heads, unsigned int head_dim, unsigned int page_size,
-                    unsigned int pos_encoding_mode, float logits_soft_cap,
+  void BeginForward(torch::Tensor float_workspace_buffer, DLTensor* int_workspace_buffer,
+                    torch::Tensor indptr, torch::Tensor last_page_len, unsigned int batch_size,
+                    unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int head_dim,
+                    unsigned int page_size, unsigned int pos_encoding_mode, float logits_soft_cap,
                     torch::Tensor empty_q_data, torch::Tensor empty_kv_data);
   void EndForward();
-  void UpdatePageLockedBufferSize(uint32_t max_workspace_size_in_bytes);
+  void UpdatePageLockedBufferSize(uint32_t int_workspace_size_in_bytes);
   bool IsCUDAGraphEnabled() const { return handler_->IsCUDAGraphEnabled(); }
   std::vector<torch::Tensor> Forward(torch::Tensor q, std::optional<torch::Tensor> paged_kv_cache,
                                      std::optional<torch::Tensor> paged_k_cache,

--- a/python/csrc/flashinfer_ops_decode.h
+++ b/python/csrc/flashinfer_ops_decode.h
@@ -28,7 +28,7 @@ torch::Tensor single_decode_with_kv_cache(torch::Tensor q, torch::Tensor k, torc
 
 class BatchDecodeWithPagedKVCachePyTorchWrapper {
  public:
-  void BeginForward(torch::Tensor float_workspace_buffer, DLTensor* int_workspace_buffer,
+  void BeginForward(torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
                     torch::Tensor indptr, torch::Tensor last_page_len, unsigned int batch_size,
                     unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int head_dim,
                     unsigned int page_size, unsigned int pos_encoding_mode, float logits_soft_cap,

--- a/python/csrc/flashinfer_ops_prefill.h
+++ b/python/csrc/flashinfer_ops_prefill.h
@@ -34,13 +34,13 @@ std::vector<torch::Tensor> single_prefill_with_kv_cache_custom_mask(
 
 class BatchPrefillWithPagedKVCachePyTorchWrapper {
  public:
-  void BeginForward(torch::Tensor workspace_buffer, torch::Tensor qo_indptr,
-                    torch::Tensor page_kv_indptr, unsigned int batch_size,
+  void BeginForward(torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
+                    torch::Tensor qo_indptr, torch::Tensor page_kv_indptr, unsigned int batch_size,
                     unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int head_dim,
                     unsigned page_size, torch::Tensor empty_q_data);
   void EndForward();
   bool IsCUDAGraphEnabled() const { return handler_->IsCUDAGraphEnabled(); }
-  void UpdatePageLockedBufferSize(uint32_t max_workspace_size_in_bytes);
+  void UpdatePageLockedBufferSize(uint32_t int_workspace_size_in_bytes);
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor qo_indptr,
                                      std::optional<torch::Tensor> paged_kv_cache,
                                      std::optional<torch::Tensor> paged_k_cache,
@@ -69,12 +69,13 @@ class BatchPrefillWithPagedKVCachePyTorchWrapper {
 
 class BatchPrefillWithRaggedKVCachePyTorchWrapper {
  public:
-  void BeginForward(torch::Tensor workspace_buffer, torch::Tensor qo_indptr,
-                    torch::Tensor kv_indptr, unsigned int batch_size, unsigned int num_qo_heads,
-                    unsigned int num_kv_heads, unsigned int head_dim, torch::Tensor empty_q_data);
+  void BeginForward(torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
+                    torch::Tensor qo_indptr, torch::Tensor kv_indptr, unsigned int batch_size,
+                    unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int head_dim,
+                    torch::Tensor empty_q_data);
   void EndForward();
   bool IsCUDAGraphEnabled() const { return handler_->IsCUDAGraphEnabled(); }
-  void UpdatePageLockedBufferSize(uint32_t max_workspace_size_in_bytes);
+  void UpdatePageLockedBufferSize(uint32_t int_workspace_size_in_bytes);
   std::vector<torch::Tensor> Forward(torch::Tensor q, torch::Tensor qo_indptr, torch::Tensor k,
                                      torch::Tensor v, torch::Tensor kv_indptr, bool causal,
                                      unsigned int pos_encoding_mode, bool allow_fp16_qk_reduction,

--- a/python/flashinfer/cascade.py
+++ b/python/flashinfer/cascade.py
@@ -257,22 +257,32 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
     manages the lifecycle of these data structures.
     """
 
-    def __init__(self, workspace_buffer: torch.Tensor, kv_layout: str = "NHD") -> None:
+    def __init__(
+        self, float_workspace_buffer: torch.Tensor, kv_layout: str = "NHD"
+    ) -> None:
         self._batch_decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
-            workspace_buffer, kv_layout
+            float_workspace_buffer, kv_layout
         )
         self._kv_layout = kv_layout
 
-    def reset_workspace_buffer(self, new_workspace_buffer: torch.Tensor) -> None:
+    def reset_workspace_buffer(
+        self, float_workspace_buffer: torch.Tensor, int_workspace_buffer
+    ) -> None:
         r"""Reset the workspace buffer.
 
         Parameters
         ----------
-        new_workspace_buffer : torch.Tensor
-            The new workspace buffer, the device of the new workspace buffer should
+        float_workspace_buffer : torch.Tensor
+            The new float workspace buffer, the device of the new float workspace buffer should
+            be the same as the device of the input tensors.
+
+        int_workspace_buffer : torch.Tensor
+            The new int workspace buffer, the device of the new int workspace buffer should
             be the same as the device of the input tensors.
         """
-        self._batch_decode_wrapper.reset_workspace_buffer(new_workspace_buffer)
+        self._batch_decode_wrapper.reset_workspace_buffer(
+            float_workspace_buffer, int_workspace_buffer
+        )
 
     def begin_forward(
         self,
@@ -503,33 +513,43 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
     layers). This wrapper class manages the lifecycle of these data structures.
     """
 
-    def __init__(self, workspace_buffer: torch.Tensor, kv_layout: str = "NHD") -> None:
+    def __init__(
+        self, float_workspace_buffer: torch.Tensor, kv_layout: str = "NHD"
+    ) -> None:
         r"""Constructor of :class:`BatchDecodeWithSharedPrefixPagedKVCacheWrapper`.
 
         Parameters
         ----------
-        workspace_buffer : torch.Tensor
-            The user reserved workspace buffer used to store auxiliary data structures,
-            recommended size is 128MB, the device of the workspace buffer should be the
-            same as the device of the input tensors.
+        float_workspace_buffer : torch.Tensor
+            The user reserved float workspace buffer used to store intermediate attention results
+            in the split-k algorithm. The recommended size is 128MB, the device of the workspace
+            buffer should be the same as the device of the input tensors.
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
         """
         self._batch_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
-            workspace_buffer, kv_layout
+            float_workspace_buffer, kv_layout
         )
         self._kv_layout = kv_layout
 
-    def reset_workspace_buffer(self, new_workspace_buffer: torch.Tensor) -> None:
+    def reset_workspace_buffer(
+        self, float_workspace_buffer: torch.Tensor, int_workspace_buffer
+    ) -> None:
         r"""Reset the workspace buffer.
 
         Parameters
         ----------
-        new_workspace_buffer : torch.Tensor
-            The new workspace buffer, the device of the new workspace buffer should
+        float_workspace_buffer : torch.Tensor
+            The new float workspace buffer, the device of the new float workspace buffer should
+            be the same as the device of the input tensors.
+
+        int_workspace_buffer : torch.Tensor
+            The new int workspace buffer, the device of the new int workspace buffer should
             be the same as the device of the input tensors.
         """
-        self._batch_prefill_wrapper.reset_workspace_buffer(new_workspace_buffer)
+        self._batch_prefill_wrapper.reset_workspace_buffer(
+            float_workspace_buffer, int_workspace_buffer
+        )
 
     def begin_forward(
         self,

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -541,7 +541,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
     def __init__(
         self,
-        workspace_buffer: torch.Tensor,
+        float_workspace_buffer: torch.Tensor,
         kv_layout: str = "NHD",
         use_cuda_graph: bool = False,
         qo_indptr_buf: Optional[torch.Tensor] = None,
@@ -555,10 +555,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         Parameters
         ----------
-        workspace_buffer : torch.Tensor
-            The user reserved workspace buffer used to store auxiliary data structures,
-            recommended size is 128MB, the device of the workspace buffer should be the
-            same as the device of the input tensors.
+        float_workspace_buffer : torch.Tensor
+            The user reserved workspace buffer used to store intermediate attention results in
+            split-k algorithm. The recommended size is 128MB, the device of the workspace buffer
+            should be the same as the device of the input tensors.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
@@ -603,7 +603,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
         """
         _check_kv_layout(kv_layout)
         self._kv_layout = kv_layout
-        self._workspace_buffer = workspace_buffer
+        self._float_workspace_buffer = float_workspace_buffer
+        self._int_workspace_buffer = torch.empty(
+            (8 * 1024 * 1024,), dtype=torch.uint8, device=float_workspace_buffer.device
+        )
         self._wrapper = _prefill.BatchPrefillWithPagedKVCachePyTorchWrapper(
             TensorLayout[kv_layout].value,
             use_cuda_graph,
@@ -649,16 +652,26 @@ class BatchPrefillWithPagedKVCacheWrapper:
     def is_cuda_graph_enabled(self) -> bool:
         return self._wrapper.is_cuda_graph_enabled()
 
-    def reset_workspace_buffer(self, new_workspace_buffer: torch.Tensor) -> None:
+    def reset_workspace_buffer(
+        self, float_workspace_buffer: torch.Tensor, int_workspace_buffer: torch.Tensor
+    ) -> None:
         r"""Reset the workspace buffer.
 
         Parameters
         ----------
-        new_workspace_buffer : torch.Tensor
-            The new workspace buffer, the device of the new workspace buffer should
+        float_workspace_buffer : torch.Tensor
+            The new float workspace buffer, the device of the new float workspace buffer should
+            be the same as the device of the input tensors.
+
+        int_workspace_buffer : torch.Tensor
+            The new int workspace buffer, the device of the new int workspace buffer should
             be the same as the device of the input tensors.
         """
-        self._workspace_buffer = new_workspace_buffer
+        self._float_workspace_buffer = float_workspace_buffer
+        self._int_workspace_buffer = int_workspace_buffer
+        self._wrapper.update_page_locked_buffer_size(
+            int_workspace_buffer.numel() * int_workspace_buffer.element_size()
+        )
 
     def begin_forward(
         self,
@@ -789,7 +802,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             ),
         )
         self._wrapper.begin_forward(
-            self._workspace_buffer,
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
             qo_indptr,
             paged_kv_indptr,
             batch_size,
@@ -1176,7 +1190,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
     def __init__(
         self,
-        workspace_buffer: torch.Tensor,
+        float_workspace_buffer: torch.Tensor,
         kv_layout: str = "NHD",
         use_cuda_graph: bool = False,
         qo_indptr_buf: Optional[torch.Tensor] = None,
@@ -1188,10 +1202,10 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         Parameters
         ----------
-        workspace_buffer : torch.Tensor
-            The user reserved workspace buffer used to store auxiliary data structures,
-            recommended size is 128MB, the device of the workspace buffer should be the
-            same as the device of the input tensors.
+        float_workspace_buffer : torch.Tensor
+            The user reserved float workspace buffer used to store intermediate attention results
+            in the split-k algorithm. The recommended size is 128MB, the device of the workspace
+            buffer should be the same as the device of the input tensors.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
@@ -1224,7 +1238,10 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         """
         _check_kv_layout(kv_layout)
         self._kv_layout = kv_layout
-        self._workspace_buffer = workspace_buffer
+        self._float_workspace_buffer = float_workspace_buffer
+        self._int_workspace_buffer = torch.empty(
+            (8 * 1024 * 1024,), dtype=torch.uint8, device=float_workspace_buffer.device
+        )
         self._wrapper = _prefill.BatchPrefillWithRaggedKVCachePyTorchWrapper(
             TensorLayout[kv_layout].value,
             use_cuda_graph,
@@ -1257,16 +1274,26 @@ class BatchPrefillWithRaggedKVCacheWrapper:
     def is_cuda_graph_enabled(self) -> bool:
         return self._wrapper.is_cuda_graph_enabled()
 
-    def reset_workspace_buffer(self, new_workspace_buffer: torch.Tensor) -> None:
+    def reset_workspace_buffer(
+        self, float_workspace_buffer: torch.Tensor, int_workspace_buffer
+    ) -> None:
         r"""Reset the workspace buffer.
 
         Parameters
         ----------
-        new_workspace_buffer : torch.Tensor
-            The new workspace buffer, the device of the new workspace buffer should
+        float_workspace_buffer : torch.Tensor
+            The new float workspace buffer, the device of the new float workspace buffer should
+            be the same as the device of the input tensors.
+
+        int_workspace_buffer : torch.Tensor
+            The new int workspace buffer, the device of the new int workspace buffer should
             be the same as the device of the input tensors.
         """
-        self._workspace_buffer = new_workspace_buffer
+        self._float_workspace_buffer = float_workspace_buffer
+        self._int_workspace_buffer = int_workspace_buffer
+        self._wrapper.update_page_locked_buffer_size(
+            int_workspace_buffer.numel() * int_workspace_buffer.element_size()
+        )
 
     def begin_forward(
         self,
@@ -1376,7 +1403,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             ),
         )
         self._wrapper.begin_forward(
-            self._workspace_buffer,
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
             qo_indptr,
             kv_indptr,
             batch_size,

--- a/python/setup.py
+++ b/python/setup.py
@@ -313,9 +313,7 @@ if __name__ == "__main__":
     files_prefill, files_decode = get_instantiation_cu()
     include_dirs = [
         str(root.resolve() / "include"),
-        str(
-            root.resolve() / "3rdparty" / "cutlass" / "include"
-        ),  # for group gemm
+        str(root.resolve() / "3rdparty" / "cutlass" / "include"),  # for group gemm
     ]
     extra_compile_args = {
         "cxx": [

--- a/src/bench_batch_decode.cu
+++ b/src/bench_batch_decode.cu
@@ -15,6 +15,7 @@
  */
 #include <thrust/device_vector.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <nvbench/nvbench.cuh>
 #include <vector>
@@ -71,13 +72,16 @@ void bench_flashinfer_batch_decode(nvbench::state& state) {
   BatchDecodeHandler handler;
 
   if (cooperative) {
-    size_t workspace_size_in_bytes = 32 * 1024 * 1024;
-    thrust::device_vector<char> buffer(workspace_size_in_bytes);
+    size_t float_workspace_size_in_bytes = 32 * 1024 * 1024;
+    thrust::device_vector<char> float_buffer(float_workspace_size_in_bytes);
+    size_t int_workspace_size_in_bytes = 8 * 1024 * 1024;
+    thrust::device_vector<char> int_buffer(int_workspace_size_in_bytes);
     // begin forward
     BatchDecodeHandlerBeginForward<PageStorage::kIndices, T, T, T, int32_t>(
-        &handler, (void*)thrust::raw_pointer_cast(buffer.data()), workspace_size_in_bytes,
-        kv_indptr_host.data(), kv_last_page_len_host.data(), batch_size, num_qo_heads, num_kv_heads,
-        head_dim, page_size, pos_encoding_mode);
+        &handler, (void*)thrust::raw_pointer_cast(float_buffer.data()),
+        float_workspace_size_in_bytes, (void*)thrust::raw_pointer_cast(int_buffer.data()),
+        int_workspace_size_in_bytes, kv_indptr_host.data(), kv_last_page_len_host.data(),
+        batch_size, num_qo_heads, num_kv_heads, head_dim, page_size, pos_encoding_mode);
     state.exec([&](nvbench::launch&) {
       cudaError_t status =
           BatchDecodeWithPagedKVCacheWrapper<PageStorage::kIndices, T, T, T, int32_t>(
@@ -148,12 +152,16 @@ void bench_flashinfer_batch_decode_with_prefill(nvbench::state& state) {
       "Read");
   state.add_global_memory_writes<uint8_t>(vec_bytes(o), "Write");
   BatchPrefillHandler handler;
-  size_t workspace_size_in_bytes = 128 * 1024 * 1024;
-  thrust::device_vector<char> buffer(workspace_size_in_bytes);
+  size_t float_workspace_size_in_bytes = 128 * 1024 * 1024;
+  thrust::device_vector<char> float_buffer(float_workspace_size_in_bytes);
+  size_t int_workspace_size_in_bytes = 8 * 1024 * 1024;
+  thrust::device_vector<char> int_buffer(int_workspace_size_in_bytes);
 
   handler.BeginForward<T, int32_t>(
-      (void*)thrust::raw_pointer_cast(buffer.data()), workspace_size_in_bytes, qo_indptr_h.data(),
-      kv_indptr_host.data(), batch_size, num_qo_heads, num_kv_heads, head_dim, page_size);
+      (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
+      (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
+      qo_indptr_h.data(), kv_indptr_host.data(), batch_size, num_qo_heads, num_kv_heads, head_dim,
+      page_size);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     cudaError_t status =

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -279,8 +279,9 @@ cudaError_t BatchDecodeWithPagedKVCacheWrapper(
 
 template <PageStorage PAGE_STORAGE, typename DTypeQ, typename DTypeKV, typename DTypeOut,
           typename IdType>
-cudaError_t BatchDecodeHandlerBeginForward(BatchDecodeHandler* handler, void* buffer,
-                                           size_t workspace_size_in_bytes, IdType* indptr_h,
+cudaError_t BatchDecodeHandlerBeginForward(BatchDecodeHandler* handler, void* float_buffer,
+                                           size_t float_workspace_size_in_bytes, void* int_buffer,
+                                           size_t int_workspace_size_in_bytes, IdType* indptr_h,
                                            IdType* last_page_len_h, uint32_t batch_size,
                                            uint32_t num_qo_heads, uint32_t num_kv_heads,
                                            uint32_t head_dim, uint32_t page_size,
@@ -295,8 +296,8 @@ cudaError_t BatchDecodeHandlerBeginForward(BatchDecodeHandler* handler, void* bu
     DISPATCH_pos_encoding_mode(pos_encoding_mode, POS_ENCODING_MODE, {
       return handler->BeginForwardDispatched<HEAD_DIM, PAGE_STORAGE, LogitsPostHook::kNone,
                                              POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeOut, IdType>(
-          buffer, workspace_size_in_bytes, indptr_h, last_page_len_h, batch_size, num_qo_heads,
-          num_kv_heads, page_size);
+          float_buffer, float_workspace_size_in_bytes, int_buffer, int_workspace_size_in_bytes,
+          indptr_h, last_page_len_h, batch_size, num_qo_heads, num_kv_heads, page_size);
     });
   });
 }

--- a/src/test_batch_decode.cu
+++ b/src/test_batch_decode.cu
@@ -98,10 +98,13 @@ void _TestBatchDecodingKernelCorrectness(size_t page_size, size_t batch_size, si
       thrust::raw_pointer_cast(kv_indptr_device.data()),
       thrust::raw_pointer_cast(kv_last_page_len_device.data()));
   flashinfer::BatchDecodeHandler handler;
-  size_t workspace_size_in_bytes = 32 * 1024 * 1024;
-  thrust::device_vector<char> buffer(workspace_size_in_bytes);
+  size_t float_workspace_size_in_bytes = 32 * 1024 * 1024;
+  thrust::device_vector<char> float_buffer(float_workspace_size_in_bytes);
+  size_t int_workspace_size_in_bytes = 8 * 1024 * 1024;
+  thrust::device_vector<char> int_buffer(int_workspace_size_in_bytes);
   BatchDecodeHandlerBeginForward<PageStorage::kIndices, DTypeQO, DTypeKV, DTypeQO, int32_t>(
-      &handler, (void*)thrust::raw_pointer_cast(buffer.data()), workspace_size_in_bytes,
+      &handler, (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
+      (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
       kv_indptr.data(), kv_last_page_len.data(), batch_size, num_qo_heads, num_kv_heads, head_dim,
       page_size, pos_encoding_mode);
 


### PR DESCRIPTION
Before this PR, flashinfer coupled float and int buffers in a single workspace buffer, and different wrappers cannot share the same buffers.

This PR decouples float and int workspace buffer. The float workspace buffer (large) can be shared in multiple wrappers, and the int buffer (small) is unique for each wrapper.  This PR can save GPU memory when multiple wrappers are created (decode, prefill paged, prefill ragged) or cascade inference.