### PR TITLE
feat(install): allow skipping nvshmem pip install via env var

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -194,6 +194,18 @@ You can follow the steps below to install FlashInfer from source code:
                python -m build --no-isolation --wheel
                ls -la dist/
 
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^
+
+FlashInfer supports the following environment variables to customize the installation process:
+
+- ``SKIP_NVSHMEM_PIP``: When set to "1", skips installing the ``nvidia-nvshmem-cu12`` dependency via pip. This is useful when the package is already provided as a system-level package (e.g., via RPM on RHEL-based distributions via the NVIDIA CUDA repository).
+
+  .. code-block:: bash
+
+      export SKIP_NVSHMEM_PIP=1
+      pip install --no-build-isolation --verbose .
+
 C++ API
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,11 @@ install_requires = [
     "nvidia-cudnn-cu12",
     "nvidia-cudnn-frontend>=1.13.0",
 ]
+
+# Skip nvidia-nvshmem-cu12 if SKIP_NVSHMEM_PIP environment variable is set
+if os.environ.get("SKIP_NVSHMEM_PIP", "0") == "1":
+    install_requires.remove("nvidia-nvshmem-cu12")
+
 generate_build_meta({})
 
 if enable_aot:


### PR DESCRIPTION
## 📌 Description

Some systems, particularly RHEL-based distributions using the NVIDIA CUDA repository, provide `nvshmem` as a system-level package (e.g., RPM).
In such cases, installing the `nvidia-nvshmem-cu12` package from pip is unnecessary and can cause conflicts.

This commit introduces the `SKIP_NVSHMEM_PIP` environment variable.
When this variable is set to "1", the `setup.py` script will remove `nvidia-nvshmem-cu12` from the list of dependencies, allowing the system-provided version to be used instead.

## 🔍 Related Issues

Fixes #1387

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).
