### PR TITLE
typo: remove another uniform samples leftover

### DIFF
--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1207,7 +1207,6 @@ def chain_speculative_sampling(
     >>> # token 2 was sampled from draft model for the first token, and
     >>> # token 1 was sampled from draft model for the second token
     >>> draft_token_ids = torch.tensor([[2, 1]], dtype=torch.int32).to(0)
-    >>> # uniform samples for rejection sampling
     >>> target_probs = torch.tensor([[[0.0, 0.1, 0.6, 0.3], [1.0, 0.0, 0.0, 0.0], [0.7, 0.1, 0.1, 0.1]]]).to(0)
     >>> output_token_ids, output_accepted_token_num, output_accepted_token_num =\
     ...     flashinfer.sampling.chain_speculative_sampling(


### PR DESCRIPTION
Looks like another typo in #912 - sorry for taking 3 PRs to fix one docstring! :roll_eyes: 

```
     >>> # uniform samples for rejection sampling
-    >>> uniform_samples = torch.rand(batch_size, num_speculate_tokens + 1).to(0)
-    tensor([[0.8823, 0.9150, 0.3829], device='cuda:0')
     >>> target_probs = torch.tensor([[[0.0, 0.1, 0.6, 0.3], [1.0, 0.0, 0.0, 0.0], [0.7, 0.1, 0.1, 0.1]]]).to(0)
```