### PR TITLE
install: remove nvidia-nvshmem-cu12 from package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ install_requires = [
     "cuda-python",
     "pynvml",
     "einops",
-    "nvidia-nvshmem-cu12",
     "nvidia-cudnn-frontend>=1.13.0",
 ]
 generate_build_meta({})


### PR DESCRIPTION
## 📌 Description

The dependency is not required because:

* For x86_64 user environments that installs pytorch from pypi, nvidia-nvshmem-cu12 is already a torch dependency
  (https://github.com/pytorch/pytorch/blob/3f1636ebef9b45e8a3cb0eb20d327ee6acb74be0/.github/scripts/generate_binary_build_matrix.py#L44-L95),
  and flashinfer depends on torch, there is no need to specify another nvidia-nvshmem-cu12 dependency in flashinfer.
* For user environments where nvidia-nvshmem-cu12 is not a torch dependency (like in nvidia's pytorch container),
  nvshmem is installed at system wide.

## 🔍 Related Issues

Fixes #1387

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).
