### PR TITLE
Finer-grained control over fp16/fp8 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ endif()
 # options. Alernatively, use cmake -DOPTION=VALUE through command-line.
 flashinfer_option(FLASHINFER_ENABLE_FP8
                   "Whether to compile fp8 kernels or not." ON)
+flashinfer_option(FLASHINFER_ENABLE_FP8_E4M3
+                  "Whether to compile fp8_e4m3 kernels or not." ON)
+flashinfer_option(FLASHINFER_ENABLE_FP8_E5M2
+                  "Whether to compile fp8_e5m2 kernels or not." ON)
+flashinfer_option(FLASHINFER_ENABLE_F16
+                  "Whether to compile f16 kernels or not." ON)
 flashinfer_option(FLASHINFER_ENABLE_BF16
                   "Whether to compile bf16 kernels or not." ON)
 flashinfer_option(
@@ -98,9 +104,19 @@ find_package(Thrust REQUIRED)
 set(FLASHINFER_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
 
 if(FLASHINFER_ENABLE_FP8)
-  message(STATUS "Compile fp8 kernels.")
-  add_definitions(-DFLASHINFER_ENABLE_FP8)
+  set(FLASHINFER_ENABLE_FP8_E4M3 ON)
+  set(FLASHINFER_ENABLE_FP8_E5M2 ON)
 endif(FLASHINFER_ENABLE_FP8)
+
+if(FLASHINFER_ENABLE_FP8_E4M3)
+  message(STATUS "Compile fp8_e4m3 kernels.")
+  add_definitions(-DFLASHINFER_ENABLE_FP8_E4M3)
+endif(FLASHINFER_ENABLE_FP8_E4M3)
+
+if(FLASHINFER_ENABLE_FP8_E5M2)
+  message(STATUS "Compile fp8_e5m2 kernels.")
+  add_definitions(-DFLASHINFER_ENABLE_FP8_E5M2)
+endif(FLASHINFER_ENABLE_FP8_E5M2)
 
 if(FLASHINFER_ENABLE_BF16)
   message(STATUS "Compile bf16 kernels.")
@@ -130,8 +146,10 @@ set(AOT_GENERATE_COMMAND
   --pos_encoding_modes ${POS_ENCODING_MODES}
   --allow_fp16_qk_reductions ${ALLOW_FP16_QK_REDUCTIONS}
   --mask_modes ${MASK_MODES}
+  --enable_f16 ${FLASHINFER_ENABLE_F16}
   --enable_bf16 ${FLASHINFER_ENABLE_BF16}
-  --enable_fp8 ${FLASHINFER_ENABLE_FP8})
+  --enable_fp8_e4m3 ${FLASHINFER_ENABLE_FP8_E4M3}
+  --enable_fp8_e5m2 ${FLASHINFER_ENABLE_FP8_E5M2})
 
 execute_process(
   COMMAND ${AOT_GENERATE_COMMAND}

--- a/aot_build_utils/generate.py
+++ b/aot_build_utils/generate.py
@@ -40,8 +40,10 @@ def get_instantiation_cu(args: argparse.Namespace) -> List[str]:
     pos_encoding_modes: List[int] = args.pos_encoding_modes
     allow_fp16_qk_reductions: List[int] = args.allow_fp16_qk_reductions
     mask_modes: List[int] = args.mask_modes
+    enable_f16: bool = args.enable_f16
     enable_bf16: bool = args.enable_bf16
-    enable_fp8: bool = args.enable_fp8
+    enable_fp8_e4m3: bool = args.enable_fp8_e4m3
+    enable_fp8_e5m2: bool = args.enable_fp8_e5m2
 
     path.mkdir(parents=True, exist_ok=True)
 
@@ -59,16 +61,24 @@ def get_instantiation_cu(args: argparse.Namespace) -> List[str]:
     )
 
     idtypes = ["i32"]
-    prefill_dtypes = ["f16"]
-    decode_dtypes = ["f16"]
-    fp16_dtypes = ["f16"]
-    fp8_dtypes = ["e4m3", "e5m2"]
+    prefill_dtypes = []
+    decode_dtypes = []
+    fp16_dtypes = []
+    fp8_dtypes = []
+    if enable_f16:
+        prefill_dtypes.append("f16")
+        decode_dtypes.append("f16")
+        fp16_dtypes.append("f16")
     if enable_bf16:
         prefill_dtypes.append("bf16")
         decode_dtypes.append("bf16")
         fp16_dtypes.append("bf16")
-    if enable_fp8:
-        decode_dtypes.extend(fp8_dtypes)
+    if enable_fp8_e4m3:
+        fp8_dtypes.extend(["e4m3"])
+        decode_dtypes.extend(["e4m3"])
+    if enable_fp8_e5m2:
+        fp8_dtypes.extend(["e5m2"])
+        decode_dtypes.extend(["e5m2"])
 
     single_decode_uris = []
     # single decode files
@@ -277,6 +287,13 @@ if __name__ == "__main__":
         help="Mask modes",
     )
     parser.add_argument(
+        "--enable_fp16",
+        type=lambda x: x if isinstance(x, int) else x.lower() == "true",
+        required=True,
+        nargs="+",
+        help="Enable fp16",
+    )
+    parser.add_argument(
         "--enable_bf16",
         type=lambda x: x if isinstance(x, int) else x.lower() == "true",
         required=True,
@@ -284,11 +301,18 @@ if __name__ == "__main__":
         help="Enable bf16",
     )
     parser.add_argument(
-        "--enable_fp8",
+        "--enable_fp8_e4m3",
         type=lambda x: x if isinstance(x, int) else x.lower() == "true",
         default=True,
         nargs="+",
-        help="Enable fp8",
+        help="Enable fp8_e4m3",
+    )
+    parser.add_argument(
+        "--enable_fp8_e5m2",
+        type=lambda x: x if isinstance(x, int) else x.lower() == "true",
+        default=True,
+        nargs="+",
+        help="Enable fp8_e5m2",
     )
     args = parser.parse_args()
     get_instantiation_cu(args)

