### PR TITLE
Customizable SM90 prefill kernels.

### DIFF
--- a/benchmarks/bench_hopper_attention.py
+++ b/benchmarks/bench_hopper_attention.py
@@ -107,13 +107,7 @@ def bench_batch_ragged_prefill(batch_size, num_heads, seq_len, causal, head_dim)
 
 
 def bench_batch_paged_prefill(
-    page_size: int,
-    batch_size: int,
-    num_heads: int,
-    seq_len: int,
-    causal: bool = True,
-    head_dim: int = 128,
-    xai_temperature_len: int = -1,
+    page_size, batch_size, num_heads, seq_len, causal, head_dim
 ):
     num_qo_heads = num_kv_heads = num_heads
     q = torch.randn(
@@ -163,14 +157,13 @@ def bench_batch_paged_prefill(
             head_dim,
             page_size,  # page_size
             causal=causal,
-            xai_temperature_len=xai_temperature_len,
         )
 
     sm80_ms, sm90_ms = (
         triton.testing.do_bench(
             lambda: wrapper.run(q, (k, v)),
-            warmup=50,
-            rep=200,
+            warmup=100,
+            rep=1000,
         )
         for wrapper in [sm80_wrapper, sm90_wrapper]
     )
@@ -186,35 +179,23 @@ def bench_batch_paged_prefill(
             )
 
     print(
-        "bench_batch_paged_prefill_"
-        f"{'causal' if causal else 'non_causal'} "
-        f"| page_size={page_size:<3d} "
-        f"batch_size={batch_size:<5d} "
-        f"num_heads={num_heads:<3d} "
-        f"seq_len={seq_len:<3d} "
-        f"head_dim={head_dim:<3d} "
-        "| TFLOPs: "
-        f"fa2={flops(sm80_ms):<8.3f} "
-        f"fa3={flops(sm90_ms):<8.3f}"
+        f"bench_batch_paged_prefill (page_size={page_size} batch_size={batch_size}, num_heads={num_heads}, seq_len={seq_len}, causal={causal}, head_dim={head_dim}), fa2-template: {flops(sm80_ms):.3f} TFLOPs/s, fa3-template: {flops(sm90_ms):.3f} TFLOPs/s"
     )
 
 
 if __name__ == "__main__":
-    bench_batch_paged_prefill(1, 1, 32, 1024, True, 128, xai_temperature_len=8192)
-    bench_batch_paged_prefill(1, 64, 32, 1024, True, 128, xai_temperature_len=8192)
-
-    # bench_batch_paged_prefill(1, 128, 32, 1024, True, 128)
-    # bench_batch_paged_prefill(1, 64, 32, 2048, True, 128)
-    # bench_batch_paged_prefill(1, 32, 32, 4096, True, 128)
-    # bench_batch_paged_prefill(1, 16, 32, 8192, True, 128)
-    # bench_batch_paged_prefill(1, 1, 32, 32768, True, 128)
-    # bench_batch_paged_prefill(16, 128, 32, 1024, True, 128)
-    # bench_batch_paged_prefill(16, 64, 32, 2048, True, 128)
-    # bench_batch_paged_prefill(16, 32, 32, 4096, True, 128)
-    # bench_batch_paged_prefill(16, 16, 32, 8192, True, 128)
-    # bench_batch_paged_prefill(16, 1, 32, 32768, True, 128)
-    # bench_batch_ragged_prefill(128, 32, 1024, True, 128)
-    # bench_batch_ragged_prefill(64, 32, 2048, True, 128)
-    # bench_batch_ragged_prefill(32, 32, 4096, True, 128)
-    # bench_batch_ragged_prefill(16, 32, 8192, True, 128)
-    # bench_batch_ragged_prefill(1, 32, 32768, True, 128)
+    bench_batch_paged_prefill(1, 128, 32, 1024, True, 128)
+    bench_batch_paged_prefill(1, 64, 32, 2048, True, 128)
+    bench_batch_paged_prefill(1, 32, 32, 4096, True, 128)
+    bench_batch_paged_prefill(1, 16, 32, 8192, True, 128)
+    bench_batch_paged_prefill(1, 1, 32, 32768, True, 128)
+    bench_batch_paged_prefill(16, 128, 32, 1024, True, 128)
+    bench_batch_paged_prefill(16, 64, 32, 2048, True, 128)
+    bench_batch_paged_prefill(16, 32, 32, 4096, True, 128)
+    bench_batch_paged_prefill(16, 16, 32, 8192, True, 128)
+    bench_batch_paged_prefill(16, 1, 32, 32768, True, 128)
+    bench_batch_ragged_prefill(128, 32, 1024, True, 128)
+    bench_batch_ragged_prefill(64, 32, 2048, True, 128)
+    bench_batch_ragged_prefill(32, 32, 4096, True, 128)
+    bench_batch_ragged_prefill(16, 32, 8192, True, 128)
+    bench_batch_ragged_prefill(1, 32, 32768, True, 128)

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -26,6 +26,8 @@ from .batch_decode_templ import batch_decode_suffix, batch_decode_templ
 from .batch_prefill_sm90_templ import (
     batch_prefill_sm90_suffix,
     batch_prefill_sm90_templ,
+    customizable_batch_prefill_sm90_suffix,
+    customizable_batch_prefill_sm90_templ,
 )
 from .batch_prefill_templ import batch_prefill_suffix, batch_prefill_templ
 from .core import load_cuda_ops, sm90a_nvcc_flags
@@ -101,11 +103,11 @@ def get_single_decode_uri(
     )
 
 
-def gen_single_decode_module(*args):
+def gen_single_decode_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
     os.makedirs(gen_directory, exist_ok=True)
-    uri = get_single_decode_uri(*args)
-    sources = get_single_decode_sources(*args)
+    uri = get_single_decode_uri(*args, **kwargs)
+    sources = get_single_decode_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(single_decode_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -161,10 +163,10 @@ def get_batch_decode_uri(
     )
 
 
-def gen_batch_decode_module(*args):
+def gen_batch_decode_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    uri = get_batch_decode_uri(*args)
-    sources = get_batch_decode_sources(*args)
+    uri = get_batch_decode_uri(*args, **kwargs)
+    sources = get_batch_decode_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(batch_decode_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -218,10 +220,10 @@ def get_batch_decode_mla_uri(
     )
 
 
-def gen_batch_decode_mla_module(*args):
+def gen_batch_decode_mla_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    uri = get_batch_decode_mla_uri(*args)
-    sources = get_batch_decode_mla_sources(*args)
+    uri = get_batch_decode_mla_uri(*args, **kwargs)
+    sources = get_batch_decode_mla_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(batch_decode_mla_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -306,14 +308,14 @@ def get_single_prefill_uri(
     )
 
 
-def get_single_prefill_sm90_uri(*args):
-    return get_single_prefill_uri(*args) + "_sm90"
+def get_single_prefill_sm90_uri(*args, **kwargs):
+    return get_single_prefill_uri(*args, **kwargs) + "_sm90"
 
 
-def gen_single_prefill_module(*args):
+def gen_single_prefill_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    uri = get_single_prefill_uri(*args)
-    sources = get_single_prefill_sources(*args)
+    uri = get_single_prefill_uri(*args, **kwargs)
+    sources = get_single_prefill_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(single_prefill_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -323,10 +325,10 @@ def gen_single_prefill_module(*args):
     return load_cuda_ops(uri, source_paths)
 
 
-def gen_single_prefill_sm90_module(*args):
+def gen_single_prefill_sm90_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    uri = get_single_prefill_sm90_uri(*args)
-    sources = get_single_prefill_sm90_sources(*args)
+    uri = get_single_prefill_sm90_uri(*args, **kwargs)
+    sources = get_single_prefill_sm90_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(single_prefill_sm90_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -418,14 +420,14 @@ def get_batch_prefill_uri(
     )
 
 
-def get_batch_prefill_sm90_uri(*args):
-    return get_batch_prefill_uri(*args) + "_sm90"
+def get_batch_prefill_sm90_uri(*args, **kwargs):
+    return get_batch_prefill_uri(*args, **kwargs) + "_sm90"
 
 
-def gen_batch_prefill_module(*args):
+def gen_batch_prefill_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    uri = get_batch_prefill_uri(*args)
-    sources = get_batch_prefill_sources(*args)
+    uri = get_batch_prefill_uri(*args, **kwargs)
+    sources = get_batch_prefill_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(batch_prefill_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -435,10 +437,10 @@ def gen_batch_prefill_module(*args):
     return load_cuda_ops(uri, source_paths)
 
 
-def gen_batch_prefill_sm90_module(*args):
+def gen_batch_prefill_sm90_module(*args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    uri = get_batch_prefill_sm90_uri(*args)
-    sources = get_batch_prefill_sm90_sources(*args)
+    uri = get_batch_prefill_sm90_uri(*args, **kwargs)
+    sources = get_batch_prefill_sm90_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(batch_prefill_sm90_suffix, sources):
         path = gen_directory / f"{uri}{suffix}"
@@ -610,9 +612,9 @@ def get_customize_single_prefill_sources(
     )
 
 
-def gen_customize_single_decode_module(module_name, *args):
+def gen_customize_single_decode_module(module_name, *args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    sources = get_customize_single_decode_sources(*args)
+    sources = get_customize_single_decode_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(single_decode_suffix, sources):
         path = gen_directory / f"{module_name}{suffix}"
@@ -622,13 +624,91 @@ def gen_customize_single_decode_module(module_name, *args):
     return load_cuda_ops(module_name, source_paths)
 
 
-def gen_customize_single_prefill_module(module_name, *args):
+def gen_customize_single_prefill_module(module_name, *args, **kwargs):
     gen_directory = FLASHINFER_GEN_SRC_DIR
-    sources = get_customize_single_prefill_sources(*args)
+    sources = get_customize_single_prefill_sources(*args, **kwargs)
     source_paths = []
     for suffix, source in zip(single_prefill_suffix, sources):
         path = gen_directory / f"{module_name}{suffix}"
         source_paths.append(path)
         write_if_different(path, source)
 
+    return load_cuda_ops(module_name, source_paths)
+
+
+def get_customize_batch_prefill_sm90_sources(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    dtype_idx: torch.dtype,
+    head_dim: int,
+    additional_input_tensor_var_names: List[str],
+    additional_input_tensor_var_types: List[str],
+    additional_input_scalar_var_names: List[str],
+    additional_input_scalar_var_types: List[str],
+    variant_name: str,
+    variant_decl: str,
+) -> List[str]:
+    additional_params_decl = ";\n  ".join(
+        [
+            f"{dtype}* {var}_ptr"
+            for dtype, var in zip(
+                additional_input_tensor_var_types, additional_input_tensor_var_names
+            )
+        ] +
+        [
+            f"{dtype} {var}"
+            for dtype, var in zip(
+                additional_input_scalar_var_types, additional_input_scalar_var_names
+            )
+        ]
+    )
+    additional_func_params = ",\n    ".join(
+        [f"at::Tensor {var}" for var in additional_input_tensor_var_names] +
+        [
+            f"{dtype} {var}"
+            for dtype, var in zip(
+                additional_input_scalar_var_types, additional_input_scalar_var_names
+            )
+        ]
+    )
+    additional_params_setter = ";\n  ".join(
+        [
+            f"params.{var}_ptr = static_cast<{dtype}*>({var}.data_ptr())"
+            for dtype, var in zip(
+                additional_input_tensor_var_types, additional_input_tensor_var_names
+            )
+        ] +
+        [f"params.{var} = {var}" for var in additional_input_scalar_var_names]
+    )
+
+    if additional_func_params:
+        additional_func_params += ","
+
+    return render_templates(
+        customizable_batch_prefill_sm90_templ,
+        {
+            "dtype_q": dtype_map[dtype_q],
+            "dtype_kv": dtype_map[dtype_kv],
+            "dtype_o": dtype_map[dtype_o],
+            "dtype_idx": dtype_map[dtype_idx],
+            "head_dim": head_dim,
+            "variant_decl": variant_decl,
+            "variant_name": variant_name,
+            "use_sliding_window": "false",
+            "additional_params_decl": additional_params_decl,
+            "additional_params_setter": additional_params_setter,
+            "additional_func_params": additional_func_params,
+        },
+    )
+
+
+def gen_customize_batch_prefill_sm90_module(module_name, *args, **kwargs):
+    gen_directory = FLASHINFER_GEN_SRC_DIR
+    sources = get_customize_batch_prefill_sm90_sources(*args, **kwargs)
+    source_paths = []
+    for suffix, source in zip(customizable_batch_prefill_sm90_suffix, sources):
+        path = gen_directory / f"{module_name}{suffix}"
+        source_paths.append(path)
+        write_if_different(path, source)
     return load_cuda_ops(module_name, source_paths)

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -19,7 +19,6 @@ import pathlib
 from typing import List, Tuple
 
 import jinja2
-import rich.syntax
 import torch
 
 from .batch_decode_mla_templ import batch_decode_mla_suffix, batch_decode_mla_templ

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -714,7 +714,11 @@ def gen_customize_batch_prefill_sm90_module(module_name, *args, **kwargs):
         path = gen_directory / f"{module_name}{suffix}"
         source_paths.append(path)
         write_if_different(path, source)
-    return load_cuda_ops(module_name, source_paths)
+    return load_cuda_ops(
+        module_name,
+        source_paths,
+        extra_cuda_cflags=["-gencode=arch=compute_90a,code=sm_90a"],
+    )
 
 
 def get_customize_single_prefill_sm90_sources(
@@ -790,4 +794,8 @@ def gen_customize_single_prefill_sm90_module(module_name, *args, **kwargs):
         path = gen_directory / f"{module_name}{suffix}"
         source_paths.append(path)
         write_if_different(path, source)
-    return load_cuda_ops(module_name, source_paths)
+    return load_cuda_ops(
+        module_name,
+        source_paths,
+        extra_cuda_cflags=["-gencode=arch=compute_90a,code=sm_90a"],
+    )

--- a/flashinfer/jit/batch_prefill_sm90_templ.py
+++ b/flashinfer/jit/batch_prefill_sm90_templ.py
@@ -14,149 +14,243 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-batch_prefill_sm90_suffix = [
-    "_plan.cu",
-    *[f"_ragged_kernel_mask_{mask_mode}.cu" for mask_mode in [0, 1, 2]],
-    "_ragged_run.cu",
-    *[f"_paged_kernel_mask_{mask_mode}.cu" for mask_mode in [0, 1, 2]],
-    "_paged_run.cu",
-    "_pybind.cc",
-]
+batch_prefill_plan_func = r"""std::vector<int64_t> BatchPrefillWithKVCacheSM90Plan(
+    bool causal,
+    at::Tensor float_workspace_buffer,
+    at::Tensor int_workspace_buffer,
+    at::Tensor page_locked_int_workspace_buffer,
+    at::Tensor qo_indptr,
+    at::Tensor kv_indptr,
+    at::Tensor kv_len_arr,
+    unsigned int total_num_rows,
+    unsigned int batch_size,
+    unsigned int num_qo_heads,
+    unsigned int num_kv_heads,
+    unsigned int page_size,
+    bool enable_cuda_graph,
+    int64_t cuda_stream)"""
 
 
-def ragged_prefill_sm90_inst_templ(mask_mode: str) -> str:
-    return (
-        r"""#include <flashinfer/attention/hopper/prefill_sm90.cuh>
-#include <flashinfer/attention/hopper/variants.cuh>
-#include <flashinfer/cutlass_utils.cuh>
-#include <flashinfer/attention/mask.cuh>
-
-namespace flashinfer {
-
-using DTypeQ = cutlass_dtype_t<{{dtype_q}}>;
-using DTypeKV = cutlass_dtype_t<{{dtype_kv}}>;
-using DTypeO = cutlass_dtype_t<{{dtype_o}}>;
-using IdType = cutlass_dtype_t<{{dtype_idx}}>;
-
-using RaggedParams =
-    BatchPrefillRaggedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
-using AttentionVariant = std::conditional_t<{{use_logits_soft_cap}}, LogitsSoftCap, StandardAttention>;
-
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/true, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true, AttentionVariant>(
-    RaggedParams& params,
-    cudaStream_t stream);
-
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/false, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true, AttentionVariant>(
-    RaggedParams& params,
-    cudaStream_t stream);
-
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/true, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false, AttentionVariant>(
-    RaggedParams& params,
-    cudaStream_t stream);
-
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/false, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false, AttentionVariant>(
-    RaggedParams& params,
-    cudaStream_t stream);
-
-}"""
-    )
-
-
-def paged_prefill_sm90_inst_templ(mask_mode: str) -> str:
-    return (
-        r"""#include <flashinfer/attention/hopper/prefill_sm90.cuh>
-#include <flashinfer/attention/hopper/variants.cuh>
-#include <flashinfer/cutlass_utils.cuh>
-#include <flashinfer/attention/mask.cuh>
-
-namespace flashinfer {
-
-using DTypeQ = cutlass_dtype_t<{{dtype_q}}>;
-using DTypeKV = cutlass_dtype_t<{{dtype_kv}}>;
-using DTypeO = cutlass_dtype_t<{{dtype_o}}>;
-using IdType = cutlass_dtype_t<{{dtype_idx}}>;
-
-using PagedParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
-using AttentionVariant = std::conditional_t<{{use_logits_soft_cap}}, LogitsSoftCap, StandardAttention>;
-
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/true, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true, AttentionVariant>(
-    PagedParams& params,
-    cudaStream_t stream);
-
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/false, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true, AttentionVariant>(
-    PagedParams& params,
-    cudaStream_t stream);
-
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/true, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false, AttentionVariant>(
-    PagedParams& params,
-    cudaStream_t stream);
-
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched<{{ head_dim }}, """
-        + mask_mode
-        + r""", /*USE_SWA=*/false, /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false, AttentionVariant>(
-    PagedParams& params,
-    cudaStream_t stream);
-
-}"""
-    )
-
-
-batch_prefill_sm90_templ = [
-    r"""#include <flashinfer/attention/scheduler.cuh>
+batch_prefill_plan_impl = f"""// _plan.cu
+#include <flashinfer/attention/scheduler.cuh>
 #include "pytorch_extension_utils.h"
 
 using namespace flashinfer;
 
-std::vector<int64_t> BatchPrefillWithKVCacheSM90Plan(
-    bool causal, at::Tensor float_workspace_buffer,
-    at::Tensor int_workspace_buffer, at::Tensor page_locked_int_workspace_buffer,
-    at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor kv_len_arr, unsigned int total_num_rows,
-    unsigned int batch_size, unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int page_size,
-    bool enable_cuda_graph, int64_t cuda_stream) {
+{batch_prefill_plan_func} {{
+
   size_t float_workspace_size_in_bytes =
-      float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
+      float_workspace_buffer.numel() * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
-      int_workspace_buffer.size(0) * int_workspace_buffer.element_size();
+      int_workspace_buffer.numel() * int_workspace_buffer.element_size();
 
   PrefillPlanSM90Info plan_info;
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
 
   cudaError_t status = PrefillSM90Plan(
-      float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
-      int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
-      int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<{{ dtype_idx }}>(),
-      kv_indptr.data_ptr<{{ dtype_idx }}>(), kv_len_arr.data_ptr<{{ dtype_idx }}>(),
-      total_num_rows, batch_size, num_qo_heads, num_kv_heads, {{ head_dim }}, page_size,
-      causal, enable_cuda_graph, sizeof({{dtype_o}}), stream);
+      float_workspace_buffer.data_ptr(),
+      float_workspace_size_in_bytes,
+      int_workspace_buffer.data_ptr(),
+      page_locked_int_workspace_buffer.data_ptr(),
+      int_workspace_size_in_bytes,
+      plan_info,
+      qo_indptr.data_ptr<{{{{ dtype_idx }}}}>(),
+      kv_indptr.data_ptr<{{{{ dtype_idx }}}}>(),
+      kv_len_arr.data_ptr<{{{{ dtype_idx }}}}>(),
+      total_num_rows,
+      batch_size,
+      num_qo_heads,
+      num_kv_heads,
+      {{{{ head_dim }}}},
+      page_size,
+      causal,
+      enable_cuda_graph,
+      sizeof({{{{dtype_o}}}}),
+      stream);
 
   TORCH_CHECK(status == cudaSuccess,
               "PrefillSM90Plan failed with error: ", cudaGetErrorString(status));
 
   return plan_info.ToVector();
-}
-""",
-    *[
-        ragged_prefill_sm90_inst_templ(mask_mode)
-        for mask_mode in ["MaskMode::kNone", "MaskMode::kCausal", "MaskMode::kCustom"]
-    ],
-    r"""
+}}
+"""
+
+
+batch_prefill_sm90_suffix = [
+    "_plan.cu",
+    "_ragged_kernel_mask_0.cu",
+    "_ragged_kernel_mask_1.cu",
+    "_ragged_kernel_mask_2.cu",
+    "_ragged_run.cu",
+    "_paged_kernel_mask_0.cu",
+    "_paged_kernel_mask_r.cu",
+    "_paged_kernel_mask_2.cu",
+    "_paged_run.cu",
+    "_pybind.cc",
+]
+
+
+batch_prefill_ragged_func_templ = r"""void BatchPrefillWithRaggedKVCacheSM90Run(
+    unsigned int mask_mode_code,
+    at::Tensor float_workspace_buffer,
+    at::Tensor int_workspace_buffer,
+    std::vector<int64_t> plan_info_vec,
+    at::Tensor q,
+    at::Tensor k,
+    at::Tensor v,
+    std::optional<at::Tensor> maybe_custom_mask,
+    std::optional<at::Tensor> maybe_alibi_slopes,
+    at::Tensor qo_indptr,
+    at::Tensor kv_indptr,
+    std::optional<at::Tensor> maybe_qk_indptr,
+    at::Tensor o,
+    unsigned int layout,
+    int32_t window_left,
+    float logits_soft_cap,
+    float sm_scale,
+    float rope_scale,
+    float rope_theta,
+    std::optional<at::Tensor> maybe_lse,
+    {{ additional_func_params }}
+    int64_t cuda_stream)"""
+
+
+def ragged_prefill_sm90_inst_templ(mask_mode: str) -> str:
+    return f"""// batch_prefill_ragged_sm90 template inst
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/hopper/params.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <flashinfer/attention/mask.cuh>
+
+namespace flashinfer {{
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
+
+using RaggedParams = BatchPrefillRaggedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
+using AttentionVariant = std::conditional_t<
+    {{{{use_logits_soft_cap}}}}, LogitsSoftCap<RaggedParams>, StandardAttention<RaggedParams>>;
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/true,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+     AttentionVariant>(RaggedParams& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/true,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+     AttentionVariant>(RaggedParams& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/false,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+     AttentionVariant>(RaggedParams& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/false,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+     AttentionVariant>(RaggedParams& params, cudaStream_t stream);
+}}"""
+
+
+batch_prefill_paged_func_templ = r"""void BatchPrefillWithPagedKVCacheSM90Run(
+    unsigned int mask_mode_code,
+    at::Tensor float_workspace_buffer,
+    at::Tensor int_workspace_buffer,
+    std::vector<int64_t> plan_info_vec,
+    at::Tensor q,
+    at::Tensor paged_k_cache,
+    at::Tensor paged_v_cache,
+    std::optional<at::Tensor> maybe_custom_mask,
+    std::optional<at::Tensor> maybe_alibi_slopes,
+    at::Tensor qo_indptr,
+    at::Tensor paged_kv_indptr,
+    at::Tensor paged_kv_indices,
+    at::Tensor paged_kv_last_page_len,
+    std::optional<at::Tensor> maybe_qk_indptr,
+    at::Tensor o,
+    unsigned int layout,
+    int32_t window_left,
+    float logits_soft_cap,
+    float sm_scale,
+    float rope_scale,
+    float rope_theta,
+    std::optional<at::Tensor> maybe_lse,
+    {{ additional_func_params }}
+    int64_t cuda_stream)"""
+
+
+def paged_prefill_sm90_inst_templ(mask_mode: str) -> str:
+    return f"""// batch_prefill_paged_sm90 template inst
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/hopper/params.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <flashinfer/attention/mask.cuh>
+
+namespace flashinfer {{
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
+
+using PagedParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
+using AttentionVariant = std::conditional_t<
+    {{{{use_logits_soft_cap}}}}, LogitsSoftCap<PagedParams>, StandardAttention<PagedParams>>;
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/true,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+     AttentionVariant>(PagedParams& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/true,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+     AttentionVariant>(PagedParams& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/false,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+     AttentionVariant>(PagedParams& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/false,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+     AttentionVariant>(PagedParams& params, cudaStream_t stream);
+
+}}"""
+
+
+batch_prefill_sm90_templ = [
+    batch_prefill_plan_impl,
+    ragged_prefill_sm90_inst_templ("MaskMode::kNone"),
+    ragged_prefill_sm90_inst_templ("MaskMode::kCausal"),
+    ragged_prefill_sm90_inst_templ("MaskMode::kCustom"),
+    f"""// _ragged_run.cu
 #include <flashinfer/attention/mask.cuh>
 #include <flashinfer/attention/hopper/variants.cuh>
 #include <flashinfer/attention/hopper/params.cuh>
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
 #include <flashinfer/attention/scheduler.cuh>
 #include <flashinfer/pos_enc.cuh>
 #include <flashinfer/cutlass_utils.cuh>
@@ -164,40 +258,24 @@ std::vector<int64_t> BatchPrefillWithKVCacheSM90Plan(
 
 #include "pytorch_extension_utils.h"
 
-namespace flashinfer {
-
-template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLINDING_WINDOW, bool SAME_SCHEDULER_FOR_ALL_HEADS,
-          typename AttentionVariant, typename DTypeQ, typename DTypeKV, typename DTypeO,
-          typename IdType>
-cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
-    BatchPrefillRaggedParams<DTypeQ, DTypeKV, DTypeO, IdType>& params, cudaStream_t stream);
-
-};  // namespace flashinfer
-
 using namespace flashinfer;
 
-using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
-using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
-using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
-using IdType = cutlass_dtype_t<{{ dtype_idx }}>;
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
 
 using RaggedParams = BatchPrefillRaggedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
 
-void BatchPrefillWithRaggedKVCacheSM90Run(
-    unsigned int mask_mode_code, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    std::vector<int64_t> plan_info_vec, at::Tensor q, at::Tensor k, at::Tensor v,
-    std::optional<at::Tensor> maybe_custom_mask, std::optional<at::Tensor> maybe_alibi_slopes,
-    at::Tensor qo_indptr, at::Tensor kv_indptr, std::optional<at::Tensor> maybe_qk_indptr,
-    at::Tensor o, unsigned int layout, int32_t window_left, float logits_soft_cap, float sm_scale,
-    float rope_scale, float rope_theta, std::optional<at::Tensor> maybe_lse, int64_t cuda_stream) {
+{batch_prefill_ragged_func_templ} {{
   PrefillPlanSM90Info plan_info;
   plan_info.FromVector(plan_info_vec);
 
-  if (maybe_lse) {
+  if (maybe_lse) {{
     const auto& lse = *maybe_lse;
     TORCH_CHECK(lse.size(0) == q.size(0), lse.size(0), q.size(0));
     TORCH_CHECK(lse.size(1) == q.size(1), lse.size(1), q.size(1));
-  }
+  }}
 
   void* float_buffer_ptr = float_workspace_buffer.data_ptr();
   void* int_buffer_ptr = int_workspace_buffer.data_ptr();
@@ -219,20 +297,20 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
   params.q_stride_h = q.stride(1);
   params.o_stride_n = o.stride(0);
   params.o_stride_h = o.stride(1);
-  if (kv_layout == QKVLayout::kNHD) {
+  if (kv_layout == QKVLayout::kNHD) {{
     params.k_stride_n = k.stride(0);
     params.k_stride_h = k.stride(1);
     params.v_stride_n = v.stride(0);
     params.v_stride_h = v.stride(1);
-  } else {
+  }} else {{
     params.k_stride_h = k.stride(0);
     params.k_stride_n = k.stride(1);
     params.v_stride_h = v.stride(0);
     params.v_stride_n = v.stride(1);
-  }
+  }}
   params.nnz_qo = q.size(0);
   params.nnz_kv = k.size(0);
-  params.head_dim = {{ head_dim }};
+  params.head_dim = {{{{ head_dim }}}};
   params.num_qo_heads = q.size(1);
   params.num_kv_heads = k.size(1);
   params.group_size = params.num_qo_heads / params.num_kv_heads;
@@ -249,30 +327,36 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
   params.head_indices =
       GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
   params.work_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
-  bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
 
-  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {
-    DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
+  bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {{
+    DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {{
       using AttentionVariant =
-          std::conditional_t<{{ use_logits_soft_cap }}, LogitsSoftCap, StandardAttention>;
+          std::conditional_t<{{{{ use_logits_soft_cap }}}},
+                             LogitsSoftCap<RaggedParams>,
+                             StandardAttention<RaggedParams>>;
       cudaError_t status =
-          BatchPrefillWithRaggedKVCacheDispatched<{{ head_dim }}, MASK_MODE, {{ use_sliding_window }},
-                                                  SAME_SCHEDULER_FOR_ALL_HEADS, AttentionVariant>(params, stream);
+          BatchPrefillWithRaggedKVCacheDispatched
+              <{{{{ head_dim }}}},
+               MASK_MODE,
+               {{{{ use_sliding_window }}}},
+               SAME_SCHEDULER_FOR_ALL_HEADS,
+               AttentionVariant>(params, stream);
       TORCH_CHECK(status == cudaSuccess,
                   "BatchPrefillWithRaggedKVCacheSM90Run failed with error: ",
                   cudaGetErrorString(status));
-
       return true;
-    });
-  });
-}
+    }});
+  }});
+}}
 """,
-    *[
-        paged_prefill_sm90_inst_templ(mask_mode)
-        for mask_mode in ["MaskMode::kNone", "MaskMode::kCausal", "MaskMode::kCustom"]
-    ],
-    r"""#include <cutlass/numeric_types.h>
+    paged_prefill_sm90_inst_templ("MaskMode::kNone"),
+    paged_prefill_sm90_inst_templ("MaskMode::kCausal"),
+    paged_prefill_sm90_inst_templ("MaskMode::kCustom"),
+    f"""// _paged_run.cu
+#include <cutlass/numeric_types.h>
 #include <flashinfer/attention/hopper/params.cuh>
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
 #include <flashinfer/attention/hopper/variants.cuh>
 #include <flashinfer/attention/mask.cuh>
 #include <flashinfer/attention/scheduler.cuh>
@@ -283,52 +367,34 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
 
 #include "pytorch_extension_utils.h"
 
-namespace flashinfer {
-
-template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLINDING_WINDOW, bool SAME_SCHEDULER_FOR_ALL_HEADS,
-          typename AttentionVariant, typename DTypeQ, typename DTypeKV, typename DTypeO,
-          typename IdType>
-cudaError_t BatchPrefillWithPagedKVCacheDispatched(
-    BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>& params, cudaStream_t stream);
-
-};  // namespace flashinfer
-
 using namespace flashinfer;
 
-using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
-using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
-using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
-using IdType = cutlass_dtype_t<{{ dtype_idx }}>;
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
 
 using PagedParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
 
-void BatchPrefillWithPagedKVCacheSM90Run(
-    unsigned int mask_mode_code, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    std::vector<int64_t> plan_info_vec, at::Tensor q, at::Tensor paged_k_cache,
-    at::Tensor paged_v_cache, std::optional<at::Tensor> maybe_custom_mask,
-    std::optional<at::Tensor> maybe_alibi_slopes, at::Tensor qo_indptr, at::Tensor paged_kv_indptr,
-    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
-    std::optional<at::Tensor> maybe_qk_indptr, at::Tensor o, unsigned int layout,
-    int32_t window_left, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
-    std::optional<at::Tensor> maybe_lse, int64_t cuda_stream) {
+{batch_prefill_paged_func_templ} {{
   PrefillPlanSM90Info plan_info;
   plan_info.FromVector(plan_info_vec);
 
-  if (maybe_lse) {
+  if (maybe_lse) {{
     const auto& lse = *maybe_lse;
     TORCH_CHECK(lse.size(0) == q.size(0), lse.size(0), q.size(0));
     TORCH_CHECK(lse.size(1) == q.size(1), lse.size(1), q.size(1));
-  }
+  }}
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
   unsigned int num_kv_heads, page_size;
   unsigned int head_dim = q.size(2);
-  if (kv_layout == QKVLayout::kHND) {
+  if (kv_layout == QKVLayout::kHND) {{
     num_kv_heads = paged_k_cache.size(1);
     page_size = paged_k_cache.size(2);
-  } else {
+  }} else {{
     page_size = paged_k_cache.size(1);
     num_kv_heads = paged_k_cache.size(2);
-  }
+  }}
 
   void* float_buffer_ptr = float_workspace_buffer.data_ptr();
   void* int_buffer_ptr = int_workspace_buffer.data_ptr();
@@ -349,19 +415,19 @@ void BatchPrefillWithPagedKVCacheSM90Run(
   params.q_stride_h = q.stride(1);
   params.o_stride_n = o.stride(0);
   params.o_stride_h = o.stride(1);
-  if (kv_layout == QKVLayout::kNHD) {
+  if (kv_layout == QKVLayout::kNHD) {{
     // (num_pages, page_size, num_heads, head_dim)
     params.k_stride_n = paged_k_cache.stride(1);
     params.k_stride_h = paged_k_cache.stride(2);
     params.v_stride_n = paged_v_cache.stride(1);
     params.v_stride_h = paged_v_cache.stride(2);
-  } else {
+  }} else {{
     // (num_pages, num_heads, page_size, head_dim)
     params.k_stride_h = paged_k_cache.stride(1);
     params.k_stride_n = paged_k_cache.stride(2);
     params.v_stride_h = paged_v_cache.stride(1);
     params.v_stride_n = paged_v_cache.stride(2);
-  }
+  }}
   params.nnz_qo = q.size(0);
   params.head_dim = head_dim;
   params.num_qo_heads = q.size(1);
@@ -382,54 +448,524 @@ void BatchPrefillWithPagedKVCacheSM90Run(
       GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
   params.work_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
   params.kv_indices = static_cast<IdType*>(paged_kv_indices.data_ptr());
-  bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
 
-  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {
-    DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
+  bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {{
+    DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {{
       using AttentionVariant =
-          std::conditional_t<{{ use_logits_soft_cap }}, LogitsSoftCap, StandardAttention>;
+          std::conditional_t<{{{{ use_logits_soft_cap }}}},
+                             LogitsSoftCap<PagedParams>,
+                             StandardAttention<PagedParams>>;
       cudaError_t status =
-          BatchPrefillWithPagedKVCacheDispatched<{{ head_dim }}, MASK_MODE, {{ use_sliding_window }},
-                                                 SAME_SCHEDULER_FOR_ALL_HEADS, AttentionVariant>(params, stream);
+          BatchPrefillWithPagedKVCacheDispatched
+              <{{{{ head_dim }}}},
+               MASK_MODE,
+               {{{{ use_sliding_window }}}},
+               SAME_SCHEDULER_FOR_ALL_HEADS,
+               AttentionVariant>(params, stream);
       TORCH_CHECK(status == cudaSuccess,
                   "BatchPrefillWithPagedKVCacheSM90Run failed with error: ",
                   cudaGetErrorString(status));
       return true;
-    });
-  });
-}
+    }});
+  }});
+}}
 """,
-    r"""#include "pytorch_extension_utils.h"
+    f"""// _pybind.cc
+#include "pytorch_extension_utils.h"
 
-std::vector<int64_t> BatchPrefillWithKVCacheSM90Plan(
-    bool causal, at::Tensor float_workspace_buffer,
-    at::Tensor int_workspace_buffer, at::Tensor page_locked_int_workspace_buffer,
-    at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor kv_len_arr, unsigned int total_num_rows,
-    unsigned int batch_size, unsigned int num_qo_heads, unsigned int num_kv_heads, unsigned int page_size,
-    bool enable_cuda_graph, int64_t cuda_stream);
+{batch_prefill_plan_func};
 
-void BatchPrefillWithRaggedKVCacheSM90Run(
-    unsigned int mask_mode_code, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    std::vector<int64_t> plan_info_vec, at::Tensor q, at::Tensor k, at::Tensor v,
-    std::optional<at::Tensor> maybe_custom_mask, std::optional<at::Tensor> maybe_alibi_slopes,
-    at::Tensor qo_indptr, at::Tensor kv_indptr, std::optional<at::Tensor> maybe_qk_indptr,
-    at::Tensor o, unsigned int layout, int32_t window_left, float logits_soft_cap, float sm_scale,
-    float rope_scale, float rope_theta, std::optional<at::Tensor> maybe_lse, int64_t cuda_stream);
+{batch_prefill_ragged_func_templ};
 
-void BatchPrefillWithPagedKVCacheSM90Run(
-    unsigned int mask_mode_code, at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    std::vector<int64_t> plan_info_vec, at::Tensor q, at::Tensor paged_k_cache,
-    at::Tensor paged_v_cache, std::optional<at::Tensor> maybe_custom_mask,
-    std::optional<at::Tensor> maybe_alibi_slopes, at::Tensor qo_indptr, at::Tensor paged_kv_indptr,
-    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
-    std::optional<at::Tensor> maybe_qk_indptr, at::Tensor o, unsigned int layout,
-    int32_t window_left, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
-    std::optional<at::Tensor> maybe_lse, int64_t cuda_stream);
+{batch_prefill_paged_func_templ};
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
   m.def("plan", &BatchPrefillWithKVCacheSM90Plan);
   m.def("ragged_run", &BatchPrefillWithRaggedKVCacheSM90Run);
   m.def("paged_run", &BatchPrefillWithPagedKVCacheSM90Run);
-}
+}}
+""",
+]
+
+
+# stuffs beyond this line are not tested
+
+
+customizable_batch_prefill_ragged_params_templ = r"""
+struct BatchPrefillRaggedParams {
+  using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
+  using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
+  using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
+  using IdType = cutlass_dtype_t<{{ dtype_idx }}>;
+
+  // The QKV matrices.
+  DTypeQ* q_ptr;
+  DTypeKV* k_ptr;
+  DTypeKV* v_ptr;
+  DTypeO* o_ptr;
+  float* lse_ptr;
+
+  // Additional params
+  {{ additional_params_decl }};
+
+  IdType* qo_tile_indices;
+  IdType* qo_indptr;
+  IdType* kv_indptr;
+  IdType* qo_lens;
+  IdType* kv_lens;
+  IdType* head_indices;
+  IdType* work_indptr;
+
+  int64_t q_stride_n;
+  int64_t k_stride_n;
+  int64_t v_stride_n;
+  int64_t o_stride_n;
+  int64_t q_stride_h;
+  int64_t k_stride_h;
+  int64_t v_stride_h;
+  int64_t o_stride_h;
+  int64_t nnz_qo;
+  int64_t nnz_kv;
+
+  int head_dim;
+  int num_qo_heads;
+  int num_kv_heads;
+  int group_size;
+  int window_left;
+
+  float logits_soft_cap;
+  float sm_scale_log2;
+  bool causal;
+
+  struct AdditionalParams {};
+};
+"""
+
+
+def customizable_ragged_prefill_sm90_inst_templ(mask_mode: str) -> str:
+    return f"""// customizable_ragged_prefill_sm90_inst
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <flashinfer/attention/mask.cuh>
+
+namespace flashinfer {{
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
+
+{customizable_batch_prefill_ragged_params_templ}
+
+{{{{ variant_decl }}}}
+
+using AttentionVariant = {{{{ variant_name }}}}<BatchPrefillRaggedParams>;
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+  <{{{{ head_dim }}}},
+    /*mask_mode*/{mask_mode},
+    /*USE_SWA=*/true,
+    /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+    AttentionVariant>
+  (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+  <{{{{ head_dim }}}},
+    /*mask_mode*/{mask_mode},
+    /*USE_SWA=*/true,
+    /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+    AttentionVariant>
+  (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+  <{{{{ head_dim }}}},
+   /*mask_mode*/{mask_mode},
+   /*USE_SWA=*/false,
+   /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+   AttentionVariant>
+  (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+  <{{{{ head_dim }}}},
+    /*mask_mode*/{mask_mode},
+    /*USE_SWA=*/false,
+    /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+    AttentionVariant>
+  (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+}}  // namespace flashinfer
+"""
+
+
+customizable_batch_prefill_paged_params_templ = r"""
+struct BatchPrefillPagedParams {
+  using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
+  using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
+  using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
+  using IdType = cutlass_dtype_t<{{ dtype_idx }}>;
+
+  // The QKV matrices.
+  DTypeQ* q_ptr;
+  DTypeKV* k_ptr;
+  DTypeKV* v_ptr;
+  DTypeO* o_ptr;
+  float* lse_ptr;
+
+  // Additional params
+  {{ additional_params_decl }};
+
+  IdType* qo_tile_indices;
+  IdType* qo_indptr;
+  IdType* kv_indptr;
+  IdType* kv_indices;
+  IdType* qo_lens;
+  IdType* kv_lens;
+  IdType* head_indices;
+  IdType* work_indptr;
+
+  int64_t q_stride_n;
+  int64_t k_stride_n;
+  int64_t v_stride_n;
+  int64_t o_stride_n;
+  int64_t q_stride_h;
+  int64_t k_stride_h;
+  int64_t v_stride_h;
+  int64_t o_stride_h;
+  int64_t nnz_qo;
+
+  int head_dim;
+  int num_qo_heads;
+  int num_kv_heads;
+  int group_size;
+  int page_size;
+  int window_left;
+
+  float logits_soft_cap;
+  float sm_scale_log2;
+  bool causal;
+
+  struct AdditionalParams {};
+};
+"""
+
+
+def customizable_paged_prefill_sm90_inst_templ(mask_mode: str) -> str:
+    return f"""#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <flashinfer/attention/mask.cuh>
+
+namespace flashinfer {{
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
+
+{customizable_batch_prefill_paged_params_templ}
+
+{{{{ variant_decl }}}}
+
+using AttentionVariant = {{{{ variant_name }}}}<BatchPrefillPagedParams>;
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/true,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+     AttentionVariant>
+    (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/true,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+     AttentionVariant>
+    (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/false,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true,
+     AttentionVariant>
+    (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+    <{{{{ head_dim }}}},
+     {mask_mode},
+     /*USE_SWA=*/false,
+     /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false,
+     AttentionVariant>
+    (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+}}
+"""
+
+
+customizable_batch_prefill_sm90_suffix = [
+    "_plan.cu",
+    "_ragged_kernel_mask_0.cu",
+    "_ragged_kernel_mask_1.cu",
+    "_ragged_kernel_mask_2.cu",
+    "_ragged_run.cu",
+    "_paged_kernel_mask_0.cu",
+    "_paged_kernel_mask_1.cu",
+    "_paged_kernel_mask_2.cu",
+    "_paged_run.cu",
+    "_pybind.cu",
+]
+
+
+customizable_batch_prefill_sm90_templ = [
+    batch_prefill_plan_impl,
+    customizable_ragged_prefill_sm90_inst_templ("MaskMode::kNone"),
+    customizable_ragged_prefill_sm90_inst_templ("MaskMode::kCausal"),
+    customizable_ragged_prefill_sm90_inst_templ("MaskMode::kCustom"),
+    f"""// _ragged_run.cu
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/mask.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/attention/scheduler.cuh>
+#include <flashinfer/pos_enc.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <optional>
+
+#include "pytorch_extension_utils.h"
+
+namespace flashinfer {{
+
+{customizable_batch_prefill_ragged_params_templ}
+
+{{{{ variant_decl }}}}
+
+}};  // namespace flashinfer
+
+using namespace flashinfer;
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
+
+using RaggedParams = BatchPrefillRaggedParams;
+
+{batch_prefill_ragged_func_templ} {{
+  PrefillPlanSM90Info plan_info;
+  plan_info.FromVector(plan_info_vec);
+
+  if (maybe_lse) {{
+    const auto& lse = *maybe_lse;
+    TORCH_CHECK(lse.size(0) == q.size(0), lse.size(0), q.size(0));
+    TORCH_CHECK(lse.size(1) == q.size(1), lse.size(1), q.size(1));
+  }}
+
+  void* float_buffer_ptr = float_workspace_buffer.data_ptr();
+  void* int_buffer_ptr = int_workspace_buffer.data_ptr();
+
+  auto q_scalar_type = q.scalar_type();
+
+  QKVLayout kv_layout = static_cast<QKVLayout>(layout);
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
+
+  RaggedParams params;
+
+  params.q_ptr = static_cast<cutlass_dtype_t<{{{{ dtype_q }}}}>*>(q.data_ptr());
+  params.k_ptr = static_cast<cutlass_dtype_t<{{{{ dtype_kv }}}}>*>(k.data_ptr());
+  params.v_ptr = static_cast<cutlass_dtype_t<{{{{ dtype_kv }}}}>*>(v.data_ptr());
+  params.o_ptr = static_cast<cutlass_dtype_t<{{{{ dtype_o }}}}>*>(o.data_ptr());
+  params.lse_ptr = maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;
+  params.q_stride_n = q.stride(0);
+  params.q_stride_h = q.stride(1);
+  params.o_stride_n = o.stride(0);
+  params.o_stride_h = o.stride(1);
+  if (kv_layout == QKVLayout::kNHD) {{
+    params.k_stride_n = k.stride(0);
+    params.k_stride_h = k.stride(1);
+    params.v_stride_n = v.stride(0);
+    params.v_stride_h = v.stride(1);
+  }} else {{
+    params.k_stride_h = k.stride(0);
+    params.k_stride_n = k.stride(1);
+    params.v_stride_h = v.stride(0);
+    params.v_stride_n = v.stride(1);
+  }}
+  params.nnz_qo = q.size(0);
+  params.nnz_kv = k.size(0);
+  params.head_dim = {{{{ head_dim }}}};
+  params.num_qo_heads = q.size(1);
+  params.num_kv_heads = k.size(1);
+  params.group_size = params.num_qo_heads / params.num_kv_heads;
+  params.window_left = window_left;
+  params.logits_soft_cap = logits_soft_cap;
+  params.sm_scale_log2 = sm_scale * math::log2e;
+  params.causal = mask_mode_code == 1;
+  params.qo_tile_indices = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_tile_indices_offset);
+  params.qo_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_indptr_offset);
+  params.kv_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_indptr_offset);
+  params.qo_lens = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_len_offset);
+  params.kv_lens = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_len_offset);
+  params.head_indices = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
+  params.work_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+  {{{{ additional_params_setter }}}};
+
+  bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {{
+    DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {{
+      using AttentionVariant = {{{{ variant_name }}}}<RaggedParams>;
+      cudaError_t status =
+          BatchPrefillWithRaggedKVCacheDispatched
+              <{{{{ head_dim }}}},
+               MASK_MODE,
+               {{{{ use_sliding_window }}}},
+               false,
+               AttentionVariant>(params, stream);
+      TORCH_CHECK(status == cudaSuccess,
+                  "BatchPrefillWithRaggedKVCacheSM90Run failed with error: ",
+                  cudaGetErrorString(status));
+      return true;
+    }});
+  }});
+}}
+""",
+    customizable_paged_prefill_sm90_inst_templ("MaskMode::kNone"),
+    customizable_paged_prefill_sm90_inst_templ("MaskMode::kCausal"),
+    customizable_paged_prefill_sm90_inst_templ("MaskMode::kCustom"),
+    f"""// _paged_run.cu
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <cutlass/numeric_types.h>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/attention/mask.cuh>
+#include <flashinfer/attention/scheduler.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <flashinfer/layout.cuh>
+#include <flashinfer/math.cuh>
+#include <optional>
+
+#include "pytorch_extension_utils.h"
+
+namespace flashinfer {{
+
+{customizable_batch_prefill_paged_params_templ}
+
+{{{{ variant_decl }}}}
+
+}};  // namespace flashinfer
+
+using namespace flashinfer;
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+using IdType = cutlass_dtype_t<{{{{ dtype_idx }}}}>;
+
+using PagedParams = BatchPrefillPagedParams;
+
+{batch_prefill_paged_func_templ} {{
+  PrefillPlanSM90Info plan_info;
+  plan_info.FromVector(plan_info_vec);
+
+  if (maybe_lse) {{
+    const auto& lse = *maybe_lse;
+    TORCH_CHECK(lse.size(0) == q.size(0), lse.size(0), q.size(0));
+    TORCH_CHECK(lse.size(1) == q.size(1), lse.size(1), q.size(1));
+  }}
+  QKVLayout kv_layout = static_cast<QKVLayout>(layout);
+  unsigned int num_kv_heads, page_size;
+  unsigned int head_dim = q.size(2);
+  if (kv_layout == QKVLayout::kHND) {{
+    num_kv_heads = paged_k_cache.size(1);
+    page_size = paged_k_cache.size(2);
+  }} else {{
+    page_size = paged_k_cache.size(1);
+    num_kv_heads = paged_k_cache.size(2);
+  }}
+
+  void* float_buffer_ptr = float_workspace_buffer.data_ptr();
+  void* int_buffer_ptr = int_workspace_buffer.data_ptr();
+
+  auto q_scalar_type = q.scalar_type();
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
+
+  PagedParams params;
+
+  params.q_ptr = static_cast<DTypeQ*>(q.data_ptr());
+  params.k_ptr = static_cast<DTypeKV*>(paged_k_cache.data_ptr());
+  params.v_ptr = static_cast<DTypeKV*>(paged_v_cache.data_ptr());
+  params.o_ptr = static_cast<DTypeO*>(o.data_ptr());
+  params.lse_ptr = maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;
+  params.q_stride_n = q.stride(0);
+  params.q_stride_h = q.stride(1);
+  params.o_stride_n = o.stride(0);
+  params.o_stride_h = o.stride(1);
+  if (kv_layout == QKVLayout::kNHD) {{
+    // (num_pages, page_size, num_heads, head_dim)
+    params.k_stride_n = paged_k_cache.stride(1);
+    params.k_stride_h = paged_k_cache.stride(2);
+    params.v_stride_n = paged_v_cache.stride(1);
+    params.v_stride_h = paged_v_cache.stride(2);
+  }} else {{
+    // (num_pages, num_heads, page_size, head_dim)
+    params.k_stride_h = paged_k_cache.stride(1);
+    params.k_stride_n = paged_k_cache.stride(2);
+    params.v_stride_h = paged_v_cache.stride(1);
+    params.v_stride_n = paged_v_cache.stride(2);
+  }}
+  params.nnz_qo = q.size(0);
+  params.head_dim = head_dim;
+  params.num_qo_heads = q.size(1);
+  params.num_kv_heads = num_kv_heads;
+  params.group_size = params.num_qo_heads / num_kv_heads;
+  params.page_size = page_size;
+  params.window_left = window_left;
+  params.logits_soft_cap = logits_soft_cap;
+  params.sm_scale_log2 = sm_scale * math::log2e;
+  params.causal = mask_mode_code == 1;
+  params.qo_tile_indices = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_tile_indices_offset);
+  params.qo_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_indptr_offset);
+  params.kv_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_indptr_offset);
+  params.qo_lens = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_len_offset);
+  params.kv_lens = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_len_offset);
+  params.head_indices = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
+  params.work_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+  params.kv_indices = static_cast<IdType*>(paged_kv_indices.data_ptr());
+  {{{{ additional_params_setter }}}};
+
+  bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {{
+    DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {{
+      using AttentionVariant = {{{{ variant_name }}}}<PagedParams>;
+      cudaError_t status = BatchPrefillWithPagedKVCacheDispatched
+          <{{{{ head_dim }}}},
+           MASK_MODE,
+           {{{{ use_sliding_window }}}},
+           false,
+           AttentionVariant>(params, stream);
+      TORCH_CHECK(status == cudaSuccess,
+                  "BatchPrefillWithPagedKVCacheSM90Run failed with error: ",
+                  cudaGetErrorString(status));
+      return true;
+    }});
+  }});
+}}
+""",
+    f"""// _pybind.cu
+#include "pytorch_extension_utils.h"
+
+{batch_prefill_plan_func};
+
+{batch_prefill_ragged_func_templ};
+
+{batch_prefill_paged_func_templ};
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
+  m.def("plan", &BatchPrefillWithKVCacheSM90Plan);
+  m.def("ragged_run", &BatchPrefillWithRaggedKVCacheSM90Run);
+  m.def("paged_run", &BatchPrefillWithPagedKVCacheSM90Run);
+}}
 """,
 ]

--- a/flashinfer/jit/batch_prefill_sm90_templ.py
+++ b/flashinfer/jit/batch_prefill_sm90_templ.py
@@ -537,8 +537,6 @@ struct BatchPrefillRaggedParams {
   float logits_soft_cap;
   float sm_scale_log2;
   bool causal;
-
-  struct AdditionalParams {};
 };
 """
 
