### PR TITLE
misc: rename some functions

### DIFF
--- a/docs/api/python/sampling.rst
+++ b/docs/api/python/sampling.rst
@@ -16,7 +16,7 @@ Kernels for LLM sampling.
     min_p_sampling_from_probs
     top_k_top_p_sampling_from_logits
     top_k_top_p_sampling_from_probs
-    top_p_renorm_prob
-    top_k_renorm_prob
+    top_p_renorm_probs
+    top_k_renorm_probs
     top_k_mask_logits
     chain_speculative_sampling

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1282,7 +1282,7 @@ __launch_bounds__(num_warps_x* num_warps_z* warp_size) void SinglePrefillWithKVC
     write_o_reg_gmem<num_warps_x, num_warps_z, num_frags_x, num_frags_y>(
         o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
         /*o_stride_n=*/
-            partition_kv ? num_qo_heads * head_dim * num_chunks : num_qo_heads * head_dim,
+        partition_kv ? num_qo_heads * head_dim * num_chunks : num_qo_heads * head_dim,
         /*o_stride_h=*/head_dim, group_size);
 
     // write lse

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -15,11 +15,11 @@
  */
 #ifndef FLASHINFER_UTILS_CUH_
 #define FLASHINFER_UTILS_CUH_
-#include <cuda_device_runtime_api.h>
-#include <cuda_runtime.h>
 #include <cuda_bf16.h>
+#include <cuda_device_runtime_api.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
+#include <cuda_runtime.h>
 
 #include <iostream>
 #include <sstream>

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -32,8 +32,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Top-p sampling from probabilities");
   m.def("top_k_top_p_sampling_from_probs", &top_k_top_p_sampling_from_probs,
         "Top-k and top-p sampling from probabilities");
-  m.def("top_k_renorm_prob", &top_k_renorm_prob, "Renormalize probabilities by top-k mask");
-  m.def("top_p_renorm_prob", &top_p_renorm_prob, "Renormalize probabilities by top-p mask");
+  m.def("top_k_renorm_probs", &top_k_renorm_probs, "Renormalize probabilities by top-k mask");
+  m.def("top_p_renorm_probs", &top_p_renorm_probs, "Renormalize probabilities by top-p mask");
   m.def("top_k_mask_logits", &top_k_mask_logits, "Mask logits by top-k mask");
   m.def("chain_speculative_sampling", &chain_speculative_sampling,
         "Speculative sampling from sequence of probabilities");

--- a/python/csrc/flashinfer_ops.h
+++ b/python/csrc/flashinfer_ops.h
@@ -58,11 +58,11 @@ std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(
     std::optional<torch::Tensor> maybe_top_k_arr, double top_k_val,
     std::optional<torch::Tensor> maybe_top_p_arr, double top_p_val, bool deterministic);
 
-torch::Tensor top_p_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_p_arr,
-                                double top_p_val);
+torch::Tensor top_p_renorm_probs(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_p_arr,
+                                 double top_p_val);
 
-torch::Tensor top_k_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_k_arr,
-                                unsigned int top_k_val);
+torch::Tensor top_k_renorm_probs(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_k_arr,
+                                 unsigned int top_k_val);
 
 torch::Tensor top_k_mask_logits(torch::Tensor logits, std::optional<torch::Tensor> maybe_top_k_arr,
                                 unsigned int top_k_val);

--- a/python/csrc/sampling.cu
+++ b/python/csrc/sampling.cu
@@ -220,8 +220,8 @@ std::vector<torch::Tensor> top_k_top_p_sampling_from_probs(
   return {samples, success};
 }
 
-torch::Tensor top_p_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_p_arr,
-                                double top_p_val) {
+torch::Tensor top_p_renorm_probs(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_p_arr,
+                                 double top_p_val) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
@@ -251,8 +251,8 @@ torch::Tensor top_p_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor
   return renorm_probs;
 }
 
-torch::Tensor top_k_renorm_prob(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_k_arr,
-                                unsigned int top_k_val) {
+torch::Tensor top_k_renorm_probs(torch::Tensor probs, std::optional<torch::Tensor> maybe_top_k_arr,
+                                 unsigned int top_k_val) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)

