### PR TITLE
Fix FusedMoeRunner does not exist error

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -329,7 +329,7 @@ def get_cutlass_fused_moe_sm100_module(use_fast_build: bool = False):
             )
 
             if instance_key not in MoERunner.runner_dict:
-                MoERunner.runner_dict[instance_key] = module.FusedMoeRunner(
+                runner = torch.classes.fused_moe_sm100.FusedMoeRunner(
                     x_dtype,
                     weight_dtype,
                     output_dtype,
@@ -337,6 +337,8 @@ def get_cutlass_fused_moe_sm100_module(use_fast_build: bool = False):
                     use_w4a8_group_scaling,
                     use_mxfp8_act_scaling,
                 )
+                MoERunner.runner_dict[instance_key] = runner
+
             self.fused_moe_runner = MoERunner.runner_dict[instance_key]
 
         def get_valid_tactics(


### PR DESCRIPTION
Fix `AttributeError: FusedMoeRunner does not exist` error when running cutlass MoE.

Broken by https://github.com/flashinfer-ai/flashinfer/pull/1201

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
