### PR TITLE
feat: add `rotary_dim` argument to rope APIs for partial apply rope

### DIFF
--- a/benchmarks/bench_rope.py
+++ b/benchmarks/bench_rope.py
@@ -1,0 +1,93 @@
+import argparse
+from typing import cast
+
+import torch
+from triton.testing import do_bench
+
+import flashinfer
+
+
+def generate_cos_sin_f32_cache(max_seq_len, head_dim, theta=1e4):
+    position = torch.arange(max_seq_len).float().unsqueeze(1)
+    freqs = 1.0 / (theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+    freqs = torch.cat([freqs, freqs], dim=-1).contiguous()
+    args = position * freqs
+    sin_cache = torch.sin(args)
+    cos_cache = torch.cos(args)
+    return cos_cache, sin_cache
+
+
+@torch.inference_mode()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-sizes", nargs="+", type=int, default=[1, 19, 99, 128])
+    parser.add_argument("--append-len", nargs="+", type=int, default=[1, 128, 1024])
+    parser.add_argument("--num-qo-heads", type=int, default=32)
+    parser.add_argument("--num-kv-heads", type=int, default=8)
+    parser.add_argument("--head-dim", type=int, default=128)
+    args = parser.parse_args()
+
+    eps = 1e-6
+    dtype = torch.float16
+    num_qo_heads = args.num_qo_heads
+    num_kv_heads = args.num_kv_heads
+    head_dim = args.head_dim
+
+    # Loop over each combination of batch_size, hidden_size, and dtype
+    for batch_size in args.batch_sizes:
+        for append_len in args.append_len:
+            for use_cos_sin_cache in [False, True]:
+                # Define tensors with the correct dtype
+
+                q = torch.randn(
+                    (batch_size * append_len, num_qo_heads, args.head_dim),
+                    dtype=dtype,
+                    device="cuda",
+                )
+                k = torch.randn(
+                    (batch_size * append_len, num_kv_heads, args.head_dim),
+                    dtype=dtype,
+                    device="cuda",
+                )
+                pos_ids = torch.repeat_interleave(
+                    torch.arange(append_len, dtype=torch.int32, device=q.device),
+                    batch_size,
+                )
+                cos_cache, sin_cache = generate_cos_sin_f32_cache(4096, head_dim)
+                cos_cache = cos_cache.to(q.device)
+                sin_cache = sin_cache.to(q.device)
+
+                @torch.cuda.nvtx.range(
+                    f"apply_rope batch_size={batch_size}, append_len={append_len}, num_qo_heads={num_qo_heads}, num_kv_heads={num_kv_heads}, head_dim={head_dim}"
+                )
+                def fn() -> None:
+                    if use_cos_sin_cache:
+                        flashinfer.apply_rope_with_cos_sin_cache(
+                            q, k, cos_cache, sin_cache, pos_ids
+                        )
+                    else:
+                        flashinfer.apply_rope_pos_ids(q, k, pos_ids)
+
+                # Run benchmarking
+                latency_ms = cast(float, do_bench(fn))
+                throughput = (
+                    q.numel() * q.element_size() * 2 + k.numel() * k.element_size() * 2
+                ) / (latency_ms * 1e-3)
+                print(
+                    f"batch_size: {batch_size:3},",
+                    f"append_len: {append_len:5},",
+                    f"num_qo_heads: {num_qo_heads:5},",
+                    f"num_kv_heads: {num_kv_heads:5},",
+                    f"head_dim: {head_dim:5},",
+                    f"use_cos_sin_cache: {use_cos_sin_cache},",
+                    f"latency: {latency_ms*1e3:2.0f}us,",
+                    f"throughput: {throughput*1e-9:7.3f}GB/s",
+                )
+
+        print("---")
+
+    torch.cuda.profiler.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/include/flashinfer/cutlass_utils.cuh
+++ b/include/flashinfer/cutlass_utils.cuh
@@ -16,9 +16,6 @@
 #ifndef FLASHINFER_CUTLASS_UTILS_CUH_
 #define FLASHINFER_CUTLASS_UTILS_CUH_
 
-#include <cuda_runtime.h>
-#include <cutlass/cutlass.h>
-
 #include "cute/tensor.hpp"
 #include "cutlass/cutlass.h"
 #include "cutlass/epilogue/collective/collective_builder.hpp"

--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -157,14 +157,14 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_cos_sin_i
   return vec;
 }
 
