### PR TITLE
feat: support green ctx creation by a list of SM counts

### DIFF
--- a/docs/api/green_ctx.rst
+++ b/docs/api/green_ctx.rst
@@ -5,4 +5,13 @@ flashinfer.green_ctx
 
 .. currentmodule:: flashinfer.green_ctx
 
-.. autofunction:: split_device_green_ctx
+This module provides utilities for creating CUDA green contexts.
+
+Green context creation
+----------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    split_device_green_ctx
+    split_device_green_ctx_by_sm_count

--- a/flashinfer/green_ctx.py
+++ b/flashinfer/green_ctx.py
@@ -246,7 +246,7 @@ def split_device_green_ctx_by_sm_count(
         )
         if sm_count <= 0:
             raise ValueError(f"SM count must be positive, got {sm_count}")
-        rounded_sm_counts.append(max(round_up(sm_count, sm_alignment), min_sm_count))
+        rounded_sm_counts.append(round_up(max(sm_count, min_sm_count), sm_alignment))
 
     # Split the device into multiple green contexts
     results, remaining = split_resource_by_sm_count(cu_dev, resource, rounded_sm_counts)

--- a/flashinfer/green_ctx.py
+++ b/flashinfer/green_ctx.py
@@ -246,7 +246,7 @@ def split_device_green_ctx_by_sm_count(
         )
         if sm_count <= 0:
             raise ValueError(f"SM count must be positive, got {sm_count}")
-        rounded_sm_counts.append(round_up(sm_count, sm_alignment, min_sm_count))
+        rounded_sm_counts.append(max(round_up(sm_count, sm_alignment), min_sm_count))
 
     # Split the device into multiple green contexts
     results, remaining = split_resource_by_sm_count(cu_dev, resource, rounded_sm_counts)

--- a/flashinfer/green_ctx.py
+++ b/flashinfer/green_ctx.py
@@ -23,7 +23,6 @@ from cuda.bindings.driver import CUdevice, CUdevResource
 
 from .cuda_utils import checkCudaErrors
 
-
 is_cuda_available = torch.cuda.is_available()
 if is_cuda_available:
     CUDA_CAPABILITY = torch.cuda.get_device_capability()
