### PR TITLE
Fix Sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,5 +16,6 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: export FLASHINFER_BUILDING_DOCS=1
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/python/flashinfer/prefill.py
+++ b/python/flashinfer/prefill.py
@@ -48,9 +48,6 @@ from .utils import (
     register_fake_op,
 )
 
-if has_prebuilt_ops:
-    from . import _kernels  # type: ignore[attr-defined]
-
 
 def compile_single_prefill_module(
     *args,
@@ -85,6 +82,8 @@ def get_single_prefill_module(*args):
     if args not in _single_prefill_modules:
         uri = get_single_prefill_uri(*args)
         if has_prebuilt_ops and uri in prebuilt_ops_uri:
+            from . import _kernels
+
             # NOTE(Zihao): we should avoid hard-coded index like this, refactor it later
             mask_mode = args[5]
             run_func = lambda *run_args: _kernels.single_prefill_with_kv_cache(
@@ -157,6 +156,8 @@ def get_batch_prefill_module(*args):
     if args not in _batch_prefill_modules:
         uri = get_batch_prefill_uri(*args)
         if has_prebuilt_ops and uri in prebuilt_ops_uri:
+            from . import _kernels
+
             # NOTE(Zihao): we should avoid hard-coded index like this, refactor it later
             head_dim = args[4]
             plan_func = lambda *plan_args: _kernels.batch_prefill_with_kv_cache_plan(


### PR DESCRIPTION
Here's the reason why docs fail to build after #552: As specified in `conf.py`, Sphinx mocks `torch`. The mock makes the following predicate behave badly: `TorchVersion(torch_version) < TorchVersion("2.4")`.

The fix is to explicitly pass in an env var indicating docs building.

Also changing the way that `prefill.py` imports compiled `_kernels` so that it's consistent with other files.