### PR TITLE
[WIP] refactor: unifying return status of different backend implementation

### DIFF
--- a/csrc/activation.cu
+++ b/csrc/activation.cu
@@ -57,7 +57,7 @@ void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
     cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
                        static_cast<c_type*>(input.data_ptr()), d);
 
-    cudaError_t err = cudaGetLastError();
+    Status err = cudaGetLastError();
     TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;
@@ -89,7 +89,7 @@ void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
     cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
                        static_cast<c_type*>(input.data_ptr()), d);
 
-    cudaError_t err = cudaGetLastError();
+    Status err = cudaGetLastError();
     TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;
@@ -120,7 +120,7 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
     cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
                        static_cast<c_type*>(input.data_ptr()), d);
 
-    cudaError_t err = cudaGetLastError();
+    Status err = cudaGetLastError();
     TORCH_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 
     return true;

--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -26,8 +26,8 @@ namespace flashinfer {
 
 template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename AttentionVariant,
           typename Params>
-cudaError_t BatchDecodeWithPagedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
-                                                  float* tmp_s, cudaStream_t stream);
+Status BatchDecodeWithPagedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
+                                             float* tmp_s, cudaStream_t stream);
 
 }  // namespace flashinfer
 
@@ -61,7 +61,7 @@ at::Tensor BatchDecodeWithPagedKVCachePlan(
         DISPATCH_GQA_GROUP_SIZE(num_qo_heads / num_kv_heads, GROUP_SIZE, {
           auto work_estimation_func = BatchDecodeWithPagedKVCacheWorkEstimationDispatched<
               GROUP_SIZE, HEAD_DIM_QK, POS_ENCODING_MODE, AttentionVariant, Params>;
-          cudaError_t status = DecodePlan<HEAD_DIM_QK, POS_ENCODING_MODE, AttentionVariant, Params>(
+          Status status = DecodePlan<HEAD_DIM_QK, POS_ENCODING_MODE, AttentionVariant, Params>(
               static_cast<void*>(float_workspace_buffer.data_ptr()), float_workspace_size_in_bytes,
               static_cast<void*>(int_workspace_buffer.data_ptr()),
               static_cast<void*>(page_locked_int_workspace_buffer.data_ptr()),
@@ -184,7 +184,7 @@ void BatchDecodeWithPagedKVCacheRun(at::Tensor float_workspace_buffer,
         }
         params.padded_batch_size = plan_info.padded_batch_size;
 
-        cudaError_t status =
+        Status status =
             flashinfer::BatchDecodeWithPagedKVCacheDispatched<HEAD_DIM_QK, POS_ENCODING_MODE,
                                                               AttentionVariant>(params, tmp_v,
                                                                                 tmp_s,

--- a/csrc/batch_decode_kernel_inst.jinja
+++ b/csrc/batch_decode_kernel_inst.jinja
@@ -5,7 +5,7 @@ using namespace flashinfer;
 
 namespace flashinfer {
 
-template cudaError_t
+template Status
 BatchDecodeWithPagedKVCacheDispatched<{{ head_dim_qk }}, {{ pos_encoding_mode }}, {{ variant_name }}, Params>(
     Params params, {{ dtype_o }}* tmp_v,
     float* tmp_s, cudaStream_t stream);

--- a/csrc/batch_decode_mla_cute_sm80.cu
+++ b/csrc/batch_decode_mla_cute_sm80.cu
@@ -22,7 +22,7 @@ std::vector<int64_t> BatchDecodeWithPagedKVCachePlanMLA(
 
   auto work_estimation_func = BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMlaCuteSM80<
       HEAD_DIM_CKV, HEAD_DIM_KPE, QO_TILE_LEN, AttentionVariant, Params>;
-  cudaError_t status =
+  Status status =
       DecodePlan<HEAD_DIM_CKV, flashinfer::PosEncodingMode::kNone, AttentionVariant, Params>(
           static_cast<void*>(float_workspace_buffer.data_ptr()), float_workspace_size_in_bytes,
           static_cast<void*>(int_workspace_buffer.data_ptr()),
@@ -95,8 +95,8 @@ void BatchDecodeWithPagedKVCacheRunMLA(
   params.padded_batch_size = plan_info.padded_batch_size;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
-  cudaError_t status = BatchDecodeWithPagedKVCacheDispatchedMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE,
-                                                                        QO_TILE_LEN, Params>(
+  Status status = BatchDecodeWithPagedKVCacheDispatchedMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE,
+                                                                   QO_TILE_LEN, Params>(
       params, tmp_v, tmp_s, /*stream=*/stream);
   TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",
               cudaGetErrorString(status));

--- a/csrc/batch_decode_mla_plan.cu
+++ b/csrc/batch_decode_mla_plan.cu
@@ -25,7 +25,7 @@ at::Tensor BatchDecodeWithPagedKVCachePlanMLA(at::Tensor float_workspace_buffer,
   auto work_estimation_func =
       BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMLA<HEAD_DIM_CKV, HEAD_DIM_KPE,
                                                              AttentionVariant, Params>;
-  cudaError_t status =
+  Status status =
       DecodePlan<HEAD_DIM_CKV, flashinfer::PosEncodingMode::kRoPELlama, AttentionVariant, Params>(
           static_cast<void*>(float_workspace_buffer.data_ptr()), float_workspace_size_in_bytes,
           static_cast<void*>(int_workspace_buffer.data_ptr()),

--- a/csrc/batch_decode_mla_run.cu
+++ b/csrc/batch_decode_mla_run.cu
@@ -65,7 +65,7 @@ void BatchDecodeWithPagedKVCacheRunMLA(
   params.padded_batch_size = plan_info.padded_batch_size;
 
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(cuda_stream);
-  cudaError_t status =
+  Status status =
       BatchDecodeWithPagedKVCacheDispatchedMLA<HEAD_DIM_CKV, HEAD_DIM_KPE, AttentionVariant,
                                                Params>(params, tmp_v, tmp_s, /*stream=*/stream);
   TORCH_CHECK(status == cudaSuccess, "BatchDecodeWithPagedKVCache failed with error ",

--- a/csrc/batch_mla_plan.cu
+++ b/csrc/batch_mla_plan.cu
@@ -39,7 +39,7 @@ at::Tensor BatchMLAPagedAttentionPlan(at::Tensor float_workspace_buffer,
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
-  cudaError_t status =
+  Status status =
       MLAPlan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
               int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
               int_workspace_size_in_bytes, plan_info, static_cast<IdType*>(qo_indptr.data_ptr()),

--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -116,7 +116,7 @@ void BatchMLAPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int
 
         params.sm_scale = sm_scale;
 
-        cudaError_t status = mla::BatchMLAPagedAttention<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
+        Status status = mla::BatchMLAPagedAttention<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
             params, plan_info.num_blks_x, plan_info.num_blks_y, stream);
 
         TORCH_CHECK(status == cudaSuccess,

--- a/csrc/batch_mla_sm90_plan.cu
+++ b/csrc/batch_mla_sm90_plan.cu
@@ -40,7 +40,7 @@ at::Tensor BatchMLAPagedAttentionSM90Plan(at::Tensor float_workspace_buffer,
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
-  cudaError_t status =
+  Status status =
       MLAPlan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
               int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
               int_workspace_size_in_bytes, plan_info, static_cast<IdType*>(qo_indptr.data_ptr()),

--- a/csrc/batch_mla_sm90_run.cu
+++ b/csrc/batch_mla_sm90_run.cu
@@ -119,9 +119,8 @@ void BatchMLAPagedAttentionSM90Run(at::Tensor float_workspace_buffer,
 
         params.sm_scale = sm_scale;
 
-        cudaError_t status =
-            mla::BatchMLAPageAttentionHopper<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
-                params, plan_info.num_blks_x, plan_info.num_blks_y, stream);
+        Status status = mla::BatchMLAPageAttentionHopper<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
+            params, plan_info.num_blks_x, plan_info.num_blks_y, stream);
 
         TORCH_CHECK(status == cudaSuccess,
                     "Failed to run MLA, error: ", cudaGetErrorString(status));

--- a/csrc/batch_prefill_fp8_paged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_fp8_paged_sm90_kernel_inst.jinja
@@ -4,7 +4,7 @@
 namespace flashinfer {
 
 {% for same_scheduler_for_all_heads in ["true", "false"] %}
-template cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched
+template Status BatchFP8PrefillWithPagedKVCacheDispatched
     <{{ head_dim_qk }},
      {{ mask_mode }},
      /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }},

--- a/csrc/batch_prefill_fp8_sm90.cu
+++ b/csrc/batch_prefill_fp8_sm90.cu
@@ -28,7 +28,7 @@ namespace flashinfer {
 
 template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
           bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
-cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t stream);
+Status BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t stream);
 
 }  // namespace flashinfer
 
@@ -50,7 +50,7 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
-  cudaError_t status =
+  Status status =
       PrefillSM90Plan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
                       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
                       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<IdType>(),
@@ -166,7 +166,7 @@ void BatchPrefillWithPagedKVCacheSM90Run(
 
         bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
         DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
-          cudaError_t status =
+          Status status =
               BatchFP8PrefillWithPagedKVCacheDispatched<HEAD_DIM_QK, MASK_MODE, USE_SLIDING_WINDOW,
                                                         SAME_SCHEDULER_FOR_ALL_HEADS,
                                                         AttentionVariant>(params, stream);

--- a/csrc/batch_prefill_paged_kernel_inst.jinja
+++ b/csrc/batch_prefill_paged_kernel_inst.jinja
@@ -6,7 +6,7 @@ namespace flashinfer {
 constexpr auto use_custom_mask = {{ mask_mode }} == MaskMode::kCustom;
 
 {% for cta_tile_q in [16, 64, 128] %}
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched<
+template Status BatchPrefillWithPagedKVCacheDispatched<
     /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}},
     {{ variant_name }}, PagedParams>(PagedParams params, {{ dtype_o }}* tmp_v, float* tmp_s, cudaStream_t stream);
 {% endfor %}

--- a/csrc/batch_prefill_paged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_paged_sm90_kernel_inst.jinja
@@ -4,7 +4,7 @@
 namespace flashinfer {
 
 {% for same_scheduler_for_all_heads in ["true", "false"] %}
-template cudaError_t BatchPrefillWithPagedKVCacheDispatched
+template Status BatchPrefillWithPagedKVCacheDispatched
     <{{ head_dim_qk }},
      {{ head_dim_vo }},
      {{ mask_mode }},

--- a/csrc/batch_prefill_ragged_kernel_inst.jinja
+++ b/csrc/batch_prefill_ragged_kernel_inst.jinja
@@ -6,7 +6,7 @@ namespace flashinfer {
 constexpr auto use_custom_mask = {{ mask_mode }} == MaskMode::kCustom;
 
 {% for cta_tile_q in [16, 64, 128] %}
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<
+template Status BatchPrefillWithRaggedKVCacheDispatched<
     /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}},
     {{ variant_name }}, RaggedParams>(RaggedParams params, {{ dtype_o }}* tmp_v, float* tmp_s, cudaStream_t stream);
 {% endfor %}

--- a/csrc/batch_prefill_ragged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_ragged_sm90_kernel_inst.jinja
@@ -4,7 +4,7 @@
 namespace flashinfer {
 
 {% for same_scheduler_for_all_heads in ["true", "false"] %}
-template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
+template Status BatchPrefillWithRaggedKVCacheDispatched
     <{{ head_dim_qk }},
      {{ head_dim_vo }},
      {{ mask_mode }},

--- a/csrc/cascade.cu
+++ b/csrc/cascade.cu
@@ -45,7 +45,7 @@ void merge_state(at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b,
   auto stream = at::cuda::getCurrentCUDAStream();
 
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(v_a.scalar_type(), c_type, [&] {
-    cudaError_t status =
+    Status status =
         MergeState(static_cast<c_type*>(v_a.data_ptr()), static_cast<float*>(s_a.data_ptr()),
                    static_cast<c_type*>(v_b.data_ptr()), static_cast<float*>(s_b.data_ptr()),
                    static_cast<c_type*>(v_merged.data_ptr()),
@@ -90,7 +90,7 @@ void merge_state_in_place(at::Tensor v, at::Tensor s, at::Tensor v_other, at::Te
   const c10::cuda::OptionalCUDAGuard device_guard(v.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(v.scalar_type(), c_type, [&] {
-    cudaError_t status = MergeStateInPlace(
+    Status status = MergeStateInPlace(
         static_cast<c_type*>(v.data_ptr()), static_cast<float*>(s.data_ptr()),
         static_cast<c_type*>(v_other.data_ptr()), static_cast<float*>(s_other.data_ptr()), seq_len,
         num_heads, head_dim, mask_ptr, stream);
@@ -120,7 +120,7 @@ void merge_states(at::Tensor v, at::Tensor s, at::Tensor v_merged, at::Tensor s_
   const c10::cuda::OptionalCUDAGuard device_guard(v.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   bool success = DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(v.scalar_type(), c_type, [&] {
-    cudaError_t status = MergeStates(
+    Status status = MergeStates(
         static_cast<c_type*>(v.data_ptr()), static_cast<float*>(s.data_ptr()),
         static_cast<c_type*>(v_merged.data_ptr()), static_cast<float*>(s_merged.data_ptr()),
         num_index_sets, seq_len, num_heads, head_dim, stream);

--- a/csrc/group_gemm_bf16_bf16_sm90.cu
+++ b/csrc/group_gemm_bf16_bf16_sm90.cu
@@ -21,7 +21,7 @@ using namespace flashinfer::group_gemm;
 namespace flashinfer {
 namespace group_gemm {
 
-template cudaError_t CutlassSegmentGEMMSM90Run<cutlass::bfloat16_t, cutlass::bfloat16_t>(
+template Status CutlassSegmentGEMMSM90Run<cutlass::bfloat16_t, cutlass::bfloat16_t>(
     void* float_buffer, size_t float_buffer_size_in_bytes, void* int_buffer,
     size_t int_buffer_size_in_bytes, void* all_problems, int64_t batch_size, void* x, void* w,
     void* y, void* x_stride, void* w_stride, void* y_stride, bool weight_column_major,

--- a/csrc/group_gemm_e4m3_bf16_sm90.cu
+++ b/csrc/group_gemm_e4m3_bf16_sm90.cu
@@ -21,7 +21,7 @@ using namespace flashinfer::group_gemm;
 namespace flashinfer {
 namespace group_gemm {
 
-template cudaError_t CutlassSegmentGEMMSM90Run<cutlass::float_e4m3_t, cutlass::bfloat16_t>(
+template Status CutlassSegmentGEMMSM90Run<cutlass::float_e4m3_t, cutlass::bfloat16_t>(
     void* float_buffer, size_t float_buffer_size_in_bytes, void* int_buffer,
     size_t int_buffer_size_in_bytes, void* all_problems, int64_t batch_size, void* x, void* w,
     void* y, void* x_stride, void* w_stride, void* y_stride, bool weight_column_major,

--- a/csrc/group_gemm_e4m3_f16_sm90.cu
+++ b/csrc/group_gemm_e4m3_f16_sm90.cu
@@ -21,7 +21,7 @@ using namespace flashinfer::group_gemm;
 namespace flashinfer {
 namespace group_gemm {
 
-template cudaError_t CutlassSegmentGEMMSM90Run<cutlass::float_e4m3_t, cutlass::half_t>(
+template Status CutlassSegmentGEMMSM90Run<cutlass::float_e4m3_t, cutlass::half_t>(
     void* float_buffer, size_t float_buffer_size_in_bytes, void* int_buffer,
     size_t int_buffer_size_in_bytes, void* all_problems, int64_t batch_size, void* x, void* w,
     void* y, void* x_stride, void* w_stride, void* y_stride, bool weight_column_major,

--- a/csrc/group_gemm_e5m2_bf16_sm90.cu
+++ b/csrc/group_gemm_e5m2_bf16_sm90.cu
@@ -21,7 +21,7 @@ using namespace flashinfer::group_gemm;
 namespace flashinfer {
 namespace group_gemm {
 
-template cudaError_t CutlassSegmentGEMMSM90Run<cutlass::float_e5m2_t, cutlass::bfloat16_t>(
+template Status CutlassSegmentGEMMSM90Run<cutlass::float_e5m2_t, cutlass::bfloat16_t>(
     void* float_buffer, size_t float_buffer_size_in_bytes, void* int_buffer,
     size_t int_buffer_size_in_bytes, void* all_problems, int64_t batch_size, void* x, void* w,
     void* y, void* x_stride, void* w_stride, void* y_stride, bool weight_column_major,

--- a/csrc/group_gemm_e5m2_f16_sm90.cu
+++ b/csrc/group_gemm_e5m2_f16_sm90.cu
@@ -21,7 +21,7 @@ using namespace flashinfer::group_gemm;
 namespace flashinfer {
 namespace group_gemm {
 
-template cudaError_t CutlassSegmentGEMMSM90Run<cutlass::float_e5m2_t, cutlass::half_t>(
+template Status CutlassSegmentGEMMSM90Run<cutlass::float_e5m2_t, cutlass::half_t>(
     void* float_buffer, size_t float_buffer_size_in_bytes, void* int_buffer,
     size_t int_buffer_size_in_bytes, void* all_problems, int64_t batch_size, void* x, void* w,
     void* y, void* x_stride, void* w_stride, void* y_stride, bool weight_column_major,

--- a/csrc/group_gemm_f16_f16_sm90.cu
+++ b/csrc/group_gemm_f16_f16_sm90.cu
@@ -21,7 +21,7 @@ using namespace flashinfer::group_gemm;
 namespace flashinfer {
 namespace group_gemm {
 
-template cudaError_t CutlassSegmentGEMMSM90Run<cutlass::half_t, cutlass::half_t>(
+template Status CutlassSegmentGEMMSM90Run<cutlass::half_t, cutlass::half_t>(
     void* float_buffer, size_t float_buffer_size_in_bytes, void* int_buffer,
     size_t int_buffer_size_in_bytes, void* all_problems, int64_t batch_size, void* x, void* w,
     void* y, void* x_stride, void* w_stride, void* y_stride, bool weight_column_major,

--- a/csrc/group_gemm_sm90.cu
+++ b/csrc/group_gemm_sm90.cu
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <flashinfer/status.h>
+
 #include <flashinfer/cutlass_utils.cuh>
 
 #include "pytorch_extension_utils.h"
@@ -38,11 +40,11 @@ namespace flashinfer {
 namespace group_gemm {
 
 template <typename DTypeIn, typename DTypeOut>
-cudaError_t CutlassSegmentGEMMSM90Run(void* float_buffer, size_t float_buffer_size_in_bytes,
-                                      void* int_buffer, size_t int_buffer_size_in_bytes,
-                                      void* all_problems, int64_t batch_size, void* x, void* w,
-                                      void* y, void* x_stride, void* w_stride, void* y_stride,
-                                      bool weight_column_major, cudaStream_t stream);
+Status CutlassSegmentGEMMSM90Run(void* float_buffer, size_t float_buffer_size_in_bytes,
+                                 void* int_buffer, size_t int_buffer_size_in_bytes,
+                                 void* all_problems, int64_t batch_size, void* x, void* w, void* y,
+                                 void* x_stride, void* w_stride, void* y_stride,
+                                 bool weight_column_major, cudaStream_t stream);
 
 }  // namespace group_gemm
 }  // namespace flashinfer
@@ -68,8 +70,7 @@ void CutlassSegmentGEMMSM90(at::Tensor float_workspace_buffer, at::Tensor int_wo
                 all_problems.data_ptr(), batch_size, x_ptr.data_ptr(), w_ptr.data_ptr(),
                 y_ptr.data_ptr(), x_stride.data_ptr(), weight_stride.data_ptr(),
                 y_stride.data_ptr(), weight_column_major, stream);
-        TORCH_CHECK(status == cudaSuccess,
-                    "Failed to run CutlassSegmentGEMM: ", cudaGetErrorString(status));
+        TORCH_CHECK(status.success(), "Failed to run CutlassSegmentGEMM: ", status.error_message());
         return true;
       });
 }

--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -37,10 +37,10 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double e
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    cudaError_t status = norm::RMSNorm(
-        static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
-        static_cast<c_type*>(output.data_ptr()), batch_size, hidden_size, input.stride(0),
-        output.stride(0), eps, enable_pdl, stream);
+    Status status = norm::RMSNorm(static_cast<c_type*>(input.data_ptr()),
+                                  static_cast<c_type*>(weight.data_ptr()),
+                                  static_cast<c_type*>(output.data_ptr()), batch_size, hidden_size,
+                                  input.stride(0), output.stride(0), eps, enable_pdl, stream);
     TORCH_CHECK(status == cudaSuccess,
                 "RMSNorm failed with error code " + std::string(cudaGetErrorString(status)));
     return true;
@@ -67,7 +67,7 @@ void fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weig
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    cudaError_t status = norm::FusedAddRMSNorm(
+    Status status = norm::FusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
         static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, input.stride(0),
         residual.stride(0), eps, enable_pdl, stream);
@@ -94,7 +94,7 @@ void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, do
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    cudaError_t status = norm::GemmaRMSNorm(
+    Status status = norm::GemmaRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
         static_cast<c_type*>(output.data_ptr()), batch_size, hidden_size, input.stride(0),
         output.stride(0), eps, enable_pdl, stream);
@@ -124,7 +124,7 @@ void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    cudaError_t status = norm::GemmaFusedAddRMSNorm(
+    Status status = norm::GemmaFusedAddRMSNorm(
         static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
         static_cast<c_type*>(weight.data_ptr()), batch_size, hidden_size, input.stride(0),
         residual.stride(0), eps, enable_pdl, stream);

--- a/csrc/page.cu
+++ b/csrc/page.cu
@@ -98,7 +98,7 @@ void append_paged_kv_cache(at::Tensor append_key, at::Tensor append_value, at::T
         static_cast<c_type*>(paged_v_cache.data_ptr()), kv_cache_strides,
         static_cast<int32_t*>(kv_indices.data_ptr()), static_cast<int32_t*>(kv_indptr.data_ptr()),
         static_cast<int32_t*>(kv_last_page_len.data_ptr()));
-    cudaError_t status =
+    Status status =
         AppendPagedKVCache(paged_kv, static_cast<c_type*>(append_key.data_ptr()),
                            static_cast<c_type*>(append_value.data_ptr()),
                            static_cast<int32_t*>(batch_indices.data_ptr()),
@@ -125,7 +125,7 @@ void block_sparse_indices_to_vector_sparse_offsets(
   const c10::cuda::OptionalCUDAGuard device_guard(block_sparse_indices.device());
   auto stream = at::cuda::getCurrentCUDAStream();
 
-  cudaError_t status = BlockSparseIndicesToVectorSparseOffset(
+  Status status = BlockSparseIndicesToVectorSparseOffset(
       static_cast<int32_t*>(block_sparse_indices.data_ptr()),
       static_cast<int32_t*>(block_sparse_indptr.data_ptr()),
       static_cast<int32_t*>(vector_sparse_offsets.data_ptr()),
@@ -201,12 +201,11 @@ void append_paged_mla_kv_cache(at::Tensor append_ckv, at::Tensor append_kpe,
         ckv_strides, static_cast<c_type*>(kpe_cache.data_ptr()), kpe_strides,
         static_cast<int32_t*>(kv_indices.data_ptr()), static_cast<int32_t*>(kv_indptr.data_ptr()),
         static_cast<int32_t*>(kv_last_page_len.data_ptr()));
-    cudaError_t status =
-        AppendPagedKVMlaCache(paged_mla_kv, static_cast<c_type*>(append_ckv.data_ptr()),
-                              static_cast<c_type*>(append_kpe.data_ptr()),
-                              static_cast<int32_t*>(batch_indices.data_ptr()),
-                              static_cast<int32_t*>(positions.data_ptr()), nnz, append_ckv_stride_n,
-                              append_kpe_stride_n, stream);
+    Status status = AppendPagedKVMlaCache(paged_mla_kv, static_cast<c_type*>(append_ckv.data_ptr()),
+                                          static_cast<c_type*>(append_kpe.data_ptr()),
+                                          static_cast<int32_t*>(batch_indices.data_ptr()),
+                                          static_cast<int32_t*>(positions.data_ptr()), nnz,
+                                          append_ckv_stride_n, append_kpe_stride_n, stream);
     TORCH_CHECK(status == cudaSuccess,
                 "AppendPagedKVMlaCache failed with error: ", cudaGetErrorString(status));
     return true;

--- a/csrc/pod.cu
+++ b/csrc/pod.cu
@@ -26,11 +26,11 @@ template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODI
           bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE_P, uint32_t CTA_TILE_Q,
           MaskMode MASK_MODE_D, typename PrefillAttentionVariant, typename DecodeAttentionVariant,
           typename PrefillParams, typename DecodeParams>
-cudaError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
-                                           typename PrefillParams::DTypeO* tmp,
-                                           DecodeParams decode_params,
-                                           typename DecodeParams::DTypeO* tmp_v, float* tmp_s,
-                                           cudaStream_t stream);
+Status PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
+                                      typename PrefillParams::DTypeO* tmp,
+                                      DecodeParams decode_params,
+                                      typename DecodeParams::DTypeO* tmp_v, float* tmp_s,
+                                      cudaStream_t stream);
 
 }  // namespace flashinfer
 
@@ -260,7 +260,7 @@ void pod_with_kv_cache_tensor(
                              USE_LOGITS_SOFT_CAP, /*use_alibi_bias=*/false>;
         // DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
         constexpr size_t CTA_TILE_Q = 16;
-        cudaError_t status = flashinfer::PODWithKVCacheTensorDispatched<
+        Status status = flashinfer::PODWithKVCacheTensorDispatched<
             HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_FP16_QK_REDUCTION, MASK_MODE_P,
             CTA_TILE_Q, MASK_MODE_D, PrefillAttentionVariant, DecodeAttentionVariant>(
             prefill_params, static_cast<DTypeO*>(tmp_p.data_ptr()), decode_params, tmp_v, tmp_s,

--- a/csrc/pod_kernel_inst.jinja
+++ b/csrc/pod_kernel_inst.jinja
@@ -21,7 +21,7 @@ constexpr auto use_custom_mask_d = {{ mask_mode_d }} == MaskMode::kCustom;
 // Not sure about the below declaration
 constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
 
-template cudaError_t PODWithKVCacheTensorDispatched<
+template Status PODWithKVCacheTensorDispatched<
     {{ head_dim_qk }}, {{ head_dim_vo }}, POS_ENCODING_MODE,
     {{ use_fp16_qk_reduction }}, {{ mask_mode_p }}, 16,
     {{ mask_mode_d }}, {{ variant_name_p }},

--- a/csrc/quantization.cu
+++ b/csrc/quantization.cu
@@ -27,7 +27,7 @@ void packbits(at::Tensor x, const std::string& bitorder, at::Tensor y) {
   int64_t num_elements = x.numel();
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = quantization::PackBits(
+  Status status = quantization::PackBits(
       static_cast<bool*>(x.data_ptr()), static_cast<uint8_t*>(y.data_ptr()), num_elements,
       bitorder == "big" ? quantization::BitOrder::kBig : quantization::BitOrder::kLittle, stream);
 
@@ -49,7 +49,7 @@ void segment_packbits(at::Tensor x, at::Tensor input_indptr, at::Tensor output_i
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = quantization::SegmentPackBits(
+  Status status = quantization::SegmentPackBits(
       static_cast<bool*>(x.data_ptr()), static_cast<uint8_t*>(y.data_ptr()),
       static_cast<int32_t*>(input_indptr.data_ptr()),
       static_cast<int32_t*>(output_indptr.data_ptr()), batch_size,

--- a/csrc/renorm.cu
+++ b/csrc/renorm.cu
@@ -30,7 +30,7 @@ void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::TopPRenormProb<float>(
+  Status status = sampling::TopPRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr, batch_size,
       top_p_val, vocab_size, stream);
@@ -49,7 +49,7 @@ void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::TopKRenormProb<float>(
+  Status status = sampling::TopKRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,
       top_k_val, vocab_size, stream);
@@ -69,7 +69,7 @@ void top_k_mask_logits(at::Tensor logits, at::Tensor mask_logits,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::TopKMaskLogits<float>(
+  Status status = sampling::TopKMaskLogits<float>(
       static_cast<float*>(logits.data_ptr()), static_cast<float*>(mask_logits.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,
       top_k_val, vocab_size, stream);

--- a/csrc/rope.cu
+++ b/csrc/rope.cu
@@ -52,7 +52,7 @@ void apply_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tensor k_rope
   const c10::cuda::OptionalCUDAGuard device_guard(q.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyRotary(
+    Status status = BatchQKApplyRotary(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<int32_t*>(indptr.data_ptr()), static_cast<int32_t*>(offsets.data_ptr()),
@@ -94,7 +94,7 @@ void apply_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tenso
   const c10::cuda::OptionalCUDAGuard device_guard(q.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyRotaryPosIds(
+    Status status = BatchQKApplyRotaryPosIds(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<int32_t*>(pos_ids.data_ptr()), nnz, num_qo_heads, num_kv_heads, rotary_dim,
@@ -141,7 +141,7 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
   const c10::cuda::OptionalCUDAGuard device_guard(q.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyRotaryPosIdsCosSinCache(
+    Status status = BatchQKApplyRotaryPosIdsCosSinCache(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<float*>(cos_sin_cache.data_ptr()), static_cast<int32_t*>(pos_ids.data_ptr()),
@@ -189,7 +189,7 @@ void apply_llama31_rope(at::Tensor q, at::Tensor k, at::Tensor q_rope, at::Tenso
   const c10::cuda::OptionalCUDAGuard device_guard(q.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyLlama31Rotary(
+    Status status = BatchQKApplyLlama31Rotary(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<int32_t*>(indptr.data_ptr()), static_cast<int32_t*>(offsets.data_ptr()),
@@ -233,7 +233,7 @@ void apply_llama31_rope_pos_ids(at::Tensor q, at::Tensor k, at::Tensor q_rope, a
   const c10::cuda::OptionalCUDAGuard device_guard(q.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(q.scalar_type(), c_type, [&] {
-    cudaError_t status = BatchQKApplyLlama31RotaryPosIds(
+    Status status = BatchQKApplyLlama31RotaryPosIds(
         static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
         static_cast<c_type*>(q_rope.data_ptr()), static_cast<c_type*>(k_rope.data_ptr()),
         static_cast<int32_t*>(pos_ids.data_ptr()), nnz, num_qo_heads, num_kv_heads, rotary_dim,

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -44,7 +44,7 @@ void sampling_from_logits(at::Tensor logits, at::Tensor output,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::SamplingFromLogits(
+  Status status = sampling::SamplingFromLogits(
       static_cast<float*>(logits.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
       batch_size, vocab_size, deterministic, philox_seed, philox_offset, stream);
@@ -71,7 +71,7 @@ void sampling_from_probs(at::Tensor probs, at::Tensor output,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::SamplingFromProb(
+  Status status = sampling::SamplingFromProb(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
       batch_size, vocab_size, deterministic, philox_seed, philox_offset, stream);
@@ -99,7 +99,7 @@ void top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
+  Status status = sampling::TopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr, batch_size,
@@ -131,7 +131,7 @@ void top_k_sampling_from_probs(at::Tensor probs, at::Tensor output,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
+  Status status = sampling::TopKSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
       maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
       has_top_k_arr ? static_cast<float*>(maybe_top_k_arr->data_ptr()) : nullptr, batch_size,
@@ -163,7 +163,7 @@ void min_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::MinPSamplingFromProb<float, int>(
+  Status status = sampling::MinPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()),
       has_min_p_arr ? static_cast<float*>(maybe_min_p_arr->data_ptr()) : nullptr,
       static_cast<int*>(output.data_ptr()),
@@ -198,7 +198,7 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::TopKTopPSamplingFromProb<float, int>(
+  Status status = sampling::TopKTopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()),
       has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr,
       has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr,
@@ -244,7 +244,7 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::ChainSpeculativeSampling<float, int>(
+  Status status = sampling::ChainSpeculativeSampling<float, int>(
       static_cast<float*>(draft_probs.data_ptr()), static_cast<int*>(draft_token_ids.data_ptr()),
       static_cast<float*>(target_probs.data_ptr()), static_cast<int*>(output_token_ids.data_ptr()),
       static_cast<int*>(output_accepted_token_num.data_ptr()),

--- a/csrc/single_decode.cu
+++ b/csrc/single_decode.cu
@@ -23,8 +23,8 @@ namespace flashinfer {
 
 template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename AttentionVariant,
           typename Params>
-cudaError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
-                                              cudaStream_t stream);
+Status SingleDecodeWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
+                                         cudaStream_t stream);
 }  // namespace flashinfer
 
 using namespace flashinfer;
@@ -93,7 +93,7 @@ void single_decode_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::T
 
         ADDITIONAL_PARAMS_SETTER
 
-        cudaError_t status =
+        Status status =
             flashinfer::SingleDecodeWithKVCacheDispatched<HEAD_DIM_QK, POS_ENCODING_MODE,
                                                           AttentionVariant>(
                 params, static_cast<DTypeO*>(tmp.data_ptr()), stream);

--- a/csrc/single_decode_kernel_inst.jinja
+++ b/csrc/single_decode_kernel_inst.jinja
@@ -5,7 +5,7 @@ using namespace flashinfer;
 
 namespace flashinfer {
 
-template cudaError_t SingleDecodeWithKVCacheDispatched<
+template Status SingleDecodeWithKVCacheDispatched<
     {{ head_dim_qk }}, {{ pos_encoding_mode }}, {{ variant_name }}, Params>(
     Params params, {{ dtype_o }}* tmp,
     cudaStream_t stream);

--- a/csrc/single_prefill.cu
+++ b/csrc/single_prefill.cu
@@ -26,8 +26,8 @@ namespace flashinfer {
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
           bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename AttentionVariant,
           typename Params>
-cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
-                                               cudaStream_t stream);
+Status SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
+                                          cudaStream_t stream);
 
 }  // namespace flashinfer
 
@@ -102,7 +102,7 @@ void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::
 
         ADDITIONAL_PARAMS_SETTER
 
-        cudaError_t status = flashinfer::SinglePrefillWithKVCacheDispatched<
+        Status status = flashinfer::SinglePrefillWithKVCacheDispatched<
             HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
             /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant>(
             params, static_cast<DTypeO*>(tmp.data_ptr()), stream);

--- a/csrc/single_prefill_fp8_sm90.cu
+++ b/csrc/single_prefill_fp8_sm90.cu
@@ -25,7 +25,7 @@ namespace flashinfer {
 
 template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLINDING_WINDOW,
           typename AttentionVariant, typename Params>
-cudaError_t SingleFP8PrefillWithKVCacheDispatched(Params& params, cudaStream_t stream);
+Status SingleFP8PrefillWithKVCacheDispatched(Params& params, cudaStream_t stream);
 
 }  // namespace flashinfer
 
@@ -91,7 +91,7 @@ void single_prefill_with_kv_cache_sm90(at::Tensor q, at::Tensor k, at::Tensor v,
         // Currently only support same quantization precision
         static_assert(std::is_same_v<DTypeQ, DTypeKV>);
 
-        cudaError_t status =
+        Status status =
             SingleFP8PrefillWithKVCacheDispatched<HEAD_DIM_QK, MASK_MODE, USE_SLIDING_WINDOW,
                                                   AttentionVariant>(params, stream);
         TORCH_CHECK(status == cudaSuccess, "single_prefill_with_kv_cache_sm90 failed with error: " +

--- a/csrc/single_prefill_fp8_sm90_kernel_inst.jinja
+++ b/csrc/single_prefill_fp8_sm90_kernel_inst.jinja
@@ -5,7 +5,7 @@ using namespace flashinfer;
 
 namespace flashinfer {
 
-template cudaError_t SingleFP8PrefillWithKVCacheDispatched
+template Status SingleFP8PrefillWithKVCacheDispatched
     <{{ head_dim_qk }}, {{ mask_mode }}, /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }}, {{ variant_name }}, Params>(
     Params& params, cudaStream_t stream);
 };

--- a/csrc/single_prefill_kernel_inst.jinja
+++ b/csrc/single_prefill_kernel_inst.jinja
@@ -7,7 +7,7 @@ namespace flashinfer {
 
 constexpr auto use_custom_mask = {{ mask_mode }} == MaskMode::kCustom;
 
-template cudaError_t SinglePrefillWithKVCacheDispatched<
+template Status SinglePrefillWithKVCacheDispatched<
     {{ head_dim_qk }}, {{ head_dim_vo }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, {{ mask_mode }}, {{ variant_name }}, Params>(
     Params params, {{ dtype_o }}* tmp,
     cudaStream_t stream);

--- a/csrc/single_prefill_sm90.cu
+++ b/csrc/single_prefill_sm90.cu
@@ -25,7 +25,7 @@ namespace flashinfer {
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool LEFT_SLINDING_WINDOW,
           typename AttentionVariant, typename Params>
-cudaError_t SinglePrefillWithKVCacheDispatched(Params& params, cudaStream_t stream);
+Status SinglePrefillWithKVCacheDispatched(Params& params, cudaStream_t stream);
 
 }  // namespace flashinfer
 
@@ -82,10 +82,9 @@ void single_prefill_with_kv_cache_sm90(at::Tensor q, at::Tensor k, at::Tensor v,
 
         ADDITIONAL_PARAMS_SETTER
 
-        cudaError_t status =
-            SinglePrefillWithKVCacheDispatched<HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE,
-                                               USE_SLIDING_WINDOW, AttentionVariant>(params,
-                                                                                     stream);
+        Status status = SinglePrefillWithKVCacheDispatched<HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE,
+                                                           USE_SLIDING_WINDOW, AttentionVariant>(
+            params, stream);
         TORCH_CHECK(status == cudaSuccess, "single_prefill_with_kv_cache_sm90 failed with error: " +
                                                std::string(cudaGetErrorString(status)));
         return true;

--- a/csrc/single_prefill_sm90_kernel_inst.jinja
+++ b/csrc/single_prefill_sm90_kernel_inst.jinja
@@ -5,7 +5,7 @@ using namespace flashinfer;
 
 namespace flashinfer {
 
-template cudaError_t SinglePrefillWithKVCacheDispatched
+template Status SinglePrefillWithKVCacheDispatched
     <{{ head_dim_qk }}, {{ head_dim_vo }}, {{ mask_mode }}, /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }}, {{ variant_name }}, Params>(
     Params& params, cudaStream_t stream);
 

--- a/include/flashinfer/attention/cutlass_mla.cuh
+++ b/include/flashinfer/attention/cutlass_mla.cuh
@@ -128,23 +128,23 @@ typename T::Fmha::Arguments args_from_options(void* out_ptr, void* lse_ptr, void
 }
 
 template <typename Element>
-cudaError_t runMla(void* workspace_ptr, void* out_ptr, void* lse_ptr, void* q_absorbed_ptr,
-                   void* ckv_kpe_cache_ptr, void* seq_lens_ptr, void* page_table_ptr, int batches,
-                   int page_count_per_seq, int page_count_total, int page_size, int device_index,
-                   cudaStream_t stream) {
+Status runMla(void* workspace_ptr, void* out_ptr, void* lse_ptr, void* q_absorbed_ptr,
+              void* ckv_kpe_cache_ptr, void* seq_lens_ptr, void* page_table_ptr, int batches,
+              int page_count_per_seq, int page_count_total, int page_size, int device_index,
+              cudaStream_t stream) {
   using MlaSm100Type = MlaSm100<Element>;
   typename MlaSm100Type::Fmha fmha;
   auto arguments = args_from_options<MlaSm100Type>(
       out_ptr, lse_ptr, q_absorbed_ptr, ckv_kpe_cache_ptr, seq_lens_ptr, page_table_ptr, batches,
       page_count_per_seq, page_count_total, page_size, device_index);
 
-  CUTLASS_CHECK(fmha.can_implement(arguments));
+  FLASHINFER_CALL(fmha.can_implement(arguments));
 
-  CUTLASS_CHECK(fmha.initialize(arguments, workspace_ptr, stream));
+  FLASHINFER_CALL(fmha.initialize(arguments, workspace_ptr, stream));
 
-  CUTLASS_CHECK(fmha.run(arguments, workspace_ptr, stream));
+  FLASHINFER_CALL(fmha.run(arguments, workspace_ptr, stream));
 
-  return cudaSuccess;
+  return Status::Success();
 }
 
 }  // namespace attention

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -1005,8 +1005,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
   }
 
 template <MaskMode MASK_MODE, uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, typename Params>
-cudaError_t BatchMLAPagedAttention(Params params, uint32_t num_blks_x, uint32_t num_blks_y,
-                                   cudaStream_t stream) {
+Status BatchMLAPagedAttention(Params params, uint32_t num_blks_x, uint32_t num_blks_y,
+                              cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
   using DTypeO = typename Params::DTypeO;
@@ -1032,9 +1032,9 @@ cudaError_t BatchMLAPagedAttention(Params params, uint32_t num_blks_x, uint32_t 
     auto kernel = BatchMLAPagedAttentionKernel<KTraits, Params>;
     void* args[] = {(void*)&params};
 
-    FLASHINFER_CUDA_CALL(
+    FLASHINFER_CALL(
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-    FLASHINFER_CUDA_CALL(
+    FLASHINFER_CALL(
         cudaLaunchCooperativeKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
   });
 

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -960,8 +960,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
 }  // namespace hopper
 
 template <MaskMode MASK_MODE, uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, typename Params>
-cudaError_t BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint32_t num_blks_y,
-                                        cudaStream_t stream) {
+Status BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint32_t num_blks_y,
+                                   cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
   using DTypeO = typename Params::DTypeO;
@@ -992,9 +992,9 @@ cudaError_t BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint
   auto kernel = hopper::BatchMLAPageAttentionHopperKernel<KTraits, Params>;
   void* args[] = {(void*)&params};
 
-  FLASHINFER_CUDA_CALL(
+  FLASHINFER_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-  FLASHINFER_CUDA_CALL(
+  FLASHINFER_CALL(
       cudaLaunchCooperativeKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
 
   return cudaSuccess;

--- a/include/flashinfer/cutlass_utils.cuh
+++ b/include/flashinfer/cutlass_utils.cuh
@@ -75,16 +75,6 @@ void compileTimeDebug(T&&) {
   static_assert(sizeof(T) == 0, "Compile time debug");
 }
 
-#define CUTLASS_CHECK(cmd)                                                            \
-  do {                                                                                \
-    auto status = cmd;                                                                \
-    if (status != cutlass::Status::kSuccess) {                                        \
-      std::ostringstream err_msg;                                                     \
-      err_msg << "cutlass " << #cmd << " failed: " << cutlassGetStatusString(status); \
-      FLASHINFER_ERROR(err_msg.str());                                                \
-    }                                                                                 \
-  } while (0)
-
 }  // namespace flashinfer
 
 #endif  // FLASHINFER_CUTLASS_UTILS_CUH_

--- a/include/flashinfer/gemm/gemm_groupwise_sm100.cuh
+++ b/include/flashinfer/gemm/gemm_groupwise_sm100.cuh
@@ -18,6 +18,7 @@
 
 #include "../allocator.h"
 #include "../cutlass_utils.cuh"
+#include "../status.h"
 #include "../utils.cuh"
 
 namespace flashinfer {
@@ -28,10 +29,10 @@ using namespace cute;
 
 template <int ScaleGranularityM, int ScaleGranularityN, int ScaleGranularityK, typename DTypeIn,
           typename DTypeOut>
-cudaError_t CutlassGroupwiseScaledGEMMSM100(void* float_buffer, size_t float_buffer_size_in_bytes,
-                                            DTypeIn* A_ptr, DTypeIn* B_ptr, float* SFA_ptr,
-                                            float* SFB_ptr, DTypeOut* C_ptr, int m, int n, int k,
-                                            int l, cudaStream_t stream) {
+Status CutlassGroupwiseScaledGEMMSM100(void* float_buffer, size_t float_buffer_size_in_bytes,
+                                       DTypeIn* A_ptr, DTypeIn* B_ptr, float* SFA_ptr,
+                                       float* SFB_ptr, DTypeOut* C_ptr, int m, int n, int k, int l,
+                                       cudaStream_t stream) {
   using ElementA = DTypeIn;                   // Element type for A matrix operand
   using LayoutA = cutlass::layout::RowMajor;  // Layout type for A matrix operand
   constexpr int AlignmentA =
@@ -134,10 +135,10 @@ cudaError_t CutlassGroupwiseScaledGEMMSM100(void* float_buffer, size_t float_buf
   auto workspace_ptr = float_allocator.aligned_alloc<void>(workspace_size, 32 * 1024 * 1024,
                                                            "sm100_groupwise_gemm_float_workspace");
 
-  CUTLASS_CHECK(gemm.can_implement(arguments));
-  CUTLASS_CHECK(gemm.initialize(arguments, workspace_ptr));
-  CUTLASS_CHECK(gemm.run(stream));
-  return cudaSuccess;
+  FLASHINFER_CALL(gemm.can_implement(arguments));
+  FLASHINFER_CALL(gemm.initialize(arguments, workspace_ptr));
+  FLASHINFER_CALL(gemm.run(stream));
+  return Status::Success();
 }
 
 }  // namespace gemm

--- a/include/flashinfer/gemm/group_gemm.cuh
+++ b/include/flashinfer/gemm/group_gemm.cuh
@@ -20,6 +20,7 @@
 
 #include "../allocator.h"
 #include "../cutlass_utils.cuh"
+#include "../status.h"
 
 namespace flashinfer {
 
@@ -44,10 +45,10 @@ namespace group_gemm {
   }
 
 template <typename DType>
-cudaError_t CutlassSegmentGEMMRun(void* workspace_buffer, size_t workspace_buffer_size_in_bytes,
-                                  void* all_problems, int64_t batch_size, void* x, void* w, void* y,
-                                  void* x_ld, void* w_ld, void* y_ld, bool weight_column_major,
-                                  cudaStream_t stream) {
+Status CutlassSegmentGEMMRun(void* workspace_buffer, size_t workspace_buffer_size_in_bytes,
+                             void* all_problems, int64_t batch_size, void* x, void* w, void* y,
+                             void* x_ld, void* w_ld, void* y_ld, bool weight_column_major,
+                             cudaStream_t stream) {
   using cutlass::epilogue::thread::LinearCombination;
   using cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle;
   int device;

--- a/include/flashinfer/page.cuh
+++ b/include/flashinfer/page.cuh
@@ -302,15 +302,17 @@ __global__ void BlockSparseIndicesToVectorSparseOffsetsKernel(
 }
 
 template <typename IdType>
-cudaError_t BlockSparseIndicesToVectorSparseOffset(
-    IdType* block_sparse_indices, IdType* block_sparse_indptr, IdType* vector_sparse_offsets,
-    IdType* vector_sparse_indptr, IdType* kv_lens, const int64_t stride_block,
-    const int64_t stride_n, const int64_t batch_size, const uint32_t block_size,
-    cudaStream_t stream = nullptr) {
+Status BlockSparseIndicesToVectorSparseOffset(IdType* block_sparse_indices,
+                                              IdType* block_sparse_indptr,
+                                              IdType* vector_sparse_offsets,
+                                              IdType* vector_sparse_indptr, IdType* kv_lens,
+                                              const int64_t stride_block, const int64_t stride_n,
+                                              const int64_t batch_size, const uint32_t block_size,
+                                              cudaStream_t stream = nullptr) {
   int dev_id = 0;
   int num_sms = 0;
-  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  FLASHINFER_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
 
   uint32_t num_threads = 512;
 
@@ -327,7 +329,7 @@ cudaError_t BlockSparseIndicesToVectorSparseOffset(
                   (void*)&batch_size,
                   (void*)&block_size_fastdiv};
 
-  FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, num_sms, num_threads, args, 0, stream));
+  FLASHINFER_CALL(cudaLaunchKernel((void*)kernel, num_sms, num_threads, args, 0, stream));
 
   return cudaSuccess;
 }
@@ -343,8 +345,8 @@ cudaError_t BlockSparseIndicesToVectorSparseOffset(
  * \return status Indicates whether CUDA calls are successful
  */
 template <typename DType, typename IdType>
-cudaError_t AppendPagedKVCacheDecode(paged_kv_t<DType, IdType> paged_kv, DType* key, DType* value,
-                                     cudaStream_t stream = nullptr) {
+Status AppendPagedKVCacheDecode(paged_kv_t<DType, IdType> paged_kv, DType* key, DType* value,
+                                cudaStream_t stream = nullptr) {
   uint32_t head_dim = paged_kv.head_dim;
   uint32_t batch_size = paged_kv.batch_size;
   uint32_t num_heads = paged_kv.num_heads;
@@ -357,7 +359,7 @@ cudaError_t AppendPagedKVCacheDecode(paged_kv_t<DType, IdType> paged_kv, DType* 
     dim3 nthrs(bdx, bdy);
     auto kernel = AppendPagedKVCacheDecodeKernel<HEAD_DIM, vec_size, DType, IdType>;
     void* args[] = {(void*)&paged_kv, (void*)&key, (void*)&value};
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
+    FLASHINFER_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
   });
   return cudaSuccess;
 }
@@ -375,18 +377,18 @@ cudaError_t AppendPagedKVCacheDecode(paged_kv_t<DType, IdType> paged_kv, DType* 
  * \return status Indicates whether CUDA calls are successful
  */
 template <typename DType, typename IdType>
-cudaError_t AppendPagedKVCache(paged_kv_t<DType, IdType> paged_kv, DType* append_key,
-                               DType* append_value, IdType* batch_indices, IdType* positions,
-                               uint32_t nnz, size_t append_k_stride_n, size_t append_k_stride_h,
-                               size_t append_v_stride_n, size_t append_v_stride_h,
-                               cudaStream_t stream = nullptr) {
+Status AppendPagedKVCache(paged_kv_t<DType, IdType> paged_kv, DType* append_key,
+                          DType* append_value, IdType* batch_indices, IdType* positions,
+                          uint32_t nnz, size_t append_k_stride_n, size_t append_k_stride_h,
+                          size_t append_v_stride_n, size_t append_v_stride_h,
+                          cudaStream_t stream = nullptr) {
   uint32_t head_dim = paged_kv.head_dim;
   uint32_t num_heads = paged_kv.num_heads;
   int dev_id = 0;
   int num_sms = 0;
   int num_blocks_per_sm = 0;
-  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  FLASHINFER_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
 
   DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
     constexpr uint32_t vec_size = std::max(16 / sizeof(DType), HEAD_DIM / 32);
@@ -395,8 +397,8 @@ cudaError_t AppendPagedKVCache(paged_kv_t<DType, IdType> paged_kv, DType* append
     uint32_t num_threads = bdx * bdy;
     uint32_t smem_size = 0;
     auto kernel = AppendPagedKVCacheKernel<HEAD_DIM, vec_size, DType, IdType>;
-    FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel,
-                                                                       num_threads, smem_size));
+    FLASHINFER_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel,
+                                                                  num_threads, smem_size));
     num_blocks_per_sm = min(num_blocks_per_sm, ceil_div(int(nnz), num_sms));
     dim3 nblks(num_blocks_per_sm * num_sms);
     dim3 nthrs(bdx, bdy);
@@ -405,7 +407,7 @@ cudaError_t AppendPagedKVCache(paged_kv_t<DType, IdType> paged_kv, DType* append
                     (void*)&batch_indices,     (void*)&positions,         (void*)&nnz,
                     (void*)&append_k_stride_n, (void*)&append_k_stride_h, (void*)&append_v_stride_n,
                     (void*)&append_v_stride_h};
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
+    FLASHINFER_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
   });
   return cudaSuccess;
 }
@@ -602,15 +604,15 @@ __global__ void AppendPagedKVMlaCacheKernel(paged_kv_mla_t<DType, IdType> paged_
 }
 
 template <typename DType, typename IdType>
-cudaError_t AppendPagedKVMlaCache(paged_kv_mla_t<DType, IdType> paged_kv, DType* append_ckv,
-                                  DType* append_kpe, IdType* batch_indices, IdType* positions,
-                                  uint32_t nnz, size_t append_ckv_stride_n,
-                                  size_t append_kpe_stride_n, cudaStream_t stream = nullptr) {
+Status AppendPagedKVMlaCache(paged_kv_mla_t<DType, IdType> paged_kv, DType* append_ckv,
+                             DType* append_kpe, IdType* batch_indices, IdType* positions,
+                             uint32_t nnz, size_t append_ckv_stride_n, size_t append_kpe_stride_n,
+                             cudaStream_t stream = nullptr) {
   int dev_id = 0;
   int num_sms = 0;
   int num_blocks_per_sm = 0;
-  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  FLASHINFER_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
 
   uint32_t head_dim_ckv = paged_kv.head_dim_ckv;
   uint32_t head_dim_kpe = paged_kv.head_dim_kpe;
@@ -624,8 +626,8 @@ cudaError_t AppendPagedKVMlaCache(paged_kv_mla_t<DType, IdType> paged_kv, DType*
   uint32_t num_threads = bdx;
   uint32_t smem_size = 0;
   auto kernel = AppendPagedKVMlaCacheKernel<HEAD_CKV_DIM, HEAD_KPE_DIM, vec_size, DType, IdType>;
-  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel,
-                                                                     num_threads, smem_size));
+  FLASHINFER_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel,
+                                                                num_threads, smem_size));
   num_blocks_per_sm = min(num_blocks_per_sm, ceil_div(int(nnz), num_sms));
   dim3 nblks(num_blocks_per_sm * num_sms);
   dim3 nthrs(bdx);
@@ -637,7 +639,7 @@ cudaError_t AppendPagedKVMlaCache(paged_kv_mla_t<DType, IdType> paged_kv, DType*
                   (void*)&nnz,
                   (void*)&append_ckv_stride_n,
                   (void*)&append_kpe_stride_n};
-  FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
+  FLASHINFER_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
   return cudaSuccess;
 }
 

--- a/include/flashinfer/quantization.cuh
+++ b/include/flashinfer/quantization.cuh
@@ -82,28 +82,27 @@ __global__ void SegmentPackBitsKernel(bool* input, uint8_t* output, IdType* inpu
   }
 }
 
-cudaError_t PackBits(bool* input, uint8_t* output, int64_t num_elements, BitOrder bitorder,
-                     cudaStream_t stream) {
+Status PackBits(bool* input, uint8_t* output, int64_t num_elements, BitOrder bitorder,
+                cudaStream_t stream) {
   DISPATCH_BITORDER(bitorder, BITORDER, {
     auto kernel = PackBitsKernel<BITORDER>;
     const dim3 nthrs(256);
     const dim3 nblks(ceil_div(num_elements, nthrs.x * 8));
     void* args[] = {&input, &output, &num_elements};
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
+    FLASHINFER_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
   });
   return cudaSuccess;
 }
 
 template <typename IdType>
-cudaError_t SegmentPackBits(bool* input, uint8_t* output, IdType* input_indptr,
-                            IdType* output_indptr, uint32_t batch_size, BitOrder bitorder,
-                            cudaStream_t stream) {
+Status SegmentPackBits(bool* input, uint8_t* output, IdType* input_indptr, IdType* output_indptr,
+                       uint32_t batch_size, BitOrder bitorder, cudaStream_t stream) {
   DISPATCH_BITORDER(bitorder, BITORDER, {
     auto kernel = SegmentPackBitsKernel<BITORDER, IdType>;
     const dim3 nthrs(256);
     const dim3 nblks(batch_size);
     void* args[] = {&input, &output, &input_indptr, &output_indptr};
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
+    FLASHINFER_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
   });
   return cudaSuccess;
 }

--- a/include/flashinfer/status.h
+++ b/include/flashinfer/status.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_STATUS_H_
+#define FLASHINFER_STATUS_H_
+
+#include <cuda_runtime.h>
+#include <cutlass/cutlass.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace flashinfer {
+enum class ErrorDomain : std::uint8_t { kNone, kCuda, kCutlass };
+
+struct [[nodiscard]] Status {
+  ErrorDomain domain{ErrorDomain::kNone};
+  std::int32_t code{0};  ///< Raw numeric value.
+
+  // Success constructor (default)
+  constexpr Status() noexcept = default;
+
+  //---------------------------------
+  // Implicit constructors per domain
+  //---------------------------------
+  constexpr Status(cudaError_t e) noexcept
+      : domain(e == cudaSuccess ? ErrorDomain::kNone : ErrorDomain::kCuda),
+        code(static_cast<std::int32_t>(e)) {}
+
+  constexpr Status(cutlass::Status s) noexcept
+      : domain(s == cutlass::Status::kSuccess ? ErrorDomain::kNone : ErrorDomain::kCutlass),
+        code(static_cast<std::int32_t>(s)) {}
+
+  bool success() const noexcept { return domain == ErrorDomain::kNone; }
+
+  static Status Success() noexcept { return Status{}; }
+
+  std::string error_message() const noexcept { return std::string(error_string(*this)); }
+};
+
+// Primary template – no definition.  Specialise for each domain.
+template <ErrorDomain>
+struct DomainTraits;
+
+// CUDA runtime -------------------------------------------------------------
+template <>
+struct DomainTraits<ErrorDomain::kCuda> {
+  using CodeT = cudaError_t;
+  static const char* to_string(CodeT c) noexcept { return cudaGetErrorString(c); }
+};
+
+// CUTLASS ------------------------------------------------------------------
+template <>
+struct DomainTraits<ErrorDomain::kCutlass> {
+  using CodeT = cutlass::Status;
+  static const char* to_string(CodeT s) noexcept { return cutlassGetStatusString(s); }
+};
+
+/// Return human‑readable string for any Status.
+inline const char* error_string(Status st) noexcept {
+  switch (st.domain) {
+    case ErrorDomain::kNone:
+      return "Success";
+    case ErrorDomain::kCuda: {
+      static std::string cuda_error =
+          "CUDA Error: " + std::string(DomainTraits<ErrorDomain::kCuda>::to_string(
+                               static_cast<DomainTraits<ErrorDomain::kCuda>::CodeT>(st.code)));
+      return cuda_error.c_str();
+    }
+    case ErrorDomain::kCutlass: {
+      static std::string cutlass_error =
+          "CUTLASS Error: " +
+          std::string(DomainTraits<ErrorDomain::kCutlass>::to_string(
+              static_cast<DomainTraits<ErrorDomain::kCutlass>::CodeT>(st.code)));
+      return cutlass_error.c_str();
+    }
+    default:
+      return "Unknown error domain";
+  }
+}
+
+};  // namespace flashinfer
+
+#endif  // FLASHINFER_STATUS_H_

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "exception.h"
+#include "status.h"
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
@@ -37,22 +38,22 @@
 #endif
 
 #ifndef NDEBUG
-#define FLASHINFER_CUDA_CALL(func, ...)                                                     \
-  {                                                                                         \
-    cudaError_t e = (func);                                                                 \
-    if (e != cudaSuccess) {                                                                 \
-      std::cerr << "CUDA Error: " << cudaGetErrorString(e) << " (" << e << ") " << __FILE__ \
-                << ": line " << __LINE__ << " at function " << STR(func) << std::endl;      \
-      return e;                                                                             \
-    }                                                                                       \
+#define FLASHINFER_CALL(func, ...)                                                         \
+  {                                                                                        \
+    flashinfer::Status e = (func);                                                         \
+    if (!e.success()) {                                                                    \
+      std::cerr << flashinfer::error_string(e) << " " << __FILE__ << ": line " << __LINE__ \
+                << " at function " << STR(func) << std::endl;                              \
+      return e;                                                                            \
+    }                                                                                      \
   }
 #else
-#define FLASHINFER_CUDA_CALL(func, ...) \
-  {                                     \
-    cudaError_t e = (func);             \
-    if (e != cudaSuccess) {             \
-      return e;                         \
-    }                                   \
+#define FLASHINFER_CALL(func, ...) \
+  {                                \
+    flashinfer::Status e = (func); \
+    if (!e.success()) {            \
+      return e;                    \
+    }                              \
   }
 #endif
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We currently support kernel implementations from multiple backends (Cutlass, TRT-LLM-Gen, etc.), each of which uses its own return codes or error types. Handling these inconsistently with separate macros (`CUTLASS_CHECK`, `TLLM_CHECK`, etc.) has become chaotic.

In This PR, we
* Introduces a single `Status` class that can wrap and implicitly convert from various backend error types (`cudaError_t`, `cutlass::Status`, etc.).
* Replaces all backend-specific check macros with one unified call macro: `FLASHINFER_CALL`.

### Future API conventions
1. **Return codes, not exceptions**
   * APIs under `include/` will return a `Status` instead of using C++ exceptions.
2. **Unified call-site error handling**
   * Every call (to FlashInfer or backend functions) must be wrapped in `FLASHINFER_CALL`.
3. **Custom errors via `Status`**
   * Replace inline exceptions with `Status` error codes using `FLASHINFER_ERROR("message")`.
4. **Exceptions in bindings**
   * In binding code (`csrc/`), parse the returned `Status` and rethrow as C++ exceptions using `TORCH_CHECK`.

This centralizes error handling, makes it easy to add new backends, and aligns FlashInfer with HPC-library practices while still supporting exception-based checks at the Python/C++ interface.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
