### PR TITLE
return type overload for return_lse

### DIFF
--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -17,7 +17,7 @@ limitations under the License.
 import functools
 import math
 from types import SimpleNamespace
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Literal, Optional, Tuple, Union, overload
 
 import torch
 
@@ -812,6 +812,28 @@ class BatchDecodeWithPagedKVCacheWrapper:
         return self.run(
             q, paged_kv_cache, q_scale=q_scale, k_scale=k_scale, v_scale=v_scale
         )
+
+    @overload
+    def run(
+        self,
+        q: torch.Tensor,
+        paged_kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        q_scale: Optional[float] = None,
+        k_scale: Optional[float] = None,
+        v_scale: Optional[float] = None,
+        return_lse: Literal[False] = False,
+    ) -> torch.Tensor: ...
+
+    @overload
+    def run(
+        self,
+        q: torch.Tensor,
+        paged_kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        q_scale: Optional[float] = None,
+        k_scale: Optional[float] = None,
+        v_scale: Optional[float] = None,
+        return_lse: Literal[True] = True,
+    ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
     def run(
         self,


### PR DESCRIPTION
Make mypy and pylance happy.

For example, here's screenshots of vscode viewing `test_batch_decode_kernels.py`.

return_lse=False:
![return_lse=False](https://github.com/user-attachments/assets/625919ca-04f8-4f37-b4b0-d89c15423c51)

return_lse=True:
![return_lse=True](https://github.com/user-attachments/assets/53a01a2b-c8b2-4629-922e-ca8dc8fad18c)
