### PR TITLE
Optimizations for TRTLLM MNNVL Allreduce

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -18,7 +18,7 @@ import logging
 import platform
 import sys
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 import pynvml
 import torch
@@ -108,6 +108,26 @@ def test_cuda_memory_access(ptr: int, size: int, device_id: int) -> bool:
     except Exception as e:
         print(f"DEBUG: Memory access test FAILED for ptr=0x{ptr:x}: {e}")
         return False
+
+
+def alloc_and_copy_to_cuda(host_ptr_array: List[int]) -> Optional[int]:
+    """
+    A helper function that allocates memory on cuda and copies the data from the host to the device.
+    """
+    if not host_ptr_array:
+        return None
+
+    ArrayType = ctypes.c_uint64 * len(host_ptr_array)
+    c_array = ArrayType(*host_ptr_array)
+    size_in_bytes = ctypes.sizeof(c_array)
+
+    device_ptr: cuda.CUdeviceptr = checkCudaErrors(cuda.cuMemAlloc(size_in_bytes))
+    checkCudaErrors(
+        cuda.cuMemcpyHtoD(device_ptr, ctypes.addressof(c_array), size_in_bytes)
+    )
+    # c_array should be freed by GC
+
+    return device_ptr
 
 
 class MpiComm:
@@ -423,7 +443,9 @@ class McastDeviceMemory:
         # CUDA memory handles and pointers
         self.mc_ptr = 0  # CUdeviceptr mMcPtr
         self.uc_ptrs: List[int] = []  # std::vector<CUdeviceptr> mUcPtrs
