### PR TITLE
sampling: dual pivot rejection sampling algorithm to improve top-p/top-k sampling efficiency

### DIFF
--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -43,17 +43,16 @@ void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::T
 at::Tensor BatchDecodeWithPagedKVCachePlan(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor indptr, int64_t batch_size,
-    int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
-    bool enable_cuda_graph, int64_t window_left, double logits_soft_cap, int64_t head_dim_qk,
-    int64_t head_dim_vo, at::Tensor empty_q_data, at::Tensor empty_kv_data, int64_t cuda_stream);
+    int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph,
+    int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
+    at::Tensor empty_q_data, at::Tensor empty_kv_data, int64_t cuda_stream);
 
 void BatchDecodeWithPagedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    at::Tensor plan_info_vec, at::Tensor q, at::Tensor paged_k_cache,
-    at::Tensor paged_v_cache, at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices,
-    at::Tensor paged_kv_last_page_len, at::Tensor o, std::optional<at::Tensor> maybe_lse,
-    int64_t kv_layout_code, int64_t window_left BATCH_DECODE_ADDITIONAL_FUNC_PARAMS,
-    int64_t cuda_stream);
+    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+    at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor paged_kv_indptr,
+    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len, at::Tensor o,
+    std::optional<at::Tensor> maybe_lse, int64_t kv_layout_code,
+    int64_t window_left BATCH_DECODE_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
 
 //========== gemm ==========
 
@@ -105,24 +104,21 @@ void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::
 at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
-    at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size,
-    int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
-    bool enable_cuda_graph, int64_t head_dim_qk, int64_t head_dim_vo, bool causal,
-    int64_t cuda_stream);
+    at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
+    int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
+    int64_t head_dim_vo, bool causal, int64_t cuda_stream);
 
 void BatchPrefillWithRaggedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    at::Tensor plan_info_vec, at::Tensor q, at::Tensor k, at::Tensor v,
-    at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor o, std::optional<at::Tensor> maybe_lse,
-    int64_t mask_mode_code, int64_t layout,
+    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+    at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo_indptr, at::Tensor kv_indptr,
+    at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
     int64_t window_left BATCH_PREFILL_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
 
 void BatchPrefillWithPagedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
-    at::Tensor plan_info_vec, at::Tensor q, at::Tensor paged_k_cache,
-    at::Tensor paged_v_cache, at::Tensor qo_indptr, at::Tensor paged_kv_indptr,
-    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len, at::Tensor o,
-    std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
+    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+    at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor qo_indptr,
+    at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
+    at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
     int64_t window_left BATCH_PREFILL_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
 
 //========== quantization ==========
@@ -139,13 +135,13 @@ void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope
                 double rope_theta, int64_t cuda_stream);
 
 void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
-                        at::Tensor indptr, at::Tensor offsets, int64_t rotary_dim,
-                        bool interleave, double rope_scale, double rope_theta, double low_freq_factor,
+                        at::Tensor indptr, at::Tensor offsets, int64_t rotary_dim, bool interleave,
+                        double rope_scale, double rope_theta, double low_freq_factor,
                         double high_freq_factor, double old_context_length, int64_t cuda_stream);
 
 void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
-                        at::Tensor pos_ids, int64_t rotary_dim, bool interleave,
-                        double rope_scale, double rope_theta, int64_t cuda_stream);
+                        at::Tensor pos_ids, int64_t rotary_dim, bool interleave, double rope_scale,
+                        double rope_theta, int64_t cuda_stream);
 
 void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                                 at::Tensor pos_ids, int64_t rotary_dim, bool interleave,
@@ -163,22 +159,21 @@ void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tenso
                          bool deterministic, int64_t cuda_stream);
 
 void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_p_arr,
-                               double top_p_val, bool deterministic, int64_t cuda_stream);
+                               std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                               bool deterministic, int64_t cuda_stream);
 
 void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_k_arr,
-                               int64_t top_k_val, bool deterministic, int64_t cuda_stream);
+                               std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
+                               bool deterministic, int64_t cuda_stream);
 
 void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
                                bool deterministic, int64_t cuda_stream);
 
 void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
-                                     at::Tensor samples, at::Tensor success,
-                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
-                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, int64_t cuda_stream);
+                                     at::Tensor samples, std::optional<at::Tensor> maybe_top_k_arr,
+                                     double top_k_val, std::optional<at::Tensor> maybe_top_p_arr,
+                                     double top_p_val, bool deterministic, int64_t cuda_stream);
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <ATen/core/Generator.h>
-
 #include "pytorch_extension_utils.h"
 
 void sampling_from_probs(at::Tensor probs, at::Tensor samples, bool deterministic,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -19,22 +19,21 @@ void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tenso
                          bool deterministic, int64_t cuda_stream);
 
 void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_p_arr,
-                               double top_p_val, bool deterministic, int64_t cuda_stream);
+                               std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                               bool deterministic, int64_t cuda_stream);
 
 void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_k_arr,
-                               int64_t top_k_val, bool deterministic, int64_t cuda_stream);
+                               std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
+                               bool deterministic, int64_t cuda_stream);
 
 void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
                                bool deterministic, int64_t cuda_stream);
 
 void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
-                                     at::Tensor samples, at::Tensor success,
-                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
-                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, int64_t cuda_stream);
+                                     at::Tensor samples, std::optional<at::Tensor> maybe_top_k_arr,
+                                     double top_k_val, std::optional<at::Tensor> maybe_top_p_arr,
+                                     double top_p_val, bool deterministic, int64_t cuda_stream);
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -13,27 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <ATen/core/Generator.h>
+
 #include "pytorch_extension_utils.h"
 
-void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                         bool deterministic, int64_t cuda_stream);
+void sampling_from_probs(at::Tensor probs, at::Tensor samples, bool deterministic,
+                         std::optional<at::Generator> gen, int64_t cuda_stream);
 
-void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+void top_p_sampling_from_probs(at::Tensor probs, at::Tensor samples,
                                std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                               bool deterministic, int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen,
+                               int64_t cuda_stream);
 
-void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+void top_k_sampling_from_probs(at::Tensor probs, at::Tensor samples,
                                std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                               bool deterministic, int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen,
+                               int64_t cuda_stream);
 
-void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+void min_p_sampling_from_probs(at::Tensor probs, at::Tensor samples,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
-                               bool deterministic, int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen,
+                               int64_t cuda_stream);
 
-void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
-                                     at::Tensor samples, std::optional<at::Tensor> maybe_top_k_arr,
-                                     double top_k_val, std::optional<at::Tensor> maybe_top_p_arr,
-                                     double top_p_val, bool deterministic, int64_t cuda_stream);
+void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor samples,
+                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
+                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                                     bool deterministic, std::optional<at::Generator> gen,
+                                     int64_t cuda_stream);
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
@@ -48,10 +54,10 @@ void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
                        int64_t cuda_stream);
 
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
-                                at::Tensor uniform_samples, at::Tensor target_probs,
-                                at::Tensor output_token_ids, at::Tensor output_accepted_token_num,
+                                at::Tensor target_probs, at::Tensor output_token_ids,
+                                at::Tensor output_accepted_token_num,
                                 at::Tensor output_emitted_token_num, bool deterministic,
-                                int64_t cuda_stream);
+                                std::optional<at::Generator> gen, int64_t cuda_stream);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Sample from probabilities

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -25,11 +25,6 @@
 
 using namespace flashinfer;
 
