### PR TITLE
bugfix: fix fp32 acc threshold for qk using math::inf according to dtype by AIDC-AI

### DIFF
--- a/include/flashinfer/attention/cascade.cuh
+++ b/include/flashinfer/attention/cascade.cuh
@@ -223,7 +223,7 @@ __global__ void MergeStatesKernel(DTypeIn* __restrict__ V, float* __restrict__ S
     v.fill(DTypeO(0.f));
     v.store(v_merged + (pos * num_heads + head_idx) * head_dim + tx * vec_size);
     if (s_merged != nullptr) {
-      s_merged[pos * num_heads + head_idx] = -math::inf;
+      s_merged[pos * num_heads + head_idx] = math::neg_inf<float>();
     }
     return;
   }
@@ -396,7 +396,7 @@ __global__ void PersistentVariableLengthMergeStatesKernel(
       v.fill(DTypeO(0.f));
       v.store(v_merged + (pos * num_heads + head_idx) * head_dim + tx * vec_size);
       if (s_merged != nullptr) {
-        s_merged[pos * num_heads + head_idx] = -math::inf;
+        s_merged[pos * num_heads + head_idx] = math::neg_inf<float>();
       }
       continue;
     }

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -96,7 +96,7 @@ __device__ __forceinline__ void compute_qk(
 
     bool mask = variant.LogitsMask(params, batch_idx, /*qo_idx=*/0, /*kv_idx=*/pos, qo_head_idx,
                                    kv_head_idx);
-    s[j] = (iter_base + tz * tile_size + j < iter_bound && mask) ? s[j] : -math::inf;
+    s[j] = (iter_base + tz * tile_size + j < iter_bound && mask) ? s[j] : math::neg_inf<float>();
     st.m = max(st.m, s[j]);
   }
 
@@ -854,7 +854,7 @@ __device__ __forceinline__ void compute_qk_and_update_local_stat_mla(
     for (uint32_t offset = bdx / 2; offset > 0; offset /= 2) {
       s[j] += math::shfl_xor_sync(s[j], offset);
     }
-    s[j] = (iter_base + tz * tile_size + j < iter_bound) ? s[j] : -math::inf;
+    s[j] = (iter_base + tz * tile_size + j < iter_bound) ? s[j] : math::neg_inf<float>();
     st.m = max(st.m, s[j]);
   }
 

--- a/include/flashinfer/attention/decode_mla_cute_sm80.cuh
+++ b/include/flashinfer/attention/decode_mla_cute_sm80.cuh
@@ -368,7 +368,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernelMlaCuteSM80(Params params) {
   }
 
   // start rolling update
