### PR TITLE
feat: support output nvfp4 in trtllm-gen function call.

### DIFF
--- a/csrc/trtllm_fmha_runner.cu
+++ b/csrc/trtllm_fmha_runner.cu
@@ -24,9 +24,9 @@ TllmGenFmhaRunner::TllmGenFmhaRunner(Data_type dtypeQ, Data_type dtypeKv, Data_t
   TORCH_CHECK(
       mDtypeKv == DATA_TYPE_E4M3 || mDtypeKv == DATA_TYPE_FP16 || mDtypeKv == DATA_TYPE_BF16,
       "Unsupported Kv data type: " + std::string(toStr(mDtypeKv)));
-  TORCH_CHECK(
-      mDtypeOut == DATA_TYPE_E4M3 || mDtypeOut == DATA_TYPE_FP16 || mDtypeOut == DATA_TYPE_BF16,
-      "Unsupported Output data type: " + std::string(toStr(mDtypeOut)));
+  TORCH_CHECK(mDtypeOut == DATA_TYPE_E4M3 || mDtypeOut == DATA_TYPE_FP16 ||
+                  mDtypeOut == DATA_TYPE_BF16 || mDtypeOut == DATA_TYPE_E2M1,
+              "Unsupported Output data type: " + std::string(toStr(mDtypeOut)));
   mKernel = getTllmFmhaKernels(mDtypeQ, mDtypeKv, mDtypeOut, mSM);
 }
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1808,7 +1808,7 @@ class TrtllmGenDecodeModule:
             self._sm_count = get_device_sm_count(query.device)
         self._op.trtllm_paged_attention_decode(
             out,
-            torch.empty(0),  # fp4 output not supported in wrapper api yet.
+            None,  # fp4 output not supported in wrapper api yet.
             query.unsqueeze(
                 1
             ),  # [B, 1, H, D], no MTP here so second dim is 1 # todo(Yingyi): add MTP??
@@ -1819,8 +1819,8 @@ class TrtllmGenDecodeModule:
             max_seq_len,
             bmm1_scale,
             bmm2_scale,
-            -1,
-            -1,
+            -1,  # o_sf_scale
+            -1,  # o_sf_vec_size
             window_left,
             self._sm_count,
         )
