### PR TITLE
bugfix: fix type annotation error in python3.8

### DIFF
--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -317,10 +317,10 @@ class MultiLevelCascadeAttentionWrapper:
         float_workspace_buffer: torch.Tensor,
         kv_layout: str = "NHD",
         use_cuda_graph: bool = False,
-        qo_indptr_buf_arr: Optional[list[torch.Tensor]] = None,
-        paged_kv_indptr_buf_arr: Optional[list[torch.Tensor]] = None,
-        paged_kv_indices_buf_arr: Optional[list[torch.Tensor]] = None,
-        paged_kv_last_page_len_buf_arr: Optional[list[torch.Tensor]] = None,
+        qo_indptr_buf_arr: Optional[List[torch.Tensor]] = None,
+        paged_kv_indptr_buf_arr: Optional[List[torch.Tensor]] = None,
+        paged_kv_indices_buf_arr: Optional[List[torch.Tensor]] = None,
+        paged_kv_last_page_len_buf_arr: Optional[List[torch.Tensor]] = None,
     ) -> None:
         r"""Constructor of :class:`MultiLevelCascadeAttentionWrapper`.
 


### PR DESCRIPTION
As mentioned in https://github.com/flashinfer-ai/flashinfer/issues/653, there is a type annotation error in cascade.py because we use `list` which is builtin since python 3.9 (related PR https://github.com/flashinfer-ai/flashinfer/pull/486).