@@ -644,8 +642,6 @@ struct BatchPrefillPagedParams {
   float logits_soft_cap;
   float sm_scale_log2;
   bool causal;
-
-  struct AdditionalParams {};
 };
 """
 

--- a/flashinfer/jit/batch_prefill_sm90_templ.py
+++ b/flashinfer/jit/batch_prefill_sm90_templ.py
@@ -651,7 +651,8 @@ struct BatchPrefillPagedParams {
 
 
 def customizable_paged_prefill_sm90_inst_templ(mask_mode: str) -> str:
-    return f"""#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+    return f"""// sm90_batch_paged_prefill template inst
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
 #include <flashinfer/attention/hopper/variants.cuh>
 #include <flashinfer/cutlass_utils.cuh>
 #include <flashinfer/attention/mask.cuh>

--- a/flashinfer/jit/single_prefill_sm90_templ.py
+++ b/flashinfer/jit/single_prefill_sm90_templ.py
@@ -218,8 +218,6 @@ struct SinglePrefillParams {
   // these are bad arguments. we should remove them from default in prefill_sm90.cuh.
   float logits_soft_cap = 0.;
   float sm_scale_log2 = 0.;
-
-  struct AdditionalParams {};
 };
 """
 

--- a/flashinfer/jit/single_prefill_sm90_templ.py
+++ b/flashinfer/jit/single_prefill_sm90_templ.py
@@ -15,51 +15,70 @@ limitations under the License.
 """
 
 single_prefill_sm90_suffix = [
-    *[f"_kernel_mask_{mask_mode}.cu" for mask_mode in [0, 1, 2]],
+    "_kernel_mask_0.cu",
+    "_kernel_mask_1.cu",
+    "_kernel_mask_2.cu",
     ".cu",
     "_pybind.cc",
 ]
 
