### PR TITLE
bugfix: fix custom mask not be reseted after convert custom mask into causal or non-causal

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1381,6 +1381,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 self._mask_indptr_buf = mask_indptr.to(
                     self.device, non_blocking=non_blocking
                 )
+            else:
+                self._custom_mask_buf = None
+                self._mask_indptr_buf = None
 
         self._cached_q_data_type = q_data_type
         self._cached_kv_data_type = kv_data_type


### PR DESCRIPTION
When using custom mask for Medusa or other method, flashinfer api will inference with custom mask buf, but when there has no draft token, the flashinfer api will be inference using causal prefill or decode. But, I found that when convert custom mask into causal inference, the custom mask buf is not setted to None, So the result will be error using non-casual or casual when after using custom mask with same prefill warpper. 
