### PR TITLE
bugfix: symlinks not set up properly in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -75,8 +75,6 @@ def link_data_files() -> Iterator[None]:
 
 
 if __name__ == "__main__":
-    link_data_files()
-    generate_build_meta()
     clear_aot_config()
 
     # Suppress warnings complaining that:
@@ -84,6 +82,8 @@ if __name__ == "__main__":
     warnings.filterwarnings("ignore", r".*flashinfer\.data.*", UserWarning)
 
     with link_data_files():
+        generate_build_meta()
+
         setuptools.setup(
             name="flashinfer",
             version=get_version(),


### PR DESCRIPTION
My last minute change in #567 changed `link_data_files()` to a context manager. I didn't properly test it. It would fail due to `this_dir / "flashinfer" / "data" / "version.txt"` not exist.

This PR fixes the issue. I tested that it works, with `pip install -v -e .`.

BTW, AOT wheel does not have this issue. I'm able to build AOT wheel.