### PR TITLE
doc: fix the use of exclude-members

### DIFF
--- a/docs/api/python/cascade.rst
+++ b/docs/api/python/cascade.rst
@@ -27,10 +27,9 @@ Cascade Attention Wrapper Classes
 
 .. autoclass:: MultiLevelCascadeAttentionWrapper
     :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
     .. automethod:: __init__
-    
-    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
 .. autoclass:: BatchDecodeWithSharedPrefixPagedKVCacheWrapper
     :members:

--- a/docs/api/python/decode.rst
+++ b/docs/api/python/decode.rst
@@ -18,10 +18,9 @@ Batch Decoding
 
 .. autoclass:: BatchDecodeWithPagedKVCacheWrapper
     :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
     .. automethod:: __init__
-    
-    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
 .. autoclass:: CUDAGraphBatchDecodeWithPagedKVCacheWrapper
     :members:

--- a/docs/api/python/group_gemm.rst
+++ b/docs/api/python/group_gemm.rst
@@ -9,5 +9,6 @@ This module provides a set of functions to group GEMM operations.
 
 .. autoclass:: SegmentGEMMWrapper
     :members:
+    :exclude-members: forward
 
     .. automethod:: __init__

--- a/docs/api/python/prefill.rst
+++ b/docs/api/python/prefill.rst
@@ -21,14 +21,12 @@ Batch Prefill/Append Attention
 
 .. autoclass:: BatchPrefillWithPagedKVCacheWrapper
     :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
     .. automethod:: __init__
-
-    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
 .. autoclass:: BatchPrefillWithRaggedKVCacheWrapper
     :members:
-    
-    .. automethod:: __init__
-    
     :exclude-members: begin_forward, end_forward, forward, forward_return_lse
+
+    .. automethod:: __init__

--- a/docs/api/python/sparse.rst
+++ b/docs/api/python/sparse.rst
@@ -9,7 +9,6 @@ Kernels for block sparse flashattention.
 
 .. autoclass:: BlockSparseAttentionWrapper
     :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
     .. automethod:: __init__
-    
-    :exclude-members: begin_forward, end_forward, forward, forward_return_lse


### PR DESCRIPTION
The usage of exclude-members in #467 is wrong, this PR fixes the issue.