### PR TITLE
misc: aot: Remove has_prebuilt_ops

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,6 @@ os.environ["BUILD_DOC"] = "1"
 autodoc_mock_imports = [
     "torch",
     "triton",
-    "flashinfer.jit.aot_config",
     "flashinfer._build_meta",
 ]
 

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -14,14 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from functools import cache
 from types import SimpleNamespace
 
 import torch
 
 from .jit import JitSpec
 from .jit import gen_act_and_mul_module as gen_act_and_mul_module_impl
-from .jit import has_prebuilt_ops
 from .utils import register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
@@ -62,12 +60,7 @@ def gen_act_and_mul_module(act_func_name: str) -> JitSpec:
 def get_act_and_mul_module(act_func_name: str):
     global _jit_modules
     if act_func_name not in _jit_modules:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            module = _kernels
-        else:
-            module = gen_act_and_mul_module(act_func_name).build_and_load()
+        module = gen_act_and_mul_module(act_func_name).build_and_load()
 
         # torch library for act_and_mul
         fname = f"{act_func_name}_and_mul"

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -22,7 +22,7 @@ import torch
 from .decode import BatchDecodeWithPagedKVCacheWrapper
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .prefill import BatchPrefillWithPagedKVCacheWrapper, single_prefill_with_kv_cache
 from .utils import register_custom_op, register_fake_op
 
@@ -42,12 +42,7 @@ def gen_cascade_module() -> JitSpec:
 def get_cascade_module():
     global _cascade_module
     if _cascade_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            _cascade_module = _kernels
-        else:
-            _cascade_module = gen_cascade_module().build_and_load()
+        _cascade_module = gen_cascade_module().build_and_load()
     return _cascade_module
 
 

--- a/flashinfer/custom_all_reduce.py
+++ b/flashinfer/custom_all_reduce.py
@@ -23,7 +23,7 @@ import torch
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .utils import register_custom_op
 
 _comm_module = None
@@ -42,11 +42,7 @@ def gen_comm_module() -> JitSpec:
 def get_comm_module():
     global _comm_module
     if _comm_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-            module = _kernels
