### PR TITLE
[small] Fix norm option in config.cmake

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -15,7 +15,7 @@ set(FLASHINFER_CASCADE ON)
 # Whether to compile sampling kernel tests/benchmarks or not.
 set(FLASHINFER_SAMPLING ON)
 # Whether to compile normalization kernel tests/benchmarks or not.
-set(FLASHINFER_NORMALIZATION ON)
+set(FLASHINFER_NORM ON)
 # Whether to compile fastdiv tests
 set(FLASHINFER_FASTDIV_TEST ON)
 # Whether to compile fastdequant tests


### PR DESCRIPTION
The option name of normalization is not aligned in config.cmake (`FLASHINFER_NORMALIZATION`) and [CMakeLists.txt](https://github.com/flashinfer-ai/flashinfer/blob/2bc3214075391c175057302023c4bd99f64b2899/CMakeLists.txt#L44) (`FLASHINFER_NORM`), so it does not build the test and bench for norm. This PR changed the option name in config.cmake to `FLASHINFER_NORM` to align with the option name in CMakeLists.txt.