### PR TITLE
misc: aot: Add platform tag to wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,16 @@ if enable_aot:
     import torch
     import torch.utils.cpp_extension as torch_cpp_ext
     from packaging.version import Version
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    class impure_bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+
+    # Make sure that the wheel has correct platform tag.
+    # See https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it
+    cmdclass["bdist_wheel"] = impure_bdist_wheel
 
     def get_cuda_version() -> Version:
         if torch_cpp_ext.CUDA_HOME is None:


### PR DESCRIPTION
Follow-up of AOT Refactor (#1064)

Currently, the wheel doesn't contains a platform tag (i.e. `none`), for example:

```
flashinfer_python-0.2.5+20250530.976cfb4.torch270.cu128-py3-none-any.whl
```

The platform tag is used to distinguish x86_64 systems and ARM systems.

The cause is that setuptools doesn't see any extensions or c libraries, so it determines that this wheel is a pure python wheel. Based on [this stackoverflow answer](https://stackoverflow.com/a/45150383), we can override this behavior.

After the fix, the wheel contains platform tag correctly:

```
flashinfer_python-0.2.5+20250530.976cfb4.torch270.cu128-cp39-abi3-linux_x86_64.whl
flashinfer_python-0.2.5+20250530.976cfb4.torch270.cu128-cp39-abi3-linux_aarch64.whl
```