### PR TITLE
misc: use the new `plan`/`run` API for unittests

### DIFF
--- a/docs/api/python/cascade.rst
+++ b/docs/api/python/cascade.rst
@@ -28,11 +28,17 @@ Cascade Attention Wrapper Classes
 .. autoclass:: MultiLevelCascadeAttentionWrapper
     :members:
 
+    .. automethod:: __init__
+    
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
 .. autoclass:: BatchDecodeWithSharedPrefixPagedKVCacheWrapper
     :members:
 
+    .. automethod:: __init__
 
 .. autoclass:: BatchPrefillWithSharedPrefixPagedKVCacheWrapper
     :members:
+
+    .. automethod:: __init__
 

--- a/docs/api/python/decode.rst
+++ b/docs/api/python/decode.rst
@@ -20,6 +20,8 @@ Batch Decoding
     :members:
 
     .. automethod:: __init__
+    
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
 .. autoclass:: CUDAGraphBatchDecodeWithPagedKVCacheWrapper
     :members:

--- a/docs/api/python/prefill.rst
+++ b/docs/api/python/prefill.rst
@@ -24,7 +24,11 @@ Batch Prefill/Append Attention
 
     .. automethod:: __init__
 
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
+
 .. autoclass:: BatchPrefillWithRaggedKVCacheWrapper
     :members:
     
     .. automethod:: __init__
+    
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse

--- a/docs/api/python/sparse.rst
+++ b/docs/api/python/sparse.rst
@@ -11,3 +11,5 @@ Kernels for block sparse flashattention.
     :members:
 
     .. automethod:: __init__
+    
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse

