### PR TITLE
[Tentative] Adding 192 head dim  (step_size = 12)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    crate2nix = {
+      url = "github:nix-community/crate2nix";
+      inputs.nixpkgs.follows = "tgi-nix/nixpkgs";
+    };
+    nix-filter.url = "github:numtide/nix-filter";
+    tgi-nix.url = "github:danieldk/tgi-nix";
+    nixpkgs.follows = "tgi-nix/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    poetry2nix.url = "github:nix-community/poetry2nix";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "tgi-nix/nixpkgs";
+    };
+  };
+  outputs =
+    {
+      self,
+      crate2nix,
+      nix-filter,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      tgi-nix,
+      poetry2nix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        config = {
+          allowUnfree = true;
+          cudaSupport = true;
+        };
+        pkgs = import nixpkgs {
+          inherit config system;
+          overlays = [
+            rust-overlay.overlays.default
+            tgi-nix.overlay
+          ];
+        };
+        crateOverrides = import ./nix/crate-overrides.nix { inherit pkgs nix-filter; };
+      in
+      {
+        devShells.default =
+          with pkgs;
+          mkShell.override { stdenv = gcc12Stdenv; } {
+            buildInputs =
+              [
+                openssl.dev
+                pkg-config
+                gcc12
+              ]
+              ++ gcc12Stdenv.defaultBuildInputs
+              ++ gcc12Stdenv.defaultNativeBuildInputs
+              ++ (with python3.pkgs; [
+                venvShellHook
+                pip
+                torch
+                pytest
+              ]);
+
+            venvDir = "./.venv";
+
+            postVenv = ''
+              unset SOURCE_DATE_EPOCH
+            '';
+            postShellHook = ''
+              unset SOURCE_DATE_EPOCH
+            '';
+          };
+      }
+    );
+}

--- a/include/flashinfer/permuted_smem.cuh
+++ b/include/flashinfer/permuted_smem.cuh
@@ -76,12 +76,14 @@ struct smem_t {
   static __device__ __forceinline__ uint32_t advance_offset_by_column(uint32_t offset,
                                                                       uint32_t step_idx) {
     if constexpr (swizzle_mode == SwizzleMode::k128B) {
-      static_assert(step_size == 2 || step_size == 4 || step_size % 8 == 0,
+      static_assert(step_size == 2 || step_size == 4 || step_size == 12 || step_size % 8 == 0,
                     "Unsupported step size");
       if constexpr (step_size == 2) {
         return (offset ^ (0x2 + (0x4 * (step_idx % 2 == 1)))) + (step_idx % 4 == 3) * 8;
       } else if constexpr (step_size == 4) {
         return (offset ^ 0x4) + (step_idx % 2 == 1) * 8;
+      } else if constexpr (step_size == 12) {
+        return (offset ^ 0x4) + (step_idx % 2 == 1) * 8 + 8;
       } else {
         // step_size % 8 == 0
         return offset + step_size;

--- a/python/tests/test_batch_decode_kernels.py
+++ b/python/tests/test_batch_decode_kernels.py
@@ -26,7 +26,7 @@ import flashinfer
 @pytest.mark.parametrize("page_size", [1, 8, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])
-@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("head_dim", [128, 192, 256])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])
 @pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])

--- a/python/tests/test_batch_prefill_kernels.py
+++ b/python/tests/test_batch_prefill_kernels.py
@@ -27,7 +27,7 @@ import flashinfer
 @pytest.mark.parametrize("page_size", [1, 5, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])
-@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("head_dim", [128, 192, 256])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA", "ALIBI"])


### PR DESCRIPTION
Not sure if this PR actually works correctly (I'm going to check it).

Deepseek models use head_dim=192, and this cannot be compiled because of this static assert.
This modification works by jumping like `step_size=4` + jumping by 8 every iteration.

Let me know if this is interesting  in here.