### PR TITLE
fix trtllm_allreduce_fusion twoshot register problem.

### DIFF
--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -1392,7 +1392,7 @@ cudaError_t allreduce_fusion_kernel_launcher(AllReduceFusionParams<T> const& par
     if (params.trigger_completion_at_end) {
       registers_per_thread = get_registers_per_thread_oneshot<Pattern, T, NRanks, Fp32Acc, true>();
     } else {
-      registers_per_thread = get_registers_per_thread_oneshot<Pattern, T, NRanks, Fp32Acc, true>();
+      registers_per_thread = get_registers_per_thread_oneshot<Pattern, T, NRanks, Fp32Acc, false>();
     }
   } else {
     registers_per_thread = get_registers_per_thread_twoshot<Pattern, T, NRanks, Fp32Acc>();

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -437,9 +437,10 @@ inline int getSMVersion() {
 inline int getSMRegisters() {
   int device{-1};
   FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
-  cudaDeviceProp prop;
-  FLASHINFER_CUDA_CALL(cudaGetDeviceProperties(&prop, device));
-  return prop.regsPerBlock;
+  int regs_per_block;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&regs_per_block, cudaDevAttrMaxRegistersPerBlock, device));
+  return regs_per_block;
 }
 
 inline __device__ int64_t get_sf_out_offset_128x4(std::optional<int> batchIdx, int mIdx, int kIdx,

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -434,6 +434,14 @@ inline int getSMVersion() {
   return sm_major * 10 + sm_minor;
 }
 
+inline int getSMRegisters() {
+  int device{-1};
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  cudaDeviceProp prop;
+  FLASHINFER_CUDA_CALL(cudaGetDeviceProperties(&prop, device));
+  return prop.regsPerBlock;
+}
+
 inline __device__ int64_t get_sf_out_offset_128x4(std::optional<int> batchIdx, int mIdx, int kIdx,
                                                   std::optional<int> numRows, int numCols) {
   // SF layout [numMTiles, numKTiles, 32 (mTile), 4 (mTile), 4(kTile)]
@@ -1310,6 +1318,16 @@ cudaError_t launch_oneshot_lamport(AllReduceFusionParams<T> const& params,
   return cudaSuccess;
 }
 
+template <AllReduceFusionPattern Pattern, typename T, int NRanks, bool Fp32Acc,
+          bool TriggerCompletionAtEnd = true>
+int get_registers_per_thread_oneshot() {
+  auto kernel =
+      allreduce_fusion_kernel_oneshot_lamport<Pattern, T, NRanks, Fp32Acc, TriggerCompletionAtEnd>;
+  cudaFuncAttributes attr;
+  cudaFuncGetAttributes(&attr, kernel);
+  return attr.numRegs;
+}
+
 template <AllReduceFusionPattern Pattern, typename T, int NRanks, bool Fp32Acc>
 cudaError_t launch_twoshot_sync(AllReduceFusionParams<T> const& params, cudaLaunchConfig_t& cfg,
                                 std::array<int, NRanks> begin_tokens,
@@ -1318,6 +1336,14 @@ cudaError_t launch_twoshot_sync(AllReduceFusionParams<T> const& params, cudaLaun
       cudaLaunchKernelEx(&cfg, allreduce_fusion_kernel_twoshot_sync<Pattern, T, NRanks, Fp32Acc>,
                          params, begin_tokens, token_num_per_ranks));
   return cudaSuccess;
+}
+
+template <AllReduceFusionPattern Pattern, typename T, int NRanks, bool Fp32Acc>
+int get_registers_per_thread_twoshot() {
+  auto kernel = allreduce_fusion_kernel_twoshot_sync<Pattern, T, NRanks, Fp32Acc>;
+  cudaFuncAttributes attr;
+  cudaFuncGetAttributes(&attr, kernel);
+  return attr.numRegs;
 }
 
 bool use_oneshot(int token_num) { return token_num <= details::kOneShotMaxToken; }
@@ -1361,7 +1387,23 @@ cudaError_t allreduce_fusion_kernel_launcher(AllReduceFusionParams<T> const& par
     cluster_size /= 2;
   }
   int sm_count = get_sm_count();
-  while (cluster_num * cluster_size > sm_count && cluster_size > 1 && threads_per_block <= 512) {
+  int registers_per_thread;
+  if (oneshot) {
+    if (params.trigger_completion_at_end) {
+      registers_per_thread = get_registers_per_thread_oneshot<Pattern, T, NRanks, Fp32Acc, true>();
+    } else {
+      registers_per_thread = get_registers_per_thread_oneshot<Pattern, T, NRanks, Fp32Acc, true>();
+    }
+  } else {
+    registers_per_thread = get_registers_per_thread_twoshot<Pattern, T, NRanks, Fp32Acc>();
+  }
+  static int max_registers = -1;
+  if (max_registers < 0) {
+    max_registers = utils::getSMRegisters();
+  }
+  int max_threads_per_block = min(max_registers / registers_per_thread, 1024);
+  while (cluster_num * cluster_size > sm_count && cluster_size > 1 &&
+         threads_per_block <= max_threads_per_block / 2) {
     threads_per_block *= 2;
     cluster_size /= 2;
   }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
twoshot kernel use 80 registers per thread, and H20 has 64k registers per sm, so num_threads should be set less than 819.
This pr use register_num to calculate limit for num_threads.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
