### PR TITLE
misc: jit: Deprecate `load_cuda_ops()`

### DIFF
--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 
 import torch
 
-from .jit import gen_act_and_mul_module, has_prebuilt_ops, load_cuda_ops  # noqa: F401
+from .jit import gen_act_and_mul_module, has_prebuilt_ops  # noqa: F401
 from .utils import register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
@@ -63,7 +63,7 @@ def get_act_and_mul_module(act_func_name: str):
         else:
             module = gen_act_and_mul_module(
                 act_func_name, act_func_def_str[act_func_name]
-            )
+            ).build_and_load()
 
         # torch library for act_and_mul
         fname = f"{act_func_name}_and_mul"

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional, Tuple
 import torch
 
 from .decode import BatchDecodeWithPagedKVCacheWrapper
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .prefill import BatchPrefillWithPagedKVCacheWrapper, single_prefill_with_kv_cache
 from .utils import register_custom_op, register_fake_op
 
@@ -35,13 +35,13 @@ def get_cascade_module():
 
             _cascade_module = _kernels
         else:
-            _cascade_module = load_cuda_ops(
+            _cascade_module = gen_jit_spec(
                 "cascade",
                 [
                     FLASHINFER_CSRC_DIR / "cascade.cu",
                     FLASHINFER_CSRC_DIR / "flashinfer_cascade_ops.cu",
                 ],
-            )
+            ).build_and_load()
     return _cascade_module
 
 

--- a/flashinfer/custom_all_reduce.py
+++ b/flashinfer/custom_all_reduce.py
@@ -21,7 +21,7 @@ from typing import List, Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op
 
 _comm_module = None
@@ -34,13 +34,13 @@ def get_comm_module():
             _kernels = torch.ops.flashinfer_kernels
             module = _kernels
         else:
