### PR TITLE
bugfix: Fix missing PyModuleDef field initializers

### DIFF
--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -49,6 +49,10 @@
         -1,    /* size of per-interpreter state of the module,            \
                   or -1 if the module keeps state in global variables. */ \
         NULL,  /* methods */                                              \
+        NULL,  /* slots */                                                \
+        NULL,  /* traverse */                                             \
+        NULL,  /* clear */                                                \
+        NULL,  /* free */                                                 \
     };                                                                    \
     return PyModule_Create(&module_def);                                  \
   }                                                                       \


### PR DESCRIPTION
Complete the PyModuleDef structure initialization in pytorch_extension_utils.h by adding NULL initializers for m_slots, m_traverse, m_clear, and m_free fields.
This resolves compiler errors when using -Werror=missing-field-initializers.