### PR TITLE
ci: change whl folder to flashinfer-python

### DIFF
--- a/scripts/update_whl_index.py
+++ b/scripts/update_whl_index.py
@@ -9,7 +9,7 @@ for path in sorted(pathlib.Path("dist").glob("*.whl")):
         r"flashinfer_python-([0-9.]+(?:\.post[0-9]+)?)\+cu(\d+)torch([0-9.]+)-",
         path.name,
     )[0]
-    index_dir = pathlib.Path(f"flashinfer-whl/cu{cu}/torch{torch}/flashinfer")
+    index_dir = pathlib.Path(f"flashinfer-whl/cu{cu}/torch{torch}/flashinfer-python")
     index_dir.mkdir(exist_ok=True)
     base_url = "https://github.com/flashinfer-ai/flashinfer/releases/download"
     full_url = f"{base_url}/v{ver}/{path.name}#sha256={sha256}"


### PR DESCRIPTION
Fixed the index for existing wheels in [another commit](https://github.com/flashinfer-ai/whl/commit/d252b0822343a09e026cefac14fe427ac0b9bc45). This PR fixes future releases.