### PR TITLE
Fix install folder regression, and JIT-vs-AOT differences

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.dist import Distribution
 
 root = Path(__file__).parent.resolve()
 aot_ops_package_dir = root / "build" / "aot-ops-package-dir"
-enable_aot = bool(os.listdir(aot_ops_package_dir))
+enable_aot = aot_ops_package_dir.is_dir() and any(aot_ops_package_dir.iterdir())
 
 
 def write_if_different(path: Path, content: str) -> None:
@@ -94,8 +94,8 @@ if enable_aot:
     generate_build_meta(aot_build_meta)
 
 
-class is_aot_wheel(Distribution):
-    def has_ext_modules(_):
+class AotDistribution(Distribution):
+    def has_ext_modules(self) -> bool:
         return enable_aot
 
 
@@ -105,5 +105,5 @@ setuptools.setup(
     cmdclass=cmdclass,
     install_requires=install_requires,
     options={"bdist_wheel": {"py_limited_api": "cp39"}},
-    distclass=is_aot_wheel,
+    distclass=AotDistribution,
 )


### PR DESCRIPTION
## 📌 Description

This encompasses a handful of fixes for build system errors after recent refactoring.

1. `enable_aot` is true when `aot_ops_package_dir` is a symlink: https://github.com/flashinfer-ai/flashinfer/blob/main/setup.py#L27

   However, this is ALWAYS a symlink, the symlink is always created before the wheel is built, at https://github.com/flashinfer-ai/flashinfer/blob/main/custom_backend.py#L53. This change checks whether the AOT folder is empty or not instead.

2. root_is_pure handling changes the package's tag, but not the actual install behaviour. The code in https://github.com/flashinfer-ai/flashinfer/blob/main/setup.py#L72-L81 does not successfully set the package as impure. This results in .so files being added to a purelib folder - see https://ci.tlcpack.ai/blue/rest/organizations/jenkins/pipelines/flashinfer-ci/branches/main/runs/374/nodes/10/steps/45/log/?start=0 where files are being added to `[site-packages]/flashinfer_python-0.2.8.data/purelib/flashinfer/` whereas in older versions, they would go in `[site-packages]/flashinfer`. ELF files in purelib is invalid, per PEP 427.

My changes a) cause the `if enable_aot` block to be skipped for jit builds, b) cause the files to be installed to `[site-packages]/flashinfer` as was the behaviour on older versions and in accordance with PEP 427, but c) do not regress the platform tag behaviour, where a JIT build produces `flashinfer_python-0.2.8-py3-none-any.whl` and an AOT build produces `flashinfer_python-0.2.8-cp39-abi3-linux_x86_64.whl`. The `-any.whl` includes `Root-Is-Purelib: true` in `.dist-info/WHEEL`, the `-linux_x86_64.whl` includes `Root-Is-Purelib: false`.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
