### PR TITLE
feat: support huggingface transformer style rope interface

### DIFF
--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -17,6 +17,7 @@
 #define FLASHINFER_POS_ENC_CUH_
 
 #include <cmath>
+#include <cstdint>
 #include <string>
 
 #include "layout.cuh"
@@ -94,6 +95,25 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope(
   return vec;
 }
 
+template <uint32_t vec_size, uint32_t bdx, typename T>
+__device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_cos_sin(
+    const T* x, const vec_t<float, vec_size>& cos, const vec_t<float, vec_size>& sin) {
+  constexpr uint32_t head_dim = vec_size * bdx;
+  vec_t<float, vec_size> permuted_vec, vec;
+  vec.cast_load(x + threadIdx.x * vec_size);
+  permuted_vec.cast_load(x + ((threadIdx.x * vec_size < head_dim / 2)
+                                  ? threadIdx.x * vec_size + head_dim / 2
+                                  : threadIdx.x * vec_size - head_dim / 2));
+
+#pragma unroll
+  for (uint32_t i = 0; i < vec_size; ++i) {
+    vec[i] =
+        vec[i] * cos[i] +
+        ((threadIdx.x * vec_size < head_dim / 2) ? -permuted_vec[i] : permuted_vec[i]) * sin[i];
+  }
+  return vec;
+}
+
 /*!
  * \brief Apply RoPE (Rotary Positional Embeddings) to x[0: head_dim] with interleave,
  *   return thread-local vector.
@@ -122,13 +142,28 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_interleav
   return vec;
 }
 
+template <uint32_t vec_size, uint32_t bdx, typename T>
+__device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_cos_sin_interleave(
+    const T* x, const vec_t<float, vec_size>& cos, const vec_t<float, vec_size>& sin) {
+  vec_t<float, vec_size> vec, vec_before;
+  vec.cast_load(x + threadIdx.x * vec_size);
+  vec_before = vec;
+
+#pragma unroll
+  for (uint32_t i = 0; i < vec_size; ++i) {
+    vec[i] = vec[i] * cos[i] + ((i % 2 == 0) ? -vec_before[i ^ 1] : vec_before[i ^ 1]) * sin[i];
+  }
+  return vec;
+}
+
 template <bool interleave, uint32_t head_dim, uint32_t vec_size, uint32_t bdx, typename DType,
           typename IdType>
-__global__ void BatchQKApplyRotaryInPlaceKernel(
-    DType* __restrict__ q, DType* __restrict__ k, IdType* __restrict__ indptr,
-    IdType* __restrict__ offsets, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
-    size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h, float smooth_a,
-    float smooth_b, float rope_rcp_scale, float rope_rcp_theta) {
+__global__ void BatchQKApplyRotaryPosIdsKernel(
+    DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ pos_ids, uint32_t nnz,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, size_t q_stride_n, size_t q_stride_h,
+    size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n, size_t q_rope_stride_h,
+    size_t k_rope_stride_n, size_t k_rope_stride_h, float smooth_a, float smooth_b,
+    float rope_rcp_scale, float rope_rcp_theta) {
   uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t bdy = blockDim.y;
   vec_t<float, vec_size> freq;
@@ -146,61 +181,56 @@ __global__ void BatchQKApplyRotaryInPlaceKernel(
     freq[i] = (1 - smooth) * (freq[i] * rope_rcp_scale) + smooth * freq[i];
   }
 
-  if (bx < batch_size * num_qo_heads) {
-    // apply rotary to q
-    const uint32_t batch_idx = bx / num_qo_heads;
-    const uint32_t qo_head_idx = bx % num_qo_heads;
-    const uint32_t seq_len = indptr[batch_idx + 1] - indptr[batch_idx];
-    const uint32_t offset = offsets[batch_idx];
-#pragma unroll 2
-    for (uint32_t i = 0; i < (seq_len + bdy - 1) / bdy; ++i) {
-      vec_t<float, vec_size> q_vec;
-      if (i * bdy + ty < seq_len) {
-        DType* q_ptr = q + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0,
-                                                q_stride_n, q_stride_h);
-        if constexpr (interleave) {
-          q_vec =
-              vec_apply_llama_rope_interleave<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
-        } else {
-          q_vec = vec_apply_llama_rope<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
-        }
-        q_vec.cast_store(q_ptr + tx * vec_size);
-      }
+  vec_t<float, vec_size> cos, sin;
+
+  if (bx * bdy + ty < nnz) {
+    const uint32_t idx = bx * bdy + ty;
+    const IdType pos = pos_ids[idx];
+
+#pragma unroll
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      float embed = float(pos) * freq[i];
+      __sincosf(embed, &sin[i], &cos[i]);
     }
-  } else {
-    // apply rotary to k
-    uint32_t batch_idx = (bx - batch_size * num_qo_heads) / num_kv_heads;
-    uint32_t kv_head_idx = (bx - batch_size * num_qo_heads) % num_kv_heads;
-    const uint32_t seq_len = indptr[batch_idx + 1] - indptr[batch_idx];
-    const uint32_t offset = offsets[batch_idx];
-#pragma unroll 2
-    for (uint32_t i = 0; i < (seq_len + bdy - 1) / bdy; ++i) {
-      vec_t<float, vec_size> k_vec;
-      if (i * bdy + ty < seq_len) {
-        DType* k_ptr = k + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0,
-                                                k_stride_n, k_stride_h);
-        if constexpr (interleave) {
-          k_vec =
-              vec_apply_llama_rope_interleave<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
-        } else {
-          k_vec = vec_apply_llama_rope<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
-        }
-        k_vec.cast_store(k_ptr + tx * vec_size);
+
+#pragma unroll 1
+    for (uint32_t qo_head_idx = 0; qo_head_idx < num_qo_heads; ++qo_head_idx) {
+      DType* q_ptr = q + get_elem_offset_impl(idx, qo_head_idx, 0, q_stride_n, q_stride_h);
+      DType* q_rope_ptr =
+          q_rope + get_elem_offset_impl(idx, qo_head_idx, 0, q_rope_stride_n, q_rope_stride_h);
+      vec_t<float, vec_size> q_vec;
+      if constexpr (interleave) {
+        q_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(q_ptr, cos, sin);
+      } else {
+        q_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(q_ptr, cos, sin);
       }
+      q_vec.cast_store(q_rope_ptr + tx * vec_size);
+    }
+
+#pragma unroll 1
+    for (uint32_t kv_head_idx = 0; kv_head_idx < num_kv_heads; ++kv_head_idx) {
+      DType* k_ptr = k + get_elem_offset_impl(idx, kv_head_idx, 0, k_stride_n, k_stride_h);
+      DType* k_rope_ptr =
+          k_rope + get_elem_offset_impl(idx, kv_head_idx, 0, k_rope_stride_n, k_rope_stride_h);
+      vec_t<float, vec_size> k_vec;
+      if constexpr (interleave) {
+        k_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(k_ptr, cos, sin);
+      } else {
+        k_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(k_ptr, cos, sin);
+      }
+      k_vec.cast_store(k_rope_ptr + tx * vec_size);
     }
   }
 }
 
 template <bool interleave, uint32_t head_dim, uint32_t vec_size, uint32_t bdx, typename DType,
           typename IdType>
-__global__ void BatchQKApplyRotaryKernel(DType* __restrict__ q, DType* __restrict__ k,
-                                         DType* __restrict__ q_rope, DType* __restrict__ k_rope,
-                                         IdType* __restrict__ indptr, IdType* __restrict__ offsets,
-                                         uint32_t batch_size, uint32_t num_qo_heads,
-                                         uint32_t num_kv_heads, size_t q_stride_n,
-                                         size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
-                                         float smooth_a, float smooth_b, float rope_rcp_scale,
-                                         float rope_rcp_theta) {
+__global__ void BatchQKApplyRotaryKernel(
+    DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ indptr,
+    IdType* __restrict__ offsets, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
+    size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
+    float smooth_a, float smooth_b, float rope_rcp_scale, float rope_rcp_theta) {
   uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t bdy = blockDim.y;
   vec_t<float, vec_size> freq;
@@ -232,8 +262,7 @@ __global__ void BatchQKApplyRotaryKernel(DType* __restrict__ q, DType* __restric
                                                 q_stride_n, q_stride_h);
         DType* q_rope_ptr =
             q_rope + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0,
-                                          /*q_stride_n=*/num_qo_heads * head_dim,
-                                          /*q_stride_h=*/head_dim);
+                                          q_rope_stride_n, q_rope_stride_h);
         if constexpr (interleave) {
           q_vec =
               vec_apply_llama_rope_interleave<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
@@ -257,8 +286,7 @@ __global__ void BatchQKApplyRotaryKernel(DType* __restrict__ q, DType* __restric
                                                 k_stride_n, k_stride_h);
         DType* k_rope_ptr =
             k_rope + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0,
-                                          /*kv_stride_n=*/num_kv_heads * head_dim,
-                                          /*kv_stride_h=*/head_dim);
+                                          k_rope_stride_n, k_rope_stride_h);
         if constexpr (interleave) {
           k_vec =
               vec_apply_llama_rope_interleave<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
@@ -281,13 +309,65 @@ __global__ void BatchQKApplyRotaryKernel(DType* __restrict__ q, DType* __restric
   }
 
 template <typename DType, typename IdType>
-cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__ k,
-                                      IdType* __restrict__ indptr, IdType* __restrict__ offsets,
-                                      uint32_t batch_size, uint32_t num_qo_heads,
-                                      uint32_t num_kv_heads, uint32_t head_dim, size_t q_stride_n,
-                                      size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
-                                      bool interleave, float rope_scale, float rope_theta,
-                                      cudaStream_t stream = nullptr) {
+cudaError_t BatchQKApplyRotaryPosIds(DType* q, DType* k, DType* q_rope, DType* k_rope,
+                                     IdType* __restrict__ pos_ids, uint32_t nnz,
+                                     uint32_t num_qo_heads, uint32_t num_kv_heads,
+                                     uint32_t head_dim, size_t q_stride_n, size_t q_stride_h,
+                                     size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
+                                     size_t q_rope_stride_h, size_t k_rope_stride_n,
+                                     size_t k_rope_stride_h, bool interleave, float rope_scale,
+                                     float rope_theta, cudaStream_t stream = nullptr) {
+  float rope_rcp_scale = 1.0f / rope_scale;
+  float rope_rcp_theta = 1.0f / rope_theta;
+  float smooth_a = 0.f;
+  float smooth_b = 0.f;
+
+  DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
+    DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
+      constexpr uint32_t vec_size = std::max(16 / sizeof(DType), HEAD_DIM / 32);
+      constexpr uint32_t bdx = HEAD_DIM / vec_size;
+      uint32_t num_threads = std::max(128U, bdx);
+      uint32_t bdy = num_threads / bdx;
+      dim3 nblks((nnz + bdy - 1) / bdy);
+      dim3 nthrs(bdx, bdy);
+      auto kernel =
+          BatchQKApplyRotaryPosIdsKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
+      void* args[] = {(void*)&q,
+                      (void*)&k,
+                      (void*)&q_rope,
+                      (void*)&k_rope,
+                      (void*)&pos_ids,
+                      (void*)&nnz,
+                      (void*)&num_qo_heads,
+                      (void*)&num_kv_heads,
+                      (void*)&q_stride_n,
+                      (void*)&q_stride_h,
+                      (void*)&k_stride_n,
+                      (void*)&k_stride_h,
+                      (void*)&q_rope_stride_n,
+                      (void*)&q_rope_stride_h,
+                      (void*)&k_rope_stride_n,
+                      (void*)&k_rope_stride_h,
+                      (void*)&smooth_a,
+                      (void*)&smooth_b,
+                      (void*)&rope_rcp_scale,
+                      (void*)&rope_rcp_theta};
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
+    });
+  });
+
+  return cudaSuccess;
+}
+
+template <typename DType, typename IdType>
+cudaError_t BatchQKApplyRotary(DType* q, DType* k, DType* q_rope, DType* k_rope,
+                               IdType* __restrict__ indptr, IdType* __restrict__ offsets,
+                               uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
+                               uint32_t head_dim, size_t q_stride_n, size_t q_stride_h,
+                               size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
+                               size_t q_rope_stride_h, size_t k_rope_stride_n,
+                               size_t k_rope_stride_h, bool interleave, float rope_scale,
+                               float rope_theta, cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = 0.f;
@@ -301,10 +381,11 @@ cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__
       uint32_t bdy = num_threads / bdx;
       dim3 nblks(batch_size * (num_qo_heads + num_kv_heads));
       dim3 nthrs(bdx, bdy);
-      auto kernel =
-          BatchQKApplyRotaryInPlaceKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
+      auto kernel = BatchQKApplyRotaryKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
       void* args[] = {(void*)&q,
                       (void*)&k,
+                      (void*)&q_rope,
+                      (void*)&k_rope,
                       (void*)&indptr,
                       (void*)&offsets,
                       (void*)&batch_size,
@@ -314,6 +395,10 @@ cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
                       (void*)&k_stride_h,
+                      (void*)&q_rope_stride_n,
+                      (void*)&q_rope_stride_h,
+                      (void*)&k_rope_stride_n,
+                      (void*)&k_rope_stride_h,
                       (void*)&smooth_a,
                       (void*)&smooth_b,
                       (void*)&rope_rcp_scale,
@@ -326,10 +411,11 @@ cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__
 }
 
 template <typename DType, typename IdType>
-cudaError_t BatchQKApplyLlama31RotaryInPlace(
-    DType* __restrict__ q, DType* __restrict__ k, IdType* __restrict__ indptr,
+cudaError_t BatchQKApplyLlama31Rotary(
+    DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ indptr,
     IdType* __restrict__ offsets, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
     uint32_t head_dim, size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
     bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
     float high_freq_factor, float old_context_length, cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
@@ -345,51 +431,6 @@ cudaError_t BatchQKApplyLlama31RotaryInPlace(
       uint32_t bdy = num_threads / bdx;
       dim3 nblks(batch_size * (num_qo_heads + num_kv_heads));
       dim3 nthrs(bdx, bdy);
-      auto kernel =
-          BatchQKApplyRotaryInPlaceKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
-      void* args[] = {(void*)&q,
-                      (void*)&k,
-                      (void*)&indptr,
-                      (void*)&offsets,
-                      (void*)&batch_size,
-                      (void*)&num_qo_heads,
-                      (void*)&num_kv_heads,
-                      (void*)&q_stride_n,
-                      (void*)&q_stride_h,
-                      (void*)&k_stride_n,
-                      (void*)&k_stride_h,
-                      (void*)&smooth_a,
-                      (void*)&smooth_b,
-                      (void*)&rope_rcp_scale,
-                      (void*)&rope_rcp_theta};
-      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
-    });
-  });
-
-  return cudaSuccess;
-}
-
-template <typename DType, typename IdType>
-cudaError_t BatchQKApplyRotary(DType* __restrict__ q, DType* __restrict__ k,
-                               DType* __restrict__ q_rope, DType* __restrict__ k_rope,
-                               IdType* __restrict__ indptr, IdType* __restrict__ offsets,
-                               uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
-                               uint32_t head_dim, size_t q_stride_n, size_t q_stride_h,
-                               size_t k_stride_n, size_t k_stride_h, bool interleave,
-                               float rope_scale, float rope_theta, cudaStream_t stream = nullptr) {
-  float rope_rcp_scale = 1.0f / rope_scale;
-  float rope_rcp_theta = 1.0f / rope_theta;
-  float smooth_a = 0.f;
-  float smooth_b = 0.f;
-
-  DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-    DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
-      constexpr uint32_t vec_size = std::max(16 / sizeof(DType), HEAD_DIM / 32);
-      constexpr uint32_t bdx = HEAD_DIM / vec_size;
-      uint32_t num_threads = std::max(128U, bdx);
-      uint32_t bdy = num_threads / bdx;
-      dim3 nblks(batch_size * (num_qo_heads + num_kv_heads));
-      dim3 nthrs(bdx, bdy);
       auto kernel = BatchQKApplyRotaryKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
       void* args[] = {(void*)&q,
                       (void*)&k,
@@ -404,6 +445,10 @@ cudaError_t BatchQKApplyRotary(DType* __restrict__ q, DType* __restrict__ k,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
                       (void*)&k_stride_h,
+                      (void*)&q_rope_stride_n,
+                      (void*)&q_rope_stride_h,
+                      (void*)&k_rope_stride_n,
+                      (void*)&k_rope_stride_h,
                       (void*)&smooth_a,
                       (void*)&smooth_b,
                       (void*)&rope_rcp_scale,
@@ -416,15 +461,13 @@ cudaError_t BatchQKApplyRotary(DType* __restrict__ q, DType* __restrict__ k,
 }
 
 template <typename DType, typename IdType>
-cudaError_t BatchQKApplyLlama31Rotary(DType* __restrict__ q, DType* __restrict__ k,
-                                      DType* __restrict__ q_rope, DType* __restrict__ k_rope,
-                                      IdType* __restrict__ indptr, IdType* __restrict__ offsets,
-                                      uint32_t batch_size, uint32_t num_qo_heads,
-                                      uint32_t num_kv_heads, uint32_t head_dim, size_t q_stride_n,
-                                      size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
-                                      bool interleave, float rope_scale, float rope_theta,
-                                      float low_freq_factor, float high_freq_factor,
-                                      float old_context_length, cudaStream_t stream = nullptr) {
+cudaError_t BatchQKApplyLlama31RotaryPosIds(
+    DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* pos_ids, uint32_t nnz,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim, size_t q_stride_n,
+    size_t q_stride_h, size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
+    size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h, bool interleave,
+    float rope_scale, float rope_theta, float low_freq_factor, float high_freq_factor,
+    float old_context_length, cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = old_context_length / (2 * M_PI * high_freq_factor - 2 * M_PI * low_freq_factor);
@@ -436,22 +479,26 @@ cudaError_t BatchQKApplyLlama31Rotary(DType* __restrict__ q, DType* __restrict__
       constexpr uint32_t bdx = HEAD_DIM / vec_size;
       uint32_t num_threads = std::max(128U, bdx);
       uint32_t bdy = num_threads / bdx;
-      dim3 nblks(batch_size * (num_qo_heads + num_kv_heads));
+      dim3 nblks((nnz + bdy - 1) / bdy);
       dim3 nthrs(bdx, bdy);
-      auto kernel = BatchQKApplyRotaryKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
+      auto kernel =
+          BatchQKApplyRotaryPosIdsKernel<INTERLEAVE, HEAD_DIM, vec_size, bdx, DType, IdType>;
       void* args[] = {(void*)&q,
                       (void*)&k,
                       (void*)&q_rope,
                       (void*)&k_rope,
-                      (void*)&indptr,
-                      (void*)&offsets,
-                      (void*)&batch_size,
+                      (void*)&pos_ids,
+                      (void*)&nnz,
                       (void*)&num_qo_heads,
                       (void*)&num_kv_heads,
                       (void*)&q_stride_n,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
                       (void*)&k_stride_h,
+                      (void*)&q_rope_stride_n,
+                      (void*)&q_rope_stride_h,
+                      (void*)&k_rope_stride_n,
+                      (void*)&k_rope_stride_h,
                       (void*)&smooth_a,
                       (void*)&smooth_b,
                       (void*)&rope_rcp_scale,

--- a/python/csrc/flashinfer_rope_ops.cu
+++ b/python/csrc/flashinfer_rope_ops.cu
@@ -15,28 +15,36 @@
  */
 #include <torch/extension.h>
 
-void apply_rope_inplace(torch::Tensor q, torch::Tensor k, torch::Tensor indptr,
-                        torch::Tensor offsets, bool interleave, float rope_scale, float rope_theta);
+#include <vector>
 
-void apply_llama31_rope_inplace(torch::Tensor q, torch::Tensor k, torch::Tensor indptr,
-                                torch::Tensor offsets, bool interleave, float rope_scale,
-                                float rope_theta, float low_freq_factor, float high_freq_factor,
-                                float old_context_length);
-
-std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::Tensor indptr,
+std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
+                                      torch::Tensor k_rope, torch::Tensor indptr,
                                       torch::Tensor offsets, bool interleave, float rope_scale,
                                       float rope_theta);
 
 std::vector<torch::Tensor> apply_llama31_rope(torch::Tensor q, torch::Tensor k,
+                                              torch::Tensor q_rope, torch::Tensor k_rope,
                                               torch::Tensor indptr, torch::Tensor offsets,
                                               bool interleave, float rope_scale, float rope_theta,
                                               float low_freq_factor, float high_freq_factor,
                                               float old_context_length);
 
+std::vector<torch::Tensor> apply_rope_pos_ids(torch::Tensor q, torch::Tensor k,
+                                              torch::Tensor q_rope, torch::Tensor k_rope,
+                                              torch::Tensor pos_ids, bool interleave,
+                                              float rope_scale, float rope_theta);
+
+std::vector<torch::Tensor> apply_llama31_rope_pos_ids(torch::Tensor q, torch::Tensor k,
+                                                      torch::Tensor q_rope, torch::Tensor k_rope,
+                                                      torch::Tensor pos_ids, bool interleave,
+                                                      float rope_scale, float rope_theta,
+                                                      float low_freq_factor, float high_freq_factor,
+                                                      float old_context_length);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("apply_rope_inplace", &apply_rope_inplace, "Apply RoPE in-place");
-  m.def("apply_llama31_rope_inplace", &apply_llama31_rope_inplace,
-        "Apply Llama 3.1 style RoPE in-place");
   m.def("apply_rope", &apply_rope, "Apply RoPE");
   m.def("apply_llama31_rope", &apply_llama31_rope, "Apply Llama 3.1 style RoPE");
+  m.def("apply_rope_pos_ids", &apply_rope_pos_ids, "Apply RoPE with positional ids");
+  m.def("apply_llama31_rope_pos_ids", &apply_llama31_rope_pos_ids,
+        "Apply Llama 3.1 style RoPE with positional ids");
 }

--- a/python/csrc/rope.cu
+++ b/python/csrc/rope.cu
@@ -19,91 +19,8 @@
 
 using namespace flashinfer;
 
-void apply_rope_inplace(torch::Tensor q, torch::Tensor k, torch::Tensor indptr,
-                        torch::Tensor offsets, bool interleave, float rope_scale,
-                        float rope_theta) {
-  CHECK_CUDA(q);  // not necessarily contiguous
-  CHECK_CUDA(k);  // not necessarily contiguous
-  CHECK_INPUT(indptr);
-  CHECK_INPUT(offsets);
-
-  auto device = q.device();
-  CHECK_EQ(k.device(), device);
-  CHECK_DIM(3, q);        // q: (nnz, H_Q, D)
-  CHECK_DIM(3, k);        // k: (nnz, H_K, D)
-  CHECK_DIM(1, indptr);   // indptr: (B + 1)
-  CHECK_DIM(1, offsets);  // offsets: (B)
-  CHECK_EQ(q.size(0), k.size(0));
-  CHECK_EQ(q.size(2), k.size(2));
-  unsigned int num_qo_heads = q.size(1);
-  unsigned int num_kv_heads = k.size(1);
-  unsigned int head_dim = q.size(2);
-  unsigned int batch_size = offsets.size(0);
-  CHECK_EQ(indptr.size(0), batch_size + 1);
-  size_t q_stride_n = q.stride(0);
-  size_t q_stride_h = q.stride(1);
-  size_t k_stride_n = k.stride(0);
-  size_t k_stride_h = k.stride(1);
-  indptr = indptr.to(torch::kInt32);
-  offsets = offsets.to(torch::kInt32);
-
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
-  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyRotaryInPlace(
-        static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
-        static_cast<int32_t*>(indptr.data_ptr()), static_cast<int32_t*>(offsets.data_ptr()),
-        batch_size, num_qo_heads, num_kv_heads, head_dim, q_stride_n, q_stride_h, k_stride_n,
-        k_stride_h, interleave, rope_scale, rope_theta, torch_current_stream);
-    TORCH_CHECK(status == cudaSuccess, "BatchQKApplyRotaryInPlace failed with error code " +
-                                           std::string(cudaGetErrorString(status)));
-    return true;
-  });
-}
-
-void apply_llama31_rope_inplace(torch::Tensor q, torch::Tensor k, torch::Tensor indptr,
-                                torch::Tensor offsets, bool interleave, float rope_scale,
-                                float rope_theta, float low_freq_factor, float high_freq_factor,
-                                float old_context_length) {
-  CHECK_CUDA(q);  // not necessarily contiguous
-  CHECK_CUDA(k);  // not necessarily contiguous
-  CHECK_INPUT(indptr);
-  CHECK_INPUT(offsets);
-
-  auto device = q.device();
-  CHECK_EQ(k.device(), device);
-  CHECK_DIM(3, q);        // q: (nnz, H_Q, D)
-  CHECK_DIM(3, k);        // k: (nnz, H_K, D)
-  CHECK_DIM(1, indptr);   // indptr: (B + 1)
-  CHECK_DIM(1, offsets);  // offsets: (B)
-  CHECK_EQ(q.size(0), k.size(0));
-  CHECK_EQ(q.size(2), k.size(2));
-  unsigned int num_qo_heads = q.size(1);
-  unsigned int num_kv_heads = k.size(1);
-  unsigned int head_dim = q.size(2);
-  unsigned int batch_size = offsets.size(0);
-  CHECK_EQ(indptr.size(0), batch_size + 1);
-  size_t q_stride_n = q.stride(0);
-  size_t q_stride_h = q.stride(1);
-  size_t k_stride_n = k.stride(0);
-  size_t k_stride_h = k.stride(1);
-  indptr = indptr.to(torch::kInt32);
-  offsets = offsets.to(torch::kInt32);
-
-  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
-  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyLlama31RotaryInPlace(
-        static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
-        static_cast<int32_t*>(indptr.data_ptr()), static_cast<int32_t*>(offsets.data_ptr()),
-        batch_size, num_qo_heads, num_kv_heads, head_dim, q_stride_n, q_stride_h, k_stride_n,
-        k_stride_h, interleave, rope_scale, rope_theta, low_freq_factor, high_freq_factor,
-        old_context_length, torch_current_stream);
-    TORCH_CHECK(status == cudaSuccess, "BatchQKApplyLlama31RotaryInPlace failed with error code " +
-                                           std::string(cudaGetErrorString(status)));
-    return true;
-  });
-}
-
-std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::Tensor indptr,
+std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
+                                      torch::Tensor k_rope, torch::Tensor indptr,
                                       torch::Tensor offsets, bool interleave, float rope_scale,
                                       float rope_theta) {
   CHECK_CUDA(q);  // not necessarily contiguous
@@ -128,11 +45,12 @@ std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::T
   size_t q_stride_h = q.stride(1);
   size_t k_stride_n = k.stride(0);
   size_t k_stride_h = k.stride(1);
+  size_t q_rope_stride_n = q_rope.stride(0);
+  size_t q_rope_stride_h = q_rope.stride(1);
+  size_t k_rope_stride_n = k_rope.stride(0);
+  size_t k_rope_stride_h = k_rope.stride(1);
   indptr = indptr.to(torch::kInt32);
   offsets = offsets.to(torch::kInt32);
-  // NOTE(Zihao): empty_like do not copy strides so it's okay to use it here.
-  auto q_rope = torch::empty_like(q);
-  auto k_rope = torch::empty_like(k);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
@@ -141,7 +59,8 @@ std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::T
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<int32_t*>(indptr.data_ptr()), static_cast<int32_t*>(offsets.data_ptr()),
         batch_size, num_qo_heads, num_kv_heads, head_dim, q_stride_n, q_stride_h, k_stride_n,
-        k_stride_h, interleave, rope_scale, rope_theta, torch_current_stream);
+        k_stride_h, q_rope_stride_n, q_rope_stride_h, k_rope_stride_n, k_rope_stride_h, interleave,
+        rope_scale, rope_theta, torch_current_stream);
     TORCH_CHECK(status == cudaSuccess, "BatchQKApplyRotary failed with error code " +
                                            std::string(cudaGetErrorString(status)));
     return true;
