### PR TITLE
Fix MLA decode error having v_scale without return_lse

### DIFF
--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -1406,7 +1406,10 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
             )
             out = (o, maybe_lse) if return_lse else (o,)
         if v_scale is not None:
-            out[0] *= v_scale
+            if return_lse:
+              out[0] *= v_scale
+            else:
+              out *= v_scale
 
         return out if return_lse else out[0]
 


### PR DESCRIPTION
In the case of v_scale is present, and return_lse is False:

```
[rank0]:   File "/home/simonmo/.conda/envs/vllm/lib/python3.10/site-packages/flashinfer/decode.py", line 1408, in run
[rank0]:     out[0] *= v_scale
[rank0]: TypeError: 'tuple' object does not support item assignment
```