--- a/aot_build_utils/generate_sm90.py
+++ b/aot_build_utils/generate_sm90.py
@@ -37,14 +37,19 @@ def get_sm90_instantiation_cu(args: argparse.Namespace) -> List[str]:
     pos_encoding_modes: List[int] = args.pos_encoding_modes
     allow_fp16_qk_reductions: List[int] = args.allow_fp16_qk_reductions
     mask_modes: List[int] = args.mask_modes
+    enable_f16: bool = args.enable_f16
     enable_bf16: bool = args.enable_bf16
 
     path.mkdir(parents=True, exist_ok=True)
 
     idtypes = ["i32"]
-    prefill_dtypes = ["f16"]
-    decode_dtypes = ["f16"]
-    fp16_dtypes = ["f16"]
+    prefill_dtypes = []
+    decode_dtypes = []
+    fp16_dtypes = []
+    if enable_f16:
+        prefill_dtypes.append("f16")
+        decode_dtypes.append("f16")
+        fp16_dtypes.append("f16")
     if enable_bf16:
         prefill_dtypes.append("bf16")
         decode_dtypes.append("bf16")
@@ -183,18 +188,18 @@ if __name__ == "__main__":
         help="Mask modes",
     )
     parser.add_argument(
+        "--enable_f16",
+        type=lambda x: x if isinstance(x, int) else x.lower() == "true",
+        required=True,
+        nargs="+",
+        help="Enable f16",
+    )
+    parser.add_argument(
         "--enable_bf16",
         type=lambda x: x if isinstance(x, int) else x.lower() == "true",
         required=True,
         nargs="+",
         help="Enable bf16",
-    )
-    parser.add_argument(
-        "--enable_fp8",
-        type=lambda x: x if isinstance(x, int) else x.lower() == "true",
-        default=True,
-        nargs="+",
-        help="Enable fp8",
     )
     args = parser.parse_args()
     get_sm90_instantiation_cu(args)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,6 @@
 # Whether to compile fp8 kernels or not.
