### PR TITLE
fix: remove default ubuntu user in Lunar/Noble

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,10 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && rm -rf /var/lib/apt/lists/*
 
+# Remove default 'ubuntu' user (UID 1000) to prevent devcontainer permission conflicts
+# Ref: https://github.com/rapidsai/devcontainers/pull/373
+RUN if grep ubuntu:x:1000:1000 /etc/passwd >/dev/null; then userdel -f -r ubuntu; fi
+
 # Copy zsh configuration to the new user's home
 RUN cp -r /root/.oh-my-zsh /home/$USERNAME/.oh-my-zsh && \
     cp /root/.zshrc /home/$USERNAME/.zshrc && \


### PR DESCRIPTION
Fix #1041 

As mentioned in rapidsai/devcontainers#373, the `ubuntu` user is pre-installed in Ubuntu Lunar/Noble base images. 
In my testing, removing the default `ubuntu` user and keeping only `devuser` successfully resolved the issue.
