### PR TITLE
Fix flag order

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -86,12 +86,12 @@ def generate_ninja_build_for_op(
     ldflags = [
         "-shared",
         "-L$torch_home/lib",
+        "-L$cuda_home/lib64",
         "-lc10",
         "-lc10_cuda",
         "-ltorch_cpu",
         "-ltorch_cuda",
         "-ltorch",
-        "-L$cuda_home/lib64",
         "-lcudart",
     ]
 


### PR DESCRIPTION
On AArch64, the order matters for the linker

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
