### PR TITLE
[Package] Add tvm binding to `flashinfer.data` when packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ packages = [
     "flashinfer.data",
     "flashinfer.data.csrc",
     "flashinfer.data.cutlass",
+    "flashinfer.data.tvm_binding",
     "flashinfer.data.include",
     "flashinfer.jit",
     "flashinfer.jit.attention",
@@ -58,6 +59,7 @@ include-package-data = false
 "flashinfer.data" = [
     "csrc/**",
     "include/**",
+    "tvm_binding/**",
     "version.txt"
 ]
 "flashinfer.data.cutlass" = [


### PR DESCRIPTION
This PR adds `tvm_binding` to `pyproject.toml` so that when releasing and building wheels, the contents under `tvm_binding` will be packed together.