### PR TITLE
misc: jit: Introduce JitSpec and Generate ninja file

### DIFF
--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -55,9 +55,13 @@ from .attention import get_batch_prefill_uri as get_batch_prefill_uri
 from .attention import get_pod_uri as get_pod_uri
 from .attention import get_single_decode_uri as get_single_decode_uri
 from .attention import get_single_prefill_uri as get_single_prefill_uri
-from .core import clear_cache_dir, load_cuda_ops  # noqa: F401
+from .core import JitSpec as JitSpec
+from .core import build_jit_specs as build_jit_specs
+from .core import clear_cache_dir as clear_cache_dir
+from .core import gen_jit_spec as gen_jit_spec
+from .core import load_cuda_ops as load_cuda_ops
 from .env import *
-from .utils import parallel_load_modules as parallel_load_modules
+from .parallel_load_modules import parallel_load_modules as parallel_load_modules
 
 cuda_lib_path = os.environ.get(
     "CUDA_LIB_PATH", "/usr/local/cuda/targets/x86_64-linux/lib/"

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -1,0 +1,174 @@
+# Adapted from https://github.com/pytorch/pytorch/blob/v2.7.0/torch/utils/cpp_extension.py
+
+import os
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+from typing import List, Optional
+
+from torch.utils.cpp_extension import (
+    _TORCH_PATH,
+    CUDA_HOME,
+    _get_cuda_arch_flags,
+    _get_glibcxx_abi_build_flags,
+    _get_num_workers,
+    _get_pybind11_abi_build_flags,
+)
+
+from .env import FLASHINFER_DATA
+
+
+def join_multiline(vs: List[str]) -> str:
+    return " $\n    ".join(vs)
+
+
+def generate_ninja_build_for_op(
+    name: str,
+    sources: List[Path],
+    extra_cflags: Optional[List[str]],
+    extra_cuda_cflags: Optional[List[str]],
+    extra_ldflags: Optional[List[str]],
+    extra_include_dirs: Optional[List[Path]],
+) -> str:
+    system_includes = [
+        "$torch_home/include",
+        "$torch_home/include/torch/csrc/api/include",
+        "$cuda_home/include",
+        "$flashinfer_data/include",
+        "$flashinfer_data/csrc",
+        "$flashinfer_data/cutlass/include",
+        "$flashinfer_data/cutlass/tools/util/include",
+        sysconfig.get_path("include"),
+    ]
+
+    common_cflags = [
+        "-DTORCH_EXTENSION_NAME=$name",
+        "-DTORCH_API_INCLUDE_EXTENSION_H",
+    ]
+    common_cflags += _get_pybind11_abi_build_flags()
+    common_cflags += _get_glibcxx_abi_build_flags()
+    if extra_include_dirs is not None:
+        for dir in extra_include_dirs:
+            common_cflags.append(f"-I{dir.resolve()}")
+    for dir in system_includes:
+        common_cflags.append(f"-isystem {dir}")
+
+    cflags = [
+        "$common_cflags",
+        "-fPIC",
+    ]
+    if extra_cflags is not None:
+        cflags += extra_cflags
+
+    cuda_cflags: List[str] = []
+    cc_env = os.environ.get("CC")
+    if cc_env is not None:
+        cuda_cflags += ["-ccbin", cc_env]
+    cuda_cflags += [
+        "$common_cflags",
+        "--compiler-options=-fPIC",
+        "--expt-relaxed-constexpr",
+    ]
+    cuda_cflags += _get_cuda_arch_flags(extra_cuda_cflags)
+    if extra_cuda_cflags is not None:
+        cuda_cflags += extra_cuda_cflags
+
+    ldflags = [
+        "-shared",
+        "-L$torch_home/lib",
+        "-lc10",
+        "-lc10_cuda",
+        "-ltorch_cpu",
+        "-ltorch_cuda",
+        "-ltorch",
+        "-ltorch_python",
+        "-L$cuda_home/lib64",
+        "-lcudart",
+    ]
+    if extra_ldflags is not None:
+        ldflags += extra_ldflags
+
+    cxx = os.environ.get("CXX", "c++")
+    cuda_home = CUDA_HOME or "/usr/local/cuda"
+    nvcc = os.environ.get("PYTORCH_NVCC", "$cuda_home/bin/nvcc")
+
+    lines = [
+        "ninja_required_version = 1.3",
+        f"name = {name}",
+        f"cuda_home = {cuda_home}",
+        f"torch_home = {_TORCH_PATH}",
+        f"flashinfer_data = {FLASHINFER_DATA.resolve()}",
+        f"cxx = {cxx}",
+        f"nvcc = {nvcc}",
+        "",
+        "common_cflags = " + join_multiline(common_cflags),
+        "cflags = " + join_multiline(cflags),
+        "post_cflags =",
+        "cuda_cflags = " + join_multiline(cuda_cflags),
+        "cuda_post_cflags =",
+        "ldflags = " + join_multiline(ldflags),
+        "",
+        "rule compile",
+        "  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out $post_cflags"
+        "  depfile = $out.d",
+        "  deps = gcc",
+        "",
+        "rule cuda_compile",
+        "  command = $nvcc --generate-dependencies-with-compile --dependency-output $out.d $cuda_cflags -c $in -o $out $cuda_post_cflags",
+        "  depfile = $out.d",
+        "  deps = gcc",
+        "",
+        "rule link",
+        "  command = $cxx $in $ldflags -o $out",
+        "",
+    ]
+
+    objects = []
+    for source in sources:
+        is_cuda = source.suffix == ".cu"
+        object_suffix = ".cuda.o" if is_cuda else ".o"
+        cmd = "cuda_compile" if is_cuda else "compile"
+        obj_name = source.with_suffix(object_suffix).name
+        obj = f"$name/{obj_name}"
+        objects.append(obj)
+        lines.append(f"build {obj}: {cmd} {source.resolve()}")
+
+    lines.append("")
+    lines.append("build $name/$name.so: link " + " ".join(objects))
+    lines.append("default $name/$name.so")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:
+    workdir.mkdir(parents=True, exist_ok=True)
+    command = [
+        "ninja",
+        "-v",
+        "-C",
+        str(workdir.resolve()),
+        "-f",
+        str(ninja_file.resolve()),
+    ]
+    num_workers = _get_num_workers(verbose)
+    if num_workers is not None:
+        command += ["-j", str(num_workers)]
+
+    sys.stdout.flush()
+    sys.stderr.flush()
+    try:
+        subprocess.run(
+            command,
+            stdout=None if verbose else subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=str(workdir.resolve()),
+            check=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        msg = "Ninja build failed."
+        if e.output:
+            msg += " Ninja output:\n" + e.output
+        raise RuntimeError(msg) from e

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -45,6 +45,7 @@ FLASHINFER_WORKSPACE_DIR = _get_workspace_dir_name()
 FLASHINFER_JIT_DIR = FLASHINFER_WORKSPACE_DIR / "cached_ops"
 FLASHINFER_GEN_SRC_DIR = FLASHINFER_WORKSPACE_DIR / "generated"
 _package_root = pathlib.Path(__file__).resolve().parents[1]
+FLASHINFER_DATA = _package_root / "data"
 FLASHINFER_INCLUDE_DIR = _package_root / "data" / "include"
 FLASHINFER_CSRC_DIR = _package_root / "data" / "csrc"
 # FLASHINFER_SRC_DIR = _package_root / "data" / "src"

--- a/flashinfer/jit/parallel_load_modules.py
+++ b/flashinfer/jit/parallel_load_modules.py
@@ -1,0 +1,37 @@
+import threading
+from typing import Any, Callable, List, Tuple
+
+from .core import logger
+
+
+def parallel_load_modules(
+    load_module_func_args: List[Tuple[Callable, List[Any]]],
+):
+    # TODO(lequn): Change callers. Remove this function. Replace by build_jit_specs().
+    from .core import JitSpec
+
+    threads = []
+    exceptions = []
+
+    def wrapper(func, args):
+        try:
+            ret = func(*args)
+            if isinstance(ret, JitSpec):
+                ret.build_and_load()
+        except Exception as e:
+            exceptions.append((func, e))
+
+    for func, args in load_module_func_args:
+        thread = threading.Thread(target=wrapper, args=(func, args))
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    if exceptions:
+        for func, e in exceptions:
+            print(f"Exception occurred in {func.__name__}: {e}")
+        raise RuntimeError("One or more exceptions occurred during module loading")
+
+    logger.info("Finished loading modules")

--- a/flashinfer/jit/utils.py
+++ b/flashinfer/jit/utils.py
@@ -15,12 +15,8 @@ limitations under the License.
 """
 
 import pathlib
-import threading
-from typing import Any, Callable, List, Tuple
 
 import torch
-
-from .core import logger
 
 
 def write_if_different(path: pathlib.Path, content: str) -> None:
@@ -32,34 +28,6 @@ def write_if_different(path: pathlib.Path, content: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         f.write(content)
-
-
-def parallel_load_modules(
-    load_module_func_args: List[Tuple[Callable, List[Any]]],
-):
-    threads = []
-    exceptions = []
-
-    def wrapper(func, args):
-        try:
-            func(*args)
-        except Exception as e:
-            exceptions.append((func, e))
-
-    for func, args in load_module_func_args:
-        thread = threading.Thread(target=wrapper, args=(func, args))
-        thread.start()
-        threads.append(thread)
-
-    for thread in threads:
-        thread.join()
-
-    if exceptions:
-        for func, e in exceptions:
-            print(f"Exception occurred in {func.__name__}: {e}")
-        raise RuntimeError("One or more exceptions occurred during module loading")
-
-    logger.info("Finished loading modules")
 
 
 dtype_map = {


### PR DESCRIPTION
Part of AOT Refactor (#1064)

First, this PR introduces a `JitSpec` class for describing the build instructions for a torch cpp extension. In future PRs, all modules will return a `JitSpec` instead of a loaded torch ops. Then, AOT can build all of these in one pass.

Second, instead of relying on torch, we generate the ninja files by ourselves. This gives us more flexible control over the build process. The major difference in the ninja file is that we prefix the target files with the extension name (i.e., `$name/xxx.o` instead of `xxx.o`). This allows us to use `subninja` to include all ops for the AOT build.