### PR TITLE
perf: add `-DNDEBUG` compilation flag

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -114,6 +114,9 @@ def load_cuda_ops(
             "--ptxas-options=-v",
             "--ptxas-options=--verbose,--register-usage-level=10,--warn-on-local-memory-usage",
         ]
+    else:
+        # non debug mode
+        cuda_cflags += ["-DNDEBUG"]
 
     cflags += extra_cflags
     cuda_cflags += extra_cuda_cflags

--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ if enable_aot:
         "-Xfatbin",
         "-compress-all",
         "-use_fast_math",
+        "-DNDEBUG",
         "-DPy_LIMITED_API=0x03080000",
     ]
     libraries = [


### PR DESCRIPTION
We observed some performance degradation after upgrading cutlass to v3.9.

This is because some runtime checks are added to cutlass in debug mode:
* https://github.com/NVIDIA/cutlass/blob/df8a550d3917b0e97f416b2ed8c2d786f7f686a3/include/cutlass/pipeline/sm90_pipeline.hpp#L66-L70
* https://github.com/NVIDIA/cutlass/blob/df8a550d3917b0e97f416b2ed8c2d786f7f686a3/include/cutlass/pipeline/sm90_pipeline.hpp#L82-L86

This PR addresses the issue by adding `-DNDEBUG` to compilation flags in both JIT and AOT mode.

After this PR, we no longer observe the performance degradation.