### PR TITLE
perf: dynamic split-k for MLA

### DIFF
--- a/benchmarks/bench_deepseek_mla.py
+++ b/benchmarks/bench_deepseek_mla.py
@@ -59,6 +59,7 @@ def bench_deepseek_mla_decode(batch_size, seq_len, num_heads):
         q_nope.dtype,
         ckv.dtype,
     )
+    o = wrapper.run(q_nope, q_pe, ckv, kpe, return_lse=False)
 
     ms = triton.testing.do_bench(
         lambda: wrapper.run(q_nope, q_pe, ckv, kpe),

--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -72,6 +72,8 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
 
         params.q_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.q_indptr_offset);
         params.kv_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_indptr_offset);
+        params.partial_indptr =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.partial_indptr_offset);
         params.kv_indices = static_cast<IdType*>(kv_indices.data_ptr());
         params.q_len = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.q_len_offset);
         params.kv_len = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_len_offset);
@@ -80,6 +82,12 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
         params.kv_end = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_end_offset);
         params.work_indptr =
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+        params.merge_packed_offset_start = GetPtrFromBaseOffset<IdType>(
+            int_buffer_ptr, plan_info.merge_packed_offset_start_offset);
+        params.merge_packed_offset_end =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_packed_offset_end_offset);
+        params.merge_indptr =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_indptr_offset);
         params.final_o = static_cast<DTypeO*>(o.data_ptr());
         params.final_lse =
             maybe_lse.has_value() ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;

--- a/include/flashinfer/attention/cascade.cuh
+++ b/include/flashinfer/attention/cascade.cuh
@@ -16,8 +16,6 @@
 #ifndef FLASHINFER_CASCADE_CUH_
 #define FLASHINFER_CASCADE_CUH_
 
-#include <cooperative_groups.h>
-
 #include "../cp_async.cuh"
 #include "../math.cuh"
 #include "../utils.cuh"
