### PR TITLE
bugfix: Fix building without `get_requires*()` invocation

### DIFF
--- a/custom_backend.py
+++ b/custom_backend.py
@@ -2,7 +2,6 @@ import shutil
 from pathlib import Path
 
 from setuptools import build_meta as orig
-from setuptools.build_meta import *  # noqa: F403
 
 _root = Path(__file__).parent.resolve()
 _data_dir = _root / "flashinfer" / "data"
@@ -94,3 +93,18 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
 def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
     _prepare_for_editable()
     return orig.prepare_metadata_for_build_editable(metadata_directory, config_settings)
+
+
+def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    _prepare_for_editable()
+    return orig.build_editable(wheel_directory, config_settings, metadata_directory)
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    get_requires_for_build_sdist(config_settings)
+    return orig.build_wheel(sdist_directory, config_settings)
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    _prepare_for_wheel()
+    return orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/custom_backend.py
+++ b/custom_backend.py
@@ -102,7 +102,7 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
 def build_sdist(sdist_directory, config_settings=None):
     get_requires_for_build_sdist(config_settings)
-    return orig.build_wheel(sdist_directory, config_settings)
+    return orig.build_sdist(sdist_directory, config_settings)
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):

--- a/custom_backend.py
+++ b/custom_backend.py
@@ -62,12 +62,7 @@ def _prepare_for_editable():
     _aot_ops_package_dir.symlink_to(_aot_ops_dir)
 
 
-def get_requires_for_build_wheel(config_settings=None):
-    _prepare_for_wheel()
-    return _requires_for_aot
-
-
-def get_requires_for_build_sdist(config_settings=None):
+def _prepare_for_sdist():
     # Remove data directory
     if _data_dir.exists():
         shutil.rmtree(_data_dir)
@@ -77,6 +72,14 @@ def get_requires_for_build_sdist(config_settings=None):
     _aot_ops_package_dir.parent.mkdir(parents=True, exist_ok=True)
     _aot_ops_package_dir.mkdir(parents=True)
 
+
+def get_requires_for_build_wheel(config_settings=None):
+    _prepare_for_wheel()
+    return _requires_for_aot
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    _prepare_for_sdist()
     return []
 
 
@@ -101,7 +104,7 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
 
 def build_sdist(sdist_directory, config_settings=None):
-    get_requires_for_build_sdist(config_settings)
+    _prepare_for_sdist()
     return orig.build_sdist(sdist_directory, config_settings)
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add the remaining PEP 517 build hooks explicitly, and ensure that they perform the required setup, in order to fix building when the build backend does not query the build dependencies.  For example, this can happen when using:

```
$ python -m build -wn --skip-de
* Building wheel...
running bdist_wheel
[...]
error: package directory 'build/aot-ops-package-dir' does not exist

ERROR Backend subprocess exited when trying to invoke build_wheel
```

Since PEP 517 does not require calling `get_requires*()` hook, and the build backend can invoke `build_*()` immediately instead, override it as well.


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
Unclear if I'm supposed to check test-related checkboxes if I'm not touching any installed code.