### PR TITLE
hotfix: fix cuda 12.9 compilation issues

### DIFF
--- a/include/flashinfer/math.cuh
+++ b/include/flashinfer/math.cuh
@@ -31,17 +31,21 @@ constexpr float loge2 = 0.693147180559945309417f;
 
 constexpr float inf = 5e4;
 
-__forceinline__ __device__ half2 uint32_as_half2(uint32_t x) { return *(half2*)&x; }
+__forceinline__ __device__ __host__ half2 uint32_as_half2(uint32_t x) { return *(half2*)&x; }
 
-__forceinline__ __device__ uint32_t half2_as_uint32(half2 x) { return *(uint32_t*)&x; }
+__forceinline__ __device__ __host__ uint32_t half2_as_uint32(half2 x) { return *(uint32_t*)&x; }
 
 /*!
  * \brief Wrapper of PTX ex2.approx instruction, which computes 2^x
  * \param x input
  */
-__forceinline__ __device__ float ptx_exp2(float x) {
+__forceinline__ __device__ __host__ float ptx_exp2(float x) {
   float y;
+#if defined(__CUDA_ARCH__)
   asm volatile("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+#else
+  y = exp2f(x);
+#endif
   return y;
 }
 
@@ -49,9 +53,13 @@ __forceinline__ __device__ float ptx_exp2(float x) {
  * \brief Wrapper of PTX lg2.approx instruction, which computes log2(x)
  * \param x input
  */
-__forceinline__ __device__ float ptx_log2(float x) {
+__forceinline__ __device__ __host__ float ptx_log2(float x) {
   float y;
+#if defined(__CUDA_ARCH__)
   asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+#else
+  y = log2f(x);
+#endif
   return y;
 }
 
@@ -59,31 +67,43 @@ __forceinline__ __device__ float ptx_log2(float x) {
  * \brief Wrapper of PTX ex2.approx.f16x2 instruction, which computes 2^x
  * \param x input
  */
-__forceinline__ __device__ half2 ptx_exp2(half2 x) {
+__forceinline__ __device__ __host__ half2 ptx_exp2(half2 x) {
+#if defined(__CUDA_ARCH__)
   uint32_t y_u32;
   uint32_t x_u32 = half2_as_uint32(x);
   asm volatile("ex2.approx.f16x2 %0, %1;" : "=r"(y_u32) : "r"(x_u32));
   return uint32_as_half2(y_u32);
+#else
+  return make_half2(hexp2(x.x), hexp2(x.y));
+#endif
 }
 
 /*!
  * \brief Wrapper of PTX ex2.approx.f16 instruction, which computes 2^x
  * \param x input
  */
-__forceinline__ __device__ half ptx_exp2(half x) {
+__forceinline__ __device__ __host__ half ptx_exp2(half x) {
+#if defined(__CUDA_ARCH__)
   ushort y_u16;
   asm volatile("ex2.approx.f16 %0, %1;" : "=h"(y_u16) : "h"(__half_as_ushort(x)));
   return __ushort_as_half(y_u16);
+#else
+  return hexp2(x);
+#endif
 }
 
 /*!
  * \brief Wrapper of PTX rcp.approx instruction, which computes 1/x
  * \param x input
  */
-__forceinline__ __device__ float ptx_rcp(float x) {
+__forceinline__ __device__ __host__ float ptx_rcp(float x) {
+#if defined(__CUDA_ARCH__)
   float y;
   asm volatile("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
   return y;
+#else
+  return 1. / x;
+#endif
 }
 
 /*!
@@ -93,20 +113,6 @@ __forceinline__ __device__ float ptx_rcp(float x) {
  * \param lane_mask The mask to perform thread index xor with: y[i] <- x[i ^ delta]
  */
 __forceinline__ __device__ float shfl_xor_sync(float x, int lane_mask) {
-  float y;
-  asm volatile("shfl.sync.bfly.b32 %0, %1, %2, 0x1f, 0xffffffff;"
-               : "=f"(y)
-               : "f"(x), "r"(lane_mask));
-  return y;
-}
-
-/*!
- * \brief Wrapper of PTX shfl.sync.bfly instruction on half2, which performs a butterfly
- *   shuffle between threads in a warp.
- * \param x The value in the source lane
- * \param lane_mask The mask to perform thread index xor with: y[i] <- x[i ^ lane_mask]
- */
-__forceinline__ __device__ half2 shfl_xor_sync(half2 x, int lane_mask) {
   return __shfl_xor_sync(0xffffffff, x, lane_mask);
 }
 
@@ -114,41 +120,57 @@ __forceinline__ __device__ half2 shfl_xor_sync(half2 x, int lane_mask) {
  * \brief Wrapper of PTX rsqrt approximation instruction, which computes 1/sqrt(x)
  * \param x input
  */
-__forceinline__ __device__ float rsqrt(float x) {
+__forceinline__ __device__ __host__ float rsqrt(float x) {
+#if defined(__CUDA_ARCH__)
   float y;
   asm volatile("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
   return y;
+#else
+  return rsqrtf(x);
+#endif
 }
 
 /*!
  * \brief Wrapper of PTX tanh.approx.f32 instruction, which computes tanh(x)
  * \param x input
  */
-__forceinline__ __device__ float tanh(float x) {
+__forceinline__ __device__ __host__ float tanh(float x) {
+#if defined(__CUDA_ARCH__)
   float y;
   asm volatile("tanh.approx.f32 %0, %1;" : "=f"(y) : "f"(x));
   return y;
+#else
+  return tanhf(x);
+#endif
 }
 
 /*!
  * \brief Wrapper of PTX tanh.approx.f16x2 instruction, which computes tanh(x)
  * \param x input
  */
-__forceinline__ __device__ half2 tanh(half2 x) {
+__forceinline__ __device__ __host__ half2 tanh(half2 x) {
+#if defined(__CUDA_ARCH__)
   uint32_t y_u32;
   uint32_t x_u32 = half2_as_uint32(x);
   asm volatile("tanh.approx.f16x2 %0, %1;" : "=r"(y_u32) : "r"(x_u32));
   return uint32_as_half2(y_u32);
+#else
+  return make_half2(htanh(x.x), htanh(x.y));
+#endif
 }
 
 /*!
  * \brief Wrapper of PTX tanh.approx.f16 instruction, which computes tanh(x)
  * \param x input
  */
-__forceinline__ __device__ half tanh(half x) {
+__forceinline__ __device__ __host__ half tanh(half x) {
+#if defined(__CUDA_ARCH__)
   ushort y_u16;
   asm volatile("tanh.approx.f16 %0, %1;" : "=h"(y_u16) : "h"(__half_as_ushort(x)));
   return __ushort_as_half(y_u16);
+#else
+  return htanh(x);
+#endif
 }
 
 }  // namespace math


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We encounter compilation error when compiling some JIT kernels on cuda 12.9 because the math functions do have host-side definition, this PR fixes the issue.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