-            module = load_cuda_ops(
+            module = gen_jit_spec(
                 "comm",
                 [
                     FLASHINFER_CSRC_DIR / "flashinfer_comm_ops.cu",
                     FLASHINFER_CSRC_DIR / "custom_all_reduce.cu",
                 ],
-            )
+            ).build_and_load()
 
         # torch library for all
         @register_custom_op(

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -21,7 +21,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn.functional as F
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import (
     _get_cache_buf,
     determine_gemm_backend,
@@ -43,7 +43,7 @@ def get_gemm_module():
 
             module = _kernels
         else:
-            module = load_cuda_ops(
+            module = gen_jit_spec(
                 "gemm",
                 [
                     FLASHINFER_CSRC_DIR / "bmm_fp8.cu",
@@ -51,7 +51,7 @@ def get_gemm_module():
                     FLASHINFER_CSRC_DIR / "flashinfer_gemm_ops.cu",
                 ],
                 extra_ldflags=["-lcublas", "-lcublasLt"],
-            )
+            ).build_and_load()
 
         # torch library for bmm_fp8
 
@@ -148,7 +148,7 @@ def get_gemm_sm100_module():
         _kernels_sm100 = torch.ops.flashinfer_kernels_sm100
         module = _kernels_sm100
     else:
-        module = load_cuda_ops(
+        module = gen_jit_spec(
             "gemm_sm100",
             [
                 FLASHINFER_CSRC_DIR / "gemm_groupwise_sm100.cu",
@@ -157,7 +157,7 @@ def get_gemm_sm100_module():
                 FLASHINFER_CSRC_DIR / "group_gemm_sm100_pybind.cu",
             ],
             extra_cuda_cflags=["-gencode", "arch=compute_100a,code=sm_100a"],
-        )
+        ).build_and_load()
 
     return module
 
@@ -170,7 +170,7 @@ def get_gemm_sm90_module():
 
             module = _kernels_sm90
         else:
-            module = load_cuda_ops(
+            module = gen_jit_spec(
                 "gemm_sm90",
                 [
                     FLASHINFER_CSRC_DIR / "group_gemm_sm90.cu",
@@ -183,7 +183,7 @@ def get_gemm_sm90_module():
                     FLASHINFER_CSRC_DIR / "group_gemm_e5m2_bf16_sm90.cu",
                 ],
                 extra_cuda_cflags=["-gencode", "arch=compute_90a,code=sm_90a"],
-            )
+            ).build_and_load()
 
         # torch library for cutlass_segment_gemm_sm90
 

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -59,7 +59,6 @@ from .core import JitSpec as JitSpec
 from .core import build_jit_specs as build_jit_specs
 from .core import clear_cache_dir as clear_cache_dir
 from .core import gen_jit_spec as gen_jit_spec
-from .core import load_cuda_ops as load_cuda_ops
 from .env import *
 from .parallel_load_modules import parallel_load_modules as parallel_load_modules
 

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -18,7 +18,7 @@ import os
 
 import jinja2
 
-from .core import load_cuda_ops
+from .core import JitSpec, gen_jit_spec
 from .env import FLASHINFER_GEN_SRC_DIR
 from .utils import write_if_different
 
@@ -76,7 +76,7 @@ def get_act_and_mul_cu_str(act_func_name: str, act_func_def: str) -> str:
     return template.render(act_func_name=act_func_name, act_func_def=act_func_def)
 
 
-def gen_act_and_mul_module(act_func_name: str, act_func_def: str) -> None:
+def gen_act_and_mul_module(act_func_name: str, act_func_def: str) -> JitSpec:
     gen_directory = FLASHINFER_GEN_SRC_DIR
     os.makedirs(gen_directory, exist_ok=True)
     sources = [gen_directory / f"{act_func_name}_and_mul.cu"]
@@ -84,7 +84,7 @@ def gen_act_and_mul_module(act_func_name: str, act_func_def: str) -> None:
         sources[0],
         get_act_and_mul_cu_str(act_func_name, act_func_def),
     )
-    return load_cuda_ops(
+    return gen_jit_spec(
         f"{act_func_name}_and_mul",
         sources,
     )

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -2,6 +2,7 @@ import dataclasses
 import logging
 import os
 import re
+import warnings
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -193,6 +194,11 @@ def load_cuda_ops(
     extra_include_paths=None,
 ):
     # TODO(lequn): Remove this function and use JitSpec directly.
+    warnings.warn(
+        "load_cuda_ops is deprecated. Use JitSpec directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     spec = gen_jit_spec(
         name=name,
         sources=sources,

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _norm_module = None
@@ -33,13 +33,13 @@ def get_norm_module():
 
             _norm_module = _kernels
         else:
-            _norm_module = load_cuda_ops(
+            _norm_module = gen_jit_spec(
                 "norm",
                 [
                     FLASHINFER_CSRC_DIR / "norm.cu",
                     FLASHINFER_CSRC_DIR / "flashinfer_norm_ops.cu",
                 ],
-            )
+            ).build_and_load()
     return _norm_module
 
 

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Tuple, Union
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import (
     TensorLayout,
     _check_kv_layout,
@@ -39,13 +39,13 @@ def get_page_module():
 
             _page_module = _kernels
         else:
-            _page_module = load_cuda_ops(
+            _page_module = gen_jit_spec(
                 "page",
                 [
                     FLASHINFER_CSRC_DIR / "page.cu",
                     FLASHINFER_CSRC_DIR / "flashinfer_page_ops.cu",
                 ],
-            )
+            ).build_and_load()
     return _page_module
 
 

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -68,7 +68,8 @@ def get_pod_module(*args):
             # No tensor deprecated due to poor performance. Just use tensor cores for both.
             run_tensor = _kernels.pod_with_kv_cache_tensor.default
         else:
-            run_tensor = gen_pod_module(*args).pod_with_kv_cache_tensor.default
+            module = gen_pod_module(*args).build_and_load()
+            run_tensor = module.pod_with_kv_cache_tensor.default
         # Register the module
         _pod_modules[args] = SimpleNamespace(run_tensor=run_tensor)
     return _pod_modules[args]

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -84,7 +84,7 @@ def get_fmha_module(
             pos_encoding_mode,
             use_sliding_window,
             use_logits_soft_cap,
-        )
+        ).build_and_load()
     else:
         raise ValueError(f"SM100A is not supported on this device")
 
@@ -109,7 +109,8 @@ def get_single_prefill_module(backend):
 
                     run_func = _kernels_sm90.single_prefill_with_kv_cache_sm90.default
             else:
-                run_func = gen_single_prefill_module(backend, *args).run.default
+                module = gen_single_prefill_module(backend, *args).build_and_load()
+                run_func = module.run.default
 
             # torch library for single_prefill_with_kv_cache
 
@@ -248,7 +249,7 @@ def get_batch_prefill_module(backend):
                         _kernels_sm90.batch_prefill_with_paged_kv_cache_sm90_run.default
                     )
             else:
-                module = gen_batch_prefill_module(backend, *args)
+                module = gen_batch_prefill_module(backend, *args).build_and_load()
                 plan_func = module.plan.default
                 ragged_run_func = module.ragged_run.default
                 paged_run_func = module.paged_run.default
@@ -1221,7 +1222,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         if jit_args is not None:
             self._jit_module = get_batch_prefill_jit_module(
                 jit_args[0],
-                gen_customize_batch_prefill_module(backend, *jit_args),
+                gen_customize_batch_prefill_module(backend, *jit_args).build_and_load(),
             )
         else:
             self._jit_module = None
@@ -2066,7 +2067,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         if jit_args is not None:
             self._jit_module = get_batch_prefill_jit_module(
                 jit_args[0],
-                gen_customize_batch_prefill_module(backend, *jit_args),
+                gen_customize_batch_prefill_module(backend, *jit_args).build_and_load(),
             )
         else:
             self._jit_module = None

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -19,7 +19,7 @@ from typing import Any, Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _quantization_module = None
@@ -33,13 +33,13 @@ def get_quantization_module():
 
             _quantization_module = _kernels
         else:
-            _quantization_module = load_cuda_ops(
+            _quantization_module = gen_jit_spec(
                 "quantization",
                 [
                     FLASHINFER_CSRC_DIR / "quantization.cu",
                     FLASHINFER_CSRC_DIR / "flashinfer_quantization_ops.cu",
                 ],
-            )
+            ).build_and_load()
     return _quantization_module
 
 

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _rope_module = None
@@ -33,13 +33,13 @@ def get_rope_module():
 
             _rope_module = _kernels
         else:
-            _rope_module = load_cuda_ops(
+            _rope_module = gen_jit_spec(
                 "rope",
                 [
                     FLASHINFER_CSRC_DIR / "rope.cu",
                     FLASHINFER_CSRC_DIR / "flashinfer_rope_ops.cu",
                 ],
-            )
+            ).build_and_load()
     return _rope_module
 
 

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -19,7 +19,7 @@ from typing import Optional, Union
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
+from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _sampling_module = None
@@ -33,14 +33,14 @@ def get_sampling_module():
 
             module = _kernels
         else:
-            module = load_cuda_ops(
+            module = gen_jit_spec(
                 "sampling",
                 [
                     FLASHINFER_CSRC_DIR / "sampling.cu",
                     FLASHINFER_CSRC_DIR / "renorm.cu",
                     FLASHINFER_CSRC_DIR / "flashinfer_sampling_ops.cu",
                 ],
-            )
+            ).build_and_load()
 
         # torch library for sampling_from_logits
         @register_custom_op("flashinfer::sampling_from_logits", mutates_args=())

--- a/tests/test_deepseek_mla.py
+++ b/tests/test_deepseek_mla.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 
 import flashinfer
+from flashinfer.jit import build_jit_specs
 from flashinfer.jit.attention import (
     gen_batch_mla_module,
     gen_batch_prefill_module,
@@ -37,20 +38,17 @@ def warmup_jit():
                 continue
 
             modules.append(
-                (
-                    gen_single_prefill_module,
-                    [
-                        backend,
-                        torch.float16,
-                        torch.float16,
-                        torch.float16,
-                        192,
-                        128,
-                        0,
-                        False,
-                        False,
-                        False,
-                    ],
+                gen_single_prefill_module(
+                    backend,
+                    torch.float16,
+                    torch.float16,
+                    torch.float16,
+                    192,
+                    128,
+                    0,
+                    False,
+                    False,
+                    False,
                 )
             )
 
@@ -59,21 +57,18 @@ def warmup_jit():
                 continue
 
             modules.append(
-                (
-                    gen_batch_prefill_module,
-                    [
-                        backend,
-                        torch.float16,
-                        torch.float16,
-                        torch.float16,
-                        torch.int32,
-                        192,
-                        128,
-                        0,
-                        False,
-                        False,
-                        False,
-                    ],
+                gen_batch_prefill_module(
+                    backend,
+                    torch.float16,
+                    torch.float16,
+                    torch.float16,
+                    torch.int32,
+                    192,
+                    128,
+                    0,
+                    False,
+                    False,
+                    False,
                 )
             )
 
@@ -82,22 +77,19 @@ def warmup_jit():
                 continue
 
             modules.append(
-                (
-                    gen_batch_mla_module,
-                    [
-                        backend,
-                        torch.float16,
-                        torch.float16,
-                        torch.float16,
-                        torch.int32,
-                        512,
-                        64,
-                        False,
-                    ],
+                gen_batch_mla_module(
+                    backend,
+                    torch.float16,
+                    torch.float16,
+                    torch.float16,
+                    torch.int32,
+                    512,
+                    64,
+                    False,
                 )
             )
 
-        flashinfer.jit.parallel_load_modules(modules)
+        build_jit_specs(modules, verbose=False)
     except Exception as e:
         # abort the test session if warmup fails
         pytest.exit(str(e))

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -55,7 +55,7 @@ struct SingleDecodeWithCustomMask : AttentionVariantBase {
         ["double"],  # additional_scalar_dtypes
         "SingleDecodeWithCustomMask",
         variant_decl,
-    )
+    ).build_and_load()
 
     f = functools.partial(single_decode_with_kv_cache_with_jit_module, jit_module)
 
@@ -140,7 +140,7 @@ def test_flash_sigmoid():
         ["double", "double"],  # additional_scalar_dtypes
         "FlashSigmoid",
         variant_decl,
-    )
+    ).build_and_load()
 
     f = functools.partial(single_prefill_with_kv_cache_with_jit_module, jit_module)
 
@@ -199,7 +199,7 @@ struct DumpLogits : AttentionVariantBase {
         ["double"],  # additional_scalar_dtypes
         "DumpLogits",
         variant_decl,
-    )
+    ).build_and_load()
 
     f = functools.partial(single_prefill_with_kv_cache_with_jit_module, jit_module)
 
@@ -606,7 +606,7 @@ struct DebugPrintLogits : AttentionVariantBase {
         ["double"],  # additional_scalar_dtypes
         "DebugPrintLogits",
         variant_decl,
-    )
+    ).build_and_load()
 
     f = functools.partial(single_prefill_with_kv_cache_with_jit_module, jit_module)
 
@@ -682,7 +682,7 @@ struct DebugPrintLogits : AttentionVariantBase {
         ["double"],  # additional_scalar_dtypes
         "DebugPrintLogits",
         variant_decl,
-    )
+    ).build_and_load()
 
     f = functools.partial(single_prefill_with_kv_cache_with_jit_module, jit_module)
 


### PR DESCRIPTION
Part of AOT Refactor (#1064).

This PR changes the caller of `load_cuda_ops()` to directly use `JitSpec`. Also add deprecation warning for `load_cuda_ops()`.