### PR TITLE
refactor: separate SM100 and legacy TRT-LLM comm modules

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -11,7 +11,6 @@ from torch.utils.cpp_extension import _get_cuda_arch_flags
 from .activation import act_func_def_str, gen_act_and_mul_module
 from .cascade import gen_cascade_module
 from .comm import gen_trtllm_comm_module, gen_vllm_comm_module
-from .comm.nvshmem import gen_nvshmem_module
 from .fp4_quantization import gen_fp4_quantization_sm100_module
 from .fused_moe import gen_fused_moe_sm100_module
 from .gemm import gen_gemm_module, gen_gemm_sm90_module, gen_gemm_sm100_module

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -11,6 +11,7 @@ from torch.utils.cpp_extension import _get_cuda_arch_flags
 from .activation import act_func_def_str, gen_act_and_mul_module
 from .cascade import gen_cascade_module
 from .comm import gen_trtllm_comm_module, gen_vllm_comm_module
+from .comm.nvshmem import gen_nvshmem_module
 from .fp4_quantization import gen_fp4_quantization_sm100_module
 from .fused_moe import gen_fused_moe_sm100_module
 from .gemm import gen_gemm_module, gen_gemm_sm90_module, gen_gemm_sm100_module
@@ -325,7 +326,8 @@ def gen_all_modules(
         jit_specs.append(gen_fused_moe_sm100_module())
         jit_specs.append(gen_fp4_quantization_sm100_module())
         jit_specs.append(gen_gemm_sm100_module())
-        jit_specs.append(gen_trtllm_comm_module())
+
+    jit_specs.append(gen_trtllm_comm_module(sm100=has_sm100))
 
     jit_specs += [
         gen_cascade_module(),


### PR DESCRIPTION
## 📌 Description

Restructure the compilation of the TensorRT-LLM communication module to
improve hardware compatibility and portability.

Previously, the module was compiled with SM100-specific flags only if a
compatible GPU was detected during the build process.
This made a single build non-portable across different GPU generations.

This change introduces two distinct modules:
- `trtllm_comm`: compiled with SM100 optimizations for Hopper+ GPUs.
- `trtllm_comm_legacy`: a fallback version for older GPU architectures.

At runtime, `get_trtllm_comm_module` now detects the GPU's compute capability
and dynamically loads the appropriate module.
This allows a single FlashInfer build to support a wider range of NVIDIA GPUs
and gracefully handles CPU-only environments.

## 🔍 Related Issues

Fixes #1256

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes
