### PR TITLE
feat: simplify prefill JIT compilation

### DIFF
--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -418,7 +418,7 @@ def single_decode_with_kv_cache(
                 sm_scale,
                 rope_scale,
                 rope_theta,
-                False,  # return_lse
+                None,  # maybe_lse
             )[0]
             .squeeze(0)
         )

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -743,8 +743,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         indptr_host = indptr.to("cpu")
         if data_type is not None:
-            q_data_type = data_type
-            kv_data_type = data_type
+            if q_data_type is None:
+                q_data_type = data_type
+            if kv_data_type is None:
+                kv_data_type = data_type
 
         q_data_type = canonicalize_torch_dtype(q_data_type)
         if kv_data_type is None:

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -400,12 +400,12 @@ def single_decode_with_kv_cache(
                 q.dtype,
                 head_dim,
                 PosEncodingMode[pos_encoding_mode].value,
-                MaskMode.NON_CAUSAL.value,
                 window_left != -1,  # use_sliding_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 False,  # allow_fp16_qk_reduction
             )
             .run(
+                MaskMode.NON_CAUSAL.value,
                 q.unsqueeze(0),
                 k,
                 v,
@@ -761,7 +761,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 indptr.dtype,
                 head_dim,
                 PosEncodingMode[pos_encoding_mode].value,
-                MaskMode.NON_CAUSAL.value,
                 window_left != -1,  # use_sliding_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 False,  # allow_fp16_qk_reduction
@@ -938,6 +937,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         if self.use_tensor_cores:
             out = self._cached_module.paged_run(
+                MaskMode.NON_CAUSAL.value,
                 self._float_workspace_buffer,
                 self._int_workspace_buffer,
                 self._plan_info,

--- a/python/flashinfer/jit/attention.py
+++ b/python/flashinfer/jit/attention.py
@@ -33,7 +33,6 @@ from .single_prefill_templ import (
 from .utils import (
     dtype_map,
     filename_safe_dtype_map,
-    mask_mode_literal,
     pos_encoding_mode_literal,
     write_if_different,
 )
@@ -216,7 +215,6 @@ def get_single_prefill_cu_str(
     dtype_o: torch.dtype,
     head_dim: int,
     pos_encoding_mode: int,
-    mask_mode: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
@@ -228,7 +226,6 @@ def get_single_prefill_cu_str(
         dtype_o=dtype_map[dtype_o],
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[pos_encoding_mode],
-        mask_mode=mask_mode_literal[mask_mode],
         use_sliding_window="true" if use_sliding_window else "false",
         use_logits_soft_cap="true" if use_logits_soft_cap else "false",
         use_fp16_qk_reduction="true" if use_fp16_qk_reduction else "false",
@@ -241,7 +238,6 @@ def get_single_prefill_uri(
     dtype_o: torch.dtype,
     head_dim: int,
     pos_encoding_mode: int,
-    mask_mode: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
@@ -252,7 +248,6 @@ def get_single_prefill_uri(
         f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
         f"head_dim_{head_dim}_"
         f"posenc_{pos_encoding_mode}_"
-        f"mask_{mask_mode}_"
         f"use_swa_{use_sliding_window}_"
         f"use_logits_cap_{use_logits_soft_cap}_"
         f"f16qk_{use_fp16_qk_reduction}"
@@ -280,7 +275,6 @@ def get_batch_prefill_cu_str(
     dtype_idx: torch.dtype,
     head_dim: int,
     pos_encoding_mode: int,
-    mask_mode: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
@@ -293,7 +287,6 @@ def get_batch_prefill_cu_str(
         dtype_idx=dtype_map[dtype_idx],
         head_dim=head_dim,
         pos_encoding_mode=pos_encoding_mode_literal[pos_encoding_mode],
-        mask_mode=mask_mode_literal[mask_mode],
         use_sliding_window="true" if use_sliding_window else "false",
         use_logits_soft_cap="true" if use_logits_soft_cap else "false",
         use_fp16_qk_reduction="true" if use_fp16_qk_reduction else "false",
@@ -307,7 +300,6 @@ def get_batch_prefill_uri(
     dtype_idx: torch.dtype,
     head_dim: int,
     pos_encoding_mode: int,
-    mask_mode: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
@@ -319,7 +311,6 @@ def get_batch_prefill_uri(
         f"dtype_idx_{filename_safe_dtype_map[dtype_idx]}_"
         f"head_dim_{head_dim}_"
         f"posenc_{pos_encoding_mode}_"
-        f"mask_{mask_mode}_"
         f"use_swa_{use_sliding_window}_"
         f"use_logits_cap_{use_logits_soft_cap}_"
         f"f16qk_{use_fp16_qk_reduction}"
@@ -424,7 +415,6 @@ def get_customize_single_prefill_cu_str(
     dtype_kv: torch.dtype,
     dtype_o: torch.dtype,
     head_dim: int,
-    mask_mode: int,
     additional_input_tensor_var_names: List[str],
     additional_input_tensor_var_types: List[str],
     additional_input_scalar_var_names: List[str],
@@ -489,7 +479,6 @@ def get_customize_single_prefill_cu_str(
         dtype_kv=dtype_map[dtype_kv],
         dtype_o=dtype_map[dtype_o],
         head_dim=head_dim,
-        mask_mode=mask_mode_literal[mask_mode],
         additional_params_decl=additional_params_decl,
         additional_params=additional_params,
         additional_params_init=additional_params_init,

--- a/python/flashinfer/jit/batch_prefill_templ.py
+++ b/python/flashinfer/jit/batch_prefill_templ.py
@@ -107,10 +107,10 @@ torch::Tensor BatchPrefillWithRaggedKVCacheRun(
   RaggedParamsT params(
     static_cast<{{ dtype_q }}*>(q.data_ptr()), static_cast<{{ dtype_kv }}*>(k.data_ptr()),
     static_cast<{{ dtype_kv }}*>(v.data_ptr()),
-    {% if mask_mode == "MaskMode::kCustom" %}static_cast<uint8_t*>(maybe_custom_mask->data_ptr()){% else %}nullptr{% endif %},
+    /*custom_mask=*/(maybe_packed_custom_mask ? static_cast<uint8_t*>(maybe_packed_custom_mask->data_ptr()) : nullptr),
     static_cast<{{ dtype_idx }}*>(qo_indptr.data_ptr()),
     static_cast<{{ dtype_idx }}*>(kv_indptr.data_ptr()),
-    {% if mask_mode == "MaskMode::kCustom" %}static_cast<{{ dtype_idx }}*>(maybe_qk_indptr->data_ptr()){% else %}nullptr{% endif %},
+    /*qk_indptr=*/(maybe_qk_indptr ? static_cast<{{ dtype_idx }}*>(maybe_qk_indptr->data_ptr()) : nullptr),
     /*q_offset=*/nullptr, /*k_rope_pos_offset=*/nullptr,
     static_cast<{{ dtype_o }}*>(o.data_ptr()),
     /*lse=*/(maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr),
@@ -220,9 +220,9 @@ torch::Tensor BatchPrefillWithPagedKVCacheRun(
 
   PagedParamsT params(
     static_cast<{{ dtype_q }}*>(q.data_ptr()), paged_kv,
-    {% if mask_mode == "MaskMode::kCustom" %}static_cast<uint8_t*>(maybe_custom_mask->data_ptr()){% else %}nullptr{% endif %},
+    /*custom_mask=*/(maybe_custom_mask ? static_cast<uint8_t*>(maybe_custom_mask->data_ptr()) : nullptr),
     static_cast<{{ dtype_idx }}*>(qo_indptr.data_ptr()),
-    {% if mask_mode == "MaskMode::kCustom" %}static_cast<{{ dtype_idx }}*>(maybe_qk_indptr->data_ptr()){% else %}nullptr{% endif %},
+    /*qk_indptr=*/(maybe_qk_indptr ? static_cast<{{ dtype_idx }}*>(maybe_qk_indptr->data_ptr()) : nullptr),
     /*q_offset=*/nullptr,
     static_cast<{{ dtype_o }}*>(o.data_ptr()),
     /*lse=*/(maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr),

--- a/python/flashinfer/jit/batch_prefill_templ.py
+++ b/python/flashinfer/jit/batch_prefill_templ.py
@@ -25,12 +25,9 @@ batch_prefill_templ = r"""
 
 using namespace flashinfer;
 
-{% set use_custom_mask = "true" if mask_mode == "MaskMode::kCustom" else "false" %}
 {% set use_alibi = "true" if pos_encoding_mode == "PosEncodingMode::kALiBi" else "false" %}
 using RaggedParamsT = BatchPrefillRaggedParams<{{ dtype_q }}, {{ dtype_kv }}, {{ dtype_o }}, {{ dtype_idx }}>;
-using RaggedAttentionVariant = ComposedAttention<RaggedParamsT, get_variant_code({{ use_custom_mask }}, {{ use_sliding_window }}, {{ use_logits_soft_cap }}, {{ use_alibi }})>;
 using PagedParamsT = BatchPrefillPagedParams<{{ dtype_q }}, {{ dtype_kv }}, {{ dtype_o }}, {{ dtype_idx }}>;
-using PagedAttentionVariant = ComposedAttention<PagedParamsT, get_variant_code({{ use_custom_mask }}, {{ use_sliding_window }}, {{ use_logits_soft_cap }}, {{ use_alibi }})>;
 
 std::vector<int64_t> BatchPrefillWithKVCachePlan(
     torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
@@ -68,6 +65,7 @@ std::vector<int64_t> BatchPrefillWithKVCachePlan(
 }
 
 torch::Tensor BatchPrefillWithRaggedKVCacheRun(
+  unsigned int mask_mode_code,
   torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
   std::vector<int64_t> plan_info_vec,
   torch::Tensor q, torch::Tensor k, torch::Tensor v,
@@ -141,10 +139,16 @@ torch::Tensor BatchPrefillWithRaggedKVCacheRun(
 
   cudaError_t status = cudaSuccess;
 
-  DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
-    status = BatchPrefillWithRaggedKVCacheDispatched<
-      CTA_TILE_Q, {{ head_dim }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, {{ mask_mode }}, RaggedAttentionVariant>(
-        params, tmp_v, tmp_s, torch_current_stream);
+  MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
+
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {
+    constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom;
+    using RaggedAttentionVariant = ComposedAttention<RaggedParamsT, get_variant_code(use_custom_mask, {{ use_sliding_window }}, {{ use_logits_soft_cap }}, {{ use_alibi }})>;
+    DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
+      status = BatchPrefillWithRaggedKVCacheDispatched<
+        CTA_TILE_Q, {{ head_dim }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, MASK_MODE, RaggedAttentionVariant>(
+          params, tmp_v, tmp_s, torch_current_stream);
+    });
   });
 
   TORCH_CHECK(status == cudaSuccess, "BatchPrefillWithRaggedKVCache failed with error ", cudaGetErrorString(status));
@@ -153,6 +157,7 @@ torch::Tensor BatchPrefillWithRaggedKVCacheRun(
 }
 
 torch::Tensor BatchPrefillWithPagedKVCacheRun(
+  unsigned int mask_mode_code,
   torch::Tensor float_workspace_buffer, torch::Tensor int_workspace_buffer,
   std::vector<int64_t> plan_info_vec,
   torch::Tensor q,
@@ -245,10 +250,16 @@ torch::Tensor BatchPrefillWithPagedKVCacheRun(
 
   cudaError_t status = cudaSuccess;
 
-  DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
-    status = BatchPrefillWithPagedKVCacheDispatched<
-      CTA_TILE_Q, {{ head_dim }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, {{ mask_mode }}, PagedAttentionVariant>(
-        params, tmp_v, tmp_s, torch_current_stream);
+  MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
+
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {
+    constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom;
+    using PagedAttentionVariant = ComposedAttention<PagedParamsT, get_variant_code(use_custom_mask, {{ use_sliding_window }}, {{ use_logits_soft_cap }}, {{ use_alibi }})>;
+    DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
+      status = BatchPrefillWithPagedKVCacheDispatched<
+        CTA_TILE_Q, {{ head_dim }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, MASK_MODE, PagedAttentionVariant>(
+          params, tmp_v, tmp_s, torch_current_stream);
+    });
   });
 
   TORCH_CHECK(status == cudaSuccess, "BatchPrefillWithPagedKVCache failed with error ", cudaGetErrorString(status));

--- a/python/flashinfer/jit/batch_prefill_templ.py
+++ b/python/flashinfer/jit/batch_prefill_templ.py
@@ -107,7 +107,7 @@ torch::Tensor BatchPrefillWithRaggedKVCacheRun(
   RaggedParamsT params(
     static_cast<{{ dtype_q }}*>(q.data_ptr()), static_cast<{{ dtype_kv }}*>(k.data_ptr()),
     static_cast<{{ dtype_kv }}*>(v.data_ptr()),
-    /*custom_mask=*/(maybe_packed_custom_mask ? static_cast<uint8_t*>(maybe_packed_custom_mask->data_ptr()) : nullptr),
+    /*custom_mask=*/(maybe_custom_mask ? static_cast<uint8_t*>(maybe_custom_mask->data_ptr()) : nullptr),
     static_cast<{{ dtype_idx }}*>(qo_indptr.data_ptr()),
     static_cast<{{ dtype_idx }}*>(kv_indptr.data_ptr()),
     /*qk_indptr=*/(maybe_qk_indptr ? static_cast<{{ dtype_idx }}*>(maybe_qk_indptr->data_ptr()) : nullptr),

--- a/python/flashinfer/jit/single_prefill_templ.py
+++ b/python/flashinfer/jit/single_prefill_templ.py
@@ -189,7 +189,7 @@ torch::Tensor single_prefill_with_kv_cache(
   ParamsT params(
     static_cast<{{ dtype_q }}*>(q.data_ptr()), static_cast<{{ dtype_kv }}*>(k.data_ptr()),
     static_cast<{{ dtype_kv }}*>(v.data_ptr()),
-    {% if mask_mode == "MaskMode::kCustom" %}static_cast<uint8_t*>(maybe_packed_custom_mask->data_ptr()){% else %}nullptr{% endif %},
+    /*custom_mask=*/(maybe_packed_custom_mask ? static_cast<uint8_t*>(maybe_packed_custom_mask->data_ptr()) : nullptr),
     static_cast<{{ dtype_o }}*>(o.data_ptr()),
     /*lse=*/(maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr),
     {% if use_alibi == "true" %}static_cast<float*>(maybe_alibi_slopes->data_ptr()){% else %}nullptr{% endif %},

--- a/python/flashinfer/sparse.py
+++ b/python/flashinfer/sparse.py
@@ -294,6 +294,7 @@ class BlockSparseAttentionWrapper:
             self._packed_mask_buf = None
             self._qk_indptr_buf = None
             mask_mode = MaskMode.NON_CAUSAL.value
+        self._mask_mode = mask_mode
 
         self.M = M
         self.N = N
@@ -343,7 +344,6 @@ class BlockSparseAttentionWrapper:
                 indptr.dtype,
                 head_dim,
                 PosEncodingMode[pos_encoding_mode].value,
-                mask_mode,
                 False,  # use_sliding_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 allow_fp16_qk_reduction,
@@ -448,6 +448,7 @@ class BlockSparseAttentionWrapper:
 
         if self._use_tensor_cores:
             out = self._cached_module.paged_run(
+                self._mask_mode,
                 self._float_workspace_buffer,
                 self._int_workspace_buffer,
                 self._plan_info,

--- a/tests/test_batch_decode_kernels.py
+++ b/tests/test_batch_decode_kernels.py
@@ -463,26 +463,86 @@ def test_cuda_graph_batch_decode_with_paged_kv_cache(
 
 if __name__ == "__main__":
     test_batch_decode_with_paged_kv_cache(
-        256, 54, 8, 8, 8, 128, "NHD", "NONE", 0.0, False, torch.float16, torch.float16
+        256,
+        54,
+        8,
+        8,
+        8,
+        128,
+        "NHD",
+        "NONE",
+        0.0,
+        False,
+        torch.float16,
+        torch.float16,
+        True,
     )
     test_batch_decode_with_tuple_paged_kv_cache(
-        256, 54, 8, 8, 8, 128, "NHD", "NONE", 0.0, False, torch.float16, torch.float16
+        256,
+        54,
+        8,
+        8,
+        8,
+        128,
+        "NHD",
+        "NONE",
+        0.0,
+        False,
+        torch.float16,
+        torch.float16,
+        True,
     )
     test_batch_decode_with_paged_kv_cache(
-        12, 2048, 8, 8, 8, 128, "NHD", "NONE", 0.0, False, torch.float16, torch.float16
+        12,
+        2048,
+        8,
+        8,
+        8,
+        128,
+        "NHD",
+        "NONE",
+        0.0,
+        False,
+        torch.float16,
+        torch.float16,
+        True,
     )
     test_batch_decode_with_paged_kv_cache(
-        12, 54, 1, 8, 8, 128, "HND", "NONE", 0.0, True, torch.float16, torch.float8_e5m2
+        12,
+        54,
+        1,
+        8,
+        8,
+        128,
+        "HND",
+        "NONE",
+        0.0,
+        True,
+        torch.float16,
+        torch.float8_e5m2,
+        True,
     )
     test_cuda_graph_batch_decode_with_paged_kv_cache(
-        12, 2048, 8, 8, 8, 128, "NHD", "NONE", torch.float16, torch.float16
+        12, 2048, 8, 8, 8, 128, "NHD", "NONE", torch.float16, torch.float16, True
     )
     test_cuda_graph_batch_decode_with_paged_kv_cache(
-        128, 54, 8, 8, 8, 128, "NHD", "NONE", torch.float16, torch.float16
+        128, 54, 8, 8, 8, 128, "NHD", "NONE", torch.float16, torch.float16, True
     )
     test_batch_decode_with_paged_kv_cache(
-        12, 54, 1, 8, 8, 128, "HND", "NONE", 0.0, True, torch.float16, torch.float8_e5m2
+        12,
+        54,
+        1,
+        8,
+        8,
+        128,
+        "HND",
+        "NONE",
+        0.0,
+        True,
+        torch.float16,
+        torch.float8_e5m2,
+        True,
     )
     test_cuda_graph_batch_decode_with_paged_kv_cache(
-        12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16, torch.float8_e5m2
+        12, 54, 8, 8, 8, 128, "HND", "NONE", torch.float16, torch.float8_e5m2, True
     )

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -688,16 +688,16 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
 
 if __name__ == "__main__":
     test_batch_prefill_with_paged_kv_cache(
-        12, 54, 37, 16, 8, 8, 128, True, "HND", "NONE", True, 0.0, False
+        12, 54, 37, 16, 8, 8, 128, True, "HND", "NONE", True, 0.0, False, True
     )
     test_batch_prefill_with_tuple_paged_kv_cache(
-        12, 54, 37, 16, 8, 8, 128, True, "HND", "NONE", True, 0.0, False
+        12, 54, 37, 16, 8, 8, 128, True, "HND", "NONE", True, 0.0, False, True
     )
     test_batch_prefill_with_paged_kv_cache(
-        12, 54, 37, 1, 8, 8, 128, True, "HND", "NONE", False, 0.0, False
+        12, 54, 37, 1, 8, 8, 128, True, "HND", "NONE", False, 0.0, False, True
     )
     test_batch_prefill_with_paged_kv_cache_custom_mask(
-        1, 137, 137, 1, 8, 8, 128, "HND", "NONE", 0.0, False
+        1, 137, 137, 1, 8, 8, 128, "HND", "NONE", 0.0, False, True
     )
     test_batch_prefill_with_ragged_kv_cache(
         12, 54, 37, 8, 8, 128, True, "NONE", 0.0, False

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -150,7 +150,6 @@ struct FlashSigmoid {
         torch.float16,  # dtype_kv
         torch.float16,  # dtype_o
         128,  # hidden_dim
-        MaskMode.NON_CAUSAL.value,
         [],  # additional_input_tensor_var_names
         [],  # additional_input_tensor_var_types
         ["logits_scale", "sigmoid_bias"],  # additional_input_scalar_var_names
@@ -167,7 +166,7 @@ struct FlashSigmoid {
     v = torch.randn(1027, 8, 128, dtype=torch.float16, device="cuda")
     logits_scale = 1.0 / math.sqrt(128)
     sigmoid_bias = 0.25
-    o = f(q, k, v, logits_scale, sigmoid_bias)
+    o = f(q, k, v, logits_scale, sigmoid_bias, mask_mode=MaskMode.NON_CAUSAL.value)
 
     p = torch.sigmoid(
         torch.einsum("mhd,nhd->hmn", q.float(), k.float()) * logits_scale + sigmoid_bias
@@ -225,7 +224,6 @@ struct DumpLogits {
         torch.float16,  # dtype_kv
         torch.float16,  # dtype_o
         128,  # hidden_dim
-        MaskMode.NON_CAUSAL.value,
         ["output_logits"],  # additional_input_tensor_var_names
         ["float"],  # additional_input_tensor_var_types
         ["sm_scale"],  # additional_input_scalar_var_names
@@ -242,7 +240,7 @@ struct DumpLogits {
     v = torch.randn(1023, 32, 128, dtype=torch.float16, device="cuda")
     logits = torch.empty(32, 128, 1023, dtype=torch.float32, device="cuda")
     sm_scale = 1.0 / math.sqrt(128)
-    o = f(q, k, v, logits, sm_scale)
+    o = f(q, k, v, logits, sm_scale, mask_mode=MaskMode.NON_CAUSAL.value)
 
     p = torch.einsum("mhd,nhd->hmn", q.float(), k.float()) * sm_scale
     o_ref = torch.einsum("hmn,nhd->mhd", torch.softmax(p, dim=-1), v.float()).half()
@@ -300,7 +298,6 @@ struct DebugPrintLogits {
         torch.float16,  # dtype_kv
         torch.float16,  # dtype_o
         128,  # hidden_dim
-        MaskMode.NON_CAUSAL.value,
         [],  # additional_input_tensor_var_names
         [],  # additional_input_tensor_var_types
         ["sm_scale"],  # additional_input_scalar_var_names
@@ -316,7 +313,7 @@ struct DebugPrintLogits {
     k = torch.randn(1023, 32, 128, dtype=torch.float16, device="cuda")
     v = torch.randn(1023, 32, 128, dtype=torch.float16, device="cuda")
     sm_scale = 1.0 / math.sqrt(128)
-    o = f(q, k, v, sm_scale)
+    o = f(q, k, v, sm_scale, mask_mode=MaskMode.NON_CAUSAL.value)
 
     p = torch.einsum("mhd,nhd->hmn", q.float(), k.float()) * sm_scale
     o_ref = torch.einsum("hmn,nhd->mhd", torch.softmax(p, dim=-1), v.float()).half()


### PR DESCRIPTION
Compile all three mask modes (causal/non-causal/custom) altogether instead of compiling them one-by-one.