### PR TITLE
adds `TensorRT-LLM` to the list of projects adopting FlashInfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ We are thrilled to share that FlashInfer is being adopted by many cutting-edge p
 - [vLLM](https://github.com/vllm-project/vllm)
 - [TGI](https://github.com/huggingface/text-generation-inference)
 - [lorax](https://github.com/predibase/lorax)
+- [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)
 
 ## Acknowledgement
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a new project, `TensorRT-LLM`, to the list of projects adopting FlashInfer.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152): Added `TensorRT-LLM` to the list of projects using FlashInfer.