### PR TITLE
Add flags to trim down AoT builds

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 import torch
+import torch.version
 from torch.utils.cpp_extension import _get_cuda_arch_flags
 
 from .activation import act_func_def_str, gen_act_and_mul_module
@@ -579,7 +580,7 @@ def main():
     def has_sm(compute: str, version: str) -> bool:
         if not any("compute_90" in flag for flag in gencode_flags):
             return False
-        if torch.cuda.version is None:
+        if torch.version.cuda is None:
             return True
         return version_at_least(torch.version.cuda, version)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR trims down AoT builds to allow wheels to be generated including only the attention kernels.
Also added a placeholder for sink attention AoT.
The comm module is not imported unless explicitly requested.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
