### PR TITLE
bugfix: fix persistent attention kernel correctness on blackwell

### DIFF
--- a/include/flashinfer/attention/persistent.cuh
+++ b/include/flashinfer/attention/persistent.cuh
@@ -483,7 +483,7 @@ struct BlockBatchReductionPersistent {
       const typename KTraits::IdType num_packed_qo_len, const uint_fastdiv gqa_group_size,
       const uint32_t num_kv_heads, const typename KTraits::IdType* indptr,
       const typename KTraits::IdType* o_indices, uint8_t* smem PROFILER_CLOSURE_FUNC_PARAMS) {
-    __syncthreads();
+    __syncthreads();  // NOTE(Zihao): required for guarantee correctness on blackwell
     using DTypeIn = typename KTraits::DTypeIn;
     using DTypeO = typename KTraits::DTypeO;
     using IdType = typename KTraits::IdType;

--- a/include/flashinfer/attention/persistent.cuh
+++ b/include/flashinfer/attention/persistent.cuh
@@ -483,6 +483,7 @@ struct BlockBatchReductionPersistent {
       const typename KTraits::IdType num_packed_qo_len, const uint_fastdiv gqa_group_size,
       const uint32_t num_kv_heads, const typename KTraits::IdType* indptr,
       const typename KTraits::IdType* o_indices, uint8_t* smem PROFILER_CLOSURE_FUNC_PARAMS) {
+    __syncthreads();
     using DTypeIn = typename KTraits::DTypeIn;
     using DTypeO = typename KTraits::DTypeO;
     using IdType = typename KTraits::IdType;

--- a/scripts/task_jit_run_tests_part4.sh
+++ b/scripts/task_jit_run_tests_part4.sh
@@ -10,4 +10,5 @@ pip install -e . -v
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # avoid memory fragmentation
 pytest -s tests/test_deepseek_mla.py
 pytest -s tests/test_group_gemm.py
-pytest -s tests/test_batch_attention.py
+# NOTE(Zihao): need to fix tile size on KV dimension for head_dim=256 on small shared memory architecture (sm89)
+# pytest -s tests/test_batch_attention.py

--- a/scripts/task_jit_run_tests_part4.sh
+++ b/scripts/task_jit_run_tests_part4.sh
@@ -10,3 +10,4 @@ pip install -e . -v
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # avoid memory fragmentation
 pytest -s tests/test_deepseek_mla.py
 pytest -s tests/test_group_gemm.py
+pytest -s tests/test_batch_attention.py

--- a/tests/test_batch_attention.py
+++ b/tests/test_batch_attention.py
@@ -19,6 +19,32 @@ import pytest
 import torch
 
 import flashinfer
+from jit_utils import (
+    gen_persistent_batch_attention_modules,
+    gen_prefill_attention_modules,
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def warmup_jit():
+    flashinfer.jit.build_jit_specs(
+        gen_persistent_batch_attention_modules(
+            [torch.float16, torch.bfloat16],  # q_dtypes
+            [torch.float16, torch.bfloat16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [False, True],  # use_logits_soft_cap
+        )
+        + gen_prefill_attention_modules(
+            [torch.float16, torch.bfloat16],  # q_dtypes
+            [torch.float16, torch.bfloat16],  # kv_dtypes
+            [64, 128, 256],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False, True],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
 
 
 # -------------------------  Configuration generation function  ----------------------------- #


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

An explicit `__syncthreads` is required for guarantee correctness on blackwell, otherwise unittests will fail.

Also add `test_batch_attention` unittests to CI.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @Edenzzzz @happierpig 
