### PR TITLE
perf: memory efficient deepseek mla fused page-attention kernel

### DIFF
--- a/benchmarks/bench_deepseek_mla.py
+++ b/benchmarks/bench_deepseek_mla.py
@@ -27,13 +27,13 @@ def bench_deepseek_mla_decode(batch_size, seq_len, num_heads):
     q_nope = torch.randn(
         batch_size * 1, num_heads, head_dim_ckv, dtype=torch.half, device="cuda"
     )
-    q_pe = torch.randn(
+    q_pe = torch.zeros(
         batch_size * 1, num_heads, head_dim_kpe, dtype=torch.half, device="cuda"
     )
     ckv = torch.randn(
         batch_size * seq_len, 1, head_dim_ckv, dtype=torch.half, device="cuda"
     )
-    kpe = torch.randn(
+    kpe = torch.zeros(
         batch_size * seq_len, 1, head_dim_kpe, dtype=torch.half, device="cuda"
     )
     sm_scale = 1.0 / ((head_dim_ckv + head_dim_kpe) ** 0.5)
@@ -59,7 +59,7 @@ def bench_deepseek_mla_decode(batch_size, seq_len, num_heads):
         q_nope.dtype,
         ckv.dtype,
     )
-    o = wrapper.run(q_nope, q_pe, ckv, kpe)
+    o = wrapper.run(q_nope, q_pe, ckv, kpe, return_lse=False)
 
     ms = triton.testing.do_bench(
         lambda: wrapper.run(q_nope, q_pe, ckv, kpe),
@@ -73,4 +73,4 @@ def bench_deepseek_mla_decode(batch_size, seq_len, num_heads):
 
 
 if __name__ == "__main__":
-    bench_deepseek_mla_decode(128, 2048, 64)
+    bench_deepseek_mla_decode(768, 2048, 16)

--- a/benchmarks/bench_deepseek_mla.py
+++ b/benchmarks/bench_deepseek_mla.py
@@ -69,8 +69,14 @@ def bench_deepseek_mla_decode(batch_size, seq_len, num_heads):
 
     io = sum([_.numel() * _.element_size() for _ in [q_nope, q_pe, ckv, kpe, o]])
 
-    print("Peak bandwidth: {:.2f} GB/s".format(io * 1e-6 / ms))
+    print(f"Config: batch_size={batch_size}, seq_len={seq_len}, num_heads={num_heads}")
+    print(f"Memory bandwidth: {io * 1e-6 / ms:.2f} GB/s")
 
 
 if __name__ == "__main__":
+    bench_deepseek_mla_decode(768, 1024, 16)
+    bench_deepseek_mla_decode(768, 1024, 32)
+    bench_deepseek_mla_decode(768, 1024, 64)
     bench_deepseek_mla_decode(768, 2048, 16)
+    bench_deepseek_mla_decode(768, 2048, 32)
+    bench_deepseek_mla_decode(768, 2048, 64)

--- a/benchmarks/bench_deepseek_mla.py
+++ b/benchmarks/bench_deepseek_mla.py
@@ -1,0 +1,76 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import torch
+import triton
+
+import flashinfer
+
+
+def bench_deepseek_mla_decode(batch_size, seq_len, num_heads):
+    head_dim_ckv = 512
+    head_dim_kpe = 64
+    page_size = 1
+    q_nope = torch.randn(
+        batch_size * 1, num_heads, head_dim_ckv, dtype=torch.half, device="cuda"
+    )
+    q_pe = torch.randn(
+        batch_size * 1, num_heads, head_dim_kpe, dtype=torch.half, device="cuda"
+    )
+    ckv = torch.randn(
+        batch_size * seq_len, 1, head_dim_ckv, dtype=torch.half, device="cuda"
+    )
+    kpe = torch.randn(
+        batch_size * seq_len, 1, head_dim_kpe, dtype=torch.half, device="cuda"
+    )
+    sm_scale = 1.0 / ((head_dim_ckv + head_dim_kpe) ** 0.5)
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
+    wrapper = flashinfer.mla.BatchMLAPageAttentionWrapper(
+        workspace_buffer, backend="fa2"
+    )
+    q_indptr = torch.arange(0, batch_size + 1).to(0).int()
+    kv_indptr = torch.arange(0, batch_size + 1).to(0).int() * seq_len
+    kv_indices = torch.arange(0, batch_size * seq_len).to(0).int()
+    kv_lens = torch.full((batch_size,), seq_len, dtype=torch.int32).to(0)
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_lens,
+        num_heads,
+        head_dim_ckv,
+        head_dim_kpe,
+        page_size,
+        False,  # causal
+        sm_scale,
+        q_nope.dtype,
+        ckv.dtype,
+    )
+    o = wrapper.run(q_nope, q_pe, ckv, kpe)
+
+    ms = triton.testing.do_bench(
+        lambda: wrapper.run(q_nope, q_pe, ckv, kpe),
+        warmup=100,
+        rep=1000,
+    )
+
+    io = sum([_.numel() * _.element_size() for _ in [q_nope, q_pe, ckv, kpe, o]])
+
+    print("Peak bandwidth: {:.2f} GB/s".format(io * 1e-6 / ms))
+
+
+if __name__ == "__main__":
+    bench_deepseek_mla_decode(128, 2048, 64)

--- a/csrc/batch_mla_config.jinja
+++ b/csrc/batch_mla_config.jinja
@@ -1,0 +1,24 @@
+#pragma once
+#include <flashinfer/page.cuh>
+#include <flashinfer/math.cuh>
+#include <flashinfer/layout.cuh>
+#include <flashinfer/utils.cuh>
+#include <flashinfer/pos_enc.cuh>
+#include <flashinfer/fastdiv.cuh>
+#include <flashinfer/attention/variant_helper.cuh>
+#include <flashinfer/attention/mla_params.cuh>
+
+using namespace flashinfer;
+
+using DTypeQ = {{ dtype_q }};
+using DTypeKV = {{ dtype_kv }};
+using DTypeO = {{ dtype_o }};
+using IdType = {{ dtype_idx }};
+constexpr int HEAD_DIM_CKV = {{ head_dim_ckv }};
+constexpr int HEAD_DIM_KPE = {{ head_dim_kpe }};
+
+#define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE, Params, ...) \
+  DISPATCH_MASK_MODE(mask_mode, MASK_MODE, { \
+    using Params = MLAParams<DTypeQ, DTypeKV, DTypeO, IdType>; \
+    __VA_ARGS__(); \
+  })

--- a/csrc/batch_mla_plan.cu
+++ b/csrc/batch_mla_plan.cu
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <flashinfer/attention/scheduler.cuh>
+#include <optional>
+
+#include "batch_mla_config.inc"
+#include "pytorch_extension_utils.h"
+
+using namespace flashinfer;
+
+std::vector<int64_t> BatchMLAPageAttentionPlan(at::Tensor float_workspace_buffer,
+                                               at::Tensor int_workspace_buffer,
+                                               at::Tensor page_locked_int_workspace_buffer,
+                                               at::Tensor qo_indptr, at::Tensor kv_indptr,
+                                               at::Tensor kv_len, unsigned int num_heads,
+                                               unsigned int head_dim_o, bool causal,
+                                               int64_t cuda_stream) {
+  size_t float_workspace_size_in_bytes =
+      float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
+  size_t int_workspace_size_in_bytes =
+      int_workspace_buffer.size(0) * int_workspace_buffer.element_size();
+
+  MLAPlanInfo plan_info;
+
+  int batch_size = kv_len.size(0);
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  cudaError_t status =
+      MLAPlan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
+              int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
+              int_workspace_size_in_bytes, plan_info, static_cast<IdType*>(qo_indptr.data_ptr()),
+              static_cast<IdType*>(kv_indptr.data_ptr()), static_cast<IdType*>(kv_len.data_ptr()),
+              batch_size, num_heads, head_dim_o, causal, stream);
+
+  TORCH_CHECK(status == cudaSuccess, "Failed to plan MLA, error: ", cudaGetErrorString(status));
+
+  return plan_info.ToVector();
+}

--- a/csrc/batch_mla_pybind.cu
+++ b/csrc/batch_mla_pybind.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "batch_mla_config.inc"
+#include "pytorch_extension_utils.h"
+
+std::vector<int64_t> BatchMLAPageAttentionPlan(at::Tensor float_workspace_buffer,
+                                               at::Tensor int_workspace_buffer,
+                                               at::Tensor page_locked_int_workspace_buffer,
+                                               at::Tensor qo_indptr, at::Tensor kv_indptr,
+                                               at::Tensor kv_len, unsigned int num_heads,
+                                               unsigned int head_dim_o, bool causal,
+                                               int64_t cuda_stream);
+
+void BatchMLAPageAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
+                              std::vector<int64_t> plan_info_vec, at::Tensor q_nope,
+                              at::Tensor q_pe, at::Tensor ckv_cache, at::Tensor kpe_cache,
+                              at::Tensor kv_indices, at::Tensor o,
+                              std::optional<at::Tensor> maybe_lse, int mask_mode_code,
+                              int num_heads, int page_size, float sm_scale, int64_t cuda_stream);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("plan", &BatchMLAPageAttentionPlan, "Batch MLA Page Attention Plan");
+  m.def("run", &BatchMLAPageAttentionRun, "Batch MLA Page Attention Run");
+}

