### PR TITLE
misc: add page ops to shared-prefix kernel unittest warmup function

### DIFF
--- a/tests/test_shared_prefix_kernels.py
+++ b/tests/test_shared_prefix_kernels.py
@@ -44,6 +44,7 @@ def warmup_jit():
                 [False],  # use_logits_soft_caps
                 [False],  # allow_fp16_qk_reductions
             )
+            + [flashinfer.page.get_page_module, []]
         )
     except Exception as e:
         # abort the test session if warmup fails


### PR DESCRIPTION
In #629 , page ops are missing in shared-prefix kernel unittest's warmup function 