### PR TITLE
bugfix: remove device allocation

### DIFF
--- a/csrc/fmha_cutlass_sm100.cu
+++ b/csrc/fmha_cutlass_sm100.cu
@@ -68,8 +68,8 @@
 
 using namespace flashinfer;
 
-void FMHACutlassSM100Run(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo_lens,
-                         at::Tensor kv_lens, at::Tensor qo_segment_offsets,
+void FMHACutlassSM100Run(at::Tensor workspace_buffer, at::Tensor q, at::Tensor k, at::Tensor v,
+                         at::Tensor qo_lens, at::Tensor kv_lens, at::Tensor qo_segment_offsets,
                          at::Tensor kv_segment_offsets, at::Tensor o,
                          std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                          double sm_scale, int64_t num_qo_heads, int64_t num_kv_heads,
@@ -92,9 +92,9 @@ void FMHACutlassSM100Run(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo
     using CutlassMaskMode =
         typename std::conditional<MASK_MODE == MaskMode::kCausal, CausalMask, ResidualMask>::type;
     run_fmha_fwd<cutlass_type_in, cutlass_type_out, TileShapeQK, TileShapePV, CutlassMaskMode>(
-        q, k, v, qo_lens, kv_lens, qo_segment_offsets, kv_segment_offsets, o, maybe_lse,
-        mask_mode_code, sm_scale, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, batch_size,
-        total_qo_len, total_kv_len, max_qo_len, max_kv_len);
+        workspace_buffer, q, k, v, qo_lens, kv_lens, qo_segment_offsets, kv_segment_offsets, o,
+        maybe_lse, mask_mode_code, sm_scale, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo,
+        batch_size, total_qo_len, total_kv_len, max_qo_len, max_kv_len);
 
     return true;
   });

--- a/csrc/fmha_cutlass_sm100_pybind.cu
+++ b/csrc/fmha_cutlass_sm100_pybind.cu
@@ -15,8 +15,8 @@
  */
 #include "pytorch_extension_utils.h"
 