-        else:
-            module = gen_comm_module().build_and_load()
+        module = gen_comm_module().build_and_load()
 
         # torch library for all
         @register_custom_op(

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -29,8 +29,6 @@ from .jit import (
     gen_single_decode_module,
     get_batch_decode_uri,
     get_single_decode_uri,
-    has_prebuilt_ops,
-    prebuilt_ops_uri,
 )
 from .page import get_seq_lens
 from .prefill import (
@@ -65,13 +63,8 @@ def get_single_decode_module(*args):
     global _single_decode_modules
     if args not in _single_decode_modules:
         uri = get_single_decode_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
-            _kernels = torch.ops.flashinfer_kernels
-
-            run_func = _kernels.single_decode_with_kv_cache.default
-        else:
-            module = gen_single_decode_module(*args).build_and_load()
-            run_func = module.run.default
+        module = gen_single_decode_module(*args).build_and_load()
+        run_func = module.run.default
 
         # torch library for single_decode_with_kv_cache
 
@@ -212,15 +205,9 @@ def get_batch_decode_module(*args):
     global _batch_decode_modules
     if args not in _batch_decode_modules:
         uri = get_batch_decode_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
-            _kernels = torch.ops.flashinfer_kernels
-
-            plan_func = _kernels.batch_decode_with_paged_kv_cache_plan.default
-            run_func = _kernels.batch_decode_with_paged_kv_cache_run.default
-        else:
-            mod = gen_batch_decode_module(*args).build_and_load()
-            plan_func = mod.plan.default
-            run_func = mod.run.default
+        mod = gen_batch_decode_module(*args).build_and_load()
+        plan_func = mod.plan.default
+        run_func = mod.run.default
 
         # torch library for batch_decode_with_paged_kv_cache_run
 

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -23,7 +23,7 @@ import torch.nn.functional as F
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops, sm90a_nvcc_flags, sm100a_nvcc_flags
+from .jit import gen_jit_spec, sm90a_nvcc_flags, sm100a_nvcc_flags
 from .utils import (
     _get_cache_buf,
     determine_gemm_backend,
@@ -52,12 +52,7 @@ def gen_gemm_module() -> JitSpec:
 def get_gemm_module():
     global _gemm_module
     if _gemm_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            module = _kernels
-        else:
-            module = gen_gemm_module().build_and_load()
+        module = gen_gemm_module().build_and_load()
 
         # torch library for bmm_fp8
 
@@ -163,11 +158,7 @@ def gen_gemm_sm100_module() -> JitSpec:
 
 @functools.cache
 def get_gemm_sm100_module():
-    if has_prebuilt_ops:
-        _kernels_sm100 = torch.ops.flashinfer_kernels_sm100
-        module = _kernels_sm100
-    else:
-        module = gen_gemm_sm100_module().build_and_load()
+    module = gen_gemm_sm100_module().build_and_load()
 
     return module
 
@@ -192,12 +183,7 @@ def gen_gemm_sm90_module() -> JitSpec:
 def get_gemm_sm90_module():
     global _gemm_module_sm90
     if _gemm_module_sm90 is None:
-        if has_prebuilt_ops:
-            _kernels_sm90 = torch.ops.flashinfer_kernels_sm90
-
-            module = _kernels_sm90
-        else:
-            module = gen_gemm_sm90_module().build_and_load()
+        module = gen_gemm_sm90_module().build_and_load()
 
         # torch library for cutlass_segment_gemm_sm90
 

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -68,19 +68,3 @@ cuda_lib_path = os.environ.get(
 )
 if os.path.exists(f"{cuda_lib_path}/libcudart.so.12"):
     ctypes.CDLL(f"{cuda_lib_path}/libcudart.so.12", mode=ctypes.RTLD_GLOBAL)
-
-
-try:
-    from .. import flashinfer_kernels, flashinfer_kernels_sm90  # noqa: F401
-    from .aot_config import prebuilt_ops_uri as prebuilt_ops_uri
-
-    has_prebuilt_ops = True
-except ImportError as e:
-    if "undefined symbol" in str(e):
-        raise ImportError("Loading prebuilt ops failed.") from e
-
-    from .core import logger
-
-    logger.info("Prebuilt kernels not found, using JIT backend")
-    prebuilt_ops_uri = {}
-    has_prebuilt_ops = False

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -21,7 +21,7 @@ import torch
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .utils import register_custom_op, register_fake_op
 
 _norm_module = None
@@ -40,12 +40,7 @@ def gen_norm_module() -> JitSpec:
 def get_norm_module():
     global _norm_module
     if _norm_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            _norm_module = _kernels
-        else:
-            _norm_module = gen_norm_module().build_and_load()
+        _norm_module = gen_norm_module().build_and_load()
     return _norm_module
 
 

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -21,7 +21,7 @@ import torch
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .utils import (
     TensorLayout,
     _check_kv_layout,
@@ -46,12 +46,7 @@ def gen_page_module() -> JitSpec:
 def get_page_module():
     global _page_module
     if _page_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            _page_module = _kernels
-        else:
-            _page_module = gen_page_module().build_and_load()
+        _page_module = gen_page_module().build_and_load()
     return _page_module
 
 

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -21,7 +21,7 @@ import torch
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .utils import register_custom_op, register_fake_op
 
 _quantization_module = None
@@ -40,12 +40,7 @@ def gen_quantization_module() -> JitSpec:
 def get_quantization_module():
     global _quantization_module
     if _quantization_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            _quantization_module = _kernels
-        else:
-            _quantization_module = gen_quantization_module().build_and_load()
+        _quantization_module = gen_quantization_module().build_and_load()
     return _quantization_module
 
 

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -21,7 +21,7 @@ import torch
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .utils import register_custom_op, register_fake_op
 
 _rope_module = None
@@ -40,12 +40,7 @@ def gen_rope_module() -> JitSpec:
 def get_rope_module():
     global _rope_module
     if _rope_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            _rope_module = _kernels
-        else:
-            _rope_module = gen_rope_module().build_and_load()
+        _rope_module = gen_rope_module().build_and_load()
     return _rope_module
 
 

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -21,7 +21,7 @@ import torch
 
 from .jit import JitSpec
 from .jit import env as jit_env
-from .jit import gen_jit_spec, has_prebuilt_ops
+from .jit import gen_jit_spec
 from .utils import register_custom_op, register_fake_op
 
 _sampling_module = None
@@ -41,12 +41,7 @@ def gen_sampling_module() -> JitSpec:
 def get_sampling_module():
     global _sampling_module
     if _sampling_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
-
-            module = _kernels
-        else:
-            module = gen_sampling_module().build_and_load()
+        module = gen_sampling_module().build_and_load()
 
         # torch library for sampling_from_logits
         @register_custom_op("flashinfer::sampling_from_logits", mutates_args=())

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -23,18 +23,15 @@ from flashinfer.utils import get_compute_capability
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            [
-                flashinfer.activation.gen_act_and_mul_module("silu"),
-                flashinfer.activation.gen_act_and_mul_module("gelu"),
-                flashinfer.activation.gen_act_and_mul_module("gelu_tanh"),
-            ],
-            verbose=False,
-        )
-        yield
+    flashinfer.jit.build_jit_specs(
+        [
+            flashinfer.activation.gen_act_and_mul_module("silu"),
+            flashinfer.activation.gen_act_and_mul_module("gelu"),
+            flashinfer.activation.gen_act_and_mul_module("gelu_tanh"),
+        ],
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])

--- a/tests/test_alibi.py
+++ b/tests/test_alibi.py
@@ -24,30 +24,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0, 2],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0, 2],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0, 2],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0, 2],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("seq_len", [1, 9, 81, 729])

