### PR TITLE
Fix missing symbols in trtllm_utils.so

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -31,7 +31,7 @@ from .page import gen_page_module
 from .quantization import gen_quantization_module
 from .rope import gen_rope_module
 from .sampling import gen_sampling_module
-from .utils import version_at_least
+from .utils import get_trtllm_utils_spec, version_at_least
 
 
 def gen_fa2(
@@ -537,38 +537,7 @@ def main():
         )
     ]
     if has_sm90:
-        jit_specs.append(
-            gen_jit_spec(
-                "trtllm_utils",
-                [
-                    jit_env.FLASHINFER_CSRC_DIR
-                    / "nv_internal"
-                    / "tensorrt_llm"
-                    / "kernels"
-                    / "delayStream.cu",
-                ],
-                extra_include_paths=[
-                    jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
-                    jit_env.FLASHINFER_CSRC_DIR / "nv_internal" / "include",
-                    jit_env.FLASHINFER_CSRC_DIR
-                    / "nv_internal"
-                    / "tensorrt_llm"
-                    / "cutlass_extensions"
-                    / "include",
-                    jit_env.FLASHINFER_CSRC_DIR
-                    / "nv_internal"
-                    / "tensorrt_llm"
-                    / "kernels"
-                    / "internal_cutlass_kernels"
-                    / "include",
-                    jit_env.FLASHINFER_CSRC_DIR
-                    / "nv_internal"
-                    / "tensorrt_llm"
-                    / "kernels"
-                    / "internal_cutlass_kernels",
-                ],
-            ),
-        )
+        jit_specs.append(get_trtllm_utils_spec())
     jit_specs += gen_all_modules(
         f16_dtype_,
         f8_dtype_,

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -31,7 +31,8 @@ from .page import gen_page_module
 from .quantization import gen_quantization_module
 from .rope import gen_rope_module
 from .sampling import gen_sampling_module
-from .utils import get_trtllm_utils_spec, version_at_least
+from .tllm_utils import get_trtllm_utils_spec
+from .utils import version_at_least
 
 
 def gen_fa2(

--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -11,7 +11,7 @@ import torch
 
 # from tensorrt_llm.bindings.internal.runtime import delay_kernel
 # from tensorrt_llm.logger import logger
-from flashinfer.utils import delay_kernel
+from flashinfer.tllm_utils import delay_kernel
 
 from .jit.core import logger
 

--- a/flashinfer/tllm_utils.py
+++ b/flashinfer/tllm_utils.py
@@ -1,0 +1,47 @@
+import functools
+
+from .jit import env as jit_env
+from .jit import gen_jit_spec
+
+
+def get_trtllm_utils_spec():
+    return gen_jit_spec(
+        "trtllm_utils",
+        [
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal/tensorrt_llm/kernels/delayStream.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/envUtils.cpp",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/logger.cpp",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/stringUtils.cpp",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/tllmException.cpp",
+        ],
+        extra_include_paths=[
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal" / "include",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal"
+            / "tensorrt_llm"
+            / "cutlass_extensions"
+            / "include",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal"
+            / "tensorrt_llm"
+            / "kernels"
+            / "internal_cutlass_kernels"
+            / "include",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal"
+            / "tensorrt_llm"
+            / "kernels"
+            / "internal_cutlass_kernels",
+        ],
+    )
+
+
+@functools.cache
+def get_trtllm_utils_module():
+    return get_trtllm_utils_spec().build_and_load()
+
+
+def delay_kernel(stream_delay_micro_secs):
+    get_trtllm_utils_module().delay_kernel(stream_delay_micro_secs)

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import functools
 import math
 import os
 from enum import Enum
@@ -24,9 +23,6 @@ import torch
 import torch.version
 from torch.torch_version import TorchVersion
 from torch.torch_version import __version__ as torch_version
-
-from .jit import env as jit_env
-from .jit import gen_jit_spec
 
 IS_BUILDING_DOCS = os.environ.get("FLASHINFER_BUILDING_DOCS") == "1"
 
@@ -469,49 +465,6 @@ log_level_map = {
 
 def set_log_level(lvl_str: str) -> None:
     get_logging_module().set_log_level(log_level_map[lvl_str].value)
-
-
-def get_trtllm_utils_spec():
-    return gen_jit_spec(
-        "trtllm_utils",
-        [
-            jit_env.FLASHINFER_CSRC_DIR
-            / "nv_internal/tensorrt_llm/kernels/delayStream.cu",
-            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/envUtils.cpp",
-            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/logger.cpp",
-            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/stringUtils.cpp",
-            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/tllmException.cpp",
-        ],
-        extra_include_paths=[
-            jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
-            jit_env.FLASHINFER_CSRC_DIR / "nv_internal" / "include",
-            jit_env.FLASHINFER_CSRC_DIR
-            / "nv_internal"
-            / "tensorrt_llm"
-            / "cutlass_extensions"
-            / "include",
-            jit_env.FLASHINFER_CSRC_DIR
-            / "nv_internal"
-            / "tensorrt_llm"
-            / "kernels"
-            / "internal_cutlass_kernels"
-            / "include",
-            jit_env.FLASHINFER_CSRC_DIR
-            / "nv_internal"
-            / "tensorrt_llm"
-            / "kernels"
-            / "internal_cutlass_kernels",
-        ],
-    )
-
-
-@functools.cache
-def get_trtllm_utils_module():
-    return get_trtllm_utils_spec().build_and_load()
-
-
-def delay_kernel(stream_delay_micro_secs):
-    get_trtllm_utils_module().delay_kernel(stream_delay_micro_secs)
 
 
 def device_support_pdl(device: torch.device) -> bool:

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -471,13 +471,16 @@ def set_log_level(lvl_str: str) -> None:
     get_logging_module().set_log_level(log_level_map[lvl_str].value)
 
 
-@functools.cache
-def get_trtllm_utils_module():
+def get_trtllm_utils_spec():
     return gen_jit_spec(
         "trtllm_utils",
         [
             jit_env.FLASHINFER_CSRC_DIR
             / "nv_internal/tensorrt_llm/kernels/delayStream.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/envUtils.cpp",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/logger.cpp",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/stringUtils.cpp",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/tllmException.cpp",
         ],
         extra_include_paths=[
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
@@ -499,7 +502,12 @@ def get_trtllm_utils_module():
             / "kernels"
             / "internal_cutlass_kernels",
         ],
-    ).build_and_load()
+    )
+
+
+@functools.cache
+def get_trtllm_utils_module():
+    return get_trtllm_utils_spec().build_and_load()
 
 
 def delay_kernel(stream_delay_micro_secs):


### PR DESCRIPTION
## 📌 Description

The `trtllm_utils` library also needs symbols from common files, e.g. the `llmException`. Extend the dependencies to link `trtllm_utils.so` with common helpers.

```python
>>> flashinfer.utils.get_trtllm_utils_module()
Traceback (most recent call last):
...
OSError: ...flashinfer/data/aot/trtllm_utils/trtllm_utils.so: undefined symbol: _ZTIN12tensorrt_llm6common13TllmExceptionE
```

## 🔍 Related Issues

Fixes: #1167

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
