### PR TITLE
[bugfix] Fix compilation failure when compiling csrc/trtllm_moe_allreduce_fusion.cu

### DIFF
--- a/csrc/trtllm_moe_allreduce_fusion.cu
+++ b/csrc/trtllm_moe_allreduce_fusion.cu
@@ -63,7 +63,7 @@ void trtllm_moe_allreduce_fusion(
         params.scale_factor = static_cast<float>(scale_factor);
         params.layout = layout_code.has_value()
                             ? static_cast<FP4QuantizationSFLayout>(layout_code.value())
-                            : FP4QuantizationSFLayout::SWIZZLED_128x4;
+                            : FP4QuantizationSFLayout::SWIZZLED;
         params.stream = stream;
 
         params.moe_reduction_device_num_experts = moe_reduction_device_num_experts;


### PR DESCRIPTION
[bugfix] Fix compilation failure when compiling csrc/trtllm_moe_allreduce_fusion.cu

This file includes FP4QuantizationSFLayout from
`flashinfer/comm/trtllm_moe_allreduce_fusion.cuh` which still uses the old format.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
