### PR TITLE
add cutlass backend for mm_fp4

### DIFF
--- a/csrc/fp4_gemm_cutlass.cu
+++ b/csrc/fp4_gemm_cutlass.cu
@@ -90,11 +90,6 @@ void runGemm(at::Tensor& out, at::Tensor const& mat1, at::Tensor const& mat2,
 constexpr auto FLOAT4_E2M1X2 = at::ScalarType::Byte;  // uint8_t
 constexpr auto SF_DTYPE = at::ScalarType::Byte;       // uint8_t
 
-#define CHECK_GPU_INPUT(x, st)                             \
-  TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")    \
-  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous") \
-  TORCH_CHECK(x.scalar_type() == st, "Inconsistency of Tensor type: " #x)
-
 // mat1: [B, M, K / 2], FLOAT4_E2M1X2 or [B, M, K], FLOAT8_E4M3FN
 // mat2: [B, N, K / 2], FLOAT4_E2M1X2
 // out: [B, M, N], fp16/bf16/fp32
@@ -105,15 +100,15 @@ constexpr auto SF_DTYPE = at::ScalarType::Byte;       // uint8_t
 at::Tensor fp4_bmm_impl(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
                         at::Tensor const& mat2Scale, at::Tensor const& globalScale, at::Tensor out,
                         at::Tensor workspace_buffer, int64_t tactic) {
-  CHECK_GPU_INPUT(mat1, FLOAT4_E2M1X2);
-  CHECK_GPU_INPUT(mat2, FLOAT4_E2M1X2);
+  CHECK_INPUT_AND_TYPE(mat1, FLOAT4_E2M1X2);
+  CHECK_INPUT_AND_TYPE(mat2, FLOAT4_E2M1X2);
 
   int mat2_k_scale = 1;
 
-  CHECK_GPU_INPUT(mat1Scale, SF_DTYPE);
-  CHECK_GPU_INPUT(mat2Scale, SF_DTYPE);
+  CHECK_INPUT_AND_TYPE(mat1Scale, SF_DTYPE);
+  CHECK_INPUT_AND_TYPE(mat2Scale, SF_DTYPE);
 
-  CHECK_GPU_INPUT(globalScale, at::ScalarType::Float);
+  CHECK_INPUT_AND_TYPE(globalScale, at::ScalarType::Float);
 
   int64_t m, n, k, b;
   if (mat1.dim() == 2) {

--- a/csrc/fp4_gemm_cutlass.cu
+++ b/csrc/fp4_gemm_cutlass.cu
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <ATen/cuda/EmptyTensor.h>
+#include <cuda_fp16.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <vector>
+
+#include "flashinfer/gemm/cutlass_gemm_configs.h"
+#include "flashinfer/gemm/fp4_gemm_cutlass.h"
+#include "flashinfer/gemm/fp4_gemm_cutlass_template.h"
+#include "pytorch_extension_utils.h"
+
+using flashinfer::gemm::ClusterShape;
+using flashinfer::gemm::CutlassFp4GemmRunner;
+using flashinfer::gemm::CutlassFp4GemmRunnerInterface;
+using flashinfer::gemm::CutlassGemmConfig;
+using flashinfer::gemm::CutlassTileConfigSM100;
+using flashinfer::gemm::EpilogueScheduleType;
+using flashinfer::gemm::FP4GemmType;
+using flashinfer::gemm::MainloopScheduleType;
+
+namespace flashinfer {
+namespace gemm {
+template class CutlassFp4GemmRunner<__nv_bfloat16, FP4GemmType::W4A4_NVFP4_NVFP4>;
+template class CutlassFp4GemmRunner<half, FP4GemmType::W4A4_NVFP4_NVFP4>;
+}  // namespace gemm
+}  // namespace flashinfer
+
+namespace torch_ext {
+
+namespace {
+
+CutlassGemmConfig getFp4GemmConfig(int64_t m, int64_t n, int64_t k, int64_t tactic) {
+  auto getCutlassFp4GemmConfigs = []() {
+    CutlassFp4GemmRunner<__nv_bfloat16, FP4GemmType::W4A4_NVFP4_NVFP4> gemmRunner;
+    return gemmRunner.getConfigs();
+  };
+  static std::vector<CutlassGemmConfig> globalConfigs = getCutlassFp4GemmConfigs();
+  TORCH_CHECK(tactic >= 0 && tactic < globalConfigs.size(), "tactic must be between 0 and ",
+              globalConfigs.size());
+  return globalConfigs[tactic];
+}
+
+template <typename T>
+void runGemm(at::Tensor& out, at::Tensor const& mat1, at::Tensor const& mat2,
+             at::Tensor const& mat1Scale, at::Tensor const& mat2Scale,
+             at::Tensor const& globalScale, int64_t m, int64_t n, int64_t k, int64_t batch_count,
+             CutlassGemmConfig const& gemmConfig, at::Tensor workspace_buffer) {
+  CutlassFp4GemmRunner<T, FP4GemmType::W4A4_NVFP4_NVFP4> gemmRunner;
+
+  int64_t const required_workspace_size = gemmRunner.getWorkspaceSize(m, n, k, batch_count);
+  int64_t const provided_workspace_size =
+      workspace_buffer.numel() * workspace_buffer.element_size();
+
+  auto runKernel = [&](void* workspace) {
+    gemmRunner.gemm(out.data_ptr(), mat1.const_data_ptr(), mat2.const_data_ptr(),
+                    mat1Scale.const_data_ptr(), mat2Scale.const_data_ptr(),
+                    globalScale.data_ptr<float>(), m, n, k, batch_count, gemmConfig,
+                    reinterpret_cast<char*>(workspace), required_workspace_size,
+                    at::cuda::getCurrentCUDAStream(mat1.get_device()));
+  };
+
+  if (provided_workspace_size < required_workspace_size) {
+    at::Tensor new_workspace = at::detail::empty_cuda(
+        {required_workspace_size}, at::ScalarType::Char, mat1.device(), std::nullopt);
+
+    runKernel(new_workspace.data_ptr());
+  } else {
+    runKernel(workspace_buffer.data_ptr());
+  }
+}
+
+constexpr auto FLOAT4_E2M1X2 = at::ScalarType::Byte;  // uint8_t
+constexpr auto SF_DTYPE = at::ScalarType::Byte;       // uint8_t
+
+#define CHECK_GPU_INPUT(x, st)                             \
+  TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")    \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous") \
+  TORCH_CHECK(x.scalar_type() == st, "Inconsistency of Tensor type: " #x)
+
+// mat1: [B, M, K / 2], FLOAT4_E2M1X2 or [B, M, K], FLOAT8_E4M3FN
+// mat2: [B, N, K / 2], FLOAT4_E2M1X2
+// out: [B, M, N], fp16/bf16/fp32
+// mat1Scale: ceil(M / 128) * 128 * ceil(K / sfVecSize / 4) * 4, SF_DTYPE (UE4M3 or UE8M0)
+// mat2Scale: ceil(N / 128) * 128 * ceil(K / sfVecSize / 4) * 4, SF_DTYPE (UE4M3 or UE8M0)
+// globalScale: [1], 1 / (((448 * 6) / mat1.abs().max()) * ((448 * 6) / mat2.abs().max()))
+// B = 1 for GEMM op as a special case
+at::Tensor fp4_bmm_impl(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
+                        at::Tensor const& mat2Scale, at::Tensor const& globalScale, at::Tensor out,
+                        at::Tensor workspace_buffer, int64_t tactic) {
+  CHECK_GPU_INPUT(mat1, FLOAT4_E2M1X2);
+  CHECK_GPU_INPUT(mat2, FLOAT4_E2M1X2);
+
+  int mat2_k_scale = 1;
+
+  CHECK_GPU_INPUT(mat1Scale, SF_DTYPE);
+  CHECK_GPU_INPUT(mat2Scale, SF_DTYPE);
+
+  CHECK_GPU_INPUT(globalScale, at::ScalarType::Float);
+
+  int64_t m, n, k, b;
+  if (mat1.dim() == 2) {
+    TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
+    TORCH_CHECK(mat1.sizes()[1] == mat2.sizes()[1] * mat2_k_scale,
+                "mat1 and mat2 shapes cannot be multiplied (", mat1.sizes()[0], "x",
+                mat1.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")");
+    m = mat1.sizes()[0];
+    n = mat2.sizes()[0];
+    k = mat2.sizes()[1] * 2;
+    b = 1;
+  } else if (mat1.dim() == 3) {
+    TORCH_CHECK(mat2.dim() == 3, "mat2 must be a batch of matrices");
+    TORCH_CHECK(mat1.sizes()[0] == mat2.sizes()[0], "mat1 and mat2 must have the same batch size (",
+                mat1.sizes()[0], " and ", mat2.sizes()[0], ")");
+    TORCH_CHECK(mat1.sizes()[2] == mat2.sizes()[2] * mat2_k_scale,
+                "mat1 and mat2 shapes cannot be multiplied (", mat1.sizes()[1], "x",
+                mat1.sizes()[2], " and ", mat2.sizes()[1], "x", mat2.sizes()[2], ")");
+    m = mat1.sizes()[1];
+    n = mat2.sizes()[1];
+    k = mat2.sizes()[2] * 2;
+    b = mat1.sizes()[0];
+  } else {
+    C10_THROW_ERROR(NotImplementedError, "mat1 must be a matrix or a batch of matrices");
+  }
+
+  // No heuristic for now, we rely on the autotuner to select the best tactic.
+  if (tactic == -1) {
+    tactic = 0;
+  }
+  auto config = getFp4GemmConfig(m, n, k, tactic);
+
+  constexpr int alignment = 32;
+  TORCH_CHECK(k % alignment == 0, "Expected k to be divisible by ", alignment,
+              ", but got mat1 shape: (", mat1.sizes()[0], "x", mat1.sizes()[1], "), k: ", k, ".");
+  TORCH_CHECK(n % alignment == 0, "Expected n to be divisible by ", alignment,
+              ", but got mat2 shape: (", mat2.sizes()[0], "x", mat2.sizes()[1], ").");
+
+  // Validate out dimensions
+  std::vector<int64_t> out_shape =
+      mat1.dim() == 2 ? std::vector<int64_t>{m, n} : std::vector<int64_t>{b, m, n};
+  TORCH_CHECK(out.dim() == out_shape.size(), "out must have ", out_shape.size(),
+              " dimensions, but got ", out.dim());
+  for (int i = 0; i < out_shape.size(); ++i) {
+    TORCH_CHECK(out.sizes()[i] == out_shape[i], "out shape mismatch at dimension ", i,
+                ": expected ", out_shape[i], ", got ", out.sizes()[i]);
+  }
+
+  c10::ScalarType out_dtype = out.scalar_type();
+
+  switch (out_dtype) {
+    case at::ScalarType::Half:
+      runGemm<half>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config,
+                    workspace_buffer);
+      break;
+    case at::ScalarType::BFloat16:
+      runGemm<__nv_bfloat16>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config,
+                             workspace_buffer);
+      break;
+    default:
+      TORCH_CHECK(false, "out_dtype must be one of fp16/bf16.");
+  }
+  return out;
+}
+
+}  // namespace
+
+at::Tensor fp4_gemm(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
+                    at::Tensor const& mat2Scale, at::Tensor const& globalScale, at::Tensor out,
+                    at::Tensor workspace_buffer, int64_t tactic) {
+  return fp4_bmm_impl(mat1, mat2, mat1Scale, mat2Scale, globalScale, out, workspace_buffer, tactic);
+}
+
+int64_t fp4_gemm_tactic_num() {
+  auto getCutlassConfigs = []() {
+    CutlassFp4GemmRunner<__nv_bfloat16, FP4GemmType::W4A4_NVFP4_NVFP4> gemmRunner;
+    return gemmRunner.getConfigs();
+  };
+  static int64_t totalTactics = getCutlassConfigs().size();
+  return totalTactics;
+}
+
+}  // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  m.def("fp4_gemm", &torch_ext::fp4_gemm);
+  m.def("fp4_gemm_tactic_num", &torch_ext::fp4_gemm_tactic_num);
+}