@@ -150,7 +69,52 @@ std::vector<torch::Tensor> apply_rope(torch::Tensor q, torch::Tensor k, torch::T
   return {q_rope, k_rope};
 }
 
+std::vector<torch::Tensor> apply_rope_pos_ids(torch::Tensor q, torch::Tensor k,
+                                              torch::Tensor q_rope, torch::Tensor k_rope,
+                                              torch::Tensor pos_ids, bool interleave,
+                                              float rope_scale, float rope_theta) {
+  CHECK_CUDA(q);  // not necessarily contiguous
+  CHECK_CUDA(k);  // not necessarily contiguous
+  CHECK_INPUT(pos_ids);
+
+  auto device = q.device();
+  CHECK_EQ(k.device(), device);
+  CHECK_DIM(3, q);  // q: (nnz, H_Q, D)
+  CHECK_DIM(3, k);  // k: (nnz, H_K, D)
+  CHECK_EQ(q.size(0), k.size(0));
+  CHECK_EQ(q.size(2), k.size(2));
+  unsigned int num_qo_heads = q.size(1);
+  unsigned int num_kv_heads = k.size(1);
+  unsigned int head_dim = q.size(2);
+  unsigned int nnz = q.size(0);
+  size_t q_stride_n = q.stride(0);
+  size_t q_stride_h = q.stride(1);
+  size_t k_stride_n = k.stride(0);
+  size_t k_stride_h = k.stride(1);
+  size_t q_rope_stride_n = q_rope.stride(0);
+  size_t q_rope_stride_h = q_rope.stride(1);
+  size_t k_rope_stride_n = k_rope.stride(0);
+  size_t k_rope_stride_h = k_rope.stride(1);
+  pos_ids = pos_ids.to(torch::kInt32);
+
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
+  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
+    cudaError_t status = BatchQKApplyRotaryPosIds(
+        static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
+        static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
+        static_cast<int32_t*>(pos_ids.data_ptr()), nnz, num_qo_heads, num_kv_heads, head_dim,
+        q_stride_n, q_stride_h, k_stride_n, k_stride_h, q_rope_stride_n, q_rope_stride_h,
+        k_rope_stride_n, k_rope_stride_h, interleave, rope_scale, rope_theta, torch_current_stream);
+    TORCH_CHECK(status == cudaSuccess, "BatchQKApplyRotaryPosIds failed with error code " +
+                                           std::string(cudaGetErrorString(status)));
+    return true;
+  });
+
+  return {q_rope, k_rope};
+}
+
 std::vector<torch::Tensor> apply_llama31_rope(torch::Tensor q, torch::Tensor k,
+                                              torch::Tensor q_rope, torch::Tensor k_rope,
                                               torch::Tensor indptr, torch::Tensor offsets,
                                               bool interleave, float rope_scale, float rope_theta,
                                               float low_freq_factor, float high_freq_factor,
@@ -177,12 +141,12 @@ std::vector<torch::Tensor> apply_llama31_rope(torch::Tensor q, torch::Tensor k,
   size_t q_stride_h = q.stride(1);
   size_t k_stride_n = k.stride(0);
   size_t k_stride_h = k.stride(1);
+  size_t q_rope_stride_n = q_rope.stride(0);
+  size_t q_rope_stride_h = q_rope.stride(1);
+  size_t k_rope_stride_n = k_rope.stride(0);
+  size_t k_rope_stride_h = k_rope.stride(1);
   indptr = indptr.to(torch::kInt32);
   offsets = offsets.to(torch::kInt32);
-
-  // NOTE(Zihao): empty_like do not copy strides so it's okay to use it here.
-  auto q_rope = torch::empty_like(q);
-  auto k_rope = torch::empty_like(k);
 
   cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
@@ -191,9 +155,57 @@ std::vector<torch::Tensor> apply_llama31_rope(torch::Tensor q, torch::Tensor k,
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<int32_t*>(indptr.data_ptr()), static_cast<int32_t*>(offsets.data_ptr()),
         batch_size, num_qo_heads, num_kv_heads, head_dim, q_stride_n, q_stride_h, k_stride_n,
-        k_stride_h, interleave, rope_scale, rope_theta, low_freq_factor, high_freq_factor,
-        old_context_length, torch_current_stream);
+        k_stride_h, q_rope_stride_n, q_rope_stride_h, k_rope_stride_n, k_rope_stride_h, interleave,
+        rope_scale, rope_theta, low_freq_factor, high_freq_factor, old_context_length,
+        torch_current_stream);
     TORCH_CHECK(status == cudaSuccess, "BatchQKApplyLlama31Rotary failed with error code " +
+                                           std::string(cudaGetErrorString(status)));
+    return true;
+  });
+
+  return {q_rope, k_rope};
+}
+
+std::vector<torch::Tensor> apply_llama31_rope_pos_ids(torch::Tensor q, torch::Tensor k,
+                                                      torch::Tensor q_rope, torch::Tensor k_rope,
+                                                      torch::Tensor pos_ids, bool interleave,
+                                                      float rope_scale, float rope_theta,
+                                                      float low_freq_factor, float high_freq_factor,
+                                                      float old_context_length) {
+  CHECK_CUDA(q);  // not necessarily contiguous
+  CHECK_CUDA(k);  // not necessarily contiguous
+  CHECK_INPUT(pos_ids);
+
+  auto device = q.device();
+  CHECK_EQ(k.device(), device);
+  CHECK_DIM(3, q);  // q: (nnz, H_Q, D)
+  CHECK_DIM(3, k);  // k: (nnz, H_K, D)
+  CHECK_EQ(q.size(0), k.size(0));
+  CHECK_EQ(q.size(2), k.size(2));
+  unsigned int num_qo_heads = q.size(1);
+  unsigned int num_kv_heads = k.size(1);
+  unsigned int head_dim = q.size(2);
+  unsigned int nnz = q.size(0);
+  size_t q_stride_n = q.stride(0);
+  size_t q_stride_h = q.stride(1);
+  size_t k_stride_n = k.stride(0);
+  size_t k_stride_h = k.stride(1);
+  size_t q_rope_stride_n = q_rope.stride(0);
+  size_t q_rope_stride_h = q_rope.stride(1);
+  size_t k_rope_stride_n = k_rope.stride(0);
+  size_t k_rope_stride_h = k_rope.stride(1);
+  pos_ids = pos_ids.to(torch::kInt32);
+
+  cudaStream_t torch_current_stream = c10::cuda::getCurrentCUDAStream(device.index());
+  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
+    cudaError_t status = BatchQKApplyLlama31RotaryPosIds(
+        static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
+        static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
+        static_cast<int32_t*>(pos_ids.data_ptr()), nnz, num_qo_heads, num_kv_heads, head_dim,
+        q_stride_n, q_stride_h, k_stride_n, k_stride_h, q_rope_stride_n, q_rope_stride_h,
+        k_rope_stride_n, k_rope_stride_h, interleave, rope_scale, rope_theta, low_freq_factor,
+        high_freq_factor, old_context_length, torch_current_stream);
+    TORCH_CHECK(status == cudaSuccess, "BatchQKApplyLlama31RotaryPosIds failed with error code " +
                                            std::string(cudaGetErrorString(status)));
     return true;
   });

--- a/python/flashinfer/__init__.py
+++ b/python/flashinfer/__init__.py
@@ -60,6 +60,8 @@ from .rope import (
     apply_llama31_rope_inplace as apply_llama31_rope_inplace,
     apply_rope as apply_rope,
     apply_rope_inplace as apply_rope_inplace,
+    apply_rope_pos_ids as apply_rope_pos_ids,
+    apply_rope_pos_ids_inplace as apply_rope_pos_ids_inplace,
 )
 from .sampling import (
     chain_speculative_sampling as chain_speculative_sampling,


### PR DESCRIPTION
Previously our rope apis assume the position indices of each request is contiguous, which is not appropriate for applications such as speculative decoding, this PR fixes the issue by supporting the huggingface transformer-style API which use `pos_ids` argument to specify positions.

This PR implements parts of the feature of #530 , other requests are coming in later PRs.

cc @dreaming-panda @abcdabcd987 @byronhsu