### PR TITLE
fix: fix autotuner failure with low precision data types

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -61,8 +61,8 @@ class DynamicTensorSpec:
         # Set default tensor_initializers if not provided
         if self.tensor_initializers is None:
             self.tensor_initializers = [
-                lambda shapes, dtype, device: torch.randn(
-                    shapes, device=device, dtype=dtype
+                lambda shapes, dtype, device: torch.randn(shapes, device=device).to(
+                    dtype
                 )
                 for _ in range(len(self.input_idx))
             ]


### PR DESCRIPTION
torch.randn() not support all datatype, e.g, the FP8 would throw failure:
        "normal_kernel_cuda" not implemented for 'Float8_e4m3fn'
so we need change to convert type after torch.randn()

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
