### PR TITLE
Allow AOT builds to be generated without aux kernels

### DIFF
--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -15,23 +15,6 @@
  */
 #include "aot_extension_utils.h"
 
-//========== activation ==========
-
-void silu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
-void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
-void gelu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
-
-//========== cascade ==========
-
-void merge_state(at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b,
-                 at::Tensor v_merged, at::Tensor s_merged, int64_t cuda_stream);
-
-void merge_state_in_place(at::Tensor v, at::Tensor s, at::Tensor v_other, at::Tensor s_other,
-                          std::optional<at::Tensor> mask, int64_t cuda_stream);
-
-void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_merged,
-                  int64_t cuda_stream);
-
 //========== decode ==========
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
@@ -54,45 +37,6 @@ void BatchDecodeWithPagedKVCacheRun(
     at::Tensor paged_kv_last_page_len, std::optional<at::Tensor> alibi_slopes, at::Tensor o,
     unsigned int kv_layout_code, int window_left, float logits_soft_cap, float sm_scale,
     float rope_scale, float rope_theta, std::optional<at::Tensor> maybe_lse, int64_t cuda_stream);
-
-//========== gemm ==========
-
-void bmm_fp8(at::Tensor A, at::Tensor B, at::Tensor D, at::Tensor A_scale, at::Tensor B_scale,
-             at::Tensor workspace_buffer, int64_t cublas_handle, int64_t cuda_stream);
-
-void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at::Tensor x_ptr,
-                        at::Tensor w_ptr, at::Tensor y_ptr, at::Tensor x_ld, at::Tensor w_ld,
-                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major,
-                        int64_t cuda_stream);
-
-//========== norm ==========
-
-void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
-             int64_t cuda_stream);
-
-void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
-                       int64_t cuda_stream);
-
-void gemma_rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
-                   int64_t cuda_stream);
-
-void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
-                             double eps, int64_t cuda_stream);
-
-//========== page ==========
-
-void append_paged_kv_cache(at::Tensor append_key, at::Tensor append_value, at::Tensor batch_indices,
-                           at::Tensor positions, at::Tensor paged_k_cache, at::Tensor paged_v_cache,
-                           at::Tensor kv_indices, at::Tensor kv_indptr, at::Tensor kv_last_page_len,
-                           unsigned int layout, int64_t cuda_stream);
-
-void block_sparse_indices_to_vector_sparse_offsets(at::Tensor block_sparse_indices,
-                                                   at::Tensor block_sparse_indptr,
-                                                   at::Tensor vector_sparse_offsets,
-                                                   at::Tensor vector_sparse_indptr,
-                                                   at::Tensor kv_len_arr, unsigned int stride_block,
-                                                   unsigned int stride_n, unsigned int batch_size,
-                                                   unsigned int block_size, int64_t cuda_stream);
 
 //========== prefill ==========
 
@@ -128,114 +72,14 @@ void BatchPrefillWithPagedKVCacheRun(
     int32_t window_left, float logits_soft_cap, float sm_scale, float rope_scale, float rope_theta,
     std::optional<at::Tensor> maybe_lse, int64_t cuda_stream);
 