--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <driver_types.h>
+
+#include <flashinfer/attention/mla_fa2.cuh>
+#include <flashinfer/attention/scheduler.cuh>
+#include <flashinfer/fastdiv.cuh>
+#include <optional>
+
+#include "batch_mla_config.inc"
+#include "pytorch_extension_utils.h"
+
+using namespace flashinfer;
+
+void BatchMLAPageAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
+                              std::vector<int64_t> plan_info_vec, at::Tensor q_nope,
+                              at::Tensor q_pe, at::Tensor ckv_cache, at::Tensor kpe_cache,
+                              at::Tensor kv_indices, at::Tensor o,
+                              std::optional<at::Tensor> maybe_lse, int mask_mode_code,
+                              int num_heads, int page_size, float sm_scale, int64_t cuda_stream) {
+  // q_nope: [n, num_heads, head_dim_ckv]
+  // q_pe: [n, num_heads, head_dim_kpe]
+  // ckv_cache: [num_pages, page_size, head_dim_ckv]
+  // kpe_cache: [num_pages, page_size, head_dim_kpe]
+  MLAPlanInfo plan_info;
+  plan_info.FromVector(plan_info_vec);
+
+  auto device = q_nope.device();
+
+  void* float_buffer_ptr = float_workspace_buffer.data_ptr();
+  void* int_buffer_ptr = int_workspace_buffer.data_ptr();
+
+  const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
+
+  auto q_scalar_type = q_nope.scalar_type();
+  auto kv_scalar_type = ckv_cache.scalar_type();
+
+  unsigned int q_nope_stride_n = q_nope.stride(0);
+  unsigned int q_nope_stride_h = q_nope.stride(1);
+  unsigned int q_pe_stride_n = q_pe.stride(0);
+  unsigned int q_pe_stride_h = q_pe.stride(1);
+  unsigned int ckv_stride_page = ckv_cache.stride(0);
+  unsigned int ckv_stride_n = ckv_cache.stride(1);
+  unsigned int kpe_stride_page = kpe_cache.stride(0);
+  unsigned int kpe_stride_n = kpe_cache.stride(1);
+  unsigned int o_stride_n = o.stride(0);
+  unsigned int o_stride_h = o.stride(1);
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+
+  DISPATCH_context(
+      DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE, Params, [&] {
+        Params params;
+
+        params.q_nope = static_cast<DTypeQ*>(q_nope.data_ptr());
+        params.q_pe = static_cast<DTypeQ*>(q_pe.data_ptr());
+        params.ckv = static_cast<DTypeKV*>(ckv_cache.data_ptr());
+        params.kpe = static_cast<DTypeKV*>(kpe_cache.data_ptr());
+        params.kv_indices = static_cast<IdType*>(kv_indices.data_ptr());
+
+        params.q_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.q_indptr_offset);
+        params.kv_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_indptr_offset);
+        params.kv_indices = static_cast<IdType*>(kv_indices.data_ptr());
+        params.q_len = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.q_len_offset);
+        params.kv_len = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_len_offset);
+        params.q_start = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.q_start_offset);
+        params.kv_start = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_start_offset);
+        params.kv_end = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_end_offset);
+        params.work_indptr =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+        params.final_o = static_cast<DTypeO*>(o.data_ptr());
+        params.final_lse =
+            maybe_lse.has_value() ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;
+        params.partial_o =
+            GetPtrFromBaseOffset<float>(float_buffer_ptr, plan_info.partial_o_offset);
+        params.partial_lse =
+            GetPtrFromBaseOffset<float>(float_buffer_ptr, plan_info.partial_lse_offset);
+
+        params.num_heads = uint_fastdiv(num_heads);
+        params.block_size = uint_fastdiv(page_size);
+
+        params.q_nope_stride_n = q_nope_stride_n;
+        params.q_nope_stride_h = q_nope_stride_h;
+        params.q_pe_stride_n = q_pe_stride_n;
+        params.q_pe_stride_h = q_pe_stride_h;
+        params.ckv_stride_page = ckv_stride_page;
+        params.ckv_stride_n = ckv_stride_n;
+        params.kpe_stride_page = kpe_stride_page;
+        params.kpe_stride_n = kpe_stride_n;
+        params.o_stride_n = o_stride_n;
+        params.o_stride_h = o_stride_h;
+
+        params.sm_scale = sm_scale;
+
+        cudaError_t status = mla::BatchMLAPageAttention<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
+            params, plan_info.num_blks_x, plan_info.num_blks_y, stream);
+
+        TORCH_CHECK(status == cudaSuccess,
+                    "Failed to run MLA, error: ", cudaGetErrorString(status));
+      });
+}

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from ._build_meta import __version__ as __version__
 from .activation import gelu_and_mul as gelu_and_mul
 from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
 from .activation import silu_and_mul as silu_and_mul
