### PR TITLE
feat: torch.compile and custom_op support

### DIFF
--- a/flashinfer-aot/csrc_aot/batch_decode.cu
+++ b/flashinfer-aot/csrc_aot/batch_decode.cu
@@ -85,13 +85,13 @@ std::vector<int64_t> BatchDecodeWithPagedKVCachePlan(
   return plan_info.ToVector();
 }
 
-std::vector<torch::Tensor> BatchDecodeWithPagedKVCacheRun(
+torch::Tensor BatchDecodeWithPagedKVCacheRun(
     torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
     std::vector<int64_t> plan_info_vec, torch::Tensor q, torch::Tensor paged_k_cache,
     torch::Tensor paged_v_cache, torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
     torch::Tensor paged_kv_last_page_len, std::optional<torch::Tensor> alibi_slopes,
     unsigned int kv_layout_code, int window_left, float logits_soft_cap, float sm_scale,
-    float rope_scale, float rope_theta, bool return_lse) {
+    float rope_scale, float rope_theta, std::optional<torch::Tensor> maybe_lse) {
   DecodePlanInfo plan_info;
   plan_info.FromVector(plan_info_vec);
   QKVLayout kv_layout = static_cast<QKVLayout>(kv_layout_code);
@@ -111,9 +111,11 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCacheRun(
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   torch::Tensor o = torch::empty_like(q);
-  torch::Tensor lse;
-  if (return_lse) {
-    lse = torch::empty({batch_size, num_qo_heads}, q.options().dtype((torch::kFloat32)));
+  if (maybe_lse) {
+    const auto& lse = *maybe_lse;
+    TORCH_CHECK(lse.size(0) == batch_size, lse.size(0), q.size(0));
+    TORCH_CHECK(lse.size(1) == num_qo_heads, lse.size(1), q.size(1));
+    TORCH_CHECK(lse.dtype() == torch::kFloat32, "lse must be float32");
   }
 
   TORCH_CHECK(logits_soft_cap >= 0.f, "logits_soft_cap must be non-negative");
@@ -160,7 +162,7 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCacheRun(
             static_cast<IdType*>(paged_kv_last_page_len.data_ptr()));
         ParamsT params(static_cast<DTypeQ*>(q.data_ptr()),
                        /*q_offset=*/nullptr, paged_kv, static_cast<DTypeO*>(o.data_ptr()),
-                       /*lse=*/(return_lse ? static_cast<float*>(lse.data_ptr()) : nullptr),
+                       /*lse=*/(maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr),
                        /*alibi_slopes=*/nullptr, num_qo_heads, q_stride_n, q_stride_h, window_left,
                        logits_soft_cap, sm_scale, rope_scale, rope_theta);
 
@@ -194,9 +196,5 @@ std::vector<torch::Tensor> BatchDecodeWithPagedKVCacheRun(
     });
   });
 
-  if (return_lse) {
-    return {o, lse};
-  } else {
-    return {o};
-  }
+  return o;
 }

--- a/flashinfer-aot/csrc_aot/flashinfer_ops_decode.cu
+++ b/flashinfer-aot/csrc_aot/flashinfer_ops_decode.cu
@@ -29,13 +29,13 @@ std::vector<int64_t> BatchDecodeWithPagedKVCachePlan(
     torch::Tensor indptr, unsigned int batch_size, unsigned int num_qo_heads,
     unsigned int num_kv_heads, unsigned int page_size, bool enable_cuda_graph);
 
