### PR TITLE
fix: a workaround to make fp8 kv-cache work for prefill

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -94,8 +94,26 @@ def _check_kv_layout(kv_layout: str) -> None:
         raise KeyError("Invalid kv_layout {}".format(kv_layout))
 
 
+def _is_float8_dtype(t: torch.dtype) -> bool:
+    return t in [torch.float8_e4m3fn, torch.float8_e5m2]
+
+
 def is_float8(x: torch.Tensor) -> bool:
-    return x.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]
+    return _is_float8_dtype(x.dtype)
+
+
+def _require_kv_cache_cast(
+    q_data_type: torch.dtype,
+    kv_data_type: torch.dtype,
+) -> bool:
+    """
+    Determine whether the kv_cache needs to be casted to q_data_type.
+    This is a temporary workaround because native fp8 support for
+    the kv cache in prefill attention kernels is not yet available.
+    We should remove this function once full fp8 kv cache support
+    is implemented.
+    """
+    return not _is_float8_dtype(q_data_type) and _is_float8_dtype(kv_data_type)
 
 
 def get_indptr(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This is for resolving an issue encountered while enabling fp8 kv-cache support in the flashinfer backend:

https://github.com/vllm-project/vllm/pull/17005#issuecomment-2998112018

The root cause seems to be that we do not have native fp8 kv-cache support for prefill. The failure that we hit, i.e.

```
static_assert(sizeof(ElementA) == 0, "No eligible GMMA operator for request configuration.");
```

is just a fact that our prefill kernels do not instantiate cute::GMMA::rs_op_selector with the correct layout for fp8, which requires k-major for B matrix:

https://github.com/flashinfer-ai/flashinfer/blob/main/include/flashinfer/attention/hopper/kernel_traits.cuh#L78

Note that we cannot simply assign k-major when DTypeKV is of fp8. There are more to fix to correctly support fp8 kv-cache in the kernel.

So, this comes to the workaround in this PR, where we convert k and v to q_data_type if they are fp8 but q is not. We can do this from vllm, but I think it seems to be better to put it in flashinfer, because we do not require any changes to the customer code if we support fp8 kv-cache for prefill in a better way.

Also please note that I am not 100% sure if this is an appropriate fix, particularly I am not familiar with flashinfer's code base. Originally, I was a bit worried about the impact to other kv-cache related things such as _paged_kv_indptr and _kv_indptr_buf. It seems to be fine to me after reading through the relevant code in prefill.py and hopper/prefill_sm90.cuh.

Last note - eventually, I think we might need to support fp8 kv-cache for prefill more appropriately.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x ] I have installed the hooks with `pre-commit install`.
- [ x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
