### PR TITLE
fix pin memory device

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -651,7 +651,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
         )
         self._pin_memory_int_workspace_buffer = torch.empty(
-            (8 * 1024 * 1024,), dtype=torch.uint8, pin_memory=True
+            (8 * 1024 * 1024,), dtype=torch.uint8,
+            pin_memory=True, device="cpu",
         )
 
         if use_cuda_graph:
@@ -718,6 +719,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
             dtype=self._int_workspace_buffer.dtype,
+            device="cpu",
             pin_memory=True,
         )
 
@@ -1277,7 +1279,8 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
             (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
         )
         self._pin_memory_int_workspace_buffer = torch.empty(
-            (8 * 1024 * 1024,), dtype=torch.uint8, pin_memory=True
+            (8 * 1024 * 1024,), dtype=torch.uint8,
+            pin_memory=True, device="cpu",
         )
 
         if use_cuda_graph:
@@ -1330,6 +1333,7 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
             dtype=self._int_workspace_buffer.dtype,
+            device="cpu",
             pin_memory=True,
         )
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1099,6 +1099,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
             dtype=self._int_workspace_buffer.dtype,
+            device="cpu",
             pin_memory=True,
         )
         self._use_cuda_graph = use_cuda_graph
@@ -1165,6 +1166,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
             dtype=self._int_workspace_buffer.dtype,
+            device="cpu",
             pin_memory=True,
         )
 
@@ -1858,7 +1860,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
         )
         self._pin_memory_int_workspace_buffer = torch.empty(
-            self._int_workspace_buffer.shape, dtype=torch.uint8, pin_memory=True
+            self._int_workspace_buffer.shape, dtype=torch.uint8,
+            pin_memory=True, device="cpu",
         )
         self._use_cuda_graph = use_cuda_graph
         if use_cuda_graph:
@@ -1911,6 +1914,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,
             dtype=self._int_workspace_buffer.dtype,
+            device="cpu",
             pin_memory=True,
         )
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1417,7 +1417,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             if page_size != 1:
                 vector_sparse_indptr_host = torch.cat(
                     [
-                        torch.tensor([0], dtype=torch.int32),
+                        torch.tensor([0], dtype=torch.int32, device=kv_lens_arr_host.device),
                         torch.cumsum(kv_lens_arr_host, dim=0, dtype=torch.int32),
                     ],
                     dim=0,


### PR DESCRIPTION
right now flashinfer does not specify the device when creating pin-memory tensor. it will cause error when users changed the default pytorch device.

we should explicitly set the device to be `"cpu"` for pin-memory tensor.