### PR TITLE
feat: Fused temperature online softmax kernel

### DIFF
--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -174,7 +174,8 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
 //========== sampling ==========
 
 void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
-             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val);
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val,
+             bool enable_pdl);
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -173,6 +173,8 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
 
 //========== sampling ==========
 
+void softmax(at::Tensor logits, at::Tensor probs);
+
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
                          std::optional<at::Generator> gen);
@@ -297,6 +299,8 @@ TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("apply_rope_pos_ids_cos_sin_cache", apply_rope_pos_ids_cos_sin_cache);
 
   // sampling
+  // Softmax
+  m.def("softmax", softmax);
   // Sample from probabilities
   m.def("sampling_from_probs", sampling_from_probs);
   // Sample from logits

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -173,7 +173,8 @@ void apply_rope_pos_ids_cos_sin_cache(at::Tensor q, at::Tensor k, at::Tensor q_r
 
 //========== sampling ==========
 
-void softmax(at::Tensor logits, at::Tensor probs);
+void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val);
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -16,7 +16,8 @@
 #include "pytorch_extension_utils.h"
 
 void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
-             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val);
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val,
+             bool enable_pdl);
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -15,7 +15,8 @@
  */
 #include "pytorch_extension_utils.h"
 
-void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor probs);
+void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val);
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -15,7 +15,7 @@
  */
 #include "pytorch_extension_utils.h"
 
-void softmax(at::Tensor logits, at::Tensor probs);
+void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor probs);
 
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,

--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -15,6 +15,8 @@
  */
 #include "pytorch_extension_utils.h"
 
+void softmax(at::Tensor logits, at::Tensor probs);
+
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
                          std::optional<at::Generator> gen);
@@ -60,6 +62,8 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
                                 std::optional<at::Generator> gen);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  // Softmax
+  m.def("softmax", softmax);
   // Sample from probabilities
   m.def("sampling_from_probs", sampling_from_probs);
   // Sample from logits

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -26,7 +26,8 @@
 using namespace flashinfer;
 
 void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
-             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val) {
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val,
+             bool enable_pdl) {
   CHECK_INPUT(workspace_buffer);
   CHECK_INPUT(logits);
   CHECK_INPUT(output);
@@ -44,7 +45,7 @@ void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
       vocab_size,
       has_temperature_arr ? static_cast<float*>(maybe_temperature_arr->data_ptr()) : nullptr,
       temperature_val, workspace_buffer.data_ptr(),
-      workspace_buffer.element_size() * workspace_buffer.size(0), stream);
+      workspace_buffer.element_size() * workspace_buffer.size(0), enable_pdl, stream);
   TORCH_CHECK(status == cudaSuccess,
               "OnlineSoftmax failed with error code " + std::string(cudaGetErrorString(status)));
 }

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -25,20 +25,25 @@
 
 using namespace flashinfer;
 
-void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor probs) {
+void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val) {
   CHECK_INPUT(workspace_buffer);
   CHECK_INPUT(logits);
-  CHECK_INPUT(probs);
+  CHECK_INPUT(output);
   auto device = logits.device();
   CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
   unsigned int batch_size = logits.size(0);
   unsigned int vocab_size = logits.size(1);
 
+  bool has_temperature_arr = maybe_temperature_arr.has_value();
+
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
-  cudaError_t status = sampling::OnlineSoftmax(
-      static_cast<float*>(logits.data_ptr()), static_cast<float*>(probs.data_ptr()), batch_size,
-      vocab_size, workspace_buffer.data_ptr(),
+  cudaError_t status = sampling::OnlineSoftmax<float>(
+      static_cast<float*>(logits.data_ptr()), static_cast<float*>(output.data_ptr()), batch_size,
+      vocab_size,
+      has_temperature_arr ? static_cast<float*>(maybe_temperature_arr->data_ptr()) : nullptr,
+      temperature_val, workspace_buffer.data_ptr(),
       workspace_buffer.element_size() * workspace_buffer.size(0), stream);
   TORCH_CHECK(status == cudaSuccess,
               "OnlineSoftmax failed with error code " + std::string(cudaGetErrorString(status)));

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -91,6 +91,7 @@ from .sampling import chain_speculative_sampling as chain_speculative_sampling
 from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
 from .sampling import sampling_from_logits as sampling_from_logits
 from .sampling import sampling_from_probs as sampling_from_probs
+from .sampling import softmax as softmax
 from .sampling import top_k_mask_logits as top_k_mask_logits
 from .sampling import top_k_renorm_probs as top_k_renorm_probs
 from .sampling import top_k_sampling_from_probs as top_k_sampling_from_probs

--- a/flashinfer/logits_processor/operators.py
+++ b/flashinfer/logits_processor/operators.py
@@ -75,8 +75,7 @@ class SoftmaxOp(Op):
     def __call__(self, tensor: TaggedTensor, **kwargs: Any) -> TaggedTensor:
         output_type = self._validate_input_type(tensor)
 
-        probs = torch.softmax(tensor.data, dim=-1)
-
+        probs = get_sampling_module().softmax(tensor.data)
         return TaggedTensor(probs, output_type)
 
 

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1242,7 +1242,7 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
                           size_t workspace_buffer_size_in_bytes, bool enable_pdl,
                           cudaStream_t stream = 0) {
   constexpr uint32_t SMALL_BATCH_THRESHOLD = 128;
-  constexpr uint32_t LARGE_VOCAB_THRESHOLD = 32768;
+  constexpr uint32_t LARGE_VOCAB_THRESHOLD = 24576;
   constexpr uint32_t DEFAULT_SLICE_SIZE = 8192;
 
   const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1288,7 +1288,9 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
             config.attrs = attribute;
             config.numAttrs = 1;
 
-            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase1_kernel, phase1_args));
+            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase1_kernel, logits, partial_results,
+                                                    temperature_arr, temperature_val, d,
+                                                    num_slices));
           } else {
             FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase1_kernel, phase1_nblks, phase1_nthrs,
                                                   phase1_args, smem_size, stream));
