### PR TITLE
ci: add torch 2.6+cu126 wheel

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["11.8", "12.1", "12.4"]
+        cuda: ["11.8", "12.1", "12.4", "12.6"]
         torch: ["2.4", "2.5", "2.6"]
         exclude: # We use release_wheel_sglang.yml for faster release and verification. If everything is okay, then we trigger release_wheel.yml. This combination (cuda 12.4 or 11.8 + torch 2.5) is already handled in release_wheel_sglang.yml
           - cuda: "12.4"
@@ -34,6 +34,11 @@ jobs:
             torch: "2.5"
           - cuda: "12.1"
             torch: "2.6"
+          - cuda: "12.6"
+            torch: "2.4"
+          - cuda: "12.6"
+            torch: "2.5"
+
 
     runs-on: [self-hosted]
     steps:


### PR DESCRIPTION
torch 2.6 + cu124 wheel is not compatible with torch 2.6 + cu126 wheel because pytorch switch from manylinux 2014 to manylinux 2_28 (https://dev-discuss.pytorch.org/t/pytorch-linux-wheels-switching-to-new-wheel-build-platform-manylinux-2-28-on-november-12-2024/2581) from torch 2.6 + cu126 on, which will result in ABI incompatibility issue: https://github.com/flashinfer-ai/flashinfer/issues/911#issuecomment-2764408674