### PR TITLE
Fix the batch size & kv indptr calculation

### DIFF
--- a/python/csrc/batch_prefill.cu
+++ b/python/csrc/batch_prefill.cu
@@ -42,9 +42,9 @@ using namespace flashinfer;
 std::vector<int64_t> BatchPrefillWithKVCachePlan(
     unsigned int head_dim, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
-    unsigned int total_num_rows, unsigned int max_seq_len, unsigned int batch_size,
-    unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int page_size,
-    bool enable_cuda_graph, int64_t cuda_stream) {
+    unsigned int total_num_rows, unsigned int batch_size, unsigned int num_qo_heads,
+    unsigned int num_kv_heads, unsigned int page_size, bool enable_cuda_graph,
+    int64_t cuda_stream) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -59,8 +59,8 @@ std::vector<int64_t> BatchPrefillWithKVCachePlan(
       float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<IdType>(),
-      kv_indptr.data_ptr<IdType>(), total_num_rows, max_seq_len, batch_size, num_qo_heads,
-      num_kv_heads, head_dim, page_size, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream);
+      kv_indptr.data_ptr<IdType>(), total_num_rows, batch_size, num_qo_heads, num_kv_heads,
+      head_dim, page_size, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream);
 
   TORCH_CHECK(status == cudaSuccess,
               "Failed to plan prefill with error: ", cudaGetErrorString(status));

