### PR TITLE
feat: support MLA decode, implemented by CuTe targeted to SM80

### DIFF
--- a/csrc/batch_decode_mla_config.jinja
+++ b/csrc/batch_decode_mla_config.jinja
@@ -14,6 +14,8 @@ constexpr bool USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
 constexpr int HEAD_DIM_CKV = {{ head_dim_ckv }};
 constexpr int HEAD_DIM_KPE = {{ head_dim_kpe }};
 
+constexpr int QO_TILE_LEN = {{ qo_tile_len }};
+
 using Params = BatchDecodeParamsMLA<DTypeQ, DTypeKV, DTypeO, IdType>;
 using AttentionVariant =
     DefaultAttention</*use_custom_mask=*/false, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, /*use_alibi*/false>;

--- a/csrc/batch_decode_mla_cute_sm80.cu
+++ b/csrc/batch_decode_mla_cute_sm80.cu
@@ -1,0 +1,107 @@
+#include <optional>
+
+#include "pytorch_extension_utils.h"
+
+#include "mla_config.inc"
+
+#include <flashinfer/attention/decode_mla_cute_sm80.cuh>
+#include <flashinfer/attention/scheduler.cuh>
+
+using namespace flashinfer;
+
+std::vector<int64_t> BatchDecodeWithPagedKVCachePlanMLA(
+    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
+    at::Tensor page_locked_int_workspace_buffer, at::Tensor indptr, unsigned int batch_size,
+    unsigned int num_qo_heads, unsigned int page_size, bool enable_cuda_graph,
+    int64_t cuda_stream) {
+  size_t float_workspace_size_in_bytes =
+      float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
+  size_t int_workspace_size_in_bytes =
+      int_workspace_buffer.size(0) * int_workspace_buffer.element_size();
+
+  DecodePlanInfo plan_info;
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+
+  auto work_estimation_func =
+      BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN,
+                                                             AttentionVariant, Params>;
+  cudaError_t status =
+      DecodePlan<HEAD_DIM_CKV, flashinfer::PosEncodingMode::kNone, AttentionVariant, Params>(
+          static_cast<void*>(float_workspace_buffer.data_ptr()), float_workspace_size_in_bytes,
+          static_cast<void*>(int_workspace_buffer.data_ptr()),
+          static_cast<void*>(page_locked_int_workspace_buffer.data_ptr()),
+          int_workspace_size_in_bytes, plan_info, static_cast<IdType*>(indptr.data_ptr()),
+          batch_size, num_qo_heads, page_size, enable_cuda_graph, /*stream=*/stream,
+          work_estimation_func);
+
+  TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCachePlanMLA failed with error ",
+              cudaGetErrorString(status));
+
+  return plan_info.ToVector();
+}
+
+
+void BatchDecodeWithPagedKVCacheRunMLA(
+    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
+    std::vector<int64_t> plan_info_vec, at::Tensor q_nope, at::Tensor q_pe,
+    at::Tensor paged_ckv_cache, at::Tensor paged_kpe_cache, at::Tensor paged_kv_indptr,
+    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len, at::Tensor o, float sm_scale,
+    int window_left, float logits_soft_cap, float rope_scale, float rope_theta,
+    std::optional<at::Tensor> maybe_lse, int64_t cuda_stream) {
+  DecodePlanInfo plan_info;
+  plan_info.FromVector(plan_info_vec);
+
+  auto device = q_nope.device();
+  int64_t batch_size = q_nope.size(0);
+  int64_t num_qo_heads = q_nope.size(1);
+  int64_t page_size = paged_ckv_cache.size(1);
+
+  if (maybe_lse) {
+    const auto& lse = *maybe_lse;
+    TORCH_CHECK(lse.size(0) == batch_size, lse.size(0), q_nope.size(0));
+    TORCH_CHECK(lse.size(1) == num_qo_heads, lse.size(1), q_nope.size(1));
+  }
+
+  TORCH_CHECK(logits_soft_cap >= 0.f, "logits_soft_cap must be non-negative");
+
+  void* float_buffer = static_cast<void*>(float_workspace_buffer.data_ptr());
+  void* int_buffer = static_cast<void*>(int_workspace_buffer.data_ptr());
+
+  paged_kv_mla_t<DTypeKV, IdType> paged_kv(
+      page_size, HEAD_DIM_CKV, HEAD_DIM_KPE, batch_size,
+      static_cast<DTypeKV*>(paged_ckv_cache.data_ptr()), paged_ckv_cache.strides().data(),
+      static_cast<DTypeKV*>(paged_kpe_cache.data_ptr()), paged_kpe_cache.strides().data(),
+      static_cast<IdType*>(paged_kv_indices.data_ptr()),
+      static_cast<IdType*>(paged_kv_indptr.data_ptr()),
+      static_cast<IdType*>(paged_kv_last_page_len.data_ptr()));
+  Params params(static_cast<DTypeQ*>(q_nope.data_ptr()), static_cast<DTypeQ*>(q_pe.data_ptr()),
+                /*q_offset=*/nullptr, paged_kv, static_cast<DTypeO*>(o.data_ptr()),
+                /*lse=*/(maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr),
+                num_qo_heads, window_left, logits_soft_cap, sm_scale, rope_scale, rope_theta);
+
+  DTypeO* tmp_v = nullptr;
+  float* tmp_s = nullptr;
+  params.request_indices =
+      GetPtrFromBaseOffset<IdType>(int_buffer, plan_info.request_indices_offset);
+  params.kv_tile_indices =
+      GetPtrFromBaseOffset<IdType>(int_buffer, plan_info.kv_tile_indices_offset);
+  params.o_indptr = GetPtrFromBaseOffset<IdType>(int_buffer, plan_info.o_indptr_offset);
+  params.kv_chunk_size_ptr =
+      GetPtrFromBaseOffset<IdType>(int_buffer, plan_info.kv_chunk_size_ptr_offset);
+  if (plan_info.split_kv) {
+    tmp_v = GetPtrFromBaseOffset<DTypeO>(float_buffer, plan_info.v_offset);
+    tmp_s = GetPtrFromBaseOffset<float>(float_buffer, plan_info.s_offset);
+    if (plan_info.enable_cuda_graph) {
+      params.block_valid_mask =
+          GetPtrFromBaseOffset<bool>(int_buffer, plan_info.block_valid_mask_offset);
+    }
+  }
+  params.padded_batch_size = plan_info.padded_batch_size;
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  cudaError_t status =
+      BatchDecodeWithPagedKVCacheDispatchedMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, 
+                                               Params>(params, tmp_v, tmp_s, /*stream=*/stream);
+  TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",
+              cudaGetErrorString(status));
+}

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1247,6 +1247,7 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         self,
         float_workspace_buffer: torch.Tensor,
         use_cuda_graph: bool = False,
