### PR TITLE
Fix the batch size/seq len args for the decode kernel with tensor cores

### DIFF
--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -777,8 +777,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     qo_indptr_host,
                     indptr_host,
                     batch_size,  # total_num_rows
-                    batch_size,
                     1,  # max_seq_len
+                    batch_size,
                     num_qo_heads,
                     num_kv_heads,
                     page_size,


### PR DESCRIPTION
A prior PR switched up the two arguments via a typo, without tests catching the problem.