-//========== quantization ==========
-
-void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
-
-void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_indptr,
-                      const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
-
-//========== rope ==========
-
-void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope, at::Tensor indptr,
-                at::Tensor offsets, unsigned int rotary_dim, bool interleave, float rope_scale,
-                float rope_theta, int64_t cuda_stream);
-
-void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
-                        at::Tensor indptr, at::Tensor offsets, unsigned int rotary_dim,
-                        bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
-                        float high_freq_factor, float old_context_length, int64_t cuda_stream);
-
-void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
-                        at::Tensor pos_ids, unsigned int rotary_dim, bool interleave,
-                        float rope_scale, float rope_theta, int64_t cuda_stream);
-
-void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
-                                at::Tensor pos_ids, unsigned int rotary_dim, bool interleave,
-                                float rope_scale, float rope_theta, float low_freq_factor,
-                                float high_freq_factor, float old_context_length,
-                                int64_t cuda_stream);
-
-void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_rope,
-                                      at::Tensor k_rope, at::Tensor cos_cache, at::Tensor sin_cache,
-                                      at::Tensor pos_ids, bool interleave, int64_t cuda_stream);
-
-//========== sampling ==========
-
-void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                         bool deterministic, int64_t cuda_stream);
-
-void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_p_arr,
-                               double top_p_val, bool deterministic, int64_t cuda_stream);
-
-void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_k_arr,
-                               unsigned int top_k_val, bool deterministic, int64_t cuda_stream);
-
-void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
-                               bool deterministic, int64_t cuda_stream);
-
-void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
-                                     at::Tensor samples, at::Tensor success,
-                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
-                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, int64_t cuda_stream);
-
-void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                        int64_t cuda_stream);
-
-void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_k_arr, unsigned int top_k_val,
-                        int64_t cuda_stream);
-
-void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
-                       std::optional<at::Tensor> maybe_top_k_arr, unsigned int top_k_val,
-                       int64_t cuda_stream);
-
-void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
-                                at::Tensor uniform_samples, at::Tensor target_probs,
-                                at::Tensor output_token_ids, at::Tensor output_accepted_token_num,
-                                at::Tensor output_emitted_token_num, bool deterministic,
-                                int64_t cuda_stream);
-
 //========== pybind11 ==========
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  // activation
-  m.def("silu_and_mul", &silu_and_mul, "Fused SiLU and Mul");
-  m.def("gelu_tanh_and_mul", &gelu_tanh_and_mul, "Fused GeLU Tanh and Mul");
-  m.def("gelu_and_mul", &gelu_and_mul, "Fused GeLU and Mul");
-
-  // cascade
-  m.def("merge_state", &merge_state, "Merge two self-attention states");
-  m.def("merge_state_in_place", &merge_state_in_place,
-        "Merge another self-attention state in-place.");
-  m.def("merge_states", &merge_states, "Merge multiple self-attention states");
-
   // decode
   m.def("single_decode_with_kv_cache", &single_decode_with_kv_cache,
         "Single-request decode with KV-Cache operator");
   m.def("batch_decode_with_paged_kv_cache_plan", &BatchDecodeWithPagedKVCachePlan);
   m.def("batch_decode_with_paged_kv_cache_run", &BatchDecodeWithPagedKVCacheRun);
-
-  // gemm
-  m.def("bmm_fp8", &bmm_fp8, "BMM FP8");
-  m.def("cutlass_segment_gemm", &CutlassSegmentGEMM, "Cutlass Segment GEMM operator");
-
-  // norm
-  m.def("rmsnorm", &rmsnorm, "Root mean square normalization");
-  m.def("fused_add_rmsnorm", &fused_add_rmsnorm, "Fused add root mean square normalization");
-  m.def("gemma_rmsnorm", &gemma_rmsnorm, "Gemma Root mean square normalization");
-  m.def("gemma_fused_add_rmsnorm", &gemma_fused_add_rmsnorm,
-        "Gemma Fused add root mean square normalization");
-
-  // page
-  m.def("append_paged_kv_cache", &append_paged_kv_cache, "Append paged KV-Cache operator");
-  m.def("block_sparse_indices_to_vector_sparse_offsets",
-        &block_sparse_indices_to_vector_sparse_offsets, "Precompute block sparse offsets");
 
   // prefill
   m.def("single_prefill_with_kv_cache", &single_prefill_with_kv_cache,
@@ -243,33 +87,4 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("batch_prefill_with_kv_cache_plan", &BatchPrefillWithKVCachePlan);
   m.def("batch_prefill_with_ragged_kv_cache_run", &BatchPrefillWithRaggedKVCacheRun);
   m.def("batch_prefill_with_paged_kv_cache_run", &BatchPrefillWithPagedKVCacheRun);
-
-  // quantization
-  m.def("packbits", &packbits, "GPU packbits operator");
-  m.def("segment_packbits", &segment_packbits, "GPU segment packbits operator");
-
-  // rope
-  m.def("apply_rope", &apply_rope, "Apply RoPE");
-  m.def("apply_llama31_rope", &apply_llama31_rope, "Apply Llama 3.1 style RoPE");
-  m.def("apply_rope_pos_ids", &apply_rope_pos_ids, "Apply RoPE with positional ids");
-  m.def("apply_llama31_rope_pos_ids", &apply_llama31_rope_pos_ids,
-        "Apply Llama 3.1 style RoPE with positional ids");
-  m.def("apply_rope_pos_ids_cos_sin_cache", &apply_rope_pos_ids_cos_sin_cache,
-        "Apply RoPE with positional ids and cosine/sine cache");
-
-  // sampling
-  m.def("sampling_from_probs", &sampling_from_probs, "Sample from probabilities");
-  m.def("top_k_sampling_from_probs", &top_k_sampling_from_probs,
-        "Top-k sampling from probabilities");
-  m.def("min_p_sampling_from_probs", &min_p_sampling_from_probs,
-        "Min-p sampling from probabilities");
-  m.def("top_p_sampling_from_probs", &top_p_sampling_from_probs,
-        "Top-p sampling from probabilities");
-  m.def("top_k_top_p_sampling_from_probs", &top_k_top_p_sampling_from_probs,
-        "Top-k and top-p sampling from probabilities");
-  m.def("top_k_renorm_probs", &top_k_renorm_probs, "Renormalize probabilities by top-k mask");
-  m.def("top_p_renorm_probs", &top_p_renorm_probs, "Renormalize probabilities by top-p mask");
-  m.def("top_k_mask_logits", &top_k_mask_logits, "Mask logits by top-k mask");
-  m.def("chain_speculative_sampling", &chain_speculative_sampling,
-        "Speculative sampling from sequence of probabilities");
 }

