### PR TITLE
[feat] optimize persistent batch attention perf.

### DIFF
--- a/csrc/batch_attention.cu
+++ b/csrc/batch_attention.cu
@@ -68,7 +68,8 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
                             at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o,
                             std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
-                            int64_t page_size, double sm_scale ADDITIONAL_FUNC_PARAMS) {
+                            int64_t page_size,
+                            double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS) {
   HolisticPlanInfo<2> plan_info;
   plan_info.FromVector(tensor_to_vec(plan_info_vec));
 
@@ -172,6 +173,7 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
           params[i].sm_scale = sm_scale;
 
           ADDITIONAL_PARAMS_SETTER
+          PROFILER_PARAMS_SETTER
         }
 
         cudaError_t status = BatchPagedAttentionPersistent<128, 16, HEAD_DIM_QK, HEAD_DIM_VO,

--- a/csrc/batch_attention_customize_config.jinja
+++ b/csrc/batch_attention_customize_config.jinja
@@ -13,6 +13,13 @@ using namespace flashinfer;
 #define ADDITIONAL_FUNC_PARAMS {{ additional_func_params }}
 #define ADDITIONAL_PARAMS_SETTER {{ additional_params_setter }}
 
+#ifdef FLASHINFER_ENABLE_PROFILER
+#define PROFILER_PARAMS_SETTER \
+  params[i].profiler_buffer = static_cast<uint64_t*>(profiler_buffer.data_ptr());
+#else
+#define PROFILER_PARAMS_SETTER
+#endif
+
 {{ variant_decl }}
 
 struct StandardAttention : AttentionVariantBase {

--- a/csrc/batch_attention_jit_pybind.cu
+++ b/csrc/batch_attention_jit_pybind.cu
@@ -28,7 +28,8 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
                             at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o,
                             std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
-                            int64_t page_size, double sm_scale ADDITIONAL_FUNC_PARAMS);
+                            int64_t page_size,
+                            double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("plan", &BatchPagedAttentionPlan);

--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -86,6 +86,7 @@ class BatchAttention:
             head_dim_qk,
             head_dim_vo,
             PosEncodingMode["NONE"].value,
+            use_profiler,  # different compiler path
         )
         self.module = get_holistic_attention_module(*get_module_args)
 
@@ -146,6 +147,9 @@ class BatchAttention:
         if self._sm_scale is None:
             self._sm_scale = 1.0 / math.sqrt(head_dim_qk)
 
+        # profiler_buffer is optional
+        profiler_args = (profiler_buffer,) if self._use_profiler else ()
+
         self.module.run(
             self.float_workspace_buffer,
             self.int_workspace_buffer,
@@ -162,6 +166,7 @@ class BatchAttention:
             self._num_kv_heads,
             self._page_size,
             self._sm_scale,
+            *profiler_args,
         )
 
         return out, lse

