### PR TITLE
docker: add cuda-python to CI docker image

### DIFF
--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -20,4 +20,4 @@ set -e
 set -u
 
 pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-pip3 install ninja pytest numpy scipy build pynvml
+pip3 install ninja pytest numpy scipy build pynvml cuda-python einops


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

cuda-python is widely used for communication kernels and so on and should be part of our CI docker image.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
