### PR TITLE
[DO NOT MERGE] Separating the k_cache and v_cache for trtllm-gen attention interface.

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -186,14 +186,18 @@ inline Data_type torch_dtype_to_tllm_data_type(at::ScalarType dtype) {
 inline bool is_4bit(Data_type data_type) { return data_type == Data_type::DATA_TYPE_E2M1; }
 
 void trtllm_paged_attention_decode(at::Tensor out, std::optional<at::Tensor> out_scale_factor,
-                                   at::Tensor query, at::Tensor key_value_cache,
+                                   at::Tensor query, at::Tensor key_cache, at::Tensor value_cache,
                                    at::Tensor workspace_buffer, at::Tensor block_tables,
                                    at::Tensor seq_lens, int64_t max_kv_len, double bmm1_scale,
                                    double bmm2_scale, double o_sf_scale, int64_t o_sf_vec_size,
                                    int64_t o_sf_start_index, int64_t window_left,
                                    int64_t sm_count) {
   auto q_data_type = torch_dtype_to_tllm_data_type(query.scalar_type());
-  auto kv_data_type = torch_dtype_to_tllm_data_type(key_value_cache.scalar_type());
+  auto kv_data_type = torch_dtype_to_tllm_data_type(key_cache.scalar_type());
+  TORCH_CHECK_EQ(key_cache.dim(), value_cache.dim());
+  for (int i = 0; i < key_cache.dim(); i++) {
+    TORCH_CHECK_EQ(key_cache.size(i), value_cache.size(i));
+  }
   auto o_data_type = torch_dtype_to_tllm_data_type(out.scalar_type());
   // NOTE(Zihao): query is [B, Q, H, D]
   // where Q is the number of query tokens per request, used in MTP
@@ -204,52 +208,45 @@ void trtllm_paged_attention_decode(at::Tensor out, std::optional<at::Tensor> out
   int sum_seq_q = batch_size * q_len_per_request;
   int num_qo_heads = query.size(2);
   // Multiply by two for FP4 tensor as it is stored as UINT8 dtype. Assume the dim is even.
-  int head_dim_kv = is_4bit(kv_data_type) ? key_value_cache.size(-1) * 2 : key_value_cache.size(-1);
-  int head_dim_qk = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
-  TORCH_CHECK(head_dim_kv == head_dim_qk, "head_dim_kv and head_dim_qk must be the same, got " +
-                                              std::to_string(head_dim_kv) + " and " +
-                                              std::to_string(head_dim_qk));
-  int head_dim_vo = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
-  TORCH_CHECK((head_dim_kv == 576 && head_dim_vo == 512) || head_dim_kv == head_dim_vo,
-              "head_dim_kv and head_dim_vo must be the same for non-MLA attention, got " +
-                  std::to_string(head_dim_kv) + " and " + std::to_string(head_dim_vo));
-  // NOTE(Zihao): key_value_cache is [num_pages, 1/2, num_kv_heads, page_size, head_dim]
-  // For KV-Cache sharing (MLA), the second dimension is 1 (key/value cache are shared)
-  // otherwise it is 2, one for key and one for value
-  TORCH_CHECK(key_value_cache.size(1) == 1 || key_value_cache.size(1) == 2,
-              "The second dimension of key_value_cache must be 1 or 2, got " +
-                  std::to_string(key_value_cache.size(1)));
-  bool share_kv_cache = key_value_cache.size(1) == 1;
-  int page_size = key_value_cache.size(-2);
-  int num_kv_heads = key_value_cache.size(-3);
+  int head_dim_k = is_4bit(kv_data_type) ? key_cache.size(-1) * 2 : key_cache.size(-1);
+  int head_dim_q = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
+  int head_dim_v = is_4bit(kv_data_type) ? value_cache.size(-1) * 2 : value_cache.size(-1);
+  int head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
+  TORCH_CHECK(head_dim_k == head_dim_q, "head_dim_k and head_dim_q must be the same, got " +
+                                            std::to_string(head_dim_k) + " and " +
+                                            std::to_string(head_dim_q));
+  TORCH_CHECK((head_dim_v == 576 && head_dim_o == 512) || head_dim_v == head_dim_o,
+              "head_dim_v and head_dim_o must be the same for non-MLA attention, got " +
+                  std::to_string(head_dim_v) + " and " + std::to_string(head_dim_o));
+  int page_size = key_cache.size(-2);
+  int num_kv_heads = key_cache.size(-3);
   int max_num_blocks_per_seq = block_tables.size(-1);
-  int num_pages_in_mem_pool = key_value_cache.size(0) * key_value_cache.size(1);
+  bool is_shared_kv = key_cache.data_ptr() == value_cache.data_ptr();
+  int num_pages_in_mem_pool = is_shared_kv ? key_cache.size(0) : key_cache.size(0) * 2;
 
-  int kv_stride_keys_values = key_value_cache.stride(-2);  // key/values
-  int kv_stride_heads = key_value_cache.stride(-3);        // head
-  int kv_stride_batch = key_value_cache.stride(0);         // batch
+  int kv_stride_keys_values = key_cache.stride(-2);  // key/values
+  int kv_stride_heads = key_cache.stride(-3);        // head
+  int kv_stride_batch = key_cache.stride(0);         // batch
 
   auto device = query.device();
   const auto stream = at::cuda::getCurrentCUDAStream(device.index());
   void* output_sf_ptr = out_scale_factor ? out_scale_factor.value().data_ptr() : nullptr;
 
   trtllm_paged_attention_launcher(
-      out.data_ptr(), output_sf_ptr, query.data_ptr(), key_value_cache.data_ptr(),
-      (char*)key_value_cache.data_ptr() +
-          (share_kv_cache ? 0 : key_value_cache.stride(1) * key_value_cache.element_size()),
+      out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()),
       static_cast<int*>(seq_lens.data_ptr()),
       /*cum_seq_lens_q=*/nullptr,
       /*cum_seq_lens_kv=*/nullptr, q_data_type, kv_data_type, o_data_type,
       TllmPagedAttentionMode::ForGen, batch_size, /*max_q_len=*/q_len_per_request, max_kv_len,
-      num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
+      num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q, head_dim_o, page_size,
       kv_stride_keys_values, kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale,
       bmm2_scale, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q, sm_count,
       stream);
 }
 
 void trtllm_paged_attention_context(at::Tensor out, std::optional<at::Tensor> out_scale_factor,
-                                    at::Tensor query, at::Tensor key_value_cache,
+                                    at::Tensor query, at::Tensor key_cache, at::Tensor value_cache,
                                     at::Tensor workspace_buffer, at::Tensor block_tables,
                                     at::Tensor seq_lens, int64_t max_q_len, int64_t max_kv_len,
                                     double bmm1_scale, double bmm2_scale, double o_sf_scale,
@@ -258,50 +255,43 @@ void trtllm_paged_attention_context(at::Tensor out, std::optional<at::Tensor> ou
                                     at::Tensor cum_seq_lens_q, at::Tensor cum_seq_lens_kv,
                                     int64_t sm_count) {
   auto q_data_type = torch_dtype_to_tllm_data_type(query.scalar_type());
-  auto kv_data_type = torch_dtype_to_tllm_data_type(key_value_cache.scalar_type());
+  auto kv_data_type = torch_dtype_to_tllm_data_type(key_cache.scalar_type());
   auto o_data_type = torch_dtype_to_tllm_data_type(out.scalar_type());
   int num_qo_heads = query.size(1);
   int sum_seq_q = query.size(0);
   // Multiply by two for FP4 tensor as it is stored as UINT8 dtype. Assume the dim is even.
-  int head_dim_kv = is_4bit(kv_data_type) ? key_value_cache.size(-1) * 2 : key_value_cache.size(-1);
-  int head_dim_qk = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
-  TORCH_CHECK(head_dim_kv == head_dim_qk, "head_dim_kv and head_dim_qk must be the same, got " +
-                                              std::to_string(head_dim_kv) + " and " +
-                                              std::to_string(head_dim_qk));
-  int head_dim_vo = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
-  TORCH_CHECK(head_dim_kv == head_dim_vo, "head_dim_kv and head_dim_vo must be the same, got " +
-                                              std::to_string(head_dim_kv) + " and " +
-                                              std::to_string(head_dim_vo));
+  int head_dim_k = is_4bit(kv_data_type) ? key_cache.size(-1) * 2 : key_cache.size(-1);
+  int head_dim_q = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
+  int head_dim_v = is_4bit(kv_data_type) ? value_cache.size(-1) * 2 : value_cache.size(-1);
+  int head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
+  TORCH_CHECK(head_dim_k == head_dim_q, "head_dim_k and head_dim_q must be the same, got " +
+                                            std::to_string(head_dim_k) + " and " +
+                                            std::to_string(head_dim_q));
+  TORCH_CHECK(head_dim_v == head_dim_o, "head_dim_v and head_dim_o must be the same, got " +
+                                            std::to_string(head_dim_v) + " and " +
+                                            std::to_string(head_dim_o));
   int max_num_blocks_per_seq = block_tables.size(-1);
-  int num_pages_in_mem_pool = key_value_cache.size(0) * key_value_cache.size(1);
-  // NOTE(Zihao): key_value_cache is [num_pages, 1/2, num_kv_heads, page_size, head_dim]
-  // For KV-Cache sharing (MLA), the second dimension is 1 (key/value cache are shared)
-  // otherwise it is 2, one for key and one for value
-  TORCH_CHECK(key_value_cache.size(1) == 1 || key_value_cache.size(1) == 2,
-              "The second dimension of key_value_cache must be 1 or 2, got " +
-                  std::to_string(key_value_cache.size(1)));
-  bool share_kv_cache = key_value_cache.size(1) == 1;
-  int page_size = key_value_cache.size(-2);
-  int num_kv_heads = key_value_cache.size(-3);
+  bool is_shared_kv = key_cache.data_ptr() == value_cache.data_ptr();
+  int num_pages_in_mem_pool = is_shared_kv ? key_cache.size(0) : key_cache.size(0) * 2;
+  int page_size = key_cache.size(-2);
+  int num_kv_heads = key_cache.size(-3);
 
-  int kv_stride_keys_values = key_value_cache.stride(-2);  // key/values
-  int kv_stride_heads = key_value_cache.stride(-3);        // head
-  int kv_stride_batch = key_value_cache.stride(0);         // batch
+  int kv_stride_keys_values = key_cache.stride(-2);  // key/values
+  int kv_stride_heads = key_cache.stride(-3);        // head
+  int kv_stride_batch = key_cache.stride(0);         // batch
 
   auto device = query.device();
   const auto stream = at::cuda::getCurrentCUDAStream(device.index());
   void* output_sf_ptr = out_scale_factor ? out_scale_factor.value().data_ptr() : nullptr;
 
   trtllm_paged_attention_launcher(
-      out.data_ptr(), output_sf_ptr, query.data_ptr(), key_value_cache.data_ptr(),
-      (char*)key_value_cache.data_ptr() +
-          (share_kv_cache ? 0 : key_value_cache.stride(1) * key_value_cache.element_size()),
+      out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()),
       static_cast<int*>(seq_lens.data_ptr()),
       /*cum_seq_lens_q=*/static_cast<int*>(cum_seq_lens_q.data_ptr()),
       /*cum_seq_lens_kv=*/static_cast<int*>(cum_seq_lens_kv.data_ptr()), q_data_type, kv_data_type,
       o_data_type, TllmPagedAttentionMode::Context, batch_size, max_q_len, max_kv_len,
-      num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
+      num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q, head_dim_o, page_size,
       kv_stride_keys_values, kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale,
       bmm2_scale, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q, sm_count,
       stream);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Some frameworks separate the storage of `k_cache` and `v_cache`, and the coupled kv-cache interface `[num_pages, 2, num_heads, page_size, head_dim]` will be hard to use for them.

This PR adds support for decoupled `k_cache`/`v_cache`, while keeping backward compatibility with original interface.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
