### PR TITLE
Fix FA2 and FA3 multi-item scoring and cuda illegal memory access error

### DIFF
--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -184,8 +184,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           auto prefix_len = __ldg(maybe_prefix_len_ptr + batch_idx);
           auto max_item_len = __ldg(maybe_max_item_len_ptr + batch_idx);
           auto valid_items_window_len =
-              std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
-          num_kv_tiles_outside_items_window = cute::ceil_div(valid_items_window_len, CTA_KV);
+              std::max(0, q_tile_idx * CTA_Q + kv_len - qo_len - max_item_len);
+          num_kv_tiles_outside_items_window = valid_items_window_len / CTA_KV;
           num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
         }
         if constexpr (MULTIITEMSCORING) {
@@ -269,8 +269,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
         auto prefix_len = __ldg(maybe_prefix_len_ptr + batch_idx);
         auto max_item_len = __ldg(maybe_max_item_len_ptr + batch_idx);
         auto valid_items_window_len =
-            std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
-        num_kv_tiles_outside_items_window = cute::ceil_div(valid_items_window_len, CTA_KV);
+            std::max(0, q_tile_idx * CTA_Q + kv_len - qo_len - max_item_len);
+        num_kv_tiles_outside_items_window = valid_items_window_len / CTA_KV;
         num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
       }
       mma_f16<Ktraits, /*LEFT_SLIDING_WINDOW=*/LEFT_SLIDING_WINDOW, CAUSAL, MULTIITEMSCORING,

--- a/include/flashinfer/attention/hopper/sparse_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/sparse_mainloop.cuh
@@ -245,7 +245,7 @@ struct SparseCollectiveMainloop {
     auto kv_tile_idx_decrement = [&](int kv_tile_idx) {
       int result = kv_tile_idx - 1;
       if constexpr (MULTIITEMSCORING) {
-        if ((kv_tile_idx == num_kv_tiles_outside_items_window - 1) &
+        if ((kv_tile_idx == num_kv_tiles_outside_items_window) &
             (kv_tile_idx >= num_kv_tiles_prefix)) {
           result = num_kv_tiles_prefix - 1;
         }

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -779,7 +779,7 @@ __device__ __forceinline__ void logits_mask(
                                                                     8 * (reg_id / 4) + reg_id % 2;
         const uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
         const bool mask =
-            (!(MASK_MODE == MaskMode::kCausal
+            (!(MASK_MODE == MaskMode::kCausal || MASK_MODE == MaskMode::kMultiItemScoring
                    ? (kv_idx + qo_len > kv_len + q_idx || (kv_idx >= chunk_end))
                    : kv_idx >= chunk_end)) &&
             variant.LogitsMask(params, batch_idx, q_idx, kv_idx, qo_head_idx, kv_head_idx);
@@ -2237,7 +2237,7 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                  CTA_TILE_KV);
 
     const uint32_t mask_iteration =
-        (MASK_MODE == MaskMode::kCausal
+        (MASK_MODE == MaskMode::kCausal || MASK_MODE == MaskMode::kMultiItemScoring
              ? min(chunk_size,
                    sub_if_greater_or_zero(kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size - qo_len,
                                           chunk_start))


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
This PR fixes FA2 and FA3 multi-item scoring and resolves CUDA illegal memory access errors in the FlashInfer attention kernels. 

**Key Changes:**
- Fixed multi-item scoring functionality for FA2 and FA3
- Resolved illegal memory access errors that could cause crashes or incorrect results

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
