### PR TITLE
[CHORE] Rename `output_emitted_token_num` -> `output_final_emitted_token_pos`

### DIFF
--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -209,7 +209,7 @@ void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,
-                                at::Tensor output_emitted_token_num, bool deterministic,
+                                at::Tensor output_final_emitted_token_pos, bool deterministic,
                                 std::optional<at::Generator> gen);
 
 //========== Torch Library ==========

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -52,7 +52,7 @@ void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,
-                                at::Tensor output_emitted_token_num, bool deterministic,
+                                at::Tensor output_final_emitted_token_pos, bool deterministic,
                                 std::optional<at::Generator> gen);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -186,7 +186,7 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,
-                                at::Tensor output_emitted_token_num, bool deterministic,
+                                at::Tensor output_final_emitted_token_pos, bool deterministic,
                                 std::optional<at::Generator> gen_) {
   CHECK_INPUT(draft_probs);
   CHECK_INPUT(draft_token_ids);
@@ -205,7 +205,7 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
   CHECK_EQ(num_speculate_tokens + 1, target_probs.size(1));
   CHECK_EQ(vocab_size, target_probs.size(2));
   CHECK_EQ(batch_size, output_accepted_token_num.size(0));
-  CHECK_EQ(batch_size, output_emitted_token_num.size(0));
+  CHECK_EQ(batch_size, output_final_emitted_token_pos.size(0));
   uint64_t philox_seed, philox_offset;
   auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
       gen_, at::cuda::detail::getDefaultCUDAGenerator());
@@ -221,7 +221,7 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
       static_cast<float*>(draft_probs.data_ptr()), static_cast<int*>(draft_token_ids.data_ptr()),
       static_cast<float*>(target_probs.data_ptr()), static_cast<int*>(output_token_ids.data_ptr()),
       static_cast<int*>(output_accepted_token_num.data_ptr()),
-      static_cast<int*>(output_emitted_token_num.data_ptr()), batch_size, num_speculate_tokens,
+      static_cast<int*>(output_final_emitted_token_pos.data_ptr()), batch_size, num_speculate_tokens,
       vocab_size, deterministic, philox_seed, philox_offset, stream);
 
   TORCH_CHECK(status == cudaSuccess, "ChainSpeculativeSampling failed with error code " +

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1383,7 +1383,7 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
 __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
                                          DType* target_probs, IdType* output_token_ids,
                                          IdType* output_accepted_token_num,
-                                         IdType* output_emitted_token_num,
+                                         IdType* output_final_emitted_token_pos,
                                          uint32_t num_speculative_tokens, uint32_t d,
                                          uint64_t philox_seed, uint64_t philox_offset) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
@@ -1426,8 +1426,8 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
   }
 
   if (tx == 0) {
-    output_accepted_token_num[row_idx] += accepted_token_num;
-    output_emitted_token_num[row_idx] += emitted_token_num;
+    output_accepted_token_num[row_idx] = accepted_token_num;
+    output_final_emitted_token_pos[row_idx] = emitted_token_num;
   }
 
   // sample from relu(target_probs - draft_probs)
@@ -1517,7 +1517,7 @@ template <typename DType, typename IdType>
 cudaError_t ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
                                      DType* target_probs, IdType* output_token_ids,
                                      IdType* output_accepted_token_num,
-                                     IdType* output_emitted_token_num, uint32_t batch_size,
+                                     IdType* output_final_emitted_token_pos, uint32_t batch_size,
                                      uint32_t num_speculative_tokens, uint32_t d,
                                      bool deterministic, uint64_t philox_seed,
                                      uint64_t philox_offset, cudaStream_t stream = 0) {
@@ -1532,7 +1532,7 @@ cudaError_t ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids
                   &target_probs,
                   &output_token_ids,
                   &output_accepted_token_num,
-                  &output_emitted_token_num,
+                  &output_final_emitted_token_pos,
                   &num_speculative_tokens,
                   &d,
                   &philox_seed,


### PR DESCRIPTION
The original name is misleading as it is off by one. The actual value returned is the token pos of the final emitted token, not the total number of emitted tokens (which includes the resampled/final sampled token).