### PR TITLE
Fix linking errors with CUDA 13

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -78,6 +78,7 @@ def generate_ninja_build_for_op(
         "$common_cflags",
         "--compiler-options=-fPIC",
         "--expt-relaxed-constexpr",
+        "-static-global-template-stub=false",
     ]
     cuda_cflags += _get_cuda_arch_flags(extra_cuda_cflags)
     if extra_cuda_cflags is not None:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Ran into errors like `undefined reference to void flashinfer::BatchDecodeWithPagedKVCacheKernel` before this change with cuda 13.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/1513

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

co-authored by:  Ben Barsdell <bbarsdell@nvidia.com>
