### PR TITLE
fix - fix bug when not relevant seq has nan data

### DIFF
--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -181,8 +181,8 @@ __device__ __forceinline__ void load_kv(
     typename KTraits::SharedStorage* smem_storage, typename KTraits::DTypeKV* ckv,
     typename KTraits::DTypeKV* kpe, typename KTraits::IdType* indices, const uint32_t ckv_stride_n,
     const uint32_t ckv_stride_page, const uint32_t kpe_stride_n, const uint32_t kpe_stride_page,
-    const uint32_t kv_bound, const uint32_t packed_block_iter_base, const uint_fastdiv& block_size,
-    const uint32_t stage_idx, const uint32_t last_page_kv_idx) {
+    const uint32_t packed_kv_bound, const uint32_t packed_block_iter_base,
+    const uint_fastdiv& block_size, const uint32_t stage_idx) {
   using DTypeKV = typename KTraits::DTypeKV;
   constexpr uint32_t UPCAST_STRIDE_CKV = KTraits::UPCAST_STRIDE_CKV;
   constexpr uint32_t UPCAST_STRIDE_KPE = KTraits::UPCAST_STRIDE_KPE;
@@ -198,21 +198,23 @@ __device__ __forceinline__ void load_kv(
   if constexpr (KTraits::NUM_MMA_KV == 1) {
     if (warpgroup_idx == 0) {
       uint32_t q, r;
+      uint32_t packed_block_iter =
+          packed_block_iter_base + lane_idx / 8 + lane_idx / 8 + warp_idx_in_wg * 4;
+      block_size.divmod(packed_block_iter, q, r);
 
-      block_size.divmod(packed_block_iter_base + lane_idx / 8 + warp_idx_in_wg * 4, q, r);
-
-      DTypeKV* ckv_ptr = ckv + (q < kv_bound ? indices[q] : 0) * ckv_stride_page +
+      DTypeKV* ckv_ptr = ckv +
+                         (packed_block_iter < packed_kv_bound ? indices[q] : 0) * ckv_stride_page +
                          r * ckv_stride_n + (lane_idx % 8) * upcast_size<DTypeKV>();
-      DTypeKV* kpe_ptr = kpe + (q < kv_bound ? indices[q] : 0) * kpe_stride_page +
+      DTypeKV* kpe_ptr = kpe +
+                         (packed_block_iter < packed_kv_bound ? indices[q] : 0) * kpe_stride_page +
                          r * kpe_stride_n + (lane_idx % 8) * upcast_size<DTypeKV>();
 
 #pragma unroll
       for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 4; ++mma_d) {
         uint32_t ckv_smem_offset_w = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
             warp_idx_in_wg * 4 + lane_idx / 8, 8 * mma_d + lane_idx % 8);
-        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(
-            ckv_smem_offset_w, ckv_ptr,
-            (q < kv_bound - 1) || ((q == kv_bound - 1) && (r <= last_page_kv_idx)));
+        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(ckv_smem_offset_w, ckv_ptr,
+                                                               packed_block_iter < packed_kv_bound);
         ckv_ptr += 8 * upcast_size<DTypeKV>();
       }
 
@@ -221,7 +223,7 @@ __device__ __forceinline__ void load_kv(
         uint32_t kpe_smem_offset_w = kpe_smem.template get_permuted_offset<UPCAST_STRIDE_KPE>(
             warp_idx_in_wg * 4 + lane_idx / 8, 8 * mma_d + lane_idx % 8);
         kpe_smem.load_128b_async<SharedMemFillMode::kFillZero>(kpe_smem_offset_w, kpe_ptr,
-                                                               q < kv_bound);
+                                                               packed_block_iter < packed_kv_bound);
         kpe_ptr += 8 * upcast_size<DTypeKV>();
       }
     }
