### PR TITLE
TRT-LLM's Multi-Node NVLink AR + fused RMSNorm kernel

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -815,8 +815,8 @@ class McastGPUBuffer:
         self.buf_size = buf_size
         self.local_device = device
 
-    def lamport_initialize(self, rank: int):
-        self.mcast_device_memory.lamport_initialize(rank)
+    def lamport_initialize(self, rank: int, dtype: torch.dtype):
+        self.mcast_device_memory.lamport_initialize(rank, dtype)
 
     def get_mc_buffer(
         self, sizes: tuple, dtype: torch.dtype, storage_offset: int = 0

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -44,6 +44,21 @@ struct AllReduceParams {
   cudaStream_t stream;
 };
 
+template <typename T>
+struct RMSNormParams {
+  void* residual_output;
+  void* output;
+  void const* input;
+  void const* gamma;
+  double epsilon;
+  void* residual;
+  uint32_t* buffer_flags;
+  int batch;
+  int hidden_dim;
+  cudaStream_t stream;
+  bool launch_with_pdl;
+};
+
 __device__ bool isNegZero(float v) { return v == 0.f && signbit(v); }
 
 __device__ bool isNegZero(__nv_bfloat16 val) { return isNegZero(__bfloat162float(val)); }
@@ -77,7 +92,7 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
   if (elt >= token_dim) return;
   int token = blockIdx.x;
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
 
@@ -135,7 +150,7 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
     }
   }
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaTriggerProgrammaticLaunchCompletion();
 #endif
 
