### PR TITLE
fix SyntaxWarning

### DIFF
--- a/python/flashinfer/jit/__init__.py
+++ b/python/flashinfer/jit/__init__.py
@@ -82,7 +82,7 @@ logger = FlashInferJITLogger("flashinfer.jit")
 def check_cuda_arch():
     # cuda arch check for fp8 at the moment.
     for cuda_arch_flags in torch_cpp_ext._get_cuda_arch_flags():
-        arch = int(re.search("compute_\d+", cuda_arch_flags).group()[-2:])
+        arch = int(re.search(r"compute_(\d+)", cuda_arch_flags).group(1))
         if arch < 75:
             raise RuntimeError("FlashInfer requires sm75+")
 


### PR DESCRIPTION
Python 3.12 raises `SyntaxWarning` for invalid escape sequence like `"\d"`.

This PR: Use raw strings for the regex and also add a capture group.

```pycon
Python 3.12.7 | packaged by conda-forge | (main, Oct  4 2024, 16:05:46) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>> import re
>>> cuda_arch_flags = '-gencode=arch=compute_90,code=compute_90'

>>> int(re.search("compute_\d+", cuda_arch_flags).group()[-2:])
<stdin>:1: SyntaxWarning: invalid escape sequence '\d'
90

>>> int(re.search(r"compute_(\d+)", cuda_arch_flags).group(1))
90
```