@@ -229,14 +231,15 @@ __device__ __forceinline__ void load_kv(
 #pragma unroll
     for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV / 2; ++mma_kv) {
       uint32_t q, r;
+      uint32_t packed_block_iter = packed_block_iter_base + lane_idx / 8 +
+                                   (warpgroup_idx + mma_kv * 2) * 16 + warp_idx_in_wg * 4;
+      block_size.divmod(packed_block_iter, q, r);
 
-      block_size.divmod(packed_block_iter_base + lane_idx / 8 + (warpgroup_idx + mma_kv * 2) * 16 +
-                            warp_idx_in_wg * 4,
-                        q, r);
-
-      DTypeKV* ckv_ptr = ckv + (q < kv_bound ? indices[q] : 0) * ckv_stride_page +
+      DTypeKV* ckv_ptr = ckv +
+                         (packed_block_iter < packed_kv_bound ? indices[q] : 0) * ckv_stride_page +
                          r * ckv_stride_n + (lane_idx % 8) * upcast_size<DTypeKV>();
-      DTypeKV* kpe_ptr = kpe + (q < kv_bound ? indices[q] : 0) * kpe_stride_page +
+      DTypeKV* kpe_ptr = kpe +
+                         (packed_block_iter < packed_kv_bound ? indices[q] : 0) * kpe_stride_page +
                          r * kpe_stride_n + (lane_idx % 8) * upcast_size<DTypeKV>();
 
 #pragma unroll
@@ -244,9 +247,8 @@ __device__ __forceinline__ void load_kv(
         uint32_t ckv_smem_offset_w = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
             32 * mma_kv + warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8,
             8 * mma_d + lane_idx % 8);
-        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(
-            ckv_smem_offset_w, ckv_ptr,
-            (q < kv_bound - 1) || ((q == kv_bound - 1) && (r <= last_page_kv_idx)));
+        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(ckv_smem_offset_w, ckv_ptr,
+                                                               packed_block_iter < packed_kv_bound);
         ckv_ptr += 8 * upcast_size<DTypeKV>();
       }
 
@@ -256,7 +258,7 @@ __device__ __forceinline__ void load_kv(
             32 * mma_kv + warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8,
             8 * mma_d + lane_idx % 8);
         kpe_smem.load_128b_async<SharedMemFillMode::kFillZero>(kpe_smem_offset_w, kpe_ptr,
-                                                               q < kv_bound);
+                                                               packed_block_iter < packed_kv_bound);
         kpe_ptr += 8 * upcast_size<DTypeKV>();
       }
     }
@@ -838,9 +840,6 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
     const uint32_t kv_start = params.kv_start[work_idx];
     const uint32_t kv_end = params.kv_end[work_idx];
 
-    uint32_t total_page_idx, last_page_kv_idx;
-    block_size.divmod(kv_end - 1, total_page_idx, last_page_kv_idx);
-
     const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
     const uint32_t qo_upperbound =
         min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
@@ -868,19 +867,19 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
     uint32_t block_iter_base = kv_indptr * block_size + kv_start;
     // last kv tile
     __syncthreads();
-    uint32_t kv_bound = kv_indptr + (kv_len + block_size - 1) / block_size;  // ceil_div
+    uint32_t packed_kv_bound = kv_indptr * block_size + kv_len;
     load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
-                     kpe_stride_n, kpe_stride_page, kv_bound,
+                     kpe_stride_n, kpe_stride_page, packed_kv_bound,
                      block_iter_base + kv_tile_idx * CTA_TILE_KV, block_size,
-                     kv_tile_idx % NUM_STAGES, last_page_kv_idx);
+                     kv_tile_idx % NUM_STAGES);
     cp_async::commit_group();
 #pragma unroll
     for (int stage_idx = 1; stage_idx < NUM_STAGES; ++stage_idx) {
       if (kv_tile_idx - stage_idx >= 0) {
         load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
-                         kpe_stride_n, kpe_stride_page, kv_bound,
+                         kpe_stride_n, kpe_stride_page, packed_kv_bound,
                          block_iter_base + (kv_tile_idx - stage_idx) * CTA_TILE_KV, block_size,
-                         (kv_tile_idx - stage_idx) % NUM_STAGES, last_page_kv_idx);
+                         (kv_tile_idx - stage_idx) % NUM_STAGES);
         cp_async::commit_group();
       }
     }
@@ -908,9 +907,9 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
       if (kv_tile_idx - NUM_STAGES >= 0) {
         __syncthreads();
         load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
-                         kpe_stride_n, kpe_stride_page, kv_bound,
+                         kpe_stride_n, kpe_stride_page, packed_kv_bound,
                          block_iter_base + (kv_tile_idx - NUM_STAGES) * CTA_TILE_KV, block_size,
-                         (kv_tile_idx - NUM_STAGES) % NUM_STAGES, last_page_kv_idx);
+                         (kv_tile_idx - NUM_STAGES) % NUM_STAGES);
         cp_async::commit_group();
       }
     }
