### PR TITLE
bugfix: Change default index in routingTopKExperts

### DIFF
--- a/csrc/trtllm_fused_moe_routing_kernel.cu
+++ b/csrc/trtllm_fused_moe_routing_kernel.cu
@@ -561,7 +561,7 @@ __forceinline__ __device__ void routingTopKExperts(cg::thread_block_tile<WarpSiz
                                                    DataType const* ptrScores) {
   DataType minScore = DataType{-INFINITY};
   DataType maxScore = minScore;
-  int32_t maxExpertIdx{-1};
+  int32_t maxExpertIdx{0};
   using DataTypeVec = std::conditional_t<sizeof(DataType) == 2, float2, float4>;
 
   // Non-vectorized loading: directly access ptrScores with expertIdx


### PR DESCRIPTION
## 📌 Description

When all expert scores are `NaN` or `-INFINITY` the default expert index is returned which is currently -1, and this causes an illegal memory access, changed the default index to 0.