### PR TITLE
perf: Fix python API overhead when CUDAGraph is not enabled

### DIFF
--- a/csrc/batch_decode_jit_pybind.cu
+++ b/csrc/batch_decode_jit_pybind.cu
@@ -21,14 +21,16 @@ at::Tensor BatchDecodeWithPagedKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor indptr, int64_t batch_size,
     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph,
     int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
-    at::Tensor empty_q_data, at::Tensor empty_kv_data, int64_t cuda_stream);
+    at::Tensor empty_q_data, at::Tensor empty_kv_data);
 
-void BatchDecodeWithPagedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
-    at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor paged_kv_indptr,
-    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len, at::Tensor o,
-    std::optional<at::Tensor> maybe_lse, int64_t kv_layout_code,
-    int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+void BatchDecodeWithPagedKVCacheRun(at::Tensor float_workspace_buffer,
+                                    at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+                                    at::Tensor q, at::Tensor paged_k_cache,
+                                    at::Tensor paged_v_cache, at::Tensor paged_kv_indptr,
+                                    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
+                                    at::Tensor o, std::optional<at::Tensor> maybe_lse,
+                                    int64_t kv_layout_code,
+                                    int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Batched decode with paged KV-Cache plan

--- a/csrc/batch_mla_plan.cu
+++ b/csrc/batch_mla_plan.cu
@@ -26,8 +26,7 @@ at::Tensor BatchMLAPagedAttentionPlan(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer,
                                       at::Tensor page_locked_int_workspace_buffer,
                                       at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor kv_len,
-                                      int64_t num_heads, int64_t head_dim_o, bool causal,
-                                      int64_t cuda_stream) {
+                                      int64_t num_heads, int64_t head_dim_o, bool causal) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -37,7 +36,9 @@ at::Tensor BatchMLAPagedAttentionPlan(at::Tensor float_workspace_buffer,
 
   int batch_size = kv_len.size(0);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+
   cudaError_t status =
       MLAPlan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
               int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),

--- a/csrc/batch_mla_pybind.cu
+++ b/csrc/batch_mla_pybind.cu
@@ -20,15 +20,14 @@ at::Tensor BatchMLAPagedAttentionPlan(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer,
                                       at::Tensor page_locked_int_workspace_buffer,
                                       at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor kv_len,
-                                      int64_t num_heads, int64_t head_dim_o, bool causal,
-                                      int64_t cuda_stream);
+                                      int64_t num_heads, int64_t head_dim_o, bool causal);
 
 void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                                at::Tensor plan_info_vec, at::Tensor q_nope, at::Tensor q_pe,
                                at::Tensor ckv_cache, at::Tensor kpe_cache, at::Tensor kv_indices,
                                at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                int64_t mask_mode_code, int64_t num_heads, int64_t page_size,
-                               double sm_scale, int64_t cuda_stream);
+                               double sm_scale);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("plan", &BatchMLAPagedAttentionPlan);

--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -29,7 +29,7 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
                                at::Tensor ckv_cache, at::Tensor kpe_cache, at::Tensor kv_indices,
                                at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                int64_t mask_mode_code, int64_t num_heads, int64_t page_size,
-                               double sm_scale, int64_t cuda_stream) {
+                               double sm_scale) {
   // q_nope: [n, num_heads, head_dim_ckv]
   // q_pe: [n, num_heads, head_dim_kpe]
   // ckv_cache: [num_pages, page_size, head_dim_ckv]
@@ -58,7 +58,8 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
   unsigned int o_stride_n = o.stride(0);
   unsigned int o_stride_h = o.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
   DISPATCH_context(
       DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE, Params, [&] {

--- a/csrc/batch_mla_sm90_plan.cu
+++ b/csrc/batch_mla_sm90_plan.cu
@@ -27,7 +27,7 @@ at::Tensor BatchMLAPagedAttentionSM90Plan(at::Tensor float_workspace_buffer,
                                           at::Tensor page_locked_int_workspace_buffer,
                                           at::Tensor qo_indptr, at::Tensor kv_indptr,
                                           at::Tensor kv_len, int64_t num_heads, int64_t head_dim_o,
-                                          bool causal, int64_t cuda_stream) {
+                                          bool causal) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -37,7 +37,9 @@ at::Tensor BatchMLAPagedAttentionSM90Plan(at::Tensor float_workspace_buffer,
 
   int batch_size = kv_len.size(0);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+
   cudaError_t status =
       MLAPlan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
               int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),

--- a/csrc/batch_mla_sm90_pybind.cu
+++ b/csrc/batch_mla_sm90_pybind.cu
@@ -21,7 +21,7 @@ at::Tensor BatchMLAPagedAttentionSM90Plan(at::Tensor float_workspace_buffer,
                                           at::Tensor page_locked_int_workspace_buffer,
                                           at::Tensor qo_indptr, at::Tensor kv_indptr,
                                           at::Tensor kv_len, int64_t num_heads, int64_t head_dim_o,
-                                          bool causal, int64_t cuda_stream);
+                                          bool causal);
 
 void BatchMLAPagedAttentionSM90Run(at::Tensor float_workspace_buffer,
                                    at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
@@ -29,7 +29,7 @@ void BatchMLAPagedAttentionSM90Run(at::Tensor float_workspace_buffer,
                                    at::Tensor kpe_cache, at::Tensor kv_indices, at::Tensor o,
                                    std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                                    int64_t num_heads, int64_t page_size,
-                                   double sm_scale ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+                                   double sm_scale ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("plan", &BatchMLAPagedAttentionSM90Plan);

--- a/csrc/batch_mla_sm90_run.cu
+++ b/csrc/batch_mla_sm90_run.cu
@@ -30,7 +30,7 @@ void BatchMLAPagedAttentionSM90Run(at::Tensor float_workspace_buffer,
                                    at::Tensor kpe_cache, at::Tensor kv_indices, at::Tensor o,
                                    std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                                    int64_t num_heads, int64_t page_size,
-                                   double sm_scale ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream) {
+                                   double sm_scale ADDITIONAL_FUNC_PARAMS) {
   // q_nope: [n, num_heads, head_dim_ckv]
   // q_pe: [n, num_heads, head_dim_kpe]
   // ckv_cache: [num_pages, page_size, head_dim_ckv]
@@ -59,7 +59,8 @@ void BatchMLAPagedAttentionSM90Run(at::Tensor float_workspace_buffer,
   unsigned int o_stride_n = o.stride(0);
   unsigned int o_stride_h = o.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
   DISPATCH_context(
       DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE, Params, [&] {

--- a/csrc/batch_prefill_jit_pybind.cu
+++ b/csrc/batch_prefill_jit_pybind.cu
@@ -21,22 +21,23 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, int64_t cuda_stream);
+    int64_t head_dim_vo, bool causal);
 
 void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
                                       at::Tensor q, at::Tensor k, at::Tensor v,
                                       at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor o,
                                       std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
-                                      int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
-                                      int64_t cuda_stream);
+                                      int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
-void BatchPrefillWithPagedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
-    at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor qo_indptr,
-    at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
-    at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+void BatchPrefillWithPagedKVCacheRun(at::Tensor float_workspace_buffer,
+                                     at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+                                     at::Tensor q, at::Tensor paged_k_cache,
+                                     at::Tensor paged_v_cache, at::Tensor qo_indptr,
+                                     at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices,
+                                     at::Tensor paged_kv_last_page_len, at::Tensor o,
+                                     std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
+                                     int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Batch-request prefill attention with KV-Cache plan

--- a/csrc/batch_prefill_sm90_jit_pybind.cu
+++ b/csrc/batch_prefill_sm90_jit_pybind.cu
@@ -21,20 +21,22 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, int64_t cuda_stream);
+    int64_t head_dim_vo, bool causal);
 
-void BatchPrefillWithRaggedKVCacheSM90Run(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
-    at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo_indptr, at::Tensor kv_indptr,
-    at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+void BatchPrefillWithRaggedKVCacheSM90Run(at::Tensor float_workspace_buffer,
+                                          at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+                                          at::Tensor q, at::Tensor k, at::Tensor v,
+                                          at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor o,
+                                          std::optional<at::Tensor> maybe_lse,
+                                          int64_t mask_mode_code, int64_t layout,
+                                          int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 void BatchPrefillWithPagedKVCacheSM90Run(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
     at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor qo_indptr,
     at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
     at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+    int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Batch-request prefill attention with KV-Cache plan

--- a/csrc/flashinfer_cascade_ops.cu
+++ b/csrc/flashinfer_cascade_ops.cu
@@ -16,13 +16,12 @@
 #include "pytorch_extension_utils.h"
 
 void merge_state(at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b,
-                 at::Tensor v_merged, at::Tensor s_merged, int64_t cuda_stream);
+                 at::Tensor v_merged, at::Tensor s_merged);
 
 void merge_state_in_place(at::Tensor v, at::Tensor s, at::Tensor v_other, at::Tensor s_other,
-                          std::optional<at::Tensor> mask, int64_t cuda_stream);
+                          std::optional<at::Tensor> mask);
 
-void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_merged,
-                  int64_t cuda_stream);
+void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_merged);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Merge two self-attention states

--- a/csrc/flashinfer_gemm_ops.cu
+++ b/csrc/flashinfer_gemm_ops.cu
@@ -16,12 +16,11 @@
 #include "pytorch_extension_utils.h"
 
 void bmm_fp8(at::Tensor A, at::Tensor B, at::Tensor D, at::Tensor A_scale, at::Tensor B_scale,
-             at::Tensor workspace_buffer, int64_t cublas_handle, int64_t cuda_stream);
+             at::Tensor workspace_buffer, int64_t cublas_handle);
 
 void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at::Tensor x_ptr,
                         at::Tensor w_ptr, at::Tensor y_ptr, at::Tensor x_ld, at::Tensor w_ld,
-                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major,
-                        int64_t cuda_stream);
+                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // "Cutlass Segment GEMM"

--- a/csrc/flashinfer_gemm_sm90_ops.cu
+++ b/csrc/flashinfer_gemm_sm90_ops.cu
@@ -18,8 +18,7 @@
 void CutlassSegmentGEMMSM90(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                             at::Tensor all_problems, at::Tensor x_ptr, at::Tensor w_ptr,
                             at::Tensor y_ptr, at::Tensor x_stride, at::Tensor weight_stride,
-                            at::Tensor y_stride, at::Tensor empty_x_data, bool weight_column_major,
-                            int64_t cuda_stream);
+                            at::Tensor y_stride, at::Tensor empty_x_data, bool weight_column_major);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // "Cutlass Segment GEMM operator for SM90"

--- a/csrc/flashinfer_norm_ops.cu
+++ b/csrc/flashinfer_norm_ops.cu
@@ -15,17 +15,16 @@
  */
 #include "pytorch_extension_utils.h"
 
-void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl,
-             int64_t cuda_stream);
+void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl);
 
 void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
-                       bool enable_pdl, int64_t cuda_stream);
+                       bool enable_pdl);
 
 void gemma_rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
-                   bool enable_pdl, int64_t cuda_stream);
+                   bool enable_pdl);
 
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
-                             double eps, bool enable_pdl, int64_t cuda_stream);
+                             double eps, bool enable_pdl);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Root mean square normalization

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -66,17 +66,16 @@ void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at
 
 //========== norm ==========
 