-// NOTE(Zihao): currently these functions are not cuda graph-safe,
-// we will fix this in the future.
-// More specifically, cuda graph-safe functions should unpack
-// https://github.com/pytorch/pytorch/blob/3f069e7679588d5ee4b1d5b2492ca0e20f9320b5/aten/src/ATen/cuda/detail/UnpackRaw.cuh
-
 void sampling_from_probs(at::Tensor probs, at::Tensor samples, bool deterministic,
                          std::optional<at::Generator> gen_, int64_t cuda_stream) {
   CHECK_INPUT(probs);

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -13,171 +13,209 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <ATen/Utils.h>
+#include <ATen/core/Generator.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+
+#include <ATen/cuda/detail/UnpackRaw.cuh>
 #include <flashinfer/sampling.cuh>
+#include <mutex>
 
 #include "pytorch_extension_utils.h"
 
 using namespace flashinfer;
 
-void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                         bool deterministic, int64_t cuda_stream) {
+// NOTE(Zihao): currently these functions are not cuda graph-safe,
+// we will fix this in the future.
+// More specifically, cuda graph-safe functions should unpack
+// https://github.com/pytorch/pytorch/blob/3f069e7679588d5ee4b1d5b2492ca0e20f9320b5/aten/src/ATen/cuda/detail/UnpackRaw.cuh
+
+void sampling_from_probs(at::Tensor probs, at::Tensor samples, bool deterministic,
+                         std::optional<at::Generator> gen_, int64_t cuda_stream) {
   CHECK_INPUT(probs);
-  CHECK_INPUT(uniform_samples);
   auto device = probs.device();
-  CHECK_EQ(uniform_samples.device(), device);
-  CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
-  CHECK_DIM(1, uniform_samples);  // uniform_samples: (batch_size)
-  CHECK_EQ(probs.size(0), uniform_samples.size(0));
+  CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
 
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
+
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::SamplingFromProb(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()), batch_size, vocab_size, deterministic, stream);
+      static_cast<float*>(probs.data_ptr()), static_cast<int*>(samples.data_ptr()), batch_size,
+      vocab_size, deterministic, philox_seed, philox_offset, stream);
   TORCH_CHECK(status == cudaSuccess, "SamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 }
 
-void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+void top_p_sampling_from_probs(at::Tensor probs, at::Tensor samples,
                                std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                               bool deterministic, int64_t cuda_stream) {
+                               bool deterministic, std::optional<at::Generator> gen_,
+                               int64_t cuda_stream) {
   CHECK_INPUT(probs);
-  CHECK_INPUT(uniform_samples);
   auto device = probs.device();
-  CHECK_EQ(uniform_samples.device(), device);
-  CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
-  CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_top_p_rounds, batch_size)
-  CHECK_EQ(probs.size(0), uniform_samples.size(1));
+  CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
-  unsigned int max_top_p_rounds = uniform_samples.size(0);
   bool has_top_p_arr = maybe_top_p_arr.has_value();
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(32 * batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()),
+      static_cast<float*>(probs.data_ptr()), static_cast<int*>(samples.data_ptr()),
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr, batch_size,
-      top_p_val, vocab_size, max_top_p_rounds, deterministic, stream);
+      top_p_val, vocab_size, deterministic, philox_seed, philox_offset, stream);
   TORCH_CHECK(status == cudaSuccess, "TopPSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 }
 
-void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+void top_k_sampling_from_probs(at::Tensor probs, at::Tensor samples,
                                std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                               bool deterministic, int64_t cuda_stream) {
+                               bool deterministic, std::optional<at::Generator> gen_,
+                               int64_t cuda_stream) {
   CHECK_INPUT(probs);
-  CHECK_INPUT(uniform_samples);
+  CHECK_INPUT(samples);
   auto device = probs.device();
-  CHECK_EQ(uniform_samples.device(), device);
-  CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
-  CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_top_k_rounds, batch_size)
-  CHECK_EQ(probs.size(0), uniform_samples.size(1));
+  CHECK_EQ(samples.device(), device);
+  CHECK_DIM(2, probs);    // probs: (batch_size, vocab_size)
+  CHECK_DIM(1, samples);  // samples: (batch_size)
+  CHECK_EQ(probs.size(0), samples.size(0));
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
-  unsigned int max_top_k_rounds = uniform_samples.size(0);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(32 * batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()),
+      static_cast<float*>(probs.data_ptr()), static_cast<int*>(samples.data_ptr()),
       has_top_k_arr ? static_cast<float*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,
-      top_k_val, vocab_size, max_top_k_rounds, deterministic, stream);
+      top_k_val, vocab_size, deterministic, philox_seed, philox_offset, stream);
   TORCH_CHECK(status == cudaSuccess, "TopKSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 }
 
-void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
+void min_p_sampling_from_probs(at::Tensor probs, at::Tensor samples,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
-                               bool deterministic, int64_t cuda_stream) {
+                               bool deterministic, std::optional<at::Generator> gen_,
+                               int64_t cuda_stream) {
   CHECK_INPUT(probs);
-  CHECK_INPUT(uniform_samples);
+  CHECK_INPUT(samples);
   auto device = probs.device();
-  CHECK_EQ(uniform_samples.device(), device);
-  CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
-  CHECK_DIM(1, uniform_samples);  // uniform_samples: (batch_size)
+  CHECK_EQ(samples.device(), device);
+  CHECK_DIM(2, probs);    // probs: (batch_size, vocab_size)
+  CHECK_DIM(1, samples);  // samples: (batch_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
-  CHECK_EQ(uniform_samples.size(0), batch_size);
   bool has_min_p_arr = maybe_min_p_arr.has_value();
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::MinPSamplingFromProb<float, int>(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
+      static_cast<float*>(probs.data_ptr()),
       has_min_p_arr ? static_cast<float*>(maybe_min_p_arr->data_ptr()) : nullptr,
       static_cast<int*>(samples.data_ptr()), batch_size, min_p_val, vocab_size, deterministic,
-      stream);
+      philox_seed, philox_offset, stream);
   TORCH_CHECK(status == cudaSuccess, "MinPSamplingFromProb failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 }
 
-void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
-                                     at::Tensor samples, std::optional<at::Tensor> maybe_top_k_arr,
-                                     double top_k_val, std::optional<at::Tensor> maybe_top_p_arr,
-                                     double top_p_val, bool deterministic, int64_t cuda_stream) {
+void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor samples,
+                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
+                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                                     bool deterministic, std::optional<at::Generator> gen_,
+                                     int64_t cuda_stream) {
   CHECK_INPUT(probs);
-  CHECK_INPUT(uniform_samples);
+  CHECK_INPUT(samples);
   auto device = probs.device();
-  CHECK_EQ(uniform_samples.device(), device);
-  CHECK_DIM(2, probs);            // probs: (batch_size, vocab_size)
-  CHECK_DIM(2, uniform_samples);  // uniform_samples: (max_rounds, batch_size)
+  CHECK_EQ(samples.device(), device);
+  CHECK_DIM(2, probs);    // probs: (batch_size, vocab_size)
+  CHECK_DIM(1, samples);  // samples: (batch_size)
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
-  unsigned int max_rounds = uniform_samples.size(0);
-  CHECK_EQ(uniform_samples.size(1), batch_size);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
   bool has_top_p_arr = maybe_top_p_arr.has_value();
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(32 * batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::TopKTopPSamplingFromProb<float, int>(
-      static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
+      static_cast<float*>(probs.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr,
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr,
       static_cast<int*>(samples.data_ptr()), batch_size, top_k_val, top_p_val, vocab_size,
-      max_rounds, deterministic, stream);
+      deterministic, philox_seed, philox_offset, stream);
   TORCH_CHECK(status == cudaSuccess, "TopKTopPSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 }
 
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
-                                at::Tensor uniform_samples, at::Tensor target_probs,
-                                at::Tensor output_token_ids, at::Tensor output_accepted_token_num,
+                                at::Tensor target_probs, at::Tensor output_token_ids,
+                                at::Tensor output_accepted_token_num,
                                 at::Tensor output_emitted_token_num, bool deterministic,
-                                int64_t cuda_stream) {
+                                std::optional<at::Generator> gen_, int64_t cuda_stream) {
   CHECK_INPUT(draft_probs);
   CHECK_INPUT(draft_token_ids);
-  CHECK_INPUT(uniform_samples);
   CHECK_INPUT(target_probs);
   auto device = draft_probs.device();
   CHECK_EQ(draft_token_ids.device(), device);
-  CHECK_EQ(uniform_samples.device(), device);
   CHECK_EQ(target_probs.device(), device);
   CHECK_DIM(3, draft_probs);      // draft_probs: (batch_size, num_speculate_tokens, vocab_size)
   CHECK_DIM(2, draft_token_ids);  // draft_token_ids: (batch_size, num_speculate_tokens)
-  CHECK_DIM(2, uniform_samples);  // uniform_samples: (batch_size, num_speculate_tokens + 1)
   CHECK_DIM(3, target_probs);  // target_probs: (batch_size, num_speculate_tokens + 1, vocab_size)
   unsigned int batch_size = draft_probs.size(0);
   unsigned int num_speculate_tokens = draft_probs.size(1);
   unsigned int vocab_size = draft_probs.size(2);
   CHECK_EQ(batch_size, draft_token_ids.size(0));
-  CHECK_EQ(batch_size, uniform_samples.size(0));
   CHECK_EQ(batch_size, target_probs.size(0));
-  CHECK_EQ(num_speculate_tokens + 1, uniform_samples.size(1));
   CHECK_EQ(num_speculate_tokens + 1, target_probs.size(1));
   CHECK_EQ(vocab_size, target_probs.size(2));
   CHECK_EQ(batch_size, output_accepted_token_num.size(0));
   CHECK_EQ(batch_size, output_emitted_token_num.size(0));
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs =
+      gen->philox_cuda_state(batch_size * (num_speculate_tokens + 1));
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::ChainSpeculativeSampling<float, int>(
       static_cast<float*>(draft_probs.data_ptr()), static_cast<int*>(draft_token_ids.data_ptr()),
-      static_cast<float*>(uniform_samples.data_ptr()), static_cast<float*>(target_probs.data_ptr()),
-      static_cast<int*>(output_token_ids.data_ptr()),
+      static_cast<float*>(target_probs.data_ptr()), static_cast<int*>(output_token_ids.data_ptr()),
       static_cast<int*>(output_accepted_token_num.data_ptr()),
       static_cast<int*>(output_emitted_token_num.data_ptr()), batch_size, num_speculate_tokens,
-      vocab_size, deterministic, stream);
+      vocab_size, deterministic, philox_seed, philox_offset, stream);
 
   TORCH_CHECK(status == cudaSuccess, "ChainSpeculativeSampling failed with error code " +
                                          std::string(cudaGetErrorString(status)));

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -40,8 +40,8 @@ void sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tenso
 }
 
 void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_p_arr,
-                               double top_p_val, bool deterministic, int64_t cuda_stream) {
+                               std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                               bool deterministic, int64_t cuda_stream) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
   auto device = probs.device();
@@ -57,7 +57,7 @@ void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at:
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()),
+      static_cast<int*>(samples.data_ptr()),
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr, batch_size,
       top_p_val, vocab_size, max_top_p_rounds, deterministic, stream);
   TORCH_CHECK(status == cudaSuccess, "TopPSamplingFromProbs failed with error code " +
@@ -65,8 +65,8 @@ void top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at:
 }
 
 void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at::Tensor samples,
