### PR TITLE
refactor: make `group_size` a part of params

### DIFF
--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -125,6 +125,7 @@ void BatchPrefillWithRaggedKVCacheRun(
         params.kv_indptr = static_cast<IdType*>(kv_indptr.data_ptr());
         params.num_qo_heads = num_qo_heads;
         params.num_kv_heads = num_kv_heads;
+        params.group_size = uint_fastdiv(num_qo_heads / num_kv_heads);
         params.q_stride_n = q_stride_n;
         params.q_stride_h = q_stride_h;
         params.k_stride_n = k_stride_n;
@@ -260,6 +261,7 @@ void BatchPrefillWithPagedKVCacheRun(
 
         params.lse = maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;
         params.num_qo_heads = num_qo_heads;
+        params.group_size = uint_fastdiv(num_qo_heads / paged_kv.num_heads);
         params.q_stride_n = q_stride_n;
         params.q_stride_h = q_stride_h;
         params.window_left = window_left;

--- a/csrc/batch_prefill_customize_config.jinja
+++ b/csrc/batch_prefill_customize_config.jinja
@@ -4,6 +4,7 @@
 #include <flashinfer/layout.cuh>
 #include <flashinfer/utils.cuh>
 #include <flashinfer/pos_enc.cuh>
+#include <flashinfer/fastdiv.cuh>
 
 #define ADDITIONAL_FUNC_PARAMS {{ additional_func_params }}
 #define ADDITIONAL_PARAMS_SETTER {{ additional_params_setter }}
@@ -42,6 +43,8 @@ struct RaggedParams {
   IdType* kv_indptr;
   DTypeO* o;
   float* lse;
+  uint_fastdiv group_size;
+
   {{ additional_params_decl }}
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
@@ -85,6 +88,8 @@ struct PagedParams {
   IdType* q_indptr;
   DTypeO* o;
   float* lse;
+  uint_fastdiv group_size;
+
   {{ additional_params_decl }}
   uint32_t num_qo_heads;
   IdType q_stride_n;

--- a/csrc/single_prefill.cu
+++ b/csrc/single_prefill.cu
@@ -17,6 +17,7 @@
 #include <flashinfer/pos_enc.cuh>
 #include <optional>
 
+#include "flashinfer/fastdiv.cuh"
 #include "pytorch_extension_utils.h"
 #include "single_prefill_config.inc"
 
@@ -85,6 +86,7 @@ void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::
         params.lse = maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;
         params.num_qo_heads = num_qo_heads;
         params.num_kv_heads = num_kv_heads;
+        params.group_size = uint_fastdiv(num_qo_heads / num_kv_heads);
         params.qo_len = qo_len;
         params.kv_len = kv_len;
         params.q_stride_n = q_stride_n;

--- a/csrc/single_prefill_customize_config.jinja
+++ b/csrc/single_prefill_customize_config.jinja
@@ -3,6 +3,7 @@
 #include <flashinfer/layout.cuh>
 #include <flashinfer/utils.cuh>
 #include <flashinfer/pos_enc.cuh>
+#include <flashinfer/fastdiv.cuh>
 
 #define ADDITIONAL_FUNC_PARAMS {{ additional_func_params }}
 #define ADDITIONAL_PARAMS_SETTER {{ additional_params_setter }}
@@ -39,6 +40,7 @@ struct Params {
   DTypeKV* v;
   DTypeO* o;
   float* lse;
+  uint_fastdiv group_size;
 
   {{ additional_params_decl }}
 

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -38,6 +38,7 @@ struct SinglePrefillParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  uint_fastdiv group_size;
   uint32_t qo_len;
   uint32_t kv_len;
   uint32_t num_qo_heads;
@@ -65,6 +66,7 @@ struct SinglePrefillParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        group_size(),
         qo_len(0),
         kv_len(0),
         num_qo_heads(0),
@@ -97,6 +99,7 @@ struct SinglePrefillParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        group_size(num_qo_heads / num_kv_heads),
         num_qo_heads(num_qo_heads),
         num_kv_heads(num_kv_heads),
         qo_len(qo_len),
@@ -143,6 +146,7 @@ struct BatchPrefillRaggedParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  uint_fastdiv group_size;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
   uint32_t q_stride_n;
@@ -182,6 +186,7 @@ struct BatchPrefillRaggedParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        group_size(),
         num_qo_heads(0),
         num_kv_heads(0),
         q_stride_n(0),
@@ -228,6 +233,7 @@ struct BatchPrefillRaggedParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        group_size(num_qo_heads / num_kv_heads),
         num_qo_heads(num_qo_heads),
         num_kv_heads(num_kv_heads),
         q_stride_n(q_stride_n),
@@ -278,6 +284,7 @@ struct BatchPrefillPagedParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  uint_fastdiv group_size;
   uint32_t num_qo_heads;
   IdType q_stride_n;
   IdType q_stride_h;
@@ -309,6 +316,7 @@ struct BatchPrefillPagedParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        group_size(),
         num_qo_heads(0),
         q_stride_n(0),
         q_stride_h(0),
@@ -345,6 +353,7 @@ struct BatchPrefillPagedParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        group_size(num_qo_heads / paged_kv.num_heads),
         num_qo_heads(num_qo_heads),
         q_stride_n(q_stride_n),
         q_stride_h(q_stride_h),


### PR DESCRIPTION
We put `group_size` outside of params mainly because we observe better performance, but with some recent refactor such as #748 and #776 , there is no need to decouple group_size with other parts of the parameters, this PR merge `group_size` back to parameter class.