@@ -932,9 +931,9 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
 
       __syncthreads();
       load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
-                       kpe_stride_n, kpe_stride_page, kv_bound,
+                       kpe_stride_n, kpe_stride_page, packed_kv_bound,
                        block_iter_base + (kv_tile_idx - NUM_STAGES) * CTA_TILE_KV, block_size,
-                       (kv_tile_idx - NUM_STAGES) % NUM_STAGES, last_page_kv_idx);
+                       (kv_tile_idx - NUM_STAGES) % NUM_STAGES);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -182,7 +182,7 @@ __device__ __forceinline__ void load_kv(
     typename KTraits::DTypeKV* kpe, typename KTraits::IdType* indices, const uint32_t ckv_stride_n,
     const uint32_t ckv_stride_page, const uint32_t kpe_stride_n, const uint32_t kpe_stride_page,
     const uint32_t kv_bound, const uint32_t packed_block_iter_base, const uint_fastdiv& block_size,
-    const uint32_t stage_idx) {
+    const uint32_t stage_idx, const uint32_t last_page_kv_idx) {
   using DTypeKV = typename KTraits::DTypeKV;
   constexpr uint32_t UPCAST_STRIDE_CKV = KTraits::UPCAST_STRIDE_CKV;
   constexpr uint32_t UPCAST_STRIDE_KPE = KTraits::UPCAST_STRIDE_KPE;
@@ -210,8 +210,9 @@ __device__ __forceinline__ void load_kv(
       for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 4; ++mma_d) {
         uint32_t ckv_smem_offset_w = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
             warp_idx_in_wg * 4 + lane_idx / 8, 8 * mma_d + lane_idx % 8);
-        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(ckv_smem_offset_w, ckv_ptr,
-                                                               q < kv_bound);
+        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(
+            ckv_smem_offset_w, ckv_ptr,
+            (q < kv_bound - 1) || ((q == kv_bound - 1) && (r <= last_page_kv_idx)));
         ckv_ptr += 8 * upcast_size<DTypeKV>();
       }
 
@@ -243,8 +244,9 @@ __device__ __forceinline__ void load_kv(
         uint32_t ckv_smem_offset_w = ckv_smem.template get_permuted_offset<UPCAST_STRIDE_CKV>(
             32 * mma_kv + warpgroup_idx * 16 + warp_idx_in_wg * 4 + lane_idx / 8,
             8 * mma_d + lane_idx % 8);
-        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(ckv_smem_offset_w, ckv_ptr,
-                                                               q < kv_bound);
+        ckv_smem.load_128b_async<SharedMemFillMode::kFillZero>(
+            ckv_smem_offset_w, ckv_ptr,
+            (q < kv_bound - 1) || ((q == kv_bound - 1) && (r <= last_page_kv_idx)));
         ckv_ptr += 8 * upcast_size<DTypeKV>();
       }
 
@@ -836,6 +838,9 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
     const uint32_t kv_start = params.kv_start[work_idx];
     const uint32_t kv_end = params.kv_end[work_idx];
 
+    uint32_t total_page_idx, last_page_kv_idx;
+    block_size.divmod(kv_end - 1, total_page_idx, last_page_kv_idx);
+
     const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
     const uint32_t qo_upperbound =
         min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
@@ -867,7 +872,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
     load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
                      kpe_stride_n, kpe_stride_page, kv_bound,
                      block_iter_base + kv_tile_idx * CTA_TILE_KV, block_size,
-                     kv_tile_idx % NUM_STAGES);
+                     kv_tile_idx % NUM_STAGES, last_page_kv_idx);
     cp_async::commit_group();
 #pragma unroll
     for (int stage_idx = 1; stage_idx < NUM_STAGES; ++stage_idx) {
@@ -875,7 +880,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
         load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
                          kpe_stride_n, kpe_stride_page, kv_bound,
                          block_iter_base + (kv_tile_idx - stage_idx) * CTA_TILE_KV, block_size,
-                         (kv_tile_idx - stage_idx) % NUM_STAGES);
+                         (kv_tile_idx - stage_idx) % NUM_STAGES, last_page_kv_idx);
         cp_async::commit_group();
       }
     }
@@ -905,7 +910,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
         load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
                          kpe_stride_n, kpe_stride_page, kv_bound,
                          block_iter_base + (kv_tile_idx - NUM_STAGES) * CTA_TILE_KV, block_size,