@@ -25,7 +23,6 @@
 
 namespace flashinfer {
 
-namespace cg = cooperative_groups;
 using cp_async::PrefetchMode;
 using cp_async::SharedMemFillMode;
 
@@ -323,8 +320,8 @@ __global__ void MergeStatesLargeNumIndexSetsKernel(DTypeIn* __restrict__ V, floa
 }
 
 /*!
- * \brief The CUDA kernel to merge self-attention states of multiple index sets, the number of index
- *   sets at each position might vary.
+ * \brief The CUDA kernel to merge self-attention states of multiple index sets, the number of
+ * index sets at each position might vary.
  *
  * For CUDA graph support, the kernel can be built with a maximum sequence length and executed
  * using a truncated, dynamic sequence length passed through `seq_len_ptr`.

--- a/include/flashinfer/attention/mla_fa2.cuh
+++ b/include/flashinfer/attention/mla_fa2.cuh
@@ -856,11 +856,10 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
             CTA_TILE_KV) -
         1 - (kv_start / CTA_TILE_KV);
 
-    // int mask_tile_idx =
-    //     (CAUSAL ? min(kv_end, kv_len - q_len + packed_qo_start / num_heads) : kv_end) /
-    //         CTA_TILE_KV -
-    //     (kv_start / CTA_TILE_KV);
-    int mask_tile_idx = 0;
+    int mask_tile_idx =
+        (CAUSAL ? min(kv_end, kv_len - q_len + packed_qo_start / num_heads) : kv_end) /
+            CTA_TILE_KV -
+        (kv_start / CTA_TILE_KV);
 
     uint32_t block_iter_base = kv_indptr * block_size + kv_start;
     // last kv tile

--- a/include/flashinfer/attention/mla_params.cuh
+++ b/include/flashinfer/attention/mla_params.cuh
@@ -39,6 +39,10 @@ struct MLAParams {
 
   IdType* q_indptr;
   IdType* kv_indptr;
+  IdType* partial_indptr;
+  IdType* merge_packed_offset_start;
+  IdType* merge_packed_offset_end;
+  IdType* merge_indptr;
   IdType* kv_indices;
   IdType* q_len;
   IdType* kv_len;

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -44,10 +44,10 @@ template <uint32_t num_stages_smem, uint32_t vec_size_ckv, uint32_t vec_size_kpe
 __global__ void BatchDecodeWithPagedKVCacheKernelMLA(Params params);
 
 template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN, typename DTypeKV>
-std::tuple<uint32_t, uint32_t, uint32_t> LaunchSpecForDecodeKernelMlaCuteSM80(const uint32_t num_qo_heads);
+std::tuple<uint32_t, uint32_t, uint32_t> LaunchSpecForDecodeKernelMlaCuteSM80(
+    const uint32_t num_qo_heads);
 
-template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN,
-      typename Params>
+template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN, typename Params>
 __global__ void BatchDecodeWithPagedKVCacheKernelMlaCuteSM80(Params params);
 
 /*!
@@ -269,20 +269,23 @@ inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMLA(
   });
 }
 
-template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN, typename AttentionVariant, typename Params>
+template <uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t QO_TILE_LEN,
+          typename AttentionVariant, typename Params>
 inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMlaCuteSM80(
-  bool& split_kv, uint32_t& max_grid_size, uint32_t& max_num_pages_per_batch,
-  uint32_t& new_batch_size, uint32_t& gdy_, uint32_t batch_size,
-  typename Params::IdType* kv_indptr_h, const uint32_t num_qo_heads, const uint32_t page_size,
-  bool enable_cuda_graph, cudaStream_t stream) {
+    bool& split_kv, uint32_t& max_grid_size, uint32_t& max_num_pages_per_batch,
+    uint32_t& new_batch_size, uint32_t& gdy_, uint32_t batch_size,
+    typename Params::IdType* kv_indptr_h, const uint32_t num_qo_heads, const uint32_t page_size,
+    bool enable_cuda_graph, cudaStream_t stream) {
   using DTypeKV = typename Params::DTypeKV;
   using IdType = typename Params::IdType;
 
-  auto [smem_size, gdy, k_warps] = LaunchSpecForDecodeKernelMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN , DTypeKV>(num_qo_heads);
+  auto [smem_size, gdy, k_warps] =
+      LaunchSpecForDecodeKernelMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, DTypeKV>(
+          num_qo_heads);
   gdy_ = gdy;
   const uint32_t num_threads = k_warps * 32;
   auto kernel =
-    BatchDecodeWithPagedKVCacheKernelMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, Params>;
+      BatchDecodeWithPagedKVCacheKernelMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, Params>;
   int num_blocks_per_sm;
   int num_sm = 0;
   int dev_id = 0;
@@ -291,28 +294,27 @@ inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMlaCuteSM8
 
   // FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel,
   //                                   num_threads, smem_size));
-  // fixme: num_blocks_per_sm is 0 derived from cudaOccupancyMaxActiveBlocksPerMultiprocessor at times, 
-  // and we fill smem with q-heads as many as possible, so num_blocks_per_sm should be 1
+  // fixme: num_blocks_per_sm is 0 derived from cudaOccupancyMaxActiveBlocksPerMultiprocessor at
+  // times, and we fill smem with q-heads as many as possible, so num_blocks_per_sm should be 1
   num_blocks_per_sm = 1;
-  
+
   max_grid_size = num_blocks_per_sm * num_sm;
   if (batch_size * gdy >= max_grid_size) {
     split_kv = false;
     max_num_pages_per_batch = 1;
     for (uint32_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
       max_num_pages_per_batch = std::max<uint32_t>(
-        max_num_pages_per_batch, kv_indptr_h[batch_idx + 1] - kv_indptr_h[batch_idx]);
+          max_num_pages_per_batch, kv_indptr_h[batch_idx + 1] - kv_indptr_h[batch_idx]);
     }
     new_batch_size = batch_size;
-  } 
-  else {
+  } else {
     // compute max_num_pages_per_batch and new_batch_size
     std::vector<IdType> num_pages(batch_size);
     for (uint32_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
       num_pages[batch_idx] = kv_indptr_h[batch_idx + 1] - kv_indptr_h[batch_idx];
     }
     std::tie(max_num_pages_per_batch, new_batch_size) =
-      PartitionPagedKVCacheBinarySearchMinNumPagePerBatch(max_grid_size, gdy, num_pages,
+        PartitionPagedKVCacheBinarySearchMinNumPagePerBatch(max_grid_size, gdy, num_pages,
                                                             std::max(128 / page_size, 1U));
     if (new_batch_size == batch_size && !enable_cuda_graph) {
       // do not use partition-kv kernel for short sequence, when not using CUDAGraph
@@ -325,7 +327,6 @@ inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMlaCuteSM8
 
   return cudaSuccess;
 }
-
 
 /*!
  * \brief Partition Paged KV-Cache into multiple chunks on KV sequence length
@@ -799,7 +800,7 @@ struct PrefillPlanSM90Info {
         head_indices_offset(0),
         work_indptr_offset(0),
         same_schedule_for_all_heads(false) {}
-  
+
   // convert PrefillPlanSM90Info to std::vector<int64_t>
   std::vector<int64_t> ToVector() const {
     return {qo_tile_indices_offset, qo_indptr_offset,
@@ -976,6 +977,10 @@ struct MLAPlanInfo {
   int64_t num_blks_y;
   int64_t q_indptr_offset;
   int64_t kv_indptr_offset;
+  int64_t partial_indptr_offset;
+  int64_t merge_packed_offset_start_offset;
+  int64_t merge_packed_offset_end_offset;
+  int64_t merge_indptr_offset;
   int64_t q_len_offset;
   int64_t kv_len_offset;
   int64_t q_start_offset;
@@ -986,13 +991,26 @@ struct MLAPlanInfo {
   int64_t partial_lse_offset;
 
   std::vector<int64_t> ToVector() const {
-    return {num_blks_x,    num_blks_y,         q_indptr_offset,  kv_indptr_offset,
-            q_len_offset,  kv_len_offset,      q_start_offset,   kv_start_offset,
-            kv_end_offset, work_indptr_offset, partial_o_offset, partial_lse_offset};
+    return {num_blks_x,
+            num_blks_y,
+            q_indptr_offset,
+            kv_indptr_offset,
+            partial_indptr_offset,
+            merge_packed_offset_start_offset,
+            merge_packed_offset_end_offset,
+            merge_indptr_offset,
+            q_len_offset,
+            kv_len_offset,
+            q_start_offset,
+            kv_start_offset,
+            kv_end_offset,
+            work_indptr_offset,
+            partial_o_offset,
+            partial_lse_offset};
   }
 
   void FromVector(const std::vector<int64_t>& vec) {
-    if (vec.size() != 12) {
+    if (vec.size() != 16) {
       std::ostringstream err_msg;
       err_msg << "MLAPlanInfo::FromVector: vec.size() should be 12, but got " << vec.size();
       FLASHINFER_ERROR(err_msg.str());
@@ -1001,14 +1019,18 @@ struct MLAPlanInfo {
     num_blks_y = vec[1];
     q_indptr_offset = vec[2];
     kv_indptr_offset = vec[3];
-    q_len_offset = vec[4];
-    kv_len_offset = vec[5];
-    q_start_offset = vec[6];
-    kv_start_offset = vec[7];
-    kv_end_offset = vec[8];
-    work_indptr_offset = vec[9];
-    partial_o_offset = vec[10];
-    partial_lse_offset = vec[11];
+    partial_indptr_offset = vec[4];
+    merge_packed_offset_start_offset = vec[5];
+    merge_packed_offset_end_offset = vec[6];
+    merge_indptr_offset = vec[7];
+    q_len_offset = vec[8];
+    kv_len_offset = vec[9];
+    q_start_offset = vec[10];
+    kv_start_offset = vec[11];
+    kv_end_offset = vec[12];
+    work_indptr_offset = vec[13];
+    partial_o_offset = vec[14];
+    partial_lse_offset = vec[15];
   }
 };
 
@@ -1056,6 +1078,18 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
   const int cta_tile_q = 64;
   int cluster_tile_q = cluster_size * cta_tile_q;
 
+  int64_t total_kv_lens = 0;
+  for (auto& [_, qo_len, kv_len] : idx_qo_kv_len_vec) {
+    int packed_qo_len = qo_len * num_heads;
+    int num_qo_tiles = ceil_div(packed_qo_len, cluster_tile_q);
+    for (int qo_tile_idx = num_qo_tiles - 1; qo_tile_idx >= 0; --qo_tile_idx) {
+      int effective_kv_len =
+          causal ? kv_len - (num_qo_tiles - qo_tile_idx - 1) * cluster_tile_q : kv_len;
+      total_kv_lens += effective_kv_len;
+    }
+  }
+  int kv_len_limit = std::max(ceil_div(total_kv_lens, num_clusters), 64L);
+
   // step 1. load-balancing scheduling algorithm
   MinHeap cluster_cost_heap(num_clusters);
   std::vector<std::vector<IdType>> cluster_q_indptr(num_clusters, std::vector<IdType>()),
@@ -1064,28 +1098,54 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
       cluster_kv_len(num_clusters, std::vector<IdType>()),
       cluster_q_start(num_clusters, std::vector<IdType>()),
       cluster_kv_start(num_clusters, std::vector<IdType>()),
-      cluster_kv_end(num_clusters, std::vector<IdType>());
+      cluster_kv_end(num_clusters, std::vector<IdType>()),
+      cluster_partial_indptr(num_clusters, std::vector<IdType>());
+
+  std::vector<IdType> merge_packed_offset_start(num_clusters, 0),
+      merge_packed_offset_end(num_clusters, 0), merge_indptr(num_clusters + 1, 0);
+
+  int partial_o_nnz = 0;
+  int split_kv_count = 0;
 
   for (auto& [i, qo_len, kv_len] : idx_qo_kv_len_vec) {
     int packed_qo_len = qo_len * num_heads;
     int num_qo_tiles = ceil_div(packed_qo_len, cluster_tile_q);
     for (int qo_tile_idx = num_qo_tiles - 1; qo_tile_idx >= 0; --qo_tile_idx) {
-      auto [cluster_idx, accum_cost] = cluster_cost_heap.pop();
-      cluster_cost_heap.insert(
-          {cluster_idx,
-           accum_cost +
-               cost_function(
-                   cluster_tile_q,
-                   causal ? kv_len - (num_qo_tiles - qo_tile_idx - 1) * cluster_tile_q : kv_len)});
-      cluster_q_len[cluster_idx].push_back(qo_len);
-      cluster_kv_len[cluster_idx].push_back(kv_len);
-      cluster_q_indptr[cluster_idx].push_back(qo_indptr_h[i]);
-      cluster_kv_indptr[cluster_idx].push_back(kv_indptr_h[i]);
-      cluster_q_start[cluster_idx].push_back(qo_tile_idx * cluster_tile_q);
-      cluster_kv_start[cluster_idx].push_back(0);
-      cluster_kv_end[cluster_idx].push_back(kv_len);
+      int remaining_len =
+          causal ? kv_len - (num_qo_tiles - qo_tile_idx - 1) * cluster_tile_q : kv_len;
+      int kv_start = 0;
+      bool split_kv = remaining_len > kv_len_limit;
+      if (split_kv) {
+        merge_indptr[split_kv_count] = partial_o_nnz;
+        merge_packed_offset_start[split_kv_count] = qo_indptr_h[i] + qo_tile_idx * cluster_tile_q;
+        merge_packed_offset_end[split_kv_count] =
+            qo_indptr_h[i] + std::min((qo_tile_idx + 1) * cluster_tile_q, qo_len);
+      }
+      while (remaining_len > 0) {
+        auto [cluster_idx, accum_cost] = cluster_cost_heap.pop();
+        int actual_len = std::min(remaining_len, kv_len_limit);
+        cluster_cost_heap.insert(
+            {cluster_idx, accum_cost + cost_function(cluster_tile_q, actual_len)});
+        cluster_q_len[cluster_idx].push_back(qo_len);
+        cluster_kv_len[cluster_idx].push_back(kv_len);
+        cluster_q_indptr[cluster_idx].push_back(qo_indptr_h[i]);
+        cluster_kv_indptr[cluster_idx].push_back(kv_indptr_h[i]);
+        if (split_kv) {
+          cluster_partial_indptr[cluster_idx].push_back(partial_o_nnz);
+          partial_o_nnz += std::min(qo_len - qo_tile_idx * cluster_tile_q, cluster_tile_q);
+        } else {
+          cluster_partial_indptr[cluster_idx].push_back(-1);
+        }
+        cluster_q_start[cluster_idx].push_back(qo_tile_idx * cluster_tile_q);
+        cluster_kv_start[cluster_idx].push_back(kv_start);
+        cluster_kv_end[cluster_idx].push_back(kv_start + actual_len);
+        remaining_len -= actual_len;
+        kv_start += actual_len;
+      }
+      split_kv_count += int(split_kv);
     }
   }
+  merge_indptr[split_kv_count] = partial_o_nnz;
 
   int max_total_num_works = 16384;  // NOTE(Zihao): adjust it later
 
@@ -1096,6 +1156,7 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
   int total_num_works = work_indptr_vec.back();
   auto q_indptr_vec = flatten(cluster_q_indptr, total_num_works);
   auto kv_indptr_vec = flatten(cluster_kv_indptr, total_num_works);
+  auto partial_indptr_vec = flatten(cluster_partial_indptr, total_num_works);
   auto q_len_vec = flatten(cluster_q_len, total_num_works);
   auto kv_len_vec = flatten(cluster_kv_len, total_num_works);
   auto q_start_vec = flatten(cluster_q_start, total_num_works);
@@ -1107,6 +1168,14 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
       int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_q_indptr");
   plan_info.kv_indptr_offset =
       int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_kv_indptr");
+  plan_info.partial_indptr_offset = int_allocator.aligned_alloc_offset(
+      sizeof(IdType) * max_total_num_works, 16, "mla_partial_indptr");
+  plan_info.merge_packed_offset_start_offset = int_allocator.aligned_alloc_offset(
+      sizeof(IdType) * num_clusters, 16, "mla_merge_packed_offset_start");
+  plan_info.merge_packed_offset_end_offset = int_allocator.aligned_alloc_offset(
+      sizeof(IdType) * num_clusters, 16, "mla_merge_packed_offset_end");
+  plan_info.merge_indptr_offset = int_allocator.aligned_alloc_offset(
+      sizeof(IdType) * (num_clusters + 1), 16, "mla_merge_indptr");
   plan_info.q_len_offset =
       int_allocator.aligned_alloc_offset(sizeof(IdType) * max_total_num_works, 16, "mla_q_len");
   plan_info.kv_len_offset =
@@ -1124,6 +1193,14 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
       GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.q_indptr_offset);
   IdType* cluster_kv_indptr_h =
       GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_indptr_offset);
+  IdType* cluster_partial_indptr_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.partial_indptr_offset);
+  IdType* cluster_merge_packed_offset_start_h = GetPtrFromBaseOffset<IdType>(
+      page_locked_int_buffer, plan_info.merge_packed_offset_start_offset);
+  IdType* cluster_merge_packed_offset_end_h = GetPtrFromBaseOffset<IdType>(
+      page_locked_int_buffer, plan_info.merge_packed_offset_end_offset);
+  IdType* cluster_merge_indptr_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.merge_indptr_offset);
   IdType* cluster_q_len_h =
       GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.q_len_offset);
   IdType* cluster_kv_len_h =
@@ -1139,6 +1216,12 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
 
   std::copy(q_indptr_vec.begin(), q_indptr_vec.end(), cluster_q_indptr_h);
   std::copy(kv_indptr_vec.begin(), kv_indptr_vec.end(), cluster_kv_indptr_h);
+  std::copy(partial_indptr_vec.begin(), partial_indptr_vec.end(), cluster_partial_indptr_h);
+  std::copy(merge_packed_offset_start.begin(), merge_packed_offset_start.end(),
+            cluster_merge_packed_offset_start_h);
+  std::copy(merge_packed_offset_end.begin(), merge_packed_offset_end.end(),
+            cluster_merge_packed_offset_end_h);
+  std::copy(merge_indptr.begin(), merge_indptr.end(), cluster_merge_indptr_h);
   std::copy(q_len_vec.begin(), q_len_vec.end(), cluster_q_len_h);
   std::copy(kv_len_vec.begin(), kv_len_vec.end(), cluster_kv_len_h);
   std::copy(q_start_vec.begin(), q_start_vec.end(), cluster_q_start_h);


### PR DESCRIPTION
#804 didn't implement split-k, which might result in performance degradation if concurrency is not large enough. This PR fixes issue.

We implemented the v2 scheduler and write-through optimization mentioned in [our paper](https://arxiv.org/pdf/2501.01005) (section 3.3 and appendix in D.2) for load-balancing.

In an early PR (https://github.com/flashinfer-ai/flashinfer/pull/72), we turned off `cudaLaunchCooperativeKernels` and `grid.sync()` because we are not sure whether it's compatible with CUDAGraph. This PR adds them back again for grid synchronization, to save some kernel launch overhead.

## Benchmark

On H100 SXM5 80GB (3352 GB/s), this PR:
```
Config: batch_size=1, seq_len=1024, num_heads=16
Memory bandwidth: 22.33 GB/s
Config: batch_size=16, seq_len=1024, num_heads=16
Memory bandwidth: 330.72 GB/s
Config: batch_size=32, seq_len=1024, num_heads=16
Memory bandwidth: 638.73 GB/s
Config: batch_size=64, seq_len=1024, num_heads=16
Memory bandwidth: 1188.90 GB/s
Config: batch_size=1, seq_len=2048, num_heads=16
Memory bandwidth: 40.74 GB/s
Config: batch_size=16, seq_len=2048, num_heads=16
Memory bandwidth: 592.77 GB/s
Config: batch_size=32, seq_len=2048, num_heads=16
Memory bandwidth: 1112.83 GB/s
Config: batch_size=64, seq_len=2048, num_heads=16
Memory bandwidth: 1506.01 GB/s
Config: batch_size=1, seq_len=4096, num_heads=16
Memory bandwidth: 72.53 GB/s
Config: batch_size=16, seq_len=4096, num_heads=16
Memory bandwidth: 1007.80 GB/s
Config: batch_size=32, seq_len=4096, num_heads=16
Memory bandwidth: 1438.99 GB/s
Config: batch_size=64, seq_len=4096, num_heads=16
Memory bandwidth: 1730.62 GB/s
Config: batch_size=1, seq_len=8192, num_heads=16
Memory bandwidth: 120.74 GB/s
Config: batch_size=16, seq_len=8192, num_heads=16
Memory bandwidth: 1340.86 GB/s
Config: batch_size=32, seq_len=8192, num_heads=16
Memory bandwidth: 1689.36 GB/s
Config: batch_size=64, seq_len=8192, num_heads=16
Memory bandwidth: 1901.26 GB/s
Config: batch_size=1, seq_len=16384, num_heads=16
Memory bandwidth: 177.94 GB/s
Config: batch_size=16, seq_len=16384, num_heads=16
Memory bandwidth: 1619.51 GB/s
Config: batch_size=32, seq_len=16384, num_heads=16
Memory bandwidth: 1876.50 GB/s
Config: batch_size=64, seq_len=16384, num_heads=16
Memory bandwidth: 2010.58 GB/s
Config: batch_size=1, seq_len=32768, num_heads=16
Memory bandwidth: 231.70 GB/s
Config: batch_size=16, seq_len=32768, num_heads=16
Memory bandwidth: 1835.16 GB/s
Config: batch_size=32, seq_len=32768, num_heads=16
Memory bandwidth: 1997.24 GB/s
Config: batch_size=64, seq_len=32768, num_heads=16
Memory bandwidth: 2067.99 GB/s
```

Before this PR:
```
Config: batch_size=1, seq_len=1024, num_heads=16
Memory bandwidth: 15.46 GB/s
Config: batch_size=16, seq_len=1024, num_heads=16
Memory bandwidth: 238.49 GB/s
Config: batch_size=32, seq_len=1024, num_heads=16
Memory bandwidth: 472.44 GB/s
Config: batch_size=64, seq_len=1024, num_heads=16
Memory bandwidth: 929.12 GB/s
Config: batch_size=1, seq_len=2048, num_heads=16
Memory bandwidth: 15.47 GB/s
Config: batch_size=16, seq_len=2048, num_heads=16
Memory bandwidth: 250.71 GB/s
Config: batch_size=32, seq_len=2048, num_heads=16
Memory bandwidth: 500.21 GB/s
Config: batch_size=64, seq_len=2048, num_heads=16
Memory bandwidth: 996.37 GB/s
Config: batch_size=1, seq_len=4096, num_heads=16
Memory bandwidth: 16.36 GB/s
Config: batch_size=16, seq_len=4096, num_heads=16
Memory bandwidth: 257.59 GB/s
Config: batch_size=32, seq_len=4096, num_heads=16
Memory bandwidth: 515.88 GB/s
Config: batch_size=64, seq_len=4096, num_heads=16
Memory bandwidth: 1035.55 GB/s
Config: batch_size=1, seq_len=8192, num_heads=16
Memory bandwidth: 16.37 GB/s
Config: batch_size=16, seq_len=8192, num_heads=16
Memory bandwidth: 261.47 GB/s
Config: batch_size=32, seq_len=8192, num_heads=16
Memory bandwidth: 524.76 GB/s
Config: batch_size=64, seq_len=8192, num_heads=16
Memory bandwidth: 1054.54 GB/s
Config: batch_size=1, seq_len=16384, num_heads=16
Memory bandwidth: 16.50 GB/s
Config: batch_size=16, seq_len=16384, num_heads=16
Memory bandwidth: 263.69 GB/s
Config: batch_size=32, seq_len=16384, num_heads=16
Memory bandwidth: 528.89 GB/s
Config: batch_size=64, seq_len=16384, num_heads=16
Memory bandwidth: 1064.87 GB/s
Config: batch_size=1, seq_len=32768, num_heads=16
Memory bandwidth: 16.45 GB/s
Config: batch_size=16, seq_len=32768, num_heads=16
Memory bandwidth: 264.66 GB/s
Config: batch_size=32, seq_len=32768, num_heads=16
Memory bandwidth: 530.87 GB/s
Config: batch_size=64, seq_len=32768, num_heads=16
Memory bandwidth: 1070.93 GB/s
```