### PR TITLE
ci: bugfix on sdist pypi workflow

### DIFF
--- a/.github/workflows/release_pypi_sdist.yml
+++ b/.github/workflows/release_pypi_sdist.yml
@@ -57,28 +57,6 @@ jobs:
 
           echo "✓ version.txt matches tag version: $VERSION_TXT"
 
-      - name: Verify tag matches package version
-        run: |
-          # Extract version from tag (remove 'v' prefix)
-          TAG_VERSION="${{ inputs.tag }}"
-          TAG_VERSION="${TAG_VERSION#v}"
-
-          # Extract version from setup.py or pyproject.toml
-          if [ -f "setup.py" ]; then
-            PACKAGE_VERSION=$(python -c "import re; content = open('setup.py').read(); match = re.search(r'version\s*=\s*[\"']([^\"']+)[\"']', content); print(match.group(1) if match else '')")
-          elif [ -f "pyproject.toml" ]; then
-            PACKAGE_VERSION=$(python -c "import tomllib; data = tomllib.load(open('pyproject.toml', 'rb')); print(data.get('project', {}).get('version', '') or data.get('tool', {}).get('poetry', {}).get('version', ''))")
-          else
-            echo "Warning: Could not find version file (setup.py or pyproject.toml)"
-            PACKAGE_VERSION=""
-          fi
-
-          if [ -n "$PACKAGE_VERSION" ] && [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "Error: Tag version ($TAG_VERSION) does not match package version ($PACKAGE_VERSION)"
-            exit 1
-          fi
-          echo "✓ Package version check passed: $TAG_VERSION"
-
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Remove "Verify tag matches package version" step because it reads package version from `setup.py` or `pyproject.yml` but our version number exist in version.txt.

"Verify tag matches version.txt" has already checked the version.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes
cc @yongwww 
