### PR TITLE
Revert "backend: Refactor trtllm-gen fmha metainfo loading (#1518)"

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -48,7 +48,7 @@ def get_available_cubin_files(source, retries=3, delay=5, timeout=10):
 
 
 class ArtifactPath:
-    TRTLLM_GEN_FMHA: str = "d8c2e4e646bd7e73ea79f06ae52b4ba13adddc64/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "c8e0abb4b0438880a2b0a9b68449e3cf1513aadf/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "364304c7693814410e18e4bae11d8da011860117/batched_gemm-6492001-c97c649/"
     )
@@ -61,7 +61,7 @@ class ArtifactPath:
 
 class MetaInfoHash:
     TRTLLM_GEN_FMHA: str = (
-        "9f8e809647a205f80547ad813892cec9b92ca086110878e135ba9e1be9ce805c"
+        "0d124e546c8a2e9fa59499625e8a6d140a2465573d4a3944f9d29f29f73292fb"
     )
     TRTLLM_GEN_BMM: str = (
         "a2543b8fce60bebe071df40ef349edca32cea081144a4516b0089bd1487beb2b"

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -32,6 +32,7 @@ from .jit import (
     get_batch_prefill_uri,
     get_single_decode_uri,
     setup_cubin_loader,
+    setup_metainfo_loader,
     trtllm_gen_fmha_module,
 )
 from .page import get_seq_lens
@@ -305,6 +306,7 @@ def get_trtllm_gen_fmha_module():
     mod = trtllm_gen_fmha_module()
     op = mod.build_and_load()
     setup_cubin_loader(mod.get_library_path())
+    setup_metainfo_loader(mod.get_library_path())
     return op
 
 
@@ -1800,9 +1802,13 @@ class TrtllmGenDecodeModule:
         self._sm_count: Optional[int] = None
         self._mod = trtllm_gen_fmha_module()
         self._op = self._mod.build_and_load()
-        from flashinfer.jit.cubin_loader import setup_cubin_loader
+        from flashinfer.jit.cubin_loader import (
+            setup_cubin_loader,
+            setup_metainfo_loader,
+        )
 
         setup_cubin_loader(self._mod.get_library_path())
+        setup_metainfo_loader(self._mod.get_library_path())
 
     def _paged_run(
         self,

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -68,7 +68,7 @@ from .core import clear_cache_dir as clear_cache_dir
 from .core import gen_jit_spec as gen_jit_spec
 from .core import sm90a_nvcc_flags as sm90a_nvcc_flags
 from .core import sm100a_nvcc_flags as sm100a_nvcc_flags
-from .cubin_loader import setup_cubin_loader
+from .cubin_loader import setup_cubin_loader, setup_metainfo_loader
 
 
 @functools.cache

--- a/flashinfer/jit/attention/pytorch.py
+++ b/flashinfer/jit/attention/pytorch.py
@@ -23,7 +23,6 @@ import torch
 from ...artifacts import ArtifactPath, MetaInfoHash
 from .. import env as jit_env
 from ..core import JitSpec, gen_jit_spec, logger, sm90a_nvcc_flags, sm100a_nvcc_flags
-from ...jit.cubin_loader import get_cubin
 from ..utils import (
     dtype_map,
     filename_safe_dtype_map,
@@ -1559,17 +1558,6 @@ def gen_fmha_cutlass_sm100a_module(
 
 
 def trtllm_gen_fmha_module():
-    include_path = f"{ArtifactPath.TRTLLM_GEN_FMHA}/include"
-    header_name = "flashInferMetaInfo"
-
-    # use `get_cubin` to get "flashinferMetaInfo.h"
-    metainfo = get_cubin(
-        f"{include_path}/{header_name}", MetaInfoHash.TRTLLM_GEN_FMHA, ".h"
-    )
-
-    # make sure "flashinferMetaInfo.h" is downloaded or cached
-    assert metainfo, f"{header_name}.h not found"
-
     return gen_jit_spec(
         "fmha_gen",
         [
@@ -1577,8 +1565,6 @@ def trtllm_gen_fmha_module():
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_fmha_kernel_launcher.cu",
         ],
         extra_ldflags=["-lcuda"],
-        # link "include" sub-directory in cache
-        extra_include_paths=[jit_env.FLASHINFER_CUBIN_DIR / include_path],
         extra_cuda_cflags=[
             f'-DTLLM_GEN_FMHA_CUBIN_PATH=\\"{ArtifactPath.TRTLLM_GEN_FMHA}\\"',
             f'-DTLLM_GEN_FMHA_METAINFO_HASH=\\"{MetaInfoHash.TRTLLM_GEN_FMHA}\\"',

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -184,3 +184,32 @@ def setup_cubin_loader(dll_path: str):
     dll_cubin_handlers[dll_path] = cb
 
     _LIB.FlashInferSetCubinCallback(cb)
+
+
+dll_metainfo_handlers = {}
+
+
+def setup_metainfo_loader(dll_path: str):
+    if dll_path in dll_metainfo_handlers:
+        return
+
+    _LIB = ctypes.CDLL(dll_path)
+
+    # Define the correct callback type
+    CALLBACK_TYPE = ctypes.CFUNCTYPE(
+        None, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p
+    )
+
+    def get_metainfo_callback(name, sha256, extension):
+        metainfo = get_cubin(
+            name.decode("utf-8"), sha256.decode("utf-8"), extension.decode("utf-8")
+        )
+        _LIB.FlashInferSetCurrentMetaInfo(
+            convert_to_ctypes_char_p(metainfo), ctypes.c_int(len(metainfo))
+        )
+
+    # Create the callback and keep a reference to prevent GC
+    cb = CALLBACK_TYPE(get_metainfo_callback)
+    dll_metainfo_handlers[dll_path] = cb
+
+    _LIB.FlashInferSetMetaInfoCallback(cb)

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -30,6 +30,7 @@ from .jit import (
     get_batch_prefill_uri,
     get_single_prefill_uri,
     setup_cubin_loader,
+    setup_metainfo_loader,
     trtllm_gen_fmha_module,
 )
 from .cudnn import cudnn_batch_prefill_with_kv_cache
@@ -171,6 +172,7 @@ def get_trtllm_gen_prefill_module():
     mod = trtllm_gen_fmha_module()
     op = mod.build_and_load()
     setup_cubin_loader(mod.get_library_path())
+    setup_metainfo_loader(mod.get_library_path())
 
     def _paged_run(
         query: torch.Tensor,
@@ -3116,6 +3118,7 @@ def get_trtllm_gen_fmha_module():
     mod = trtllm_gen_fmha_module()
     op = mod.build_and_load()
     setup_cubin_loader(mod.get_library_path())
+    setup_metainfo_loader(mod.get_library_path())
     return op
 
 

--- a/include/flashinfer/trtllm/fmha/cubin/kernelMetaInfo.h
+++ b/include/flashinfer/trtllm/fmha/cubin/kernelMetaInfo.h
@@ -1,0 +1,170 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <flashinfer/trtllm/fmha/kernelParams.h>
+// Helper to print Data_type
+inline const char* dataTypeToString(Data_type dt) {
+  switch (dt) {
+    case DATA_TYPE_FP16:
+      return "FP16";
+    case DATA_TYPE_BF16:
+      return "BF16";
+    case DATA_TYPE_FP32:
+      return "FP32";
+    case DATA_TYPE_E4M3:
+      return "E4M3";
+    case DATA_TYPE_E2M1:
+      return "E2M1";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+inline Data_type stringToDataType(std::string str) {
+  if (str == "DATA_TYPE_FP16") return DATA_TYPE_FP16;
+  if (str == "DATA_TYPE_BF16") return DATA_TYPE_BF16;
+  if (str == "DATA_TYPE_FP32") return DATA_TYPE_FP32;
+  if (str == "DATA_TYPE_E4M3") return DATA_TYPE_E4M3;
+  if (str == "DATA_TYPE_E2M1") return DATA_TYPE_E2M1;
+  return DATA_TYPE_UNKNOWN;
+}
+
+inline int stringToArch(std::string str) {
+  if (str == "kSM_90") return kSM_90;
+  if (str == "kSM_100") return kSM_100;
+  if (str == "kSM_120") return kSM_120;
+  return 0;
+}
+
+struct TllmGenFmhaKernelMetaInfo {
+  Data_type mDataTypeQ;
+  Data_type mDataTypeKv;
+  Data_type mDataTypeO;
+  int mTileSizeQ;
+  int mTileSizeKv;
+  int mStepQ;
+  int mStepKv;
+  int mHeadDimPerCtaV;
+  int mHeadDimQk;
+  int mHeadDimV;
+  int mSM;
+  const char* mFuncName;
+  int mSharedMemBytes;
+  int mThreadsPerCTA;
+  int mQkvLayout;
+  int mNumTokensPerPage;
+  int mMaskType;
+  int mKernelType;
+  int mMaxNumHeadsQPerKvInCta;
+  int mTileScheduler;
+  int mMultiCtasKvMode;
+  bool mGroupsHeadsQ;
+  bool mReuseSmemKForV;
+  bool m2CtaMma;
+  const char* sha256;
+
+  void print() const {
+    std::cout << "TllmGenFmhaKernelMetaInfo {\n";
+    std::cout << "  mDataTypeQ: " << dataTypeToString(mDataTypeQ) << "\n";
+    std::cout << "  mDataTypeKv: " << dataTypeToString(mDataTypeKv) << "\n";
+    std::cout << "  mDataTypeO: " << dataTypeToString(mDataTypeO) << "\n";
+    std::cout << "  mTileSizeQ: " << mTileSizeQ << "\n";
+    std::cout << "  mTileSizeKv: " << mTileSizeKv << "\n";
+    std::cout << "  mStepQ: " << mStepQ << "\n";
+    std::cout << "  mStepKv: " << mStepKv << "\n";
+    std::cout << "  mHeadDimPerCtaV: " << mHeadDimPerCtaV << "\n";
+    std::cout << "  mHeadDimQk: " << mHeadDimQk << "\n";
+    std::cout << "  mHeadDimV: " << mHeadDimV << "\n";
+    std::cout << "  mSM: " << mSM << "\n";
+    std::cout << "  mFuncName: " << (mFuncName ? mFuncName : "null") << "\n";
+    std::cout << "  mSharedMemBytes: " << mSharedMemBytes << "\n";
+    std::cout << "  mThreadsPerCTA: " << mThreadsPerCTA << "\n";
+    std::cout << "  mQkvLayout: " << mQkvLayout << "\n";
+    std::cout << "  mNumTokensPerPage: " << mNumTokensPerPage << "\n";
+    std::cout << "  mMaskType: " << mMaskType << "\n";
+    std::cout << "  mKernelType: " << mKernelType << "\n";
+    std::cout << "  mMaxNumHeadsQPerKvInCta: " << mMaxNumHeadsQPerKvInCta << "\n";
+    std::cout << "  mTileScheduler: " << mTileScheduler << "\n";
+    std::cout << "  mGroupsHeadsQ: " << std::boolalpha << mGroupsHeadsQ << "\n";
+    std::cout << "  mMultiCtasKvMode: " << std::boolalpha << mMultiCtasKvMode << "\n";
+    std::cout << "  mReuseSmemKForV: " << std::boolalpha << mReuseSmemKForV << "\n";
+    std::cout << "  m2CtaMma: " << std::boolalpha << m2CtaMma << "\n";
+    std::cout << "  sha256: " << (sha256 ? sha256 : "null") << "\n";
+    std::cout << "}\n";
+  }
+
+  static TllmGenFmhaKernelMetaInfo fromString(std::string code) {
+    std::vector<std::string> param_list;
+    std::string current_param = "";
+    for (int i = 0; i < code.size(); ++i) {
+      if (code[i] != ' ' && code[i] != ',' && code[i] != '"') {
+        current_param += code[i];
+      }
+      if (code[i] == ',') {
+        param_list.push_back(current_param);
+        current_param = "";
+      }
+    }
+    param_list.push_back(current_param);
+    assert(param_list.size() == 25);
+    const char* mFuncName = strdup(param_list[11].c_str());
+    const char* sha256 = strdup(param_list[24].c_str());
+    return TllmGenFmhaKernelMetaInfo{stringToDataType(param_list[0]),
+                                     stringToDataType(param_list[1]),
+                                     stringToDataType(param_list[2]),
+                                     std::stoi(param_list[3]),
+                                     std::stoi(param_list[4]),
+                                     std::stoi(param_list[5]),
+                                     std::stoi(param_list[6]),
+                                     std::stoi(param_list[7]),
+                                     std::stoi(param_list[8]),
+                                     std::stoi(param_list[9]),
+                                     stringToArch(param_list[10]),
+                                     mFuncName,
+                                     std::stoi(param_list[12]),
+                                     std::stoi(param_list[13]),
+                                     std::stoi(param_list[14]),
+                                     std::stoi(param_list[15]),
+                                     std::stoi(param_list[16]),
+                                     std::stoi(param_list[17]),
+                                     std::stoi(param_list[18]),
+                                     std::stoi(param_list[19]),
+                                     std::stoi(param_list[20]),
+                                     param_list[21] == "true" ? true : false,
+                                     param_list[22] == "true" ? true : false,
+                                     param_list[23] == "true" ? true : false,
+                                     sha256};
+  };
+
+  static std::vector<TllmGenFmhaKernelMetaInfo> loadFromMetaInfoRaw(std::string metainfo_raw) {
+    std::vector<TllmGenFmhaKernelMetaInfo> metainfo;
+    int left_braces = std::count(metainfo_raw.begin(), metainfo_raw.end(), '{');
+    int right_braces = std::count(metainfo_raw.begin(), metainfo_raw.end(), '}');
+    assert(left_braces == right_braces);
+    int left_brace_pos = -1;
+    for (int i = 0; i < metainfo_raw.size(); ++i) {
+      if (metainfo_raw[i] == '{') {
+        left_brace_pos = i;
+      } else if (metainfo_raw[i] == '}') {
+        metainfo.push_back(TllmGenFmhaKernelMetaInfo::fromString(
+            metainfo_raw.substr(left_brace_pos + 1, i - left_brace_pos - 1)));
+      }
+    }
+    return metainfo;
+  };
+};

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -26,8 +26,8 @@
 
 #include "../../utils.cuh"
 #include "../common.h"
+#include "cubin/kernelMetaInfo.h"
 #include "cuda_runtime_api.h"
-#include "flashInferMetaInfo.h"
 #include "fmhaRunnerParams.h"
 #include "kernelParams.h"
 
@@ -45,13 +45,16 @@ static_assert(false, "TLLM_GEN_FMHA_METAINFO_HASH macro is not defined when comp
 
 namespace flashinfer::trtllm_cubin_loader {
 std::string getCubin(const std::string& kernelName, const std::string& sha256);
+std::string getMetaInfo(const std::string& name, const std::string& sha256,
+                        const std::string& extension);
 }  // namespace flashinfer::trtllm_cubin_loader
 using flashinfer::trtllm_cubin_loader::getCubin;
+using flashinfer::trtllm_cubin_loader::getMetaInfo;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class TllmGenFmhaKernel {
  public:
-  using KernelMeta = tensorrt_llm::kernels::TllmGenFmhaKernelMetaInfo;
+  using KernelMeta = TllmGenFmhaKernelMetaInfo;
   using RunnerParams = TllmGenFmhaRunnerParams;
   using SelectKernelParams = TllmGenSelectKernelParams;
 
@@ -588,16 +591,23 @@ class TllmFmhaKernelFactory {
  public:
   using KernelType = TllmGenFmhaKernel;
 
-  KernelType const* getKernels(const typename KernelType::KernelMeta* pKernelList,
-                               unsigned int nbKernels, Data_type dtypeQ, Data_type dtypeKv,
-                               Data_type dtypeOut, unsigned int sm) {
+  KernelType const* getKernels(Data_type dtypeQ, Data_type dtypeKv, Data_type dtypeOut,
+                               unsigned int sm) {
     static std::mutex s_mutex;
     std::lock_guard<std::mutex> lg(s_mutex);
+
+    if (!metainfo_loaded) {
+      std::string metainfo_raw = getMetaInfo(tllm_gen_fmha_cubin_path + "flashInferMetaInfo",
+                                             tllm_gen_fmha_metainfo_hash, ".h");
+      metainfo = KernelType::KernelMeta::loadFromMetaInfoRaw(metainfo_raw);
+      metainfo_loaded = true;
+    }
 
     auto const id = hashID(dtypeQ, dtypeKv, dtypeOut, sm);
     auto const findIter = mKernels.find(id);
     if (findIter == mKernels.end()) {
-      KernelType* newKernel = new KernelType{pKernelList, nbKernels, dtypeQ, dtypeKv, dtypeOut, sm};
+      KernelType* newKernel =
+          new KernelType{metainfo.data(), metainfo.size(), dtypeQ, dtypeKv, dtypeOut, sm};
       newKernel->loadKernels();
       mKernels.insert(std::make_pair(id, std::unique_ptr<KernelType>(newKernel)));
       IKL_LOG_DEBUG(
@@ -630,16 +640,14 @@ class TllmFmhaKernelFactory {
   }
 
   std::unordered_map<uint64_t, const std::unique_ptr<KernelType>> mKernels;
+  std::vector<KernelType::KernelMeta> metainfo;
+  bool metainfo_loaded = false;
 };
 
 inline TllmGenFmhaKernel const* getTllmFmhaKernels(Data_type dtypeQ, Data_type dtypeKv,
                                                    Data_type dtypeOut, unsigned int sm) {
 #ifndef EXCLUDE_SM_100
-  return TllmFmhaKernelFactory::Get().getKernels(
-      tensorrt_llm::kernels::sTllmGenFmhaKernelMetaInfos,
-      sizeof(tensorrt_llm::kernels::sTllmGenFmhaKernelMetaInfos) /
-          sizeof(tensorrt_llm::kernels::sTllmGenFmhaKernelMetaInfos[0]),
-      dtypeQ, dtypeKv, dtypeOut, sm);
+  return TllmFmhaKernelFactory::Get().getKernels(dtypeQ, dtypeKv, dtypeOut, sm);
 #else
   return nullptr;
 #endif  // EXCLUDE_SM_100

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -136,6 +136,9 @@ struct KernelParams {
   int32_t mNumHeadsQPerKv;
   // The hidden size of O.
   int64_t mNumHiddenEltsO;
+  // The number of MTP tokens per sequence. Assume that all requests have the same numMtpTokens
+  // without paddings.
+  int32_t mNumMtpTokens;
   // The total number of pages in the paged-kv memory pool.
   int32_t mNumPagesInMemPool;
   // The output scale for FP8 quantization.
@@ -675,6 +678,7 @@ struct KernelParams {
     params.mMaxNumCtasKv = maxNumCtasKv;
     params.mMaxNumPagesPerSeqKv = options.mMaxNumPagesPerSeqKv;
     // TODO: just use mMaxSeqLenQ for number of MTP tokens.
+    params.mNumMtpTokens = options.mMaxSeqLenQ;
     params.mSumOfSeqLensQ = options.mSumOfSeqLensQ;
     params.mSumOfSeqLensKv = options.mSumOfSeqLensKv;
     params.mBatchSize = options.mBatchSize;

--- a/tests/test_trtllm_gen_attention.py
+++ b/tests/test_trtllm_gen_attention.py
@@ -545,8 +545,3 @@ def test_trtllm_batch_decode(
             torch.testing.assert_close(
                 output.float(), output_wrapper.float(), rtol=1e-1, atol=1e-1
             )
-
-
-if __name__ == "__main__":
-    test_trtllm_batch_prefill("HND", 128, 32, 2, 5, -1, "half", "half", "half", False)
-    test_trtllm_batch_decode("HND", 128, 32, 2, 5, -1, "half", "half", "half", False)


### PR DESCRIPTION
This reverts commit 7812a779776ba104a99bf9fa45865ff23c582234.

<!-- .github/pull_request_template.md -->

## 📌 Description

Revert #1518 because it relies on cubins built for cuda 13 and not compatible for cuda-12 based user environment.
Will bring it back once artifactory for both cuda-12 and cuda-13 is ready.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
