### PR TITLE
Fix pointer dtype bug in rope

### DIFF
--- a/csrc/rope.cu
+++ b/csrc/rope.cu
@@ -144,7 +144,7 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
     cudaError_t status = BatchQKApplyRotaryPosIdsCosSinCache(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
-        static_cast<float*>(cos_sin_cache.data_ptr()), static_cast<int32_t*>(pos_ids.data_ptr()),
+        static_cast<float*>(cos_sin_cache.data_ptr()), static_cast<int64_t*>(pos_ids.data_ptr()),
         nnz, num_qo_heads, num_kv_heads, rotary_dim, head_dim, q_stride_n, q_stride_h, k_stride_n,
         k_stride_h, q_rope_stride_n, q_rope_stride_h, k_rope_stride_n, k_rope_stride_h, interleave,
         stream);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
According to sgl-kernel(https://github.com/sgl-project/sglang/blob/c2c4f57f6311ba143c6156ab1d1a1d9413e6e4d0/sgl-kernel/README.md?plain=1#L155), python's int should be cast to int64_t instead of int32_t. This caused precision errors [when upstreaming it to flashinfer 2.6](https://github.com/sgl-project/sglang/pull/6722).

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
