### PR TITLE
bugfix: MLA decode should multiply sm_scale by math::log2e

### DIFF
--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -180,6 +180,7 @@ def gen_batch_decode_mla_module(
         dtype_o,
         dtype_idx,
         head_dim,
+        head_dim,
         use_sliding_window,
         use_logits_soft_cap,
     )

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -857,6 +857,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernelMLA(Params params) {
   const float rope_rcp_scale = params.rope_rcp_scale;
   const float rope_rcp_theta = params.rope_rcp_theta;
   const bool partition_kv = params.partition_kv;
+  params.sm_scale *= math::log2e;
 
   constexpr uint32_t head_dim_ckv = bdx * vec_size_ckv;
   constexpr uint32_t head_dim_kpe = bdx * vec_size_kpe;


### PR DESCRIPTION
After this fix, the `mse_use_flashinfer` in `test_mla_decode_kernel.py` will improve significantly.