### PR TITLE
Fix Cutlass grouped GEMM stride

### DIFF
--- a/csrc/group_gemm_groupwise_sm100.cu
+++ b/csrc/group_gemm_groupwise_sm100.cu
@@ -70,6 +70,7 @@ void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor int_workspace_buffer,
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   int batch_size = m_indptr.size(0) - 1;
+  int max_m = SFA.size(1);
   DISPATCH_PYTORCH_INPUT_OUTPUT_DTYPE(A.scalar_type(), C.scalar_type(), c_type_in, c_type_out, [&] {
     return DISPATCH_MMA_SM(mma_sm, MMA_SM, [&] {
       return DISPATCH_SCALE_GRANULARITY(
@@ -86,7 +87,7 @@ void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor int_workspace_buffer,
                 static_cast<cutlass_t_in*>(A.data_ptr()), static_cast<cutlass_t_in*>(B.data_ptr()),
                 static_cast<float*>(SFA.data_ptr()), static_cast<float*>(SFB.data_ptr()),
                 static_cast<cutlass_t_out*>(C.data_ptr()), static_cast<int*>(m_indptr.data_ptr()),
-                n, k, batch_size, stream);
+                max_m, n, k, batch_size, stream);
             return true;
           });
     });

--- a/include/flashinfer/gemm/group_gemm_groupwise_sm100.cuh
+++ b/include/flashinfer/gemm/group_gemm_groupwise_sm100.cuh
@@ -33,19 +33,19 @@ template <typename ScaleConfig, typename DTypeIn, typename DTypeSF, typename DTy
           typename ProblemShape, typename StrideA, typename StrideB, typename StrideC,
           typename LayoutSFA, typename LayoutSFB>
 __global__ void compute_sm100_cutlass_group_gemm_args(
-    DTypeIn* A, DTypeIn* B, DTypeSF* SFA, DTypeSF* SFB, DTypeOut* C, int* m_indptr, int n, int k,
-    int batch_size, int scale_granularity_m, int scale_granularity_n, int scale_granularity_k,
-    ProblemShape* problem_sizes, const DTypeIn** A_ptr, const DTypeIn** B_ptr,
-    const DTypeSF** SFA_ptr, const DTypeSF** SFB_ptr, const DTypeOut** C_ptr, DTypeOut** D_ptr,
-    StrideA* stride_A, StrideB* stride_B, StrideC* stride_C, LayoutSFA* layout_SFA,
-    LayoutSFB* layout_SFB) {
+    DTypeIn* A, DTypeIn* B, DTypeSF* SFA, DTypeSF* SFB, DTypeOut* C, int* m_indptr, int max_m,
+    int n, int k, int batch_size, int scale_granularity_m, int scale_granularity_n,
+    int scale_granularity_k, ProblemShape* problem_sizes, const DTypeIn** A_ptr,
+    const DTypeIn** B_ptr, const DTypeSF** SFA_ptr, const DTypeSF** SFB_ptr, const DTypeOut** C_ptr,
+    DTypeOut** D_ptr, StrideA* stride_A, StrideB* stride_B, StrideC* stride_C,
+    LayoutSFA* layout_SFA, LayoutSFB* layout_SFB) {
   int i = blockIdx.x;
   int m = m_indptr[i + 1] - m_indptr[i];
   problem_sizes[i] = ProblemShape(m, n, k);
   stride_A[i] = cutlass::make_cute_packed_stride(StrideA{}, {m, k, 1});
   stride_B[i] = cutlass::make_cute_packed_stride(StrideB{}, {n, k, 1});
   stride_C[i] = cutlass::make_cute_packed_stride(StrideC{}, {m, n, 1});
-  layout_SFA[i] = ScaleConfig::tile_atom_to_shape_SFA(make_shape(m_indptr[batch_size], n, k, 1));
+  layout_SFA[i] = ScaleConfig::tile_atom_to_shape_SFA(make_shape(max_m, n, k, 1));
   layout_SFB[i] = ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
   A_ptr[i] = A + int64_t(m_indptr[i]) * int64_t(k);
   B_ptr[i] = B + int64_t(i) * int64_t(k) * int64_t(n);
@@ -65,8 +65,8 @@ cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* int_buffer, size_t int_bu
                                                  void* float_buffer,
                                                  size_t float_buffer_size_in_bytes, DTypeIn* A,
                                                  DTypeIn* B, float* SFA, float* SFB, DTypeOut* C,
-                                                 int* m_indptr, int n, int k, int batch_size,
-                                                 cudaStream_t stream) {
+                                                 int* m_indptr, int max_m, int n, int k,
+                                                 int batch_size, cudaStream_t stream) {
   using ProblemShape = cutlass::gemm::GroupProblemShape<Shape<int, int, int>>;  // <M,N,K> per group
 
   using ElementA = DTypeIn;                   // Element type for A matrix operand
@@ -187,7 +187,7 @@ cudaError_t CutlassGroupwiseScaledGroupGEMMSM100(void* int_buffer, size_t int_bu
                                             StrideC, LayoutSFA, LayoutSFB>;
 
   FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(
-      &config, prepare_args_kernel, A, B, SFA, SFB, C, m_indptr, n, k, batch_size,
+      &config, prepare_args_kernel, A, B, SFA, SFB, C, m_indptr, max_m, n, k, batch_size,
       ScaleGranularityM, ScaleGranularityN, ScaleGranularityK, problem_sizes, A_ptr, B_ptr, SFA_ptr,
       SFB_ptr, C_ptr, D_ptr, stride_A, stride_B, stride_C, layout_SFA, layout_SFB));
 


### PR DESCRIPTION
Fix stride for cutlass sm100 grouped gemm. The input scale tensor may be larger than `m_indptr[-1]`. The real stride should be infered from tensor shape.