### PR TITLE
feat: support f32 attention output in FA2 template

### DIFF
--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -38,8 +38,6 @@ struct SinglePrefillParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
-  float* tmp_o;
-  float* tmp_lse;
   uint_fastdiv group_size;
   uint32_t qo_len;
   uint32_t kv_len;

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -38,6 +38,8 @@ struct SinglePrefillParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  float* tmp_o;
+  float* tmp_lse;
   uint_fastdiv group_size;
   uint32_t qo_len;
   uint32_t kv_len;
@@ -114,8 +116,8 @@ struct SinglePrefillParams {
         window_left(window_left),
         logits_soft_cap(logits_soft_cap),
         sm_scale(sm_scale),
-        rope_rcp_scale(-std::log2f(rope_scale)),
-        rope_rcp_theta(-std::log2f(rope_theta)),
+        rope_rcp_scale(1. / rope_scale),
+        rope_rcp_theta(1. / rope_theta),
         partition_kv(false) {}
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {


### PR DESCRIPTION
For bf16 kernels, we need to use f32 as the intermediate data type for split-k partial output to avoid numerical errors. This PR adds support for f32 output in CUDA templates.

This PR is the first step towards addressing the bf16 kernel numerical issues.

The remaining tasks include:
1. do not pre-apply `sm_scale` to query, apply `sm_scale` to logits instead.
2. change the split-k default partial output dtype to float32.