### PR TITLE
feat: experimenta support of PDL

### DIFF
--- a/csrc/activation.cu
+++ b/csrc/activation.cu
@@ -51,10 +51,13 @@ void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t c
     config.numAttrs = 1;
     config.attrs = attrs;
 
-    using kernel = flashinfer::activation::act_and_mul_kernel<c_type, silu>;
+    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, silu>;
 
-    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
-                                            static_cast<c_type*>(input.data_ptr()), d));
+    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
+                       static_cast<c_type*>(input.data_ptr()), d);
+
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;
   });
@@ -78,10 +81,13 @@ void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int6
     config.numAttrs = 1;
     config.attrs = attrs;
 
-    using kernel = flashinfer::activation::act_and_mul_kernel<c_type, gelu_tanh>;
+    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, gelu_tanh>;
 
-    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
-                                            static_cast<c_type*>(input.data_ptr()), d));
+    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
+                       static_cast<c_type*>(input.data_ptr()), d);
+
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;
   });
@@ -106,10 +112,13 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t c
     config.numAttrs = 1;
     config.attrs = attrs;
 
-    using kernel = flashinfer::activation::act_and_mul_kernel<c_type, gelu>;
+    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, gelu>;
 
-    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
-                                            static_cast<c_type*>(input.data_ptr()), d));
+    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
+                       static_cast<c_type*>(input.data_ptr()), d);
+
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;
   });

--- a/csrc/flashinfer_norm_ops.cu
+++ b/csrc/flashinfer_norm_ops.cu
@@ -15,17 +15,17 @@
  */
 #include "pytorch_extension_utils.h"
 
-void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
+void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl,
              int64_t cuda_stream);
 
 void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
-                       int64_t cuda_stream);
+                       bool enable_pdl, int64_t cuda_stream);
 
 void gemma_rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
-                   int64_t cuda_stream);
+                   bool enable_pdl, int64_t cuda_stream);
 
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
-                             double eps, int64_t cuda_stream);
+                             double eps, bool enable_pdl, int64_t cuda_stream);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Root mean square normalization

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -18,9 +18,9 @@
 
 //========== activation ==========
 
-void silu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
-void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
-void gelu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
+void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream);
+void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream);
+void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream);
 
 //========== cascade ==========
 

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -66,17 +66,17 @@ void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at
 
 //========== norm ==========
 
-void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
+void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl,
              int64_t cuda_stream);
 
 void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
-                       int64_t cuda_stream);
+                       bool enable_pdl, int64_t cuda_stream);
 
 void gemma_rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
-                   int64_t cuda_stream);
+                   bool enable_pdl, int64_t cuda_stream);
 
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
-                             double eps, int64_t cuda_stream);
+                             double eps, bool enable_pdl, int64_t cuda_stream);
 
 //========== page ==========
 

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 
 import torch
 
-from .jit import gen_act_and_mul_module, has_prebuilt_ops, load_cuda_ops    # noqa: F401
+from .jit import gen_act_and_mul_module, has_prebuilt_ops, load_cuda_ops  # noqa: F401
 from .utils import get_cuda_stream, register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
@@ -69,12 +69,16 @@ def get_act_and_mul_module(act_func_name: str):
         fn = getattr(module, fname)
 
         @register_custom_op(f"flashinfer::{fname}", mutates_args=("out",))
-        def _act_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
+        def _act_and_mul(
+            out: torch.Tensor, input: torch.Tensor, enable_pdl: bool = False
+        ) -> None:
             with input.device as device:  # device guard
-                fn(out, input, get_cuda_stream(device))
+                fn(out, input, enable_pdl, get_cuda_stream(device))
 
         @register_fake_op(f"flashinfer::{fname}")
-        def _fake_act_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
+        def _fake_act_and_mul(
+            out: torch.Tensor, input: torch.Tensor, enable_pdl: bool = False
+        ) -> None:
             pass
 
         # Register the module