+        use_tensor_cores: bool = False,
         paged_kv_indptr_buffer: Optional[torch.Tensor] = None,
         paged_kv_indices_buffer: Optional[torch.Tensor] = None,
         paged_kv_last_page_len_buffer: Optional[torch.Tensor] = None,
@@ -1264,7 +1265,11 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
             Whether to enable CUDAGraph for batch decode attention, if enabled, the
             auxiliary data structures will be stored as the provided buffers. The ``batch_size``
             cannot change during the lifecycle of this wrapper when CUDAGraph is enabled.
-
+        
+        use_tensor_cores : bool
+            Whether to use tensor cores for the computation. Will be faster for large group
+            size in grouped query attention. Defaults to ``False``.
+        
         paged_kv_indptr_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
             of the buffer should be ``[batch_size + 1]``.
@@ -1314,6 +1319,7 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         else:
             self._fixed_batch_size = 0
 
+        self._use_tensor_cores = use_tensor_cores
         self._paged_kv_indptr_buf = paged_kv_indptr_buffer
         self._paged_kv_indices_buf = paged_kv_indices_buffer
         self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buffer
@@ -1322,6 +1328,10 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
     @property
     def is_cuda_graph_enabled(self) -> bool:
         return self._use_cuda_graph
+
+    @property
+    def use_tensor_cores(self) -> bool:
+        return self._use_tensor_cores
 
     def reset_workspace_buffer(
         self, float_workspace_buffer: torch.Tensor, int_workspace_buffer: torch.Tensor
@@ -1440,8 +1450,10 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
             q_data_type,
             indptr.dtype,
             head_dim_compressed_kv,
+            num_qo_heads,
             window_left != -1,  # use_sliding_window
             logits_soft_cap > 0,  # use_logits_soft_cap
+            self._use_tensor_cores,
         )
         with self.device as device:
             self._plan_info = self._cached_module.plan(

--- a/include/flashinfer/attention/decode_mla_cute_sm80.cuh
+++ b/include/flashinfer/attention/decode_mla_cute_sm80.cuh
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_DECODE_CUTE_SM80_CUH_
+#define FLASHINFER_DECODE_CUTE_SM80_CUH_
+#include <cooperative_groups.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include "cute/tensor.hpp"
+
+#include <iostream>
+
+#include "../cp_async.cuh"
+#include "../math.cuh"
+#include "../pos_enc.cuh"
+#include "../utils.cuh"
+#include "../vec_dtypes.cuh"
+#include "cascade.cuh"
+#include "state.cuh"
+
+namespace flashinfer {
+
+using namespace cute;
+
+namespace cg = cooperative_groups;
+using cp_async::PrefetchMode;
+using cp_async::SharedMemFillMode;
+
+
+template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN, typename DTypeKV>
+std::tuple<uint32_t, uint32_t, uint32_t> LaunchSpecForDecodeKernelMlaCuteSM80(const uint32_t num_qo_heads) {
+using namespace cute;
+  // fixme: below types and consts are duplicated from the ones from MLA decode kernel, we may refactor the duplication later
+  constexpr int k_smem_stages = 2;
+  constexpr int k_kv_tile_len = 8;
+  constexpr int k_warps = 4;
+
+  using LayoutQo = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_CKV>>, Stride<Int<HEAD_DIM_CKV>, _1>>;
+
+  using LayoutQnope = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_CKV>>, Stride<Int<HEAD_DIM_CKV>, _1>>;
+  using LayoutQpe = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_KPE>>, Stride<Int<HEAD_DIM_KPE>, _1>>;
+
+  using LayoutAtt = Layout< Shape< Int<QO_TILE_LEN>, Int<k_kv_tile_len>>, Stride<Int<k_kv_tile_len>, _1>>;
+
+  using LayoutOScaleVec = Layout<Shape<Int<QO_TILE_LEN>>>;
+
+  using LayoutSwizzleAtomKV = decltype(
+                                composition(Swizzle<3, 3, 3>{}, 
+                                    make_layout(make_shape(_8{}, _64{}), 
+                                            make_stride(_64{}, _1{}))));
+  using LayoutSwizzleQnope = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        LayoutQnope{}.shape() ) );
+  using LayoutSwizzleCkv = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        Shape<Int<k_kv_tile_len>, Int<HEAD_DIM_CKV>, Int<k_smem_stages>>{} ) );
+  using LayoutSwizzleQpe = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        LayoutQpe{}.shape() ) );
+  using LayoutSwizzleKpe = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        Shape<Int<k_kv_tile_len>, Int<HEAD_DIM_KPE>, Int<k_smem_stages>>{} ) );
+
+  uint32_t smem_size = k_warps * 32 * sizeof(size_t) * 2 +
+                        ( cosize(LayoutSwizzleQnope{}) + cosize(LayoutSwizzleQpe{}) + 
+                            cosize(LayoutSwizzleCkv{}) + cosize(LayoutSwizzleKpe{}) ) * sizeof(DTypeKV) + 
+                        cosize(LayoutAtt{}) * sizeof(float) + 
+                        cosize(LayoutOScaleVec{}) * sizeof(DTypeKV) * 2;
+
+  const uint32_t gdy = ceil_div(num_qo_heads, QO_TILE_LEN);
+  
+  return  {smem_size, gdy, k_warps};
+}
+
+
+template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN,
+      typename Params>
+__global__ void BatchDecodeWithPagedKVCacheKernelMlaCuteSM80(Params params) {
+  auto block = cooperative_groups::this_thread_block();
+
+  static_assert(std::is_same<typename Params::DTypeQ, half>::value, "DTypeQ is expeted to be fp16");
+  static_assert(std::is_same<typename Params::DTypeKV, half>::value, "DTypeKV is expeted to be fp16");
+  static_assert(std::is_same<typename Params::DTypeO, half>::value, "DTypeO is expeted to be fp16");
+  
+  using IdType = typename Params::IdType;
+  using DTypeKV = half;
+  const DTypeKV* q_nope_ptr = params.q_nope;
+  const DTypeKV* q_pe_ptr = params.q_pe;
+  DTypeKV* output_ptr = params.o;
+  float* lse = params.lse;
+  const auto& paged_kv = params.paged_kv;
+  // const IdType* q_rope_offset = params.q_rope_offset;
+  const bool* block_valid_mask = params.block_valid_mask;
+  const uint32_t num_qo_heads = params.num_qo_heads;
+  // const float rope_rcp_scale = params.rope_rcp_scale;
+  // const float rope_rcp_theta = params.rope_rcp_theta;
+  const bool partition_kv = params.partition_kv;
+
+  const uint32_t batch_idx = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+
+  // when CUDAGraph is enabled, we will launch more blocks than
+  // the actual batch size, so we need to check if the current batch is valid
+  if (block_valid_mask && !block_valid_mask[batch_idx]) return;
+  const uint32_t mapped_batch_idx = params.request_indices[batch_idx];
+
+  const uint32_t orig_seq_len = paged_kv.get_length(mapped_batch_idx);
+  // int32_t q_rope_offset_val =
+  //   q_rope_offset == nullptr ? (orig_seq_len - 1) : q_rope_offset[mapped_batch_idx];
+
+  const uint32_t kv_chunk_idx_in_orig_mapped_batch = params.kv_tile_indices[batch_idx];
+  const uint32_t kv_chunk_size = *(params.kv_chunk_size_ptr);
+  const uint32_t cur_chunk_start =
+    partition_kv ? kv_chunk_idx_in_orig_mapped_batch * kv_chunk_size : 0;
+  const uint32_t cur_chunk_end =
+    partition_kv ? min((kv_chunk_idx_in_orig_mapped_batch + 1) * kv_chunk_size, orig_seq_len)
+           : orig_seq_len;
+  const uint32_t cur_chunk_len = cur_chunk_end - cur_chunk_start;
+
+  uint32_t packed_page_iter_base = 
+    paged_kv.indptr[mapped_batch_idx] * paged_kv.page_size + cur_chunk_start;
+  const IdType last_indptr = paged_kv.indptr[paged_kv.batch_size];
+
+  const auto sm_scale = params.sm_scale * math::log2e;
+
+  constexpr int k_smem_stages = 2;
+  constexpr int k_kv_tile_len = 8;
+  constexpr int k_warps = 4;
+
+  using LayoutQo = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_CKV>>, Stride<Int<HEAD_DIM_CKV>, _1>>;
+
+  using LayoutQnope = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_CKV>>, Stride<Int<HEAD_DIM_CKV>, _1>>;
+  using LayoutQpe = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_KPE>>, Stride<Int<HEAD_DIM_KPE>, _1>>;
+
+  using LayoutAtt = Layout< Shape< Int<QO_TILE_LEN>, Int<k_kv_tile_len>>, Stride<Int<k_kv_tile_len>, _1>>;
+
+  using LayoutOScaleVec = Layout<Shape<Int<QO_TILE_LEN>>>;
+
+  using LayoutSwizzleAtomKV = decltype(
+                                composition(Swizzle<3, 3, 3>{}, 
+                                    make_layout(make_shape(_8{}, _64{}), 
+                                        make_stride(_64{}, _1{}))));
+  using LayoutSwizzleQnope = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        LayoutQnope{}.shape() ) );
+  using LayoutSwizzleCkv = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        Shape<Int<k_kv_tile_len>, Int<HEAD_DIM_CKV>, Int<k_smem_stages>>{} ) );
+
+  using LayoutSwizzleQpe = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        LayoutQpe{}.shape() ) );
+  using LayoutSwizzleKpe = decltype( 
+                                tile_to_shape( LayoutSwizzleAtomKV{},
+                                        Shape<Int<k_kv_tile_len>, Int<HEAD_DIM_KPE>, Int<k_smem_stages>>{} ) );
+
+  const uint32_t q_head_idx_start = mapped_batch_idx * num_qo_heads + blockIdx.y * QO_TILE_LEN;
+  const uint32_t o_head_idx_start = batch_idx * num_qo_heads + blockIdx.y * QO_TILE_LEN;
+
+  Tensor gmem_q_nope_chunk = make_tensor(make_gmem_ptr(q_nope_ptr + q_head_idx_start * HEAD_DIM_CKV), LayoutQnope{});
+  Tensor gmem_q_pe_chunk = make_tensor(make_gmem_ptr(q_pe_ptr + q_head_idx_start * HEAD_DIM_KPE), LayoutQpe{});
+  Tensor gmem_output_chunk = make_tensor(make_gmem_ptr(output_ptr + o_head_idx_start * HEAD_DIM_CKV), LayoutQo{});
+
+  extern __shared__ char smem_data[];
+  size_t* ckv_offset_smem = (size_t*)smem_data;
+  size_t* kpe_offset_smem = ckv_offset_smem + k_warps * 32;   
+  Tensor smem_q_nope = make_tensor(make_smem_ptr( (DTypeKV*)(kpe_offset_smem + k_warps * 32) ), LayoutSwizzleQnope{});
+  Tensor smem_q_pe = make_tensor(make_smem_ptr( smem_q_nope.data() + cute::cosize(LayoutSwizzleQnope{}) ), LayoutSwizzleQpe{});
+
+  Tensor smem_ckv_chunk = make_tensor(make_smem_ptr( smem_q_pe.data() + cute::cosize(LayoutSwizzleQpe{}) ), LayoutSwizzleCkv{});
+  Tensor smem_kpe_chunk = make_tensor(make_smem_ptr( smem_ckv_chunk.data() + cute::cosize(LayoutSwizzleCkv{}) ), LayoutSwizzleKpe{});
+
+  Tensor smem_att = make_tensor(make_smem_ptr( (float*)( smem_kpe_chunk.data().ptr_ + cute::cosize(LayoutSwizzleKpe{}) ) ), LayoutAtt{});
+
+  DTypeKV* ptr_o_scale = (DTypeKV*)( smem_att.data().ptr_ + cute::cosize(LayoutAtt{}) );
+  Tensor smem_o_scale = make_tensor(make_smem_ptr(ptr_o_scale), LayoutOScaleVec{});
+  DTypeKV* ptr_denom = ptr_o_scale + cute::cosize(LayoutOScaleVec{});
+  Tensor smem_denom = make_tensor(make_smem_ptr(ptr_denom), LayoutOScaleVec{});
+
+  constexpr uint32_t k_thr_g2s_tile_m = k_kv_tile_len; // 8
+  constexpr uint32_t k_thr_g2s_tile_k = k_warps*32/k_thr_g2s_tile_m; // 16
+  auto layout_thr_g2s_tile = make_layout(make_shape(Int<k_thr_g2s_tile_m>{}, Int<k_thr_g2s_tile_k>{}), LayoutLeft{});
+  const uint32_t thr_m_idx_within_tile = tx % k_thr_g2s_tile_m; // it's also kv-idx for ckv and kpe sequence
+  const uint32_t thr_k_idx_within_tile = tx / k_thr_g2s_tile_m;
+
+  // load q data to smem
+  Tensor gmem_q_nope_chunk_128bit = recast<cute::uint128_t>(gmem_q_nope_chunk);
+  Tensor gmem_q_nope_part_128bit = local_partition(gmem_q_nope_chunk_128bit, layout_thr_g2s_tile, tx);
+  Tensor smem_q_nope_128bit = recast<cute::uint128_t>(smem_q_nope);
+  Tensor smem_q_nope_part_128bit = local_partition(smem_q_nope_128bit, layout_thr_g2s_tile, tx); 
+#pragma unroll
+  for (int n=0; n < size<0>(gmem_q_nope_part_128bit); ++n)
+#pragma unroll
+    for (int k=0; k < size<1>(gmem_q_nope_part_128bit); ++k) {
+      smem_q_nope_part_128bit(n, k) = gmem_q_nope_part_128bit(n, k);
+    }
+  if ( thr_k_idx_within_tile < (HEAD_DIM_KPE * sizeof(DTypeKV) / sizeof(cute::uint128_t)) ) {
+    Tensor gmem_q_pe_chunk_128bit = recast<cute::uint128_t>(gmem_q_pe_chunk);
+    Tensor gmem_q_pe_part_128bit = local_partition(gmem_q_pe_chunk_128bit, layout_thr_g2s_tile, tx);
+    Tensor smem_q_pe_128bit = recast<cute::uint128_t>(smem_q_pe);
+    Tensor smem_q_pe_part_128bit = local_partition(smem_q_pe_128bit, layout_thr_g2s_tile, tx); 
+    static_assert(size<1>(gmem_q_pe_part_128bit) == 1);
+#pragma unroll
+    for (int n=0; n < size<0>(gmem_q_pe_part_128bit); ++n) {
+      smem_q_pe_part_128bit(n, _0{}) = gmem_q_pe_part_128bit(n, _0{});
+    }
+  }
+  block.sync();
+
+  // initialize variables needed by phase2
+  Tensor smem_ckv_chunk_128bit = recast<cute::uint128_t>(smem_ckv_chunk);
+  Tensor smem_ckv_load_part_128bit = local_partition(smem_ckv_chunk_128bit, layout_thr_g2s_tile, tx);
+  Tensor smem_kpe_chunk_128bit = recast<cute::uint128_t>(smem_kpe_chunk);
+  Tensor smem_kpe_load_part_128bit = local_partition(smem_kpe_chunk_128bit, layout_thr_g2s_tile, tx);
+
+  constexpr uint32_t k_mma_att_tile_k = 16;
+  using TiledMmaAtt = decltype(make_tiled_mma(MMA_Atom<MMA_Traits<SM80_16x8x16_F32F16F16F32_TN>>{}, 
+                make_layout(Shape<Int<k_warps>, _1, _1>{}, LayoutRight{})// , Tile<_32, _8, _16>{}
+                ) );             
+  TiledMmaAtt tiled_mma_att;
+  auto thr_mma = tiled_mma_att.get_slice(tx);
+
+  Tensor smem_q_nope_local_tiles = local_tile(smem_q_nope, make_tile(Int<QO_TILE_LEN>{}, Int<k_mma_att_tile_k>{}), make_coord(_0{}, _));
+  Tensor reg_q_nope_tile_part = thr_mma.partition_fragment_A(smem_q_nope_local_tiles(_, _, 0));
+
+  Tensor smem_ckv_local_tiles = local_tile(smem_ckv_chunk, make_tile(Int<k_kv_tile_len>{}, Int<k_mma_att_tile_k>{}), make_coord(_0{}, _));
+  Tensor reg_ckv_tile_part = thr_mma.partition_fragment_B(smem_ckv_local_tiles(_, _, _0{}, _0{}));
+  
+  auto s2r_tiled_copy_a = make_tiled_copy_A(Copy_Atom<SM75_U32x4_LDSM_N, DTypeKV>{}, tiled_mma_att);
+  auto s2r_thr_copy_a = s2r_tiled_copy_a.get_slice(tx);
+  Tensor smem_q_nope_tiles_part = s2r_thr_copy_a.partition_S(smem_q_nope_local_tiles);
+  Tensor reg_q_nope_tile_part_view = s2r_thr_copy_a.retile_D(reg_q_nope_tile_part);
+  
+  auto s2r_tiled_copy_b = make_tiled_copy_B(Copy_Atom<SM75_U32x2_LDSM_N, DTypeKV>{}, tiled_mma_att);
+  auto s2r_thr_copy_b = s2r_tiled_copy_b.get_slice(tx);
+  
+  Tensor smem_ckv_tiles_part = s2r_thr_copy_b.partition_S(smem_ckv_local_tiles); 
+  Tensor reg_ckv_tile_part_view = s2r_thr_copy_b.retile_D(reg_ckv_tile_part);
+  
+  Tensor smem_q_pe_local_tiles = local_tile(smem_q_pe, make_tile(Int<QO_TILE_LEN>{}, Int<k_mma_att_tile_k>{}), make_coord(_0{}, _));
+  Tensor reg_q_pe_tile_part = thr_mma.partition_fragment_A(smem_q_pe_local_tiles(_, _, _0{}));
+
+  Tensor smem_kpe_local_tiles = local_tile(smem_kpe_chunk, make_tile(Int<k_kv_tile_len>{}, Int<k_mma_att_tile_k>{}), make_coord(_0{}, _));
+  Tensor reg_kpe_tile_part = thr_mma.partition_fragment_B(smem_kpe_local_tiles(_, _, _0{}, _0{}));
+
+  Tensor smem_q_pe_tiles_part = s2r_thr_copy_a.partition_S(smem_q_pe_local_tiles);
+  Tensor reg_q_pe_tile_part_view = s2r_thr_copy_a.retile_D(reg_q_pe_tile_part);
+
+  Tensor smem_kpe_tiles_part = s2r_thr_copy_b.partition_S(smem_kpe_local_tiles);
+  Tensor reg_kpe_tile_part_view = s2r_thr_copy_b.retile_D(reg_kpe_tile_part);
+
+
+  Tensor smem_att_part_c = thr_mma.partition_C(smem_att);
+  Tensor reg_att_part_c = make_fragment_like(smem_att_part_c);
+  
+  using LayoutOScaleMat = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_CKV>>, Stride<_1, _0>>;
+  Tensor o_scale_broadcast_mat = make_tensor((ptr_o_scale), LayoutOScaleMat{});
+  Tensor denom_broadcast_mat = make_tensor(make_smem_ptr(ptr_denom), LayoutOScaleMat{});
+
+  // initialize variables needed by phase3
+  using TiledMmaOutput = decltype(make_tiled_mma(MMA_Atom<MMA_Traits<SM80_16x8x8_F16F16F16F16_TN>>{}, 
+                          make_layout(Shape<Int<k_warps>, _1, _1>{}, LayoutRight{}) ) );
+  TiledMmaOutput tiled_mma_output;
+  auto thr_mma_output = tiled_mma_output.get_slice(tx);
+
+  Tensor smem_att_part_a = thr_mma_output.partition_A(smem_att);
+  Tensor reg_att_part_a = thr_mma_output.partition_fragment_A(make_tensor((DTypeKV*)0x0, LayoutAtt{}));
+  
+  auto layout_ckv_trans = make_layout(make_shape(Int<HEAD_DIM_CKV>{}, Int<k_kv_tile_len>{}, Int<k_smem_stages>{}), 
+                    make_stride(Int<k_kv_tile_len>{}, _1{}, Int<HEAD_DIM_CKV * k_kv_tile_len>{}));
+  auto layout_ckv_trans_cps = composition(smem_ckv_chunk.layout(), layout_ckv_trans);
+  Tensor smem_ckv_trans = make_tensor(smem_ckv_chunk.data(), layout_ckv_trans_cps);
+  
+  auto s2r_tiled_copy_b_ckv = make_tiled_copy_B(Copy_Atom<SM75_U16x2_LDSM_T, DTypeKV>{}, tiled_mma_output);
+  auto s2r_thr_copy_b_ckv = s2r_tiled_copy_b_ckv.get_slice(tx);
+  Tensor smem_v_part = s2r_thr_copy_b_ckv.partition_S(smem_ckv_trans);
+  
+  auto layout_ckv_trans_no_stage = make_layout(make_shape(Int<HEAD_DIM_CKV>{}, Int<k_kv_tile_len>{}), 
+                    make_stride(Int<k_kv_tile_len>{}, _1{}));
+  Tensor reg_v_part = thr_mma_output.partition_fragment_B(make_tensor((DTypeKV*)0x0, layout_ckv_trans_no_stage));
+  Tensor reg_v_part_view = s2r_thr_copy_b_ckv.retile_D(reg_v_part);
+  
+  Tensor gmem_output_chunk_part = thr_mma_output.partition_C(gmem_output_chunk);
+  Tensor reg_output_part = make_fragment_like(gmem_output_chunk_part);
+  clear(reg_output_part);
+  
+  Tensor o_scale_mat_part = thr_mma_output.partition_C(o_scale_broadcast_mat);
+  Tensor denom_mat_part = thr_mma_output.partition_C(denom_broadcast_mat);
+
+  // init paged-cache read offset to be used
+  uint32_t q, r;
+  paged_kv.page_size.divmod(packed_page_iter_base + tx, q, r);
+  ckv_offset_smem[tx] = paged_kv.protective_get_offset_ckv(q, r, /*feat_idx*/ 0, last_indptr);
+  kpe_offset_smem[tx] = paged_kv.protective_get_offset_kpe(q, r, /*feat_idx*/ 0, last_indptr);
+  block.sync();
+
+  uint32_t stage_idx = 0;
+  size_t offset_bytes;
+  bool is_valid_range;
+#pragma unroll
+  for (uint32_t iter = 0; iter < k_smem_stages; ++iter) {
+    uint32_t kv_idx = iter * k_kv_tile_len + thr_m_idx_within_tile;
+    is_valid_range = kv_idx < cur_chunk_len;
+
+    offset_bytes = ckv_offset_smem[kv_idx];
+    static_assert(size<0>(smem_ckv_load_part_128bit) == 1);
+#pragma unroll
+    for (int k=0; k < size<1>(smem_ckv_load_part_128bit); ++k) {
+        cp_async::pred_load<128, cp_async::PrefetchMode::kPrefetch, cp_async::SharedMemFillMode::kNoFill>(
+            &smem_ckv_load_part_128bit(_0{}, k, stage_idx),
+            (cute::uint128_t*)(paged_kv.ckv_data + offset_bytes) + k * k_thr_g2s_tile_k +  thr_k_idx_within_tile,
+            is_valid_range);
+    }
+
+    offset_bytes = kpe_offset_smem[kv_idx];
+    is_valid_range = is_valid_range && ( thr_k_idx_within_tile < (HEAD_DIM_KPE * sizeof(DTypeKV) / sizeof(cute::uint128_t)) ) ;
+    static_assert(size<0>(smem_kpe_load_part_128bit) == 1 && size<1>(smem_kpe_load_part_128bit) == 1);
+    cp_async::pred_load<128, cp_async::PrefetchMode::kPrefetch, cp_async::SharedMemFillMode::kNoFill>(
+        &smem_kpe_load_part_128bit(_0{}, _0{}, stage_idx),
+        (cute::uint128_t*)(paged_kv.kpe_data + offset_bytes) + thr_k_idx_within_tile,
+        is_valid_range);
+    
+    cp_async::commit_group();
+    stage_idx = (stage_idx + 1) % k_smem_stages;
+  }
+
+  // start rolling update
+  float row_max = -flashinfer::math::inf;
+  float row_denom = 1.0;
+  for (uint32_t iter = 0; iter < ceil_div(cur_chunk_len, k_kv_tile_len); ++iter) {
+    cp_async::wait_group<1 * k_smem_stages - 1>();
+    block.sync();
+
+    // const int32_t kv_idx_base =
+    //   (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[mapped_batch_idx]) +
+    //   cur_chunk_start + iter * k_kv_tile_len;
+
+    clear(reg_att_part_c);
+#pragma unroll
+    for (int k_tile=0; k_tile < size<3>(smem_q_nope_tiles_part); ++k_tile) {
+        cute::copy(s2r_tiled_copy_a, smem_q_nope_tiles_part(_, _, _, k_tile), reg_q_nope_tile_part_view);
+        cute::copy(s2r_tiled_copy_b, smem_ckv_tiles_part(_, _, _, k_tile, stage_idx), reg_ckv_tile_part_view);
+        cute::gemm(tiled_mma_att, reg_att_part_c, reg_q_nope_tile_part, reg_ckv_tile_part, reg_att_part_c);
+    }
+#pragma unroll
+    for (int k_tile=0; k_tile < size<3>(smem_q_pe_tiles_part); ++k_tile) {
+        cute::copy(s2r_tiled_copy_a, smem_q_pe_tiles_part(_, _, _, k_tile), reg_q_pe_tile_part_view);
+        cute::copy(s2r_tiled_copy_b, smem_kpe_tiles_part(_, _, _, k_tile, stage_idx), reg_kpe_tile_part_view);
+        cute::gemm(tiled_mma_att, reg_att_part_c, reg_q_pe_tile_part, reg_kpe_tile_part, reg_att_part_c);
+    }
+#pragma unroll
+    for (int i=0; i<cute::size(reg_att_part_c); ++i) {
+        reg_att_part_c(i) *= sm_scale;
+    }
+
+    cute::copy(reg_att_part_c, smem_att_part_c);
+    block.sync();
+
+    // Phase2 compute softmax
+    if (tx < QO_TILE_LEN) {
+        uint32_t valid_kv_len = cur_chunk_len - iter * k_kv_tile_len;
+        valid_kv_len = (valid_kv_len < k_kv_tile_len) ? valid_kv_len : k_kv_tile_len;
+
+        float att[k_kv_tile_len];
+        float row_max_prev = row_max;
+        int i=0;
+        for ( ; i<valid_kv_len; ++i) {
+            att[i] = smem_att(tx, i);
+            row_max = max(row_max, att[i]);
+        }
+        for ( ; i<k_kv_tile_len; ++i) {
+            att[i] = -flashinfer::math::inf;
+        }
+
+        float row_o_scale = math::ptx_exp2(row_max_prev - row_max); 
+        smem_o_scale(tx) = row_o_scale;
+
+        row_denom *= row_o_scale;
+#pragma unroll
+        for (int i=0; i<k_kv_tile_len; ++i) {
+            att[i] = math::ptx_exp2(att[i] - row_max);
+            smem_att(tx, i) = att[i];
+            row_denom += att[i];
+        }
+        smem_denom(tx) = row_denom;
+    }
+    block.sync();
+
+    // Phase3 compute output
+#pragma unroll
+    for (int i=0; i<cute::size(reg_output_part); ++i)
+        reg_output_part(i) = reg_output_part(i) * o_scale_mat_part(i);
+    cute::copy(smem_att_part_a, reg_att_part_a);
+    cute::copy(s2r_tiled_copy_b_ckv, smem_v_part(_, _, _, stage_idx), reg_v_part_view);
+    cute::gemm(tiled_mma_output, reg_output_part, reg_att_part_a, reg_v_part, reg_output_part);
+
+    // refill offset_smem
+    constexpr uint32_t how_many__kv_tile_len__in__offset_smem = k_warps * 32 / k_kv_tile_len;
+    if ( ((iter + k_smem_stages) % how_many__kv_tile_len__in__offset_smem ) == 0 ) {
+        uint32_t q, r;
+        paged_kv.page_size.divmod(
+        packed_page_iter_base + (iter + k_smem_stages) * k_kv_tile_len + tx, q, r);
+        ckv_offset_smem[tx] =
+        paged_kv.protective_get_offset_ckv(q, r, 0, last_indptr);
+        kpe_offset_smem[tx] =
+        paged_kv.protective_get_offset_kpe(q, r, 0, last_indptr);
+    }
+    block.sync();
+
+    // commit next async copy task to pipeline
+    uint32_t kv_idx = (iter + k_smem_stages) * k_kv_tile_len + thr_m_idx_within_tile;
+    is_valid_range = kv_idx < cur_chunk_len;
+
+    offset_bytes = ckv_offset_smem[kv_idx % (k_warps * 32)];
+    static_assert(size<0>(smem_ckv_load_part_128bit) == 1);
+#pragma unroll
+    for (int k=0; k < size<1>(smem_ckv_load_part_128bit); ++k) {
+        cp_async::pred_load<128, cp_async::PrefetchMode::kPrefetch, cp_async::SharedMemFillMode::kNoFill>(
+            &smem_ckv_load_part_128bit(_0{}, k, stage_idx),
+            (cute::uint128_t*)(paged_kv.ckv_data + offset_bytes) + k * k_thr_g2s_tile_k + thr_k_idx_within_tile,
+            is_valid_range);
+    }
+
+    offset_bytes = kpe_offset_smem[kv_idx % (k_warps * 32)];
+    is_valid_range = is_valid_range && ( thr_k_idx_within_tile < (HEAD_DIM_KPE * sizeof(DTypeKV) / sizeof(cute::uint128_t)) ) ;
+    static_assert(size<0>(smem_kpe_load_part_128bit) == 1 && size<1>(smem_kpe_load_part_128bit) == 1);
+    cp_async::pred_load<128, cp_async::PrefetchMode::kPrefetch, cp_async::SharedMemFillMode::kNoFill>(
+        &smem_kpe_load_part_128bit(_0{}, _0{}, stage_idx),
+        (cute::uint128_t*)(paged_kv.kpe_data + offset_bytes) + thr_k_idx_within_tile,
+        is_valid_range);
+    cp_async::commit_group();
+
+    stage_idx = (stage_idx + 1) % k_smem_stages;
+  } // end for kv tile iteration
+  cp_async::wait_group<0>();
+  block.sync();
+
+  // final output phase
+#pragma unroll
+  for (int i=0; i<cute::size(reg_output_part); ++i) {
+    reg_output_part(i) = reg_output_part(i) / denom_mat_part(i);
+  }
+
+  cute::copy(reg_output_part, gmem_output_chunk_part);
+  
+  if (lse != nullptr && tx < QO_TILE_LEN) {
+    lse[o_head_idx_start + tx] = row_max + math::ptx_log2(row_denom);
+  }
+}
+
+template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN, typename AttentionVariant, typename Params>
+cudaError_t BatchDecodeWithPagedKVCacheDispatchedMlaCuteSM80(Params params, typename Params::DTypeO* tmp_v,
+                           float* tmp_s, cudaStream_t stream) {
+  using DTypeQ = typename Params::DTypeQ;
+  using DTypeKV = typename Params::DTypeKV;
+  using DTypeO = typename Params::DTypeO;
+  using IdType = typename Params::IdType;
+  const uint32_t num_qo_heads = params.num_qo_heads;
+  const uint32_t padded_batch_size = params.padded_batch_size;
+
+  auto [smem_size, gdy, k_warps] = LaunchSpecForDecodeKernelMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, DTypeKV>(num_qo_heads);
+  auto kernel =
+    BatchDecodeWithPagedKVCacheKernelMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, Params>;
+  
+  FLASHINFER_CUDA_CALL(
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+  if (tmp_v == nullptr) {
+    // do not use partition-kv kernel
+    dim3 nblks(padded_batch_size, gdy);
+    dim3 nthrs(k_warps * 32);
+    params.partition_kv = false;
+    void* args[] = {(void*)&params};
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+  } else {
+    // use partition-kv kernel
+    params.partition_kv = true;
+    auto o = params.o;
+    auto lse = params.lse;
+    params.o = tmp_v;
+    params.lse = tmp_s;
+    void* args[] = {(void*)&params};
+    dim3 nblks(padded_batch_size, gdy);
+    dim3 nthrs(k_warps * 32);
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v, tmp_s, params.o_indptr, o, lse,
+                           params.paged_kv.batch_size, nullptr,
+                           num_qo_heads, HEAD_DIM_CKV, stream));
+  }
+  
+  return cudaSuccess;
+}
+
+
+
+
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_DECODE_CUTE_SM80_CUH_

