### PR TITLE
Fix crash when pos_encoding_mode is passed as int

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2592,7 +2592,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 kv_indptr.dtype,
                 head_dim_qk,
                 head_dim_vo,
-                PosEncodingMode[pos_encoding_mode].value,
+                PosEncodingMode[pos_encoding_mode],
                 window_left >= 0,  # use_sliding_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
@@ -2969,7 +2969,7 @@ def fmha_varlen(
         torch.int32,
         q.shape[2],
         v.shape[2],
-        PosEncodingMode.NONE.value,
+        PosEncodingMode.NONE,
         False,  # use_sliding_window
         False,  # use_logits_soft_cap
     )


### PR DESCRIPTION
This PR is to fix this issue caused by https://github.com/flashinfer-ai/flashinfer/commit/85d75ca915e64f664dfc33ea5f52446d279bc2ad
```  
File "/scratch/repo/flashinfer/flashinfer/prefill.py", line 83, in get_fmha_module                                                                                                               pos_encoding_mode.value,                                                                                                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                    AttributeError: 'int' object has no attribute 'value' 
```

Update get_fmha_module to expect pos_encoding_mode as an Enum instead of an int; raises error otherwise.

cc @yzh119 