--- a/csrc/fp4_gemm_cutlass.jinja
+++ b/csrc/fp4_gemm_cutlass.jinja
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flashinfer/gemm/fp4_gemm_cutlass_template.h"
+
+namespace flashinfer {
+namespace gemm {
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 1, 1, _1SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 2, 1, _1SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 4, 1, _1SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 2, 1, 1, _2SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 2, 2, 1, _2SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 2, 4, 1, _2SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 4, 2, 1, _2SM)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 4, 4, 1, _2SM)
+
+}  // namespace gemm
+}  // namespace flashinfer

--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -314,6 +314,10 @@ inline constexpr uint32_t pack_u16(uint16_t a, uint16_t b) {
   CHECK_CONTIGUOUS(x)
 #define CHECK_INPUT_TYPE(x, st) \
   TORCH_CHECK(x.scalar_type() == st, "Inconsistency of Tensor type: " #x)
+#define CHECK_INPUT_AND_TYPE(x, st) \
+  CHECK_CUDA(x);                    \
+  CHECK_CONTIGUOUS(x);              \
+  CHECK_INPUT_TYPE(x, st)
 #define CHECK_LAST_DIM_CONTIGUOUS_INPUT(x) \
   CHECK_CUDA(x);                           \
   CHECK_LAST_DIM_CONTIGUOUS(x)

--- a/include/flashinfer/arch_condition.h
+++ b/include/flashinfer/arch_condition.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLASHINFER_ARCH_CONDITION_H_
+#define FLASHINFER_ARCH_CONDITION_H_
+
+namespace flashinfer {
+
+namespace detail {
+
+#ifdef __CUDA_ARCH__
+
+#ifdef __CUDA_ARCH_SPECIFIC__
+static constexpr bool isArchSpecific = true;
+#else
+static constexpr bool isArchSpecific = false;
+#endif
+
+struct arch_info {
+  static constexpr bool mIsDevice = true;
+  static constexpr bool mArchSpecific = isArchSpecific;
+  static constexpr int mMajor = __CUDA_ARCH__ / 100;
+  static constexpr int mMinor = __CUDA_ARCH__ / 10 % 10;
+  static constexpr int mArch = __CUDA_ARCH__ / 10;
+};
+
+#else
+
+struct arch_info {
+  static constexpr bool mIsDevice = false;
+  static constexpr bool mArchSpecific = false;
+  static constexpr int mMajor = 0;
+  static constexpr int mMinor = 0;
+  static constexpr int mArch = 0;
+};
+
+#endif
+
+#if __CUDA_ARCH__ >= 900
+#if !defined(__CUDA_ARCH_SPECIFIC__) && !defined(__CUDA_ARCH_FAMILY_SPECIFIC__)
+#error \
+    "Compiling for SM90 or newer architectures must use Arch specific or Arch Family specific target"
+#endif
+#endif
+
+}  // namespace detail
+
+namespace arch {
+
+struct is_device : std::bool_constant<detail::arch_info::mIsDevice> {};
+
+struct is_arch_specific : std::bool_constant<detail::arch_info::mArchSpecific> {};
+
+template <int Arch>
+struct is_match : std::bool_constant<is_device::value && detail::arch_info::mArch == Arch> {};
+
+template <int Major>
+struct is_major : std::bool_constant<is_device::value && detail::arch_info::mMajor == Major> {};
+
+template <int Arch>
+struct is_compatible
+    : std::bool_constant<is_major<Arch>::value && detail::arch_info::mArch >= Arch> {};
+
+inline constexpr bool is_device_v = is_device::value;
+
+inline constexpr bool is_arch_specific_v = is_arch_specific::value;
+
+template <int Arch>
+inline constexpr bool is_match_v = is_match<Arch>::value;
+
+template <int Major>
+inline constexpr bool is_major_v = is_major<Major>::value;
+
+template <int Arch>
+inline constexpr bool is_compatible_v = is_compatible<Arch>::value;
+
+}  // namespace arch
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ARCH_CONDITION_H_

--- a/include/flashinfer/arch_condition.h
+++ b/include/flashinfer/arch_condition.h
@@ -50,9 +50,11 @@ struct arch_info {
 #endif
 
 #if __CUDA_ARCH__ >= 900
+#if CUDA_VERSION >= 12090
 #if !defined(__CUDA_ARCH_SPECIFIC__) && !defined(__CUDA_ARCH_FAMILY_SPECIFIC__)
 #error \
     "Compiling for SM90 or newer architectures must use Arch specific or Arch Family specific target"
+#endif
 #endif
 #endif
 

--- a/include/flashinfer/cutlass_utils.cuh
+++ b/include/flashinfer/cutlass_utils.cuh
@@ -103,6 +103,45 @@ void compileTimeDebug(T&&) {
     }                                                                                 \
   } while (0)
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Tllm to Cutlass
+
+template <typename T>
+struct TllmToCutlassTypeAdapter {
+  using type = T;
+};
+
+template <>
+struct TllmToCutlassTypeAdapter<half> {
+  using type = cutlass::half_t;
+};
+
+#if defined(ENABLE_BF16)
+template <>
+struct TllmToCutlassTypeAdapter<__nv_bfloat16> {
+  using type = cutlass::bfloat16_t;
+};
+#endif
+
+#if defined(ENABLE_FP8)
+template <>
+struct TllmToCutlassTypeAdapter<__nv_fp8_e4m3> {
+  using type = cutlass::float_e4m3_t;
+};
+
+template <>
+struct TllmToCutlassTypeAdapter<__nv_fp8_e5m2> {
+  using type = cutlass::float_e5m2_t;
+};
+#endif
+
+#if defined(ENABLE_FP4)
+template <>
+struct TllmToCutlassTypeAdapter<__nv_fp4_e2m1> {
+  using type = cutlass::float_e2m1_t;
+};
+#endif
+
 }  // namespace flashinfer
 
 #endif  // FLASHINFER_CUTLASS_UTILS_CUH_

--- a/include/flashinfer/cutlass_utils.cuh
+++ b/include/flashinfer/cutlass_utils.cuh
@@ -103,45 +103,6 @@ void compileTimeDebug(T&&) {
     }                                                                                 \
   } while (0)
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Tllm to Cutlass
-
-template <typename T>
-struct TllmToCutlassTypeAdapter {
-  using type = T;
-};
-
-template <>
-struct TllmToCutlassTypeAdapter<half> {
-  using type = cutlass::half_t;
-};
-
-#if defined(ENABLE_BF16)
-template <>
-struct TllmToCutlassTypeAdapter<__nv_bfloat16> {
-  using type = cutlass::bfloat16_t;
-};
-#endif
-
-#if defined(ENABLE_FP8)
-template <>
-struct TllmToCutlassTypeAdapter<__nv_fp8_e4m3> {
-  using type = cutlass::float_e4m3_t;
-};
-
-template <>
-struct TllmToCutlassTypeAdapter<__nv_fp8_e5m2> {
-  using type = cutlass::float_e5m2_t;
-};
-#endif
-
-#if defined(ENABLE_FP4)
-template <>
-struct TllmToCutlassTypeAdapter<__nv_fp4_e2m1> {
-  using type = cutlass::float_e2m1_t;
-};
-#endif
-
 }  // namespace flashinfer
 
 #endif  // FLASHINFER_CUTLASS_UTILS_CUH_

