### PR TITLE
feat(aot): add nvshmem module for aot compilation

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -11,6 +11,7 @@ from torch.utils.cpp_extension import _get_cuda_arch_flags
 
 from .activation import act_func_def_str, gen_act_and_mul_module
 from .cascade import gen_cascade_module
+from .comm.nvshmem import gen_nvshmem_module
 from .fp4_quantization import gen_fp4_quantization_sm100_module
 from .fused_moe import gen_cutlass_fused_moe_sm100_module
 from .gemm import gen_gemm_module, gen_gemm_sm90_module, gen_gemm_sm100_module
@@ -380,6 +381,7 @@ def gen_all_modules(
         jit_specs += [
             gen_cascade_module(),
             gen_norm_module(),
+            gen_nvshmem_module(),
             gen_page_module(),
             gen_quantization_module(),
             gen_rope_module(),


### PR DESCRIPTION
## 📌 Description

This change integrates the `gen_nvshmem_module` into the Ahead-of-Time (AOT) build process.

By including this module, users can now pre-compile the NVSHMEM-based communication kernels,
which is necessary for using this backend in environments where just-in-time compilation
is not available or desired.

## 🔍 Related Issues

Fixes #1260

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