@@ -2024,7 +2024,7 @@ def trtllm_batch_decode_with_kv_cache(
 
     run_func(
         out,
-        out_scale_factor if out_scale_factor is not None else torch.empty(0),
+        out_scale_factor,
         query.unsqueeze(1),  # [B, 1, H, D], no MTP here so second dim is 1
         kv_cache,
         workspace_buffer,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -566,3 +566,4 @@ class FP4Tensor:
         self.data = data
         self.scale = scale
         self.original_shape = original_shape
+        self.dtype = "nvfp4"

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -269,6 +269,8 @@ struct TllmGenFmhaRunnerParams {
   int mSfStartTokenIdx;
   // The SF scale for Kv.
   float mScaleSfKv;
+  // The SF scale for output.
+  float mScaleSfO;
   // The cuda stream.
   cudaStream_t stream;
 

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -654,6 +654,7 @@ struct KernelParams {
 
     params.ptrScaleSfKv = options.kvSfScalePtr;
     params.ptrScaleSfO = options.oSfScalePtr;
+    params.mScaleSfO = options.mScaleSfO;
 
     params.mAttentionWindowSize = options.mAttentionWindowSize;
     if (isSlidingOrChunkedCausalMask(
@@ -687,7 +688,6 @@ struct KernelParams {
     params.mStartTokenIdxSfO = options.mSfStartTokenIdx;
     params.mScaleSfKv = options.mScaleSfKv;
     params.ptrSoftmaxStats = nullptr;
-
     return params;
   }
 };

--- a/tests/test_fp4_quantize.py
+++ b/tests/test_fp4_quantize.py
@@ -2,6 +2,7 @@ import functools
 
 import pytest
 import torch
+from utils_fp4 import cast_from_fp4, recover_swizzled_scales, ref_nvfp4_quant
 
 from flashinfer import (
     e2m1_and_ufp8sf_scale_to_float,
@@ -19,33 +20,6 @@ CUDA_DEVICES = ["cuda:0"]
 FLOAT4_E2M1_MAX = 6.0
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
 
-# E2M1 to float
-# 0111 -> 6
-# 0110 -> 4
-# 0101 -> 3
-# 0100 -> 2
-# 0011 -> 1.5
-# 0010 -> 1
-# 0001 -> 0.5
-# 0000 -> 0
-E2M1_TO_FLOAT32 = [
-    0.0,
-    0.5,
-    1.0,
-    1.5,
-    2.0,
-    3.0,
-    4.0,
-    6.0,
-    0.0,
-    -0.5,
-    -1.0,
-    -1.5,
-    -2.0,
-    -3.0,
-    -4.0,
-    -6.0,
-]
 BLOCK_SIZE = 16
 
 
@@ -110,66 +84,6 @@ def unswizzle_sf(
     return sf_unswizzle_sliced.contiguous()
 
 
-def cast_from_fp4(x, m, n):
-    # The fp4 values are packed in uint8 as [v_1st | v_2nd]
-    v_2nd = x & 0xF
-    v_1st = (x >> 4) & 0xF
-    c = torch.stack((v_2nd, v_1st), dim=-1)
-    out = torch.tensor([E2M1_TO_FLOAT32[x] for x in c.flatten()])
-    out = out.reshape(m, n).to(torch.float32)
-    return out
-
-
-def cast_to_fp4(x):
-    sign = torch.sign(x)
-    x = torch.abs(x)
-    x[(x >= 0.0) & (x <= 0.25)] = 0.0
-    x[(x > 0.25) & (x < 0.75)] = 0.5
-    x[(x >= 0.75) & (x <= 1.25)] = 1.0
-    x[(x > 1.25) & (x < 1.75)] = 1.5
-    x[(x >= 1.75) & (x <= 2.5)] = 2.0
-    x[(x > 2.5) & (x < 3.5)] = 3.0
-    x[(x >= 3.5) & (x <= 5.0)] = 4.0
-    x[x > 5.0] = 6.0
-    return x * sign
-
-
-def get_reciprocal(x):
-    if isinstance(x, torch.Tensor):
-        return torch.where(x == 0, torch.tensor(0.0, dtype=x.dtype), 1.0 / x)
-    elif isinstance(x, (float, int)):
-        return 0.0 if x == 0 else 1.0 / x
-    else:
-        raise TypeError("Input must be a float, int, or a torch.Tensor.")
-
-
-def ref_nvfp4_quant(x, global_scale):
-    assert global_scale.dtype == torch.float32
-    assert x.ndim == 2
-    m, n = x.shape
-    x = torch.reshape(x, (m, n // BLOCK_SIZE, BLOCK_SIZE))
-    vec_max = torch.max(torch.abs(x), dim=-1, keepdim=True)[0].to(torch.float32)
-    scale = global_scale * (vec_max * get_reciprocal(FLOAT4_E2M1_MAX))
-    scale = scale.to(torch.float8_e4m3fn).to(torch.float32)
-    output_scale = get_reciprocal(scale * get_reciprocal(global_scale))
-
-    scaled_x = x.to(torch.float32) * output_scale
-    clipped_x = torch.clamp(scaled_x, -6.0, 6.0).reshape(m, n)
-    return cast_to_fp4(clipped_x), scale.squeeze(-1)
-
-
-def recover_swizzled_scales(scale, m, n):
-    round_up = lambda x, y: (x + y - 1) // y * y
-    rounded_m = round_up(m, 128)
-    scale_n = n // BLOCK_SIZE
-    rounded_n = round_up(scale_n, 4)
-    # Recover the swizzled scaling factor to linear layout
-    tmp = torch.reshape(scale, (1, rounded_m // 128, rounded_n // 4, 32, 4, 4))
-    tmp = torch.permute(tmp, (0, 1, 4, 3, 2, 5))
-    result = torch.reshape(tmp, (rounded_m, rounded_n)).to(torch.float32)
-    return result[:m, :scale_n]
-
-
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("shape", SHAPES)
 @pytest.mark.parametrize("seed", SEEDS)
@@ -189,13 +103,16 @@ def test_fp4_quantization(
     x = torch.randn((m, n), dtype=dtype)
     tensor_amax = torch.abs(x).max().to(torch.float32)
     global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
-    out_ref, scale_ref = ref_nvfp4_quant(x, global_scale)
+    out_ref, scale_ref = ref_nvfp4_quant(x, global_scale, BLOCK_SIZE)
     out, out_scale = fp4_quantize(x, global_scale, BLOCK_SIZE, False)
     assert n % BLOCK_SIZE == 0, f"cols needs to be {BLOCK_SIZE} divisible"
     scale_ans = recover_swizzled_scales(
-        out_scale.reshape(-1, n // BLOCK_SIZE).view(torch.float8_e4m3fn), m, n
+        out_scale.reshape(-1, n // BLOCK_SIZE).view(torch.float8_e4m3fn),
+        m,
+        n,
+        BLOCK_SIZE,
     )
-    out_ans = cast_from_fp4(out, m, n)
+    out_ans = cast_from_fp4(out).reshape(m, n)
     torch.testing.assert_close(out_ans, out_ref, rtol=1e0, atol=1e-1)
     torch.testing.assert_close(scale_ans, scale_ref, rtol=1e-1, atol=1e-1)
 

--- a/tests/test_trtllm_gen_decode.py
+++ b/tests/test_trtllm_gen_decode.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F
+from utils_fp4 import cast_from_fp4, recover_swizzled_scales, ref_nvfp4_quant
 
 import flashinfer
 
@@ -103,7 +104,10 @@ def reference_paged_attention(
 @pytest.mark.parametrize("head_grp_size", [1, 5, 8])
 @pytest.mark.parametrize("window_left", [-1, 127])
 @pytest.mark.parametrize("q_dtype", ["half", "bf16", "fp8"])
-@pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8"])
+@pytest.mark.parametrize("o_dtype", ["auto", "fp4"])  # auto means same as q_dtype
+@pytest.mark.parametrize(
+    "kv_cache_dtype", ["auto", "fp8"]
+)  # auto means same as q_dtype
 def test_trtllm_batch_decode_fmha(
     kv_layout,
     batch_size,
@@ -112,10 +116,13 @@ def test_trtllm_batch_decode_fmha(
     head_grp_size,
     window_left,
     q_dtype,
+    o_dtype,
     kv_cache_dtype,
 ):
     if kv_cache_dtype == "auto" and q_dtype == "fp8":
-        pytest.skip("duplicated test to fp8 kvcache type.")
+        pytest.skip("duplicated test to fp8 kvcache type")
+    if o_dtype == "fp4" and q_dtype != "fp8":
+        pytest.skip("fp4 output is only supported for fp8 query")
 
     # Set up test parameters
     seed = 0
@@ -208,11 +215,15 @@ def test_trtllm_batch_decode_fmha(
         [k_cache, v_cache], dim=1
     )  # Shape: (num_blocks, 2, num_kv_heads, page_size, head_dim)
 
-    # Output type is fp8 when q is fp8, set scale for it.
-    o_scale = (
-        1.0 if q_dtype != "fp8" else torch.rand(1).item() * 0.5 + 0.5
-    )  # Scale range: 0.5 ~ 1.0
+    if q_dtype == "fp8" and o_dtype == "auto":  # Output type is fp8.
+        o_scale = torch.rand(1).item() * 0.5 + 0.5  # Scale range: 0.5 ~ 1.0
+    else:
+        o_scale = 1.0
+
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    o_sf_scale = (
+        0.2 if o_dtype == "fp4" else None
+    )  # choose a value to make error smaller by testing.
 
     output = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
         q.contiguous(),
@@ -224,7 +235,19 @@ def test_trtllm_batch_decode_fmha(
         q_scale * k_scale * sm_scale,  # bmm1_scale
         v_scale / o_scale,  # bmm2_scale
         window_left,  # window_left
-    ).squeeze(1)
+        out_dtype=o_dtype,
+        o_sf_scale=o_sf_scale,
+        o_sf_vec_size=16 if o_dtype == "fp4" else None,
+    )
+
+    # Handle different return types based on out_dtype
+    if o_dtype == "fp4":
+        out_scale_factor = output.scale  # FP4Tensor.scale
+        output = output.data  # FP4Tensor.data
+    else:
+        out_scale_factor = None
+
+    output = output.squeeze(1)
 
     wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout, use_tensor_cores=True
@@ -257,42 +280,62 @@ def test_trtllm_batch_decode_fmha(
 
     output_ref = wrapper.run(ref_q, ref_kv_cache)
 
-    rtol, atol = (1e-2, 5e-2) if q_dtype != "fp8" else (5e-2, 7e-2)
+    if q_dtype == "fp8" and o_dtype == "fp4":
+        rtol, atol = 5e-1, 1.1e0
+    elif q_dtype == "fp8" and o_dtype == "auto":
+        rtol, atol = 5e-2, 7e-2
+    else:
+        rtol, atol = 1e-2, 5e-2
+
+    if o_dtype == "fp4":
+        output = cast_from_fp4(output)
+        output_ref, out_scale_factor_ref = ref_nvfp4_quant(output_ref, o_sf_scale, 16)
+        out_scale_factor = recover_swizzled_scales(
+            out_scale_factor, output.shape[0], output.shape[1] * output.shape[2], 16
+        )
+
+        torch.testing.assert_close(
+            out_scale_factor.float().reshape(out_scale_factor_ref.shape),
+            out_scale_factor_ref.float(),
+            rtol=rtol,
+            atol=atol,
+        )
 
     # convert to float32 for fp8 is not supported by assert_close
     torch.testing.assert_close(
         output.float() * o_scale, output_ref.float(), rtol=rtol, atol=atol
     )
 
-    # test wrapper with trtllm-gen backend
-    wrapper2 = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout, backend="trtllm-gen"
-    )
-    wrapper2.plan(
-        kv_indptr,
-        kv_indices,
-        kv_last_page_len,
-        num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
-        pos_encoding_mode="NONE",
-        data_type=kv_cache.dtype,
-        q_data_type=q.dtype,
-        window_left=window_left,
-    )
-    output2 = wrapper2.run(
-        q.contiguous(),
-        kv_cache,
-        q_scale=q_scale,
-        k_scale=k_scale,
-        v_scale=v_scale / o_scale,
-    )
-    # skip compare due to v_scale, o_scale is not supported in wrapper api yet.
-    if v_scale == o_scale == 1.0:
-        torch.testing.assert_close(
-            output2.float(), output.float(), rtol=rtol, atol=atol
+    if o_dtype != "fp4":  # wrapper api does not support fp4 output yet.
+        # test wrapper with trtllm-gen backend
+        wrapper2 = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+            workspace_buffer, kv_layout, backend="trtllm-gen"
         )
+        wrapper2.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            pos_encoding_mode="NONE",
+            data_type=kv_cache.dtype,
+            q_data_type=q.dtype,
+            window_left=window_left,
+        )
+        output2 = wrapper2.run(
+            q.contiguous(),
+            kv_cache,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale / o_scale,
+        )
+        # v_scale, o_scale is not supported in wrapper api yet.
+        if v_scale == o_scale == 1.0:
+            torch.testing.assert_close(
+                output2.float(), output.float(), rtol=rtol, atol=atol
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/utils_fp4.py
+++ b/tests/utils_fp4.py
@@ -1,5 +1,7 @@
 import torch
 
+import flashinfer.utils as utils
+
 FLOAT4_E2M1_MAX = 6.0
 
 # E2M1 to float
@@ -83,10 +85,9 @@ def ref_nvfp4_quant(x, global_scale, block_size):
 
 
 def recover_swizzled_scales(scale, m, n, block_size):
-    round_up = lambda x, y: (x + y - 1) // y * y
-    rounded_m = round_up(m, 128)
+    rounded_m = utils.round_up(m, 128)
     scale_n = n // block_size
-    rounded_n = round_up(scale_n, 4)
+    rounded_n = utils.round_up(scale_n, 4)
     # Recover the swizzled scaling factor to linear layout
     tmp = torch.reshape(scale, (1, rounded_m // 128, rounded_n // 4, 32, 4, 4))
     tmp = torch.permute(tmp, (0, 1, 4, 3, 2, 5))

--- a/tests/utils_fp4.py
+++ b/tests/utils_fp4.py
@@ -1,0 +1,94 @@
+import torch
+
+FLOAT4_E2M1_MAX = 6.0
+
+# E2M1 to float
+# 0111 -> 6
+# 0110 -> 4
+# 0101 -> 3
+# 0100 -> 2
+# 0011 -> 1.5
+# 0010 -> 1
+# 0001 -> 0.5
+# 0000 -> 0
+E2M1_TO_FLOAT32 = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
+
+
+def cast_from_fp4(x):
+    # The fp4 values are packed in uint8 as [v_1st | v_2nd]
+    v_2nd = x & 0xF
+    v_1st = (x >> 4) & 0xF
+    c = torch.stack((v_2nd, v_1st), dim=-1)
+    new_shape = c.shape[:-2] + (
+        c.shape[-2] * c.shape[-1],
+    )  # fuse the dim added by stack
+    lookup_table = torch.tensor(E2M1_TO_FLOAT32, device=c.device)
+    out = lookup_table[c.to(torch.long)].reshape(new_shape).to(torch.float32)
+    return out
+
+
+def cast_to_fp4(x):
+    sign = torch.sign(x)
+    x = torch.abs(x)
+    x[(x >= 0.0) & (x <= 0.25)] = 0.0
+    x[(x > 0.25) & (x < 0.75)] = 0.5
+    x[(x >= 0.75) & (x <= 1.25)] = 1.0
+    x[(x > 1.25) & (x < 1.75)] = 1.5
+    x[(x >= 1.75) & (x <= 2.5)] = 2.0
+    x[(x > 2.5) & (x < 3.5)] = 3.0
+    x[(x >= 3.5) & (x <= 5.0)] = 4.0
+    x[x > 5.0] = 6.0
+    return x * sign
+
+
+def get_reciprocal(x):
+    if isinstance(x, torch.Tensor):
+        return torch.where(x == 0, torch.tensor(0.0, dtype=x.dtype), 1.0 / x)
+    elif isinstance(x, (float, int)):
+        return 0.0 if x == 0 else 1.0 / x
+    else:
+        raise TypeError("Input must be a float, int, or a torch.Tensor.")
+
+
+def ref_nvfp4_quant(x, global_scale, block_size):
+    assert isinstance(global_scale, (float, int)) or global_scale.dtype == torch.float32
+
+    sliced_shape = x.shape[:-1] + (x.shape[-1] // block_size, block_size)
+    sliced_x = torch.reshape(x, sliced_shape)
+    vec_max = torch.max(torch.abs(sliced_x), dim=-1, keepdim=True)[0].to(torch.float32)
+    scale = global_scale * (vec_max * get_reciprocal(FLOAT4_E2M1_MAX))
+    scale = scale.to(torch.float8_e4m3fn).to(torch.float32)
+    output_scale = get_reciprocal(scale * get_reciprocal(global_scale))
+
+    scaled_x = sliced_x.to(torch.float32) * output_scale
+    clipped_x = torch.clamp(scaled_x, -6.0, 6.0).reshape(x.shape)
+    return cast_to_fp4(clipped_x), scale.squeeze(-1)
+
+
+def recover_swizzled_scales(scale, m, n, block_size):
+    round_up = lambda x, y: (x + y - 1) // y * y
+    rounded_m = round_up(m, 128)
+    scale_n = n // block_size
+    rounded_n = round_up(scale_n, 4)
+    # Recover the swizzled scaling factor to linear layout
+    tmp = torch.reshape(scale, (1, rounded_m // 128, rounded_n // 4, 32, 4, 4))
+    tmp = torch.permute(tmp, (0, 1, 4, 3, 2, 5))
+    result = torch.reshape(tmp, (rounded_m, rounded_n)).to(torch.float32)
+    return result[:m, :scale_n]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Only added fp4 support to trtllm_batch_decode_with_kv_cache, not added to wrapper yet.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
