### PR TITLE
Pass a dynamic token count to the cascade kernels

### DIFF
--- a/include/flashinfer/attention/prefill_params.cuh
+++ b/include/flashinfer/attention/prefill_params.cuh
@@ -136,7 +136,8 @@ struct BatchPrefillRaggedParams {
   IdType* o_indptr;
   IdType* kv_chunk_size_ptr;
   bool* block_valid_mask;
-  uint32_t total_num_rows;
+  uint32_t max_total_num_rows;
+  uint32_t* total_num_rows;
   uint32_t padded_batch_size;
   bool partition_kv;
 
@@ -178,7 +179,8 @@ struct BatchPrefillRaggedParams {
         o_indptr(nullptr),
         kv_chunk_size_ptr(nullptr),
         block_valid_mask(nullptr),
-        total_num_rows(0),
+        max_total_num_rows(0),
+        total_num_rows(nullptr),
         padded_batch_size(0),
         partition_kv(false) {}
 
@@ -227,7 +229,8 @@ struct BatchPrefillPagedParams {
   IdType* o_indptr;
   bool* block_valid_mask;
   IdType* kv_chunk_size_ptr;
-  uint32_t total_num_rows;
+  uint32_t max_total_num_rows;
+  uint32_t* total_num_rows;
   uint32_t padded_batch_size;
   bool partition_kv;
 
@@ -261,7 +264,8 @@ struct BatchPrefillPagedParams {
         o_indptr(nullptr),
         block_valid_mask(nullptr),
         kv_chunk_size_ptr(nullptr),
-        total_num_rows(0),
+        max_total_num_rows(0),
+        total_num_rows(nullptr),
         padded_batch_size(0),
         partition_kv(false) {}
 

--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -160,8 +160,12 @@ void BatchPrefillWithRaggedKVCacheRun(
                   GetPtrFromBaseOffset<bool>(int_buffer_ptr, plan_info.block_valid_mask_offset);
             }
           }
-          params.total_num_rows = plan_info.total_num_rows;
           params.padded_batch_size = plan_info.padded_batch_size;
+          params.max_total_num_rows = plan_info.total_num_rows;
+          if (plan_info.enable_cuda_graph) {
+            params.total_num_rows =
+                GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
+          }
 
           cudaError_t status = cudaSuccess;
 
@@ -290,8 +294,12 @@ void BatchPrefillWithPagedKVCacheRun(
                   GetPtrFromBaseOffset<bool>(int_buffer_ptr, plan_info.block_valid_mask_offset);
             }
           }
-          params.total_num_rows = plan_info.total_num_rows;
           params.padded_batch_size = plan_info.padded_batch_size;
+          params.max_total_num_rows = plan_info.total_num_rows;
+          if (plan_info.enable_cuda_graph) {
+            params.total_num_rows =
+                GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
+          }
 
           cudaError_t status = cudaSuccess;
 


### PR DESCRIPTION
Under CUDA graph, if the graph is built with a maximal token count, the actual number of tokens from `qo_indptr` is passed on to the cascade kernels.