@@ -93,7 +97,9 @@ def _check_shape(input: torch.Tensor, output: torch.Tensor) -> None:
     ), f"{input.shape[-1]} != {2 * output.shape[-1]}"
 
 
-def silu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
+def silu_and_mul(
+    input: torch.Tensor, out: torch.Tensor = None, enable_pdl: bool = False
+) -> torch.Tensor:
     r"""Fused SiLU and Mul operation.
 
     ``silu(input[..., :hidden_size]) * input[..., hidden_size:]``
@@ -105,6 +111,10 @@ def silu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
 
     out: Optional[torch.Tensor]
         The output tensor, if specified, the kernel will update this tensor inplace.
+
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
 
     Returns
     -------
@@ -124,11 +134,14 @@ def silu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
     get_act_and_mul_module("silu").silu_and_mul(
         out,
         input,
+        enable_pdl,
     )
     return out
 
 
-def gelu_tanh_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
+def gelu_tanh_and_mul(
+    input: torch.Tensor, out: torch.Tensor = None, enable_pdl: bool = False
+) -> torch.Tensor:
     r"""Fused GeLU Tanh and Mul operation.
 
     ``gelu(tanh(input[..., :hidden_size])) * input[..., hidden_size:]``
@@ -141,6 +154,10 @@ def gelu_tanh_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Te
     out: Optional[torch.Tensor]
         The output tensor, if specified, the kernel will update this tensor inplace.
 
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
+
     Returns
     -------
     output: torch.Tensor
@@ -156,11 +173,13 @@ def gelu_tanh_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Te
             device=input.device,
             dtype=input.dtype,
         )
-    get_act_and_mul_module("gelu_tanh").gelu_tanh_and_mul(out, input)
+    get_act_and_mul_module("gelu_tanh").gelu_tanh_and_mul(out, input, enable_pdl)
     return out
 
 
-def gelu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
+def gelu_and_mul(
+    input: torch.Tensor, out: torch.Tensor = None, enable_pdl: bool = False
+) -> torch.Tensor:
     r"""Fused GeLU and Mul operation.
 
     ``gelu(input[..., :hidden_size]) * input[..., hidden_size:]``
@@ -173,6 +192,10 @@ def gelu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
     out: Optional[torch.Tensor]
         The output tensor, if specified, the kernel will update this tensor inplace.
 
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
+
     Returns
     -------
     output: torch.Tensor
@@ -188,5 +211,5 @@ def gelu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
             device=input.device,
             dtype=input.dtype,
         )
-    get_act_and_mul_module("gelu").gelu_and_mul(out, input)
+    get_act_and_mul_module("gelu").gelu_and_mul(out, input, enable_pdl)
     return out

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -25,6 +25,7 @@ from .utils import write_if_different
 activation_templ = r"""
 #include <flashinfer/activation.cuh>
 #include "pytorch_extension_utils.h"
+#include <cuda_runtime.h>
 
 {% set func_name = act_func_name ~ '_and_mul' %}
 
@@ -32,7 +33,7 @@ using namespace flashinfer;
 
 {{ act_func_def }}
 
-void {{ func_name }}(at::Tensor& out, at::Tensor& input, int64_t cuda_stream) {
+void {{ func_name }}(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
   dim3 grid(num_tokens);
@@ -40,10 +41,24 @@ void {{ func_name }}(at::Tensor& out, at::Tensor& input, int64_t cuda_stream) {
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
-    dim3 block(std::min(d / vec_size, 1024U));
-    flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}>
-        <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()),
-                                     static_cast<c_type*>(input.data_ptr()), d);
+    cudaLaunchConfig_t config;
+    config.gridDim = num_tokens;
+    config.blockDim = std::min(d / vec_size, 1024U);
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = enable_pdl;
+    config.numAttrs = 1;
+    config.attrs = attrs;
+
+    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}>;
+
+    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
+                       static_cast<c_type*>(input.data_ptr()), d);
+
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;
   });

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -47,6 +47,7 @@ def rmsnorm(
     weight: torch.Tensor,
     eps: float = 1e-6,
     out: Optional[torch.Tensor] = None,
+    enable_pdl: bool = False,
 ) -> torch.Tensor:
     r"""Root mean square normalization.
 
@@ -62,6 +63,9 @@ def rmsnorm(
         Epsilon for numerical stability.
     out: Optional[torch.Tensor]
         The output tensor, if specified, the kernel will update this tensor inplace.
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
 
     Returns
     -------
@@ -70,28 +74,42 @@ def rmsnorm(
     """
     if out is None:
         out = torch.empty_like(input)
