### PR TITLE
ci: select 2_28 manylinux builder for new torch+cuda versions

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Select builder image based on PyTorch and CUDA versions
         id: select-builder
         run: |
-          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" == "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
+          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" >= "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
             echo "BUILDER_IMAGE=pytorch/manylinux2_28-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
           else
             echo "BUILDER_IMAGE=pytorch/manylinux-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -46,7 +46,18 @@ jobs:
         with:
           submodules: true
 
+      - name: Select builder image based on PyTorch and CUDA versions
+        id: select-builder
+        run: |
+          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" == "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
+            echo "BUILDER_IMAGE=pytorch/manylinux2_28-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
+          else
+            echo "BUILDER_IMAGE=pytorch/manylinux-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build wheel
+        env:
+          BUILDER_IMAGE: ${{ steps.select-builder.outputs.BUILDER_IMAGE }}
         run: |
           chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
           docker run --rm -t \
@@ -59,7 +70,7 @@ jobs:
               -e TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
               -e MAX_JOBS=128 \
               --user $CI_UID:$CI_GID \
-              pytorch/manylinux-builder:cuda${{ matrix.cuda }} \
+              $BUILDER_IMAGE \
               bash /app/scripts/run-ci-build-wheel.sh
         timeout-minutes: 120
       - run: du -h dist/*

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -46,10 +46,25 @@ jobs:
         with:
           submodules: true
 
+      - name: Set torch and cuda version value
+        id: set_torch_and_cuda_version
+        run: |
+          IFS='.' read -r major minor <<< "${{ matrix.torch }}"
+          version_value=$((major * 100 + minor))
+          echo "TORCH_VERSION=$version_value" >> $GITHUB_OUTPUT
+          IFS='.' read -r major minor <<< "${{ matrix.cuda }}"
+          version_value=$((major * 100 + minor))
+          echo "CUDA_VERSION=$version_value" >> $GITHUB_OUTPUT
+
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ ((matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6') && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          TORCH_VERSION: ${{ steps.set_torch_and_cuda_version.outputs.TORCH_VERSION }}
+          CUDA_VERSION: ${{ steps.set_torch_and_cuda_version.outputs.CUDA_VERSION }}
+          BUILDER_IMAGE: ${{ ((steps.set_torch_and_cuda_version.outputs.TORCH_VERSION == 206 && steps.set_torch_and_cuda_version.outputs.CUDA_VERSION >= 1206) || steps.set_torch_and_cuda_version.outputs.TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
+          echo "TORCH_VERSION: $TORCH_VERSION"
+          echo "CUDA_VERSION: $CUDA_VERSION"
+          echo "BUILDER_IMAGE: $BUILDER_IMAGE"
           chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
           docker run --rm -t \
               -v "$CI_RUNNER_CACHE_DIR":/ci-cache \

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build wheel
         env:
-          BUILDER_IMAGE: "${{ matrix.torch == '2.6' && matrix.cuda >= '12.6' || matrix.torch > '2.6' ? 'pytorch/manylinux2_28-builder:cuda' : 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}"
+          BUILDER_IMAGE: ${{ (matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6' && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
           docker run --rm -t \

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda: ["11.8", "12.1", "12.4", "12.6"]
-        torch: ["2.4", "2.5", "2.6"]
+        torch: ["2.4", "2.5", "2.6", "2.10"]
         exclude: # We use release_wheel_sglang.yml for faster release and verification. If everything is okay, then we trigger release_wheel.yml. This combination (cuda 12.4 or 11.8 + torch 2.5) is already handled in release_wheel_sglang.yml
           - cuda: "12.4"
             torch: "2.5"

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -46,18 +46,9 @@ jobs:
         with:
           submodules: true
 
-      - name: Select builder image based on PyTorch and CUDA versions
-        id: select-builder
-        run: |
-          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" >= "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
-            echo "BUILDER_IMAGE=pytorch/manylinux2_28-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
-          else
-            echo "BUILDER_IMAGE=pytorch/manylinux-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ steps.select-builder.outputs.BUILDER_IMAGE }}
+          BUILDER_IMAGE: "${{ matrix.torch == '2.6' && matrix.cuda >= '12.6' || matrix.torch > '2.6' ? 'pytorch/manylinux2_28-builder:cuda' : 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}"
         run: |
           chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
           docker run --rm -t \

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ (matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6' && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          BUILDER_IMAGE: ${{ ((matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6') && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
           docker run --rm -t \

--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda: ["11.8", "12.1", "12.4", "12.6"]
-        torch: ["2.4", "2.5", "2.6", "2.10"]
+        torch: ["2.4", "2.5", "2.6"]
         exclude: # We use release_wheel_sglang.yml for faster release and verification. If everything is okay, then we trigger release_wheel.yml. This combination (cuda 12.4 or 11.8 + torch 2.5) is already handled in release_wheel_sglang.yml
           - cuda: "12.4"
             torch: "2.5"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Select builder image based on PyTorch and CUDA versions
         id: select-builder
         run: |
-          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" == "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
+          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" >= "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
             echo "BUILDER_IMAGE=pytorch/manylinux2_28-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
           else
             echo "BUILDER_IMAGE=pytorch/manylinux-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda: ["11.8", "12.4", "12.6"]
-        torch: ["2.5", "2.6"]
+        torch: ["2.5", "2.6", "2.10"]
 
     runs-on: [self-hosted]
     steps:

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      
+
       - name: Set torch and cuda version value
         id: set_torch_and_cuda_version
         run: |

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -45,9 +45,7 @@ jobs:
 
       - name: Build wheel
         env:
-          TORCH_VERSION: ${{ steps.torch_version.outputs.TORCH_VERSION }}
-          CUDA_VERSION: ${{ steps.cuda_version.outputs.CUDA_VERSION }}
-          BUILDER_IMAGE: ${{ (($TORCH_VERSION == 206 && $CUDA_VERSION >= 1206) || $TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          BUILDER_IMAGE: ${{ ((steps.torch_version.outputs.TORCH_VERSION == 206 && steps.cuda_version.outputs.CUDA_VERSION >= 1206) || steps.torch_version.outputs.TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "torch: ${{ matrix.torch }}"
           echo "cuda: ${{ matrix.cuda }}"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           TORCH_VERSION: ${{ steps.torch_version.outputs.TORCH_VERSION }}
           CUDA_VERSION: ${{ steps.cuda_version.outputs.CUDA_VERSION }}
-          BUILDER_IMAGE: ${{ ((TORCH_VERSION == 206 && CUDA_VERSION >= 1206) || TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          BUILDER_IMAGE: ${{ (($TORCH_VERSION == 206 && $CUDA_VERSION >= 1206) || $TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "torch: ${{ matrix.torch }}"
           echo "cuda: ${{ matrix.cuda }}"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           TORCH_VERSION: ${{ steps.torch_version.outputs.TORCH_VERSION }}
           CUDA_VERSION: ${{ steps.cuda_version.outputs.CUDA_VERSION }}
-          BUILDER_IMAGE: ${{ ((TORCH_VERSION == 206 && CUDA_VERSION >= 1206) || TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          BUILDER_IMAGE: ${{ ((steps.torch_version.outputs.TORCH_VERSION == 206 && steps.cuda_version.outputs.CUDA_VERSION >= 1206) || steps.torch_version.outputs.TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "TORCH_VERSION: $TORCH_VERSION"
           echo "CUDA_VERSION: $CUDA_VERSION"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -31,7 +31,18 @@ jobs:
         with:
           submodules: true
 
+      - name: Select builder image based on PyTorch and CUDA versions
+        id: select-builder
+        run: |
+          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" == "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
+            echo "BUILDER_IMAGE=pytorch/manylinux2_28-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
+          else
+            echo "BUILDER_IMAGE=pytorch/manylinux-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build wheel
+        env:
+          BUILDER_IMAGE: ${{ steps.select-builder.outputs.BUILDER_IMAGE }}
         run: |
           chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
           docker run --rm -t \
@@ -45,7 +56,7 @@ jobs:
               -e TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
               -e MAX_JOBS=128 \
               --user $CI_UID:$CI_GID \
-              pytorch/manylinux-builder:cuda${{ matrix.cuda }} \
+              $BUILDER_IMAGE \
               bash /app/scripts/run-ci-build-wheel.sh
         timeout-minutes: 120
       - run: du -h dist/*

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ (matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6' && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          BUILDER_IMAGE: ${{ ((matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6') && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "torch: ${{ matrix.torch }}"
           echo "cuda: ${{ matrix.cuda }}"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -33,10 +33,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      
+      - name: Set torch and cuda version value
+        run: |
+          IFS='.' read -r major minor <<< "${{ matrix.torch }}"
+          version_value=$((major * 100 + minor))
+          echo "TORCH_VERSION=$version_value" >> $GITHUB_OUTPUT
+          IFS='.' read -r major minor <<< "${{ matrix.cuda }}"
+          version_value=$((major * 100 + minor))
+          echo "CUDA_VERSION=$version_value" >> $GITHUB_OUTPUT
 
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ ((matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6') && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          TORCH_VERSION: ${{ steps.torch_version.outputs.TORCH_VERSION }}
+          CUDA_VERSION: ${{ steps.cuda_version.outputs.CUDA_VERSION }}
+          BUILDER_IMAGE: ${{ ((TORCH_VERSION == 206 && CUDA_VERSION >= 1206) || TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "torch: ${{ matrix.torch }}"
           echo "cuda: ${{ matrix.cuda }}"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -1,5 +1,8 @@
 name: Release Wheel
 on:
+  pull_request: # debug
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       tag_name:
@@ -31,78 +34,73 @@ jobs:
         with:
           submodules: true
 
-      - name: Select builder image based on PyTorch and CUDA versions
-        id: select-builder
-        run: |
-          if [[ "${{ matrix.torch }}" == "2.6" && "${{ matrix.cuda }}" >= "12.6" ]] || [[ "${{ matrix.torch }}" > "2.6" ]]; then
-            echo "BUILDER_IMAGE=pytorch/manylinux2_28-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
-          else
-            echo "BUILDER_IMAGE=pytorch/manylinux-builder:cuda${{ matrix.cuda }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ steps.select-builder.outputs.BUILDER_IMAGE }}
+          BUILDER_IMAGE: "${{ matrix.torch == '2.6' && matrix.cuda >= '12.6' || matrix.torch > '2.6' ? 'pytorch/manylinux2_28-builder:cuda' : 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}"
         run: |
-          chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
-          docker run --rm -t \
-              -v "$CI_RUNNER_CACHE_DIR":/ci-cache \
-              -v "$GITHUB_WORKSPACE":/app \
-              -e FLASHINFER_CI_CACHE=/ci-cache \
-              -e FLASHINFER_CI_CUDA_VERSION=${{ matrix.cuda }} \
-              -e FLASHINFER_CI_TORCH_VERSION=${{ matrix.torch }} \
-              -e FLASHINFER_CI_PYTHON_VERSION=3.10 \
-              -e FLASHINFER_HEAD_DIMS="64,128,256" \
-              -e TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
-              -e MAX_JOBS=128 \
-              --user $CI_UID:$CI_GID \
-              $BUILDER_IMAGE \
-              bash /app/scripts/run-ci-build-wheel.sh
-        timeout-minutes: 120
-      - run: du -h dist/*
+          echo "torch: ${{ matrix.torch }}"
+          echo "cuda: ${{ matrix.cuda }}"
+          echo "BUILDER_IMAGE: $BUILDER_IMAGE"
+      #   run: |
+      #     chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
+      #     docker run --rm -t \
+      #         -v "$CI_RUNNER_CACHE_DIR":/ci-cache \
+      #         -v "$GITHUB_WORKSPACE":/app \
+      #         -e FLASHINFER_CI_CACHE=/ci-cache \
+      #         -e FLASHINFER_CI_CUDA_VERSION=${{ matrix.cuda }} \
+      #         -e FLASHINFER_CI_TORCH_VERSION=${{ matrix.torch }} \
+      #         -e FLASHINFER_CI_PYTHON_VERSION=3.10 \
+      #         -e FLASHINFER_HEAD_DIMS="64,128,256" \
+      #         -e TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+      #         -e MAX_JOBS=128 \
+      #         --user $CI_UID:$CI_GID \
+      #         $BUILDER_IMAGE \
+      #         bash /app/scripts/run-ci-build-wheel.sh
+      #   timeout-minutes: 120
+      # - run: du -h dist/*
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheel-cuda${{ matrix.cuda }}-torch${{ matrix.torch }}
-          path: dist/*
+      # - uses: actions/upload-artifact@v4
+      #   with:
+      #     name: wheel-cuda${{ matrix.cuda }}-torch${{ matrix.torch }}
+      #     path: dist/*
 
-  release:
-    needs: build
-    runs-on: [self-hosted]
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          merge-multiple: true
-          pattern: wheel-*
+  # release:
+  #   needs: build
+  #   runs-on: [self-hosted]
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist/
+  #         merge-multiple: true
+  #         pattern: wheel-*
 
-      - run: ls -lah dist/
+  #     - run: ls -lah dist/
 
-      - uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ inputs.tag_name }}
-          files: |
-            dist/flashinfer*.whl
+  #     - uses: softprops/action-gh-release@v1
+  #       with:
+  #         tag_name: ${{ inputs.tag_name }}
+  #         files: |
+  #           dist/flashinfer*.whl
 
-      - uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ inputs.tag_name }}
-          files: |
-            dist/flashinfer-*.tar.gz
+  #     - uses: softprops/action-gh-release@v1
+  #       with:
+  #         tag_name: ${{ inputs.tag_name }}
+  #         files: |
+  #           dist/flashinfer-*.tar.gz
 
-      - name: Clone wheel index
-        run: git clone https://oauth2:${WHL_TOKEN}@github.com/flashinfer-ai/whl.git flashinfer-whl
-        env:
-          WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
+  #     - name: Clone wheel index
+  #       run: git clone https://oauth2:${WHL_TOKEN}@github.com/flashinfer-ai/whl.git flashinfer-whl
+  #       env:
+  #         WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
 
-      - name: Update wheel index
-        run: python3 scripts/update_whl_index.py
+  #     - name: Update wheel index
+  #       run: python3 scripts/update_whl_index.py
 
-      - name: Push wheel index
-        run: |
-          cd flashinfer-whl
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "update whl"
-          git push
+  #     - name: Push wheel index
+  #       run: |
+  #         cd flashinfer-whl
+  #         git config --local user.name "github-actions[bot]"
+  #         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  #         git add -A
+  #         git commit -m "update whl"
+  #         git push

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -35,6 +35,7 @@ jobs:
           submodules: true
       
       - name: Set torch and cuda version value
+        id: set_torch_and_cuda_version
         run: |
           IFS='.' read -r major minor <<< "${{ matrix.torch }}"
           version_value=$((major * 100 + minor))
@@ -45,9 +46,9 @@ jobs:
 
       - name: Build wheel
         env:
-          TORCH_VERSION: ${{ steps.torch_version.outputs.TORCH_VERSION }}
-          CUDA_VERSION: ${{ steps.cuda_version.outputs.CUDA_VERSION }}
-          BUILDER_IMAGE: ${{ ((steps.torch_version.outputs.TORCH_VERSION == 206 && steps.cuda_version.outputs.CUDA_VERSION >= 1206) || steps.torch_version.outputs.TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          TORCH_VERSION: ${{ steps.set_torch_and_cuda_version.outputs.TORCH_VERSION }}
+          CUDA_VERSION: ${{ steps.set_torch_and_cuda_version.outputs.CUDA_VERSION }}
+          BUILDER_IMAGE: ${{ ((steps.set_torch_and_cuda_version.outputs.TORCH_VERSION == 206 && steps.set_torch_and_cuda_version.outputs.CUDA_VERSION >= 1206) || steps.set_torch_and_cuda_version.outputs.TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "TORCH_VERSION: $TORCH_VERSION"
           echo "CUDA_VERSION: $CUDA_VERSION"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -45,10 +45,12 @@ jobs:
 
       - name: Build wheel
         env:
-          BUILDER_IMAGE: ${{ ((steps.torch_version.outputs.TORCH_VERSION == 206 && steps.cuda_version.outputs.CUDA_VERSION >= 1206) || steps.torch_version.outputs.TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
+          TORCH_VERSION: ${{ steps.torch_version.outputs.TORCH_VERSION }}
+          CUDA_VERSION: ${{ steps.cuda_version.outputs.CUDA_VERSION }}
+          BUILDER_IMAGE: ${{ ((TORCH_VERSION == 206 && CUDA_VERSION >= 1206) || TORCH_VERSION > 206) && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
-          echo "torch: ${{ matrix.torch }}"
-          echo "cuda: ${{ matrix.cuda }}"
+          echo "TORCH_VERSION: $TORCH_VERSION"
+          echo "CUDA_VERSION: $CUDA_VERSION"
           echo "BUILDER_IMAGE: $BUILDER_IMAGE"
       #   run: |
       #     chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -1,8 +1,5 @@
 name: Release Wheel
 on:
-  pull_request: # debug
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       tag_name:

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["11.8", "12.4", "12.6"]
-        torch: ["2.5", "2.6", "2.10"]
+        cuda: ["11.8", "12.4"]
+        torch: ["2.5"]
 
     runs-on: [self-hosted]
     steps:
@@ -53,66 +53,65 @@ jobs:
           echo "TORCH_VERSION: $TORCH_VERSION"
           echo "CUDA_VERSION: $CUDA_VERSION"
           echo "BUILDER_IMAGE: $BUILDER_IMAGE"
-      #   run: |
-      #     chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
-      #     docker run --rm -t \
-      #         -v "$CI_RUNNER_CACHE_DIR":/ci-cache \
-      #         -v "$GITHUB_WORKSPACE":/app \
-      #         -e FLASHINFER_CI_CACHE=/ci-cache \
-      #         -e FLASHINFER_CI_CUDA_VERSION=${{ matrix.cuda }} \
-      #         -e FLASHINFER_CI_TORCH_VERSION=${{ matrix.torch }} \
-      #         -e FLASHINFER_CI_PYTHON_VERSION=3.10 \
-      #         -e FLASHINFER_HEAD_DIMS="64,128,256" \
-      #         -e TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
-      #         -e MAX_JOBS=128 \
-      #         --user $CI_UID:$CI_GID \
-      #         $BUILDER_IMAGE \
-      #         bash /app/scripts/run-ci-build-wheel.sh
-      #   timeout-minutes: 120
-      # - run: du -h dist/*
+          chown -R $CI_UID:$CI_GID "$GITHUB_WORKSPACE"
+          docker run --rm -t \
+              -v "$CI_RUNNER_CACHE_DIR":/ci-cache \
+              -v "$GITHUB_WORKSPACE":/app \
+              -e FLASHINFER_CI_CACHE=/ci-cache \
+              -e FLASHINFER_CI_CUDA_VERSION=${{ matrix.cuda }} \
+              -e FLASHINFER_CI_TORCH_VERSION=${{ matrix.torch }} \
+              -e FLASHINFER_CI_PYTHON_VERSION=3.10 \
+              -e FLASHINFER_HEAD_DIMS="64,128,256" \
+              -e TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+              -e MAX_JOBS=128 \
+              --user $CI_UID:$CI_GID \
+              $BUILDER_IMAGE \
+              bash /app/scripts/run-ci-build-wheel.sh
+        timeout-minutes: 120
+      - run: du -h dist/*
 
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: wheel-cuda${{ matrix.cuda }}-torch${{ matrix.torch }}
-      #     path: dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-cuda${{ matrix.cuda }}-torch${{ matrix.torch }}
+          path: dist/*
 
-  # release:
-  #   needs: build
-  #   runs-on: [self-hosted]
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         path: dist/
-  #         merge-multiple: true
-  #         pattern: wheel-*
+  release:
+    needs: build
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+          pattern: wheel-*
 
-  #     - run: ls -lah dist/
+      - run: ls -lah dist/
 
-  #     - uses: softprops/action-gh-release@v1
-  #       with:
-  #         tag_name: ${{ inputs.tag_name }}
-  #         files: |
-  #           dist/flashinfer*.whl
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
+            dist/flashinfer*.whl
 
-  #     - uses: softprops/action-gh-release@v1
-  #       with:
-  #         tag_name: ${{ inputs.tag_name }}
-  #         files: |
-  #           dist/flashinfer-*.tar.gz
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
+            dist/flashinfer-*.tar.gz
 
-  #     - name: Clone wheel index
-  #       run: git clone https://oauth2:${WHL_TOKEN}@github.com/flashinfer-ai/whl.git flashinfer-whl
-  #       env:
-  #         WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
+      - name: Clone wheel index
+        run: git clone https://oauth2:${WHL_TOKEN}@github.com/flashinfer-ai/whl.git flashinfer-whl
+        env:
+          WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
 
-  #     - name: Update wheel index
-  #       run: python3 scripts/update_whl_index.py
+      - name: Update wheel index
+        run: python3 scripts/update_whl_index.py
 
-  #     - name: Push wheel index
-  #       run: |
-  #         cd flashinfer-whl
-  #         git config --local user.name "github-actions[bot]"
-  #         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  #         git add -A
-  #         git commit -m "update whl"
-  #         git push
+      - name: Push wheel index
+        run: |
+          cd flashinfer-whl
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "update whl"
+          git push

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build wheel
         env:
-          BUILDER_IMAGE: "${{ matrix.torch == '2.6' && matrix.cuda >= '12.6' || matrix.torch > '2.6' ? 'pytorch/manylinux2_28-builder:cuda' : 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}"
+          BUILDER_IMAGE: ${{ (matrix.torch == '2.6' && matrix.cuda >= '12.6') || matrix.torch > '2.6' && 'pytorch/manylinux2_28-builder:cuda' || 'pytorch/manylinux-builder:cuda' }}${{ matrix.cuda }}
         run: |
           echo "torch: ${{ matrix.torch }}"
           echo "cuda: ${{ matrix.cuda }}"

--- a/.github/workflows/release_wheel_sglang.yml
+++ b/.github/workflows/release_wheel_sglang.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["11.8", "12.4"]
-        torch: ["2.5"]
+        cuda: ["11.8", "12.4", "12.6"]
+        torch: ["2.5", "2.6"]
 
     runs-on: [self-hosted]
     steps:


### PR DESCRIPTION
torch 2.6 + cu126 and later torch versions uses manylinux_2_28 instead of manylinux_2014 and we have to select manylinux_2_28 docker images for new versions.

Ref: https://dev-discuss.pytorch.org/t/pytorch-linux-wheels-switching-to-new-wheel-build-platform-manylinux-2-28-on-november-12-2024/2581

cc @abcdabcd987 @zhyncs 