### PR TITLE
install: remove nvidia-cudnn-12 from package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ install_requires = [
     "pynvml",
     "einops",
     "nvidia-nvshmem-cu12",
-    "nvidia-cudnn-cu12",
     "nvidia-cudnn-frontend>=1.13.0",
 ]
 generate_build_meta({})


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The dependency is not required because:
1. For x86_64 user environments that installs pytorch from pypi, `nvidia-cudnn-12` is already a torch dependency (https://github.com/pytorch/pytorch/blob/3f1636ebef9b45e8a3cb0eb20d327ee6acb74be0/.github/scripts/generate_binary_build_matrix.py#L44-L95), and flashinfer depends on torch, there is no need to specify another `nvidia-cudnn-12` dependency in flashinfer.
2. For user environments where `nvidia-cudnn-12` is not a torch dependency (like in nvidia's pytorch container), cudnn is installed at system wide and cudnn-frontend will rely on cudnn system installation instead of through `nvidia-cudnn-12`.

## 🔍 Related Issues

`nvidia-nvshmem-12` package is a similar redundant dependency: https://github.com/flashinfer-ai/flashinfer/pull/1388

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
