### PR TITLE
Move allocations out of torch ops

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -93,6 +93,7 @@ def load_cuda_ops(
         "--threads",
         "4",
         "-use_fast_math",
+        "-DFLASHINFER_ENABLE_F16",
         "-DFLASHINFER_ENABLE_BF16",
         "-DFLASHINFER_ENABLE_FP8_E4M3",
         "-DFLASHINFER_ENABLE_FP8_E5M2",


### PR DESCRIPTION
Torch ops ban the input and output pointers from aliasing altogether, thus they cannot be sliced from the same allocation. Some use cases migth also wish to explicitly specify the output buffers, this is a step towards enabling that.