-void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl,
-             int64_t cuda_stream);
+void rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl);
 
 void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
-                       bool enable_pdl, int64_t cuda_stream);
+                       bool enable_pdl);
 
 void gemma_rmsnorm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double eps,
-                   bool enable_pdl, int64_t cuda_stream);
+                   bool enable_pdl);
 
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
-                             double eps, bool enable_pdl, int64_t cuda_stream);
+                             double eps, bool enable_pdl);
 
 //========== page ==========
 

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -56,12 +56,11 @@ void BatchDecodeWithPagedKVCacheRun(
 //========== gemm ==========
 
 void bmm_fp8(at::Tensor A, at::Tensor B, at::Tensor D, at::Tensor A_scale, at::Tensor B_scale,
-             at::Tensor workspace_buffer, int64_t cublas_handle, int64_t cuda_stream);
+             at::Tensor workspace_buffer, int64_t cublas_handle);
 
 void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at::Tensor x_ptr,
                         at::Tensor w_ptr, at::Tensor y_ptr, at::Tensor x_ld, at::Tensor w_ld,
-                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major,
-                        int64_t cuda_stream);
+                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major);
 
 //========== norm ==========
 

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -25,13 +25,12 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl);
 //========== cascade ==========
 
 void merge_state(at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b,
-                 at::Tensor v_merged, at::Tensor s_merged, int64_t cuda_stream);
+                 at::Tensor v_merged, at::Tensor s_merged);
 
 void merge_state_in_place(at::Tensor v, at::Tensor s, at::Tensor v_other, at::Tensor s_other,
-                          std::optional<at::Tensor> mask, int64_t cuda_stream);
+                          std::optional<at::Tensor> mask);
 
-void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_merged,
-                  int64_t cuda_stream);
+void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_merged);
 
 //========== decode ==========
 
@@ -82,20 +81,17 @@ void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor
 void append_paged_kv_cache(at::Tensor append_key, at::Tensor append_value, at::Tensor batch_indices,
                            at::Tensor positions, at::Tensor paged_k_cache, at::Tensor paged_v_cache,
                            at::Tensor kv_indices, at::Tensor kv_indptr, at::Tensor kv_last_page_len,
-                           int64_t layout, int64_t cuda_stream);
+                           int64_t layout);
 
 void append_paged_mla_kv_cache(at::Tensor append_ckv, at::Tensor append_kpe,
                                at::Tensor batch_indices, at::Tensor positions, at::Tensor ckv_cache,
                                at::Tensor kpe_cache, at::Tensor kv_indices, at::Tensor kv_indptr,
-                               at::Tensor kv_last_page_len, int64_t cuda_stream);
+                               at::Tensor kv_last_page_len);
 
-void block_sparse_indices_to_vector_sparse_offsets(at::Tensor block_sparse_indices,
-                                                   at::Tensor block_sparse_indptr,
-                                                   at::Tensor vector_sparse_offsets,
-                                                   at::Tensor vector_sparse_indptr,
-                                                   at::Tensor kv_len_arr, int64_t stride_block,
-                                                   int64_t stride_n, int64_t batch_size,
-                                                   int64_t block_size, int64_t cuda_stream);
+void block_sparse_indices_to_vector_sparse_offsets(
+    at::Tensor block_sparse_indices, at::Tensor block_sparse_indptr,
+    at::Tensor vector_sparse_offsets, at::Tensor vector_sparse_indptr, at::Tensor kv_len_arr,
+    int64_t stride_block, int64_t stride_n, int64_t batch_size, int64_t block_size);
 
 //========== prefill ==========
 
@@ -146,84 +142,79 @@ void pod_with_kv_cache_tensor(
     int64_t cuda_stream);
 //========== quantization ==========
 
-void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
+void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y);
 
 void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_indptr,
-                      const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
+                      const std::string& bitorder, at::Tensor y);
 
 //========== rope ==========
 
 void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope, at::Tensor indptr,
                 at::Tensor offsets, int64_t rotary_dim, bool interleave, double rope_scale,
-                double rope_theta, int64_t cuda_stream);
+                double rope_theta);
 
 void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                         at::Tensor indptr, at::Tensor offsets, int64_t rotary_dim, bool interleave,
                         double rope_scale, double rope_theta, double low_freq_factor,
-                        double high_freq_factor, double old_context_length, int64_t cuda_stream);
+                        double high_freq_factor, double old_context_length);
 
 void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                         at::Tensor pos_ids, int64_t rotary_dim, bool interleave, double rope_scale,
-                        double rope_theta, int64_t cuda_stream);
+                        double rope_theta);
 
 void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                                 at::Tensor pos_ids, int64_t rotary_dim, bool interleave,
                                 double rope_scale, double rope_theta, double low_freq_factor,
-                                double high_freq_factor, double old_context_length,
-                                int64_t cuda_stream);
+                                double high_freq_factor, double old_context_length);
 
 void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_rope,
                                       at::Tensor k_rope, at::Tensor cos_sin_cache,
-                                      at::Tensor pos_ids, bool interleave, int64_t cuda_stream);
+                                      at::Tensor pos_ids, bool interleave);
 
 //========== sampling ==========
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
-                         std::optional<at::Generator> gen, int64_t cuda_stream);
+                         std::optional<at::Generator> gen);
 
 void top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                               bool deterministic, std::optional<at::Generator> gen,
-                               int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen);
 
 void top_k_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                               bool deterministic, std::optional<at::Generator> gen,
-                               int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen);
 
 void min_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
-                               bool deterministic, std::optional<at::Generator> gen,
-                               int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen);
 
 void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                      std::optional<at::Tensor> maybe_indices,
                                      std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, std::optional<at::Generator> gen,
-                                     int64_t cuda_stream);
+                                     bool deterministic, std::optional<at::Generator> gen);
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                        int64_t cuda_stream);
+                        bool deterministic, std::optional<at::Generator> gen);
 
 void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                        int64_t cuda_stream);
+                        bool deterministic, std::optional<at::Generator> gen);
 
 void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                       int64_t cuda_stream);
+                       bool deterministic, std::optional<at::Generator> gen);
 
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,
                                 at::Tensor output_emitted_token_num, bool deterministic,
-                                std::optional<at::Generator> gen, int64_t cuda_stream);
+                                std::optional<at::Generator> gen);
 
 //========== Torch Library ==========
 

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -18,9 +18,9 @@
 
 //========== activation ==========
 
-void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream);
-void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream);
-void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream);
+void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl);
+void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl);
+void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl);
 
 //========== cascade ==========
 

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -36,22 +36,23 @@ void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                  at::Tensor o, int64_t layout,
-                                 int64_t window_left SINGLE_DECODE_ADDITIONAL_FUNC_PARAMS,
-                                 int64_t cuda_stream);
+                                 int64_t window_left SINGLE_DECODE_ADDITIONAL_FUNC_PARAMS);
 
 at::Tensor BatchDecodeWithPagedKVCachePlan(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor indptr, int64_t batch_size,
     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph,
     int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
-    at::Tensor empty_q_data, at::Tensor empty_kv_data, int64_t cuda_stream);
+    at::Tensor empty_q_data, at::Tensor empty_kv_data);
 
-void BatchDecodeWithPagedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
-    at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor paged_kv_indptr,
-    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len, at::Tensor o,
-    std::optional<at::Tensor> maybe_lse, int64_t kv_layout_code,
-    int64_t window_left BATCH_DECODE_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+void BatchDecodeWithPagedKVCacheRun(at::Tensor float_workspace_buffer,
+                                    at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+                                    at::Tensor q, at::Tensor paged_k_cache,
+                                    at::Tensor paged_v_cache, at::Tensor paged_kv_indptr,
+                                    at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
+                                    at::Tensor o, std::optional<at::Tensor> maybe_lse,
+                                    int64_t kv_layout_code,
+                                    int64_t window_left BATCH_DECODE_ADDITIONAL_FUNC_PARAMS);
 
 //========== gemm ==========
 
@@ -97,28 +98,29 @@ void block_sparse_indices_to_vector_sparse_offsets(
 void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                   at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                   int64_t mask_mode_code, int64_t layout,
-                                  int64_t window_left SINGLE_PREFILL_ADDITIONAL_FUNC_PARAMS,
-                                  int64_t cuda_stream);
+                                  int64_t window_left SINGLE_PREFILL_ADDITIONAL_FUNC_PARAMS);
 
 at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, int64_t cuda_stream);
+    int64_t head_dim_vo, bool causal);
 
-void BatchPrefillWithRaggedKVCacheRun(
-    at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
-    at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo_indptr, at::Tensor kv_indptr,
-    at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left BATCH_PREFILL_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
+                                      at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
+                                      at::Tensor q, at::Tensor k, at::Tensor v,
+                                      at::Tensor qo_indptr, at::Tensor kv_indptr, at::Tensor o,
+                                      std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
+                                      int64_t layout,
+                                      int64_t window_left BATCH_PREFILL_ADDITIONAL_FUNC_PARAMS);
 
 void BatchPrefillWithPagedKVCacheRun(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
     at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor qo_indptr,
     at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
     at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left BATCH_PREFILL_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+    int64_t window_left BATCH_PREFILL_ADDITIONAL_FUNC_PARAMS);
 
 //========== pod-attention =========
 void pod_with_kv_cache_tensor(
@@ -136,9 +138,7 @@ void pod_with_kv_cache_tensor(
     std::optional<at::Tensor> maybe_lse_d, int64_t mask_mode_code_d, int64_t layout_d,
     int64_t window_left, std::optional<at::Tensor> maybe_custom_mask_d,
     std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
-    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
-    // Shared params
-    int64_t cuda_stream);
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d);
 //========== quantization ==========
 
 void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y);

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -198,16 +198,13 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                      bool deterministic, std::optional<at::Generator> gen);
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                        bool deterministic, std::optional<at::Generator> gen);
+                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val);
 
 void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                        bool deterministic, std::optional<at::Generator> gen);
+                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val);
 
 void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
-                       std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                       bool deterministic, std::optional<at::Generator> gen);
+                       std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val);
 
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,

