### PR TITLE
sampling: simplify min-p sampling

### DIFF
--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -27,8 +27,8 @@ void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at:
                                unsigned int top_k_val, bool deterministic, int64_t cuda_stream);
 
 void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_min_p_arr,
-                               double min_p_val, bool deterministic, int64_t cuda_stream);
+                               std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
+                               bool deterministic, int64_t cuda_stream);
 
 void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
                                      at::Tensor samples, at::Tensor success,

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -164,7 +164,7 @@ def get_sampling_module():
             maybe_min_p_arr: Optional[torch.Tensor],
             min_p_val: float,
             deterministic: bool,
-        ) -> Tuple[torch.Tensor, torch.Tensor]:
+        ) -> torch.Tensor:
             with probs.device as device:
                 probs = probs.float()
                 uniform_samples = uniform_samples.float()
@@ -172,18 +172,16 @@ def get_sampling_module():
                     maybe_min_p_arr.float() if maybe_min_p_arr is not None else None
                 )
                 samples = torch.empty(probs.size(0), dtype=torch.int32, device=device)
-                success = torch.empty(probs.size(0), dtype=torch.bool, device=device)
                 module.min_p_sampling_from_probs(
                     probs,
                     uniform_samples,
                     samples,
-                    success,
                     maybe_min_p_arr,
                     min_p_val,
                     deterministic,
                     get_cuda_stream(device),
                 )
-                return samples, success
+                return samples
 
         # torch library for top_k_top_p_sampling_from_probs
 
