### PR TITLE
feat: add `MultiLevelCascadeAttentionWrapper` API

### DIFF
--- a/docs/api/python/cascade.rst
+++ b/docs/api/python/cascade.rst
@@ -25,6 +25,10 @@ Cascade Attention
 Cascade Attention Wrapper Classes
 ---------------------------------
 
+.. autoclass:: MultiLevelCascadeAttentionWrapper
+    :members:
+
+
 .. autoclass:: BatchDecodeWithSharedPrefixPagedKVCacheWrapper
     :members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@ project = "FlashInfer"
 author = "FlashInfer Contributors"
 copyright = "2023-2024, {}".format(author)
 
-version = "0.1.4"
-release = "0.1.4"
+version = "0.1.5"
+release = "0.1.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/tutorials/kv_layout.rst
+++ b/docs/tutorials/kv_layout.rst
@@ -41,6 +41,24 @@ shape ``(indptr[-1], num_heads, head_dim)`` when the layout is ``NHD``.
 
 We can use ``data[indptr[i]:indptr[i+1]]`` to slice the keys (or values) of request ``i``.
 
+.. _cascade-qo-indptr-layout:
+
+Multi-level Cascade Inference Query/Output Layout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using multi-level `cascade inference <https://flashinfer.ai/2024/02/02/cascade-inference.html>`_,
+the query and output of each level are stored in ragged tensors, each level's ``qo_indptr`` array stores
+the interval information of each node in the cascade tree at that level, the figure below shows the
+``qo_indptr`` for each level in cascade inference:
+
+.. image:: https://raw.githubusercontent.com/flashinfer-ai/web-data/main/tutorials/cascade_qo_indptr.png
+  :width: 800
+  :align: center
+  :alt: The ``qo_indptr`` for each level in cascade inference.
+
+Note that each level's ``qo_indptr`` array should start from 0, and the last element of the ``qo_indptr`` array
+should be equal to the sum of length for all query/output tensors.
+
 FlashInfer APIs
 ~~~~~~~~~~~~~~~
 

--- a/python/flashinfer/__init__.py
+++ b/python/flashinfer/__init__.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from .cascade import (
+    MultiLevelCascadeAttentionWrapper,
     BatchDecodeWithSharedPrefixPagedKVCacheWrapper,
     BatchPrefillWithSharedPrefixPagedKVCacheWrapper,
     merge_state,


### PR DESCRIPTION
Our existing cascade inference APIs all assumes shared prefix kv-cache are standalone tensors which is not the case for real-world llm serving.

This PR adds a more general `MultiLevelCascadeAttentionWrapper` API which not only supports multi-level cascade inference, and the kv-cache of all levels are stored in the unified paged kv-cache, which can seamlessly integrate with existing LLM serving frameworks.

Tutorials, tests and examples are updated correspondingly.

The old `BatchDecodeWithSharedPrefixPagedKVCacheWrapper` and `BatchPrefillWithSharedPrefixPagedKVCacheWrapper` should be deprecated, starting from 0.2.0.