+single_prefill_sm90_func = r"""void single_prefill_with_kv_cache_sm90(
+    unsigned int mask_mode_code,
+    at::Tensor q,
+    at::Tensor k,
+    at::Tensor v,
+    std::optional<at::Tensor> maybe_packed_custom_mask,
+    std::optional<at::Tensor> maybe_alibi_slopes,
+    at::Tensor o,
+    unsigned int layout,
+    int32_t window_left,
+    float logits_soft_cap,
+    float sm_scale,
+    float rope_scale,
+    float rope_theta,
+    std::optional<at::Tensor> maybe_lse,
+    int64_t cuda_stream)"""
+
 
 def single_prefill_sm90_inst_templ(mask_mode: str) -> str:
-    return (
-        r"""#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+    return f""" // single_prefill_sm90 template instantiation
+#include <flashinfer/attention/hopper/params.cuh>
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
 #include <flashinfer/attention/hopper/variants.cuh>
 #include <flashinfer/cutlass_utils.cuh>
 
-namespace flashinfer {
+namespace flashinfer {{
 
-using DTypeQ = cutlass_dtype_t<{{dtype_q}}>;
-using DTypeKV = cutlass_dtype_t<{{dtype_kv}}>;
-using DTypeO = cutlass_dtype_t<{{dtype_o}}>;
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
 
 using Params = SinglePrefillParams<DTypeQ, DTypeKV, DTypeO>;
-using AttentionVariant = std::conditional_t<{{use_logits_soft_cap}}, LogitsSoftCap, StandardAttention>;
+using AttentionVariant = std::conditional_t<
+    {{{{use_logits_soft_cap}}}},
+    LogitsSoftCap<Params>,
+    StandardAttention<Params>>;
 
-template cudaError_t SinglePrefillWithKVCacheDispatched<{{ head_dim }},"""
-        f"{mask_mode}"
-        r""", /*USE_SWA=*/false, AttentionVariant>(
-    Params& params,
-    cudaStream_t stream);
+template cudaError_t SinglePrefillWithKVCacheDispatched
+    <{{{{ head_dim }}}}, {mask_mode}, /*USE_SWA=*/true, AttentionVariant>(
+    Params& params, cudaStream_t stream);
 
-template cudaError_t SinglePrefillWithKVCacheDispatched<{{ head_dim }},"""
-        f"{mask_mode}"
-        r""", /*USE_SWA=*/true, AttentionVariant>(
-    Params& params,
-    cudaStream_t stream);
+template cudaError_t SinglePrefillWithKVCacheDispatched
+    <{{{{ head_dim }}}}, {mask_mode}, /*USE_SWA=*/false, AttentionVariant>(
+    Params& params, cudaStream_t stream);
 
-}  // namespace flashinfer
+}}  // namespace flashinfer
 """
-    )
 
 
 single_prefill_sm90_templ = [
-    *[
-        single_prefill_sm90_inst_templ(mask_mode)
-        for mask_mode in ["MaskMode::kNone", "MaskMode::kCausal", "MaskMode::kCustom"]
-    ],
-    r"""#include <optional>
+    single_prefill_sm90_inst_templ("MaskMode::kNone"),
+    single_prefill_sm90_inst_templ("MaskMode::kCausal"),
+    single_prefill_sm90_inst_templ("MaskMode::kCustom"),
+    f"""// _run.cu
+#include <optional>
 #include <flashinfer/attention/hopper/params.cuh>
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
 #include <flashinfer/attention/hopper/variants.cuh>
 #include <flashinfer/attention/mask.cuh>
 #include <flashinfer/pos_enc.cuh>
@@ -68,25 +87,7 @@ single_prefill_sm90_templ = [
 
 using namespace flashinfer;
 
-namespace flashinfer {
-
-template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLINDING_WINDOW,
-          typename AttentionVariant, typename DTypeQ, typename DTypeKV, typename DTypeO>
-cudaError_t SinglePrefillWithKVCacheDispatched(SinglePrefillParams<DTypeQ, DTypeKV, DTypeO>& params,
-                                               cudaStream_t stream);
-
-}  // namespace flashinfer
-
-using namespace flashinfer;
-
-void single_prefill_with_kv_cache_sm90(unsigned int mask_mode_code, at::Tensor q, at::Tensor k,
-                                       at::Tensor v,
-                                       std::optional<at::Tensor> maybe_packed_custom_mask,
-                                       std::optional<at::Tensor> maybe_alibi_slopes, at::Tensor o,
-                                       unsigned int layout, int32_t window_left,
-                                       float logits_soft_cap, float sm_scale, float rope_scale,
-                                       float rope_theta, std::optional<at::Tensor> maybe_lse,
-                                       int64_t cuda_stream) {
+{single_prefill_sm90_func} {{
   unsigned int head_dim = q.size(2);
   unsigned int num_qo_heads = q.size(1);
   unsigned int qo_len = q.size(0);
@@ -97,11 +98,12 @@ void single_prefill_with_kv_cache_sm90(unsigned int mask_mode_code, at::Tensor q
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
 
-  using DTypeQ = cutlass_dtype_t<{{dtype_q}}>;
-  using DTypeKV = cutlass_dtype_t<{{dtype_kv}}>;
-  using DTypeO = cutlass_dtype_t<{{dtype_o}}>;
+  using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+  using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+  using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
 
-  SinglePrefillParams<DTypeQ, DTypeKV, DTypeO> params;
+  using SinglePrefillParams = SinglePrefillParams<DTypeQ, DTypeKV, DTypeO>;
+  SinglePrefillParams params;
   params.q_ptr = static_cast<DTypeQ*>(q.data_ptr());
   params.k_ptr = static_cast<DTypeKV*>(k.data_ptr());
   params.v_ptr = static_cast<DTypeKV*>(v.data_ptr());
@@ -111,17 +113,17 @@ void single_prefill_with_kv_cache_sm90(unsigned int mask_mode_code, at::Tensor q
   params.q_stride_h = q.stride(1);
   params.o_stride_n = o.stride(0);
   params.o_stride_h = o.stride(1);
-  if (kv_layout == QKVLayout::kNHD) {
+  if (kv_layout == QKVLayout::kNHD) {{
     params.k_stride_n = k.stride(0);
     params.k_stride_h = k.stride(1);
     params.v_stride_n = v.stride(0);
     params.v_stride_h = v.stride(1);
-  } else {
+  }} else {{
     params.k_stride_h = k.stride(0);
     params.k_stride_n = k.stride(1);
     params.v_stride_h = v.stride(0);
     params.v_stride_n = v.stride(1);
-  }
+  }}
   params.qo_len = q.size(0);
   params.kv_len = k.size(0);
   params.head_dim = head_dim;
@@ -132,32 +134,30 @@ void single_prefill_with_kv_cache_sm90(unsigned int mask_mode_code, at::Tensor q
   params.window_left = window_left;
   params.logits_soft_cap = logits_soft_cap;
   params.sm_scale_log2 = sm_scale * math::log2e;
-  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {
+
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {{
     using AttentionVariant =
-        std::conditional_t<{{ use_logits_soft_cap }}, LogitsSoftCap, StandardAttention>;
+        std::conditional_t<{{{{ use_logits_soft_cap }}}},
+                           LogitsSoftCap<SinglePrefillParams>,
+                           StandardAttention<SinglePrefillParams>>;
     cudaError_t status =
-        SinglePrefillWithKVCacheDispatched<{{ head_dim }}, MASK_MODE, {{ use_sliding_window }}, AttentionVariant>(
-            params, stream);
+        SinglePrefillWithKVCacheDispatched
+            <{{{{ head_dim }}}}, MASK_MODE, {{{{ use_sliding_window }}}}, AttentionVariant>
+            (params, stream);
     TORCH_CHECK(status == cudaSuccess,
-                "single_prefill_with_kv_cache_sm90 failed with error: " +
-                    std::string(cudaGetErrorString(status)));
-  });
-}
+                "SinglePrefillWithKVCacheDispatched failed with error: ",
+                cudaGetErrorString(status));
+  }});
+}}
 """,
-    r"""#include "pytorch_extension_utils.h"
+    f"""// _pybind.cc
+#include "pytorch_extension_utils.h"
 
-void single_prefill_with_kv_cache_sm90(unsigned int mask_mode_code, at::Tensor q, at::Tensor k,
-                                       at::Tensor v,
-                                       std::optional<at::Tensor> maybe_packed_custom_mask,
-                                       std::optional<at::Tensor> maybe_alibi_slopes, at::Tensor o,
-                                       unsigned int layout, int32_t window_left,
-                                       float logits_soft_cap, float sm_scale, float rope_scale,
-                                       float rope_theta, std::optional<at::Tensor> maybe_lse,
-                                       int64_t cuda_stream);
+{single_prefill_sm90_func};
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
   m.def("run", &single_prefill_with_kv_cache_sm90,
         "Single-request prefill attention with KV-Cache operator");
-}
+}}
 """,
 ]

--- a/flashinfer/jit/single_prefill_sm90_templ.py
+++ b/flashinfer/jit/single_prefill_sm90_templ.py
@@ -22,6 +22,7 @@ single_prefill_sm90_suffix = [
     "_pybind.cc",
 ]
 
+
 single_prefill_sm90_func = r"""void single_prefill_with_kv_cache_sm90(
     unsigned int mask_mode_code,
     at::Tensor q,
@@ -37,6 +38,7 @@ single_prefill_sm90_func = r"""void single_prefill_with_kv_cache_sm90(
     float rope_scale,
     float rope_theta,
     std::optional<at::Tensor> maybe_lse,
+    {{ additional_func_params }}
     int64_t cuda_stream)"""
 
 
@@ -154,6 +156,192 @@ using namespace flashinfer;
 #include "pytorch_extension_utils.h"
 
 {single_prefill_sm90_func};
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
+  m.def("run", &single_prefill_with_kv_cache_sm90,
+        "Single-request prefill attention with KV-Cache operator");
+}}
+""",
+]
+
+
+customizable_single_prefill_sm90_func = r"""void single_prefill_with_kv_cache_sm90(
+    unsigned int mask_mode_code,
+    at::Tensor q,
+    at::Tensor k,
+    at::Tensor v,
+    at::Tensor buffer,
+    at::Tensor o,
+    unsigned int layout,
+    int32_t window_left,
+    std::optional<at::Tensor> maybe_lse,
+    {{ additional_func_params }}
+    int64_t cuda_stream)"""
+
+
+customizable_single_prefill_sm90_params_templ = r"""
+struct SinglePrefillParams {
+  using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
+  using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
+  using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
+  using IdType = cutlass_dtype_t<int32_t>;
+
+  // The QKV matrices.
+  DTypeQ* q_ptr;
+  DTypeKV* k_ptr;
+  DTypeKV* v_ptr;
+  DTypeO* o_ptr;
+  float* lse_ptr;
+
+  // Additional params
+  {{ additional_params_decl }};
+
+  int64_t q_stride_n;
+  int64_t k_stride_n;
+  int64_t v_stride_n;
+  int64_t o_stride_n;
+  int64_t q_stride_h;
+  int64_t k_stride_h;
+  int64_t v_stride_h;
+  int64_t o_stride_h;
+
+  int qo_len;
+  int kv_len;
+  int head_dim;
+  int num_qo_heads;
+  int num_kv_heads;
+  int group_size;
+  int window_left;
+
+  bool causal;
+
+  // these are bad arguments. we should remove them from default in prefill_sm90.cuh.
+  float logits_soft_cap = 0.;
+  float sm_scale_log2 = 0.;
+
+  struct AdditionalParams {};
+};
+"""
+
+
+def customizable_single_prefill_sm90_inst_templ(mask_mode: str) -> str:
+    return f"""// single_prefill_sm90 template instantiation
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+
+namespace flashinfer {{
+
+using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+
+{customizable_single_prefill_sm90_params_templ}
+
+{{{{ variant_decl }}}}
+
+using AttentionVariant = {{{{ variant_name }}}}<SinglePrefillParams>;
+
+template cudaError_t SinglePrefillWithKVCacheDispatched
+    <{{{{ head_dim }}}}, {mask_mode}, /*USE_SWA=*/true, AttentionVariant>
+    (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+template cudaError_t SinglePrefillWithKVCacheDispatched
+    <{{{{ head_dim }}}}, {mask_mode}, /*USE_SWA=*/false, AttentionVariant>
+    (typename AttentionVariant::ParamsT& params, cudaStream_t stream);
+
+}}  // namespace flashinfer
+"""
+
+
+customizable_single_prefill_sm90_suffix = single_prefill_sm90_suffix
+
+
+customizable_single_prefill_sm90_templ = [
+    customizable_single_prefill_sm90_inst_templ("MaskMode::kNone"),
+    customizable_single_prefill_sm90_inst_templ("MaskMode::kCausal"),
+    customizable_single_prefill_sm90_inst_templ("MaskMode::kCustom"),
+    f"""// _run.cu
+#include <optional>
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/attention/mask.cuh>
+#include <flashinfer/pos_enc.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include "pytorch_extension_utils.h"
+
+namespace flashinfer {{
+
+{customizable_single_prefill_sm90_params_templ}
+
+{{{{ variant_decl }}}}
+
+}};  // namespace flashinfer
+
+using namespace flashinfer;
+
+{customizable_single_prefill_sm90_func} {{
+  unsigned int head_dim = q.size(2);
+  unsigned int num_qo_heads = q.size(1);
+  unsigned int qo_len = q.size(0);
+
+  auto q_scalar_type = q.scalar_type();
+
+  QKVLayout kv_layout = static_cast<QKVLayout>(layout);
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
+
+  using DTypeQ = cutlass_dtype_t<{{{{ dtype_q }}}}>;
+  using DTypeKV = cutlass_dtype_t<{{{{ dtype_kv }}}}>;
+  using DTypeO = cutlass_dtype_t<{{{{ dtype_o }}}}>;
+
+  SinglePrefillParams params;
+  params.q_ptr = static_cast<DTypeQ*>(q.data_ptr());
+  params.k_ptr = static_cast<DTypeKV*>(k.data_ptr());
+  params.v_ptr = static_cast<DTypeKV*>(v.data_ptr());
+  params.o_ptr = static_cast<DTypeO*>(o.data_ptr());
+  params.lse_ptr = maybe_lse ? (static_cast<float*>(maybe_lse->data_ptr())) : nullptr;
+  params.q_stride_n = q.stride(0);
+  params.q_stride_h = q.stride(1);
+  params.o_stride_n = o.stride(0);
+  params.o_stride_h = o.stride(1);
+  if (kv_layout == QKVLayout::kNHD) {{
+    params.k_stride_n = k.stride(0);
+    params.k_stride_h = k.stride(1);
+    params.v_stride_n = v.stride(0);
+    params.v_stride_h = v.stride(1);
+  }} else {{
+    params.k_stride_h = k.stride(0);
+    params.k_stride_n = k.stride(1);
+    params.v_stride_h = v.stride(0);
+    params.v_stride_n = v.stride(1);
+  }}
+  params.qo_len = q.size(0);
+  params.kv_len = k.size(0);
+  params.head_dim = head_dim;
+  params.num_qo_heads = q.size(1);
+  params.num_kv_heads = k.size(1);
+  params.causal = mask_mode == MaskMode::kCausal;
+  params.group_size = params.num_qo_heads / params.num_kv_heads;
+  params.window_left = window_left;
+  {{{{ additional_params_setter }}}};
+
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, {{
+    using AttentionVariant = {{{{ variant_name }}}}<SinglePrefillParams>;
+    cudaError_t status =
+        SinglePrefillWithKVCacheDispatched
+            <{{{{ head_dim }}}}, MASK_MODE, {{{{ use_sliding_window }}}}, AttentionVariant>
+            (params, stream);
+    TORCH_CHECK(status == cudaSuccess,
+                "SinglePrefillWithKVCacheDispatched failed with error: ",
+                cudaGetErrorString(status));
+  }});
+}}
+""",
+    f"""// _pybind.cc
+#include "pytorch_extension_utils.h"
+
+{customizable_single_prefill_sm90_func};
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
   m.def("run", &single_prefill_with_kv_cache_sm90,

--- a/include/flashinfer/attention/hopper/attention_updater.cuh
+++ b/include/flashinfer/attention/hopper/attention_updater.cuh
@@ -10,6 +10,8 @@
 #include <cute/tensor.hpp>
 #include <cutlass/detail/helper_macros.hpp>
 
+#include "flashinfer/attention/hopper/utils.cuh"
+
 namespace flashinfer {
 
 using namespace cute;

--- a/include/flashinfer/attention/hopper/kernel_traits.cuh
+++ b/include/flashinfer/attention/hopper/kernel_traits.cuh
@@ -40,13 +40,14 @@ struct SharedStorageQKVO {
 };
 
 template <bool USE_TMA_LOAD_KV, int HEAD_DIM_, int CTA_Q_, int CTA_KV_, int NUM_STAGES_,
-          typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_,
           typename AttentionVariant_>
 struct AttentionKernelTraits {
-  using DTypeQ = DTypeQ_;
-  using DTypeKV = DTypeKV_;
-  using DTypeO = DTypeO_;
-  using IdType = IdType_;
+  using AttentionVariant = AttentionVariant_;
+
+  using DTypeQ = cutlass_dtype_t<typename AttentionVariant::DTypeQ>;
+  using DTypeKV = cutlass_dtype_t<typename AttentionVariant::DTypeKV>;
+  using DTypeO = cutlass_dtype_t<typename AttentionVariant::DTypeO>;
+  using IdType = cutlass_dtype_t<typename AttentionVariant::IdType>;
   using DTypeQKAccum = float;
 
   static constexpr int CTA_Q = CTA_Q_;
@@ -61,7 +62,6 @@ struct AttentionKernelTraits {
   // where only one warp inside a warp group is used for TMA.
   static constexpr int NUM_PRODUCER_THREADS = cutlass::NumThreadsPerWarp;
 
-  using AttentionVariant = AttentionVariant_;
   using TileShape_QKD = Shape<Int<CTA_Q>, Int<CTA_KV>, Int<HEAD_DIM>>;
 
   static constexpr int NUM_STAGES = NUM_STAGES_;

--- a/include/flashinfer/attention/hopper/params.cuh
+++ b/include/flashinfer/attention/hopper/params.cuh
@@ -22,11 +22,12 @@
 
 namespace flashinfer {
 
-template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_>
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_ = int32_t>
 struct SinglePrefillParams {
   using DTypeQ = DTypeQ_;
   using DTypeKV = DTypeKV_;
   using DTypeO = DTypeO_;
+  using IdType = IdType_;
   // The QKV matrices.
   DTypeQ* q_ptr;
   DTypeKV* k_ptr;

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -7,6 +7,7 @@ from flashinfer.decode import single_decode_with_kv_cache_with_jit_module
 from flashinfer.jit.attention import (
     gen_customize_single_decode_module,
     gen_customize_single_prefill_module,
+    gen_customize_single_prefill_sm90_module,
     single_decode_suffix,
     single_prefill_suffix,
 )
@@ -302,6 +303,76 @@ struct DebugPrintLogits {
     k = torch.randn(1023, 32, 128, dtype=torch.float16, device="cuda")
     v = torch.randn(1023, 32, 128, dtype=torch.float16, device="cuda")
     sm_scale = 1.0 / math.sqrt(128)
+    o = f(q, k, v, sm_scale, mask_mode=MaskMode.NON_CAUSAL.value)
+
+    p = torch.einsum("mhd,nhd->hmn", q.float(), k.float()) * sm_scale
+    o_ref = torch.einsum("hmn,nhd->mhd", torch.softmax(p, dim=-1), v.float()).half()
+    torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_sm90_debug_print_logits():
+    torch.manual_seed(42)
+    variant_decl = r"""
+template <typename ParamsT_>
+struct DebugPrintLogits {
+  using ParamsT = ParamsT_;
+  using DTypeQ = typename ParamsT::DTypeQ;
+  using DTypeKV = typename ParamsT::DTypeKV;
+  using DTypeO = typename ParamsT::DTypeO;
+  using IdType = typename ParamsT::IdType;
+
+  template <int NUM_ROWS_PER_THREAD>
+  using Updater = OnlineSoftmaxWithoutScale<NUM_ROWS_PER_THREAD>;
+
+  static constexpr auto use_softmax = true;
+
+  float sm_scale_log2;
+
+  // Init
+  __device__ __host__ DebugPrintLogits(const ParamsT& params) {
+    sm_scale_log2 = params.sm_scale * math::log2e;
+  }
+
+  template <typename MainloopParams, typename T>
+  __device__ __forceinline__ T LogitsTransform(const MainloopParams& params, T logits,
+                                               uint32_t batch_idx, uint32_t qo_idx, uint32_t kv_idx,
+                                               uint32_t qo_head_idx, uint32_t kv_head_idx) {
+    printf(
+        "---> LOGITS DEBUG: "
+        "qo_idx=%-5d "
+        "kv_idx=%-5d "
+        "sm_scale_log2=%-12.5f "
+        "logits=%-12.5f "
+        "\n",
+        qo_idx,
+        kv_idx,
+        sm_scale_log2,
+        static_cast<float>(logits));
+    logits *= sm_scale_log2;
+    return logits;
+  }
+};
+"""
+    jit_module = gen_customize_single_prefill_sm90_module(
+        module_name="sm90_debug_print_logits",
+        dtype_q=torch.float16,  # dtype_q
+        dtype_kv=torch.float16,  # dtype_kv
+        dtype_o=torch.float16,  # dtype_o
+        head_dim=128,  # hidden_dim
+        additional_input_tensor_var_names=[],  # additional_input_tensor_var_names
+        additional_input_tensor_var_types=[],  # additional_input_tensor_var_types
+        additional_input_scalar_var_names=["sm_scale"],  # additional_input_scalar_var_names
+        additional_input_scalar_var_types=["float"],  # additional_input_scalar_var_types
+        variant_name="DebugPrintLogits",
+        variant_decl=variant_decl,
+    )
+
+    f = functools.partial(single_prefill_with_kv_cache_with_jit_module, jit_module)
+
+    q = torch.randn(16, 2, 128, dtype=torch.float16, device="cuda")
+    k = torch.randn(16, 1, 128, dtype=torch.float16, device="cuda")
+    v = torch.randn(16, 1, 128, dtype=torch.float16, device="cuda")
+    sm_scale = 1. / math.sqrt(128)
     o = f(q, k, v, sm_scale, mask_mode=MaskMode.NON_CAUSAL.value)
 
     p = torch.einsum("mhd,nhd->hmn", q.float(), k.float()) * sm_scale

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -326,28 +326,34 @@ struct DebugPrintLogits {
 
   static constexpr auto use_softmax = true;
 
+  int qo_len;
+  int kv_len;
   float sm_scale_log2;
 
   // Init
   __device__ __host__ DebugPrintLogits(const ParamsT& params) {
     sm_scale_log2 = params.sm_scale * math::log2e;
+    qo_len = params.qo_len;
+    kv_len = params.kv_len;
   }
 
   template <typename MainloopParams, typename T>
   __device__ __forceinline__ T LogitsTransform(const MainloopParams& params, T logits,
                                                uint32_t batch_idx, uint32_t qo_idx, uint32_t kv_idx,
                                                uint32_t qo_head_idx, uint32_t kv_head_idx) {
-    printf(
-        "---> LOGITS DEBUG: "
-        "qo_idx=%-5d "
-        "kv_idx=%-5d "
-        "sm_scale_log2=%-12.5f "
-        "logits=%-12.5f "
-        "\n",
-        qo_idx,
-        kv_idx,
-        sm_scale_log2,
-        static_cast<float>(logits));
+    if (qo_idx < qo_len && kv_idx < kv_len) {
+      printf(
+          "---> LOGITS DEBUG: "
+          "qo_idx=%-5d "
+          "kv_idx=%-5d "
+          "sm_scale_log2=%-12.5f "
+          "logits=%-12.5f "
+          "\n",
+          qo_idx,
+          kv_idx,
+          sm_scale_log2,
+          static_cast<float>(logits));
+    }
     logits *= sm_scale_log2;
     return logits;
   }


### PR DESCRIPTION
Added customizable SM90 prefill kernels.

AOT command:
```
MAX_JOBS=224 \
FLASHINFER_ENABLE_AOT=1 \
TORCH_CUDA_ARCH_LIST=9.0a \
pip install -e . \
  --no-cache-dir --ignore-installed --verbose --force-reinstall
```

JIT command:
```
MAX_JOBS=224 \
FLASHINFER_ENABLE_AOT=0 \
TORCH_CUDA_ARCH_LIST=9.0a \
pip install -e . \
  --no-cache-dir --ignore-installed --verbose --force-reinstall
```

After either command, you can make sure the SM90 kernels work by:
```
pytest -x tests/test_hopper.py
```

An example for a `customizable_sm90_prefill_kernel` has also been added to `tests/test_jit_example.py". You can follow that example to add custom kernels.