### PR TITLE
fix: sync after create_workspace

### DIFF
--- a/flashinfer/comm.py
+++ b/flashinfer/comm.py
@@ -579,6 +579,8 @@ def trtllm_create_ipc_workspace_for_all_reduce(
         torch.float16,
     )
 
+    dist.barrier(group=group)  # must sync after create_workspace
+
     return ipc_handles
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

A sync across all ranks is required after lamport initialization in create_workspace.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
