### PR TITLE
perf: fix MLA split-k performance bug

### DIFF
--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -85,8 +85,12 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
             int_buffer_ptr, plan_info.merge_packed_offset_start_offset);
         params.merge_packed_offset_end =
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_packed_offset_end_offset);
-        params.merge_indptr =
-            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_indptr_offset);
+        params.merge_partial_packed_offset_start = GetPtrFromBaseOffset<IdType>(
+            int_buffer_ptr, plan_info.merge_partial_packed_offset_start_offset);
+        params.merge_partial_packed_offset_end = GetPtrFromBaseOffset<IdType>(
+            int_buffer_ptr, plan_info.merge_partial_packed_offset_end_offset);
+        params.merge_partial_stride =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_partial_stride_offset);
         params.final_o = static_cast<DTypeO*>(o.data_ptr());
         params.final_lse =
             maybe_lse.has_value() ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;

--- a/csrc/batch_mla_sm90_run.cu
+++ b/csrc/batch_mla_sm90_run.cu
@@ -86,8 +86,12 @@ void BatchMLAPagedAttentionSM90Run(at::Tensor float_workspace_buffer,
             int_buffer_ptr, plan_info.merge_packed_offset_start_offset);
         params.merge_packed_offset_end =
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_packed_offset_end_offset);
-        params.merge_indptr =
-            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_indptr_offset);
+        params.merge_partial_packed_offset_start = GetPtrFromBaseOffset<IdType>(
+            int_buffer_ptr, plan_info.merge_partial_packed_offset_start_offset);
+        params.merge_partial_packed_offset_end = GetPtrFromBaseOffset<IdType>(
+            int_buffer_ptr, plan_info.merge_partial_packed_offset_end_offset);
+        params.merge_partial_stride =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_partial_stride_offset);
         params.final_o = static_cast<DTypeO*>(o.data_ptr());
         params.final_lse =
             maybe_lse.has_value() ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -615,31 +615,32 @@ __device__ __forceinline__ void finalize_m_(typename KTraits::AttentionVariant v
 }
 
 template <typename KTraits>
-__device__ void DevicePersistentMergeStates(typename KTraits::IdType* merge_packed_offset_start,
-                                            typename KTraits::IdType* merge_packed_offset_end,
-                                            typename KTraits::IdType* merge_indptr,
-                                            float* partial_o, float* partial_lse,
-                                            typename KTraits::DTypeO* final_o, float* final_lse,
-                                            const uint32_t o_stride_n, const uint32_t o_stride_h,
-                                            const uint_fastdiv& num_heads) {
-  constexpr uint32_t VEC_SIZE = 8;  // partial o has data type float
+__device__ void DevicePersistentMergeStates(
+    typename KTraits::IdType* merge_packed_offset_start,
+    typename KTraits::IdType* merge_packed_offset_end,
+    typename KTraits::IdType* merge_partial_packed_offset_start,
+    typename KTraits::IdType* merge_partial_packed_offset_end,
+    typename KTraits::IdType* merge_partial_stride, float* partial_o, float* partial_lse,
+    typename KTraits::DTypeO* final_o, float* final_lse, const uint32_t o_stride_n,
+    const uint32_t o_stride_h, const uint_fastdiv& num_heads) {
+  constexpr uint32_t VEC_SIZE = 4;  // partial o has data type float
   constexpr uint32_t NUM_THRS_PER_ROW = KTraits::HEAD_DIM_CKV / VEC_SIZE;
   constexpr uint32_t ROWS_PER_ITERATION = (KTraits::NUM_THREADS) / NUM_THRS_PER_ROW;
   const uint32_t cta_idx = (gridDim.x * blockIdx.y + blockIdx.x);
   const uint32_t thread_id = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x;
   const uint32_t offset_start = merge_packed_offset_start[cta_idx];
-  const uint32_t offset_end = merge_packed_offset_end[cta_idx];
-  const uint32_t partial_offset_start = merge_indptr[cta_idx];
-  const uint32_t partial_offset_end = merge_indptr[cta_idx + 1];
-  const uint32_t stride = offset_end - offset_start;
+  const uint32_t len = merge_packed_offset_end[cta_idx] - offset_start;
+  const uint32_t partial_offset_start = merge_partial_packed_offset_start[cta_idx];
+  const uint32_t partial_offset_end = merge_partial_packed_offset_end[cta_idx];
+  const uint32_t stride = merge_partial_stride[cta_idx];
 #pragma unroll 1
-  for (uint32_t local_packed_offset = ROWS_PER_ITERATION + thread_id / NUM_THRS_PER_ROW;
-       local_packed_offset < stride; local_packed_offset += ROWS_PER_ITERATION) {
+  for (uint32_t local_packed_offset = thread_id / NUM_THRS_PER_ROW; local_packed_offset < len;
+       local_packed_offset += ROWS_PER_ITERATION) {
     uint32_t final_packed_offset = offset_start + local_packed_offset;
     uint32_t q, r;
     num_heads.divmod(final_packed_offset, q, r);
     state_t<VEC_SIZE> st;
-#pragma unroll 4
+#pragma unroll 8
     for (uint32_t partial_packed_offset = partial_offset_start + local_packed_offset;
          partial_packed_offset < partial_offset_end; partial_packed_offset += stride) {
       vec_t<float, VEC_SIZE> o_partial;
@@ -966,8 +967,10 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
 
   // the second stage, merge partial outputs
   DevicePersistentMergeStates<KTraits>(
-      params.merge_packed_offset_start, params.merge_packed_offset_end, params.merge_indptr,
-      partial_o, partial_lse, final_o, final_lse, o_stride_n, o_stride_h, num_heads);
+      params.merge_packed_offset_start, params.merge_packed_offset_end,
+      params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
+      params.merge_partial_stride, partial_o, partial_lse, final_o, final_lse, o_stride_n,
+      o_stride_h, num_heads);
 }
 
 #define DISPATCH_SMEM_CONFIG(smem_limit_per_sm, NUM_STAGES, CTA_TILE_KV, QK_SHARD, ...) \

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -839,8 +839,10 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
   __syncthreads();
   // the second stage, merge partial outputs
   DevicePersistentMergeStates<KTraits>(
-      params.merge_packed_offset_start, params.merge_packed_offset_end, params.merge_indptr,
-      partial_o, partial_lse, final_o, final_lse, o_stride_n, o_stride_h, num_heads);
+      params.merge_packed_offset_start, params.merge_packed_offset_end,
+      params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
+      params.merge_partial_stride, partial_o, partial_lse, final_o, final_lse, o_stride_n,
+      o_stride_h, num_heads);
 }
 
 }  // namespace hopper

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -838,10 +838,9 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
 
   __syncthreads();
   // the second stage, merge partial outputs