-                               at::Tensor success, std::optional<at::Tensor> maybe_top_k_arr,
-                               int64_t top_k_val, bool deterministic, int64_t cuda_stream) {
+                               std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
+                               bool deterministic, int64_t cuda_stream) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
   auto device = probs.device();
@@ -82,7 +82,7 @@ void top_k_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at:
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
-      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()),
+      static_cast<int*>(samples.data_ptr()),
       has_top_k_arr ? static_cast<float*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,
       top_k_val, vocab_size, max_top_k_rounds, deterministic, stream);
   TORCH_CHECK(status == cudaSuccess, "TopKSamplingFromProbs failed with error code " +
@@ -114,10 +114,9 @@ void min_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples, at:
 }
 
 void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_samples,
-                                     at::Tensor samples, at::Tensor success,
-                                     std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
-                                     std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, int64_t cuda_stream) {
+                                     at::Tensor samples, std::optional<at::Tensor> maybe_top_k_arr,
+                                     double top_k_val, std::optional<at::Tensor> maybe_top_p_arr,
+                                     double top_p_val, bool deterministic, int64_t cuda_stream) {
   CHECK_INPUT(probs);
   CHECK_INPUT(uniform_samples);
   auto device = probs.device();
@@ -136,8 +135,8 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_sample
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(uniform_samples.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr,
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr,
-      static_cast<int*>(samples.data_ptr()), static_cast<bool*>(success.data_ptr()), batch_size,
-      top_k_val, top_p_val, vocab_size, max_rounds, deterministic, stream);
+      static_cast<int*>(samples.data_ptr()), batch_size, top_k_val, top_p_val, vocab_size,
+      max_rounds, deterministic, stream);
   TORCH_CHECK(status == cudaSuccess, "TopKTopPSamplingFromProbs failed with error code " +
                                          std::string(cudaGetErrorString(status)));
 }

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -484,7 +484,6 @@ def top_p_sampling_from_probs(
     >>> torch.manual_seed(42)
     >>> batch_size = 4
     >>> vocab_size = 5
-    >>> max_top_p_rounds = 3
     >>> top_p = 0.5
     >>> pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
     >>> norm_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
@@ -501,8 +500,6 @@ def top_p_sampling_from_probs(
     Note
     ----
     This function expects float32 inputs, and the output is int32.
-    We encourage users to set ``max_top_p_rounds`` to a reasonable value, e.g., 32. The actual
-    implementation usually use much fewer rounds for rejection sampling because of early stopping.
 
     See Also
     --------
@@ -559,7 +556,6 @@ def top_k_sampling_from_probs(
     >>> torch.manual_seed(42)
     >>> batch_size = 4
     >>> vocab_size = 5
-    >>> max_top_k_rounds = 3
     >>> top_k = 1
     >>> pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
     >>> norm_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
@@ -576,8 +572,6 @@ def top_k_sampling_from_probs(
     Note
     ----
     This function expects float32 inputs, and the output is int32.
-    We encourage users to set ``max_top_k_rounds`` to a reasonable value, e.g., 32. The actual
-    implementation usually use much fewer rounds for rejection sampling because of early stopping.
 
     See Also
     --------
@@ -651,8 +645,6 @@ def min_p_sampling_from_probs(
     Note
     ----
     This function expects float32 inputs, and the output is int32.
-    We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
-    implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
 
     if check_nan:
@@ -717,7 +709,6 @@ def top_k_top_p_sampling_from_logits(
     >>> torch.manual_seed(42)
     >>> batch_size = 4
     >>> vocab_size = 5
-    >>> max_rounds = 3
     >>> top_p = 0.5
     >>> top_k = 3
     >>> logits = torch.rand(batch_size, vocab_size).to(0)
@@ -741,8 +732,6 @@ def top_k_top_p_sampling_from_logits(
     Note
     ----
     This function expects float32 inputs, and the output is int32.
-    We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
-    implementation usually use much fewer rounds for rejection sampling because of early stopping.
 
     See Also
     --------
@@ -826,7 +815,6 @@ def top_k_top_p_sampling_from_probs(
     >>> torch.manual_seed(42)
     >>> batch_size = 4
     >>> vocab_size = 5
-    >>> max_rounds = 3
     >>> top_p = torch.full((batch_size,), 0.2).to(0)
     >>> top_k = torch.full((batch_size,), 2).to(0)
     >>> pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
@@ -843,8 +831,6 @@ def top_k_top_p_sampling_from_probs(
     Note
     ----
     This function expects float32 inputs, and the output is int32.
-    We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
-    implementation usually use much fewer rounds for rejection sampling because of early stopping.
 
     See Also
     --------

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -47,18 +47,16 @@ def get_sampling_module():
         @register_custom_op("flashinfer::sampling_from_probs", mutates_args=())
         def sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             deterministic: bool,
         ) -> torch.Tensor:
             with probs.device as device:
                 probs = probs.float()
-                uniform_samples = uniform_samples.float()
                 samples = torch.empty(probs.size(0), dtype=torch.int32, device=device)
                 module.sampling_from_probs(
                     probs,
-                    uniform_samples,
                     samples,
                     deterministic,
+                    None,
                     get_cuda_stream(device),
                 )
                 return samples
@@ -66,7 +64,6 @@ def get_sampling_module():
         @register_fake_op("flashinfer::sampling_from_probs")
         def _fake_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             deterministic: bool,
         ) -> torch.Tensor:
             return torch.empty(probs.size(0), dtype=torch.int32, device=probs.device)
@@ -76,25 +73,23 @@ def get_sampling_module():
         @register_custom_op("flashinfer::top_p_sampling_from_probs", mutates_args=())
         def top_p_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_top_p_arr: Optional[torch.Tensor],
             top_p_val: float,
             deterministic: bool,
         ) -> torch.Tensor:
             with probs.device as device:
                 probs = probs.float()
-                uniform_samples = uniform_samples.float()
                 maybe_top_p_arr = (
                     maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
                 )
                 samples = torch.empty(probs.size(0), dtype=torch.int32, device=device)
                 module.top_p_sampling_from_probs(
                     probs,
-                    uniform_samples,
                     samples,
                     maybe_top_p_arr,
                     top_p_val,
                     deterministic,
+                    None,
                     get_cuda_stream(device),
                 )
                 return samples
@@ -102,7 +97,6 @@ def get_sampling_module():
         @register_fake_op("flashinfer::top_p_sampling_from_probs")
         def _fake_top_p_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_top_p_arr: Optional[torch.Tensor],
             top_p_val: float,
             deterministic: bool,
@@ -115,25 +109,23 @@ def get_sampling_module():
         @register_custom_op("flashinfer::top_k_sampling_from_probs", mutates_args=())
         def top_k_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_top_k_arr: Optional[torch.Tensor],
             top_k_val: int,
             deterministic: bool,
         ) -> torch.Tensor:
             with probs.device as device:
                 probs = probs.float()
-                uniform_samples = uniform_samples.float()
                 maybe_top_k_arr = (
                     maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
                 )
                 samples = torch.empty(probs.size(0), dtype=torch.int32, device=device)
                 module.top_k_sampling_from_probs(
                     probs,
-                    uniform_samples,
                     samples,
                     maybe_top_k_arr,
                     top_k_val,
                     deterministic,
+                    None,
                     get_cuda_stream(device),
                 )
                 return samples
@@ -141,7 +133,6 @@ def get_sampling_module():
         @register_fake_op("flashinfer::top_k_sampling_from_probs")
         def _fake_top_k_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_top_k_arr: Optional[torch.Tensor],
             top_k_val: int,
             deterministic: bool,
@@ -154,25 +145,23 @@ def get_sampling_module():
         @register_custom_op("flashinfer::min_p_sampling_from_probs", mutates_args=())
         def min_p_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_min_p_arr: Optional[torch.Tensor],
             min_p_val: float,
             deterministic: bool,
         ) -> torch.Tensor:
             with probs.device as device:
                 probs = probs.float()
-                uniform_samples = uniform_samples.float()
                 maybe_min_p_arr = (
                     maybe_min_p_arr.float() if maybe_min_p_arr is not None else None
                 )
                 samples = torch.empty(probs.size(0), dtype=torch.int32, device=device)
                 module.min_p_sampling_from_probs(
                     probs,
-                    uniform_samples,
                     samples,
                     maybe_min_p_arr,
                     min_p_val,
                     deterministic,
+                    None,
                     get_cuda_stream(device),
                 )
                 return samples
@@ -184,7 +173,6 @@ def get_sampling_module():
         )
         def top_k_top_p_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_top_k_arr: Optional[torch.Tensor],
             top_k_val: int,
             maybe_top_p_arr: Optional[torch.Tensor],
@@ -193,7 +181,6 @@ def get_sampling_module():
         ) -> torch.Tensor:
             with probs.device as device:
                 probs = probs.float()
-                uniform_samples = uniform_samples.float()
                 maybe_top_k_arr = (
                     maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
                 )
@@ -203,13 +190,13 @@ def get_sampling_module():
                 samples = torch.empty(probs.size(0), dtype=torch.int32, device=device)
                 module.top_k_top_p_sampling_from_probs(
                     probs,
-                    uniform_samples,
                     samples,
                     maybe_top_k_arr,
                     top_k_val,
                     maybe_top_p_arr,
                     top_p_val,
                     deterministic,
+                    None,
                     get_cuda_stream(device),
                 )
                 return samples
@@ -217,7 +204,6 @@ def get_sampling_module():
         @register_fake_op("flashinfer::top_k_top_p_sampling_from_probs")
         def _fake_top_k_top_p_sampling_from_probs(
             probs: torch.Tensor,
-            uniform_samples: torch.Tensor,
             maybe_top_k_arr: Optional[torch.Tensor],
             top_k_val: int,
             maybe_top_p_arr: Optional[torch.Tensor],
@@ -329,7 +315,6 @@ def get_sampling_module():
         def chain_speculative_sampling(
             draft_probs: torch.Tensor,
             draft_token_ids: torch.Tensor,
-            uniform_samples: torch.Tensor,
             target_probs: torch.Tensor,
             output_accepted_token_num: torch.Tensor,
             output_emitted_token_num: torch.Tensor,
@@ -338,7 +323,6 @@ def get_sampling_module():
             with draft_probs.device as device:
                 draft_probs = draft_probs.float()
                 draft_token_ids = draft_token_ids.int()
-                uniform_samples = uniform_samples.float()
                 target_probs = target_probs.float()
                 output_accepted_token_num = output_accepted_token_num.int()
                 output_emitted_token_num = output_emitted_token_num.int()
@@ -349,12 +333,12 @@ def get_sampling_module():
                 module.chain_speculative_sampling(
                     draft_probs,
                     draft_token_ids,
-                    uniform_samples,
                     target_probs,
                     output_token_ids,
                     output_accepted_token_num,
                     output_emitted_token_num,
                     deterministic,
+                    None,
                     get_cuda_stream(device),
                 )
                 return output_token_ids
@@ -363,7 +347,6 @@ def get_sampling_module():
         def _fake_chain_speculative_sampling(
             draft_probs: torch.Tensor,
             draft_token_ids: torch.Tensor,
-            uniform_samples: torch.Tensor,
             target_probs: torch.Tensor,
             output_accepted_token_num: torch.Tensor,
             output_emitted_token_num: torch.Tensor,
@@ -398,7 +381,6 @@ def _to_tensor_scalar_tuple(x):
 
 def sampling_from_probs(
     probs: torch.Tensor,
-    uniform_samples: torch.Tensor,
     deterministic: bool = True,
     check_nan: bool = False,
 ) -> torch.Tensor:
@@ -408,9 +390,6 @@ def sampling_from_probs(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(batch_size,)``.
-        Expected to be uniformly distributed in ``[0, 1)``.
     deterministic: bool
         Whether to use deterministic kernel implementation, default is ``True``.
     check_nan: bool
@@ -436,8 +415,7 @@ def sampling_from_probs(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> uniform_samples = torch.rand(batch_size).to(0)
-    >>> samples = flashinfer.sampling.sampling_from_probs(norm_prob, uniform_samples)
+    >>> samples = flashinfer.sampling.sampling_from_probs(norm_prob)
     >>> samples
     tensor([1, 2, 1, 4], device='cuda:0', dtype=torch.int32)
 
@@ -448,14 +426,11 @@ def sampling_from_probs(
     if check_nan:
         if torch.any(torch.isnan(probs)):
             raise ValueError("Input probs contains NaN.")
-    return get_sampling_module().sampling_from_probs(
-        probs, uniform_samples, deterministic
-    )
+    return get_sampling_module().sampling_from_probs(probs, deterministic)
 
 
 def top_p_sampling_from_probs(
     probs: torch.Tensor,
-    uniform_samples: torch.Tensor,
     top_p: Union[torch.Tensor, float],
     deterministic: bool = True,
     check_nan: bool = False,
@@ -470,10 +445,6 @@ def top_p_sampling_from_probs(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(max_top_p_rounds, batch_size,)``,
-        where the first dimension is the maximum number of rounds for rejection sampling.
-        Expected to be uniformly distributed in ``[0, 1)``.
     top_p: Union[torch.Tensor, float]
         Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
         If a scalar, the same threshold is used for all requests.
@@ -505,8 +476,7 @@ def top_p_sampling_from_probs(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> uniform_samples = torch.rand(max_top_p_rounds, batch_size).to(0)
-    >>> samples = flashinfer.sampling.top_p_sampling_from_probs(norm_prob, uniform_samples, top_p)
+    >>> samples = flashinfer.sampling.top_p_sampling_from_probs(norm_prob, top_p)
     >>> samples
     tensor([1, 2, 0, 4], device='cuda:0', dtype=torch.int32)
 
@@ -527,13 +497,12 @@ def top_p_sampling_from_probs(
         if torch.any(torch.isnan(probs)):
             raise ValueError("Input probs contains NaN.")
     return get_sampling_module().top_p_sampling_from_probs(
-        probs, uniform_samples, *_to_tensor_scalar_tuple(top_p), deterministic
+        probs, *_to_tensor_scalar_tuple(top_p), deterministic
     )
 
 
 def top_k_sampling_from_probs(
     probs: torch.Tensor,
-    uniform_samples: torch.Tensor,
     top_k: Union[torch.Tensor, int],
     deterministic: bool = True,
     check_nan: bool = False,
@@ -548,10 +517,6 @@ def top_k_sampling_from_probs(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
-        where the first dimension is the maximum number of rounds for rejection sampling.
-        Expected to be uniformly distributed in ``[0, 1)``.
     top_k: Union[torch.Tensor, int]
         Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
         If a scalar, the same threshold is used for all requests.
@@ -583,8 +548,7 @@ def top_k_sampling_from_probs(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> uniform_samples = torch.rand(max_top_k_rounds, batch_size).to(0)
-    >>> samples = flashinfer.sampling.top_k_sampling_from_probs(norm_prob, uniform_samples, top_k)
+    >>> samples = flashinfer.sampling.top_k_sampling_from_probs(norm_prob, top_k)
     >>> samples
     tensor([3, 3, 0, 1], device='cuda:0', dtype=torch.int32)
 
@@ -605,13 +569,12 @@ def top_k_sampling_from_probs(
         if torch.any(torch.isnan(probs)):
             raise ValueError("Input probs contains NaN.")
     return get_sampling_module().top_k_sampling_from_probs(
-        probs, uniform_samples, *_to_tensor_scalar_tuple(top_k), deterministic
+        probs, *_to_tensor_scalar_tuple(top_k), deterministic
     )
 
 
 def min_p_sampling_from_probs(
     probs: torch.Tensor,
-    uniform_samples: torch.Tensor,
     min_p: Union[torch.Tensor, float],
     deterministic: bool = True,
     check_nan: bool = False,
@@ -627,9 +590,6 @@ def min_p_sampling_from_probs(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(batch_size,)``,
-        Expected to be uniformly distributed in ``[0, 1)``.
     min_p: torch.Tensor
         Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for min-p sampling.
         If a scalar, the same threshold is used for all requests.
@@ -661,8 +621,7 @@ def min_p_sampling_from_probs(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> uniform_samples = torch.rand(batch_size).to(0)
-    >>> samples = flashinfer.sampling.min_p_sampling_from_probs(norm_prob, uniform_samples, min_p)
+    >>> samples = flashinfer.sampling.min_p_sampling_from_probs(norm_prob, min_p)
     >>> samples
     tensor([1, 2, 1, 4], device='cuda:0', dtype=torch.int32)
 
@@ -672,22 +631,17 @@ def min_p_sampling_from_probs(
     We encourage users to set ``max_rounds`` to a reasonable value, e.g., 32. The actual
     implementation usually use much fewer rounds for rejection sampling because of early stopping.
     """
-    # NOTE(Zihao): for backward compatibility (https://github.com/flashinfer-ai/flashinfer/pull/713)
-    if uniform_samples.dim() == 2:
-        # Take the first row (round) of uniform_samples
-        uniform_samples = uniform_samples[0]
 
     if check_nan:
         if torch.any(torch.isnan(probs)):
             raise ValueError("Input probs contains NaN.")
     return get_sampling_module().min_p_sampling_from_probs(
-        probs, uniform_samples, *_to_tensor_scalar_tuple(min_p), deterministic
+        probs, *_to_tensor_scalar_tuple(min_p), deterministic
     )
 
 
 def top_k_top_p_sampling_from_logits(
     logits: torch.Tensor,
-    uniform_samples: torch.Tensor,
     top_k: Union[torch.Tensor, int],
     top_p: Union[torch.Tensor, float],
     filter_apply_order: str = "top_k_first",
@@ -705,9 +659,7 @@ def top_k_top_p_sampling_from_logits(
     ----------
     logits: torch.Tensor
         Pre-softmax logits, shape ``(batch_size, num_classes)``.
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
-        where the first dimension is the maximum number of rounds for rejection sampling.
+    top_k: Union[torch.Tensor, int]
         Expected to be uniformly distributed in ``[0, 1)``.
     top_k: Union[torch.Tensor, int]
         Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
@@ -748,8 +700,7 @@ def top_k_top_p_sampling_from_logits(
             [ 1.0783,  0.8008,  1.6806,  0.3559, -0.6866],
             [-0.4934,  0.2415, -0.2316,  0.0418, -0.2516],
             [ 0.8599, -0.3097, -0.3957,  0.8034, -0.6216]], device='cuda:0')
-    >>> uniform_samples = torch.rand(max_rounds, batch_size).to(0)
-    >>> samples = flashinfer.sampling.top_k_top_p_sampling_from_logits(logits, uniform_samples, top_k, top_p)
+    >>> samples = flashinfer.sampling.top_k_top_p_sampling_from_logits(logits, top_k, top_p)
     >>> samples
     tensor([0, 2, 1, 3], device='cuda:0', dtype=torch.int32
     >>> probs = torch.softmax(logits, dim=-1)
@@ -777,7 +728,7 @@ def top_k_top_p_sampling_from_logits(
         masked_logits = top_k_mask_logits(logits, top_k)
         probs = torch.softmax(masked_logits, dim=-1)
         return top_p_sampling_from_probs(
-            probs, uniform_samples, top_p, deterministic, check_nan=check_nan
+            probs, top_p, deterministic, check_nan=check_nan
         )
     elif filter_apply_order == "joint":
         probs = torch.softmax(logits, dim=-1)
@@ -786,7 +737,6 @@ def top_k_top_p_sampling_from_logits(
                 raise ValueError("Input probs contains NaN.")
         return get_sampling_module().top_k_top_p_sampling_from_probs(
             probs,
-            uniform_samples,
             *_to_tensor_scalar_tuple(top_k),
             *_to_tensor_scalar_tuple(top_p),
             deterministic,
@@ -797,7 +747,6 @@ def top_k_top_p_sampling_from_logits(
 
 def top_k_top_p_sampling_from_probs(
     probs: torch.Tensor,
-    uniform_samples: torch.Tensor,
     top_k: Union[torch.Tensor, int],
     top_p: Union[torch.Tensor, float],
     filter_apply_order: str = "top_k_first",
@@ -815,9 +764,7 @@ def top_k_top_p_sampling_from_probs(
     ----------
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(max_top_k_rounds, batch_size,)``,
-        where the first dimension is the maximum number of rounds for rejection sampling.
+    top_k: Union[torch.Tensor, int]
         Expected to be uniformly distributed in ``[0, 1)``.
     top_k: Union[torch.Tensor, int]
         Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
@@ -859,8 +806,7 @@ def top_k_top_p_sampling_from_probs(
             [0.2205, 0.0942, 0.2912, 0.3452, 0.0489],
             [0.2522, 0.1602, 0.2346, 0.1532, 0.2000],
             [0.1543, 0.3182, 0.2062, 0.0958, 0.2255]], device='cuda:0')
-    >>> uniform_samples = torch.rand(max_rounds, batch_size).to(0)
-    >>> samples = flashinfer.sampling.top_k_top_p_sampling_from_probs(norm_prob, uniform_samples, top_k, top_p)
+    >>> samples = flashinfer.sampling.top_k_top_p_sampling_from_probs(norm_prob, top_k, top_p)
     >>> samples
     tensor([3, 3, 0, 1], device='cuda:0', dtype=torch.int32)
 
@@ -881,7 +827,7 @@ def top_k_top_p_sampling_from_probs(
     if filter_apply_order == "top_k_first":
         renorm_probs = top_k_renorm_probs(probs, top_k)
         return top_p_sampling_from_probs(
-            renorm_probs, uniform_samples, top_p, deterministic, check_nan=check_nan
+            renorm_probs, top_p, deterministic, check_nan=check_nan
         )
     elif filter_apply_order == "joint":
         if check_nan:
@@ -889,7 +835,6 @@ def top_k_top_p_sampling_from_probs(
                 raise ValueError("Input probs contains NaN.")
         return get_sampling_module().top_k_top_p_sampling_from_probs(
             probs,
-            uniform_samples,
             *_to_tensor_scalar_tuple(top_k),
             *_to_tensor_scalar_tuple(top_p),
             deterministic,
@@ -1086,7 +1031,6 @@ def top_k_mask_logits(
 def chain_speculative_sampling(
     draft_probs,
     draft_token_ids,
-    uniform_samples,
     target_probs,
     maybe_output_accepted_token_num: Optional[torch.Tensor] = None,
     maybe_output_emitted_token_num: Optional[torch.Tensor] = None,
@@ -1104,8 +1048,7 @@ def chain_speculative_sampling(
     draft_token_ids: torch.Tensor
         The draft model's generated token indices.
         Shape: ``(batch_size, num_specutate_tokens)``
-    uniform_samples: torch.Tensor
-        The uniform samples used as needle for sampling, shape ``(batch_size, num_speculate_tokens + 1)``.
+    target_probs: torch.Tensor
         Expected to be uniformly distributed in ``[0, 1)``.
     target_probs: torch.Tensor
         The probability over vocabulary generated by target model.
@@ -1159,12 +1102,10 @@ def chain_speculative_sampling(
     >>> # token 1 was sampled from draft model for the second token
     >>> draft_token_ids = torch.tensor([[2, 1]], dtype=torch.int32).to(0)
     >>> # uniform samples for rejection sampling
-    >>> uniform_samples = torch.rand(batch_size, num_speculate_tokens + 1).to(0)
-    tensor([[0.8823, 0.9150, 0.3829], device='cuda:0')
     >>> target_probs = torch.tensor([[[0.0, 0.1, 0.6, 0.3], [1.0, 0.0, 0.0, 0.0], [0.7, 0.1, 0.1, 0.1]]]).to(0)
     >>> output_token_ids, output_accepted_token_num, output_accepted_token_num =\
     ...     flashinfer.sampling.chain_speculative_sampling(
-    ...         draft_probs, draft_token_ids, uniform_samples, target_probs)
+    ...         draft_probs, draft_token_ids, target_probs)
     >>> # the first token is accepted, the second token is rejected and sampled from the difference
     >>> # between the target model and the draft model, the third token is padded with -1
     >>> output_token_ids
@@ -1187,7 +1128,6 @@ def chain_speculative_sampling(
     output_token_ids = get_sampling_module().chain_speculative_sampling(
         draft_probs,
         draft_token_ids,
-        uniform_samples,
         target_probs,
         output_accepted_token_num,
         output_emitted_token_num,

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -16,6 +16,10 @@
 #ifndef FLASHINFER_SAMPLING_CUH_
 #define FLASHINFER_SAMPLING_CUH_
 
+#include <curand.h>
+#include <curand_kernel.h>
+#include <curand_philox4x32_x.h>
+
 #include <cub/block/block_adjacent_difference.cuh>
 #include <cub/block/block_reduce.cuh>
 #include <cub/block/block_scan.cuh>
@@ -246,9 +250,11 @@ __device__ __forceinline__ void DeviceSamplingFromProb(
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void SamplingFromProbKernel(DType* probs, DType* uniform_samples, IdType* output,
-                                       IdType* row_indices, uint32_t d) {
+__global__ void SamplingFromProbKernel(DType* probs, IdType* output, IdType* row_indices,
+                                       uint32_t d, uint64_t philox_seed, uint64_t philox_offset) {
+  curandStatePhilox4_32_10_t state;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  curand_init(philox_seed, bx, philox_offset, &state);
   const uint32_t row_idx = row_indices == nullptr ? bx : row_indices[bx];
 
   extern __shared__ __align__(
@@ -261,7 +267,7 @@ __global__ void SamplingFromProbKernel(DType* probs, DType* uniform_samples, IdT
 
   vec_t<DType, VEC_SIZE> probs_vec;
   DType aggregate(0);
-  float u = uniform_samples[bx];
+  float u = curand_uniform(&state);
 
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
     probs_vec.fill(DType(0));
@@ -282,11 +288,13 @@ __global__ void SamplingFromProbKernel(DType* probs, DType* uniform_samples, IdT
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void TopKSamplingFromProbKernel(DType* probs, DType* uniform_samples, IdType* output,
-                                           IdType* top_k_arr, uint32_t top_k_val, uint32_t d,
-                                           uint32_t max_top_k_rounds) {
+__global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, IdType* top_k_arr,
+                                           uint32_t top_k_val, uint32_t d, uint64_t philox_seed,
+                                           uint64_t philox_offset) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
   uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[bx];
 
   extern __shared__ __align__(
@@ -300,10 +308,10 @@ __global__ void TopKSamplingFromProbKernel(DType* probs, DType* uniform_samples,
   float q = 1;
   double low = 0, high = 1;
   IdType sampled_id;
-  for (uint32_t round = 0; round < max_top_k_rounds; ++round) {
+  do {
     temp_storage.sampled_id = d - 1;
     __syncthreads();
-    float u = uniform_samples[round * batch_size + bx] * q;
+    float u = curand_uniform(&state) * q;
     aggregate = DType(0);
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
       probs_vec.fill(DType(0));
@@ -373,7 +381,7 @@ __global__ void TopKSamplingFromProbKernel(DType* probs, DType* uniform_samples,
       low = pivot_1;
       q = aggregate_gt_pivot_1.value;
     }
-  }
+  } while (low < high);
   __syncthreads();
   if (tx == 0) {
     output[bx] = sampled_id;
@@ -383,11 +391,13 @@ __global__ void TopKSamplingFromProbKernel(DType* probs, DType* uniform_samples,
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void TopPSamplingFromProbKernel(DType* probs, DType* uniform_samples, IdType* output,
-                                           IdType* row_indices, float* top_p_arr, float top_p_val,
-                                           uint32_t d, uint32_t max_top_p_rounds) {
+__global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, IdType* row_indices,
+                                           float* top_p_arr, float top_p_val, uint32_t d,
+                                           uint64_t philox_seed, uint64_t philox_offset) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
   float top_p = (top_p_arr == nullptr) ? top_p_val : top_p_arr[bx];
 
   const uint32_t row_idx = row_indices == nullptr ? bx : row_indices[bx];
@@ -403,10 +413,10 @@ __global__ void TopPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
   DType q = DType(1);
   double low = 0, high = 1;
   IdType sampled_id;
-  for (uint32_t round = 0; round < max_top_p_rounds; ++round) {
+  do {
     temp_storage.sampled_id = d - 1;
     __syncthreads();
-    DType u = uniform_samples[round * batch_size + bx] * q;
+    DType u = curand_uniform(&state) * q;
     aggregate = DType(0);
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
       probs_vec.fill(DType(0));
@@ -470,7 +480,7 @@ __global__ void TopPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
       low = pivot_1;
       q = aggregate_gt_pivot_1;
     }
-  }
+  } while (low < high);
   __syncthreads();
   if (tx == 0) {
     output[bx] = sampled_id;
@@ -480,10 +490,13 @@ __global__ void TopPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples, DType* min_p_arr,
-                                           IdType* output, float min_p_val, uint32_t d) {
+__global__ void MinPSamplingFromProbKernel(DType* probs, DType* min_p_arr, IdType* output,
+                                           float min_p_val, uint32_t d, uint64_t philox_seed,
+                                           uint64_t philox_offset) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   DType p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
 
   extern __shared__ __align__(
       alignof(SamplingTempStorage<DType, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
@@ -541,7 +554,7 @@ __global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
   IdType sampled_id;
   temp_storage.sampled_id = d - 1;
   __syncthreads();
-  DType u = uniform_samples[bx] * q;
+  DType u = curand_uniform(&state) * q;
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
     probs_vec.fill(DType(0));
     if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
@@ -561,12 +574,14 @@ __global__ void MinPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
-__global__ void TopKTopPSamplingFromProbKernel(DType* probs, DType* uniform_samples,
-                                               IdType* top_k_arr, DType* top_p_arr, IdType* output,
-                                               IdType top_k_val, DType top_p_val, uint32_t d,
-                                               uint32_t max_rounds) {
+__global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, DType* top_p_arr,
+                                               IdType* output, IdType top_k_val, DType top_p_val,
+                                               uint32_t d, uint64_t philox_seed,
+                                               uint64_t philox_offset) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
   IdType k = top_k_arr == nullptr ? top_k_val : top_k_arr[bx];
   DType p = top_p_arr == nullptr ? top_p_val : top_p_arr[bx];
 
@@ -581,10 +596,10 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, DType* uniform_samp
   float q = 1;
   double low = 0, high = 1;
   IdType sampled_id;
-  for (uint32_t round = 0; round < max_rounds; ++round) {
+  do {
     temp_storage.sampled_id = d - 1;
     __syncthreads();
-    float u = uniform_samples[round * batch_size + bx] * q;
+    float u = curand_uniform(&state) * q;
     aggregate = 0;
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
       probs_vec.fill(DType(0));
@@ -654,7 +669,7 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, DType* uniform_samp
       low = pivot_1;
       q = aggregate_gt_pivot_1.value;
     }
-  }
+  } while (low < high);
   __syncthreads();
   if (tx == 0) {
     output[bx] = sampled_id;
@@ -662,14 +677,15 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, DType* uniform_samp
 }
 
 template <typename T, typename IdType>
-cudaError_t SamplingFromProb(T* probs, T* uniform_samples, IdType* output, uint32_t batch_size,
-                             uint32_t d, bool deterministic, cudaStream_t stream = 0) {
+cudaError_t SamplingFromProb(T* probs, IdType* output, uint32_t batch_size, uint32_t d,
+                             bool deterministic, uint64_t philox_seed, uint64_t philox_offset,
+                             cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
   IdType* row_indices_placeholder = nullptr;
-  void* args[] = {&probs, &uniform_samples, &output, &row_indices_placeholder, &d};
+  void* args[] = {&probs, &output, &row_indices_placeholder, &d, &philox_seed, &philox_offset, &d};
   const uint32_t smem_size = sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
 
   DISPATCH_ALIGNED_VEC_SIZE(
@@ -683,14 +699,15 @@ cudaError_t SamplingFromProb(T* probs, T* uniform_samples, IdType* output, uint3
 }
 
 template <typename T, typename IdType>
-cudaError_t ParallelSamplingFromProb(T* probs, T* uniform_samples, IdType* output,
-                                     IdType* row_indices, uint32_t batch_size, uint32_t d,
-                                     bool deterministic, cudaStream_t stream = 0) {
+cudaError_t ParallelSamplingFromProb(T* probs, IdType* output, IdType* row_indices,
+                                     uint32_t batch_size, uint32_t d, bool deterministic,
+                                     uint64_t philox_seed, uint64_t philox_offset,
+                                     cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
-  void* args[] = {&probs, &uniform_samples, &output, &row_indices, &d};
+  void* args[] = {&probs, &output, &row_indices, &philox_seed, &philox_offset, &d};
   const uint32_t smem_size = sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
 
   DISPATCH_ALIGNED_VEC_SIZE(
@@ -704,9 +721,9 @@ cudaError_t ParallelSamplingFromProb(T* probs, T* uniform_samples, IdType* outpu
 }
 
 template <typename T, typename IdType>
-cudaError_t TopKSamplingFromProb(T* probs, T* uniform_samples, IdType* output, T* top_k_arr,
-                                 uint32_t batch_size, uint32_t top_k_val, uint32_t d,
-                                 uint32_t max_top_k_rounds, bool deterministic,
+cudaError_t TopKSamplingFromProb(T* probs, IdType* output, T* top_k_arr, uint32_t batch_size,
+                                 uint32_t top_k_val, uint32_t d, bool deterministic,
+                                 uint64_t philox_seed, uint64_t philox_offset,
                                  cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
@@ -716,8 +733,7 @@ cudaError_t TopKSamplingFromProb(T* probs, T* uniform_samples, IdType* output, T
         sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &uniform_samples, &output, &top_k_arr, &top_k_val,
-                    &d,     &max_top_k_rounds};
+    void* args[] = {&probs, &output, &top_k_arr, &top_k_val, &d, &philox_seed, &philox_offset};
 
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -733,10 +749,9 @@ cudaError_t TopKSamplingFromProb(T* probs, T* uniform_samples, IdType* output, T
 }
 
 template <typename T, typename IdType>
-cudaError_t TopPSamplingFromProb(T* probs, T* uniform_samples, IdType* output, T* top_p_arr,
-                                 uint32_t batch_size, T top_p_val, uint32_t d,
-                                 uint32_t max_top_p_rounds, bool deterministic,
-                                 cudaStream_t stream = 0) {
+cudaError_t TopPSamplingFromProb(T* probs, IdType* output, T* top_p_arr, uint32_t batch_size,
+                                 T top_p_val, uint32_t d, bool deterministic, uint64_t philox_seed,
+                                 uint64_t philox_offset, cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
@@ -744,8 +759,8 @@ cudaError_t TopPSamplingFromProb(T* probs, T* uniform_samples, IdType* output, T
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
   IdType* row_indices_placeholder = nullptr;
-  void* args[] = {&probs,     &uniform_samples, &output, &row_indices_placeholder,
-                  &top_p_arr, &top_p_val,       &d,      &max_top_p_rounds};
+  void* args[] = {&probs,       &output,       &row_indices_placeholder, &top_p_arr, &top_p_val, &d,
+                  &philox_seed, &philox_offset};
 
   DISPATCH_ALIGNED_VEC_SIZE(
       vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -760,16 +775,17 @@ cudaError_t TopPSamplingFromProb(T* probs, T* uniform_samples, IdType* output, T
 }
 
 template <typename T, typename IdType>
-cudaError_t MinPSamplingFromProb(T* probs, T* uniform_samples, T* min_p_arr, IdType* output,
-                                 uint32_t batch_size, float min_p_val, uint32_t d,
-                                 bool deterministic, cudaStream_t stream = 0) {
+cudaError_t MinPSamplingFromProb(T* probs, T* min_p_arr, IdType* output, uint32_t batch_size,
+                                 float min_p_val, uint32_t d, bool deterministic,
+                                 uint64_t philox_seed, uint64_t philox_offset,
+                                 cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   const uint32_t smem_size = sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
-  void* args[] = {&probs, &uniform_samples, &min_p_arr, &output, &min_p_val, &d};
+  void* args[] = {&probs, &min_p_arr, &output, &min_p_val, &d, &philox_seed, &philox_offset};
 
   DISPATCH_ALIGNED_VEC_SIZE(
       vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -784,10 +800,10 @@ cudaError_t MinPSamplingFromProb(T* probs, T* uniform_samples, T* min_p_arr, IdT
 }
 
 template <typename T, typename IdType>
-cudaError_t TopKTopPSamplingFromProb(T* probs, T* uniform_samples, IdType* top_k_arr, T* top_p_arr,
-                                     IdType* output, uint32_t batch_size, IdType top_k_val,
-                                     T top_p_val, uint32_t d, uint32_t max_rounds,
-                                     bool deterministic, cudaStream_t stream = 0) {
+cudaError_t TopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, IdType* output,
+                                     uint32_t batch_size, IdType top_k_val, T top_p_val, uint32_t d,
+                                     bool deterministic, uint64_t philox_seed,
+                                     uint64_t philox_offset, cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
@@ -796,8 +812,8 @@ cudaError_t TopKTopPSamplingFromProb(T* probs, T* uniform_samples, IdType* top_k
         sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs,     &uniform_samples, &top_k_arr, &top_p_arr, &output,
-                    &top_k_val, &top_p_val,       &d,         &max_rounds};
+    void* args[] = {&probs,     &top_k_arr, &top_p_arr,   &output,       &top_k_val,
+                    &top_p_val, &d,         &philox_seed, &philox_offset};
 
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -1258,13 +1274,15 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
 __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
-                                         DType* uniform_samples, DType* target_probs,
-                                         IdType* output_token_ids,
+                                         DType* target_probs, IdType* output_token_ids,
                                          IdType* output_accepted_token_num,
                                          IdType* output_emitted_token_num,
-                                         uint32_t num_speculative_tokens, uint32_t d) {
+                                         uint32_t num_speculative_tokens, uint32_t d,
+                                         uint64_t philox_seed, uint64_t philox_offset) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;
+  curandStatePhilox4_32_10_t curand_state;
+  curand_init(philox_seed, bx, philox_offset, &curand_state);
 
   extern __shared__ __align__(
       alignof(SamplingTempStorage<DType, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
@@ -1277,7 +1295,7 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
     IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
     float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
           p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
-    DType u = uniform_samples[row_idx * (num_speculative_tokens + 1) + i];
+    DType u = curand_uniform(&curand_state);
     if (u * p < q) {
       // accept the draft models output
       output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
@@ -1293,7 +1311,7 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
     IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
     float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
           p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
-    DType u = uniform_samples[row_idx * (num_speculative_tokens + 1) + i];
+    DType u = curand_uniform(&curand_state);
     if (u * p < q) {
       ++accepted_token_num;
     }
@@ -1336,9 +1354,8 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
   temp_storage.sampled_id = d - 1;
   __syncthreads();
   sum_relu_q_minus_p = temp_storage.block_aggregate.value;
-  DType u = uniform_samples[row_idx * (num_speculative_tokens + 1) +
-                            min(pos + 1, num_speculative_tokens)] *
-            sum_relu_q_minus_p;
+  DType u = curand_uniform(&curand_state);
+  u = u * sum_relu_q_minus_p;
 
   DType aggregate_relu_q_minus_p(0);
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
@@ -1381,19 +1398,17 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
 }
 
 template <typename T, typename IdType>
-cudaError_t ParallelTopPSamplingFromProb(T* probs, T* uniform_samples, IdType* output,
-                                         IdType* row_indices, T* top_p_arr, uint32_t batch_size,
-                                         uint32_t d, uint32_t max_top_p_rounds, bool deterministic,
-                                         cudaStream_t stream = 0) {
+cudaError_t ParallelTopPSamplingFromProb(T* probs, IdType* output, IdType* row_indices,
+                                         float* top_p_arr, uint32_t batch_size, uint64_t seed,
+                                         uint64_t offset, float top_p_val, uint32_t d,
+                                         bool deterministic, cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   const uint32_t smem_size = sizeof(SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
-  T top_p_placeholder = 0;
-  void* args[] = {&probs,     &uniform_samples,   &output, &row_indices,
-                  &top_p_arr, &top_p_placeholder, &d,      &max_top_p_rounds};
+  void* args[] = {&probs, &output, &row_indices, &seed, &offset, &top_p_arr, &top_p_val, &d};
 
   DISPATCH_ALIGNED_VEC_SIZE(
       vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -1409,11 +1424,12 @@ cudaError_t ParallelTopPSamplingFromProb(T* probs, T* uniform_samples, IdType* o
 
 template <typename DType, typename IdType>
 cudaError_t ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
-                                     DType* uniform_samples, DType* target_probs,
-                                     IdType* output_token_ids, IdType* output_accepted_token_num,
+                                     DType* target_probs, IdType* output_token_ids,
+                                     IdType* output_accepted_token_num,
                                      IdType* output_emitted_token_num, uint32_t batch_size,
                                      uint32_t num_speculative_tokens, uint32_t d,
-                                     bool deterministic, cudaStream_t stream = 0) {
+                                     bool deterministic, uint64_t philox_seed,
+                                     uint64_t philox_offset, cudaStream_t stream = 0) {
   constexpr uint32_t BLOCK_THREADS = 1024;
   const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
 
@@ -1423,13 +1439,14 @@ cudaError_t ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids
   dim3 nthrs(BLOCK_THREADS);
   void* args[] = {&draft_probs,
                   &draft_token_ids,
-                  &uniform_samples,
                   &target_probs,
                   &output_token_ids,
                   &output_accepted_token_num,
                   &output_emitted_token_num,
                   &num_speculative_tokens,
-                  &d};
+                  &d,
+                  &philox_seed,
+                  &philox_offset};
   DISPATCH_ALIGNED_VEC_SIZE(
       vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
         auto kernel = ChainSpeculativeSampling<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -347,21 +347,15 @@ def test_chain_speculative_sampling(
         selected_target_probs = target_onehot_prob[
             batch_indices, probs_indicies, draft_token_ids
         ]
-        capped_ratio = torch.minimum(
-            selected_target_probs / selected_draft_probs,
-            torch.full((1,), 1, device=normalized_draft_prob.device),
-        )
-        # ref_accepted = (uniform_samples[:, :-1] < capped_ratio).sum(dim=1)
-        # assert torch.all(accepted_num == ref_accepted)
 
 
 if __name__ == "__main__":
     test_sampling(19, 500)
-    # test_sampling(1, 111)
-    # test_top_p_sampling(3, 111, 0.9)
-    # test_top_k_sampling(3, 111, 10)
-    # test_top_p_renorm_probs(3, 111, 0.9)
-    # test_top_k_renorm_probs(3, 111, 10)
-    # test_top_k_mask_logits(99, 989, 10)
-    # test_chain_speculative_sampling(3, 111, 3, False)
-    # test_chain_speculative_sampling(3, 111, 3, True)
+    test_sampling(1, 111)
+    test_top_p_sampling(3, 111, 0.9)
+    test_top_k_sampling(3, 111, 10)
+    test_top_p_renorm_probs(3, 111, 0.9)
+    test_top_k_renorm_probs(3, 111, 10)
+    test_top_k_mask_logits(99, 989, 10)
+    test_chain_speculative_sampling(3, 111, 3, False)
+    test_chain_speculative_sampling(3, 111, 3, True)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -57,10 +57,9 @@ def test_top_p_sampling(batch_size, vocab_size, p):
     num_trails = 1000
     for _ in range(num_trails):
         uniform_samples.uniform_()
-        samples, success = flashinfer.sampling.top_p_sampling_from_probs(
+        samples = flashinfer.sampling.top_p_sampling_from_probs(
             normalized_prob, uniform_samples, p
         )
-        assert torch.all(success)
         assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
         assert torch.all(mask[torch.arange(batch_size), samples] == 1)
 
@@ -85,10 +84,9 @@ def test_top_k_sampling(batch_size, vocab_size, k):
     num_trails = 1000
     for _ in range(num_trails):
         uniform_samples.uniform_()
-        samples, success = flashinfer.sampling.top_k_sampling_from_probs(
+        samples = flashinfer.sampling.top_k_sampling_from_probs(
             normalized_prob, uniform_samples, k
         )
-        assert torch.all(success)
         assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
         assert torch.all(mask[torch.arange(batch_size), samples] == 1), normalized_prob[
             torch.arange(batch_size), samples
@@ -161,14 +159,13 @@ def test_top_k_top_p_joint_sampling_from_probs(batch_size, vocab_size, p):
     num_trails = 1000
     for _ in range(num_trails):
         uniform_samples.uniform_()
-        samples, success = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+        samples = flashinfer.sampling.top_k_top_p_sampling_from_probs(
             normalized_prob,
             uniform_samples,
             top_k_tensor,
             top_p_tensor,
             filter_apply_order="joint",
         )
-        assert torch.all(success)
         assert torch.all(samples < vocab_size) and torch.all(samples >= 0)
         assert torch.all(mask[torch.arange(batch_size), samples] == 1), normalized_prob[
             torch.arange(batch_size), samples
@@ -183,21 +180,17 @@ def test_top_k_top_p_sampling_from_probs_logits_alignment(batch_size, vocab_size
     torch.manual_seed(42)
     logits = torch.randn(batch_size, vocab_size).to(0) * 5
     uniform_samples = torch.empty(32, batch_size).to(0)
-    samples, success = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+    samples = flashinfer.sampling.top_k_top_p_sampling_from_logits(
         logits, uniform_samples, k, p, filter_apply_order="top_k_first"
     )
-    samples_ref, success_ref = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+    samples_ref = flashinfer.sampling.top_k_top_p_sampling_from_probs(
         torch.softmax(logits, dim=-1),
         uniform_samples,
         k,
         p,
         filter_apply_order="top_k_first",
     )
-    assert torch.all(
-        samples == samples_ref
-    ), f"{samples} != {samples_ref}, {success}, {success_ref}"
-    assert torch.all(success)
-    assert torch.all(success_ref)
+    assert torch.all(samples == samples_ref)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
@@ -214,16 +207,14 @@ def test_top_k_top_p_joint_sampling_from_logits(batch_size, vocab_size, p):
     else:
         raise ValueError("p not recognized")
 
-    samples, success = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+    samples = flashinfer.sampling.top_k_top_p_sampling_from_logits(
         logits, uniform_samples, k, p, filter_apply_order="joint"
     )
 
-    samples_ref, success_ref = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+    samples_ref = flashinfer.sampling.top_k_top_p_sampling_from_probs(
         torch.softmax(logits, dim=-1), uniform_samples, k, p, filter_apply_order="joint"
     )
     assert torch.all(samples == samples_ref)
-    assert torch.all(success)
-    assert torch.all(success_ref)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
@@ -335,7 +326,7 @@ def test_chain_speculative_sampling(
         target_onehot_prob.scatter_(2, target_token_ids.unsqueeze(-1), 1)
 
     # NOTE(Zihao): this is a very simple test that only checks whether output is valid or not.
-    for trials in range(10):    # noqa: B007
+    for trials in range(10):  # noqa: B007
         uniform_samples.uniform_()
         accepted_num = torch.zeros(batch_size, dtype=torch.int32).to(0)
         emitted_num = torch.zeros(batch_size, dtype=torch.int32).to(0)


### PR DESCRIPTION
In our previous sampling algorithms, the rejection sampling algorithm for top-p/top-k sampling is not guaranteed to stop within given number of rounds, and the API would return an `success` array indicating whether the sampling is successful or not. If not, serving engines will fall back to naive sorting-base sampling algorithm.

This PR improves the rejection sampling algorithm, instead of relying on a single pivot, we propose to use dual pivot, and the bound `[low, high]` is guaranteed to shrink by half each round. After 32 rounds, the gap between low and high will be within 2^-32.

Design doc: https://docs.google.com/document/d/1rhdgOM5VawSMAK6jjapFS02-1neGYd8dNazhtmZg7fA/edit?usp=sharing

# Breaking Changes
* This PR removes the `success` return value of all sampling API, which is not compatible with earlier design.
* Instead of passing `uniform` tensor, we changed to interface to accept `torch.Generator` (optional, https://pytorch.org/docs/stable/generated/torch.Generator.html), to align with the behavior of torch.
* C++ API and TVM interface would break in this PR, let's fix the behavior later.

Co-authored-by: Shanli Xing <shanlx@cs.washington.edu>