### PR TITLE
fix cu121 torch2.6

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -32,6 +32,8 @@ jobs:
             torch: "2.5"
           - cuda: "11.8"
             torch: "2.5"
+          - cuda: "12.1"
+            torch: "2.6"
 
     runs-on: [self-hosted]
     steps:


### PR DESCRIPTION
ref
https://github.com/flashinfer-ai/flashinfer/actions/runs/13376817887/job/37357692946

fix
```
Looking in indexes: https://download.pytorch.org/whl/cu121
  ERROR: Could not find a version that satisfies the requirement torch==2.6.* (from versions: 2.1.0+cu1[21](https://github.com/flashinfer-ai/flashinfer/actions/runs/13376817887/job/37357692946#step:3:22), 2.1.1+cu121, 2.1.2+cu121, 2.2.0+cu121, 2.2.1+cu121, 2.2.2+cu121, 2.3.0+cu121, 2.3.1+cu121, 2.4.0+cu121, 2.4.1+cu121, 2.5.0+cu121, 2.5.1+cu121)
  ERROR: No matching distribution found for torch==2.6.*
```