### PR TITLE
Remote const qualifier to avoid compilation error

### DIFF
--- a/include/flashinfer/comm/vllm_custom_all_reduce.cuh
+++ b/include/flashinfer/comm/vllm_custom_all_reduce.cuh
@@ -58,7 +58,7 @@ struct Signal {
 };
 
 struct __align__(16) RankData {
-  const void* __restrict__ ptrs[8];
+  void* __restrict__ ptrs[8];
 };
 
 struct __align__(16) RankSignals {


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Removing the const qualifier so that compiler could generate the copy constructor.

## 🔍 Related Issues

Without the change, I'm seeing the following build error.

```
flashinfer/comm/vllm_custom_all_reduce.cuh:60:35: error: cannot initialize a parameter of type 'void *' with an rvalue of type 'const void *__restrict (*)[8]'
   60 | struct __attribute((aligned(16))) RankData { 
      |                                   ^~~~~~~~

...

flashinfer/comm/vllm_custom_all_reduce.cuh:407:26: note: in instantiation of member function 'std::vector<vllm::RankData>::vector' requested here
  407 | __T0::vector< RankData>  rank_data(num_buffers); 
      |                          ^

```

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
