### PR TITLE
Add more logging to TRTLLM-GEN debug trace (NFC)

### DIFF
--- a/include/flashinfer/trtllm/common.h
+++ b/include/flashinfer/trtllm/common.h
@@ -226,6 +226,29 @@ enum Data_type {
   DATA_TYPE_UNKNOWN
 };
 
+inline constexpr const char* toStr(Data_type dtype) {
+  switch (dtype) {
+    case DATA_TYPE_FP16:
+      return "FP16";
+    case DATA_TYPE_BF16:
+      return "BF16";
+    case DATA_TYPE_FP32:
+      return "FP32";
+    case DATA_TYPE_INT8:
+      return "INT8";
+    case DATA_TYPE_INT32:
+      return "INT32";
+    case DATA_TYPE_E4M3:
+      return "E4M3";
+    case DATA_TYPE_E5M2:
+      return "E5M2";
+    case DATA_TYPE_E2M1:
+      return "E2M1";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 // Type trait to map types to enum values
 template <typename T>
 struct TypeToDataType {


### PR DESCRIPTION
This is meant to help debugging the lookup/launch sequence for these kernels.

New log will look like this:
```
[DEBUG] Loading new kernel for dtypeQ=FP16, dtypeKv=FP16, dtypeOut=FP16, sm=100 with 18 loaded kernels
[DEBUG] Searching for kernel traits (18 available) in TllmGenFmhaKernel(FP16, FP16, FP16, 100) qkvLayout=2, maskType=0, kernelType=2, tileScheduler=0, multiCtasKvMode=1, headDimPerCtaV=128, headDimQk=128, headDimV=128, tileSizeKv=128, numTokensPerPage=16, maxNumHeadsQPerKvInCta=8, reuseSmemKForV=0, uses2CtaMma=0
...
[DEBUG] TRTLLM-Gen launch info (in TllmGenFmhaKernel FP16, FP16, FP16, 100): kernelName = fmhaSm100Kernel_QFp16KvFp16AccFp32OFp16HQk128HV128LayoutPagedKvMaskDenseP16VarSeqLenTileSizeQ8TileSizeKv128PersistentSwapsMmaAbForGeneration
```
