### PR TITLE
Unify groupwise fp8 GEMM test

### DIFF
--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -175,7 +175,10 @@ def dequantize_fp8(x, x_scale, scale_major_mode):
 
     # 2. Tiling and Scale Calculation
     if ndim == 2:
-        s0, s1 = x_scale.shape
+        if scale_major_mode == "K":
+            s0, s1 = x_scale.shape
+        else:
+            s1, s0 = x_scale.shape
         x = rearrange(
             x.to(torch.float32), "(s0 t0) (s1 t1) -> s0 s1 t0 t1", s0=s0, s1=s1
         )
@@ -186,7 +189,10 @@ def dequantize_fp8(x, x_scale, scale_major_mode):
         out = rearrange(x * x_scale, "s0 s1 t0 t1 -> (s0 t0) (s1 t1)")
 
     elif ndim == 3:
-        s0, s1, s2 = x_scale.shape
+        if scale_major_mode == "K":
+            s0, s1, s2 = x_scale.shape
+        else:
+            s0, s2, s1 = x_scale.shape
         x = rearrange(
             x.to(torch.float32),
             "(s0 t0) (s1 t1) (s2 t2)-> s0 s1 s2 t0 t1 t2",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Unify the groupwise fp8 GEMM to same quantize/dequantize interface.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