-    _rmsnorm(out, input, weight, eps)
+    _rmsnorm(out, input, weight, eps, enable_pdl)
     return out
 
 
 @register_custom_op("flashinfer::rmsnorm", mutates_args=("out",))
 def _rmsnorm(
-    out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor, eps: float
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    enable_pdl: bool,
 ) -> None:
     with input.device as device:  # device guard
-        get_norm_module().rmsnorm(out, input, weight, eps, get_cuda_stream(device))
+        get_norm_module().rmsnorm(
+            out, input, weight, eps, enable_pdl, get_cuda_stream(device)
+        )
 
 
 @register_fake_op("flashinfer::rmsnorm")
 def _rmsnorm_fake(
-    out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor, eps: float
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    enable_pdl: bool,
 ) -> None:
     pass
 
 
 @register_custom_op("flashinfer::fused_add_rmsnorm", mutates_args=("input", "residual"))
 def fused_add_rmsnorm(
-    input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+    enable_pdl: bool = False,
 ) -> None:
     r"""Fused add root mean square normalization.
 
@@ -111,16 +129,23 @@ def fused_add_rmsnorm(
         Weight tensor, shape (hidden_size,).
     eps: float
         Epsilon for numerical stability.
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
     """
     with input.device as device:  # device guard
         get_norm_module().fused_add_rmsnorm(
-            input, residual, weight, eps, get_cuda_stream(device)
+            input, residual, weight, eps, enable_pdl, get_cuda_stream(device)
         )
 
 
 @register_fake_op("flashinfer::fused_add_rmsnorm")
 def _fused_add_rmsnorm_fake(
-    input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+    enable_pdl: bool = False,
 ) -> None:
     pass
 
@@ -130,6 +155,7 @@ def gemma_rmsnorm(
     weight: torch.Tensor,
     eps: float = 1e-6,
     out: Optional[torch.Tensor] = None,
+    enable_pdl: bool = False,
 ) -> torch.Tensor:
     r"""Gemma-style root mean square normalization.
 
@@ -145,6 +171,9 @@ def gemma_rmsnorm(
         Epsilon for numerical stability.
     out: Optional[torch.Tensor]
         The output tensor, if specified, the kernel will update this tensor inplace.
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
 
     Returns
     -------
@@ -153,23 +182,31 @@ def gemma_rmsnorm(
     """
     if out is None:
         out = torch.empty_like(input)
-    _gemma_rmsnorm(out, input, weight, eps)
+    _gemma_rmsnorm(out, input, weight, eps, enable_pdl)
     return out
 
 
 @register_custom_op("flashinfer::gemma_rmsnorm", mutates_args=("out",))
 def _gemma_rmsnorm(
-    out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor, eps: float
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    enable_pdl: bool,
 ) -> None:
     with input.device as device:  # device guard
         get_norm_module().gemma_rmsnorm(
-            out, input, weight, eps, get_cuda_stream(device)
+            out, input, weight, eps, enable_pdl, get_cuda_stream(device)
         )
 
 
 @register_fake_op("flashinfer::gemma_rmsnorm")
 def _gemma_rmsnorm_fake(
-    out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor, eps: float
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    enable_pdl: bool,
 ) -> None:
     pass
 