--- a/python/csrc/flashinfer_ops.cu
+++ b/python/csrc/flashinfer_ops.cu
@@ -99,9 +99,8 @@ void single_prefill_with_kv_cache(unsigned int mask_mode_code, at::Tensor q, at:
 std::vector<int64_t> BatchPrefillWithKVCachePlan(
     unsigned int head_dim, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
-    unsigned total_num_rows, unsigned int max_seq_len, unsigned int batch_size,
-    unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int page_size,
-    bool enable_cuda_graph, int64_t cuda_stream);
+    unsigned total_num_rows, unsigned int batch_size, unsigned int num_qo_heads,
+    unsigned int num_kv_heads, unsigned int page_size, bool enable_cuda_graph, int64_t cuda_stream);
 
 void BatchPrefillWithRaggedKVCacheRun(
     unsigned int mask_mode_code, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -777,7 +777,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     qo_indptr_host,
                     indptr_host,
                     batch_size,  # total_num_rows
-                    1,  # max_seq_len
                     batch_size,
                     num_qo_heads,
                     num_kv_heads,

--- a/python/flashinfer/jit/batch_prefill_templ.py
+++ b/python/flashinfer/jit/batch_prefill_templ.py
@@ -140,7 +140,6 @@ std::vector<int64_t> BatchPrefillWithKVCachePlan(
     at::Tensor qo_indptr,
     at::Tensor kv_indptr,
     unsigned int total_num_rows,
-    unsigned int max_seq_len,
     unsigned int batch_size,
     unsigned int num_qo_heads,
     unsigned int num_kv_heads,
@@ -158,7 +157,7 @@ std::vector<int64_t> BatchPrefillWithKVCachePlan(
       float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<{{dtype_idx}}>(),
-      kv_indptr.data_ptr<{{dtype_idx}}>(), total_num_rows, max_seq_len,
+      kv_indptr.data_ptr<{{dtype_idx}}>(), total_num_rows,
       batch_size, num_qo_heads, num_kv_heads, {{head_dim}}, page_size,
       enable_cuda_graph, sizeof({{dtype_o}}), stream);
 
@@ -461,7 +460,6 @@ std::vector<int64_t> BatchPrefillWithKVCachePlan(
     at::Tensor qo_indptr,
     at::Tensor kv_indptr,
     unsigned int total_num_rows,
-    unsigned int max_seq_len,
     unsigned int batch_size,
     unsigned int num_qo_heads,
     unsigned int num_kv_heads,

--- a/src/bench_batch_decode.cu
+++ b/src/bench_batch_decode.cu
@@ -147,8 +147,8 @@ void bench_flashinfer_batch_decode_with_prefill(nvbench::state& state) {
   handler.Plan<T, int32_t>(
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
-      qo_indptr_h.data(), kv_indptr_host.data(), /*total_num_rows=*/batch_size, /*max_seq_len=*/1,
-      batch_size, num_qo_heads, num_kv_heads, head_dim, page_size);
+      qo_indptr_h.data(), kv_indptr_host.data(), /*total_num_rows=*/batch_size, batch_size,
+      num_qo_heads, num_kv_heads, head_dim, page_size);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     cudaError_t status = BatchPrefillWithPagedKVCacheWrapper<T, TKV, T, int32_t>(

--- a/src/bench_batch_prefill.cu
+++ b/src/bench_batch_prefill.cu
@@ -76,8 +76,8 @@ void bench_flashinfer_batch_prefill_with_ragged_kv(nvbench::state& state) {
   handler.Plan<dtype_out>(
       thrust::raw_pointer_cast(float_workspace.data()), float_workspace_size_in_bytes,
       thrust::raw_pointer_cast(int_workspace.data()), int_workspace_size_in_bytes,
-      qo_indptr_h.data(), kv_indptr_h.data(), /*total_num_rows=*/batch_size * qo_len,
-      /*max_seq_len=*/qo_len, batch_size, num_qo_heads, num_kv_heads, head_dim,
+      qo_indptr_h.data(), kv_indptr_h.data(), /*total_num_rows=*/batch_size * qo_len, batch_size,
+      num_qo_heads, num_kv_heads, head_dim,
       /*page_size=*/1);
 
   state.exec(nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {

--- a/src/bench_cascade.cu
+++ b/src/bench_cascade.cu
@@ -257,9 +257,8 @@ void bench_two_level_single_prefix_cascade_append(nvbench::state& state) {
         (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
         (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
         qo_indptr_h.data(), kv_indptr_unique_h.data(),
-        /*total_num_rows=*/batch_size * qo_append_length,
-        /*max_seq_len=*/qo_append_length, batch_size, num_qo_heads, num_kv_heads, head_dim,
-        page_size);
+        /*total_num_rows=*/batch_size * qo_append_length, batch_size, num_qo_heads, num_kv_heads,
+        head_dim, page_size);
     state.exec(nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       timer.start();
       cudaError_t status = SinglePrefillWithKVCache(
@@ -320,9 +319,8 @@ void bench_two_level_single_prefix_cascade_append(nvbench::state& state) {
         (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
         (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
         qo_indptr_h.data(), kv_indptr_combined_h.data(),
-        /*total_num_rows=*/batch_size * qo_append_length,
-        /*max_seq_len=*/qo_append_length, batch_size, num_qo_heads, num_kv_heads, head_dim,
-        page_size);
+        /*total_num_rows=*/batch_size * qo_append_length, batch_size, num_qo_heads, num_kv_heads,
+        head_dim, page_size);
     state.exec(nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       timer.start();
       cudaError_t status = BatchPrefillWithPagedKVCacheWrapper<T, T, T, int32_t>(

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -183,15 +183,14 @@ class BatchPrefillHandler {
   template <typename DTypeO, typename IdType>
   cudaError_t Plan(void* float_buffer, size_t float_workspace_size_in_bytes, void* int_buffer,
                    size_t int_workspace_size_in_bytes, IdType* qo_indptr_h, IdType* kv_indptr_h,
-                   uint32_t total_num_rows, uint32_t max_seq_len, uint32_t batch_size,
-                   uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
-                   uint32_t page_size) {
+                   uint32_t total_num_rows, uint32_t batch_size, uint32_t num_qo_heads,
+                   uint32_t num_kv_heads, uint32_t head_dim, uint32_t page_size) {
     int_buffer_ = int_buffer;
     float_buffer_ = float_buffer;
     return PrefillPlan<IdType>(float_buffer, float_workspace_size_in_bytes, int_buffer,
                                page_locked_buffer_, int_workspace_size_in_bytes, plan_info_,
-                               qo_indptr_h, kv_indptr_h, total_num_rows, max_seq_len, batch_size,
-                               num_qo_heads, num_kv_heads, head_dim, page_size, enable_cuda_graph_,
+                               qo_indptr_h, kv_indptr_h, total_num_rows, batch_size, num_qo_heads,
+                               num_kv_heads, head_dim, page_size, enable_cuda_graph_,
                                sizeof(DTypeO), stream_);
   }
 

--- a/src/test_batch_prefill.cu
+++ b/src/test_batch_prefill.cu
@@ -111,8 +111,8 @@ void _TestBatchPagedPrefillKernelOneHotCorrectness(size_t num_kv_heads, size_t n
     handler.Plan<DTypeQO, int32_t>(
         (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
         (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
-        q_indptr.data(), kv_indptr.data(), /*total_num_rows=*/q_indptr.back(),
-        /*max_seq_len=*/q_len, batch_size, num_qo_heads, num_kv_heads, head_dim, page_size);
+        q_indptr.data(), kv_indptr.data(), /*total_num_rows=*/q_indptr.back(), batch_size,
+        num_qo_heads, num_kv_heads, head_dim, page_size);
 
     for (uint32_t num_runs = 0; num_runs < 10; ++num_runs) {
       auto status =
@@ -154,8 +154,7 @@ void _TestBatchRaggedPrefillKernelCorrectness(size_t num_kv_heads, size_t num_qo
                                               bool allow_fp16_qk_reduction) {
   uint32_t batch_size = 9;
   std::vector<int32_t> q_lens(batch_size), kv_lens(batch_size);
-  const uint32_t max_seq_len = 15;
-  utils::vec_randint_(q_lens, 10, max_seq_len);
+  utils::vec_randint_(q_lens, 10, 15);
   utils::vec_randint_(kv_lens, 128, 2048);
   std::vector<int32_t> append_indptr{0}, kv_indptr{0};
 
@@ -203,8 +202,8 @@ void _TestBatchRaggedPrefillKernelCorrectness(size_t num_kv_heads, size_t num_qo
   handler.Plan<DTypeQO, int32_t>(
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
-      append_indptr.data(), kv_indptr.data(), /*total_num_rows=*/append_indptr.back(), max_seq_len,
-      batch_size, num_qo_heads, num_kv_heads, head_dim, /*page_size=*/1);
+      append_indptr.data(), kv_indptr.data(), /*total_num_rows=*/append_indptr.back(), batch_size,
+      num_qo_heads, num_kv_heads, head_dim, /*page_size=*/1);
 
   auto status = BatchPrefillWithRaggedKVCacheWrapper<DTypeQO, DTypeKV, DTypeQO, int32_t>(
       &handler, thrust::raw_pointer_cast(queries_device.data()),
@@ -247,9 +246,8 @@ void _TestBatchPagedPrefillKernelShortContextCorrectness(size_t num_kv_heads, si
                                                          PosEncodingMode pos_encoding_mode,
                                                          bool allow_fp16_qk_reduction) {
   const uint32_t batch_size = 7;
-  const uint32_t max_seq_len = 64;
   std::vector<int32_t> q_lens(batch_size);
-  utils::vec_randint_(q_lens, 1, max_seq_len);
+  utils::vec_randint_(q_lens, 1, 64);
   std::vector<int32_t> kv_lens(q_lens);
 
   std::vector<int32_t> q_indptr{0};
@@ -339,8 +337,8 @@ void _TestBatchPagedPrefillKernelShortContextCorrectness(size_t num_kv_heads, si
   handler.Plan<DTypeQO, int32_t>(
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
-      q_indptr.data(), kv_indptr.data(), /*total_num_rows=*/q_indptr.back(), max_seq_len,
-      batch_size, num_qo_heads, num_kv_heads, head_dim, page_size);
+      q_indptr.data(), kv_indptr.data(), /*total_num_rows=*/q_indptr.back(), batch_size,
+      num_qo_heads, num_kv_heads, head_dim, page_size);
 
   auto status = BatchPrefillWithPagedKVCacheWrapper<DTypeQO, DTypeKV, DTypeQO, int32_t>(
       &handler, thrust::raw_pointer_cast(q_device.data()),
@@ -468,7 +466,7 @@ void _TestBatchPagedPrefillKernelQMinMaxKVMinMaxCorrectness(
   handler.Plan<DTypeQO, int32_t>(
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
-      q_indptr.data(), kv_indptr.data(), /*total_num_rows=*/q_indptr.back(), q_len_max, batch_size,
+      q_indptr.data(), kv_indptr.data(), /*total_num_rows=*/q_indptr.back(), batch_size,
       num_qo_heads, num_kv_heads, head_dim, page_size);
 
   auto status = BatchPrefillWithPagedKVCacheWrapper<DTypeQO, DTypeKV, DTypeQO, int32_t>(
@@ -571,7 +569,6 @@ void _TestBatchPagedPrefillKernelLongContextCorrectness(size_t num_kv_heads, siz
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
       append_indptr.data(), kv_indptr.data(), /*total_num_rows=*/append_indptr.back(),
-      /*max_seq_len=*/append_indptr.back(),
       /*batch_size=*/1, num_qo_heads, num_kv_heads, head_dim, page_size);
 
   auto status = BatchPrefillWithPagedKVCacheWrapper<DTypeQO, DTypeKV, DTypeQO, int32_t>(

--- a/src/test_cascade.cu
+++ b/src/test_cascade.cu
@@ -495,14 +495,12 @@ void _TestTwoLevelSinglePrefixCascadeAppendCorrectness(size_t batch_size,
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
       qo_indptr_h.data(), kv_indptr_combined_h.data(), /*total_num_rows=*/qo_indptr_h.back(),
-      /*max_seq_len=*/qo_append_length, batch_size, num_qo_heads, num_kv_heads, head_dim,
-      page_size);
+      batch_size, num_qo_heads, num_kv_heads, head_dim, page_size);
   cascade_handler.Plan<T, int32_t>(
       (void*)thrust::raw_pointer_cast(float_buffer.data()), float_workspace_size_in_bytes,
       (void*)thrust::raw_pointer_cast(int_buffer.data()), int_workspace_size_in_bytes,
       qo_indptr_h.data(), kv_indptr_unique_h.data(), /*total_num_rows=*/qo_indptr_h.back(),
-      /*max_seq_len=*/qo_append_length, batch_size, num_qo_heads, num_kv_heads, head_dim,
-      page_size);
+      batch_size, num_qo_heads, num_kv_heads, head_dim, page_size);
 
   cudaError_t status = BatchPrefillWithPagedKVCacheWrapper<T, T, T, int32_t>(
       &baseline_handler, thrust::raw_pointer_cast(q_d.data()),


### PR DESCRIPTION
The new_batch_size was not computed correctly for CUDA graph mode. Now we ensure it is in sync with the contents of the per-block indices. Also adjusted the computation of the KV chunk sizes for CUDA graph mode.

This PR also removes the `max_seq_len` parameter from kernels, as a reasonable upper bound from it can be derived from `total_num_rows`.