-  float row_max = -flashinfer::math::inf;
+  float row_max = flashinfer::math::neg_inf<float>();
   float row_denom = 1.0;
   for (uint32_t iter = 0; iter < ceil_div(cur_chunk_len, k_kv_tile_len); ++iter) {
     if (tx < k_warp_rows * 32) {
@@ -412,7 +412,7 @@ __global__ void BatchDecodeWithPagedKVCacheKernelMlaCuteSM80(Params params) {
       float row_max_prev = row_max;
 #pragma unroll
       for (int i = 0; i < k_kv_tile_len; ++i) {
-        if (i >= valid_kv_len) smem_att(tx, i) = -flashinfer::math::inf;
+        if (i >= valid_kv_len) smem_att(tx, i) = flashinfer::math::neg_inf<float>();
         row_max = max(row_max, smem_att(tx, i));
       }
 

--- a/include/flashinfer/attention/hopper/attention_updater.cuh
+++ b/include/flashinfer/attention/hopper/attention_updater.cuh
@@ -165,7 +165,7 @@ struct DefaultUpdater {
 
 template <int NUM_ROWS_PER_THREAD, bool WITH_SCALE>
 struct OnlineSoftmax {
-  constexpr static float fill_value = -math::inf;
+  constexpr static float fill_value = std::numeric_limits<float>::lowest();
   using TensorT = decltype(make_tensor<float>(Shape<Int<NUM_ROWS_PER_THREAD>>{}));
   TensorT row_max, row_sum, scores_scale;
   float sm_scale_log2;

--- a/include/flashinfer/attention/hopper/epilogue.cuh
+++ b/include/flashinfer/attention/hopper/epilogue.cuh
@@ -248,7 +248,7 @@ struct CollectiveEpilogue {
     static_assert(CTA_Q <= NUM_MMA_THREADS);
     if (epilogue_params.lse_ptr) {  // don't write to LSE if it's nullptr
       if (thread_idx < qo_len - qo_tile_idx * CTA_Q) {
-        gLSE(thread_idx) = -math::inf;
+        gLSE(thread_idx) = math::neg_inf<float>();
       }
     }
   }

--- a/include/flashinfer/attention/hopper/quantization/epilogue.cuh
+++ b/include/flashinfer/attention/hopper/quantization/epilogue.cuh
@@ -205,7 +205,7 @@ struct FP8CollectiveEpilogue {
     static_assert(CTA_Q <= NUM_MMA_THREADS);
     if (epilogue_params.lse_ptr) {  // don't write to LSE if it's nullptr
       if (thread_idx < qo_len - qo_tile_idx * CTA_Q) {
-        gLSE(thread_idx) = -math::inf;
+        gLSE(thread_idx) = math::neg_inf<float>();
       }
     }
   }

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -110,7 +110,7 @@ __device__ __forceinline__ void init_states_(float* o_frag, float* m, float* d, 
 
 #pragma unroll
   for (uint32_t j = 0; j < 2; ++j) {
-    m[j] = -math::inf;
+    m[j] = math::neg_inf<float>();
     d[j] = 1.f;
     o_scale[j] = 1.f;
   }
@@ -439,7 +439,7 @@ __device__ __forceinline__ void normalize_d_(typename KTraits::SharedStorage* sm
   // compute reciprocal of d
 #pragma unroll
   for (uint32_t j = 0; j < 2; ++j) {
-    d_rcp[j] = (m[j] != -math::inf) ? math::ptx_rcp(d[j]) : 0.f;
+    d_rcp[j] = (m[j] != math::neg_inf<float>()) ? math::ptx_rcp(d[j]) : 0.f;
   }
 
 #pragma unroll

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -158,7 +158,8 @@ struct KernelTraits {
                 "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
                 "then recompile to support fp16 reduction");
   static constexpr DTypeQKAccum MaskFillValue =
-      AttentionVariant::use_softmax ? DTypeQKAccum(-math::inf) : DTypeQKAccum(0.f);
+      AttentionVariant::use_softmax ? DTypeQKAccum(std::numeric_limits<float>::lowest())
+                                    : DTypeQKAccum(0.f);
 #endif
 };
 
@@ -417,7 +418,8 @@ __device__ __forceinline__ void init_states(typename KTraits::AttentionVariant v
     for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
-        m[mma_q][j] = typename KTraits::DTypeQKAccum(-math::inf);
+        m[mma_q][j] =
+            typename KTraits::DTypeQKAccum(math::neg_inf<typename KTraits::DTypeQKAccum>());
         d[mma_q][j] = 1.f;
       }
     }
@@ -1042,7 +1044,8 @@ __device__ __forceinline__ void normalize_d(float (*o_frag)[KTraits::NUM_MMA_D_V
     for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
-        d_rcp[mma_q][j] = (m[mma_q][j] != typename KTraits::DTypeQKAccum(-math::inf))
+        d_rcp[mma_q][j] = (m[mma_q][j] != typename KTraits::DTypeQKAccum(
+                                              math::neg_inf<typename KTraits::DTypeQKAccum>()))
                               ? math::ptx_rcp(d[mma_q][j])
                               : 0.f;
       }
@@ -1070,7 +1073,8 @@ __device__ __forceinline__ void finalize_m(typename KTraits::AttentionVariant va
     for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
       for (uint32_t j = 0; j < 2; ++j) {
-        if (m[mma_q][j] != typename KTraits::DTypeQKAccum(-math::inf)) {
+        if (m[mma_q][j] !=
+            typename KTraits::DTypeQKAccum(math::neg_inf<typename KTraits::DTypeQKAccum>())) {
           m[mma_q][j] *= variant.sm_scale_log2;
         }
       }
@@ -1122,7 +1126,7 @@ __device__ __forceinline__ void threadblock_sync_mdo_states(
         float o_scale[2][KTraits::NUM_WARPS_KV];
 #pragma unroll
         for (uint32_t j = 0; j < 2; ++j) {
-          float m_new = -math::inf, d_new = 1.f;
+          float m_new = math::neg_inf<float>(), d_new = 1.f;
 #pragma unroll
           for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
             float2 md = smem_md[(((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) *

--- a/include/flashinfer/attention/state.cuh
+++ b/include/flashinfer/attention/state.cuh
@@ -36,7 +36,7 @@ struct state_t {
 
   __device__ __forceinline__ void init() {
     o.fill(0.f);
-    m = -math::inf;
+    m = math::neg_inf<float>();
     d = 1.f;
   }
 

--- a/include/flashinfer/math.cuh
+++ b/include/flashinfer/math.cuh
@@ -20,6 +20,7 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
+#include <limits>
 
 namespace flashinfer {
 namespace math {
@@ -29,7 +30,17 @@ constexpr float log2e = 1.44269504088896340736f;
 
 constexpr float loge2 = 0.693147180559945309417f;
 
+// only for bf16 or fp16
 constexpr float inf = 5e4;
+
+template <typename DT>
+__forceinline__ __device__ DT neg_inf() {
+  if constexpr (std::is_same<DT, float>::value) {
+    return std::numeric_limits<DT>::lowest();
+  } else {
+    return -inf;
+  }
+}
 
 __forceinline__ __device__ half2 uint32_as_half2(uint32_t x) { return *(half2*)&x; }
 


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description
In some models, the acc fp32 of QK will be small than math::inf which leading to bad output 
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