-template <bool interleave, uint32_t head_dim, uint32_t vec_size, uint32_t bdx, typename DType,
-          typename IdType>
+template <bool interleave, bool partial, uint32_t head_dim, uint32_t vec_size, uint32_t bdx,
+          typename DType, typename IdType>
 __global__ void BatchQKApplyRotaryPosIdsCosSinCacheKernel(
     DType* q, DType* k, DType* q_rope, DType* k_rope, float* __restrict__ cos_cache,
     float* __restrict__ sin_cache, IdType* __restrict__ pos_ids, uint32_t nnz,
-    uint32_t num_qo_heads, uint32_t num_kv_heads, size_t q_stride_n, size_t q_stride_h,
-    size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n, size_t q_rope_stride_h,
-    size_t k_rope_stride_n, size_t k_rope_stride_h) {
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rope_dim, size_t q_stride_n,
+    size_t q_stride_h, size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
+    size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h) {
   uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t bdy = blockDim.y;
 
@@ -506,16 +506,15 @@ cudaError_t BatchQKApplyRotary(DType* q, DType* k, DType* q_rope, DType* k_rope,
 template <typename DType, typename IdType>
 cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__ k,
                                       IdType* __restrict__ indptr, IdType* __restrict__ offsets,
-                                      uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads, 
-                                      uint32_t head_dim, size_t q_stride_n, size_t q_stride_h, 
-                                      size_t k_stride_n, size_t k_stride_h,
+                                      uint32_t batch_size, uint32_t num_qo_heads,
+                                      uint32_t num_kv_heads, uint32_t head_dim, size_t q_stride_n,
+                                      size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
                                       bool interleave, float rope_scale, float rope_theta,
                                       cudaStream_t stream = nullptr) {
-  return BatchQKApplyRotary<DType, IdType>(q, k, q, k, indptr, offsets, batch_size, num_qo_heads, num_kv_heads,
-                            head_dim, q_stride_n, q_stride_h, k_stride_n, k_stride_h,
-                            q_stride_n, q_stride_h, k_stride_n, k_stride_h, 
-                            interleave, rope_scale, rope_theta, stream);
-
+  return BatchQKApplyRotary<DType, IdType>(
+      q, k, q, k, indptr, offsets, batch_size, num_qo_heads, num_kv_heads, head_dim, q_stride_n,
+      q_stride_h, k_stride_n, k_stride_h, q_stride_n, q_stride_h, k_stride_n, k_stride_h,
+      interleave, rope_scale, rope_theta, stream);
 }
 
 template <typename DType, typename IdType>

--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -77,40 +77,45 @@ __device__ __forceinline__ float get_alibi_slope(uint32_t head_idx, uint32_t num
  */
 template <uint32_t vec_size, uint32_t bdx, typename T>
 __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope(
-    const T* x, const vec_t<float, vec_size>& freq, int32_t offset) {
-  constexpr uint32_t head_dim = vec_size * bdx;
+    const T* x, const vec_t<float, vec_size>& freq, int32_t offset,
+    const uint32_t rotary_dim = vec_size * bdx) {
   vec_t<float, vec_size> permuted_vec, vec;
   vec.cast_load(x + threadIdx.x * vec_size);
-  permuted_vec.cast_load(x + ((threadIdx.x * vec_size < head_dim / 2)
-                                  ? threadIdx.x * vec_size + head_dim / 2
-                                  : threadIdx.x * vec_size - head_dim / 2));
 
+  if (threadIdx.x * vec_size < rotary_dim) {
+    permuted_vec.cast_load(x + ((threadIdx.x * vec_size < rotary_dim / 2)
+                                    ? threadIdx.x * vec_size + rotary_dim / 2
+                                    : threadIdx.x * vec_size - rotary_dim / 2));
 #pragma unroll
-  for (uint32_t i = 0; i < vec_size; ++i) {
-    float embed = float(offset) * freq[i];
-    float cos, sin;
-    __sincosf(embed, &sin, &cos);
-    vec[i] = vec[i] * cos +
-             ((threadIdx.x * vec_size < head_dim / 2) ? -permuted_vec[i] : permuted_vec[i]) * sin;
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      float embed = float(offset) * freq[i];
+      float cos, sin;
+      __sincosf(embed, &sin, &cos);
+      vec[i] =
+          vec[i] * cos +
+          ((threadIdx.x * vec_size < rotary_dim / 2) ? -permuted_vec[i] : permuted_vec[i]) * sin;
+    }
   }
   return vec;
 }
 
 template <uint32_t vec_size, uint32_t bdx, typename T>
 __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_cos_sin(
-    const T* x, const vec_t<float, vec_size>& cos, const vec_t<float, vec_size>& sin) {
-  constexpr uint32_t head_dim = vec_size * bdx;
+    const T* x, const vec_t<float, vec_size>& cos, const vec_t<float, vec_size>& sin,
+    const uint32_t rotary_dim = vec_size * bdx) {
   vec_t<float, vec_size> permuted_vec, vec;
   vec.cast_load(x + threadIdx.x * vec_size);
-  permuted_vec.cast_load(x + ((threadIdx.x * vec_size < head_dim / 2)
-                                  ? threadIdx.x * vec_size + head_dim / 2
-                                  : threadIdx.x * vec_size - head_dim / 2));
 
+  if (threadIdx.x * vec_size < rotary_dim) {
+    permuted_vec.cast_load(x + ((threadIdx.x * vec_size < rotary_dim / 2)
+                                    ? threadIdx.x * vec_size + rotary_dim / 2
+                                    : threadIdx.x * vec_size - rotary_dim / 2));
 #pragma unroll
-  for (uint32_t i = 0; i < vec_size; ++i) {
-    vec[i] =
-        vec[i] * cos[i] +
-        ((threadIdx.x * vec_size < head_dim / 2) ? -permuted_vec[i] : permuted_vec[i]) * sin[i];
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      vec[i] =
+          vec[i] * cos[i] +
+          ((threadIdx.x * vec_size < rotary_dim / 2) ? -permuted_vec[i] : permuted_vec[i]) * sin[i];
+    }
   }
   return vec;
 }
@@ -128,41 +133,47 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_cos_sin(
  */
 template <uint32_t vec_size, uint32_t bdx, typename T>
 __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_interleave(
-    const T* x, const vec_t<float, vec_size>& freq, int32_t offset) {
+    const T* x, const vec_t<float, vec_size>& freq, int32_t offset,
+    const uint32_t rotary_dim = vec_size * bdx) {
   vec_t<float, vec_size> vec, vec_before;
   vec.cast_load(x + threadIdx.x * vec_size);
-  vec_before = vec;
 
+  if (threadIdx.x * vec_size < rotary_dim) {
+    vec_before = vec;
 #pragma unroll
-  for (uint32_t i = 0; i < vec_size; ++i) {
-    float embed = float(offset) * freq[i];
-    float cos, sin;
-    __sincosf(embed, &sin, &cos);
-    vec[i] = vec[i] * cos + ((i % 2 == 0) ? -vec_before[i ^ 1] : vec_before[i ^ 1]) * sin;
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      float embed = float(offset) * freq[i];
+      float cos, sin;
+      __sincosf(embed, &sin, &cos);
+      vec[i] = vec[i] * cos + ((i % 2 == 0) ? -vec_before[i ^ 1] : vec_before[i ^ 1]) * sin;
+    }
   }
   return vec;
 }
 
 template <uint32_t vec_size, uint32_t bdx, typename T>
 __device__ __forceinline__ vec_t<float, vec_size> vec_apply_llama_rope_cos_sin_interleave(
-    const T* x, const vec_t<float, vec_size>& cos, const vec_t<float, vec_size>& sin) {
+    const T* x, const vec_t<float, vec_size>& cos, const vec_t<float, vec_size>& sin,
+    const uint32_t rotary_dim = vec_size * bdx) {
   vec_t<float, vec_size> vec, vec_before;
   vec.cast_load(x + threadIdx.x * vec_size);
-  vec_before = vec;
 
+  if (threadIdx.x * vec_size < rotary_dim) {
+    vec_before = vec;
 #pragma unroll
-  for (uint32_t i = 0; i < vec_size; ++i) {
-    vec[i] = vec[i] * cos[i] + ((i % 2 == 0) ? -vec_before[i ^ 1] : vec_before[i ^ 1]) * sin[i];
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      vec[i] = vec[i] * cos[i] + ((i % 2 == 0) ? -vec_before[i ^ 1] : vec_before[i ^ 1]) * sin[i];
+    }
   }
   return vec;
 }
 
-template <bool interleave, bool partial, uint32_t head_dim, uint32_t vec_size, uint32_t bdx,
-          typename DType, typename IdType>
+template <bool interleave, uint32_t head_dim, uint32_t vec_size, uint32_t bdx, typename DType,
+          typename IdType>
 __global__ void BatchQKApplyRotaryPosIdsCosSinCacheKernel(
     DType* q, DType* k, DType* q_rope, DType* k_rope, float* __restrict__ cos_cache,
     float* __restrict__ sin_cache, IdType* __restrict__ pos_ids, uint32_t nnz,
-    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rope_dim, size_t q_stride_n,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rotary_dim, size_t q_stride_n,
     size_t q_stride_h, size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
     size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h) {
   uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y;
@@ -173,8 +184,10 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheKernel(
     const uint32_t idx = bx * bdy + ty;
     const IdType pos = pos_ids[idx];
 
-    cos.load(cos_cache + pos * head_dim + tx * vec_size);
-    sin.load(sin_cache + pos * head_dim + tx * vec_size);
+    if (tx * vec_size < rotary_dim) {
+      cos.load(cos_cache + pos * rotary_dim + tx * vec_size);
+      sin.load(sin_cache + pos * rotary_dim + tx * vec_size);
+    }
 
 #pragma unroll 1
     for (uint32_t qo_head_idx = 0; qo_head_idx < num_qo_heads; ++qo_head_idx) {
@@ -183,9 +196,9 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheKernel(
           q_rope + get_elem_offset_impl(idx, qo_head_idx, 0, q_rope_stride_n, q_rope_stride_h);
       vec_t<float, vec_size> q_vec;
       if constexpr (interleave) {
-        q_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(q_ptr, cos, sin);
+        q_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(q_ptr, cos, sin, rotary_dim);
       } else {
-        q_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(q_ptr, cos, sin);
+        q_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(q_ptr, cos, sin, rotary_dim);
       }
       q_vec.cast_store(q_rope_ptr + tx * vec_size);
     }
@@ -197,9 +210,9 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheKernel(
           k_rope + get_elem_offset_impl(idx, kv_head_idx, 0, k_rope_stride_n, k_rope_stride_h);
       vec_t<float, vec_size> k_vec;
       if constexpr (interleave) {
-        k_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(k_ptr, cos, sin);
+        k_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(k_ptr, cos, sin, rotary_dim);
       } else {
-        k_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(k_ptr, cos, sin);
+        k_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(k_ptr, cos, sin, rotary_dim);
       }
       k_vec.cast_store(k_rope_ptr + tx * vec_size);
     }
@@ -210,26 +223,28 @@ template <bool interleave, uint32_t head_dim, uint32_t vec_size, uint32_t bdx, t
           typename IdType>
 __global__ void BatchQKApplyRotaryPosIdsKernel(
     DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ pos_ids, uint32_t nnz,
-    uint32_t num_qo_heads, uint32_t num_kv_heads, size_t q_stride_n, size_t q_stride_h,
-    size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n, size_t q_rope_stride_h,
-    size_t k_rope_stride_n, size_t k_rope_stride_h, float smooth_a, float smooth_b,
-    float rope_rcp_scale, float rope_rcp_theta) {
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rotary_dim, size_t q_stride_n,
+    size_t q_stride_h, size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
+    size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h, float smooth_a,
+    float smooth_b, float rope_rcp_scale, float rope_rcp_theta) {
   // NOTE: q and q_rope may be the same ptr, so do k and k_rope
   uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t bdy = blockDim.y;
   vec_t<float, vec_size> freq;
+  if (tx * vec_size < rotary_dim) {
 #pragma unroll
-  for (uint32_t i = 0; i < vec_size; ++i) {
-    if constexpr (interleave) {
-      freq[i] = __powf(rope_rcp_theta, float(2 * ((tx * vec_size + i) / 2)) / float(head_dim));
-    } else {
-      freq[i] = __powf(rope_rcp_theta,
-                       float(2 * ((tx * vec_size + i) % (head_dim / 2))) / float(head_dim));
-    }
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      if constexpr (interleave) {
+        freq[i] = __powf(rope_rcp_theta, float(2 * ((tx * vec_size + i) / 2)) / float(rotary_dim));
+      } else {
+        freq[i] = __powf(rope_rcp_theta,
+                         float(2 * ((tx * vec_size + i) % (rotary_dim / 2))) / float(rotary_dim));
+      }
 
-    float smooth = freq[i] * smooth_a + smooth_b;
-    smooth = max(0.0f, min(1.0f, smooth));  // clamp to [0, 1]
-    freq[i] = (1 - smooth) * (freq[i] * rope_rcp_scale) + smooth * freq[i];
+      float smooth = freq[i] * smooth_a + smooth_b;
+      smooth = max(0.0f, min(1.0f, smooth));  // clamp to [0, 1]
+      freq[i] = (1 - smooth) * (freq[i] * rope_rcp_scale) + smooth * freq[i];
+    }
   }
 
   vec_t<float, vec_size> cos, sin;
@@ -238,10 +253,12 @@ __global__ void BatchQKApplyRotaryPosIdsKernel(
     const uint32_t idx = bx * bdy + ty;
     const IdType pos = pos_ids[idx];
 
+    if (tx * vec_size < rotary_dim) {
 #pragma unroll
-    for (uint32_t i = 0; i < vec_size; ++i) {
-      float embed = float(pos) * freq[i];
-      __sincosf(embed, &sin[i], &cos[i]);
+      for (uint32_t i = 0; i < vec_size; ++i) {
+        float embed = float(pos) * freq[i];
+        __sincosf(embed, &sin[i], &cos[i]);
+      }
     }
 
 #pragma unroll 1
@@ -251,9 +268,9 @@ __global__ void BatchQKApplyRotaryPosIdsKernel(
           q_rope + get_elem_offset_impl(idx, qo_head_idx, 0, q_rope_stride_n, q_rope_stride_h);
       vec_t<float, vec_size> q_vec;
       if constexpr (interleave) {
-        q_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(q_ptr, cos, sin);
+        q_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(q_ptr, cos, sin, rotary_dim);
       } else {
-        q_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(q_ptr, cos, sin);
+        q_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(q_ptr, cos, sin, rotary_dim);
       }
       q_vec.cast_store(q_rope_ptr + tx * vec_size);
     }
@@ -265,9 +282,9 @@ __global__ void BatchQKApplyRotaryPosIdsKernel(
           k_rope + get_elem_offset_impl(idx, kv_head_idx, 0, k_rope_stride_n, k_rope_stride_h);
       vec_t<float, vec_size> k_vec;
       if constexpr (interleave) {
-        k_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(k_ptr, cos, sin);
+        k_vec = vec_apply_llama_rope_cos_sin_interleave<vec_size, bdx>(k_ptr, cos, sin, rotary_dim);
       } else {
-        k_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(k_ptr, cos, sin);
+        k_vec = vec_apply_llama_rope_cos_sin<vec_size, bdx>(k_ptr, cos, sin, rotary_dim);
       }
       k_vec.cast_store(k_rope_ptr + tx * vec_size);
     }
@@ -279,24 +296,26 @@ template <bool interleave, uint32_t head_dim, uint32_t vec_size, uint32_t bdx, t
 __global__ void BatchQKApplyRotaryKernel(
     DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ indptr,
     IdType* __restrict__ offsets, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
-    size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+    uint32_t rotary_dim, size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
     size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
     float smooth_a, float smooth_b, float rope_rcp_scale, float rope_rcp_theta) {
   uint32_t bx = blockIdx.x, tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t bdy = blockDim.y;
   vec_t<float, vec_size> freq;
+  if (tx * vec_size < rotary_dim) {
 #pragma unroll
-  for (uint32_t i = 0; i < vec_size; ++i) {
-    if constexpr (interleave) {
-      freq[i] = __powf(rope_rcp_theta, float(2 * ((tx * vec_size + i) / 2)) / float(head_dim));
-    } else {
-      freq[i] = __powf(rope_rcp_theta,
-                       float(2 * ((tx * vec_size + i) % (head_dim / 2))) / float(head_dim));
-    }
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      if constexpr (interleave) {
+        freq[i] = __powf(rope_rcp_theta, float(2 * ((tx * vec_size + i) / 2)) / float(rotary_dim));
+      } else {
+        freq[i] = __powf(rope_rcp_theta,
+                         float(2 * ((tx * vec_size + i) % (rotary_dim / 2))) / float(rotary_dim));
+      }
 
-    float smooth = freq[i] * smooth_a + smooth_b;
-    smooth = max(0.0f, min(1.0f, smooth));  // clamp to [0, 1]
-    freq[i] = (1 - smooth) * (freq[i] * rope_rcp_scale) + smooth * freq[i];
+      float smooth = freq[i] * smooth_a + smooth_b;
+      smooth = max(0.0f, min(1.0f, smooth));  // clamp to [0, 1]
+      freq[i] = (1 - smooth) * (freq[i] * rope_rcp_scale) + smooth * freq[i];
+    }
   }
 
   if (bx < batch_size * num_qo_heads) {
@@ -315,10 +334,11 @@ __global__ void BatchQKApplyRotaryKernel(
             q_rope + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, qo_head_idx, 0,
                                           q_rope_stride_n, q_rope_stride_h);
         if constexpr (interleave) {
-          q_vec =
-              vec_apply_llama_rope_interleave<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
+          q_vec = vec_apply_llama_rope_interleave<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty,
+                                                                 rotary_dim);
         } else {
-          q_vec = vec_apply_llama_rope<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty);
+          q_vec =
+              vec_apply_llama_rope<vec_size, bdx>(q_ptr, freq, offset + i * bdy + ty, rotary_dim);
         }
         q_vec.cast_store(q_rope_ptr + tx * vec_size);
       }
@@ -339,10 +359,11 @@ __global__ void BatchQKApplyRotaryKernel(
             k_rope + get_elem_offset_impl(indptr[batch_idx] + i * bdy + ty, kv_head_idx, 0,
                                           k_rope_stride_n, k_rope_stride_h);
         if constexpr (interleave) {
-          k_vec =
-              vec_apply_llama_rope_interleave<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
+          k_vec = vec_apply_llama_rope_interleave<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty,
+                                                                 rotary_dim);
         } else {
-          k_vec = vec_apply_llama_rope<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty);
+          k_vec =
+              vec_apply_llama_rope<vec_size, bdx>(k_ptr, freq, offset + i * bdy + ty, rotary_dim);
         }
         k_vec.cast_store(k_rope_ptr + tx * vec_size);
       }
@@ -362,10 +383,10 @@ __global__ void BatchQKApplyRotaryKernel(
 template <typename DType, typename IdType>
 cudaError_t BatchQKApplyRotaryPosIdsCosSinCache(
     DType* q, DType* k, DType* q_rope, DType* k_rope, float* cos_cache, float* sin_cache,
-    IdType* pos_ids, uint32_t nnz, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
-    size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
-    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
-    bool interleave, cudaStream_t stream = nullptr) {
+    IdType* pos_ids, uint32_t nnz, uint32_t num_qo_heads, uint32_t num_kv_heads,
+    uint32_t rotary_dim, uint32_t head_dim, size_t q_stride_n, size_t q_stride_h, size_t k_stride_n,
+    size_t k_stride_h, size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n,
+    size_t k_rope_stride_h, bool interleave, cudaStream_t stream = nullptr) {
   DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
     DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
       constexpr uint32_t vec_size = std::max(16 / sizeof(DType), HEAD_DIM / 32);
@@ -386,6 +407,7 @@ cudaError_t BatchQKApplyRotaryPosIdsCosSinCache(
                       (void*)&nnz,
                       (void*)&num_qo_heads,
                       (void*)&num_kv_heads,
+                      (void*)&rotary_dim,
                       (void*)&q_stride_n,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
@@ -402,14 +424,12 @@ cudaError_t BatchQKApplyRotaryPosIdsCosSinCache(
 }
 
 template <typename DType, typename IdType>
-cudaError_t BatchQKApplyRotaryPosIds(DType* q, DType* k, DType* q_rope, DType* k_rope,
-                                     IdType* __restrict__ pos_ids, uint32_t nnz,
-                                     uint32_t num_qo_heads, uint32_t num_kv_heads,
-                                     uint32_t head_dim, size_t q_stride_n, size_t q_stride_h,
-                                     size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
-                                     size_t q_rope_stride_h, size_t k_rope_stride_n,
-                                     size_t k_rope_stride_h, bool interleave, float rope_scale,
-                                     float rope_theta, cudaStream_t stream = nullptr) {
+cudaError_t BatchQKApplyRotaryPosIds(
+    DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ pos_ids, uint32_t nnz,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rotary_dim, uint32_t head_dim,
+    size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
+    bool interleave, float rope_scale, float rope_theta, cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = 0.f;
@@ -433,6 +453,7 @@ cudaError_t BatchQKApplyRotaryPosIds(DType* q, DType* k, DType* q_rope, DType* k
                       (void*)&nnz,
                       (void*)&num_qo_heads,
                       (void*)&num_kv_heads,
+                      (void*)&rotary_dim,
                       (void*)&q_stride_n,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
@@ -456,11 +477,11 @@ template <typename DType, typename IdType>
 cudaError_t BatchQKApplyRotary(DType* q, DType* k, DType* q_rope, DType* k_rope,
                                IdType* __restrict__ indptr, IdType* __restrict__ offsets,
                                uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
-                               uint32_t head_dim, size_t q_stride_n, size_t q_stride_h,
-                               size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
-                               size_t q_rope_stride_h, size_t k_rope_stride_n,
-                               size_t k_rope_stride_h, bool interleave, float rope_scale,
-                               float rope_theta, cudaStream_t stream = nullptr) {
+                               uint32_t rotary_dim, uint32_t head_dim, size_t q_stride_n,
+                               size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+                               size_t q_rope_stride_n, size_t q_rope_stride_h,
+                               size_t k_rope_stride_n, size_t k_rope_stride_h, bool interleave,
+                               float rope_scale, float rope_theta, cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = 0.f;
@@ -484,6 +505,7 @@ cudaError_t BatchQKApplyRotary(DType* q, DType* k, DType* q_rope, DType* k_rope,
                       (void*)&batch_size,
                       (void*)&num_qo_heads,
                       (void*)&num_kv_heads,
+                      (void*)&rotary_dim,
                       (void*)&q_stride_n,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
@@ -507,24 +529,25 @@ template <typename DType, typename IdType>
 cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__ k,
                                       IdType* __restrict__ indptr, IdType* __restrict__ offsets,
                                       uint32_t batch_size, uint32_t num_qo_heads,
-                                      uint32_t num_kv_heads, uint32_t head_dim, size_t q_stride_n,
-                                      size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
-                                      bool interleave, float rope_scale, float rope_theta,
-                                      cudaStream_t stream = nullptr) {
+                                      uint32_t num_kv_heads, uint32_t rotary_dim, uint32_t head_dim,
+                                      size_t q_stride_n, size_t q_stride_h, size_t k_stride_n,
+                                      size_t k_stride_h, bool interleave, float rope_scale,
+                                      float rope_theta, cudaStream_t stream = nullptr) {
   return BatchQKApplyRotary<DType, IdType>(
-      q, k, q, k, indptr, offsets, batch_size, num_qo_heads, num_kv_heads, head_dim, q_stride_n,
-      q_stride_h, k_stride_n, k_stride_h, q_stride_n, q_stride_h, k_stride_n, k_stride_h,
-      interleave, rope_scale, rope_theta, stream);
+      q, k, q, k, indptr, offsets, batch_size, num_qo_heads, num_kv_heads, rotary_dim, head_dim,
+      q_stride_n, q_stride_h, k_stride_n, k_stride_h, q_stride_n, q_stride_h, k_stride_n,
+      k_stride_h, interleave, rope_scale, rope_theta, stream);
 }
 
 template <typename DType, typename IdType>
 cudaError_t BatchQKApplyLlama31Rotary(
     DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ indptr,
     IdType* __restrict__ offsets, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
-    uint32_t head_dim, size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
-    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
-    bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
-    float high_freq_factor, float old_context_length, cudaStream_t stream = nullptr) {
+    uint32_t rotary_dim, uint32_t head_dim, size_t q_stride_n, size_t q_stride_h, size_t k_stride_n,
+    size_t k_stride_h, size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n,
+    size_t k_rope_stride_h, bool interleave, float rope_scale, float rope_theta,
+    float low_freq_factor, float high_freq_factor, float old_context_length,
+    cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = old_context_length / (2 * M_PI * high_freq_factor - 2 * M_PI * low_freq_factor);
@@ -548,6 +571,7 @@ cudaError_t BatchQKApplyLlama31Rotary(
                       (void*)&batch_size,
                       (void*)&num_qo_heads,
                       (void*)&num_kv_heads,
+                      (void*)&rotary_dim,
                       (void*)&q_stride_n,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,
@@ -570,11 +594,11 @@ cudaError_t BatchQKApplyLlama31Rotary(
 template <typename DType, typename IdType>
 cudaError_t BatchQKApplyLlama31RotaryPosIds(
     DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* pos_ids, uint32_t nnz,
-    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim, size_t q_stride_n,
-    size_t q_stride_h, size_t k_stride_n, size_t k_stride_h, size_t q_rope_stride_n,
-    size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h, bool interleave,
-    float rope_scale, float rope_theta, float low_freq_factor, float high_freq_factor,
-    float old_context_length, cudaStream_t stream = nullptr) {
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rotary_dim, uint32_t head_dim,
+    size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
+    bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
+    float high_freq_factor, float old_context_length, cudaStream_t stream = nullptr) {
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = old_context_length / (2 * M_PI * high_freq_factor - 2 * M_PI * low_freq_factor);
@@ -598,6 +622,7 @@ cudaError_t BatchQKApplyLlama31RotaryPosIds(
                       (void*)&nnz,
                       (void*)&num_qo_heads,
                       (void*)&num_kv_heads,
+                      (void*)&rotary_dim,
                       (void*)&q_stride_n,
                       (void*)&q_stride_h,
                       (void*)&k_stride_n,

--- a/python/csrc/flashinfer_rope_ops.cu
+++ b/python/csrc/flashinfer_rope_ops.cu
@@ -18,22 +18,24 @@
 #include <vector>
 
 void apply_rope(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope, torch::Tensor k_rope,
-                torch::Tensor indptr, torch::Tensor offsets, bool interleave, float rope_scale,
-                float rope_theta);
+                torch::Tensor indptr, torch::Tensor offsets, unsigned int rotary_dim,
+                bool interleave, float rope_scale, float rope_theta);
 
 void apply_llama31_rope(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
                         torch::Tensor k_rope, torch::Tensor indptr, torch::Tensor offsets,
-                        bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
-                        float high_freq_factor, float old_context_length);
+                        unsigned int rotary_dim, bool interleave, float rope_scale,
+                        float rope_theta, float low_freq_factor, float high_freq_factor,
+                        float old_context_length);
 
 void apply_rope_pos_ids(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
-                        torch::Tensor k_rope, torch::Tensor pos_ids, bool interleave,
-                        float rope_scale, float rope_theta);
+                        torch::Tensor k_rope, torch::Tensor pos_ids, unsigned int rotary_dim,
+                        bool interleave, float rope_scale, float rope_theta);
 
 void apply_llama31_rope_pos_ids(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
-                                torch::Tensor k_rope, torch::Tensor pos_ids, bool interleave,
-                                float rope_scale, float rope_theta, float low_freq_factor,
-                                float high_freq_factor, float old_context_length);
+                                torch::Tensor k_rope, torch::Tensor pos_ids,
+                                unsigned int rotary_dim, bool interleave, float rope_scale,
+                                float rope_theta, float low_freq_factor, float high_freq_factor,
+                                float old_context_length);
 
 void apply_rope_pos_ids_cos_sin_cache(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
                                       torch::Tensor k_rope, torch::Tensor cos_cache,

--- a/python/csrc_aot/flashinfer_ops.cu
+++ b/python/csrc_aot/flashinfer_ops.cu
@@ -129,22 +129,29 @@ torch::Tensor segment_packbits(torch::Tensor x, torch::Tensor input_indptr,
 //========== rope ==========
 
 void apply_rope(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope, torch::Tensor k_rope,
-                torch::Tensor indptr, torch::Tensor offsets, bool interleave, float rope_scale,
-                float rope_theta);
+                torch::Tensor indptr, torch::Tensor offsets, unsigned int rotary_dim,
+                bool interleave, float rope_scale, float rope_theta);
 
 void apply_llama31_rope(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
                         torch::Tensor k_rope, torch::Tensor indptr, torch::Tensor offsets,
-                        bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
-                        float high_freq_factor, float old_context_length);
+                        unsigned int rotary_dim, bool interleave, float rope_scale,
+                        float rope_theta, float low_freq_factor, float high_freq_factor,
+                        float old_context_length);
 
 void apply_rope_pos_ids(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
-                        torch::Tensor k_rope, torch::Tensor pos_ids, bool interleave,
-                        float rope_scale, float rope_theta);
+                        torch::Tensor k_rope, torch::Tensor pos_ids, unsigned int rotary_dim,
+                        bool interleave, float rope_scale, float rope_theta);
 
 void apply_llama31_rope_pos_ids(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
-                                torch::Tensor k_rope, torch::Tensor pos_ids, bool interleave,
-                                float rope_scale, float rope_theta, float low_freq_factor,
-                                float high_freq_factor, float old_context_length);
+                                torch::Tensor k_rope, torch::Tensor pos_ids,
+                                unsigned int rotary_dim, bool interleave, float rope_scale,
+                                float rope_theta, float low_freq_factor, float high_freq_factor,
+                                float old_context_length);
+
+void apply_rope_pos_ids_cos_sin_cache(torch::Tensor q, torch::Tensor k, torch::Tensor q_rope,
+                                      torch::Tensor k_rope, torch::Tensor cos_cache,
+                                      torch::Tensor sin_cache, torch::Tensor pos_ids,
+                                      bool interleave);
 
 //========== sampling ==========
 


### PR DESCRIPTION
This PR implements the final piece of #530 , so that we can partially apply rotary embedding to first head dimensions instead of entire head dimensions.

We also add a simple benchmark for RoPE, below is the result on H100:
```python
batch_size:   1, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 23us, throughput:   0.876GB/s
batch_size:   1, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 26us, throughput:   0.801GB/s
batch_size:   1, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 27us, throughput:  95.735GB/s
batch_size:   1, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 27us, throughput:  95.639GB/s
batch_size:   1, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 31us, throughput: 672.889GB/s
batch_size:   1, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 32us, throughput: 662.972GB/s
---
batch_size:  19, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 27us, throughput:  14.559GB/s
batch_size:  19, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 27us, throughput:  14.435GB/s
batch_size:  19, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 37us, throughput: 1339.450GB/s
batch_size:  19, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 37us, throughput: 1340.399GB/s
batch_size:  19, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 148us, throughput: 2696.563GB/s
batch_size:  19, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 148us, throughput: 2689.104GB/s
---
batch_size:  99, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 27us, throughput:  74.186GB/s
batch_size:  99, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 27us, throughput:  74.452GB/s
batch_size:  99, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 110us, throughput: 2350.830GB/s
batch_size:  99, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 110us, throughput: 2359.814GB/s
batch_size:  99, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 717us, throughput: 2895.389GB/s
batch_size:  99, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 718us, throughput: 2891.385GB/s
---
batch_size: 128, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 27us, throughput:  95.449GB/s
batch_size: 128, append_len:     1, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 27us, throughput:  95.646GB/s
batch_size: 128, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 130us, throughput: 2576.101GB/s
batch_size: 128, append_len:   128, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 130us, throughput: 2582.447GB/s
batch_size: 128, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: False, latency: 924us, throughput: 2906.154GB/s
batch_size: 128, append_len:  1024, num_qo_heads:    32, num_kv_heads:     8, head_dim:   128, use_cos_sin_cache: True, latency: 925us, throughput: 2903.484GB/s
```