--- a/csrc/flashinfer_ops_aux.cu
+++ b/csrc/flashinfer_ops_aux.cu
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "aot_extension_utils.h"
+
+//========== activation ==========
+
+void silu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
+void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
+void gelu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
+
+//========== cascade ==========
+
+void merge_state(at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b,
+                 at::Tensor v_merged, at::Tensor s_merged, int64_t cuda_stream);
+
+void merge_state_in_place(at::Tensor v, at::Tensor s, at::Tensor v_other, at::Tensor s_other,
+                          std::optional<at::Tensor> mask, int64_t cuda_stream);
+
+void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_merged,
+                  int64_t cuda_stream);
+
+//========== gemm ==========
+
+void bmm_fp8(at::Tensor A, at::Tensor B, at::Tensor D, at::Tensor A_scale, at::Tensor B_scale,
+             at::Tensor workspace_buffer, int64_t cublas_handle, int64_t cuda_stream);
+
+void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at::Tensor x_ptr,
+                        at::Tensor w_ptr, at::Tensor y_ptr, at::Tensor x_ld, at::Tensor w_ld,
+                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major,
+                        int64_t cuda_stream);
+
+//========== norm ==========
+
+void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
+             int64_t cuda_stream);
+
+void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
+                       int64_t cuda_stream);
+
+void gemma_rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
+                   int64_t cuda_stream);
+
+void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
+                             double eps, int64_t cuda_stream);
+
+//========== page ==========
+
+void append_paged_kv_cache(at::Tensor append_key, at::Tensor append_value, at::Tensor batch_indices,
+                           at::Tensor positions, at::Tensor paged_k_cache, at::Tensor paged_v_cache,
+                           at::Tensor kv_indices, at::Tensor kv_indptr, at::Tensor kv_last_page_len,
+                           unsigned int layout, int64_t cuda_stream);
+
+void block_sparse_indices_to_vector_sparse_offsets(at::Tensor block_sparse_indices,
+                                                   at::Tensor block_sparse_indptr,
+                                                   at::Tensor vector_sparse_offsets,
+                                                   at::Tensor vector_sparse_indptr,
+                                                   at::Tensor kv_len_arr, unsigned int stride_block,
+                                                   unsigned int stride_n, unsigned int batch_size,
+                                                   unsigned int block_size, int64_t cuda_stream);
+
+//========== quantization ==========
+
+void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
+
+void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_indptr,
+                      const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
+
+//========== rope ==========
+
+void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope, at::Tensor indptr,
+                at::Tensor offsets, unsigned int rotary_dim, bool interleave, float rope_scale,
+                float rope_theta, int64_t cuda_stream);
+
+void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
+                        at::Tensor indptr, at::Tensor offsets, unsigned int rotary_dim,
+                        bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
+                        float high_freq_factor, float old_context_length, int64_t cuda_stream);
+
+void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
+                        at::Tensor pos_ids, unsigned int rotary_dim, bool interleave,
+                        float rope_scale, float rope_theta, int64_t cuda_stream);
+
+void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
+                                at::Tensor pos_ids, unsigned int rotary_dim, bool interleave,
+                                float rope_scale, float rope_theta, float low_freq_factor,
+                                float high_freq_factor, float old_context_length,
+                                int64_t cuda_stream);
+
+void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_rope,
+                                      at::Tensor k_rope, at::Tensor cos_cache, at::Tensor sin_cache,
+                                      at::Tensor pos_ids, bool interleave, int64_t cuda_stream);
+
+//========== sampling ==========
+
+void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+                         bool deterministic, int64_t cuda_stream);
+
+void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+                               at::Tensor success, std::optional<at::Tensor> maybe_top_p_arr,
+                               double top_p_val, bool deterministic, int64_t cuda_stream);
+
+void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+                               at::Tensor success, std::optional<at::Tensor> maybe_top_k_arr,
+                               unsigned int top_k_val, bool deterministic, int64_t cuda_stream);
+
+void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+                               std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
+                               bool deterministic, int64_t cuda_stream);
+
+void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
+                                     at::Tensor samples, at::Tensor success,
+                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
+                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                                     bool deterministic, int64_t cuda_stream);
+
+void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
+                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                        int64_t cuda_stream);
+
+void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
+                        std::optional<at::Tensor> maybe_top_k_arr, unsigned int top_k_val,
+                        int64_t cuda_stream);
+
+void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
+                       std::optional<at::Tensor> maybe_top_k_arr, unsigned int top_k_val,
+                       int64_t cuda_stream);
+
+void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
+                                at::Tensor uniform_samples, at::Tensor target_probs,
+                                at::Tensor output_token_ids, at::Tensor output_accepted_token_num,
+                                at::Tensor output_emitted_token_num, bool deterministic,
+                                int64_t cuda_stream);
+
+//========== pybind11 ==========
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  // activation
+  m.def("silu_and_mul", &silu_and_mul, "Fused SiLU and Mul");
+  m.def("gelu_tanh_and_mul", &gelu_tanh_and_mul, "Fused GeLU Tanh and Mul");
+  m.def("gelu_and_mul", &gelu_and_mul, "Fused GeLU and Mul");
+
+  // cascade
+  m.def("merge_state", &merge_state, "Merge two self-attention states");
+  m.def("merge_state_in_place", &merge_state_in_place,
+        "Merge another self-attention state in-place.");
+  m.def("merge_states", &merge_states, "Merge multiple self-attention states");
+
+  // gemm
+  m.def("bmm_fp8", &bmm_fp8, "BMM FP8");
+  m.def("cutlass_segment_gemm", &CutlassSegmentGEMM, "Cutlass Segment GEMM operator");
+
+  // norm
+  m.def("rmsnorm", &rmsnorm, "Root mean square normalization");
+  m.def("fused_add_rmsnorm", &fused_add_rmsnorm, "Fused add root mean square normalization");
+  m.def("gemma_rmsnorm", &gemma_rmsnorm, "Gemma Root mean square normalization");
+  m.def("gemma_fused_add_rmsnorm", &gemma_fused_add_rmsnorm,
+        "Gemma Fused add root mean square normalization");
+
+  // page
+  m.def("append_paged_kv_cache", &append_paged_kv_cache, "Append paged KV-Cache operator");
+  m.def("block_sparse_indices_to_vector_sparse_offsets",
+        &block_sparse_indices_to_vector_sparse_offsets, "Precompute block sparse offsets");
+
+  // quantization
+  m.def("packbits", &packbits, "GPU packbits operator");
+  m.def("segment_packbits", &segment_packbits, "GPU segment packbits operator");
+
+  // rope
+  m.def("apply_rope", &apply_rope, "Apply RoPE");
+  m.def("apply_llama31_rope", &apply_llama31_rope, "Apply Llama 3.1 style RoPE");
+  m.def("apply_rope_pos_ids", &apply_rope_pos_ids, "Apply RoPE with positional ids");
+  m.def("apply_llama31_rope_pos_ids", &apply_llama31_rope_pos_ids,
+        "Apply Llama 3.1 style RoPE with positional ids");
+  m.def("apply_rope_pos_ids_cos_sin_cache", &apply_rope_pos_ids_cos_sin_cache,
+        "Apply RoPE with positional ids and cosine/sine cache");
+
+  // sampling
+  m.def("sampling_from_probs", &sampling_from_probs, "Sample from probabilities");
+  m.def("top_k_sampling_from_probs", &top_k_sampling_from_probs,
+        "Top-k sampling from probabilities");
+  m.def("min_p_sampling_from_probs", &min_p_sampling_from_probs,
+        "Min-p sampling from probabilities");
+  m.def("top_p_sampling_from_probs", &top_p_sampling_from_probs,
+        "Top-p sampling from probabilities");
+  m.def("top_k_top_p_sampling_from_probs", &top_k_top_p_sampling_from_probs,
+        "Top-k and top-p sampling from probabilities");
+  m.def("top_k_renorm_probs", &top_k_renorm_probs, "Renormalize probabilities by top-k mask");
+  m.def("top_p_renorm_probs", &top_p_renorm_probs, "Renormalize probabilities by top-p mask");
+  m.def("top_k_mask_logits", &top_k_mask_logits, "Mask logits by top-k mask");
+  m.def("chain_speculative_sampling", &chain_speculative_sampling,
+        "Speculative sampling from sequence of probabilities");
+}

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 
 import torch
 
