### PR TITLE
feat: Add support for FLASHINFER_EXTRA_LDFLAGS environment variable

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -93,6 +93,20 @@ def generate_ninja_build_for_op(
         "-L$cuda_home/lib64",
         "-lcudart",
     ]
+
+    env_extra_ldflags = os.environ.get("FLASHINFER_EXTRA_LDFLAGS")
+    if env_extra_ldflags:
+        try:
+            import shlex
+
+            ldflags += shlex.split(env_extra_ldflags)
+        except ValueError as e:
+            print(
+                f"Warning: Could not parse FLASHINFER_EXTRA_LDFLAGS with shlex: {e}. Falling back to simple split.",
+                file=sys.stderr,
+            )
+            ldflags += env_extra_ldflags.split()
+
     if extra_ldflags is not None:
         ldflags += extra_ldflags
 


### PR DESCRIPTION
## Summary
- Added support for `FLASHINFER_EXTRA_LDFLAGS` environment variable to allow users to pass additional linker flags
- Enables users to specify custom CUDA library paths when the default `$cuda_home/lib64` is not available on their system

## Changes
- Modified `flashinfer/jit/cpp_ext.py` to read and parse the `FLASHINFER_EXTRA_LDFLAGS` environment variable
- The environment variable is split on whitespace and added to the ldflags list before any explicit extra_ldflags

## Usage
Users can now set:
```bash
export FLASHINFER_EXTRA_LDFLAGS="-L/usr/local/cuda/lib"
```

This addresses systems where CUDA libraries are located in `$cuda_home/lib` instead of the default `$cuda_home/lib64`.

Fixes #1143