### PR TITLE
Removes MPI dependency from MNNVL AllReduce

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -843,6 +843,7 @@ class McastGPUBuffer:
         group_rank: int,
         device: torch.device,
         mn_nvlink: bool = True,
+        group: dist.ProcessGroup = None,
     ):
         """
         Constructor for McastGpuBuffer.
@@ -855,7 +856,7 @@ class McastGPUBuffer:
             mn_nvlink: Flag indicating if multi-node NVLink is used
         """
         self.mcast_device_memory = McastDeviceMemory(
-            buf_size, group_size, group_rank, device.index, mn_nvlink
+            buf_size, group_size, group_rank, device.index, mn_nvlink, group
         )
         self.buf_size = buf_size
         self.local_device = device

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -129,7 +129,7 @@ def get_trtllm_mnnvl_comm_module():
 
 
 def get_allreduce_mnnvl_workspace(
-    mapping: Mapping, dtype: torch.dtype
+    mapping: Mapping, dtype: torch.dtype, group: Optional[dist.ProcessGroup] = None
 ) -> Tuple[McastGPUBuffer, torch.Tensor, int]:
     """Get workspace buffers needed for multi-node NVLink all-reduce operation.
 
@@ -171,6 +171,7 @@ def get_allreduce_mnnvl_workspace(
         mapping.tp_rank,
         torch.device("cuda", mapping.local_rank),
         mapping.is_multi_node() or force_mn,
+        group=group,
     )
 
     # Initialize the unicast buffer with -0.0

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -21,8 +21,6 @@ from ..utils import register_custom_op
 from .mnnvl import McastGPUBuffer
 
 
-
-
 def gen_trtllm_mnnvl_comm_module() -> JitSpec:
     return gen_jit_spec(
         "trtllm_mnnvl_comm",

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from typing import List, Optional, Tuple
 
 import torch
-from mpi4py import MPI
+import torch.distributed as dist
 
 from flashinfer.comm.mapping import Mapping
 
@@ -21,9 +21,6 @@ from ..utils import register_custom_op
 from .mnnvl import McastGPUBuffer
 
 
-def mpi_barrier():
-    """MPI barrier - could potentially be replaced with dist.barrier()"""
-    MPI.COMM_WORLD.Barrier()
 
 
 def gen_trtllm_mnnvl_comm_module() -> JitSpec:
@@ -181,7 +178,7 @@ def get_allreduce_mnnvl_workspace(
 
     # CPU barrier since we assume this should not be called in cuda graph
     torch.cuda.synchronize()
-    mpi_barrier()
+    dist.barrier()
 
     # This is a buffer to maintain the state of this allreduce Op
     # [Buffer_ptr, Clear_ptr, Buffer_size, num_tokens_prev, atomic access counter]

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -51,18 +51,20 @@ def _get_workspace_dir_name() -> pathlib.Path:
 FLASHINFER_WORKSPACE_DIR = _get_workspace_dir_name()
 FLASHINFER_JIT_DIR = FLASHINFER_WORKSPACE_DIR / "cached_ops"
 FLASHINFER_GEN_SRC_DIR = FLASHINFER_WORKSPACE_DIR / "generated"
-_package_root = pathlib.Path(__file__).resolve().parents[1]
-FLASHINFER_DATA = _package_root / "data"
-FLASHINFER_INCLUDE_DIR = _package_root / "data" / "include"
-FLASHINFER_CSRC_DIR = _package_root / "data" / "csrc"
-# FLASHINFER_SRC_DIR = _package_root / "data" / "src"
-FLASHINFER_TVM_BINDING_DIR = _package_root / "data" / "tvm_binding"
-FLASHINFER_AOT_DIR = _package_root / "data" / "aot"
+# TODO (pranavm): Check if this is right?
+# Why were these pointing to non-existent directories? Must be a copy missing somewhere?
+_package_root = pathlib.Path(__file__).resolve().parents[2]
+FLASHINFER_DATA = _package_root
+FLASHINFER_INCLUDE_DIR = _package_root  / "include"
+FLASHINFER_CSRC_DIR = _package_root  / "csrc"
+# FLASHINFER_SRC_DIR = _package_root  / "src"
+FLASHINFER_TVM_BINDING_DIR = _package_root  / "tvm_binding"
+FLASHINFER_AOT_DIR = _package_root  / "aot"
 CUTLASS_INCLUDE_DIRS = [
-    _package_root / "data" / "cutlass" / "include",
-    _package_root / "data" / "cutlass" / "tools" / "util" / "include",
+    _package_root / "3rdparty" / "cutlass" / "include",
+    _package_root / "3rdparty" / "cutlass" / "tools" / "util" / "include",
 ]
-SPDLOG_INCLUDE_DIR = _package_root / "data" / "spdlog" / "include"
+SPDLOG_INCLUDE_DIR = _package_root / "3rdparty" / "spdlog" / "include"
 
 
 def get_nvshmem_include_dirs():

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -55,11 +55,11 @@ FLASHINFER_GEN_SRC_DIR = FLASHINFER_WORKSPACE_DIR / "generated"
 # Why were these pointing to non-existent directories? Must be a copy missing somewhere?
 _package_root = pathlib.Path(__file__).resolve().parents[2]
 FLASHINFER_DATA = _package_root
-FLASHINFER_INCLUDE_DIR = _package_root  / "include"
-FLASHINFER_CSRC_DIR = _package_root  / "csrc"
+FLASHINFER_INCLUDE_DIR = _package_root / "include"
+FLASHINFER_CSRC_DIR = _package_root / "csrc"
 # FLASHINFER_SRC_DIR = _package_root  / "src"
-FLASHINFER_TVM_BINDING_DIR = _package_root  / "tvm_binding"
-FLASHINFER_AOT_DIR = _package_root  / "aot"
+FLASHINFER_TVM_BINDING_DIR = _package_root / "tvm_binding"
+FLASHINFER_AOT_DIR = _package_root / "aot"
 CUTLASS_INCLUDE_DIRS = [
     _package_root / "3rdparty" / "cutlass" / "include",
     _package_root / "3rdparty" / "cutlass" / "tools" / "util" / "include",


### PR DESCRIPTION
## 📌 Description

This change removes the MPI dependency from the MNNVL AllReduce kernel, using `torch.distributed` instead. 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

There are two hacks here I want to call out:

1. I needed to change the paths in the JIT environment since they were pointing to non-existent directories. I'm not sure if this is a real bug or whether I missed a step when setting something up.
2. The unit test is now tied to SLURM, which might not be desirable, but I am unsure how to generalize it or how the existing CI works with multi-node. 
