### PR TITLE
benchmark: add sampling.renorm benchmarks

### DIFF
--- a/benchmarks/bench_renorm.py
+++ b/benchmarks/bench_renorm.py
@@ -77,7 +77,6 @@ def main():
 
     print("---")
     print("top-k mask logits")
-
     for vocab_size in [128512]:
         for batch_size in [1, 16, 32, 64, 128, 256, 512]:
             for distrib in [

--- a/benchmarks/bench_renorm.py
+++ b/benchmarks/bench_renorm.py
@@ -1,0 +1,119 @@
+import torch
+from triton.testing import do_bench
+
+import flashinfer
+
+
+def normal_distribution(std):
+    def normal_noise(shape, device):
+        return torch.randn(shape, device=device) * std
+
+    normal_noise.__name__ = f"normal_distribution(std={std})"
+    return normal_noise
+
+
+def gumbel_distribution(beta):
+    def gumbel_noise(shape, device):
+        U = torch.rand(shape, device=device)
+        eps = 1e-20
+        return torch.log(-torch.log(U + eps) + eps) / beta
+
+    gumbel_noise.__name__ = f"gumbel_distribution(beta={beta})"
+    return gumbel_noise
+
+
+def init_seed_top_p_renorm(*args, **kwargs):
+    torch.manual_seed(42)
+    return flashinfer.sampling.top_p_renorm_probs(*args, **kwargs)
+
+
+def init_seed_top_k_renorm(*args, **kwargs):
+    torch.manual_seed(42)
+    return flashinfer.sampling.top_k_renorm_probs(*args, **kwargs)
+
+
+def init_seed_top_k_mask_logits(*args, **kwargs):
+    torch.manual_seed(42)
+    return flashinfer.sampling.top_k_mask_logits(*args, **kwargs)
+
+
+@torch.inference_mode()
+def main():
+    print("---")
+    print("top-p renorm")
+    for vocab_size in [128512]:
+        for batch_size in [1, 16, 32, 64, 128, 256, 512]:
+            for distrib in [
+                normal_distribution(1),
+                normal_distribution(5),
+                gumbel_distribution(0.1),
+                gumbel_distribution(1),
+            ]:
+                for p in [0.1, 0.5, 0.9]:
+                    logits = distrib((batch_size, vocab_size), device="cuda")
+                    probs = torch.softmax(logits, dim=-1)
+                    ms = do_bench(
+                        lambda: init_seed_top_p_renorm(probs, p),
+                        warmup=100,
+                        rep=1000,
+                    )
+
+                    io = (probs.numel() * probs.element_size()) * 2
+                    bandwidth = io * 1e-6 / ms
+                    print(
+                        f"vocab_size: {vocab_size}, batch_size: {batch_size}, distrib: {distrib.__name__}, p: {p}, duration: {ms*1e3:.2f} us, effective bandwidth: {bandwidth:.2f} GB/s"
+                    )
+
+    print("---")
+    print("top-k renorm")
+    for vocab_size in [128512]:
+        for batch_size in [1, 16, 32, 64, 128, 256, 512]:
+            for distrib in [
+                normal_distribution(1),
+                normal_distribution(5),
+                gumbel_distribution(0.1),
+                gumbel_distribution(1),
+            ]:
+                for k in [10, 100, 1000, 5000]:
+                    logits = distrib((batch_size, vocab_size), device="cuda")
+                    probs = torch.softmax(logits, dim=-1)
+                    ms = do_bench(
+                        lambda: init_seed_top_k_renorm(probs, k),
+                        warmup=100,
+                        rep=1000,
+                    )
+
+                    io = (probs.numel() * probs.element_size()) * 2
+                    bandwidth = io * 1e-6 / ms
+                    print(
+                        f"vocab_size: {vocab_size}, batch_size: {batch_size}, distrib: {distrib.__name__}, k: {k}, duration: {ms*1e3:.2f} us, effective bandwidth: {bandwidth:.2f} GB/s"
+                    )
+
+    print("---")
+    print("top-k mask logits")
+
+    for vocab_size in [128512]:
+        for batch_size in [1, 16, 32, 64, 128, 256, 512]:
+            for distrib in [
+                normal_distribution(1),
+                normal_distribution(5),
+                gumbel_distribution(0.1),
+                gumbel_distribution(1),
+            ]:
+                for k in [10, 100, 1000, 5000]:
+                    logits = distrib((batch_size, vocab_size), device="cuda")
+                    ms = do_bench(
+                        lambda: init_seed_top_k_mask_logits(logits, k),
+                        warmup=100,
+                        rep=1000,
+                    )
+
+                    io = (logits.numel() * logits.element_size()) * 2
+                    bandwidth = io * 1e-6 / ms
+                    print(
+                        f"vocab_size: {vocab_size}, batch_size: {batch_size}, distrib: {distrib.__name__}, k: {k}, duration: {ms*1e3:.2f} us, effective bandwidth: {bandwidth:.2f} GB/s"
+                    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_renorm.py
+++ b/benchmarks/bench_renorm.py
@@ -22,23 +22,9 @@ def gumbel_distribution(beta):
     return gumbel_noise
 
 
-def init_seed_top_p_renorm(*args, **kwargs):
-    torch.manual_seed(42)
-    return flashinfer.sampling.top_p_renorm_probs(*args, **kwargs)
-
-
-def init_seed_top_k_renorm(*args, **kwargs):
-    torch.manual_seed(42)
-    return flashinfer.sampling.top_k_renorm_probs(*args, **kwargs)
-
-
-def init_seed_top_k_mask_logits(*args, **kwargs):
-    torch.manual_seed(42)
-    return flashinfer.sampling.top_k_mask_logits(*args, **kwargs)
-
-
 @torch.inference_mode()
 def main():
+    torch.manual_seed(42)
     print("---")
     print("top-p renorm")
     for vocab_size in [128512]:
@@ -53,7 +39,7 @@ def main():
                     logits = distrib((batch_size, vocab_size), device="cuda")
                     probs = torch.softmax(logits, dim=-1)
                     ms = do_bench(
-                        lambda: init_seed_top_p_renorm(probs, p),
+                        lambda: flashinfer.sampling.top_p_renorm_probs(probs, p),
                         warmup=100,
                         rep=1000,
                     )
@@ -78,7 +64,7 @@ def main():
                     logits = distrib((batch_size, vocab_size), device="cuda")
                     probs = torch.softmax(logits, dim=-1)
                     ms = do_bench(
-                        lambda: init_seed_top_k_renorm(probs, k),
+                        lambda: flashinfer.sampling.top_k_renorm_probs(probs, k),
                         warmup=100,
                         rep=1000,
                     )
@@ -103,7 +89,7 @@ def main():
                 for k in [10, 100, 1000, 5000]:
                     logits = distrib((batch_size, vocab_size), device="cuda")
                     ms = do_bench(
-                        lambda: init_seed_top_k_mask_logits(logits, k),
+                        lambda: flashinfer.sampling.top_k_mask_logits(logits, k),
                         warmup=100,
                         rep=1000,
                     )


### PR DESCRIPTION
Partial results:
```
---
top-p renorm
vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), p: 0.1, duration: 2014.94 us, effective bandwidth: 261.24 GB/s
vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), p: 0.9, duration: 2568.39 us, effective bandwidth: 204.95 GB/s
vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), p: 0.1, duration: 2021.48 us, effective bandwidth: 260.40 GB/s
vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), p: 0.9, duration: 2377.93 us, effective bandwidth: 221.36 GB/s
---
top-k renorm
vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), k: 10, duration: 1761.15 us, effective bandwidth: 298.89 GB/s
vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), k: 100, duration: 2299.25 us, effective bandwidth: 228.94 GB/s
vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), k: 10, duration: 1830.94 us, effective bandwidth: 287.49 GB/s
vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), k: 100, duration: 2286.19 us, effective bandwidth: 230.25 GB/s
---
top-k mask logits
vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), k: 10, duration: 1401.01 us, effective bandwidth: 375.72 GB/s
vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), k: 100, duration: 1661.22 us, effective bandwidth: 316.87 GB/s
vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), k: 10, duration: 1551.09 us, effective bandwidth: 339.36 GB/s
vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), k: 100, duration: 1798.39 us, effective bandwidth: 292.70 GB/s
```