### PR TITLE
misc: followup

### DIFF
--- a/aot_build_utils/generate_batch_paged_decode_inst.py
+++ b/aot_build_utils/generate_batch_paged_decode_inst.py
@@ -71,7 +71,6 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatchedMLA<{head_dim}, {head_
 }}
     """.format(
         head_dim_qk=head_dim_qk,
-        head_dim_vo=head_dim_vo,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_q=dtype_literal[dtype_q],
         dtype_kv=dtype_literal[dtype_kv],

--- a/aot_build_utils/generate_batch_paged_decode_inst.py
+++ b/aot_build_utils/generate_batch_paged_decode_inst.py
@@ -71,6 +71,7 @@ template cudaError_t BatchDecodeWithPagedKVCacheDispatchedMLA<{head_dim}, {head_
 }}
     """.format(
         head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_q=dtype_literal[dtype_q],
         dtype_kv=dtype_literal[dtype_kv],

--- a/aot_build_utils/generate_batch_ragged_prefill_sm90_inst.py
+++ b/aot_build_utils/generate_batch_ragged_prefill_sm90_inst.py
@@ -18,12 +18,7 @@ import re
 import sys
 from pathlib import Path
 
-from .literal_map import (
-    dtype_literal,
-    idtype_literal,
-    mask_mode_literal,
-    pos_encoding_mode_literal,
-)
+from .literal_map import dtype_literal, idtype_literal, mask_mode_literal
 
 
 def get_cu_file_str(

--- a/aot_build_utils/generate_single_decode_inst.py
+++ b/aot_build_utils/generate_single_decode_inst.py
@@ -62,7 +62,6 @@ template cudaError_t SingleDecodeWithKVCacheDispatched<{head_dim_qk}, {pos_encod
 }}
     """.format(
         head_dim_qk=head_dim_qk,
-        head_dim_vo=head_dim_vo,
         pos_encoding_mode=pos_encoding_mode_literal[int(pos_encoding_mode)],
         dtype_q=dtype_literal[dtype_q],
         dtype_kv=dtype_literal[dtype_kv],

--- a/aot_build_utils/generate_single_prefill_sm90_inst.py
+++ b/aot_build_utils/generate_single_prefill_sm90_inst.py
@@ -18,7 +18,7 @@ import re
 import sys
 from pathlib import Path
 
-from .literal_map import dtype_literal, mask_mode_literal, pos_encoding_mode_literal
+from .literal_map import dtype_literal, mask_mode_literal
 
 
 def get_cu_file_str(

--- a/ci/scripts/jenkins/git_utils.py
+++ b/ci/scripts/jenkins/git_utils.py
@@ -134,7 +134,7 @@ class GitHubRepo:
         logging.info(f"Got response from {full_url}: {content}")
         try:
             response = json.loads(content)
-        except json.decoder.JSONDecodeError as e:
+        except json.decoder.JSONDecodeError:
             return content
 
         return response

--- a/tests/test_custom_allreduce.py
+++ b/tests/test_custom_allreduce.py
@@ -1,13 +1,10 @@
 # flashinfer: adapted from sglang + vllm
 # refer to sgl-kernel/tests/test_custom_allreduce.py from sglang
 
-import ctypes
 import logging
 import multiprocessing as mp
-import random
 import socket
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import pytest
 import torch

--- a/tests/test_groupwise_scaled_gemm_fp8.py
+++ b/tests/test_groupwise_scaled_gemm_fp8.py
@@ -21,7 +21,6 @@ import torch
 import torch.nn.functional as F
 from einops import einsum, rearrange
 
-import flashinfer
 from flashinfer.gemm import (
     gemm_fp8_nt_blockscaled,
     gemm_fp8_nt_groupwise,


### PR DESCRIPTION
Followup of https://github.com/flashinfer-ai/flashinfer/pull/1092

The last one.


Additionally @yzh119 I didn't fix the below unused imports, I am not sure if it will break the build.

```
flashinfer/jit/attention/__init__.py:17:15: F401 `.pytorch` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
   |
15 | """
16 |
17 | from . import pytorch, tvm
   |               ^^^^^^^ F401
18 | from .pytorch import gen_batch_decode_mla_module as gen_batch_decode_mla_module
19 | from .pytorch import gen_batch_decode_module as gen_batch_decode_module
   |
   = help: Use an explicit re-export: `pytorch as pytorch`

flashinfer/jit/attention/__init__.py:17:24: F401 `.tvm` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
   |
15 | """
16 |
17 | from . import pytorch, tvm
   |                        ^^^ F401
18 | from .pytorch import gen_batch_decode_mla_module as gen_batch_decode_mla_module
19 | from .pytorch import gen_batch_decode_module as gen_batch_decode_module
   |
   = help: Use an explicit re-export: `tvm as tvm`

flashinfer/prefill.py:2664:13: F841 Local variable `module` is assigned to but never used
     |
2662 |         if args not in modules_dict:
2663 |             uri = get_batch_prefill_uri("cutlass", *args)
2664 |             module = get_fmha_module(*args)
     |             ^^^^^^ F841
2665 |
2666 |             @register_custom_op(
     |
     = help: Remove assignment to unused variable `module`

flashinfer/profiler/__init__.py:17:8: F401 `argparse` imported but unused
   |
15 | """
16 |
17 | import argparse
   |        ^^^^^^^^ F401
18 | import csv
19 | import json
   |
   = help: Remove unused import: `argparse`

flashinfer/profiler/__init__.py:18:8: F401 `csv` imported but unused
   |
17 | import argparse
18 | import csv
   |        ^^^ F401
19 | import json
20 | from collections import namedtuple
   |
   = help: Remove unused import: `csv`

flashinfer/profiler/__init__.py:19:8: F401 `json` imported but unused
   |
17 | import argparse
18 | import csv
19 | import json
   |        ^^^^ F401
20 | from collections import namedtuple
21 | from enum import Enum
   |
   = help: Remove unused import: `json`

flashinfer/profiler/__init__.py:20:25: F401 `collections.namedtuple` imported but unused
   |
18 | import csv
19 | import json
20 | from collections import namedtuple
   |                         ^^^^^^^^^^ F401
21 | from enum import Enum
22 | from typing import List
   |
   = help: Remove unused import: `collections.namedtuple`
   ```