### PR TITLE
bugfix: gemm_sm90 compilation error

### DIFF
--- a/include/flashinfer/gemm/group_gemm_sm90.cuh
+++ b/include/flashinfer/gemm/group_gemm_sm90.cuh
@@ -16,6 +16,12 @@
 #ifndef FLASHINFER_GEMM_GROUP_GEMM_SM90_CUH_
 #define FLASHINFER_GEMM_GROUP_GEMM_SM90_CUH_
 
+// clang-format off
+// NOTE: This header needs to be included before cutlass headers.
+// See: https://github.com/NVIDIA/cutlass/issues/1827
+#include "group_gemm_cutlass.cuh"
+// clang-format on
+
 #include <sstream>
 
 #include "../allocator.h"
@@ -39,7 +45,6 @@
 #include "cutlass/util/reference/device/tensor_compare.h"
 #include "cutlass/util/reference/device/tensor_fill.h"
 #include "cutlass/util/tensor_view_io.h"
-#include "group_gemm_cutlass.cuh"
 
 namespace flashinfer {
 


### PR DESCRIPTION
The pre-commit hook (#584) re-ordered the headers. It causes `group_gemm_sm90.cuh` not able to compile. This PR add a clang-format section to preserve the include order.

Related: https://github.com/NVIDIA/cutlass/issues/1827
