### PR TITLE
bugfix: Fix no return type error

### DIFF
--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -551,7 +551,7 @@ __device__ __forceinline__ auto get_block_coord(const Params& params, const uint
 }
 
 template <typename KTraits>
-__device__ __forceinline__ convert_s_to_p(float* s_frag, uint32_t* p_frag) {
+__device__ __forceinline__ void convert_s_to_p(float* s_frag, uint32_t* p_frag) {
 #pragma unroll
   for (uint32_t i = 0; i < KTraits::NUM_REGS_S_FRAG / 8; ++i) {
     vec_cast<typename KTraits::DTypeKV, float>::cast<8>(


### PR DESCRIPTION
This pull request includes a change to the `convert_s_to_p` function in the `mla_hopper.cuh` file to improve type safety and clarity.

Function signature modification:

* [`include/flashinfer/attention/mla_hopper.cuh`](diffhunk://#diff-5ebeba4848db48074fb2636d9ef52f85409674d9fcaba1e2b8091cf6fc36e651L554-R554): Changed the return type of the `convert_s_to_p` function from `auto` to `void` to explicitly indicate that the function does not return a value.