### PR TITLE
bugfix: fix ninja generation rule for non-cuda input

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -115,7 +115,7 @@ def generate_ninja_build_for_op(
         "ldflags = " + join_multiline(ldflags),
         "",
         "rule compile",
-        "  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out $post_cflags"
+        "  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out $post_cflags",
         "  depfile = $out.d",
         "  deps = gcc",
         "",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The ninja generation rule for non-cuda source file is buggy because a comma is missing, and the string for two lines are concatenated:

```ninja
rule compile
  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out $post_cflags  depfile = $out.d
  deps = gcc

rule cuda_compile
  command = $nvcc --generate-dependencies-with-compile --dependency-output $out.d $cuda_cflags -c $in -o $out $cuda_post_cflags
  depfile = $out.d
  deps = gcc
```

depfile in `rule compile` should start with a new line, same to `rule cuda_compile`.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @wenscarl @abcdabcd987 
