### PR TITLE
[fix] move VariableBlockSparsePlan to GPU-side & add buffer overflow warning.

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -116,3 +116,6 @@ from .sampling import top_k_top_p_sampling_from_probs as top_k_top_p_sampling_fr
 from .sampling import top_p_renorm_probs as top_p_renorm_probs
 from .sampling import top_p_sampling_from_probs as top_p_sampling_from_probs
 from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper
+from .sparse import (
+    VariableBlockSparseAttentionWrapper as VariableBlockSparseAttentionWrapper,
+)

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -131,9 +131,10 @@ class BlockSparseAttentionWrapper:
             (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
         )
         if backend in ["fa3", "auto"]:
-            # NOTE(Zihao): assume maximum accumulate kv length is 4M
+            # NOTE(Zihao): assume maximum accumulate kv length is 128M
+            # NOTE(Yilong): 128M is required by video DiT models
             self._vector_sparse_indices_buffer = torch.empty(
-                (4 * 1024 * 1024,), dtype=torch.int32, device=self.device
+                (128 * 1024 * 1024,), dtype=torch.int32, device=self.device
             )
             # NOTE(Zihao): assume maximum batch size is 32768
             self._vector_sparse_indptr_buffer = torch.empty(
@@ -589,6 +590,14 @@ class BlockSparseAttentionWrapper:
 
         if self._use_tensor_cores:
             if self._backend == "fa3":
+                if (
+                    self._vector_sparse_indices_buffer.numel()
+                    <= self._paged_kv_indices_buf.numel() * self.C
+                ):
+                    raise ValueError(
+                        "_vector_sparse_indices_buffer is not large enough. Please increase the size."
+                    )
+
                 sparse_indices = block_sparse_indices_to_vector_sparse_offsets(
                     self._paged_kv_indices_buf,
                     self._paged_kv_indptr_buf,
@@ -725,11 +734,9 @@ class VariableBlockSparseAttentionWrapper:
             (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
         )
         if backend in ["fa3", "auto"]:
-            # NOTE(Zihao): assume maximum accumulate kv length is 4M
             self._vector_sparse_indices_buffer = torch.empty(
-                (4 * 1024 * 1024,), dtype=torch.int32, device=self.device
+                (128 * 1024 * 1024,), dtype=torch.int32, device=self.device
             )
-            # NOTE(Zihao): assume maximum batch size is 32768
             self._vector_sparse_indptr_buffer = torch.empty(
                 (32768,), dtype=torch.int32, device=self.device
             )
@@ -860,14 +867,14 @@ class VariableBlockSparseAttentionWrapper:
 
         # q layout: [seq_len, num_kv_heads, gqa_group_size, head_dim]
         # padded into: [seq_len * num_kv_heads, 1, gqa_group_size, head_dim]
-        qo_indptr_host = torch.cat(
+        qo_indptr = torch.cat(
             [
                 torch.zeros(1, dtype=torch.int32, device=block_row_sz.device),
                 torch.cumsum(block_row_sz.flatten(), dim=0, dtype=torch.int32),
             ],
             dim=0,
         )
-        qo_indptr = qo_indptr_host.to(block_mask_map.device, non_blocking=non_blocking)
+        qo_indptr_host = qo_indptr.to("cpu", non_blocking=non_blocking)
         last_block_len = torch.full(
             (num_blocks_row * num_kv_heads,),
             1,
@@ -926,20 +933,21 @@ class VariableBlockSparseAttentionWrapper:
                 dtype=dtype_i, device=device
             )
 
-        kv_indptr_host, kv_indices_host = _block_mask_map_to_expanded_indices(
+        kv_indptr, kv_indices = _block_mask_map_to_expanded_indices(
             block_mask_map, block_col_sz
         )
+        kv_indptr_host = kv_indptr.to("cpu", non_blocking=non_blocking)
+        kv_indices_host = kv_indices.to("cpu", non_blocking=non_blocking)
 
         self._qo_indptr = qo_indptr.to(self.device, non_blocking=non_blocking)
-        self._paged_kv_indptr_buf = kv_indptr_host.to(
-            self.device, non_blocking=non_blocking
-        )
-        self._paged_kv_indices_buf = kv_indices_host.to(
+        self._paged_kv_indptr_buf = kv_indptr.to(self.device, non_blocking=non_blocking)
+        self._paged_kv_indices_buf = kv_indices.to(
             self.device, non_blocking=non_blocking
         )
         self._paged_kv_last_page_len = last_block_len.to(
             self.device, non_blocking=non_blocking
         )
+        torch.cuda.synchronize()  # for non-blocking copy
         self._mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
 
         # Sanity check
@@ -947,14 +955,14 @@ class VariableBlockSparseAttentionWrapper:
             num_qo_heads % num_kv_heads == 0
         ), "num_qo_heads must be a multiple of num_kv_heads"
         assert num_blocks_row * num_kv_heads + 1 == kv_indptr_host.shape[0]
-        assert kv_indptr_host[-1].item() == kv_indices_host.shape[0]
+        assert (
+            kv_indptr_host[-1].item() == kv_indices_host.shape[0]
+        ), f"{kv_indptr_host[-1].item()} != {kv_indices_host.shape[0]}"
         assert num_kv_heads == block_mask_map.shape[0]
         assert num_kv_heads == block_row_sz.shape[0]
         assert num_kv_heads == block_col_sz.shape[0]
         assert num_blocks_row == block_mask_map.shape[1]
         assert num_blocks_col == block_mask_map.shape[2]
-
-        kv_indptr_host = kv_indptr_host.to("cpu")
 
         if self._backend == "auto":
             self._backend = determine_attention_backend(
@@ -986,8 +994,12 @@ class VariableBlockSparseAttentionWrapper:
         )
 
         if self._backend == "fa3":
-            self._vector_sparse_indptr_buffer[: len(kv_indptr_host)].copy_(
-                kv_indptr_host, non_blocking=non_blocking
+            if self._vector_sparse_indptr_buffer.numel() <= kv_indptr.numel():
+                raise ValueError(
+                    "_vector_sparse_indptr_buffer is not large enough. Please increase the buffer size."
+                )
+            self._vector_sparse_indptr_buffer[: len(kv_indptr)].copy_(
+                kv_indptr, non_blocking=non_blocking
             )
 
         self._plan_info = self._cached_module.plan(
@@ -1135,6 +1147,14 @@ class VariableBlockSparseAttentionWrapper:
             _check_shape_dtype_device(out, q.shape, self._o_dtype, q.device, "out")
 
         if self._backend == "fa3":
+            if (
+                self._vector_sparse_indices_buffer.numel()
+                <= self._paged_kv_indices_buf.numel()
+            ):
+                raise ValueError(
+                    "_vector_sparse_indices_buffer is not large enough. Please increase the buffer size."
+                )
+
             sparse_indices = block_sparse_indices_to_vector_sparse_offsets(
                 self._paged_kv_indices_buf,
                 self._paged_kv_indptr_buf,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Per discussion with @haochengxi and @radioheading, this PR moves the `plan` function in `VariableBlockSparseAttentionWrapper` to the GPU side, to avoid expensive (hundreds ms) host operations.  This PR also enlarges the default internal buffer size to accommodate video DiT use cases.
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues
This PR should solve https://github.com/flashinfer-ai/flashinfer/issues/1271
<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
