### PR TITLE
Fix the "not enough values to unpack" error.

### DIFF
--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -62,7 +62,7 @@ def compile_batch_decode_module(
     *args,
     verbose: bool = False,
 ):
-    uri, path = gen_batch_decode_cu(*args),
+    uri, path = gen_batch_decode_cu(*args)
     return load_cuda_ops(
         uri, [path],
         verbose=verbose,


### PR DESCRIPTION
This PR fixes the following error:

```
File "/home/yuxianq/flashinfer/python/flashinfer/decode.py", line 616, in plan
  self._cached_module = get_batch_decode_module(
File "/home/yuxianq/flashinfer/python/flashinfer/decode.py", line 114, in get_batch_decode_module
  _batch_decode_modules[args] = compile_batch_decode_module(*args)
File "/home/yuxianq/flashinfer/python/flashinfer/decode.py", line 65, in compile_batch_decode_module
  uri, path = gen_batch_decode_cu(*args),
ValueError: not enough values to unpack (expected 2, got 1)
```