@@ -178,7 +215,11 @@ def _gemma_rmsnorm_fake(
     "flashinfer::gemma_fused_add_rmsnorm", mutates_args=("input", "residual")
 )
 def gemma_fused_add_rmsnorm(
-    input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+    enable_pdl: bool = False,
 ) -> None:
     r"""Gemma-style fused add root mean square normalization.
 
@@ -198,15 +239,22 @@ def gemma_fused_add_rmsnorm(
         Weight tensor, shape (hidden_size,).
     eps: float
         Epsilon for numerical stability.
+    enable_pdl: bool
+        Whether to enable `programmatic dependency loading
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
     """
     with input.device as device:
         get_norm_module().gemma_fused_add_rmsnorm(
-            input, residual, weight, eps, get_cuda_stream(device)
+            input, residual, weight, eps, enable_pdl, get_cuda_stream(device)
         )
 
 
 @register_fake_op("flashinfer::gemma_fused_add_rmsnorm")
 def _gemma_fused_add_rmsnorm_fake(
-    input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+    enable_pdl: bool = False,
 ) -> None:
     pass

--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -131,6 +131,8 @@ cudaError_t RMSNorm(T* input, T* weight, T* output, uint32_t batch_size, uint32_
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
     auto kernel = RMSNormKernel<VEC_SIZE, T>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, weight, output, d, stride_input,
                                             stride_output, weight_bias, eps));
   });
@@ -258,6 +260,8 @@ cudaError_t FusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batch_siz
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
     auto kernel = FusedAddRMSNormKernel<VEC_SIZE, T>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, residual, weight, d,
                                             stride_input, stride_residual, weight_bias, eps));
   });
@@ -292,6 +296,8 @@ cudaError_t GemmaRMSNorm(T* input, T* weight, T* output, uint32_t batch_size, ui
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
     auto kernel = RMSNormKernel<VEC_SIZE, T>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, weight, output, d, stride_input,
                                             stride_output, weight_bias, eps));
   });
@@ -327,6 +333,8 @@ cudaError_t GemmaFusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batc
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
     auto kernel = FusedAddRMSNormKernel<VEC_SIZE, T>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, residual, weight, d,
                                             stride_input, stride_residual, weight_bias, eps));
   });

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -199,4 +199,4 @@ def test_gemma_fused_add_rmsnorm(
 
 if __name__ == "__main__":
     # test_norm(1, 1024, torch.float16, False, True)
-    test_norm(1, 1024, torch.float16, False, True, True)
+    test_fused_add_rmsnorm(1, 16384, torch.float16, True, True)

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 
 import flashinfer
+from flashinfer.utils import get_compute_capability
 
 
 def llama_rms_norm(x, w, eps=1e-6):
@@ -68,22 +69,27 @@ def fused_add_rms_norm(x, residual, weight, eps):
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("specify_out", [True, False])
+@pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-def test_norm(batch_size, hidden_size, dtype, specify_out, contiguous):
+def test_norm(batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguous):
     if contiguous:
         x = torch.randn(batch_size, hidden_size).to(0).to(dtype)
     else:
         x = torch.randn(batch_size, hidden_size * 2, device="cuda").to(dtype)
         x = x[:, :hidden_size]
 
+    major, _ = get_compute_capability(x.device)
+    if major < 9 and enable_pdl:
+        pytest.skip("PDL is only available for Hopper and later GPUs")
+
     w = torch.randn(hidden_size).to(0).to(dtype)
 
     y_ref = llama_rms_norm(x, w)
     if specify_out:
         y = torch.empty_like(x)
-        flashinfer.norm.rmsnorm(x, w, out=y)
+        flashinfer.norm.rmsnorm(x, w, out=y, enable_pdl=enable_pdl)
     else:
-        y = flashinfer.norm.rmsnorm(x, w)
+        y = flashinfer.norm.rmsnorm(x, w, enable_pdl=enable_pdl)
 
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
@@ -91,8 +97,9 @@ def test_norm(batch_size, hidden_size, dtype, specify_out, contiguous):
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
+def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguous):
     eps = 1e-6
 
     if contiguous:
