### PR TITLE
Perf: support scale_a/scale_b instead of combined scale in cutlass bmm_fp8

### DIFF
--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -406,7 +406,8 @@ def get_gemm_sm100_module_cutlass_fp8():
                 module.fp8_gemm.default(
                     a,
                     b.transpose(-2, -1),
-                    scale_a * scale_b,
+                    scale_a,
+                    scale_b,
                     out,
                     workspace_buffer,
                     tactic,

--- a/include/flashinfer/gemm/fp8_gemm_cutlass.h
+++ b/include/flashinfer/gemm/fp8_gemm_cutlass.h
@@ -31,9 +31,10 @@ class CutlassFp8GemmRunnerInterface {
   CutlassFp8GemmRunnerInterface() = default;
   virtual ~CutlassFp8GemmRunnerInterface() = default;
 
-  virtual void gemm(__nv_fp8_e4m3 const* A, __nv_fp8_e4m3 const* B, float const* alpha, void* D,
-                    int m, int n, int k, int b, CutlassGemmConfig gemmConfig, char* workspacePtr,
-                    size_t const workspaceBytes, cudaStream_t stream) = 0;
+  virtual void gemm(__nv_fp8_e4m3 const* A, __nv_fp8_e4m3 const* B, float const* scale_a,
+                    float const* scale_b, void* D, int m, int n, int k, int b,
+                    CutlassGemmConfig gemmConfig, char* workspacePtr, size_t const workspaceBytes,
+                    cudaStream_t stream) = 0;
 
   virtual size_t getWorkspaceSize(int m, int n, int k) = 0;
 
@@ -46,9 +47,9 @@ class CutlassFp8GemmRunner : public virtual CutlassFp8GemmRunnerInterface {
   CutlassFp8GemmRunner() = default;
   ~CutlassFp8GemmRunner() = default;
 
-  void gemm(__nv_fp8_e4m3 const* A, __nv_fp8_e4m3 const* B, float const* alpha, void* D, int m,
-            int n, int k, int b, CutlassGemmConfig gemmConfig, char* workspacePtr,
-            size_t const workspaceBytes, cudaStream_t stream) override;
+  void gemm(__nv_fp8_e4m3 const* A, __nv_fp8_e4m3 const* B, float const* scale_a,
+            float const* scale_b, void* D, int m, int n, int k, int b, CutlassGemmConfig gemmConfig,
+            char* workspacePtr, size_t const workspaceBytes, cudaStream_t stream) override;
   size_t getWorkspaceSize(int m, int n, int k) override;
   std::vector<CutlassGemmConfig> getConfigs() const override;
 


### PR DESCRIPTION
Previous cutlass implementation require combine of scale_a/scale_b in the python, so extra aten kernel is used which may cost 1us. Now we support separate alpha_a and alpha_b in epilog, to avoid this extra aten kernel.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
