### PR TITLE
bugfix: suppress warning #63-D: shift count is too large

### DIFF
--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -135,7 +135,7 @@ __device__ void fast_dequant_f8f16x4(uint32_t* input, uint2* output) {
 
     constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
     // Construct and apply exponent bias
-    if (std::is_same<fp16_dtype, half>::value) {
+    if constexpr (std::is_same<fp16_dtype, half>::value) {
       const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
 
       // Convert to half2 and apply bias


### PR DESCRIPTION
Followup of #439 , use `constexpr` in if conditions so that `BIAS_OFFSET` won't exceed 32 at compile time.