--- a/docs/tutorials/kv_layout.rst
+++ b/docs/tutorials/kv_layout.rst
@@ -155,7 +155,7 @@ When using multi-level `cascade inference <https://flashinfer.ai/2024/02/02/casc
 the query and output are stored in ragged tensors, and KV-Cache of all levels are stored
 in a unified Paged KV-Cache. Each level has a unique ``qo_indptr`` array which is the prefix sum of the
 accumulated number of tokens to append in the subtree, as well as ``kv_page_indptr``, ``kv_page_indices``, and
-``kv_last_page_len`` which has same semantics as in :ref:`<page-layout>` section. The following figure
+``kv_last_page_len`` which has same semantics as in :ref:`page-layout` section. The following figure
 introduce how to construct these data structures for append attention operation for 8 requests where we
 treat their KV-Cache as 3 levels for prefix reuse:
 

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -478,15 +478,14 @@ class BatchPrefillWithPagedKVCacheWrapper:
     ...     num_kv_heads,
     ...     head_dim,
     ...     page_size,
+    ...     causal=True,
     ... )
     >>> outputs = []
     >>> for i in range(num_layers):
     ...     q = q_at_layer[i]
     ...     kv_cache = kv_cache_at_layer[i]
     ...     # compute batch prefill attention, reuse auxiliary data structures
-    ...     o = prefill_wrapper.run(
-    ...         q, kv_cache, causal=True
-    ...     )
+    ...     o = prefill_wrapper.run(q, kv_cache)
     ...     outputs.append(o)
     ...
     >>> outputs[0].shape
@@ -513,18 +512,16 @@ class BatchPrefillWithPagedKVCacheWrapper:
     ...     num_kv_heads,
     ...     head_dim,
     ...     page_size,
-    ...     mask
+    ...     custom_mask=mask,
     ... )
-    >>> outputs_custom_mask = []
     >>> for i in range(num_layers):
     ...     q = q_at_layer[i]
     ...     kv_cache = kv_cache_at_layer[i]
     ...     # compute batch prefill attention, reuse auxiliary data structures
-    ...     o_custom = prefill_wrapper.run(
-    ...         q, kv_cache
-    ...     )
+    ...     o_custom = prefill_wrapper.run(q, kv_cache)
     ...     assert torch.allclose(o_custom, outputs[i], rtol=1e-3, atol=1e-3)
     ...
+
 
 
     Note
@@ -1161,7 +1158,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
     ...     kv_indptr,
     ...     num_qo_heads,
     ...     num_kv_heads,
-    ...     head_dim
+    ...     head_dim,
+    ...     causal=True,
     ... )
     >>> outputs = []
     >>> for i in range(num_layers):
@@ -1169,9 +1167,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
     ...     k = k_at_layer[i]
     ...     v = v_at_layer[i]
     ...     # compute batch prefill attention, reuse auxiliary data structures
-    ...     o = prefill_wrapper.run(
-    ...         q, k, v, causal=True
-    ...     )
+    ...     o = prefill_wrapper.run(q, k, v)
     ...     outputs.append(o)
     ...
     >>> outputs[0].shape
@@ -1195,7 +1191,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
     ...     num_qo_heads,
     ...     num_kv_heads,
     ...     head_dim,
-    ...     mask
+    ...     custom_mask=mask
     ... )
     >>> outputs_custom_mask = []
     >>> for i in range(num_layers):

--- a/python/tests/test_block_sparse.py
+++ b/python/tests/test_block_sparse.py
@@ -72,7 +72,7 @@ def test_block_sparse_attention(
     workspace_buffer = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=0)
     sparse_attention_wrapper = flashinfer.BlockSparseAttentionWrapper(workspace_buffer)
 
-    sparse_attention_wrapper.begin_forward(
+    sparse_attention_wrapper.plan(
         indptr,
         indices,
         M,
@@ -85,8 +85,7 @@ def test_block_sparse_attention(
         mask=data_mask if mask_inside_block else None,
     )
 
-    o = sparse_attention_wrapper.forward(q, k, v)
-    sparse_attention_wrapper.end_forward()
+    o = sparse_attention_wrapper.run(q, k, v)
     np.testing.assert_allclose(o_ref.cpu(), o.cpu(), atol=1e-2, rtol=1e-3)
 
 

--- a/python/tests/test_decode_prefill_lse.py
+++ b/python/tests/test_decode_prefill_lse.py
@@ -35,7 +35,7 @@ def test_mlc_failed_case():
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
     wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
-    wrapper.begin_forward(
+    wrapper.plan(
         kv_indptr_1,
         kv_indices_1,
         kv_last_page_len_1,
@@ -47,12 +47,12 @@ def test_mlc_failed_case():
         data_type=torch.float16,
         q_data_type=torch.float16,
     )
-    o_1, lse_1 = wrapper.forward_return_lse(q, kv_data)
+    o_1, lse_1 = wrapper.run_return_lse(q, kv_data)
 
     wrapper_tensor_cores = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout, use_tensor_cores=True
     )
-    wrapper_tensor_cores.begin_forward(
+    wrapper_tensor_cores.plan(
         kv_indptr_1,
         kv_indices_1,
         kv_last_page_len_1,
@@ -64,7 +64,7 @@ def test_mlc_failed_case():
         data_type=torch.float16,
         q_data_type=torch.float16,
     )
-    o_1_tc, lse_1_tc = wrapper_tensor_cores.forward_return_lse(q, kv_data)
+    o_1_tc, lse_1_tc = wrapper_tensor_cores.run_return_lse(q, kv_data)
 
     np.testing.assert_allclose(
         lse_1.cpu().numpy(), lse_1_tc.cpu().numpy(), rtol=1e-3, atol=1e-3

--- a/python/tests/test_fp8_prefill.py
+++ b/python/tests/test_fp8_prefill.py
@@ -81,7 +81,6 @@ def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
         q_data_type=torch.float16,
     )
     o_fp16 = wrapper.run(q, kv_data)
-
     k_data, v_data = torch.chunk(kv_data, 2, dim=1)
     k_scale = k_data.amax().item() / 256
     v_scale = v_data.amax().item() / 256

--- a/python/tests/test_fp8_prefill.py
+++ b/python/tests/test_fp8_prefill.py
@@ -69,7 +69,7 @@ def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
     wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
-    wrapper.begin_forward(
+    wrapper.plan(
         qo_indptr,
         kv_indptr,
         kv_indices,
@@ -80,8 +80,7 @@ def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
         page_size,
         q_data_type=torch.float16,
     )
-    o_fp16 = wrapper.forward(q, kv_data)
-    wrapper.end_forward()
+    o_fp16 = wrapper.run(q, kv_data)
 
     k_data, v_data = torch.chunk(kv_data, 2, dim=1)
     k_scale = k_data.amax().item() / 256
@@ -91,7 +90,7 @@ def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
     v_fp8 = (v_data / v_scale).to(dtype)
     kv_data_fp8 = torch.cat([k_fp8, v_fp8], dim=1)
 
-    wrapper.begin_forward(
+    wrapper.plan(
         qo_indptr,
         kv_indptr,
         kv_indices,
@@ -102,7 +101,7 @@ def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
         page_size,
         q_data_type=torch.float16,
     )
-    o_fp8 = wrapper.forward(
+    o_fp8 = wrapper.run(
         q,
         kv_data_fp8.to(dtype),
         k_scale=k_scale,
@@ -158,7 +157,7 @@ def test_batch_decode_with_prefill_with_paged_kv_cache(
     wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
-    wrapper.begin_forward(
+    wrapper.plan(
         qo_indptr,
         kv_indptr,
         kv_indices,
@@ -169,15 +168,12 @@ def test_batch_decode_with_prefill_with_paged_kv_cache(
         page_size,
         q_data_type=torch.float16,
     )
-    o_fp8 = wrapper.forward(
-        q,
-        kv_data,
-    )
+    o_fp8 = wrapper.run(q, kv_data)
 
     decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
-    decode_wrapper.begin_forward(
+    decode_wrapper.plan(
         kv_indptr,
         kv_indices,
         kv_last_page_len,
@@ -185,14 +181,10 @@ def test_batch_decode_with_prefill_with_paged_kv_cache(
         num_kv_heads,
         head_dim,
         page_size,
-        "NONE",
         data_type=dtype,
         q_data_type=torch.float16,
     )
-    o_decode_fp8 = decode_wrapper.forward(
-        q,
-        kv_data,
-    )
+    o_decode_fp8 = decode_wrapper.run(q, kv_data)
 
     np.testing.assert_allclose(
         o_decode_fp8.cpu().numpy(), o_fp8.cpu().numpy(), atol=1e-2, rtol=1e-2

--- a/python/tests/test_group_gemm.py
+++ b/python/tests/test_group_gemm.py
@@ -59,7 +59,7 @@ def test_segment_gemm(
             weight = (torch.randn(batch_size, d_out, d_in) / 10).to(0).to(torch.float16)
         else:
             weight = (torch.randn(batch_size, d_in, d_out) / 10).to(0).to(torch.float16)
-    y = segment_gemm.forward(
+    y = segment_gemm.run(
         x,
         weight,
         batch_size,

--- a/python/tests/test_non_contiguous_prefill.py
+++ b/python/tests/test_non_contiguous_prefill.py
@@ -91,17 +91,11 @@ def test_batch_ragged_prefill_packed_input(
         (256 * 1024 * 1024,), dtype=torch.uint8, device="cuda:0"
     )
     wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace_buffer)
-    wrapper.begin_forward(
-        qo_indptr,
-        kv_indptr,
-        num_qo_heads,
-        num_kv_heads,
-        head_dim,
+    wrapper.plan(
+        qo_indptr, kv_indptr, num_qo_heads, num_kv_heads, head_dim, causal=causal
     )
-    o_packed = wrapper.forward(q, k, v, causal=causal)
-    o_contiguous = wrapper.forward(
-        q.contiguous(), k.contiguous(), v.contiguous(), causal=causal
-    )
+    o_packed = wrapper.run(q, k, v)
+    o_contiguous = wrapper.run(q.contiguous(), k.contiguous(), v.contiguous())
 
     numpy.testing.assert_allclose(
         o_packed.cpu(), o_contiguous.cpu(), rtol=1e-3, atol=1e-3

--- a/python/tests/test_shared_prefix_kernels.py
+++ b/python/tests/test_shared_prefix_kernels.py
@@ -141,7 +141,7 @@ def test_batch_attention_with_shared_prefix_paged_kv_cache(
             head_dim,
             page_size,
         )
-        o_multi_level = multi_level_wrapper.forward(q, kv_data)
+        o_multi_level = multi_level_wrapper.run(q, kv_data)
     else:
         qo_indptr_bottom = torch.arange(0, batch_size + 1).to(0) * unique_kv_len
         multi_level_wrapper.plan(
@@ -155,7 +155,7 @@ def test_batch_attention_with_shared_prefix_paged_kv_cache(
             page_size,
             causal=causal,
         )
-        o_multi_level = multi_level_wrapper.forward(q, kv_data)
+        o_multi_level = multi_level_wrapper.run(q, kv_data)
 
     if stage == "decode":
         shared_prefix_decode_wrapper.begin_forward(

--- a/python/tests/test_sliding_window.py
+++ b/python/tests/test_sliding_window.py
@@ -84,7 +84,7 @@ def test_batch_decode_sliding_window(
 
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(0)
     wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, "NHD")
-    wrapper.begin_forward(
+    wrapper.plan(
         kv_indptr,
         kv_indices,
         kv_last_page_len,
@@ -92,13 +92,9 @@ def test_batch_decode_sliding_window(
         num_kv_heads,
         head_dim,
         page_size,
-        "NONE",
-    )
-    o = wrapper.forward(
-        q,
-        (k_data, v_data),
         window_left=window_left,
     )
+    o = wrapper.run(q, (k_data, v_data))
 
     for i in range(batch_size):
         qi = q[i]
@@ -236,7 +232,7 @@ def test_batch_paged_prefill_sliding_window(
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
     wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace_buffer, "NHD")
-    wrapper.begin_forward(
+    wrapper.plan(
         q_indptr,
         kv_indptr,
         kv_indices,
@@ -245,11 +241,11 @@ def test_batch_paged_prefill_sliding_window(
         num_kv_heads,
         head_dim,
         page_size,
+        window_left=window_left,
     )
-    o = wrapper.forward(
+    o = wrapper.run(
         q,
         (k_data, v_data),
-        window_left=window_left,
     )
 
     for i in range(batch_size):
@@ -319,19 +315,15 @@ def test_batch_ragged_prefill_sliding_window(
     kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
     wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace_buffer, "NHD")
-    wrapper.begin_forward(
+    wrapper.plan(
         q_indptr,
         kv_indptr,
         num_qo_heads,
         num_kv_heads,
         head_dim,
-    )
-    o = wrapper.forward(
-        q,
-        k,
-        v,
         window_left=window_left,
     )
+    o = wrapper.run(q, k, v)
 
     for i in range(batch_size):
         qi = q[q_indptr[i] : q_indptr[i + 1]]

--- a/python/tests/test_sliding_window.py
+++ b/python/tests/test_sliding_window.py
@@ -242,6 +242,7 @@ def test_batch_paged_prefill_sliding_window(
         head_dim,
         page_size,
         window_left=window_left,
+        causal=True,
     )
     o = wrapper.run(
         q,

--- a/python/tests/test_tensor_cores_decode.py
+++ b/python/tests/test_tensor_cores_decode.py
@@ -121,6 +121,7 @@ def test_batch_decode_tensor_cores(
         num_kv_heads,
         head_dim,
         page_size,
+        pos_encoding_mode=pos_encoding_mode,
         data_type=torch.float16,
         q_data_type=torch.float16,
     )


### PR DESCRIPTION
In the previous PR #466 we replace the old-style `begin_forward`/`end_forward`/`forward` APIs with the new `plan`/`run` APIs, but didn't update the unit tests accordingly (this is intentional because we want a commit that keeps unit tests that uses the old-style API to check backward compatibility).

This PR updates the unit tests with new APIs.

Some other changes:
- Remove old-style APIs from docstring.
- Fix some errors in docstring with new APIs.