--- a/tests/test_batch_decode_kernels.py
+++ b/tests/test_batch_decode_kernels.py
@@ -23,36 +23,33 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [
-                    torch.float16,
-                    torch.float8_e4m3fn,
-                ],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0, 1],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [
-                    torch.float16,
-                    torch.float8_e4m3fn,
-                ],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0, 1],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [
+                torch.float16,
+                torch.float8_e4m3fn,
+            ],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0, 1],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [
+                torch.float16,
+                torch.float8_e4m3fn,
+            ],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0, 1],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("batch_size", [12, 17, 128])

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -24,26 +24,23 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [
-                    torch.float16,
-                    torch.float8_e4m3fn,
-                    torch.float8_e5m2,
-                ],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0, 1],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
-        )
-        yield
+    flashinfer.jit.build_jit_specs(
+        gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [
+                torch.float16,
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            ],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0, 1],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("batch_size", [12, 17, 128])

--- a/tests/test_block_sparse.py
+++ b/tests/test_block_sparse.py
@@ -25,30 +25,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 def bsr_attention_ref(

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -26,14 +26,11 @@ CUDA_DEVICES = ["cuda:0"]
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        jit_specs = [flashinfer.gemm.gen_gemm_module()]
-        if is_sm90a_supported(torch.device("cuda:0")):
-            jit_specs.append(flashinfer.gemm.gen_gemm_sm90_module())
-        flashinfer.jit.build_jit_specs(jit_specs, verbose=False)
-        yield
+    jit_specs = [flashinfer.gemm.gen_gemm_module()]
+    if is_sm90a_supported(torch.device("cuda:0")):
+        jit_specs.append(flashinfer.gemm.gen_gemm_sm90_module())
+    flashinfer.jit.build_jit_specs(jit_specs, verbose=False)
+    yield
 
 
 @pytest.mark.parametrize("batch_size", [1, 77, 199])

--- a/tests/test_logits_cap.py
+++ b/tests/test_logits_cap.py
@@ -25,30 +25,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False, True],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False, True],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False, True],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False, True],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 def attention_logits_soft_cap_torch(q, k, v, soft_cap):

