### PR TITLE
Add PyTorch 2.7.0 build

### DIFF
--- a/.github/workflows/release_wheel.yml
+++ b/.github/workflows/release_wheel.yml
@@ -25,19 +25,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["11.8", "12.1", "12.4", "12.6"]
-        torch: ["2.4", "2.5", "2.6"]
+        cuda: ["11.8", "12.1", "12.4", "12.6", "12.8"]
+        torch: ["2.5", "2.6", "2.7"]
         exclude: # We use release_wheel_sglang.yml for faster release and verification. If everything is okay, then we trigger release_wheel.yml. This combination (cuda 12.4 or 11.8 + torch 2.5) is already handled in release_wheel_sglang.yml
-          - cuda: "12.4"
-            torch: "2.5"
           - cuda: "11.8"
             torch: "2.5"
-          - cuda: "12.1"
-            torch: "2.6"
-          - cuda: "12.6"
-            torch: "2.4"
+          - cuda: "12.4"
+            torch: "2.5"
+          # 2.5 supports 11.8, 12.1, and 12.4
           - cuda: "12.6"
             torch: "2.5"
+          - cuda: "12.8"
+            torch: "2.5"
+          # 2.6 supports 11.8, 12.4, and 12.6
+          - cuda: "12.1"
+            torch: "2.6"
+          - cuda: "12.8"
+            torch: "2.6"
+          # 2.7 supports 11.8, 12.6, and 12.8
+          - cuda: "12.1"
+            torch: "2.7"
+          - cuda: "12.4"
+            torch: "2.7"
 
 
     runs-on: [self-hosted]


### PR DESCRIPTION
## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

---

## 📌 Description

Add a build for PyTorch 2.7.0 https://pytorch.org/blog/pytorch-2-7 and also remove 2.4 to keep only the last 3 PyTorch releases https://github.com/flashinfer-ai/flashinfer/pull/835

## 🔍 Related Issues

As there is no official release of FlashInfer for PyTorch 2.7 yet, I'm currently building FlashInfer from [source on vLLM](https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile#L258-L261) and that adds to the build time there.

---

## Reviewer Notes

PyTorch 2.7 also moves to CUDA 12.8 build and removes 12.4 (and 12.1)
