### PR TITLE
doc: Fix the incorrect DeepSeek-V3 paper link

### DIFF
--- a/docs/api/mla.rst
+++ b/docs/api/mla.rst
@@ -4,7 +4,7 @@ flashinfer.mla
 ==============
 
 MLA (Multi-head Latent Attention) is an attention mechanism proposed in DeepSeek series of models (
-`DeepSeek-V2 <https://arxiv.org/abs/2405.04434>`_, `DeepSeek-V3 <https://arxiv.org/abs/2405.04434>`_,
+`DeepSeek-V2 <https://arxiv.org/abs/2405.04434>`_, `DeepSeek-V3 <https://arxiv.org/abs/2412.19437>`_,
 and `DeepSeek-R1 <https://arxiv.org/abs/2501.12948>`_).
 
 .. currentmodule:: flashinfer.mla


### PR DESCRIPTION
DeepSeek-V3 paper link is incorrect in docs，this commit fix it.