### PR TITLE
Fix compilation with FP16_QK_REDUCTION enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(flashinfer CUDA CXX)
 
 include(cmake/utils/Utils.cmake)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CUDA_STANDARD 20)
 
 if(EXISTS ${CMAKE_BINARY_DIR}/config.cmake)
   include(${CMAKE_BINARY_DIR}/config.cmake)
@@ -63,7 +63,7 @@ flashinfer_option(FLASHINFER_GEN_HEAD_DIMS "Head dims to enable" 64 128 256)
 flashinfer_option(FLASHINFER_GEN_POS_ENCODING_MODES "Pos encodings to enable" 0
                   1 2)
 flashinfer_option(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS
-                  "QK reductions to enable" "false" "true")
+                  "QK reductions to enable" OFF)
 flashinfer_option(FLASHINFER_GEN_MASK_MODES "Mask modes to enable" 0 1 2)
 
 if(DEFINED FLASHINFER_CUDA_ARCHITECTURES)
@@ -125,24 +125,76 @@ set(POS_ENCODING_MODES ${FLASHINFER_GEN_POS_ENCODING_MODES})
 set(USE_FP16_QK_REDUCTIONS ${FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS})
 set(MASK_MODES ${FLASHINFER_GEN_MASK_MODES})
 
+set(SM90_ALLOWED_HEAD_DIMS "64,64" "128,128" "256,256" "192,128")
+set(HEAD_DIMS_SM90 "")
+
+foreach(DIM_VAL ${HEAD_DIMS})
+  string(CONCAT TUPLE_VAL "${DIM_VAL}" "," "${DIM_VAL}")
+  list(FIND SM90_ALLOWED_HEAD_DIMS ${TUPLE_VAL} RESULT)
+  if(NOT ${RESULT} EQUAL -1)
+    list(APPEND HEAD_DIMS_SM90 ${TUPLE_VAL})
+  endif(NOT ${RESULT} EQUAL -1)
+endforeach(DIM_VAL)
+
+foreach(TUPLE_VAL ${SM90_ALLOWED_HEAD_DIMS})
+  string(REPLACE "," ";" HEAD_DIMS_LIST ${TUPLE_VAL})
+  list(GET HEAD_DIMS_LIST 0 K)
+  list(GET HEAD_DIMS_LIST 1 V)
+  if(NOT K EQUAL V)
+    list(APPEND HEAD_DIMS_SM90 ${TUPLE_VAL})
+  endif(NOT K EQUAL V)
+endforeach(TUPLE_VAL)
+
+list(REMOVE_DUPLICATES HEAD_DIMS_SM90)
+
 # log options
 message(STATUS "FLASHINFER_HEAD_DIMS=${HEAD_DIMS}")
 message(STATUS "FLASHINFER_POS_ENCODING_MODES=${POS_ENCODING_MODES}")
 message(STATUS "FLASHINFER_USE_FP16_QK_REDUCTIONS=${USE_FP16_QK_REDUCTIONS}")
 message(STATUS "FLASHINFER_MASK_MODES=${MASK_MODES}")
 