@@ -229,7 +228,7 @@ def split_device_green_ctx_by_sm_count(
         - Requested 10 SMs → Allocated 16 SMs (rounded up to multiple of 8)
         - Requested 16 SMs → Allocated 16 SMs (no rounding needed)
         - Requested 17 SMs → Allocated 24 SMs (rounded up to multiple of 8)
-        
+
         See `CUDA Green Contexts <https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GREEN__CONTEXTS.html>`_
         for more details.
     """
@@ -242,7 +241,8 @@ def split_device_green_ctx_by_sm_count(
         if sm_counts[i] <= 0:
             raise ValueError(f"SM count must be positive, got {sm_counts[i]}")
         sm_counts[i] = max(
-            min_sm_count, (sm_counts[i] + sm_alignment - 1) // sm_alignment * sm_alignment
+            min_sm_count,
+            (sm_counts[i] + sm_alignment - 1) // sm_alignment * sm_alignment,
         )
 
     # Split the device into multiple green contexts

--- a/flashinfer/green_ctx.py
+++ b/flashinfer/green_ctx.py
@@ -236,17 +236,20 @@ def split_device_green_ctx_by_sm_count(
     resource = get_device_resource(cu_dev)
 
     # Round sm counts to meet the alignment and granularity requirements
-    for i in range(len(sm_counts)):
+    rounded_sm_counts = []
+    for sm_count in sm_counts:
         min_sm_count, sm_alignment = get_sm_count_constraint(CUDA_CAPABILITY)
-        if sm_counts[i] <= 0:
-            raise ValueError(f"SM count must be positive, got {sm_counts[i]}")
-        sm_counts[i] = max(
-            min_sm_count,
-            (sm_counts[i] + sm_alignment - 1) // sm_alignment * sm_alignment,
+        if sm_count <= 0:
+            raise ValueError(f"SM count must be positive, got {sm_count}")
+        rounded_sm_counts.append(
+            max(
+                min_sm_count,
+                (sm_count + sm_alignment - 1) // sm_alignment * sm_alignment,
+            )
         )
 
     # Split the device into multiple green contexts
-    results, remaining = split_resource_by_sm_count(cu_dev, resource, sm_counts)
+    results, remaining = split_resource_by_sm_count(cu_dev, resource, rounded_sm_counts)
     resources = results + [remaining]
     streams = create_green_ctx_streams(cu_dev, resources)
     return streams, resources

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -470,3 +470,8 @@ def set_log_level(lvl_str: str) -> None:
 def device_support_pdl(device: torch.device) -> bool:
     major, _ = get_compute_capability(device)
     return major >= 9
+
+
+def round_up(x: int, y: int, min_value: int = 0) -> int:
+    """Round up x to the nearest multiple of y, with a minimum value of min_value."""
+    return (max(min_value, x) + y - 1) // y * y

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -472,6 +472,6 @@ def device_support_pdl(device: torch.device) -> bool:
     return major >= 9
 
 
-def round_up(x: int, y: int, min_value: int = 0) -> int:
-    """Round up x to the nearest multiple of y, with a minimum value of min_value."""
-    return (max(min_value, x) + y - 1) // y * y
+def round_up(x: int, y: int) -> int:
+    """Round up x to the nearest multiple of y"""
+    return (x + y - 1) // y * y

--- a/tests/test_green_ctx.py
+++ b/tests/test_green_ctx.py
@@ -122,7 +122,7 @@ def test_split_device_green_ctx_by_sm_count_alignment(
         assert sm_count > 0
 
         min_sm_count, sm_alignment = green_ctx.get_sm_count_constraint(
-            green_ctx.CUDA_CAPABILITY
+            *green_ctx.get_compute_capability(torch.device(device))
         )
         assert sm_count >= min_sm_count
         assert sm_count % sm_alignment == 0

--- a/tests/test_green_ctx.py
+++ b/tests/test_green_ctx.py
@@ -43,3 +43,86 @@ def test_green_ctx_kernel_execution(
             y = torch.randn(8192, 8192, device=device, dtype=torch.bfloat16)
             z = x @ y
             print(z.shape)
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.parametrize(
+    "sm_counts",
+    [
+        [16, 16, 16],
+        [8, 16, 24],
+        [32],
+        [8, 8, 8, 8],
+    ],
+)
+def test_split_device_green_ctx_by_sm_count_creation(
+    device: str,
+    sm_counts: list,
+):
+    streams, resources = green_ctx.split_device_green_ctx_by_sm_count(
+        torch.device(device), sm_counts
+    )
+    num_partitions = len(sm_counts) + 1
+    assert len(resources) == num_partitions
+    assert len(streams) == num_partitions
+
+    # Check that each partition has the expected SM count
+    for i, expected_sm_count in enumerate(sm_counts):
+        actual_sm_count = resources[i].sm.smCount
+        assert actual_sm_count >= expected_sm_count
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.parametrize(
+    "sm_counts",
+    [
+        [16, 16, 16],
+        [8, 16, 24],
+        [32],
+    ],
+)
+def test_split_device_green_ctx_by_sm_count_kernel_execution(
+    device: str,
+    sm_counts: list,
+):
+    streams, resources = green_ctx.split_device_green_ctx_by_sm_count(
+        torch.device(device), sm_counts
+    )
+    num_partitions = len(sm_counts) + 1
+    assert len(streams) == num_partitions
+    assert len(resources) == num_partitions
+
+    for i, stream in enumerate(streams):
+        with torch.cuda.stream(stream):
+            x = torch.randn(4096, 4096, device=device, dtype=torch.bfloat16)
+            y = torch.randn(4096, 4096, device=device, dtype=torch.bfloat16)
+            z = x @ y
+            print(f"Partition {i}: {z.shape}")
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.parametrize(
+    "sm_counts",
+    [
+        [1, 2, 3, 4],  # Should be aligned to minimum requirements
+        [7, 8, 9, 10],  # Should be aligned to 8 for compute capability 9+
+        [15, 16, 17, 18],  # Should be aligned to 8 for compute capability 9+
+    ],
+)
+def test_split_device_green_ctx_by_sm_count_alignment(
+    device: str,
+    sm_counts: list,
+):
+    _, resources = green_ctx.split_device_green_ctx_by_sm_count(
+        torch.device(device), sm_counts
+    )
+
+    for resource in resources[:-1]:  # Exclude remaining SMs
+        sm_count = resource.sm.smCount
+        assert sm_count > 0
+
+        min_sm_count, sm_alignment = green_ctx.get_sm_count_constraint(
+            green_ctx.CUDA_CAPABILITY
+        )
+        assert sm_count >= min_sm_count
+        assert sm_count % sm_alignment == 0


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Add `split_device_green_ctx_by_sm_count` to create green context by a list of SM count.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

cc @yzh119 
