### PR TITLE
feat: support environment variable overrides for NVSHMEM paths and linker flags

### DIFF
--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -65,15 +65,23 @@ CUTLASS_INCLUDE_DIRS = [
 SPDLOG_INCLUDE_DIR = _package_root / "data" / "spdlog" / "include"
 
 
-def get_nvshmem_include_dir():
+def get_nvshmem_include_dirs():
+    paths = os.environ.get("NVSHMEM_INCLUDE_PATH")
+    if paths is not None:
+        return [pathlib.Path(p) for p in paths.split(os.pathsep) if p]
+
     import nvidia.nvshmem
 
     path = pathlib.Path(nvidia.nvshmem.__path__[0]) / "include"
-    return path
+    return [path]
 
 
-def get_nvshmem_lib_dir():
+def get_nvshmem_lib_dirs():
+    paths = os.environ.get("NVSHMEM_LIBRARY_PATH")
+    if paths is not None:
+        return [pathlib.Path(p) for p in paths.split(os.pathsep) if p]
+
     import nvidia.nvshmem
 
     path = pathlib.Path(nvidia.nvshmem.__path__[0]) / "lib"
-    return path
+    return [path]


### PR DESCRIPTION
## 📌 Description

- Add `get_nvshmem_include_dirs`, `get_nvshmem_lib_dirs`, and `get_nvshmem_ldflags` to flashinfer/jit/env.py, to:
  - Allow overriding NVSHMEM include and library paths via NVSHMEM_INCLUDE_PATH and NVSHMEM_LIBRARY_PATH environment variables
  - Allow custom linker flags via NVSHMEM_LDFLAGS environment variable
  - Fallback to nvidia.nvshmem package paths if environment variables are not set
- Update `flashinfer/comm/nvshmem.py` to use new env functions and support multiple include/library paths and custom linker flags

This enables downstream builds with system NVSHMEM packages and ensures all communication backends can be AOT-compiled.

## 🔍 Related Issues

Fixes #1252

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

