### PR TITLE
[TVM] Remove `enable_pdl` from TVM binding interface

### DIFF
--- a/tvm_binding/batch_decode.cu
+++ b/tvm_binding/batch_decode.cu
@@ -87,7 +87,7 @@ void BatchDecodeWithPagedKVCacheRun(
     DLTensor* q, DLTensor* paged_kv_cache, DLTensor* paged_kv_indptr, DLTensor* paged_kv_indices,
     DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset, DLTensor* paged_kv_rope_pos_offset,
     DLTensor* o, DLTensor* lse, int64_t pos_encoding_mode_code, int64_t kv_layout_code,
-    int64_t window_left, bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
+    int64_t window_left ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
   DecodePlanInfo plan_info;
   std::vector<int64_t> plan_info_vec_(plan_info_vec->data,
                                       plan_info_vec->data + plan_info_vec->size);
@@ -209,7 +209,7 @@ void BatchDecodeWithPagedKVCacheRun(
         cudaError_t status =
             flashinfer::BatchDecodeWithPagedKVCacheDispatched<HEAD_DIM_QK, POS_ENCODING_MODE,
                                                               AttentionVariant>(
-                params, tmp_v, tmp_s, enable_pdl, stream);
+                params, tmp_v, tmp_s, /*enable_pdl=*/false, stream);
         CHECK(status == cudaSuccess)
             << "BatchDecodeWithPagedKVCache failed with error " << cudaGetErrorString(status);
         return true;

--- a/tvm_binding/batch_decode_jit_tvm_binding.cu
+++ b/tvm_binding/batch_decode_jit_tvm_binding.cu
@@ -28,7 +28,7 @@ void BatchDecodeWithPagedKVCacheRun(
     DLTensor* q, DLTensor* paged_kv_cache, DLTensor* paged_kv_indptr, DLTensor* paged_kv_indices,
     DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset, DLTensor* paged_kv_rope_pos_offset,
     DLTensor* o, DLTensor* lse, int64_t pos_encoding_mode_code, int64_t kv_layout_code,
-    int64_t window_left, bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
+    int64_t window_left ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(batch_decode_with_paged_kv_cache_plan,
                               BatchDecodeWithPagedKVCachePlan);

--- a/tvm_binding/batch_prefill.cu
+++ b/tvm_binding/batch_prefill.cu
@@ -75,12 +75,14 @@ IntTuple BatchPrefillWithKVCachePlan(
   return IntTuple{plan_info_vec.begin(), plan_info_vec.end()};
 }
 
-void BatchPrefillWithRaggedKVCacheRun(
-    DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
-    DLTensor* q, DLTensor* k, DLTensor* v, DLTensor* qo_indptr, DLTensor* kv_indptr,
-    DLTensor* q_rope_offset, DLTensor* k_rope_offset, DLTensor* o, DLTensor* lse,
-    int64_t mask_mode_code, int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
+void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
+                                      DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
+                                      DLTensor* q, DLTensor* k, DLTensor* v, DLTensor* qo_indptr,
+                                      DLTensor* kv_indptr, DLTensor* q_rope_offset,
+                                      DLTensor* k_rope_offset, DLTensor* o, DLTensor* lse,
+                                      int64_t mask_mode_code, int64_t pos_encoding_mode_code,
+                                      int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
+                                      TVMStreamHandle cuda_stream) {
   PrefillPlanInfo plan_info;
   std::vector<int64_t> plan_info_vec_(plan_info_vec->data,
                                       plan_info_vec->data + plan_info_vec->size);
@@ -212,7 +214,7 @@ void BatchPrefillWithRaggedKVCacheRun(
           status = flashinfer::BatchPrefillWithRaggedKVCacheDispatched<
               CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
               /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant,
-              RaggedParams>(params, tmp_v, tmp_s, enable_pdl, stream);
+              RaggedParams>(params, tmp_v, tmp_s, /*enable_pdl=*/false, stream);
         });
 
         CHECK(status == cudaSuccess)
@@ -228,8 +230,8 @@ void BatchPrefillWithPagedKVCacheRun(DLTensor* float_workspace_buffer,
                                      DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset,
                                      DLTensor* paged_kv_rope_pos_offset, DLTensor* o, DLTensor* lse,
                                      int64_t mask_mode_code, int64_t pos_encoding_mode_code,
-                                     int64_t layout, int64_t window_left, bool enable_pdl,
-                                     ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
+                                     int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
+                                     TVMStreamHandle cuda_stream) {
   PrefillPlanInfo plan_info;
   std::vector<int64_t> plan_info_vec_(plan_info_vec->data,
                                       plan_info_vec->data + plan_info_vec->size);
@@ -371,7 +373,7 @@ void BatchPrefillWithPagedKVCacheRun(DLTensor* float_workspace_buffer,
           status = flashinfer::BatchPrefillWithPagedKVCacheDispatched<
               CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
               /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant,
-              PagedParams>(params, tmp_v, tmp_s, enable_pdl, stream);
+              PagedParams>(params, tmp_v, tmp_s, /*enable_pdl=*/false, stream);
         });
 
         CHECK(status == cudaSuccess)

--- a/tvm_binding/batch_prefill_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_jit_tvm_binding.cu
@@ -25,20 +25,24 @@ IntTuple BatchPrefillWithKVCachePlan(DLTensor* float_workspace_buffer,
                                      bool enable_cuda_graph, int64_t head_dim_qk,
                                      int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream);
 
-void BatchPrefillWithRaggedKVCacheRun(
-    DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
-    DLTensor* q, DLTensor* k, DLTensor* v, DLTensor* qo_indptr, DLTensor* kv_indptr,
-    DLTensor* q_rope_offset, DLTensor* k_rope_offset, DLTensor* o, DLTensor* lse,
-    int64_t mask_mode_code, int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
+void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
+                                      DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
+                                      DLTensor* q, DLTensor* k, DLTensor* v, DLTensor* qo_indptr,
+                                      DLTensor* kv_indptr, DLTensor* q_rope_offset,
+                                      DLTensor* k_rope_offset, DLTensor* o, DLTensor* lse,
+                                      int64_t mask_mode_code, int64_t pos_encoding_mode_code,
+                                      int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
+                                      TVMStreamHandle cuda_stream);
 
-void BatchPrefillWithPagedKVCacheRun(
-    DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
-    DLTensor* q, DLTensor* paged_kv_cache, DLTensor* qo_indptr, DLTensor* paged_kv_indptr,
-    DLTensor* paged_kv_indices, DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset,
-    DLTensor* paged_kv_rope_pos_offset, DLTensor* o, DLTensor* lse, int64_t mask_mode_code,
-    int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
+void BatchPrefillWithPagedKVCacheRun(DLTensor* float_workspace_buffer,
+                                     DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
+                                     DLTensor* q, DLTensor* paged_kv_cache, DLTensor* qo_indptr,
+                                     DLTensor* paged_kv_indptr, DLTensor* paged_kv_indices,
+                                     DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset,
+                                     DLTensor* paged_kv_rope_pos_offset, DLTensor* o, DLTensor* lse,
+                                     int64_t mask_mode_code, int64_t pos_encoding_mode_code,
+                                     int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
+                                     TVMStreamHandle cuda_stream);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(batch_prefill_with_kv_cache_plan, BatchPrefillWithKVCachePlan);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(batch_prefill_with_ragged_kv_cache_run,

--- a/tvm_binding/batch_prefill_sm90.cu
+++ b/tvm_binding/batch_prefill_sm90.cu
@@ -80,8 +80,8 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
     DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
     DLTensor* q, DLTensor* k, DLTensor* v, DLTensor* qo_indptr, DLTensor* kv_indptr,
     DLTensor* q_rope_offset, DLTensor* k_rope_offset, DLTensor* o, DLTensor* lse,
-    int64_t mask_mode_code, int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
+    int64_t mask_mode_code, int64_t pos_encoding_mode_code, int64_t layout,
+    int64_t window_left ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
   PrefillPlanSM90Info plan_info;
   std::vector<int64_t> plan_info_vec_(plan_info_vec->data,
                                       plan_info_vec->data + plan_info_vec->size);
@@ -184,7 +184,7 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
         DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
           cudaError_t status = BatchPrefillWithRaggedKVCacheDispatched<
               HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE, USE_SLIDING_WINDOW, SAME_SCHEDULER_FOR_ALL_HEADS,
-              AttentionVariant>(params, enable_pdl, stream);
+              AttentionVariant>(params, /*enable_pdl=*/false, stream);
           CHECK(status == cudaSuccess) << "BatchPrefillWithRaggedKVCacheSM90Run failed with error: "
                                        << cudaGetErrorString(status);
           return true;
@@ -197,8 +197,8 @@ void BatchPrefillWithPagedKVCacheSM90Run(
     DLTensor* q, DLTensor* paged_kv_cache, DLTensor* qo_indptr, DLTensor* paged_kv_indptr,
     DLTensor* paged_kv_indices, DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset,
     DLTensor* paged_kv_rope_pos_offset, DLTensor* o, DLTensor* lse, int64_t mask_mode_code,
-    int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream) {
+    int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
+    TVMStreamHandle cuda_stream) {
   PrefillPlanSM90Info plan_info;
   std::vector<int64_t> plan_info_vec_(plan_info_vec->data,
                                       plan_info_vec->data + plan_info_vec->size);

--- a/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
@@ -27,16 +27,16 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
     DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
     DLTensor* q, DLTensor* k, DLTensor* v, DLTensor* qo_indptr, DLTensor* kv_indptr,
     DLTensor* q_rope_offset, DLTensor* k_rope_offset, DLTensor* o, DLTensor* lse,
-    int64_t mask_mode_code, int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
+    int64_t mask_mode_code, int64_t pos_encoding_mode_code, int64_t layout,
+    int64_t window_left ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
 
 void BatchPrefillWithPagedKVCacheSM90Run(
     DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,
     DLTensor* q, DLTensor* paged_kv_cache, DLTensor* qo_indptr, DLTensor* paged_kv_indptr,
     DLTensor* paged_kv_indices, DLTensor* paged_kv_last_page_len, DLTensor* q_rope_offset,
     DLTensor* paged_kv_rope_pos_offset, DLTensor* o, DLTensor* lse, int64_t mask_mode_code,
-    int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left,
-    bool enable_pdl ADDITIONAL_FUNC_PARAMS, TVMStreamHandle cuda_stream);
+    int64_t pos_encoding_mode_code, int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS,
+    TVMStreamHandle cuda_stream);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(batch_prefill_with_kv_cache_plan, BatchPrefillWithKVCacheSM90Plan);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(batch_prefill_with_ragged_kv_cache_run,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

As of now PDL is not introduced in the TVM attention kernel interface, so we remove it from here and use false by default.


## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.


## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
