### PR TITLE
perf: accelerate blackwell grouped gemm

### DIFF
--- a/benchmarks/bench_groupwise_grouped_gemm_fp8_blackwell.py
+++ b/benchmarks/bench_groupwise_grouped_gemm_fp8_blackwell.py
@@ -41,7 +41,7 @@ def bench_groupwise_grouped_gemm_fp8_blackwell(
 
     ms = do_bench(
         lambda: flashinfer.gemm.group_gemm_fp8_nt_groupwise(
-            a, b, a_scale, b_scale, segment_offsets, out=out
+            a, b, a_scale, b_scale, segment_offsets, out=out, mma_sm=2
         ),
         warmup=100,
         rep=1000,

--- a/csrc/group_gemm_groupwise_sm100.cu
+++ b/csrc/group_gemm_groupwise_sm100.cu
@@ -20,6 +20,19 @@
 
 using namespace flashinfer;
 
+#define DISPATCH_MMA_SM(mma_sm, MMA_SM, ...)  \
+  [&]() -> bool {                             \
+    if (mma_sm == 1) {                        \
+      constexpr int MMA_SM = 1;               \
+      return __VA_ARGS__();                   \
+    } else if (mma_sm == 2) {                 \
+      constexpr int MMA_SM = 2;               \
+      return __VA_ARGS__();                   \
+    }                                         \
+    TORCH_CHECK(false, "Unsupported MMA SM"); \
+    return false;                             \
+  }()
+
 #define DISPATCH_PYTORCH_INPUT_OUTPUT_DTYPE(input_dtype, output_dtype, c_type_in, c_type_out, ...) \
   [&]() -> bool {                                                                                  \
     return DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, c_type_out, [&] {                    \
@@ -53,27 +66,29 @@ void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor int_workspace_buffer,
                                           at::Tensor B, at::Tensor SFA, at::Tensor SFB,
                                           at::Tensor C, at::Tensor m_indptr, int64_t n, int64_t k,
                                           int64_t scale_granularity_m, int64_t scale_granularity_n,
-                                          int64_t scale_granularity_k) {
+                                          int64_t scale_granularity_k, int64_t mma_sm) {
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   int batch_size = m_indptr.size(0) - 1;
   DISPATCH_PYTORCH_INPUT_OUTPUT_DTYPE(A.scalar_type(), C.scalar_type(), c_type_in, c_type_out, [&] {
-    return DISPATCH_SCALE_GRANULARITY(
-        scale_granularity_m, scale_granularity_n, scale_granularity_k, SCALE_GRANULARITY_M,
-        SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, [&] {
-          using cutlass_t_in = cutlass_dtype_t<c_type_in>;
-          using cutlass_t_out = cutlass_dtype_t<c_type_out>;
-          auto status = flashinfer::gemm::CutlassGroupwiseScaledGroupGEMMSM100<
-              SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K>(
-              static_cast<int*>(int_workspace_buffer.data_ptr()),
-              int_workspace_buffer.element_size() * int_workspace_buffer.size(0),
-              static_cast<float*>(float_workspace_buffer.data_ptr()),
-              float_workspace_buffer.element_size() * float_workspace_buffer.size(0),
-              static_cast<cutlass_t_in*>(A.data_ptr()), static_cast<cutlass_t_in*>(B.data_ptr()),
-              static_cast<float*>(SFA.data_ptr()), static_cast<float*>(SFB.data_ptr()),
-              static_cast<cutlass_t_out*>(C.data_ptr()), static_cast<int*>(m_indptr.data_ptr()), n,
-              k, batch_size, stream);
-          return true;
-        });
+    return DISPATCH_MMA_SM(mma_sm, MMA_SM, [&] {
+      return DISPATCH_SCALE_GRANULARITY(
+          scale_granularity_m, scale_granularity_n, scale_granularity_k, SCALE_GRANULARITY_M,
+          SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, [&] {
+            using cutlass_t_in = cutlass_dtype_t<c_type_in>;
+            using cutlass_t_out = cutlass_dtype_t<c_type_out>;
+            auto status = flashinfer::gemm::CutlassGroupwiseScaledGroupGEMMSM100<
+                SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, MMA_SM>(
+                static_cast<int*>(int_workspace_buffer.data_ptr()),
+                int_workspace_buffer.element_size() * int_workspace_buffer.size(0),
+                static_cast<float*>(float_workspace_buffer.data_ptr()),
+                float_workspace_buffer.element_size() * float_workspace_buffer.size(0),
+                static_cast<cutlass_t_in*>(A.data_ptr()), static_cast<cutlass_t_in*>(B.data_ptr()),
+                static_cast<float*>(SFA.data_ptr()), static_cast<float*>(SFB.data_ptr()),
+                static_cast<cutlass_t_out*>(C.data_ptr()), static_cast<int*>(m_indptr.data_ptr()),
+                n, k, batch_size, stream);
+            return true;
+          });
+    });
   });
 }

--- a/csrc/group_gemm_sm100_pybind.cu
+++ b/csrc/group_gemm_sm100_pybind.cu
@@ -20,7 +20,7 @@ void CutlassGroupGemmGroupwiseScaledSM100(at::Tensor int_workspace_buffer,
                                           at::Tensor B, at::Tensor SFA, at::Tensor SFB,
                                           at::Tensor C, at::Tensor m_indptr, int64_t n, int64_t k,
                                           int64_t scale_granularity_m, int64_t scale_granularity_n,
-                                          int64_t scale_granularity_k);
+                                          int64_t scale_granularity_k, int64_t mma_sm);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("group_gemm_fp8_nt_groupwise", CutlassGroupGemmGroupwiseScaledSM100);

--- a/docs/api/gemm.rst
+++ b/docs/api/gemm.rst
@@ -14,6 +14,7 @@ FP8 Batch GEMM
     :toctree: ../generated
 
     gemm_fp8_nt_groupwise
+    group_gemm_fp8_nt_groupwise
     bmm_fp8
 
 Grouped GEMM

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -842,8 +842,42 @@ def group_gemm_fp8_nt_groupwise(
     out: Optional[torch.Tensor] = None,  # (cum_m, n)
     out_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
-    from .triton.gemm import compute_padding_mapping
+    r"""Perform group GEMM with FP8 data types using groupwise scaling. Currently only supported on NVIDIA
+    Blackwell architecture.
 
+    Parameters
+    ----------
+    a: torch.Tensor
+        Row-major input tensor shape ``(cum_m, k)``, data type is ``torch.float8_e4m3fn`` or ``torch.float8_e5m2``.
+        ``cum_m`` is the cumulative sum of the segment lengths.
+
+    b: torch.Tensor
+        Column-major input tensor shape ``(batch_size, n, k)``, data type is ``torch.float8_e4m3fn`` or ``torch.float8_e5m2``.
+
+    a_scale: torch.Tensor
+        Column-major scale tensor for a, shape ``(k // block_size, cum_m)``.
+
+    b_scale: torch.Tensor
+        Row-major scale tensor for b, shape ``(batch_size, k // block_size, n // block_size)``.
+
+    m_indptr: torch.Tensor
+        The indptr of the segment lengths, shape ``(batch_size + 1,)``.
+        Element element in ``m_indptr`` must be a multiple of 4.
+
+    scale_granularity_mnk: Tuple[int, int, int]
+        The granularity of the scale tensor, (m_granularity, n_granularity, k_granularity).
+
+    out: Optional[torch.Tensor]
+        The output tensor, shape ``(cum_m, n)``. If not specified, we will create an output tensor explicitly.
+
+    out_dtype: Optional[torch.dtype]
+        The data type of the output tensor.
+
+    Returns
+    -------
+    out: torch.Tensor
+        The output tensor, shape ``(cum_m, n)``.
+    """
     int_workspace_buffer = _get_cache_buf(
         "group_gemm_fp8_nt_groupwise_int_workspace", 32 * 1024 * 1024, a.device
     )
@@ -861,22 +895,28 @@ def group_gemm_fp8_nt_groupwise(
         out_dtype = out_dtype or torch.bfloat16
         out = torch.empty(a.shape[0], n, dtype=out_dtype, device=a.device)
 
-    if (m_indptr % 4 == 0).all():
-        get_gemm_sm100_module().group_gemm_fp8_nt_groupwise.default(
-            int_workspace_buffer,
-            float_workspace_buffer,
-            a,
-            b,
-            a_scale,
-            b_scale,
-            out,
-            m_indptr,
-            n,
-            k,
-            *scale_granularity_mnk,
-        )
-        return out
+    get_gemm_sm100_module().group_gemm_fp8_nt_groupwise.default(
+        int_workspace_buffer,
+        float_workspace_buffer,
+        a,
+        b,
+        a_scale,
+        b_scale,
+        out,
+        m_indptr,
+        n,
+        k,
+        *scale_granularity_mnk,
+    )
+    return out
 
+
+def pad_indptr_to_multiple_of_4(
+    m_indptr: torch.Tensor,
+):
+    from .triton.gemm import compute_padding_mapping
+
+    batch_size = m_indptr.shape[0] - 1
     m = m_indptr[1:] - m_indptr[:-1]
     m = m + 3 - (m + 3) % 4
     padded_m_indptr = torch.cat((torch.zeros((1,), device=m.device, dtype=m.dtype), m))
@@ -891,33 +931,4 @@ def group_gemm_fp8_nt_groupwise(
         m_indptr, padded_m_indptr, m_rank, padded_m_rank
     )
 
-    padded_a = torch.zeros((padded_m_indptr[-1], k), dtype=a.dtype, device=a.device)
-    padded_out = torch.zeros(
-        (padded_m_indptr[-1], n), dtype=out.dtype, device=out.device
-    )
-    padded_a_scale = torch.zeros(
-        (k // scale_granularity_mnk[2], padded_m_indptr[-1]),
-        dtype=a_scale.dtype,
-        device=a_scale.device,
-    )
-
-    padded_a[padded_m_rank] = a[m_rank]
-    padded_a_scale[::, padded_m_rank] = a_scale[::, m_rank]
-
-    get_gemm_sm100_module().group_gemm_fp8_nt_groupwise.default(
-        int_workspace_buffer,
-        float_workspace_buffer,
-        padded_a,
-        b,
-        padded_a_scale,
-        b_scale,
-        padded_out,
-        padded_m_indptr,
-        n,
-        k,
-        *scale_granularity_mnk,
-    )
-
-    out[m_rank] = padded_out[padded_m_rank]
-
-    return out
+    return padded_m_indptr, padded_m_rank

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -839,6 +839,7 @@ def group_gemm_fp8_nt_groupwise(
     b_scale: torch.Tensor,  # (batch_size, k // block_size, n // block_size)
     m_indptr: torch.Tensor,  # (batch_size + 1, )
     scale_granularity_mnk: Tuple[int, int, int] = (1, 128, 128),
+    mma_sm: int = 1,
     out: Optional[torch.Tensor] = None,  # (cum_m, n)
     out_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
@@ -866,6 +867,10 @@ def group_gemm_fp8_nt_groupwise(
 
     scale_granularity_mnk: Tuple[int, int, int]
         The granularity of the scale tensor, (m_granularity, n_granularity, k_granularity).
+
+    mma_sm: int
+        How many SMs to use for the MMA operation, must be 1 or 2.
+        2 is faster when number of rows (M) per group is large (>= 256).
 
     out: Optional[torch.Tensor]
         The output tensor, shape ``(cum_m, n)``. If not specified, we will create an output tensor explicitly.
@@ -907,6 +912,7 @@ def group_gemm_fp8_nt_groupwise(
         n,
         k,
         *scale_granularity_mnk,
+        mma_sm,
     )
     return out
 

--- a/tests/test_groupwise_scaled_gemm_fp8.py
+++ b/tests/test_groupwise_scaled_gemm_fp8.py
@@ -179,7 +179,7 @@ def test_fp8_groupwise_gemm(
     torch.testing.assert_close(c, ref_c, atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.parametrize("m", [1, 128, 256, 512, 4096, 8192])
+@pytest.mark.parametrize("m", [4, 128, 256, 512, 4096, 8192])
 @pytest.mark.parametrize("n", [128, 256, 512, 4096, 8192])
 @pytest.mark.parametrize("k", [128, 256, 512, 4096, 8192])
 @pytest.mark.parametrize("group_size", [1, 2, 4, 8])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 📌 Description

This PR reduce the grouped gemm overhead outside kernel itself:
1. remove the multiple of 4 check, and add notice in the documentation (the multiple ensurance should be guaranteed when we prepare these inputs, in an outer moe module).
2. use pdl for prepare args and gemm kernel.
3. fixed int overflow bug in prepare args kernel (use int64 to compute stride instead).

## 🔍 Related Issues

<!-- Link any related issues here -->

---

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

---

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

---

## Reviewer Notes

cc @cyx-6  @yongwww  @elfiegg 
