### PR TITLE
add benchmark for append_paged_kv_cache

### DIFF
--- a/benchmarks/bench_append_paged_kv_cache.py
+++ b/benchmarks/bench_append_paged_kv_cache.py
@@ -9,7 +9,6 @@ from triton.testing import do_bench
 
 @dataclasses.dataclass(kw_only=True)
 class ModelConfig:
-    hidden_size: int
     num_kv_heads: int
     num_layers: int
     head_dim: int
@@ -17,7 +16,6 @@ class ModelConfig:
 
 def _make_70b(tp: int) -> ModelConfig:
     return ModelConfig(
-        hidden_size=8192,
         num_kv_heads=8 // tp,
         num_layers=80,
         head_dim=128,
@@ -26,19 +24,16 @@ def _make_70b(tp: int) -> ModelConfig:
 
 MODELS = {
     "l1b": ModelConfig(
-        hidden_size=2048,
         num_kv_heads=8,
         num_layers=16,
         head_dim=64,
     ),
     "l3b": ModelConfig(
-        hidden_size=3072,
         num_kv_heads=8,
         num_layers=28,
         head_dim=128,
     ),
     "l8b": ModelConfig(
-        hidden_size=4096,
         num_kv_heads=8,
         num_layers=32,
         head_dim=128,

--- a/benchmarks/bench_append_paged_kv_cache.py
+++ b/benchmarks/bench_append_paged_kv_cache.py
@@ -1,0 +1,150 @@
+import argparse
+import dataclasses
+from typing import cast
+
+import flashinfer
+import torch
+from triton.testing import do_bench
+
+
+@dataclasses.dataclass(kw_only=True)
+class ModelConfig:
+    hidden_size: int
+    intermediate_size: int
+    num_qo_heads: int
+    num_kv_heads: int
+    num_layers: int
+    head_dim: int
+
+
+def _make_70b(tp: int) -> ModelConfig:
+    return ModelConfig(
+        hidden_size=8192,
+        intermediate_size=28672,
+        num_qo_heads=64,
+        num_kv_heads=8 // tp,
+        num_layers=80,
+        head_dim=128,
+    )
+
+
+MODELS = {
+    "l1b": ModelConfig(
+        hidden_size=2048,
+        intermediate_size=8192,
+        num_qo_heads=32,
+        num_kv_heads=8,
+        num_layers=16,
+        head_dim=64,
+    ),
+    "l3b": ModelConfig(
+        hidden_size=3072,
+        intermediate_size=8192,
+        num_qo_heads=24,
+        num_kv_heads=8,
+        num_layers=28,
+        head_dim=128,
+    ),
+    "l8b": ModelConfig(
+        hidden_size=4096,
+        intermediate_size=14336,
+        num_qo_heads=32,
+        num_kv_heads=8,
+        num_layers=32,
+        head_dim=128,
+    ),
+    "l70b-tp8": _make_70b(8),
+}
+
+
+@torch.inference_mode()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seqlen", type=int, default=5000)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--page-len", type=int, default=16)
+    parser.add_argument("--dtype", type=str, default="float16")
+    args = parser.parse_args()
+
+    seqlens_ = [
+        [1] * args.batch_size,
+        [args.seqlen] + [1] * args.batch_size,
+        [args.seqlen],
+        [args.seqlen // args.batch_size] * args.batch_size,
+    ]
+    page_len = int(args.page_len)
+    dtype = getattr(torch, args.dtype)
+    assert isinstance(dtype, torch.dtype)
+    device = torch.device("cuda:0")
+    total_pages = int(256000 / page_len)
+
+    torch.cuda.profiler.start()
+
+    for model_name, model in MODELS.items():
+        page_shape = (2, page_len, model.num_kv_heads, model.head_dim)
+        layer_buf = torch.empty((total_pages,) + page_shape, dtype=dtype, device=device)
+        for seqlens in seqlens_:
+            k = torch.rand(
+                (sum(seqlens), model.num_kv_heads, model.head_dim),
+                dtype=dtype,
+                device=device,
+            )
+            v = torch.rand(
+                (sum(seqlens), model.num_kv_heads, model.head_dim),
+                dtype=dtype,
+                device=device,
+            )
+            x_indptr = torch.tensor([0] + seqlens, device=device, dtype=torch.int32)
+            x_indptr = torch.cumsum(x_indptr, 0, dtype=torch.int32)
+            kv_indices_host = []
+            kv_indptr_host = [0]
+            next_page_id = 0
+            for seqlen in seqlens:
+                npages = (seqlen + page_len - 1) // page_len
+                kv_indices_host.extend(range(next_page_id, next_page_id + npages))
+                next_page_id += npages
+                kv_indptr_host.append(len(kv_indices_host))
+            kv_indices = torch.tensor(kv_indices_host, device=device, dtype=torch.int32)
+            kv_indptr = torch.tensor(kv_indptr_host, device=device, dtype=torch.int32)
+            kv_last_page_len = torch.tensor(
+                [(seqlen - 1) % page_len + 1 for seqlen in seqlens],
+                device=device,
+                dtype=torch.int32,
+            )
+
+            @torch.cuda.nvtx.range(f"model={model_name}, seqlens={seqlens}")
+            def fn():
+                flashinfer.append_paged_kv_cache(
+                    k,
+                    v,
+                    x_indptr,
+                    layer_buf,
+                    kv_indices,
+                    kv_indptr,
+                    kv_last_page_len,
+                    "NHD",
+                )
+
+            latency_ms = cast(float, do_bench(fn))
+            all_layers_latency_ms = latency_ms * model.num_layers
+            throughput = (
+                k.numel()
+                * k.element_size()
+                * sum(1 for _ in ["k", "v"])
+                * sum(1 for _ in ["read", "write"])
+                / (latency_ms * 1e-3)
+            )
+            print(
+                f"model: {model_name:8}",
+                f"seqlens: {str(seqlens):50}",
+                f"single_layer: {latency_ms:5.3f}ms",
+                f"all_layers: {all_layers_latency_ms:7.3f}ms",
+                f"throughput: {throughput*1e-9:8.3f}GB/s",
+            )
+        print("---")
+
+    torch.cuda.profiler.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_append_paged_kv_cache.py
+++ b/benchmarks/bench_append_paged_kv_cache.py
@@ -57,6 +57,7 @@ def main():
         [args.seqlen],
         [args.seqlen // args.batch_size] * args.batch_size,
     ]
+    seqlen_strlen = max(len(str(seqlens)) for seqlens in seqlens_)
     page_len = int(args.page_len)
     dtype = getattr(torch, args.dtype)
     assert isinstance(dtype, torch.dtype)
@@ -121,7 +122,7 @@ def main():
             )
             print(
                 f"model: {model_name:8}",
-                f"seqlens: {str(seqlens):50}",
+                f"seqlens: {seqlens!r:{seqlen_strlen}}",
                 f"single_layer: {latency_ms:5.3f}ms",
                 f"all_layers: {all_layers_latency_ms:7.3f}ms",
                 f"throughput: {throughput*1e-9:8.3f}GB/s",

--- a/benchmarks/bench_append_paged_kv_cache.py
+++ b/benchmarks/bench_append_paged_kv_cache.py
@@ -10,8 +10,6 @@ from triton.testing import do_bench
 @dataclasses.dataclass(kw_only=True)
 class ModelConfig:
     hidden_size: int
-    intermediate_size: int
-    num_qo_heads: int
     num_kv_heads: int
     num_layers: int
     head_dim: int
@@ -20,8 +18,6 @@ class ModelConfig:
 def _make_70b(tp: int) -> ModelConfig:
     return ModelConfig(
         hidden_size=8192,
-        intermediate_size=28672,
-        num_qo_heads=64,
         num_kv_heads=8 // tp,
         num_layers=80,
         head_dim=128,
@@ -31,24 +27,18 @@ def _make_70b(tp: int) -> ModelConfig:
 MODELS = {
     "l1b": ModelConfig(
         hidden_size=2048,
-        intermediate_size=8192,
-        num_qo_heads=32,
         num_kv_heads=8,
         num_layers=16,
         head_dim=64,
     ),
     "l3b": ModelConfig(
         hidden_size=3072,
-        intermediate_size=8192,
-        num_qo_heads=24,
         num_kv_heads=8,
         num_layers=28,
         head_dim=128,
     ),
     "l8b": ModelConfig(
         hidden_size=4096,
-        intermediate_size=14336,
-        num_qo_heads=32,
         num_kv_heads=8,
         num_layers=32,
         head_dim=128,
@@ -68,7 +58,7 @@ def main():
 
     seqlens_ = [
         [1] * args.batch_size,
-        [args.seqlen] + [1] * args.batch_size,
+        [args.seqlen - args.batch_size + 1] + [1] * (args.batch_size - 1),
         [args.seqlen],
         [args.seqlen // args.batch_size] * args.batch_size,
     ]


### PR DESCRIPTION
Add a python benchmark for `append_paged_kv_cache`. Currently, its performance is really bad for prefill.

For example, here's the result on H100:

```
model: l1b      seqlens: [1, 1, 1, 1, 1, 1, 1, 1]                 single_layer: 0.011ms all_layers:   0.173ms throughput:    3.035GB/s
model: l1b      seqlens: [4993, 1, 1, 1, 1, 1, 1, 1]              single_layer: 2.363ms all_layers:  37.807ms throughput:    8.667GB/s
model: l1b      seqlens: [5000]                                   single_layer: 2.346ms all_layers:  37.529ms throughput:    8.731GB/s
model: l1b      seqlens: [625, 625, 625, 625, 625, 625, 625, 625] single_layer: 0.301ms all_layers:   4.819ms throughput:   68.005GB/s
---
model: l3b      seqlens: [1, 1, 1, 1, 1, 1, 1, 1]                 single_layer: 0.009ms all_layers:   0.253ms throughput:    7.241GB/s
model: l3b      seqlens: [4993, 1, 1, 1, 1, 1, 1, 1]              single_layer: 2.342ms all_layers:  65.579ms throughput:   17.489GB/s
model: l3b      seqlens: [5000]                                   single_layer: 2.331ms all_layers:  65.270ms throughput:   17.571GB/s
model: l3b      seqlens: [625, 625, 625, 625, 625, 625, 625, 625] single_layer: 0.313ms all_layers:   8.752ms throughput:  131.045GB/s
---
model: l8b      seqlens: [1, 1, 1, 1, 1, 1, 1, 1]                 single_layer: 0.008ms all_layers:   0.264ms throughput:    7.955GB/s
model: l8b      seqlens: [4993, 1, 1, 1, 1, 1, 1, 1]              single_layer: 2.342ms all_layers:  74.937ms throughput:   17.491GB/s
model: l8b      seqlens: [5000]                                   single_layer: 2.330ms all_layers:  74.564ms throughput:   17.578GB/s
model: l8b      seqlens: [625, 625, 625, 625, 625, 625, 625, 625] single_layer: 0.312ms all_layers:   9.995ms throughput:  131.142GB/s
---
model: l70b-tp8 seqlens: [1, 1, 1, 1, 1, 1, 1, 1]                 single_layer: 0.008ms all_layers:   0.641ms throughput:    1.023GB/s
model: l70b-tp8 seqlens: [4993, 1, 1, 1, 1, 1, 1, 1]              single_layer: 2.252ms all_layers: 180.172ms throughput:    2.273GB/s
model: l70b-tp8 seqlens: [5000]                                   single_layer: 2.264ms all_layers: 181.145ms throughput:    2.261GB/s
model: l70b-tp8 seqlens: [625, 625, 625, 625, 625, 625, 625, 625] single_layer: 0.295ms all_layers:  23.582ms throughput:   17.369GB/s
```