### PR TITLE
Unique the symbol of maybe_q_rope_offset_v.

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -33,7 +33,7 @@
 
 namespace flashinfer {
 
-DEFINE_HAS_MEMBER(maybe_q_rope_offset)
+DEFINE_HAS_MEMBER(decode_maybe_q_rope_offset)
 
 namespace cg = cooperative_groups;
 using cp_async::PrefetchMode;
@@ -441,7 +441,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernel(const __grid_constant__ Params
   const uint32_t q_stride_h = params.q_stride_h;
   if constexpr (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
     const IdType* q_rope_offset = nullptr;
-    if constexpr (has_maybe_q_rope_offset_v<Params>) {
+    if constexpr (has_decode_maybe_q_rope_offset_v<Params>) {
       q_rope_offset = params.maybe_q_rope_offset;
     }
     int32_t q_rope_offset_val = q_rope_offset == nullptr ? (kv_len - 1) : q_rope_offset[batch_idx];


### PR DESCRIPTION
Having building error with multiple definitions of `has_maybe_q_rope_offset_v` with building command:

```
TORCH_CUDA_ARCH_LIST="9.0a" FLASHINFER_ENABLE_AOT=1 pip install -e . -v
```

The reason is that we both defined same template struct in `prefill.cuh` and `decode.cuh`:

https://github.com/flashinfer-ai/flashinfer/blob/7bee1cfb6d0322c58ee864f0b592d1952e8c758c/include/flashinfer/attention/prefill.cuh#L39

https://github.com/flashinfer-ai/flashinfer/blob/7bee1cfb6d0322c58ee864f0b592d1952e8c758c/include/flashinfer/attention/decode.cuh#L36

So if the struct is just for condition check, add a prefix of `decode` could avoid this, if no other uses of this struct.