### PR TITLE
misc: Remove duplicate param set in MLA kernel

### DIFF
--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -68,7 +68,6 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
         params.q_pe = static_cast<DTypeQ*>(q_pe.data_ptr());
         params.ckv = static_cast<DTypeKV*>(ckv_cache.data_ptr());
         params.kpe = static_cast<DTypeKV*>(kpe_cache.data_ptr());
-        params.kv_indices = static_cast<IdType*>(kv_indices.data_ptr());
 
         params.q_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.q_indptr_offset);
         params.kv_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_indptr_offset);


### PR DESCRIPTION
This PR removes the duplicate set of `params.kv_indices` in the MLA kernel.