### PR TITLE
hotfix: fix deepgemm artifactory hash

### DIFF
--- a/flashinfer/deep_gemm.py
+++ b/flashinfer/deep_gemm.py
@@ -886,6 +886,9 @@ static void __instantiate_kernel() {{
         return cbd.cuLaunchKernelEx(config, kernel, (arg_values, arg_types), 0)
 
 
+_artifact_hash = "d25901733420c7cddc1adf799b0d4639ed1e162f"
+
+
 def load_all():
     for cubin_name in KERNEL_MAP:
         if cubin_name in RUNTIME_CACHE:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The artifactory hash in #1266 haven't been updated to the latest.
We should avoid such mistakes fundamentally w/ blackwell CI.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @cyx-6 