--- a/profiler/batch_attention.py
+++ b/profiler/batch_attention.py
@@ -1,0 +1,217 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+
+import torch
+
+import flashinfer
+from flashinfer.profiler import export_to_perfetto_trace
+
+
+def profile_persistent_batch_attention(
+    kv_lens,
+    qo_lens,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    layout,
+    test_dtype,
+    causal,
+    profiler_buffer_size,
+    device="cuda",
+):
+    seq_lens = torch.tensor(kv_lens, dtype=torch.int32)
+    q_lens = torch.tensor(qo_lens, dtype=torch.int32)
+
+    seq_lens_blocks = torch.ceil(seq_lens / page_size).int()
+
+    q_indptr = torch.cat([torch.tensor([0]), torch.cumsum(q_lens, 0)], dim=0).int()
+    kv_indptr = torch.cat(
+        [torch.tensor([0]), torch.cumsum(seq_lens_blocks, 0)], dim=0
+    ).int()
+
+    num_blocks = kv_indptr[-1].item()
+
+    q = torch.rand(
+        q_indptr[-1].item(), num_qo_heads, head_dim, device=device, dtype=test_dtype
+    )
+    if layout == "NHD":
+        kv_data = torch.randn(
+            num_blocks,
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            dtype=test_dtype,
+            device=device,
+        )
+    elif layout == "HND":
+        kv_data = torch.randn(
+            num_blocks,
+            2,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            dtype=test_dtype,
+            device=device,
+        )
+
+    wrapper = flashinfer.BatchAttention(kv_layout=layout)
+    wrapper.plan(
+        q_indptr.to(device),
+        kv_indptr.to(device),
+        torch.arange(num_blocks).int().to(device),
+        seq_lens.to(device),
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=test_dtype,
+        kv_data_type=test_dtype,
+        use_profiler=True,
+    )
+
+    profiler_buffer = torch.zeros(
+        (profiler_buffer_size,), dtype=torch.uint64, device=device
+    )
+
+    # warmup
+    wrapper.run(q, kv_data, profiler_buffer=profiler_buffer)
+    profiler_buffer.zero_()
+
+    wrapper.run(q, kv_data, profiler_buffer=profiler_buffer)
+
+    trace_name = f"batch_attention.perfetto-trace"
+    events = ["prefill", "decode", "reduction"]
+    export_to_perfetto_trace(profiler_buffer, events, trace_name)
+
+    print(f"Profile trace exported to {trace_name}")
+
+
+def persistent_batch_attention(
+    kv_lens,
+    qo_lens,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    layout,
+    test_dtype,
+    causal,
+    device="cuda",
+):
+    seq_lens = torch.tensor(kv_lens, dtype=torch.int32)
+    q_lens = torch.tensor(qo_lens, dtype=torch.int32)
+
+    seq_lens_blocks = torch.ceil(seq_lens / page_size).int()
+
+    q_indptr = torch.cat([torch.tensor([0]), torch.cumsum(q_lens, 0)], dim=0).int()
+    kv_indptr = torch.cat(
+        [torch.tensor([0]), torch.cumsum(seq_lens_blocks, 0)], dim=0
+    ).int()
+
+    num_blocks = kv_indptr[-1].item()
+
+    q = torch.rand(
+        q_indptr[-1].item(), num_qo_heads, head_dim, device=device, dtype=test_dtype
+    )
+    if layout == "NHD":
+        kv_data = torch.randn(
+            num_blocks,
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            dtype=test_dtype,
+            device=device,
+        )
+    elif layout == "HND":
+        kv_data = torch.randn(
+            num_blocks,
+            2,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            dtype=test_dtype,
+            device=device,
+        )
+
+    wrapper = flashinfer.BatchAttention(kv_layout=layout)
+    wrapper.plan(
+        q_indptr.to(device),
+        kv_indptr.to(device),
+        torch.arange(num_blocks).int().to(device),
+        seq_lens.to(device),
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=test_dtype,
+        kv_data_type=test_dtype,
+    )
+    wrapper.run(q, kv_data)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profiler-buffer-size", type=int, default=1048576)
+    parser.add_argument("--use-profiler", action="store_true")
+    args = parser.parse_args()
+
+    seq_len_config = [(600, 1)] * 122 + [(10000, 17)] * 8
+
+    kv_lens = [p[0] for p in seq_len_config]
+    qo_lens = [p[1] for p in seq_len_config]
+
+    page_size = 1
+    num_kv_heads = 4
+    num_qo_heads = 28
+    head_dim = 128
+    layout = "NHD"
+    test_dtype = torch.bfloat16
+    causal = True
+
+    if args.use_profiler:
+        profile_persistent_batch_attention(
+            kv_lens=kv_lens,
+            qo_lens=qo_lens,
+            profiler_buffer_size=args.profiler_buffer_size,
+            page_size=page_size,
+            num_kv_heads=num_kv_heads,
+            num_qo_heads=num_qo_heads,
+            head_dim=head_dim,
+            layout=layout,
+            test_dtype=test_dtype,
+            causal=causal,
+        )
+    else:
+        persistent_batch_attention(
+            kv_lens=kv_lens,
+            qo_lens=qo_lens,
+            page_size=page_size,
+            num_kv_heads=num_kv_heads,
+            num_qo_heads=num_qo_heads,
+            head_dim=head_dim,
+            layout=layout,
+            test_dtype=test_dtype,
+            causal=causal,
+        )

--- a/tests/test_batch_attention.py
+++ b/tests/test_batch_attention.py
@@ -1,4 +1,19 @@
-# test_flashinfer_attention.py
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import numpy as np
 import pytest
 import torch


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
This is a follow-up PR on https://github.com/flashinfer-ai/flashinfer/pull/1137, optimizing scheduling balance & reduction overhead, and achieving 2x speedup. Optimization includes:
1. Conduct fewer kv-split on decode requests. This reduces the number of reduction operations needed.
2. Write-through. Attention without kv-split is directly written back into the final buffer without additional copy.
3. Warp-level reduction. Changing CTA-wise reduction into warp-wise reduction increase parallelism, greatly reducing the reduction overhead.

This PR also investigates _**fine-grained gmem barrier**_ as discussed in https://github.com/flashinfer-ai/flashinfer/pull/1137. However, due to the overhead of memory ordering operations, we do not see performance gain on our usecases (static scheduling), thus leaving for future work. Implementations are available in a separate fork (https://github.com/happierpig/flashinfer-ai/tree/fine-grained-barrier-reduction). Visualization: 
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/27ebc173-6ef6-4b21-9277-3793e270c9f6" />

Perf benchmarks (`benchmarks/bench_batch_attention.py`) on `head_dim=128, num_qo_heads=28, num_kv_heads=4, page_size=1` with H200.
<img width="609" alt="image" src="https://github.com/user-attachments/assets/361d8c43-3fb6-431b-bf9e-2bf3a7a0df87" />


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes
cc @yzh119 @yyihuang 
<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
