### PR TITLE
fix: update cutedsl masked moe gemm

### DIFF
--- a/flashinfer/cute_dsl/blockscaled_gemm.py
+++ b/flashinfer/cute_dsl/blockscaled_gemm.py
@@ -2753,7 +2753,9 @@ def grouped_gemm_nt_masked(
     n, _, _ = b_torch.shape
 
     if ab_dtype == "float4_e2m1fn":
-        k = k * 2  # todo(yingyi): update mnk based on a_major and b_major
+        # todo(yingyi): update mnk based on a_major and b_major, and support more major.
+        # Note: only support deepgemm-like shape for now
+        k = k * 2
 
     mma_tiler_mn = kwargs.get("mma_tiler_mm", (128, 128))
     cluster_shape_mn = kwargs.get("cluster_shape_mm", (1, 1))

--- a/flashinfer/cute_dsl/blockscaled_gemm.py
+++ b/flashinfer/cute_dsl/blockscaled_gemm.py
@@ -2752,6 +2752,10 @@ def grouped_gemm_nt_masked(
     m, k, l = a_torch.shape
     n, _, _ = b_torch.shape
 
+    if ab_dtype == "float4_e2m1fn":
+        k = k * 2 # todo(yingyi): update mnk based on a_major and b_major
+    
+
     mma_tiler_mn = kwargs.get("mma_tiler_mm", (128, 128))
     cluster_shape_mn = kwargs.get("cluster_shape_mm", (1, 1))
 

--- a/flashinfer/cute_dsl/blockscaled_gemm.py
+++ b/flashinfer/cute_dsl/blockscaled_gemm.py
@@ -2753,8 +2753,7 @@ def grouped_gemm_nt_masked(
     n, _, _ = b_torch.shape
 
     if ab_dtype == "float4_e2m1fn":
-        k = k * 2 # todo(yingyi): update mnk based on a_major and b_major
-    
+        k = k * 2  # todo(yingyi): update mnk based on a_major and b_major
 
     mma_tiler_mn = kwargs.get("mma_tiler_mm", (128, 128))
     cluster_shape_mn = kwargs.get("cluster_shape_mm", (1, 1))

--- a/tests/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/test_cute_dsl_blockscaled_gemm.py
@@ -286,21 +286,3 @@ def test_blockscaled_gemm_python_interface(
                 atol=tolerance,
                 rtol=1e-02,
             )
-
-
-if __name__ == "__main__":
-    test_blockscaled_gemm_python_interface(
-        lm=(1, 1024),
-        kn=(7168, 4096),
-        ab_dtype="float8_e4m3fn",
-        sf_dtype="float8_e8m0fnu",
-        sf_vec_size=32,
-        c_dtype="float16",
-        a_major="k",
-        b_major="k",
-        c_major="n",
-        mma_tiler_mn=(128, 128),
-        cluster_shape_mn=(1, 1),
-        tolerance=1e-01,
-        iterations=3,
-    )

--- a/tests/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/test_cute_dsl_blockscaled_gemm.py
@@ -50,9 +50,9 @@ from flashinfer.cute_dsl.utils import (
         ("float8_e5m2", "float8_e8m0fnu", "float8_e5m2", 32),
     ],
 )
-@pytest.mark.parametrize("a_major", ["k"])
-@pytest.mark.parametrize("b_major", ["k"])
-@pytest.mark.parametrize("c_major", ["n"])
+@pytest.mark.parametrize("a_major", ["k", "m"])
+@pytest.mark.parametrize("b_major", ["k", "n"])
+@pytest.mark.parametrize("c_major", ["n", "m"])
 @pytest.mark.parametrize("mma_tiler_mn", [(128, 128)])
 @pytest.mark.parametrize("cluster_shape_mn", [(1, 1)])
 @pytest.mark.parametrize("tolerance", [1e-01])
@@ -167,7 +167,6 @@ def test_blockscaled_gemm_python_interface(
     masked_m_tensor = torch.randint(0, m, (l,), dtype=torch.int32, device="cuda")
 
     for _ in range(iterations):
-        assert a_major == "k" and b_major == "k" and c_major == "n"
         grouped_gemm_nt_masked(
             (a_torch, sfa_torch),
             (b_torch, sfb_torch),

--- a/tests/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/test_cute_dsl_blockscaled_gemm.py
@@ -189,21 +189,6 @@ def test_blockscaled_gemm_python_interface(
     masked_m_tensor = torch.randint(0, m, (l,), dtype=torch.int32, device="cuda")
 
     for _ in range(iterations):
-        # deepgemm-like python interface: fp4 not packed, not for DLFW integration
-        grouped_gemm_nt_masked(
-            (a_torch, sfa_torch),
-            (b_torch, sfb_torch),
-            c_torch,
-            masked_m_tensor,
-            ab_dtype=ab_dtype,
-            sf_dtype=sf_dtype,
-            c_dtype=c_dtype,
-            sf_vec_size=sf_vec_size,
-            mma_tiler_mn=mma_tiler_mn,
-            cluster_shape_mn=cluster_shape_mn,
-            is_packed=False,
-        )
-
         # deepgemm-like python interface: fp4 packed, for DLFW integration
         grouped_gemm_nt_masked(
             (a_torch_clone, sfa_torch),
@@ -216,7 +201,6 @@ def test_blockscaled_gemm_python_interface(
             sf_vec_size=sf_vec_size,
             mma_tiler_mn=mma_tiler_mn,
             cluster_shape_mn=cluster_shape_mn,
-            is_packed=True,
         )
         torch.cuda.synchronize()
 
@@ -245,12 +229,7 @@ def test_blockscaled_gemm_python_interface(
 
     if c_dtype in ("float32", "float16", "bfloat16"):
         for i in range(l):
-            torch.testing.assert_close(
-                c_ref[: masked_m_tensor[i].item(), :, i],
-                ref[: masked_m_tensor[i].item(), :, i],
-                atol=tolerance,
-                rtol=1e-02,
-            )
+            # skip testing c_ref & ref
             torch.testing.assert_close(
                 c_ref_clone[: masked_m_tensor[i].item(), :, i],
                 ref[: masked_m_tensor[i].item(), :, i],
@@ -274,12 +253,7 @@ def test_blockscaled_gemm_python_interface(
         cute.testing.convert(ref_f8, ref_tensor)
         ref = ref_device.cpu()
         for i in range(l):
-            torch.testing.assert_close(
-                c_ref[: masked_m_tensor[i].item(), :, i],
-                ref[: masked_m_tensor[i].item(), :, i],
-                atol=tolerance,
-                rtol=1e-02,
-            )
+            # skip testing c_ref & ref
             torch.testing.assert_close(
                 c_ref_clone[: masked_m_tensor[i].item(), :, i],
                 ref[: masked_m_tensor[i].item(), :, i],


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

initial PR: https://github.com/flashinfer-ai/flashinfer/pull/1331
fix following PR #1481

For problem shape (l, m, k), k is leading:
- We assume DLFW passed in packed tensors with 8-bit storage (eg, int8, fp4x2, fp8) with shape (l, m, k//2), which takes half as the shape at leading dim.
- Therefore we introduce is_packed params (default True) to indicate if it's packed or not. If it's packed, we deduce the leading dim by *2.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