@@ -634,7 +632,7 @@ def min_p_sampling_from_probs(
     min_p: Union[torch.Tensor, float],
     deterministic: bool = True,
     check_nan: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     r"""Fused GPU kernel for `min_p sampling <https://arxiv.org/abs/2407.01082>`_ from probabilities,
 
     this operator implements GPU-based rejection sampling without explicit sorting.
@@ -647,8 +645,7 @@ def min_p_sampling_from_probs(
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
     uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
-        where the first dimension is the maximum number of rounds for rejection sampling.
+        The uniform samples used as needle for sampling, shape ``(batch_size,)``,
         Expected to be uniformly distributed in ``[0, 1)``.
     min_p: torch.Tensor
         Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for min-p sampling.
@@ -663,9 +660,6 @@ def min_p_sampling_from_probs(
     -------
     samples: torch.Tensor
         Sampled categories, shape ``(batch_size,)``.
-    success: torch.Tensor
-        Whether the sampling is successful within ``max_top_k_rounds`` rounds,
-        shape ``(batch_size,)``.
 
     Examples
     --------
@@ -676,7 +670,6 @@ def min_p_sampling_from_probs(
     <torch._C.Generator object at 0x7f8b3db06df0>
     >>> batch_size = 4
     >>> vocab_size = 5
-    >>> max_rounds = 3
     >>> min_p = torch.full((batch_size,), 0.05).to(0)
     >>> pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
     >>> norm_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
@@ -685,12 +678,10 @@ def min_p_sampling_from_probs(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> uniform_samples = torch.rand(max_rounds, batch_size).to(0)
-    >>> samples, success = flashinfer.sampling.min_p_sampling_from_probs(norm_prob, uniform_samples, min_p)
+    >>> uniform_samples = torch.rand(batch_size).to(0)
+    >>> samples = flashinfer.sampling.min_p_sampling_from_probs(norm_prob, uniform_samples, min_p)
     >>> samples
     tensor([1, 2, 1, 4], device='cuda:0', dtype=torch.int32)
-    >>> success
-    tensor([True, True, True, True], device='cuda:0')
 
     Note
     ----

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -459,8 +459,7 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
 __global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples, DType* min_p_arr,
-                                           IdType* output, bool* success, float min_p_val,
-                                           uint32_t d, uint32_t max_min_p_rounds) {
+                                           IdType* output, float min_p_val, uint32_t d) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   DType p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
@@ -472,9 +471,6 @@ __global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
       SamplingTempStorage<DType, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
 
   vec_t<DType, VEC_SIZE> probs_vec;
-  DType aggregate;
-  DType q = DType(1);
-  DType pivot = DType(0);
 
   DType max_p = 0;
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
@@ -495,70 +491,49 @@ __global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
     temp_storage.block_aggregate.max_p = max_p;
   }
   __syncthreads();
-  DType scaled_p = temp_storage.block_aggregate.max_p * p;
+  DType pivot = temp_storage.block_aggregate.max_p * p;
+
+  DType aggregate_gt_pivot = DType(0);
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(DType(0));
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.load(probs + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+
+    DType probs_gt_pivot[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      probs_gt_pivot[j] = (probs_vec[j] > pivot) ? probs_vec[j] : DType(0);
+    }
+
+    aggregate_gt_pivot += BlockReduce<DType, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                              .Sum<VEC_SIZE>(probs_gt_pivot);
+    if (tx == 0) {
+      temp_storage.block_aggregate.value = aggregate_gt_pivot;
+    }
+    __syncthreads();
+  }
+
+  DType aggregate(0);
+  DType q = temp_storage.block_aggregate.value;
 
   IdType sampled_id;
-  for (uint32_t round = 0; round < max_min_p_rounds; ++round) {
-    temp_storage.sampled_id = d - 1;
-    __syncthreads();
-    DType u = uniform_samples[round * batch_size + bx] * q;
-    aggregate = DType(0);
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(DType(0));
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.load(probs + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-
-      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                             DETERMINISTIC, DType>(i, d, pivot, u, probs_vec, aggregate,
-                                                   &temp_storage);
-      if (aggregate > u) {
-        break;
-      }
+  temp_storage.sampled_id = d - 1;
+  __syncthreads();
+  DType u = uniform_samples[bx] * q;
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(DType(0));
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.load(probs + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
     }
-    __syncthreads();
-    sampled_id = temp_storage.sampled_id;
-    pivot = max(pivot, probs[bx * d + sampled_id]);
-    if (pivot >= scaled_p) {
+
+    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC,
+                           DType>(i, d, pivot, u, probs_vec, aggregate, &temp_storage);
+    if (aggregate > u) {
       break;
     }
-
-    DType aggregate_gt_pivot = DType(0);
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(DType(0));
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.load(probs + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-
-      DType probs_gt_pivot[VEC_SIZE];
-#pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot[j] = (probs_vec[j] > pivot) ? probs_vec[j] : DType(0);
-      }
-
-      aggregate_gt_pivot += BlockReduce<DType, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                                .Sum<VEC_SIZE>(probs_gt_pivot);
-      if (tx == 0) {
-        temp_storage.block_aggregate.value = aggregate_gt_pivot;
-      }
-      __syncthreads();
-    }
-    q = temp_storage.block_aggregate.value;
   }
-  __syncthreads();
-  if (tx == 0) {
-    output[bx] = sampled_id;
-    if (pivot < scaled_p) {
-      // failed to sample within MAX_ROUNDS
-      if (success != nullptr) {
-        success[bx] = false;
-      }
-    } else {
-      if (success != nullptr) {
-        success[bx] = true;
-      }
-    }
-  }
+  output[bx] = temp_storage.sampled_id;
 }
 
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
@@ -749,16 +724,15 @@ cudaError_t TopPSamplingFromProb(T* probs, T* uniform_samples, IdType* output, b
 
 template <typename T, typename IdType>
 cudaError_t MinPSamplingFromProb(T* probs, T* uniform_samples, T* min_p_arr, IdType* output,
-                                 bool* success, uint32_t batch_size, float min_p_val, uint32_t d,
-                                 uint32_t max_rounds, bool deterministic, cudaStream_t stream = 0) {
+                                 uint32_t batch_size, float min_p_val, uint32_t d,
+                                 bool deterministic, cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   const uint32_t smem_size = sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
-  void* args[] = {&probs,   &uniform_samples, &min_p_arr, &output,
-                  &success, &min_p_val,       &d,         &max_rounds};
+  void* args[] = {&probs, &uniform_samples, &min_p_arr, &output, &min_p_val, &d};
 
   DISPATCH_ALIGNED_VEC_SIZE(
       vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -100,7 +100,6 @@ def test_top_k_sampling(batch_size, vocab_size, k):
 @pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])
 def test_min_p_sampling(batch_size, vocab_size, p):
     torch.manual_seed(42)
-    max_min_p_trails = 32
     pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
     normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
     sorted_prob, indices = torch.sort(normalized_prob, descending=False)
@@ -111,18 +110,15 @@ def test_min_p_sampling(batch_size, vocab_size, p):
     mask = torch.zeros(batch_size, vocab_size, dtype=torch.int32).to(0)
     mask.scatter_add_(1, indices, (sorted_prob >= scaled_p).int())
 
-    uniform_samples = torch.empty(max_min_p_trails, batch_size, dtype=torch.float32).to(
-        0
-    )
+    uniform_samples = torch.empty(batch_size, dtype=torch.float32).to(0)
     min_p_tensor = torch.full((batch_size,), p).to(0)
 
     num_trails = 1000
     for _ in range(num_trails):
         uniform_samples.uniform_()
-        samples, success = flashinfer.sampling.min_p_sampling_from_probs(
+        samples = flashinfer.sampling.min_p_sampling_from_probs(
             normalized_prob, uniform_samples, min_p_tensor
         )
-        assert torch.all(success)
         assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
         assert torch.all(mask[torch.arange(batch_size), samples] == 1), normalized_prob[
             torch.arange(batch_size), samples
@@ -390,11 +386,12 @@ def test_chain_speculative_sampling(
 
 
 if __name__ == "__main__":
-    test_sampling(1, 111)
-    test_top_p_sampling(3, 111, 0.9)
-    test_top_k_sampling(3, 111, 10)
-    test_top_p_renorm_probs(3, 111, 0.9)
-    test_top_k_renorm_probs(3, 111, 10)
-    test_top_k_mask_logits(99, 989, 10)
-    test_chain_speculative_sampling(3, 111, 3, False)
-    test_chain_speculative_sampling(3, 111, 3, True)
+    # test_sampling(1, 111)
+    # test_top_p_sampling(3, 111, 0.9)
+    # test_top_k_sampling(3, 111, 10)
+    # test_top_p_renorm_probs(3, 111, 0.9)
+    # test_top_k_renorm_probs(3, 111, 10)
+    # test_top_k_mask_logits(99, 989, 10)
+    # test_chain_speculative_sampling(3, 111, 3, False)
+    # test_chain_speculative_sampling(3, 111, 3, True)
+    test_min_p_sampling(3, 111, 0.9)


### PR DESCRIPTION
Per #710 , we don't need rejection algorithm for min-p sampling, this PR simplifies the design.

There is a breaking change on API: we no longer returns `success` array for min-p sampling because there is no risk of rejecting the samples.

In later PRs, we will also remove the `success` array in top-p/top-k sampling APIs.