### PR TITLE
bugfix: Fix block-sparse attention API

### DIFF
--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -583,8 +583,8 @@ class BlockSparseAttentionWrapper:
                 self._paged_kv_indptr_buf,
                 self._paged_kv_indices_buf,
                 self._paged_kv_last_page_len,
-                lse,
                 out,
+                lse,
                 TensorLayout[self._kv_layout].value,
                 -1,  # window_left
                 _get_cache_alibi_slopes_buf(q.shape[1], self.device),


### PR DESCRIPTION
This pull request includes a small change to the `flashinfer/sparse.py` file. The change reorders the `lse` parameter to ensure it is placed correctly in the argument list.

* [`flashinfer/sparse.py`](diffhunk://#diff-de586226b1037125dbf7d04b1037c052a7651cd335e01fabd39400ee877054fdL586-R587): Reordered the `lse` parameter in the `run` method to follow the `out` parameter.