### PR TITLE
hotfix: accelerate plan speed of fa3 template

### DIFF
--- a/aot_build_utils/generate_batch_paged_prefill_sm90_inst.py
+++ b/aot_build_utils/generate_batch_paged_prefill_sm90_inst.py
@@ -39,11 +39,19 @@ def get_cu_file_str(
     def get_insts(attention_variant):
         return "\n".join(
             [
-                """template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/true, {attention_variant}>(
+                """template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/true, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/true, {attention_variant}>(
     Params& params,
     cudaStream_t stream);
 
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/false, {attention_variant}>(
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/false, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/true, {attention_variant}>(
+    Params& params,
+    cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/true, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/false, {attention_variant}>(
+    Params& params,
+    cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/false, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/false, {attention_variant}>(
     Params& params,
     cudaStream_t stream);
     """.format(

--- a/aot_build_utils/generate_batch_ragged_prefill_sm90_inst.py
+++ b/aot_build_utils/generate_batch_ragged_prefill_sm90_inst.py
@@ -40,11 +40,19 @@ def get_cu_file_str(
     def get_insts(attention_variant):
         return "\n".join(
             [
-                """template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/true, {attention_variant}>(
+                """template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/true, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/true, {attention_variant}>(
     Params& params,
     cudaStream_t stream);
 
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/false, {attention_variant}>(
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/false, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/true, {attention_variant}>(
+    Params& params,
+    cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/true, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/false, {attention_variant}>(
+    Params& params,
+    cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{head_dim}, {mask_mode}, /*USE_SWA=*/false, /*SAME_SCHEDULE_FOR_ALL_HEADS=*/false, {attention_variant}>(
     Params& params,
     cudaStream_t stream);
         """.format(

--- a/csrc/aot_extension_utils.h
+++ b/csrc/aot_extension_utils.h
@@ -30,17 +30,6 @@
 #define DISPATCH_mask_mode(expr, const_expr, ...) \
   _DISPATCH_SWITCH("mask_mode", expr, _DISPATCH_CASES_mask_mode(const_expr, __VA_ARGS__))
 
-#define DISPATCH_BOOL(expr, const_expr, ...) \
-  [&]() -> bool {                            \
-    if (expr) {                              \
-      constexpr bool const_expr = true;      \
-      return __VA_ARGS__();                  \
-    } else {                                 \
-      constexpr bool const_expr = false;     \
-      return __VA_ARGS__();                  \
-    }                                        \
-  }()
-
 #define DISPATCH_PYTORCH_QKV_DTYPE_TO_CTYPE(q_dtype, kv_dtype, c_type_q, c_type_kv, ...) \
   [&]() -> bool {                                                                        \
     if (kv_dtype == q_dtype) {                                                           \

--- a/csrc/flashinfer_ops_sm90.cu
+++ b/csrc/flashinfer_ops_sm90.cu
@@ -33,9 +33,9 @@ void single_prefill_with_kv_cache_sm90(unsigned int mask_mode_code, at::Tensor q
 std::vector<int64_t> BatchPrefillWithKVCacheSM90Plan(
     unsigned int head_dim, bool causal, at::Tensor float_workspace_buffer,
     at::Tensor int_workspace_buffer, at::Tensor page_locked_int_workspace_buffer,
-    at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor kv_len_arr, unsigned int batch_size,
-    unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int page_size,
-    bool enable_cuda_graph, int64_t cuda_stream);
+    at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor kv_len_arr, unsigned int total_num_rows,
+    unsigned int batch_size, unsigned int num_qo_heads, unsigned int num_kv_heads,
+    unsigned int page_size, bool enable_cuda_graph, int64_t cuda_stream);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     unsigned int mask_mode_code, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,

--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -189,6 +189,17 @@
     return __VA_ARGS__();                        \
   }
 
+#define DISPATCH_BOOL(expr, const_expr, ...) \
+  [&]() -> bool {                            \
+    if (expr) {                              \
+      constexpr bool const_expr = true;      \
+      return __VA_ARGS__();                  \
+    } else {                                 \
+      constexpr bool const_expr = false;     \
+      return __VA_ARGS__();                  \
+    }                                        \
+  }()
+
 inline void check_shape(const at::Tensor& a, const at::Tensor& b, const char* a_name,
                         const char* b_name) {
   TORCH_CHECK(a.dim() == b.dim(), a_name, ".dim() != ", b_name, ".dim(). ", a.dim(), " vs ",

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -147,7 +147,7 @@ class BlockSparseAttentionWrapper:
             )
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
-            dtype=self.device,
+            dtype=torch.uint8,
             pin_memory=True,
         )
         self._use_cuda_graph = False

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -130,13 +130,13 @@ class BlockSparseAttentionWrapper:
         """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
+        self._int_workspace_buffer = torch.empty(
+            (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
+        )
         if backend in ["fa3", "auto"]:
-            self._int_workspace_buffer = torch.empty(
-                (64 * 1024 * 1024,), dtype=torch.uint8, device=self.device
-            )
-            # NOTE(Zihao): assume maximum accumulate kv length is 16M
+            # NOTE(Zihao): assume maximum accumulate kv length is 4M
             self._vector_sparse_indices_buffer = torch.empty(
-                (16 * 1024 * 1024,), dtype=torch.int32, device=self.device
+                (4 * 1024 * 1024,), dtype=torch.int32, device=self.device
             )
             # NOTE(Zihao): assume maximum batch size is 32768
             self._vector_sparse_indptr_buffer = torch.empty(
@@ -145,15 +145,9 @@ class BlockSparseAttentionWrapper:
             self._kv_lens_buffer = torch.empty(
                 (32768,), dtype=torch.int32, device=self.device
             )
-        else:
-            self._int_workspace_buffer = torch.empty(
-                (8 * 1024 * 1024,),
-                dtype=torch.uint8,
-                device=float_workspace_buffer.device,
-            )
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
-            dtype=self._int_workspace_buffer.dtype,
+            dtype=self.device,
             pin_memory=True,
         )
         self._use_cuda_graph = False
@@ -453,6 +447,7 @@ class BlockSparseAttentionWrapper:
                         qo_indptr_host,
                         vector_sparse_indptr_host,
                         kv_lens_arr_host,
+                        M,  # total_num_rows
                         num_blocks_row,  # batch_size
                         num_qo_heads,
                         num_kv_heads,

--- a/include/flashinfer/attention/hopper/tile_scheduler.cuh
+++ b/include/flashinfer/attention/hopper/tile_scheduler.cuh
@@ -217,7 +217,7 @@ struct BatchPrefillTileScheduler {
   }
 
   static dim3 get_grid_dim(Arguments const& args, int num_sm) {
-    return {(unsigned)num_sm, args.num_qo_heads};
+    return {(unsigned)num_sm, (unsigned)args.num_qo_heads};
   }
 
   struct WorkTileInfo {

--- a/tests/test_hopper.py
+++ b/tests/test_hopper.py
@@ -175,7 +175,8 @@ def test_batch_paged_prefill(
     kv_indptr = torch.arange(
         0, batch_size * num_pages_per_request + 1, num_pages_per_request
     ).int()
-    kv_indices = torch.arange(0, batch_size * num_pages_per_request).int()
+    # NOTE(Zihao): pad 256 elements to avoid out-of-bound because we didn't check the boundary in the kernel
+    kv_indices = torch.arange(0, batch_size * num_pages_per_request + 256).int()
     last_page_len = torch.full((batch_size,), last_page_len, dtype=torch.int32)
 
     wrapper_sm80.plan(


### PR DESCRIPTION
The fa3 template's plan speed is very slow because we overestimate the workspace size that needs to be transferred from CPU to GPU, this PR fixes the issue.

cc @nandor @zhyncs 