--- a/tests/test_mla_decode_kernel.py
+++ b/tests/test_mla_decode_kernel.py
@@ -345,7 +345,10 @@ class DeepseekV2AttentionMatAbsorbDecode(nn.Module):
             workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(
                 dev_id
             )
-            wrapper = flashinfer.BatchDecodeMlaWithPagedKVCacheWrapper(workspace_buffer)
+            wrapper = flashinfer.BatchDecodeMlaWithPagedKVCacheWrapper(
+                workspace_buffer,
+                use_tensor_cores=True,
+            )
             wrapper.plan(
                 kv_indptr,
                 kv_indices,

--- a/tests/test_mla_decode_kernel.py
+++ b/tests/test_mla_decode_kernel.py
@@ -345,10 +345,8 @@ class DeepseekV2AttentionMatAbsorbDecode(nn.Module):
             workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8).to(
                 dev_id
             )
-            wrapper = flashinfer.BatchDecodeMlaWithPagedKVCacheWrapper(
-                workspace_buffer,
-                use_tensor_cores=True,
-            )
+            # 'use_tensor_cores=True' to turn on tensor-core kernel
+            wrapper = flashinfer.BatchDecodeMlaWithPagedKVCacheWrapper(workspace_buffer)
             wrapper.plan(
                 kv_indptr,
                 kv_indices,


### PR DESCRIPTION
The scheduling design is shown in below diagram (q_pe and kpe parts are omitted), you can tell where each tensor resides by the prefix of their name, such as `smem`, `reg` and `gmem`. 
![image](https://github.com/user-attachments/assets/7c3bebde-70d4-4c7e-8672-e343c6ae8405)

### Some design key points:
- we want to load as many q-heads to smem as possible, so we let `k_kv_tile_len` be the minimum value 8, to save the smem space for `q_nope`
- I didn't concat `q_nope` with `q_pe`  and `ckv` and `kpe` in smem, because `ckv` can be transposed in the output matmul stage more easily
- the softmax calculation stage only utilize 2 warps, each thread process one row, and I didn't use warp shuffle intrins, just for the simplicity of implementation and also because the reduction axis of `smem_att` is only 8 rather small
- There is one very interesting trick usage of CUTLASS CuTe Layout:
```
  using LayoutOScaleMat = Layout< Shape< Int<QO_TILE_LEN>, Int<HEAD_DIM_CKV>>, Stride<_1, _0>>;
  Tensor o_scale_broadcast_mat = make_tensor((ptr_o_scale), LayoutOScaleMat{});
``` 
`o_scale_broadcast_mat` shared the same smem data with `smem_o_scale` , the column stride of `o_scale_broadcast_mat` is set to 0,  and `o_scale_broadcast_mat` is then partitioned by `thr_mma_output `
```
Tensor o_scale_mat_part = thr_mma_output.partition_C(o_scale_broadcast_mat);
```
and we further 
```
for (int i=0; i<cute::size(reg_output_part); ++i)
    reg_output_part(i) = reg_output_part(i) * o_scale_mat_part(i);
```
in this way we can easily implement row-wise broadcasting, each element of `smem_o_scale` multiplies one row of output tensor and we don't need to care about the complex register value layout of mma.

### Benchmark data:
![image](https://github.com/user-attachments/assets/3326248b-9ad8-49e2-8ae3-154b4ef765b5)
I benchmark the kernel on 4090 which can accommodate 64 q-heads at most, so for 128 q-heads we need to load all kv-cache data twice, we can see for 64 q-heads the BWUtil is up to 85%, for 128 q-heads BWUtil is up to 44% * 2 (88% is higher than 85%, I think it's because of the L2 cache benefit), you can also make a comparison with the benchmark screenshot of the cuda-core implementation:
[#551](https://github.com/flashinfer-ai/flashinfer/pull/551)

### Limitation:
- The current implementation only supports q-heads num to be multiple of 64, which is ok for normal version of Deepseek models, but not compatible with lite version models which have 16 q-heads num. We need a different tiled-mma layout design for 16 q-heads.
- Not support for SM75, since the mma wrapper in CuTe for SM75 is rather limited.