### PR TITLE
misc: jit: Refactor gen JitSpec out of get_xxx_module

### DIFF
--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -19,7 +19,9 @@ from types import SimpleNamespace
 
 import torch
 
-from .jit import gen_act_and_mul_module, has_prebuilt_ops  # noqa: F401
+from .jit import JitSpec
+from .jit import gen_act_and_mul_module as gen_act_and_mul_module_impl
+from .jit import has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
@@ -53,6 +55,10 @@ act_func_def_str = {
 _jit_modules = {}
 
 
+def gen_act_and_mul_module(act_func_name: str) -> JitSpec:
+    return gen_act_and_mul_module_impl(act_func_name, act_func_def_str[act_func_name])
+
+
 def get_act_and_mul_module(act_func_name: str):
     global _jit_modules
     if act_func_name not in _jit_modules:
@@ -61,9 +67,7 @@ def get_act_and_mul_module(act_func_name: str):
 
             module = _kernels
         else:
-            module = gen_act_and_mul_module(
-                act_func_name, act_func_def_str[act_func_name]
-            ).build_and_load()
+            module = gen_act_and_mul_module(act_func_name).build_and_load()
 
         # torch library for act_and_mul
         fname = f"{act_func_name}_and_mul"

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -20,11 +20,21 @@ from typing import Any, List, Optional, Tuple
 import torch
 
 from .decode import BatchDecodeWithPagedKVCacheWrapper
-from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
+from .jit import FLASHINFER_CSRC_DIR, JitSpec, gen_jit_spec, has_prebuilt_ops
 from .prefill import BatchPrefillWithPagedKVCacheWrapper, single_prefill_with_kv_cache
 from .utils import register_custom_op, register_fake_op
 
 _cascade_module = None
+
+
+def gen_cascade_module() -> JitSpec:
+    return gen_jit_spec(
+        "cascade",
+        [
+            FLASHINFER_CSRC_DIR / "cascade.cu",
+            FLASHINFER_CSRC_DIR / "flashinfer_cascade_ops.cu",
+        ],
+    )
 
 
 def get_cascade_module():
@@ -35,13 +45,7 @@ def get_cascade_module():
 
             _cascade_module = _kernels
         else:
-            _cascade_module = gen_jit_spec(
-                "cascade",
-                [
-                    FLASHINFER_CSRC_DIR / "cascade.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_cascade_ops.cu",
-                ],
-            ).build_and_load()
+            _cascade_module = gen_cascade_module().build_and_load()
     return _cascade_module
 
 

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -59,6 +59,8 @@ from .core import JitSpec as JitSpec
 from .core import build_jit_specs as build_jit_specs
 from .core import clear_cache_dir as clear_cache_dir
 from .core import gen_jit_spec as gen_jit_spec
+from .core import sm90a_nvcc_flags as sm90a_nvcc_flags
+from .core import sm100a_nvcc_flags as sm100a_nvcc_flags
 from .env import *
 from .parallel_load_modules import parallel_load_modules as parallel_load_modules
 

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -19,10 +19,20 @@ from typing import Any, Optional
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
+from .jit import FLASHINFER_CSRC_DIR, JitSpec, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _norm_module = None
+
+
+def gen_norm_module() -> JitSpec:
+    return gen_jit_spec(
+        "norm",
+        [
+            FLASHINFER_CSRC_DIR / "norm.cu",
+            FLASHINFER_CSRC_DIR / "flashinfer_norm_ops.cu",
+        ],
+    )
 
 
 def get_norm_module():
@@ -33,13 +43,7 @@ def get_norm_module():
 
             _norm_module = _kernels
         else:
-            _norm_module = gen_jit_spec(
-                "norm",
-                [
-                    FLASHINFER_CSRC_DIR / "norm.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_norm_ops.cu",
-                ],
-            ).build_and_load()
+            _norm_module = gen_norm_module().build_and_load()
     return _norm_module
 
 

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Tuple, Union
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
+from .jit import FLASHINFER_CSRC_DIR, JitSpec, gen_jit_spec, has_prebuilt_ops
 from .utils import (
     TensorLayout,
     _check_kv_layout,
@@ -31,6 +31,16 @@ from .utils import (
 _page_module = None
 
 
+def gen_page_module() -> JitSpec:
+    return gen_jit_spec(
+        "page",
+        [
+            FLASHINFER_CSRC_DIR / "page.cu",
+            FLASHINFER_CSRC_DIR / "flashinfer_page_ops.cu",
+        ],
+    )
+
+
 def get_page_module():
     global _page_module
     if _page_module is None:
@@ -39,13 +49,7 @@ def get_page_module():
 
             _page_module = _kernels
         else:
-            _page_module = gen_jit_spec(
-                "page",
-                [
-                    FLASHINFER_CSRC_DIR / "page.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_page_ops.cu",
-                ],
-            ).build_and_load()
+            _page_module = gen_page_module().build_and_load()
     return _page_module
 
 

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -19,10 +19,20 @@ from typing import Any, Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
+from .jit import FLASHINFER_CSRC_DIR, JitSpec, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _quantization_module = None
+
+
+def gen_quantization_module() -> JitSpec:
+    return gen_jit_spec(
+        "quantization",
+        [
+            FLASHINFER_CSRC_DIR / "quantization.cu",
+            FLASHINFER_CSRC_DIR / "flashinfer_quantization_ops.cu",
+        ],
+    )
 
 
 def get_quantization_module():
@@ -33,13 +43,7 @@ def get_quantization_module():
 
             _quantization_module = _kernels
         else:
-            _quantization_module = gen_jit_spec(
-                "quantization",
-                [
-                    FLASHINFER_CSRC_DIR / "quantization.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_quantization_ops.cu",
-                ],
-            ).build_and_load()
+            _quantization_module = gen_quantization_module().build_and_load()
     return _quantization_module
 
 

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -19,10 +19,20 @@ from typing import Any, Optional, Tuple
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, gen_jit_spec, has_prebuilt_ops
+from .jit import FLASHINFER_CSRC_DIR, JitSpec, gen_jit_spec, has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 _rope_module = None
+
+
+def gen_rope_module() -> JitSpec:
+    return gen_jit_spec(
+        "rope",
+        [
+            FLASHINFER_CSRC_DIR / "rope.cu",
+            FLASHINFER_CSRC_DIR / "flashinfer_rope_ops.cu",
+        ],
+    )
 
 
 def get_rope_module():
@@ -33,13 +43,7 @@ def get_rope_module():
 
             _rope_module = _kernels
         else:
-            _rope_module = gen_jit_spec(
-                "rope",
-                [
-                    FLASHINFER_CSRC_DIR / "rope.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_rope_ops.cu",
-                ],
-            ).build_and_load()
+            _rope_module = gen_rope_module().build_and_load()
     return _rope_module
 
 


### PR DESCRIPTION
Part of AOT Refactor (#1064).

Separate `gen_xxx_module() -> JitSpec` out of `get_xxx_module()`. In upcoming PR, AOT script will call `gen_xxx_module()` to get all `JitSpec` then compile everything in one run.