### PR TITLE
hotfix: update mxfp4 groupwise-scaled gemm unittests

### DIFF
--- a/tests/test_groupwise_scaled_gemm_mxfp4.py
+++ b/tests/test_groupwise_scaled_gemm_mxfp4.py
@@ -64,13 +64,8 @@ def swizzle_blockscale(
         _pad_scale_factors(unswizzled_sf[i], m, n, sf_vec_size) for i in range(b)
     ]
     padded_input_sf = torch.stack(padded_input_sf_chunked)
-    out = torch.empty_like(padded_input_sf)
-    get_fp4_quantization_sm100_module().fp4_swizzle_blockscale_sm100(
-        padded_input_sf.flatten(0, 1),
-        out.flatten(0, 1),
-        out.shape[0],
-        out.shape[1],
-        out.shape[2],
+    out = get_fp4_quantization_sm100_module().nvfp4_block_scale_interleave_sm100(
+        padded_input_sf
     )
     out = out.view(padded_input_sf.shape)
     return out


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`fp4_swizzle_blockscale_sm100` function was removed in #1214 and thus breaking tests/test_groupwise_scaled_gemm_mxfp4.py unittest, this PR fixes the issue.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @ttyio @azhurkevich