--- a/include/flashinfer/gemm/cutlass_gemm_configs.h
+++ b/include/flashinfer/gemm/cutlass_gemm_configs.h
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_CUTLASS_GEMM_CONFIG_H_
+#define FLASHINFER_CUTLASS_GEMM_CONFIG_H_
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "cute/tensor.hpp"
+
+namespace flashinfer {
+namespace gemm {
+
+// Note: The shapes are in the format MxNxK. The K shape of the runtime config MUST match the K
+// shape
+//       in the kernel layout details when doing weight only quantization.
+enum class CutlassTileConfig {
+  // Signals that we should run heuristics do choose a config
+  Undefined,
+
+  // Signals that we should run heuristics do choose a config
+  ChooseWithHeuristic,
+
+  // SiMT config
+  CtaShape128x128x8_WarpShape64x64x8,
+
+  // TensorCore configs CTA_N = 128, CTA_K = 64
+  // Warp configs for M=16
+  CtaShape16x128x64_WarpShape16x32x64,
+  // Warp configs for M=32
+  CtaShape32x128x64_WarpShape32x32x64,
+
+  // Warp configs for M=64
+  CtaShape64x128x64_WarpShape32x64x64,
+  CtaShape64x64x128_WarpShape32x64x64,
+  CtaShape64x128x64_WarpShape64x32x64,
+
+  // Warp configs for M=128
+  CtaShape128x64x64_WarpShape64x32x64,
+  CtaShape128x128x64_WarpShape64x32x64,
+  CtaShape128x128x64_WarpShape64x64x64,
+  CtaShape128x128x64_WarpShape128x32x64,
+  CtaShape128x256x64_WarpShape64x64x64,
+
+  // Warp configs for M=256
+  CtaShape256x128x64_WarpShape64x64x64,
+
+  // TensorCore config CTA_N = 64, CTA_K = 128
+  CtaShape128x64x128_WarpShape64x32x128,
+
+  // TensorCore config CTA_N = 256, CTA_K = 64
+  CtaShape16x256x64_WarpShape16x64x64,
+
+  // TensorCore config CTA_N = 256, CTA_K = 128
+  CtaShape16x256x128_WarpShape16x64x128
+
+};
+
+enum class SplitKStyle {
+  NO_SPLIT_K,
+  SPLIT_K_SERIAL,
+  STREAM_K,  // Sm80+
+             // SPLIT_K_PARALLEL // Not supported yet
+};
+
+enum class CutlassTileConfigSM90 {
+  // Signals that we should run heuristics do choose a config
+  Undefined,
+
+  // Signals that we should run heuristics do choose a config
+  ChooseWithHeuristic,
+
+  // CTA configs for M=64
+  CtaShape64x16x128B,
+  CtaShape64x32x128B,
+  CtaShape64x64x128B,
+  CtaShape64x128x128B,
+  CtaShape64x256x128B,
+
+  // CTA configs for M=128
+  CtaShape128x16x128B,
+  CtaShape128x32x128B,
+  CtaShape128x64x128B,
+  CtaShape128x128x128B,
+  CtaShape128x256x128B,
+
+  // CTA configs for M=128
+  CtaShape256x128x128B,
+};
+
+enum class CutlassTileConfigSM100 {
+  // Signals that we should run heuristics do choose a config
+  Undefined,
+
+  // Signals that we should run heuristics do choose a config
+  ChooseWithHeuristic,
+
+  /*
+   * Grouped GEMM
+   */
+  // M=64
+  CtaShape64x32x128B,
+  CtaShape64x64x128B,
+  CtaShape64x128x128B,
+  CtaShape64x256x128B,
+
+  // M=128
+  CtaShape128x8x256B,
+  CtaShape128x16x128B,
+  CtaShape128x32x128B,
+  CtaShape128x64x128B,
+  CtaShape128x128x128B,
+  CtaShape128x256x128B,
+  CtaShape128x128x256B,
+  CtaShape128x256x256B,
+
+  // M=256
+  CtaShape256x64x128B,
+  CtaShape256x128x128B,
+  CtaShape256x256x128B,
+};
+
+enum class CutlassTileConfigSM120 {
+  // Signals that we should run heuristics do choose a config
+  Undefined,
+
+  // Signals that we should run heuristics do choose a config
+  ChooseWithHeuristic,
+
+  CtaShape128x128x128B,
+  CtaShape128x128x64B,
+  CtaShape256x128x64B,
+  CtaShape128x256x64B,
+  CtaShape128x128x256B,
+  CtaShape256x128x128B,
+};
+
+enum class MainloopScheduleType {
+  AUTO,  // Automatically selects between pingpong and cooperative schedules on Hopper. On older
+         // architectures, this defaults to the "legacy" main loop schedule.
+  PINGPONG,
+  COOPERATIVE,
+  WARPSPECIALIZED
+};
+
+static auto get_mainloop_schedule_name(MainloopScheduleType schedule) {
+  if (schedule == MainloopScheduleType::AUTO) {
+    return "auto";
+  } else if (schedule == MainloopScheduleType::PINGPONG) {
+    return "pingpong";
+  } else if (schedule == MainloopScheduleType::COOPERATIVE) {
+    return "cooperative";
+  } else if (schedule == MainloopScheduleType::WARPSPECIALIZED) {
+    return "warpspecialized";
+  }
+  return "unknown schedule";
+}
+
+enum class EpilogueScheduleType {
+  AUTO,  // Automatically chooses an epilogue schedule compatible with the selected main loop
+         // schedule for Hopper. For architectures older than hopper, the epilogue is always
+         // performed by the same thread block as the main loop.
+};
+
+enum class TileShape {
+  TileShape_64x16x128,
+  TileShape_64x32x128,
+  TileShape_64x64x128,
+  TileShape_64x128x128,
+  TileShape_64x256x128,
+  TileShape_64x512x128,
+  TileShape_128x16x128,
+  TileShape_128x32x128,
+  TileShape_128x64x128,
+  TileShape_128x128x128,
+  TileShape_128x256x128
+};
+
+template <TileShape Shape_MNK>
+constexpr auto get_tile_shape() {
+  using namespace cute;
+  if constexpr (Shape_MNK == TileShape::TileShape_64x16x128) {
+    return cute::Shape<_64, _16, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_64x32x128) {
+    return cute::Shape<_64, _32, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_64x64x128) {
+    return cute::Shape<_64, _64, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_64x128x128) {
+    return cute::Shape<_64, _128, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_64x256x128) {
+    return cute::Shape<_64, _256, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_64x512x128) {
+    return cute::Shape<_64, _512, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_128x16x128) {
+    return cute::Shape<_128, _16, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_128x32x128) {
+    return cute::Shape<_128, _32, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_128x64x128) {
+    return cute::Shape<_128, _64, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_128x128x128) {
+    return cute::Shape<_128, _128, _128>{};
+  } else if constexpr (Shape_MNK == TileShape::TileShape_128x256x128) {
+    return cute::Shape<_128, _256, _128>{};
+  }
+}
+
+static auto get_tile_shape_name(TileShape Shape_MNK) {
+  if (Shape_MNK == TileShape::TileShape_64x16x128) {
+    return "64x16x128";
+  } else if (Shape_MNK == TileShape::TileShape_64x32x128) {
+    return "64x32x128";
+  } else if (Shape_MNK == TileShape::TileShape_64x64x128) {
+    return "64x64x128";
+  } else if (Shape_MNK == TileShape::TileShape_64x128x128) {
+    return "64x128x128";
+  } else if (Shape_MNK == TileShape::TileShape_64x256x128) {
+    return "64x256x128";
+  } else if (Shape_MNK == TileShape::TileShape_64x512x128) {
+    return "64x512x128";
+  } else if (Shape_MNK == TileShape::TileShape_128x16x128) {
+    return "128x16x128";
+  } else if (Shape_MNK == TileShape::TileShape_128x32x128) {
+    return "128x32x128";
+  } else if (Shape_MNK == TileShape::TileShape_128x64x128) {
+    return "128x64x128";
+  } else if (Shape_MNK == TileShape::TileShape_128x128x128) {
+    return "128x128x128";
+  } else if (Shape_MNK == TileShape::TileShape_128x256x128) {
+    return "128x256x128";
+  }
+  return "Unknown shape";
+}
+
+enum class ClusterShape {
+  ClusterShape_1x1x1,
+  ClusterShape_2x1x1,
+  ClusterShape_1x2x1,
+  ClusterShape_2x2x1,
+  ClusterShape_1x4x1,
+  ClusterShape_4x2x1,
+  ClusterShape_2x4x1,
+  ClusterShape_4x4x1,
+  ClusterShape_1x8x1,
+  ClusterShape_8x1x1
+};
+
+static auto get_cluster_shape_name(ClusterShape Shape_MNK) {
+  if (Shape_MNK == ClusterShape::ClusterShape_1x1x1) {
+    return "1x1x1";
+  } else if (Shape_MNK == ClusterShape::ClusterShape_2x1x1) {
+    return "2x1x1";
+  } else if (Shape_MNK == ClusterShape::ClusterShape_1x2x1) {
+    return "1x2x1";
+  } else if (Shape_MNK == ClusterShape::ClusterShape_2x2x1) {
+    return "2x2x1";
+  } else if (Shape_MNK == ClusterShape::ClusterShape_1x8x1) {
+    return "1x8x1";
+  } else if (Shape_MNK == ClusterShape::ClusterShape_8x1x1) {
+    return "8x1x1";
+  }
+  return "Unknown shape";
+}
+
+template <ClusterShape Shape_MNK>
+constexpr auto get_cluster_shape() {
+  using namespace cute;
+  if constexpr (Shape_MNK == ClusterShape::ClusterShape_1x1x1) {
+    return cute::Shape<_1, _1, _1>{};
+  } else if constexpr (Shape_MNK == ClusterShape::ClusterShape_2x1x1) {
+    return cute::Shape<_2, _1, _1>{};
+  } else if constexpr (Shape_MNK == ClusterShape::ClusterShape_1x2x1) {
+    return cute::Shape<_1, _2, _1>{};
+  } else if constexpr (Shape_MNK == ClusterShape::ClusterShape_2x2x1) {
+    return cute::Shape<_2, _2, _1>{};
+  } else if constexpr (Shape_MNK == ClusterShape::ClusterShape_1x8x1) {
+    return cute::Shape<_1, _8, _1>{};
+  } else if constexpr (Shape_MNK == ClusterShape::ClusterShape_8x1x1) {
+    return cute::Shape<_8, _1, _1>{};
+  }
+}
+
+struct CutlassGemmConfig {
+  enum CandidateConfigTypeParam : int {
+    NONE = 0,
+    WEIGHT_ONLY = 1u << 0,
+    SIMT_ONLY = 1u << 1,
+    INT8_ONLY = 1u << 2,
+    HOPPER = 1u << 3,
+    BLACKWELL = 1u << 4,
+    GROUPED_GEMM = 1u << 5,
+    FP8_ONLY = 1u << 6,
+    FP4_ONLY = 1u << 7
+  };
+
+  CutlassTileConfig tile_config_sm80 = CutlassTileConfig::ChooseWithHeuristic;
+  SplitKStyle split_k_style = SplitKStyle::NO_SPLIT_K;
+  int split_k_factor = -1;
+  int stages = -1;
+
+  // config options for sm90
+  CutlassTileConfigSM90 tile_config_sm90 = CutlassTileConfigSM90::ChooseWithHeuristic;
+  CutlassTileConfigSM100 tile_config_sm100 = CutlassTileConfigSM100::ChooseWithHeuristic;
+  CutlassTileConfigSM120 tile_config_sm120 = CutlassTileConfigSM120::ChooseWithHeuristic;
+  MainloopScheduleType mainloop_schedule = MainloopScheduleType::AUTO;
+  EpilogueScheduleType epilogue_schedule = EpilogueScheduleType::AUTO;
+  ClusterShape cluster_shape = ClusterShape::ClusterShape_1x1x1;
+  bool enableCudaKernel = false;
+  int sm_version = 80;  // Use 80 as a catch all for <90
+  bool is_tma_warp_specialized = false;
+
+  CutlassGemmConfig() = default;
+
+  CutlassGemmConfig(CutlassTileConfig tile_config, SplitKStyle split_k_style, int split_k_factor,
+                    int stages)
+      : tile_config_sm80(tile_config),
+        split_k_style(split_k_style),
+        split_k_factor(split_k_factor),
+        stages(stages),
+        sm_version(80) {}
+
+  CutlassGemmConfig(CutlassTileConfigSM90 tile_config_sm90, MainloopScheduleType mainloop_schedule,
+                    EpilogueScheduleType epilogue_schedule, ClusterShape cluster_shape)
+      : tile_config_sm90(tile_config_sm90),
+        mainloop_schedule(mainloop_schedule),
+        epilogue_schedule(epilogue_schedule),
+        cluster_shape(cluster_shape),
+        sm_version(90),
+        is_tma_warp_specialized(true) {}
+
+  CutlassGemmConfig(CutlassTileConfigSM100 tile_config_sm100,
+                    MainloopScheduleType mainloop_schedule, EpilogueScheduleType epilogue_schedule,
+                    ClusterShape cluster_shape)
+      : tile_config_sm100(tile_config_sm100),
+        mainloop_schedule(mainloop_schedule),
+        epilogue_schedule(epilogue_schedule),
+        cluster_shape(cluster_shape),
+        sm_version(100),
+        is_tma_warp_specialized(true) {}
+
+  CutlassGemmConfig(CutlassTileConfigSM120 tile_config_sm120,
+                    MainloopScheduleType mainloop_schedule, EpilogueScheduleType epilogue_schedule,
+                    ClusterShape cluster_shape)
+      : tile_config_sm120(tile_config_sm120),
+        mainloop_schedule(mainloop_schedule),
+        epilogue_schedule(epilogue_schedule),
+        cluster_shape(cluster_shape),
+        sm_version(120),
+        is_tma_warp_specialized(true) {}
+
+  int getTileConfigAsInt() const {
+    if (sm_version == 120) return (int)tile_config_sm120;
+    if (sm_version >= 100) return (int)tile_config_sm100;
+    if (sm_version == 90) return (int)tile_config_sm90;
+    if (sm_version < 90) return (int)tile_config_sm80;
+    assert(false && "Invalid SM version");
+    return -1;
+  }
+
+  std::string toString() const {
+    std::stringstream tactic;
+    tactic << "Cutlass GEMM Tactic";
+    if (is_tma_warp_specialized) {
+      assert(sm_version >= 90 && "Invalid cutlass GEMM config");
+      tactic << "\n\tstyle=TMA Warp Specialized"
+             << "\n\tsm: " << sm_version << "\n\ttile shape ID: " << getTileConfigAsInt()
+             << "\n\tcluster shape ID: " << (int)cluster_shape
+             << "\n\tmainloop sched: " << (int)mainloop_schedule
+             << "\n\tepi sched: " << (int)epilogue_schedule
+             << "\n\tenable cuda kernel: " << (enableCudaKernel ? "true" : "false");
+    } else if (tile_config_sm80 != flashinfer::gemm::CutlassTileConfig::ChooseWithHeuristic) {
+      assert(sm_version < 90 && "Invalid cutlass GEMM config");
+      tactic << "\n\tstyle=compatible"
+             << "\n\ttile shape ID: " << (int)tile_config_sm80 << "\n\tstages: " << (int)stages
+             << "\n\tsplit k: " << (int)split_k_factor
+             << "\n\tenable cuda kernel: " << (enableCudaKernel ? "true" : "false");
+    } else if (enableCudaKernel) {
+      tactic << "\n\tenable cuda kernel: " << (enableCudaKernel ? "true" : "false");
+    } else {
+      tactic << "\n\tundefined";
+    }
+    tactic << "\n";
+    return tactic.str();
+  }
+};
+
+inline std::ostream& operator<<(std::ostream& out, CutlassGemmConfig const& config) {
+  // clang-format off
+    if (config.is_tma_warp_specialized)
+    {
+        out << "tile_config_sm90_enum: " << config.getTileConfigAsInt()
+            << ", mainloop_schedule_enum: " << int(config.mainloop_schedule)
+            << ", epilogue_schedule_enum: " << int(config.epilogue_schedule)
+            << ", cluster_shape_enum: " << int(config.cluster_shape)
+            << ", enable_cuda_kernel: " << (config.enableCudaKernel ? "true" : "false");
+    }
+    else
+    {
+        out << "tile_config_enum: " << config.getTileConfigAsInt()
+            << ", split_k_style_enum: " << int(config.split_k_style)
+            << ", split_k_factor: " << config.split_k_factor
+            << ", stages: " << config.stages
+            << ", enable_cuda_kernel: " << (config.enableCudaKernel ? "true" : "false");
+    }
+  // clang-format on
+  return out;
+}
+
+}  // namespace gemm
+}  // namespace flashinfer
+#endif  // FLASHINFER_CUTLASS_GEMM_CONFIG_H_

