### PR TITLE
FlashInfer Windows support

### DIFF
--- a/csrc/activation.cu
+++ b/csrc/activation.cu
@@ -17,6 +17,10 @@
 
 #include "pytorch_extension_utils.h"
 
+#ifdef _WIN32
+#define M_SQRT1_2 0.707106781186547524401
+#endif
+
 using namespace flashinfer;
 
 __device__ __forceinline__ float silu(const float& val) { return val / (1.0f + __expf(-val)); }

--- a/csrc/batch_decode_config.inc
+++ b/csrc/batch_decode_config.inc
@@ -35,14 +35,16 @@ using IdType = int32_t;
     DISPATCH_PYTORCH_QKV_DTYPE_TO_CTYPE(q_scalar_type, kv_scalar_type, DTypeQ, DTypeKV, [&] { \
       using DTypeO = DTypeQ;                                                                  \
       using Params = BatchDecodeParams<DTypeQ, DTypeKV, DTypeO, IdType>;                      \
-      constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                              \
+      static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                       \
       return DISPATCH_head_dim(head_dim_qk, HEAD_DIM_QK, [&] {                                \
-        [[maybe_unused]] constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                                              \
+        [[maybe_unused]] static constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                      \
         return DISPATCH_BOOL(window_left > -1, USE_SLIDING_WINDOW, [&] {                      \
           return DISPATCH_BOOL(logits_soft_cap > 0.f, USE_LOGITS_SOFT_CAP, [&] {              \
+            static constexpr bool stat_use_slid_window = USE_SLIDING_WINDOW;                  \
+            static constexpr bool stat_use_logits_soft_cap = USE_LOGITS_SOFT_CAP;             \
             using AttentionVariant =                                                          \
-                DefaultAttention</*use_custom_mask=*/false, USE_SLIDING_WINDOW,               \
-                                 USE_LOGITS_SOFT_CAP, /*use_alibi_bias=*/false>;              \
+                DefaultAttention</*use_custom_mask=*/false, stat_use_slid_window,             \
+                                 stat_use_logits_soft_cap, /*use_alibi_bias=*/false>;         \
             __VA_ARGS__();                                                                    \
             return true;                                                                      \
           });                                                                                 \

--- a/csrc/batch_decode_customize_config.jinja
+++ b/csrc/batch_decode_customize_config.jinja
@@ -19,11 +19,11 @@ using DTypeQ = {{ dtype_q }};
 using DTypeKV = {{ dtype_kv }};
 using DTypeO = {{ dtype_o }};
 using IdType = {{ idtype }};
-constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
-constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
-constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
-constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
-constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
+static constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+static constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+static constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
+static constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
+static constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;

--- a/csrc/batch_prefill_config.inc
+++ b/csrc/batch_prefill_config.inc
@@ -40,16 +40,18 @@ using IdType = int32_t;
             using DTypeO = DTypeQ;                                                                \
             using RaggedParams = BatchPrefillRaggedParams<DTypeQ, DTypeKV, DTypeO, IdType>;       \
             using PagedParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;         \
-            constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                            \
-            constexpr bool USE_FP16_QK_REDUCTION = false;                                         \
-            constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom;                      \
+            static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                     \
+            static constexpr bool USE_FP16_QK_REDUCTION = false;                                  \
+            static constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom;               \
             return DISPATCH_head_dim(head_dim_qk, HEAD_DIM_QK, [&] {                              \
-              [[maybe_unused]] constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                                            \
+              [[maybe_unused]] static constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                    \
               return DISPATCH_BOOL(window_left > -1, USE_SLIDING_WINDOW, [&] {                    \
                 return DISPATCH_BOOL(logits_soft_cap > 0.f, USE_LOGITS_SOFT_CAP, [&] {            \
+                  static constexpr bool stat_use_slid_window = USE_SLIDING_WINDOW;                \
+                  static constexpr bool stat_use_logits_soft_cap = USE_LOGITS_SOFT_CAP;           \
                   using AttentionVariant =                                                        \
-                      DefaultAttention</*use_custom_mask=*/use_custom_mask, USE_SLIDING_WINDOW,   \
-                                       USE_LOGITS_SOFT_CAP, /*use_alibi_bias=*/false>;            \
+                      DefaultAttention</*use_custom_mask=*/use_custom_mask, stat_use_slid_window, \
+                                       stat_use_logits_soft_cap, /*use_alibi_bias=*/false>;       \
                   __VA_ARGS__();                                                                  \
                   return true;                                                                    \
                 });                                                                               \

--- a/csrc/batch_prefill_customize_config.jinja
+++ b/csrc/batch_prefill_customize_config.jinja
@@ -12,7 +12,7 @@
 
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, USE_FP16_QK_REDUCTION, AttentionVariant, RaggedParams, PagedParams, ...) \
   DISPATCH_MASK_MODE(mask_mode, MASK_MODE, { \
-    constexpr auto use_custom_mask = MASK_MODE == MaskMode::kCustom; \
+    static constexpr auto use_custom_mask = MASK_MODE == MaskMode::kCustom; \
     using AttentionVariant = {{ variant_name }}; \
     __VA_ARGS__(); \
   })
@@ -23,12 +23,12 @@ using DTypeQ = {{ dtype_q }};
 using DTypeKV = {{ dtype_kv }};
 using DTypeO = {{ dtype_o }};
 using IdType = {{ idtype }};
-constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
-constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
-constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
-constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
-constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
-constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
+static constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+static constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+static constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
+static constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
+static constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
+static constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 
 struct RaggedParams {

--- a/csrc/flashinfer_ops_sm90.cu
+++ b/csrc/flashinfer_ops_sm90.cu
@@ -16,6 +16,49 @@
 #include "aot_default_additional_params.h"
 #include "pytorch_extension_utils.h"
 
+// MSVC compiler only allows to link with a single
+// PyInit_flashinfer_kernels defined per .pyd, define here
+
+#ifdef _WIN32
+#ifndef FLASHINFER_EXT_MODULE_INITED
+#define FLASHINFER_EXT_MODULE_INITED
+
+// To expand macros in #name
+#define FLASHINFER_EXT_MODULE_INIT_EXPAND(name) FLASHINFER_EXT_MODULE_INIT(name)
+
+/* Creates a dummy empty module that can be imported from Python.
+   The import from Python will load the .so consisting of the file
+   in this extension, so that the TORCH_LIBRARY_FRAGMENT static initializers
+   are run. */
+#ifdef _WIN32
+#define FLASHINFER_EXT_MODULE_INIT(name)                                  \
+  extern "C" {                                                            \
+  PyObject* PyInit_##name(void) {                                         \
+    static struct PyModuleDef module_def = {                              \
+        PyModuleDef_HEAD_INIT,                                            \
+        #name, /* name of module */                                       \
+        NULL,  /* module documentation, may be NULL */                    \
+        -1,    /* size of per-interpreter state of the module,            \
+                  or -1 if the module keeps state in global variables. */ \
+        NULL,  /* methods */                                              \
+        NULL,  /* slots */                                                \
+        NULL,  /* traverse */                                             \
+        NULL,  /* clear */                                                \
+        NULL,  /* free */                                                 \
+    };                                                                    \
+    return PyModule_Create(&module_def);                                  \
+  }                                                                       \
+  }
+#endif
+
+FLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)
+
+#undef FLASHINFER_EXT_MODULE_INIT
+#undef FLASHINFER_EXT_MODULE_INIT_EXPAND
+
+#endif
+#endif
+
 void CutlassSegmentGEMMSM90(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                             at::Tensor all_problems, at::Tensor x_ptr, at::Tensor w_ptr,
                             at::Tensor y_ptr, at::Tensor x_stride, at::Tensor weight_stride,

--- a/csrc/pod.cu
+++ b/csrc/pod.cu
@@ -37,6 +37,132 @@ cudaError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
 
 using namespace flashinfer;
 
+template <MaskMode MASK_MODE_P, MaskMode MASK_MODE_D, typename DTypeQ, typename DTypeO,
+          typename DTypeKV, uint32_t HEAD_DIM_QK, bool USE_SLIDING_WINDOW_P,
+          bool USE_SLIDING_WINDOW_D, bool USE_LOGITS_SOFT_CAP, int HEAD_DIM_VO,
+          auto POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, typename PrefillParams,
+          typename DecodeParams>
+void pod_with_kv_cache_tensor_impl_(
+    PrefillParams prefill_params, DecodeParams decode_params, const int64_t* kv_cache_strides_d,
+    at::Tensor q_p, at::Tensor k_p, at::Tensor v_p, at::Tensor o_p,
+    std::optional<at::Tensor> maybe_lse_p, unsigned int num_qo_heads, unsigned int num_kv_heads,
+    unsigned int qo_len_p, unsigned int kv_len_p, uint32_t q_stride_n_p, uint32_t q_stride_h_p,
+    uint32_t k_stride_n_p, uint32_t k_stride_h_p, uint32_t v_stride_n_p, uint32_t v_stride_h_p,
+    int64_t window_left_p, std::optional<at::Tensor> maybe_custom_mask_p,
+    std::optional<at::Tensor> maybe_alibi_slopes_p, double logits_soft_cap_p, double sm_scale_p,
+    double rope_rcp_scale_p, double rope_rcp_theta_p, at::Tensor q_d, int64_t page_size_d,
+    int64_t batch_size, QKVLayout kv_layout_d, at::Tensor paged_k_cache_d,
+    at::Tensor paged_v_cache_d, at::Tensor paged_kv_indices_d, at::Tensor paged_kv_indptr_d,
+    at::Tensor paged_kv_last_page_len_d, at::Tensor qo_indptr_d, at::Tensor o_d,
+    std::optional<at::Tensor> maybe_lse_d, int64_t window_left_d,
+    std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
+    void* int_buffer_ptr, PrefillPlanInfo plan_info) {
+  using IdType = int32_t;
+
+  // get q_stride_n and q_stride_h
+  const auto q_stride_n_d = q_d.stride(0);
+  const auto q_stride_h_d = q_d.stride(1);
+  {
+    // Make params a reference to prefill_params to set values
+    PrefillParams& params = prefill_params;
+    params.q = static_cast<DTypeQ*>(q_p.data_ptr());
+    params.k = static_cast<DTypeKV*>(k_p.data_ptr());
+    params.v = static_cast<DTypeKV*>(v_p.data_ptr());
+    params.o = static_cast<DTypeO*>(o_p.data_ptr());
+    params.lse = maybe_lse_p ? static_cast<float*>(maybe_lse_p->data_ptr()) : nullptr;
+    params.num_qo_heads = num_qo_heads;
+    params.num_kv_heads = num_kv_heads;
+    params.group_size = uint_fastdiv(num_qo_heads / num_kv_heads);
+    params.qo_len = qo_len_p;
+    params.kv_len = kv_len_p;
+    params.q_stride_n = q_stride_n_p;
+    params.q_stride_h = q_stride_h_p;
+    params.k_stride_n = k_stride_n_p;
+    params.k_stride_h = k_stride_h_p;
+    params.v_stride_n = v_stride_n_p;
+    params.v_stride_h = v_stride_h_p;
+
+    params.window_left = window_left_p;
+    params.partition_kv = false;
+
+    params.maybe_custom_mask =
+        maybe_custom_mask_p ? static_cast<uint8_t*>(maybe_custom_mask_p->data_ptr()) : nullptr;
+    params.maybe_alibi_slopes =
+        maybe_alibi_slopes_p ? static_cast<float*>(maybe_alibi_slopes_p->data_ptr()) : nullptr;
+    params.logits_soft_cap = logits_soft_cap_p;
+    params.sm_scale = sm_scale_p;
+    params.rope_rcp_scale = rope_rcp_scale_p;
+    params.rope_rcp_theta = rope_rcp_theta_p;
+  }
+  {
+    DecodeParams& params = decode_params;
+    params.q = static_cast<DTypeQ*>(q_d.data_ptr());
+    paged_kv_t<DTypeKV, IdType> paged_kv(
+        num_kv_heads, page_size_d, HEAD_DIM_VO, batch_size, kv_layout_d,
+        static_cast<DTypeKV*>(paged_k_cache_d.data_ptr()),
+        static_cast<DTypeKV*>(paged_v_cache_d.data_ptr()), kv_cache_strides_d,
+        static_cast<IdType*>(paged_kv_indices_d.data_ptr()),
+        static_cast<IdType*>(paged_kv_indptr_d.data_ptr()),
+        static_cast<IdType*>(paged_kv_last_page_len_d.data_ptr()));
+    params.paged_kv = paged_kv;
+    params.q_indptr = static_cast<IdType*>(qo_indptr_d.data_ptr());
+    params.o = static_cast<DTypeO*>(o_d.data_ptr());
+
+    params.lse = maybe_lse_d ? static_cast<float*>(maybe_lse_d->data_ptr()) : nullptr;
+    params.num_qo_heads = num_qo_heads;
+    params.group_size = uint_fastdiv(num_qo_heads / paged_kv.num_heads);
+    params.q_stride_n = q_stride_n_d;
+    params.q_stride_h = q_stride_h_d;
+    params.window_left = window_left_d;
+
+    params.request_indices = nullptr;
+    params.qo_tile_indices = nullptr;
+    params.kv_tile_indices = nullptr;
+    params.merge_indptr = nullptr;
+    params.o_indptr = nullptr;
+    params.kv_chunk_size_ptr = nullptr;
+    params.block_valid_mask = nullptr;
+    params.total_num_rows = nullptr;
+    params.max_total_num_rows = 0;
+    params.padded_batch_size = 0;
+    params.partition_kv = false;
+
+    params.maybe_mask_indptr =
+        maybe_mask_indptr_d ? static_cast<int32_t*>(maybe_mask_indptr_d->data_ptr()) : nullptr;
+    params.maybe_alibi_slopes =
+        maybe_alibi_slopes_d ? static_cast<float*>(maybe_alibi_slopes_d->data_ptr()) : nullptr;
+    params.logits_soft_cap = logits_soft_cap_d;
+    params.sm_scale = sm_scale_d;
+    params.rope_rcp_scale = rope_rcp_scale_d;
+    params.rope_rcp_theta = rope_rcp_theta_d;
+
+    params.request_indices =
+        GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.request_indices_offset);
+    params.qo_tile_indices =
+        GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_tile_indices_offset);
+    params.kv_tile_indices =
+        GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_tile_indices_offset);
+    params.o_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.o_indptr_offset);
+    params.kv_chunk_size_ptr =
+        GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_chunk_size_ptr_offset);
+    if (plan_info.split_kv) {
+      params.merge_indptr =
+          GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_indptr_offset);
+      if (plan_info.enable_cuda_graph) {
+        params.block_valid_mask =
+            GetPtrFromBaseOffset<bool>(int_buffer_ptr, plan_info.block_valid_mask_offset);
+      }
+    }
+    params.padded_batch_size = plan_info.padded_batch_size;
+    params.max_total_num_rows = plan_info.total_num_rows;
+    if (plan_info.enable_cuda_graph) {
+      params.total_num_rows =
+          GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
+    }
+  }
+}
+
 void pod_with_kv_cache_tensor(
     // Prefill params
     at::Tensor q_p, at::Tensor k_p, at::Tensor v_p, at::Tensor tmp_p, at::Tensor o_p,
@@ -126,10 +252,6 @@ void pod_with_kv_cache_tensor(
   auto q_scalar_type_d = q_d.scalar_type();
   auto kv_scalar_type_d = paged_k_cache_d.scalar_type();
 
-  // get q_stride_n and q_stride_h
-  const auto q_stride_n_d = q_d.stride(0);
-  const auto q_stride_h_d = q_d.stride(1);
-
   // get kv_cache_strides
   const int64_t* kv_cache_strides_d = nullptr;
   auto k_strides_d = paged_k_cache_d.strides();
@@ -143,115 +265,24 @@ void pod_with_kv_cache_tensor(
       MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeKV, HEAD_DIM_QK, USE_SLIDING_WINDOW_P,
       USE_SLIDING_WINDOW_D, USE_LOGITS_SOFT_CAP, [&] {
         PrefillParams prefill_params;
-        {
-          // Make params a reference to prefill_params to set values
-          PrefillParams& params = prefill_params;
-          params.q = static_cast<DTypeQ*>(q_p.data_ptr());
-          params.k = static_cast<DTypeKV*>(k_p.data_ptr());
-          params.v = static_cast<DTypeKV*>(v_p.data_ptr());
-          params.o = static_cast<DTypeO*>(o_p.data_ptr());
-          params.lse = maybe_lse_p ? static_cast<float*>(maybe_lse_p->data_ptr()) : nullptr;
-          params.num_qo_heads = num_qo_heads;
-          params.num_kv_heads = num_kv_heads;
-          params.group_size = uint_fastdiv(num_qo_heads / num_kv_heads);
-          params.qo_len = qo_len_p;
-          params.kv_len = kv_len_p;
-          params.q_stride_n = q_stride_n_p;
-          params.q_stride_h = q_stride_h_p;
-          params.k_stride_n = k_stride_n_p;
-          params.k_stride_h = k_stride_h_p;
-          params.v_stride_n = v_stride_n_p;
-          params.v_stride_h = v_stride_h_p;
-
-          params.window_left = window_left_p;
-          params.partition_kv = false;
-
-          params.maybe_custom_mask = maybe_custom_mask_p
-                                         ? static_cast<uint8_t*>(maybe_custom_mask_p->data_ptr())
-                                         : nullptr;
-          params.maybe_alibi_slopes = maybe_alibi_slopes_p
-                                          ? static_cast<float*>(maybe_alibi_slopes_p->data_ptr())
-                                          : nullptr;
-          params.logits_soft_cap = logits_soft_cap_p;
-          params.sm_scale = sm_scale_p;
-          params.rope_rcp_scale = rope_rcp_scale_p;
-          params.rope_rcp_theta = rope_rcp_theta_p;
-        }
-
         DecodeParams decode_params;
-        DTypeO* tmp_v = nullptr;
-        float* tmp_s = nullptr;
-        {
-          DecodeParams& params = decode_params;
-          params.q = static_cast<DTypeQ*>(q_d.data_ptr());
-          paged_kv_t<DTypeKV, IdType> paged_kv(
-              num_kv_heads, page_size_d, HEAD_DIM_VO, batch_size, kv_layout_d,
-              static_cast<DTypeKV*>(paged_k_cache_d.data_ptr()),
-              static_cast<DTypeKV*>(paged_v_cache_d.data_ptr()), kv_cache_strides_d,
-              static_cast<IdType*>(paged_kv_indices_d.data_ptr()),
-              static_cast<IdType*>(paged_kv_indptr_d.data_ptr()),
-              static_cast<IdType*>(paged_kv_last_page_len_d.data_ptr()));
-          params.paged_kv = paged_kv;
-          params.q_indptr = static_cast<IdType*>(qo_indptr_d.data_ptr());
-          params.o = static_cast<DTypeO*>(o_d.data_ptr());
-
-          params.lse = maybe_lse_d ? static_cast<float*>(maybe_lse_d->data_ptr()) : nullptr;
-          params.num_qo_heads = num_qo_heads;
-          params.group_size = uint_fastdiv(num_qo_heads / paged_kv.num_heads);
-          params.q_stride_n = q_stride_n_d;
-          params.q_stride_h = q_stride_h_d;
-          params.window_left = window_left_d;
-
-          params.request_indices = nullptr;
-          params.qo_tile_indices = nullptr;
-          params.kv_tile_indices = nullptr;
-          params.merge_indptr = nullptr;
-          params.o_indptr = nullptr;
-          params.kv_chunk_size_ptr = nullptr;
-          params.block_valid_mask = nullptr;
-          params.total_num_rows = nullptr;
-          params.max_total_num_rows = 0;
-          params.padded_batch_size = 0;
-          params.partition_kv = false;
-
-          params.maybe_mask_indptr = maybe_mask_indptr_d
-                                         ? static_cast<int32_t*>(maybe_mask_indptr_d->data_ptr())
-                                         : nullptr;
-          params.maybe_alibi_slopes = maybe_alibi_slopes_d
-                                          ? static_cast<float*>(maybe_alibi_slopes_d->data_ptr())
-                                          : nullptr;
-          params.logits_soft_cap = logits_soft_cap_d;
-          params.sm_scale = sm_scale_d;
-          params.rope_rcp_scale = rope_rcp_scale_d;
-          params.rope_rcp_theta = rope_rcp_theta_d;
-
-          params.request_indices =
-              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.request_indices_offset);
-          params.qo_tile_indices =
-              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_tile_indices_offset);
-          params.kv_tile_indices =
-              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_tile_indices_offset);
-          params.o_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.o_indptr_offset);
-          params.kv_chunk_size_ptr =
-              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_chunk_size_ptr_offset);
-          if (plan_info.split_kv) {
-            params.merge_indptr =
-                GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_indptr_offset);
-            tmp_v = GetPtrFromBaseOffset<DTypeO>(float_buffer_ptr, plan_info.v_offset);
-            tmp_s = GetPtrFromBaseOffset<float>(float_buffer_ptr, plan_info.s_offset);
-            if (plan_info.enable_cuda_graph) {
-              params.block_valid_mask =
-                  GetPtrFromBaseOffset<bool>(int_buffer_ptr, plan_info.block_valid_mask_offset);
-            }
-          }
-          params.padded_batch_size = plan_info.padded_batch_size;
-          params.max_total_num_rows = plan_info.total_num_rows;
-          if (plan_info.enable_cuda_graph) {
-            params.total_num_rows =
-                GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
-          }
-        }
-
+        // Windows C1060 fix: Params assignments moved to an external function to avoid compiler
+        // error due to large code size inside multiple lambda functions
+        pod_with_kv_cache_tensor_impl_<MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeO, DTypeKV,
+                                       HEAD_DIM_QK, USE_SLIDING_WINDOW_P, USE_SLIDING_WINDOW_D,
+                                       USE_LOGITS_SOFT_CAP, HEAD_DIM_VO, POS_ENCODING_MODE,
+                                       USE_FP16_QK_REDUCTION, PrefillParams, DecodeParams>(
+            prefill_params, decode_params, kv_cache_strides_d, q_p, k_p, v_p, o_p, maybe_lse_p,
+            num_qo_heads, num_kv_heads, qo_len_p, kv_len_p, q_stride_n_p, q_stride_h_p,
+            k_stride_n_p, k_stride_h_p, v_stride_n_p, v_stride_h_p, window_left_p,
+            maybe_custom_mask_p, maybe_alibi_slopes_p, logits_soft_cap_p, sm_scale_p,
+            rope_rcp_scale_p, rope_rcp_theta_p, q_d, page_size_d, batch_size, kv_layout_d,
+            paged_k_cache_d, paged_v_cache_d, paged_kv_indices_d, paged_kv_indptr_d,
+            paged_kv_last_page_len_d, qo_indptr_d, o_d, maybe_lse_d, window_left_d,
+            maybe_mask_indptr_d, maybe_alibi_slopes_d, logits_soft_cap_d, sm_scale_d,
+            rope_rcp_scale_d, rope_rcp_theta_d, int_buffer_ptr, plan_info);
+        DTypeO* tmp_v = GetPtrFromBaseOffset<DTypeO>(float_buffer_ptr, plan_info.v_offset);
+        float* tmp_s = GetPtrFromBaseOffset<float>(float_buffer_ptr, plan_info.s_offset);
         constexpr bool use_custom_mask_p = MASK_MODE_P == MaskMode::kCustom;
         using PrefillAttentionVariant =
             DefaultAttention</*use_custom_mask=*/use_custom_mask_p, USE_SLIDING_WINDOW_P,

--- a/csrc/pod_config.inc
+++ b/csrc/pod_config.inc
@@ -22,10 +22,10 @@ using namespace flashinfer;
       return DISPATCH_PYTORCH_QKV_DTYPE_TO_CTYPE(                                    \
         q_scalar_type, kv_scalar_type, DTypeQ, DTypeKV, [&] {                        \
           using DTypeO = DTypeQ;                                                     \
-          constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                 \
-          constexpr bool USE_FP16_QK_REDUCTION = false;                              \
+          static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;          \
+          static constexpr bool USE_FP16_QK_REDUCTION = false;                       \
           return DISPATCH_head_dim(head_dim_qk, HEAD_DIM_QK, [&] {                   \
-            [[maybe_unused]] constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                \
+            [[maybe_unused]] static constexpr int HEAD_DIM_VO = HEAD_DIM_QK;         \
             return DISPATCH_BOOL(window_left_p > -1, USE_SLIDING_WINDOW_P, [&] {     \
               return DISPATCH_BOOL(window_left_d > -1, USE_SLIDING_WINDOW_D, [&] {   \
                 return DISPATCH_BOOL(false, USE_LOGITS_SOFT_CAP, [&] {               \

--- a/csrc/pod_customize_config.jinja
+++ b/csrc/pod_customize_config.jinja
@@ -7,6 +7,7 @@
 #include <flashinfer/fastdiv.cuh>
 #include <flashinfer/attention/scheduler.cuh>
 #include <flashinfer/attention/mask.cuh>
+#include <flashinfer/attention/pod.cuh>
 #include <flashinfer/attention/variant_helper.cuh>
 #include <flashinfer/attention/default_prefill_params.cuh>
 
@@ -16,19 +17,19 @@ using DTypeQ = {{ dtype_q }};
 using DTypeKV = {{ dtype_kv }};
 using DTypeO = {{ dtype_o }};
 using IdType = {{ idtype }};
-constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
-constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
-constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
-constexpr auto USE_LOGITS_SOFT_CAP_P = {{ use_logits_soft_cap_p }};
-constexpr auto POS_ENCODING_MODE_P = {{ pos_encoding_mode_p }};
-constexpr auto USE_SLIDING_WINDOW_P = {{ use_sliding_window_p }};
+static constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+static constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+static constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
+static constexpr auto USE_LOGITS_SOFT_CAP_P = {{ use_logits_soft_cap_p }};
+static constexpr auto POS_ENCODING_MODE_P = {{ pos_encoding_mode_p }};
+static constexpr auto USE_SLIDING_WINDOW_P = {{ use_sliding_window_p }};
 
-constexpr auto USE_LOGITS_SOFT_CAP_D = {{ use_logits_soft_cap_d }};
-constexpr auto POS_ENCODING_MODE_D = {{ pos_encoding_mode_d }};
-constexpr auto USE_SLIDING_WINDOW_D = {{ use_sliding_window_d }};
+static constexpr auto USE_LOGITS_SOFT_CAP_D = {{ use_logits_soft_cap_d }};
+static constexpr auto POS_ENCODING_MODE_D = {{ pos_encoding_mode_d }};
+static constexpr auto USE_SLIDING_WINDOW_D = {{ use_sliding_window_d }};
 
-constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
-constexpr bool USE_LOGITS_SOFT_CAP = false;
+static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
+static constexpr bool USE_LOGITS_SOFT_CAP = false;
 
 using PrefillParams = SinglePrefillParams<DTypeQ, DTypeKV, DTypeO>;
 using DecodeParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;

--- a/csrc/pod_kernel_inst.jinja
+++ b/csrc/pod_kernel_inst.jinja
@@ -18,10 +18,10 @@
 using namespace flashinfer;
 
 namespace flashinfer {
-constexpr auto use_custom_mask_p = {{ mask_mode_p }} == MaskMode::kCustom;
-constexpr auto use_custom_mask_d = {{ mask_mode_d }} == MaskMode::kCustom;
+static constexpr auto use_custom_mask_p = {{ mask_mode_p }} == MaskMode::kCustom;
+static constexpr auto use_custom_mask_d = {{ mask_mode_d }} == MaskMode::kCustom;
 // Not sure about the below declaration
-constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
+static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
 
 template cudaError_t PODWithKVCacheTensorDispatched<
     {{ head_dim_qk }}, {{ head_dim_vo }}, POS_ENCODING_MODE,

--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -29,6 +29,7 @@
 #include <cuda_fp8.h>
 #endif
 
+#ifndef _WIN32
 #ifndef FLASHINFER_EXT_MODULE_INITED
 #define FLASHINFER_EXT_MODULE_INITED
 
@@ -63,6 +64,7 @@ FLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)
 #undef FLASHINFER_EXT_MODULE_INIT
 #undef FLASHINFER_EXT_MODULE_INIT_EXPAND
 
+#endif
 #endif
 
 #ifdef FLASHINFER_ENABLE_F16
@@ -173,26 +175,26 @@ FLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)
 
 #define _DISPATCH_CASE(case_expr, case_var, ...) \
   case case_expr: {                              \
-    constexpr auto case_var = case_expr;         \
+    static constexpr auto case_var = case_expr;  \
     return __VA_ARGS__();                        \
   }
 
 #define _DISPATCH_CASE_U16x2(case_expr1, case_expr2, case_var1, case_var2, ...) \
   case pack_u16(case_expr1, case_expr2): {                                      \
-    constexpr auto case_var1 = case_expr1;                                      \
-    constexpr auto case_var2 = case_expr2;                                      \
+    static constexpr auto case_var1 = case_expr1;                               \
+    static constexpr auto case_var2 = case_expr2;                               \
     return __VA_ARGS__();                                                       \
   }
 
-#define DISPATCH_BOOL(expr, const_expr, ...) \
-  [&]() -> bool {                            \
-    if (expr) {                              \
-      constexpr bool const_expr = true;      \
-      return __VA_ARGS__();                  \
-    } else {                                 \
-      constexpr bool const_expr = false;     \
-      return __VA_ARGS__();                  \
-    }                                        \
+#define DISPATCH_BOOL(expr, const_expr, ...)    \
+  [&]() -> bool {                               \
+    if (expr) {                                 \
+      static constexpr bool const_expr = true;  \
+      return __VA_ARGS__();                     \
+    } else {                                    \
+      static constexpr bool const_expr = false; \
+      return __VA_ARGS__();                     \
+    }                                           \
   }()
 
 inline void check_shape(const at::Tensor& a, const at::Tensor& b, const char* a_name,

--- a/csrc/single_decode_config.inc
+++ b/csrc/single_decode_config.inc
@@ -34,14 +34,16 @@ using IdType = int32_t;
     DISPATCH_PYTORCH_QKV_DTYPE_TO_CTYPE(q_scalar_type, kv_scalar_type, DTypeQ, DTypeKV, [&] { \
       using DTypeO = DTypeQ;                                                                  \
       using Params = SingleDecodeParams<DTypeQ, DTypeKV, DTypeO>;                             \
-      constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                              \
+      static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                       \
       return DISPATCH_head_dim(head_dim_qk, HEAD_DIM_QK, [&] {                                \
-        [[maybe_unused]] constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                                              \
+        [[maybe_unused]] static constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                      \
         return DISPATCH_BOOL(window_left > -1, USE_SLIDING_WINDOW, [&] {                      \
           return DISPATCH_BOOL(logits_soft_cap > 0.f, USE_LOGITS_SOFT_CAP, [&] {              \
+            static constexpr bool stat_use_slid_window = USE_SLIDING_WINDOW;                  \
+            static constexpr bool stat_use_logits_soft_cap = USE_LOGITS_SOFT_CAP;             \
             using AttentionVariant =                                                          \
-                DefaultAttention</*use_custom_mask=*/false, USE_SLIDING_WINDOW,               \
-                                 USE_LOGITS_SOFT_CAP, /*use_alibi_bias=*/false>;              \
+                DefaultAttention</*use_custom_mask=*/false, stat_use_slid_window,             \
+                                 stat_use_logits_soft_cap, /*use_alibi_bias=*/false>;         \
             __VA_ARGS__();                                                                    \
             return true;                                                                      \
           });                                                                                 \

--- a/csrc/single_decode_customize_config.jinja
+++ b/csrc/single_decode_customize_config.jinja
@@ -18,11 +18,11 @@ using DTypeQ = {{ dtype_q }};
 using DTypeKV = {{ dtype_kv }};
 using DTypeO = {{ dtype_o }};
 using IdType = int32_t;
-constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
-constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
-constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
-constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
-constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
+static constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+static constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+static constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
+static constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
+static constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;

--- a/csrc/single_prefill_config.inc
+++ b/csrc/single_prefill_config.inc
@@ -36,16 +36,18 @@ using IdType = int32_t;
           q_scalar_type, kv_scalar_type, DTypeQ, DTypeKV, [&] {                                 \
             using DTypeO = DTypeQ;                                                              \
             using Params = SinglePrefillParams<DTypeQ, DTypeKV, DTypeO>;                        \
-            constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                          \
-            constexpr bool USE_FP16_QK_REDUCTION = false;                                       \
-            constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom;                    \
+            static constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;                   \
+            static constexpr bool USE_FP16_QK_REDUCTION = false;                                \
+            static constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom;             \
             return DISPATCH_head_dim(head_dim_qk, HEAD_DIM_QK, [&] {                            \
-              [[maybe_unused]] constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                                          \
+              [[maybe_unused]] static constexpr int HEAD_DIM_VO = HEAD_DIM_QK;                  \
               return DISPATCH_BOOL(window_left > -1, USE_SLIDING_WINDOW, [&] {                  \
                 return DISPATCH_BOOL(logits_soft_cap > 0.f, USE_LOGITS_SOFT_CAP, [&] {          \
+                  static constexpr bool stat_use_slid_window = USE_SLIDING_WINDOW;              \
+                  static constexpr bool stat_use_logits_soft_cap = USE_LOGITS_SOFT_CAP;         \
                   using AttentionVariant =                                                      \
-                      DefaultAttention</*use_custom_mask=*/use_custom_mask, USE_SLIDING_WINDOW, \
-                                       USE_LOGITS_SOFT_CAP, /*use_alibi_bias=*/false>;          \
+                     DefaultAttention</*use_custom_mask=*/use_custom_mask, stat_use_slid_window,\
+                                       stat_use_logits_soft_cap, /*use_alibi_bias=*/false>;     \
                   __VA_ARGS__();                                                                \
                   return true;                                                                  \
                 });                                                                             \

--- a/csrc/single_prefill_customize_config.jinja
+++ b/csrc/single_prefill_customize_config.jinja
@@ -12,7 +12,7 @@
 
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, USE_FP16_QK_REDUCTION, AttentionVariant, Params, ...) \
   DISPATCH_MASK_MODE(mask_mode, MASK_MODE, { \
-    constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom; \
+    static constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom; \
     using AttentionVariant = {{ variant_name }}; \
     __VA_ARGS__(); \
   })
@@ -24,12 +24,12 @@ using DTypeQ = {{ dtype_q }};
 using DTypeKV = {{ dtype_kv }};
 using DTypeO = {{ dtype_o }};
 using IdType = int32_t;
-constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
-constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
-constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
-constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
-constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
-constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
+static constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+static constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+static constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
+static constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
+static constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
+static constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;

--- a/csrc/single_prefill_sm90_config.inc
+++ b/csrc/single_prefill_sm90_config.inc
@@ -42,7 +42,8 @@ using IdType = int32_t;
         return DISPATCH_head_dim_sm90(head_dim_qk, head_dim_vo, HEAD_DIM_QK, HEAD_DIM_VO, [&] {  \
           return DISPATCH_BOOL(window_left > -1, USE_SLIDING_WINDOW, [&] {                       \
             return DISPATCH_BOOL(logits_soft_cap > 0.f, USE_LOGITS_SOFT_CAP, [&] {               \
-              using AttentionVariant = DefaultAttention<USE_LOGITS_SOFT_CAP>;                    \
+              static constexpr bool stat_use_logits_soft_cap = USE_LOGITS_SOFT_CAP;              \
+              using AttentionVariant = DefaultAttention<stat_use_logits_soft_cap>;               \
               __VA_ARGS__();                                                                     \
               return true;                                                                       \
             });                                                                                  \

--- a/csrc/single_prefill_sm90_customize_config.jinja
+++ b/csrc/single_prefill_sm90_customize_config.jinja
@@ -21,10 +21,10 @@ using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
 using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
 using IdType = cutlass_dtype_t<int32_t>;
 
-constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
-constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
-constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
-constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
+static constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+static constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+static constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
+static constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -16,6 +16,9 @@ limitations under the License.
 
 import ctypes
 import os
+import platform
+
+import torch
 
 # Re-export
 from .activation import gen_act_and_mul_module as gen_act_and_mul_module
@@ -57,15 +60,53 @@ from .core import clear_cache_dir, load_cuda_ops  # noqa: F401
 from .env import *
 from .utils import parallel_load_modules as parallel_load_modules
 
-cuda_lib_path = os.environ.get(
-    "CUDA_LIB_PATH", "/usr/local/cuda/targets/x86_64-linux/lib/"
-)
-if os.path.exists(f"{cuda_lib_path}/libcudart.so.12"):
-    ctypes.CDLL(f"{cuda_lib_path}/libcudart.so.12", mode=ctypes.RTLD_GLOBAL)
+if platform.system == "Windows":
+    cuda_path = None
+    if os.environ.get("CUDA_LIB_PATH"):
+        cuda_path = os.environ.get("CUDA_LIB_PATH")
+    elif os.environ.get("CUDA_HOME"):
+        cuda_path = os.environ.get("CUDA_HOME")
+    elif os.environ.get("CUDA_ROOT"):
+        cuda_path = os.environ.get("CUDA_ROOT")
+    elif os.environ.get("CUDA_PATH"):
+        cuda_path = os.environ.get("CUDA_PATH")
+    else:
+        cuda_path = f"C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v{torch.version.cuda}"
+
+    if cuda_path and os.path.exists(cuda_path):
+        cudart_version = torch.version.cuda.split(".")[0]
+        if cudart_version < "12":
+            cudart_version += "0"
+        ctypes.CDLL(
+            os.path.join(cuda_path, "bin", f"cudart64_{cudart_version}.dll"),
+            mode=ctypes.RTLD_GLOBAL,
+        )
+    else:
+        raise ValueError(
+            "CUDA_LIB_PATH is not set. "
+            "CUDA_LIB_PATH need to be set with the absolute path "
+            "to CUDA root folder on Windows (for example, set "
+            "CUDA_LIB_PATH=C:\\CUDA\\v12.4)"
+        )
+else:
+    cuda_lib_path = os.environ.get(
+        "CUDA_LIB_PATH", "/usr/local/cuda/targets/x86_64-linux/lib/"
+    )
+    if os.path.exists(f"{cuda_lib_path}/libcudart.so.12"):
+        ctypes.CDLL(f"{cuda_lib_path}/libcudart.so.12", mode=ctypes.RTLD_GLOBAL)
 
 
 try:
-    from .. import flashinfer_kernels, flashinfer_kernels_sm90  # noqa: F401
+    from .. import flashinfer_kernels  # noqa: F401
+
+    load_sm90 = False
+    for device_index in range(torch.cuda.device_count()):
+        if torch.cuda.get_device_properties(device_index).major > 8:
+            load_sm90 = True
+            break
+    if load_sm90:
+        from .. import flashinfer_kernels_sm90
+
     from .aot_config import prebuilt_ops_uri as prebuilt_ops_uri
 
     has_prebuilt_ops = True

--- a/include/flashinfer/math.cuh
+++ b/include/flashinfer/math.cuh
@@ -16,6 +16,10 @@
 #ifndef FLASHINFER_MATH_CUH_
 #define FLASHINFER_MATH_CUH_
 
+#ifdef _WIN32
+typedef unsigned short ushort;
+#endif
+
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 

--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -26,6 +26,10 @@
 #include "utils.cuh"
 #include "vec_dtypes.cuh"
 
+#ifdef _WIN32
+#define M_PI 3.14159265358979323846
+#endif
+
 namespace flashinfer {
 
 /*!
@@ -780,6 +784,15 @@ cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__
 }
 
 template <typename DType, typename IdType>
+#ifdef _WIN32
+cudaError_t BatchQKApplyLlama31Rotary(
+    DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* indptr, IdType* offsets,
+    uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t rotary_dim,
+    uint32_t head_dim, size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
+    size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
+    bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
+    float high_freq_factor, float old_context_length, cudaStream_t stream = nullptr)
+#else
 cudaError_t BatchQKApplyLlama31Rotary(
     DType* q, DType* k, DType* q_rope, DType* k_rope, IdType* __restrict__ indptr,
     IdType* __restrict__ offsets, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
@@ -787,7 +800,9 @@ cudaError_t BatchQKApplyLlama31Rotary(
     size_t k_stride_h, size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n,
     size_t k_rope_stride_h, bool interleave, float rope_scale, float rope_theta,
     float low_freq_factor, float high_freq_factor, float old_context_length,
-    cudaStream_t stream = nullptr) {
+    cudaStream_t stream = nullptr)
+#endif
+{
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = old_context_length / (2 * M_PI * high_freq_factor - 2 * M_PI * low_freq_factor);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -29,7 +29,11 @@ namespace flashinfer {
 #define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
 #endif
 
+#ifdef _WIN32
+#define FLASHINFER_INLINE inline [[msvc::forceinline]] __device__
+#else
 #define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
+#endif
 
 #if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 < 120200) && \
     (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))


### PR DESCRIPTION
This PR adds support for Windows OS, including AOT and JIT builds.

Due to standard console (cmd.exe) command length limit of 8192 chars, PowerShell is required to do the installation / build.

A Visual Studio 2019 or newer is required to launch the compiler x64 environment. The installation path is referred in the instructions as VISUAL_STUDIO_INSTALL_PATH, just replace it with your Visual Studio installation path.

### **Instructions for Windows build:**

1. Open PowerShell
2. Clone the repository
3. Change the working directory to the cloned repository path, for example: `cd C:\flashinfer`
4. Execute the following commands in order: 
```
Import-Module "VISUAL_STUDIO_INSTALL_PATH\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
Enter-VsDevShell -VsInstallPath "VISUAL_STUDIO_INSTALL_PATH" -DevCmdArguments '-arch=x64'
$env:DISTUTILS_USE_SDK=1;
$env:FLASHINFER_ENABLE_AOT=1;
$env:MAX_JOBS=10;
```
5. (Optional) To speed up compilation time, set environment var TORCH_CUDA_ARCH_LIST to match your gpu arch. For example: `$env:TORCH_CUDA_ARCH_LIST="8.6";`
6. (Optional) To use the installed torch in the case you have a nightly / built from source version, execute: `$env:FLASHINFER_USE_CURRENT_TORCH=1;`
7. Execute: `pip install . --no-build-isolation` to install or `python setup.py bdist_wheel` to generate a installable Windows wheel
8. (Optional) Clean the Windows customized build folder: `python setup.py clean`

Special mention to changes made on:
- pod.cu: To solve a C1060 compiler error, the PrefillParams and DecodeParams assignments has been moved to an external function.
- setup.py: To support current and future compiled kernels object linking, the build directory has been customized on Windows to keep the final linker command below the PowerShell limit of 32767 characters, 