-from .jit import gen_act_and_mul_module, has_prebuilt_ops, load_cuda_ops
+from .jit import gen_act_and_mul_module, has_prebuilt_kernels_aux, load_cuda_ops
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
@@ -55,10 +55,10 @@ _jit_modules = {}
 def get_act_and_mul_module(act_func_name: str):
     global _jit_modules
     if act_func_name not in _jit_modules:
-        if has_prebuilt_ops:
-            from . import _kernels  # type: ignore[attr-defined]
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux  # type: ignore[attr-defined]
 
-            module = _kernels
+            module = _kernels_aux
         else:
             module = gen_act_and_mul_module(
                 act_func_name, act_func_def_str[act_func_name]

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -19,7 +19,7 @@ from typing import List, Optional, Tuple
 import torch
 
 from .decode import BatchDecodeWithPagedKVCacheWrapper
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, load_cuda_ops
 from .prefill import BatchPrefillWithPagedKVCacheWrapper, single_prefill_with_kv_cache
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
@@ -29,10 +29,10 @@ _cascade_module = None
 def get_cascade_module():
     global _cascade_module
     if _cascade_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            _cascade_module = _kernels
+            _cascade_module = _kernels_aux
         else:
             _cascade_module = load_cuda_ops(
                 "cascade",

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -28,7 +28,7 @@ from .jit import (
     get_batch_decode_mla_uri,
     get_batch_decode_uri,
     get_single_decode_uri,
-    has_prebuilt_ops,
+    has_prebuilt_kernels,
     prebuilt_ops_uri,
 )
 from .prefill import get_batch_prefill_module, get_single_prefill_module
@@ -58,7 +58,7 @@ def get_single_decode_module(*args):
     global _single_decode_modules
     if args not in _single_decode_modules:
         uri = get_single_decode_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
+        if has_prebuilt_kernels and uri in prebuilt_ops_uri:
             from . import _kernels
 
             run_func = _kernels.single_decode_with_kv_cache
@@ -126,7 +126,7 @@ def get_batch_decode_module(*args):
     global _batch_decode_modules
     if args not in _batch_decode_modules:
         uri = get_batch_decode_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
+        if has_prebuilt_kernels and uri in prebuilt_ops_uri:
             from . import _kernels
 
             # NOTE(Zihao): we should avoid hard-coded index like this, refactor it later

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -21,7 +21,7 @@ import torch
 import triton
 import triton.language as tl
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, has_prebuilt_kernels_sm90, load_cuda_ops
 from .utils import (
     _get_cache_buf,
     determine_gemm_backend,
@@ -38,10 +38,10 @@ _gemm_module_sm90 = None
 def get_gemm_module():
     global _gemm_module
     if _gemm_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            module = _kernels
+            module = _kernels_aux
         else:
             module = load_cuda_ops(
                 "gemm",
@@ -148,7 +148,7 @@ def get_gemm_module():
 def get_gemm_sm90_module():
     global _gemm_module_sm90
     if _gemm_module_sm90 is None:
-        if has_prebuilt_ops:
+        if has_prebuilt_kernels_sm90:
             from . import _kernels_sm90
 
             module = _kernels_sm90

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -43,8 +43,23 @@ from .env import *
 from .utils import parallel_load_modules as parallel_load_modules
 
 try:
-    from .. import _kernels, _kernels_sm90
+    from .. import _kernels
 
-    has_prebuilt_ops = True
-except ImportError:
-    has_prebuilt_ops = False
+    has_prebuilt_kernels = True
+except ImportError as exn:
+    print(type(exn))
+    has_prebuilt_kernels = False
+
+try:
+    from .. import _kernels_sm90
+
+    has_prebuilt_kernels_sm90 = True
+except ImportError as exn:
+    has_prebuilt_kernels_sm90 = False
+
+try:
+    from .. import _kernels_aux
+
+    has_prebuilt_kernels_aux = True
+except ImportError as exn:
+    has_prebuilt_kernels_aux = False

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, load_cuda_ops
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
 _norm_module = None
@@ -27,10 +27,10 @@ _norm_module = None
 def get_norm_module():
     global _norm_module
     if _norm_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            _norm_module = _kernels
+            _norm_module = _kernels_aux
         else:
             _norm_module = load_cuda_ops(
                 "norm",

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -20,7 +20,7 @@ import torch
 import triton
 import triton.language as tl
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, load_cuda_ops
 from .utils import (
     TensorLayout,
     _check_kv_layout,
@@ -36,10 +36,10 @@ _page_module = None
 def get_page_module():
     global _page_module
     if _page_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            _page_module = _kernels
+            _page_module = _kernels_aux
         else:
             _page_module = load_cuda_ops(
                 "page",

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -31,7 +31,8 @@ from .jit import (
     get_batch_prefill_uri,
     get_single_prefill_sm90_uri,
     get_single_prefill_uri,
-    has_prebuilt_ops,
+    has_prebuilt_kernels,
+    has_prebuilt_kernels_sm90,
     load_cuda_ops,
     prebuilt_ops_uri,
 )
@@ -66,7 +67,7 @@ def get_single_prefill_sm90_module(*args):
     global _single_prefill_sm90_modules
     if args not in _single_prefill_sm90_modules:
         uri = get_single_prefill_sm90_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
+        if has_prebuilt_kernels and uri in prebuilt_ops_uri:
             from . import _kernels_sm90
 
             run_func = _kernels_sm90.single_prefill_with_kv_cache_sm90
@@ -143,7 +144,7 @@ def get_single_prefill_module(*args):
     global _single_prefill_modules
     if args not in _single_prefill_modules:
         uri = get_single_prefill_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
+        if has_prebuilt_kernels and uri in prebuilt_ops_uri:
             from . import _kernels
 
             run_func = _kernels.single_prefill_with_kv_cache
@@ -221,7 +222,7 @@ def get_batch_prefill_sm90_module(*args):
     if args not in _batch_prefill_sm90_modules:
         uri = get_batch_prefill_sm90_uri(*args)
 
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
+        if has_prebuilt_kernels and uri in prebuilt_ops_uri:
             from . import _kernels_sm90
 
             head_dim = args[4]
@@ -427,7 +428,7 @@ def get_batch_prefill_module(*args):
     global _batch_prefill_modules
     if args not in _batch_prefill_modules:
         uri = get_batch_prefill_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
+        if has_prebuilt_kernels and uri in prebuilt_ops_uri:
             from . import _kernels
 
             # NOTE(Zihao): we should avoid hard-coded index like this, refactor it later

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -18,7 +18,7 @@ from typing import Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, load_cuda_ops
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
 _quantization_module = None
@@ -27,10 +27,10 @@ _quantization_module = None
 def get_quantization_module():
     global _quantization_module
     if _quantization_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            _quantization_module = _kernels
+            _quantization_module = _kernels_aux
         else:
             _quantization_module = load_cuda_ops(
                 "quantization",

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -18,7 +18,7 @@ from typing import Optional, Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, load_cuda_ops
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
 _rope_module = None
@@ -27,10 +27,10 @@ _rope_module = None
 def get_rope_module():
     global _rope_module
     if _rope_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            _rope_module = _kernels
+            _rope_module = _kernels_aux
         else:
             _rope_module = load_cuda_ops(
                 "rope",

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -19,7 +19,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_kernels_aux, load_cuda_ops
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
 _sampling_module = None
@@ -28,10 +28,10 @@ _sampling_module = None
 def get_sampling_module():
     global _sampling_module
     if _sampling_module is None:
-        if has_prebuilt_ops:
-            from . import _kernels
+        if has_prebuilt_kernels_aux:
+            from . import _kernels_aux
 
-            module = _kernels
+            module = _kernels_aux
         else:
             module = load_cuda_ops(
                 "sampling",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ enable_fp8 = os.environ.get("FLASHINFER_ENABLE_FP8", "1") == "1"
 enable_fp8_e4m3 = os.environ.get("FLASHINFER_ENABLE_FP8_E4M3", "1" if enable_fp8 else "0") == "1"
 enable_fp8_e5m2 = os.environ.get("FLASHINFER_ENABLE_FP8_E5M2", "1" if enable_fp8 else "0") == "1"
 enable_sm90 = os.environ.get("FLASHINFER_ENABLE_SM90", "1") == "1"
+enable_aux = os.environ.get("FLASHINFER_ENABLE_AUX", "1") == "1"
 
 
 def get_version():
@@ -191,6 +192,13 @@ if enable_aot:
     ]
     sm90a_flags = "-gencode arch=compute_90a,code=sm_90a".split()
     kernel_sources = [
+        "csrc/batch_decode.cu",
+        "csrc/batch_prefill.cu",
+        "csrc/single_decode.cu",
+        "csrc/single_prefill.cu",
+        "csrc/flashinfer_ops.cu",
+    ]
+    kernel_aux_sources = [
         "csrc/bmm_fp8.cu",
         "csrc/cascade.cu",
         "csrc/group_gemm.cu",
@@ -201,11 +209,7 @@ if enable_aot:
         "csrc/sampling.cu",
         "csrc/renorm.cu",
         "csrc/activation.cu",
-        "csrc/batch_decode.cu",
-        "csrc/batch_prefill.cu",
-        "csrc/single_decode.cu",
-        "csrc/single_prefill.cu",
-        "csrc/flashinfer_ops.cu",
+        "csrc/flashinfer_ops_aux.cu",
     ]
     kernel_sm90_sources = [
         "csrc/group_gemm_sm90.cu",
@@ -238,6 +242,18 @@ if enable_aot:
                 extra_compile_args={
                     "cxx": cxx_flags,
                     "nvcc": nvcc_flags + sm90a_flags,
+                },
+            ),
+        ]
+    if enable_aux:
+        ext_modules += [
+            torch_cpp_ext.CUDAExtension(
+                name="flashinfer._kernels_aux",
+                sources=kernel_aux_sources,
+                include_dirs=include_dirs,
+                extra_compile_args={
+                    "cxx": cxx_flags,
+                    "nvcc": nvcc_flags,
                 },
             ),
         ]

--- a/tests/test_alibi.py
+++ b/tests/test_alibi.py
@@ -25,7 +25,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_batch_decode_kernels.py
+++ b/tests/test_batch_decode_kernels.py
@@ -23,7 +23,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -23,7 +23,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_block_sparse.py
+++ b/tests/test_block_sparse.py
@@ -25,7 +25,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_logits_cap.py
+++ b/tests/test_logits_cap.py
@@ -25,7 +25,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_non_contiguous_decode.py
+++ b/tests/test_non_contiguous_decode.py
@@ -7,7 +7,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_non_contiguous_prefill.py
+++ b/tests/test_non_contiguous_prefill.py
@@ -23,7 +23,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_shared_prefix_kernels.py
+++ b/tests/test_shared_prefix_kernels.py
@@ -23,7 +23,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -23,7 +23,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:

--- a/tests/test_tensor_cores_decode.py
+++ b/tests/test_tensor_cores_decode.py
@@ -23,7 +23,7 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
+    if flashinfer.jit.has_prebuilt_kernels:
         yield
     else:
         try:


### PR DESCRIPTION
This PR further trims down AOT build costs by optionally disabling sampling/top-k/etc kernels