@@ -217,6 +232,384 @@ cudaError_t twoshot_allreduce_dispatch_world_size(AllReduceParams<T>& params) {
     default:
       FLASHINFER_ERROR("MNNVL AllReduce: unsupported world_size " + std::to_string(params.nranks) +
                        ". Supported sizes: {2, 4, 8, 16, 32, 64}");
+      return cudaErrorInvalidValue;
+  }
+}
+
+template <typename T_IN>
+__device__ void copy_f4(T_IN* dst, T_IN const* src) {
+  float4* dst4 = (float4*)dst;
+  float4 const* src4 = (float4 const*)src;
+  __pipeline_memcpy_async(dst4, src4, sizeof(float4));
+}
+
+template <typename T_IN>
+__device__ void copy_f4_ldg(T_IN* dst, T_IN const* src) {
+  float4* dst4 = (float4*)dst;
+  float4 const* src4 = (float4*)src;
+  *dst4 = *src4;
+}
+
+__device__ float4 loadfloat4(void const* ptr) {
+  // Check alignment - ptr should be 16-byte aligned for safe float4 load
+  if (reinterpret_cast<uintptr_t>(ptr) % 16 != 0) {
+    // Fall back to scalar loads if not aligned
+    float return_value[4];
+    float const* float_ptr = reinterpret_cast<float const*>(ptr);
+    return_value[0] = float_ptr[0];
+    return_value[1] = float_ptr[1];
+    return_value[2] = float_ptr[2];
+    return_value[3] = float_ptr[3];
+    return *(float4*)return_value;
+  }
+
+  float return_value[4];
+
+  asm volatile("ld.volatile.global.v4.f32 {%0, %1, %2, %3}, [%4];\n"
+               : "=f"(return_value[0]), "=f"(return_value[1]), "=f"(return_value[2]),
+                 "=f"(return_value[3])
+               : "l"(ptr));
+
+  return *(float4*)return_value;
+}
+
+// Safer version that checks bounds before loading
+template <typename T>
+__device__ float4 loadfloat4_safe(T const* ptr, int remaining_elements) {
+  float return_value[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+  if (remaining_elements <= 0) {
+    return *(float4*)return_value;
+  }
+
+  // Check alignment - ptr should be 16-byte aligned for safe float4 load
+  bool is_aligned = (reinterpret_cast<uintptr_t>(ptr) % 16 == 0);
+
+  if (is_aligned && remaining_elements >= 4) {
+    // Safe to do vectorized load
+    asm volatile("ld.volatile.global.v4.f32 {%0, %1, %2, %3}, [%4];\n"
+                 : "=f"(return_value[0]), "=f"(return_value[1]), "=f"(return_value[2]),
+                   "=f"(return_value[3])
+                 : "l"(ptr));
+  } else {
+    // Fall back to scalar loads with bounds checking
+    float const* float_ptr = reinterpret_cast<float const*>(ptr);
+    for (int i = 0; i < 4 && i < remaining_elements; i++) {
+      return_value[i] = toFloat(float_ptr[i]);
+    }
+  }
+
+  return *(float4*)return_value;
+}
+
+template <typename T>
+inline __device__ T add(T a, T b) {
+  return a + b;
+}
+
+#define FINAL_MASK 0xffffffff
+
+template <typename T>
+__inline__ __device__ T warpReduceSum(T val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val = add<T>(val, __shfl_xor_sync(FINAL_MASK, val, mask,
+                                      32));  //__shfl_sync bf16 return float when sm < 80
+  return val;
+}
+
+inline __device__ float block_reduce_sum(float val) {
+  __shared__ float smem[32];
+  int lane_id = threadIdx.x % 32, warp_id = threadIdx.x / 32, warp_num = blockDim.x / 32;
+  val = warpReduceSum(val);
+  if (lane_id == 0) {
+    smem[warp_id] = val;
+  }
+  __syncthreads();
+  val = lane_id < warp_num ? smem[lane_id] : 0.f;
+  val = warpReduceSum(val);
+  return val;
+}
+
+template <int DIM, int NUM_THREADS, int NUM_INPUTS, typename T_OUT, typename T_IN>
+__global__ void __launch_bounds__(128, 1)
+    RMSNorm(T_IN* input_plus_residual, T_OUT* output_norm, T_IN const* buffer_input,
+            T_IN const* gamma, float epsilon, T_IN const* residual, int batch_size,
+            uint32_t* buffer_flags) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+
+  static bool const LAMPORT = true;
+
+  extern __shared__ uint8_t smem[];
+
+  int sample = blockIdx.y;
+
+  static int const CGA_THREADS = NUM_THREADS * 1;
+
+  static int const ITERS = DIM / CGA_THREADS;
+  float r_input[ITERS];
+  float r_gamma[ITERS];
+
+  T_IN* sh_input = (T_IN*)&smem[0];
+  T_IN* sh_residual = (T_IN*)&smem[NUM_INPUTS * NUM_THREADS * ITERS * sizeof(T_IN)];
+  T_IN* sh_gamma = (T_IN*)&smem[(NUM_INPUTS + 1) * NUM_THREADS * ITERS * sizeof(T_IN)];
+
+  static int const ELTS_PER_THREAD = sizeof(float4) / sizeof(T_IN);
+
+  int offsets[NUM_INPUTS][DIM / (1 * ELTS_PER_THREAD * NUM_THREADS)];
+
+  uint32_t* offset_access_ptr = &buffer_flags[3];
+  // Buffer size is M * N, and we need two buffers for reduce-scatter and allgather
+  uint32_t buffer_size = buffer_flags[2];
+  uint32_t buffer_offset = buffer_flags[0] * (buffer_size << 1);
+  T_IN const* input = &buffer_input[buffer_offset + buffer_size];
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    atomicAdd(offset_access_ptr, 1);
+  }
+
+  for (int i = 0; i < NUM_INPUTS; i++) {
+    for (int j = 0; j < DIM / (1 * ELTS_PER_THREAD * NUM_THREADS); j++) {
+      int k = j * NUM_THREADS + threadIdx.x;
+      offsets[i][j] =
+          i * batch_size * DIM + sample * DIM + blockIdx.x * DIM / 1 + k * ELTS_PER_THREAD;
+    }
+  }
+
+#pragma unroll
+  for (int j = 0; j < DIM / (1 * ELTS_PER_THREAD * NUM_THREADS); j++) {
+    int i = j * NUM_THREADS + threadIdx.x;
+    copy_f4(&sh_residual[i * ELTS_PER_THREAD],
+            &residual[sample * DIM + blockIdx.x * DIM + i * ELTS_PER_THREAD]);
+  }
+
+  __pipeline_commit();
+
+#pragma unroll
+  for (int j = 0; j < DIM / (ELTS_PER_THREAD * NUM_THREADS); j++) {
+    int i = j * NUM_THREADS + threadIdx.x;
+    copy_f4(&sh_gamma[i * ELTS_PER_THREAD], &gamma[blockIdx.x * DIM + i * ELTS_PER_THREAD]);
+  }
+
+  __pipeline_commit();
+
+  // Load all inputs
+  bool valid = false;
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  if (!LAMPORT) cudaGridDependencySynchronize();
+#endif
+
+  while (!valid) {
+    valid = true;
+#pragma unroll
+    for (int i = 0; i < NUM_INPUTS; i++) {
+      for (int j = 0; j < DIM / (ELTS_PER_THREAD * NUM_THREADS); j++) {
+        int k = j * NUM_THREADS + threadIdx.x;
+
+        float4* dst4 = (float4*)&sh_input[i * NUM_THREADS * ITERS + k * ELTS_PER_THREAD];
+
+        // Calculate the absolute element offset from the start of buffer_input
+        int element_offset = offsets[i][j];
+
+        // The input pointer is already offset to: &buffer_input[buffer_offset + buffer_size]
+        // So the actual pointer we're accessing is: input + element_offset
+        // Which equals: &buffer_input[buffer_offset + buffer_size + element_offset]
+
+        // Calculate the total buffer size in elements
+        int total_buffer_elements = (buffer_size << 1) / sizeof(T_IN);  // Two buffers worth
+
+        // The maximum valid element index relative to the input pointer
+        int max_valid_element_index = total_buffer_elements - buffer_size / sizeof(T_IN);
+
+        float4* src4 = (float4*)&input[element_offset];
+
+        float4 value;
+        // Check if we have enough elements remaining for a safe float4 load
+        if (element_offset >= 0 && element_offset + ELTS_PER_THREAD <= max_valid_element_index) {
+          value = loadfloat4(src4);
+        } else {
+          // Use safe load for boundary cases or out-of-bounds
+          int remaining_elements = max_valid_element_index - element_offset;
+          if (remaining_elements <= 0) {
+            // Completely out of bounds, return zeros
+            float return_value[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+            value = *(float4*)return_value;
+          } else {
+            value = loadfloat4_safe(reinterpret_cast<T_IN const*>(src4), remaining_elements);
+          }
+        }
+
+        if (LAMPORT) {
+          // Assume that the 16B were written atomically, so we only need to check one value
+          T_IN lowest_val = *(T_IN*)&value;
+          valid &= !isNegZero(lowest_val);
+        }
+        *dst4 = value;
+      }
+    }
+  }
+
+  __syncthreads();
+
+  // Perform the initial input reduction
+  if (NUM_INPUTS > 0) {
+    T_IN accum[ELTS_PER_THREAD];
+    float4* accum4 = (float4*)&accum;
+
+    for (int j = 0; j < DIM / (ELTS_PER_THREAD * NUM_THREADS); j++) {
+      int k = j * NUM_THREADS + threadIdx.x;
+
+      *accum4 = *(float4*)&sh_input[k * ELTS_PER_THREAD];
+
+      for (int i = 1; i < NUM_INPUTS; i++) {
+        float4 data = *(float4*)&sh_input[i * NUM_THREADS * ITERS + k * ELTS_PER_THREAD];
+        T_IN* p_d = (T_IN*)&data;
+        for (int x = 0; x < ELTS_PER_THREAD; x++) {
+          accum[x] += p_d[x];
+        }
+      }
+
+      // Write back to input 0's staging location.  No sync needed since all data localized to
+      // thread.
+      *(float4*)&sh_input[k * ELTS_PER_THREAD] = *accum4;
+    }
+  }
+
+  // Wait for residual
+  __pipeline_wait_prior(1);
+  __syncthreads();
+
+  float thread_sum = 0.f;
+
+#pragma unroll
+  for (int io = 0; io < ITERS / ELTS_PER_THREAD; io++) {
+    float4 inp4 =
+        *(float4*)&sh_input[io * NUM_THREADS * ELTS_PER_THREAD + threadIdx.x * ELTS_PER_THREAD];
+    float4 res4 =
+        *(float4*)&sh_residual[io * NUM_THREADS * ELTS_PER_THREAD + threadIdx.x * ELTS_PER_THREAD];
+
+    T_IN* r_inp = (T_IN*)&inp4;
+    T_IN* r_res = (T_IN*)&res4;
+
+    float4 out4;
+
+    T_IN* r_out = (T_IN*)&out4;
+
+    for (int ii = 0; ii < ELTS_PER_THREAD; ii++) {
+      int i = io * ELTS_PER_THREAD + ii;
+
+      T_IN inp_plus_resid = r_inp[ii] + r_res[ii];
+      r_out[ii] = inp_plus_resid;
+      r_input[i] = toFloat(inp_plus_resid);
+
+      // Accumulate the squares for RMSNorm
+      thread_sum += toFloat(inp_plus_resid * inp_plus_resid);
+    }
+
+    *(float4*)&input_plus_residual[sample * DIM + blockIdx.x * DIM +
+                                   io * NUM_THREADS * ELTS_PER_THREAD +
+                                   threadIdx.x * ELTS_PER_THREAD] = out4;
+  }
+
+  // Wait for Gamma.  There will be a global synchronization as part of the reduction
+  __pipeline_wait_prior(0);
+
+  float cluster_sum = block_reduce_sum(thread_sum);
+
+  float rcp_rms = rsqrtf(cluster_sum / DIM + epsilon);
+
+#pragma unroll
+  for (int io = 0; io < ITERS / ELTS_PER_THREAD; io++) {
+    float4 gamma4 =
+        *(float4*)&sh_gamma[io * NUM_THREADS * ELTS_PER_THREAD + threadIdx.x * ELTS_PER_THREAD];
+    T_IN* r_g4 = (T_IN*)&gamma4;
+
+    float4 out4;
+    // FIXME: this only works if T_OUT == T_IN
+    T_OUT* r_out = (T_OUT*)&out4;
+
+    for (int ii = 0; ii < ELTS_PER_THREAD; ii++) {
+      int i = io * ELTS_PER_THREAD + ii;
+      r_gamma[i] = toFloat(r_g4[ii]);
+      r_out[ii] = fromFloat<T_OUT>(r_gamma[i] * r_input[i] * rcp_rms);
+    }
+
+    *(float4*)&output_norm[sample * DIM + blockIdx.x * DIM + io * NUM_THREADS * ELTS_PER_THREAD +
+                           threadIdx.x * ELTS_PER_THREAD] = out4;
+  }
+  // Update the buffer pointers
+  if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
+    // Make sure all blocks have finished accessing the buffer
+    while (*reinterpret_cast<uint32_t volatile*>(offset_access_ptr) != gridDim.x * gridDim.y) {
+    }
+    buffer_flags[0] = (buffer_flags[0] + 1) % 3;
+    buffer_flags[1] = (buffer_flags[1] + 1) % 3;
+    *(offset_access_ptr) = 0;
+  }
+  __syncthreads();
+#endif
+}
+
+template <typename T, int H_DIM>
+cudaError_t twoshot_rmsnorm_dispatch(RMSNormParams<T>& params) {
+  static constexpr int NUM_THREADS = 128;
+  static constexpr int CGA_THREADS = NUM_THREADS;
+  constexpr int iters = H_DIM / CGA_THREADS;
+
+  dim3 grid(1, params.batch, 1);
+
+  FLASHINFER_LOG_DEBUG("[MNNVL TwoShot RMSNorm] batch: %d, hidden_dim: %d, epsilon: %f",
+                       params.batch, params.hidden_dim, params.epsilon);
+
+  cudaLaunchConfig_t config;
+  cudaLaunchAttribute attrs[1];
+  config.stream = params.stream;
+  config.gridDim = grid;
+  config.blockDim = NUM_THREADS;
+  config.attrs = attrs;
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = params.launch_with_pdl ? 1 : 0;
+  config.numAttrs = 1;
+
+  size_t shmem_size = 3 * NUM_THREADS * iters * sizeof(T);
+  config.dynamicSmemBytes = shmem_size;
+
+  cudaFuncSetAttribute(&RMSNorm<H_DIM, NUM_THREADS, 1, T, T>,
+                       cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_size);
+
+  cudaLaunchKernelEx(
+      &config, &RMSNorm<H_DIM, NUM_THREADS, 1, T, T>, reinterpret_cast<T*>(params.residual_output),
+      reinterpret_cast<T*>(params.output), reinterpret_cast<T const*>(params.input),
+      reinterpret_cast<T const*>(params.gamma), static_cast<float>(params.epsilon),
+      reinterpret_cast<T const*>(params.residual), params.batch, params.buffer_flags);
+
+  return cudaSuccess;
+}
+
+template <typename T>
+cudaError_t twoshot_rmsnorm_dispatch_hidden_dim(RMSNormParams<T>& params) {
+  FLASHINFER_LOG_DEBUG("twoshot_rmsnorm_dispatch_hidden_dim");
+  switch (params.hidden_dim) {
+    case 2048:
+      return twoshot_rmsnorm_dispatch<T, 2048>(params);
+    case 4096:
+      return twoshot_rmsnorm_dispatch<T, 4096>(params);
+    case 5120:
+      return twoshot_rmsnorm_dispatch<T, 5120>(params);  // Llama-4
+    case 7168:
+      return twoshot_rmsnorm_dispatch<T, 7168>(params);  // DeepSeek
+    case 8192:
+      return twoshot_rmsnorm_dispatch<T, 8192>(params);
+    default:
+      FLASHINFER_ERROR("MNNVL TwoShot RMSNorm: unsupported hidden_dim " +
+                       std::to_string(params.hidden_dim) +
+                       ". Supported sizes: {2048, 4096, 5120, 7168, 8192}");
       return cudaErrorInvalidValue;
   }
 }

