### PR TITLE
bugfix: fix cudnn decode attention APIs

### DIFF
--- a/flashinfer/cudnn/decode.py
+++ b/flashinfer/cudnn/decode.py
@@ -12,17 +12,9 @@ def cudnn_batch_decode_with_kv_cache(
     v_cache: torch.Tensor,
     scale: float,
     workspace_buffer: torch.Tensor,
-    *,
-    max_token_per_sequence: Optional[int] = 1,
-    max_sequence_kv: int,
-    actual_seq_lens_q: Optional[torch.Tensor] = None,
     actual_seq_lens_kv: torch.Tensor,
     block_tables: torch.Tensor,
     is_cuda_graph_compatible: bool = False,
-    batch_offsets_q: Optional[torch.Tensor] = None,
-    batch_offsets_o: Optional[torch.Tensor] = None,
-    batch_offsets_k: Optional[torch.Tensor] = None,
-    batch_offsets_v: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Performs batched decode attention with paged KV cache using cuDNN.
@@ -33,31 +25,20 @@ def cudnn_batch_decode_with_kv_cache(
         v_cache: Value cache tensor of shape (total_num_pages, num_heads_kv, page_size, head_dim)
         scale: Scaling factor for attention scores, typically 1/sqrt(head_dim)
         workspace_buffer: Workspace buffer for cuDNN operations. Scales with batch size. 128 MB should be sufficient for most cases
-        max_token_per_sequence: Maximum number of tokens per query sequence (s_qo_max)
-        max_sequence_kv: Maximum number of tokens per key/value sequence (s_kv_max)
-        actual_seq_lens_q:  Actual number of tokens per query sequence shape (batch_size,) on cpu or device (cpu if cuda_graph is False)
         actual_seq_lens_kv: Actual sequence lengths for key/values per batch, shape (batch_size,) on CPU
         block_tables: Page table mapping for KV cache, shape (batch_size, num_pages_per_seq) on GPU
         is_cuda_graph_compatible: Whether the decode operation is compatible with CUDA graph
-        batch_offsets: Optional batch offsets tensor of shape (batch_size,) on GPU
         out: Optional pre-allocated output tensor
-        lse: Optional pre-allocated tensor for log-sum-exp values if return_lse is True else returns None
-        batch_offsets_q: Optional batch offsets for query tensor of shape (batch_size,) on GPU
-        batch_offsets_o: Optional batch offsets for output tensor of shape (batch_size,) on GPU
-        batch_offsets_k: Optional batch offsets for key tensor of shape (batch_size,) on GPU
-        batch_offsets_v: Optional batch offsets for value tensor of shape (batch_size,) on GPU
 
     Returns:
         Output tensor of shape (batch_size, num_heads_qo, head_dim)
 
     Note:
-        Currently only supports causal attention (causal must be True)
         All tensors must be contiguous and on the same CUDA device
         Query and KV heads can have different sizes (num_heads_qo >= num_heads_kv)
     """
 
     bs = q.shape[0]
-    s_q = max_token_per_sequence
     h_qo = q.shape[1]
     d_vo = v_cache.shape[3]
 
@@ -77,7 +58,7 @@ def cudnn_batch_decode_with_kv_cache(
         actual_seq_lens_kv_gpu,
         block_tables,
         out,
-        batch_offsets_q,
+        None,  # batch_offsets_q
         is_cuda_graph_compatible,
     )
 

--- a/tests/test_cudnn_decode.py
+++ b/tests/test_cudnn_decode.py
@@ -104,7 +104,7 @@ def test_cudnn_decode(
         workspace_buffer,
         actual_seq_lens_kv,
         block_tables,
-        use_cuda_graph=use_cuda_graph,
+        is_cuda_graph_compatible=use_cuda_graph,
     )
 
     torch.cuda.synchronize()

--- a/tests/test_cudnn_decode.py
+++ b/tests/test_cudnn_decode.py
@@ -107,22 +107,7 @@ def test_cudnn_decode(
         is_cuda_graph_compatible=use_cuda_graph,
     )
 
-    torch.cuda.synchronize()
-
-    tokens_per_seq_device = torch.ones([batch_size], device=device)
-
     actual_seq_lens_kv_device = actual_seq_lens_kv.to(device)
-    qo_indptr = (
-        torch.cat(
-            [
-                torch.tensor([0], device=device),
-                torch.cumsum(tokens_per_seq_device.view(-1), dim=0),
-            ]
-        )
-        .int()
-        .to(device)
-    )
-
     kv_indptr = (
         torch.cat(
             [
@@ -177,7 +162,5 @@ def test_cudnn_decode(
     )
 
     output_ref = wrapper.run(q, kv_cache)
-
-    torch.cuda.synchronize()
 
     torch.testing.assert_close(output, output_ref, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

There are some redundant arguments in cudnn decode attention APIs of #1187, and a API mismatch in the test_cudnn_decode file: https://github.com/flashinfer-ai/flashinfer/blob/main/tests/test_cudnn_decode.py#L99-L108

This PR fixes these issues.

## 🔍 Related Issues

Build upon #1227 , will be rebased upon main once #1227 got merged.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @Anerudhan 