@@ -1318,7 +1320,9 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
             config.attrs = attribute;
             config.numAttrs = 1;
 
-            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase2_kernel, phase2_args));
+            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase2_kernel, logits, output,
+                                                    partial_results, temperature_arr,
+                                                    temperature_val, d, num_slices));
           } else {
             FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase2_kernel, phase2_nblks, phase2_nthrs,
                                                   phase2_args, smem_size, stream));
@@ -1363,7 +1367,8 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
               config.attrs = attribute;
               config.numAttrs = 1;
 
-              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, args));
+              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, logits, output,
+                                                      temperature_arr, temperature_val, d));
             } else {
               FLASHINFER_CUDA_CALL(
                   cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -38,6 +38,25 @@ def gumbel_distribution(beta):
     return gumbel_noise
 
 
+@pytest.mark.parametrize("batch_size", [1, 99, 989])
+@pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
+@pytest.mark.parametrize(
+    "distribution",
+    [
+        normal_distribution(1),
+        normal_distribution(5),
+        gumbel_distribution(0.1),
+    ],
+)
+def test_softmax(batch_size, vocab_size, distribution):
+    torch.manual_seed(42)
+    logits = distribution((batch_size, vocab_size), "cuda:0")
+    probs = flashinfer.sampling.softmax(logits)
+    probs_ref = torch.softmax(logits, dim=-1)
+
+    assert torch.allclose(probs, probs_ref)
+
+
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize(
     "distribution",

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -48,13 +48,23 @@ def gumbel_distribution(beta):
         gumbel_distribution(0.1),
     ],
 )
-def test_softmax(batch_size, vocab_size, distribution):
+@pytest.mark.parametrize("temperature", [1.0, 0.5, 0.1])
+@pytest.mark.parametrize("temperature_arr", [True, False])
+def test_softmax(batch_size, vocab_size, distribution, temperature, temperature_arr):
     torch.manual_seed(42)
     logits = distribution((batch_size, vocab_size), "cuda:0")
-    probs = flashinfer.sampling.softmax(logits)
-    probs_ref = torch.softmax(logits, dim=-1)
 
-    assert torch.allclose(probs, probs_ref)
+    if temperature_arr:
+        temperature_arr = torch.full((batch_size,), temperature, device="cuda:0")
+        probs = flashinfer.sampling.softmax(logits, temperature=temperature_arr)
+        logits_scaled = logits / temperature_arr.unsqueeze(-1)
+    else:
+        probs = flashinfer.sampling.softmax(logits, temperature=temperature)
+        logits_scaled = logits / temperature
+
+    probs_ref = torch.softmax(logits_scaled, dim=-1)
+
+    assert torch.allclose(probs, probs_ref, atol=1e-3)
 
 
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
This adds the fused temperature online softmax kernel to the sampling and logits processor API.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).


## Benchamrk
Baseline: [torch.softmax()](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/SoftMax.cu) on H200
![softmax_benchmark_results_32000_128](https://github.com/user-attachments/assets/0fd8d9ad-2c78-4199-b051-72d66c816504)


