### PR TITLE
Allow the cascade kernels to be executed using varying sequence lenghts

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -764,12 +764,12 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(typename AttentionVariant::Par
             cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
         if constexpr (AttentionVariant::use_softmax) {
           FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v, tmp_s, params.o_indptr, o, lse,
-                                                         params.paged_kv.batch_size, num_qo_heads,
-                                                         HEAD_DIM, stream));
+                                                         params.paged_kv.batch_size, nullptr,
+                                                         num_qo_heads, HEAD_DIM, stream));
         } else {
           FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(tmp_v, o, params.o_indptr,
-                                                          params.paged_kv.batch_size, num_qo_heads,
-                                                          HEAD_DIM, stream));
+                                                          params.paged_kv.batch_size, nullptr,
+                                                          num_qo_heads, HEAD_DIM, stream));
         }
       }
     });
@@ -1087,8 +1087,8 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatchedMLA(typename AttentionVariant::
       dim3 nthrs(bdx, bdy, bdz);
       FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
       FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v, tmp_s, params.o_indptr, o, lse,
-                                                     params.paged_kv.batch_size, num_qo_heads,
-                                                     HEAD_DIM_CKV, stream));
+                                                     params.paged_kv.batch_size, nullptr,
+                                                     num_qo_heads, HEAD_DIM_CKV, stream));
     }
   });
   return cudaSuccess;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -2199,11 +2199,12 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(typename AttentionVariant::P
             cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
         if constexpr (AttentionVariant::use_softmax) {
           FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v, tmp_s, params.merge_indptr, o, lse,
-                                                         total_num_rows, num_qo_heads, HEAD_DIM,
-                                                         stream));
+                                                         total_num_rows, nullptr, num_qo_heads,
+                                                         HEAD_DIM, stream));
         } else {
-          FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
-              tmp_v, params.merge_indptr, o, total_num_rows, num_qo_heads, HEAD_DIM, stream));
+          FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(tmp_v, params.merge_indptr, o,
+                                                          total_num_rows, nullptr, num_qo_heads,
+                                                          HEAD_DIM, stream));
         }
       }
     }
@@ -2300,11 +2301,12 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(typename AttentionVariant::Pa
             cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
         if constexpr (AttentionVariant::use_softmax) {
           FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v, tmp_s, params.merge_indptr, o, lse,
-                                                         total_num_rows, num_qo_heads, HEAD_DIM,
-                                                         stream));
+                                                         total_num_rows, nullptr, num_qo_heads,
+                                                         HEAD_DIM, stream));
         } else {
-          FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
-              tmp_v, params.merge_indptr, o, total_num_rows, num_qo_heads, HEAD_DIM, stream));
+          FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(tmp_v, params.merge_indptr, o,
+                                                          total_num_rows, nullptr, num_qo_heads,
+                                                          HEAD_DIM, stream));
         }
       }
     }


### PR DESCRIPTION
The cascade kernels can take a dynamic sequence length in order to allow the number of tokens to vary when executed under CUDA graphs.

This is the first step towards implementing CUDA graph support for arbitrary `qo_indptr` contents, as tracked by #626.