### PR TITLE
refactor: change the structure of attention updater

### DIFF
--- a/include/flashinfer/attention/hopper/attention_updater.cuh
+++ b/include/flashinfer/attention/hopper/attention_updater.cuh
@@ -252,12 +252,6 @@ struct OnlineSoftmax {
   };
 };
 
-template <int NUM_ROWS_PER_THREAD>
-using OnlineSoftmaxWithScale = OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/true>;
-
-template <int NUM_ROWS_PER_THREAD>
-using OnlineSoftmaxWithoutScale = OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/false>;
-
 }  // namespace flashinfer
 
 #endif  // FLASHINFER_ATTENTION_HOPPER_ATTENTION_UPDATER_CUH_

--- a/include/flashinfer/attention/hopper/attention_updater.cuh
+++ b/include/flashinfer/attention/hopper/attention_updater.cuh
@@ -143,8 +143,7 @@ template <int NUM_ROWS_PER_THREAD>
 struct DefaultUpdater {
   using TensorT = decltype(make_tensor<float>(Shape<Int<NUM_ROWS_PER_THREAD>>{}));
   constexpr static float fill_value = 0.f;
-  template <typename MainloopParams>
-  CUTLASS_DEVICE DefaultUpdater(MainloopParams params) {};
+  CUTLASS_DEVICE DefaultUpdater() {};
 
   __forceinline__ __device__ TensorT get_lse() { return TensorT(); }
 
@@ -171,13 +170,7 @@ struct OnlineSoftmax {
   TensorT row_max, row_sum, scores_scale;
   float sm_scale_log2;
 
-  template <typename MainloopParams>
-  CUTLASS_DEVICE OnlineSoftmax(MainloopParams params) {
-    if constexpr (WITH_SCALE) {
-      sm_scale_log2 = params.additional_params.sm_scale * math::log2e;
-    } else {
-      sm_scale_log2 = 0.f;
-    }
+  CUTLASS_DEVICE OnlineSoftmax(float sm_scale_log2) : sm_scale_log2(sm_scale_log2) {
     clear(scores_scale);
   };
 

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -194,7 +194,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           block_coord;
 
       AttentionVariant variant(mainloop_params, block_coord);
-      auto attention_updater = variant.GetAttentionUpdater<2 * (2 * CTA_Q / NUM_MMA_THREADS)>();
+      auto attention_updater =
+          variant.template GetAttentionUpdater<2 * (2 * CTA_Q / NUM_MMA_THREADS)>();
 
       if (q_tile_idx * CTA_Q >= qo_len) {
         continue;

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -14,7 +14,6 @@
 #include <cutlass/cutlass.h>
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
-#include <driver_types.h>
 
 #include <type_traits>
 #include <vector>
@@ -60,8 +59,6 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
 
   static constexpr bool use_tma_load_kv = CollectiveMainloop::USE_TMA_LOAD_KV;
 
-  using AttentionUpdater =
-      typename AttentionVariant::template Updater<2 * (2 * CTA_Q / NUM_MMA_THREADS)>;
   using MainloopPipeline = typename CollectiveMainloop::MainloopPipeline;
   using PipelineParams = typename MainloopPipeline::Params;
   using PipelineState = typename MainloopPipeline::PipelineState;
@@ -191,13 +188,13 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
                                                                                   work_tile_info)) {
       // Attention output (GEMM-II) accumulator.
       Tensor tOrO = partition_fragment_C(tiled_mma_pv, select<0, 1>(TileShape_PDV{}));
-      AttentionUpdater attention_updater(mainloop_params);
 
       auto block_coord = work_tile_info.get_block_coord(scheduler_params);
       auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len] =
           block_coord;
 
       AttentionVariant variant(mainloop_params, block_coord);
+      auto attention_updater = variant.GetAttentionUpdater<2 * (2 * CTA_Q / NUM_MMA_THREADS)>();
 
       if (q_tile_idx * CTA_Q >= qo_len) {
         continue;

--- a/include/flashinfer/attention/hopper/variants.cuh
+++ b/include/flashinfer/attention/hopper/variants.cuh
@@ -32,7 +32,7 @@ struct StandardAttention {
   }
 
   template <int NUM_ROWS_PER_THREAD>
-  auto GetAttentionUpdater() {
+  __device__ auto GetAttentionUpdater() {
     return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/true>(sm_scale_log2);
   }
 
@@ -56,7 +56,7 @@ struct LogitsSoftCap {
   }
 
   template <int NUM_ROWS_PER_THREAD>
-  auto GetAttentionUpdater() {
+  __device__ auto GetAttentionUpdater() {
     return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/false>(0.);
   }
 

--- a/include/flashinfer/attention/hopper/variants.cuh
+++ b/include/flashinfer/attention/hopper/variants.cuh
@@ -24,11 +24,17 @@
 namespace flashinfer {
 
 struct StandardAttention {
-  template <int NUM_ROWS_PER_THREAD>
-  using Updater = OnlineSoftmaxWithScale<NUM_ROWS_PER_THREAD>;
+  float sm_scale_log2;
 
   template <typename MainloopParams, typename BlockCoord>
-  __device__ StandardAttention(const MainloopParams& params, const BlockCoord& block_coord) {}
+  __device__ StandardAttention(const MainloopParams& params, const BlockCoord& block_coord) {
+    sm_scale_log2 = params.sm_scale * math::log2e;
+  }
+
+  template <int NUM_ROWS_PER_THREAD>
+  auto GetAttentionUpdater() {
+    return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/true>(sm_scale_log2);
+  }
 
   template <typename MainloopParams, typename T>
   __device__ __forceinline__ T LogitsTransform(const MainloopParams& params, T logits,
@@ -42,14 +48,16 @@ struct LogitsSoftCap {
   float pre_tanh_scale;
   float post_tanh_scale;
 
-  template <int NUM_ROWS_PER_THREAD>
-  using Updater = OnlineSoftmaxWithoutScale<NUM_ROWS_PER_THREAD>;
-
   template <typename MainloopParams, typename BlockCoord>
   __device__ LogitsSoftCap(const MainloopParams& params, const BlockCoord& block_coord) {
     pre_tanh_scale =
         params.additional_params.sm_scale * math::ptx_rcp(params.additional_params.logits_soft_cap);
     post_tanh_scale = math::log2e * params.additional_params.logits_soft_cap;
+  }
+
+  template <int NUM_ROWS_PER_THREAD>
+  auto GetAttentionUpdater() {
+    return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/false>(0.);
   }
 
   template <typename MainloopParams, typename T>

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -138,7 +138,7 @@ struct FlashSigmoid {
 
 
   template <int NUM_ROWS_PER_THREAD>
-  auto GetAttentionUpdater() {
+  __device__ auto GetAttentionUpdater() {
     return DefaultUpdater<NUM_ROWS_PER_THREAD>();
   }
 
@@ -695,7 +695,7 @@ struct DebugPrintLogits {
 
 
   template <int NUM_ROWS_PER_THREAD>
-  auto GetAttentionUpdater() {
+  __device__ auto GetAttentionUpdater() {
     return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE*/true>(sm_scale_log2);
   }
 

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -128,15 +128,18 @@ struct FlashSigmoid {
 
 flash_sigmoid_sm90_decl = r"""
 struct FlashSigmoid {
-  template <int NUM_ROWS_PER_THREAD>
-  using Updater = DefaultUpdater<NUM_ROWS_PER_THREAD>;
-
   float logits_scale_log2, sigmoid_bias_log2e;
   // Init
   template <typename MainloopParams, typename BlockCoord>
   __device__ __host__ FlashSigmoid(const MainloopParams& params, const BlockCoord& block_coord) {
     logits_scale_log2 = params.additional_params.logits_scale * math::log2e;
     sigmoid_bias_log2e = params.additional_params.sigmoid_bias * math::log2e;
+  }
+
+
+  template <int NUM_ROWS_PER_THREAD>
+  auto GetAttentionUpdater() {
+    return DefaultUpdater<NUM_ROWS_PER_THREAD>();
   }
 
   template <typename MainloopParams, typename T>
@@ -676,10 +679,6 @@ def test_sm90_debug_print_logits():
     torch.manual_seed(42)
     variant_decl = r"""
 struct DebugPrintLogits {
-
-  template <int NUM_ROWS_PER_THREAD>
-  using Updater = OnlineSoftmaxWithoutScale<NUM_ROWS_PER_THREAD>;
-
   float sm_scale_log2;
   int qo_len, kv_len;
 
@@ -693,6 +692,13 @@ struct DebugPrintLogits {
     qo_len = qo_len_;
     kv_len = kv_len_;
   }
+
+
+  template <int NUM_ROWS_PER_THREAD>
+  auto GetAttentionUpdater() {
+    return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE*/true>(sm_scale_log2);
+  }
+
 
   template <typename MainloopParams, typename T>
   __device__ __forceinline__ T LogitsTransform(const MainloopParams& params, T logits,


### PR DESCRIPTION
Per discussion with @happierpig , user should be able to construct attention updater in their own way (and parameters).

We change the JIT interface a little bit: let user define a `GetAttentionUpdater` function for attention updater construction, so that user can compute some values in the attention variant constructor and pass them to the constructor. One example is head-wise scale for fp8 attention, where user can pre-compute `qk_scale` in the attention variant constructor, then pass it to OnlineSoftmax (with scale) constructor.