@@ -100,6 +107,10 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
     else:
         x = torch.randn(batch_size, hidden_size * 2, device="cuda").to(dtype)
         x = x[:, :hidden_size]
+
+    major, _ = get_compute_capability(x.device)
+    if major < 9 and enable_pdl:
+        pytest.skip("PDL is only available for Hopper and later GPUs")
 
     residual = torch.randn_like(x)
     weight = torch.randn(hidden_size, dtype=dtype, device="cuda")
@@ -110,7 +121,9 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
 
     x_fused = x.clone()
     residual_fused = residual.clone()
-    flashinfer.fused_add_rmsnorm(x_fused, residual_fused, weight, eps)
+    flashinfer.fused_add_rmsnorm(
+        x_fused, residual_fused, weight, eps, enable_pdl=enable_pdl
+    )
 
     torch.testing.assert_close(x_fused, x_native, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(residual_fused, residual_native, rtol=1e-3, atol=1e-3)
@@ -120,22 +133,29 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("specify_out", [True, False])
+@pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-def test_gemma_norm(batch_size, hidden_size, dtype, specify_out, contiguous):
+def test_gemma_norm(
+    batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguous
+):
     if contiguous:
         x = torch.randn(batch_size, hidden_size).to(0).to(dtype)
     else:
         x = torch.randn(batch_size, hidden_size * 2, device="cuda").to(dtype)
         x = x[:, :hidden_size]
 
+    major, _ = get_compute_capability(x.device)
+    if major < 9 and enable_pdl:
+        pytest.skip("PDL is only available for Hopper and later GPUs")
+
     w = torch.randn(hidden_size).to(0).to(dtype)
 
     y_ref = gemma_rms_norm(x, w)
     if specify_out:
         y = torch.empty_like(x)
-        flashinfer.norm.gemma_rmsnorm(x, w, out=y)
+        flashinfer.norm.gemma_rmsnorm(x, w, out=y, enable_pdl=enable_pdl)
     else:
-        y = flashinfer.norm.gemma_rmsnorm(x, w)
+        y = flashinfer.norm.gemma_rmsnorm(x, w, enable_pdl=enable_pdl)
 
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
@@ -143,8 +163,11 @@ def test_gemma_norm(batch_size, hidden_size, dtype, specify_out, contiguous):
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-def test_gemma_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
+def test_gemma_fused_add_rmsnorm(
+    batch_size, hidden_size, dtype, enable_pdl, contiguous
+):
     eps = 1e-6
 
     if contiguous:
@@ -152,6 +175,10 @@ def test_gemma_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
     else:
         x = torch.randn(batch_size, hidden_size * 2, device="cuda").to(dtype)
         x = x[:, :hidden_size]
+
+    major, _ = get_compute_capability(x.device)
+    if major < 9 and enable_pdl:
+        pytest.skip("PDL is only available for Hopper and later GPUs")
 
     residual = torch.randn_like(x)
     weight = torch.randn(hidden_size, dtype=dtype, device="cuda")
@@ -162,11 +189,14 @@ def test_gemma_fused_add_rmsnorm(batch_size, hidden_size, dtype, contiguous):
 
     x_fused = x.clone()
     residual_fused = residual.clone()
-    flashinfer.gemma_fused_add_rmsnorm(x_fused, residual_fused, weight, eps)
+    flashinfer.gemma_fused_add_rmsnorm(
+        x_fused, residual_fused, weight, eps, enable_pdl=enable_pdl
+    )
 
     torch.testing.assert_close(x_fused, x_native, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(residual_fused, residual_native, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":
-    test_norm(1, 1024, torch.float16, False, True)
+    # test_norm(1, 1024, torch.float16, False, True)
+    test_norm(1, 1024, torch.float16, False, True, True)


### PR DESCRIPTION
[PDL](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization) can be used to overlap prologue and epilogue of two kernels on Hopper or later architectures. This PR adds initial PDL support for some simple kernels such as norm and activations.