### PR TITLE
fix: Replace cub Max/Min with cuda::maximum/minimum for cuda 13 compatibility

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -16,13 +16,12 @@
 #ifndef FLASHINFER_SAMPLING_CUH_
 #define FLASHINFER_SAMPLING_CUH_
 
+#include <cuda.h>
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
 
-#include <cub/block/block_adjacent_difference.cuh>
-#include <cub/block/block_reduce.cuh>
-#include <cub/block/block_scan.cuh>
+#include <cub/cub.cuh>
 #include <cuda/functional>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
@@ -34,6 +33,22 @@
 #include "math.cuh"
 #include "utils.cuh"
 #include "vec_dtypes.cuh"
+
+#if CUDA_VERSION >= 12090
+using MaxReduceOp = cuda::maximum<>;
+using MinReduceOp = cuda::minimum<>;
+#define MAX_OP \
+  cuda::maximum<> {}
+#define MIN_OP \
+  cuda::minimum<> {}
+#else
+using MaxReduceOp = cub::Max;
+using MinReduceOp = cub::Min;
+#define MAX_OP \
+  cub::Max {}
+#define MIN_OP \
+  cub::Min {}
+#endif
 
 namespace flashinfer {
 
@@ -254,11 +269,11 @@ __device__ __forceinline__ std::tuple<float, float> GetMinMaxValue(float* in_dat
     }
     max_val = max(
         max_val, BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-                     .Reduce<VEC_SIZE>(in_data_, cub::Max()));
+                     .Reduce<VEC_SIZE>(in_data_, MAX_OP));
     __syncthreads();
     min_val = min(
         min_val, BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-                     .Reduce<VEC_SIZE>(in_data_, cub::Min()));
+                     .Reduce<VEC_SIZE>(in_data_, MIN_OP));
     __syncthreads();
   }
   if (tx == 0) {
@@ -292,7 +307,7 @@ __device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, u
     }
     max_val = max(
         max_val, BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-                     .Reduce<VEC_SIZE>(in_data_, cub::Max()));
+                     .Reduce<VEC_SIZE>(in_data_, MAX_OP));
     __syncthreads();
   }
   if (tx == 0) {
@@ -352,7 +367,7 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
       thread_max = max(thread_max, logits_vec[j]);
     }
     float block_max = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                          .Reduce(thread_max, cub::Max());
+                          .Reduce(thread_max, MAX_OP);
 
     if (tx == 0) {
       temp_storage.shared_state.max_val = block_max;
@@ -468,7 +483,7 @@ __global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* part
     }
 
     float block_max = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                          .Reduce(thread_max, cub::Max());
+                          .Reduce(thread_max, MAX_OP);
 
     if (tx == 0) {
       temp_storage.shared_state.max_val = block_max;
@@ -653,7 +668,7 @@ __device__ __forceinline__ void DeviceSamplingFromProb(
   }
   int max_valid_index =
       BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce_int)
-          .Reduce(valid_index, cub::Max());
+          .Reduce(valid_index, MAX_OP);
   if (tx == 0 && max_valid_index != -1) {
     temp_storage->last_valid_id = max_valid_index;
   }
@@ -1674,11 +1689,11 @@ __global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* 
       __syncthreads();
     }
     min_gt_low = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-                     .Reduce(min_gt_low, cub::Min());
+                     .Reduce(min_gt_low, MIN_OP);
     __syncthreads();
     max_le_high =
         BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-            .Reduce(max_le_high, cub::Max());
+            .Reduce(max_le_high, MAX_OP);
     if (tx == 0) {
       temp_storage.block_aggregate.values[0] = aggregate_gt_pivot_0;
       temp_storage.block_aggregate.values[1] = aggregate_gt_pivot_1;
@@ -1796,11 +1811,11 @@ __global__ void TopKMaskLogitsKernel(DType* logits, DType* masked_logits, IdType
       }
       min_gt_low =
           BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-              .Reduce(min_gt_low, cub::Min());
+              .Reduce(min_gt_low, MIN_OP);
       __syncthreads();
       max_le_high =
           BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-              .Reduce(max_le_high, cub::Max());
+              .Reduce(max_le_high, MAX_OP);
       if (tx == 0) {
         temp_storage.block_aggregate.counts[0] = aggregate_gt_pivot_0;
         temp_storage.block_aggregate.counts[1] = aggregate_gt_pivot_1;
@@ -1916,11 +1931,11 @@ __global__ void TopKRenormProbKernel(DType* probs, DType* renormed_prob, IdType*
       }
       min_gt_low =
           BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-              .Reduce(min_gt_low, cub::Min());
+              .Reduce(min_gt_low, MIN_OP);
       __syncthreads();
       max_le_high =
           BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-              .Reduce(max_le_high, cub::Max());
+              .Reduce(max_le_high, MAX_OP);
       if (tx == 0) {
         temp_storage.block_aggregate.pairs[0] = aggregate_gt_pivot_0;
         temp_storage.block_aggregate.pairs[1] = aggregate_gt_pivot_1;
@@ -2102,7 +2117,7 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
     }
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], 0);
+      relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], 0.0f);
     }
     sum_relu_q_minus_p +=
         BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
@@ -2136,7 +2151,7 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
     vec_t<float, VEC_SIZE> relu_q_minus_p_vec;
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], 0);
+      relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], 0.0f);
     }
 
     DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,


### PR DESCRIPTION
- Replace deprecated cub::Max/Min with cuda::maximum/minimum for CUDA 12.9+
- Consolidate 12 repeated CUDA version checks into single definition
- Define MAX_OP/MIN_OP macros once at file scope for cleaner code
- Change from individual CUB headers to unified cub/cub.cuh include
- Maintains backward compatibility with older CUDA versions

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc: @yzh119  @xslingcn 
