### PR TITLE
Defer mpi import for comm module

### DIFF
--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -30,12 +30,6 @@ from .trtllm_ar import trtllm_moe_allreduce_fusion as trtllm_moe_allreduce_fusio
 from .trtllm_ar import (
     trtllm_moe_finalize_allreduce_fusion as trtllm_moe_finalize_allreduce_fusion,
 )
-from .trtllm_mnnvl_ar import (
-    gen_trtllm_mnnvl_comm_module,
-    get_allreduce_mnnvl_workspace,
-    mpi_barrier,
-    trtllm_mnnvl_all_reduce,
-)
 from .vllm_ar import all_reduce as vllm_all_reduce
 from .vllm_ar import dispose as vllm_dispose
 from .vllm_ar import gen_vllm_comm_module as gen_vllm_comm_module


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We shouldn't assume user to have installed mpi when using comm module (especially in single-node setting).
This PR defers the import of mpi in comm modules (only used when import mnnvl).

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