-        self.signal_pads_dev: List[int] = []  # std::vector<CUdeviceptr> mSignalPadsDev
+        self.signal_pads: List[int] = []  # mSignalPads
+        self.signal_pads_dev = 0  # std::vector<CUdeviceptr> mSignalPadsDev
+        self.uc_ptrs_dev = 0
         self.mc_handle = 0  # CUmemGenericAllocationHandle mMcHandle
         self.uc_handles: List[int] = (
             []
@@ -475,13 +497,17 @@ class McastDeviceMemory:
             raise NotImplementedError("Single-node NVLS allocation not implemented yet")
 
         # Initialize signal pads
-        self.signal_pads_dev = [0] * self.group_size
+        self.signal_pads = [0] * self.group_size
         for i in range(self.group_size):
-            self.signal_pads_dev[i] = self.uc_ptrs[i] + self.signal_pad_offset
+            self.signal_pads[i] = self.uc_ptrs[i] + self.signal_pad_offset
             if i == self.group_rank:
                 checkCudaErrors(
-                    cuda.cuMemsetD8(self.signal_pads_dev[i], 0, self.SIGNAL_PAD_SIZE)
+                    cuda.cuMemsetD8(self.signal_pads[i], 0, self.SIGNAL_PAD_SIZE)
                 )
+
+        # Create device pointers
+        self.signal_pads_dev = alloc_and_copy_to_cuda(self.signal_pads)
+        self.uc_ptrs_dev = alloc_and_copy_to_cuda(self.uc_ptrs)
 
     def __del__(self):
         """Destructor - cleanup allocated memory"""
@@ -504,6 +530,12 @@ class McastDeviceMemory:
         except Exception as e:
             print(f"Destructor: CUDA context invalid, skipping cleanup: {e}")
             return
+
+        # Free device pointers
+        if self.signal_pads_dev:
+            checkCudaErrors(cuda.cuMemFree(self.signal_pads_dev))
+        if self.uc_ptrs_dev:
+            checkCudaErrors(cuda.cuMemFree(self.uc_ptrs_dev))
 
         # Unmap UC regions and release their handles
         if hasattr(self, "uc_handles") and self.uc_handles:
@@ -541,13 +573,21 @@ class McastDeviceMemory:
             except Exception as e:
                 print(f"Destructor: Failed to release MC handle: {e}")
 
-    def get_signal_pad_ptrs_dev(self) -> List[int]:
+    def get_signal_pad_ptrs_host(self) -> List[int]:
+        """Get the raw array of signal pad pointers to all ranks (including self)"""
+        return self.signal_pads
+
+    def get_buffer_ptrs_host(self) -> List[int]:
+        """Get the raw array of unicast pointers to all ranks (including self)"""
+        return self.uc_ptrs
+
+    def get_signal_pad_ptrs_dev(self) -> int:
         """Get the raw array of signal pad pointers to all ranks (including self)"""
         return self.signal_pads_dev
 
-    def get_buffer_ptrs_dev(self) -> List[int]:
+    def get_buffer_ptrs_dev(self) -> int:
         """Get the raw array of unicast pointers to all ranks (including self)"""
-        return self.uc_ptrs
+        return self.uc_ptrs_dev
 
     def get_unicast_ptr(self, rank: int) -> int:
         """Get the raw unicast pointer to a given rank"""
@@ -842,29 +882,12 @@ class McastGPUBuffer:
         """Get the multicast pointer as int64"""
         return self.get_multicast_ptr()
 
-    def get_buffer_ptrs_dev(self) -> List[int]:
+    def get_buffer_ptrs_dev(self) -> int:
         """Get the buffer pointers device array"""
         return self.mcast_device_memory.get_buffer_ptrs_dev()
 
     def get_buffer_ptrs_dev_as_int64(self) -> int:
         """Get the buffer pointers device as int64 (returning first UC pointer)"""
-        ptrs = self.get_buffer_ptrs_dev()
+        ptrs = self.mcast_device_memory.get_buffer_ptrs_host()
         assert ptrs is not None
         return ptrs[0] if ptrs else 0
-
-    def get_buffer_ptrs_dev_as_ctypes_ptr(self) -> int:
-        """
-        Get buffer pointers as ctypes array pointer (equivalent to C++ void**).
-        Returns the address of a ctypes array that can be cast to int64_t and back to void**.
-
-        This matches the C++ pattern:
-        reinterpret_cast<int64_t>(reinterpret_cast<void**>(mUcPtrs.data()))
-        """
-        # Create ctypes array of void pointers
-        ArrayType = ctypes.c_void_p * len(self.mcast_device_memory.uc_ptrs)
-        self._buffer_ptrs_array = ArrayType(
-            *self.mcast_device_memory.uc_ptrs
-        )  # Keep reference to prevent GC
-
-        # Return the address of this array (equivalent to .data() in C++)
-        return ctypes.cast(self._buffer_ptrs_array, ctypes.c_void_p).value

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -184,9 +184,9 @@ def get_allreduce_mnnvl_workspace(
     mpi_barrier()
 
     # This is a buffer to maintain the state of this allreduce Op
-    # [Buffer_ptr, Clear_ptr, Buffer_size, atomic access counter]
+    # [Buffer_ptr, Clear_ptr, Buffer_size, num_tokens_prev, atomic access counter]
     buffer_flags = torch.tensor(
-        [0, 2, max_num_elements, 0],
+        [0, 2, max_num_elements, 0, 0],
         dtype=torch.uint32,
         device=torch.device("cuda", mapping.local_rank),
     )

--- a/tests/test_trtllm_mnnvl_allreduce.py
+++ b/tests/test_trtllm_mnnvl_allreduce.py
@@ -28,7 +28,7 @@ def row_linear_residual_norm_fusion_forward(
     fusion: bool,
     reference_output: tuple[torch.Tensor, ...],
     multicast_ptr: int,
-    buffer_ptrs_dev: torch.Tensor,
+    buffer_ptrs_dev: int,
     unicast_ptr: int,
     max_num_elements_mnnvl: int,
     buffer_flags_mnnvl: torch.Tensor,

--- a/tests/test_trtllm_mnnvl_allreduce.py
+++ b/tests/test_trtllm_mnnvl_allreduce.py
@@ -24,10 +24,14 @@ def row_linear_residual_norm_fusion_forward(
     eps: float,
     hidden_size: int,
     dtype: torch.dtype,
-    tensor_parallel_size: int,
-    tensor_parallel_rank: int,
+    mapping: Mapping,
     fusion: bool,
     reference_output: tuple[torch.Tensor, ...],
+    multicast_ptr: int,
+    buffer_ptrs_dev: torch.Tensor,
+    unicast_ptr: int,
+    max_num_elements_mnnvl: int,
+    buffer_flags_mnnvl: torch.Tensor,
 ):
 
     x = x.cuda()
@@ -35,13 +39,10 @@ def row_linear_residual_norm_fusion_forward(
     norm_weight = norm_weight.cuda()
     reference_output = tuple(t.cuda() for t in reference_output)
 
-    MPI.COMM_WORLD.barrier()
+    tensor_parallel_size = mapping.tp_size
+    tensor_parallel_rank = mapping.tp_rank
 
-    mapping = Mapping(
-        world_size=tensor_parallel_size,
-        tp_size=tensor_parallel_size,
-        rank=tensor_parallel_rank,
-    )
+    MPI.COMM_WORLD.barrier()
 
     def func(
         input,
@@ -56,8 +57,6 @@ def row_linear_residual_norm_fusion_forward(
     ):
         # For both fused and unfused cases:
         shape = input.shape
-
-        hidden_size = shape[-1]
 
         assert max_num_elements_mnnvl % hidden_size == 0
 
@@ -109,78 +108,75 @@ def row_linear_residual_norm_fusion_forward(
             )
             return (output.view(shape),)
 
-    # Get workspace buffers using MPI rank
-    mcast_buffer_mnnvl, buffer_flags_mnnvl, max_num_elements_mnnvl = (
-        trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(mapping, dtype)
+    output = func(
+        x.clone(),
+        residual.clone(),
+        norm_weight,
+        eps,
+        fusion,
+        multicast_ptr,
+        buffer_ptrs_dev,
+        unicast_ptr,
+        max_num_elements_mnnvl,
     )
 
-    multicast_ptr = mcast_buffer_mnnvl.get_multicast_ptr_as_int64()
-    buffer_ptrs_dev = mcast_buffer_mnnvl.get_buffer_ptrs_dev_as_ctypes_ptr()
-    unicast_ptr = mcast_buffer_mnnvl.mcast_device_memory.get_unicast_ptr(
-        tensor_parallel_rank
-    )
+    assert output[0].shape == reference_output[0].shape
 
-    try:
-        output = func(
-            x.clone(),
-            residual.clone(),
-            norm_weight,
-            eps,
-            fusion,
-            multicast_ptr,
-            buffer_ptrs_dev,
-            unicast_ptr,
-            max_num_elements_mnnvl,
-        )
-
-        assert output[0].shape == reference_output[0].shape
-
-        if tensor_parallel_rank == 0:
-            print("output[0] (first 10 values):", output[0].flatten()[:10])
-            print(
-                "reference_output[0] (first 10 values):",
-                reference_output[0].flatten()[:10],
-            )
-
-            if fusion:
-                print("output[1] (first 10 values):", output[1].flatten()[:10])
-                print(
-                    "reference_output[1] (first 10 values):",
-                    reference_output[1].flatten()[:10],
-                )
-
-        torch.testing.assert_close(
-            output[0],
-            reference_output[0],
-            rtol=0.05,
-            atol=0.15,
+    if tensor_parallel_rank == 0:
+        print("output[0] (first 10 values):", output[0].flatten()[:10])
+        print(
+            "reference_output[0] (first 10 values):",
+            reference_output[0].flatten()[:10],
         )
 
         if fusion:
-            torch.testing.assert_close(
-                output[1],
-                reference_output[1],
-                rtol=0.05,
-                atol=0.15,
+            print("output[1] (first 10 values):", output[1].flatten()[:10])
+            print(
+                "reference_output[1] (first 10 values):",
+                reference_output[1].flatten()[:10],
             )
 
-    finally:
-        # Ensure cleanup happens even if assertions fail
-        del mcast_buffer_mnnvl
+    torch.testing.assert_close(
+        output[0],
+        reference_output[0],
+        rtol=0.05,
+        atol=0.15,
+    )
+
+    if fusion:
+        torch.testing.assert_close(
+            output[1],
+            reference_output[1],
+            rtol=0.05,
+            atol=0.15,
+        )
 
 
 """Main test function that runs on each MPI rank"""
 
 
 # seq_lens = [1, 4, 32, 128]
-@pytest.mark.parametrize("seq_len", [4])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [1],
+        [4],
+        [15],
+        [27, 11, 24],
+        [127],
+    ],
+)  # Test with different sequence length lists
 @pytest.mark.parametrize("fusion", [False, True])
-def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
+def test_mnnvl_allreduce_full(monkeypatch, seq_lens: list[int], fusion: bool):
     monkeypatch.setenv("TRTLLM_FORCE_MNNVL_AR", "1")  # force multi-node allreduce.
 
     # Get MPI info
     rank = MPI.COMM_WORLD.Get_rank()
     world_size = MPI.COMM_WORLD.Get_size()
+    gpus_per_node = torch.cuda.device_count()
+
+    if gpus_per_node == 0:
+        pytest.skip("MNNVL allreduce test requires at least one CUDA device per node")
 
     # Ensure we have exactly 2 ranks for this test
     if world_size < 2:
@@ -188,12 +184,23 @@ def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
             print(f"ERROR: This test requires at least 2 MPI ranks, got {world_size}")
         sys.exit(1)
 
-    # Set CUDA device based on rank
-    torch.cuda.set_device(rank)
+    mapping = Mapping(
+        world_size=world_size,
+        rank=rank,
+        gpus_per_node=gpus_per_node,
+        tp_size=world_size,
+    )
 
-    if rank == 0:
-        print(f"Running MNNVL AllReduce test with {world_size} ranks")
-        print(f"Rank {rank} using GPU {torch.cuda.current_device()}")
+    # Set CUDA device based on rank
+    torch.cuda.set_device(mapping.local_rank)
+
+    if mapping.local_rank == 0:
+        print(
+            f"[Node {mapping.node_rank}] Running MNNVL AllReduce test with {world_size} ranks"
+        )
+        print(
+            f"[Node {mapping.node_rank}] Rank {rank} using GPU {torch.cuda.current_device()}"
+        )
 
     hidden_size = 7168
     dtype = torch.bfloat16
@@ -207,68 +214,87 @@ def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
     failure_message = ""
 
     try:
-        if rank == 0:
-            print(
-                f"Testing seq_len={seq_len}, hidden_size={hidden_size}, fusion={fusion}"
-            )
-
-        # Generate test data (same on all ranks due to same seed)
-        x_full = torch.randn(
-            (tensor_parallel_size, seq_len, hidden_size),
-            dtype=dtype,
-            device=torch.device("cuda"),
-        )
-        residual = torch.randn(
-            (seq_len, hidden_size), dtype=dtype, device=torch.device("cuda")
-        )
-        norm_weight = torch.randn(
-            (hidden_size,), dtype=dtype, device=torch.device("cuda")
+        # Get workspace buffers using MPI rank - allocate once per seq_lens list and reuse within the list
+        # This workspace is sized for the maximum expected sequence length and can be reused within each list
+        # Each parameterized list gets its own fresh workspace allocation
+        mcast_buffer_mnnvl, buffer_flags_mnnvl, max_num_elements_mnnvl = (
+            trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(mapping, dtype)
         )
 
-        # Each rank gets its slice of the input
-        x = x_full[rank, :, :]
+        multicast_ptr = mcast_buffer_mnnvl.get_multicast_ptr_as_int64()
+        buffer_ptrs_dev = mcast_buffer_mnnvl.get_buffer_ptrs_dev()
+        unicast_ptr = mcast_buffer_mnnvl.mcast_device_memory.get_unicast_ptr(
+            mapping.tp_rank
+        )
 
-        # Compute reference output based on fusion mode
-        if fusion:
-            # Fused case: AllReduce + Residual Add + RMS Norm
-            allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
-            residual_out = allreduce_result + residual  # Add residual
-            print(
-                "Device of residual_out:{}, norm_weight:{}".format(
-                    residual_out.device, norm_weight.device
+        # Test each sequence length with the same workspace (reusing allocated buffers within this list)
+        for seq_len in seq_lens:
+            if rank == 0:
+                print(
+                    f"Testing seq_len={seq_len}, hidden_size={hidden_size}, fusion={fusion}"
                 )
+
+            # Generate test data (same on all ranks due to same seed)
+            x_full = torch.randn(
+                (tensor_parallel_size, seq_len, hidden_size),
+                dtype=dtype,
+                device=torch.device("cuda"),
             )
-            norm_out = rmsnorm(residual_out, norm_weight, eps, enable_pdl=False)
+            residual = torch.randn(
+                (seq_len, hidden_size), dtype=dtype, device=torch.device("cuda")
+            )
+            norm_weight = torch.randn(
+                (hidden_size,), dtype=dtype, device=torch.device("cuda")
+            )
 
-            reference_output = (norm_out, residual_out)
-        else:
-            # Non-fused case: Only AllReduce
-            allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
-            reference_output = (allreduce_result,)
+            # Each rank gets its slice of the input
+            x = x_full[rank, :, :]
 
-        # Run the test
-        row_linear_residual_norm_fusion_forward(
-            x,
-            residual,
-            norm_weight,
-            eps,
-            hidden_size,
-            dtype,
-            tensor_parallel_size,
-            rank,
-            fusion,
-            reference_output,
-        )
+            # Compute reference output based on fusion mode
+            if fusion:
+                # Fused case: AllReduce + Residual Add + RMS Norm
+                allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
+                residual_out = allreduce_result + residual  # Add residual
+                print(
+                    "Device of residual_out:{}, norm_weight:{}".format(
+                        residual_out.device, norm_weight.device
+                    )
+                )
+                norm_out = rmsnorm(residual_out, norm_weight, eps, enable_pdl=False)
 
-        # Synchronize before next test
-        trtllm_mnnvl_ar.mpi_barrier()
+                reference_output = (norm_out, residual_out)
+            else:
+                # Non-fused case: Only AllReduce
+                allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
+                reference_output = (allreduce_result,)
 
-        print(f"PASSED[rank={rank}]: seq_len={seq_len}, fusion={fusion}")
+            # Run the test with the same workspace
+            row_linear_residual_norm_fusion_forward(
+                x,
+                residual,
+                norm_weight,
+                eps,
+                hidden_size,
+                dtype,
+                mapping,
+                fusion,
+                reference_output,
+                multicast_ptr,
+                buffer_ptrs_dev,
+                unicast_ptr,
+                max_num_elements_mnnvl,
+                buffer_flags_mnnvl,
+            )
+
+            # Synchronize before next test
+            trtllm_mnnvl_ar.mpi_barrier()
+
+            print(f"PASSED[rank={rank}]: seq_len={seq_len}, fusion={fusion}")
 
     except Exception as e:
         rank_failed = True
         failure_message = (
-            f"FAILED[rank={rank}]: seq_len={seq_len}, fusion={fusion} failed: {e}"
+            f"FAILED[rank={rank}]: seq_lens={seq_lens}, fusion={fusion} failed: {e}"
         )
         print(failure_message)
         # Gather failure status from all ranks
@@ -283,6 +309,11 @@ def test_mnnvl_allreduce_full(monkeypatch, seq_len: int, fusion: bool):
             # Fail the test on all ranks
             pytest.fail(f"Test failed on ranks {failed_ranks}")
             trtllm_mnnvl_ar.mpi_barrier()
+
+    finally:
+        # Ensure cleanup happens for this list's workspace
+        if "mcast_buffer_mnnvl" in locals():
+            del mcast_buffer_mnnvl
 
     # Final synchronization and check for failures across all ranks
     trtllm_mnnvl_ar.mpi_barrier()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR introduces a series of optimizations to the trtllm_mnnvl_allreduce. These optimizations are also added by [https://github.com/NVIDIA/TensorRT-LLM/pull/5934](https://github.com/NVIDIA/TensorRT-LLM/pull/5934) and [https://github.com/NVIDIA/TensorRT-LLM/pull/6237](https://github.com/NVIDIA/TensorRT-LLM/pull/6237)。

- Use GPU array to pass the uc pointers in the mcast memory.
- Use L2 reduction to replace the expensive atomicAdd.
- Adjust the point of synchronization for buffer flag read.
- Optimize the lamport polling performance.
- Clean up the code structure.
- Enhance the unittest to cover more test cases.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
