### PR TITLE
[Hotfix] Add flashinfer.jit.attention into packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ packages = [
     "flashinfer.data.cutlass",
     "flashinfer.data.include",
     "flashinfer.jit",
+    "flashinfer.jit.attention",
     "flashinfer.triton",
     "flashinfer.triton.kernels",
 ]


### PR DESCRIPTION
`flashinfer.jit.attention` package is introduced in https://github.com/flashinfer-ai/flashinfer/pull/880, but it's not added into the packages list when building wheel. Python will complain about the package not found during import.

Repro steps:
```
FLASHINFER_ENABLE_AOT=1 python -m build --no-isolation --wheel
pip install --force-reinstall dist/flashinfer_python-0.2.1.post2-cp38-abi3-linux_x86_64.whl
```

Log:
```
Python 3.11.11 (main, Dec 06 2024, 17:06:18) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import flashinfer
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/build/ktransformers/venv/lib64/python3.11/site-packages/flashinfer/__init__.py", line 18, in <module>
    from .activation import gelu_and_mul as gelu_and_mul
  File "/build/ktransformers/venv/lib64/python3.11/site-packages/flashinfer/activation.py", line 21, in <module>
    from .jit import gen_act_and_mul_module, has_prebuilt_ops, load_cuda_ops    # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/build/ktransformers/venv/lib64/python3.11/site-packages/flashinfer/jit/__init__.py", line 20, in <module>
    from .attention import gen_batch_decode_mla_module as gen_batch_decode_mla_module
ModuleNotFoundError: No module named 'flashinfer.jit.attention'
```
