### PR TITLE
feat: specify gemm backend

### DIFF
--- a/include/flashinfer/gemm/group_gemm_sm90.cuh
+++ b/include/flashinfer/gemm/group_gemm_sm90.cuh
@@ -16,8 +16,6 @@
 #ifndef FLASHINFER_GEMM_GROUP_GEMM_SM90_CUH_
 #define FLASHINFER_GEMM_GROUP_GEMM_SM90_CUH_
 
-#include <sstream>
-
 #include "../allocator.h"
 #include "../cutlass_utils.cuh"
 #include "../utils.cuh"

--- a/python/flashinfer/utils.py
+++ b/python/flashinfer/utils.py
@@ -252,3 +252,11 @@ else:
 
 def get_cuda_stream(device: torch.device) -> int:
     return torch.cuda.current_stream(device).cuda_stream
+
+
+def determine_gemm_backend(device: torch.device) -> str:
+    major, _ = get_compute_capability(device)
+    if major >= 9:
+        return "sm90"
+    else:
+        return "sm80"

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -51,7 +51,7 @@ def test_segment_gemm(
         pytest.skip("sm90 backend not supported on this device.")
     torch.manual_seed(42)
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(device)
-    segment_gemm = flashinfer.gemm.SegmentGEMMWrapper(workspace_buffer, backend)
+    segment_gemm = flashinfer.gemm.SegmentGEMMWrapper(workspace_buffer, backend=backend)
     x = torch.randn(batch_size * num_rows_per_batch, d_in, dtype=dtype).to(device)
     if use_weight_indices:
         num_weights = 1024

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -31,6 +31,7 @@ CUDA_DEVICES = ["cuda:0"]
 @pytest.mark.parametrize("column_major", [False, True])
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("backend", ["auto", "sm90", "sm80"])
 def test_segment_gemm(
     batch_size,
     num_rows_per_batch,
@@ -40,12 +41,13 @@ def test_segment_gemm(
     column_major,
     dtype,
     device,
+    backend,
 ):
     if batch_size * num_rows_per_batch > 8192:
         pytest.skip("batch_size * num_rows_per_batch too large for test.")
     torch.manual_seed(42)
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(device)
-    segment_gemm = flashinfer.gemm.SegmentGEMMWrapper(workspace_buffer)
+    segment_gemm = flashinfer.gemm.SegmentGEMMWrapper(workspace_buffer, backend)
     x = torch.randn(batch_size * num_rows_per_batch, d_in, dtype=dtype).to(device)
     if use_weight_indices:
         num_weights = 1024
@@ -99,7 +101,7 @@ def test_segment_gemm(
 
 
 if __name__ == "__main__":
-    test_segment_gemm(199, 17, 128, 1024, False, False, torch.float16, "cuda:0")
-    test_segment_gemm(199, 17, 128, 1024, False, True, torch.float16, "cuda:0")
-    test_segment_gemm(199, 17, 128, 1024, True, False, torch.float16, "cuda:0")
-    test_segment_gemm(199, 17, 128, 1024, True, True, torch.float16, "cuda:0")
+    test_segment_gemm(199, 17, 128, 1024, False, False, torch.float16, "cuda:0", "auto")
+    test_segment_gemm(199, 17, 128, 1024, False, True, torch.float16, "cuda:0", "auto")
+    test_segment_gemm(199, 17, 128, 1024, True, False, torch.float16, "cuda:0", "auto")
+    test_segment_gemm(199, 17, 128, 1024, True, True, torch.float16, "cuda:0", "auto")


### PR DESCRIPTION
Add optional `backend` api at gemm initialization.

Usage:
```python
# this will load cutlass_segment_gemm_sm90 kernel
backend="sm90" 
segment_gemm = flashinfer.gemm.SegmentGEMMWrapper(workspace_buffer, backend) 
```
Supported values: `sm90`, `sm80`, `auto`;
Default: `auto`.