### PR TITLE
ci: add blackwell unittest scripts

### DIFF
--- a/scripts/run_test_blackwell_attention_kernels.sh
+++ b/scripts/run_test_blackwell_attention_kernels.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+
+pytest -s tests/test_blackwell_fmha.py
+pytest -s tests/test_deepseek_mla.py
+
+# trtllm-gen
+pytest -s tests/test_trtllm_gen_context.py
+pytest -s tests/test_trtllm_gen_decode.py
+
+# cudnn
+pytest -s tests/test_cudnn_decode.py
+pytest -s tests/test_cudnn_prefill.py
+pytest -s tests/test_cudnn_prefill_deepseek.py

--- a/scripts/run_test_blackwell_gemm_kernels.sh
+++ b/scripts/run_test_blackwell_gemm_kernels.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+
+pytest -s tests/test_mm_fp4.py
+pytest -s tests/test_groupwise_scaled_gemm_fp8.py
+pytest -s tests/test_groupwise_scaled_gemm_mxfp4.py

--- a/scripts/run_test_blackwell_moe_kernels.sh
+++ b/scripts/run_test_blackwell_moe_kernels.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+
+pytest -s tests/test_trtllm_gen_fused_moe.py
+pytest -s tests/test_trtllm_cutlass_fused_moe.py

--- a/scripts/run_test_blackwell_utils_kernels.sh
+++ b/scripts/run_test_blackwell_utils_kernels.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# utils kernels
+pytest -s tests/test_fp4_quantize.py

--- a/scripts/task_test_blackwell_kernels.sh
+++ b/scripts/task_test_blackwell_kernels.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+: ${MAX_JOBS:=$(nproc)}
+: ${CUDA_VISIBLE_DEVICES:=0}
+
+pip install -e . -v
+
+# run task_blackwell_utils_kernels.sh
+bash scripts/run_test_blackwell_utils_kernels.sh
+
+# run task_blackwell_attention_kernels.sh
+bash scripts/run_test_blackwell_attention_kernels.sh
+
+# gemm kernels
+bash scripts/run_test_blackwell_gemm_kernels.sh
+
+# moe kernels
+bash scripts/run_test_blackwell_moe_kernels.sh

--- a/scripts/task_test_multi_node_comm_kernels.sh
+++ b/scripts/task_test_multi_node_comm_kernels.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+: ${MAX_JOBS:=$(nproc)}
+: ${CUDA_VISIBLE_DEVICES:=0}
+
+pip install -e . -v
+
+pytest -s tests/test_mnnvl_memory.py
+pytest -s tests/test_trtllm_mnnvl_allreduce.py

--- a/scripts/task_test_single_node_comm_kernels.sh
+++ b/scripts/task_test_single_node_comm_kernels.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+: ${MAX_JOBS:=$(nproc)}
+: ${CUDA_VISIBLE_DEVICES:=0}
+
+pip install -e . -v
+
+# vllm ar
+pytest -s tests/test_vllm_custom_allreduce.py
+# trtllm ar + fusion
+pytest -s tests/test_trtllm_allreduce.py
+pytest -s tests/test_trtllm_allreduce_fusion.py
+pytest -s tests/test_trtllm_cutlass_fused_moe.py
+pytest -s tests/test_trtllm_moe_allreduce_fusion.py
+pytest -s tests/test_trtllm_moe_allreduce_fusion_finalize.py
+# nvshmem ar
+pytest -s tests/test_nvshmem.py
+pytest -s tests/test_nvshmem_allreduce.py


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Initial setup of blackwell unittest scripts
* scripts/run_test_blackwell_attention_kernels.sh for moe/gemm/attention/utils/etc
* scripts/task_test_multi_node_comm_kernels.sh for multi-node communication kernels
* scripts/task_test_single_node_comm_kernels.sh for single-node communication kernels

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