@@ -41,6 +42,7 @@ from .decode import (
 from .decode import single_decode_with_kv_cache as single_decode_with_kv_cache
 from .gemm import SegmentGEMMWrapper as SegmentGEMMWrapper
 from .gemm import bmm_fp8 as bmm_fp8
+from .mla import BatchMLAPageAttentionWrapper as BatchMLAPageAttentionWrapper
 from .norm import fused_add_rmsnorm as fused_add_rmsnorm
 from .norm import gemma_fused_add_rmsnorm as gemma_fused_add_rmsnorm
 from .norm import gemma_rmsnorm as gemma_rmsnorm
@@ -87,5 +89,3 @@ from .sampling import top_k_top_p_sampling_from_probs as top_k_top_p_sampling_fr
 from .sampling import top_p_renorm_probs as top_p_renorm_probs
 from .sampling import top_p_sampling_from_probs as top_p_sampling_from_probs
 from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper
-
-from ._build_meta import __version__ as __version__

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -19,6 +19,7 @@ from .activation import gen_act_and_mul_module as gen_act_and_mul_module
 from .activation import get_act_and_mul_cu_str as get_act_and_mul_cu_str
 from .attention import gen_batch_decode_mla_module as gen_batch_decode_mla_module
 from .attention import gen_batch_decode_module as gen_batch_decode_module
+from .attention import gen_batch_mla_module as gen_batch_mla_module
 from .attention import gen_batch_prefill_module as gen_batch_prefill_module
 from .attention import (
     gen_customize_batch_decode_module as gen_customize_batch_decode_module,
@@ -36,6 +37,7 @@ from .attention import gen_single_decode_module as gen_single_decode_module
 from .attention import gen_single_prefill_module as gen_single_prefill_module
 from .attention import get_batch_decode_mla_uri as get_batch_decode_mla_uri
 from .attention import get_batch_decode_uri as get_batch_decode_uri
+from .attention import get_batch_mla_uri as get_batch_mla_uri
 from .attention import get_batch_prefill_uri as get_batch_prefill_uri
 from .attention import get_single_decode_uri as get_single_decode_uri
 from .attention import get_single_prefill_uri as get_single_prefill_uri

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -138,4 +138,4 @@ class BatchMLAPageAttentionWrapper:
                 get_cuda_stream(device),
             )
 
-        return tuple(o, maybe_lse) if return_lse else o
+        return o, maybe_lse if return_lse else o

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -1,0 +1,142 @@
+"""
+Copyright (c) 2023 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from types import SimpleNamespace
+from typing import List, Optional, Tuple, Union
+
+import torch
+
+from .jit import gen_batch_mla_module, get_batch_mla_uri
+from .utils import MaskMode, get_cuda_stream, register_custom_op, register_fake_op
+
+_batch_mla_modules = {}
+
+
+def get_batch_mla_module(*args):
+    global _batch_mla_modules
+    if args not in _batch_mla_modules:
+        _batch_mla_modules[args] = gen_batch_mla_module(*args)
+    return _batch_mla_modules[args]
+
+
+class BatchMLAPageAttentionWrapper:
+    def __init__(
+        self,
+        float_workspace_buffer: torch.Tensor,
+        backend: str = "fa2",
+    ) -> None:
+        r"""Constructor for BatchMLAPageAttentionWrapper."""
+        self._float_workspace_buffer = float_workspace_buffer
+        self.device = float_workspace_buffer.device
+        self._int_workspace_buffer = torch.empty(
+            (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
+        )
+        self._pin_memory_int_workspace_buffer = torch.empty(
+            self._int_workspace_buffer.shape,
+            dtype=self._int_workspace_buffer.dtype,
+            pin_memory=True,
+        )
+
+    def plan(
+        self,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_len_arr: torch.Tensor,
+        num_heads: torch.Tensor,
+        head_dim_ckv: int,
+        head_dim_kpe: int,
+        page_size: int,
+        causal: bool,
+        sm_scale: float,
+        q_data_type: torch.dtype,
+        kv_data_type: torch.dtype,
+    ) -> None:
+        self._cached_module = get_batch_mla_module(
+            q_data_type,
+            kv_data_type,
+            q_data_type,
+            qo_indptr.dtype,
+            head_dim_ckv,
+            head_dim_kpe,
+        )
+        qo_indptr_host = qo_indptr.to("cpu")
+        kv_indptr_host = kv_indptr.to("cpu")
+        kv_len_arr_host = kv_len_arr.to("cpu")
+
+        self._qo_indptr_buf = qo_indptr
+        self._kv_indptr_buf = kv_indptr
+        self._kv_indices_buf = kv_indices
+        self._kv_len_arr_buf = kv_len_arr
+        self._causal = causal
+        self._page_size = page_size
+        self._sm_scale = sm_scale
+
+        with self.device as device:
+            self._plan_info = self._cached_module.plan(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._pin_memory_int_workspace_buffer,
+                qo_indptr_host,
+                kv_indptr_host,
+                kv_len_arr_host,
+                num_heads,
+                head_dim_ckv,  # head_dim_o
+                causal,
+                get_cuda_stream(device),
+            )
+
+    def run(
+        self,
+        q_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        ckv_cache: torch.Tensor,
+        kpe_cache: torch.Tensor,
+        return_lse: bool = False,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        num_heads = q_nope.shape[1]
+        page_size = self._page_size
+        sm_scale = self._sm_scale
+        causal = self._causal
+        mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
+        with self.device as device:
+            o = torch.empty_like(q_nope)
+            maybe_lse = (
+                torch.empty(q_nope.shape[:2], dtype=torch.float32, device=device)
+                if return_lse
+                else None
+            )
+            print(self._kv_indices_buf)
+            self._cached_module.run(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._plan_info,
+                q_nope,
+                q_pe,
+                ckv_cache,
+                kpe_cache,
+                self._kv_indices_buf,
+                o,
+                maybe_lse,
+                mask_mode,
+                num_heads,
+                page_size,
+                sm_scale,
+                get_cuda_stream(device),
+            )
+
+        return tuple(o, maybe_lse) if return_lse else o

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -57,7 +57,7 @@ class BatchMLAPageAttentionWrapper:
         kv_indptr: torch.Tensor,
         kv_indices: torch.Tensor,
         kv_len_arr: torch.Tensor,
-        num_heads: torch.Tensor,
+        num_heads: int,
         head_dim_ckv: int,
         head_dim_kpe: int,
         page_size: int,
@@ -108,9 +108,8 @@ class BatchMLAPageAttentionWrapper:
         ckv_cache: torch.Tensor,
         kpe_cache: torch.Tensor,
         return_lse: Literal[False] = False,
-    ) -> torch.Tensor:
-        ...
-    
+    ) -> torch.Tensor: ...
+
     @overload
     def run(
         self,
@@ -119,8 +118,7 @@ class BatchMLAPageAttentionWrapper:
         ckv_cache: torch.Tensor,
         kpe_cache: torch.Tensor,
         return_lse: Literal[True] = True,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        ...
+    ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
     def run(
         self,

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -120,7 +120,6 @@ class BatchMLAPageAttentionWrapper:
                 if return_lse
                 else None
             )
-            print(self._kv_indices_buf)
             self._cached_module.run(
                 self._float_workspace_buffer,
                 self._int_workspace_buffer,

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -138,4 +138,4 @@ class BatchMLAPageAttentionWrapper:
                 get_cuda_stream(device),
             )
 
-        return o, maybe_lse if return_lse else o
+        return (o, maybe_lse) if return_lse else o

--- a/include/flashinfer/attention/heap.h
+++ b/include/flashinfer/attention/heap.h
@@ -27,12 +27,12 @@ namespace flashinfer {
  * \brief Heap data structure for (index, value) pairs
  * \note minimal element on top
  */
-class CTACostHeap {
+class MinHeap {
  public:
   // first: index, second: cost
   using Element = std::pair<int, float>;
 
-  CTACostHeap(int capacity) : heap_(capacity) {
+  MinHeap(int capacity) : heap_(capacity) {
     for (int i = 0; i < capacity; ++i) {
       heap_[i] = std::make_pair(i, 0.f);
     }
@@ -49,6 +49,8 @@ class CTACostHeap {
     heap_.pop_back();
     return minElement;
   }
+
+  std::vector<Element> getHeap() const { return heap_; }
 
  private:
   // Custom comparator for the min-heap: compare based on 'val' in the pair

--- a/include/flashinfer/attention/mla_fa2.cuh
+++ b/include/flashinfer/attention/mla_fa2.cuh
@@ -306,7 +306,6 @@ __device__ __forceinline__ void update_mdo_states_(typename KTraits::SharedStora
   const float sm_scale = variant.sm_scale_log2;
   const uint32_t warpgroup_idx = threadIdx.z, lane_idx = threadIdx.x, warp_idx_in_wg = threadIdx.y;
   float m_prev[2];
-  __syncthreads();
 #pragma unroll
   for (uint32_t j = 0; j < 2; ++j) {
     m_prev[j] = m[j];

--- a/include/flashinfer/attention/mla_fa2.cuh
+++ b/include/flashinfer/attention/mla_fa2.cuh
@@ -46,8 +46,8 @@ struct SharedStorageQKVO {
       union {
         alignas(16) DTypeKV kpe[CTA_TILE_KV * HEAD_DIM_KPE];
         alignas(16) DTypeKV p[CTA_TILE_Q * HEAD_DIM_KPE];
-        alignas(16) float m_wg[2][CTA_TILE_Q];
-        alignas(16) float d_wg[2][CTA_TILE_Q];
+        alignas(16) float m_wg[2][CTA_TILE_Q];  // cross warpgroup synchronization
+        alignas(16) float d_wg[2][CTA_TILE_Q];  // cross warpgroup synchronization
       } aux_smem[NUM_STAGES];
     };
     alignas(16) DTypeO o_smem[CTA_TILE_Q * HEAD_DIM_CKV];
@@ -672,7 +672,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionKer
     normalize_d_<KTraits>(&smem_storage, 0 % NUM_STAGES, o_frag, m, d);
 
     write_o<KTraits>(&smem_storage, final_o + q_indptr * o_stride_n, final_lse, partial_o,
-                     partial_lse, o_frag, m, d, o_stride_n, o_stride_h, q_len, packed_qo_start,
+                     partial_lse, o_frag, m, d, o_stride_n, o_stride_h, q_len, qo_packed_idx_base,
                      num_heads);
 
     // #pragma unroll

--- a/include/flashinfer/attention/mla_fa2.cuh
+++ b/include/flashinfer/attention/mla_fa2.cuh
@@ -642,7 +642,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionKer
     const uint32_t kv_end = params.kv_end[work_idx];
 
     const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
-    const uint32_t qo_upperbound = min(q_len, (qo_packed_idx_base + cluster_tile_q) / num_heads);
+    const uint32_t qo_upperbound =
+        min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
 
     init_states_<KTraits>(o_frag, m, d);
 

--- a/include/flashinfer/attention/mla_fa2.cuh
+++ b/include/flashinfer/attention/mla_fa2.cuh
@@ -1,0 +1,785 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_MLA_FA2_CUH_
+#define FLASHINFER_MLA_FA2_CUH_
+#include <cstdint>
+
+#include "mla_params.cuh"
+#include "prefill.cuh"
+#include "variant_helper.cuh"
+
+namespace flashinfer {
+
+namespace mla {
+
+struct StandardAttention : AttentionVariantBase {
+  float sm_scale_log2;
+
+  template <typename Params>
+  __device__ __host__ StandardAttention(const Params& params, uint32_t batch_idx,
+                                        uint8_t* smem_ptr) {
+    sm_scale_log2 = params.sm_scale * math::log2e;
+  }
+};
+
+template <uint32_t NUM_STAGES, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_CKV,
+          uint32_t HEAD_DIM_KPE, typename DTypeQ, typename DTypeKV, typename DTypeO>
+struct SharedStorageQKVO {
+  union {
+    struct {
+      alignas(16) DTypeQ q_smem_nope[CTA_TILE_Q * HEAD_DIM_CKV];
+      alignas(16) DTypeQ q_smem_pe[CTA_TILE_Q * HEAD_DIM_KPE];
+      alignas(16) DTypeKV ckv_smem[NUM_STAGES][CTA_TILE_KV * HEAD_DIM_CKV];
+      union {
+        alignas(16) DTypeKV kpe[CTA_TILE_KV * HEAD_DIM_KPE];
+        alignas(16) DTypeKV p[CTA_TILE_Q * HEAD_DIM_KPE];
+        alignas(16) float m_wg[2][CTA_TILE_Q];
+        alignas(16) float d_wg[2][CTA_TILE_Q];
+      } aux_smem[NUM_STAGES];
+    };
+    alignas(16) DTypeO o_smem[CTA_TILE_Q * HEAD_DIM_CKV];
+  };
+};
+
+template <bool CAUSAL_, uint32_t NUM_STAGES_, uint32_t HEAD_DIM_CKV_, uint32_t HEAD_DIM_KPE_,
+          uint32_t CTA_TILE_Q_, uint32_t CTA_TILE_KV_, typename DTypeQ_, typename DTypeKV_,
+          typename DTypeO_, typename IdType_>
+struct KernelTraits {
+  static constexpr bool CAUSAL = CAUSAL_;
+  static constexpr uint32_t NUM_STAGES = NUM_STAGES_;
+  static constexpr uint32_t NUM_MMA_KV = CTA_TILE_KV_ / 16;
+  static constexpr uint32_t HEAD_DIM_CKV = HEAD_DIM_CKV_;
+  static constexpr uint32_t HEAD_DIM_KPE = HEAD_DIM_KPE_;
+  static constexpr uint32_t HEAD_DIM_ALL = HEAD_DIM_CKV + HEAD_DIM_KPE;
+  static constexpr uint32_t NUM_MMA_D_CKV = HEAD_DIM_CKV / 16;
+  static constexpr uint32_t NUM_MMA_D_KPE = HEAD_DIM_KPE / 16;
+  static constexpr uint32_t NUM_THREADS = 256;
+  static constexpr uint32_t CTA_TILE_Q = CTA_TILE_Q_;
+  static constexpr uint32_t CTA_TILE_KV = CTA_TILE_KV_;
+
+  static constexpr SwizzleMode SWIZZLE_MODE_Q_NOPE = SwizzleMode::k128B;
+  static constexpr SwizzleMode SWIZZLE_MODE_Q_PE = SwizzleMode::k128B;
+  static constexpr SwizzleMode SWIZZLE_MODE_CKV = SwizzleMode::k128B;
+  static constexpr SwizzleMode SWIZZLE_MODE_KPE = SwizzleMode::k128B;
+  static constexpr SwizzleMode SWIZZLE_MODE_P = SwizzleMode::k128B;
+  static constexpr SwizzleMode SWIZZLE_MODE_O = SwizzleMode::k128B;
+  static constexpr uint32_t KV_THR_LAYOUT_ROW = 4;
+  static constexpr uint32_t KV_THR_LAYOUT_COL = 8;
+  static constexpr uint32_t UPCAST_STRIDE_Q_NOPE = HEAD_DIM_CKV / upcast_size<DTypeQ_>();
+  static constexpr uint32_t UPCAST_STRIDE_Q_PE = HEAD_DIM_KPE / upcast_size<DTypeQ_>();
+  static constexpr uint32_t UPCAST_STRIDE_CKV = HEAD_DIM_CKV / upcast_size<DTypeKV_>();
+  static constexpr uint32_t UPCAST_STRIDE_KPE = HEAD_DIM_KPE / upcast_size<DTypeKV_>();
+  static constexpr uint32_t UPCAST_STRIDE_FINAL_O = HEAD_DIM_CKV / upcast_size<DTypeO_>();
+  static constexpr uint32_t UPCAST_STRIDE_P = CTA_TILE_KV_ / upcast_size<DTypeKV_>();
+  static constexpr uint32_t UPCAST_STRIDE_PARTIAL_O = HEAD_DIM_CKV / upcast_size<float>();
+
+  using DTypeQ = DTypeQ_;
+  using DTypeKV = DTypeKV_;
+  using DTypeO = DTypeO_;
+  using IdType = IdType_;
+  using DTypeQKAccum = float;
+
+  using SharedStorage = SharedStorageQKVO<NUM_STAGES, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_CKV,
+                                          HEAD_DIM_KPE, DTypeQ, DTypeKV, DTypeO>;
+  using AttentionVariant = StandardAttention;
+
+  static constexpr DTypeQKAccum MaskFillValue = -math::inf;
+};
+
+template <typename KTraits>
+__device__ __forceinline__ void init_states_(float (*o_frag)[8], typename KTraits::DTypeQKAccum* m,
+                                             float* d) {
+#pragma unroll
+  for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 2; ++mma_d) {
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+      o_frag[mma_d][reg_id] = 0.f;
+    }
+  }
+
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    m[j] = typename KTraits::DTypeQKAccum(-math::inf);
+    d[j] = 1.f;
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void load_q(
+    typename KTraits::SharedStorage* smem_storage, typename KTraits::DTypeQ* q_nope,
+    typename KTraits::DTypeQ* q_pe, const uint32_t q_nope_stride_n, const uint32_t q_nope_stride_h,
+    const uint32_t q_pe_stride_n, const uint32_t q_pe_stride_h, const uint32_t q_len,
+    const uint32_t packed_offset, const uint_fastdiv& num_heads) {
+  using DTypeQ = typename KTraits::DTypeQ;
+  constexpr uint32_t UPCAST_STRIDE_Q_NOPE = KTraits::UPCAST_STRIDE_Q_NOPE;
+  constexpr uint32_t UPCAST_STRIDE_Q_PE = KTraits::UPCAST_STRIDE_Q_PE;
+  constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
+  constexpr uint32_t NUM_MMA_D_KPE = KTraits::NUM_MMA_D_KPE;
+  const uint32_t lane_idx = threadIdx.x;
+  const uint32_t warpgroup_idx = threadIdx.z;
+  const uint32_t warp_idx_in_wg = threadIdx.y;
+
+  smem_t<KTraits::SWIZZLE_MODE_Q_NOPE> q_smem_nope(smem_storage->q_smem_nope);
+  smem_t<KTraits::SWIZZLE_MODE_Q_PE> q_smem_pe(smem_storage->q_smem_pe);
+
+  uint32_t q_smem_nope_offset_w = q_smem_nope.template get_permuted_offset<UPCAST_STRIDE_Q_NOPE>(
+      warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8, lane_idx % 8);
+  uint32_t q_smem_pe_offset_w = q_smem_pe.template get_permuted_offset<UPCAST_STRIDE_Q_PE>(
+      warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8, lane_idx % 8);
+
+#pragma unroll
+  for (uint32_t mma_q = 0; mma_q < 2; ++mma_q) {
+    uint32_t q, r;
+    num_heads.divmod(
+        packed_offset + lane_idx / 8 + (warpgroup_idx + mma_q * 2) * 16 + warp_idx_in_wg * 4, q, r);
+    DTypeQ* q_nope_ptr =
+        q_nope + q * q_nope_stride_n + r * q_nope_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
+    DTypeQ* q_pe_ptr =
+        q_pe + q * q_pe_stride_n + r * q_pe_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 4; ++mma_d) {
+      q_smem_nope.load_128b_async<SharedMemFillMode::kFillZero>(q_smem_nope_offset_w, q_nope_ptr,
+                                                                q < q_len);
+      q_smem_nope_offset_w =
+          q_smem_nope.template advance_offset_by_column<8>(q_smem_nope_offset_w, mma_d);
+      q_nope_ptr += 8 * upcast_size<DTypeQ>();
+    }
+    q_smem_nope_offset_w =
+        q_smem_nope.template advance_offset_by_row<32, UPCAST_STRIDE_Q_NOPE>(q_smem_nope_offset_w) -
+        2 * NUM_MMA_D_CKV;
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_KPE / 4; ++mma_d) {
+      q_smem_pe.load_128b_async<SharedMemFillMode::kFillZero>(q_smem_pe_offset_w, q_pe_ptr,
+                                                              q < q_len);
+      q_smem_pe_offset_w =
+          q_smem_pe.template advance_offset_by_column<8>(q_smem_pe_offset_w, mma_d);
+      q_pe_ptr += 8 * upcast_size<DTypeQ>();
+    }
+    q_smem_pe_offset_w =
+        q_smem_pe.template advance_offset_by_row<32, UPCAST_STRIDE_Q_PE>(q_smem_pe_offset_w) -
+        2 * NUM_MMA_D_KPE;
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void load_kv(
+    typename KTraits::SharedStorage* smem_storage, typename KTraits::DTypeKV* ckv,
+    typename KTraits::DTypeKV* kpe, typename KTraits::IdType* indices, const uint32_t ckv_stride_n,
+    const uint32_t ckv_stride_page, const uint32_t kpe_stride_n, const uint32_t kpe_stride_page,
+    const uint32_t kv_len, const uint32_t packed_block_iter_base, const uint_fastdiv& block_size,
+    const uint32_t stage_idx) {
+  using DTypeKV = typename KTraits::DTypeKV;
+  constexpr uint32_t UPCAST_STRIDE_CKV = KTraits::UPCAST_STRIDE_CKV;
+  constexpr uint32_t UPCAST_STRIDE_KPE = KTraits::UPCAST_STRIDE_KPE;
+  constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
+  constexpr uint32_t NUM_MMA_D_KPE = KTraits::NUM_MMA_D_KPE;
+  const uint32_t lane_idx = threadIdx.x;
+  const uint32_t warpgroup_idx = threadIdx.z;
+  const uint32_t warp_idx_in_wg = threadIdx.y;
+
+  smem_t<KTraits::SWIZZLE_MODE_CKV> ckv_smem(smem_storage->ckv_smem[stage_idx]);
+  smem_t<KTraits::SWIZZLE_MODE_KPE> kpe_smem(smem_storage->aux_smem[stage_idx].kpe);
+
+  uint32_t ckv_smem_offset_w = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
+      warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8, lane_idx % 8);
+  uint32_t kpe_smem_offset_w = kpe_smem.template get_permuted_offset<UPCAST_STRIDE_KPE>(
+      warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8, lane_idx % 8);
+#pragma unroll
+  for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
+    uint32_t q, r;
+
+    block_size.divmod(packed_block_iter_base + lane_idx / 8 + (warpgroup_idx + mma_kv * 2) * 16 +
+                          warp_idx_in_wg * 4,
+                      q, r);
+    DTypeKV* ckv_ptr = ckv + indices[q] * ckv_stride_page + r * ckv_stride_n +
+                       (lane_idx % 8) * upcast_size<DTypeKV>();
+    DTypeKV* kpe_ptr = kpe + indices[q] * kpe_stride_page + r * kpe_stride_n +
+                       (lane_idx % 8) * upcast_size<DTypeKV>();
+
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 4; ++mma_d) {
+      ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(ckv_smem_offset_w, ckv_ptr,
+                                                             q < kv_len);
+      ckv_smem_offset_w = ckv_smem.template advance_offset_by_column<8>(ckv_smem_offset_w, mma_d);
+      ckv_ptr += 8 * upcast_size<DTypeKV>();
+    }
+    ckv_smem_offset_w =
+        ckv_smem.template advance_offset_by_row<32, UPCAST_STRIDE_CKV>(ckv_smem_offset_w) -
+        2 * NUM_MMA_D_CKV;
+
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_KPE / 4; ++mma_d) {
+      kpe_smem.load_128b_async<SharedMemFillMode::kFillZero>(kpe_smem_offset_w, kpe_ptr,
+                                                             q < kv_len);
+      kpe_smem_offset_w = kpe_smem.template advance_offset_by_column<8>(kpe_smem_offset_w, mma_d);
+      kpe_ptr += 8 * upcast_size<DTypeKV>();
+    }
+    kpe_smem_offset_w =
+        kpe_smem.template advance_offset_by_row<32, UPCAST_STRIDE_KPE>(kpe_smem_offset_w) -
+        2 * NUM_MMA_D_KPE;
+  }
+}
+
+template <bool init, typename KTraits, uint32_t NUM_MMA_D_QK, uint32_t UPCAST_STRIDE_Q,
+          uint32_t UPCAST_STRIDE_K, SwizzleMode SWIZZLE_MODE_Q, SwizzleMode SWIZZLE_MODE_KV>
+__device__ __forceinline__ void compute_qk_(smem_t<SWIZZLE_MODE_Q> q_smem, uint32_t q_smem_offset_r,
+                                            smem_t<SWIZZLE_MODE_KV> k_smem,
+                                            uint32_t k_smem_offset_r,
+                                            typename KTraits::DTypeQKAccum (*s_frag)[8]) {
+  uint32_t a_frag[4], b_frag[4];
+  // compute q*k^T
+#pragma unroll
+  for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_QK; ++mma_d) {
+    q_smem.ldmatrix_m8n8x4(q_smem_offset_r, a_frag);
+    q_smem_offset_r = q_smem.template advance_offset_by_column<2>(q_smem_offset_r, mma_d);
+
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
+      k_smem.ldmatrix_m8n8x4(k_smem_offset_r, b_frag);
+      k_smem_offset_r = k_smem.template advance_offset_by_row<16, UPCAST_STRIDE_K>(k_smem_offset_r);
+
+      if (init && mma_d == 0) {
+        mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ, MMAMode::kInit>(
+            s_frag[mma_kv], a_frag, b_frag);
+      } else {
+        mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(s_frag[mma_kv], a_frag,
+                                                                            b_frag);
+      }
+    }
+    k_smem_offset_r = k_smem.template advance_offset_by_column<2>(k_smem_offset_r, mma_d) -
+                      (KTraits::NUM_MMA_KV / 2) * 16 * UPCAST_STRIDE_K;
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void logits_mask_(const uint32_t qo_packed_idx_base,
+                                             const uint32_t kv_idx_base, const uint32_t qo_len,
+                                             const uint32_t kv_len, const uint32_t chunk_end,
+                                             const uint_fastdiv num_heads,
+                                             typename KTraits::DTypeQKAccum (*s_frag)[8]) {
+  const uint32_t lane_idx = threadIdx.x, warpgroup_idx = threadIdx.z, warp_idx_in_wg = threadIdx.y;
+  constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+  using DTypeQKAccum = typename KTraits::DTypeQKAccum;
+  uint32_t q[2];
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    q[j] = (qo_packed_idx_base + warp_idx_in_wg * 16 + lane_idx / 4 + 8 * j) / num_heads;
+  }
+
+#pragma unroll
+  for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV / 2; ++mma_kv) {
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+      const uint32_t q_idx = q[(reg_id % 4) / 2],
+                     kv_idx = kv_idx_base + warpgroup_idx * (NUM_MMA_KV / 2) * 16 + mma_kv * 16 +
+                              2 * (lane_idx % 4) + 8 * (reg_id / 4) + reg_id % 2;
+      const bool mask =
+          (!(KTraits::CAUSAL ? (kv_idx + qo_len > kv_len + q_idx || (kv_idx >= chunk_end))
+                             : kv_idx >= chunk_end));
+      s_frag[mma_kv][reg_id] = (mask) ? s_frag[mma_kv][reg_id] : (KTraits::MaskFillValue);
+    }
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void update_mdo_states_(typename KTraits::SharedStorage* smem_storage,
+                                                   const uint32_t stage_idx,
+                                                   typename KTraits::AttentionVariant variant,
+                                                   typename KTraits::DTypeQKAccum (*s_frag)[8],
+                                                   float (*o_frag)[8],
+                                                   typename KTraits::DTypeQKAccum* m, float* d) {
+  using DTypeQKAccum = typename KTraits::DTypeQKAccum;
+  using AttentionVariant = typename KTraits::AttentionVariant;
+  const float sm_scale = variant.sm_scale_log2;
+  const uint32_t warpgroup_idx = threadIdx.z, lane_idx = threadIdx.x, warp_idx_in_wg = threadIdx.y;
+  float m_prev[2];
+  __syncthreads();
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    m_prev[j] = m[j];
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
+      float m_local = max(max(s_frag[mma_kv][j * 2 + 0], s_frag[mma_kv][j * 2 + 1]),
+                          max(s_frag[mma_kv][j * 2 + 4], s_frag[mma_kv][j * 2 + 5]));
+      m[j] = max(m[j], m_local);
+    }
+    m[j] = max(m[j], math::shfl_xor_sync(m[j], 0x2));
+    m[j] = max(m[j], math::shfl_xor_sync(m[j], 0x1));
+    if (lane_idx % 4 == 0) {
+      smem_storage->aux_smem[stage_idx]
+          .m_wg[warpgroup_idx][warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = m[j];
+    }
+  }
+
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    m[j] = max(smem_storage->aux_smem[stage_idx]
+                   .m_wg[1 - warpgroup_idx][warp_idx_in_wg * 16 + j * 8 + lane_idx / 4],
+               m[j]);
+    float o_scale = math::ptx_exp2(m_prev[j] * sm_scale - m[j] * sm_scale);
+    d[j] *= o_scale;
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 2; ++mma_d) {
+      o_frag[mma_d][j * 2 + 0] *= o_scale;
+      o_frag[mma_d][j * 2 + 1] *= o_scale;
+      o_frag[mma_d][j * 2 + 4] *= o_scale;
+      o_frag[mma_d][j * 2 + 5] *= o_scale;
+    }
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
+      s_frag[mma_kv][j * 2 + 0] =
+          math::ptx_exp2(s_frag[mma_kv][j * 2 + 0] * sm_scale - m[j] * sm_scale);
+      s_frag[mma_kv][j * 2 + 1] =
+          math::ptx_exp2(s_frag[mma_kv][j * 2 + 1] * sm_scale - m[j] * sm_scale);
+      s_frag[mma_kv][j * 2 + 4] =
+          math::ptx_exp2(s_frag[mma_kv][j * 2 + 4] * sm_scale - m[j] * sm_scale);
+      s_frag[mma_kv][j * 2 + 5] =
+          math::ptx_exp2(s_frag[mma_kv][j * 2 + 5] * sm_scale - m[j] * sm_scale);
+    }
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void store_p_smem(typename KTraits::SharedStorage* smem_storage,
+                                             const uint32_t stage_idx,
+                                             typename KTraits::DTypeQKAccum (*s_frag)[8],
+                                             typename KTraits::DTypeQKAccum* d) {
+  const uint32_t lane_idx = threadIdx.x, warpgroup_idx = threadIdx.z, warp_idx_in_wg = threadIdx.y;
+  typename KTraits::DTypeKV p_f16[KTraits::NUM_MMA_KV][8];
+#pragma unroll
+  for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
+    vec_cast<typename KTraits::DTypeKV, float>::cast<8>(p_f16[mma_kv], s_frag[mma_kv]);
+    mma::m16k16_rowsum_f16f16f32(d, p_f16[mma_kv]);
+  }
+
+  __syncthreads();
+  smem_t<KTraits::SWIZZLE_MODE_P> p_smem(smem_storage->aux_smem[stage_idx].p);
+#pragma unroll
+  for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
+#ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
+    uint32_t p_smem_offset_w = p_smem.template get_permuted_offset<KTraits::UPCAST_STRIDE_P>(
+        warp_idx_in_wg * 16 + lane_idx % 16,
+        warpgroup_idx * KTraits::NUM_MMA_KV + mma_kv * 2 + lane_idx / 16);
+    p_smem.stmatrix_m8n8x4(p_smem_offset_w, (uint32_t*)p_f16[mma_kv]);
+#else
+    static_assert(false, "Not implemented yet");
+#endif
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void compute_mla_qk(typename KTraits::SharedStorage* smem_storage,
+                                               const uint32_t stage_idx,
+                                               typename KTraits::DTypeQKAccum (*s_frag)[8]) {
+  constexpr uint32_t UPCAST_STRIDE_Q_NOPE = KTraits::UPCAST_STRIDE_Q_NOPE;
+  constexpr uint32_t UPCAST_STRIDE_Q_PE = KTraits::UPCAST_STRIDE_Q_PE;
+  constexpr uint32_t UPCAST_STRIDE_CKV = KTraits::UPCAST_STRIDE_CKV;
+  constexpr uint32_t UPCAST_STRIDE_KPE = KTraits::UPCAST_STRIDE_KPE;
+  constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+  smem_t<KTraits::SWIZZLE_MODE_Q_NOPE> q_smem_nope(smem_storage->q_smem_nope);
+  smem_t<KTraits::SWIZZLE_MODE_Q_PE> q_smem_pe(smem_storage->q_smem_pe);
+  smem_t<KTraits::SWIZZLE_MODE_CKV> ckv_smem(smem_storage->ckv_smem[stage_idx]);
+  smem_t<KTraits::SWIZZLE_MODE_KPE> kpe_smem(smem_storage->aux_smem[stage_idx].kpe);
+  const uint32_t lane_idx = threadIdx.x, warpgroup_idx = threadIdx.z, warp_idx_in_wg = threadIdx.y;
+  uint32_t q_smem_nope_offset_r = q_smem_nope.template get_permuted_offset<UPCAST_STRIDE_Q_NOPE>(
+      warp_idx_in_wg * 16 + lane_idx % 16, lane_idx / 16);
+  uint32_t q_smem_pe_offset_r = q_smem_pe.template get_permuted_offset<UPCAST_STRIDE_Q_PE>(
+      warp_idx_in_wg * 16 + lane_idx % 16, lane_idx / 16);
+  uint32_t ckv_smem_offset_r = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
+      warpgroup_idx * (NUM_MMA_KV / 2) * 16 + 8 * (lane_idx / 16) + lane_idx % 8,
+      (lane_idx % 16) / 8);
+  uint32_t kpe_smem_offset_r = kpe_smem.template get_permuted_offset<UPCAST_STRIDE_KPE>(
+      warpgroup_idx * (NUM_MMA_KV / 2) * 16 + 8 * (lane_idx / 16) + lane_idx % 8,
+      (lane_idx % 16) / 8);
+  compute_qk_</*init=*/true, KTraits, KTraits::NUM_MMA_D_KPE, KTraits::UPCAST_STRIDE_Q_PE,
+              KTraits::UPCAST_STRIDE_KPE>(q_smem_pe, q_smem_pe_offset_r, kpe_smem,
+                                          kpe_smem_offset_r, s_frag);
+  compute_qk_</*init=*/false, KTraits, KTraits::NUM_MMA_D_CKV, KTraits::UPCAST_STRIDE_Q_NOPE,
+              KTraits::UPCAST_STRIDE_CKV>(q_smem_nope, q_smem_nope_offset_r, ckv_smem,
+                                          ckv_smem_offset_r, s_frag);
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void compute_mla_pk(typename KTraits::SharedStorage* smem_storage,
+                                               const uint32_t stage_idx, float (*o_frag)[8]) {
+  constexpr uint32_t UPCAST_STRIDE_P = KTraits::UPCAST_STRIDE_P;
+  constexpr uint32_t UPCAST_STRIDE_CKV = KTraits::UPCAST_STRIDE_CKV;
+  constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+  constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
+  smem_t<KTraits::SWIZZLE_MODE_P> p_smem(smem_storage->aux_smem[stage_idx].p);
+  smem_t<KTraits::SWIZZLE_MODE_CKV> ckv_smem(smem_storage->ckv_smem[stage_idx]);
+  const uint32_t lane_idx = threadIdx.x, warpgroup_idx = threadIdx.z, warp_idx_in_wg = threadIdx.y;
+  uint32_t p_smem_offset_r = p_smem.template get_permuted_offset<UPCAST_STRIDE_P>(
+      warp_idx_in_wg * 16 + lane_idx % 16, lane_idx / 16);
+  uint32_t ckv_smem_offset_r = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
+      lane_idx % 16, warpgroup_idx * NUM_MMA_D_CKV + lane_idx / 16);
+
+  // wait for p_smem to be filled
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+    uint32_t p_frag[4];
+    p_smem.ldmatrix_m8n8x4(p_smem_offset_r, p_frag);
+    p_smem_offset_r = p_smem.template advance_offset_by_column<2>(p_smem_offset_r, mma_kv);
+
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_CKV / 2; ++mma_d) {
+      uint32_t v_frag[4];
+      ckv_smem.ldmatrix_m8n8x4_trans(ckv_smem_offset_r, v_frag);
+      mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeKV>(o_frag[mma_d], p_frag,
+                                                                           v_frag);
+      ckv_smem_offset_r = ckv_smem.template advance_offset_by_column<2>(ckv_smem_offset_r, mma_d);
+    }
+    ckv_smem_offset_r =
+        ckv_smem.template advance_offset_by_row<16, UPCAST_STRIDE_CKV>(ckv_smem_offset_r) -
+        NUM_MMA_D_CKV;
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void normalize_d_(typename KTraits::SharedStorage* smem_storage,
+                                             const uint32_t stage_idx, float (*o_frag)[8],
+                                             typename KTraits::DTypeQKAccum* m, float* d) {
+  const uint32_t warpgroup_idx = threadIdx.z, lane_idx = threadIdx.x, warp_idx_in_wg = threadIdx.y;
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    if (lane_idx % 4 == 0) {
+      smem_storage->aux_smem[stage_idx]
+          .d_wg[warpgroup_idx][warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = d[j];
+    }
+  }
+  __syncthreads();
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    d[j] = max(smem_storage->aux_smem[stage_idx]
+                   .d_wg[1 - warpgroup_idx][warp_idx_in_wg * 16 + j * 8 + lane_idx / 4],
+               d[j]);
+  }
+
+  float d_rcp[2];
+  // compute reciprocal of d
+#pragma unroll
+  for (uint32_t j = 0; j < 2; ++j) {
+    d_rcp[j] = (m[j] != typename KTraits::DTypeQKAccum(-math::inf)) ? math::ptx_rcp(d[j]) : 0.f;
+  }
+
+#pragma unroll
+  for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 2; ++mma_d) {
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+      o_frag[mma_d][reg_id] = o_frag[mma_d][reg_id] * d_rcp[(reg_id % 4) / 2];
+    }
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_storage,
+                                        typename KTraits::DTypeO* final_o, float* final_lse,
+                                        float* partial_o, float* partial_lse, float (*o_frag)[8],
+                                        typename KTraits::DTypeQKAccum* m, float* d,
+                                        const uint32_t o_stride_n, const uint32_t o_stride_h,
+                                        const uint32_t q_len, const uint32_t packed_offset,
+                                        const uint_fastdiv& num_heads) {
+  using DTypeO = typename KTraits::DTypeO;
+  constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
+  constexpr uint32_t HEAD_DIM_CKV = KTraits::HEAD_DIM_CKV;
+  constexpr uint32_t UPCAST_STRIDE_FINAL_O = KTraits::UPCAST_STRIDE_FINAL_O;
+  const uint32_t lane_idx = threadIdx.x, warpgroup_idx = threadIdx.z, warp_idx_in_wg = threadIdx.y;
+
+  if (false) {
+    // TOOD(Zihao): write to partial
+  } else {
+    // write to final_o
+    smem_t<KTraits::SWIZZLE_MODE_O> o_smem(smem_storage->o_smem);
+
+    // step 0. rmem to smem
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_CKV / 2; ++mma_d) {
+      uint32_t o_frag_f16[8 / 2];
+      vec_cast<DTypeO, float>::cast<8>((DTypeO*)o_frag_f16, o_frag[mma_d]);
+#ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
+      uint32_t o_smem_offset_w = o_smem.template get_permuted_offset<UPCAST_STRIDE_FINAL_O>(
+          warp_idx_in_wg * 16 + lane_idx % 16,
+          warpgroup_idx * NUM_MMA_D_CKV + mma_d * 2 + lane_idx / 16);
+      o_smem.template stmatrix_m8n8x4(o_smem_offset_w, o_frag_f16);
+#else
+      uint32_t o_smem_offset_w = o_smem.template get_permuted_offset<UPCAST_STRIDE_FINAL_O>(
+          warp_idx_in_wg * 16 + lane_idx / 4, warpgroup_idx * NUM_MMA_D_CKV + mma_d * 2);
+      ((uint32_t*)(o_smem.base + o_smem_offset_w))[lane_idx % 4] = o_frag_f16[0];
+      ((uint32_t*)(o_smem.base + o_smem_offset_w + 8 * UPCAST_STRIDE_FINAL_O))[lane_idx % 4] =
+          o_frag_f16[1];
+      ((uint32_t*)(o_smem.base + (o_smem_offset_w ^ 0x1)))[lane_idx % 4] = o_frag_f16[2];
+      ((uint32_t*)(o_smem.base + (o_smem_offset_w ^ 0x1) +
+                   8 * UPCAST_STRIDE_FINAL_O))[lane_idx % 4] = o_frag_f16[3];
+#endif
+    }
+
+    // step 1. smem to gmem
+    uint32_t o_smem_offset_w = o_smem.template get_permuted_offset<UPCAST_STRIDE_FINAL_O>(
+        warp_idx_in_wg * 16 + lane_idx / 8, warpgroup_idx * NUM_MMA_D_CKV + lane_idx % 8);
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      uint32_t q, r;
+      num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 4 * j + lane_idx / 8, q, r);
+      DTypeO* o_final_ptr = final_o + q * o_stride_n + r * o_stride_h +
+                            warpgroup_idx * (HEAD_DIM_CKV / 2) +
+                            (lane_idx % 8) * upcast_size<DTypeO>();
+#pragma unroll
+      for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_CKV / 8; ++mma_d) {
+        if (q < q_len) {
+          o_smem.template store_128b(o_smem_offset_w, o_final_ptr);
+        }
+        o_final_ptr += 8 * upcast_size<DTypeO>();
+        o_smem_offset_w = o_smem.template advance_offset_by_column<8>(o_smem_offset_w, mma_d);
+      }
+      o_smem_offset_w =
+          o_smem.template advance_offset_by_row<4, UPCAST_STRIDE_FINAL_O>(o_smem_offset_w) -
+          NUM_MMA_D_CKV;
+    }
+  }
+}
+
+template <typename KTraits, typename Params>
+__global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionKernel(
+    const __grid_constant__ Params params) {
+  using DTypeQ = typename Params::DTypeQ;
+  using DTypeKV = typename Params::DTypeKV;
+  using DTypeO = typename Params::DTypeO;
+  using IdType = typename Params::IdType;
+
+  extern __shared__ uint8_t smem[];
+  auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+
+  typename KTraits::AttentionVariant variant(params, blockIdx.y, smem);
+
+  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q_NOPE = KTraits::SWIZZLE_MODE_Q_NOPE;
+  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q_PE = KTraits::SWIZZLE_MODE_Q_PE;
+  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_CKV = KTraits::SWIZZLE_MODE_CKV;
+  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_KPE = KTraits::SWIZZLE_MODE_KPE;
+  [[maybe_unused]] constexpr uint32_t KV_THR_LAYOUT_ROW = KTraits::KV_THR_LAYOUT_ROW;
+  [[maybe_unused]] constexpr uint32_t KV_THR_LAYOUT_COL = KTraits::KV_THR_LAYOUT_COL;
+  [[maybe_unused]] constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+  [[maybe_unused]] constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
+  [[maybe_unused]] constexpr uint32_t CTA_TILE_Q = KTraits::CTA_TILE_Q;
+  [[maybe_unused]] constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+  [[maybe_unused]] constexpr uint32_t NUM_STAGES = KTraits::NUM_STAGES;
+  [[maybe_unused]] constexpr bool CAUSAL = KTraits::CAUSAL;
+
+  DTypeQ* q_nope = params.q_nope;
+  DTypeQ* q_pe = params.q_pe;
+  DTypeKV* ckv = params.ckv;
+  DTypeKV* kpe = params.kpe;
+  IdType* kv_indices = params.kv_indices;
+  float* partial_o = params.partial_o;
+  float* partial_lse = params.partial_lse;
+  DTypeO* final_o = params.final_o;
+  float* final_lse = params.final_lse;
+  IdType* work_indptr = params.work_indptr;
+  // IdType* indices = params.indices;
+
+  float s_frag[NUM_MMA_KV / 2][8];
+  alignas(16) float o_frag[NUM_MMA_D_CKV / 2][8];
+  float m[2];
+  float d[2];
+
+  const uint_fastdiv& num_heads = params.num_heads;
+  const uint_fastdiv& block_size = params.block_size;
+  const uint32_t q_nope_stride_n = params.q_nope_stride_n;
+  const uint32_t q_nope_stride_h = params.q_nope_stride_h;
+  const uint32_t q_pe_stride_n = params.q_pe_stride_n;
+  const uint32_t q_pe_stride_h = params.q_pe_stride_h;
+  const uint32_t ckv_stride_page = params.ckv_stride_page;
+  const uint32_t ckv_stride_n = params.ckv_stride_n;
+  const uint32_t kpe_stride_page = params.kpe_stride_page;
+  const uint32_t kpe_stride_n = params.kpe_stride_n;
+  const uint32_t o_stride_n = params.o_stride_n;
+  const uint32_t o_stride_h = params.o_stride_h;
+  const uint32_t cluster_tile_q = blockDim.x * KTraits::CTA_TILE_Q;
+
+#pragma unroll 1
+  for (IdType work_idx = work_indptr[blockIdx.y]; work_idx < work_indptr[blockIdx.y + 1];
+       ++work_idx) {
+    const uint32_t q_indptr = params.q_indptr[work_idx];
+    const uint32_t kv_indptr = params.kv_indptr[work_idx];
+    const uint32_t q_len = params.q_len[work_idx];
+    const uint32_t kv_len = params.kv_len[work_idx];
+    const uint32_t packed_qo_start = params.q_start[work_idx];
+    const uint32_t kv_start = params.kv_start[work_idx];
+    const uint32_t kv_end = params.kv_end[work_idx];
+
+    const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
+
+    init_states_<KTraits>(o_frag, m, d);
+
+    load_q<KTraits>(&smem_storage, q_nope + q_indptr * q_nope_stride_n,
+                    q_pe + q_indptr * q_pe_stride_n, q_nope_stride_n, q_nope_stride_h,
+                    q_pe_stride_n, q_pe_stride_h, q_len, qo_packed_idx_base, params.num_heads);
+
+    cp_async::commit_group();
+    cp_async::wait_group<0>();
+    __syncthreads();
+
+    int kv_tile_idx = ceil_div(
+        (CAUSAL ? min(kv_end, kv_len - q_len + (packed_qo_start + cluster_tile_q) / num_heads)
+                : kv_end),
+        CTA_TILE_KV);
+
+    int mask_tile_idx = ceil_div(
+        (CAUSAL ? min(kv_end, kv_len - q_len + packed_qo_start / num_heads) : kv_end), CTA_TILE_KV);
+
+    int start_tile_idx = ceil_div(kv_start, CTA_TILE_KV);
+    uint32_t block_iter_base = (kv_indptr + kv_start) * block_size;
+
+    // load_mla_kv_global_smem<KTraits>();  // last kv tile
+    load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
+                     kpe_stride_n, kpe_stride_page, kv_len, block_iter_base + 0 * CTA_TILE_KV,
+                     block_size, 0 % NUM_STAGES);
+    cp_async::commit_group();
+    // if (kv_tile_idx > start_tile_idx) {
+    //   // load_mla_kv_global_smem<KTraits>();  // second last kv tile
+    //   cp_async::commit_group();
+    // }
+
+    cp_async::wait_group<0>();
+    __syncthreads();
+
+    compute_mla_qk<KTraits>(&smem_storage, 0 % NUM_STAGES, s_frag);
+
+    logits_mask_<KTraits>(qo_packed_idx_base, kv_start + 0 * CTA_TILE_KV, q_len, kv_len, kv_end,
+                          num_heads, s_frag);
+
+    update_mdo_states_<KTraits>(&smem_storage, 0 % NUM_STAGES, variant, s_frag, o_frag, m, d);
+
+    store_p_smem<KTraits>(&smem_storage, 0 % NUM_STAGES, s_frag, d);
+
+    compute_mla_pk<KTraits>(&smem_storage, 0 % NUM_STAGES, o_frag);
+
+    normalize_d_<KTraits>(&smem_storage, 0 % NUM_STAGES, o_frag, m, d);
+
+    write_o<KTraits>(&smem_storage, final_o + q_indptr * o_stride_n, final_lse, partial_o,
+                     partial_lse, o_frag, m, d, o_stride_n, o_stride_h, q_len, packed_qo_start,
+                     num_heads);
+
+    // #pragma unroll
+    //     for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV / 2; ++mma_kv) {
+    // #pragma unroll
+    //       for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+    //         uint32_t lane_idx = threadIdx.x, warp_idx_in_wg = threadIdx.y, warpgroup_idx =
+    //         threadIdx.z; uint32_t q_idx = packed_qo_start + warp_idx_in_wg * 16 + lane_idx / 4 +
+    //         8 * (reg_id / 4); uint32_t kv_idx = kv_start + mma_kv * 16 + 2 * (lane_idx % 4) + 8 *
+    //         (reg_id / 4) +
+    //                           reg_id % 2 + warpgroup_idx * (NUM_MMA_KV / 2) * 16;
+    //         printf("%d %d %.4f\n", q_idx, kv_idx, s_frag[mma_kv][reg_id]);
+    //       }
+    //     }
+
+    // store_p_smem;
+
+#pragma unroll 1
+    for (; kv_tile_idx > mask_tile_idx; --kv_tile_idx) {
+      // cp_async::wait_group<1>();
+      // block.sync();
+
+      // compute qk
+
+      // logits_transform
+
+      // logits mask
+
+      // compute m,d states in online softmax
+
+      // compute sfm * v
+
+      // block.sync();
+      // load_mla_kv_global_smem<KTraits>();
+      // cp_async::commit_group();
+    }
+
+    // #pragma unroll 1
+    //     for (; kv_tile_idx > kv_start; --iter) {
+    //       uint32_t packed_block_iter_base = kv_indptr * block_size + kv_tile_idx * CTA_TILE_KV;
+
+    //       cp_async::wait_group<1>();
+    //       block.sync();
+
+    //       // compute qk
+
+    //       // logits transform
+
+    //       // compute m,d states in online softmax
+
+    //       // compute sfm * v
+
+    //       block.sync();
+    //       load_mla_kv_global_smem<KTraits>();
+    //       cp_async::commit_group();
+    //     }
+    //     cp_async::wait_group<0>();
+    //     block.sync();
+
+    //     // compute qk
+
+    //     // logits transform
+
+    //     // compute m,d states in online softmax
+
+    //     // compute sfm * v
+
+    //     // write back
+  }
+}
+
+template <MaskMode MASK_MODE, uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, typename Params>
+cudaError_t BatchMLAPageAttention(Params params, uint32_t num_blks_x, uint32_t num_blks_y,
+                                  cudaStream_t stream) {
+  using DTypeQ = typename Params::DTypeQ;
+  using DTypeKV = typename Params::DTypeKV;
+  using DTypeO = typename Params::DTypeO;
+  using IdType = typename Params::IdType;
+  if (MASK_MODE == MaskMode::kCustom) {
+    return cudaErrorNotSupported;
+  }
+  constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
+
+  using DTypeQ = typename Params::DTypeQ;
+  using DTypeKV = typename Params::DTypeKV;
+  using DTypeO = typename Params::DTypeO;
+
+  dim3 nblks(num_blks_x, num_blks_y);
+  dim3 nthrs(32, 4, 2);
+
+  using KTraits =
+      KernelTraits<CAUSAL, /*NUM_STAGES_=*/2, HEAD_DIM_CKV, HEAD_DIM_KPE, /*CTA_TILE_Q_=*/64,
+                   /*CTA_TILE_KV_=*/64, DTypeQ, DTypeKV, DTypeO, IdType>;
+  size_t smem_size = sizeof(typename KTraits::SharedStorage);
+
+  auto kernel = BatchMLAPageAttentionKernel<KTraits, Params>;
+  void* args[] = {(void*)&params};
+
+  FLASHINFER_CUDA_CALL(
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+  FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+  return cudaSuccess;
+}
+
+}  // namespace mla
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_MLA_FA2_CUH_

--- a/include/flashinfer/attention/mla_params.cuh
+++ b/include/flashinfer/attention/mla_params.cuh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_MLA_PARAMS_CUH_
+#define FLASHINFER_MLA_PARAMS_CUH_
+#include <cuda.h>
+
+#include "../fastdiv.cuh"
+
+namespace flashinfer {
+
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_>
+struct MLAParams {
+  using DTypeQ = DTypeQ_;
+  using DTypeKV = DTypeKV_;
+  using DTypeO = DTypeO_;
+  using IdType = IdType_;
+
+  DTypeQ* q_nope;
+  DTypeQ* q_pe;
+  DTypeKV* ckv;
+  DTypeKV* kpe;
+  float* partial_o;
+  float* partial_lse;
+  DTypeO* final_o;
+  float* final_lse;
+
+  IdType* q_indptr;
+  IdType* kv_indptr;
+  IdType* kv_indices;
+  IdType* q_len;
+  IdType* kv_len;
+  IdType* q_start;
+  IdType* kv_start;
+  IdType* kv_end;
+  IdType* work_indptr;
+  uint_fastdiv block_size;
+  uint_fastdiv num_heads;
+
+  uint32_t q_nope_stride_n;
+  uint32_t q_nope_stride_h;
+  uint32_t q_pe_stride_n;
+  uint32_t q_pe_stride_h;
+  uint32_t ckv_stride_page;
+  uint32_t ckv_stride_n;
+  uint32_t kpe_stride_page;
+  uint32_t kpe_stride_n;
+  uint32_t o_stride_n;
+  uint32_t o_stride_h;
+
+  float sm_scale;
+};
+
+};  // namespace flashinfer
+
+#endif  // FLASHINFER_MLA_PARAMS_CUH_

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -17,6 +17,7 @@
 #define FLASHINFER_ATTENTION_SCHEDULER_CUH_
 
 #include <cuda_runtime_api.h>
+#include <driver_types.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -702,9 +703,7 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
   return cudaSuccess;
 }
 
-inline float cost_function(int qo_len, int kv_len, int group_size) {
-  return 2 * float(qo_len) * float(group_size) + kv_len;
-}
+inline float cost_function(int qo_len, int kv_len) { return 2 * float(qo_len) + kv_len; }
 
 template <typename T>
 std::vector<T> flatten(const std::vector<std::vector<T>>& vec, int size_after_flatten) {
@@ -808,7 +807,7 @@ inline cudaError_t PrefillSM90Plan(
   FLASHINFER_CUDA_CALL(
       cudaDeviceGetAttribute(&num_sm90_ctas, cudaDevAttrMultiProcessorCount, device));
 
-  CTACostHeap cta_cost_heap(num_sm90_ctas);
+  MinHeap cta_cost_heap(num_sm90_ctas);
   std::vector<std::vector<IdType>> cta_qo_tile_indices(num_sm90_ctas, std::vector<IdType>()),
       cta_qo_indptr(num_sm90_ctas, std::vector<IdType>()),
       cta_kv_indptr(num_sm90_ctas, std::vector<IdType>()),
@@ -828,12 +827,10 @@ inline cudaError_t PrefillSM90Plan(
         // NOTE(Zihao): our current FA3 implementation do not fuse query and group heads
         // so the group_size in cost_function is always 1
         cta_cost_heap.insert(
-            {cta_idx,
-             accum_cost + cost_function(cta_tile_q,
-                                        causal
-                                            ? kv_len - (num_qo_tiles - qo_tile_idx - 1) * cta_tile_q
-                                            : kv_len,
-                                        /*group_size=*/1)});
+            {cta_idx, accum_cost + cost_function(cta_tile_q, causal ? kv_len - (num_qo_tiles -
+                                                                                qo_tile_idx - 1) *
+                                                                                   cta_tile_q
+                                                                    : kv_len)});
         cta_qo_tile_indices[cta_idx].push_back(qo_tile_idx);
         cta_qo_indptr[cta_idx].push_back(qo_indptr_h[i]);
         cta_qo_len[cta_idx].push_back(qo_len);
@@ -906,6 +903,194 @@ inline cudaError_t PrefillSM90Plan(
   size_t num_bytes_to_copy = int_allocator.num_allocated_bytes();
   FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, num_bytes_to_copy,
                                        cudaMemcpyHostToDevice, stream));
+  return cudaSuccess;
+}
+
+struct MLAPlanInfo {
+  int64_t num_blks_x;
+  int64_t num_blks_y;
+  int64_t q_indptr_offset;
+  int64_t kv_indptr_offset;
+  int64_t q_len_offset;
+  int64_t kv_len_offset;
+  int64_t q_start_offset;
+  int64_t kv_start_offset;
+  int64_t kv_end_offset;
+  int64_t work_indptr_offset;
+  int64_t partial_o_offset;
+  int64_t partial_lse_offset;
+
+  std::vector<int64_t> ToVector() const {
+    return {num_blks_x,    num_blks_y,         q_indptr_offset,  kv_indptr_offset,
+            q_len_offset,  kv_len_offset,      q_start_offset,   kv_start_offset,
+            kv_end_offset, work_indptr_offset, partial_o_offset, partial_lse_offset};
+  }
+
+  void FromVector(const std::vector<int64_t>& vec) {
+    if (vec.size() != 12) {
+      std::ostringstream err_msg;
+      err_msg << "MLAPlanInfo::FromVector: vec.size() should be 12, but got " << vec.size();
+      FLASHINFER_ERROR(err_msg.str());
+    }
+    num_blks_x = vec[0];
+    num_blks_y = vec[1];
+    q_indptr_offset = vec[2];
+    kv_indptr_offset = vec[3];
+    q_len_offset = vec[4];
+    kv_len_offset = vec[5];
+    q_start_offset = vec[6];
+    kv_start_offset = vec[7];
+    kv_end_offset = vec[8];
+    work_indptr_offset = vec[9];
+    partial_o_offset = vec[10];
+    partial_lse_offset = vec[11];
+  }
+};
+
+template <typename IdType>
+inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_bytes,
+                           void* int_buffer, void* page_locked_int_buffer,
+                           size_t int_workspace_size_in_bytes, MLAPlanInfo& plan_info,
+                           IdType* qo_indptr_h, IdType* kv_indptr_h, IdType* kv_len_arr_h,
+                           uint32_t batch_size, uint32_t num_heads, uint32_t head_dim_o,
+                           bool causal, cudaStream_t stream) {
+  int num_sm = 0;
+  int dev_id = 0;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+
+  // step 0. determine the number of blocks in x and y dimensions
+  int accum_packed_qo_len = 0;
+  std::vector<std::tuple<int, int, int>> idx_qo_kv_len_vec;
+  for (uint32_t i = 0; i < batch_size; ++i) {
+    if (qo_indptr_h[i + 1] - qo_indptr_h[i] < 0) {
+      std::ostringstream err_msg;
+      err_msg << "qo_indptr[" << i + 1 << "]" << qo_indptr_h[i + 1] << " - qo_indptr[" << i << "]"
+              << qo_indptr_h[i] << " should be non-negative";
+      FLASHINFER_ERROR(err_msg.str());
+    }
+
+    int qo_len = qo_indptr_h[i + 1] - qo_indptr_h[i];
+    int packed_qo_len = qo_len * num_heads;
+    accum_packed_qo_len += packed_qo_len;
+
+    int kv_len = kv_len_arr_h[i];
+    idx_qo_kv_len_vec.push_back({i, qo_len, kv_len});
+  }
+  int avg_packed_qo_len = accum_packed_qo_len / batch_size;
+
+  int cluster_size;
+  if (avg_packed_qo_len > 64) {
+    cluster_size = 2;  // two ctas in a cluster
+  } else {
+    cluster_size = 1;  // one cta in a cluster
+  }
+  int num_clusters = num_sm / cluster_size;
+  plan_info.num_blks_x = cluster_size;
+  plan_info.num_blks_y = num_clusters;
+  const int cta_tile_q = 64;
+  int cluster_tile_q = cluster_size * cta_tile_q;
+
+  // step 1. load-balancing scheduling algorithm
+  MinHeap cluster_cost_heap(num_clusters);
+  std::vector<std::vector<IdType>> cluster_q_indptr(num_clusters, std::vector<IdType>()),
+      cluster_kv_indptr(num_clusters, std::vector<IdType>()),
+      cluster_q_len(num_clusters, std::vector<IdType>()),
+      cluster_kv_len(num_clusters, std::vector<IdType>()),
+      cluster_q_start(num_clusters, std::vector<IdType>()),
+      cluster_kv_start(num_clusters, std::vector<IdType>()),
+      cluster_kv_end(num_clusters, std::vector<IdType>());
+
+  for (auto& [i, qo_len, kv_len] : idx_qo_kv_len_vec) {
+    int packed_qo_len = qo_len * num_heads;
+    int num_qo_tiles = ceil_div(packed_qo_len, cluster_tile_q);
+    for (int qo_tile_idx = num_qo_tiles - 1; qo_tile_idx >= 0; --qo_tile_idx) {
+      auto [cluster_idx, accum_cost] = cluster_cost_heap.pop();
+      cluster_cost_heap.insert(
+          {cluster_idx,
+           accum_cost +
+               cost_function(
+                   cluster_tile_q,
+                   causal ? kv_len - (num_qo_tiles - qo_tile_idx - 1) * cluster_tile_q : kv_len)});
+      cluster_q_len[cluster_idx].push_back(qo_len);
+      cluster_kv_len[cluster_idx].push_back(kv_len);
+      cluster_q_indptr[cluster_idx].push_back(qo_indptr_h[i]);
+      cluster_kv_indptr[cluster_idx].push_back(kv_indptr_h[i]);
+      cluster_q_start[cluster_idx].push_back(qo_tile_idx * cluster_tile_q);
+      cluster_kv_start[cluster_idx].push_back(0);
+      cluster_kv_end[cluster_idx].push_back(kv_len);
+    }
+  }
+
+  int max_total_num_works = 16384;  // NOTE(Zihao): adjust it later
+
+  std::vector<IdType> work_indptr_vec(num_clusters + 1, 0);
+  for (uint32_t i = 0; i < num_clusters; ++i) {
+    work_indptr_vec[i + 1] = work_indptr_vec[i] + cluster_q_indptr[i].size();
+  }
+  int total_num_works = work_indptr_vec.back();
+  auto q_indptr_vec = flatten(cluster_q_indptr, total_num_works);
+  auto kv_indptr_vec = flatten(cluster_kv_indptr, total_num_works);
+  auto q_len_vec = flatten(cluster_q_len, total_num_works);
+  auto kv_len_vec = flatten(cluster_kv_len, total_num_works);
+  auto q_start_vec = flatten(cluster_q_start, total_num_works);
+  auto kv_start_vec = flatten(cluster_kv_start, total_num_works);
+  auto kv_end_vec = flatten(cluster_kv_end, total_num_works);
+
+  AlignedAllocator int_allocator(int_buffer, int_workspace_size_in_bytes);
+  plan_info.q_indptr_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_q_indptr");
+  plan_info.kv_indptr_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_kv_indptr");
+  plan_info.q_len_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_q_len");
+  plan_info.kv_len_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_kv_len");
+  plan_info.q_start_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_q_start");
+  plan_info.kv_start_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_kv_start");
+  plan_info.kv_end_offset =
+      int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_kv_end");
+  plan_info.work_indptr_offset = int_allocator.aligned_alloc_offset(
+      sizeof(IdType) * max_total_num_works, 16, "mla_work_indptr");
+
+  IdType* cluster_q_indptr_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.q_indptr_offset);
+  IdType* cluster_kv_indptr_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_indptr_offset);
+  IdType* cluster_q_len_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.q_len_offset);
+  IdType* cluster_kv_len_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_len_offset);
+  IdType* cluster_q_start_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.q_start_offset);
+  IdType* cluster_kv_start_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_start_offset);
+  IdType* cluster_kv_end_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_end_offset);
+  IdType* cluster_work_indptr_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.work_indptr_offset);
+
+  std::copy(q_indptr_vec.begin(), q_indptr_vec.end(), cluster_q_indptr_h);
+  std::copy(kv_indptr_vec.begin(), kv_indptr_vec.end(), cluster_kv_indptr_h);
+  std::copy(q_len_vec.begin(), q_len_vec.end(), cluster_q_len_h);
+  std::copy(kv_len_vec.begin(), kv_len_vec.end(), cluster_kv_len_h);
+  std::copy(q_start_vec.begin(), q_start_vec.end(), cluster_q_start_h);
+  std::copy(kv_start_vec.begin(), kv_start_vec.end(), cluster_kv_start_h);
+  std::copy(kv_end_vec.begin(), kv_end_vec.end(), cluster_kv_end_h);
+  std::copy(work_indptr_vec.begin(), work_indptr_vec.end(), cluster_work_indptr_h);
+
+  size_t num_bytes_to_copy = int_allocator.num_allocated_bytes();
+  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, num_bytes_to_copy,
+                                       cudaMemcpyHostToDevice, stream));
+
+  AlignedAllocator float_allocator(float_buffer, float_workspace_size_in_bytes);
+  plan_info.partial_o_offset = float_allocator.aligned_alloc_offset(
+      2 * num_clusters * cluster_tile_q * sizeof(float) * head_dim_o, 16, "mla_partial_o");
+  plan_info.partial_lse_offset = float_allocator.aligned_alloc_offset(
+      2 * num_clusters * cluster_tile_q * sizeof(float), 16, "mla_partial_lse");
+
   return cudaSuccess;
 }
 

--- a/include/flashinfer/attention/variant_helper.cuh
+++ b/include/flashinfer/attention/variant_helper.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 by FlashInfer team.
+ * Copyright (c) 2025 by FlashInfer team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ namespace flashinfer {
   }
 
 struct AttentionVariantBase {
+  constexpr static bool use_softmax = true;
   REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx,
                             { return logits; })
 

--- a/tests/test_deepseek_mla.py
+++ b/tests/test_deepseek_mla.py
@@ -166,20 +166,20 @@ def test_batch_mla_page_attention(
         pytest.skip("kv_len not divisible by page_size")
     head_dim_ckv = 512
     head_dim_kpe = 64
-    q_nope = torch.ones(
+    q_nope = torch.randn(
         batch_size * qo_len, num_heads, head_dim_ckv, dtype=torch.half, device="cuda"
     )
-    q_pe = torch.ones(
+    q_pe = torch.randn(
         batch_size * qo_len, num_heads, head_dim_kpe, dtype=torch.half, device="cuda"
     )
-    ckv = torch.ones(
+    ckv = torch.randn(
         batch_size * kv_len // page_size,
         page_size,
         head_dim_ckv,
         dtype=torch.half,
         device="cuda",
     )
-    kpe = torch.ones(
+    kpe = torch.randn(
         batch_size * kv_len // page_size,
         page_size,
         head_dim_kpe,
@@ -221,13 +221,14 @@ def test_batch_mla_page_attention(
     q = torch.cat([q_nope, q_pe], dim=-1)
     o_ref, lse_ref = attention_ref(batch_size, q, k, v, causal, sm_scale)
 
-    lse_ref = lse_ref.squeeze(1)
+    lse_ref = lse_ref.flatten(0, 1)
     torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
-    # torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":
     # test_single_prefill_with_kv_cache(54, 37, 4, 32, False, "fa2")
     # test_batch_prefill_with_ragged_kv_cache(12, 54, 37, 4, 4, False, "fa2")
     # test_batch_mla_page_attention(12, 54, 37, 128, False, "fa2")
-    test_batch_mla_page_attention(1, 33, 1, 1, False, 1, "fa2")
+    # test_batch_mla_page_attention(1, 33, 1, 1, False, 1, "fa2")
+    test_batch_mla_page_attention(1, 17, 37, 4, True, 1, "fa2")

--- a/tests/test_deepseek_mla.py
+++ b/tests/test_deepseek_mla.py
@@ -224,9 +224,8 @@ def test_batch_mla_page_attention(
     o_ref, lse_ref = attention_ref(batch_size, q, k, v, causal, sm_scale)
 
     lse_ref = lse_ref.flatten(0, 1)
-    print(lse, lse_ref)
     torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
-    torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
+    # torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_deepseek_mla.py
+++ b/tests/test_deepseek_mla.py
@@ -189,6 +189,7 @@ def test_batch_mla_page_attention(
     q = torch.cat([q_nope, q_pe], dim=-1)
     o_ref = attention_ref(batch_size, q, k, v, causal, sm_scale)
 
+    print(o, o_ref)
     torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
 
 
@@ -196,4 +197,4 @@ if __name__ == "__main__":
     # test_single_prefill_with_kv_cache(54, 37, 4, 32, False, "fa2")
     # test_batch_prefill_with_ragged_kv_cache(12, 54, 37, 4, 4, False, "fa2")
     # test_batch_mla_page_attention(12, 54, 37, 128, False, "fa2")
-    test_batch_mla_page_attention(1, 19, 1, 64, False, "fa2")
+    test_batch_mla_page_attention(1, 33, 5, 127, False, "fa2")


### PR DESCRIPTION
**Description:**

This PR implements a memory efficient fused Deepseek MLA PageAttention kernel for decode, prefill, and chunked prefill operations.
MLA computation after matrix absorption can be described as a (multi-query attention) MQA kernel, with same K/V cache and special head dimensions: `head_dim_qk=576, head_dim_vo=512`.

**Background:**  
For Deepseek v2/3, the large `head_dim` (512) makes it challenging to store the output tensor in registers when using tensor cores. A previous approach ([#551](https://github.com/flashinfer-ai/flashinfer/pull/551)) split `head_dim` across `gridDim.y`, which led to two main issues:
- **Re-computation Overhead:** Multiple blocks had to redundantly compute the Q*K operation.
- **Memory Access Latency:** Using multiple blocks prevented shared memory usage, forcing reliance on slower L2 for KV-Cache accesses.

**New Design:**
We use head-group fusion to increase the operational intensity of the kernel ([appendix A in the paper](https://arxiv.org/pdf/2501.01005) ). To address the large head-dimension issue, we redesign the kernel (diagram below) to use two warp groups (WG1 and WG2, each with 4 warps) per CTA:
<img width="688" alt="image" src="https://github.com/user-attachments/assets/be684e8d-eaa7-41fb-8160-35e121711d8d" />
- **QK Computation:** Each warp group processes half of the CTA_TILE_KV dimension, eliminating redundant computations.
- **Shared Memory Broadcast:** Local QK results are written to shared memory (reusing the `kpe` buffer) to efficiently broadcast data for PV computation.
- **PV Computation:** The head dimension is split between the warp groups, with each computing half.

The maximum `CTA_TILE_Q` (bounded by register files) is 64, and in this case the maximum `CTA_TILE_KV` (bounded by shared memory limit) is 64 (for H100) and 32 (for A100) when number of pipeline stages is set to 2.

For large `num_local_heads` such as 128 (if no TP and no MTP), we create a cluster of size 2, and the upper half (64) and lower half (64) are dispatched to two SMs in a cluster, and we can use software-managed multicasting (for large page size), we leave it to later PR.

## Benchmark results

Decoding Memory bandwidth on H100 SXM5 (Peak bandwidth = 3352 GB/s):
```
Config: batch_size=768, seq_len=1024, num_heads=16
Memory bandwidth: 2002.11 GB/s
Config: batch_size=768, seq_len=1024, num_heads=32
Memory bandwidth: 2035.59 GB/s
Config: batch_size=768, seq_len=1024, num_heads=64
Memory bandwidth: 2082.20 GB/s
Config: batch_size=768, seq_len=2048, num_heads=16
Memory bandwidth: 2064.97 GB/s
Config: batch_size=768, seq_len=2048, num_heads=32
Memory bandwidth: 2080.99 GB/s
Config: batch_size=768, seq_len=2048, num_heads=64
Memory bandwidth: 2082.78 GB/s
```