--- a/python/flashinfer/__init__.py
+++ b/python/flashinfer/__init__.py
@@ -49,11 +49,11 @@ from .sampling import (
     min_p_sampling_from_probs,
     sampling_from_probs,
     top_k_mask_logits,
-    top_k_renorm_prob,
+    top_k_renorm_probs,
     top_k_sampling_from_probs,
     top_k_top_p_sampling_from_logits,
     top_k_top_p_sampling_from_probs,
-    top_p_renorm_prob,
+    top_p_renorm_probs,
     top_p_sampling_from_probs,
 )
 from .sparse import BlockSparseAttentionWrapper

--- a/python/flashinfer/sampling.py
+++ b/python/flashinfer/sampling.py
@@ -165,7 +165,7 @@ def top_p_sampling_from_probs(
     --------
     top_k_top_p_sampling_from_probs
     top_k_sampling_from_probs
-    top_p_renorm_prob
+    top_p_renorm_probs
     """
     if check_nan:
         if torch.any(torch.isnan(probs)):
@@ -247,7 +247,7 @@ def top_k_sampling_from_probs(
     --------
     top_k_top_p_sampling_from_probs
     top_p_sampling_from_probs
-    top_k_renorm_prob
+    top_k_renorm_probs
     """
     if check_nan:
         if torch.any(torch.isnan(probs)):
@@ -536,12 +536,12 @@ def top_k_top_p_sampling_from_probs(
     --------
     top_k_sampling_from_probs
     top_p_sampling_from_probs
-    top_k_renorm_prob
-    top_p_renorm_prob
+    top_k_renorm_probs
+    top_p_renorm_probs
     top_k_mask_logits
     """
     if filter_apply_order == "top_k_first":
-        renorm_probs = top_k_renorm_prob(probs, top_k)
+        renorm_probs = top_k_renorm_probs(probs, top_k)
         return top_p_sampling_from_probs(
             renorm_probs, uniform_samples, top_p, deterministic, check_nan=check_nan
         )
@@ -560,7 +560,7 @@ def top_k_top_p_sampling_from_probs(
         raise ValueError(f"Invalid filter_apply_order: {filter_apply_order}")
 
 
-def top_p_renorm_prob(
+def top_p_renorm_probs(
     probs: torch.Tensor,
     top_p: Union[torch.Tensor, float],
 ) -> torch.Tensor:
@@ -599,8 +599,8 @@ def top_p_renorm_prob(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> renormed_prob = flashinfer.sampling.top_p_renorm_prob(prob, top_p)
-    >>> renormed_prob
+    >>> renormed_probs = flashinfer.sampling.top_p_renorm_probs(prob, top_p)
+    >>> renormed_probs
     tensor([[0.0000, 0.4882, 0.0000, 0.5118, 0.0000],
             [0.0000, 0.0000, 0.0000, 1.0000, 0.0000],
             [0.5181, 0.0000, 0.4819, 0.0000, 0.0000],
@@ -608,19 +608,22 @@ def top_p_renorm_prob(
 
     Note
     ----
-    This combination of ``top_p_renorm_prob`` and ``sampling_from_probs`` should be equivalent to
+    This combination of ``top_p_renorm_probs`` and ``sampling_from_probs`` should be equivalent to
     ``top_p_sampling_from_probs``.
 
     See Also
     --------
     top_p_sampling_from_probs
     sampling_from_probs
-    top_k_renorm_prob
+    top_k_renorm_probs
     """
-    return _kernels.top_p_renorm_prob(probs, *_to_tensor_scalar_tuple(top_p))
+    return _kernels.top_p_renorm_probs(probs, *_to_tensor_scalar_tuple(top_p))
 
 
-def top_k_renorm_prob(
+top_p_renorm_prob = top_p_renorm_probs
+
+
+def top_k_renorm_probs(
     probs: torch.Tensor,
     top_k: Union[torch.Tensor, int],
 ) -> torch.Tensor:
@@ -658,8 +661,8 @@ def top_k_renorm_prob(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> renormed_prob = flashinfer.sampling.top_k_renorm_prob(prob, top_k)
-    >>> renormed_prob
+    >>> renormed_probs = flashinfer.sampling.top_k_renorm_probs(prob, top_k)
+    >>> renormed_probs
     tensor([[0.3201, 0.3319, 0.0000, 0.3480, 0.0000],
             [0.2573, 0.0000, 0.3398, 0.4028, 0.0000],
             [0.3672, 0.0000, 0.3416, 0.0000, 0.2912],
@@ -667,16 +670,19 @@ def top_k_renorm_prob(
 
     Note
     ----
-    This combination of ``top_k_renorm_prob`` and ``sampling_from_probs`` should be equivalent to
+    This combination of ``top_k_renorm_probs`` and ``sampling_from_probs`` should be equivalent to
     ``top_k_sampling_from_probs``.
 
     See Also
     --------
     top_k_sampling_from_probs
     sampling_from_probs
-    top_p_renorm_prob
+    top_p_renorm_probs
     """
-    return _kernels.top_k_renorm_prob(probs, *_to_tensor_scalar_tuple(top_k))
+    return _kernels.top_k_renorm_probs(probs, *_to_tensor_scalar_tuple(top_k))
+
+
+top_k_renorm_prob = top_k_renorm_probs
 
 
 def top_k_mask_logits(
@@ -724,11 +730,11 @@ def top_k_mask_logits(
 
     Note
     ----
-    The combination of ``top_k_mask_logits`` and ``softmax`` should be equivalent to ``top_k_renorm_prob``.
+    The combination of ``top_k_mask_logits`` and ``softmax`` should be equivalent to ``top_k_renorm_probs``.
 
     See Also
     --------
-    top_k_renorm_prob
+    top_k_renorm_probs
     """
     return _kernels.top_k_mask_logits(logits, *_to_tensor_scalar_tuple(top_k))
 

--- a/python/tests/test_sampling.py
+++ b/python/tests/test_sampling.py
@@ -231,7 +231,7 @@ def test_top_k_top_p_joint_sampling_from_logits(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5, 0.9])
-def test_top_p_renorm_prob(batch_size, vocab_size, p):
+def test_top_p_renorm_probs(batch_size, vocab_size, p):
     pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
     normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
     sorted_prob, indices = torch.sort(normalized_prob, descending=False)
@@ -244,7 +244,7 @@ def test_top_p_renorm_prob(batch_size, vocab_size, p):
         dim=-1, keepdim=True
     )
 
-    renorm_prob = flashinfer.sampling.top_p_renorm_prob(normalized_prob, p)
+    renorm_prob = flashinfer.sampling.top_p_renorm_probs(normalized_prob, p)
     torch.testing.assert_close(
         renorm_prob_ground_truth.cpu().numpy(),
         renorm_prob.cpu().numpy(),
@@ -256,7 +256,7 @@ def test_top_p_renorm_prob(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 500, 32000, 128256])
 @pytest.mark.parametrize("k", [10, 100, 500])
-def test_top_k_renorm_prob(batch_size, vocab_size, k):
+def test_top_k_renorm_probs(batch_size, vocab_size, k):
     if k > vocab_size:
         pytest.skip("k should be less than vocab_size")
     torch.manual_seed(42)
@@ -271,7 +271,7 @@ def test_top_k_renorm_prob(batch_size, vocab_size, k):
         dim=-1, keepdim=True
     )
 
-    renorm_prob = flashinfer.sampling.top_k_renorm_prob(normalized_prob, k)
+    renorm_prob = flashinfer.sampling.top_k_renorm_probs(normalized_prob, k)
     torch.testing.assert_close(
         renorm_prob_ground_truth.cpu().numpy(),
         renorm_prob.cpu().numpy(),
@@ -392,8 +392,8 @@ if __name__ == "__main__":
     test_sampling(1, 111)
     test_top_p_sampling(3, 111, 0.9)
     test_top_k_sampling(3, 111, 10)
-    test_top_p_renorm_prob(3, 111, 0.9)
-    test_top_k_renorm_prob(3, 111, 10)
+    test_top_p_renorm_probs(3, 111, 0.9)
+    test_top_k_renorm_probs(3, 111, 10)
     test_top_k_mask_logits(99, 989, 10)
     test_chain_speculative_sampling(3, 111, 3, False)
     test_chain_speculative_sampling(3, 111, 3, True)


### PR DESCRIPTION
- `top_p_renorm_prob` -> `top_p_renorm_probs`
- `top_k_renorm_prob` -> `top_k_renorm_probs`

`top_p_renorm_prob` and `top_k_renorm_prob` are kept as alias for backward compatibility.