### PR TITLE
refactor fp4 masked gemm cute-dsl implementation and add manual cache

### DIFF
--- a/flashinfer/cute_dsl/blockscaled_gemm.py
+++ b/flashinfer/cute_dsl/blockscaled_gemm.py
@@ -2739,7 +2739,7 @@ def grouped_gemm_nt_masked(
         ab_dtype=get_cutlass_dtype(ab_dtype),
         sf_dtype=get_cutlass_dtype(sf_dtype),
         c_dtype=get_cutlass_dtype(c_dtype),
-        alpha_dtype=get_cutlass_dtype(alpha_dtype),
+        alpha_dtype=None if alpha is None else get_cutlass_dtype(alpha_dtype),
         sf_vec_size=sf_vec_size,
         mma_tiler_mn=mma_tiler_mn,
         cluster_shape_mn=cluster_shape_mn,

--- a/flashinfer/cute_dsl/blockscaled_gemm.py
+++ b/flashinfer/cute_dsl/blockscaled_gemm.py
@@ -40,7 +40,7 @@ import torch
 import functools
 from cutlass._mlir import ir
 from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.cute.runtime import make_ptr
+from cutlass.cute.runtime import from_dlpack, make_ptr
 from cutlass.cutlass_dsl import (
     Int32,
     Integer,
@@ -2314,6 +2314,89 @@ def cvt_sf_MKL_to_M32x4xrm_K4xrk_L_mma_spec(
     # group to ((32, 4, rest_m), (4, rest_k), l)
     sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
     sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+
+
+# Create scale factor tensor SFA/SFB
+def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype, device):
+    def ceil_div(a, b):
+        return (a + b - 1) // b
+
+    sf_k = ceil_div(k, sf_vec_size)
+    ref_shape = (l, mn, sf_k)
+
+    atom_m = (32, 4)
+    atom_k = 4
+    mma_shape = (
+        l,
+        ceil_div(mn, atom_m[0] * atom_m[1]),
+        ceil_div(sf_k, atom_k),
+        atom_m[0],
+        atom_m[1],
+        atom_k,
+    )
+
+    ref_permute_order = (1, 2, 0)
+    mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+    # Create f32 ref torch tensor
+    ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        ref_shape,
+        torch.float32,
+        permute_order=ref_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=1,
+            max_val=3,
+        ),
+    )
+
+    # Create f32 cute torch tensor
+    cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        mma_shape,
+        torch.float32,
+        permute_order=mma_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=0,
+            max_val=1,
+        ),
+    )
+
+    # convert ref f32 tensor to cute f32 tensor
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+        from_dlpack(ref_f32_torch_tensor_cpu),
+        from_dlpack(cute_f32_torch_tensor_cpu),
+    )
+    cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.to(device, non_blocking=True)
+
+    # reshape makes memory contiguous
+    ref_f32_torch_tensor_cpu = (
+        ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+        .unsqueeze(-1)
+        .expand(l, mn, sf_k, sf_vec_size)
+        .reshape(l, mn, sf_k * sf_vec_size)
+        .permute(*ref_permute_order)
+    )
+    # prune to mkl for reference check.
+    ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+    ref_f32_torch_tensor = ref_f32_torch_tensor_cpu.to(device, non_blocking=True)
+
+    # Create dtype cute torch tensor (cpu)
+    cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
+        cute_f32_torch_tensor_cpu,
+        dtype,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    # Convert f32 cute tensor to dtype cute tensor
+    cute_tensor = cutlass_torch.convert_cute_tensor(
+        cute_f32_torch_tensor,
+        cute_tensor,
+        dtype,
+        is_dynamic_layout=True,
+    )
+    return ref_f32_torch_tensor, cute_tensor, cute_torch_tensor
 
 
 class MaskedBatchedMatmulCuteDSL:

--- a/flashinfer/cute_dsl/blockscaled_gemm.py
+++ b/flashinfer/cute_dsl/blockscaled_gemm.py
@@ -40,7 +40,7 @@ import torch
 import functools
 from cutlass._mlir import ir
 from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.cute.runtime import from_dlpack, make_ptr