--- a/tests/test_non_contiguous_decode.py
+++ b/tests/test_non_contiguous_decode.py
@@ -7,30 +7,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99])

--- a/tests/test_non_contiguous_prefill.py
+++ b/tests/test_non_contiguous_prefill.py
@@ -23,22 +23,19 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
-        )
-        yield
+    flashinfer.jit.build_jit_specs(
+        gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("seq_len", [1, 7, 127, 999, 3579])

--- a/tests/test_pod_kernels.py
+++ b/tests/test_pod_kernels.py
@@ -24,48 +24,45 @@ from flashinfer.jit.attention.pytorch import gen_pod_module
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_fp16_qk_reductions
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [
-                    torch.float16,
-                ],  # kv_dtypes
-                [128],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_cap
-                [False],  # use_fp16_qk_reductions
-            )
-            + [
-                gen_pod_module(
-                    torch.float16,  # dtype_q
-                    torch.float16,  # dtype_kv
-                    torch.float16,  # dtype_o
-                    128,  # head_dim
-                    0,  # pos_encoding_mode_p
-                    False,  # use_sliding_window_p
-                    False,  # use_logits_soft_cap_p
-                    False,  # use_fp16_qk_reduction
-                    torch.int32,  # dtype_idx
-                    0,  # pos_encoding_mode_d
-                    False,  # use_sliding_window_d
-                    False,  # use_logits_soft_cap_d
-                )
-            ],
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_fp16_qk_reductions
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [
+                torch.float16,
+            ],  # kv_dtypes
+            [128],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_cap
+            [False],  # use_fp16_qk_reductions
+        )
+        + [
+            gen_pod_module(
+                torch.float16,  # dtype_q
+                torch.float16,  # dtype_kv
+                torch.float16,  # dtype_o
+                128,  # head_dim
+                0,  # pos_encoding_mode_p
+                False,  # use_sliding_window_p
+                False,  # use_logits_soft_cap_p
+                False,  # use_fp16_qk_reduction
+                torch.int32,  # dtype_idx
+                0,  # pos_encoding_mode_d
+                False,  # use_sliding_window_d
+                False,  # use_logits_soft_cap_d
+            )
+        ],
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("kv_len_p", [127, 12288])

--- a/tests/test_shared_prefix_kernels.py
+++ b/tests/test_shared_prefix_kernels.py
@@ -23,30 +23,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 def ceil_div(a, b):

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -23,30 +23,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False, True],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0],  # pos_encoding_modes
-                [False, True],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False, True],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False, True],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("seq_len", [1, 3, 19, 99, 199, 1999])

--- a/tests/test_tensor_cores_decode.py
+++ b/tests/test_tensor_cores_decode.py
@@ -23,30 +23,27 @@ import flashinfer
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
-    if flashinfer.jit.has_prebuilt_ops:
-        yield
-    else:
-        flashinfer.jit.build_jit_specs(
-            gen_decode_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0, 1],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-            )
-            + gen_prefill_attention_modules(
-                [torch.float16],  # q_dtypes
-                [torch.float16],  # kv_dtypes
-                [64, 128, 256],  # head_dims
-                [0, 1],  # pos_encoding_modes
-                [False],  # use_sliding_windows
-                [False],  # use_logits_soft_caps
-                [False],  # use_fp16_qk_reductions
-            ),
-            verbose=False,
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0, 1],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
-        yield
+        + gen_prefill_attention_modules(
+            [torch.float16],  # q_dtypes
+            [torch.float16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0, 1],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
 
 
 @pytest.mark.parametrize("kv_len", [54, 128, 999, 32789])


### PR DESCRIPTION
Part of AOT Refactor (#1064).

`has_prebuilt_ops` and `prebuilt_ops_uri` is no longer needed. Inside `JitSpec.build_and_load()`, it tests if prebuilt ops exists.