### PR TITLE
fix: add missing 'requests' when building the package with AOT

### DIFF
--- a/custom_backend.py
+++ b/custom_backend.py
@@ -8,7 +8,7 @@ _data_dir = _root / "flashinfer" / "data"
 _aot_ops_dir = _root / "aot-ops"
 _aot_ops_package_dir = _root / "build" / "aot-ops-package-dir"
 
-_requires_for_aot = ["torch", "ninja", "numpy"]
+_requires_for_aot = ["torch", "ninja", "numpy", "requests"]
 
 
 def _rm_aot_ops_package_dir():


### PR DESCRIPTION
## 📌 Description

When building flashinfer-python with AOT enabled, we need the 'requests'
package otherwise it fails with missing packages when importing modules.

## 🔍 Related Issues

Fixes #1516

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
