### PR TITLE
Fix the issue with auxillary kernel launch and grid dim calculation

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -100,10 +100,9 @@ def cudnn_batch_prefill_with_kv_cache(
         out_shape = (q.shape[0], h_qo, d_vo)
         out = torch.empty(out_shape, device=q.device, dtype=q.dtype)
 
-    if actual_seq_lens_q.is_cuda == False:
-        actual_seq_lens_q_gpu = actual_seq_lens_q.to(q.device)
-    if actual_seq_lens_kv.is_cuda == False:
-        actual_seq_lens_kv_gpu = actual_seq_lens_kv.to(q.device)
+    actual_seq_lens_q_gpu = actual_seq_lens_q.to(q.device, non_blocking=True)
+
+    actual_seq_lens_kv_gpu = actual_seq_lens_kv.to(q.device, non_blocking=True)
 
     run_func = get_cudnn_fmha_gen_module().prefill
     run_func(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- Fixes an issue where the auxillary kernel launch was incorrect causing kernel hangs in some cases. 
- Also, fixes the grid dim calculation

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

-  x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ x] Tests have been added or updated as needed.
- [x ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
