### PR TITLE
misc: aot: Refactor AOT packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/generated/
 flashinfer/_build_meta.py
 flashinfer/data/
 flashinfer/jit/aot_config.py
+aot-ops/
 src/generated/
 csrc/aot_default_additional_params.h
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,20 @@ Alternatively, build FlashInfer from source:
 ```bash
 git clone https://github.com/flashinfer-ai/flashinfer.git --recursive
 cd flashinfer
-pip install -e . -v
+python -m pip install -v .
 ```
 
-To pre-compile essential kernels, set the environment variable `FLASHINFER_ENABLE_AOT=1` before running the installation command:
+To pre-compile essential kernels ahead-of-time (AOT), run the following command:
 
 ```bash
-FLASHINFER_ENABLE_AOT=1 pip install -e . -v
+# Set target CUDA architectures
+export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a"
+# Build AOT kernels. Will produce AOT kernels in aot-ops/
+python -m flashinfer.aot
+# Build AOT wheel
+python -m build --no-isolation --wheel
+# Install AOT wheel
+python -m pip install dist/flashinfer-*.whl
 ```
 
 For more details, refer to the [Install from Source documentation](https://docs.flashinfer.ai/installation.html#install-from-source).

--- a/custom_backend.py
+++ b/custom_backend.py
@@ -1,33 +1,29 @@
-import os
+import shutil
 from pathlib import Path
 
-from setuptools import build_meta as orig
 from setuptools.build_meta import *  # noqa: F403
 
+_root = Path(__file__).parent.resolve()
+_data_dir = _root / "flashinfer" / "data"
+_aot_ops_dir = _root / "aot-ops"
+_aot_ops_package_dir = _root / "build" / "aot-ops-package-dir"
 
-def _get_requires_for_build():
-    requires = []
-    if os.environ.get("FLASHINFER_ENABLE_AOT", "0") == "1":
-        requires += ["torch", "ninja", "numpy"]
-    return requires
-
-
-def get_requires_for_build_wheel(config_settings=None):
-    return _get_requires_for_build()
+_requires_for_aot = ["torch", "ninja", "numpy"]
 
 
-def get_requires_for_build_editable(config_settings=None):
-    return _get_requires_for_build()
+def _rm_aot_ops_package_dir():
+    if _aot_ops_package_dir.is_symlink():
+        _aot_ops_package_dir.unlink()
+    elif _aot_ops_package_dir.exists():
+        shutil.rmtree(_aot_ops_package_dir)
 
 
-def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
-    root = Path(__file__).parent.resolve()
-    data_dir = root / "flashinfer" / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
+def _create_data_dir():
+    _data_dir.mkdir(parents=True, exist_ok=True)
 
-    def ln(src: str, dst: str) -> None:
-        src: Path = root / src
-        dst: Path = data_dir / dst
+    def ln(source: str, target: str) -> None:
+        src = _root / source
+        dst = _data_dir / target
         if dst.exists():
             if dst.is_symlink():
                 dst.unlink()
@@ -39,4 +35,42 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     ln("csrc", "csrc")
     ln("include", "include")
     ln("tvm_binding", "tvm_binding")
-    return orig.build_editable(wheel_directory, config_settings, metadata_directory)
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    # Remove data directory
+    if _data_dir.exists():
+        shutil.rmtree(_data_dir)
+
+    # Link AOT ops directory to "aot-ops"
+    _rm_aot_ops_package_dir()
+    if len(list(_aot_ops_dir.glob("*/*.so"))) == 0:
+        raise RuntimeError(f"No AOT ops found in {_aot_ops_dir}")
+    _aot_ops_package_dir.parent.mkdir(parents=True, exist_ok=True)
+    _aot_ops_package_dir.symlink_to(_aot_ops_dir)
+
+    return _requires_for_aot
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    # Remove data directory
+    if _data_dir.exists():
+        shutil.rmtree(_data_dir)
+
+    # Create an empty directory for AOT ops
+    _rm_aot_ops_package_dir()
+    _aot_ops_package_dir.parent.mkdir(parents=True, exist_ok=True)
+    _aot_ops_package_dir.mkdir(parents=True)
+
+    return []
+
+
+def get_requires_for_build_editable(config_settings=None):
+    _create_data_dir()
+
+    _rm_aot_ops_package_dir()
+    _aot_ops_dir.mkdir(parents=True, exist_ok=True)
+    _aot_ops_package_dir.parent.mkdir(parents=True, exist_ok=True)
+    _aot_ops_package_dir.symlink_to(_aot_ops_dir)
+
+    return _requires_for_aot

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -123,7 +123,7 @@ AOT mode
    - Core CUDA kernels are pre-compiled and included in the library, reducing runtime compilation overhead.
    - If a required kernel is not pre-compiled, it will be compiled at runtime using JIT. AOT mode is recommended for production environments.
 
-JIT mode is the default installation mode. To enable AOT mode, set the environment variable ``FLASHINFER_ENABLE_AOT=1`` before installing FlashInfer.
+JIT mode is the default installation mode. To enable AOT mode, see steps below.
 You can follow the steps below to install FlashInfer from source code:
 
 1. Clone the FlashInfer repository:
@@ -153,14 +153,16 @@ You can follow the steps below to install FlashInfer from source code:
            .. code-block:: bash
 
                cd flashinfer
-               pip install --no-build-isolation --verbose --editable .
+               pip install --no-build-isolation --verbose .
 
        .. tab:: AOT mode
 
            .. code-block:: bash
 
                cd flashinfer
-               TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a" FLASHINFER_ENABLE_AOT=1 pip install --no-build-isolation --verbose --editable .
+               export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a"
+               python -m flashinfer.aot  # Produces AOT kernels in aot-ops/
+               python -m pip install --no-build-isolation --verbose .
 
 5. Create FlashInfer distributions (optional):
 
@@ -187,7 +189,9 @@ You can follow the steps below to install FlashInfer from source code:
            .. code-block:: bash
 
                cd flashinfer
-               TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a" FLASHINFER_ENABLE_AOT=1 python -m build --no-isolation --wheel
+               export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a"
+               python -m flashinfer.aot  # Produces AOT kernels in aot-ops/
+               python -m build --no-isolation --wheel
                ls -la dist/
 
 C++ API

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -14,8 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+try:
+    from ._build_meta import __version__ as __version__
+except ModuleNotFoundError:
+    __version__ = "0.0.0+unknown"
+
+
 from . import jit as jit
-from ._build_meta import __version__ as __version__
 from .activation import gelu_and_mul as gelu_and_mul
 from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
 from .activation import silu_and_mul as silu_and_mul

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -506,7 +506,7 @@ def main():
     print("Total ops:", len(jit_specs))
 
     # Build
-    build_jit_specs(jit_specs, verbose=True)
+    build_jit_specs(jit_specs, verbose=True, skip_prebuilt=False)
 
     # Copy built kernels
     copy_built_kernels(jit_specs, out_dir)

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -51,6 +51,7 @@ def generate_ninja_build_for_op(
     common_cflags = [
         "-DTORCH_EXTENSION_NAME=$name",
         "-DTORCH_API_INCLUDE_EXTENSION_H",
+        "-DPy_LIMITED_API=0x03090000",
     ]
     common_cflags += _get_pybind11_abi_build_flags()
     common_cflags += _get_glibcxx_abi_build_flags()
@@ -88,7 +89,6 @@ def generate_ninja_build_for_op(
         "-ltorch_cpu",
         "-ltorch_cuda",
         "-ltorch",
-        "-ltorch_python",
         "-L$cuda_home/lib64",
         "-lcudart",
     ]

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -54,6 +54,7 @@ FLASHINFER_INCLUDE_DIR = _package_root / "data" / "include"
 FLASHINFER_CSRC_DIR = _package_root / "data" / "csrc"
 # FLASHINFER_SRC_DIR = _package_root / "data" / "src"
 FLASHINFER_TVM_BINDING_DIR = _package_root / "data" / "tvm_binding"
+FLASHINFER_AOT_DIR = _package_root / "data" / "aot"
 CUTLASS_INCLUDE_DIRS = [
     _package_root / "data" / "cutlass" / "include",
     _package_root / "data" / "cutlass" / "tools" / "util" / "include",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@
 [project]
 name = "flashinfer-python"
 description = "FlashInfer: Kernel Library for LLM Serving"
-requires-python = ">=3.8,<4.0"
+requires-python = ">=3.9,<4.0"
 authors = [{ name = "FlashInfer team" }]
-license = { text = "Apache License 2.0" }
+license = "Apache-2.0"
 readme = "README.md"
 urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 dynamic = ["dependencies", "version"]
@@ -40,6 +40,7 @@ skip = [
 packages = [
     "flashinfer",
     "flashinfer.data",
+    "flashinfer.data.aot",
     "flashinfer.data.csrc",
     "flashinfer.data.cutlass",
     "flashinfer.data.tvm_binding",
@@ -53,6 +54,7 @@ include-package-data = false
 
 [tool.setuptools.package-dir]
 "flashinfer.data" = "."
+"flashinfer.data.aot" = "build/aot-ops-package-dir"
 "flashinfer.data.cutlass" = "3rdparty/cutlass"
 
 [tool.setuptools.package-data]
@@ -61,6 +63,9 @@ include-package-data = false
     "include/**",
     "tvm_binding/**",
     "version.txt"
+]
+"flashinfer.data.aot" = [
+    "**"
 ]
 "flashinfer.data.cutlass" = [
     "include/**",

--- a/scripts/run-ci-build-wheel.sh
+++ b/scripts/run-ci-build-wheel.sh
@@ -33,12 +33,6 @@ FLASHINFER_LOCAL_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}torch${FLASHINFER_CI_TORCH
 if [ -n "${FLASHINFER_GIT_SHA}" ]; then
     FLASHINFER_LOCAL_VERSION="${FLASHINFER_GIT_SHA}.${FLASHINFER_LOCAL_VERSION}"
 fi
-# wgmma work for cuda 12.3 and above
-if [ "$CUDA_MAJOR" -gt 12 ] || { [ "$CUDA_MAJOR" -eq 12 ] && [ "$CUDA_MINOR" -ge 3 ]; }; then
-    FLASHINFER_ENABLE_SM90=1
-else
-    FLASHINFER_ENABLE_SM90=0
-fi
 
 echo "::group::Install PyTorch"
 pip install torch==${FLASHINFER_CI_TORCH_VERSION}.* --index-url "https://download.pytorch.org/whl/cu${CUDA_MAJOR}${CUDA_MINOR}"
@@ -52,8 +46,12 @@ echo "::endgroup::"
 
 echo "::group::Build wheel for FlashInfer"
 cd "$PROJECT_ROOT"
-FLASHINFER_ENABLE_AOT=1 FLASHINFER_LOCAL_VERSION=$FLASHINFER_LOCAL_VERSION FLASHINFER_ENABLE_SM90=$FLASHINFER_ENABLE_SM90 \
-    python -m build --no-isolation --wheel
+
 python -m build --no-isolation --sdist
+
+python -m flashinfer.aot
+FLASHINFER_LOCAL_VERSION=$FLASHINFER_LOCAL_VERSION \
+    python -m build --no-isolation --wheel
+
 ls -la dist/
 echo "::endgroup::"

--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -5,15 +5,13 @@ set -x
 : ${MAX_JOBS:=$(nproc)}
 : ${CUDA_VISIBLE_DEVICES:=""}
 export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0+PTX"
-export FLASHINFER_ENABLE_AOT=1
 
 python -c "import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI)"
+python -m flashinfer.aot
 python -m build --no-isolation --wheel
 pip install dist/*.whl
 
 # test import
 mkdir -p tmp
 cd tmp
-python -c "import flashinfer.flashinfer_kernels"
-python -c "import flashinfer.flashinfer_kernels_sm90"
-python -c "import flashinfer"
+python -c "from flashinfer.page import gen_page_module; p = gen_page_module().aot_path; print(p); assert p.exists();"

--- a/setup.py
+++ b/setup.py
@@ -14,41 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import argparse
 import os
 import platform
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 import setuptools
 
 root = Path(__file__).parent.resolve()
-gen_dir = root / "csrc" / "generated"
-
-head_dims = os.environ.get("FLASHINFER_HEAD_DIMS", "128,256").split(",")
-head_dims = list(map(int, head_dims))
-SM90_ALLOWED_HEAD_DIMS = {(64, 64), (128, 128), (256, 256), (192, 128)}
-head_dims_sm90 = [(d, d) for d in head_dims if (d, d) in SM90_ALLOWED_HEAD_DIMS]
-head_dims_sm90.extend(
-    [(k, v) for k, v in SM90_ALLOWED_HEAD_DIMS if k != v]
-)  # Always enable (192,128)
-
-# NOTE(Zihao): exclude 3 (multi-item scoring) from AOT wheel
-mask_modes = [0, 1, 2]
-
-enable_aot = os.environ.get("FLASHINFER_ENABLE_AOT", "0") == "1"
-enable_f16 = os.environ.get("FLASHINFER_ENABLE_F16", "1") == "1"
-enable_bf16 = os.environ.get("FLASHINFER_ENABLE_BF16", "1") == "1"
-enable_fp8 = os.environ.get("FLASHINFER_ENABLE_FP8", "1") == "1"
-enable_fp8_e4m3 = (
-    os.environ.get("FLASHINFER_ENABLE_FP8_E4M3", "1" if enable_fp8 else "0") == "1"
-)
-enable_fp8_e5m2 = (
-    os.environ.get("FLASHINFER_ENABLE_FP8_E5M2", "1" if enable_fp8 else "0") == "1"
-)
-enable_sm90 = os.environ.get("FLASHINFER_ENABLE_SM90", "1") == "1"
+aot_ops_package_dir = root / "build" / "aot-ops-package-dir"
+enable_aot = aot_ops_package_dir.is_symlink()
 
 
 def write_if_different(path: Path, content: str) -> None:
@@ -73,68 +49,6 @@ def generate_build_meta(aot_build_meta: dict) -> None:
     write_if_different(root / "flashinfer" / "_build_meta.py", build_meta_str)
 
 
-def generate_cuda() -> None:
-    try:  # no aot_build_utils in sdist
-        sys.path.append(str(root))
-        from aot_build_utils import generate_dispatch_inc
-        from aot_build_utils.generate import get_instantiation_cu
-        from aot_build_utils.generate_aot_default_additional_params_header import (
-            get_aot_default_additional_params_header_str,
-        )
-        from aot_build_utils.generate_sm90 import get_sm90_instantiation_cu
-    except ImportError:
-        return
-
-    # dispatch.inc
-    write_if_different(
-        gen_dir / "dispatch.inc",
-        generate_dispatch_inc.get_dispatch_inc_str(
-            argparse.Namespace(
-                head_dims=head_dims,
-                head_dims_sm90=head_dims_sm90,
-                pos_encoding_modes=[0],
-                use_fp16_qk_reductions=[0],
-                mask_modes=mask_modes,
-            )
-        ),
-    )
-
-    # _kernels
-    aot_kernel_uris = get_instantiation_cu(
-        argparse.Namespace(
-            path=gen_dir,
-            head_dims=head_dims,
-            pos_encoding_modes=[0],
-            use_fp16_qk_reductions=[0],
-            mask_modes=mask_modes,
-            enable_f16=enable_f16,
-            enable_bf16=enable_bf16,
-            enable_fp8_e4m3=enable_fp8_e4m3,
-            enable_fp8_e5m2=enable_fp8_e5m2,
-        )
-    )
-
-    # _kernels_sm90
-    if enable_sm90:
-        aot_kernel_uris += get_sm90_instantiation_cu(
-            argparse.Namespace(
-                path=gen_dir,
-                head_dims=head_dims_sm90,
-                pos_encoding_modes=[0],
-                use_fp16_qk_reductions=[0],
-                mask_modes=mask_modes,
-                enable_f16=enable_f16,
-                enable_bf16=enable_bf16,
-            )
-        )
-    aot_config_str = f"""prebuilt_ops_uri = set({aot_kernel_uris})"""
-    write_if_different(root / "flashinfer" / "jit" / "aot_config.py", aot_config_str)
-    write_if_different(
-        root / "csrc" / "aot_default_additional_params.h",
-        get_aot_default_additional_params_header_str(),
-    )
-
-
 ext_modules = []
 cmdclass = {}
 install_requires = ["numpy", "torch", "ninja"]
@@ -145,8 +59,6 @@ if enable_aot:
     import torch.utils.cpp_extension as torch_cpp_ext
     from packaging.version import Version
 
-    generate_cuda()
-
     def get_cuda_version() -> Version:
         if torch_cpp_ext.CUDA_HOME is None:
             nvcc = "nvcc"
@@ -155,29 +67,9 @@ if enable_aot:
         txt = subprocess.check_output([nvcc, "--version"], text=True)
         return Version(re.findall(r"release (\d+\.\d+),", txt)[0])
 
-    class NinjaBuildExtension(torch_cpp_ext.BuildExtension):
-        def __init__(self, *args, **kwargs) -> None:
-            # do not override env MAX_JOBS if already exists
-            if not os.environ.get("MAX_JOBS"):
-                max_num_jobs_cores = max(1, os.cpu_count())
-                os.environ["MAX_JOBS"] = str(max_num_jobs_cores)
-
-            super().__init__(*args, **kwargs)
-
-    # cuda arch check for fp8 at the moment.
-    for cuda_arch_flags in torch_cpp_ext._get_cuda_arch_flags():
-        arch = int(re.search(r"compute_(\d+)", cuda_arch_flags).group(1))
-        if arch < 75:
-            raise RuntimeError("FlashInfer requires sm75+")
-
-    if os.environ.get("FLASHINFER_USE_CXX11_ABI"):
-        # force use cxx11 abi
-        torch._C._GLIBCXX_USE_CXX11_ABI = 1
-
     cuda_version = get_cuda_version()
     torch_full_version = Version(torch.__version__)
     torch_version = f"{torch_full_version.major}.{torch_full_version.minor}"
-    cmdclass["build_ext"] = NinjaBuildExtension
     install_requires = [f"torch == {torch_version}.*"]
 
     aot_build_meta = {}
@@ -188,122 +80,10 @@ if enable_aot:
     aot_build_meta["TORCH_CUDA_ARCH_LIST"] = os.environ.get("TORCH_CUDA_ARCH_LIST")
     generate_build_meta(aot_build_meta)
 
-    if enable_f16:
-        torch_cpp_ext.COMMON_NVCC_FLAGS.append("-DFLASHINFER_ENABLE_F16")
-    if enable_bf16:
-        torch_cpp_ext.COMMON_NVCC_FLAGS.append("-DFLASHINFER_ENABLE_BF16")
-    if enable_fp8_e4m3:
-        torch_cpp_ext.COMMON_NVCC_FLAGS.append("-DFLASHINFER_ENABLE_FP8_E4M3")
-    if enable_fp8_e5m2:
-        torch_cpp_ext.COMMON_NVCC_FLAGS.append("-DFLASHINFER_ENABLE_FP8_E5M2")
-
-    for flag in [
-        "-D__CUDA_NO_HALF_OPERATORS__",
-        "-D__CUDA_NO_HALF_CONVERSIONS__",
-        "-D__CUDA_NO_BFLOAT16_CONVERSIONS__",
-        "-D__CUDA_NO_HALF2_OPERATORS__",
-    ]:
-        try:
-            torch_cpp_ext.COMMON_NVCC_FLAGS.remove(flag)
-        except ValueError:
-            pass
-
-    cutlass = root / "3rdparty" / "cutlass"
-    include_dirs = [
-        root.resolve() / "include",
-        cutlass.resolve() / "include",  # for group gemm
-        cutlass.resolve() / "tools" / "util" / "include",
-    ]
-    cxx_flags = [
-        "-O3",
-        "-Wno-switch-bool",
-        "-DPy_LIMITED_API=0x03080000",
-    ]
-    nvcc_flags = [
-        "-O3",
-        "-std=c++17",
-        "--threads=1",
-        "-Xfatbin",
-        "-compress-all",
-        "-use_fast_math",
-        "-DNDEBUG",
-        "-DPy_LIMITED_API=0x03080000",
-    ]
-    libraries = [
-        "cublas",
-        "cublasLt",
-    ]
-    sm90a_flags = "-gencode arch=compute_90a,code=sm_90a".split()
-    kernel_sources = [
-        "csrc/bmm_fp8.cu",
-        "csrc/cascade.cu",
-        "csrc/group_gemm.cu",
-        "csrc/norm.cu",
-        "csrc/page.cu",
-        "csrc/quantization.cu",
-        "csrc/rope.cu",
-        "csrc/sampling.cu",
-        "csrc/renorm.cu",
-        "csrc/activation.cu",
-        "csrc/batch_decode.cu",
-        "csrc/batch_prefill.cu",
-        "csrc/single_decode.cu",
-        "csrc/single_prefill.cu",
-        # "csrc/pod.cu",  # Temporarily disabled
-        "csrc/flashinfer_ops.cu",
-        "csrc/custom_all_reduce.cu",
-    ]
-    kernel_sm90_sources = [
-        "csrc/group_gemm_sm90.cu",
-        "csrc/single_prefill_sm90.cu",
-        "csrc/batch_prefill_sm90.cu",
-        "csrc/flashinfer_ops_sm90.cu",
-        "csrc/group_gemm_f16_f16_sm90.cu",
-        "csrc/group_gemm_bf16_bf16_sm90.cu",
-        "csrc/group_gemm_e4m3_f16_sm90.cu",
-        "csrc/group_gemm_e5m2_f16_sm90.cu",
-        "csrc/group_gemm_e4m3_bf16_sm90.cu",
-        "csrc/group_gemm_e5m2_bf16_sm90.cu",
-    ]
-    decode_sources = [str(path) for path in gen_dir.glob("*decode_head*.cu")]
-    prefill_sources = [
-        str(f) for f in gen_dir.glob("*prefill_head*.cu") if "_sm90" not in f.name
-    ]
-    prefill_sm90_sources = [
-        str(path) for path in gen_dir.glob("*prefill_head*_sm90.cu")
-    ]
-    ext_modules = [
-        torch_cpp_ext.CUDAExtension(
-            name="flashinfer.flashinfer_kernels",
-            sources=kernel_sources + decode_sources + prefill_sources,
-            include_dirs=include_dirs,
-            libraries=libraries,
-            extra_compile_args={
-                "cxx": cxx_flags,
-                "nvcc": nvcc_flags,
-            },
-            py_limited_api=True,
-        )
-    ]
-    if enable_sm90:
-        ext_modules += [
-            torch_cpp_ext.CUDAExtension(
-                name="flashinfer.flashinfer_kernels_sm90",
-                sources=kernel_sm90_sources + prefill_sm90_sources,
-                include_dirs=include_dirs,
-                libraries=libraries,
-                extra_compile_args={
-                    "cxx": cxx_flags,
-                    "nvcc": nvcc_flags + sm90a_flags,
-                },
-                py_limited_api=True,
-            ),
-        ]
-
 setuptools.setup(
     version=get_version(),
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     install_requires=install_requires,
-    options={"bdist_wheel": {"py_limited_api": "cp38"}},
+    options={"bdist_wheel": {"py_limited_api": "cp39"}},
 )


### PR DESCRIPTION
Part of AOT Refactor (#1064).

This PR updates packaging for AOT wheel and JIT sdist, and update documents.

How AOT kernel is selected at runtime:

* In `JitSpec.build_and_load()`, if `flashinfer/data/aot/$name/$name.so` exists, it loads the so file and skips JIT.
* `prebuilt_ops_uri` and `has_prebuilt_ops` are not longer needed (will remove in next PR).

AOT wheel packaging flow:

1. `python -m flashinfer.aot`. This generates AOT kernels in `aot-ops/$name/$name.so`. 
2. `python -m build --no-isolation --wheel`
    * The custom build backend symlinks `build/aot-ops-package-dir` to `aot-ops`. All kernels are then copied to `flashinfer/data/aot/` as package data.
    * Note that there's no need for `FLASHINFER_ENABLE_AOT=1` any more.

JIT sdist packaging flow:

1. `python -m build --sdist`
    * The custom build backend makes an empty dir for `build/aot-ops-package-dir`. Then, nothing is copied to `flashinfer/data/aot/`, effectively disabling AOT even if there are some prebuilt kernels in `aot-ops` folder.
    * Note that in JIT mode, `torch` is not required for build. So even without `--no-isolation`, this command will run very fast.

Package size:

```
$ du -sh dist/*
211M    dist/flashinfer_python-0.2.5-py3-none-any.whl
2.5M    dist/flashinfer_python-0.2.5.tar.gz
```