### PR TITLE
[fix] fix precision errors when applying causal mask on Qwen-2.5 series models

### DIFF
--- a/flashinfer/jit/attention/pytorch.py
+++ b/flashinfer/jit/attention/pytorch.py
@@ -894,49 +894,6 @@ def gen_batch_attention_module(
     )
 
 
-def gen_batch_attention_module(
-    dtype_q: torch.dtype,
-    dtype_kv: torch.dtype,
-    dtype_o: torch.dtype,
-    dtype_idx: torch.dtype,
-    head_dim_qk: int,
-    head_dim_vo: int,
-    pos_encoding_mode: int,
-):
-    uri = get_batch_attention_uri(
-        dtype_q,
-        dtype_kv,
-        dtype_o,
-        dtype_idx,
-        head_dim_qk,
-        head_dim_vo,
-        pos_encoding_mode,
-    )
-    additional_tensor_names = []
-    additional_tensor_dtypes = []
-    additional_scalar_names = []
-    additional_scalar_dtypes = []
-    variant_name = f"StandardAttention"
-    variant_decl = f"#include<flashinfer/attention/variants.cuh>"
-
-    return gen_customize_batch_attention_module(
-        uri,
-        dtype_q,
-        dtype_kv,
-        dtype_o,
-        dtype_idx,
-        head_dim_qk,
-        head_dim_vo,
-        additional_tensor_names,
-        additional_tensor_dtypes,
-        additional_scalar_names,
-        additional_scalar_dtypes,
-        variant_name,
-        variant_decl,
-        pos_encoding_mode=pos_encoding_mode,
-    )
-
-
 def gen_customize_single_decode_module(
     uri: str,
     dtype_q: torch.dtype,

--- a/tests/test_batch_attention.py
+++ b/tests/test_batch_attention.py
@@ -137,8 +137,8 @@ def _run_attention(
 # -------------------------  PyTest test case  ----------------------------- #
 @pytest.mark.parametrize("seq_len_pairs", _build_seq_len_configs())
 @pytest.mark.parametrize("page_block_size", [1, 8, 16])
-@pytest.mark.parametrize("num_kv_heads", [1, 4, 8])
-@pytest.mark.parametrize("gqa_group_size", [1, 4])
+@pytest.mark.parametrize("num_kv_heads", [1, 4])
+@pytest.mark.parametrize("gqa_group_size", [1, 4, 7])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("layout", ["HND", "NHD"])

--- a/tests/test_single_prefill.py
+++ b/tests/test_single_prefill.py
@@ -1,0 +1,103 @@
+import math
+
+import pytest
+import torch
+
+import flashinfer
+
+
+def build_causal_mask(qo_len, kv_len):
+    i = torch.arange(qo_len).unsqueeze(1).to("cuda:0")
+    j = torch.arange(kv_len).unsqueeze(0).to("cuda:0")
+    offset = kv_len - qo_len
+
+    mask = (j - offset > i).to(torch.bool)
+    return mask
+
+
+def _repeat_kv(t: torch.Tensor, num_groups: int) -> torch.Tensor:
+    return t.repeat_interleave(num_groups, dim=1)
+
+
+def single_prefill_with_kv_cache_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    causal: bool = False,
+):
+    Lq, Hq, D = q.shape
+    Lk, Hkv, _ = k.shape
+    assert (Lk, Hkv, D) == v.shape
+    assert Hq % Hkv == 0
+
+    groups = Hq // Hkv
+    k_states = _repeat_kv(k, groups)
+    v_states = _repeat_kv(v, groups)
+
+    q_t = q.permute(1, 0, 2)  # (Hq, Lq, D)
+    k_t = k_states.permute(1, 2, 0)  # (Hq, D, Lk)
+    v_t = v_states.permute(1, 0, 2)  # (Hq, Lk, D)
+
+    scale = 1.0 / math.sqrt(D)
+    attn_scores = torch.bmm(q_t, k_t) * scale  # (Hq, Lq, Lk)
+
+    if causal:
+        # apply causal mask
+        causal_mask = build_causal_mask(Lq, Lk)
+        attn_scores = attn_scores.masked_fill(causal_mask, float("-inf"))
+
+    attn_weights = torch.softmax(attn_scores, dim=-1, dtype=torch.float32).to(q.dtype)
+
+    attn_output = torch.bmm(attn_weights, v_t)  # (Hq, Lq, D)
+    attn_output = attn_output.permute(1, 0, 2).contiguous()  # (Lq, Hq, D)
+
+    return attn_output
+
+
+@pytest.mark.parametrize("kv_len", [501, 2042, 3771, 4932])
+@pytest.mark.parametrize("qo_len", [37, 127, 577, 1024])
+@pytest.mark.parametrize("num_kv_heads", [1])
+@pytest.mark.parametrize("num_qo_heads", [4, 7])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE"])
+def test_sinqle_prefill_with_paged_kv_cache(
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    causal,
+    pos_encoding_mode,
+):
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+    if qo_len > kv_len and causal:
+        pytest.skip("qo_len > kv_len and causal is not supported")
+    q = torch.randn(
+        qo_len,
+        num_qo_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    k = torch.randn(
+        kv_len,
+        num_kv_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    v = torch.randn(
+        kv_len,
+        num_kv_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    o = flashinfer.prefill.single_prefill_with_kv_cache(
+        q, k, v, causal=causal, pos_encoding_mode=pos_encoding_mode, backend="fa2"
+    )
+
+    o_ref = single_prefill_with_kv_cache_ref(q, k, v, causal=causal)
+    torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
This PR identifies and fixes a precision error that occurs (rarely but possibly) on models with non-power-of-two `gqa_group_size` when applying causal masks, e.g., Qwen-2.5-7B with `gqa_group_size=7`. 
1. This PR adds a unit test `test_single_prefill.py` to demonstrate the potential precision errors by adding a reference implementation from PyTorch. 
2. This PR fixes `batch_attention` module's precision errors as well. Also add more unit tests into `test_batch_attention.py`
## 🔍 Related Issues

Pre-PR:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/af01d71f-1d0a-4b04-96b5-745b0e53224f" />

Post-PR (w/ same random seed):
<img width="744" alt="image" src="https://github.com/user-attachments/assets/33d730bb-df82-4821-9942-50eeee14b5ea" />

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