-  DevicePersistentMergeStates<KTraits>(params.merge_packed_offset_start,
-                                       params.merge_packed_offset_end, params.merge_indptr,
-                                       partial_o, partial_lse, final_o, final_lse, o_stride_n,
-                                       o_stride_h, cluster_tile_q, num_heads);
+  DevicePersistentMergeStates<KTraits>(
+      params.merge_packed_offset_start, params.merge_packed_offset_end, params.merge_indptr,
+      partial_o, partial_lse, final_o, final_lse, o_stride_n, o_stride_h, num_heads);
 }
 
 }  // namespace hopper

--- a/include/flashinfer/attention/mla_params.cuh
+++ b/include/flashinfer/attention/mla_params.cuh
@@ -42,7 +42,9 @@ struct MLAParams {
   IdType* partial_indptr;
   IdType* merge_packed_offset_start;
   IdType* merge_packed_offset_end;
-  IdType* merge_indptr;
+  IdType* merge_partial_packed_offset_start;
+  IdType* merge_partial_packed_offset_end;
+  IdType* merge_partial_stride;
   IdType* kv_indices;
   IdType* q_len;
   IdType* kv_len;

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -1117,9 +1117,9 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
       cluster_kv_end(num_clusters, std::vector<IdType>()),
       cluster_partial_indptr(num_clusters, std::vector<IdType>());
 
-  std::vector<IdType> merge_packed_offset_start(num_clusters, 0),
-      merge_packed_offset_end(num_clusters, 0), merge_partial_packed_offset_start(num_clusters, 0),
-      merge_partial_packed_offset_end(num_clusters, 0), merge_partial_stride(num_clusters, 0);
+  std::vector<IdType> merge_packed_offset_start(num_sm, 0), merge_packed_offset_end(num_sm, 0),
+      merge_partial_packed_offset_start(num_sm, 0), merge_partial_packed_offset_end(num_sm, 0),
+      merge_partial_stride(num_sm, 0);
 
   int merge_cta_counter = 0;
   int partial_o_nnz = 0;

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -1151,7 +1151,8 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
         int num_qo_chunks = std::max(remaining_len * cluster_size / kv_len_limit, 1);
         // row_chunk_size * num_qo_chunks >= row_tile_size
         int row_chunk_size = ceil_div(row_tile_size, num_qo_chunks);
-        int current_q_tile_end = std::min((qo_tile_idx + 1) * cluster_tile_q, packed_qo_len);
+        int current_q_tile_end =
+            std::min(cluster_tile_q, packed_qo_len - qo_tile_idx * cluster_tile_q);
         for (int offset_start = 0; offset_start < row_tile_size; offset_start += row_chunk_size) {
           merge_packed_offset_start[merge_cta_counter] =
               qo_indptr_h[i] * num_heads + qo_tile_idx * cluster_tile_q + offset_start;


### PR DESCRIPTION
As observed in #892 , we found flashinfer mla's second stage of split-k is very slow (when batch size is small), this is because our scheduler only uses one CTA for the second stage of split-k.

This PR fixes the issue.