### PR TITLE
Fix MLA decode error having v_scale without return_lse

### DIFF
--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -1406,7 +1406,10 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
             )
             out = (o, maybe_lse) if return_lse else (o,)
         if v_scale is not None:
-            out[0] *= v_scale
+            if return_lse:
+              out[0] *= v_scale
+            else:
+              out *= v_scale
 
         return out if return_lse else out[0]
 

--- a/python/flashinfer/decode.py
+++ b/python/flashinfer/decode.py
@@ -1404,13 +1404,10 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
                 maybe_lse,
                 get_cuda_stream(device),
             )
-            out = (o, maybe_lse) if return_lse else (o,)
+            out = [o, maybe_lse] if return_lse else [o]
         if v_scale is not None:
-            if return_lse:
-              out[0] *= v_scale
-            else:
-              out *= v_scale
+            out[0] *= v_scale
 
-        return out if return_lse else out[0]
+        return tuple(out) if return_lse else out[0]
 
     run_return_lse = functools.partialmethod(run, return_lse=True)


### PR DESCRIPTION
```
[rank0]:   File "/home/simonmo/.conda/envs/vllm/lib/python3.10/site-packages/flashinfer/decode.py", line 1408, in run
[rank0]:     out[0] *= v_scale
[rank0]: TypeError: 'tuple' object does not support item assignment
```

This is saying `out[0]` does not allow mutation. 