--- a/tests/test_trtllm_mnnvl_allreduce.py
+++ b/tests/test_trtllm_mnnvl_allreduce.py
@@ -8,8 +8,12 @@ import torch
 from mpi4py import MPI  # Added MPI import
 
 import flashinfer.comm as comm
+import flashinfer.comm.trtllm_mnnvl_ar as trtllm_mnnvl_ar
 from flashinfer.comm.mapping import Mapping
 from flashinfer.comm.mnnvl import McastDeviceMemory, McastGPUBuffer
+
+# Use flashinfer.norm.rmsnorm as reference implementation.
+from flashinfer.norm import rmsnorm
 
 
 @torch.inference_mode()
@@ -47,6 +51,7 @@ def row_linear_residual_norm_fusion_forward(
         enable_fusion,
         multicast_ptr,
         buffer_ptrs_dev,
+        unicast_ptr,
         max_num_elements_mnnvl,
     ):
         # For both fused and unfused cases:
@@ -62,10 +67,35 @@ def row_linear_residual_norm_fusion_forward(
         buffer_M = max_num_elements_mnnvl // hidden_size
 
         if enable_fusion:
-            raise NotImplementedError("Fusion not implemented")
+            use_pdl = True
+
+            prenorm_output = torch.empty_like(residual)
+            normed_output = torch.empty_like(residual)
+
+            trtllm_mnnvl_ar.mpi_barrier()
+
+            trtllm_mnnvl_ar.trtllm_mnnvl_fused_allreduce_rmsnorm(
+                output,  # TODO: can we remove the output argument if we don't use it?
+                prenorm_output,
+                normed_output,
+                input,
+                multicast_ptr,
+                buffer_ptrs_dev,
+                unicast_ptr,
+                buffer_M,
+                buffer_flags_mnnvl,
+                tensor_parallel_size,
+                tensor_parallel_rank,
+                norm_weight,
+                eps,
+                residual,
+                use_pdl,
+            )
+
+            return normed_output.view(shape), prenorm_output.view(shape)
 
         else:
-            comm.trtllm_mnnvl_ar.trtllm_mnnvl_all_reduce(
+            trtllm_mnnvl_ar.trtllm_mnnvl_all_reduce(
                 input,
                 output,
                 multicast_ptr,
@@ -81,11 +111,14 @@ def row_linear_residual_norm_fusion_forward(
 
     # Get workspace buffers using MPI rank
     mcast_buffer_mnnvl, buffer_flags_mnnvl, max_num_elements_mnnvl = (
-        comm.trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(mapping, dtype)
+        trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(mapping, dtype)
     )
 
     multicast_ptr = mcast_buffer_mnnvl.get_multicast_ptr_as_int64()
     buffer_ptrs_dev = mcast_buffer_mnnvl.get_buffer_ptrs_dev_as_ctypes_ptr()
+    unicast_ptr = mcast_buffer_mnnvl.mcast_device_memory.get_unicast_ptr(
+        tensor_parallel_rank
+    )
 
     try:
         output = func(
@@ -96,6 +129,7 @@ def row_linear_residual_norm_fusion_forward(
             fusion,
             multicast_ptr,
             buffer_ptrs_dev,
+            unicast_ptr,
             max_num_elements_mnnvl,
         )
 
@@ -140,7 +174,7 @@ def row_linear_residual_norm_fusion_forward(
 
 # seq_lens = [1, 4, 32, 128]
 @pytest.mark.parametrize("seq_len", [4])
-@pytest.mark.parametrize("fusion", [False])
+@pytest.mark.parametrize("fusion", [False, True])
 def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
     monkeypatch.setenv("TRTLLM_FORCE_MNNVL_AR", "1")  # force multi-node allreduce.
 
@@ -168,6 +202,10 @@ def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
 
     torch.manual_seed(42)
 
+    # Track if this rank failed
+    rank_failed = False
+    failure_message = ""
+
     try:
         if rank == 0:
             print(
@@ -175,16 +213,34 @@ def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
             )
 
         # Generate test data (same on all ranks due to same seed)
-        x_full = torch.randn((tensor_parallel_size, seq_len, hidden_size), dtype=dtype)
-        residual = torch.randn((seq_len, hidden_size), dtype=dtype)
-        norm_weight = torch.randn((hidden_size,), dtype=dtype)
+        x_full = torch.randn(
+            (tensor_parallel_size, seq_len, hidden_size),
+            dtype=dtype,
+            device=torch.device("cuda"),
+        )
+        residual = torch.randn(
+            (seq_len, hidden_size), dtype=dtype, device=torch.device("cuda")
+        )
+        norm_weight = torch.randn(
+            (hidden_size,), dtype=dtype, device=torch.device("cuda")
+        )
 
         # Each rank gets its slice of the input
         x = x_full[rank, :, :]
 
         # Compute reference output based on fusion mode
         if fusion:
-            raise NotImplementedError("Fusion not implemented")
+            # Fused case: AllReduce + Residual Add + RMS Norm
+            allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
+            residual_out = allreduce_result + residual  # Add residual
+            print(
+                "Device of residual_out:{}, norm_weight:{}".format(
+                    residual_out.device, norm_weight.device
+                )
+            )
+            norm_out = rmsnorm(residual_out, norm_weight, eps, enable_pdl=False)
+
+            reference_output = (norm_out, residual_out)
         else:
             # Non-fused case: Only AllReduce
             allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
@@ -205,16 +261,28 @@ def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
         )
 
         # Synchronize before next test
-        comm.trtllm_mnnvl_ar.mpi_barrier()
+        trtllm_mnnvl_ar.mpi_barrier()
 
         print(f"PASSED[rank={rank}]: seq_len={seq_len}, fusion={fusion}")
 
     except Exception as e:
-        print(f"FAILED[rank={rank}]: seq_len={seq_len}, fusion={fusion} failed: {e}")
-        if rank == 0:
-            traceback.print_exc()
-        # Don't exit immediately, let other tests run
-        comm.trtllm_mnnvl_ar.mpi_barrier()
+        rank_failed = True
+        failure_message = (
+            f"FAILED[rank={rank}]: seq_len={seq_len}, fusion={fusion} failed: {e}"
+        )
+        print(failure_message)
+        # Gather failure status from all ranks
+        all_failures = MPI.COMM_WORLD.allgather(rank_failed)
 
-    # Final synchronization and results
-    comm.trtllm_mnnvl_ar.mpi_barrier()
+        # If any rank failed, fail the test
+        if any(all_failures):
+            failed_ranks = [i for i, failed in enumerate(all_failures) if failed]
+            if rank == 0:
+                print(f"Test failed on ranks: {failed_ranks}")
+
+            # Fail the test on all ranks
+            pytest.fail(f"Test failed on ranks {failed_ranks}")
+            trtllm_mnnvl_ar.mpi_barrier()
+
+    # Final synchronization and check for failures across all ranks
+    trtllm_mnnvl_ar.mpi_barrier()


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Extending MR-1213, this MR adds a fused RMSNorm kernel on top of the AR kernel. It reads directly from the multicast/unicast buffers.

Some other changes:
* Minor bug fix
* Updated reporting through pytest

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [/] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [/] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Similarly as before tests can be ran as:
srun -N2 --container-image=<your_aarch64_container> --mpi=pmix --container-name=mb_flashinfer --container-mounts=<parentdir_to_flash_infer>:/home -- bash -c 'cd /home/flashinfer && python -m pytest tests/test_trtllm_mnnvl_allreduce.py -v -s'

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
