### PR TITLE
fix: add install step of profiler's dependency

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -8,6 +8,7 @@ The Chrome tracing do not support overlapping events inside a single thread (the
 
 ```bash
 # pip install from github
+pip install protobuf==3.20.0
 pip install git+https://github.com/ihavnoid/tg4perfetto.git
 ```
 


### PR DESCRIPTION
As the title suggest, `tg4perfetto` requires the specific version of `protobuf` as dependency (i.e., 3.20.0) 