### PR TITLE
hotfix: fix aot compilation after #618

### DIFF
--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -17,9 +17,9 @@
 
 //========== activation ==========
 
-void silu_and_mul(at::Tensor& out, at::Tensor& input, int cuda_stream);
-void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, int cuda_stream);
-void gelu_and_mul(at::Tensor& out, at::Tensor& input, int cuda_stream);
+void silu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
+void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
+void gelu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
 
 //========== cascade ==========
 


### PR DESCRIPTION
#618 breaks aot compilation because of function signature mismatch, this PR fixes the issue.