### PR TITLE
feat: support non-contiguous input/output in normalization functions

### DIFF
--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -22,8 +22,8 @@ using namespace flashinfer;
 
 void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps,
              int64_t cuda_stream) {
-  CHECK_INPUT(input);
-  CHECK_INPUT(weight);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
   auto device = input.device();
   CHECK_EQ(weight.device(), device);
   CHECK_DIM(2, input);   // input: (batch_size, hidden_size)
@@ -48,9 +48,9 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double e
 
 void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
                        int64_t cuda_stream) {
-  CHECK_INPUT(input);
-  CHECK_INPUT(residual);
-  CHECK_INPUT(weight);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(residual);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
   auto device = input.device();
   CHECK_EQ(residual.device(), device);
   CHECK_EQ(weight.device(), device);
@@ -68,7 +68,7 @@ void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weig
     cudaError_t status = norm::FusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
         static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, input.stride(0),
-        residual.stride(0), output.stride(0), eps, stream);
+        residual.stride(0), eps, stream);
     TORCH_CHECK(status == cudaSuccess, "FusedAddRMSNorm failed with error code " +
                                            std::string(cudaGetErrorString(status)));
     return true;
@@ -77,8 +77,8 @@ void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weig
 
 void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps,
                    int64_t cuda_stream) {
-  CHECK_INPUT(input);
-  CHECK_INPUT(weight);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
   auto device = input.device();
   CHECK_EQ(weight.device(), device);
   CHECK_DIM(2, input);   // input: (batch_size, hidden_size)
@@ -103,9 +103,9 @@ void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, do
 
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
                              double eps, int64_t cuda_stream) {
-  CHECK_INPUT(input);
-  CHECK_INPUT(residual);
-  CHECK_INPUT(weight);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(residual);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
   auto device = input.device();
   CHECK_EQ(residual.device(), device);
   CHECK_EQ(weight.device(), device);
@@ -123,7 +123,7 @@ void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor
     cudaError_t status = norm::GemmaFusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
         static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, input.stride(0),
-        residual.stride(0), output.stride(0), eps, stream);
+        residual.stride(0), eps, stream);
     TORCH_CHECK(status == cudaSuccess, "GemmaFusedAddRMSNorm failed with error code " +
                                            std::string(cudaGetErrorString(status)));
     return true;

--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -36,9 +36,10 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double e
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    cudaError_t status = norm::RMSNorm(
-        static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
-        static_cast<c_type*>(output.data_ptr()), batch_size, hidden_size, eps, stream);
+    cudaError_t status = norm::RMSNorm(static_cast<c_type*>(input.data_ptr()),
+                                       static_cast<c_type*>(weight.data_ptr()),
+                                       static_cast<c_type*>(output.data_ptr()), batch_size,
+                                       hidden_size, input.stride(0), output.stride(0), eps, stream);
     TORCH_CHECK(status == cudaSuccess,
                 "RMSNorm failed with error code " + std::string(cudaGetErrorString(status)));
     return true;
@@ -66,7 +67,8 @@ void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weig
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::FusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
-        static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, eps, stream);
+        static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, input.stride(0),
+        residual.stride(0), output.stride(0), eps, stream);
     TORCH_CHECK(status == cudaSuccess, "FusedAddRMSNorm failed with error code " +
                                            std::string(cudaGetErrorString(status)));
     return true;
@@ -91,7 +93,8 @@ void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, do
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::GemmaRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
-        static_cast<c_type*>(output.data_ptr()), batch_size, hidden_size, eps, stream);
+        static_cast<c_type*>(output.data_ptr()), batch_size, hidden_size, input.stride(0),
+        output.stride(0), eps, stream);
     TORCH_CHECK(status == cudaSuccess,
                 "GemmaRMSNorm failed with error code " + std::string(cudaGetErrorString(status)));
     return true;
@@ -119,7 +122,8 @@ void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::GemmaFusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
-        static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, eps, stream);
+        static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, input.stride(0),
+        residual.stride(0), output.stride(0), eps, stream);
     TORCH_CHECK(status == cudaSuccess, "GemmaFusedAddRMSNorm failed with error code " +
                                            std::string(cudaGetErrorString(status)));
     return true;


### PR DESCRIPTION
We should support normalization functions where input and output are not contiguous.