### PR TITLE
CI: install `nvidia-nvshmem-cu12`

### DIFF
--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -20,4 +20,4 @@ set -e
 set -u
 
 pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-pip3 install ninja pytest numpy scipy build pynvml cuda-python einops
+pip3 install ninja pytest numpy scipy build pynvml cuda-python einops nvidia-nvshmem-cu12


### PR DESCRIPTION
## 📌 Description

Since we added nvidia-nvshmem-cu12 in setup.py, we need to install it in
the CI container image so unit tests can run when the module is loaded.


## 🔍 Related Issues

Related #1260

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
