### PR TITLE
minor: remove unused PyPI upload comment

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -100,10 +100,3 @@ jobs:
           git add -A
           git commit -m "update whl"
           git push
-
-      # - name: Upload sdist to pypi
-      #   run: |
-      #     pip install twine
-      #     python -m twine upload --repository testpypi --username=__token__ dist/*.tar.gz
-      #   env:
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_TEST_TOKEN }}


### PR DESCRIPTION
This PR is just to update the commit of main, which will be used later to trigger verification https://github.com/flashinfer-ai/flashinfer-nightly/pull/5