### PR TITLE
bugfix: import wrapper of mla decode

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -31,6 +31,9 @@ from .cascade import merge_state as merge_state
 from .cascade import merge_state_in_place as merge_state_in_place
 from .cascade import merge_states as merge_states
 from .decode import (
+    BatchDecodeMlaWithPagedKVCacheWrapper as BatchDecodeMlaWithPagedKVCacheWrapper,
+)
+from .decode import (
     BatchDecodeWithPagedKVCacheWrapper as BatchDecodeWithPagedKVCacheWrapper,
 )
 from .decode import (


### PR DESCRIPTION
In `tests/test_mla_decode_kernel.py`, the code below uses `BatchDecodeMlaWithPagedKVCacheWrapper`:

https://github.com/flashinfer-ai/flashinfer/blob/f579ca254ca321f9ab4ba23ab6ea2e49b0da9c11/tests/test_mla_decode_kernel.py#L348-L355

However an AttributeError is thrown:

```
AttributeError: module 'flashinfer' has no attribute 'BatchDecodeMlaWithPagedKVCacheWrapper'. Did you mean: 'BatchDecodeWithPagedKVCacheWrapper'?
```

Because the module `flashinfer` does not import  `BatchDecodeMlaWithPagedKVCacheWrapper` from submodule `.decode` and export it.

This patch can solve it.