--- a/include/flashinfer/gemm/fp4_gemm_cutlass.h
+++ b/include/flashinfer/gemm/fp4_gemm_cutlass.h
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLASHINFER_FP4_GEMM_CUTLASS_H_
+#define FLASHINFER_FP4_GEMM_CUTLASS_H_
+
+#include <cuda_runtime_api.h>
+
+#include <vector>
+
+#include "flashinfer/gemm/cutlass_gemm_configs.h"
+
+namespace flashinfer {
+namespace gemm {
+
+/*
+  This runner supports:
+  FP4 inputs (A and B)
+  float blockwise scaling factor
+  float alpha scalings
+  T output (D) where T = {float, half, __nv_bfloat16}
+
+  Activations, biases and outputs are all assumed to be row-major.
+  Weights are assumed to be column-major.
+  Block scaling factor are interleaved.
+*/
+
+class CutlassFp4GemmRunnerInterface {
+ public:
+  CutlassFp4GemmRunnerInterface() {}
+
+  virtual ~CutlassFp4GemmRunnerInterface() {}
+
+  virtual void gemm(void* D, void const* A, void const* B, void const* input_sf,
+                    void const* weight_sf, float const* global_sf, int m, int n, int k,
+                    int batch_count, CutlassGemmConfig gemmConfig, char* workspace,
+                    const size_t workspaceBytes, cudaStream_t stream) = 0;
+
+  // Returns desired workspace size in bytes.
+  virtual size_t getWorkspaceSize(int const m, int const n, int const k, int batch_count) = 0;
+
+  virtual std::vector<CutlassGemmConfig> getConfigs() const = 0;
+};
+
+enum class FP4GemmType {
+  W4A4_NVFP4_NVFP4,
+};
+
+template <typename T, FP4GemmType gemmType = FP4GemmType::W4A4_NVFP4_NVFP4>
+class CutlassFp4GemmRunner : public virtual CutlassFp4GemmRunnerInterface {
+ public:
+  CutlassFp4GemmRunner();
+  ~CutlassFp4GemmRunner();
+
+  void gemm(void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,
+            float const* global_sf, int m, int n, int k, int batch_count,
+            CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes,
+            cudaStream_t stream) override;
+
+  // Returns desired workspace size in bytes.
+  size_t getWorkspaceSize(int const m, int const n, int const k, int const batch_count) override;
+
+  std::vector<CutlassGemmConfig> getConfigs() const override;
+
+ private:
+  size_t dispatchToArch(T* D, void const* A, void const* B, void const* input_sf,
+                        void const* weight_sf, float const* global_sf, int m, int n, int k,
+                        int batch_count, CutlassGemmConfig gemmConfig, char* workspace,
+                        const size_t workspaceBytes, cudaStream_t stream, int* occupancy = nullptr);
+
+  size_t getWorkspaceSizeImpl(int const m, int const n, int const k, int const batch_count);
+};
+
+}  // namespace gemm
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_FP4_GEMM_CUTLASS_H_

--- a/include/flashinfer/gemm/fp4_gemm_cutlass_template.h
+++ b/include/flashinfer/gemm/fp4_gemm_cutlass_template.h
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLASHINFER_FP4_GEMM_CUTLASS_TEMPLATE_H_
+#define FLASHINFER_FP4_GEMM_CUTLASS_TEMPLATE_H_
+
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif  // #ifndef _WIN32
+
+#include "cutlass/arch/arch.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/gemm.h"
+#include "flashinfer/gemm/cutlass_gemm_configs.h"
+
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif  // #ifndef _WIN32
+
+#include "flashinfer/gemm/fp4_gemm_cutlass.h"
+#include "fp4_gemm_template_sm100.h"
+
+namespace flashinfer {
+namespace gemm {
+using namespace cute;
+
+template <typename T, typename CTA_M_, typename CTA_N_, typename CTA_K_>
+size_t dispatchNVFP4xNVFP4GemmClusterShapeSm100(T* D, void const* A, void const* B,
+                                                void const* input_sf, void const* weight_sf,
+                                                float const* global_sf, int m, int n, int k,
+                                                int batch_count, CutlassGemmConfig gemmConfig,
+                                                char* workspace, const size_t workspaceBytes,
+                                                cudaStream_t stream, int* occupancy = nullptr) {
+  switch (gemmConfig.cluster_shape) {
+    case ClusterShape::ClusterShape_1x1x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<1>,
+                                          cute::Int<1>, _1SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_2x1x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<1>,
+                                          cute::Int<1>, _2SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_1x2x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<2>,
+                                          cute::Int<1>, _1SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_2x2x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<2>,
+                                          cute::Int<1>, _2SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_1x4x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<4>,
+                                          cute::Int<1>, _1SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_4x2x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<4>, cute::Int<2>,
+                                          cute::Int<1>, _2SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_2x4x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<4>,
+                                          cute::Int<1>, _2SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case ClusterShape::ClusterShape_4x4x1:
+      return genericFp4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<4>, cute::Int<4>,
+                                          cute::Int<1>, _2SM>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    default:
+      throw std::runtime_error(
+          "[Error][FP4][dispatch_gemm_cluster_shape] Config is invalid for FP4 GEMM.");
+      break;
+  }
+}
+
+template <typename T>
+size_t dispatchNVFP4xNVFP4GemmCTAShapeSm100(T* D, void const* A, void const* B,
+                                            void const* input_sf, void const* weight_sf,
+                                            float const* global_sf, int m, int n, int k,
+                                            int batch_count, CutlassGemmConfig gemmConfig,
+                                            char* workspace, const size_t workspaceBytes,
+                                            cudaStream_t stream, int* occupancy = nullptr) {
+  // Several constraints:
+  // Cta N should be one of 128/192/256.
+  // M-mode size should be 128 or 256 for 2 CTA cluster MMA;
+  // M-mode size should be 128 for 1 CTA cluster OMMA.
+  // K256 looks to be better than K128
+  switch (gemmConfig.tile_config_sm100) {
+    case CutlassTileConfigSM100::CtaShape128x64x128B:
+      return dispatchNVFP4xNVFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<64>,
+                                                      cute::Int<128>>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case CutlassTileConfigSM100::CtaShape128x256x128B:
+      return dispatchNVFP4xNVFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<256>,
+                                                      cute::Int<128>>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case CutlassTileConfigSM100::CtaShape128x128x256B:
+      return dispatchNVFP4xNVFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<128>,
+                                                      cute::Int<256>>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case CutlassTileConfigSM100::CtaShape128x256x256B:
+      return dispatchNVFP4xNVFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<256>,
+                                                      cute::Int<256>>(
+          D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace,
+          workspaceBytes, stream, occupancy);
+      break;
+    case CutlassTileConfigSM100::Undefined:
+      throw std::runtime_error("[Error][FP4][dispatch_gemm_cta_shape] Gemm config undefined.");
+      break;
+    case CutlassTileConfigSM100::ChooseWithHeuristic:
+      throw std::runtime_error(
+          "[Error][FP4][dispatch_gemm_cta_shape] Gemm config should have already been "
+          "set by "
+          "heuristic.");
+      break;
+    default:
+      throw std::runtime_error(
+          "[Error][FP4][dispatch_gemm_cta_shape] Config is invalid for FP4 GEMM.");
+      break;
+  }
+}
+template <typename T, FP4GemmType fp4GemmType>
+CutlassFp4GemmRunner<T, fp4GemmType>::CutlassFp4GemmRunner() {}
+
+template <typename T, FP4GemmType fp4GemmType>
+CutlassFp4GemmRunner<T, fp4GemmType>::~CutlassFp4GemmRunner() {}
+
+template <typename T, FP4GemmType fp4GemmType>
+size_t CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(
+    T* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,
+    float const* global_sf, int m, int n, int k, int batch_count, CutlassGemmConfig gemmConfig,
+    char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {
+  if constexpr (fp4GemmType == FP4GemmType::W4A4_NVFP4_NVFP4) {
+    return dispatchNVFP4xNVFP4GemmCTAShapeSm100<T>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,
+                                                   batch_count, gemmConfig, workspace,
+                                                   workspaceBytes, stream, occupancy);
+  } else {
+    throw std::runtime_error(
+        "[Error][CutlassFp4GemmRunner][GEMM Dispatch] FP4 Gemm type unsupported for "
+        "CUTLASS FP4 GEMM");
+  }
+}
+
+template <typename T, FP4GemmType fp4GemmType>
+void CutlassFp4GemmRunner<T, fp4GemmType>::gemm(void* D, void const* A, void const* B,
+                                                void const* input_sf, void const* weight_sf,
+                                                float const* global_sf, int m, int n, int k,
+                                                int batch_count, CutlassGemmConfig gemmConfig,
+                                                char* workspace, const size_t workspaceBytes,
+                                                cudaStream_t stream) {
+  CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(
+      reinterpret_cast<T*>(D), A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count,
+      gemmConfig, workspace, workspaceBytes, stream);
+}
+
+template <typename T, FP4GemmType fp4GemmType>
+std::vector<CutlassGemmConfig> CutlassFp4GemmRunner<T, fp4GemmType>::getConfigs() const {
+  std::vector<CutlassGemmConfig> candidateConfigs;
+
+  std::vector<CutlassTileConfigSM100> tilesSm100 = {
+      CutlassTileConfigSM100::CtaShape128x64x128B,
+      CutlassTileConfigSM100::CtaShape128x256x128B,
+      CutlassTileConfigSM100::CtaShape128x128x256B,
+      CutlassTileConfigSM100::CtaShape128x256x256B,
+  };
+  std::vector<ClusterShape> clusterShapes = {
+      ClusterShape::ClusterShape_1x1x1, ClusterShape::ClusterShape_1x2x1,
+      ClusterShape::ClusterShape_2x1x1, ClusterShape::ClusterShape_2x2x1,
+      ClusterShape::ClusterShape_1x4x1, ClusterShape::ClusterShape_4x2x1,
+      ClusterShape::ClusterShape_2x4x1, ClusterShape::ClusterShape_4x4x1,
+  };
+  for (auto const& tile_config : tilesSm100) {
+    for (auto const& cluster_config : clusterShapes) {
+      CutlassGemmConfig config(tile_config, MainloopScheduleType::AUTO, EpilogueScheduleType::AUTO,
+                               cluster_config);
+      candidateConfigs.push_back(config);
+    }
+  }
+
+  // There’s no heuristic yet, so for users without autotuning, we provide an ordering based on
+  // performance sweeps from common workloads.
+  std::vector<int64_t> best_tactics_index = {22, 20, 29, 4, 18};
+  std::vector<CutlassGemmConfig> newCandidateConfigs;
+  for (auto const& tactic_index : best_tactics_index) {
+    newCandidateConfigs.push_back(candidateConfigs[tactic_index]);
+  }
+  for (int64_t i = 0; i < candidateConfigs.size(); i++) {
+    if (std::find(best_tactics_index.begin(), best_tactics_index.end(), i) ==
+        best_tactics_index.end()) {
+      newCandidateConfigs.push_back(candidateConfigs[i]);
+    }
+  }
+  return newCandidateConfigs;
+}
+
+template <typename T, FP4GemmType fp4GemmType>
+size_t CutlassFp4GemmRunner<T, fp4GemmType>::getWorkspaceSizeImpl(int const m, int const n,
+                                                                  int const k,
+                                                                  int const batch_count) {
+  size_t workspace_size = 0;
+  auto gemmConfigs = CutlassFp4GemmRunner<T, fp4GemmType>{}.getConfigs();
+  for (auto const& gemmConfig : gemmConfigs) {
+    try {
+      size_t curr_workspace_size = CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(
+          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, m, n, k, batch_count, gemmConfig,
+          nullptr, 0, 0);
+      workspace_size = std::max(workspace_size, curr_workspace_size);
+    } catch (std::runtime_error& e) {
+      // Swallow errors when SMEM exceeds maximum allowed
+      continue;
+    }
+  }
+  return workspace_size;
+}
+
+template <typename T, FP4GemmType fp4GemmType>
+size_t CutlassFp4GemmRunner<T, fp4GemmType>::getWorkspaceSize(int const m, int const n, int const k,
+                                                              int const batch_count) {
+  // Custom hash function for the MNKB type
+  using MNK = std::tuple<int, int, int, int>;
+
+  struct MNKHash {
+    size_t operator()(const MNK& mnk) const {
+      auto h1 = std::hash<int>{}(std::get<0>(mnk));
+      auto h2 = std::hash<int>{}(std::get<1>(mnk));
+      auto h3 = std::hash<int>{}(std::get<2>(mnk));
+      auto h4 = std::hash<int>{}(std::get<3>(mnk));
+      return h1 ^ h2 ^ h3 ^ h4;
+    }
+  };
+
+  static std::unordered_map<MNK, size_t, MNKHash> workspace_hashmap;
+
+  size_t workspace_size = 0;
+  if (workspace_hashmap.find(std::make_tuple(m, n, k, batch_count)) == workspace_hashmap.end()) {
+    workspace_size =
+        CutlassFp4GemmRunner<T, fp4GemmType>::getWorkspaceSizeImpl(m, n, k, batch_count);
+    workspace_hashmap[std::make_tuple(m, n, k, batch_count)] = workspace_size;
+  } else {
+    workspace_size = workspace_hashmap[std::make_tuple(m, n, k, batch_count)];
+  }
+  return workspace_size;
+}
+
+}  // namespace gemm
+}  // namespace flashinfer
+#endif  // FLASHINFER_FP4_GEMM_CUTLASS_TEMPLATE_H_

--- a/include/flashinfer/gemm/fp4_gemm_template_sm100.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm100.h
@@ -100,7 +100,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
                                              XSM_)                                                           \
   struct                                                                                                     \
       DeviceGemmFp4GemmSm100_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_ {   \
-    using OutElementType = flashinfer::TllmToCutlassTypeAdapter<T>::type;                                    \
+    using OutElementType = flashinfer::cutlass_dtype<T>::type;                                               \
     using CTAShape = cute::Shape<cute::Int<CTA_M_>, cute::Int<CTA_N_>, cute::Int<CTA_K_>>;                   \
     /*using ClusterShape = cute::Shape<cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>>;*/           \
     using ClusterShape = cute::Shape<int, int, _1>;                                                          \

--- a/include/flashinfer/gemm/fp4_gemm_template_sm100.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm100.h
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_FP4_GEMM_TEMPLATE_SM100_H_
+#define FLASHINFER_FP4_GEMM_TEMPLATE_SM100_H_
+
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif  // #ifndef _WIN32
+
+#include "cutlass/arch/arch.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/gemm.h"
+#include "flashinfer/arch_condition.h"
+#include "flashinfer/cutlass_utils.cuh"
+
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif  // #ifndef _WIN32
+
+namespace flashinfer {
+namespace gemm {
+using namespace cute;
+
+#ifdef ENABLE_BF16
+using SafeBF16 = __nv_bfloat16;
+#else
+using SafeBF16 = void;
+#endif
+
+struct _1SM {};
+
+struct _2SM {};
+
+template <typename T>
+struct SMTypeAdapter {};
+
+template <>
+struct SMTypeAdapter<_1SM> {
+  static int const Scale = 1;
+  using AtomThrShape = cute::Shape<_1, _1, _1>;
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized1Sm;
+  using MainloopSchedule = cutlass::gemm::KernelTmaWarpSpecialized1SmNvf4Sm100;
+};
+
+template <>
+struct SMTypeAdapter<_2SM> {
+  static int const Scale = 2;
+  using AtomThrShape = cute::Shape<_2, _1, _1>;
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized2Sm;
+  using MainloopSchedule = cutlass::gemm::KernelTmaWarpSpecialized2SmNvf4Sm100;
+};
+
+template <typename>
+constexpr auto always_false = false;
+
+template <typename T, typename CTA_M_, typename CTA_N_, typename CTA_K_, typename CGA_M_,
+          typename CGA_N_, typename CGA_K_, typename XSM_>
+size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void const* input_sf,
+                                    void const* weight_sf, float const* global_sf, int m, int n,
+                                    int k, int batch_count, CutlassGemmConfig gemmConfig,
+                                    char* workspace, size_t const workspaceBytes,
+                                    cudaStream_t stream, int* occupancy);
+
+#ifdef PLACEHOLDER_KERNELS
+
+#define INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER(T, CTA_M_, CTA_N_, CTA_K_, CGA_M_, CGA_N_, CGA_K_,   \
+                                             XSM_)                                                \
+  template <>                                                                                     \
+  size_t                                                                                          \
+  genericFp4GemmKernelLauncher<T, cute::Int<CTA_M_>, cute::Int<CTA_N_>, cute::Int<CTA_K_>,        \
+                               cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>, XSM_>(    \
+      void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,         \
+      float const* global_sf, int m, int n, int k, int batch_count, CutlassGemmConfig gemmConfig, \
+      char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {        \
+    throw std::runtime_error(                                                                     \
+        "FP4 gemm kernel is not compiled with support for "                                       \
+        "this Architecture.");                                                                    \
+  }
+
+#else
+
+#define INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER(T, CTA_M_, CTA_N_, CTA_K_, CGA_M_, CGA_N_, CGA_K_,              \
+                                             XSM_)                                                           \
+  struct                                                                                                     \
+      DeviceGemmFp4GemmSm100_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_ {   \
+    using OutElementType = flashinfer::TllmToCutlassTypeAdapter<T>::type;                                    \
+    using CTAShape = cute::Shape<cute::Int<CTA_M_>, cute::Int<CTA_N_>, cute::Int<CTA_K_>>;                   \
+    /*using ClusterShape = cute::Shape<cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>>;*/           \
+    using ClusterShape = cute::Shape<int, int, _1>;                                                          \
+    using ElementType = cutlass::float_e2m1_t;                                                               \
+    using Arch = cutlass::arch::Sm100;                                                                       \
+    /* // Input A */                                                                                         \
+    using ElementA = ElementType;                                                                            \
+    using LayoutA = cutlass::layout::RowMajor;                                                               \
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementType>::value;                        \
+    /* // Input B */                                                                                         \
+    using ElementB = ElementType;                                                                            \
+    using LayoutB = cutlass::layout::ColumnMajor;                                                            \
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementType>::value;                        \
+    /* // Input C */                                                                                         \
+    using ElementC = void;                                                                                   \
+    using LayoutC = cutlass::layout::RowMajor;                                                               \
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<OutElementType>::value;                     \
+                                                                                                             \
+    using SFType = cutlass::float_ue4m3_t;                                                                   \
+    using ElementCompute = float;                                                                            \
+    using ElementAccumulator = float;                                                                        \
+    using OperatorClass = cutlass::arch::OpClassTensorOp;                                                    \
+    using EpilogueTileType = std::conditional_t<CTA_M_ == 128 && CTA_N_ == 256 && CTA_K_ == 256,             \
+                                                cute::Shape<cute::_128, cute::_64>,                          \
+                                                cutlass::epilogue::collective::EpilogueTileAuto>;            \
+    using EpilogueSchedule = SMTypeAdapter<XSM_>::EpilogueSchedule;                                          \
+    using MainloopSchedule = SMTypeAdapter<XSM_>::MainloopSchedule;                                          \
+    using MmaTileShape = cute::Shape<cute::Int<CTA_M_ * SMTypeAdapter<XSM_>::Scale>,                         \
+                                     cute::Int<CTA_N_>, cute::Int<CTA_K_>>;                                  \
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<                    \
+        Arch, OperatorClass, MmaTileShape, ClusterShape, EpilogueTileType, ElementAccumulator,               \
+        ElementCompute, ElementC, LayoutC, AlignmentC, OutElementType, LayoutC, AlignmentC,                  \
+        EpilogueSchedule,                                                                                    \
+        cutlass::epilogue::fusion::LinearCombination<OutElementType, float, void,                            \
+                                                     float>>::CollectiveOp;                                  \
+                                                                                                             \
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<                        \
+        Arch, cutlass::arch::OpClassBlockScaledTensorOp, cute::tuple<ElementA, SFType>, LayoutA,             \
+        AlignmentA, cute::tuple<ElementB, SFType>, LayoutB, AlignmentB, ElementAccumulator,                  \
+        MmaTileShape, ClusterShape,                                                                          \
+        cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(                                  \
+            sizeof(typename CollectiveEpilogue::SharedStorage))>,                                            \
+        MainloopSchedule>::CollectiveOp;                                                                     \
+                                                                                                             \
+    template <typename Base>                                                                                 \
+    struct Sm10xOnly : Base {                                                                                \
+      using typename Base::Params;                                                                           \
+      CUTLASS_DEVICE                                                                                         \
+      void operator()(Params const& params, char* smem_buf) {                                                \
+        if constexpr (flashinfer::arch::is_major_v<10>) {                                                    \
+          this->Base::operator()(params, smem_buf);                                                          \
+        } else {                                                                                             \
+          if (cute::thread0()) {                                                                             \
+            printf("%s : This kernel shall only run on SM10x devices.\n", __PRETTY_FUNCTION__);              \
+            __trap();                                                                                        \
+          }                                                                                                  \
+        }                                                                                                    \
+      }                                                                                                      \
+    };                                                                                                       \
+    using GemmKernel =                                                                                       \
+        Sm10xOnly<cutlass::gemm::kernel::GemmUniversal<cute::Shape<int, int, int, int>,                      \
+                                                       CollectiveMainloop, CollectiveEpilogue,               \
+                                                       cutlass::gemm::PersistentScheduler>>;                 \
+                                                                                                             \
+    using Gemm = typename cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;                           \
+  };                                                                                                         \
+                                                                                                             \
+  template <typename Gemm>                                                                                   \
+  typename Gemm::Arguments                                                                                   \
+      prepareGemmArgs_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_(           \
+          void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,                \
+          float const* global_sf, int m, int n, int k, int batch_count) {                                    \
+    using Sm1xxBlkScaledConfig =                                                                             \
+        typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;                                 \
+    using ElementA = typename Gemm::ElementA;                                                                \
+    using ElementB = typename Gemm::ElementB;                                                                \
+    using ElementSFA = cutlass::float_ue4m3_t;                                                               \
+    using ElementSFB = cutlass::float_ue4m3_t;                                                               \
+    using ElementC = void;                                                                                   \
+    using ElementD = typename Gemm::ElementD;                                                                \
+    using ElementCompute = float;                                                                            \
+                                                                                                             \
+    typename Gemm::Arguments operator_args;                                                                  \
+    operator_args.mode = cutlass::gemm::GemmUniversalMode::kGemm;                                            \
+    auto& fusion_args = operator_args.epilogue.thread;                                                       \
+    fusion_args.alpha_ptr = static_cast<ElementCompute const*>(global_sf);                                   \
+                                                                                                             \
+    operator_args.problem_shape = cute::make_shape(m, n, k, batch_count);                                    \
+                                                                                                             \
+    operator_args.mainloop.ptr_A = static_cast<ElementA const*>(A);                                          \
+    operator_args.mainloop.ptr_B = static_cast<ElementB const*>(B);                                          \
+    operator_args.mainloop.ptr_SFA = static_cast<ElementSFA const*>(input_sf);                               \
+    operator_args.mainloop.ptr_SFB = static_cast<ElementSFB const*>(weight_sf);                              \
+    operator_args.epilogue.ptr_C = static_cast<ElementC const*>(D);                                          \
+    operator_args.epilogue.ptr_D = static_cast<ElementD*>(D);                                                \
+                                                                                                             \
+    int const stride_A = batch_count == 1 ? 0 : m * k;                                                       \
+    int const stride_B = batch_count == 1 ? 0 : n * k;                                                       \
+    int const stride_C = batch_count == 1 ? 0 : m * n;                                                       \
+                                                                                                             \
+    operator_args.mainloop.dA =                                                                              \
+        cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideA>(k, stride_A);                          \
+    operator_args.mainloop.dB =                                                                              \
+        cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideB>(k, stride_B);                          \
+    operator_args.epilogue.dC =                                                                              \
+        cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideC>(n, stride_C);                          \
+    operator_args.epilogue.dD = operator_args.epilogue.dC;                                                   \
+                                                                                                             \
+    operator_args.mainloop.layout_SFA =                                                                      \
+        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(operator_args.problem_shape);                           \
+    operator_args.mainloop.layout_SFB =                                                                      \
+        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(operator_args.problem_shape);                           \
+                                                                                                             \
+    if constexpr (!std::is_const_v<decltype(operator_args.scheduler.max_swizzle_size)>) {                    \
+      operator_args.scheduler.max_swizzle_size = 1;                                                          \
+    }                                                                                                        \
+    if constexpr (!std::is_const_v<decltype(operator_args.scheduler.raster_order)>) {                        \
+      using Enum_t = decltype(operator_args.scheduler.raster_order);                                         \
+      operator_args.scheduler.raster_order = Enum_t::Heuristic;                                              \
+    }                                                                                                        \
+    operator_args.hw_info.cluster_shape = dim3(CGA_M_, CGA_N_, CGA_K_);                                      \
+    operator_args.hw_info.cluster_shape_fallback = dim3(SMTypeAdapter<XSM_>::Scale, 1, 1);                   \
+                                                                                                             \
+    return operator_args;                                                                                    \
+  }                                                                                                          \
+                                                                                                             \
+  template <>                                                                                                \
+  size_t                                                                                                     \
+  genericFp4GemmKernelLauncher<T, cute::Int<CTA_M_>, cute::Int<CTA_N_>, cute::Int<CTA_K_>,                   \
+                               cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>, XSM_>(               \
+      void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,                    \
+      float const* global_sf, int m, int n, int k, int batch_count, CutlassGemmConfig gemmConfig,            \
+      char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {                   \
+    using ElementOutput__ =                                                                                  \
+        typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value,                  \
+                                                cutlass::half_t, T>::type;                                   \
+    using ElementOutput_ = typename cutlass::platform::conditional<                                          \
+        cutlass::platform::is_same<ElementOutput__, float>::value, float, ElementOutput__>::type;            \
+    using ElementOutput = typename cutlass::platform::conditional<                                           \
+        cutlass::platform::is_same<ElementOutput_, SafeBF16>::value, cutlass::bfloat16_t,                    \
+        ElementOutput_>::type;                                                                               \
+                                                                                                             \
+    using Fp4GemmOperator =                                                                                  \
+        DeviceGemmFp4GemmSm100_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_:: \
+            Gemm;                                                                                            \
+    Fp4GemmOperator gemm;                                                                                    \
+    auto args =                                                                                              \
+        prepareGemmArgs_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_<         \
+            Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count);                 \
+    /* // Return workspace size */                                                                           \
+    if (!A && !B && !D) {                                                                                    \
+      return gemm.get_workspace_size(args);                                                                  \
+    }                                                                                                        \
+    if (gemm.get_workspace_size(args) > workspaceBytes) {                                                    \
+      std::string errMsg("Requested workspace size insufficient. Required " +                                \
+                         std::to_string(gemm.get_workspace_size(args)) + ", got " +                          \
+                         std::to_string(workspaceBytes));                                                    \
+      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                               \
+    }                                                                                                        \
+    auto can_implement = gemm.can_implement(args);                                                           \
+    if (can_implement != cutlass::Status::kSuccess) {                                                        \
+      std::string errMsg = "FP4 Gemm cutlass kernel will fail for params. Error: " +                         \
+                           std::string(cutlassGetStatusString(can_implement));                               \
+      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                               \
+    }                                                                                                        \
+    auto initStatus = gemm.initialize(args, workspace, stream);                                              \
+    if (initStatus != cutlass::Status::kSuccess) {                                                           \
+      std::string errMsg = "Failed to initialize cutlass FP4 gemm. Error: " +                                \
+                           std::string(cutlassGetStatusString(initStatus));                                  \
+      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                               \
+    }                                                                                                        \
+    auto runStatus = gemm.run(args, workspace, stream, nullptr, /* enablePDL */ false);                      \
+    if (runStatus != cutlass::Status::kSuccess) {                                                            \
+      std::string errMsg = "Failed to run cutlass FP4 gemm. Error: " +                                       \
+                           std::string(cutlassGetStatusString(runStatus));                                   \
+      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                               \
+    }                                                                                                        \
+    return gemm.get_workspace_size(args);                                                                    \
+  }
+
+#endif
+
+}  // namespace gemm
+}  // namespace flashinfer
+#endif  // FLASHINFER_FP4_GEMM_TEMPLATE_SM100_H_

