### PR TITLE
misc: Customize kv lens buffer size for sparse attention 

### DIFF
--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -126,7 +126,7 @@ class BlockSparseAttentionWrapper:
             If set to ``auto``, the function will automatically choose the backend based on the
             device architecture and kernel availability.
         kv_lens_buffer_size : int
-            The size of the kv lens buffer (num_kv_heads * MB), defaults to 32768.
+            The size of the kv lens buffer (num_kv_heads * num_blocks_row/batch_size), defaults to 32768.
         """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
@@ -139,7 +139,6 @@ class BlockSparseAttentionWrapper:
             self._vector_sparse_indices_buffer = torch.empty(
                 (128 * 1024 * 1024,), dtype=torch.int32, device=self.device
             )
-            # NOTE(Zihao): assume maximum batch size is 32768
             self._vector_sparse_indptr_buffer = torch.empty(
                 (kv_lens_buffer_size,), dtype=torch.int32, device=self.device
             )
@@ -727,6 +726,7 @@ class VariableBlockSparseAttentionWrapper:
         self,
         float_workspace_buffer: torch.Tensor,
         backend: str = "auto",
+        kv_lens_buffer_size: int = 32768,
     ) -> None:
         r"""Constructs of :class:`VariableBlockSparseAttentionWrapper`.
 
@@ -740,6 +740,8 @@ class VariableBlockSparseAttentionWrapper:
             The implementation backend, could be ``auto``/``fa2`` or ``fa3``. Defaults to ``auto``.
             If set to ``auto``, the function will automatically choose the backend based on the
             device architecture and kernel availability.
+        kv_lens_buffer_size : int
+            The size of the kv lens buffer (num_kv_heads * num_blocks_row/batch_size), defaults to 32768.
         """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
@@ -751,11 +753,11 @@ class VariableBlockSparseAttentionWrapper:
                 (128 * 1024 * 1024,), dtype=torch.int32, device=self.device
             )
             self._vector_sparse_indptr_buffer = torch.empty(
-                (32768,), dtype=torch.int32, device=self.device
+                (kv_lens_buffer_size,), dtype=torch.int32, device=self.device
             )
 
         self._kv_lens_buffer = torch.empty(
-            (32768,), dtype=torch.int32, device=self.device
+            (kv_lens_buffer_size,), dtype=torch.int32, device=self.device
         )
         self._pin_memory_int_workspace_buffer = torch.empty(
             self._int_workspace_buffer.shape,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

Fixes https://github.com/flashinfer-ai/flashinfer/issues/1367
## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
