### PR TITLE
doc: expose MLA decode API to documentation

### DIFF
--- a/docs/api/decode.rst
+++ b/docs/api/decode.rst
@@ -26,3 +26,8 @@ Batch Decoding
     :members:
 
     .. automethod:: __init__
+
+.. autoclass:: BatchDecodeMlaWithPagedKVCacheWrapper
+    :members:
+
+    .. automethod:: __init__


### PR DESCRIPTION
`BatchDecodeMlaWithPagedKVCacheWrapper` is not indexed.