--- a/tests/test_mm_fp4.py
+++ b/tests/test_mm_fp4.py
@@ -17,7 +17,7 @@ from flashinfer import (
 @pytest.mark.parametrize("n", [128, 256, 512])
 @pytest.mark.parametrize("k", [128, 256, 512])
 @pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("backend", ["trtllm", "cudnn"])
+@pytest.mark.parametrize("backend", ["trtllm", "cudnn", "cutlass"])
 @pytest.mark.parametrize("use_128x4_sf_layout", [False, True])
 @pytest.mark.parametrize("auto_tuning", [False, True])
 def test_mm_fp4(m, n, k, res_dtype, backend, use_128x4_sf_layout, auto_tuning):
@@ -28,8 +28,8 @@ def test_mm_fp4(m, n, k, res_dtype, backend, use_128x4_sf_layout, auto_tuning):
     if not use_128x4_sf_layout and backend != "trtllm":
         print("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
         return
-    if auto_tuning and backend != "trtllm":
-        print("Skipping test for non-trtllm fp4 with auto_tuning=True")
+    if auto_tuning and backend == "cudnn":
+        print("Skipping test for cudnn fp4 with auto_tuning=True")
         return
 
     input = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)


### PR DESCRIPTION
support a/b input type e2m1, block quant type e4m3 with block size 16 output bfloat16 and fp16.

<!-- .github/pull_request_template.md -->

## 📌 Description

add mm_fp4 use trtllm cutlass backend. those kernels are known to have better perf for large bs. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
