### PR TITLE
bugfix: fix sliding window attention tests of ragged attention api

### DIFF
--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -352,6 +352,7 @@ def test_batch_ragged_prefill_sliding_window(
         num_kv_heads,
         head_dim,
         window_left=window_left,
+        causal=True,
     )
     o = wrapper.run(q, k, v)
 


### PR DESCRIPTION
The unittests of sliding window atteniton didn't pass because we forget to set `causal` in `plan` function. This PR fixes the issue.