### PR TITLE
fix: pin_memory use cpu as default device

### DIFF
--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -164,6 +164,7 @@ class BatchMLAPagedAttentionWrapper:
             self._int_workspace_buffer.shape,
             dtype=self._int_workspace_buffer.dtype,
             pin_memory=True,
+            device="cpu"
         )
         self._use_cuda_graph = use_cuda_graph
         self._qo_indptr_buf = qo_indptr

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -146,6 +146,7 @@ class BlockSparseAttentionWrapper:
             self._int_workspace_buffer.shape,
             dtype=torch.uint8,
             pin_memory=True,
+            device="cpu"
         )
         self._use_cuda_graph = False
         self._kv_layout = "NHD"


### PR DESCRIPTION
Use cpu as default device for pin_memory in mla.py and sparse.py