### PR TITLE
ci: Pass FLASHINFER_ENABLE_SM90 to setup.py

### DIFF
--- a/scripts/run-ci-build-wheel.sh
+++ b/scripts/run-ci-build-wheel.sh
@@ -52,7 +52,8 @@ echo "::endgroup::"
 
 echo "::group::Build wheel for FlashInfer"
 cd "$PROJECT_ROOT"
-FLASHINFER_ENABLE_AOT=1 FLASHINFER_LOCAL_VERSION=$FLASHINFER_LOCAL_VERSION python -m build --no-isolation --wheel
+FLASHINFER_ENABLE_AOT=1 FLASHINFER_LOCAL_VERSION=$FLASHINFER_LOCAL_VERSION FLASHINFER_ENABLE_SM90=$FLASHINFER_ENABLE_SM90 \
+    python -m build --no-isolation --wheel
 python -m build --no-isolation --sdist
 ls -la dist/
 echo "::endgroup::"


### PR DESCRIPTION
`FLASHINFER_ENABLE_SM90` is a bash script local variable. We need to either put an `export` before it or explicitly set the env var when running `python -m build`.