### PR TITLE
bugfix: fix ci for aot-compile

### DIFF
--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -8,7 +8,7 @@ export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0+PTX"
 
 python -c "import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI)"
 python -m flashinfer.aot
-python -m build --no-isolation --wheel
+python -m build --wheel
 pip install dist/*.whl
 
 # test import


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Address the CI error such as https://ci.tlcpack.ai/blue/organizations/jenkins/flashinfer-ci/detail/main/481/pipeline

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