-set(FLASHINFER_ENABLE_FP8 ON)
+set(FLASHINFER_ENABLE_FP8_E4M3 ON)
+set(FLASHINFER_ENABLE_FP8_E5M2 ON)
 # Whether to compile bf16 kernels or not.
 set(FLASHINFER_ENABLE_BF16 ON)
 # Whether to compile tvm bindings or not.

--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -33,19 +33,20 @@ void bmm_fp8(at::Tensor A, at::Tensor B, at::Tensor D, at::Tensor A_scale, at::T
   TORCH_CHECK(A.size(1) == D.size(1) && B.size(2) == D.size(2),
               "Result tensor has incorrect shape");
 
-  auto batch_size = A.size(0);
-  auto m = A.size(1);
-  auto k = A.size(2);
-  auto n = B.size(2);
-
-  auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
-  auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   // PyTorch is row major by default. cuBLASLt is column major by default.
   // We need row major D as expected.
   // A ^ T * B = D, so D ^ T = B ^ T * A
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(B.scalar_type(), b_type, [&] {
     return DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(A.scalar_type(), a_type, [&] {
       return DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(D.scalar_type(), d_type, [&] {
+        auto batch_size = A.size(0);
+        auto m = A.size(1);
+        auto k = A.size(2);
+        auto n = B.size(2);
+
+        auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
+        auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+
         auto status = flashinfer::bmm_fp8::bmm_fp8_internal_cublaslt(
             workspace_buffer.data_ptr(), workspace_buffer.numel(),
             static_cast<b_type*>(B.data_ptr()), static_cast<a_type*>(A.data_ptr()),

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -94,7 +94,8 @@ def load_cuda_ops(
         "4",
         "-use_fast_math",
         "-DFLASHINFER_ENABLE_BF16",
-        "-DFLASHINFER_ENABLE_FP8",
+        "-DFLASHINFER_ENABLE_FP8_E4M3",
+        "-DFLASHINFER_ENABLE_FP8_E5M2",
     ]
     cflags += extra_cflags
     cuda_cflags += extra_cuda_cflags

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -456,7 +456,6 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           typename DType, typename IdType>
 __global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples, DType* min_p_arr,
                                            IdType* output, float min_p_val, uint32_t d) {
-  const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   DType p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
 

--- a/src/test_batch_decode.cu
+++ b/src/test_batch_decode.cu
@@ -169,11 +169,13 @@ TEST(FlashInferCorrectnessTest, TestBatchDecodeKernelCorrectnessBF16) {
 }
 #endif
 
-#ifdef FLASHINFER_ENABLE_FP8
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
 TEST(FlashInferCorrectnessTest, TestBatchDecodeKernelCorrectnessE4M3) {
   TestBatchDecodeKernelCorrectness<half, __nv_fp8_e4m3>();
 }
+#endif
 
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
 TEST(FlashInferCorrectnessTest, TestBatchDecodeKernelCorrectnessE5M2) {
   TestBatchDecodeKernelCorrectness<half, __nv_fp8_e5m2>();
 }

--- a/src/test_batch_prefill.cu
+++ b/src/test_batch_prefill.cu
@@ -787,19 +787,24 @@ TEST(FlashInferCorrectnessTest, BatchRaggedPrefillTestFP16QKHalfAccum) {
   TestBatchRaggedPrefillKernelCorrectness<half>(true);
 }
 
-#ifdef FLASHINFER_ENABLE_FP8
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
 
 TEST(FlashInferCorrectnessTest, BatchPagedPrefillShortContextTestE4M3) {
   TestBatchPagedPrefillFP8KernelShortContextCorrectness<__nv_fp8_e4m3>(false);
 }
 
+TEST(FlashInferCorrectnessTest, BatchPagedPrefillLongContextTestE4M3) {
+  TestBatchPagedPrefillFP8KernelLongContextCorrectness<__nv_fp8_e4m3>(false);
+}
+
+#endif
+
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
+
 TEST(FlashInferCorrectnessTest, BatchPagedPrefillShortContextTestE5M2) {
   TestBatchPagedPrefillFP8KernelShortContextCorrectness<__nv_fp8_e5m2>(false);
 }
 
-TEST(FlashInferCorrectnessTest, BatchPagedPrefillLongContextTestE4M3) {
-  TestBatchPagedPrefillFP8KernelLongContextCorrectness<__nv_fp8_e4m3>(false);
-}
 
 TEST(FlashInferCorrectnessTest, BatchPagedPrefillLongContextTestE5M2) {
   TestBatchPagedPrefillFP8KernelLongContextCorrectness<__nv_fp8_e5m2>(false);

--- a/src/test_page.cu
+++ b/src/test_page.cu
@@ -195,11 +195,13 @@ TEST(FlashInferCorrectnessTest, AppendPagedKVKernelCorrectnessTestBF16) {
 }
 #endif
 
-#ifdef FLASHINFER_ENABLE_FP8
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
 TEST(FlashInferCorrectnessTest, AppendPagedKVKernelCorrectnessTestE4M3) {
   TestAppendPagedKVKernelCorrectness<__nv_fp8_e4m3>();
 }
+#endif
 
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
 TEST(FlashInferCorrectnessTest, AppendPagedKVKernelCorrectnessTestE5M2) {
   TestAppendPagedKVKernelCorrectness<__nv_fp8_e5m2>();
 }

--- a/src/test_single_decode.cu
+++ b/src/test_single_decode.cu
@@ -108,10 +108,13 @@ TEST(FlashInferCorrectnessTest, SingleDecodeKernelCorrectnessTestBF16) {
 }
 #endif
 
-#ifdef FLASHINFER_ENABLE_FP8
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
 TEST(FlashInferCorrectnessTest, SingleDecodeKernelCorrectnessTestE4M3) {
   TestSingleDecodeKernelCorrectness<half, __nv_fp8_e4m3>();
 }
+#endif
+
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
 TEST(FlashInferCorrectnessTest, SingleDecodeKernelCorrectnessTestE5M2) {
   TestSingleDecodeKernelCorrectness<half, __nv_fp8_e5m2>();
 }

--- a/src/test_single_prefill.cu
+++ b/src/test_single_prefill.cu
@@ -251,21 +251,24 @@ TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelCorrectnessTestBF16) {
 }
 #endif
 
-#ifdef FLASHINFER_ENABLE_FP8
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
 TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelShortContextCorrectnessE4M3) {
   TestSinglePrefillFP8KernelShortContextCorrectness<__nv_fp8_e4m3>(false);
-}
-TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelShortContextCorrectnessE5M2) {
-  TestSinglePrefillFP8KernelShortContextCorrectness<__nv_fp8_e5m2>(false);
 }
 TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelCorrectnessTestE4M3) {
   TestSinglePrefillFP8KernelCorrectness<__nv_fp8_e4m3>(false);
 }
-TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelCorrectnessTestE5M2) {
-  TestSinglePrefillFP8KernelCorrectness<__nv_fp8_e5m2>(false);
-}
 TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelLongContextCorrectnessE4M3) {
   TestSinglePrefillFP8KernelLongContextCorrectness<__nv_fp8_e4m3>(false);
+}
+#endif
+
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
+TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelShortContextCorrectnessE5M2) {
+  TestSinglePrefillFP8KernelShortContextCorrectness<__nv_fp8_e5m2>(false);
+}
+TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelCorrectnessTestE5M2) {
+  TestSinglePrefillFP8KernelCorrectness<__nv_fp8_e5m2>(false);
 }
 TEST(FlashInferCorrectnessTest, TestSinglePrefillKernelLongContextCorrectnessE5M2) {
   TestSinglePrefillFP8KernelLongContextCorrectness<__nv_fp8_e5m2>(false);


### PR DESCRIPTION
Flags can be used to disable fp16 and either of the fp8 variants in order to speed up AOT builds.

By default, the configuration remains unchanged and the `FLASHINFER_ENABLE_FP8` flag will enable both fp8 modes.