### PR TITLE
fix: Pass backend in BatchPrefillWith*KVCacheWrapper.plan()

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1195,6 +1195,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         q_data_type: Union[str, torch.dtype] = "float16",
         kv_data_type: Optional[Union[str, torch.dtype]] = None,
         non_blocking: bool = False,
+        backend: str = "auto",
     ) -> None:
         r"""Plan batch prefill/append attention on Paged KV-Cache for given problem specification.
 
@@ -1394,7 +1395,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
-            if self._backend == "auto":
+            if backend == "auto":
                 self._backend = determine_attention_backend(
                     self.device,
                     PosEncodingMode[pos_encoding_mode].value,
@@ -1953,6 +1954,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         rope_theta: Optional[float] = None,
         q_data_type: Union[str, torch.dtype] = "float16",
         kv_data_type: Optional[Union[str, torch.dtype]] = None,
+        backend: str = "auto",
     ) -> None:
         r"""Plan batch prefill/append attention on Ragged KV-Cache for given problem specification.
 
@@ -2109,7 +2111,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
-            if self._backend == "auto":
+            if backend == "auto":
                 self._backend = determine_attention_backend(
                     self.device,
                     PosEncodingMode[pos_encoding_mode].value,


### PR DESCRIPTION
Fix https://github.com/flashinfer-ai/flashinfer/issues/807

For the BatchPrefillWith*KVCacheWrapper that support both FA2 and FA3, user may call the ctor() once and the plan() multiple times.

This PR adds support to reset/select backend in plan()