--- a/csrc/flashinfer_ops_sm90.cu
+++ b/csrc/flashinfer_ops_sm90.cu
@@ -19,8 +19,7 @@
 void CutlassSegmentGEMMSM90(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                             at::Tensor all_problems, at::Tensor x_ptr, at::Tensor w_ptr,
                             at::Tensor y_ptr, at::Tensor x_stride, at::Tensor weight_stride,
-                            at::Tensor y_stride, at::Tensor empty_x_data, bool weight_column_major,
-                            int64_t cuda_stream);
+                            at::Tensor y_stride, at::Tensor empty_x_data, bool weight_column_major);
 
 void single_prefill_with_kv_cache_sm90(
     at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp, at::Tensor o,

--- a/csrc/flashinfer_ops_sm90.cu
+++ b/csrc/flashinfer_ops_sm90.cu
@@ -24,27 +24,27 @@ void CutlassSegmentGEMMSM90(at::Tensor float_workspace_buffer, at::Tensor int_wo
 void single_prefill_with_kv_cache_sm90(
     at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp, at::Tensor o,
     std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left SINGLE_PREFILL_SM90_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+    int64_t window_left SINGLE_PREFILL_SM90_ADDITIONAL_FUNC_PARAMS);
 
 at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, int64_t cuda_stream);
+    int64_t head_dim_vo, bool causal);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
     at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left BATCH_PREFILL_SM90_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+    int64_t window_left BATCH_PREFILL_SM90_ADDITIONAL_FUNC_PARAMS);
 
 void BatchPrefillWithPagedKVCacheSM90Run(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,
     at::Tensor q, at::Tensor paged_k_cache, at::Tensor paged_v_cache, at::Tensor qo_indptr,
     at::Tensor paged_kv_indptr, at::Tensor paged_kv_indices, at::Tensor paged_kv_last_page_len,
     at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code, int64_t layout,
-    int64_t window_left BATCH_PREFILL_SM90_ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+    int64_t window_left BATCH_PREFILL_SM90_ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // "Cutlass Segment GEMM operator for SM90"

--- a/csrc/flashinfer_page_ops.cu
+++ b/csrc/flashinfer_page_ops.cu
@@ -18,20 +18,17 @@
 void append_paged_kv_cache(at::Tensor append_key, at::Tensor append_value, at::Tensor batch_indices,
                            at::Tensor positions, at::Tensor paged_k_cache, at::Tensor paged_v_cache,
                            at::Tensor kv_indices, at::Tensor kv_indptr, at::Tensor kv_last_page_len,
-                           int64_t layout, int64_t cuda_stream);
+                           int64_t layout);
 
 void append_paged_mla_kv_cache(at::Tensor append_ckv, at::Tensor append_kpe,
                                at::Tensor batch_indices, at::Tensor positions, at::Tensor ckv_cache,
                                at::Tensor kpe_cache, at::Tensor kv_indices, at::Tensor kv_indptr,
-                               at::Tensor kv_last_page_len, int64_t cuda_stream);
+                               at::Tensor kv_last_page_len);
 
-void block_sparse_indices_to_vector_sparse_offsets(at::Tensor block_sparse_indices,
-                                                   at::Tensor block_sparse_indptr,
-                                                   at::Tensor vector_sparse_offsets,
-                                                   at::Tensor vector_sparse_indptr,
-                                                   at::Tensor kv_len_arr, int64_t stride_block,
-                                                   int64_t stride_n, int64_t batch_size,
-                                                   int64_t block_size, int64_t cuda_stream);
+void block_sparse_indices_to_vector_sparse_offsets(
+    at::Tensor block_sparse_indices, at::Tensor block_sparse_indptr,
+    at::Tensor vector_sparse_offsets, at::Tensor vector_sparse_indptr, at::Tensor kv_len_arr,
+    int64_t stride_block, int64_t stride_n, int64_t batch_size, int64_t block_size);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // "Append paged KV-Cache operator"

--- a/csrc/flashinfer_quantization_ops.cu
+++ b/csrc/flashinfer_quantization_ops.cu
@@ -15,10 +15,10 @@
  */
 #include "pytorch_extension_utils.h"
 
-void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
+void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y);
 
 void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_indptr,
-                      const std::string& bitorder, at::Tensor y, int64_t cuda_stream);
+                      const std::string& bitorder, at::Tensor y);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // GPU packbits operator

--- a/csrc/flashinfer_rope_ops.cu
+++ b/csrc/flashinfer_rope_ops.cu
@@ -19,26 +19,25 @@
 
 void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope, at::Tensor indptr,
                 at::Tensor offsets, int64_t rotary_dim, bool interleave, double rope_scale,
-                double rope_theta, int64_t cuda_stream);
+                double rope_theta);
 
 void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                         at::Tensor indptr, at::Tensor offsets, int64_t rotary_dim, bool interleave,
                         double rope_scale, double rope_theta, double low_freq_factor,
-                        double high_freq_factor, double old_context_length, int64_t cuda_stream);
+                        double high_freq_factor, double old_context_length);
 
 void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                         at::Tensor pos_ids, int64_t rotary_dim, bool interleave, double rope_scale,
-                        double rope_theta, int64_t cuda_stream);
+                        double rope_theta);
 
 void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                                 at::Tensor pos_ids, int64_t rotary_dim, bool interleave,
                                 double rope_scale, double rope_theta, double low_freq_factor,
-                                double high_freq_factor, double old_context_length,
-                                int64_t cuda_stream);
+                                double high_freq_factor, double old_context_length);
 
 void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_rope,
                                       at::Tensor k_rope, at::Tensor cos_sin_cache,
-                                      at::Tensor pos_ids, bool interleave, int64_t cuda_stream);
+                                      at::Tensor pos_ids, bool interleave);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // "Apply RoPE"

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -17,50 +17,43 @@
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
-                         std::optional<at::Generator> gen, int64_t cuda_stream);
+                         std::optional<at::Generator> gen);
 
 void top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                               bool deterministic, std::optional<at::Generator> gen,
-                               int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen);
 
 void top_k_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                               bool deterministic, std::optional<at::Generator> gen,
-                               int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen);
 
 void min_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
-                               bool deterministic, std::optional<at::Generator> gen,
-                               int64_t cuda_stream);
+                               bool deterministic, std::optional<at::Generator> gen);
 
 void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                      std::optional<at::Tensor> maybe_indices,
                                      std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, std::optional<at::Generator> gen,
-                                     int64_t cuda_stream);
+                                     bool deterministic, std::optional<at::Generator> gen);
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                        int64_t cuda_stream);
+                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val);
 
 void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                        int64_t cuda_stream);
+                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val);
 
 void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
-                       std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                       int64_t cuda_stream);
+                       std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val);
 
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,
                                 at::Tensor output_emitted_token_num, bool deterministic,
-                                std::optional<at::Generator> gen, int64_t cuda_stream);
+                                std::optional<at::Generator> gen);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Sample from probabilities

