### PR TITLE
perf: cache `get_compute_capability`

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 import math
 import os
 from enum import Enum
@@ -207,6 +208,7 @@ def canonicalize_torch_dtype(dtype: Union[torch.dtype, str]) -> torch.dtype:
         )
 
 
+@functools.cache
 def get_compute_capability(device: torch.device) -> Tuple[int, int]:
     if device.type != "cuda":
         raise ValueError("device must be a cuda device")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Cache compute capability to reduce repeat cpu overload mentioned in https://github.com/flashinfer-ai/flashinfer/issues/1425#issuecomment-3173450034

Results reproduced from https://gist.github.com/yzh119/d9bf2abbb667abcbb806979f4bbea633 :
```bash
before the fix
w/o CUDAGraph 0.0054492950439453125
w/  CUDAGraph 0.002916574478149414
after the fix
w/o CUDAGraph 0.0038330554962158203
w/  CUDAGraph 0.0030286312103271484
```

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/1425

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
