### PR TITLE
Fix typo in sampling.cuh: Remove duplicate parameter

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1415,7 +1415,7 @@ cudaError_t SamplingFromProb(T* probs, IdType* output, IdType* indices, uint32_t
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
   dim3 nblks(batch_size);
   dim3 nthrs(BLOCK_THREADS);
-  void* args[] = {&probs, &output, &indices, &d, &philox_seed, &philox_offset, &d};
+  void* args[] = {&probs, &output, &indices, &d, &philox_seed, &philox_offset};
   const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
 
   DISPATCH_ALIGNED_VEC_SIZE(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fixed a typo in `sampling.cuh` line 1418 where `args[]` was declared with 7 parameters, including a duplicate `&d`, while `SamplingFromProbKernel` only accepts 6. Removed the redundant `&d` parameter.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/1544#issuecomment-3213659293

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