+# Log SM90_ALLOWED_HEAD_DIMS and HEAD_DIMS_SM90
+message(STATUS "SM90_ALLOWED_HEAD_DIMS=${SM90_ALLOWED_HEAD_DIMS}")
+message(STATUS "HEAD_DIMS_SM90=${HEAD_DIMS_SM90}")
+
+set(GENERATED_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/generated)
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/src/generated)
+
+if(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
+  # ----------------------------- Dependencies -------------------------------#
+  include(FetchContent)
+
+  set(BOOST_ENABLE_CMAKE ON)
+  FetchContent_Declare(boost_math
+                       GIT_REPOSITORY https://github.com/boostorg/math.git)
+  FetchContent_MakeAvailable(boost_math)
+  # --------------------------------------------------------------------------#
+  set(USE_FP16_QK_REDUCTIONS "true")
+  message(STATUS "USE_FP16_QK_REDUCTIONS=${USE_FP16_QK_REDUCTIONS}")
+else(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
+  set(USE_FP16_QK_REDUCTIONS "false")
+  message(STATUS "USE_FP16_QK_REDUCTIONS=${USE_FP16_QK_REDUCTIONS}")
+endif(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
 
 set(AOT_GENERATE_COMMAND
     ${Python3_EXECUTABLE} -m aot_build_utils.generate --path
-    ${PROJECT_SOURCE_DIR}/src/generated --head_dims ${HEAD_DIMS}
-    --pos_encoding_modes ${POS_ENCODING_MODES} --use_fp16_qk_reductions
-    ${USE_FP16_QK_REDUCTIONS} --mask_modes ${MASK_MODES} --enable_f16
-    ${FLASHINFER_ENABLE_F16} --enable_bf16 ${FLASHINFER_ENABLE_BF16}
-    --enable_fp8_e4m3 ${FLASHINFER_ENABLE_FP8_E4M3} --enable_fp8_e5m2
+    ${GENERATED_SOURCE_DIR} --head_dims ${HEAD_DIMS} --pos_encoding_modes
+    ${POS_ENCODING_MODES} --use_fp16_qk_reductions ${USE_FP16_QK_REDUCTIONS}
+    --mask_modes ${MASK_MODES} --enable_f16 ${FLASHINFER_ENABLE_F16}
+    --enable_bf16 ${FLASHINFER_ENABLE_BF16} --enable_fp8_e4m3
+    ${FLASHINFER_ENABLE_FP8_E4M3} --enable_fp8_e5m2
     ${FLASHINFER_ENABLE_FP8_E5M2})
 
+set(AOT_GENERATE_DISPATCH_INC_COMMAND
+    ${Python3_EXECUTABLE} -m aot_build_utils.generate_dispatch_inc --path
+    "${GENERATED_SOURCE_DIR}/dispatch.inc" --head_dims ${HEAD_DIMS}
+    --head_dims_sm90 ${HEAD_DIMS_SM90} --pos_encoding_modes
+    ${POS_ENCODING_MODES} --use_fp16_qk_reductions ${USE_FP16_QK_REDUCTIONS}
+    --mask_modes ${MASK_MODES})
+
 execute_process(COMMAND ${AOT_GENERATE_COMMAND}
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+execute_process(COMMAND ${AOT_GENERATE_DISPATCH_INC_COMMAND}
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 file(GLOB_RECURSE FLASHINFER_GENERATORS
@@ -157,21 +209,33 @@ file(GLOB_RECURSE DISPATCH_INC_FILE
 add_custom_command(
   OUTPUT ${DECODE_KERNELS_SRCS} ${PREFILL_KERNELS_SRCS} ${DISPATCH_INC_FILE}
   COMMAND ${AOT_GENERATE_COMMAND}
+  COMMAND ${AOT_GENERATE_DISPATCH_INC_COMMAND}
   DEPENDS ${FLASHINFER_GENERATORS}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   COMMENT "Generating kernel sources"
   VERBATIM)
 add_custom_target(dispatch_inc DEPENDS ${DISPATCH_INC_FILE})
 
+string(CONCAT CXX_FLAGS "-fpic " "-fPIC ")
+
+string(CONCAT NVCC_FLAGS "-O3 " "--threads=1 " "-Xfatbin=-compress-all "
+              "-use_fast_math " "--expt-relaxed-constexpr ")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS}")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${NVCC_FLAGS}")
+
 add_library(decode_kernels STATIC ${DECODE_KERNELS_SRCS})
 target_include_directories(decode_kernels PRIVATE ${FLASHINFER_INCLUDE_DIR})
-target_compile_options(decode_kernels PRIVATE -Xcompiler=-fPIC --fatbin-options
-                                              -compress-all)
+if(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
+  target_link_libraries(decode_kernels PRIVATE Boost::math)
+endif(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
 
 add_library(prefill_kernels STATIC ${PREFILL_KERNELS_SRCS})
 target_include_directories(prefill_kernels PRIVATE ${FLASHINFER_INCLUDE_DIR})
-target_compile_options(prefill_kernels PRIVATE -Xcompiler=-fPIC
-                                               --fatbin-options -compress-all)
+if(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
+  add_definitions(-DFP16_QK_REDUCTION_SUPPORTED)
+  target_link_libraries(prefill_kernels PRIVATE Boost::math)
+endif(FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS)
 
 if(FLASHINFER_DECODE)
   message(STATUS "Compile single decode kernel benchmarks.")

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -721,8 +721,8 @@ __device__ __forceinline__ void logits_transform(
         }
 #else
         static_assert(!std::is_same<DTypeQKAccum, __half>::value,
-          "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
-          "then recompile to support fp16 reduction");
+                      "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
+                      "then recompile to support fp16 reduction");
         logits = s_frag[mma_q][mma_kv][reg_id];
 #endif
         logitsTransformed = variant.LogitsTransform(params, logits, batch_idx, q_idx, kv_idx,

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -15,6 +15,7 @@
  */
 #ifndef FLASHINFER_PREFILL_CUH_
 #define FLASHINFER_PREFILL_CUH_
+
 #include <cooperative_groups.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
@@ -23,6 +24,9 @@
 
 #include "../cp_async.cuh"
 #include "../fastdiv.cuh"
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+#include "../fp16.h"
+#endif
 #include "../frag_layout_swizzle.cuh"
 #include "../math.cuh"
 #include "../mma.cuh"
@@ -33,7 +37,6 @@
 #include "cascade.cuh"
 #include "mask.cuh"
 #include "variants.cuh"
-
 namespace flashinfer {
 
 DEFINE_HAS_MEMBER(maybe_q_rope_offset)
@@ -133,9 +136,25 @@ struct KernelTraits {
 
   using SharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
                                           HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+  template <typename DT>
+  static constexpr DT getNegInf() {
+    if constexpr (std::is_same<DT, __half>::value) {
+      return std::bit_cast<half>(fp16_ieee_from_fp32_value(-math::inf));
+    } else {
+      return static_cast<DTypeQKAccum>(-math::inf);
+    }
+  }
 
   static constexpr DTypeQKAccum MaskFillValue =
+      AttentionVariant::use_softmax ? getNegInf<DTypeQKAccum>() : DTypeQKAccum(0.f);
+#else
+  static_assert(!std::is_same<DTypeQKAccum, __half>::value,
+                "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
+                "then recompile to support fp16 reduction");
+  static constexpr DTypeQKAccum MaskFillValue =
       AttentionVariant::use_softmax ? DTypeQKAccum(-math::inf) : DTypeQKAccum(0.f);
+#endif
 };
 
 namespace {
@@ -672,6 +691,8 @@ __device__ __forceinline__ void logits_transform(
     const uint32_t kv_head_idx = blockIdx.z) {
   const uint32_t lane_idx = tid.x;
   uint32_t q[KTraits::NUM_MMA_Q][2], r[KTraits::NUM_MMA_Q][2];
+  float logits = 0., logitsTransformed = 0.;
+
 #pragma unroll
   for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
@@ -691,9 +712,31 @@ __device__ __forceinline__ void logits_transform(
                                                                     2 * (lane_idx % 4) +
                                                                     8 * (reg_id / 4) + reg_id % 2;
         const uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
-        s_frag[mma_q][mma_kv][reg_id] =
-            variant.LogitsTransform(params, s_frag[mma_q][mma_kv][reg_id], batch_idx, q_idx, kv_idx,
-                                    qo_head_idx, kv_head_idx);
+
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+        if constexpr (std::is_same<DTypeQKAccum, __half>::value) {
+          logits = std::bit_cast<float>(fp16_ieee_to_fp32_value(s_frag[mma_q][mma_kv][reg_id]));
+        } else if constexpr (!std::is_same<DTypeQKAccum, __half>::value) {
+          logits = s_frag[mma_q][mma_kv][reg_id];
+        }
+#else
+        static_assert(!std::is_same<DTypeQKAccum, __half>::value,
+          "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
+          "then recompile to support fp16 reduction");
+        logits = s_frag[mma_q][mma_kv][reg_id];
+#endif
+        logitsTransformed = variant.LogitsTransform(params, logits, batch_idx, q_idx, kv_idx,
+                                                    qo_head_idx, kv_head_idx);
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+        if constexpr (std::is_same<DTypeQKAccum, __half>::value) {
+          s_frag[mma_q][mma_kv][reg_id] =
+              std::bit_cast<half>(fp16_ieee_from_fp32_value(logitsTransformed));
+        } else if constexpr (!std::is_same<DTypeQKAccum, __half>::value) {
+          s_frag[mma_q][mma_kv][reg_id] = logitsTransformed;
+        }
+#else
+        s_frag[mma_q][mma_kv][reg_id] = logitsTransformed;
+#endif
       }
     }
   }

--- a/include/flashinfer/fp16.h
+++ b/include/flashinfer/fp16.h
@@ -1,0 +1,177 @@
+// SPDX - FileCopyrightText : 2017 - 2024 Marat Dukhan
+// SPDX - FileCopyrightText : 2025 Advanced Micro Devices, Inc.
+//
+// SPDX - License - Identifier : MIT
+
+#pragma once
+
+#ifndef FLASHINFER_FP16_H
+#define FLASHINFER_FP16_H
+
+#include <bit>
+#include <boost/math/ccmath/fabs.hpp>
+#include <cstdint>
+#include <limits>
+
+/*
+ * Convert a 32-bit floating-point number in IEEE single-precision format to a
+ * 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation.
+ *
+ * @note The implementation relies on IEEE-like (no assumption about rounding
+ * mode and no operations on denormals) floating-point operations and bitcasts
+ * between integer and floating-point variables.
+ */
+static constexpr uint16_t fp16_ieee_from_fp32_value(float f) {
+  const float scale_to_inf = std::bit_cast<float>(UINT32_C(0x77800000));
+  const float scale_to_zero = std::bit_cast<float>(UINT32_C(0x08800000));
+  const float saturated_f = boost::math::ccmath::fabs<float>(f) * scale_to_inf;
+
+  float base = saturated_f * scale_to_zero;
+
+  const uint32_t w = std::bit_cast<uint32_t>(f);
+  const uint32_t shl1_w = w + w;
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  uint32_t bias = shl1_w & UINT32_C(0xFF000000);
+  if (bias < UINT32_C(0x71000000)) {
+    bias = UINT32_C(0x71000000);
+  }
+
+  base = std::bit_cast<float>((bias >> 1) + UINT32_C(0x07800000)) + base;
+  const uint32_t bits = std::bit_cast<uint32_t>(base);
+  const uint32_t exp_bits = (bits >> 13) & UINT32_C(0x00007C00);
+  const uint32_t mantissa_bits = bits & UINT32_C(0x00000FFF);
+  const uint32_t nonsign = exp_bits + mantissa_bits;
+  return (sign >> 16) | (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign);
+}
+
+static constexpr float fp16_ieee_to_fp32_value(uint16_t h) {
+  /*
+   * Extend the half-precision floating-point number to 32 bits and shift to
+   * the upper part of the 32-bit word:
+   *      +---+-----+------------+-------------------+
+   *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  31  26-30    16-25            0-15
+   *
+   * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa,
+   * 0 - zero bits.
+   */
+  const uint32_t w = (uint32_t)h << 16;
+  /*
+   * Extract the sign of the input number into the high bit of the 32-bit
+   * word:
+   *
+   *      +---+----------------------------------+
+   *      | S |0000000 00000000 00000000 00000000|
+   *      +---+----------------------------------+
+   * Bits  31                 0-31
+   */
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  /*
+   * Extract mantissa and biased exponent of the input number into the high
+   * bits of the 32-bit word:
+   *
+   *      +-----+------------+---------------------+
+   *      |EEEEE|MM MMMM MMMM|0 0000 0000 0000 0000|
+   *      +-----+------------+---------------------+
+   * Bits  27-31    17-26            0-16
+   */
+  const uint32_t two_w = w + w;
+
+  /*
+   * Shift mantissa and exponent into bits 23-28 and bits 13-22 so they become
+   * mantissa and exponent of a single-precision floating-point number:
+   *
+   *       S|Exponent |          Mantissa
+   *      +-+---+-----+------------+----------------+
+   *      |0|000|EEEEE|MM MMMM MMMM|0 0000 0000 0000|
+   *      +-+---+-----+------------+----------------+
+   * Bits   | 23-31   |           0-22
+   *
+   * Next, there are some adjustments to the exponent:
+   * - The exponent needs to be corrected by the difference in exponent bias
+   *   between single-precision and half-precision
+   *   formats (0x7F - 0xF = 0x70)
+   * - Inf and NaN values in the inputs should become Inf and NaN values after
+   *   conversion to the single-precision number.
+   *   Therefore, if the biased exponent of the half-precision input was 0x1F
+   *   (max possible value), the biased exponent
+   *   of the single-precision output must be 0xFF (max possible value). We do
+   *   this correction in two steps:
+   *   - First, we adjust the exponent by (0xFF - 0x1F) = 0xE0 (see exp_offset
+   *     below) rather than by 0x70 suggested
+   *     by the difference in the exponent bias (see above).
+   *   - Then we multiply the single-precision result of exponent adjustment
+   *     by 2**(-112) to reverse the effect of
+   *     exponent adjustment by 0xE0 less the necessary exponent adjustment by
+   *     0x70 due to difference in exponent bias.
+   *     The floating-point multiplication hardware would ensure than Inf and
+   *     NaN would retain their value on at least
+   *     partially IEEE754-compliant implementations.
+   *
+   * Note that the above operations do not handle denormal inputs (where
+   * biased exponent == 0). However, they also do not operate on denormal
+   * inputs, and do not produce denormal results.
+   */
+  const uint32_t exp_offset = UINT32_C(0xE0) << 23;
+  const float exp_scale = std::bit_cast<float>(UINT32_C(0x7800000));
+  const float normalized_value = std::bit_cast<float>((two_w >> 4) + exp_offset) * exp_scale;
+
+  /*
+   * Convert denormalized half-precision inputs into single-precision results
+   * (always normalized).
+   * Zero inputs are also handled here.
+   *
+   * In a denormalized number the biased exponent is zero, and mantissa has
+   * on-zero bits.
+   * First, we shift mantissa into bits 0-9 of the 32-bit word.
+   *
+   *                  zeros           |  mantissa
+   *      +---------------------------+------------+
+   *      |0000 0000 0000 0000 0000 00|MM MMMM MMMM|
+   *      +---------------------------+------------+
+   * Bits             10-31                0-9
+   *
+   * Now, remember that denormalized half-precision numbers are represented
+   * as:
+   *    FP16 = mantissa * 2**(-24).
+   * The trick is to construct a normalized single-precision number with the
+   * same mantissa and thehalf-precision input
+   * and with an exponent which would scale the corresponding mantissa bits
+   * to 2**(-24).
+   * A normalized single-precision floating-point number is represented as:
+   *    FP32 = (1 + mantissa * 2**(-23)) * 2**(exponent - 127)
+   * Therefore, when the biased exponent is 126, a unit change in the mantissa
+   * of the input denormalized half-precision
+   * number causes a change of the constructud single-precision number by
+   * 2**(-24), i.e. the same ammount.
+   *
+   * The last step is to adjust the bias of the constructed single-precision
+   * number. When the input half-precision number
+   * is zero, the constructed single-precision number has the value of
+   *    FP32 = 1 * 2**(126 - 127) = 2**(-1) = 0.5
+   * Therefore, we need to subtract 0.5 from the constructed single-precision
+   * number to get the numerical equivalent of
+   * the input half-precision number.
+   */
+  const uint32_t magic_mask = UINT32_C(126) << 23;
+  const float magic_bias = 0.5f;
+  const float denormalized_value = std::bit_cast<float>((two_w >> 17) | magic_mask) - magic_bias;
+
+  /*
+   * - Choose either results of conversion of input as a normalized number, or
+   *   as a denormalized number, depending on the
+   *   input exponent. The variable two_w contains input exponent in bits
+   *   27-31, therefore if its smaller than 2**27, the
+   *   input is either a denormal number, or zero.
+   * - Combine the result of conversion of exponent and mantissa with the sign
+   *   of the input number.
+   */
+  const uint32_t denormalized_cutoff = UINT32_C(1) << 27;
+  const uint32_t result =
+      sign | (two_w < denormalized_cutoff ? std::bit_cast<uint32_t>(denormalized_value)
+                                          : std::bit_cast<uint32_t>(normalized_value));
+  return std::bit_cast<float>(result);
+#endif
+}


### PR DESCRIPTION
As described in #806 and #936, setting the cmake build flag `FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS` to "true" causes a build failure due to `cuda_fp16.h` not supporting `constexpr` cast from `__half` type to `float`. Note that the issue is not just a CMake/C++ configuration issue the issue will be triggered even in the flashinfer JIT code compilation path as reported in #915.

The PR fixes #806 and #936 by adding a modified version of the FP16 header from the [FP16 library](https://github.com/Maratyszcza/FP16) that supports `constexpr` versions of the conversion functions. To make the conversion functions `constexpr`, I am using `std::bit_cast` that is the reason for bumping the required standard to 20.

With these changes I am able to build the C++ API with both `FLASHINFER_GEN_USE_FP16_QK_REDUCTIONS` ON and OFF.

Fixes #936 
Fixes #806