-void FMHACutlassSM100Run(at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor qo_lens,
-                         at::Tensor kv_lens, at::Tensor qo_segment_offsets,
+void FMHACutlassSM100Run(at::Tensor workspace_buffer, at::Tensor q, at::Tensor k, at::Tensor v,
+                         at::Tensor qo_lens, at::Tensor kv_lens, at::Tensor qo_segment_offsets,
                          at::Tensor kv_segment_offsets, at::Tensor o,
                          std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                          double sm_scale, int64_t num_qo_heads, int64_t num_kv_heads,

--- a/csrc/group_gemm_groupwise_sm100.cu
+++ b/csrc/group_gemm_groupwise_sm100.cu
@@ -48,7 +48,8 @@ using namespace flashinfer;
     return false;                                                                                 \
   }()
 
-void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor float_workspace_buffer, at::Tensor A,
+void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor int_workspace_buffer,
+                                          at::Tensor float_workspace_buffer, at::Tensor A,
                                           at::Tensor B, at::Tensor SFA, at::Tensor SFB,
                                           at::Tensor C, at::Tensor m_indptr, int64_t cum_m,
                                           int64_t n, int64_t k, int64_t scale_granularity_m,
@@ -65,6 +66,8 @@ void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor float_workspace_buffer, at:
           using cutlass_t_out = cutlass_dtype_t<c_type_out>;
           auto status = flashinfer::gemm::CutlassGroupwiseScaledGroupGEMMSM100<
               SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K>(
+              static_cast<int*>(int_workspace_buffer.data_ptr()),
+              int_workspace_buffer.element_size() * int_workspace_buffer.size(0),
               static_cast<float*>(float_workspace_buffer.data_ptr()),
               float_workspace_buffer.element_size() * float_workspace_buffer.size(0),
               static_cast<cutlass_t_in*>(A.data_ptr()), static_cast<cutlass_t_in*>(B.data_ptr()),

--- a/csrc/group_gemm_sm100_pybind.cu
+++ b/csrc/group_gemm_sm100_pybind.cu
@@ -15,7 +15,8 @@
  */
 #include "pytorch_extension_utils.h"
 
-void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor float_workspace_buffer, at::Tensor A,
+void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor int_workspace_buffer,
+                                          at::Tensor float_workspace_buffer, at::Tensor A,
                                           at::Tensor B, at::Tensor SFA, at::Tensor SFB,
                                           at::Tensor C, at::Tensor m_indptr, int64_t cum_m,
                                           int64_t n, int64_t k, int64_t scale_granularity_m,

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -845,10 +845,10 @@ def group_gemm_fp8_nt_groupwise(
     from .triton.gemm import compute_padding_mapping
 
     int_workspace_buffer = _get_cache_buf(
-        "group_gemm_fp8_nt_groupwise_int_workspace", 32 * 1024 * 1024, a[0].device
+        "group_gemm_fp8_nt_groupwise_int_workspace", 32 * 1024 * 1024, a.device
     )
     float_workspace_buffer = _get_cache_buf(
-        "group_gemm_fp8_nt_groupwise_float_workspace", 32 * 1024 * 1024, a[0].device
+        "group_gemm_fp8_nt_groupwise_float_workspace", 32 * 1024 * 1024, a.device
     )
 
     batch_size = m_indptr.shape[0] - 1

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2620,6 +2620,9 @@ def fmha_varlen(
     causal: bool = False,
     sm_scale: Optional[float] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    workspace_buffer = _get_cache_buf(
+        "fmha_varlen_cutlass_workspace", 32 * 1024 * 1024, q.device
+    )
     module = get_fmha_module(
         q.dtype,
         k.dtype,
@@ -2659,6 +2662,7 @@ def fmha_varlen(
         )
 
     module.run(
+        workspace_buffer,
         q,
         k,
         v,

--- a/include/flashinfer/gemm/gemm_groupwise_sm100.cuh
+++ b/include/flashinfer/gemm/gemm_groupwise_sm100.cuh
@@ -131,7 +131,7 @@ cudaError_t CutlassGroupwiseScaledGEMMSM100(void* float_buffer, size_t float_buf
 
   size_t workspace_size = Gemm::get_workspace_size(arguments);
   AlignedAllocator float_allocator(float_buffer, float_buffer_size_in_bytes);
-  auto workspace_ptr = float_allocator.aligned_alloc<void>(workspace_size, 32 * 1024 * 1024,
+  auto workspace_ptr = float_allocator.aligned_alloc<void>(workspace_size, 16,
                                                            "sm100_groupwise_gemm_float_workspace");
 
   CUTLASS_CHECK(gemm.can_implement(arguments));

--- a/include/flashinfer/gemm/group_gemm_groupwise_sm100.cuh
+++ b/include/flashinfer/gemm/group_gemm_groupwise_sm100.cuh
@@ -57,7 +57,8 @@ __global__ void compute_sm100_cutlass_group_gemm_args(
 
 template <int ScaleGranularityM, int ScaleGranularityN, int ScaleGranularityK, typename DTypeIn,
           typename DTypeOut>
-cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* float_buffer,
+cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* int_buffer, size_t int_buffer_size_in_bytes,
+                                                 void* float_buffer,
                                                  size_t float_buffer_size_in_bytes, DTypeIn* A,
                                                  DTypeIn* B, float* SFA, float* SFB, DTypeOut* C,
                                                  int* m_indptr, int cum_m, int n, int k,
@@ -127,30 +128,40 @@ cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* float_buffer,
   static_assert(
       cute::is_same_v<typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFB, LayoutSFB>);
 
-  cutlass::DeviceAllocation<typename ProblemShape::UnderlyingProblemShape> problem_sizes(
-      batch_size);
+  AlignedAllocator allocator(int_buffer, int_buffer_size_in_bytes);
 
-  cutlass::DeviceAllocation<const typename Gemm::ElementA*> A_ptr(batch_size);
-  cutlass::DeviceAllocation<const typename Gemm::ElementB*> B_ptr(batch_size);
-  cutlass::DeviceAllocation<const typename Gemm::ElementC*> C_ptr(batch_size);
-  cutlass::DeviceAllocation<typename Gemm::EpilogueOutputOp::ElementOutput*> D_ptr(batch_size);
-  cutlass::DeviceAllocation<const ElementAccumulator*> SFA_ptr(batch_size);
-  cutlass::DeviceAllocation<const ElementAccumulator*> SFB_ptr(batch_size);
+  auto problem_sizes = allocator.aligned_alloc<typename ProblemShape::UnderlyingProblemShape>(
+      batch_size * sizeof(typename ProblemShape::UnderlyingProblemShape), 16,
+      "sm100_groupwise_group_gemm_problem_sizes");
+  auto A_ptr = allocator.aligned_alloc<const typename Gemm::ElementA*>(
+      batch_size * sizeof(const typename Gemm::ElementA*), 16, "sm100_groupwise_group_gemm_A_ptr");
+  auto B_ptr = allocator.aligned_alloc<const typename Gemm::ElementB*>(
+      batch_size * sizeof(const typename Gemm::ElementB*), 16, "sm100_groupwise_group_gemm_B_ptr");
+  auto C_ptr = allocator.aligned_alloc<const typename Gemm::ElementC*>(
+      batch_size * sizeof(const typename Gemm::ElementC*), 16, "sm100_groupwise_group_gemm_C_ptr");
+  auto D_ptr = allocator.aligned_alloc<typename Gemm::EpilogueOutputOp::ElementOutput*>(
+      batch_size * sizeof(typename Gemm::EpilogueOutputOp::ElementOutput*), 16,
+      "sm100_groupwise_group_gemm_D_ptr");
+  auto SFA_ptr = allocator.aligned_alloc<const ElementAccumulator*>(
+      batch_size * sizeof(const ElementAccumulator*), 16, "sm100_groupwise_group_gemm_SFA_ptr");
+  auto SFB_ptr = allocator.aligned_alloc<const ElementAccumulator*>(
+      batch_size * sizeof(const ElementAccumulator*), 16, "sm100_groupwise_group_gemm_SFB_ptr");
 
-  cutlass::DeviceAllocation<StrideA> stride_A(batch_size);
-  cutlass::DeviceAllocation<StrideB> stride_B(batch_size);
-  cutlass::DeviceAllocation<StrideC> stride_C(batch_size);
-  cutlass::DeviceAllocation<LayoutSFA> layout_SFA(batch_size);
-  cutlass::DeviceAllocation<LayoutSFB> layout_SFB(batch_size);
+  auto stride_A = allocator.aligned_alloc<StrideA>(batch_size * sizeof(StrideA), 16,
+                                                   "sm100_groupwise_group_gemm_stride_A");
+  auto stride_B = allocator.aligned_alloc<StrideB>(batch_size * sizeof(StrideB), 16,
+                                                   "sm100_groupwise_group_gemm_stride_B");
+  auto stride_C = allocator.aligned_alloc<StrideC>(batch_size * sizeof(StrideC), 16,
+                                                   "sm100_groupwise_group_gemm_stride_C");
+  auto layout_SFA = allocator.aligned_alloc<LayoutSFA>(batch_size * sizeof(LayoutSFA), 16,
+                                                       "sm100_groupwise_group_gemm_layout_SFA");
+  auto layout_SFB = allocator.aligned_alloc<LayoutSFB>(batch_size * sizeof(LayoutSFB), 16,
+                                                       "sm100_groupwise_group_gemm_layout_SFB");
 
   compute_sm100_cutlass_group_gemm_args<ScaleConfig><<<batch_size, 1, 0, stream>>>(
       A, B, SFA, SFB, C, m_indptr, cum_m, n, k, batch_size, ScaleGranularityM, ScaleGranularityN,
-      ScaleGranularityK, problem_sizes.get(), A_ptr.get(), B_ptr.get(), SFA_ptr.get(),
-      SFB_ptr.get(), C_ptr.get(), D_ptr.get(), stride_A.get(), stride_B.get(), stride_C.get(),
-      layout_SFA.get(), layout_SFB.get());
-
-  std::vector<typename ProblemShape::UnderlyingProblemShape> problem_sizes_host(batch_size);
-  problem_sizes.copy_to_host(problem_sizes_host.data());
+      ScaleGranularityK, problem_sizes, A_ptr, B_ptr, SFA_ptr, SFB_ptr, C_ptr, D_ptr, stride_A,
+      stride_B, stride_C, layout_SFA, layout_SFB);
 
   cutlass::KernelHardwareInfo hw_info;
   hw_info.device_id = 0;
@@ -158,23 +169,23 @@ cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* float_buffer,
       cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
 
   typename Gemm::Arguments arguments{cutlass::gemm::GemmUniversalMode::kGrouped,
-                                     {batch_size, problem_sizes.get(), problem_sizes_host.data()},
+                                     {batch_size, problem_sizes, /*problem_sizes_host=*/nullptr},
                                      {
-                                         A_ptr.get(),
-                                         stride_A.get(),
-                                         B_ptr.get(),
-                                         stride_B.get(),
-                                         SFA_ptr.get(),
-                                         layout_SFA.get(),
-                                         SFB_ptr.get(),
-                                         layout_SFB.get(),
+                                         A_ptr,
+                                         stride_A,
+                                         B_ptr,
+                                         stride_B,
+                                         SFA_ptr,
+                                         layout_SFA,
+                                         SFB_ptr,
+                                         layout_SFB,
                                      },
                                      {
                                          {},  // epilogue.thread
-                                         C_ptr.get(),
-                                         stride_C.get(),
-                                         D_ptr.get(),
-                                         stride_C.get(),
+                                         C_ptr,
+                                         stride_C,
+                                         D_ptr,
+                                         stride_C,
                                      },
                                      hw_info};
   auto& fusion_args = arguments.epilogue.thread;
@@ -186,7 +197,7 @@ cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* float_buffer,
   size_t workspace_size = Gemm::get_workspace_size(arguments);
   AlignedAllocator float_allocator(float_buffer, float_buffer_size_in_bytes);
   auto workspace_ptr = float_allocator.aligned_alloc<void>(
-      workspace_size, 32 * 1024 * 1024, "sm100_groupwise_group_gemm_float_workspace");
+      workspace_size, 16, "sm100_groupwise_group_gemm_float_workspace");
 
   CUTLASS_CHECK(gemm.can_implement(arguments));
   CUTLASS_CHECK(gemm.initialize(arguments, workspace_ptr));


### PR DESCRIPTION
Instead of device allocation inside operators, we should pre-allocate (and cache) workspace buffers to avoid allocation for each kernel run.

cc @yongwww  @cyx-6 .