### PR TITLE
Add errors when dtype is anything other than int32 for ptr metatdata

### DIFF
--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -231,15 +231,15 @@ class BatchMLAPagedAttentionWrapper:
 
         Parameters
         ----------
-        qo_indptr : torch.Tensor
+        qo_indptr : torch.IntTensor
             The indptr of the query/output tensor, shape: ``[batch_size + 1]``.
             For decoding attention, the length of each query is 1, and the content
             of the tensor should be ``[0, 1, 2, ..., batch_size]``.
-        kv_indptr : torch.Tensor(int32)
+        kv_indptr : torch.IntTensor
             The indptr of the paged kv-cache, shape: ``[batch_size + 1]``.
-        kv_indices : torch.Tensor(int32)
+        kv_indices : torch.IntTensor
             The page indices of the paged kv-cache, shape: ``[kv_indptr[-1]]`` or larger.
-        kv_len_arr : torch.Tensor(int32)
+        kv_len_arr : torch.IntTensor
             The query length of each request, shape: ``[batch_size]``.
         num_heads : int
             The number of heads in query/output tensor.
@@ -260,18 +260,17 @@ class BatchMLAPagedAttentionWrapper:
         use_profiler : bool, optional
             Whether to enable intra-kernel profiler, default is False.
         """
-        if kv_len_arr.dtype != torch.int32:
-            raise ValueError(
-                f"Expected kv_len_arr.dtype == torch.int32, got {kv_len_arr.dtype}"
-            )
-        if kv_indptr.dtype != torch.int32:
-            raise ValueError(
-                f"Expected kv_indptr.dtype == torch.int32, got {kv_indptr.dtype}"
-            )
-        if qo_indptr.dtype != torch.int32:
-            raise ValueError(
-                f"Expected qo_indptr.dtype == torch.int32, got {qo_indptr.dtype}"
-            )
+
+        for tensor, name in [
+            (kv_len_arr, "kv_len_arr"),
+            (kv_indptr, "kv_indptr"),
+            (qo_indptr, "qo_indptr"),
+            (kv_indices, "kv_indices"),
+        ]:
+            if tensor.dtype != torch.int32:
+                raise ValueError(
+                    f"Expected {name}.dtype == torch.int32, got {tensor.dtype}"
+                )
 
         self._cached_module = get_batch_mla_module(
             self._backend,


### PR DESCRIPTION
This PR adds a very simple error check for the metadata arguments qo_indptr, kv_indptr and kv_lens array.



## 📌 Description

This PR adds a very simple error check for the metadata arguments qo_indptr, kv_indptr and kv_lens array.


## 🔍 Related Issues



## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [N/A] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [N/A] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
