### PR TITLE
feat: update decode attention APIs

### DIFF
--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -35,7 +35,7 @@ void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_
 //========== decode ==========
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
-                                 at::Tensor o, int64_t layout,
+                                 at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t layout,
                                  int64_t window_left SINGLE_DECODE_ADDITIONAL_FUNC_PARAMS);
 
 at::Tensor BatchDecodeWithPagedKVCachePlan(

--- a/csrc/single_decode.cu
+++ b/csrc/single_decode.cu
@@ -30,7 +30,7 @@ cudaError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DT
 using namespace flashinfer;
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
-                                 at::Tensor o, int64_t layout,
+                                 at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t layout,
                                  int64_t window_left ADDITIONAL_FUNC_PARAMS) {
   CHECK_INPUT(q);
   CHECK_INPUT(k);
@@ -79,7 +79,7 @@ void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::T
         params.k = static_cast<DTypeKV*>(k.data_ptr());
         params.v = static_cast<DTypeKV*>(v.data_ptr());
         params.o = static_cast<DTypeO*>(o.data_ptr());
-        params.lse = nullptr;
+        params.lse = maybe_lse ? static_cast<float*>(maybe_lse->data_ptr()) : nullptr;
         params.kv_len = kv_len;
         params.num_qo_heads = num_qo_heads;
         params.num_kv_heads = num_kv_heads;

--- a/csrc/single_decode_jit_pybind.cu
+++ b/csrc/single_decode_jit_pybind.cu
@@ -18,7 +18,7 @@
 #include "single_decode_config.inc"
 
 void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor tmp,
-                                 at::Tensor o, int64_t layout,
+                                 at::Tensor o, std::optional<at::Tensor> maybe_lse, int64_t layout,
                                  int64_t window_left ADDITIONAL_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -354,7 +354,7 @@ def single_decode_with_kv_cache(
     v: torch.Tensor,
     kv_layout: str = "NHD",
     pos_encoding_mode: str = "NONE",
-    use_tensor_cores: bool = True,
+    use_tensor_cores: bool = False,
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
@@ -374,7 +374,7 @@ def single_decode_with_kv_cache(
     v: torch.Tensor,
     kv_layout: str = "NHD",
     pos_encoding_mode: str = "NONE",
-    use_tensor_cores: bool = True,
+    use_tensor_cores: bool = False,
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
@@ -393,7 +393,7 @@ def single_decode_with_kv_cache(
     v: torch.Tensor,
     kv_layout: str = "NHD",
     pos_encoding_mode: str = "NONE",
-    use_tensor_cores: bool = True,
+    use_tensor_cores: bool = False,
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
@@ -426,7 +426,7 @@ def single_decode_with_kv_cache(
         Defaults to ``NONE``.
     use_tensor_cores: bool
         Whether to use tensor cores for the computation. Will be faster for large group
-        size in grouped query attention. Defaults to ``True``.
+        size in grouped query attention. Defaults to ``False``.
     q_scale : Optional[float]
         The calibration scale of query for fp8 input, if not provided, will be set to ``1.0``.
     k_scale : Optional[float]
@@ -522,7 +522,7 @@ def single_decode_with_kv_cache(
             v,
             tmp,
             out,
-            lse.unsqueeze(0),
+            lse.unsqueeze(0) if lse is not None else None,
             MaskMode.NON_CAUSAL.value,
             TensorLayout[kv_layout].value,
             window_left,
@@ -642,7 +642,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         float_workspace_buffer: torch.Tensor,
         kv_layout: str = "NHD",
         use_cuda_graph: bool = False,
-        use_tensor_cores: bool = True,
+        use_tensor_cores: bool = False,
         paged_kv_indptr_buffer: Optional[torch.Tensor] = None,
         paged_kv_indices_buffer: Optional[torch.Tensor] = None,
         paged_kv_last_page_len_buffer: Optional[torch.Tensor] = None,
@@ -667,7 +667,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         use_tensor_cores : bool
             Whether to use tensor cores for the computation. Will be faster for large group
-            size in grouped query attention. Defaults to ``True``.
+            size in grouped query attention. Defaults to ``False``.
 
         paged_kv_indptr_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
@@ -1271,7 +1271,7 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper(BatchDecodeWithPagedKVCacheWra
         indices_buffer: torch.Tensor,
         last_page_len_buffer: torch.Tensor,
         kv_layout: str = "NHD",
-        use_tensor_cores: bool = True,
+        use_tensor_cores: bool = False,
     ) -> None:
         r"""Constructor of :class:`BatchDecodeWithPagedKVCacheWrapper`.
 
@@ -1299,7 +1299,7 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper(BatchDecodeWithPagedKVCacheWra
 
         use_tensor_cores : bool
             Whether to use tensor cores for the computation. Will be faster for large group
-            size in grouped query attention. Defaults to ``True``.
+            size in grouped query attention. Defaults to ``False``.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
@@ -1325,7 +1325,7 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         self,
         float_workspace_buffer: torch.Tensor,
         use_cuda_graph: bool = False,
-        use_tensor_cores: bool = True,
+        use_tensor_cores: bool = False,
         paged_kv_indptr_buffer: Optional[torch.Tensor] = None,
         paged_kv_indices_buffer: Optional[torch.Tensor] = None,
         paged_kv_last_page_len_buffer: Optional[torch.Tensor] = None,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -632,6 +632,7 @@ def single_prefill_with_kv_cache(
     logits_soft_cap: Optional[float] = None,
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
+    backend: str = "auto",
     return_lse: Literal[False] = False,
 ) -> torch.Tensor: ...
 
@@ -652,6 +653,7 @@ def single_prefill_with_kv_cache(
     logits_soft_cap: Optional[float] = None,
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
+    backend: str = "auto",
     return_lse: Literal[True] = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
@@ -671,8 +673,8 @@ def single_prefill_with_kv_cache(
     logits_soft_cap: Optional[float] = None,
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
-    return_lse: bool = False,
     backend: str = "auto",
+    return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Prefill/Append attention with KV cache for single request, return the attention
     output.
@@ -728,12 +730,12 @@ def single_prefill_with_kv_cache(
         The scale used in RoPE interpolation, if not provided, will be set to 1.0.
     rope_theta : Optional[float]
         The theta used in RoPE, if not provided, will be set to 1e4.
-    return_lse : bool
-        Whether to return the log sum exp value of the attention logits.
     backend : str
         The implementation backend, could be ``auto``/``fa2`` or ``fa3``. Defaults to ``auto``.
         If set to ``auto``, the function will automatically choose the backend based on the
         device architecture and kernel availability.
+    return_lse : bool
+        Whether to return the log sum exp value of the attention logits.
 
     Returns
     -------

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -700,6 +700,7 @@ cudaError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DT
         dim3 nthrs = dim3(bdx, bdy, bdz);
         float* tmp_lse = (float*)(tmp + num_chunks * num_qo_heads * HEAD_DIM);
         auto o = params.o;
+        auto lse = params.lse;
         params.o = tmp;
         params.lse = tmp_lse;
         params.kv_chunk_size = kv_chunk_size;
@@ -708,7 +709,7 @@ cudaError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DT
             cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
         if constexpr (AttentionVariant::use_softmax) {
           FLASHINFER_CUDA_CALL(
-              MergeStates(tmp, tmp_lse, o, nullptr, num_chunks, 1, num_qo_heads, HEAD_DIM, stream));
+              MergeStates(tmp, tmp_lse, o, lse, num_chunks, 1, num_qo_heads, HEAD_DIM, stream));
         } else {
           FLASHINFER_CUDA_CALL(AttentionSum(tmp, o, num_chunks, 1, num_qo_heads, HEAD_DIM, stream));
         }


### PR DESCRIPTION
This PR updates the decode attention APIs by:
* Adding `lse` return value for `single_decode_with_kv_cache` API per requested in #1006 (note that it's not the preferred API and only useful for single batch inference).

There is no breaking changes in this PR.