-                         (kv_tile_idx - NUM_STAGES) % NUM_STAGES);
+                         (kv_tile_idx - NUM_STAGES) % NUM_STAGES, last_page_kv_idx);
         cp_async::commit_group();
       }
     }
@@ -929,7 +934,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
       load_kv<KTraits>(&smem_storage, ckv, kpe, kv_indices, ckv_stride_n, ckv_stride_page,
                        kpe_stride_n, kpe_stride_page, kv_bound,
                        block_iter_base + (kv_tile_idx - NUM_STAGES) * CTA_TILE_KV, block_size,
-                       (kv_tile_idx - NUM_STAGES) % NUM_STAGES);
+                       (kv_tile_idx - NUM_STAGES) % NUM_STAGES, last_page_kv_idx);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();


### PR DESCRIPTION
We found that in the batch MLA FA2 implementation, if there exists NaN data within the computed CKV cache page, the kernel implementation would inadvertently read these invalid values and corrupt other valid data, ultimately resulting in all outputs becoming NaN. Therefore, this PR introduces masking logic to exclude CKV entries outside the computation scope from being processed.  It may cause other requests to get error response when previous request precision overflow
 and write nan to kvcache.
### How to reproduce
1. modify `test_batch_mla_varlen_page_attention` in `test_deepseek_mla.py` to use fa2 implement, and set an nan data in unrelated sequence
```
    # disable fa3 check
    # if not is_sm90a_supported(torch.device("cuda")):
    #     pytest.skip("FA3 is not supported on this device")
    if causal and qo_len > min(kv_len_0, kv_len_1, kv_len_2):
        pytest.skip("qo_len > kv_len not supported for causal attention")
    num_different_kv_len = 3
    .....
    kpe = torch.randn(
        batch_size * pages_nums_sum,
        page_size,
        head_dim_kpe,
        dtype=dtype,
        device="cuda",
    )
    # set a not related seq to nan
    ckv[1][10] = float("nan")
```
2. use test in put as below
# test_deepseek_mla.py
``` python
if __name__ == "__main__":    
    test_batch_mla_varlen_page_attention(
        1, 65, 65, 65, 1, 128, True, 64, "fa2", torch.half
    )
```
3. nan output can be observed in output
``` python
2025-03-14 10:06:40,470 - INFO - flashinfer.jit: Finished loading JIT ops: batch_mla_attention_dtype_q_f16_dtype_kv_f16_dtype_o_f16_dtype_idx_i32_head_dim_ckv_512_head_dim_kpe_64_profiler_False
tensor([[[    nan,     nan,     nan,  ...,     nan,     nan,     nan],
         [    nan,     nan,     nan,  ...,     nan,     nan,     nan],
         [    nan,     nan,     nan,  ...,     nan,     nan,     nan],
         ...,
         [    nan,     nan,     nan,  ...,     nan,     nan,     nan],
         [    nan,     nan,     nan,  ...,     nan,     nan,     nan],
         [    nan,     nan,     nan,  ...,     nan,     nan,     nan]],

        [[ 0.2800, -0.1050,  0.0584,  ..., -0.3953,  0.2433,  0.0251],
         [ 0.2006,  0.2817, -0.1516,  ...,  0.2883,  0.2686, -0.1577],
         [ 0.1216, -0.8970, -0.1066,  ...,  0.5020, -0.7349,  0.3784],
         ...,
         [ 0.0591,  0.5034, -0.3750,  ..., -0.2786, -0.2483,  0.0037],
         [ 0.2854,  0.1653, -0.1549,  ..., -0.5571, -0.3015,  0.0625],
         [ 0.0942, -0.3574,  0.1144,  ...,  0.1730, -0.2646,  0.2479]],

        [[ 0.0208, -0.3357,  0.2020,  ..., -0.1625, -0.0917,  0.2349],
         [ 0.0799,  0.6021, -0.0385,  ...,  0.5962,  0.3550,  0.2208],
         [ 0.3367, -0.5327, -0.2496,  ...,  0.0653, -0.2144,  0.1873],
         ...,
         [ 0.0577, -1.1670,  1.5000,  ...,  1.4023,  0.7612, -0.6890],
         [-0.2124, -0.2549,  0.3342,  ..., -0.5610, -0.1438, -0.1825],
         [ 0.0499, -0.3467, -0.1461,  ..., -0.0058,  0.0474,  0.3188]]],
       device='cuda:0', dtype=torch.float16)

```
