### PR TITLE
fix: add trtllm-allreduce-fusion api notes and fix memory error

### DIFF
--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
@@ -541,7 +542,7 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
         else tp_size * max_token_num * hidden_dim * 4
     )
     if lamport_comm_size > MAX_COMM_SIZE:
-        print(
+        logging.warning(
             f"warning: lamport_comm_size {lamport_comm_size} is greater than MAX_COMM_SIZE {MAX_COMM_SIZE}, set to MAX_COMM_SIZE"
         )
         lamport_comm_size = MAX_COMM_SIZE

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -711,6 +711,17 @@ def trtllm_allreduce_fusion(
     scale_factor: Optional[float],
     layout_code: Optional[FP4QuantizationSFLayout],
 ) -> None:
+    """
+    Note:
+    use_oneshot should be only be enabled when
+    (1) prefer one-shot strategy than two-shot strategy
+    (2) in min-latency mode, sequence length < one-shot max token num (128 now)
+    Otherwise, use_oneshot should be disabled.
+    """
+    if not use_oneshot:
+        seq_len = allreduce_in.shape[0]
+        assert seq_len > world_size, "sequence length should be larger than tp_size"
+
     get_trtllm_comm_module().trtllm_allreduce_fusion(
         allreduce_in=allreduce_in,
         world_size=world_size,

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -713,14 +713,16 @@ def trtllm_allreduce_fusion(
 ) -> None:
     """
     Note:
-    use_oneshot should be only be enabled when
-    (1) prefer one-shot strategy than two-shot strategy
-    (2) in min-latency mode, sequence length < one-shot max token num (128 now)
-    Otherwise, use_oneshot should be disabled.
+    Regarding the `use_oneshot` parameter:
+
+    It should only be enabled when:
+    (1) Preferring the one-shot strategy over the two-shot strategy.
+    (2) In min-latency mode, the sequence length is less than the one-shot max token number (currently 128).
+
+    Otherwise, it should be disabled.
     """
     if not use_oneshot:
-        seq_len = allreduce_in.shape[0]
-        assert seq_len > world_size, "sequence length should be larger than tp_size"
+        assert token_num > world_size, "sequence length should be larger than tp_size"
 
     get_trtllm_comm_module().trtllm_allreduce_fusion(
         allreduce_in=allreduce_in,

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -547,13 +547,14 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     )
 
     # Initialize lamport buffer
+    aligned_lamport_buffer_size = ((lamport_buffer_size + (1 << 21) - 1) >> 21) << 21
     if use_fp32_lamport:
         trtllm_lamport_initialize(
-            ipc_handles[2][tp_rank], lamport_buffer_size // 4, torch.float32
+            ipc_handles[2][tp_rank], aligned_lamport_buffer_size // 4, torch.float32
         )
     else:
         trtllm_lamport_initialize(
-            ipc_handles[2][tp_rank], lamport_buffer_size // 2, torch.float16
+            ipc_handles[2][tp_rank], aligned_lamport_buffer_size // 2, torch.float16
         )
 
     # initialize workspace

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -785,8 +785,8 @@ struct LamportComm {
     int data_offset = flag_value % 3;
     int clear_offset = (flag_value + 2) % 3;
     for (int r = 0; r < NRanks; ++r) {
-      data_bufs[r] =
-          reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) + data_offset * comm_size;
+      data_bufs[r] = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) +
+                     static_cast<int64_t>(data_offset) * comm_size;
     }
     clear_buf = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + rank]) + clear_offset * comm_size;
     __syncthreads();

--- a/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
@@ -702,7 +702,7 @@ struct LamportComm {
     int clear_offset = (flag_value + 2) % 3;
     for (int r = 0; r < NRanks; ++r) {
       data_bufs[r] =
-          reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) + data_offset * comm_size;
+          reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) + static_cast<int64_t>(data_offset) * comm_size;
     }
     clear_buf = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + rank]) + clear_offset * comm_size;
     __syncthreads();

--- a/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
@@ -701,8 +701,8 @@ struct LamportComm {
     int data_offset = flag_value % 3;
     int clear_offset = (flag_value + 2) % 3;
     for (int r = 0; r < NRanks; ++r) {
-      data_bufs[r] =
-          reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) + static_cast<int64_t>(data_offset) * comm_size;
+      data_bufs[r] = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) +
+                     static_cast<int64_t>(data_offset) * comm_size;
     }
     clear_buf = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + rank]) + clear_offset * comm_size;
     __syncthreads();

--- a/tests/test_trtllm_allreduce_fusion.py
+++ b/tests/test_trtllm_allreduce_fusion.py
@@ -76,6 +76,8 @@ def _run_correctness_worker(world_size, rank, dtype, hidden_dim, distributed_ini
                         for use_oneshot in use_oneshots:
                             for trigger_completion_at_end in trigger_completion_at_ends:
                                 for fp32_acc in fp32_accs:
+                                    if token_num < world_size and not use_oneshot:
+                                        continue
                                     if dtype == torch.float32 and (
                                         pattern_code
                                         == comm.AllReduceFusionPattern.kARResidualRMSNormOutFP4Quant


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

We add some notes on each api to help integration to vllm/sgl.
And we try to fix the error in issues.

To avoid workspace size overflow, the max lamport communication size MAX_COMM_SIZE (computed as hidden * max_token) should be less than round_down(INT_32_MAX, 2MB). For any larger size, it would be rewritten to this value with a warning "warning: lamport_comm_size 2147483648 is greater than MAX_COMM_SIZE 2145386496, set to MAX_COMM_SIZE".

If the actual lamport communication size (computed as hidden * token_num) exceeds this MAX_COMM_SIZE, always set use_oneshot to be False.
Otherwise, you could set use_oneshot on your preference; and for the min-latency case, set it to be (token_num <= 128).


## 🔍 Related Issues

#1223 

https://github.com/sgl-project/sglang/pull/7621

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