+from cutlass.cute.runtime import make_ptr
 from cutlass.cutlass_dsl import (
     Int32,
     Integer,
@@ -2316,88 +2316,6 @@ def cvt_sf_MKL_to_M32x4xrm_K4xrk_L_mma_spec(
     sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
 
 
-# Create scale factor tensor SFA/SFB
-def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):
-    def ceil_div(a, b):
-        return (a + b - 1) // b
-
-    sf_k = ceil_div(k, sf_vec_size)
-    ref_shape = (l, mn, sf_k)
-
-    atom_m = (32, 4)
-    atom_k = 4
-    mma_shape = (
-        l,
-        ceil_div(mn, atom_m[0] * atom_m[1]),
-        ceil_div(sf_k, atom_k),
-        atom_m[0],
-        atom_m[1],
-        atom_k,
-    )
-
-    ref_permute_order = (1, 2, 0)
-    mma_permute_order = (3, 4, 1, 5, 2, 0)
-
-    # Create f32 ref torch tensor (cpu)
-    ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
-        ref_shape,
-        torch.float32,
-        permute_order=ref_permute_order,
-        init_type=cutlass_torch.TensorInitType.RANDOM,
-        init_config=cutlass_torch.RandomInitConfig(
-            min_val=1,
-            max_val=3,
-        ),
-    )
-
-    # Create f32 cute torch tensor (cpu)
-    cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
-        mma_shape,
-        torch.float32,
-        permute_order=mma_permute_order,
-        init_type=cutlass_torch.TensorInitType.RANDOM,
-        init_config=cutlass_torch.RandomInitConfig(
-            min_val=0,
-            max_val=1,
-        ),
-    )
-
-    # convert ref f32 tensor to cute f32 tensor
-    cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
-        from_dlpack(ref_f32_torch_tensor_cpu),
-        from_dlpack(cute_f32_torch_tensor_cpu),
-    )
-    cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
-
-    # reshape makes memory contiguous
-    ref_f32_torch_tensor_cpu = (
-        ref_f32_torch_tensor_cpu.permute(2, 0, 1)
-        .unsqueeze(-1)
-        .expand(l, mn, sf_k, sf_vec_size)
-        .reshape(l, mn, sf_k * sf_vec_size)
-        .permute(*ref_permute_order)
-    )
-    # prune to mkl for reference check.
-    ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
-
-    # Create dtype cute torch tensor (cpu)
-    cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
-        cute_f32_torch_tensor_cpu,
-        dtype,
-        is_dynamic_layout=True,
-        assumed_align=16,
-    )
-
-    # Convert f32 cute tensor to dtype cute tensor
-    cute_tensor = cutlass_torch.convert_cute_tensor(
-        cute_f32_torch_tensor,
-        cute_tensor,
-        dtype,
-        is_dynamic_layout=True,
-    )
-    return ref_f32_torch_tensor_cpu, cute_tensor, cute_torch_tensor
-
-
 class MaskedBatchedMatmulCuteDSL:
     def __init__(
         self,
@@ -2585,7 +2503,6 @@ def get_cute_dsl_compiled_masked_gemm_kernel(
     def get_cute_pointers(
         input_tensors: Optional[List[torch.tensor]],
     ) -> List[cute.Pointer]:
-        mock_ptr = torch.randn(16, device="cuda:0").data_ptr()
         if input_tensors is None:
             (
                 a_data_ptr,
@@ -2595,7 +2512,7 @@ def get_cute_dsl_compiled_masked_gemm_kernel(
                 c_data_ptr,
                 masked_m_data_ptr,
                 alpha_data_ptr,
-            ) = [mock_ptr for _ in range(7)]
+            ) = [16 for _ in range(7)]
         else:
             (
                 a_tensor_gpu,

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import cutlass
+import torch
 import importlib.util
 
 
@@ -36,3 +37,26 @@ def get_cutlass_dtype(dtype: str) -> cutlass.dtype:
         "float4_e2m1fn": cutlass.Float4E2M1FN,
     }
     return dtype_map[dtype]
+
+
+def cutlass_to_torch_dtype(cutlass_dtype):
+    """
+    Return the corresponding torch.dtype per the given DSL type
+    """
+    torch_dtype = getattr(torch, cutlass_dtype.__name__.lower(), None)
+
+    torch_type_map = {
+        cutlass.dtypes.TFloat32: torch.float32,
+        cutlass.dtypes.Float32: torch.float32,
+        cutlass.dtypes.Float16: torch.float16,
+        cutlass.dtypes.BFloat16: torch.bfloat16,
+        cutlass.dtypes.Float8E5M2: torch.float8_e5m2,
+        cutlass.dtypes.Float8E4M3FN: torch.float8_e4m3fn,
+        cutlass.dtypes.Float8E4M3B11FNUZ: torch.float8_e4m3fnuz,
+    }
+    if torch_dtype is None:
+        torch_dtype = torch_type_map.get(cutlass_dtype)
+
+    if torch_dtype is None:
+        raise TypeError(f"{cutlass_dtype} is not supported by torch")
+    return torch_dtype

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -46,13 +46,13 @@ def cutlass_to_torch_dtype(cutlass_dtype):
     torch_dtype = getattr(torch, cutlass_dtype.__name__.lower(), None)
 
     torch_type_map = {
-        cutlass.dtypes.TFloat32: torch.float32,
-        cutlass.dtypes.Float32: torch.float32,
-        cutlass.dtypes.Float16: torch.float16,
-        cutlass.dtypes.BFloat16: torch.bfloat16,
-        cutlass.dtypes.Float8E5M2: torch.float8_e5m2,
-        cutlass.dtypes.Float8E4M3FN: torch.float8_e4m3fn,
-        cutlass.dtypes.Float8E4M3B11FNUZ: torch.float8_e4m3fnuz,
+        cutlass.TFloat32: torch.float32,
+        cutlass.Float32: torch.float32,
+        cutlass.Float16: torch.float16,
+        cutlass.BFloat16: torch.bfloat16,
+        cutlass.Float8E5M2: torch.float8_e5m2,
+        cutlass.Float8E4M3FN: torch.float8_e4m3fn,
+        cutlass.Float8E4M3B11FNUZ: torch.float8_e4m3fnuz,
     }
     if torch_dtype is None:
         torch_dtype = torch_type_map.get(cutlass_dtype)

--- a/tests/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/test_cute_dsl_blockscaled_gemm.py
@@ -13,14 +13,97 @@ import torch
 from cutlass.cute.runtime import from_dlpack
 
 from flashinfer.cute_dsl.blockscaled_gemm import (
-    create_scale_factor_tensor,
     Sm100BlockScaledPersistentDenseGemmKernel,  # not used in python interface
     grouped_gemm_nt_masked,  # deepgemm-like python interface for DLFW integration
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L,
 )
 from flashinfer.cute_dsl.utils import (
     get_cutlass_dtype,
     is_cute_dsl_available,
 )
+
+
+# Create scale factor tensor SFA/SFB
+def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype, device):
+    def ceil_div(a, b):
+        return (a + b - 1) // b
+
+    sf_k = ceil_div(k, sf_vec_size)
+    ref_shape = (l, mn, sf_k)
+
+    atom_m = (32, 4)
+    atom_k = 4
+    mma_shape = (
+        l,
+        ceil_div(mn, atom_m[0] * atom_m[1]),
+        ceil_div(sf_k, atom_k),
+        atom_m[0],
+        atom_m[1],
+        atom_k,
+    )
+
+    ref_permute_order = (1, 2, 0)
+    mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+    # Create f32 ref torch tensor
+    ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        ref_shape,
+        torch.float32,
+        permute_order=ref_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=1,
+            max_val=3,
+        ),
+    )
+
+    # Create f32 cute torch tensor
+    cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        mma_shape,
+        torch.float32,
+        permute_order=mma_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=0,
+            max_val=1,
+        ),
+    )
+
+    # convert ref f32 tensor to cute f32 tensor
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+        from_dlpack(ref_f32_torch_tensor_cpu),
+        from_dlpack(cute_f32_torch_tensor_cpu),
+    )
+    cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.to(device, non_blocking=True)
+
+    # reshape makes memory contiguous
+    ref_f32_torch_tensor_cpu = (
+        ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+        .unsqueeze(-1)
+        .expand(l, mn, sf_k, sf_vec_size)
+        .reshape(l, mn, sf_k * sf_vec_size)
+        .permute(*ref_permute_order)
+    )
+    # prune to mkl for reference check.
+    ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+    ref_f32_torch_tensor = ref_f32_torch_tensor_cpu.to(device, non_blocking=True)
+
+    # Create dtype cute torch tensor (cpu)
+    cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
+        cute_f32_torch_tensor_cpu,
+        dtype,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    # Convert f32 cute tensor to dtype cute tensor
+    cute_tensor = cutlass_torch.convert_cute_tensor(
+        cute_f32_torch_tensor,
+        cute_tensor,
+        dtype,
+        is_dynamic_layout=True,
+    )
+    return ref_f32_torch_tensor, cute_tensor, cute_torch_tensor
 
 
 @pytest.mark.skipif(
@@ -76,6 +159,7 @@ def test_blockscaled_gemm_python_interface(
     iterations: int,
 ):
     torch.manual_seed(42)
+    device = torch.device("cuda:0")
     l, m = lm
     k, n = kn
     if not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
@@ -103,51 +187,15 @@ def test_blockscaled_gemm_python_interface(
             f"Skip non deepgemm-like cases {a_major}, {b_major}, {c_major}. Might be added later"
         )
 
-    # not used for now
-    def create_torch_tensor(l, mode0, mode1, is_mode0_major, cutlass_dtype, device):
-        """
-        Create a torch tensor with specified shape and dtype for testing. Optionally permute it.
-        todo(Yingyi): Initialize it with specified init type and config
-        For dtype, you should pass:
-        - Float32: torch.float32
-        - Float16: torch.float16
-        - BFloat16: torch.bfloat16
-        - Float8E5M2: torch.uint8
-        - Float8E4M3FN: torch.uint8
-        - Float8E4M3B11FNUZ: torch.uint8
-        - Float8E8M0FNU: torch.uint8
-        - Float4E2M1FN: torch.int8
-
-        - Return: torch tensor with cutlass dtype
-        """
-        torch_type_map = {
-            # TFloat32 is just alias of float32
-            cutlass.TFloat32: torch.float32,
-            cutlass.Float32: torch.float32,
-            cutlass.BFloat16: torch.bfloat16,
-            cutlass.Float16: torch.float16,
-            cutlass.Float8E5M2: torch.int8,  # todo(Yingyi): removed after 2.8?
-            cutlass.Float8E4M3FN: torch.int8,
-            cutlass.Float8E4M3B11FNUZ: torch.int8,
-            cutlass.Float4E2M1FN: torch.int8,
-        }
-        shape = (l, mode1, mode0) if is_mode0_major else (l, mode0, mode1)
-
-        if cutlass_dtype == cutlass.Float4E2M1FN:
-            mode0 = mode0 // 2 if is_mode0_major else mode0
-            mode1 = mode1 if is_mode0_major else mode1 // 2
-
-        shape = (l, mode1, mode0) if is_mode0_major else (l, mode0, mode1)
-        permute_order = (2, 1, 0) if is_mode0_major else (1, 2, 0)
-        fp32_torch_tensor = torch.randn(*shape, dtype=torch.float32, device=device)
-        dtype_torch_tensor = fp32_torch_tensor.to(dtype=torch_type_map[cutlass_dtype])
-        dtype_torch_tensor = dtype_torch_tensor.permute(permute_order)
-
-        return dtype_torch_tensor
-
-    a_ref = cutlass_torch.matrix(l, m, k, a_major == "m", cutlass.Float32)
-    b_ref = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
-    c_ref = cutlass_torch.matrix(l, m, n, c_major == "m", cutlass.Float32)
+    a_ref = cutlass_torch.matrix(
+        l, m, k, a_major == "m", cutlass.Float32, device=device
+    )
+    b_ref = cutlass_torch.matrix(
+        l, n, k, b_major == "n", cutlass.Float32, device=device
+    )
+    c_ref = cutlass_torch.matrix(
+        l, m, n, c_major == "m", cutlass.Float32, device=device
+    )
 
     a_tensor, a_torch = cutlass_torch.cute_tensor_like(
         a_ref,
@@ -168,7 +216,7 @@ def test_blockscaled_gemm_python_interface(
         assumed_align=16,
     )
     alpha_tensor = (
-        torch.randn(l, dtype=torch.float32, device="cuda") if fuse_alpha else None
+        torch.randn(l, dtype=torch.float32, device=device) if fuse_alpha else None
     )
 
     # for deepgemm-like python interface
@@ -192,12 +240,12 @@ def test_blockscaled_gemm_python_interface(
         )
 
     sfa_ref, sfa_tensor, sfa_torch = create_scale_factor_tensor(
-        l, m, k, sf_vec_size, get_cutlass_dtype(sf_dtype)
+        l, m, k, sf_vec_size, get_cutlass_dtype(sf_dtype), device
     )
     sfb_ref, sfb_tensor, sfb_torch = create_scale_factor_tensor(
-        l, n, k, sf_vec_size, get_cutlass_dtype(sf_dtype)
+        l, n, k, sf_vec_size, get_cutlass_dtype(sf_dtype), device
     )
-    masked_m_tensor = torch.randint(0, m, (l,), dtype=torch.int32, device="cuda")
+    masked_m_tensor = torch.randint(0, m, (l,), dtype=torch.int32, device=device)
 
     for _ in range(iterations):
         # deepgemm-like python interface: fp4 packed, for DLFW integration
@@ -215,25 +263,22 @@ def test_blockscaled_gemm_python_interface(
             alpha=alpha_tensor,
             alpha_dtype=alpha_dtype,
         )
-        torch.cuda.synchronize()
 
     # compute ref output
     if not fuse_alpha:
-        alpha_tensor = torch.ones(l, dtype=torch.float32, device="cuda")
+        alpha_tensor = torch.ones(l, dtype=torch.float32, device=device)
     res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
     res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
     ref = torch.einsum("mkl,nkl->mnl", res_a, res_b)
-    ref = torch.einsum("mnl,l->mnl", ref, alpha_tensor.cpu())
+    ref = torch.einsum("mnl,l->mnl", ref, alpha_tensor)
 
     # Convert c back to f32 for comparison.
-    c_ref_device = c_ref.cuda()
     cute.testing.convert(
         c_tensor,
-        from_dlpack(c_ref_device, assumed_align=16).mark_layout_dynamic(
+        from_dlpack(c_ref, assumed_align=16).mark_layout_dynamic(
             leading_dim=(1 if c_major == "n" else 0)
         ),
     )
-    c_ref = c_ref_device.cpu()
 
     if c_dtype in ("float32", "float16", "bfloat16"):
         for i in range(l):
@@ -246,20 +291,19 @@ def test_blockscaled_gemm_python_interface(
             )
     elif c_dtype in ("float8_e5m2", "float8_e4m3fn"):
         # Convert ref : f32 -> f8 -> f32
-        ref_f8_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(
+        ref_f8_ = torch.empty(*(l, m, n), dtype=torch.uint8, device=device).permute(
             1, 2, 0
         )
         ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(
             leading_dim=1
         )
         ref_f8.element_type = get_cutlass_dtype(c_dtype)
-        ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
-        ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+        ref = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0)
+        ref_tensor = from_dlpack(ref, assumed_align=16).mark_layout_dynamic(
             leading_dim=1
         )
         cute.testing.convert(ref_tensor, ref_f8)
         cute.testing.convert(ref_f8, ref_tensor)
-        ref = ref_device.cpu()
         for i in range(l):
             # skip testing c_ref & ref
             torch.testing.assert_close(
@@ -268,3 +312,23 @@ def test_blockscaled_gemm_python_interface(
                 atol=tolerance,
                 rtol=1e-02,
             )
+
+
+if __name__ == "__main__":
+    test_blockscaled_gemm_python_interface(
+        (1, 1024),
+        (7168, 4096),
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float16",
+        "k",
+        "k",
+        "n",
+        False,
+        "float32",
+        (128, 128),
+        (1, 1),
+        1e-01,
+        3,
+    )

--- a/tests/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/test_cute_dsl_blockscaled_gemm.py
@@ -23,7 +23,6 @@ from flashinfer.cute_dsl.utils import (
 )
 
 
-# todo(Yingyi): complete this test for target python interface
 @pytest.mark.skipif(
     not is_cute_dsl_available(), reason="Please `pip install nvidia-cutlass-dsl`"
 )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The kernel interface exposed in #1331 is not friendly for JIT caching and mix the compile time parameters and runtime arguments. This PR refactors these classes following these rules:

1. Compile time parameters should be passed to `__init__` functions.
2. Use `@cute.kernel` to decorate device-side kernels.
3. Use `@cute.jit` to decorate host-side launcher functions (https://docs.nvidia.com/cutlass/media/docs/pythonDSL/cute_dsl_general/dsl_introduction.html), where we can call device-side kernels.
4. `cute.compile` accepts a host-side launcher function decorated by `@cute.jit`.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/1519

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
