### PR TITLE
Remove sm100+ requirment for trtllm allreduce kernels

### DIFF
--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -26,7 +26,7 @@ from torch.distributed import ProcessGroup
 
 from ..jit import JitSpec
 from ..jit import env as jit_env
-from ..jit import gen_jit_spec
+from ..jit import gen_jit_spec, sm100a_nvcc_flags
 from ..utils import register_custom_op, round_up
 from .cuda_ipc import create_shared_buffer, cudart, free_shared_buffer
 
@@ -96,6 +96,7 @@ class FP4QuantizationSFLayout:
 
 
 def gen_trtllm_comm_module() -> JitSpec:
+    major, minor = torch.cuda.get_device_capability()
     return gen_jit_spec(
         "trtllm_comm",
         [
@@ -103,6 +104,7 @@ def gen_trtllm_comm_module() -> JitSpec:
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_allreduce_fusion.cu",
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_moe_allreduce_fusion.cu",
         ],
+        extra_cuda_cflags=sm100a_nvcc_flags if major >= 10 and minor >= 0 else [],
     )
 
 

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -26,7 +26,7 @@ from torch.distributed import ProcessGroup
 
 from ..jit import JitSpec
 from ..jit import env as jit_env
-from ..jit import gen_jit_spec, sm100a_nvcc_flags
+from ..jit import gen_jit_spec
 from ..utils import register_custom_op, round_up
 from .cuda_ipc import create_shared_buffer, cudart, free_shared_buffer
 
@@ -103,7 +103,6 @@ def gen_trtllm_comm_module() -> JitSpec:
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_allreduce_fusion.cu",
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_moe_allreduce_fusion.cu",
         ],
-        extra_cuda_cflags=sm100a_nvcc_flags,
     )
 
 

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -534,26 +534,25 @@ __forceinline__ __device__ uint32_t pack_bytes(uint8_t c0, uint8_t c1, uint8_t c
 
 // Convert 8 float32 values into 8 e2m1 values (represented as one uint32_t).
 inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
-  // #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
-  //   uint32_t val;
-  //   asm volatile(
-  //       "{\n"
-  //       ".reg .b8 byte0;\n"
-  //       ".reg .b8 byte1;\n"
-  //       ".reg .b8 byte2;\n"
-  //       ".reg .b8 byte3;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
-  //       "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
-  //       "}"
-  //       : "=r"(val)
-  //       : "f"(array[0]), "f"(array[1]), "f"(array[2]), "f"(array[3]), "f"(array[4]),
-  //       "f"(array[5]),
-  //         "f"(array[6]), "f"(array[7]));
-  //   return val;
-  // #else
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0]), "f"(array[1]), "f"(array[2]), "f"(array[3]), "f"(array[4]), "f"(array[5]),
+        "f"(array[6]), "f"(array[7]));
+  return val;
+#else
   uint32_t val;
   __nv_fp4x2_storage_t vals[4];
   for (int i = 0; i < 4; i++) {
@@ -561,30 +560,30 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
   }
   val = pack_bytes(vals[0], vals[1], vals[2], vals[3]);
   return val;
-  // #endif
+#endif
 }
 
 // Convert 4 float2 values into 8 e2m1 values (represented as one uint32_t).
 inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
-  // #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
-  //   uint32_t val;
-  //   asm volatile(
-  //       "{\n"
-  //       ".reg .b8 byte0;\n"
-  //       ".reg .b8 byte1;\n"
-  //       ".reg .b8 byte2;\n"
-  //       ".reg .b8 byte3;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
-  //       "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
-  //       "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
-  //       "}"
-  //       : "=r"(val)
-  //       : "f"(array[0].x), "f"(array[0].y), "f"(array[1].x), "f"(array[1].y), "f"(array[2].x),
-  //         "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
-  //   return val;
-  // #else
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0].x), "f"(array[0].y), "f"(array[1].x), "f"(array[1].y), "f"(array[2].x),
+        "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
+  return val;
+#else
   uint32_t val;
   __nv_fp4x2_storage_t vals[4];
   for (int i = 0; i < 4; i++) {
@@ -592,7 +591,7 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
   }
   val = pack_bytes(vals[0], vals[1], vals[2], vals[3]);
   return val;
-  // #endif
+#endif
 }
 
 // Quantizes the provided PackedVec into the uint32_t output

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -1,6 +1,7 @@
 #include <cooperative_groups.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <cuda_fp4.h>
 
 #include <cuda/std/optional>
 #include <tuple>
@@ -544,6 +545,7 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
   //         "f"(array[6]), "f"(array[7]));
   //   return val;
   // #else
+  uint32_t val;
   __nv_fp4x2_storage_t vals[4];
   for (int i = 0; i < 4; i++) {
     vals[i] = __nv_cvt_float2_to_fp4x2(*(((float2*)array) + i), __NV_E2M1, cudaRoundNearest);
@@ -576,6 +578,7 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
   //         "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
   //   return val;
   // #else
+  uint32_t val;
   __nv_fp4x2_storage_t vals[4];
   for (int i = 0; i < 4; i++) {
     vals[i] = __nv_cvt_float2_to_fp4x2(array[i], __NV_E2M1, cudaRoundNearest);

--- a/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
@@ -1,6 +1,7 @@
 #include <cooperative_groups.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <cuda_fp4.h>
 
 #include <cuda/std/optional>
 #include <tuple>
@@ -530,8 +531,13 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
         "f"(array[6]), "f"(array[7]));
   return val;
 #else
-  // static_assert(false, "not supported.");
-  return 0;
+  uint32_t val;
+  __nv_fp4x2_storage_t vals[4];
+  for (int i = 0; i < 4; i++) {
+    vals[i] = __nv_cvt_float2_to_fp4x2(*(((float2*)array) + i), __NV_E2M1, cudaRoundNearest);
+  }
+  val = pack_bytes(vals[0], vals[1], vals[2], vals[3]);
+  return val;
 #endif
 }
 
@@ -556,8 +562,13 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
         "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
   return val;
 #else
-  // static_assert(false, "not supported.");
-  return 0;
+  uint32_t val;
+  __nv_fp4x2_storage_t vals[4];
+  for (int i = 0; i < 4; i++) {
+    vals[i] = __nv_cvt_float2_to_fp4x2(array[i], __NV_E2M1, cudaRoundNearest);
+  }
+  val = pack_bytes(vals[0], vals[1], vals[2], vals[3]);
+  return val;
 #endif
 }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The trtllm allreduce kernels requires sm100 arch, because when fused with fp4 quant, we rely on `cvt.rn{.relu}.f16x2.{e2m1x2/e2m3x2/e3m2x2}` instructions which is only supported for sm100+.

This PR adds fallback software implementation for ealier architectures.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
