### PR TITLE
tests(attn): add short-seq CUDA edge-case test (qo_len=1) for prefill

### DIFF
--- a/tests/test_attention_short_seq.py
+++ b/tests/test_attention_short_seq.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+pytestmark = pytest.mark.cuda
+
+def _import_flashinfer():
+    try:
+        import flashinfer as fi
+        return fi
+    except Exception as e:
+        pytest.skip(f"flashinfer import failed in test env: {e}")
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_single_prefill_short_seq_is_finite():
+    fi = _import_flashinfer()
+
+    torch.manual_seed(0)
+    device = "cuda"
+
+    # KV cache (typical shapes from README/docs)
+    kv_len = 3
+    num_kv_heads = 4
+    head_dim = 64
+    k = torch.randn(kv_len, num_kv_heads, head_dim, device=device, dtype=torch.float16)
+    v = torch.randn(kv_len, num_kv_heads, head_dim, device=device, dtype=torch.float16)
+
+    # Short query length: qo_len = 1 (the edge case we care about)
+    qo_len = 1
+    num_qo_heads = 4
+    q = torch.randn(qo_len, num_qo_heads, head_dim, device=device, dtype=torch.float16)
+
+    # Use the public API documented by FlashInfer
+    # https://docs.flashinfer.ai/generated/flashinfer.decode.single_decode_with_kv_cache.html
+    out = fi.single_prefill_with_kv_cache(q, k, v, causal=True)
+
+    # Some APIs may return (out, lse); accept both
+    if isinstance(out, (tuple, list)):
+        out = out[0]
+
+    assert torch.isfinite(out).all(), "Non-finite values from single_prefill_with_kv_cache on qo_len=1"
+    # shape sanity: [qo_len, num_qo_heads, head_dim] for prefill
+    assert out.shape[0] == qo_len and out.shape[1] == num_qo_heads


### PR DESCRIPTION
## 📌 Description
Adds a CUDA unit test for a short-sequence attention edge case using the public API
`single_prefill_with_kv_cache` with `qo_len = 1`. This improves coverage for minimal-length inputs.

- New test: tests/test_attention_short_seq.py
- Ensures outputs are finite and basic shape invariants hold.
- Test auto-skips if CUDA is unavailable (so it doesn't block CI on CPU runners).

## 🔍 Related Issues
- References #1243 (Beginner Getting Started Tasks)

## 🚀 Pull Request Checklist
### ✅ Pre-commit Checks
- [x] I ran `pre-commit run --all-files` locally or ensured formatting matches the repo style.

## 🧪 Tests
- [x] Added a CUDA test for `qo_len = 1` (prefill).
- [x] CI should exercise this on GPU runners.

## Reviewer Notes
- If maintainers prefer a different test filename or an additional config (e.g., different head dims), I’m happy to adjust.
