### PR TITLE
Fix illegal mem access in routingIndicesWarpKernel

### DIFF
--- a/csrc/trtllm_fused_moe_routing_kernel.cu
+++ b/csrc/trtllm_fused_moe_routing_kernel.cu
@@ -640,6 +640,11 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
       if (cute::elect_one_sync()) {
         // one thread updates the count linking token to chosen expert
         auto expertTokenCount = 0;
+        // If the expert index is out of range, set it to 0 as a fail-safe
+        // mechanism.
+        if (warpMaxExpertIdx[0] >= params.mNumExperts || warpMaxExpertIdx[0] < 0) {
+          warpMaxExpertIdx[0] = 0;
+        }
         setBits</* IsZero= */ true>(expertTokenCount, 1, warpMaxExpertIdx[0] % ExpertsPerThread);
         smemExpertTokenCountFull[tokenIdx][warpMaxExpertIdx[0] / ExpertsPerThread] =
             expertTokenCount;


### PR DESCRIPTION
When all scores are -INF or NaNs, the resulting warpMaxExpertIdx[0] will become 65535, and that causes illegal mem access at this line:

```
smemExpertTokenCountFull[tokenIdx][warpMaxExpertIdx[0] / ExpertsPerThread] =
            expertTokenCount;
```

To avoid this, add a check before accessing the shared memory. If warpMaxExpertIdx[0] is out of range, we just set it to 0 as a fail-safe mechanism.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
