### PR TITLE
bugfix: fix unittests not yield error in AOT mode

### DIFF
--- a/tests/test_alibi.py
+++ b/tests/test_alibi.py
@@ -26,7 +26,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_batch_decode_kernels.py
+++ b/tests/test_batch_decode_kernels.py
@@ -24,7 +24,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -24,7 +24,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_prefill_attention_func_args(

--- a/tests/test_block_sparse.py
+++ b/tests/test_block_sparse.py
@@ -26,7 +26,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_logits_cap.py
+++ b/tests/test_logits_cap.py
@@ -26,7 +26,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_non_contiguous_decode.py
+++ b/tests/test_non_contiguous_decode.py
@@ -8,7 +8,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_non_contiguous_prefill.py
+++ b/tests/test_non_contiguous_prefill.py
@@ -24,7 +24,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_prefill_attention_func_args(

--- a/tests/test_shared_prefix_kernels.py
+++ b/tests/test_shared_prefix_kernels.py
@@ -24,7 +24,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -24,7 +24,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(

--- a/tests/test_tensor_cores_decode.py
+++ b/tests/test_tensor_cores_decode.py
@@ -24,7 +24,7 @@ import flashinfer
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     if flashinfer.jit.has_prebuilt_ops:
-        return
+        yield
     try:
         flashinfer.jit.parallel_load_modules(
             jit_decode_attention_func_args(


### PR DESCRIPTION
The unittests in AOT mode failed since https://github.com/flashinfer-ai/flashinfer/pull/629 because we didn't use return instead of yield in warmup functions, this PR fixes the issue.