### PR TITLE
[fix] fix BatchAttention CTA_TILE_KV mask issue

### DIFF
--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -39,6 +39,7 @@ class BatchAttention:
     def __init__(
         self,
         kv_layout: str = "NHD",
+        device: str = "cuda",
     ):
         _check_kv_layout(kv_layout)
         self._kv_layout = kv_layout
@@ -46,12 +47,12 @@ class BatchAttention:
         self.float_workspace_buffer = torch.empty(
             256 * 1024 * 1024,
             dtype=torch.uint8,
-            device=torch.device("cuda"),
+            device=torch.device(device),
         )
         self.int_workspace_buffer = torch.empty(
             8 * 1024 * 1024,
             dtype=torch.uint8,
-            device=torch.device("cuda"),
+            device=torch.device(device),
         )
         self.page_locked_int_workspace_buffer = torch.empty(
             8 * 1024 * 1024,

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -1133,14 +1133,10 @@ inline cudaError_t TwoStageHolisticPlan(void* float_buffer, size_t float_workspa
   plan_info.num_blks_y = num_clusters;
 
   auto f = [](int x) {
-    if (x <= 8) {
-      return 32;
-    } else if (x <= 16) {
-      return 64;
-    } else if (x <= 32) {
+    if (x <= 128) {
+      // This aligns with CTA_TILE_KV in persistent mainloop
+      // NOTE (Yilong): Optimize here for smaller batch/seqlen scenarios
       return 128;
-    } else if (x <= 64) {
-      return 192;
     }
     return ceil_div(x, 256) * 256;
   };

--- a/tests/test_batch_attention.py
+++ b/tests/test_batch_attention.py
@@ -31,6 +31,9 @@ def _build_seq_len_configs():
     torch.manual_seed(42)
 
     seq_len_configs = [
+        [(67, 1)],
+        [(182, 1)],
+        [(2011, 1)],
         [(2048, 1)] * 77,  # decode-only
         [(4099, 129)] * 2,  # prefill-only
         [(600, 1)] * 132 * 2 + [(5000, 3)] * 128,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
The mismatch between `kv_chunk_size` and `CTA_TILE_KV` could lead to unmask `nan` value during small batch inference. This PR enforces `kv_chunk_size` to be multiple times of `CTA_TILE_KV` to avoid this case.
## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
