### PR TITLE
refactor: use functools.cache instead of global dict for caching modules

### DIFF
--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 from functools import cache
 from typing import Any, List, Optional, Tuple
 
@@ -26,8 +27,6 @@ from .jit import gen_jit_spec
 from .prefill import BatchPrefillWithPagedKVCacheWrapper, single_prefill_with_kv_cache
 from .utils import register_custom_op, register_fake_op
 
-_cascade_module = None
-
 
 def gen_cascade_module() -> JitSpec:
     return gen_jit_spec(
@@ -39,11 +38,9 @@ def gen_cascade_module() -> JitSpec:
     )
 
 
+@functools.cache
 def get_cascade_module():
-    global _cascade_module
-    if _cascade_module is None:
-        _cascade_module = gen_cascade_module().build_and_load()
-    return _cascade_module
+    return gen_cascade_module().build_and_load()
 
 
 @cache

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -43,14 +43,6 @@ def get_cascade_module():
     return gen_cascade_module().build_and_load()
 
 
-@cache
-def get_module_attr(attr: str) -> Any:
-    global _cascade_module
-    if _cascade_module is None:
-        get_cascade_module()
-    return getattr(_cascade_module, attr).default
-
-
 @register_custom_op("flashinfer::merge_state", mutates_args=())
 def merge_state(
     v_a: torch.Tensor, s_a: torch.Tensor, v_b: torch.Tensor, s_b: torch.Tensor
@@ -105,7 +97,7 @@ def merge_state(
     s_b = s_b.to(torch.float32)
     v_merged = torch.empty_like(v_a)
     s_merged = torch.empty_like(s_a)
-    get_module_attr("merge_state")(v_a, s_a, v_b, s_b, v_merged, s_merged)
+    get_cascade_module().merge_state(v_a, s_a, v_b, s_b, v_merged, s_merged)
     return v_merged, s_merged
 
 
@@ -164,7 +156,7 @@ def merge_state_in_place(
     """
     s = s.to(torch.float32)
     s_other = s_other.to(torch.float32)
-    get_module_attr("merge_state_in_place")(v, s, v_other, s_other, mask)
+    get_cascade_module().merge_state_in_place(v, s, v_other, s_other, mask)
 
 
 @register_fake_op("flashinfer::merge_state_in_place")
@@ -221,7 +213,7 @@ def merge_states(v: torch.Tensor, s: torch.Tensor) -> Tuple[torch.Tensor, torch.
     seq_len, _, num_heads, head_dim = v.size()
     v_merged = torch.empty(seq_len, num_heads, head_dim, dtype=v.dtype, device=device)
     s_merged = torch.empty(seq_len, num_heads, dtype=torch.float32, device=device)
-    get_module_attr("merge_states")(v, s, v_merged, s_merged)
+    get_cascade_module().merge_states(v, s, v_merged, s_merged)
     return v_merged, s_merged
 
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -916,7 +916,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             if self._jit_module is not None:
                 self._cached_module = self._jit_module
             else:
-                self._cached_module = get_batch_prefill_module("fa2")(
+                self._cached_module = get_batch_prefill_module(
+                    "fa2",
                     q_data_type,
                     kv_data_type,
                     q_data_type,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -496,7 +496,8 @@ def single_decode_with_kv_cache(
 
     if use_tensor_cores:
         out = torch.empty_like(q.unsqueeze(0))
-        get_single_prefill_module("fa2")(
+        get_single_prefill_module(
+            "fa2",
             q.dtype,
             k.dtype,
             q.dtype,

--- a/flashinfer/fp4_quantization.py
+++ b/flashinfer/fp4_quantization.py
@@ -10,8 +10,6 @@ from .jit import env as jit_env
 from .jit import gen_jit_spec, sm100a_nvcc_flags
 from .utils import register_custom_op, register_fake_op
 
-_fp4_quantization_sm100 = None
-
 
 def gen_fp4_quantization_sm100_module() -> JitSpec:
     return gen_jit_spec(
@@ -43,65 +41,59 @@ def gen_fp4_quantization_sm100_module() -> JitSpec:
 
 @functools.cache
 def get_fp4_quantization_sm100_module():
-    global _fp4_quantization_sm100
-    if _fp4_quantization_sm100 is None:
-        module = gen_fp4_quantization_sm100_module().build_and_load()
+    module = gen_fp4_quantization_sm100_module().build_and_load()
 
-        @register_custom_op(
-            "flashinfer::fp4_quantize_sm100",
-            mutates_args=(""),
-        )
-        def fp4_quantize_sm100(
-            input: torch.Tensor,
-            global_scale: torch.Tensor,
-            sf_vec_size: int = 16,
-            sf_use_ue8m0: bool = False,
-            is_sf_swizzled_layout: bool = True,
-        ) -> Tuple[torch.Tensor, torch.Tensor]:
-            """Quantize input tensor to FP4 format.
+    @register_custom_op(
+        "flashinfer::fp4_quantize_sm100",
+        mutates_args=(""),
+    )
+    def fp4_quantize_sm100(
+        input: torch.Tensor,
+        global_scale: torch.Tensor,
+        sf_vec_size: int = 16,
+        sf_use_ue8m0: bool = False,
+        is_sf_swizzled_layout: bool = True,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize input tensor to FP4 format.
 
-            Args:
-                input (torch.Tensor): Input tensor of shape [M, K] with dtype fp16/bf16/fp8_quantized.
-                global_scale (torch.Tensor): Global scale factor of shape [1] and dtype float32.
-                sf_vec_size (int, optional): Scale factor vector size. Defaults to 16.
-                sf_use_ue8m0 (bool, optional): Whether to use UE8M0 format for scale factors. Defaults to False.
-                is_sf_swizzled_layout (bool, optional): Whether to use swizzled layout for scale factors. Defaults to True.
+        Args:
+            input (torch.Tensor): Input tensor of shape [M, K] with dtype fp16/bf16/fp8_quantized.
+            global_scale (torch.Tensor): Global scale factor of shape [1] and dtype float32.
+            sf_vec_size (int, optional): Scale factor vector size. Defaults to 16.
+            sf_use_ue8m0 (bool, optional): Whether to use UE8M0 format for scale factors. Defaults to False.
+            is_sf_swizzled_layout (bool, optional): Whether to use swizzled layout for scale factors. Defaults to True.
 
-            Returns:
-                Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
-                    - Quantized tensor of shape [M, K/2] with dtype FLOAT4_E2M1X2
-                    - Scale factors tensor with shape determined by layout and sf_vec_size
-            """
-            return module.fp4_quantize(
-                input,
-                global_scale,
-                sf_vec_size,
-                sf_use_ue8m0,
-                is_sf_swizzled_layout,
-            )
-
-        @register_fake_op("flashinfer::fp4_quantize_sm100")
-        def _fake_fp4_quantize_sm100(
-            input: torch.Tensor,
-            global_scale: torch.Tensor,
-            sf_vec_size: int = 16,
-            sf_use_ue8m0: bool = False,
-            is_sf_swizzled_layout: bool = True,
-        ) -> Tuple[torch.Tensor, torch.Tensor]:
-            m, k = input.shape
-            return (
-                input.new_empty([m, k // 2], dtype=torch.int64),  # FLOAT4_E2M1X2
-                input.new_empty(
-                    [m * k // sf_vec_size], dtype=torch.int32
-                ),  # Scale factors
-            )
-
-        # Register the module
-        _fp4_quantization_sm100 = SimpleNamespace(
-            fp4_quantize_sm100=fp4_quantize_sm100,
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+                - Quantized tensor of shape [M, K/2] with dtype FLOAT4_E2M1X2
+                - Scale factors tensor with shape determined by layout and sf_vec_size
+        """
+        return module.fp4_quantize(
+            input,
+            global_scale,
+            sf_vec_size,
+            sf_use_ue8m0,
+            is_sf_swizzled_layout,
         )
 
-    return _fp4_quantization_sm100
+    @register_fake_op("flashinfer::fp4_quantize_sm100")
+    def _fake_fp4_quantize_sm100(
+        input: torch.Tensor,
+        global_scale: torch.Tensor,
+        sf_vec_size: int = 16,
+        sf_use_ue8m0: bool = False,
+        is_sf_swizzled_layout: bool = True,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        m, k = input.shape
+        return (
+            input.new_empty([m, k // 2], dtype=torch.int64),  # FLOAT4_E2M1X2
+            input.new_empty([m * k // sf_vec_size], dtype=torch.int32),  # Scale factors
+        )
+
+    # Register the module
+    return SimpleNamespace(
+        fp4_quantize_sm100=fp4_quantize_sm100,
+    )
 
 
 def fp4_quantize(

--- a/flashinfer/fused_moe.py
+++ b/flashinfer/fused_moe.py
@@ -26,8 +26,6 @@ from .jit import env as jit_env
 from .jit import gen_jit_spec, sm100a_nvcc_flags
 from .utils import register_custom_op, register_fake_op
 
-_fused_moe_module_sm100 = None
-
 
 def gen_fused_moe_sm100_module() -> JitSpec:
     return gen_jit_spec(
@@ -125,269 +123,259 @@ def gen_fused_moe_sm100_module() -> JitSpec:
 
 @functools.cache
 def get_fused_moe_sm100_module():
-    global _fused_moe_module_sm100
-    if _fused_moe_module_sm100 is None:
-        module = gen_fused_moe_sm100_module().build_and_load(
-            class_name="FusedMoeRunner"
-        )
+    module = gen_fused_moe_sm100_module().build_and_load(class_name="FusedMoeRunner")
 
-        class MoERunner(TunableRunner):
-            # avoid overhead of creating a new runner in forward pass
-            _runner_dict: Dict[str, module] = dict()
+    class MoERunner(TunableRunner):
+        # avoid overhead of creating a new runner in forward pass
+        _runner_dict: Dict[str, module] = dict()
 
-            def __init__(
-                self,
-                x_dtype: torch.dtype,
-                weight_dtype: torch.dtype,
-                output_dtype: torch.dtype,
-                top_k: int,
-                tp_size: int,
-                tp_rank: int,
-                ep_size: int,
-                ep_rank: int,
-                cluster_size: int,
-                cluster_rank: int,
-                use_fp8_block_scaling: bool,
-                use_w4a8_group_scaling: bool,
-            ):
-                self.x_dtype = x_dtype
-                self.weight_dtype = weight_dtype
-                self.output_dtype = output_dtype
-                self.top_k = top_k
-                self.tp_size = tp_size
-                self.tp_rank = tp_rank
-                self.ep_size = ep_size
-                self.ep_rank = ep_rank
-                self.cluster_size = cluster_size
-                self.cluster_rank = cluster_rank
-                self.use_fp8_block_scaling = use_fp8_block_scaling
-                self.use_w4a8_group_scaling = use_w4a8_group_scaling
-
-                instance_key = (
-                    x_dtype,
-                    weight_dtype,
-                    output_dtype,
-                    use_fp8_block_scaling,
-                    use_w4a8_group_scaling,
-                )
-
-                if instance_key not in MoERunner._runner_dict:
-                    MoERunner._runner_dict[instance_key] = (
-                        torch.classes.fused_moe_sm100.FusedMoeRunner(
-                            x_dtype,
-                            weight_dtype,
-                            output_dtype,
-                            use_fp8_block_scaling,
-                            use_w4a8_group_scaling,
-                        )
-                    )
-                self._fused_moe_runner = MoERunner._runner_dict[instance_key]
-                self._is_nvfp4 = weight_dtype == torch.int64
-
-            def get_valid_tactics(
-                self,
-                inputs: List[torch.Tensor],
-            ) -> List[int]:
-                x, _, _, min_latency_mode_tensor = inputs
-                min_latency_mode = min_latency_mode_tensor.size(0) == 1
-                m = x.shape[0]
-
-                # Only profile m <= 128 for min latency mode = True
-                # Profile all valid buckets for min latency mode = False
-                # TODO: min_latency_mode = True will cause the following error:
-                # Cannot profile configuration 4: Cutlass GEMM Tactic
-                # [TensorRT-LLM][ERROR] Assertion failed: Failed to initialize cutlass TMA WS grouped gemm.
-                # Should be fixed in the moe_kernels in the future.
-                invalid = (m > 128 and min_latency_mode) or (
-                    m <= 128 and min_latency_mode and (not self._is_nvfp4)
-                )
-
-                return (
-                    []
-                    if invalid
-                    else list(range(self._fused_moe_runner.get_tactic_num()))
-                )
-
-            def forward(
-                self,
-                inputs: List[torch.Tensor],
-                gemm_idx: int = 0,
-                tactic: int = -1,
-                do_preparation: bool = False,
-            ):
-                x, fc1_expert_weights, fc2_expert_weights, min_latency_mode_tensor = (
-                    inputs
-                )
-                min_latency_mode = min_latency_mode_tensor.size(0) == 1
-                # determine if we should use min latency mode according to the profiled seq len
-                self._fused_moe_runner.run_gemm_profile(
-                    x,
-                    fc1_expert_weights,
-                    fc2_expert_weights,
-                    self.top_k,
-                    self.tp_size,
-                    self.tp_rank,
-                    self.ep_size,
-                    self.ep_rank,
-                    self.cluster_size,
-                    self.cluster_rank,
-                    min_latency_mode,
-                    gemm_idx,
-                    tactic,
-                    do_preparation,
-                )
-
-        @register_custom_op(
-            "flashinfer::cutlass_fused_moe_sm100",
-            mutates_args=(""),
-        )
-        def cutlass_fused_moe_sm100(
-            input: torch.Tensor,
-            token_selected_experts: torch.Tensor,
-            token_final_scales: torch.Tensor,
-            fc1_expert_weights: torch.Tensor,
-            fc2_expert_weights: torch.Tensor,
+        def __init__(
+            self,
+            x_dtype: torch.dtype,
+            weight_dtype: torch.dtype,
             output_dtype: torch.dtype,
-            quant_scales: List[torch.Tensor],
-            input_sf: Optional[torch.Tensor] = None,
-            tp_size: int = 1,
-            tp_rank: int = 0,
-            ep_size: int = 1,
-            ep_rank: int = 0,
-            cluster_size: int = 1,
-            cluster_rank: int = 0,
-            use_fp8_block_scaling: bool = False,
-            use_w4a8_group_scaling: bool = False,
-            min_latency_mode: bool = False,
-            tune_max_num_tokens: int = 8192,
-        ) -> List[torch.Tensor]:
-            tuner = AutoTuner.get()
+            top_k: int,
+            tp_size: int,
+            tp_rank: int,
+            ep_size: int,
+            ep_rank: int,
+            cluster_size: int,
+            cluster_rank: int,
+            use_fp8_block_scaling: bool,
+            use_w4a8_group_scaling: bool,
+        ):
+            self.x_dtype = x_dtype
+            self.weight_dtype = weight_dtype
+            self.output_dtype = output_dtype
+            self.top_k = top_k
+            self.tp_size = tp_size
+            self.tp_rank = tp_rank
+            self.ep_size = ep_size
+            self.ep_rank = ep_rank
+            self.cluster_size = cluster_size
+            self.cluster_rank = cluster_rank
+            self.use_fp8_block_scaling = use_fp8_block_scaling
+            self.use_w4a8_group_scaling = use_w4a8_group_scaling
 
-            def next_positive_power_of_2(x: int) -> int:
-                if x < 1:
-                    return 1
+            instance_key = (
+                x_dtype,
+                weight_dtype,
+                output_dtype,
+                use_fp8_block_scaling,
+                use_w4a8_group_scaling,
+            )
 
-                return 1 << (x - 1).bit_length()
-
-            tune_num_tokens_list = []
-            tune_num_tokens = next_positive_power_of_2(tune_max_num_tokens)
-            while tune_num_tokens > 0:
-                tune_num_tokens_list.append(tune_num_tokens)
-                tune_num_tokens //= 2
-            # TODO: only profile for min_latency_mode = False due to the error in the moe_kernels
-            tuning_config = TuningConfig(
-                dynamic_tensors=(
-                    # input, dim 0, all valid buckets, map a seq_len to power of 2 bucket index
-                    (0, 0, (tuple(tune_num_tokens_list), next_positive_power_of_2)),
-                    # min_latency_tensor, dim 0, (0 for False, 1 for True), map to it self
-                    (3, 0, ((0,), lambda x: x)),
+            if instance_key not in MoERunner._runner_dict:
+                MoERunner._runner_dict[instance_key] = (
+                    torch.classes.fused_moe_sm100.FusedMoeRunner(
+                        x_dtype,
+                        weight_dtype,
+                        output_dtype,
+                        use_fp8_block_scaling,
+                        use_w4a8_group_scaling,
+                    )
                 )
+            self._fused_moe_runner = MoERunner._runner_dict[instance_key]
+            self._is_nvfp4 = weight_dtype == torch.int64
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+        ) -> List[int]:
+            x, _, _, min_latency_mode_tensor = inputs
+            min_latency_mode = min_latency_mode_tensor.size(0) == 1
+            m = x.shape[0]
+
+            # Only profile m <= 128 for min latency mode = True
+            # Profile all valid buckets for min latency mode = False
+            # TODO: min_latency_mode = True will cause the following error:
+            # Cannot profile configuration 4: Cutlass GEMM Tactic
+            # [TensorRT-LLM][ERROR] Assertion failed: Failed to initialize cutlass TMA WS grouped gemm.
+            # Should be fixed in the moe_kernels in the future.
+            invalid = (m > 128 and min_latency_mode) or (
+                m <= 128 and min_latency_mode and (not self._is_nvfp4)
             )
 
-            # TODO: set min_latency_mode always to False due to the error in the moe_kernels
-            min_latency_tensor = torch.empty(0)
-
-            # allocate workspace for profiling
-            moe_runner = MoERunner(
-                x_dtype=input.dtype,
-                weight_dtype=fc1_expert_weights.dtype,
-                output_dtype=output_dtype,
-                top_k=token_selected_experts.size(1),
-                tp_size=tp_size,
-                tp_rank=tp_rank,
-                ep_size=ep_size,
-                ep_rank=ep_rank,
-                cluster_size=cluster_size,
-                cluster_rank=cluster_rank,
-                use_fp8_block_scaling=use_fp8_block_scaling,
-                use_w4a8_group_scaling=use_w4a8_group_scaling,
+            return (
+                [] if invalid else list(range(self._fused_moe_runner.get_tactic_num()))
             )
 
-            _, gemm_tactic_1 = tuner.choose_one(
-                "trtllm::fused_moe::gemm1",
-                [moe_runner],
-                tuning_config,
-                [input, fc1_expert_weights, fc2_expert_weights, min_latency_tensor],
-                gemm_idx=1,
-            )
-
-            _, gemm_tactic_2 = tuner.choose_one(
-                "trtllm::fused_moe::gemm2",
-                [moe_runner],
-                tuning_config,
-                [input, fc1_expert_weights, fc2_expert_weights, min_latency_tensor],
-                gemm_idx=2,
-            )
-
-            run_moe = (
-                moe_runner._fused_moe_runner.run_moe_min_latency
-                if min_latency_mode
-                else moe_runner._fused_moe_runner.run_moe
-            )
-            output = run_moe(
-                input,
-                token_selected_experts,
-                token_final_scales,
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            gemm_idx: int = 0,
+            tactic: int = -1,
+            do_preparation: bool = False,
+        ):
+            x, fc1_expert_weights, fc2_expert_weights, min_latency_mode_tensor = inputs
+            min_latency_mode = min_latency_mode_tensor.size(0) == 1
+            # determine if we should use min latency mode according to the profiled seq len
+            self._fused_moe_runner.run_gemm_profile(
+                x,
                 fc1_expert_weights,
                 fc2_expert_weights,
-                quant_scales,
-                input_sf,
-                tp_size,
-                tp_rank,
-                ep_size,
-                ep_rank,
-                cluster_size,
-                cluster_rank,
+                self.top_k,
+                self.tp_size,
+                self.tp_rank,
+                self.ep_size,
+                self.ep_rank,
+                self.cluster_size,
+                self.cluster_rank,
                 min_latency_mode,
-                [gemm_tactic_1, gemm_tactic_2],
+                gemm_idx,
+                tactic,
+                do_preparation,
             )
 
-            return output if min_latency_mode else [output]
+    @register_custom_op(
+        "flashinfer::cutlass_fused_moe_sm100",
+        mutates_args=(""),
+    )
+    def cutlass_fused_moe_sm100(
+        input: torch.Tensor,
+        token_selected_experts: torch.Tensor,
+        token_final_scales: torch.Tensor,
+        fc1_expert_weights: torch.Tensor,
+        fc2_expert_weights: torch.Tensor,
+        output_dtype: torch.dtype,
+        quant_scales: List[torch.Tensor],
+        input_sf: Optional[torch.Tensor] = None,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        ep_size: int = 1,
+        ep_rank: int = 0,
+        cluster_size: int = 1,
+        cluster_rank: int = 0,
+        use_fp8_block_scaling: bool = False,
+        use_w4a8_group_scaling: bool = False,
+        min_latency_mode: bool = False,
+        tune_max_num_tokens: int = 8192,
+    ) -> List[torch.Tensor]:
+        tuner = AutoTuner.get()
 
-        @register_fake_op("flashinfer::cutlass_fused_moe_sm100")
-        def _fake_cutlass_fused_moe_sm100(
-            input: torch.Tensor,
-            token_selected_experts: torch.Tensor,
-            token_final_scales: torch.Tensor,
-            fc1_expert_weights: torch.Tensor,
-            fc2_expert_weights: torch.Tensor,
-            output_dtype: torch.dtype,
-            quant_scales: List[torch.Tensor],
-            input_sf: Optional[torch.Tensor] = None,
-            tp_size: int = 1,
-            tp_rank: int = 0,
-            ep_size: int = 1,
-            ep_rank: int = 0,
-            cluster_size: int = 1,
-            cluster_rank: int = 0,
-            use_fp8_block_scaling: bool = False,
-            use_w4a8_group_scaling: bool = False,
-            min_latency_mode: bool = False,
-            tune_max_num_tokens: int = 8192,
-        ):
-            seq_len = input.shape[0]
-            hidden_size = fc2_expert_weights.shape[1]
+        def next_positive_power_of_2(x: int) -> int:
+            if x < 1:
+                return 1
 
-            if min_latency_mode:
-                num_experts_on_rank = fc2_expert_weights.shape[0]
-                output_shape = [seq_len * num_experts_on_rank, hidden_size]
-                experts_to_token_score_shape = [num_experts_on_rank, seq_len]
-                active_expert_global_ids_shape = [num_experts_on_rank]
-                return [
-                    input.new_empty(output_shape, dtype=output_dtype),
-                    input.new_empty([1], dtype=torch.int32),
-                    input.new_empty(experts_to_token_score_shape, dtype=torch.float32),
-                    input.new_empty(active_expert_global_ids_shape, dtype=torch.int32),
-                ]
-            else:
-                return [input.new_empty([seq_len, hidden_size], dtype=output_dtype)]
+            return 1 << (x - 1).bit_length()
 
-        # Register the module
-        _fused_moe_module_sm100 = SimpleNamespace(
-            cutlass_fused_moe_sm100=cutlass_fused_moe_sm100,
+        tune_num_tokens_list = []
+        tune_num_tokens = next_positive_power_of_2(tune_max_num_tokens)
+        while tune_num_tokens > 0:
+            tune_num_tokens_list.append(tune_num_tokens)
+            tune_num_tokens //= 2
+        # TODO: only profile for min_latency_mode = False due to the error in the moe_kernels
+        tuning_config = TuningConfig(
+            dynamic_tensors=(
+                # input, dim 0, all valid buckets, map a seq_len to power of 2 bucket index
+                (0, 0, (tuple(tune_num_tokens_list), next_positive_power_of_2)),
+                # min_latency_tensor, dim 0, (0 for False, 1 for True), map to it self
+                (3, 0, ((0,), lambda x: x)),
+            )
         )
 
-    return _fused_moe_module_sm100
+        # TODO: set min_latency_mode always to False due to the error in the moe_kernels
+        min_latency_tensor = torch.empty(0)
+
+        # allocate workspace for profiling
+        moe_runner = MoERunner(
+            x_dtype=input.dtype,
+            weight_dtype=fc1_expert_weights.dtype,
+            output_dtype=output_dtype,
+            top_k=token_selected_experts.size(1),
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            cluster_size=cluster_size,
+            cluster_rank=cluster_rank,
+            use_fp8_block_scaling=use_fp8_block_scaling,
+            use_w4a8_group_scaling=use_w4a8_group_scaling,
+        )
+
+        _, gemm_tactic_1 = tuner.choose_one(
+            "trtllm::fused_moe::gemm1",
+            [moe_runner],
+            tuning_config,
+            [input, fc1_expert_weights, fc2_expert_weights, min_latency_tensor],
+            gemm_idx=1,
+        )
+
+        _, gemm_tactic_2 = tuner.choose_one(
+            "trtllm::fused_moe::gemm2",
+            [moe_runner],
+            tuning_config,
+            [input, fc1_expert_weights, fc2_expert_weights, min_latency_tensor],
+            gemm_idx=2,
+        )
+
+        run_moe = (
+            moe_runner._fused_moe_runner.run_moe_min_latency
+            if min_latency_mode
+            else moe_runner._fused_moe_runner.run_moe
+        )
+        output = run_moe(
+            input,
+            token_selected_experts,
+            token_final_scales,
+            fc1_expert_weights,
+            fc2_expert_weights,
+            quant_scales,
+            input_sf,
+            tp_size,
+            tp_rank,
+            ep_size,
+            ep_rank,
+            cluster_size,
+            cluster_rank,
+            min_latency_mode,
+            [gemm_tactic_1, gemm_tactic_2],
+        )
+
+        return output if min_latency_mode else [output]
+
+    @register_fake_op("flashinfer::cutlass_fused_moe_sm100")
+    def _fake_cutlass_fused_moe_sm100(
+        input: torch.Tensor,
+        token_selected_experts: torch.Tensor,
+        token_final_scales: torch.Tensor,
+        fc1_expert_weights: torch.Tensor,
+        fc2_expert_weights: torch.Tensor,
+        output_dtype: torch.dtype,
+        quant_scales: List[torch.Tensor],
+        input_sf: Optional[torch.Tensor] = None,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        ep_size: int = 1,
+        ep_rank: int = 0,
+        cluster_size: int = 1,
+        cluster_rank: int = 0,
+        use_fp8_block_scaling: bool = False,
+        use_w4a8_group_scaling: bool = False,
+        min_latency_mode: bool = False,
+        tune_max_num_tokens: int = 8192,
+    ):
+        seq_len = input.shape[0]
+        hidden_size = fc2_expert_weights.shape[1]
+
+        if min_latency_mode:
+            num_experts_on_rank = fc2_expert_weights.shape[0]
+            output_shape = [seq_len * num_experts_on_rank, hidden_size]
+            experts_to_token_score_shape = [num_experts_on_rank, seq_len]
+            active_expert_global_ids_shape = [num_experts_on_rank]
+            return [
+                input.new_empty(output_shape, dtype=output_dtype),
+                input.new_empty([1], dtype=torch.int32),
+                input.new_empty(experts_to_token_score_shape, dtype=torch.float32),
+                input.new_empty(active_expert_global_ids_shape, dtype=torch.int32),
+            ]
+        else:
+            return [input.new_empty([seq_len, hidden_size], dtype=output_dtype)]
+
+    # Register the module
+    return SimpleNamespace(
+        cutlass_fused_moe_sm100=cutlass_fused_moe_sm100,
+    )
 
 
 # TODO(shuw): wrap into a FusedMoeModule once trtllm-gen is readly.

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -33,9 +33,6 @@ from .utils import (
     register_fake_op,
 )
 
-_gemm_module = None
-_gemm_module_sm90 = None
-
 
 def gen_gemm_module() -> JitSpec:
     return gen_jit_spec(
@@ -49,96 +46,93 @@ def gen_gemm_module() -> JitSpec:
     )
 
 
+@functools.tools
 def get_gemm_module():
-    global _gemm_module
-    if _gemm_module is None:
-        module = gen_gemm_module().build_and_load()
+    module = gen_gemm_module().build_and_load()
 
-        # torch library for bmm_fp8
+    # torch library for bmm_fp8
 
-        @register_custom_op(
-            "flashinfer::bmm_fp8", mutates_args=("workspace_buffer", "D")
+    @register_custom_op("flashinfer::bmm_fp8", mutates_args=("workspace_buffer", "D"))
+    def bmm_fp8(
+        workspace_buffer: torch.Tensor,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        D: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+    ) -> None:
+        cublas_handle = torch.cuda.current_blas_handle()
+        module.bmm_fp8.default(
+            A,
+            B,
+            D,
+            A_scale,
+            B_scale,
+            workspace_buffer,
+            cublas_handle,
         )
-        def bmm_fp8(
-            workspace_buffer: torch.Tensor,
-            A: torch.Tensor,
-            B: torch.Tensor,
-            D: torch.Tensor,
-            A_scale: torch.Tensor,
-            B_scale: torch.Tensor,
-        ) -> None:
-            cublas_handle = torch.cuda.current_blas_handle()
-            module.bmm_fp8.default(
-                A,
-                B,
-                D,
-                A_scale,
-                B_scale,
-                workspace_buffer,
-                cublas_handle,
-            )
 
-        @register_fake_op("flashinfer::bmm_fp8")
-        def _fake_bmm_fp8(
-            workspace_buffer: torch.Tensor,
-            A: torch.Tensor,
-            B: torch.Tensor,
-            D: torch.Tensor,
-            A_scale: torch.Tensor,
-            B_scale: torch.Tensor,
-        ) -> None:
-            pass
+    @register_fake_op("flashinfer::bmm_fp8")
+    def _fake_bmm_fp8(
+        workspace_buffer: torch.Tensor,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        D: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+    ) -> None:
+        pass
 
-        # torch library for cutlass_segment_gemm
+    # torch library for cutlass_segment_gemm
 
-        @register_custom_op("flashinfer::cutlass_segment_gemm", mutates_args=("y"))
-        def cutlass_segment_gemm(
-            workspace_buffer: torch.Tensor,
-            all_problems: torch.Tensor,
-            x_data: torch.Tensor,
-            w_data: torch.Tensor,
-            y_data: torch.Tensor,
-            x_ld: torch.Tensor,
-            w_ld: torch.Tensor,
-            y_ld: torch.Tensor,
-            y: torch.Tensor,
-            empty_x_data: torch.Tensor,
-            weight_column_major: bool,
-        ) -> None:
-            module.cutlass_segment_gemm.default(
-                workspace_buffer,
-                all_problems,
-                x_data,
-                w_data,
-                y_data,
-                x_ld,
-                w_ld,
-                y_ld,
-                empty_x_data,
-                weight_column_major,
-            )
-
-        @register_fake_op("flashinfer::cutlass_segment_gemm")
-        def _fake_cutlass_segment_gemm(
-            workspace_buffer: torch.Tensor,
-            all_problems: torch.Tensor,
-            x_data: torch.Tensor,
-            w_data: torch.Tensor,
-            y_data: torch.Tensor,
-            x_ld: torch.Tensor,
-            w_ld: torch.Tensor,
-            y_ld: torch.Tensor,
-            y: torch.Tensor,
-            empty_x_data: torch.Tensor,
-            weight_column_major: bool,
-        ) -> None:
-            pass
-
-        # Register the module
-        _gemm_module = SimpleNamespace(
-            bmm_fp8=bmm_fp8,
-            cutlass_segment_gemm=cutlass_segment_gemm,
+    @register_custom_op("flashinfer::cutlass_segment_gemm", mutates_args=("y"))
+    def cutlass_segment_gemm(
+        workspace_buffer: torch.Tensor,
+        all_problems: torch.Tensor,
+        x_data: torch.Tensor,
+        w_data: torch.Tensor,
+        y_data: torch.Tensor,
+        x_ld: torch.Tensor,
+        w_ld: torch.Tensor,
+        y_ld: torch.Tensor,
+        y: torch.Tensor,
+        empty_x_data: torch.Tensor,
+        weight_column_major: bool,
+    ) -> None:
+        module.cutlass_segment_gemm.default(
+            workspace_buffer,
+            all_problems,
+            x_data,
+            w_data,
+            y_data,
+            x_ld,
+            w_ld,
+            y_ld,
+            empty_x_data,
+            weight_column_major,
         )
+
+    @register_fake_op("flashinfer::cutlass_segment_gemm")
+    def _fake_cutlass_segment_gemm(
+        workspace_buffer: torch.Tensor,
+        all_problems: torch.Tensor,
+        x_data: torch.Tensor,
+        w_data: torch.Tensor,
+        y_data: torch.Tensor,
+        x_ld: torch.Tensor,
+        w_ld: torch.Tensor,
+        y_ld: torch.Tensor,
+        y: torch.Tensor,
+        empty_x_data: torch.Tensor,
+        weight_column_major: bool,
+    ) -> None:
+        pass
+
+    # Register the module
+    _gemm_module = SimpleNamespace(
+        bmm_fp8=bmm_fp8,
+        cutlass_segment_gemm=cutlass_segment_gemm,
+    )
 
     return _gemm_module
 
@@ -180,71 +174,68 @@ def gen_gemm_sm90_module() -> JitSpec:
     )
 
 
+@functools.cache
 def get_gemm_sm90_module():
-    global _gemm_module_sm90
-    if _gemm_module_sm90 is None:
-        module = gen_gemm_sm90_module().build_and_load()
+    module = gen_gemm_sm90_module().build_and_load()
 
-        # torch library for cutlass_segment_gemm_sm90
+    # torch library for cutlass_segment_gemm_sm90
 
-        @register_custom_op(
-            "flashinfer::cutlass_segment_gemm_sm90",
-            mutates_args=("workspace_buffer", "y"),
-        )
-        def cutlass_segment_gemm_sm90(
-            workspace_buffer: torch.Tensor,
-            int_workspace_buffer: torch.Tensor,
-            all_problems: torch.Tensor,
-            x_data: torch.Tensor,
-            w_data: torch.Tensor,
-            y_data: torch.Tensor,
-            x_stride: torch.Tensor,
-            w_stride: torch.Tensor,
-            y_stride: torch.Tensor,
-            y: torch.Tensor,
-            empty_x_data: torch.Tensor,
-            empty_y_data: torch.Tensor,
-            weight_column_major: bool,
-        ) -> None:
-            module.cutlass_segment_gemm_sm90.default(
-                workspace_buffer,
-                int_workspace_buffer,
-                all_problems,
-                x_data,
-                w_data,
-                y_data,
-                x_stride,
-                w_stride,
-                y_stride,
-                empty_x_data,
-                empty_y_data,
-                weight_column_major,
-            )
-
-        @register_fake_op("flashinfer::cutlass_segment_gemm_sm90")
-        def _fake_cutlass_segment_gemm_sm90(
-            workspace_buffer: torch.Tensor,
-            int_workspace_buffer: torch.Tensor,
-            all_problems: torch.Tensor,
-            x_data: torch.Tensor,
-            w_data: torch.Tensor,
-            y_data: torch.Tensor,
-            x_stride: torch.Tensor,
-            w_stride: torch.Tensor,
-            y_stride: torch.Tensor,
-            y: torch.Tensor,
-            empty_x_data: torch.Tensor,
-            empty_y_data: torch.Tensor,
-            weight_column_major: bool,
-        ) -> None:
-            pass
-
-        # Register the module
-        _gemm_module_sm90 = SimpleNamespace(
-            cutlass_segment_gemm_sm90=cutlass_segment_gemm_sm90,
+    @register_custom_op(
+        "flashinfer::cutlass_segment_gemm_sm90",
+        mutates_args=("workspace_buffer", "y"),
+    )
+    def cutlass_segment_gemm_sm90(
+        workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        all_problems: torch.Tensor,
+        x_data: torch.Tensor,
+        w_data: torch.Tensor,
+        y_data: torch.Tensor,
+        x_stride: torch.Tensor,
+        w_stride: torch.Tensor,
+        y_stride: torch.Tensor,
+        y: torch.Tensor,
+        empty_x_data: torch.Tensor,
+        empty_y_data: torch.Tensor,
+        weight_column_major: bool,
+    ) -> None:
+        module.cutlass_segment_gemm_sm90.default(
+            workspace_buffer,
+            int_workspace_buffer,
+            all_problems,
+            x_data,
+            w_data,
+            y_data,
+            x_stride,
+            w_stride,
+            y_stride,
+            empty_x_data,
+            empty_y_data,
+            weight_column_major,
         )
 
-    return _gemm_module_sm90
+    @register_fake_op("flashinfer::cutlass_segment_gemm_sm90")
+    def _fake_cutlass_segment_gemm_sm90(
+        workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        all_problems: torch.Tensor,
+        x_data: torch.Tensor,
+        w_data: torch.Tensor,
+        y_data: torch.Tensor,
+        x_stride: torch.Tensor,
+        w_stride: torch.Tensor,
+        y_stride: torch.Tensor,
+        y: torch.Tensor,
+        empty_x_data: torch.Tensor,
+        empty_y_data: torch.Tensor,
+        weight_column_major: bool,
+    ) -> None:
+        pass
+
+    # Register the module
+    return SimpleNamespace(
+        cutlass_segment_gemm_sm90=cutlass_segment_gemm_sm90,
+    )
 
 
 def launch_compute_sm80_group_gemm_args(

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -46,7 +46,7 @@ def gen_gemm_module() -> JitSpec:
     )
 
 
-@functools.tools
+@functools.cache
 def get_gemm_module():
     module = gen_gemm_module().build_and_load()
 

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 from functools import cache
 from typing import Any, Optional
 
@@ -23,8 +24,6 @@ from .jit import JitSpec
 from .jit import env as jit_env
 from .jit import gen_jit_spec
 from .utils import device_support_pdl, register_custom_op, register_fake_op
-
-_norm_module = None
 
 
 def gen_norm_module() -> JitSpec:
@@ -37,11 +36,9 @@ def gen_norm_module() -> JitSpec:
     )
 
 
+@functools.cache
 def get_norm_module():
-    global _norm_module
-    if _norm_module is None:
-        _norm_module = gen_norm_module().build_and_load()
-    return _norm_module
+    return gen_norm_module().build_and_load()
 
 
 @cache

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -43,10 +43,7 @@ def get_norm_module():
 
 @cache
 def get_module_attr(attr: str) -> Any:
-    global _norm_module
-    if _norm_module is None:
-        get_norm_module()
-    return getattr(_norm_module, attr).default
+    return getattr(get_norm_module, attr).default
 
 
 def rmsnorm(

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -41,11 +41,6 @@ def get_norm_module():
     return gen_norm_module().build_and_load()
 
 
-@cache
-def get_module_attr(attr: str) -> Any:
-    return getattr(get_norm_module, attr).default
-
-
 def rmsnorm(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -94,7 +89,7 @@ def _rmsnorm(
 ) -> None:
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    get_module_attr("rmsnorm")(out, input, weight, eps, enable_pdl)
+    get_norm_module().rmsnorm(out, input, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::rmsnorm")
@@ -140,7 +135,7 @@ def fused_add_rmsnorm(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    get_module_attr("fused_add_rmsnorm")(input, residual, weight, eps, enable_pdl)
+    get_norm_module().fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::fused_add_rmsnorm")
@@ -202,7 +197,7 @@ def _gemma_rmsnorm(
 ) -> None:
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    get_module_attr("gemma_rmsnorm")(out, input, weight, eps, enable_pdl)
+    get_norm_module().gemma_rmsnorm(out, input, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::gemma_rmsnorm")
@@ -250,7 +245,7 @@ def gemma_fused_add_rmsnorm(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    get_module_attr("gemma_fused_add_rmsnorm")(input, residual, weight, eps, enable_pdl)
+    get_norm_module().gemma_fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
 
 
 @register_fake_op("flashinfer::gemma_fused_add_rmsnorm")

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -47,11 +47,6 @@ def get_page_module():
     return gen_page_module().build_and_load()
 
 
-@functools.cache
-def get_module_attr(attr: str) -> Any:
-    return getattr(get_page_module(), attr).default
-
-
 def block_sparse_indices_to_vector_sparse_offsets(
     block_sparse_indices: torch.Tensor,
     block_sparse_indptr: torch.Tensor,
@@ -74,7 +69,7 @@ def block_sparse_indices_to_vector_sparse_offsets(
     assert vector_sparse_indptr.dtype == torch.int32
     assert kv_lens.dtype == torch.int32
     batch_size = block_sparse_indptr.size(0) - 1
-    get_module_attr("block_sparse_indices_to_vector_sparse_offsets")(
+    get_page_module().block_sparse_indices_to_vector_sparse_offsets(
         block_sparse_indices,
         block_sparse_indptr,
         vector_sparse_offsets,
@@ -108,7 +103,7 @@ def _append_paged_mla_kv_cache_kernel(
     kv_indices = kv_indices.int()
     kv_indptr = kv_indptr.int()
     kv_last_page_len = kv_last_page_len.int()
-    get_module_attr("append_paged_mla_kv_cache")(
+    get_page_module().append_paged_mla_kv_cache(
         append_ckv,
         append_kpe,
         batch_indices,
@@ -142,7 +137,7 @@ def _append_paged_kv_cache_kernel(
     kv_indices = kv_indices.int()
     kv_indptr = kv_indptr.int()
     kv_last_page_len = kv_last_page_len.int()
-    get_module_attr("append_paged_kv_cache")(
+    get_page_module().append_paged_kv_cache(
         append_key,
         append_value,
         batch_indices,

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 from functools import cache
 from typing import Any, Optional, Tuple, Union
 
@@ -30,8 +31,6 @@ from .utils import (
     register_fake_op,
 )
 
-_page_module = None
-
 
 def gen_page_module() -> JitSpec:
     return gen_jit_spec(
@@ -43,19 +42,14 @@ def gen_page_module() -> JitSpec:
     )
 
 
+@functools.cache
 def get_page_module():
-    global _page_module
-    if _page_module is None:
-        _page_module = gen_page_module().build_and_load()
-    return _page_module
+    return gen_page_module().build_and_load()
 
 
-@cache
+@functools.cache
 def get_module_attr(attr: str) -> Any:
-    global _page_module
-    if _page_module is None:
-        get_page_module()
-    return getattr(_page_module, attr).default
+    return getattr(get_page_module(), attr).default
 
 
 def block_sparse_indices_to_vector_sparse_offsets(

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 import math
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple, Union
@@ -39,17 +40,11 @@ from .utils import (
     device_support_pdl,
 )
 
-_pod_modules = {}
 
-
+@functools.cache
 def get_pod_module(*args):
-    global _pod_modules
-    if args not in _pod_modules:
-        module = gen_pod_module(*args).build_and_load()
-        run_tensor = module.pod_with_kv_cache_tensor.default
-        # Register the module
-        _pod_modules[args] = SimpleNamespace(run_tensor=run_tensor)
-    return _pod_modules[args]
+    module = gen_pod_module(*args).build_and_load()
+    return SimpleNamespace(run_tensor=module.pod_with_kv_cache_tensor.default)
 
 
 class PODWithPagedKVCacheWrapper:

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -382,7 +382,8 @@ class PODWithPagedKVCacheWrapper:
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
-            self._cached_module = get_batch_prefill_module("fa2")(
+            self._cached_module = get_batch_prefill_module(
+                "fa2",
                 q_data_type,
                 kv_data_type,
                 q_data_type,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -52,12 +52,6 @@ from .utils import (
     register_fake_op,
 )
 
-_single_prefill_modules = {}
-_single_prefill_sm90_modules = {}
-_batch_prefill_modules = {}
-_batch_prefill_sm90_modules = {}
-_batch_prefill_jit_modules = {}
-
 
 @functools.cache
 def get_fmha_module(
@@ -88,437 +82,415 @@ def get_fmha_module(
         raise ValueError("SM100A is not supported on this device")
 
 
-def get_single_prefill_module(backend):
-    def backend_module(*args):
-        global _single_prefill_modules, _single_prefill_sm90_modules
-        modules_dict = (
-            _single_prefill_modules
-            if backend == "fa2"
-            else _single_prefill_sm90_modules
-        )
-        if args not in modules_dict:
-            uri = get_single_prefill_uri(backend, *args)
-            module = gen_single_prefill_module(backend, *args).build_and_load()
-            run_func = module.run.default
+@functools.cache
+def get_single_prefill_module(backend, *args):
+    uri = get_single_prefill_uri(backend, *args)
+    module = gen_single_prefill_module(backend, *args).build_and_load()
+    run_func = module.run.default
 
-            # torch library for single_prefill_with_kv_cache
+    # torch library for single_prefill_with_kv_cache
 
-            @register_custom_op(
-                f"flashinfer::{uri}_run", mutates_args=("tmp", "o", "maybe_lse")
+    @register_custom_op(
+        f"flashinfer::{uri}_run", mutates_args=("tmp", "o", "maybe_lse")
+    )
+    def run_single_prefill(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        tmp: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        maybe_packed_custom_mask: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        scale_q: Optional[torch.Tensor],
+        scale_k: Optional[torch.Tensor],
+        scale_v: Optional[torch.Tensor],
+        rope_scale: float,
+        rope_theta: float,
+    ) -> None:
+        if backend == "fa3":
+            if not is_float8(q):
+                run_func(
+                    q,
+                    k,
+                    v,
+                    tmp,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    logits_soft_cap,
+                    sm_scale,
+                )
+            else:
+                # FP8 enabled
+                run_func(
+                    q,
+                    k,
+                    v,
+                    tmp,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    scale_q,
+                    scale_k,
+                    scale_v,
+                    sm_scale,
+                )
+        else:
+            run_func(
+                q,
+                k,
+                v,
+                tmp,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                maybe_packed_custom_mask,
+                maybe_alibi_slopes,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
             )
-            def run_single_prefill(
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                tmp: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_packed_custom_mask: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                scale_q: Optional[torch.Tensor],
-                scale_k: Optional[torch.Tensor],
-                scale_v: Optional[torch.Tensor],
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                if backend == "fa3":
-                    if not is_float8(q):
-                        run_func(
-                            q,
-                            k,
-                            v,
-                            tmp,
-                            o,
-                            maybe_lse,
-                            mask_mode,
-                            layout,
-                            window_left,
-                            logits_soft_cap,
-                            sm_scale,
-                        )
-                    else:
-                        # FP8 enabled
-                        run_func(
-                            q,
-                            k,
-                            v,
-                            tmp,
-                            o,
-                            maybe_lse,
-                            mask_mode,
-                            layout,
-                            window_left,
-                            scale_q,
-                            scale_k,
-                            scale_v,
-                            sm_scale,
-                        )
-                else:
-                    run_func(
-                        q,
-                        k,
-                        v,
-                        tmp,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        maybe_packed_custom_mask,
-                        maybe_alibi_slopes,
-                        logits_soft_cap,
-                        sm_scale,
-                        1.0 / rope_scale,  # rope_rcp_scale
-                        1.0 / rope_theta,  # rope_rcp_theta
-                    )
-                return o
+        return o
 
-            @register_fake_op(f"flashinfer::{uri}_run")
-            def _fake_run_single_prefill(
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                tmp: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_packed_custom_mask: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                pass
+    @register_fake_op(f"flashinfer::{uri}_run")
+    def _fake_run_single_prefill(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        tmp: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        maybe_packed_custom_mask: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+    ) -> None:
+        pass
 
-            # Register the module
-            modules_dict[args] = SimpleNamespace(run=run_single_prefill)
-
-        return modules_dict[args]
-
-    return backend_module
+    # Register the module
+    return SimpleNamespace(run=run_single_prefill)
 
 
-def get_batch_prefill_module(backend):
-    def backend_module(*args):
-        global _batch_prefill_modules, _batch_prefill_sm90_modules
-        modules_dict = (
-            _batch_prefill_modules if backend == "fa2" else _batch_prefill_sm90_modules
-        )
-        if args not in modules_dict:
-            uri = get_batch_prefill_uri(backend, *args)
-            module = gen_batch_prefill_module(backend, *args).build_and_load()
-            plan_func = module.plan.default
-            ragged_run_func = module.ragged_run.default
-            paged_run_func = module.paged_run.default
+@functools.cache
+def get_batch_prefill_module(backend, *args):
+    uri = get_batch_prefill_uri(backend, *args)
+    module = gen_batch_prefill_module(backend, *args).build_and_load()
+    plan_func = module.plan.default
+    ragged_run_func = module.ragged_run.default
+    paged_run_func = module.paged_run.default
 
-            # torch library for ragged_run
+    # torch library for ragged_run
 
-            @register_custom_op(
-                f"flashinfer::{uri}_ragged_run",
-                mutates_args=(
-                    "float_workspace_buffer",
-                    "int_workspace_buffer",
-                    "o",
-                    "maybe_lse",
-                ),
+    @register_custom_op(
+        f"flashinfer::{uri}_ragged_run",
+        mutates_args=(
+            "float_workspace_buffer",
+            "int_workspace_buffer",
+            "o",
+            "maybe_lse",
+        ),
+    )
+    def ragged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+    ) -> None:
+        if backend == "fa2":
+            ragged_run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                k,
+                v,
+                qo_indptr,
+                kv_indptr,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                enable_pdl,
+                maybe_custom_mask,
+                maybe_mask_indptr,
+                maybe_alibi_slopes,
+                maybe_prefix_len_ptr,
+                maybe_token_pos_in_items_ptr,
+                maybe_max_item_len_ptr,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
+                token_pos_in_items_len,
             )
-            def ragged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                kv_indptr: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                enable_pdl: bool,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                maybe_prefix_len_ptr: Optional[torch.Tensor],
-                maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
-                maybe_max_item_len_ptr: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-                token_pos_in_items_len: int,
-            ) -> None:
-                if backend == "fa2":
-                    ragged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        k,
-                        v,
-                        qo_indptr,
-                        kv_indptr,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        enable_pdl,
-                        maybe_custom_mask,
-                        maybe_mask_indptr,
-                        maybe_alibi_slopes,
-                        maybe_prefix_len_ptr,
-                        maybe_token_pos_in_items_ptr,
-                        maybe_max_item_len_ptr,
-                        logits_soft_cap,
-                        sm_scale,
-                        1.0 / rope_scale,  # rope_rcp_scale
-                        1.0 / rope_theta,  # rope_rcp_theta
-                        token_pos_in_items_len,
-                    )
-                else:
-                    ragged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        k,
-                        v,
-                        qo_indptr,
-                        kv_indptr,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        enable_pdl,
-                        maybe_prefix_len_ptr,
-                        maybe_token_pos_in_items_ptr,
-                        maybe_max_item_len_ptr,
-                        logits_soft_cap,
-                        sm_scale,
-                        token_pos_in_items_len,
-                    )
-
-                return o
-
-            @register_fake_op(f"flashinfer::{uri}_ragged_run")
-            def _fake_ragged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                kv_indptr: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                enable_pdl: bool,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                maybe_prefix_len_ptr: Optional[torch.Tensor],
-                maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
-                maybe_max_item_len_ptr: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-                token_pos_in_items_len: int,
-            ) -> None:
-                pass
-
-            # torch library for paged_run
-
-            @register_custom_op(
-                f"flashinfer::{uri}_paged_run",
-                mutates_args=(
-                    "float_workspace_buffer",
-                    "int_workspace_buffer",
-                    "paged_k_cache",
-                    "paged_v_cache",
-                    "o",
-                    "maybe_lse",
-                ),
+        else:
+            ragged_run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                k,
+                v,
+                qo_indptr,
+                kv_indptr,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                enable_pdl,
+                maybe_prefix_len_ptr,
+                maybe_token_pos_in_items_ptr,
+                maybe_max_item_len_ptr,
+                logits_soft_cap,
+                sm_scale,
+                token_pos_in_items_len,
             )
-            def paged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                paged_k_cache: torch.Tensor,
-                paged_v_cache: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                paged_kv_indptr: torch.Tensor,
-                paged_kv_indices: torch.Tensor,
-                paged_kv_last_page_len: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                enable_pdl: bool,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                maybe_prefix_len_ptr: Optional[torch.Tensor],
-                maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
-                maybe_max_item_len_ptr: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                scale_q: Optional[torch.Tensor],
-                scale_k: Optional[torch.Tensor],
-                scale_v: Optional[torch.Tensor],
-                rope_scale: float,
-                rope_theta: float,
-                token_pos_in_items_len: int,
-            ) -> None:
-                if backend == "fa2":
-                    assert not is_float8(q)
-                    paged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        paged_k_cache,
-                        paged_v_cache,
-                        qo_indptr,
-                        paged_kv_indptr,
-                        paged_kv_indices,
-                        paged_kv_last_page_len,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        enable_pdl,
-                        maybe_custom_mask,
-                        maybe_mask_indptr,
-                        maybe_alibi_slopes,
-                        maybe_prefix_len_ptr,
-                        maybe_token_pos_in_items_ptr,
-                        maybe_max_item_len_ptr,
-                        logits_soft_cap,
-                        sm_scale,
-                        1.0 / rope_scale,  # rope_rcp_scale
-                        1.0 / rope_theta,  # rope_rcp_theta
-                        token_pos_in_items_len,
-                    )
-                else:
-                    if not is_float8(q):
-                        paged_run_func(
-                            float_workspace_buffer,
-                            int_workspace_buffer,
-                            plan_info_vec,
-                            q,
-                            paged_k_cache,
-                            paged_v_cache,
-                            qo_indptr,
-                            paged_kv_indptr,
-                            paged_kv_indices,
-                            paged_kv_last_page_len,
-                            o,
-                            maybe_lse,
-                            mask_mode,
-                            layout,
-                            window_left,
-                            enable_pdl,
-                            maybe_prefix_len_ptr,
-                            maybe_token_pos_in_items_ptr,
-                            maybe_max_item_len_ptr,
-                            logits_soft_cap,
-                            sm_scale,
-                            token_pos_in_items_len,
-                        )
-                    else:
-                        paged_run_func(
-                            float_workspace_buffer,
-                            int_workspace_buffer,
-                            plan_info_vec,
-                            q,
-                            paged_k_cache,
-                            paged_v_cache,
-                            qo_indptr,
-                            paged_kv_indptr,
-                            paged_kv_indices,
-                            paged_kv_last_page_len,
-                            o,
-                            maybe_lse,
-                            mask_mode,
-                            layout,
-                            window_left,
-                            enable_pdl,
-                            scale_q,
-                            scale_k,
-                            scale_v,
-                            sm_scale,
-                        )
-                return o
 
-            @register_fake_op(f"flashinfer::{uri}_paged_run")
-            def _fake_paged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                paged_k_cache: torch.Tensor,
-                paged_v_cache: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                paged_kv_indptr: torch.Tensor,
-                paged_kv_indices: torch.Tensor,
-                paged_kv_last_page_len: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                enable_pdl: bool,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                maybe_prefix_len_ptr: Optional[torch.Tensor],
-                maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
-                maybe_max_item_len_ptr: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-                token_pos_in_items_len: int,
-            ) -> None:
-                pass
+        return o
 
-            # Register the module.
-            #
-            # Note that plan is not part of model logic. It should not be included in
-            # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
-            modules_dict[args] = SimpleNamespace(
-                plan=plan_func,
-                ragged_run=ragged_run,
-                paged_run=paged_run,
+    @register_fake_op(f"flashinfer::{uri}_ragged_run")
+    def _fake_ragged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+    ) -> None:
+        pass
+
+    # torch library for paged_run
+
+    @register_custom_op(
+        f"flashinfer::{uri}_paged_run",
+        mutates_args=(
+            "float_workspace_buffer",
+            "int_workspace_buffer",
+            "paged_k_cache",
+            "paged_v_cache",
+            "o",
+            "maybe_lse",
+        ),
+    )
+    def paged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        paged_k_cache: torch.Tensor,
+        paged_v_cache: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        scale_q: Optional[torch.Tensor],
+        scale_k: Optional[torch.Tensor],
+        scale_v: Optional[torch.Tensor],
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+    ) -> None:
+        if backend == "fa2":
+            assert not is_float8(q)
+            paged_run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                paged_k_cache,
+                paged_v_cache,
+                qo_indptr,
+                paged_kv_indptr,
+                paged_kv_indices,
+                paged_kv_last_page_len,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                enable_pdl,
+                maybe_custom_mask,
+                maybe_mask_indptr,
+                maybe_alibi_slopes,
+                maybe_prefix_len_ptr,
+                maybe_token_pos_in_items_ptr,
+                maybe_max_item_len_ptr,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
+                token_pos_in_items_len,
             )
-        return modules_dict[args]
+        else:
+            if not is_float8(q):
+                paged_run_func(
+                    float_workspace_buffer,
+                    int_workspace_buffer,
+                    plan_info_vec,
+                    q,
+                    paged_k_cache,
+                    paged_v_cache,
+                    qo_indptr,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_len,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    enable_pdl,
+                    maybe_prefix_len_ptr,
+                    maybe_token_pos_in_items_ptr,
+                    maybe_max_item_len_ptr,
+                    logits_soft_cap,
+                    sm_scale,
+                    token_pos_in_items_len,
+                )
+            else:
+                paged_run_func(
+                    float_workspace_buffer,
+                    int_workspace_buffer,
+                    plan_info_vec,
+                    q,
+                    paged_k_cache,
+                    paged_v_cache,
+                    qo_indptr,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_len,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    enable_pdl,
+                    scale_q,
+                    scale_k,
+                    scale_v,
+                    sm_scale,
+                )
+        return o
 
-    return backend_module
+    @register_fake_op(f"flashinfer::{uri}_paged_run")
+    def _fake_paged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        paged_k_cache: torch.Tensor,
+        paged_v_cache: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+    ) -> None:
+        pass
+
+    # Register the module.
+    #
+    # Note that plan is not part of model logic. It should not be included in
+    # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
+    return SimpleNamespace(
+        plan=plan_func,
+        ragged_run=ragged_run,
+        paged_run=paged_run,
+    )
 
 
+@functools.cache
 def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
-    global _batch_prefill_jit_modules
-    if module_name in _batch_prefill_jit_modules:
-        return _batch_prefill_jit_modules[module_name]
-
     plan_func = jit_module.plan.default
     ragged_run_func = jit_module.ragged_run.default
     paged_run_func = jit_module.paged_run.default
@@ -659,13 +631,11 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
     #
     # Note that plan is not part of model logic. It should not be included in
     # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
-    _batch_prefill_jit_modules[module_name] = SimpleNamespace(
+    return SimpleNamespace(
         plan=plan_func,
         ragged_run=ragged_run,
         paged_run=paged_run,
     )
-
-    return _batch_prefill_jit_modules[module_name]
 
 
 def single_prefill_with_kv_cache_with_jit_module(
@@ -947,14 +917,14 @@ def single_prefill_with_kv_cache(
             q.dtype,
             k.dtype,
         )
-    module_getter = get_single_prefill_module(backend)
 
     # o_dtype should be provided for FP8 attention
     if o_dtype is None:
         o_dtype = q.dtype
     out = torch.empty(q.shape[:-1] + v.shape[-1:], dtype=o_dtype, device=q.device)
 
-    module_getter(
+    module = get_single_prefill_module(
+        backend,
         q.dtype,
         k.dtype,
         out.dtype,
@@ -964,7 +934,9 @@ def single_prefill_with_kv_cache(
         window_left >= 0,  # use_sliding_window
         logits_soft_cap > 0,  # use_logits_soft_cap
         use_fp16_qk_reduction,
-    ).run(
+    )
+
+    module.run(
         q,
         k,
         v,
@@ -1568,8 +1540,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 use_fp16_qk_reduction,
             )
 
-            self._cached_module = get_batch_prefill_module(self._backend)(
-                *get_module_args
+            self._cached_module = get_batch_prefill_module(
+                self._backend, *get_module_args
             )
 
         if self._backend == "fa3":
@@ -2352,8 +2324,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             if self._backend == "cutlass":
                 self._cached_module = get_fmha_module(*get_module_args)
             else:
-                self._cached_module = get_batch_prefill_module(self._backend)(
-                    *get_module_args
+                self._cached_module = get_batch_prefill_module(
+                    self._backend, *get_module_args
                 )
 
         if self._backend == "cutlass":

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from functools import cache
+import functools
 from typing import Any, Tuple
 
 import torch
@@ -23,8 +23,6 @@ from .jit import JitSpec
 from .jit import env as jit_env
 from .jit import gen_jit_spec
 from .utils import register_custom_op, register_fake_op
-
-_quantization_module = None
 
 
 def gen_quantization_module() -> JitSpec:
@@ -37,19 +35,14 @@ def gen_quantization_module() -> JitSpec:
     )
 
 
+@functools.cache
 def get_quantization_module():
-    global _quantization_module
-    if _quantization_module is None:
-        _quantization_module = gen_quantization_module().build_and_load()
-    return _quantization_module
+    return gen_quantization_module().build_and_load()
 
 
-@cache
+@functools.cache
 def get_module_attr(attr: str) -> Any:
-    global _quantization_module
-    if _quantization_module is None:
-        get_quantization_module()
-    return getattr(_quantization_module, attr).default
+    return getattr(get_quantization_module(), attr).default
 
 
 @register_custom_op("flashinfer::packbits", mutates_args=())

--- a/flashinfer/quantization.py
+++ b/flashinfer/quantization.py
@@ -40,17 +40,12 @@ def get_quantization_module():
     return gen_quantization_module().build_and_load()
 
 
-@functools.cache
-def get_module_attr(attr: str) -> Any:
-    return getattr(get_quantization_module(), attr).default
-
-
 @register_custom_op("flashinfer::packbits", mutates_args=())
 def _packbits(x: torch.Tensor, bitorder: str) -> torch.Tensor:
     device = x.device
     x = x.to(torch.bool)
     y = torch.empty((x.size(0) + 7) // 8, dtype=torch.uint8, device=device)
-    get_module_attr("packbits")(x, bitorder, y)
+    get_quantization_module().packbits(x, bitorder, y)
     return y
 
 
@@ -149,5 +144,5 @@ def segment_packbits(
     indptr = indptr.to(torch.int32)
     indptr_new = indptr_new.to(torch.int32)
     y = torch.empty(output_nnzs, dtype=torch.uint8, device=device)
-    get_module_attr("segment_packbits")(x, indptr, indptr_new, bitorder, y)
+    get_quantization_module().segment_packbits(x, indptr, indptr_new, bitorder, y)
     return y, indptr_new

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -40,11 +40,6 @@ def get_rope_module():
     return gen_rope_module().build_and_load()
 
 
-@functools.cache
-def get_module_attr(attr: str) -> Any:
-    return getattr(get_rope_module(), attr).default
-
-
 @register_custom_op("flashinfer::apply_rope", mutates_args=("q_rope", "k_rope"))
 def _apply_rope(
     q: torch.Tensor,
@@ -58,7 +53,7 @@ def _apply_rope(
     rope_scale: float,
     rope_theta: float,
 ) -> None:
-    get_module_attr("apply_rope")(
+    get_rope_module().apply_rope(
         q,
         k,
         q_rope,
@@ -104,7 +99,7 @@ def _apply_llama31_rope(
     high_freq_factor: float,
     old_context_len: float,
 ) -> None:
-    get_module_attr("apply_llama31_rope")(
+    get_rope_module().apply_llama31_rope(
         q,
         k,
         q_rope,
@@ -152,7 +147,7 @@ def _apply_rope_pos_ids(
     rope_scale: float,
     rope_theta: float,
 ) -> None:
-    get_module_attr("apply_rope_pos_ids")(
+    get_rope_module().apply_rope_pos_ids(
         q,
         k,
         q_rope,
@@ -192,7 +187,7 @@ def _apply_rope_pos_ids_cos_sin_cache(
     pos_ids: torch.Tensor,
     interleave: bool,
 ) -> None:
-    get_module_attr("apply_rope_pos_ids_cos_sin_cache")(
+    get_rope_module().apply_rope_pos_ids_cos_sin_cache(
         q,
         k,
         q_rope,
@@ -234,7 +229,7 @@ def _apply_llama31_rope_pos_ids(
     high_freq_factor: float,
     old_context_len: float,
 ) -> None:
-    get_module_attr("apply_llama31_rope_pos_ids")(
+    get_rope_module().apply_llama31_rope_pos_ids(
         q,
         k,
         q_rope,

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from functools import cache
+import functools
 from typing import Any, Optional, Tuple
 
 import torch
@@ -23,8 +23,6 @@ from .jit import JitSpec
 from .jit import env as jit_env
 from .jit import gen_jit_spec
 from .utils import register_custom_op, register_fake_op
-
-_rope_module = None
 
 
 def gen_rope_module() -> JitSpec:
@@ -37,19 +35,14 @@ def gen_rope_module() -> JitSpec:
     )
 
 
+@functools.cache
 def get_rope_module():
-    global _rope_module
-    if _rope_module is None:
-        _rope_module = gen_rope_module().build_and_load()
-    return _rope_module
+    return gen_rope_module().build_and_load()
 
 
-@cache
+@functools.cache
 def get_module_attr(attr: str) -> Any:
-    global _rope_module
-    if _rope_module is None:
-        get_rope_module()
-    return getattr(_rope_module, attr).default
+    return getattr(get_rope_module(), attr).default
 
 
 @register_custom_op("flashinfer::apply_rope", mutates_args=("q_rope", "k_rope"))

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -412,8 +412,8 @@ class BlockSparseAttentionWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
-            self._cached_module = get_batch_prefill_module(self._backend)(
-                *get_module_args
+            self._cached_module = get_batch_prefill_module(
+                self._backend, *get_module_args
             )
 
             kv_lens_arr_host = (kv_indptr_host[1:] - kv_indptr_host[:-1]) * self.C


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Our codebase widely uses global dict for caching modules, and it's preferable to use functools.cache instead.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
