### PR TITLE
perf: refactor fa2 template to unlock half-mma

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -65,42 +65,115 @@ constexpr uint32_t get_num_mma_q(const uint32_t cta_tile_q) {
   }
 }
 
+template <uint32_t NUM_WARPS_KV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK,
+          uint32_t HEAD_DIM_VO, typename DTypeQ, typename DTypeKV, typename DTypeO>
+struct SharedStorageQKVO {
+  union {
+    struct {
+      alignas(16) DTypeQ q_smem[CTA_TILE_Q * HEAD_DIM_QK];
+      alignas(16) DTypeKV k_smem[CTA_TILE_KV * HEAD_DIM_QK];
+      alignas(16) DTypeKV v_smem[CTA_TILE_KV * HEAD_DIM_VO];
+    };
+    struct {
+      alignas(16) float cta_sync_o_smem[NUM_WARPS_KV * CTA_TILE_Q * HEAD_DIM_VO];
+      alignas(16) float2 cta_sync_md_smem[NUM_WARPS_KV * CTA_TILE_Q];
+    };
+    alignas(16) DTypeO smem_o[CTA_TILE_Q * HEAD_DIM_VO];
+  };
+};
+
+template <uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          typename DTypeQ, typename DTypeKV, typename DTypeO>
+struct SharedStorageQKVO<1, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV,
+                         DTypeO> {
+  union {
+    struct {
+      alignas(16) DTypeQ q_smem[CTA_TILE_Q * HEAD_DIM_QK];
+      alignas(16) DTypeKV k_smem[CTA_TILE_KV * HEAD_DIM_QK];
+      alignas(16) DTypeKV v_smem[CTA_TILE_KV * HEAD_DIM_VO];
+    };
+    alignas(16) DTypeO o_smem[CTA_TILE_Q * HEAD_DIM_VO];
+  };
+};
+
+template <uint32_t NUM_MMA_Q_, uint32_t NUM_MMA_KV_, uint32_t NUM_MMA_D_QK_, uint32_t NUM_MMA_D_VO_,
+          uint32_t NUM_WARPS_Q_, uint32_t NUM_WARPS_KV_, PosEncodingMode POS_ENCODING_MODE_,
+          typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename DTypeQKAccum_,
+          typename IdType_, typename AttentionVariant_>
+struct KernelTraits {
+  static constexpr uint32_t NUM_MMA_Q = NUM_MMA_Q_;
+  static constexpr uint32_t NUM_MMA_KV = NUM_MMA_KV_;
+  static constexpr uint32_t NUM_MMA_D_QK = NUM_MMA_D_QK_;
+  static constexpr uint32_t NUM_MMA_D_VO = NUM_MMA_D_VO_;
+  static constexpr uint32_t NUM_WARPS_Q = NUM_WARPS_Q_;
+  static constexpr uint32_t NUM_WARPS_KV = NUM_WARPS_KV_;
+  static constexpr uint32_t NUM_THREADS = NUM_WARPS_Q * NUM_WARPS_KV * WARP_SIZE;
+  static constexpr uint32_t NUM_WARPS = NUM_WARPS_Q * NUM_WARPS_KV;
+  static constexpr uint32_t HEAD_DIM_QK = NUM_MMA_D_QK * 16;
+  static constexpr uint32_t HEAD_DIM_VO = NUM_MMA_D_VO * 16;
+  static constexpr uint32_t UPCAST_HEAD_DIM_Q = HEAD_DIM_QK / upcast_size<DTypeQ_>();
+  static constexpr uint32_t UPCAST_HEAD_DIM_K = HEAD_DIM_QK / upcast_size<DTypeKV_>();
+  static constexpr uint32_t UPCAST_HEAD_DIM_V = HEAD_DIM_VO / upcast_size<DTypeKV_>();
+  static constexpr uint32_t UPCAST_HEAD_DIM_O = HEAD_DIM_VO / upcast_size<DTypeO_>();
+  static constexpr uint32_t CTA_TILE_Q = NUM_MMA_Q * NUM_WARPS_Q * 16;
+  static constexpr uint32_t CTA_TILE_KV = NUM_MMA_KV * NUM_WARPS_KV * 16;
+
+  static constexpr SwizzleMode SWIZZLE_MODE_Q = SwizzleMode::k128B;
+  static constexpr SwizzleMode SWIZZLE_MODE_KV =
+      (sizeof(DTypeKV_) == 1 && HEAD_DIM_VO == 64) ? SwizzleMode::k64B : SwizzleMode::k128B;
+  static constexpr PosEncodingMode POS_ENCODING_MODE = POS_ENCODING_MODE_;
+  using DTypeQ = DTypeQ_;
+  using DTypeKV = DTypeKV_;
+  using DTypeO = DTypeO_;
+  using DTypeQKAccum = DTypeQKAccum_;
+  using IdType = IdType_;
+  using AttentionVariant = AttentionVariant_;
+
+  static constexpr bool IsInvalid() {
+    return ((NUM_MMA_D_VO < 4) || (NUM_MMA_D_VO == 4 && NUM_MMA_KV % 2 == 1) ||
+            (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && NUM_MMA_D_VO > 4 &&
+             NUM_MMA_D_VO % (2 * NUM_WARPS_Q) != 0) ||
+            (NUM_MMA_Q * (8 * NUM_MMA_D_VO + 2 * sizeof(DTypeQKAccum) * NUM_MMA_KV) >= 256) ||
+            (sizeof(DTypeKV) == 1 && NUM_MMA_KV * 2 % NUM_WARPS_Q != 0) ||
+            (sizeof(DTypeKV) == 1 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
+  }
+
+  static constexpr size_t SmemSizeThreadBlockAttnSync() {
+    if constexpr (NUM_WARPS_KV == 1) {
+      return 0;
+    } else {
+      return NUM_WARPS_KV * CTA_TILE_Q * HEAD_DIM_VO * sizeof(float) +
+             NUM_WARPS_KV * CTA_TILE_Q * 2 * sizeof(float);
+    }
+  }
+
+  using SharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
+                                          HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
+};
+
 namespace {
 
-template <PosEncodingMode POS_ENCODING_MODE, typename DTypeKV, typename DTypeQKAccum>
-constexpr bool is_invalid_configuration(uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_QK,
-                                        uint32_t NUM_MMA_D_VO, uint32_t NUM_MMA_KV,
-                                        uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV) {
-  return ((NUM_MMA_D_VO < 4) || (NUM_MMA_D_VO == 4 && NUM_MMA_KV % 2 == 1) ||
-          (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && NUM_MMA_D_VO > 4 &&
-           NUM_MMA_D_VO % (2 * NUM_WARPS_Q) != 0) ||
-          (NUM_MMA_Q * (8 * NUM_MMA_D_VO + 2 * sizeof(DTypeQKAccum) * NUM_MMA_KV) >= 256) ||
-          (sizeof(DTypeKV) == 1 && NUM_MMA_KV * 2 % NUM_WARPS_Q != 0) ||
-          (sizeof(DTypeKV) == 1 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
-}
-
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV>
+template <typename KTraits>
 __device__ __forceinline__ uint32_t get_warp_idx_q() {
-  if constexpr (NUM_WARPS_Q == 1) {
+  if constexpr (KTraits::NUM_WARPS_Q == 1) {
     return 0;
   } else {
     return threadIdx.y;
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV>
+template <typename KTraits>
 __device__ __forceinline__ uint32_t get_warp_idx_kv() {
-  if constexpr (NUM_WARPS_KV == 1) {
+  if constexpr (KTraits::NUM_WARPS_KV == 1) {
     return 0;
   } else {
     return threadIdx.z;
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV>
+template <typename KTraits>
 __device__ __forceinline__ uint32_t get_warp_idx() {
-  return get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_WARPS_Q +
-         get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>();
+  return get_warp_idx_kv<KTraits>() * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>();
 }
 
 /*!
@@ -186,107 +259,111 @@ __device__ __forceinline__ void q_frag_apply_llama_rope_with_pos(T* x_first_half
  * \param kv_idx_base The base kv index.
  * \param kv_len The length of kv tensor.
  */
-template <SharedMemFillMode fill_mode, uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV,
-          uint32_t NUM_MMA_D, uint32_t NUM_MMA_KV, SwizzleMode swizzle_mode, typename T>
-__device__ __forceinline__ void produce_kv(smem_t<swizzle_mode> smem, uint32_t* smem_offset,
-                                           T** gptr, const uint32_t stride_n,
-                                           const uint32_t kv_idx_base, const uint32_t kv_len) {
-  // NOTE(Zihao): for fp8, this function doesn't work for head_dim = 64 at the moment
-  constexpr uint32_t head_dim = NUM_MMA_D * 16;
-  constexpr uint32_t num_warps = NUM_WARPS_Q * NUM_WARPS_KV;
-  constexpr uint32_t upcast_head_dim_kv = head_dim / upcast_size<T>();
-  const uint32_t warp_idx = get_warp_idx<NUM_WARPS_Q, NUM_WARPS_KV>(), lane_idx = threadIdx.x;
+template <bool produce_v, SharedMemFillMode fill_mode, typename KTraits>
+__device__ __forceinline__ void produce_kv(smem_t<KTraits::SWIZZLE_MODE_KV> smem,
+                                           uint32_t* smem_offset, typename KTraits::DTypeKV** gptr,
+                                           const uint32_t stride_n, const uint32_t kv_idx_base,
+                                           const uint32_t kv_len) {
+  // NOTE: for fp8, this function doesn't work for head_dim = 64 at the moment
+  using DTypeKV = typename KTraits::DTypeKV;
+  constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS;
+  constexpr uint32_t NUM_MMA_D = produce_v ? KTraits::NUM_MMA_D_VO : KTraits::NUM_MMA_D_QK;
+  constexpr uint32_t UPCAST_HEAD_DIM =
+      produce_v ? KTraits::UPCAST_HEAD_DIM_V : KTraits::UPCAST_HEAD_DIM_K;
+  const uint32_t warp_idx = get_warp_idx<KTraits>(), lane_idx = threadIdx.x;
 
-  if constexpr (swizzle_mode == SwizzleMode::k128B) {
+  if constexpr (KTraits::SWIZZLE_MODE_KV == SwizzleMode::k128B) {
     uint32_t kv_idx = kv_idx_base + warp_idx * 4 + lane_idx / 8;
-    // NOTE(Zihao): NUM_MMA_KV * 4 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 4 / num_warps
-    static_assert(NUM_MMA_KV * 4 % NUM_WARPS_Q == 0);
+    // NOTE: NUM_MMA_KV * 4 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 4 / num_warps
+    static_assert(KTraits::NUM_MMA_KV * 4 % KTraits::NUM_WARPS_Q == 0);
 #pragma unroll
-    for (uint32_t i = 0; i < NUM_MMA_KV * 4 / NUM_WARPS_Q; ++i) {
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV * 4 / KTraits::NUM_WARPS_Q; ++i) {
 #pragma unroll
-      for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(T)); ++j) {
+      for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DTypeKV)); ++j) {
         smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
         *smem_offset = smem.template advance_offset_by_column<8>(*smem_offset, j);
-        *gptr += 8 * upcast_size<T>();
+        *gptr += 8 * upcast_size<DTypeKV>();
       }
-      kv_idx += num_warps * 4;
+      kv_idx += NUM_WARPS * 4;
       *smem_offset =
-          smem.template advance_offset_by_row<num_warps * 4, upcast_head_dim_kv>(*smem_offset) -
-          sizeof(T) * NUM_MMA_D;
-      *gptr += num_warps * 4 * stride_n - sizeof(T) * NUM_MMA_D * upcast_size<T>();
+          smem.template advance_offset_by_row<NUM_WARPS * 4, UPCAST_HEAD_DIM>(*smem_offset) -
+          sizeof(DTypeKV) * NUM_MMA_D;
+      *gptr += NUM_WARPS * 4 * stride_n - sizeof(DTypeKV) * NUM_MMA_D * upcast_size<DTypeKV>();
     }
-    *smem_offset -= NUM_WARPS_KV * NUM_MMA_KV * 16 * upcast_head_dim_kv;
+    *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_HEAD_DIM;
   } else {
     uint32_t kv_idx = kv_idx_base + warp_idx * 8 + lane_idx / 4;
-    // NOTE(Zihao): NUM_MMA_KV * 2 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 2 / num_warps
-    static_assert(NUM_MMA_KV * 2 % NUM_WARPS_Q == 0);
+    // NOTE: NUM_MMA_KV * 2 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 2 / num_warps
+    static_assert(KTraits::NUM_MMA_KV * 2 % KTraits::NUM_WARPS_Q == 0);
 #pragma unroll
-    for (uint32_t i = 0; i < NUM_MMA_KV * 2 / NUM_WARPS_Q; ++i) {
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV * 2 / KTraits::NUM_WARPS_Q; ++i) {
       smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
       *smem_offset =
-          smem.template advance_offset_by_row<num_warps * 8, upcast_head_dim_kv>(*smem_offset);
-      kv_idx += num_warps * 8;
-      *gptr += num_warps * 8 * stride_n;
+          smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_HEAD_DIM>(*smem_offset);
+      kv_idx += NUM_WARPS * 8;
+      *gptr += NUM_WARPS * 8 * stride_n;
     }
-    *smem_offset -= NUM_WARPS_KV * NUM_MMA_KV * 16 * upcast_head_dim_kv;
+    *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_HEAD_DIM;
   }
 }
 
-template <bool produce_v, uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_D_VO,
-          uint32_t NUM_MMA_KV, SwizzleMode swizzle_mode, typename DType, typename IdType>
-__device__ __forceinline__ void page_produce_kv(smem_t<swizzle_mode> smem, uint32_t* smem_offset,
-                                                const paged_kv_t<DType, IdType>& paged_kv,
-                                                const uint32_t kv_idx_base, const size_t* kv_offset,
-                                                const uint32_t kv_len) {
-  // NOTE(Zihao): for fp8, this function doesn't work for head_dim = 64 at the moment
+template <bool produce_v, typename KTraits>
+__device__ __forceinline__ void page_produce_kv(
+    smem_t<KTraits::SWIZZLE_MODE_KV> smem, uint32_t* smem_offset,
+    const paged_kv_t<typename KTraits::DTypeKV, typename KTraits::IdType>& paged_kv,
+    const uint32_t kv_idx_base, const size_t* kv_offset, const uint32_t kv_len) {
+  // NOTE: for fp8, this function doesn't work for head_dim = 64 at the moment
+  using DType = typename KTraits::DTypeKV;
+  using IdType = typename KTraits::IdType;
   constexpr SharedMemFillMode fill_mode =
       produce_v ? SharedMemFillMode::kFillZero : SharedMemFillMode::kNoFill;
-  constexpr uint32_t head_dim = NUM_MMA_D_VO * 16;
-  constexpr uint32_t num_warps = NUM_WARPS_Q * NUM_WARPS_KV;
-  constexpr uint32_t upcast_head_dim_kv = head_dim / upcast_size<DType>();
-  const uint32_t warp_idx = get_warp_idx<NUM_WARPS_Q, NUM_WARPS_KV>(), lane_idx = threadIdx.x;
-  if constexpr (swizzle_mode == SwizzleMode::k128B) {
+  constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS_Q * KTraits::NUM_WARPS_KV;
+  constexpr uint32_t NUM_MMA_D = produce_v ? KTraits::NUM_MMA_D_VO : KTraits::NUM_MMA_D_QK;
+  constexpr uint32_t UPCAST_HEAD_DIM =
+      produce_v ? KTraits::UPCAST_HEAD_DIM_V : KTraits::UPCAST_HEAD_DIM_K;
+  const uint32_t warp_idx = get_warp_idx<KTraits>(), lane_idx = threadIdx.x;
+  if constexpr (KTraits::SWIZZLE_MODE_KV == SwizzleMode::k128B) {
     uint32_t kv_idx = kv_idx_base + warp_idx * 4 + lane_idx / 8;
-    // NOTE(Zihao): NUM_MMA_KV * 4 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 4 / num_warps
-    static_assert(NUM_MMA_KV * 4 % NUM_WARPS_Q == 0);
+    // NOTE: NUM_MMA_KV * 4 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 4 / num_warps
+    static_assert(KTraits::NUM_MMA_KV * 4 % KTraits::NUM_WARPS_Q == 0);
 #pragma unroll
-    for (uint32_t i = 0; i < NUM_MMA_KV * 4 / NUM_WARPS_Q; ++i) {
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV * 4 / KTraits::NUM_WARPS_Q; ++i) {
       DType* gptr = produce_v ? paged_kv.v_data + kv_offset[i] : paged_kv.k_data + kv_offset[i];
 #pragma unroll
-      for (uint32_t j = 0; j < NUM_MMA_D_VO / (8 / sizeof(DType)); ++j) {
+      for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DType)); ++j) {
         smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
         *smem_offset = smem.template advance_offset_by_column<8>(*smem_offset, j);
         gptr += 8 * upcast_size<DType>();
       }
-      kv_idx += num_warps * 4;
+      kv_idx += NUM_WARPS * 4;
       *smem_offset =
-          smem.template advance_offset_by_row<num_warps * 4, upcast_head_dim_kv>(*smem_offset) -
-          sizeof(DType) * NUM_MMA_D_VO;
+          smem.template advance_offset_by_row<NUM_WARPS * 4, UPCAST_HEAD_DIM>(*smem_offset) -
+          sizeof(DType) * NUM_MMA_D;
     }
-    *smem_offset -= NUM_WARPS_KV * NUM_MMA_KV * 16 * upcast_head_dim_kv;
+    *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_HEAD_DIM;
   } else {
     uint32_t kv_idx = kv_idx_base + warp_idx * 8 + lane_idx / 4;
-    // NOTE(Zihao): NUM_MMA_KV * 2 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 2 / num_warps
-    static_assert(NUM_MMA_KV * 2 % NUM_WARPS_Q == 0);
+    // NOTE: NUM_MMA_KV * 2 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 2 / num_warps
+    static_assert(KTraits::NUM_MMA_KV * 2 % KTraits::NUM_WARPS_Q == 0);
 #pragma unroll
-    for (uint32_t i = 0; i < NUM_MMA_KV * 2 / NUM_WARPS_Q; ++i) {
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV * 2 / KTraits::NUM_WARPS_Q; ++i) {
       DType* gptr = produce_v ? paged_kv.v_data + kv_offset[i] : paged_kv.k_data + kv_offset[i];
       smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
-      kv_idx += num_warps * 8;
+      kv_idx += NUM_WARPS * 8;
       *smem_offset =
-          smem.template advance_offset_by_row<num_warps * 8, upcast_head_dim_kv>(*smem_offset);
+          smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_HEAD_DIM>(*smem_offset);
     }
-    *smem_offset -= NUM_WARPS_KV * NUM_MMA_KV * 16 * upcast_head_dim_kv;
+    *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_HEAD_DIM;
   }
 }
 
-template <uint32_t NUM_MMA_D_VO>
+template <typename KTraits>
 __device__ __forceinline__ void init_rope_freq(float (*rope_freq)[4], const float rope_rcp_scale,
                                                const float rope_rcp_theta) {
-  constexpr uint32_t head_dim = NUM_MMA_D_VO * 16;
+  constexpr uint32_t head_dim = KTraits::NUM_MMA_D_VO * 16;
   const uint32_t lane_idx = threadIdx.x;
 #pragma unroll
-  for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO / 2; ++mma_d) {
+  for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO / 2; ++mma_d) {
 #pragma unroll
     for (uint32_t j = 0; j < 4; ++j) {
       rope_freq[mma_d][j] =
@@ -299,15 +376,14 @@ __device__ __forceinline__ void init_rope_freq(float (*rope_freq)[4], const floa
   }
 }
 
-template <uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_VO, typename DTypeQKAccum,
-          typename AttentionVariant>
-__device__ __forceinline__ void init_states(AttentionVariant variant,
-                                            float (*o_frag)[NUM_MMA_D_VO][8], DTypeQKAccum (*m)[2],
-                                            float (*d)[2]) {
+template <typename KTraits>
+__device__ __forceinline__ void init_states(typename KTraits::AttentionVariant variant,
+                                            float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                            typename KTraits::DTypeQKAccum (*m)[2], float (*d)[2]) {
 #pragma unroll
-  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+  for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-    for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
 #pragma unroll
       for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
         o_frag[mma_q][mma_d][reg_id] = 0.f;
@@ -317,34 +393,31 @@ __device__ __forceinline__ void init_states(AttentionVariant variant,
 
   if constexpr (variant.use_softmax) {
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
-        m[mma_q][j] = DTypeQKAccum(-math::inf);
+        m[mma_q][j] = typename KTraits::DTypeQKAccum(-math::inf);
         d[mma_q][j] = 1.f;
       }
     }
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_QK,
-          SwizzleMode swizzle_mode, typename DTypeQ>
-__device__ __forceinline__ void load_q_global_smem(uint32_t packed_offset,
-                                                   const uint32_t qo_upper_bound,
-                                                   DTypeQ* q_ptr_base, const uint32_t q_stride_n,
-                                                   const uint32_t q_stride_h,
-                                                   const uint_fastdiv group_size,
-                                                   smem_t<swizzle_mode>* q_smem) {
-  constexpr uint32_t head_dim = NUM_MMA_D_QK * 16;
-  constexpr uint32_t upcast_head_dim_q = head_dim / upcast_size<DTypeQ>();
-  const uint32_t lane_idx = threadIdx.x, warp_idx_x = get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>();
+template <typename KTraits>
+__device__ __forceinline__ void load_q_global_smem(
+    uint32_t packed_offset, const uint32_t qo_upper_bound, typename KTraits::DTypeQ* q_ptr_base,
+    const uint32_t q_stride_n, const uint32_t q_stride_h, const uint_fastdiv group_size,
+    smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem) {
+  using DTypeQ = typename KTraits::DTypeQ;
+  constexpr uint32_t UPCAST_HEAD_DIM_Q = KTraits::UPCAST_HEAD_DIM_Q;
+  const uint32_t lane_idx = threadIdx.x, warp_idx_x = get_warp_idx_q<KTraits>();
 
-  if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
-    uint32_t q_smem_offset_w = q_smem->get_permuted_offset<upcast_head_dim_q>(
-        warp_idx_x * NUM_MMA_Q * 16 + lane_idx / 8, lane_idx % 8);
+  if (get_warp_idx_kv<KTraits>() == 0) {
+    uint32_t q_smem_offset_w = q_smem->get_permuted_offset<UPCAST_HEAD_DIM_Q>(
+        warp_idx_x * KTraits::NUM_MMA_Q * 16 + lane_idx / 8, lane_idx % 8);
 
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 4; ++j) {
         uint32_t q, r;
@@ -352,7 +425,7 @@ __device__ __forceinline__ void load_q_global_smem(uint32_t packed_offset,
         const uint32_t q_idx = q;
         DTypeQ* q_ptr = q_ptr_base + q * q_stride_n + r * q_stride_h;
 #pragma unroll
-        for (uint32_t mma_do = 0; mma_do < NUM_MMA_D_QK / 4; ++mma_do) {
+        for (uint32_t mma_do = 0; mma_do < KTraits::NUM_MMA_D_QK / 4; ++mma_do) {
           // load q fragment from gmem to smem
           q_smem->load_128b_async<SharedMemFillMode::kNoFill>(q_smem_offset_w, q_ptr,
                                                               q_idx < qo_upper_bound);
@@ -360,36 +433,36 @@ __device__ __forceinline__ void load_q_global_smem(uint32_t packed_offset,
           q_ptr += 8 * upcast_size<DTypeQ>();
         }
         q_smem_offset_w =
-            q_smem->template advance_offset_by_row<4, upcast_head_dim_q>(q_smem_offset_w) -
-            2 * NUM_MMA_D_QK;
+            q_smem->template advance_offset_by_row<4, UPCAST_HEAD_DIM_Q>(q_smem_offset_w) -
+            2 * KTraits::NUM_MMA_D_QK;
       }
     }
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_QK,
-          SwizzleMode swizzle_mode, typename DTypeQ>
+template <typename KTraits>
 __device__ __forceinline__ void q_smem_inplace_apply_rotary(
     const uint32_t q_packed_idx, const uint32_t qo_len, const uint32_t kv_len,
-    const uint_fastdiv group_size, smem_t<swizzle_mode>* q_smem, uint32_t* q_smem_offset_r,
-    float (*rope_freq)[4]) {
-  if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
-    constexpr uint32_t head_dim = NUM_MMA_D_QK * 16;
-    constexpr uint32_t upcast_head_dim_q = head_dim / upcast_size<DTypeQ>();
+    const uint_fastdiv group_size, smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem,
+    uint32_t* q_smem_offset_r, float (*rope_freq)[4]) {
+  if (get_warp_idx_kv<KTraits>() == 0) {
+    constexpr uint32_t UPCAST_HEAD_DIM_Q = KTraits::UPCAST_HEAD_DIM_Q;
     const uint32_t lane_idx = threadIdx.x;
     uint32_t q_frag_local[2][4];
-    static_assert(NUM_MMA_D_QK % 4 == 0, "NUM_MMA_D_QK must be a multiple of 4");
+    static_assert(KTraits::NUM_MMA_D_QK % 4 == 0, "NUM_MMA_D_QK must be a multiple of 4");
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
       uint32_t q_smem_offset_r_first_half = *q_smem_offset_r;
 #pragma unroll
-      for (uint32_t mma_di = 0; mma_di < NUM_MMA_D_QK / 2; ++mma_di) {
+      for (uint32_t mma_di = 0; mma_di < KTraits::NUM_MMA_D_QK / 2; ++mma_di) {
         q_smem->ldmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
         uint32_t q_smem_offset_r_last_half =
-            q_smem->template advance_offset_by_column<NUM_MMA_D_QK>(q_smem_offset_r_first_half, 0);
+            q_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(
+                q_smem_offset_r_first_half, 0);
         q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
-        q_frag_apply_llama_rope<DTypeQ>(
-            (DTypeQ*)q_frag_local[0], (DTypeQ*)q_frag_local[1], rope_freq[mma_di],
+        q_frag_apply_llama_rope<typename KTraits::DTypeQ>(
+            (typename KTraits::DTypeQ*)q_frag_local[0], (typename KTraits::DTypeQ*)q_frag_local[1],
+            rope_freq[mma_di],
             q_packed_idx + kv_len * group_size - qo_len * group_size + mma_q * 16 + lane_idx / 4,
             group_size);
         q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
@@ -397,58 +470,58 @@ __device__ __forceinline__ void q_smem_inplace_apply_rotary(
         q_smem_offset_r_first_half =
             q_smem->template advance_offset_by_column<2>(q_smem_offset_r_first_half, mma_di);
       }
-      *q_smem_offset_r += 16 * upcast_head_dim_q;
+      *q_smem_offset_r += 16 * UPCAST_HEAD_DIM_Q;
     }
-    *q_smem_offset_r -= NUM_MMA_Q * 16 * upcast_head_dim_q;
+    *q_smem_offset_r -= KTraits::NUM_MMA_Q * 16 * UPCAST_HEAD_DIM_Q;
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_QK,
-          SwizzleMode swizzle_mode, typename DTypeQ, typename IdType>
+template <typename KTraits>
 __device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos(
-    const uint32_t q_packed_idx_base, const IdType* q_rope_offset, smem_t<swizzle_mode>* q_smem,
-    const uint_fastdiv group_size, uint32_t* q_smem_offset_r, float (*rope_freq)[4]) {
-  if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
-    constexpr uint32_t head_dim = NUM_MMA_D_QK * 16;
-    constexpr uint32_t upcast_head_dim_q = head_dim / upcast_size<DTypeQ>();
+    const uint32_t q_packed_idx_base, const typename KTraits::IdType* q_rope_offset,
+    smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem, const uint_fastdiv group_size,
+    uint32_t* q_smem_offset_r, float (*rope_freq)[4]) {
+  if (get_warp_idx_kv<KTraits>() == 0) {
+    constexpr uint32_t UPCAST_HEAD_DIM_Q = KTraits::UPCAST_HEAD_DIM_Q;
     const uint32_t lane_idx = threadIdx.x;
     uint32_t q_frag_local[2][4];
-    static_assert(NUM_MMA_D_QK % 4 == 0, "NUM_MMA_D must be a multiple of 4");
+    static_assert(KTraits::NUM_MMA_D_QK % 4 == 0, "NUM_MMA_D_QK must be a multiple of 4");
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
       uint32_t q_smem_offset_r_first_half = *q_smem_offset_r;
 #pragma unroll
-      for (uint32_t mma_di = 0; mma_di < NUM_MMA_D_QK / 2; ++mma_di) {
+      for (uint32_t mma_di = 0; mma_di < KTraits::NUM_MMA_D_QK / 2; ++mma_di) {
         q_smem->ldmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
         uint32_t q_smem_offset_r_last_half =
-            q_smem->template advance_offset_by_column<NUM_MMA_D_QK>(q_smem_offset_r_first_half, 0);
+            q_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(
+                q_smem_offset_r_first_half, 0);
         q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
-        q_frag_apply_llama_rope_with_pos<DTypeQ>(
-            (DTypeQ*)q_frag_local[0], (DTypeQ*)q_frag_local[1], rope_freq[mma_di],
-            q_packed_idx_base + mma_q * 16 + lane_idx / 4, group_size, q_rope_offset);
+        q_frag_apply_llama_rope_with_pos<typename KTraits::DTypeQ, typename KTraits::IdType>(
+            (typename KTraits::DTypeQ*)q_frag_local[0], (typename KTraits::DTypeQ*)q_frag_local[1],
+            rope_freq[mma_di], q_packed_idx_base + mma_q * 16 + lane_idx / 4, group_size,
+            q_rope_offset);
         q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
         q_smem->stmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
         q_smem_offset_r_first_half =
             q_smem->template advance_offset_by_column<2>(q_smem_offset_r_first_half, mma_di);
       }
-      *q_smem_offset_r += 16 * upcast_head_dim_q;
+      *q_smem_offset_r += 16 * UPCAST_HEAD_DIM_Q;
     }
-    *q_smem_offset_r -= NUM_MMA_Q * 16 * upcast_head_dim_q;
+    *q_smem_offset_r -= KTraits::NUM_MMA_Q * 16 * UPCAST_HEAD_DIM_Q;
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_QK,
-          SwizzleMode swizzle_mode, typename AttentionVariant, typename Params>
+template <typename KTraits, typename Params>
 __device__ __forceinline__ void q_smem_inplace_transform(const Params& params,
-                                                         AttentionVariant variant,
-                                                         smem_t<swizzle_mode>* q_smem) {
-  using DTypeQ = typename Params::DTypeQ;
-  const uint32_t warp_idx = get_warp_idx<NUM_WARPS_Q, NUM_WARPS_KV>(), lane_idx = threadIdx.x;
-  constexpr uint32_t head_dim = NUM_MMA_D_QK * 16;
-  constexpr uint32_t upcast_head_dim_q = head_dim / upcast_size<DTypeQ>();
-  constexpr uint32_t num_warps = NUM_WARPS_Q * NUM_WARPS_KV;
+                                                         typename KTraits::AttentionVariant variant,
+                                                         smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem) {
+  using DTypeQ = typename KTraits::DTypeQ;
+  const uint32_t warp_idx = get_warp_idx<KTraits>(), lane_idx = threadIdx.x;
+  constexpr uint32_t head_dim = KTraits::HEAD_DIM_QK;
+  constexpr uint32_t UPCAST_HEAD_DIM_Q = head_dim / upcast_size<DTypeQ>();
+  constexpr uint32_t num_warps = KTraits::NUM_WARPS;
 #pragma unroll
-  for (uint32_t i = 0; i < NUM_MMA_Q * head_dim / (NUM_WARPS_KV * 16); ++i) {
+  for (uint32_t i = 0; i < KTraits::NUM_MMA_Q * head_dim / (KTraits::NUM_WARPS_KV * 16); ++i) {
     vec_t<DTypeQ, 8> tmp;
     tmp.load((DTypeQ*)(q_smem->base) + (i * num_warps + warp_idx) * 256 + lane_idx * 8);
 #pragma unroll
@@ -459,34 +532,30 @@ __device__ __forceinline__ void q_smem_inplace_transform(const Params& params,
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_D_QK, uint32_t NUM_MMA_KV,
-          SwizzleMode swizzle_mode, typename DTypeKV>
-__device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_idx_base,
-                                                            smem_t<swizzle_mode>* k_smem,
-                                                            uint32_t* k_smem_offset_r,
-                                                            float (*rope_freq)[4]) {
+template <typename KTraits>
+__device__ __forceinline__ void k_smem_inplace_apply_rotary(
+    const uint32_t kv_idx_base, smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem, uint32_t* k_smem_offset_r,
+    float (*rope_freq)[4]) {
+  using DTypeKV = typename KTraits::DTypeKV;
   static_assert(sizeof(DTypeKV) == 2);
-  constexpr uint32_t head_dim = NUM_MMA_D_QK * 16;
-  constexpr uint32_t upcast_head_dim_kv = head_dim / upcast_size<DTypeKV>();
+  constexpr uint32_t UPCAST_HEAD_DIM_K = KTraits::UPCAST_HEAD_DIM_K;
   uint32_t k_frag_local[2][4];
   const uint32_t lane_idx = threadIdx.x;
-  if constexpr (NUM_MMA_D_QK == 4 && NUM_WARPS_Q == 4) {
-    static_assert(NUM_WARPS_KV == 1);
-    const uint32_t warp_idx = get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>();
-    // horizontal-axis: y
+  if constexpr (KTraits::NUM_MMA_D_QK == 4 && KTraits::NUM_WARPS_Q == 4) {
+    static_assert(KTraits::NUM_WARPS_KV == 1);
+    const uint32_t warp_idx = get_warp_idx_q<KTraits>();
     // horizontal-axis: y
     // vertical-axis: z
     //         | 1-16       | 16-32      | 32-48      | 48-64      |
     // | 1-16  | warp_idx=0 | warp_idx=1 | warp_idx=0 | warp_idx=1 |
     // | 16-32 | warp_idx=2 | warp_idx=3 | warp_idx=2 | warp_idx=3 |
-    static_assert(NUM_MMA_KV % 2 == 0,
+    static_assert(KTraits::NUM_MMA_KV % 2 == 0,
                   "when NUM_MMA_D_QK == 4, NUM_MMA_KV must be a multiple of 2");
     uint32_t kv_idx = kv_idx_base + (warp_idx / 2) * 16 + lane_idx / 4;
     *k_smem_offset_r =
-        (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) + (warp_idx / 2) * 16 * upcast_head_dim_kv;
+        (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) + (warp_idx / 2) * 16 * UPCAST_HEAD_DIM_K;
 #pragma unroll
-    for (uint32_t i = 0; i < NUM_MMA_KV / 2; ++i) {
-      // uint32_t mma_kv = warp_idx / 2 + i * 2;
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV / 2; ++i) {
       uint32_t k_smem_offset_r_first_half = *k_smem_offset_r;
       uint32_t mma_di = (warp_idx % 2);
       k_smem->ldmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
@@ -497,76 +566,74 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t kv_id
                                        rope_freq[mma_di], kv_idx);
       k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
       k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
-      *k_smem_offset_r += 32 * upcast_head_dim_kv;
+      *k_smem_offset_r += 32 * UPCAST_HEAD_DIM_K;
       kv_idx += 32;
     }
     *k_smem_offset_r = (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) -
-                       ((warp_idx / 2) + NUM_MMA_KV) * 16 * upcast_head_dim_kv;
+                       ((warp_idx / 2) + KTraits::NUM_MMA_KV) * 16 * UPCAST_HEAD_DIM_K;
   } else {
-    const uint32_t warp_idx_x = get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>(),
-                   warp_idx_z = get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>();
-    static_assert(NUM_MMA_D_QK % (2 * NUM_WARPS_Q) == 0);
+    const uint32_t warp_idx_x = get_warp_idx_q<KTraits>(), warp_idx_z = get_warp_idx_kv<KTraits>();
+    static_assert(KTraits::NUM_MMA_D_QK % (2 * KTraits::NUM_WARPS_Q) == 0);
     // horizontal axis: y
     // vertical axis: z
     // | (warp_idx_z, warp_idx_x)       | 1-16   | 16-32  | 32-48  | 48-64  | ...
     // | 1-16*NUM_MMA_KV               | (0, 0) | (0, 1) | (0, 2) | (0, 3) | ...
     // | 16*NUM_MMA_KV-32*NUM_MMA_KV  | (1, 0) | (1, 1) | (1, 2) | (1, 3) | ...
     // ...
-    uint32_t kv_idx = kv_idx_base + (warp_idx_z * NUM_MMA_KV * 16) + lane_idx / 4;
+    uint32_t kv_idx = kv_idx_base + (warp_idx_z * KTraits::NUM_MMA_KV * 16) + lane_idx / 4;
     *k_smem_offset_r = *k_smem_offset_r ^ (0x2 * warp_idx_x);
 #pragma unroll
-    for (uint32_t i = 0; i < NUM_MMA_KV; ++i) {
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV; ++i) {
       uint32_t k_smem_offset_r_first_half = *k_smem_offset_r;
 #pragma unroll
-      for (uint32_t j = 0; j < NUM_MMA_D_QK / (2 * NUM_WARPS_Q); ++j) {
-        uint32_t mma_di = warp_idx_x + j * NUM_WARPS_Q;
+      for (uint32_t j = 0; j < KTraits::NUM_MMA_D_QK / (2 * KTraits::NUM_WARPS_Q); ++j) {
+        uint32_t mma_di = warp_idx_x + j * KTraits::NUM_WARPS_Q;
         k_smem->ldmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
         uint32_t k_smem_offset_r_last_half =
-            k_smem->template advance_offset_by_column<NUM_MMA_D_QK>(k_smem_offset_r_first_half, 0);
+            k_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(
+                k_smem_offset_r_first_half, 0);
         k_smem->ldmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
         k_frag_apply_llama_rope<DTypeKV>((DTypeKV*)k_frag_local[0], (DTypeKV*)k_frag_local[1],
                                          rope_freq[mma_di], kv_idx);
         k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
         k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
-        k_smem_offset_r_first_half = k_smem->template advance_offset_by_column<2 * NUM_WARPS_Q>(
-            k_smem_offset_r_first_half, mma_di);
+        k_smem_offset_r_first_half =
+            k_smem->template advance_offset_by_column<2 * KTraits::NUM_WARPS_Q>(
+                k_smem_offset_r_first_half, mma_di);
       }
-      *k_smem_offset_r += 16 * upcast_head_dim_kv;
+      *k_smem_offset_r += 16 * UPCAST_HEAD_DIM_K;
       kv_idx += 16;
     }
     *k_smem_offset_r =
-        (*k_smem_offset_r ^ (0x2 * warp_idx_x)) - NUM_MMA_KV * 16 * upcast_head_dim_kv;
+        (*k_smem_offset_r ^ (0x2 * warp_idx_x)) - KTraits::NUM_MMA_KV * 16 * UPCAST_HEAD_DIM_K;
   }
 }
 
-template <uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_QK, uint32_t NUM_MMA_KV,
-          SwizzleMode swizzle_mode_q, SwizzleMode swizzle_mode_kv, typename DTypeQ,
-          typename DTypeKV, typename DTypeQKAccum>
-__device__ __forceinline__ void compute_qk(smem_t<swizzle_mode_q>* q_smem,
-                                           uint32_t* q_smem_offset_r,
-                                           smem_t<swizzle_mode_kv>* k_smem,
-                                           uint32_t* k_smem_offset_r,
-                                           DTypeQKAccum (*s_frag)[NUM_MMA_KV][8]) {
-  constexpr uint32_t head_dim = NUM_MMA_D_QK * 16;
-  constexpr uint32_t upcast_head_dim_q = head_dim / upcast_size<DTypeQ>();
-  constexpr uint32_t upcast_head_dim_k = head_dim / upcast_size<DTypeKV>();
-  uint32_t a_frag[NUM_MMA_Q][4], b_frag[4];
+template <typename KTraits>
+__device__ __forceinline__ void compute_qk(
+    smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem, uint32_t* q_smem_offset_r,
+    smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem, uint32_t* k_smem_offset_r,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
+  constexpr uint32_t head_dim = KTraits::NUM_MMA_D_QK * 16;
+  constexpr uint32_t UPCAST_HEAD_DIM_Q = head_dim / upcast_size<typename KTraits::DTypeQ>();
+  constexpr uint32_t UPCAST_HEAD_DIM_K = head_dim / upcast_size<typename KTraits::DTypeKV>();
+  uint32_t a_frag[KTraits::NUM_MMA_Q][4], b_frag[4];
   // compute q*k^T
 #pragma unroll
-  for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_QK; ++mma_d) {
+  for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_QK; ++mma_d) {
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
       q_smem->ldmatrix_m8n8x4(*q_smem_offset_r, a_frag[mma_q]);
       *q_smem_offset_r =
-          q_smem->template advance_offset_by_row<16, upcast_head_dim_q>(*q_smem_offset_r);
+          q_smem->template advance_offset_by_row<16, UPCAST_HEAD_DIM_Q>(*q_smem_offset_r);
     }
 
     *q_smem_offset_r = q_smem->template advance_offset_by_column<2>(*q_smem_offset_r, mma_d) -
-                       NUM_MMA_Q * 16 * upcast_head_dim_q;
+                       KTraits::NUM_MMA_Q * 16 * UPCAST_HEAD_DIM_Q;
 
 #pragma unroll
-    for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
-      if constexpr (sizeof(DTypeKV) == 1) {
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+      if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
         uint32_t b_frag_f8[2];
         if (mma_d % 2 == 0) {
           k_smem->ldmatrix_m8n8x4_left_half(*k_smem_offset_r, b_frag_f8);
@@ -575,24 +642,25 @@ __device__ __forceinline__ void compute_qk(smem_t<swizzle_mode_q>* q_smem,
         }
         b_frag_f8[0] = frag_layout_swizzle_16b_to_8b(b_frag_f8[0]);
         b_frag_f8[1] = frag_layout_swizzle_16b_to_8b(b_frag_f8[1]);
-        vec_cast<DTypeQ, DTypeKV>::cast<8>((DTypeQ*)b_frag, (DTypeKV*)b_frag_f8);
+        vec_cast<typename KTraits::DTypeQ, typename KTraits::DTypeKV>::cast<8>(
+            (typename KTraits::DTypeQ*)b_frag, (typename KTraits::DTypeKV*)b_frag_f8);
       } else {
         k_smem->ldmatrix_m8n8x4(*k_smem_offset_r, b_frag);
       }
       *k_smem_offset_r =
-          k_smem->template advance_offset_by_row<16, upcast_head_dim_k>(*k_smem_offset_r);
+          k_smem->template advance_offset_by_row<16, UPCAST_HEAD_DIM_K>(*k_smem_offset_r);
 
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
-        if constexpr (std::is_same_v<DTypeQKAccum, float>) {
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+        if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
           if (mma_d == 0) {
-            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ, MMAMode::kInit>(
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ, MMAMode::kInit>(
                 s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
           } else {
-            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(s_frag[mma_q][mma_kv], a_frag[mma_q],
-                                                              b_frag);
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(
+                s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
           }
-        } else if (std::is_same_v<DTypeQKAccum, half>) {
+        } else if (std::is_same_v<typename KTraits::DTypeQKAccum, half>) {
           if (mma_d == 0) {
             mma::mma_sync_m16n16k16_row_col_f16f16f16<MMAMode::kInit>(
                 (uint32_t*)s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
@@ -603,31 +671,31 @@ __device__ __forceinline__ void compute_qk(smem_t<swizzle_mode_q>* q_smem,
         }
       }
     }
-    if constexpr (sizeof(DTypeKV) == 1) {
+    if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
       if (mma_d % 2 == 1) {
         *k_smem_offset_r =
             k_smem->template advance_offset_by_column<2>(*k_smem_offset_r, mma_d / 2);
       }
-      *k_smem_offset_r -= NUM_MMA_KV * 16 * upcast_head_dim_k;
+      *k_smem_offset_r -= KTraits::NUM_MMA_KV * 16 * UPCAST_HEAD_DIM_K;
     } else {
       *k_smem_offset_r = k_smem->template advance_offset_by_column<2>(*k_smem_offset_r, mma_d) -
-                         NUM_MMA_KV * 16 * upcast_head_dim_k;
+                         KTraits::NUM_MMA_KV * 16 * UPCAST_HEAD_DIM_K;
     }
   }
-  *q_smem_offset_r -= NUM_MMA_D_QK * 2;
-  *k_smem_offset_r -= NUM_MMA_D_QK * sizeof(DTypeKV);
+  *q_smem_offset_r -= KTraits::NUM_MMA_D_QK * 2;
+  *k_smem_offset_r -= KTraits::NUM_MMA_D_QK * sizeof(typename KTraits::DTypeKV);
 }
 
-template <uint32_t NUM_MMA_Q, uint32_t NUM_MMA_KV, typename AttentionVariant, typename Params,
-          typename DTypeQKAccum>
+template <typename KTraits, typename Params, typename DTypeQKAccum>
 __device__ __forceinline__ void logits_transform(
-    const Params& params, AttentionVariant variant, const uint32_t batch_idx,
+    const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
     const uint32_t qo_packed_idx_base, const uint32_t kv_idx_base, const uint32_t qo_len,
-    const uint32_t kv_len, const uint_fastdiv group_size, DTypeQKAccum (*s_frag)[NUM_MMA_KV][8]) {
+    const uint32_t kv_len, const uint_fastdiv group_size,
+    DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
   const uint32_t lane_idx = threadIdx.x, kv_head_idx = blockIdx.z;
-  uint32_t q[NUM_MMA_Q][2], r[NUM_MMA_Q][2];
+  uint32_t q[KTraits::NUM_MMA_Q][2], r[KTraits::NUM_MMA_Q][2];
 #pragma unroll
-  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+  for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
     for (uint32_t j = 0; j < 2; ++j) {
       group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j],
@@ -636,9 +704,9 @@ __device__ __forceinline__ void logits_transform(
   }
 
 #pragma unroll
-  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+  for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-    for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
 #pragma unroll
       for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
         const uint32_t q_idx = q[mma_q][(reg_id % 4) / 2], kv_idx = kv_idx_base + mma_kv * 16 +
@@ -653,19 +721,16 @@ __device__ __forceinline__ void logits_transform(
   }
 }
 
-template <MaskMode MASK_MODE, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_KV, typename AttentionVariant,
-          typename Params, typename DTypeQKAccum>
-__device__ __forceinline__ void logits_mask(const Params& params, AttentionVariant variant,
-                                            const uint32_t batch_idx,
-                                            const uint32_t qo_packed_idx_base,
-                                            const uint32_t kv_idx_base, const uint32_t qo_len,
-                                            const uint32_t kv_len, const uint32_t chunk_end,
-                                            const uint_fastdiv group_size,
-                                            DTypeQKAccum (*s_frag)[NUM_MMA_KV][8]) {
+template <MaskMode MASK_MODE, typename KTraits, typename Params>
+__device__ __forceinline__ void logits_mask(
+    const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
+    const uint32_t qo_packed_idx_base, const uint32_t kv_idx_base, const uint32_t qo_len,
+    const uint32_t kv_len, const uint32_t chunk_end, const uint_fastdiv group_size,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
   const uint32_t lane_idx = threadIdx.x, kv_head_idx = blockIdx.z;
-  uint32_t q[NUM_MMA_Q][2], r[NUM_MMA_Q][2];
+  uint32_t q[KTraits::NUM_MMA_Q][2], r[KTraits::NUM_MMA_Q][2];
 #pragma unroll
-  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+  for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
     for (uint32_t j = 0; j < 2; ++j) {
       group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j],
@@ -674,9 +739,9 @@ __device__ __forceinline__ void logits_mask(const Params& params, AttentionVaria
   }
 
 #pragma unroll
-  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+  for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-    for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
 #pragma unroll
       for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
         const uint32_t q_idx = q[mma_q][(reg_id % 4) / 2], kv_idx = kv_idx_base + mma_kv * 16 +
@@ -688,29 +753,33 @@ __device__ __forceinline__ void logits_mask(const Params& params, AttentionVaria
                    ? (kv_idx + qo_len > kv_len + q_idx || (kv_idx >= chunk_end))
                    : kv_idx >= chunk_end)) &&
             variant.LogitsMask(params, batch_idx, q_idx, kv_idx, qo_head_idx, kv_head_idx);
-        s_frag[mma_q][mma_kv][reg_id] =
-            (mask) ? s_frag[mma_q][mma_kv][reg_id]
-                   : (variant.use_softmax ? DTypeQKAccum(-math::inf) : DTypeQKAccum(0.f));
+        s_frag[mma_q][mma_kv][reg_id] = (mask) ? s_frag[mma_q][mma_kv][reg_id]
+                                               : (KTraits::AttentionVariant::use_softmax
+                                                      ? typename KTraits::DTypeQKAccum(-math::inf)
+                                                      : typename KTraits::DTypeQKAccum(0.f));
       }
     }
   }
 }
 
-template <uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_VO, uint32_t NUM_MMA_KV, typename DTypeQKAccum,
-          typename AttentionVariant>
-__device__ __forceinline__ void update_mdo_states(AttentionVariant variant,
-                                                  DTypeQKAccum (*s_frag)[NUM_MMA_KV][8],
-                                                  float (*o_frag)[NUM_MMA_D_VO][8],
-                                                  DTypeQKAccum (*m)[2], float (*d)[2]) {
-  if constexpr (variant.use_softmax) {
+template <typename KTraits>
+__device__ __forceinline__ void update_mdo_states(
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+    float (*o_frag)[KTraits::NUM_MMA_D_VO][8], typename KTraits::DTypeQKAccum (*m)[2],
+    float (*d)[2]) {
+  using DTypeQKAccum = typename KTraits::DTypeQKAccum;
+  using AttentionVariant = typename KTraits::AttentionVariant;
+  constexpr bool use_softmax = AttentionVariant::use_softmax;
+
+  if constexpr (use_softmax) {
     if constexpr (std::is_same_v<DTypeQKAccum, float>) {
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
         for (uint32_t j = 0; j < 2; ++j) {
           float m_prev = m[mma_q][j];
 #pragma unroll
-          for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+          for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
             float m_local =
                 max(max(s_frag[mma_q][mma_kv][j * 2 + 0], s_frag[mma_q][mma_kv][j * 2 + 1]),
                     max(s_frag[mma_q][mma_kv][j * 2 + 4], s_frag[mma_q][mma_kv][j * 2 + 5]));
@@ -722,14 +791,14 @@ __device__ __forceinline__ void update_mdo_states(AttentionVariant variant,
           float o_scale = math::ptx_exp2(m_prev - m[mma_q][j]);
           d[mma_q][j] *= o_scale;
 #pragma unroll
-          for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+          for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
             o_frag[mma_q][mma_d][j * 2 + 0] *= o_scale;
             o_frag[mma_q][mma_d][j * 2 + 1] *= o_scale;
             o_frag[mma_q][mma_d][j * 2 + 4] *= o_scale;
             o_frag[mma_q][mma_d][j * 2 + 5] *= o_scale;
           }
 #pragma unroll
-          for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+          for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
             s_frag[mma_q][mma_kv][j * 2 + 0] =
                 math::ptx_exp2(s_frag[mma_q][mma_kv][j * 2 + 0] - m[mma_q][j]);
             s_frag[mma_q][mma_kv][j * 2 + 1] =
@@ -743,13 +812,13 @@ __device__ __forceinline__ void update_mdo_states(AttentionVariant variant,
       }
     } else if constexpr (std::is_same_v<DTypeQKAccum, half>) {
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
         half m_prev[2];
 #pragma unroll
         for (uint32_t j = 0; j < 2; ++j) {
           m_prev[j] = m[mma_q][j];
 #pragma unroll
-          for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+          for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
             half2 m_local = __hmax2(*(half2*)&s_frag[mma_q][mma_kv][j * 2],
                                     *(half2*)&s_frag[mma_q][mma_kv][j * 2 + 4]);
             m[mma_q][j] = __hmax(m[mma_q][j], __hmax(m_local.x, m_local.y));
@@ -764,7 +833,7 @@ __device__ __forceinline__ void update_mdo_states(AttentionVariant variant,
           float o_scale = math::ptx_exp2(float(m_prev[j] - m[mma_q][j]));
           d[mma_q][j] *= o_scale;
 #pragma unroll
-          for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+          for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
             o_frag[mma_q][mma_d][j * 2 + 0] *= o_scale;
             o_frag[mma_q][mma_d][j * 2 + 1] *= o_scale;
             o_frag[mma_q][mma_d][j * 2 + 4] *= o_scale;
@@ -772,7 +841,7 @@ __device__ __forceinline__ void update_mdo_states(AttentionVariant variant,
           }
           half2 m2 = make_half2(m[mma_q][j], m[mma_q][j]);
 #pragma unroll
-          for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+          for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
             *(half2*)&s_frag[mma_q][mma_kv][j * 2] =
                 math::ptx_exp2(*(half2*)&s_frag[mma_q][mma_kv][j * 2] - m2);
             *(half2*)&s_frag[mma_q][mma_kv][j * 2 + 4] =
@@ -784,33 +853,32 @@ __device__ __forceinline__ void update_mdo_states(AttentionVariant variant,
   }
 }
 
-template <uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_VO, uint32_t NUM_MMA_KV, SwizzleMode swizzle_mode,
-          typename DTypeQ, typename DTypeKV, typename DTypeQKAccum, typename AttentionVariant>
-__device__ __forceinline__ void compute_sfm_v(AttentionVariant variant,
-                                              smem_t<swizzle_mode>* v_smem,
-                                              uint32_t* v_smem_offset_r,
-                                              DTypeQKAccum (*s_frag)[NUM_MMA_KV][8],
-                                              float (*o_frag)[NUM_MMA_D_VO][8], float (*d)[2]) {
-  constexpr uint32_t head_dim = NUM_MMA_D_VO * 16;
-  constexpr uint32_t upcast_head_dim_v = head_dim / upcast_size<DTypeKV>();
+template <typename KTraits>
+__device__ __forceinline__ void compute_sfm_v(
+    smem_t<KTraits::SWIZZLE_MODE_KV>* v_smem, uint32_t* v_smem_offset_r,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+    float (*o_frag)[KTraits::NUM_MMA_D_VO][8], float (*d)[2]) {
+  constexpr uint32_t head_dim = KTraits::NUM_MMA_D_VO * 16;
+  constexpr uint32_t UPCAST_HEAD_DIM_V = head_dim / upcast_size<typename KTraits::DTypeKV>();
 
-  DTypeQ s_frag_f16[NUM_MMA_Q][NUM_MMA_KV][8];
-  if constexpr (std::is_same_v<DTypeQKAccum, float>) {
+  typename KTraits::DTypeQ s_frag_f16[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_KV][8];
+  if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-      for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
-        vec_cast<DTypeQ, float>::cast<8>(s_frag_f16[mma_q][mma_kv], s_frag[mma_q][mma_kv]);
+      for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+        vec_cast<typename KTraits::DTypeQ, float>::cast<8>(s_frag_f16[mma_q][mma_kv],
+                                                           s_frag[mma_q][mma_kv]);
       }
     }
   }
 
-  if constexpr (variant.use_softmax) {
+  if constexpr (KTraits::AttentionVariant::use_softmax) {
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-      for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
-        if constexpr (std::is_same_v<DTypeQKAccum, float>) {
+      for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+        if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
           mma::m16k16_rowsum_f16f16f32(d[mma_q], s_frag_f16[mma_q][mma_kv]);
         } else {
           mma::m16k16_rowsum_f16f16f32(d[mma_q], s_frag[mma_q][mma_kv]);
@@ -820,11 +888,11 @@ __device__ __forceinline__ void compute_sfm_v(AttentionVariant variant,
   }
 
 #pragma unroll
-  for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+  for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
 #pragma unroll
-    for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
       uint32_t b_frag[4];
-      if constexpr (sizeof(DTypeKV) == 1) {
+      if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
         uint32_t b_frag_f8[2];
         if (mma_d % 2 == 0) {
           v_smem->ldmatrix_m8n8x4_trans_left_half(*v_smem_offset_r, b_frag_f8);
@@ -833,22 +901,23 @@ __device__ __forceinline__ void compute_sfm_v(AttentionVariant variant,
         }
         b_frag_f8[0] = frag_layout_swizzle_16b_to_8b_trans(b_frag_f8[0]);
         b_frag_f8[1] = frag_layout_swizzle_16b_to_8b_trans(b_frag_f8[1]);
-        vec_cast<DTypeQ, DTypeKV>::cast<8>((DTypeQ*)b_frag, (DTypeKV*)b_frag_f8);
+        vec_cast<typename KTraits::DTypeQ, typename KTraits::DTypeKV>::cast<8>(
+            (typename KTraits::DTypeQ*)b_frag, (typename KTraits::DTypeKV*)b_frag_f8);
         swap(b_frag[1], b_frag[2]);
       } else {
         v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag);
       }
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
-        if constexpr (std::is_same_v<DTypeQKAccum, float>) {
-          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+        if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+          mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(
               o_frag[mma_q][mma_d], (uint32_t*)(s_frag_f16[mma_q][mma_kv]), b_frag);
         } else {
-          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
+          mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(
               o_frag[mma_q][mma_d], (uint32_t*)s_frag[mma_q][mma_kv], b_frag);
         }
       }
-      if constexpr (sizeof(DTypeKV) == 1) {
+      if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
         if (mma_d % 2 == 1) {
           *v_smem_offset_r =
               v_smem->template advance_offset_by_column<2>(*v_smem_offset_r, mma_d / 2);
@@ -858,33 +927,33 @@ __device__ __forceinline__ void compute_sfm_v(AttentionVariant variant,
       }
     }
     *v_smem_offset_r =
-        v_smem->template advance_offset_by_row<16, upcast_head_dim_v>(*v_smem_offset_r) -
-        sizeof(DTypeKV) * NUM_MMA_D_VO;
+        v_smem->template advance_offset_by_row<16, UPCAST_HEAD_DIM_V>(*v_smem_offset_r) -
+        sizeof(typename KTraits::DTypeKV) * KTraits::NUM_MMA_D_VO;
   }
-  *v_smem_offset_r -= 16 * NUM_MMA_KV * upcast_head_dim_v;
+  *v_smem_offset_r -= 16 * KTraits::NUM_MMA_KV * UPCAST_HEAD_DIM_V;
 }
 
-template <uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_VO, typename DTypeQKAccum,
-          typename AttentionVariant>
-__device__ __forceinline__ void normalize_d(AttentionVariant variant,
-                                            float (*o_frag)[NUM_MMA_D_VO][8], DTypeQKAccum (*m)[2],
-                                            float (*d)[2]) {
-  if constexpr (variant.use_softmax) {
-    float d_rcp[NUM_MMA_Q][2];
+template <typename KTraits>
+__device__ __forceinline__ void normalize_d(float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                            typename KTraits::DTypeQKAccum (*m)[2], float (*d)[2]) {
+  using AttentionVariant = typename KTraits::AttentionVariant;
+  if constexpr (AttentionVariant::use_softmax) {
+    float d_rcp[KTraits::NUM_MMA_Q][2];
     // compute reciprocal of d
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
-        d_rcp[mma_q][j] =
-            (m[mma_q][j] != DTypeQKAccum(-math::inf)) ? math::ptx_rcp(d[mma_q][j]) : 0.f;
+        d_rcp[mma_q][j] = (m[mma_q][j] != typename KTraits::DTypeQKAccum(-math::inf))
+                              ? math::ptx_rcp(d[mma_q][j])
+                              : 0.f;
       }
     }
 
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-      for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+      for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
 #pragma unroll
         for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
           o_frag[mma_q][mma_d][reg_id] =
@@ -895,49 +964,39 @@ __device__ __forceinline__ void normalize_d(AttentionVariant variant,
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t HEAD_DIM_VO,
-          typename DTypeO>
-constexpr size_t SmemSizeThreadBlockAttnSync() {
-  if constexpr (NUM_WARPS_KV == 1) {
-    return 0;
-  } else {
-    return (NUM_WARPS_Q * NUM_WARPS_KV) * (NUM_MMA_Q * 16) * HEAD_DIM_VO * sizeof(float) +
-           (NUM_WARPS_Q * NUM_WARPS_KV) * (NUM_MMA_Q * 16) * 2 * sizeof(float);
-  }
-}
-
 /*!
  * \brief Synchronize the states of the MDO kernel across the threadblock along threadIdx.z.
  */
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_VO,
-          typename DTypeQKAccum, typename AttentionVariant>
+template <typename KTraits>
 __device__ __forceinline__ void threadblock_sync_mdo_states(
-    AttentionVariant variant, float (*o_frag)[NUM_MMA_D_VO][8], float* smem_workspace,
-    DTypeQKAccum (*m)[2], float (*d)[2], const uint32_t warp_idx, const uint32_t lane_idx) {
+    float (*o_frag)[KTraits::NUM_MMA_D_VO][8], typename KTraits::SharedStorage smem_storage,
+    typename KTraits::DTypeQKAccum (*m)[2], float (*d)[2], const uint32_t warp_idx,
+    const uint32_t lane_idx) {
   // only necessary when blockDim.z > 1
-  if constexpr (NUM_WARPS_KV > 1) {
-    float2* smem_md = (float2*)(smem_workspace + NUM_MMA_Q * NUM_MMA_D_VO * NUM_WARPS_Q *
-                                                     NUM_WARPS_KV * WARP_SIZE * 8);
+  if constexpr (KTraits::NUM_WARPS_KV > 1) {
+    float* smem_o = smem_storage.cta_sync_o_smem;
+    float2* smem_md = smem_storage.cta_sync_md_smem;
     // o: [num_warps, NUM_MMA_Q, NUM_MMA_D_VO, WARP_SIZE(32), 8]
     // md: [num_warps, NUM_MMA_Q, 16, 2 (m/d)]
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-      for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+      for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
         vec_t<float, 8>::memcpy(
-            smem_workspace +
-                (((warp_idx * NUM_MMA_Q + mma_q) * NUM_MMA_D_VO + mma_d) * WARP_SIZE + lane_idx) *
-                    8,
+            smem_o + (((warp_idx * KTraits::NUM_MMA_Q + mma_q) * KTraits::NUM_MMA_D_VO + mma_d) *
+                          WARP_SIZE +
+                      lane_idx) *
+                         8,
             o_frag[mma_q][mma_d]);
       }
     }
 
-    if constexpr (variant.use_softmax) {
+    if constexpr (KTraits::AttentionVariant::use_softmax) {
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
         for (uint32_t j = 0; j < 2; ++j) {
-          smem_md[((warp_idx * NUM_MMA_Q + mma_q) * 2 + j) * 8 + lane_idx / 4] =
+          smem_md[((warp_idx * KTraits::NUM_MMA_Q + mma_q) * 2 + j) * 8 + lane_idx / 4] =
               make_float2(float(m[mma_q][j]), d[mma_q][j]);
         }
       }
@@ -945,15 +1004,15 @@ __device__ __forceinline__ void threadblock_sync_mdo_states(
       // synchronize m,d first
       __syncthreads();
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
-        float o_scale[2][NUM_WARPS_KV];
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+        float o_scale[2][KTraits::NUM_WARPS_KV];
 #pragma unroll
         for (uint32_t j = 0; j < 2; ++j) {
           float m_new = -math::inf, d_new = 1.f;
 #pragma unroll
-          for (uint32_t i = 0; i < NUM_WARPS_KV; ++i) {
-            float2 md = smem_md[(((i * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                                      NUM_MMA_Q +
+          for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
+            float2 md = smem_md[(((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) *
+                                      KTraits::NUM_MMA_Q +
                                   mma_q) *
                                      2 +
                                  j) *
@@ -965,9 +1024,9 @@ __device__ __forceinline__ void threadblock_sync_mdo_states(
           }
 
 #pragma unroll
-          for (uint32_t i = 0; i < NUM_WARPS_KV; ++i) {
-            float2 md = smem_md[(((i * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                                      NUM_MMA_Q +
+          for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
+            float2 md = smem_md[(((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) *
+                                      KTraits::NUM_MMA_Q +
                                   mma_q) *
                                      2 +
                                  j) *
@@ -976,21 +1035,21 @@ __device__ __forceinline__ void threadblock_sync_mdo_states(
             float mi = md.x;
             o_scale[j][i] = math::ptx_exp2(float(mi - m_new));
           }
-          m[mma_q][j] = DTypeQKAccum(m_new);
+          m[mma_q][j] = typename KTraits::DTypeQKAccum(m_new);
           d[mma_q][j] = d_new;
         }
 
 #pragma unroll
-        for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+        for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
           vec_t<float, 8> o_new;
           o_new.fill(0.f);
 #pragma unroll
-          for (uint32_t i = 0; i < NUM_WARPS_KV; ++i) {
+          for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
             vec_t<float, 8> oi;
-            oi.load(smem_workspace +
-                    ((((i * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) * NUM_MMA_Q +
+            oi.load(smem_o +
+                    ((((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) * KTraits::NUM_MMA_Q +
                        mma_q) *
-                          NUM_MMA_D_VO +
+                          KTraits::NUM_MMA_D_VO +
                       mma_d) *
                          WARP_SIZE +
                      lane_idx) *
@@ -1007,18 +1066,18 @@ __device__ __forceinline__ void threadblock_sync_mdo_states(
       // synchronize m,d first
       __syncthreads();
 #pragma unroll
-      for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-        for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+        for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
           vec_t<float, 8> o_new;
           o_new.fill(0.f);
 #pragma unroll
-          for (uint32_t i = 0; i < NUM_WARPS_KV; ++i) {
+          for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
             vec_t<float, 8> oi;
-            oi.load(smem_workspace +
-                    ((((i * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) * NUM_MMA_Q +
+            oi.load(smem_o +
+                    ((((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) * KTraits::NUM_MMA_Q +
                        mma_q) *
-                          NUM_MMA_D_VO +
+                          KTraits::NUM_MMA_D_VO +
                       mma_d) *
                          WARP_SIZE +
                      lane_idx) *
@@ -1035,63 +1094,64 @@ __device__ __forceinline__ void threadblock_sync_mdo_states(
   }
 }
 
-template <uint32_t NUM_WARPS_Q, uint32_t NUM_WARPS_KV, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_D_VO,
-          SwizzleMode swizzle_mode, typename DTypeO>
+template <typename KTraits>
 __device__ __forceinline__ void write_o_reg_gmem(
-    float (*o_frag)[NUM_MMA_D_VO][8], smem_t<swizzle_mode>* o_smem, DTypeO* o_ptr_base,
-    const uint32_t o_packed_idx_base, const uint32_t qo_upper_bound, const uint32_t o_stride_n,
-    const uint32_t o_stride_h, const uint_fastdiv group_size) {
-  constexpr uint32_t head_dim = NUM_MMA_D_VO * 16;
-  constexpr uint32_t upcast_head_dim_o = head_dim / upcast_size<DTypeO>();
-  const uint32_t warp_idx_x = get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>();
+    float (*o_frag)[KTraits::NUM_MMA_D_VO][8], smem_t<KTraits::SWIZZLE_MODE_Q>* o_smem,
+    typename KTraits::DTypeO* o_ptr_base, const uint32_t o_packed_idx_base,
+    const uint32_t qo_upper_bound, const uint32_t o_stride_n, const uint32_t o_stride_h,
+    const uint_fastdiv group_size) {
+  constexpr uint32_t UPCAST_HEAD_DIM_O = KTraits::UPCAST_HEAD_DIM_O;
+  const uint32_t warp_idx_x = get_warp_idx_q<KTraits>();
   const uint32_t lane_idx = threadIdx.x;
 
-  if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
+  if (get_warp_idx_kv<KTraits>() == 0) {
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
-      for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_VO; ++mma_d) {
+      for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
         uint32_t o_frag_f16[4];
-        vec_cast<DTypeO, float>::cast<8>((DTypeO*)o_frag_f16, o_frag[mma_q][mma_d]);
+        vec_cast<typename KTraits::DTypeO, float>::cast<8>((typename KTraits::DTypeO*)o_frag_f16,
+                                                           o_frag[mma_q][mma_d]);
 #ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
-        uint32_t o_smem_offset_w = o_smem->get_permuted_offset<upcast_head_dim_o>(
-            (warp_idx_x * NUM_MMA_Q + mma_q) * 16 + lane_idx % 16, mma_d * 2 + lane_idx / 16);
+        uint32_t o_smem_offset_w = o_smem->get_permuted_offset<UPCAST_HEAD_DIM_O>(
+            (warp_idx_x * KTraits::NUM_MMA_Q + mma_q) * 16 + lane_idx % 16,
+            mma_d * 2 + lane_idx / 16);
         o_smem->stmatrix_m8n8x4(o_smem_offset_w, o_frag_f16);
 #else
-        uint32_t o_smem_offset_w = o_smem->get_permuted_offset<upcast_head_dim_o>(
-            (warp_idx_x * NUM_MMA_Q + mma_q) * 16 + lane_idx / 4, mma_d * 2);
+        uint32_t o_smem_offset_w = o_smem->get_permuted_offset<UPCAST_HEAD_DIM_O>(
+            (warp_idx_x * KTraits::NUM_MMA_Q + mma_q) * 16 + lane_idx / 4, mma_d * 2);
         ((uint32_t*)(o_smem->base + o_smem_offset_w))[lane_idx % 4] = o_frag_f16[0];
-        ((uint32_t*)(o_smem->base + o_smem_offset_w + 8 * upcast_head_dim_o))[lane_idx % 4] =
+        ((uint32_t*)(o_smem->base + o_smem_offset_w + 8 * UPCAST_HEAD_DIM_O))[lane_idx % 4] =
             o_frag_f16[1];
         ((uint32_t*)(o_smem->base + (o_smem_offset_w ^ 0x1)))[lane_idx % 4] = o_frag_f16[2];
         ((uint32_t*)(o_smem->base + (o_smem_offset_w ^ 0x1) +
-                     8 * upcast_head_dim_o))[lane_idx % 4] = o_frag_f16[3];
+                     8 * UPCAST_HEAD_DIM_O))[lane_idx % 4] = o_frag_f16[3];
 #endif
       }
     }
 
-    uint32_t o_smem_offset_w = o_smem->get_permuted_offset<upcast_head_dim_o>(
-        warp_idx_x * NUM_MMA_Q * 16 + lane_idx / 8, lane_idx % 8);
+    uint32_t o_smem_offset_w = o_smem->get_permuted_offset<UPCAST_HEAD_DIM_O>(
+        warp_idx_x * KTraits::NUM_MMA_Q * 16 + lane_idx / 8, lane_idx % 8);
 
 #pragma unroll
-    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 4; ++j) {
         uint32_t q, r;
         group_size.divmod(o_packed_idx_base + lane_idx / 8 + mma_q * 16 + j * 4, q, r);
         const uint32_t o_idx = q;
-        DTypeO* o_ptr = o_ptr_base + q * o_stride_n + r * o_stride_h;
+        typename KTraits::DTypeO* o_ptr = o_ptr_base + q * o_stride_n + r * o_stride_h;
 #pragma unroll
-        for (uint32_t mma_do = 0; mma_do < NUM_MMA_D_VO / 4; ++mma_do) {
+        for (uint32_t mma_do = 0; mma_do < KTraits::NUM_MMA_D_VO / 4; ++mma_do) {
           if (o_idx < qo_upper_bound) {
             o_smem->store_128b(o_smem_offset_w, o_ptr);
           }
-          o_ptr += 8 * upcast_size<DTypeO>();
+          o_ptr += 8 * upcast_size<typename KTraits::DTypeO>();
           o_smem_offset_w = o_smem->template advance_offset_by_column<8>(o_smem_offset_w, mma_do);
         }
         o_smem_offset_w =
-            o_smem->template advance_offset_by_row<4, upcast_head_dim_o>(o_smem_offset_w) -
-            2 * NUM_MMA_D_VO;
+            o_smem->template advance_offset_by_row<4, UPCAST_HEAD_DIM_O>(o_smem_offset_w) -
+            2 * KTraits::NUM_MMA_D_VO;
       }
     }
   }
@@ -1122,11 +1182,8 @@ __device__ __forceinline__ void write_o_reg_gmem(
  * \param rope_rcp_theta 1/(rope_theta), where rope_theta is the theta
  *   used in RoPE.
  */
-template <MaskMode MASK_MODE, PosEncodingMode POS_ENCODING_MODE, uint32_t NUM_MMA_Q,
-          uint32_t NUM_MMA_D_QK, uint32_t NUM_MMA_D_VO, uint32_t NUM_MMA_KV, uint32_t NUM_WARPS_Q,
-          uint32_t NUM_WARPS_KV, typename DTypeQKAccum, typename AttentionVariant, typename Params>
-__global__
-__launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void SinglePrefillWithKVCacheKernel(
+template <MaskMode MASK_MODE, typename KTraits, typename Params>
+__global__ __launch_bounds__(KTraits::NUM_THREADS) void SinglePrefillWithKVCacheKernel(
     const uint_fastdiv group_size, const __grid_constant__ Params params) {
   using DTypeQ = typename Params::DTypeQ;
 #if (__CUDA_ARCH__ < 800)
@@ -1154,10 +1211,11 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void SinglePrefillWithKV
 
     static_assert(sizeof(DTypeQ) == 2);
     static_assert(sizeof(DTypeO) == 2);
-    const uint32_t lane_idx = threadIdx.x, warp_idx = get_warp_idx<NUM_WARPS_Q, NUM_WARPS_KV>();
+    const uint32_t lane_idx = threadIdx.x, warp_idx = get_warp_idx<KTraits>();
     const uint32_t bx = blockIdx.x, chunk_idx = blockIdx.y, kv_head_idx = blockIdx.z;
     const uint32_t num_kv_heads = gridDim.z, num_qo_heads = num_kv_heads * group_size;
-    constexpr uint32_t num_rows_per_cta = NUM_MMA_Q * NUM_WARPS_Q * 16;
+    constexpr uint32_t CTA_TILE_Q = KTraits::CTA_TILE_Q;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
 
     const uint32_t num_chunks = gridDim.y;
     const uint32_t max_chunk_size = partition_kv ? ceil_div(kv_len, num_chunks) : kv_len;
@@ -1168,34 +1226,35 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void SinglePrefillWithKV
 
     auto block = cg::this_thread_block();
     extern __shared__ uint8_t smem[];
-    AttentionVariant variant(params, /*batch_idx=*/0, smem);
+    auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+    typename KTraits::AttentionVariant variant(params, /*batch_idx=*/0, smem);
     const uint32_t window_left = variant.window_left;
 
-    constexpr uint32_t head_dim_vo = NUM_MMA_D_VO * 16;
-    constexpr uint32_t head_dim_qk = NUM_MMA_D_QK * 16;
-    constexpr uint32_t upcast_head_dim_q = head_dim_qk / upcast_size<DTypeQ>();
-    constexpr uint32_t upcast_head_dim_k = head_dim_qk / upcast_size<DTypeKV>();
-    constexpr uint32_t upcast_head_dim_v = head_dim_vo / upcast_size<DTypeKV>();
-    constexpr uint32_t upcast_head_dim_o = head_dim_vo / upcast_size<DTypeO>();
+    constexpr uint32_t HEAD_DIM_VO = KTraits::HEAD_DIM_VO;
+    constexpr uint32_t HEAD_DIM_QK = KTraits::HEAD_DIM_QK;
+    constexpr uint32_t UPCAST_HEAD_DIM_Q = KTraits::UPCAST_HEAD_DIM_Q;
+    constexpr uint32_t UPCAST_HEAD_DIM_K = KTraits::UPCAST_HEAD_DIM_K;
+    constexpr uint32_t UPCAST_HEAD_DIM_V = KTraits::UPCAST_HEAD_DIM_V;
+    constexpr uint32_t UPCAST_HEAD_DIM_O = KTraits::UPCAST_HEAD_DIM_O;
 
-    DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
-    alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
-    DTypeQKAccum m[NUM_MMA_Q][2];
-    float d[NUM_MMA_Q][2];
-    float rope_freq[NUM_MMA_D_QK / 2][4];
-    if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+    typename KTraits::DTypeQKAccum s_frag[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_KV][8];
+    alignas(16) float o_frag[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_D_VO][8];
+    typename KTraits::DTypeQKAccum m[KTraits::NUM_MMA_Q][2];
+    float d[KTraits::NUM_MMA_Q][2];
+    float rope_freq[KTraits::NUM_MMA_D_QK / 2][4];
+    if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
-      init_rope_freq<NUM_MMA_D_QK>(rope_freq, rope_rcp_scale, rope_rcp_theta);
+      init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta);
     }
-    init_states<NUM_MMA_Q, NUM_MMA_D_VO>(variant, o_frag, m, d);
+    init_states<KTraits>(variant, o_frag, m, d);
 
     // cooperative fetch q fragment from gmem to reg
     const uint32_t qo_packed_idx_base =
-        (bx * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) * NUM_MMA_Q * 16;
-    constexpr SwizzleMode swizzle_mode_q = SwizzleMode::k128B;
-    smem_t<swizzle_mode_q> qo_smem(smem);
-    const uint32_t o_stride_n = num_qo_heads * head_dim_vo, o_stride_h = head_dim_vo;
+        (bx * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) * KTraits::NUM_MMA_Q * 16;
+    constexpr SwizzleMode swizzle_mode_q = KTraits::SWIZZLE_MODE_Q;
+    smem_t<swizzle_mode_q> qo_smem(smem_storage.q_smem);
+    const uint32_t o_stride_n = num_qo_heads * HEAD_DIM_VO, o_stride_h = HEAD_DIM_VO;
     DTypeQ* q_ptr_base =
         q + (kv_head_idx * group_size) * q_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
     DTypeO* o_ptr_base =
@@ -1204,55 +1263,47 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void SinglePrefillWithKV
                   (lane_idx % 8) * upcast_size<DTypeO>()
             : o + (kv_head_idx * group_size) * o_stride_h + (lane_idx % 8) * upcast_size<DTypeO>();
 
-    uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<upcast_head_dim_q>(
-        get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_Q * 16 + lane_idx % 16,
-        lane_idx / 16);
+    uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<UPCAST_HEAD_DIM_Q>(
+        get_warp_idx_q<KTraits>() * KTraits::NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
 
-    load_q_global_smem<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_QK>(
-        qo_packed_idx_base, qo_len, q_ptr_base, q_stride_n, q_stride_h, group_size, &qo_smem);
+    load_q_global_smem<KTraits>(qo_packed_idx_base, qo_len, q_ptr_base, q_stride_n, q_stride_h,
+                                group_size, &qo_smem);
 
     cp_async::commit_group();
     cp_async::wait_group<0>();
     block.sync();
 
-    if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
-      q_smem_inplace_apply_rotary<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO,
-                                  swizzle_mode_q, DTypeQ>(
-          qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq);
+    if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+      q_smem_inplace_apply_rotary<KTraits>(qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem,
+                                           &q_smem_offset_r, rope_freq);
       block.sync();
     }
-    q_smem_inplace_transform<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO, swizzle_mode_q>(
-        params, variant, &qo_smem);
+    q_smem_inplace_transform<KTraits>(params, variant, &qo_smem);
 
-    constexpr SwizzleMode swizzle_mode_kv =
-        (sizeof(DTypeKV) == 1 && head_dim_vo == 64) ? SwizzleMode::k64B : SwizzleMode::k128B;
+    constexpr SwizzleMode swizzle_mode_kv = KTraits::SWIZZLE_MODE_KV;
     constexpr uint32_t kv_frag_rows = swizzle_mode_kv == SwizzleMode::k128B ? 4 : 8;
     constexpr uint32_t kv_frag_cols = swizzle_mode_kv == SwizzleMode::k128B ? 8 : 4;
-    smem_t<swizzle_mode_kv> k_smem(smem +
-                                   (NUM_WARPS_Q * NUM_MMA_Q * sizeof(DTypeQ)) * 16 * head_dim_qk),
-        v_smem(smem + (NUM_WARPS_Q * NUM_MMA_Q * sizeof(DTypeQ) * 16 * head_dim_qk) +
-               (NUM_WARPS_KV * NUM_MMA_KV * sizeof(DTypeKV) * 16 * head_dim_qk));
+    smem_t<swizzle_mode_kv> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
 
-    const uint32_t num_iterations = ceil_div(
-        MASK_MODE == MaskMode::kCausal
-            ? min(chunk_size,
-                  sub_if_greater_or_zero(
-                      kv_len - qo_len + ((bx + 1) * num_rows_per_cta) / group_size, chunk_start))
-            : chunk_size,
-        16 * NUM_WARPS_KV * NUM_MMA_KV);
+    const uint32_t num_iterations =
+        ceil_div(MASK_MODE == MaskMode::kCausal
+                     ? min(chunk_size,
+                           sub_if_greater_or_zero(
+                               kv_len - qo_len + ((bx + 1) * CTA_TILE_Q) / group_size, chunk_start))
+                     : chunk_size,
+                 CTA_TILE_KV);
 
     const uint32_t window_iteration =
-        ceil_div(sub_if_greater_or_zero(kv_len + (bx + 1) * num_rows_per_cta / group_size,
+        ceil_div(sub_if_greater_or_zero(kv_len + (bx + 1) * CTA_TILE_Q / group_size,
                                         qo_len + window_left + chunk_start),
-                 (16 * NUM_WARPS_KV * NUM_MMA_KV));
+                 CTA_TILE_KV);
 
     const uint32_t mask_iteration =
         (MASK_MODE == MaskMode::kCausal
-             ? min(chunk_size,
-                   sub_if_greater_or_zero(kv_len + (bx * num_rows_per_cta) / group_size - qo_len,
-                                          chunk_start))
+             ? min(chunk_size, sub_if_greater_or_zero(
+                                   kv_len + (bx * CTA_TILE_Q) / group_size - qo_len, chunk_start))
              : chunk_size) /
-        (16 * NUM_WARPS_KV * NUM_MMA_KV);
+        CTA_TILE_KV;
 
     DTypeKV* k_ptr =
         k + (chunk_start + warp_idx * kv_frag_rows + lane_idx / kv_frag_cols) * k_stride_n +
@@ -1261,22 +1312,22 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void SinglePrefillWithKV
         v + (chunk_start + warp_idx * kv_frag_rows + lane_idx / kv_frag_cols) * v_stride_n +
         kv_head_idx * v_stride_h + (lane_idx % kv_frag_cols) * upcast_size<DTypeKV>();
 
-    uint32_t k_smem_offset_r = k_smem.get_permuted_offset<upcast_head_dim_k>(
-                 get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_KV * 16 +
-                     8 * (lane_idx / 16) + lane_idx % 8,
+    uint32_t k_smem_offset_r = k_smem.get_permuted_offset<UPCAST_HEAD_DIM_K>(
+                 get_warp_idx_kv<KTraits>() * KTraits::NUM_MMA_KV * 16 + 8 * (lane_idx / 16) +
+                     lane_idx % 8,
                  (lane_idx % 16) / 8),
-             v_smem_offset_r = v_smem.get_permuted_offset<upcast_head_dim_v>(
-                 get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_KV * 16 + lane_idx % 16,
+             v_smem_offset_r = v_smem.get_permuted_offset<UPCAST_HEAD_DIM_V>(
+                 get_warp_idx_kv<KTraits>() * KTraits::NUM_MMA_KV * 16 + lane_idx % 16,
                  lane_idx / 16),
-             k_smem_offset_w = k_smem.get_permuted_offset<upcast_head_dim_k>(
+             k_smem_offset_w = k_smem.get_permuted_offset<UPCAST_HEAD_DIM_K>(
                  warp_idx * kv_frag_rows + lane_idx / kv_frag_cols, lane_idx % kv_frag_cols),
-             v_smem_offset_w = v_smem.get_permuted_offset<upcast_head_dim_v>(
+             v_smem_offset_w = v_smem.get_permuted_offset<UPCAST_HEAD_DIM_V>(
                  warp_idx * kv_frag_rows + lane_idx / kv_frag_cols, lane_idx % kv_frag_cols);
-    produce_kv<SharedMemFillMode::kNoFill, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_QK, NUM_MMA_KV>(
-        k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, 0, chunk_size);
+    produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(k_smem, &k_smem_offset_w, &k_ptr,
+                                                           k_stride_n, 0, chunk_size);
     cp_async::commit_group();
-    produce_kv<SharedMemFillMode::kFillZero, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV>(
-        v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, 0, chunk_size);
+    produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(v_smem, &v_smem_offset_w, &v_ptr,
+                                                            v_stride_n, 0, chunk_size);
     cp_async::commit_group();
 
 #pragma unroll 1
@@ -1284,77 +1335,69 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void SinglePrefillWithKV
       cp_async::wait_group<1>();
       block.sync();
 
-      if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
-        k_smem_inplace_apply_rotary<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV,
-                                    swizzle_mode_kv, DTypeKV>(
-            chunk_start + iter * 16 * NUM_WARPS_KV * NUM_MMA_KV, &k_smem, &k_smem_offset_r,
-            rope_freq);
+      if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+        k_smem_inplace_apply_rotary<KTraits>(chunk_start + iter * CTA_TILE_KV, &k_smem,
+                                             &k_smem_offset_r, rope_freq);
         block.sync();
       }
 
       // compute attention score
-      compute_qk<NUM_MMA_Q, NUM_MMA_D_QK, NUM_MMA_KV, swizzle_mode_q, swizzle_mode_kv, DTypeQ,
-                 DTypeKV>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+      compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
 
-      logits_transform<NUM_MMA_Q, NUM_MMA_KV>(
+      logits_transform<KTraits>(
           params, variant, /*batch_idx=*/0, qo_packed_idx_base,
-          chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                            NUM_MMA_KV * 16,
+          chunk_start + (iter * KTraits::NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) *
+                            KTraits::NUM_MMA_KV * 16,
           qo_len, kv_len, group_size, s_frag);
 
       // apply mask
       if (MASK_MODE == MaskMode::kCustom || (iter >= mask_iteration || iter < window_iteration)) {
-        logits_mask<MASK_MODE, NUM_MMA_Q, NUM_MMA_KV>(
+        logits_mask<MASK_MODE, KTraits>(
             params, variant, /*batch_idx=*/0, qo_packed_idx_base,
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                              NUM_MMA_KV * 16,
+            chunk_start + (iter * KTraits::NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) *
+                              KTraits::NUM_MMA_KV * 16,
             qo_len, kv_len, chunk_end, group_size, s_frag);
       }
 
       // compute m,d states in online softmax
-      update_mdo_states<NUM_MMA_Q, NUM_MMA_D_VO, NUM_MMA_KV>(variant, s_frag, o_frag, m, d);
+      update_mdo_states<KTraits>(s_frag, o_frag, m, d);
 
       block.sync();
-      produce_kv<SharedMemFillMode::kNoFill, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_QK, NUM_MMA_KV>(
-          k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, (iter + 1) * 16 * NUM_WARPS_KV * NUM_MMA_KV,
-          chunk_size);
+      produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(
+          k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size);
       cp_async::commit_group();
       cp_async::wait_group<1>();
       block.sync();
 
       // compute sfm*v
-      compute_sfm_v<NUM_MMA_Q, NUM_MMA_D_VO, NUM_MMA_KV, swizzle_mode_kv, DTypeQ, DTypeKV>(
-          variant, &v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
 
       block.sync();
-      produce_kv<SharedMemFillMode::kFillZero, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV>(
-          v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * 16 * NUM_WARPS_KV * NUM_MMA_KV,
-          chunk_size);
+      produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+          v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();
     block.sync();
 
     // threadblock synchronization
-    threadblock_sync_mdo_states<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO, DTypeQKAccum>(
-        variant, o_frag, (float*)smem, m, d, warp_idx, lane_idx);
+    threadblock_sync_mdo_states<KTraits>(o_frag, smem_storage, m, d, warp_idx, lane_idx);
 
     // normalize d
-    normalize_d<NUM_MMA_Q, NUM_MMA_D_VO>(variant, o_frag, m, d);
+    normalize_d<KTraits>(o_frag, m, d);
 
     // write back
-    write_o_reg_gmem<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO>(
-        o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
-        /*o_stride_n=*/
-        partition_kv ? num_chunks * o_stride_n : o_stride_n,
-        /*o_stride_h=*/o_stride_h, group_size);
+    write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
+                              /*o_stride_n=*/
+                              partition_kv ? num_chunks * o_stride_n : o_stride_n,
+                              /*o_stride_h=*/o_stride_h, group_size);
 
     // write lse
     if constexpr (variant.use_softmax) {
       if (lse != nullptr || partition_kv) {
-        if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
+        if (get_warp_idx_kv<KTraits>() == 0) {
 #pragma unroll
-          for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+          for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
             for (uint32_t j = 0; j < 2; ++j) {
               uint32_t q, r;
@@ -1456,9 +1499,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
 
     // control NUM_MMA_KV for maximum warp occupancy
     DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
-      if constexpr (is_invalid_configuration<POS_ENCODING_MODE, DTypeKV, DTypeQKAccum>(
-                        NUM_MMA_Q, NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_MMA_KV, NUM_WARPS_Q,
-                        NUM_WARPS_KV)) {
+      using KTraits = KernelTraits<NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_WARPS_Q,
+                                   NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
+                                   DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+      if constexpr (KTraits::IsInvalid()) {
         // Invalid configuration, skip
         std::ostringstream err_msg;
         err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
@@ -1470,17 +1514,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
         FLASHINFER_ERROR(err_msg.str());
       } else {
         constexpr uint32_t num_threads = (NUM_WARPS_Q * NUM_WARPS_KV) * WARP_SIZE;
-        constexpr uint32_t num_rows_per_cta = NUM_MMA_Q * NUM_WARPS_Q * 16;
-        auto kernel =
-            SinglePrefillWithKVCacheKernel<MASK_MODE, POS_ENCODING_MODE, NUM_MMA_Q, NUM_MMA_D_QK,
-                                           NUM_MMA_D_VO, NUM_MMA_KV, NUM_WARPS_Q, NUM_WARPS_KV,
-                                           DTypeQKAccum, AttentionVariant, Params>;
+        auto kernel = SinglePrefillWithKVCacheKernel<MASK_MODE, KTraits, Params>;
         // TODO(Zihao): fix the following computation
-        size_t smem_size =
-            max(SmemSizeThreadBlockAttnSync<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, HEAD_DIM_VO,
-                                            DTypeO>(),
-                NUM_MMA_Q * NUM_WARPS_Q * 16 * HEAD_DIM_QK * sizeof(DTypeQ) +
-                    NUM_MMA_KV * NUM_WARPS_KV * 16 * (HEAD_DIM_QK + HEAD_DIM_VO) * sizeof(DTypeKV));
+        constexpr int CTA_TILE_KV = NUM_MMA_KV * NUM_WARPS_KV * 16;
+        size_t smem_size = sizeof(typename KTraits::SharedStorage);
         FLASHINFER_CUDA_CALL(
             cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
         int num_blocks_per_sm = 0;
@@ -1489,9 +1526,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
             cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
         FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
             &num_blocks_per_sm, kernel, num_threads, smem_size));
-        uint32_t max_num_kv_chunks =
-            (num_blocks_per_sm * num_sm) /
-            (num_kv_heads * ceil_div(qo_len * group_size, num_rows_per_cta));
+        uint32_t max_num_kv_chunks = (num_blocks_per_sm * num_sm) /
+                                     (num_kv_heads * ceil_div(qo_len * group_size, CTA_TILE_Q));
         uint32_t num_chunks;
         if (max_num_kv_chunks > 0) {
           uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
@@ -1504,7 +1540,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
           // Enough parallelism, do not split-kv
           params.partition_kv = false;
           void* args[] = {(void*)&group_size_fastdiv, (void*)&params};
-          dim3 nblks(ceil_div(qo_len * group_size, num_rows_per_cta), 1, num_kv_heads);
+          dim3 nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), 1, num_kv_heads);
           dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
           FLASHINFER_CUDA_CALL(
               cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
@@ -1517,7 +1553,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
           params.o = tmp;
           params.lse = tmp_lse;
           void* args[] = {(void*)&group_size_fastdiv, (void*)&params};
-          dim3 nblks(ceil_div(qo_len * group_size, num_rows_per_cta), num_chunks, num_kv_heads);
+          dim3 nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), num_chunks, num_kv_heads);
           dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
           FLASHINFER_CUDA_CALL(
               cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
@@ -1535,11 +1571,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
   return cudaSuccess;
 }
 
-template <MaskMode MASK_MODE, PosEncodingMode POS_ENCODING_MODE, uint32_t NUM_MMA_Q,
-          uint32_t NUM_MMA_D_QK, uint32_t NUM_MMA_D_VO, uint32_t NUM_MMA_KV, uint32_t NUM_WARPS_Q,
-          uint32_t NUM_WARPS_KV, typename DTypeQKAccum, typename AttentionVariant, typename Params>
-__global__
-__launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRaggedKVCacheKernel(
+template <MaskMode MASK_MODE, typename KTraits, typename Params>
+__global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKVCacheKernel(
     const uint_fastdiv group_size, const __grid_constant__ Params params) {
   using DTypeQ = typename Params::DTypeQ;
 #if (__CUDA_ARCH__ < 800)
@@ -1573,22 +1606,24 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRag
 
     static_assert(sizeof(DTypeQ) == 2);
     static_assert(sizeof(DTypeO) == 2);
-    constexpr uint32_t head_dim_qk = NUM_MMA_D_QK * 16;
-    constexpr uint32_t head_dim_vo = NUM_MMA_D_VO * 16;
+    constexpr uint32_t HEAD_DIM_QK = KTraits::HEAD_DIM_QK;
+    constexpr uint32_t HEAD_DIM_VO = KTraits::HEAD_DIM_VO;
     const uint32_t kv_chunk_size = *(params.kv_chunk_size_ptr);
+    constexpr uint32_t CTA_TILE_Q = KTraits::CTA_TILE_Q;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
 
     auto block = cg::this_thread_block();
-    const uint32_t bx = blockIdx.x, lane_idx = threadIdx.x,
-                   warp_idx = get_warp_idx<NUM_WARPS_Q, NUM_WARPS_KV>(), kv_head_idx = blockIdx.z;
+    const uint32_t bx = blockIdx.x, lane_idx = threadIdx.x, warp_idx = get_warp_idx<KTraits>(),
+                   kv_head_idx = blockIdx.z;
     if (block_valid_mask && !block_valid_mask[bx]) {
       return;
     }
     const uint32_t num_kv_heads = gridDim.z, num_qo_heads = group_size * num_kv_heads;
     const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
                    kv_tile_idx = kv_tile_indices[bx];
-    constexpr uint32_t num_rows_per_cta = NUM_MMA_Q * NUM_WARPS_Q * 16;
     extern __shared__ uint8_t smem[];
-    AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
+    auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+    typename KTraits::AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
     const uint32_t qo_len = variant.qo_len, kv_len = variant.kv_len,
                    window_left = variant.window_left;
     const uint32_t kv_len_safe = kv_len > 0 ? kv_len : 1;
@@ -1598,31 +1633,31 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRag
         partition_kv ? min((kv_tile_idx + 1) * max_chunk_size, kv_len) : kv_len;
     const uint32_t chunk_size = chunk_end - chunk_start;
     const uint32_t qo_upper_bound =
-        min(qo_len, ceil_div((qo_tile_idx + 1) * num_rows_per_cta, group_size));
+        min(qo_len, ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size));
 
-    constexpr uint32_t upcast_head_dim_q = head_dim_qk / upcast_size<DTypeQ>();
-    constexpr uint32_t upcast_head_dim_k = head_dim_qk / upcast_size<DTypeKV>();
-    constexpr uint32_t upcast_head_dim_v = head_dim_vo / upcast_size<DTypeKV>();
-    constexpr uint32_t upcast_head_dim_o = head_dim_vo / upcast_size<DTypeO>();
+    constexpr uint32_t UPCAST_HEAD_DIM_Q = KTraits::UPCAST_HEAD_DIM_Q;
+    constexpr uint32_t UPCAST_HEAD_DIM_K = KTraits::UPCAST_HEAD_DIM_K;
+    constexpr uint32_t UPCAST_HEAD_DIM_V = KTraits::UPCAST_HEAD_DIM_V;
+    constexpr uint32_t UPCAST_HEAD_DIM_O = KTraits::UPCAST_HEAD_DIM_O;
 
-    DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
-    alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
-    DTypeQKAccum m[NUM_MMA_Q][2];
-    float d[NUM_MMA_Q][2];
-    float rope_freq[NUM_MMA_D_QK / 2][4];
+    typename KTraits::DTypeQKAccum s_frag[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_KV][8];
+    alignas(16) float o_frag[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_D_VO][8];
+    typename KTraits::DTypeQKAccum m[KTraits::NUM_MMA_Q][2];
+    float d[KTraits::NUM_MMA_Q][2];
+    float rope_freq[KTraits::NUM_MMA_D_QK / 2][4];
 
-    if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+    if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
-      init_rope_freq<NUM_MMA_D_QK>(rope_freq, rope_rcp_scale, rope_rcp_theta);
+      init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta);
     }
-    init_states<NUM_MMA_Q, NUM_MMA_D_VO>(variant, o_frag, m, d);
+    init_states<KTraits>(variant, o_frag, m, d);
 
     const uint32_t qo_packed_idx_base =
-        (qo_tile_idx * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) * NUM_MMA_Q * 16;
-    constexpr SwizzleMode swizzle_mode_q = SwizzleMode::k128B;
-    smem_t<swizzle_mode_q> qo_smem(smem);
-    const uint32_t o_stride_n = num_qo_heads * head_dim_vo, o_stride_h = head_dim_vo;
+        (qo_tile_idx * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) * KTraits::NUM_MMA_Q * 16;
+    constexpr SwizzleMode swizzle_mode_q = KTraits::SWIZZLE_MODE_Q;
+    smem_t<swizzle_mode_q> qo_smem(smem_storage.q_smem);
+    const uint32_t o_stride_n = num_qo_heads * HEAD_DIM_VO, o_stride_h = HEAD_DIM_VO;
 
     DTypeQ* q_ptr_base = q + q_indptr[request_idx] * q_stride_n +
                          kv_head_idx * group_size * q_stride_h +
@@ -1635,80 +1670,70 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRag
             : o + o_indptr[request_idx] * o_stride_n + (kv_head_idx * group_size) * o_stride_h +
                   (lane_idx % 8) * upcast_size<DTypeO>();
 
-    uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<upcast_head_dim_q>(
-        get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_Q * 16 + lane_idx % 16,
-        lane_idx / 16);
+    uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<UPCAST_HEAD_DIM_Q>(
+        get_warp_idx_q<KTraits>() * KTraits::NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
 
-    load_q_global_smem<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_QK>(
-        qo_packed_idx_base, qo_upper_bound, q_ptr_base, q_stride_n, q_stride_h, group_size,
-        &qo_smem);
+    load_q_global_smem<KTraits>(qo_packed_idx_base, qo_upper_bound, q_ptr_base, q_stride_n,
+                                q_stride_h, group_size, &qo_smem);
 
     cp_async::commit_group();
     cp_async::wait_group<0>();
     block.sync();
 
-    if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+    if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       IdType* q_rope_offset = nullptr;
 
       if constexpr (has_maybe_q_rope_offset_v<Params>) {
         q_rope_offset = params.maybe_q_rope_offset;
       }
       if (!q_rope_offset) {
-        q_smem_inplace_apply_rotary<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO,
-                                    swizzle_mode_q, DTypeQ>(
-            qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq);
+        q_smem_inplace_apply_rotary<KTraits>(qo_packed_idx_base, qo_len, kv_len, group_size,
+                                             &qo_smem, &q_smem_offset_r, rope_freq);
       } else {
-        q_smem_inplace_apply_rotary_with_pos<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO,
-                                             swizzle_mode_q, DTypeQ>(
+        q_smem_inplace_apply_rotary_with_pos<KTraits>(
             qo_packed_idx_base, q_rope_offset + q_indptr[request_idx], &qo_smem, group_size,
             &q_smem_offset_r, rope_freq);
       }
       block.sync();
     }
-    q_smem_inplace_transform<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO, swizzle_mode_q>(
-        params, variant, &qo_smem);
+    q_smem_inplace_transform<KTraits>(params, variant, &qo_smem);
 
     const uint32_t num_iterations = ceil_div(
         (MASK_MODE == MaskMode::kCausal
-             ? min(chunk_size,
-                   sub_if_greater_or_zero(
-                       kv_len - qo_len + ((qo_tile_idx + 1) * num_rows_per_cta) / group_size,
-                       chunk_start))
+             ? min(chunk_size, sub_if_greater_or_zero(
+                                   kv_len - qo_len + ((qo_tile_idx + 1) * CTA_TILE_Q) / group_size,
+                                   chunk_start))
              : chunk_size),
-        16 * NUM_WARPS_KV * NUM_MMA_KV);
+        CTA_TILE_KV);
 
     const uint32_t window_iteration =
-        ceil_div(sub_if_greater_or_zero(kv_len + (qo_tile_idx + 1) * num_rows_per_cta / group_size,
+        ceil_div(sub_if_greater_or_zero(kv_len + (qo_tile_idx + 1) * CTA_TILE_Q / group_size,
                                         qo_len + window_left + chunk_start),
-                 (16 * NUM_WARPS_KV * NUM_MMA_KV));
+                 CTA_TILE_KV);
 
     const uint32_t mask_iteration =
         (MASK_MODE == MaskMode::kCausal
-             ? min(chunk_size, sub_if_greater_or_zero(
-                                   kv_len + (qo_tile_idx * num_rows_per_cta) / group_size - qo_len,
-                                   chunk_start))
+             ? min(chunk_size,
+                   sub_if_greater_or_zero(kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size - qo_len,
+                                          chunk_start))
              : chunk_size) /
-        (16 * NUM_WARPS_KV * NUM_MMA_KV);
+        CTA_TILE_KV;
 
-    constexpr SwizzleMode swizzle_mode_kv =
-        (sizeof(DTypeKV) == 1 && head_dim_vo == 64) ? SwizzleMode::k64B : SwizzleMode::k128B;
+    constexpr SwizzleMode swizzle_mode_kv = KTraits::SWIZZLE_MODE_KV;
     constexpr uint32_t kv_frag_rows = swizzle_mode_kv == SwizzleMode::k128B ? 4 : 8;
     constexpr uint32_t kv_frag_cols = swizzle_mode_kv == SwizzleMode::k128B ? 8 : 4;
-    smem_t<swizzle_mode_kv> k_smem(smem +
-                                   (NUM_WARPS_Q * NUM_MMA_Q * sizeof(DTypeQ)) * 16 * head_dim_qk),
-        v_smem(smem + (NUM_WARPS_Q * NUM_MMA_Q * sizeof(DTypeQ) * 16 * head_dim_qk) +
-               (NUM_WARPS_KV * NUM_MMA_KV * sizeof(DTypeKV) * 16 * head_dim_qk));
+    smem_t<swizzle_mode_kv> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
 
-    uint32_t k_smem_offset_r = k_smem.get_permuted_offset<upcast_head_dim_k>(
-                 get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_KV * 16 +
-                     8 * (lane_idx / 16) + lane_idx % 8,
+    uint32_t k_smem_offset_r = k_smem.get_permuted_offset<UPCAST_HEAD_DIM_K>(
+                 get_warp_idx_kv<KTraits>() * KTraits::NUM_MMA_KV * 16 + 8 * (lane_idx / 16) +
+                     lane_idx % 8,
                  (lane_idx % 16) / 8),
-             v_smem_offset_r = v_smem.get_permuted_offset<upcast_head_dim_v>(
-                 get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_KV * 16 + lane_idx % 16,
+             v_smem_offset_r = v_smem.get_permuted_offset<UPCAST_HEAD_DIM_V>(
+                 get_warp_idx_kv<KTraits>() * KTraits::NUM_MMA_KV * 16 + lane_idx % 16,
                  lane_idx / 16),
-             k_smem_offset_w = k_smem.get_permuted_offset<upcast_head_dim_k>(
+             k_smem_offset_w = k_smem.get_permuted_offset<UPCAST_HEAD_DIM_K>(
                  warp_idx * kv_frag_rows + lane_idx / kv_frag_cols, lane_idx % kv_frag_cols),
-             v_smem_offset_w = v_smem.get_permuted_offset<upcast_head_dim_v>(
+             v_smem_offset_w = v_smem.get_permuted_offset<UPCAST_HEAD_DIM_V>(
                  warp_idx * kv_frag_rows + lane_idx / kv_frag_cols, lane_idx % kv_frag_cols);
 
     DTypeKV* k_ptr =
@@ -1722,11 +1747,11 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRag
             v_stride_n +
         kv_head_idx * v_stride_h + (lane_idx % kv_frag_cols) * upcast_size<DTypeKV>();
 
-    produce_kv<SharedMemFillMode::kNoFill, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_QK, NUM_MMA_KV>(
-        k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, 0, chunk_size);
+    produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(k_smem, &k_smem_offset_w, &k_ptr,
+                                                           k_stride_n, 0, chunk_size);
     cp_async::commit_group();
-    produce_kv<SharedMemFillMode::kFillZero, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV>(
-        v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, 0, chunk_size);
+    produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(v_smem, &v_smem_offset_w, &v_ptr,
+                                                            v_stride_n, 0, chunk_size);
     cp_async::commit_group();
 
 #pragma unroll 1
@@ -1734,84 +1759,77 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRag
       cp_async::wait_group<1>();
       block.sync();
 
-      if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+      if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
         IdType* k_rope_offset = nullptr;
         if constexpr (has_maybe_k_rope_offset_v<Params>) {
           k_rope_offset = params.maybe_k_rope_offset;
         }
-        k_smem_inplace_apply_rotary<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV,
-                                    swizzle_mode_kv, DTypeKV>(
+        k_smem_inplace_apply_rotary<KTraits>(
             (k_rope_offset == nullptr ? 0 : k_rope_offset[request_idx]) + chunk_start +
-                iter * 16 * NUM_WARPS_KV * NUM_MMA_KV,
+                iter * CTA_TILE_KV,
             &k_smem, &k_smem_offset_r, rope_freq);
         block.sync();
       }
 
       // compute attention score
-      compute_qk<NUM_MMA_Q, NUM_MMA_D_QK, NUM_MMA_KV, swizzle_mode_q, swizzle_mode_kv, DTypeQ,
-                 DTypeKV>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+      compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
 
-      logits_transform<NUM_MMA_Q, NUM_MMA_KV>(
+      logits_transform<KTraits>(
           params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-          chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                            NUM_MMA_KV * 16,
+          chunk_start + (iter * KTraits::NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) *
+                            KTraits::NUM_MMA_KV * 16,
           qo_len, kv_len, group_size, s_frag);
 
       // apply mask
       if (MASK_MODE == MaskMode::kCustom || (iter >= mask_iteration || iter < window_iteration)) {
-        logits_mask<MASK_MODE, NUM_MMA_Q, NUM_MMA_KV>(
+        logits_mask<MASK_MODE, KTraits>(
             params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                              NUM_MMA_KV * 16,
+            chunk_start + (iter * KTraits::NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) *
+                              KTraits::NUM_MMA_KV * 16,
             qo_len, kv_len, chunk_end, group_size, s_frag);
       }
 
       // compute m,d states in online softmax
-      update_mdo_states<NUM_MMA_Q, NUM_MMA_D_VO, NUM_MMA_KV>(variant, s_frag, o_frag, m, d);
+      update_mdo_states<KTraits>(s_frag, o_frag, m, d);
 
       block.sync();
-      produce_kv<SharedMemFillMode::kNoFill, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_QK, NUM_MMA_KV>(
-          k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, (iter + 1) * 16 * NUM_WARPS_KV * NUM_MMA_KV,
-          chunk_size);
+      produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(
+          k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size);
       cp_async::commit_group();
       cp_async::wait_group<1>();
       block.sync();
 
       // compute sfm*v
-      compute_sfm_v<NUM_MMA_Q, NUM_MMA_D_VO, NUM_MMA_KV, swizzle_mode_kv, DTypeQ, DTypeKV>(
-          variant, &v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
 
       block.sync();
-      produce_kv<SharedMemFillMode::kFillZero, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV>(
-          v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * 16 * NUM_WARPS_KV * NUM_MMA_KV,
-          chunk_size);
+      produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+          v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();
     block.sync();
 
     // threadblock synchronization
-    threadblock_sync_mdo_states<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO, DTypeQKAccum>(
-        variant, o_frag, (float*)smem, m, d, warp_idx, lane_idx);
+    threadblock_sync_mdo_states<KTraits>(o_frag, smem_storage, m, d, warp_idx, lane_idx);
 
     // normalize d
-    normalize_d<NUM_MMA_Q, NUM_MMA_D_VO>(variant, o_frag, m, d);
+    normalize_d<KTraits>(o_frag, m, d);
 
     const uint32_t num_kv_chunks = (kv_len_safe + kv_chunk_size - 1) / kv_chunk_size;
 
     // write back
-    write_o_reg_gmem<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO>(
-        o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
-        /*o_stride_n=*/
-        partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
-        /*o_stride_h=*/o_stride_h, group_size);
+    write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
+                              /*o_stride_n=*/
+                              partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
+                              /*o_stride_h=*/o_stride_h, group_size);
 
     // write lse
-    if constexpr (variant.use_softmax) {
+    if constexpr (KTraits::AttentionVariant::use_softmax) {
       if (lse != nullptr) {
-        if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
+        if (get_warp_idx_kv<KTraits>() == 0) {
 #pragma unroll
-          for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+          for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
             for (uint32_t j = 0; j < 2; ++j) {
               uint32_t q, r;
@@ -1838,11 +1856,8 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithRag
 #endif
 }
 
-template <MaskMode MASK_MODE, PosEncodingMode POS_ENCODING_MODE, uint32_t NUM_MMA_Q,
-          uint32_t NUM_MMA_D_QK, uint32_t NUM_MMA_D_VO, uint32_t NUM_MMA_KV, uint32_t NUM_WARPS_Q,
-          uint32_t NUM_WARPS_KV, typename DTypeQKAccum, typename AttentionVariant, typename Params>
-__global__
-__launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithPagedKVCacheKernel(
+template <MaskMode MASK_MODE, typename KTraits, typename Params>
+__global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithPagedKVCacheKernel(
     const uint_fastdiv group_size, const __grid_constant__ Params params) {
   using DTypeQ = typename Params::DTypeQ;
 #if (__CUDA_ARCH__ < 800)
@@ -1871,18 +1886,19 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithPag
     auto block = cg::this_thread_block();
     const uint32_t kv_chunk_size = *(params.kv_chunk_size_ptr);
 
-    const uint32_t bx = blockIdx.x, lane_idx = threadIdx.x,
-                   warp_idx = get_warp_idx<NUM_WARPS_Q, NUM_WARPS_KV>(), kv_head_idx = blockIdx.z;
+    const uint32_t bx = blockIdx.x, lane_idx = threadIdx.x, warp_idx = get_warp_idx<KTraits>(),
+                   kv_head_idx = blockIdx.z;
     if (block_valid_mask && !block_valid_mask[bx]) {
       return;
     }
     const uint32_t num_kv_heads = gridDim.z, num_qo_heads = num_kv_heads * group_size;
-
     const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
                    kv_tile_idx = kv_tile_indices[bx];
-    constexpr uint32_t num_rows_per_cta = NUM_MMA_Q * NUM_WARPS_Q * 16;
+    constexpr uint32_t CTA_TILE_Q = KTraits::CTA_TILE_Q;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
     extern __shared__ uint8_t smem[];
-    AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
+    auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+    typename KTraits::AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
     const uint32_t qo_len = variant.qo_len, kv_len = variant.kv_len,
                    window_left = variant.window_left;
     const uint32_t kv_len_safe = kv_len > 0 ? kv_len : 1;
@@ -1892,34 +1908,34 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithPag
         partition_kv ? min((kv_tile_idx + 1) * max_chunk_size, kv_len) : kv_len;
     const uint32_t chunk_size = chunk_end - chunk_start;
     const uint32_t qo_upper_bound =
-        min(qo_len, ceil_div((qo_tile_idx + 1) * num_rows_per_cta, group_size));
+        min(qo_len, ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size));
 
-    constexpr uint32_t head_dim_qk = NUM_MMA_D_QK * 16;
-    constexpr uint32_t head_dim_vo = NUM_MMA_D_VO * 16;
-    constexpr uint32_t upcast_head_dim_q = head_dim_qk / upcast_size<DTypeQ>();
-    constexpr uint32_t upcast_head_dim_k = head_dim_qk / upcast_size<DTypeKV>();
-    constexpr uint32_t upcast_head_dim_v = head_dim_vo / upcast_size<DTypeKV>();
-    constexpr uint32_t upcast_head_dim_o = head_dim_vo / upcast_size<DTypeO>();
+    constexpr uint32_t HEAD_DIM_QK = KTraits::HEAD_DIM_QK;
+    constexpr uint32_t HEAD_DIM_VO = KTraits::HEAD_DIM_VO;
+    constexpr uint32_t UPCAST_HEAD_DIM_Q = KTraits::UPCAST_HEAD_DIM_Q;
+    constexpr uint32_t UPCAST_HEAD_DIM_K = KTraits::UPCAST_HEAD_DIM_K;
+    constexpr uint32_t UPCAST_HEAD_DIM_V = KTraits::UPCAST_HEAD_DIM_V;
+    constexpr uint32_t UPCAST_HEAD_DIM_O = KTraits::UPCAST_HEAD_DIM_O;
 
-    DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
-    alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
-    DTypeQKAccum m[NUM_MMA_Q][2];
-    float d[NUM_MMA_Q][2];
-    float rope_freq[NUM_MMA_D_QK / 2][4];
+    typename KTraits::DTypeQKAccum s_frag[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_KV][8];
+    alignas(16) float o_frag[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_D_VO][8];
+    typename KTraits::DTypeQKAccum m[KTraits::NUM_MMA_Q][2];
+    float d[KTraits::NUM_MMA_Q][2];
+    float rope_freq[KTraits::NUM_MMA_D_QK / 2][4];
 
-    if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+    if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
-      init_rope_freq<NUM_MMA_D_QK>(rope_freq, rope_rcp_scale, rope_rcp_theta);
+      init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta);
     }
-    init_states<NUM_MMA_Q, NUM_MMA_D_VO>(variant, o_frag, m, d);
+    init_states<KTraits>(variant, o_frag, m, d);
 
     const uint32_t qo_packed_idx_base =
-        (qo_tile_idx * NUM_WARPS_Q + get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>()) * NUM_MMA_Q * 16;
+        (qo_tile_idx * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>()) * KTraits::NUM_MMA_Q * 16;
     const uint32_t q_stride_n = params.q_stride_n, q_stride_h = params.q_stride_h;
-    constexpr SwizzleMode swizzle_mode_q = SwizzleMode::k128B;
-    smem_t<swizzle_mode_q> qo_smem(smem);
-    const uint32_t o_stride_n = num_qo_heads * head_dim_vo, o_stride_h = head_dim_vo;
+    constexpr SwizzleMode swizzle_mode_q = KTraits::SWIZZLE_MODE_Q;
+    smem_t<swizzle_mode_q> qo_smem(smem_storage.q_smem);
+    const uint32_t o_stride_n = num_qo_heads * HEAD_DIM_VO, o_stride_h = HEAD_DIM_VO;
     DTypeQ* q_ptr_base = q + q_indptr[request_idx] * q_stride_n +
                          (kv_head_idx * group_size) * q_stride_h +
                          (lane_idx % 8) * upcast_size<DTypeQ>();
@@ -1929,115 +1945,107 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithPag
                   (kv_head_idx * group_size) * o_stride_h + (lane_idx % 8) * upcast_size<DTypeO>()
             : o + o_indptr[request_idx] * o_stride_n + (kv_head_idx * group_size) * o_stride_h +
                   (lane_idx % 8) * upcast_size<DTypeO>();
-    uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<upcast_head_dim_q>(
-        get_warp_idx_q<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_Q * 16 + lane_idx % 16,
-        lane_idx / 16);
+    uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<UPCAST_HEAD_DIM_Q>(
+        get_warp_idx_q<KTraits>() * KTraits::NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
 
-    load_q_global_smem<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_QK>(
-        qo_packed_idx_base, qo_upper_bound, q_ptr_base, q_stride_n, q_stride_h, group_size,
-        &qo_smem);
+    load_q_global_smem<KTraits>(qo_packed_idx_base, qo_upper_bound, q_ptr_base, q_stride_n,
+                                q_stride_h, group_size, &qo_smem);
 
     cp_async::commit_group();
     cp_async::wait_group<0>();
     block.sync();
 
-    if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+    if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       IdType* q_rope_offset = nullptr;
       if constexpr (has_maybe_q_rope_offset_v<Params>) {
         q_rope_offset = params.maybe_q_rope_offset;
       }
       if (q_rope_offset == nullptr) {
-        q_smem_inplace_apply_rotary<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO,
-                                    swizzle_mode_q, DTypeQ>(
-            qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq);
+        q_smem_inplace_apply_rotary<KTraits>(qo_packed_idx_base, qo_len, kv_len, group_size,
+                                             &qo_smem, &q_smem_offset_r, rope_freq);
       } else {
-        q_smem_inplace_apply_rotary_with_pos<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO,
-                                             swizzle_mode_q, DTypeQ>(
+        q_smem_inplace_apply_rotary_with_pos<KTraits>(
             qo_packed_idx_base, q_rope_offset + q_indptr[request_idx], &qo_smem, group_size,
             &q_smem_offset_r, rope_freq);
       }
       block.sync();
     }
-    q_smem_inplace_transform<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO, swizzle_mode_q>(
-        params, variant, &qo_smem);
+    q_smem_inplace_transform<KTraits>(params, variant, &qo_smem);
 
-    constexpr SwizzleMode swizzle_mode_kv =
-        (sizeof(DTypeKV) == 1 && head_dim_vo == 64) ? SwizzleMode::k64B : SwizzleMode::k128B;
+    constexpr SwizzleMode swizzle_mode_kv = KTraits::SWIZZLE_MODE_KV;
     constexpr uint32_t kv_frag_rows = swizzle_mode_kv == SwizzleMode::k128B ? 4 : 8;
     constexpr uint32_t kv_frag_cols = swizzle_mode_kv == SwizzleMode::k128B ? 8 : 4;
-    smem_t<swizzle_mode_kv> k_smem(smem +
-                                   (NUM_WARPS_Q * NUM_MMA_Q * sizeof(DTypeQ)) * 16 * head_dim_qk),
-        v_smem(smem + (NUM_WARPS_Q * NUM_MMA_Q * sizeof(DTypeQ) * 16 * head_dim_qk) +
-               (NUM_WARPS_KV * NUM_MMA_KV * sizeof(DTypeKV) * 16 * head_dim_qk));
-    size_t kv_offset[NUM_MMA_KV * (swizzle_mode_kv == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q];
+    smem_t<swizzle_mode_kv> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
+    size_t kv_offset[KTraits::NUM_MMA_KV * (swizzle_mode_kv == SwizzleMode::k128B ? 4 : 2) /
+                     KTraits::NUM_WARPS_Q];
 
-    uint32_t k_smem_offset_r = k_smem.get_permuted_offset<upcast_head_dim_k>(
-                 get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_KV * 16 +
-                     8 * (lane_idx / 16) + lane_idx % 8,
+    uint32_t k_smem_offset_r = k_smem.get_permuted_offset<UPCAST_HEAD_DIM_K>(
+                 get_warp_idx_kv<KTraits>() * KTraits::NUM_MMA_KV * 16 + 8 * (lane_idx / 16) +
+                     lane_idx % 8,
                  (lane_idx % 16) / 8),
-             v_smem_offset_r = v_smem.get_permuted_offset<upcast_head_dim_v>(
-                 get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() * NUM_MMA_KV * 16 + lane_idx % 16,
+             v_smem_offset_r = v_smem.get_permuted_offset<UPCAST_HEAD_DIM_V>(
+                 get_warp_idx_kv<KTraits>() * KTraits::NUM_MMA_KV * 16 + lane_idx % 16,
                  lane_idx / 16),
-             k_smem_offset_w = k_smem.get_permuted_offset<upcast_head_dim_k>(
+             k_smem_offset_w = k_smem.get_permuted_offset<UPCAST_HEAD_DIM_K>(
                  warp_idx * kv_frag_rows + lane_idx / kv_frag_cols, lane_idx % kv_frag_cols),
-             v_smem_offset_w = v_smem.get_permuted_offset<upcast_head_dim_v>(
+             v_smem_offset_w = v_smem.get_permuted_offset<UPCAST_HEAD_DIM_V>(
                  warp_idx * kv_frag_rows + lane_idx / kv_frag_cols, lane_idx % kv_frag_cols);
     const IdType last_indptr = paged_kv.indptr[paged_kv.batch_size];
 
     uint32_t packed_page_iter_base =
         paged_kv.indptr[request_idx] * paged_kv.page_size + chunk_start;
 #pragma unroll
-    for (uint32_t i = 0;
-         i < NUM_MMA_KV * (swizzle_mode_kv == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+    for (uint32_t i = 0; i < KTraits::NUM_MMA_KV * (swizzle_mode_kv == SwizzleMode::k128B ? 4 : 2) /
+                                 KTraits::NUM_WARPS_Q;
+         ++i) {
       uint32_t page_iter, entry_idx;
       paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * kv_frag_rows +
                                     lane_idx / kv_frag_cols +
-                                    kv_frag_rows * NUM_WARPS_Q * NUM_WARPS_KV * i,
+                                    kv_frag_rows * KTraits::NUM_WARPS_Q * KTraits::NUM_WARPS_KV * i,
                                 page_iter, entry_idx);
       kv_offset[i] = paged_kv.protective_get_kv_offset(
           page_iter, kv_head_idx, entry_idx, (lane_idx % kv_frag_cols) * upcast_size<DTypeKV>(),
           last_indptr);
     }
-    page_produce_kv<false, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_QK, NUM_MMA_KV>(
-        k_smem, &k_smem_offset_w, paged_kv, 0, kv_offset, chunk_size);
+    page_produce_kv<false, KTraits>(k_smem, &k_smem_offset_w, paged_kv, 0, kv_offset, chunk_size);
     cp_async::commit_group();
-    page_produce_kv<true, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV>(
-        v_smem, &v_smem_offset_w, paged_kv, 0, kv_offset, chunk_size);
+    page_produce_kv<true, KTraits>(v_smem, &v_smem_offset_w, paged_kv, 0, kv_offset, chunk_size);
     cp_async::commit_group();
 
     const uint32_t num_iterations = ceil_div(
         (MASK_MODE == MaskMode::kCausal
-             ? min(chunk_size,
-                   sub_if_greater_or_zero(
-                       kv_len - qo_len + ((qo_tile_idx + 1) * num_rows_per_cta) / group_size,
-                       chunk_start))
+             ? min(chunk_size, sub_if_greater_or_zero(
+                                   kv_len - qo_len + ((qo_tile_idx + 1) * CTA_TILE_Q) / group_size,
+                                   chunk_start))
              : chunk_size),
-        16 * NUM_WARPS_KV * NUM_MMA_KV);
+        16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV);
 
     const uint32_t window_iteration =
-        ceil_div(sub_if_greater_or_zero(kv_len + (qo_tile_idx + 1) * num_rows_per_cta / group_size,
+        ceil_div(sub_if_greater_or_zero(kv_len + (qo_tile_idx + 1) * CTA_TILE_Q / group_size,
                                         qo_len + window_left + chunk_start),
-                 (16 * NUM_WARPS_KV * NUM_MMA_KV));
+                 (16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV));
 
     const uint32_t mask_iteration =
         (MASK_MODE == MaskMode::kCausal
-             ? min(chunk_size, sub_if_greater_or_zero(
-                                   kv_len + (qo_tile_idx * num_rows_per_cta) / group_size - qo_len,
-                                   chunk_start))
+             ? min(chunk_size,
+                   sub_if_greater_or_zero(kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size - qo_len,
+                                          chunk_start))
              : chunk_size) /
-        (16 * NUM_WARPS_KV * NUM_MMA_KV);
+        (16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV);
 
 #pragma unroll 1
     for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-      packed_page_iter_base += 16 * NUM_WARPS_KV * NUM_MMA_KV;
+      packed_page_iter_base += 16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV;
 #pragma unroll
       for (uint32_t i = 0;
-           i < NUM_MMA_KV * (swizzle_mode_kv == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+           i < KTraits::NUM_MMA_KV * (swizzle_mode_kv == SwizzleMode::k128B ? 4 : 2) /
+                   KTraits::NUM_WARPS_Q;
+           ++i) {
         uint32_t page_iter, entry_idx;
-        paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * kv_frag_rows +
-                                      lane_idx / kv_frag_cols +
-                                      kv_frag_rows * NUM_WARPS_Q * NUM_WARPS_KV * i,
-                                  page_iter, entry_idx);
+        paged_kv.page_size.divmod(
+            packed_page_iter_base + warp_idx * kv_frag_rows + lane_idx / kv_frag_cols +
+                kv_frag_rows * KTraits::NUM_WARPS_Q * KTraits::NUM_WARPS_KV * i,
+            page_iter, entry_idx);
         kv_offset[i] = paged_kv.protective_get_kv_offset(
             page_iter, kv_head_idx, entry_idx, (lane_idx % kv_frag_cols) * upcast_size<DTypeKV>(),
             last_indptr);
@@ -2045,80 +2053,75 @@ __launch_bounds__(NUM_WARPS_Q* NUM_WARPS_KV* WARP_SIZE) void BatchPrefillWithPag
       cp_async::wait_group<1>();
       block.sync();
 
-      if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
-        k_smem_inplace_apply_rotary<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV,
-                                    swizzle_mode_kv, DTypeKV>(
+      if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+        k_smem_inplace_apply_rotary<KTraits>(
             (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[request_idx]) +
-                chunk_start + iter * 16 * NUM_WARPS_KV * NUM_MMA_KV,
+                chunk_start + iter * 16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV,
             &k_smem, &k_smem_offset_r, rope_freq);
         block.sync();
       }
 
       // compute attention score
-      compute_qk<NUM_MMA_Q, NUM_MMA_D_QK, NUM_MMA_KV, swizzle_mode_q, swizzle_mode_kv, DTypeQ,
-                 DTypeKV>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+      compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
 
-      logits_transform<NUM_MMA_Q, NUM_MMA_KV>(
+      logits_transform<KTraits>(
           params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-          chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                            NUM_MMA_KV * 16,
+          chunk_start + (iter * KTraits::NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) *
+                            KTraits::NUM_MMA_KV * 16,
           qo_len, kv_len, group_size, s_frag);
 
       // apply mask
       if (MASK_MODE == MaskMode::kCustom || (iter >= mask_iteration || iter < window_iteration)) {
-        logits_mask<MASK_MODE, NUM_MMA_Q, NUM_MMA_KV>(
+        logits_mask<MASK_MODE, KTraits>(
             params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>()) *
-                              NUM_MMA_KV * 16,
+            chunk_start + (iter * KTraits::NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) *
+                              KTraits::NUM_MMA_KV * 16,
             qo_len, kv_len, chunk_end, group_size, s_frag);
       }
 
       // compute m,d states in online softmax
-      update_mdo_states<NUM_MMA_Q, NUM_MMA_D_VO, NUM_MMA_KV>(variant, s_frag, o_frag, m, d);
+      update_mdo_states<KTraits>(s_frag, o_frag, m, d);
 
       block.sync();
-      page_produce_kv<false, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_QK, NUM_MMA_KV>(
-          k_smem, &k_smem_offset_w, paged_kv, (iter + 1) * 16 * NUM_WARPS_KV * NUM_MMA_KV,
-          kv_offset, chunk_size);
+      page_produce_kv<false, KTraits>(k_smem, &k_smem_offset_w, paged_kv,
+                                      (iter + 1) * 16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV,
+                                      kv_offset, chunk_size);
       cp_async::commit_group();
       cp_async::wait_group<1>();
       block.sync();
 
       // compute sfm*v
-      compute_sfm_v<NUM_MMA_Q, NUM_MMA_D_VO, NUM_MMA_KV, swizzle_mode_kv, DTypeQ, DTypeKV>(
-          variant, &v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
 
       block.sync();
-      page_produce_kv<true, NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_D_VO, NUM_MMA_KV>(
-          v_smem, &v_smem_offset_w, paged_kv, (iter + 1) * 16 * NUM_WARPS_KV * NUM_MMA_KV,
-          kv_offset, chunk_size);
+      page_produce_kv<true, KTraits>(v_smem, &v_smem_offset_w, paged_kv,
+                                     (iter + 1) * 16 * KTraits::NUM_WARPS_KV * KTraits::NUM_MMA_KV,
+                                     kv_offset, chunk_size);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();
     block.sync();
 
     // threadblock synchronization
-    threadblock_sync_mdo_states<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO, DTypeQKAccum>(
-        variant, o_frag, (float*)smem, m, d, warp_idx, lane_idx);
+    threadblock_sync_mdo_states<KTraits>(o_frag, smem_storage, m, d, warp_idx, lane_idx);
 
     // normalize d
-    normalize_d<NUM_MMA_Q, NUM_MMA_D_VO>(variant, o_frag, m, d);
+    normalize_d<KTraits>(o_frag, m, d);
 
     const uint32_t num_kv_chunks = (kv_len_safe + kv_chunk_size - 1) / kv_chunk_size;
 
     // write_back
-    write_o_reg_gmem<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, NUM_MMA_D_VO>(
-        o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
-        /*o_stride_n=*/
-        partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
-        /*o_stride_h=*/o_stride_h, group_size);
+    write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base, qo_packed_idx_base, qo_len,
+                              /*o_stride_n=*/
+                              partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
+                              /*o_stride_h=*/o_stride_h, group_size);
 
     // write lse
     if constexpr (variant.use_softmax) {
       if (lse != nullptr) {
-        if (get_warp_idx_kv<NUM_WARPS_Q, NUM_WARPS_KV>() == 0) {
+        if (get_warp_idx_kv<KTraits>() == 0) {
 #pragma unroll
-          for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+          for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
             for (uint32_t j = 0; j < 2; ++j) {
               uint32_t q, r;
@@ -2196,9 +2199,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       (2 * NUM_WARPS_KV);
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
-    if constexpr (is_invalid_configuration<POS_ENCODING_MODE, DTypeKV, DTypeQKAccum>(
-                      NUM_MMA_Q, NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_MMA_KV, NUM_WARPS_Q,
-                      NUM_WARPS_KV)) {
+    using KTraits = KernelTraits<NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_WARPS_Q,
+                                 NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
+                                 DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+    if constexpr (KTraits::IsInvalid()) {
       // Invalid configuration, skip
       std::ostringstream err_msg;
       err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
@@ -2210,14 +2214,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       FLASHINFER_ERROR(err_msg.str());
     } else {
       // TODO(Zihao): fix the following computation
-      size_t smem_size = max(
-          SmemSizeThreadBlockAttnSync<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, HEAD_DIM_VO, DTypeO>(),
-          NUM_MMA_Q * NUM_WARPS_Q * 16 * HEAD_DIM_QK * sizeof(DTypeQ) +
-              NUM_MMA_KV * NUM_WARPS_KV * 16 * (HEAD_DIM_QK + HEAD_DIM_VO) * sizeof(DTypeKV));
-      auto kernel =
-          BatchPrefillWithRaggedKVCacheKernel<MASK_MODE, POS_ENCODING_MODE, NUM_MMA_Q, NUM_MMA_D_QK,
-                                              NUM_MMA_D_VO, NUM_MMA_KV, NUM_WARPS_Q, NUM_WARPS_KV,
-                                              DTypeQKAccum, AttentionVariant, Params>;
+      constexpr int CTA_TILE_KV = NUM_MMA_KV * NUM_WARPS_KV * 16;
+      size_t smem_size = sizeof(typename KTraits::SharedStorage);
+      auto kernel = BatchPrefillWithRaggedKVCacheKernel<MASK_MODE, KTraits, Params>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
       if (tmp_v == nullptr) {
@@ -2303,9 +2302,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       (2 * NUM_WARPS_KV);
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
-    if constexpr (is_invalid_configuration<POS_ENCODING_MODE, DTypeKV, DTypeQKAccum>(
-                      NUM_MMA_Q, NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_MMA_KV, NUM_WARPS_Q,
-                      NUM_WARPS_KV)) {
+    using KTraits = KernelTraits<NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_WARPS_Q,
+                                 NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
+                                 DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+    if constexpr (KTraits::IsInvalid()) {
       // Invalid configuration, skip
       std::ostringstream err_msg;
       err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
@@ -2317,14 +2317,9 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       FLASHINFER_ERROR(err_msg.str());
     } else {
       // TODO(Zihao): fix the following computation
-      size_t smem_size = max(
-          SmemSizeThreadBlockAttnSync<NUM_WARPS_Q, NUM_WARPS_KV, NUM_MMA_Q, HEAD_DIM_VO, DTypeO>(),
-          NUM_MMA_Q * NUM_WARPS_Q * 16 * HEAD_DIM_QK * sizeof(DTypeQ) +
-              NUM_MMA_KV * NUM_WARPS_KV * 16 * (HEAD_DIM_QK + HEAD_DIM_VO) * sizeof(DTypeKV));
-      auto kernel =
-          BatchPrefillWithPagedKVCacheKernel<MASK_MODE, POS_ENCODING_MODE, NUM_MMA_Q, NUM_MMA_D_QK,
-                                             NUM_MMA_D_VO, NUM_MMA_KV, NUM_WARPS_Q, NUM_WARPS_KV,
-                                             DTypeQKAccum, AttentionVariant, Params>;
+      constexpr int CTA_TILE_KV = NUM_MMA_KV * NUM_WARPS_KV * 16;
+      size_t smem_size = sizeof(typename KTraits::SharedStorage);
+      auto kernel = BatchPrefillWithPagedKVCacheKernel<MASK_MODE, KTraits, Params>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
       if (tmp_v == nullptr) {

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -811,9 +811,9 @@ __device__ __forceinline__ void compute_sfm_v(AttentionVariant variant,
 #pragma unroll
       for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
         if constexpr (std::is_same_v<DTypeQKAccum, float>) {
-          mma::rowsum_f16f16f32(d[mma_q], s_frag_f16[mma_q][mma_kv]);
+          mma::m16k16_rowsum_f16f16f32(d[mma_q], s_frag_f16[mma_q][mma_kv]);
         } else {
-          mma::rowsum_f16f16f32(d[mma_q], s_frag[mma_q][mma_kv]);
+          mma::m16k16_rowsum_f16f16f32(d[mma_q], s_frag[mma_q][mma_kv]);
         }
       }
     }


### PR DESCRIPTION
For decoding kernels with GQA ratio <= 8, we can only use upper half of MMA shape instead of the entire MMA shape, to reduce shared memory/register usage as well as CUDA Cores (e.g. exp2) instructions, this PR refactors the FA2 template to support this acceleration.