### PR TITLE
ci: rename python package name to `flashinfer-python`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [project]
-name = "flashinfer"
+name = "flashinfer-python"
 description = "FlashInfer: Kernel Library for LLM Serving"
 requires-python = ">=3.8,<4.0"
 authors = [{ name = "FlashInfer team" }]


### PR DESCRIPTION
The name `flashinfer` is not available in PyPI and we haven't got response from PyPI team yet(https://github.com/pypi/support/issues/5355).

In this PR, we rename the package to `flashinfer-python`, it is approved, and we successfully uploaded a sdist of v0.2.0.post1 there:
https://pypi.org/project/flashinfer-python/0.2.0.post1/#history
