### PR TITLE
hotfix: skip prefill kernels on sm75 for bf16

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1058,7 +1058,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     const float logits_soft_cap, float sm_scale, const float log2_rope_rcp_scale,
     const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
-  if (std::is_same<DTypeQ, nv_bfloat16>::value) {
+  if constexpr (std::is_same<DTypeQ, nv_bfloat16>::value) {
     FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
   } else {
 #endif
@@ -1332,7 +1332,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     const uint32_t kv_stride_h, const int32_t maybe_window_left, const float logits_soft_cap,
     float sm_scale, const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
-  if (std::is_same<DTypeQ, nv_bfloat16>::value) {
+  if constexpr (std::is_same<DTypeQ, nv_bfloat16>::value) {
     FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
   } else {
 #endif
@@ -1634,7 +1634,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     int32_t maybe_window_left, const float logits_soft_cap, float sm_scale,
     const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
-  if (std::is_same<DTypeQ, nv_bfloat16>::value) {
+  if constexpr (std::is_same<DTypeQ, nv_bfloat16>::value) {
     FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
   } else {
 #endif

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1058,7 +1058,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     const float logits_soft_cap, float sm_scale, const float log2_rope_rcp_scale,
     const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
-  if (std::is_same(DTypeQ, nv_bfloat16)::value) {
+  if (std::is_same<DTypeQ, nv_bfloat16>::value) {
     FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.")
   } else {
 #endif
@@ -1332,7 +1332,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     const uint32_t kv_stride_h, const int32_t maybe_window_left, const float logits_soft_cap,
     float sm_scale, const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
-  if (std::is_same(DTypeQ, nv_bfloat16)::value) {
+  if (std::is_same<DTypeQ, nv_bfloat16>::value) {
     FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.")
   } else {
 #endif
@@ -1634,7 +1634,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     int32_t maybe_window_left, const float logits_soft_cap, float sm_scale,
     const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
-  if (std::is_same(DTypeQ, nv_bfloat16)::value) {
+  if (std::is_same<DTypeQ, nv_bfloat16>::value) {
     FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.")
   } else {
 #endif

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -428,7 +428,7 @@ __device__ __forceinline__ void q_smem_inplace_multiply_sm_scale(smem_t<swizzle_
     tmp.load((DTypeQ*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
 #pragma unroll
     for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
-      tmp[reg_id] *= sm_scale;
+      tmp[reg_id] *= DTypeQ(sm_scale);
     }
     tmp.store((DTypeQ*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
   }

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1059,7 +1059,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
   if (std::is_same<DTypeQ, nv_bfloat16>::value) {
-    FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.")
+    FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
   } else {
 #endif
     static_assert(sizeof(DTypeQ) == 2);
@@ -1333,7 +1333,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithRagg
     float sm_scale, const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
   if (std::is_same<DTypeQ, nv_bfloat16>::value) {
-    FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.")
+    FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
   } else {
 #endif
     static_assert(sizeof(DTypeQ) == 2);
@@ -1635,7 +1635,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void BatchPrefillWithPage
     const float log2_rope_rcp_scale, const float log2_rope_rcp_theta) {
 #if (__CUDA_ARCH__ < 800)
   if (std::is_same<DTypeQ, nv_bfloat16>::value) {
-    FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.")
+    FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
   } else {
 #endif
     static_assert(sizeof(DTypeQ) == 2);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -41,6 +41,13 @@ FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __n
   return t;
 }
 
+FLASHNFFLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+  __nv_bfloat162 val;
+  val.x = __hmul(a.x, b.x);
+  val.y = __hmul(a.y, b.y);
+  return val;
+}
+
 FLASHINFER_INLINE __nv_bfloat162 __floats2bfloat162_rn(const float a, const float b) {
   __nv_bfloat162 val;
   val = __nv_bfloat162(__float2bfloat16_rn(a), __float2bfloat16_rn(b));

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -41,7 +41,7 @@ FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __n
   return t;
 }
 
-FLASHFLASHINFER_INLINE __nv_bfloat16 __hmul(const __nv_bfloat16 a, const __nv_bfloat16 b) {
+FLASHINFER_INLINE __nv_bfloat16 __hmul(const __nv_bfloat16 a, const __nv_bfloat16 b) {
   __nv_bfloat16 val;
   const float fa = __bfloat162float(a);
   const float fb = __bfloat162float(b);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -41,7 +41,7 @@ FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __n
   return t;
 }
 
-FLASHNFFLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+FLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
   __nv_bfloat162 val;
   val.x = __hmul(a.x, b.x);
   val.y = __hmul(a.y, b.y);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -41,6 +41,15 @@ FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __n
   return t;
 }
 
+FLASHFLASHINFER_INLINE __nv_bfloat16 __hmul(const __nv_bfloat16 a, const __nv_bfloat16 b) {
+  __nv_bfloat16 val;
+  const float fa = __bfloat162float(a);
+  const float fb = __bfloat162float(b);
+  // avoid ftz in device code
+  val = __float2bfloat16(__fmaf_ieee_rn(fa, fb, -0.0f));
+  return val;
+}
+
 FLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
   __nv_bfloat162 val;
   val.x = __hmul(a.x, b.x);


### PR DESCRIPTION
Followup of #472 .