-std::vector<torch::Tensor> BatchDecodeWithPagedKVCacheRun(
+torch::Tensor BatchDecodeWithPagedKVCacheRun(
     torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
     std::vector<int64_t> plan_info_vec, torch::Tensor q, torch::Tensor paged_k_cache,
     torch::Tensor paged_v_cache, torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
     torch::Tensor paged_kv_last_page_len, std::optional<torch::Tensor> alibi_slopes,
     unsigned int kv_layout_code, int window_left, float logits_soft_cap, float sm_scale,
-    float rope_scale, float rope_theta, bool return_lse);
+    float rope_scale, float rope_theta, std::optional<torch::Tensor> maybe_lse);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("single_decode_with_kv_cache", &single_decode_with_kv_cache,

--- a/flashinfer-aot/csrc_aot/flashinfer_ops_prefill.cu
+++ b/flashinfer-aot/csrc_aot/flashinfer_ops_prefill.cu
@@ -15,11 +15,12 @@
  */
 #include <torch/extension.h>
 
-std::vector<torch::Tensor> single_prefill_with_kv_cache(
+torch::Tensor single_prefill_with_kv_cache(
     unsigned int mask_mode_code, torch::Tensor q, torch::Tensor k, torch::Tensor v,
     std::optional<torch::Tensor> maybe_packed_custom_mask, torch::Tensor tmp,
     std::optional<torch::Tensor> maybe_alibi_slopes, unsigned int layout, int32_t window_left,
-    float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta, bool return_lse);
+    float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
+    std::optional<torch::Tensor> maybe_lse);
 
 std::vector<int64_t> BatchPrefillWithKVCachePlan(
     unsigned int head_dim, torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
@@ -27,16 +28,16 @@ std::vector<int64_t> BatchPrefillWithKVCachePlan(
     torch::Tensor kv_indptr, unsigned int batch_size, unsigned int num_qo_heads,
     unsigned int num_kv_heads, unsigned int page_size, bool enable_cuda_graph);
 
-std::vector<torch::Tensor> BatchPrefillWithRaggedKVCacheRun(
+torch::Tensor BatchPrefillWithRaggedKVCacheRun(
     unsigned int mask_mode_code, torch::Tensor float_workspace_buffer,
     torch::Tensor int_workspace_buffer, std::vector<int64_t> plan_info_vec, torch::Tensor q,
     torch::Tensor k, torch::Tensor v, std::optional<torch::Tensor> maybe_custom_mask,
     std::optional<torch::Tensor> maybe_alibi_slopes, torch::Tensor qo_indptr,
     torch::Tensor kv_indptr, std::optional<torch::Tensor> maybe_qk_indptr, unsigned int layout,
     int32_t window_left, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
-    bool return_lse);
+    std::optional<torch::Tensor> maybe_lse);
 
-std::vector<torch::Tensor> BatchPrefillWithPagedKVCacheRun(
+torch::Tensor BatchPrefillWithPagedKVCacheRun(
     unsigned int mask_mode_code, torch::Tensor float_workspace_buffer,
     torch::Tensor int_workspace_buffer, std::vector<int64_t> plan_info_vec, torch::Tensor q,
     torch::Tensor paged_k_cache, torch::Tensor paged_v_cache,
@@ -44,7 +45,7 @@ std::vector<torch::Tensor> BatchPrefillWithPagedKVCacheRun(
     torch::Tensor qo_indptr, torch::Tensor paged_kv_indptr, torch::Tensor paged_kv_indices,
     torch::Tensor paged_kv_last_page_len, std::optional<torch::Tensor> maybe_qk_indptr,
     unsigned int layout, int32_t window_left, float logits_soft_cap, float sm_scale,
-    float rope_scale, float rope_theta, bool return_lse);
+    float rope_scale, float rope_theta, std::optional<torch::Tensor> maybe_lse);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("single_prefill_with_kv_cache", &single_prefill_with_kv_cache,

--- a/python/csrc/flashinfer_sampling_ops.cu
+++ b/python/csrc/flashinfer_sampling_ops.cu
@@ -47,10 +47,10 @@ torch::Tensor top_k_renorm_probs(torch::Tensor probs, std::optional<torch::Tenso
 torch::Tensor top_k_mask_logits(torch::Tensor logits, std::optional<torch::Tensor> maybe_top_k_arr,
                                 unsigned int top_k_val);
 
-std::vector<torch::Tensor> chain_speculative_sampling(
+torch::Tensor chain_speculative_sampling(
     torch::Tensor draft_probs, torch::Tensor draft_token_ids, torch::Tensor uniform_samples,
-    torch::Tensor target_probs, std::optional<torch::Tensor> maybe_output_accepted_token_num,
-    std::optional<torch::Tensor> maybe_output_emitted_token_num, bool deterministic);
+    torch::Tensor target_probs, torch::Tensor output_accepted_token_num,
+    torch::Tensor output_emitted_token_num, bool deterministic);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sampling_from_probs", &sampling_from_probs, "Sample from probabilities");

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -688,6 +688,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         The ``num_qo_heads`` must be a multiple of ``num_kv_heads``. If ``num_qo_heads``
         is not equal to ``num_kv_heads``, the function will use
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
+
+        The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
         batch_size = len(last_page_len)
         if logits_soft_cap is None:

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -922,6 +922,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         The ``num_qo_heads`` must be a multiple of ``num_kv_heads``. If ``num_qo_heads``
         is not equal to ``num_kv_heads``, the function will use
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
+
+        The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
         q_data_type = canonicalize_torch_dtype(q_data_type)
         if kv_data_type is None:
@@ -1514,6 +1516,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         The ``num_qo_heads`` must be a multiple of ``num_kv_heads``. If ``num_qo_heads``
         is not equal to ``num_kv_heads``, the function will use
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
+
+        The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
         q_data_type = canonicalize_torch_dtype(q_data_type)
         if kv_data_type is None:

--- a/python/flashinfer/quantization.py
+++ b/python/flashinfer/quantization.py
@@ -120,12 +120,14 @@ def segment_packbits(
     >>> new_indptr
     tensor([0, 1, 2, 3], device='cuda:0')
 
+    Note
+    ----
+    ``torch.compile`` is not supported for this function because it's data dependent.
+
     See Also
     --------
     packbits
     """
-    # NOTE: torch.compile not supported for this function because it's data dependent.
-
     seglen = indptr[1:] - indptr[:-1]
     packed_len = (seglen + 7) // 8
     indptr_new = torch.zeros(len(indptr), dtype=indptr.dtype, device=indptr.device)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,50 @@ from torch.torch_version import TorchVersion
 from torch.torch_version import __version__ as torch_version
 
 TORCH_COMPILE_FNS = [
+    flashinfer.activation.silu_and_mul,
+    flashinfer.activation.gelu_and_mul,
+    flashinfer.activation.gelu_tanh_and_mul,
+    flashinfer.cascade.merge_state,
+    flashinfer.cascade.merge_state_in_place,
+    flashinfer.cascade.merge_states,
+    flashinfer.cascade.MultiLevelCascadeAttentionWrapper.run,
+    flashinfer.cascade.BatchDecodeWithSharedPrefixPagedKVCacheWrapper.forward,
+    flashinfer.cascade.BatchPrefillWithSharedPrefixPagedKVCacheWrapper.forward,
+    flashinfer.decode.single_decode_with_kv_cache,
+    flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper.run,
+    flashinfer.gemm.bmm_fp8,
+    flashinfer.gemm.SegmentGEMMWrapper.run,
     flashinfer.norm.rmsnorm,
     flashinfer.norm.fused_add_rmsnorm,
     flashinfer.norm.gemma_rmsnorm,
     flashinfer.norm.gemma_fused_add_rmsnorm,
+    flashinfer.page.append_paged_kv_cache,
+    flashinfer.prefill.single_prefill_with_kv_cache,
+    flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper.run,
+    flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper.run,
+    flashinfer.quantization.packbits,
+    flashinfer.rope.apply_rope,
+    flashinfer.rope.apply_rope_inplace,
+    flashinfer.rope.apply_llama31_rope,
+    flashinfer.rope.apply_llama31_rope_inplace,
+    flashinfer.sampling.sampling_from_probs,
+    flashinfer.sampling.top_p_sampling_from_probs,
+    flashinfer.sampling.top_k_sampling_from_probs,
+    flashinfer.sampling.min_p_sampling_from_probs,
+    flashinfer.sampling.top_k_top_p_sampling_from_probs,
+    flashinfer.sampling.top_p_renorm_probs,
+    flashinfer.sampling.top_k_renorm_probs,
+    flashinfer.sampling.top_k_mask_logits,
+    flashinfer.sampling.chain_speculative_sampling,
 ]
+
+_TORCH_COMPILE_CACHE = dict()
+
+
+def _set_torch_compile_options():
+    import torch._dynamo.config
+
+    torch._dynamo.config.cache_size_limit = 128
 
 
 def _monkeypatch_add_torch_compile(func):
@@ -29,28 +68,49 @@ def _monkeypatch_add_torch_compile(func):
     else:
         raise ValueError(f"Unsupported fn type {type(func)}")
 
-    components = fn.__module__.split(".")
+    fullname = fn.__module__ + "." + fn.__qualname__
+    components = fullname.split(".")
     assert components[0] == "flashinfer"
     module = flashinfer
-    for component in components[1:]:
+    for component in components[1:-1]:
         module = getattr(module, component)
+    if not hasattr(module, components[-1]):
+        raise ValueError(f"Failed to monkeypatch: {fullname}")
 
-    setattr(
-        module,
-        fn.__name__,
-        torch.compile(
-            func,
-            fullgraph=True,
-            backend="inductor",
-            mode="max-autotune-no-cudagraphs",
-        ),
-    )
-    print("Applied torch.compile to", f"{fn.__module__}.{fn.__name__}")
+    def wrapper(*args, **kwargs):
+        compiled = _TORCH_COMPILE_CACHE.get(fullname)
+        if compiled is None:
+            # Warmup -- JIT compile / import the kernels.
+            #
+            # From user side, users also need to warmup the model beforehand,
+            # as suggested by PyTorch Cuda Graph docs (not sure if it's also
+            # recommended for torch.compile as well.)
+            #
+            # For the convenience of FlashInfer testing, we do the warmup here,
+            # on the first run of the function. The caveat is that the first
+            # call will run twice: once to warmup, and another through the
+            # compiled version.
+            func(*args, **kwargs)
+
+            # Compile
+            compiled = torch.compile(
+                func,
+                fullgraph=True,
+                backend="inductor",
+                mode="max-autotune-no-cudagraphs",
+            )
+            _TORCH_COMPILE_CACHE[fn.__name__] = compiled
+
+        return compiled(*args, **kwargs)
+
+    setattr(module, fn.__name__, wrapper)
+    print("Applied torch.compile to", fullname)
 
 
 def pytest_configure(config):
     if os.environ.get("FLASHINFER_TEST_TORCH_COMPILE", "0") == "1":
         if torch_version < TorchVersion("2.4"):
             pytest.skip("torch.compile requires torch >= 2.4")
+        _set_torch_compile_options()
         for fn in TORCH_COMPILE_FNS:
             _monkeypatch_add_torch_compile(fn)

--- a/tests/test_batch_decode_kernels.py
+++ b/tests/test_batch_decode_kernels.py
@@ -81,7 +81,9 @@ def test_batch_decode_with_paged_kv_cache(
     ).to(0)
 
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(0)
-    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
     wrapper.plan(
         kv_indptr,
         kv_indices,
@@ -96,7 +98,7 @@ def test_batch_decode_with_paged_kv_cache(
         q_data_type=q_dtype,
     )
     if return_lse:
-        o, _ = wrapper.run_return_lse(q, kv_data)
+        o, _ = wrapper.run(q, kv_data, return_lse=True)
     else:
         o = wrapper.run(q, kv_data)
 
@@ -134,7 +136,7 @@ def test_batch_decode_with_paged_kv_cache(
             ],
             dim=0,
         ).to(kv_dtype)
-        o_ref_i = flashinfer.single_decode_with_kv_cache(
+        o_ref_i = flashinfer.decode.single_decode_with_kv_cache(
             qi,
             ki,
             vi,
@@ -212,7 +214,9 @@ def test_batch_decode_with_tuple_paged_kv_cache(
     ).to(0)
 
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(0)
-    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
     wrapper.plan(
         kv_indptr,
         kv_indices,
@@ -227,7 +231,7 @@ def test_batch_decode_with_tuple_paged_kv_cache(
         q_data_type=q_dtype,
     )
     if return_lse:
-        o, _ = wrapper.run_return_lse(q, kv_data)
+        o, _ = wrapper.run(q, kv_data, return_lse=True)
     else:
         o = wrapper.run(q, kv_data)
 
@@ -267,7 +271,7 @@ def test_batch_decode_with_tuple_paged_kv_cache(
             ],
             dim=0,
         ).to(kv_dtype)
-        o_ref_i = flashinfer.single_decode_with_kv_cache(
+        o_ref_i = flashinfer.decode.single_decode_with_kv_cache(
             qi,
             ki,
             vi,
@@ -289,7 +293,6 @@ def test_batch_decode_with_tuple_paged_kv_cache(
 @pytest.mark.parametrize(
     "kv_dtype", [torch.float16, torch.float8_e4m3fn, torch.float8_e5m2]
 )
-@pytest.mark.parametrize("contiguous_kv", [True, False])
 def test_cuda_graph_batch_decode_with_paged_kv_cache(
     batch_size,
     kv_len,
@@ -340,7 +343,7 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
     kv_last_page_device_buffer = torch.empty(batch_size).int().to(0)
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
-    wrapper = flashinfer.CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
+    wrapper = flashinfer.decode.CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
         workspace_buffer,
         kv_indptr_device_buffer,
         kv_indices_device_buffer,
@@ -451,7 +454,7 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
             ],
             dim=0,
         ).to(kv_dtype)
-        o_ref_i = flashinfer.single_decode_with_kv_cache(
+        o_ref_i = flashinfer.decode.single_decode_with_kv_cache(
             qi, ki, vi, pos_encoding_mode=pos_encoding_mode
         )
         torch.testing.assert_close(o[i], o_ref_i, rtol=1e-3, atol=1e-3)

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -87,7 +87,7 @@ def test_batch_prefill_with_paged_kv_cache(
         kv_indptr_gpu = kv_indptr_cpu.to(0)
         kv_indices_gpu = kv_indices_cpu.to(0)
         kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
-        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
             workspace_buffer, kv_layout
         )
         wrapper.plan(
@@ -104,7 +104,7 @@ def test_batch_prefill_with_paged_kv_cache(
             logits_soft_cap=logits_soft_cap,
         )
         if return_lse:
-            o, _ = wrapper.run_return_lse(q, kv_data)
+            o, _ = wrapper.run(q, kv_data, return_lse=True)
         else:
             o = wrapper.run(q, kv_data)
     else:
@@ -112,7 +112,7 @@ def test_batch_prefill_with_paged_kv_cache(
         kv_indptr_buffer = torch.empty(batch_size + 1).int().to(0)
         kv_indices_buffer = torch.empty(total_num_pages).int().to(0)
         kv_last_page_len_buffer = torch.empty(batch_size).int().to(0)
-        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
             workspace_buffer,
             kv_layout,
             use_cuda_graph=True,
@@ -148,7 +148,7 @@ def test_batch_prefill_with_paged_kv_cache(
         with torch.cuda.stream(s):
             for _ in range(3):
                 if return_lse:
-                    o, _ = wrapper.run_return_lse(q, kv_data)
+                    o, _ = wrapper.run(q, kv_data, return_lse=True)
                 else:
                     o = wrapper.run(q, kv_data)
         torch.cuda.current_stream().wait_stream(s)
@@ -156,9 +156,9 @@ def test_batch_prefill_with_paged_kv_cache(
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             if return_lse:
-                o, _ = wrapper.run_return_lse(q, kv_data)
+                o, _ = wrapper.run(q, kv_data, return_lse=True)
             else:
-                o = wrapper.run(q, kv_data) 
+                o = wrapper.run(q, kv_data)
 
         wrapper.plan(
             q_indptr_cpu,
@@ -218,7 +218,7 @@ def test_batch_prefill_with_paged_kv_cache(
             ],
             dim=0,
         ).half()
-        o_ref_i = flashinfer.single_prefill_with_kv_cache(
+        o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
             qi,
             ki,
             vi,
@@ -304,7 +304,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
         kv_indptr_gpu = kv_indptr_cpu.to(0)
         kv_indices_gpu = kv_indices_cpu.to(0)
         kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
-        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
             workspace_buffer, kv_layout
         )
         wrapper.plan(
@@ -321,7 +321,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
             logits_soft_cap=logits_soft_cap,
         )
         if return_lse:
-            o, _ = wrapper.run_return_lse(q, kv_data)
+            o, _ = wrapper.run(q, kv_data, return_lse=True)
         else:
             o = wrapper.run(q, kv_data)
     else:
@@ -329,7 +329,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
         kv_indptr_buffer = torch.empty(batch_size + 1).int().to(0)
         kv_indices_buffer = torch.empty(total_num_pages).int().to(0)
         kv_last_page_len_buffer = torch.empty(batch_size).int().to(0)
-        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
             workspace_buffer,
             kv_layout,
             use_cuda_graph=True,
@@ -364,7 +364,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
         with torch.cuda.stream(s):
             for _ in range(3):
                 if return_lse:
-                    o, _ = wrapper.run_return_lse(q, kv_data)
+                    o, _ = wrapper.run(q, kv_data, return_lse=True)
                 else:
                     o = wrapper.run(q, kv_data)
         torch.cuda.current_stream().wait_stream(s)
@@ -372,7 +372,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             if return_lse:
-                o, _ = wrapper.run_return_lse(q, kv_data)
+                o, _ = wrapper.run(q, kv_data, return_lse=True)
             else:
                 o = wrapper.run(q, kv_data)
 
@@ -427,7 +427,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
             ],
             dim=0,
         ).half()
-        o_ref_i = flashinfer.single_prefill_with_kv_cache(
+        o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
             qi,
             ki,
             vi,
@@ -495,7 +495,7 @@ def test_batch_prefill_with_paged_kv_cache_custom_mask(
     ).to(0)
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
-    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
     custom_mask = (
@@ -522,7 +522,7 @@ def test_batch_prefill_with_paged_kv_cache_custom_mask(
         logits_soft_cap=logits_soft_cap,
     )
     if return_lse:
-        o_custom, _ = wrapper.run_return_lse(q, kv_data)
+        o_custom, _ = wrapper.run(q, kv_data, return_lse=True)
     else:
         o_custom = wrapper.run(q, kv_data)
 
@@ -541,12 +541,10 @@ def test_batch_prefill_with_paged_kv_cache_custom_mask(
         logits_soft_cap=logits_soft_cap,
     )
     if return_lse:
-        o_causal, _ = wrapper.run_return_lse(q, kv_data)
+        o_causal, _ = wrapper.run(q, kv_data, return_lse=True)
     else:
         o_causal = wrapper.run(q, kv_data)
-    torch.testing.assert_close(
-        o_custom, o_causal, rtol=1e-3, atol=1e-3
-    )
+    torch.testing.assert_close(o_custom, o_causal, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("batch_size", [12, 17])
@@ -580,7 +578,7 @@ def test_batch_prefill_with_ragged_kv_cache(
     kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
-    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+    wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
     wrapper.plan(
@@ -594,12 +592,12 @@ def test_batch_prefill_with_ragged_kv_cache(
         logits_soft_cap=logits_soft_cap,
     )
     if return_lse:
-        o, _ = wrapper.run_return_lse(q, k, v)
+        o, _ = wrapper.run(q, k, v, return_lse=True)
     else:
         o = wrapper.run(q, k, v)
 
     for i in range(batch_size):
-        o_ref_i = flashinfer.single_prefill_with_kv_cache(
+        o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
             q[q_indptr[i] : q_indptr[i + 1]],
             k[kv_indptr[i] : kv_indptr[i + 1]],
             v[kv_indptr[i] : kv_indptr[i + 1]],
@@ -640,7 +638,7 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
     kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * kv_len
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
-    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+    wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
 
@@ -665,7 +663,7 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
         logits_soft_cap=logits_soft_cap,
     )
     if return_lse:
-        o_custom, _ = wrapper.run_return_lse(q, k, v)
+        o_custom, _ = wrapper.run(q, k, v, return_lse=True)
     else:
         o_custom = wrapper.run(q, k, v)
 
@@ -681,12 +679,10 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
         logits_soft_cap=logits_soft_cap,
     )
     if return_lse:
-        o_causal, _ = wrapper.run_return_lse(q, k, v)
+        o_causal, _ = wrapper.run(q, k, v, return_lse=True)
     else:
         o_causal = wrapper.run(q, k, v)
-    torch.testing.assert_close(
-        o_custom, o_causal, rtol=1e-3, atol=1e-3
-    )
+    torch.testing.assert_close(o_custom, o_causal, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_block_sparse.py
+++ b/tests/test_block_sparse.py
@@ -36,7 +36,7 @@ def bsr_attention_ref(
         shape=(M, N),
     )
     dense_mask = torch.tensor(bsr.toarray(), dtype=bool, device=q.device)
-    o = flashinfer.single_prefill_with_kv_cache(q, k, v, custom_mask=dense_mask)
+    o = flashinfer.prefill.single_prefill_with_kv_cache(q, k, v, custom_mask=dense_mask)
     return o
 
 
@@ -70,7 +70,9 @@ def test_block_sparse_attention(
 
     o_ref = bsr_attention_ref(q, k, v, indptr, indices, data_mask)
     workspace_buffer = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=0)
-    sparse_attention_wrapper = flashinfer.BlockSparseAttentionWrapper(workspace_buffer)
+    sparse_attention_wrapper = flashinfer.sparse.BlockSparseAttentionWrapper(
+        workspace_buffer
+    )
 
     sparse_attention_wrapper.plan(
         indptr,

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,0 +1,41 @@
+import flashinfer
+import torch
+
+
+def test_append_paged_kv_cache():
+    nnz_kv = 100
+    num_kv_heads = 32
+    head_dim = 128
+    k_append = torch.randn(nnz_kv, num_kv_heads, head_dim).half().to(0)
+    v_append = torch.randn(nnz_kv, num_kv_heads, head_dim).half().to(0)
+    # 45 + 8 + 25 + 22 = nnz_kv
+    kv_append_length = torch.tensor([45, 8, 25, 22], dtype=torch.int32, device="cuda:0")
+    kv_append_indptr = torch.cat(
+        [torch.zeros(1).int().to(0), torch.cumsum(kv_append_length, dim=0)]
+    ).int()
+    max_num_pages = 1000
+    page_size = 16
+    paged_kv_cache = (
+        torch.randn(max_num_pages, 2, page_size, num_kv_heads, head_dim).half().to(0)
+    )
+    num_pages_per_req = torch.tensor([3, 1, 2, 2], dtype=torch.int32, device="cuda:0")
+    kv_page_indptr = torch.cat(
+        [torch.zeros(1).int().to(0), torch.cumsum(num_pages_per_req, dim=0)]
+    ).int()
+    # use first 8 pages in the paged-kv
+    kv_page_indices = torch.arange(8, dtype=torch.int32, device="cuda:0")
+    # 45 = (3 - 1) * 16 + 13
+    # 8 = (1 - 1) * 16 + 8
+    # 25 = (2 - 1) * 16 + 9
+    # 22 = (2 - 1) * 16 + 6
+    kv_last_page_len = torch.tensor([13, 8, 9, 6], dtype=torch.int32, device="cuda:0")
+
+    flashinfer.page.append_paged_kv_cache(
+        k_append,
+        v_append,
+        kv_append_indptr,
+        paged_kv_cache,
+        kv_page_indices,
+        kv_page_indptr,
+        kv_last_page_len,
+    )

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -33,7 +33,7 @@ def test_packbits(num_elements, bitorder):
     x_cpu = torch.rand(num_elements) < 0.5
     x_gpu = x_cpu.to(0)
     x_packed_ref = numpy_packbits_ref(x_cpu, bitorder)
-    x_packed = flashinfer.packbits(x_gpu, bitorder)
+    x_packed = flashinfer.quantization.packbits(x_gpu, bitorder)
 
     assert torch.equal(x_packed_ref.cpu(), x_packed.cpu())
 
@@ -47,7 +47,9 @@ def test_segment_packbits(batch_size, bitorder):
     x_cpu = torch.rand(num_elements) < 0.5
     x_gpu = x_cpu.to(0)
 
-    y_gpu, new_indptr = flashinfer.segment_packbits(x_gpu, old_indptr, bitorder)
+    y_gpu, new_indptr = flashinfer.quantization.segment_packbits(
+        x_gpu, old_indptr, bitorder
+    )
 
     for i in range(batch_size):
         x_segment_i = x_gpu[old_indptr[i] : old_indptr[i + 1]]


### PR DESCRIPTION
Follow up of #552. This PR adds torch library annotation to all FlashInfer kernels so that torch.compile can recognize the kernels. Most changes are tedious.

I manually ran subsets of pytest test cases when I made these changes, but since there are too many of them and also some of them didn't pass even before I made the change, I cannot guarantee it's all working. To run tests with torch.compile, pass `FLASHINFER_TEST_TORCH_COMPILE=1` env.

```bash
# With torch.compile
FLASHINFER_TEST_TORCH_COMPILE=1 pytest -svx tests/test_norm.py

# Without torch.compile
pytest -svx tests/test_norm.py
```

Notable changes:
* For the prefill and decode pybind, it used to return `Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]` depending on `return_lse`. This causes trouble for `torch.compile`. I changed the pybind interface to accept a `maybe_lse: Optional[torch.Tensor]` and only return one tensor. The allocation of the lse tensor is moved to Python side. The Python API does not change.
* `chain_speculative_sampling` pybind: Move the allocation of `accepted` and `emitted` from C++ to Python. This is because `torch.compile` doesn't like returning input tensor as output tensor. The Python API does not change.

Piggyback changes:
* `BatchPrefillWithRaggedKVCacheWrapper.plan`: Bugfix qo_indptr not on CPU
* `merge_state`: Fix typo in docs
* Change `run_return_lse(...)` to `run(..., return_lse=True)` because torch.compile does not recognize `functools.partial`.
* In tests, change `flashinfer.xxx()` to `flashinfer.<module>.xxx()` so that the monkeypatch works. 

Unsupported for torch.compile:
* `flashinfer.quantization.segment_packbits`: Because it's data dependent.

Untouched:
* `sparse.py`: Tests didn't pass beforehand, so I skiped this. Also, it doesn't seem like need custom_op annotations, as it does not have CUDA kernels.

Failed test cases:
* batch_decode non contiguous kv: `test_batch_decode_with_paged_kv_cache[False-kv_dtype0-q_dtype0-True-0.0-NONE-NHD-128-4-4-1-54-12]`