--- a/csrc/group_gemm.cu
+++ b/csrc/group_gemm.cu
@@ -22,11 +22,11 @@ using namespace flashinfer::group_gemm;
 
 void CutlassSegmentGEMM(at::Tensor workspace_buffer, at::Tensor all_problems, at::Tensor x_ptr,
                         at::Tensor w_ptr, at::Tensor y_ptr, at::Tensor x_ld, at::Tensor w_ld,
-                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major,
-                        int64_t cuda_stream) {
+                        at::Tensor y_ld, at::Tensor empty_x_data, bool weight_column_major) {
   unsigned int batch_size = x_ptr.size(0);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(workspace_buffer.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(empty_x_data.scalar_type(), c_type, [&] {
     using cutlass_t = cutlass_dtype_t<c_type>;
     auto status = CutlassSegmentGEMMRun<cutlass_t>(

--- a/csrc/group_gemm_sm90.cu
+++ b/csrc/group_gemm_sm90.cu
@@ -23,12 +23,11 @@ using namespace flashinfer::group_gemm;
 void CutlassSegmentGEMMSM90(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                             at::Tensor all_problems, at::Tensor x_ptr, at::Tensor w_ptr,
                             at::Tensor y_ptr, at::Tensor x_stride, at::Tensor weight_stride,
-                            at::Tensor y_stride, at::Tensor empty_x_data, bool weight_column_major,
-                            int64_t cuda_stream) {
+                            at::Tensor y_stride, at::Tensor empty_x_data,
+                            bool weight_column_major) {
   unsigned int batch_size = x_ptr.size(0);
-  auto device = float_workspace_buffer.device();
-
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE(empty_x_data.scalar_type(), c_type, [&] {
     using cutlass_t = cutlass_dtype_t<c_type>;
     auto status = CutlassSegmentGEMMSM90Run<cutlass_t, cutlass_t>(

--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -20,8 +20,8 @@
 
 using namespace flashinfer;
 
-void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl,
-             int64_t cuda_stream) {
+void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps,
+             bool enable_pdl) {
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
   auto device = input.device();
@@ -34,7 +34,8 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double e
   CHECK_EQ(output.size(0), batch_size);
   CHECK_EQ(output.size(1), hidden_size);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::RMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
@@ -47,7 +48,7 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double e
 }
 
 void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps,
-                       bool enable_pdl, int64_t cuda_stream) {
+                       bool enable_pdl) {
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(residual);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
@@ -63,7 +64,8 @@ void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weig
   unsigned int batch_size = input.size(0);
   unsigned int hidden_size = input.size(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::FusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
@@ -76,7 +78,7 @@ void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weig
 }
 
 void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps,
-                   bool enable_pdl, int64_t cuda_stream) {
+                   bool enable_pdl) {
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
   auto device = input.device();
@@ -89,7 +91,8 @@ void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, do
   CHECK_EQ(output.size(0), batch_size);
   CHECK_EQ(output.size(1), hidden_size);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::GemmaRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
@@ -102,7 +105,7 @@ void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, do
 }
 
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight,
-                             double eps, bool enable_pdl, int64_t cuda_stream) {
+                             double eps, bool enable_pdl) {
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(residual);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
@@ -118,7 +121,8 @@ void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor
   unsigned int batch_size = input.size(0);
   unsigned int hidden_size = input.size(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     cudaError_t status = norm::GemmaFusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),

--- a/csrc/pod.cu
+++ b/csrc/pod.cu
@@ -52,9 +52,7 @@ void pod_with_kv_cache_tensor(
     std::optional<at::Tensor> maybe_lse_d, int64_t mask_mode_code_d, int64_t layout_d,
     int64_t window_left_d, std::optional<at::Tensor> maybe_custom_mask_d,
     std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
-    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
-    // Shared params
-    int64_t cuda_stream) {
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d) {
   // Prefill setup
   unsigned int head_dim_qk = q_p.size(2);
   unsigned int kv_len_p, qo_len_p, num_kv_heads, num_qo_heads;
@@ -137,7 +135,8 @@ void pod_with_kv_cache_tensor(
   TORCH_CHECK(k_strides_d == v_strides_d, "k/v strides must be identical");
   kv_cache_strides_d = k_strides_d.data();
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer_d.device());
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
   DISPATCH_context(
       MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeKV, HEAD_DIM_QK, USE_SLIDING_WINDOW_P,

--- a/csrc/pod_jit_pybind.cu
+++ b/csrc/pod_jit_pybind.cu
@@ -31,9 +31,7 @@ void pod_with_kv_cache_tensor(
     std::optional<at::Tensor> maybe_lse_d, int64_t mask_mode_code_d, int64_t layout_d,
     int64_t window_left_d, std::optional<at::Tensor> maybe_custom_mask_d,
     std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
-    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
-    // Shared params
-    int64_t cuda_stream);
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Batch-request prefill attention with KV-Cache operator

--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 #include <Python.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
 #include <torch/library.h>
 
 #ifdef FLASHINFER_ENABLE_BF16

--- a/csrc/quantization.cu
+++ b/csrc/quantization.cu
@@ -19,13 +19,14 @@
 
 using namespace flashinfer;
 
-void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y, int64_t cuda_stream) {
+void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y) {
   CHECK_INPUT(x);
   auto device = x.device();
   TORCH_CHECK(bitorder == "big" || bitorder == "little", "bitorder must be 'big' or 'little'");
 
   int64_t num_elements = x.numel();
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = quantization::PackBits(
       static_cast<bool*>(x.data_ptr()), static_cast<uint8_t*>(y.data_ptr()), num_elements,
       bitorder == "big" ? quantization::BitOrder::kBig : quantization::BitOrder::kLittle, stream);
@@ -35,7 +36,7 @@ void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y, int64_t c
 }
 
 void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_indptr,
-                      const std::string& bitorder, at::Tensor y, int64_t cuda_stream) {
+                      const std::string& bitorder, at::Tensor y) {
   CHECK_INPUT(x);
   CHECK_INPUT(input_indptr);
   CHECK_INPUT(output_indptr);
@@ -46,7 +47,8 @@ void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_i
   unsigned int batch_size = input_indptr.size(0) - 1;
   CHECK_EQ(output_indptr.size(0), batch_size + 1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = quantization::SegmentPackBits(
       static_cast<bool*>(x.data_ptr()), static_cast<uint8_t*>(y.data_ptr()),
       static_cast<int32_t*>(input_indptr.data_ptr()),

--- a/csrc/renorm.cu
+++ b/csrc/renorm.cu
@@ -20,8 +20,7 @@
 using namespace flashinfer;
 
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                        int64_t cuda_stream) {
+                        std::optional<at::Tensor> maybe_top_p_arr, double top_p_val) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
@@ -29,7 +28,8 @@ void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
   unsigned int vocab_size = probs.size(1);
   bool has_top_p_arr = maybe_top_p_arr.has_value();
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::TopPRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr, batch_size,
@@ -39,8 +39,7 @@ void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
 }
 
 void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
-                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                        int64_t cuda_stream) {
+                        std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
@@ -48,7 +47,8 @@ void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
   unsigned int vocab_size = probs.size(1);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::TopKRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,
@@ -59,8 +59,7 @@ void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
 }
 
 void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
-                       std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                       int64_t cuda_stream) {
+                       std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val) {
   CHECK_INPUT(logits);
   auto device = logits.device();
   CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
@@ -68,7 +67,8 @@ void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
   unsigned int vocab_size = logits.size(1);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::TopKMaskLogits<float>(
       static_cast<float*>(logits.data_ptr()), static_cast<float*>(mask_logits.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,

--- a/csrc/rope.cu
+++ b/csrc/rope.cu
@@ -21,7 +21,7 @@ using namespace flashinfer;
 
 void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope, at::Tensor indptr,
                 at::Tensor offsets, int64_t rotary_dim, bool interleave, double rope_scale,
-                double rope_theta, int64_t cuda_stream) {
+                double rope_theta) {
   CHECK_LAST_DIM_CONTIGUOUS(q);
   CHECK_LAST_DIM_CONTIGUOUS(k);
   CHECK_INPUT(indptr);
@@ -49,7 +49,8 @@ void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     cudaError_t status = BatchQKApplyRotary(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
@@ -66,7 +67,7 @@ void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope
 
 void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                         at::Tensor pos_ids, int64_t rotary_dim, bool interleave, double rope_scale,
-                        double rope_theta, int64_t cuda_stream) {
+                        double rope_theta) {
   CHECK_LAST_DIM_CONTIGUOUS(q);
   CHECK_LAST_DIM_CONTIGUOUS(k);
   CHECK_INPUT(pos_ids);
@@ -90,7 +91,8 @@ void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tenso
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     cudaError_t status = BatchQKApplyRotaryPosIds(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
@@ -106,7 +108,7 @@ void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tenso
 
 void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_rope,
                                       at::Tensor k_rope, at::Tensor cos_sin_cache,
-                                      at::Tensor pos_ids, bool interleave, int64_t cuda_stream) {
+                                      at::Tensor pos_ids, bool interleave) {
   CHECK_LAST_DIM_CONTIGUOUS(q);
   CHECK_LAST_DIM_CONTIGUOUS(k);
   CHECK_INPUT(cos_sin_cache);
@@ -136,7 +138,8 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     cudaError_t status = BatchQKApplyRotaryPosIdsCosSinCache(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
@@ -155,7 +158,7 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
 void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                         at::Tensor indptr, at::Tensor offsets, int64_t rotary_dim, bool interleave,
                         double rope_scale, double rope_theta, double low_freq_factor,
-                        double high_freq_factor, double old_context_length, int64_t cuda_stream) {
+                        double high_freq_factor, double old_context_length) {
   CHECK_CUDA(q);  // not necessarily contiguous
   CHECK_CUDA(k);  // not necessarily contiguous
   CHECK_INPUT(indptr);
@@ -183,7 +186,8 @@ void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tenso
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     cudaError_t status = BatchQKApplyLlama31Rotary(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
@@ -202,8 +206,7 @@ void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tenso
 void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope,
                                 at::Tensor pos_ids, int64_t rotary_dim, bool interleave,
                                 double rope_scale, double rope_theta, double low_freq_factor,
-                                double high_freq_factor, double old_context_length,
-                                int64_t cuda_stream) {
+                                double high_freq_factor, double old_context_length) {
   CHECK_CUDA(q);  // not necessarily contiguous
   CHECK_CUDA(k);  // not necessarily contiguous
   CHECK_INPUT(pos_ids);
@@ -227,7 +230,8 @@ void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, a
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
     cudaError_t status = BatchQKApplyLlama31RotaryPosIds(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -27,7 +27,7 @@ using namespace flashinfer;
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
-                         std::optional<at::Generator> gen_, int64_t cuda_stream) {
+                         std::optional<at::Generator> gen_) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
@@ -42,7 +42,8 @@ void sampling_from_probs(at::Tensor probs, at::Tensor output,
   philox_seed = rng_engine_inputs.seed_.val;
   philox_offset = rng_engine_inputs.offset_.val;
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::SamplingFromProb(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
@@ -54,8 +55,7 @@ void sampling_from_probs(at::Tensor probs, at::Tensor output,
 void top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                               bool deterministic, std::optional<at::Generator> gen_,
-                               int64_t cuda_stream) {
+                               bool deterministic, std::optional<at::Generator> gen_) {
   CHECK_INPUT(probs);
   auto device = probs.device();
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
@@ -70,7 +70,8 @@ void top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
   philox_seed = rng_engine_inputs.seed_.val;
   philox_offset = rng_engine_inputs.offset_.val;
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
@@ -83,8 +84,7 @@ void top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
 void top_k_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val,
-                               bool deterministic, std::optional<at::Generator> gen_,
-                               int64_t cuda_stream) {
+                               bool deterministic, std::optional<at::Generator> gen_) {
   CHECK_INPUT(probs);
   CHECK_INPUT(output);
   auto device = probs.device();
@@ -102,7 +102,8 @@ void top_k_sampling_from_probs(at::Tensor probs, at::Tensor output,
   philox_seed = rng_engine_inputs.seed_.val;
   philox_offset = rng_engine_inputs.offset_.val;
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
@@ -115,8 +116,7 @@ void top_k_sampling_from_probs(at::Tensor probs, at::Tensor output,
 void min_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                std::optional<at::Tensor> maybe_indices,
                                std::optional<at::Tensor> maybe_min_p_arr, double min_p_val,
-                               bool deterministic, std::optional<at::Generator> gen_,
-                               int64_t cuda_stream) {
+                               bool deterministic, std::optional<at::Generator> gen_) {
   CHECK_INPUT(probs);
   CHECK_INPUT(output);
   auto device = probs.device();
@@ -134,7 +134,8 @@ void min_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
   philox_seed = rng_engine_inputs.seed_.val;
   philox_offset = rng_engine_inputs.offset_.val;
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::MinPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()),
       has_min_p_arr ? static_cast<float*>(maybe_min_p_arr->data_ptr()) : nullptr,
@@ -149,8 +150,7 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                      std::optional<at::Tensor> maybe_indices,
                                      std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
-                                     bool deterministic, std::optional<at::Generator> gen_,
-                                     int64_t cuda_stream) {
+                                     bool deterministic, std::optional<at::Generator> gen_) {
   CHECK_INPUT(probs);
   CHECK_INPUT(output);
   auto device = probs.device();
@@ -169,7 +169,8 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
   philox_seed = rng_engine_inputs.seed_.val;
   philox_offset = rng_engine_inputs.offset_.val;
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::TopKTopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr,
@@ -186,7 +187,7 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,
                                 at::Tensor output_emitted_token_num, bool deterministic,
-                                std::optional<at::Generator> gen_, int64_t cuda_stream) {
+                                std::optional<at::Generator> gen_) {
   CHECK_INPUT(draft_probs);
   CHECK_INPUT(draft_token_ids);
   CHECK_INPUT(target_probs);
@@ -214,7 +215,8 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
   philox_seed = rng_engine_inputs.seed_.val;
   philox_offset = rng_engine_inputs.offset_.val;
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
   cudaError_t status = sampling::ChainSpeculativeSampling<float, int>(
       static_cast<float*>(draft_probs.data_ptr()), static_cast<int*>(draft_token_ids.data_ptr()),
       static_cast<float*>(target_probs.data_ptr()), static_cast<int*>(output_token_ids.data_ptr()),

--- a/csrc/single_decode.cu
+++ b/csrc/single_decode.cu
@@ -31,7 +31,7 @@ using namespace flashinfer;
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                  at::Tensor o, int64_t layout,
-                                 int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream) {
+                                 int64_t window_left ADDITIONAL_FUNC_PARAMS) {
   CHECK_INPUT(q);
   CHECK_INPUT(k);
   CHECK_INPUT(v);
@@ -63,7 +63,8 @@ void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::T
   auto q_scalar_type = q.scalar_type();
   auto kv_scalar_type = k.scalar_type();
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
   TORCH_CHECK(head_dim_qk == head_dim_vo,
               "CUDA cores template only supports equal head dim for QK and VO, please use tensor "

--- a/csrc/single_decode_jit_pybind.cu
+++ b/csrc/single_decode_jit_pybind.cu
@@ -19,7 +19,7 @@
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                  at::Tensor o, int64_t layout,
-                                 int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+                                 int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Single-request decode with KV-Cache operator

--- a/csrc/single_prefill.cu
+++ b/csrc/single_prefill.cu
@@ -36,7 +36,7 @@ using namespace flashinfer;
 void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                   at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                   int64_t mask_mode_code, int64_t layout,
-                                  int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream) {
+                                  int64_t window_left ADDITIONAL_FUNC_PARAMS) {
   auto device = q.device();
   unsigned int head_dim_qk = q.size(2);
   unsigned int kv_len, qo_len, num_kv_heads, num_qo_heads;
@@ -71,7 +71,8 @@ void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::
   auto q_scalar_type = q.scalar_type();
   auto kv_scalar_type = k.scalar_type();
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
   DISPATCH_context(
       DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,

--- a/csrc/single_prefill_jit_pybind.cu
+++ b/csrc/single_prefill_jit_pybind.cu
@@ -19,7 +19,7 @@
 void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                   at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                   int64_t mask_mode_code, int64_t layout,
-                                  int64_t window_left ADDITIONAL_FUNC_PARAMS, int64_t cuda_stream);
+                                  int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Single-request prefill attention with KV-Cache operator

--- a/csrc/single_prefill_sm90.cu
+++ b/csrc/single_prefill_sm90.cu
@@ -34,8 +34,7 @@ using namespace flashinfer;
 void single_prefill_with_kv_cache_sm90(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                        at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                        int64_t mask_mode_code, int64_t layout,
-                                       int64_t window_left ADDITIONAL_FUNC_PARAMS,
-                                       int64_t cuda_stream) {
+                                       int64_t window_left ADDITIONAL_FUNC_PARAMS) {
   unsigned int head_dim_qk = q.size(2);
   unsigned int head_dim_vo = v.size(2);
   unsigned int num_qo_heads = q.size(1);
@@ -45,7 +44,8 @@ void single_prefill_with_kv_cache_sm90(at::Tensor q, at::Tensor k, at::Tensor v,
   auto kv_scalar_type = k.scalar_type();
 
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
 
   DISPATCH_context(

--- a/csrc/single_prefill_sm90_jit_pybind.cu
+++ b/csrc/single_prefill_sm90_jit_pybind.cu
@@ -19,8 +19,7 @@
 void single_prefill_with_kv_cache_sm90(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
                                        at::Tensor o, std::optional<at::Tensor> maybe_lse,
                                        int64_t mask_mode_code, int64_t layout,
-                                       int64_t window_left ADDITIONAL_FUNC_PARAMS,
-                                       int64_t cuda_stream);
+                                       int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   // Single-request prefill attention with KV-Cache operator

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from functools import cache
 from types import SimpleNamespace
 
 import torch
@@ -72,8 +73,7 @@ def get_act_and_mul_module(act_func_name: str):
         def _act_and_mul(
             out: torch.Tensor, input: torch.Tensor, enable_pdl: bool = False
         ) -> None:
-            with input.device as device:  # device guard
-                fn(out, input, enable_pdl, get_cuda_stream(device))
+            fn(out, input, enable_pdl)
 
         @register_fake_op(f"flashinfer::{fname}")
         def _fake_act_and_mul(

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 import torch
 
 from .jit import gen_act_and_mul_module, has_prebuilt_ops, load_cuda_ops  # noqa: F401
-from .utils import get_cuda_stream, register_custom_op, register_fake_op
+from .utils import register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
 __device__ __forceinline__ float silu(const float& val) {

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -51,7 +51,6 @@ from .utils import (
     _get_range_buf,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
-    get_cuda_stream,
     register_custom_op,
     register_fake_op,
 )
@@ -90,22 +89,20 @@ def get_single_decode_module(*args):
             rope_scale: float,
             rope_theta: float,
         ) -> None:
-            with q.device as device:
-                run_func(
-                    q,
-                    k,
-                    v,
-                    tmp,
-                    o,
-                    kv_layout_code,
-                    window_left,
-                    alibi_slopes,
-                    logits_soft_cap,
-                    sm_scale,
-                    1.0 / rope_scale,  # rope_rcp_scale
-                    1.0 / rope_theta,  # rope_rcp_theta
-                    get_cuda_stream(device),
-                )
+            run_func(
+                q,
+                k,
+                v,
+                tmp,
+                o,
+                kv_layout_code,
+                window_left,
+                alibi_slopes,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
+            )
 
         @register_fake_op(f"flashinfer::{uri}_run")
         def _fake_run_single_decode(
@@ -164,24 +161,22 @@ def get_batch_decode_jit_module(module_name: str, jit_module: Any):
         window_left: int,
         *args,
     ) -> None:
-        with q.device as device:
-            run_func(
-                float_workspace_buffer,
-                int_workspace_buffer,
-                plan_info_vec,
-                q,
-                paged_k_cache,
-                paged_v_cache,
-                paged_kv_indptr,
-                paged_kv_indices,
-                paged_kv_last_page_len,
-                o,
-                maybe_lse,
-                kv_layout_code,
-                window_left,
-                *args,
-                get_cuda_stream(device),
-            )
+        run_func(
+            float_workspace_buffer,
+            int_workspace_buffer,
+            plan_info_vec,
+            q,
+            paged_k_cache,
+            paged_v_cache,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+            o,
+            maybe_lse,
+            kv_layout_code,
+            window_left,
+            *args,
+        )
 
     @register_fake_op(f"flashinfer::{module_name}_run")
     def _fake_run_batch_decode(
@@ -256,28 +251,26 @@ def get_batch_decode_module(*args):
             rope_scale: float,
             rope_theta: float,
         ) -> None:
-            with q.device as device:
-                run_func(
-                    float_workspace_buffer,
-                    int_workspace_buffer,
-                    plan_info_vec,
-                    q,
-                    paged_k_cache,
-                    paged_v_cache,
-                    paged_kv_indptr,
-                    paged_kv_indices,
-                    paged_kv_last_page_len,
-                    o,
-                    maybe_lse,
-                    kv_layout_code,
-                    window_left,
-                    alibi_slopes,
-                    logits_soft_cap,
-                    sm_scale,
-                    1.0 / rope_scale,  # rope_rcp_scale
-                    1.0 / rope_theta,  # rope_rcp_theta
-                    get_cuda_stream(device),
-                )
+            run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                paged_k_cache,
+                paged_v_cache,
+                paged_kv_indptr,
+                paged_kv_indices,
+                paged_kv_last_page_len,
+                o,
+                maybe_lse,
+                kv_layout_code,
+                window_left,
+                alibi_slopes,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
+            )
 
         @register_fake_op(f"flashinfer::{uri}_run")
         def _fake_run_batch_decode(
@@ -322,23 +315,20 @@ def single_decode_with_kv_cache_with_jit_module(
     kv_layout: str = "NHD",
     window_left: int = -1,
 ):
-    with q.device as device:
-        tmp = _get_cache_buf(
-            "single_decode_with_kv_cache_tmp", 32 * 1024 * 1024, device
-        )
-        o = torch.empty_like(q)
-        jit_module.run.default(
-            q,
-            k,
-            v,
-            tmp,
-            o,
-            TensorLayout[kv_layout].value,
-            window_left,
-            *args,
-            get_cuda_stream(device),
-        )
-        return o
+    device = q.device
+    tmp = _get_cache_buf("single_decode_with_kv_cache_tmp", 32 * 1024 * 1024, device)
+    o = torch.empty_like(q)
+    jit_module.run.default(
+        q,
+        k,
+        v,
+        tmp,
+        o,
+        TensorLayout[kv_layout].value,
+        window_left,
+        *args,
+    )
+    return o
 
 
 def get_batch_decode_mla_module(*args):
@@ -875,25 +865,24 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     logits_soft_cap > 0,  # use_logits_soft_cap
                     False,  # use_fp16_qk_reduction
                 )
-            with self.device as device:
-                self._plan_info = self._cached_module.plan(
-                    self._float_workspace_buffer,
-                    self._int_workspace_buffer,
-                    self._pin_memory_int_workspace_buffer,
-                    qo_indptr_host,
-                    indptr_host,
-                    kv_lens_arr_host,
-                    batch_size,  # total_num_rows
-                    batch_size,
-                    num_qo_heads,
-                    num_kv_heads,
-                    page_size,
-                    self.is_cuda_graph_enabled,
-                    head_dim,
-                    head_dim,
-                    False,  # causal
-                    get_cuda_stream(device),
-                )
+
+            self._plan_info = self._cached_module.plan(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._pin_memory_int_workspace_buffer,
+                qo_indptr_host,
+                indptr_host,
+                kv_lens_arr_host,
+                batch_size,  # total_num_rows
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                page_size,
+                self.is_cuda_graph_enabled,
+                head_dim,
+                head_dim,
+                False,  # causal
+            )
         else:
             if self._jit_module is not None:
                 self._cached_module = self._jit_module
@@ -909,25 +898,24 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     window_left != -1,  # use_sliding_window
                     logits_soft_cap > 0,  # use_logits_soft_cap
                 )
-            with self.device as device:
-                self._plan_info = self._cached_module.plan(
-                    self._float_workspace_buffer,
-                    self._int_workspace_buffer,
-                    self._pin_memory_int_workspace_buffer,
-                    indptr_host,
-                    batch_size,
-                    num_qo_heads,
-                    num_kv_heads,
-                    page_size,
-                    self.is_cuda_graph_enabled,
-                    window_left,
-                    logits_soft_cap,
-                    head_dim,
-                    head_dim,
-                    torch.empty(0, dtype=q_data_type),
-                    torch.empty(0, dtype=kv_data_type),
-                    get_cuda_stream(device),
-                )
+
+            self._plan_info = self._cached_module.plan(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._pin_memory_int_workspace_buffer,
+                indptr_host,
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                page_size,
+                self.is_cuda_graph_enabled,
+                window_left,
+                logits_soft_cap,
+                head_dim,
+                head_dim,
+                torch.empty(0, dtype=q_data_type),
+                torch.empty(0, dtype=kv_data_type),
+            )
 
         self._pos_encoding_mode = pos_encoding_mode
         self._window_left = window_left
@@ -1479,18 +1467,16 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
             logits_soft_cap > 0,  # use_logits_soft_cap
             self._use_tensor_cores,
         )
-        with self.device as device:
-            self._plan_info = self._cached_module.plan(
-                self._float_workspace_buffer,
-                self._int_workspace_buffer,
-                self._pin_memory_int_workspace_buffer,
-                indptr_host,
-                batch_size,
-                num_qo_heads,
-                page_size,
-                self.is_cuda_graph_enabled,
-                get_cuda_stream(device),
-            )
+        self._plan_info = self._cached_module.plan(
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._pin_memory_int_workspace_buffer,
+            indptr_host,
+            batch_size,
+            num_qo_heads,
+            page_size,
+            self.is_cuda_graph_enabled,
+        )
 
         self._sm_scale = sm_scale
         self._window_left = window_left
@@ -1563,50 +1549,49 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         if rope_theta is None:
             rope_theta = 1e4
 
-        with self.device as device:
-            if out is None:
-                out = torch.empty_like(q_nope, device=device)
+        device = self.device
+        if out is None:
+            out = torch.empty_like(q_nope, device=device)
+        else:
+            _check_shape_dtype_device(
+                out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
+            )
+
+        if return_lse:
+            if lse is None:
+                lse = torch.empty(
+                    (q_nope.size(0), q_nope.size(1)),
+                    dtype=torch.float32,
+                    device=device,
+                )
             else:
                 _check_shape_dtype_device(
-                    out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
+                    lse,
+                    (q_nope.size(0), q_nope.size(1)),
+                    q_nope.dtype,
+                    q_nope.device,
+                    "lse",
                 )
-
-            if return_lse:
-                if lse is None:
-                    lse = torch.empty(
-                        (q_nope.size(0), q_nope.size(1)),
-                        dtype=torch.float32,
-                        device=device,
-                    )
-                else:
-                    _check_shape_dtype_device(
-                        lse,
-                        (q_nope.size(0), q_nope.size(1)),
-                        q_nope.dtype,
-                        q_nope.device,
-                        "lse",
-                    )
-            self._cached_module.run(
-                self._float_workspace_buffer,
-                self._int_workspace_buffer,
-                self._plan_info,
-                q_nope,
-                q_pe,
-                paged_ckv_cache,
-                paged_kpe_cache,
-                self._paged_kv_indptr_buf,
-                self._paged_kv_indices_buf,
-                self._paged_kv_last_page_len_buf,
-                out,
-                sm_scale,
-                window_left,
-                logits_soft_cap,
-                rope_scale,
-                rope_theta,
-                lse,
-                get_cuda_stream(device),
-            )
-            out = [out, lse] if return_lse else [out]
+        self._cached_module.run(
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._plan_info,
+            q_nope,
+            q_pe,
+            paged_ckv_cache,
+            paged_kpe_cache,
+            self._paged_kv_indptr_buf,
+            self._paged_kv_indices_buf,
+            self._paged_kv_last_page_len_buf,
+            out,
+            sm_scale,
+            window_left,
+            logits_soft_cap,
+            rope_scale,
+            rope_theta,
+            lse,
+        )
+        out = [out, lse] if return_lse else [out]
         if v_scale is not None:
             out[0] *= v_scale
 

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -64,18 +64,16 @@ def get_gemm_module():
             A_scale: torch.Tensor,
             B_scale: torch.Tensor,
         ) -> None:
-            with A.device as device:
-                cublas_handle = torch.cuda.current_blas_handle()
-                module.bmm_fp8.default(
-                    A,
-                    B,
-                    D,
-                    A_scale,
-                    B_scale,
-                    workspace_buffer,
-                    cublas_handle,
-                    get_cuda_stream(device),
-                )
+            cublas_handle = torch.cuda.current_blas_handle()
+            module.bmm_fp8.default(
+                A,
+                B,
+                D,
+                A_scale,
+                B_scale,
+                workspace_buffer,
+                cublas_handle,
+            )
 
         @register_fake_op("flashinfer::bmm_fp8")
         def _fake_bmm_fp8(
@@ -104,20 +102,18 @@ def get_gemm_module():
             empty_x_data: torch.Tensor,
             weight_column_major: bool,
         ) -> None:
-            with x_data.device as device:
-                module.cutlass_segment_gemm.default(
-                    workspace_buffer,
-                    all_problems,
-                    x_data,
-                    w_data,
-                    y_data,
-                    x_ld,
-                    w_ld,
-                    y_ld,
-                    empty_x_data,
-                    weight_column_major,
-                    get_cuda_stream(device),
-                )
+            module.cutlass_segment_gemm.default(
+                workspace_buffer,
+                all_problems,
+                x_data,
+                w_data,
+                y_data,
+                x_ld,
+                w_ld,
+                y_ld,
+                empty_x_data,
+                weight_column_major,
+            )
 
         @register_fake_op("flashinfer::cutlass_segment_gemm")
         def _fake_cutlass_segment_gemm(
@@ -181,21 +177,19 @@ def get_gemm_sm90_module():
             empty_x_data: torch.Tensor,
             weight_column_major: bool,
         ) -> None:
-            with x_data.device as device:
-                module.cutlass_segment_gemm_sm90.default(
-                    workspace_buffer,
-                    int_workspace_buffer,
-                    all_problems,
-                    x_data,
-                    w_data,
-                    y_data,
-                    x_stride,
-                    w_stride,
-                    y_stride,
-                    empty_x_data,
-                    weight_column_major,
-                    get_cuda_stream(device),
-                )
+            module.cutlass_segment_gemm_sm90.default(
+                workspace_buffer,
+                int_workspace_buffer,
+                all_problems,
+                x_data,
+                w_data,
+                y_data,
+                x_stride,
+                w_stride,
+                y_stride,
+                empty_x_data,
+                weight_column_major,
+            )
 
         @register_fake_op("flashinfer::cutlass_segment_gemm_sm90")
         def _fake_cutlass_segment_gemm_sm90(

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -23,7 +23,6 @@ from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
 from .utils import (
     _get_cache_buf,
     determine_gemm_backend,
-    get_cuda_stream,
     get_indptr,
     register_custom_op,
     register_fake_op,

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -33,12 +33,13 @@ using namespace flashinfer;
 
 {{ act_func_def }}
 
-void {{ func_name }}(at::Tensor& out, at::Tensor& input, bool enable_pdl, int64_t cuda_stream) {
+void {{ func_name }}(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
   dim3 grid(num_tokens);
 
-  cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const c10::cuda::OptionalCUDAGuard device_guard(out.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
     cudaLaunchConfig_t config;

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -25,7 +25,6 @@ from .utils import (
     MaskMode,
     _check_shape_dtype_device,
     determine_mla_backend,
-    get_cuda_stream,
     register_custom_op,
     register_fake_op,
 )
@@ -253,19 +252,17 @@ class BatchMLAPagedAttentionWrapper:
         self._sm_scale = sm_scale
         self._use_profiler = use_profiler
 
-        with self.device as device:
-            self._plan_info = self._cached_module.plan.default(
-                self._float_workspace_buffer,
-                self._int_workspace_buffer,
-                self._pin_memory_int_workspace_buffer,
-                qo_indptr_host,
-                kv_indptr_host,
-                kv_len_arr_host,
-                num_heads,
-                head_dim_ckv,  # head_dim_o
-                causal,
-                get_cuda_stream(device),
-            )
+        self._plan_info = self._cached_module.plan.default(
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._pin_memory_int_workspace_buffer,
+            qo_indptr_host,
+            kv_indptr_host,
+            kv_len_arr_host,
+            num_heads,
+            head_dim_ckv,  # head_dim_o
+            causal,
+        )
 
     @overload
     def run(
@@ -331,41 +328,38 @@ class BatchMLAPagedAttentionWrapper:
         sm_scale = self._sm_scale
         causal = self._causal
         mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
-        with self.device as device:
-            if out is None:
-                out = torch.empty_like(q_nope)
+        device = self.device
+        if out is None:
+            out = torch.empty_like(q_nope)
+        else:
+            _check_shape_dtype_device(
+                out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
+            )
+
+        if return_lse:
+            if lse is None:
+                lse = torch.empty(q_nope.shape[:2], dtype=torch.float32, device=device)
             else:
                 _check_shape_dtype_device(
-                    out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
+                    lse, q_nope.shape[:2], torch.float32, q_nope.device, "lse"
                 )
-
-            if return_lse:
-                if lse is None:
-                    lse = torch.empty(
-                        q_nope.shape[:2], dtype=torch.float32, device=device
-                    )
-                else:
-                    _check_shape_dtype_device(
-                        lse, q_nope.shape[:2], torch.float32, q_nope.device, "lse"
-                    )
-            profiler_args = (profiler_buffer,) if self._use_profiler else ()
-            self._cached_module.run.default(
-                self._float_workspace_buffer,
-                self._int_workspace_buffer,
-                self._plan_info,
-                q_nope,
-                q_pe,
-                ckv_cache,
-                kpe_cache,
-                self._kv_indices_buf,
-                out,
-                lse,
-                mask_mode,
-                num_heads,
-                page_size,
-                sm_scale,
-                *profiler_args,
-                get_cuda_stream(device),
-            )
+        profiler_args = (profiler_buffer,) if self._use_profiler else ()
+        self._cached_module.run.default(
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._plan_info,
+            q_nope,
+            q_pe,
+            ckv_cache,
+            kpe_cache,
+            self._kv_indices_buf,
+            out,
+            lse,
+            mask_mode,
+            num_heads,
+            page_size,
+            sm_scale,
+            *profiler_args,
+        )
 
         return (out, lse) if return_lse else out

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional
+from functools import cache
+from typing import Any, Optional
 
 import torch
 
 from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
-from .utils import get_cuda_stream, register_custom_op, register_fake_op
+from .utils import register_custom_op, register_fake_op
 
 _norm_module = None
 
@@ -40,6 +41,14 @@ def get_norm_module():
                 ],
             )
     return _norm_module
+
+
+@cache
+def get_module_attr(attr: str) -> Any:
+    global _norm_module
+    if _norm_module is None:
+        get_norm_module()
+    return getattr(_norm_module, attr).default
 
 
 def rmsnorm(
@@ -86,10 +95,7 @@ def _rmsnorm(
     eps: float,
     enable_pdl: bool,
 ) -> None:
-    with input.device as device:  # device guard
-        get_norm_module().rmsnorm.default(
-            out, input, weight, eps, enable_pdl, get_cuda_stream(device)
-        )
+    get_module_attr("rmsnorm")(out, input, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::rmsnorm")
@@ -101,9 +107,6 @@ def _rmsnorm_fake(
     enable_pdl: bool,
 ) -> None:
     pass
-
-
-_fused_add_rmsnorm_kernel = None
 
 
 @register_custom_op("flashinfer::fused_add_rmsnorm", mutates_args=("input", "residual"))
@@ -136,12 +139,7 @@ def fused_add_rmsnorm(
         Whether to enable `programmatic dependent launch
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
     """
-    global _fused_add_rmsnorm_kernel
-    if _fused_add_rmsnorm_kernel is None:
-        _fused_add_rmsnorm_kernel = get_norm_module().fused_add_rmsnorm.default
-    _fused_add_rmsnorm_kernel(
-        input, residual, weight, eps, enable_pdl, get_cuda_stream(input.device)
-    )
+    get_module_attr("fused_add_rmsnorm")(input, residual, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::fused_add_rmsnorm")
@@ -199,10 +197,7 @@ def _gemma_rmsnorm(
     eps: float,
     enable_pdl: bool,
 ) -> None:
-    with input.device as device:  # device guard
-        get_norm_module().gemma_rmsnorm.default(
-            out, input, weight, eps, enable_pdl, get_cuda_stream(device)
-        )
+    get_module_attr("gemma_rmsnorm")(out, input, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::gemma_rmsnorm")
@@ -248,10 +243,7 @@ def gemma_fused_add_rmsnorm(
         Whether to enable `programmatic dependent launch
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
     """
-    with input.device as device:
-        get_norm_module().gemma_fused_add_rmsnorm.default(
-            input, residual, weight, eps, enable_pdl, get_cuda_stream(device)
-        )
+    get_module_attr("gemma_fused_add_rmsnorm")(input, residual, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::gemma_fused_add_rmsnorm")

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional, Tuple, Union
+from functools import cache
+from typing import Any, Optional, Tuple, Union
 
 import torch
 
@@ -49,6 +50,14 @@ def get_page_module():
     return _page_module
 
 
+@cache
+def get_module_attr(attr: str) -> Any:
+    global _page_module
+    if _page_module is None:
+        get_page_module()
+    return getattr(_page_module, attr).default
+
+
 def block_sparse_indices_to_vector_sparse_offsets(
     block_sparse_indices: torch.Tensor,
     block_sparse_indptr: torch.Tensor,
@@ -65,25 +74,23 @@ def block_sparse_indices_to_vector_sparse_offsets(
         else:
             return block_sparse_indices * stride_block
 
-    with block_sparse_indices.device as device:
-        assert block_sparse_indices.dtype == torch.int32
-        assert block_sparse_indptr.dtype == torch.int32
-        assert vector_sparse_offsets.dtype == torch.int32
-        assert vector_sparse_indptr.dtype == torch.int32
-        assert kv_lens.dtype == torch.int32
-        batch_size = block_sparse_indptr.size(0) - 1
-        get_page_module().block_sparse_indices_to_vector_sparse_offsets.default(
-            block_sparse_indices,
-            block_sparse_indptr,
-            vector_sparse_offsets,
-            vector_sparse_indptr,
-            kv_lens,
-            stride_block,
-            stride_n,
-            batch_size,
-            block_size,
-            get_cuda_stream(device),
-        )
+    assert block_sparse_indices.dtype == torch.int32
+    assert block_sparse_indptr.dtype == torch.int32
+    assert vector_sparse_offsets.dtype == torch.int32
+    assert vector_sparse_indptr.dtype == torch.int32
+    assert kv_lens.dtype == torch.int32
+    batch_size = block_sparse_indptr.size(0) - 1
+    get_module_attr("block_sparse_indices_to_vector_sparse_offsets")(
+        block_sparse_indices,
+        block_sparse_indptr,
+        vector_sparse_offsets,
+        vector_sparse_indptr,
+        kv_lens,
+        stride_block,
+        stride_n,
+        batch_size,
+        block_size,
+    )
     return vector_sparse_offsets
 
 
@@ -102,24 +109,22 @@ def _append_paged_mla_kv_cache_kernel(
     kv_indptr: torch.Tensor,
     kv_last_page_len: torch.Tensor,
 ) -> None:
-    with append_ckv.device as device:
-        batch_indices = batch_indices.int()
-        positions = positions.int()
-        kv_indices = kv_indices.int()
-        kv_indptr = kv_indptr.int()
-        kv_last_page_len = kv_last_page_len.int()
-        get_page_module().append_paged_mla_kv_cache.default(
-            append_ckv,
-            append_kpe,
-            batch_indices,
-            positions,
-            ckv_cache,
-            kpe_cache,
-            kv_indices,
-            kv_indptr,
-            kv_last_page_len,
-            get_cuda_stream(device),
-        )
+    batch_indices = batch_indices.int()
+    positions = positions.int()
+    kv_indices = kv_indices.int()
+    kv_indptr = kv_indptr.int()
+    kv_last_page_len = kv_last_page_len.int()
+    get_module_attr("append_paged_mla_kv_cache")(
+        append_ckv,
+        append_kpe,
+        batch_indices,
+        positions,
+        ckv_cache,
+        kpe_cache,
+        kv_indices,
+        kv_indptr,
+        kv_last_page_len,
+    )
 
 
 @register_custom_op(
@@ -138,25 +143,23 @@ def _append_paged_kv_cache_kernel(
     kv_last_page_len: torch.Tensor,
     layout: int,
 ) -> None:
-    with append_key.device as device:
-        batch_indices = batch_indices.int()
-        positions = positions.int()
-        kv_indices = kv_indices.int()
-        kv_indptr = kv_indptr.int()
-        kv_last_page_len = kv_last_page_len.int()
-        get_page_module().append_paged_kv_cache.default(
-            append_key,
-            append_value,
-            batch_indices,
-            positions,
-            paged_k_cache,
-            paged_v_cache,
-            kv_indices,
-            kv_indptr,
-            kv_last_page_len,
-            layout,
-            get_cuda_stream(device),
-        )
+    batch_indices = batch_indices.int()
+    positions = positions.int()
+    kv_indices = kv_indices.int()
+    kv_indptr = kv_indptr.int()
+    kv_last_page_len = kv_last_page_len.int()
+    get_module_attr("append_paged_kv_cache")(
+        append_key,
+        append_value,
+        batch_indices,
+        positions,
+        paged_k_cache,
+        paged_v_cache,
+        kv_indices,
+        kv_indptr,
+        kv_last_page_len,
+        layout,
+    )
 
 
 @register_fake_op("flashinfer::append_paged_kv_cache")

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -24,7 +24,6 @@ from .utils import (
     TensorLayout,
     _check_kv_layout,
     _unpack_paged_kv_cache,
-    get_cuda_stream,
     register_custom_op,
     register_fake_op,
 )

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -49,7 +49,6 @@ from .utils import (
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
     determine_attention_backend,
-    get_cuda_stream,
     is_float8,
     register_custom_op,
     register_fake_op,
@@ -422,25 +421,23 @@ class PODWithPagedKVCacheWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 False,  # use_fp16_qk_reduction
             )
-        with self.device as device:
-            self._plan_info = self._cached_module.plan(
-                self._float_workspace_buffer,
-                self._int_workspace_buffer,
-                self._pin_memory_int_workspace_buffer,
-                qo_indptr_host,
-                indptr_host,
-                kv_lens_arr_host,
-                batch_size,  # total_num_rows
-                batch_size,
-                num_qo_heads,
-                num_kv_heads,
-                page_size,
-                self.is_cuda_graph_enabled,
-                head_dim,
-                head_dim,
-                False,  # causal
-                get_cuda_stream(device),
-            )
+        self._plan_info = self._cached_module.plan(
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._pin_memory_int_workspace_buffer,
+            qo_indptr_host,
+            indptr_host,
+            kv_lens_arr_host,
+            batch_size,  # total_num_rows
+            batch_size,
+            num_qo_heads,
+            num_kv_heads,
+            page_size,
+            self.is_cuda_graph_enabled,
+            head_dim,
+            head_dim,
+            False,  # causal
+        )
 
         self._indptr_type = indptr.dtype
         self._pos_encoding_mode = pos_encoding_mode
@@ -561,70 +558,68 @@ class PODWithPagedKVCacheWrapper:
             )
         out_d = torch.empty_like(q_d)
 
-        with q_p.device as device:  # device guard
-            module_getter = get_pod_module(
-                # Prefill params
-                q_p.dtype,
-                k_p.dtype,
-                q_p.dtype,
-                q_p.shape[-1],
-                PosEncodingMode[pos_encoding_mode_p].value,
-                window_left_p >= 0,  # use_sliding_window
-                logits_soft_cap_p > 0,  # use_logits_soft_cap
-                use_fp16_qk_reduction,
-                # Decode params
-                # q_d.dtype,
-                # self._cached_kv_data_type,
-                # self._cached_q_data_type,
-                self._indptr_type,
-                # head_dim,  # head_dim_qk
-                # head_dim,  # head_dim_vo
-                PosEncodingMode[pos_encoding_mode_d].value,
-                window_left_d != -1,  # use_sliding_window
-                logits_soft_cap_d > 0,  # use_logits_soft_cap
-            )
-            module_getter.run_tensor(
-                # Prefill params
-                q_p,
-                k_p,
-                v_p,
-                tmp_p,
-                out_p,
-                lse_p,
-                mask_mode_p,
-                TensorLayout[kv_layout_p].value,
-                window_left_p,
-                packed_custom_mask_p,
-                _get_cache_alibi_slopes_buf(q_p.shape[1], q_p.device),
-                logits_soft_cap_p,
-                sm_scale_p,
-                1.0 / rope_scale_p,
-                1.0 / rope_theta_p,
-                # Decode params
-                self._float_workspace_buffer,
-                self._int_workspace_buffer,
-                self._plan_info,
-                q_d,
-                k_cache_d,
-                v_cache_d,
-                self._qo_indptr_buf,
-                self._paged_kv_indptr_buf,
-                self._paged_kv_indices_buf,
-                self._paged_kv_last_page_len_buf,
-                out_d,
-                lse_d,
-                MaskMode.NON_CAUSAL.value,
-                TensorLayout[self._kv_layout].value,
-                window_left_d,
-                None,  # packed_custom_mask
-                None,  # mask_indptr_buf
-                _get_cache_alibi_slopes_buf(q_d.shape[1], q_d.device),
-                logits_soft_cap_d,
-                sm_scale_d,
-                1.0 / rope_scale_d,
-                1.0 / rope_theta_d,
-                get_cuda_stream(device),
-            )
+        module_getter = get_pod_module(
+            # Prefill params
+            q_p.dtype,
+            k_p.dtype,
+            q_p.dtype,
+            q_p.shape[-1],
+            PosEncodingMode[pos_encoding_mode_p].value,
+            window_left_p >= 0,  # use_sliding_window
+            logits_soft_cap_p > 0,  # use_logits_soft_cap
+            use_fp16_qk_reduction,
+            # Decode params
+            # q_d.dtype,
+            # self._cached_kv_data_type,
+            # self._cached_q_data_type,
+            self._indptr_type,
+            # head_dim,  # head_dim_qk
+            # head_dim,  # head_dim_vo
+            PosEncodingMode[pos_encoding_mode_d].value,
+            window_left_d != -1,  # use_sliding_window
+            logits_soft_cap_d > 0,  # use_logits_soft_cap
+        )
+        module_getter.run_tensor(
+            # Prefill params
+            q_p,
+            k_p,
+            v_p,
+            tmp_p,
+            out_p,
+            lse_p,
+            mask_mode_p,
+            TensorLayout[kv_layout_p].value,
+            window_left_p,
+            packed_custom_mask_p,
+            _get_cache_alibi_slopes_buf(q_p.shape[1], q_p.device),
+            logits_soft_cap_p,
+            sm_scale_p,
+            1.0 / rope_scale_p,
+            1.0 / rope_theta_p,
+            # Decode params
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._plan_info,
+            q_d,
+            k_cache_d,
+            v_cache_d,
+            self._qo_indptr_buf,
+            self._paged_kv_indptr_buf,
+            self._paged_kv_indices_buf,
+            self._paged_kv_last_page_len_buf,
+            out_d,
+            lse_d,
+            MaskMode.NON_CAUSAL.value,
+            TensorLayout[self._kv_layout].value,
+            window_left_d,
+            None,  # packed_custom_mask
+            None,  # mask_indptr_buf
+            _get_cache_alibi_slopes_buf(q_d.shape[1], q_d.device),
+            logits_soft_cap_d,
+            sm_scale_d,
+            1.0 / rope_scale_d,
+            1.0 / rope_theta_d,
+        )
 
         if v_scale is not None:
             out_d *= v_scale

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -20,7 +20,7 @@ from typing import Any, Tuple
 import torch
 
 from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
-from .utils import get_cuda_stream, register_custom_op, register_fake_op
+from .utils import register_custom_op, register_fake_op
 
 _quantization_module = None
 

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -20,7 +20,7 @@ from typing import Optional, Union
 import torch
 
 from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
-from .utils import get_cuda_stream, register_custom_op, register_fake_op
+from .utils import register_custom_op, register_fake_op
 
 _sampling_module = None
 
@@ -51,19 +51,18 @@ def get_sampling_module():
             deterministic: bool,
             generator: Optional[torch.Generator],
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                batch_size = indices.size(0) if indices is not None else probs.size(0)
-                samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-                module.sampling_from_probs.default(
-                    probs,
-                    samples,
-                    indices,
-                    deterministic,
-                    generator,
-                    get_cuda_stream(device),
-                )
-                return samples
+            device = probs.device
+            probs = probs.float()
+            batch_size = indices.size(0) if indices is not None else probs.size(0)
+            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+            module.sampling_from_probs.default(
+                probs,
+                samples,
+                indices,
+                deterministic,
+                generator,
+            )
+            return samples
 
         @register_fake_op("flashinfer::sampling_from_probs")
         def _fake_sampling_from_probs(
@@ -86,24 +85,23 @@ def get_sampling_module():
             deterministic: bool,
             generator: Optional[torch.Generator],
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                maybe_top_p_arr = (
-                    maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
-                )
-                batch_size = indices.size(0) if indices is not None else probs.size(0)
-                samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-                module.top_p_sampling_from_probs.default(
-                    probs,
-                    samples,
-                    indices,
-                    maybe_top_p_arr,
-                    top_p_val,
-                    deterministic,
-                    generator,
-                    get_cuda_stream(device),
-                )
-                return samples
+            device = probs.device
+            probs = probs.float()
+            maybe_top_p_arr = (
+                maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+            )
+            batch_size = indices.size(0) if indices is not None else probs.size(0)
+            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+            module.top_p_sampling_from_probs.default(
+                probs,
+                samples,
+                indices,
+                maybe_top_p_arr,
+                top_p_val,
+                deterministic,
+                generator,
+            )
+            return samples
 
         @register_fake_op("flashinfer::top_p_sampling_from_probs")
         def _fake_top_p_sampling_from_probs(
@@ -128,24 +126,23 @@ def get_sampling_module():
             deterministic: bool,
             generator: Optional[torch.Generator],
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                batch_size = indices.size(0) if indices is not None else probs.size(0)
-                maybe_top_k_arr = (
-                    maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-                )
-                samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-                module.top_k_sampling_from_probs.default(
-                    probs,
-                    samples,
-                    indices,
-                    maybe_top_k_arr,
-                    top_k_val,
-                    deterministic,
-                    generator,
-                    get_cuda_stream(device),
-                )
-                return samples
+            device = probs.device
+            probs = probs.float()
+            batch_size = indices.size(0) if indices is not None else probs.size(0)
+            maybe_top_k_arr = (
+                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+            )
+            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+            module.top_k_sampling_from_probs.default(
+                probs,
+                samples,
+                indices,
+                maybe_top_k_arr,
+                top_k_val,
+                deterministic,
+                generator,
+            )
+            return samples
 
         @register_fake_op("flashinfer::top_k_sampling_from_probs")
         def _fake_top_k_sampling_from_probs(
@@ -171,24 +168,23 @@ def get_sampling_module():
             deterministic: bool,
             generator: Optional[torch.Generator],
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                maybe_min_p_arr = (
-                    maybe_min_p_arr.float() if maybe_min_p_arr is not None else None
-                )
-                batch_size = indices.size(0) if indices is not None else probs.size(0)
-                samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-                module.min_p_sampling_from_probs.default(
-                    probs,
-                    samples,
-                    indices,
-                    maybe_min_p_arr,
-                    min_p_val,
-                    deterministic,
-                    generator,
-                    get_cuda_stream(device),
-                )
-                return samples
+            device = probs.device
+            probs = probs.float()
+            maybe_min_p_arr = (
+                maybe_min_p_arr.float() if maybe_min_p_arr is not None else None
+            )
+            batch_size = indices.size(0) if indices is not None else probs.size(0)
+            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+            module.min_p_sampling_from_probs.default(
+                probs,
+                samples,
+                indices,
+                maybe_min_p_arr,
+                min_p_val,
+                deterministic,
+                generator,
+            )
+            return samples
 
         # torch library for top_k_top_p_sampling_from_probs
 
@@ -205,29 +201,28 @@ def get_sampling_module():
             deterministic: bool,
             generator: Optional[torch.Generator],
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                maybe_top_k_arr = (
-                    maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-                )
-                maybe_top_p_arr = (
-                    maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
-                )
-                batch_size = indices.size(0) if indices is not None else probs.size(0)
-                samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-                module.top_k_top_p_sampling_from_probs.default(
-                    probs,
-                    samples,
-                    indices,
-                    maybe_top_k_arr,
-                    top_k_val,
-                    maybe_top_p_arr,
-                    top_p_val,
-                    deterministic,
-                    generator,
-                    get_cuda_stream(device),
-                )
-                return samples
+            device = probs.device
+            probs = probs.float()
+            maybe_top_k_arr = (
+                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+            )
+            maybe_top_p_arr = (
+                maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+            )
+            batch_size = indices.size(0) if indices is not None else probs.size(0)
+            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+            module.top_k_top_p_sampling_from_probs.default(
+                probs,
+                samples,
+                indices,
+                maybe_top_k_arr,
+                top_k_val,
+                maybe_top_p_arr,
+                top_p_val,
+                deterministic,
+                generator,
+            )
+            return samples
 
         @register_fake_op("flashinfer::top_k_top_p_sampling_from_probs")
         def _fake_top_k_top_p_sampling_from_probs(
@@ -252,20 +247,19 @@ def get_sampling_module():
             maybe_top_p_arr: Optional[torch.Tensor],
             top_p_val: float,
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                maybe_top_p_arr = (
-                    maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
-                )
-                renorm_probs = torch.empty_like(probs)
-                module.top_p_renorm_probs.default(
-                    probs,
-                    renorm_probs,
-                    maybe_top_p_arr,
-                    top_p_val,
-                    get_cuda_stream(device),
-                )
-                return renorm_probs
+            device = probs.device
+            probs = probs.float()
+            maybe_top_p_arr = (
+                maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+            )
+            renorm_probs = torch.empty_like(probs)
+            module.top_p_renorm_probs.default(
+                probs,
+                renorm_probs,
+                maybe_top_p_arr,
+                top_p_val,
+            )
+            return renorm_probs
 
         @register_fake_op("flashinfer::top_p_renorm_probs")
         def _fake_top_p_renorm_probs(
@@ -283,20 +277,19 @@ def get_sampling_module():
             maybe_top_k_arr: Optional[torch.Tensor],
             top_k_val: int,
         ) -> torch.Tensor:
-            with probs.device as device:
-                probs = probs.float()
-                maybe_top_k_arr = (
-                    maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-                )
-                renorm_probs = torch.empty_like(probs)
-                module.top_k_renorm_probs.default(
-                    probs,
-                    renorm_probs,
-                    maybe_top_k_arr,
-                    top_k_val,
-                    get_cuda_stream(device),
-                )
-                return renorm_probs
+            device = probs.device
+            probs = probs.float()
+            maybe_top_k_arr = (
+                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+            )
+            renorm_probs = torch.empty_like(probs)
+            module.top_k_renorm_probs.default(
+                probs,
+                renorm_probs,
+                maybe_top_k_arr,
+                top_k_val,
+            )
+            return renorm_probs
 
         @register_fake_op("flashinfer::top_k_renorm_probs")
         def _fake_top_k_renorm_probs(
@@ -314,20 +307,19 @@ def get_sampling_module():
             maybe_top_k_arr: Optional[torch.Tensor],
             top_k_val: int,
         ) -> torch.Tensor:
-            with logits.device as device:
-                logits = logits.float()
-                maybe_top_k_arr = (
-                    maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-                )
-                mask_logits = torch.empty_like(logits)
-                module.top_k_mask_logits.default(
-                    logits,
-                    mask_logits,
-                    maybe_top_k_arr,
-                    top_k_val,
-                    get_cuda_stream(device),
-                )
-                return mask_logits
+            device = logits.device
+            logits = logits.float()
+            maybe_top_k_arr = (
+                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+            )
+            mask_logits = torch.empty_like(logits)
+            module.top_k_mask_logits.default(
+                logits,
+                mask_logits,
+                maybe_top_k_arr,
+                top_k_val,
+            )
+            return mask_logits
 
         @register_fake_op("flashinfer::top_k_mask_logits")
         def _fake_top_k_mask_logits(
@@ -352,28 +344,25 @@ def get_sampling_module():
             deterministic: bool,
             generator: Optional[torch.Generator],
         ) -> torch.Tensor:
-            with draft_probs.device as device:
-                draft_probs = draft_probs.float()
-                draft_token_ids = draft_token_ids.int()
-                target_probs = target_probs.float()
-                output_accepted_token_num = output_accepted_token_num.int()
-                output_emitted_token_num = output_emitted_token_num.int()
-                b, n = draft_token_ids.shape
-                output_token_ids = torch.empty(
-                    (b, n + 1), dtype=torch.int32, device=device
-                )
-                module.chain_speculative_sampling.default(
-                    draft_probs,
-                    draft_token_ids,
-                    target_probs,
-                    output_token_ids,
-                    output_accepted_token_num,
-                    output_emitted_token_num,
-                    deterministic,
-                    generator,
-                    get_cuda_stream(device),
-                )
-                return output_token_ids
+            device = draft_probs.device
+            draft_probs = draft_probs.float()
+            draft_token_ids = draft_token_ids.int()
+            target_probs = target_probs.float()
+            output_accepted_token_num = output_accepted_token_num.int()
+            output_emitted_token_num = output_emitted_token_num.int()
+            b, n = draft_token_ids.shape
+            output_token_ids = torch.empty((b, n + 1), dtype=torch.int32, device=device)
+            module.chain_speculative_sampling.default(
+                draft_probs,
+                draft_token_ids,
+                target_probs,
+                output_token_ids,
+                output_accepted_token_num,
+                output_emitted_token_num,
+                deterministic,
+                generator,
+            )
+            return output_token_ids
 
         @register_fake_op("flashinfer::chain_speculative_sampling")
         def _fake_chain_speculative_sampling(

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -256,10 +256,6 @@ else:
         return lambda x: x
 
 
-def get_cuda_stream(device: torch.device) -> int:
-    return torch.cuda.current_stream(device).cuda_stream
-
-
 def determine_gemm_backend(device: torch.device) -> str:
     major, _ = get_compute_capability(device)
     if major == 9 and torch.version.cuda >= "12.3":

--- a/scripts/task_jit_run_tests_part4.sh
+++ b/scripts/task_jit_run_tests_part4.sh
@@ -9,3 +9,4 @@ pip install -e . -v
 
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # avoid memory fragmentation
 pytest -s tests/test_deepseek_mla.py
+pytest -s tests/test_group_gemm.py

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -101,13 +101,13 @@ def test_segment_gemm(
             torch.testing.assert_close(
                 y[i * num_rows_per_batch : (i + 1) * num_rows_per_batch],
                 torch.matmul(
-                    x[i * num_rows_per_batch : (i + 1) * num_rows_per_batch],
+                    x[i * num_rows_per_batch : (i + 1) * num_rows_per_batch].float(),
                     (
-                        weight[i % num_weights].T
+                        weight[i % num_weights].float().T
                         if column_major
-                        else weight[i % num_weights]
+                        else weight[i % num_weights].float()
                     ),
-                ),
+                ).to(dtype),
                 rtol=1e-3,
                 atol=1e-3,
             )
@@ -115,9 +115,11 @@ def test_segment_gemm(
         torch.testing.assert_close(
             y,
             torch.matmul(
-                x.view(batch_size, num_rows_per_batch, d_in),
-                weight.transpose(-1, -2) if column_major else weight,
-            ).view(batch_size * num_rows_per_batch, d_out),
+                x.view(batch_size, num_rows_per_batch, d_in).float(),
+                weight.float().transpose(-1, -2) if column_major else weight.float(),
+            )
+            .view(batch_size * num_rows_per_batch, d_out)
+            .to(dtype),
             rtol=1e-3,
             atol=1e-3,
         )

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -63,6 +63,7 @@ def test_segment_gemm(
     device,
     backend,
 ):
+    torch.manual_seed(42)
     if batch_size * num_rows_per_batch > 8192:
         pytest.skip("batch_size * num_rows_per_batch too large for test.")
     latest_supported_backend = determine_gemm_backend(torch.device(device))

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -122,7 +122,7 @@ def test_segment_gemm(
             .view(batch_size * num_rows_per_batch, d_out)
             .to(dtype),
             rtol=1e-3,
-            atol=1e-3,
+            atol=2e-3,
         )
 
 


### PR DESCRIPTION
This PR fixes issue #960 , we identifies several performance bottlenecks for our python APIs when kernels are not captured by CUDAGraph:
1. The device guard in Python is slow (`with input.device as device:`)
2. Get current cuda stream in Python is time-consuming.

These issues were introduced in JIT refactor after v0.1.6 (mainly for accelerating JIT compilation speed). In this PR, we changed back to get stream and device guard in C++).

@MichoChan @xiaoqi35 