### PR TITLE
ci: add unittest for different cuda version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,9 @@ stage('Unittest') {
     'AOT-Build-Import-x86-64-cu126': {
       try {
         run_unittest_CPU_AOT_COMPILE('CPU-LARGE-SPOT', 'cu126')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -243,6 +246,9 @@ stage('Unittest') {
     'AOT-Build-Import-aarch64-cu126': {
       try {
         run_unittest_CPU_AOT_COMPILE('ARM-LARGE-SPOT', 'cu126')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -255,70 +261,13 @@ stage('Unittest') {
         }
       }
     },
-    'JIT-Unittest-1-cu126': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 1, 'cu126')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 1, 'cu126')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
-    'JIT-Unittest-2-cu126': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 2, 'cu126')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 2, 'cu126')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
-    'JIT-Unittest-3-cu126': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 3, 'cu126')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 3, 'cu126')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
-    'JIT-Unittest-4-cu126': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 4, 'cu126')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 4, 'cu126')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
     // CUDA 12.8 Tests
     'AOT-Build-Import-x86-64-cu128': {
       try {
         run_unittest_CPU_AOT_COMPILE('CPU-LARGE-SPOT', 'cu128')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -334,6 +283,9 @@ stage('Unittest') {
     'AOT-Build-Import-aarch64-cu128': {
       try {
         run_unittest_CPU_AOT_COMPILE('ARM-LARGE-SPOT', 'cu128')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -346,70 +298,13 @@ stage('Unittest') {
         }
       }
     },
-    'JIT-Unittest-1-cu128': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 1, 'cu128')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 1, 'cu128')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
-    'JIT-Unittest-2-cu128': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 2, 'cu128')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 2, 'cu128')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
-    'JIT-Unittest-3-cu128': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 3, 'cu128')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 3, 'cu128')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
-    'JIT-Unittest-4-cu128': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 4, 'cu128')
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 4, 'cu128')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
-    },
     // CUDA 12.9 Tests
     'AOT-Build-Import-x86-64-cu129': {
       try {
         run_unittest_CPU_AOT_COMPILE('CPU-LARGE-SPOT', 'cu129')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -425,6 +320,9 @@ stage('Unittest') {
     'AOT-Build-Import-aarch64-cu129': {
       try {
         run_unittest_CPU_AOT_COMPILE('ARM-LARGE-SPOT', 'cu129')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -437,9 +335,13 @@ stage('Unittest') {
         }
       }
     },
+    // JIT unittest only for cu129
     'JIT-Unittest-1-cu129': {
       try {
         shard_run_unittest_GPU('GPU-G5-SPOT', 1, 'cu129')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -455,6 +357,9 @@ stage('Unittest') {
     'JIT-Unittest-2-cu129': {
       try {
         shard_run_unittest_GPU('GPU-G5-SPOT', 2, 'cu129')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -470,6 +375,9 @@ stage('Unittest') {
     'JIT-Unittest-3-cu129': {
       try {
         shard_run_unittest_GPU('GPU-G5-SPOT', 3, 'cu129')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {
@@ -485,6 +393,9 @@ stage('Unittest') {
     'JIT-Unittest-4-cu129': {
       try {
         shard_run_unittest_GPU('GPU-G5-SPOT', 4, 'cu129')
+      } catch (hudson.AbortException abortEx) {
+        echo "Received normal AbortException, exit now: " + abortEx.toString()
+        throw abortEx
       } catch (Throwable ex) {
         echo 'Exception during SPOT run ' + ex.toString()
         if (is_last_build()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,25 @@ def init_git(submodule = false) {
   }
 }
 
+def run_with_spot_retry(spot_node_type, on_demand_node_type, test_name, test_closure) {
+  try {
+    test_closure(spot_node_type)
+  } catch (hudson.AbortException abortEx) {
+    echo "Received normal AbortException, exit now: " + abortEx.toString()
+    throw abortEx
+  } catch (Throwable ex) {
+    echo "Exception during SPOT run for ${test_name}: " + ex.toString()
+    if (is_last_build()) {
+      echo "Exception during SPOT run for ${test_name}: " + ex.toString() + " retry on-demand"
+      currentBuild.result = 'SUCCESS'
+      test_closure(on_demand_node_type)
+    } else {
+      echo 'Exit since it is not last build'
+      throw ex
+    }
+  }
+}
+
 // stage('Lint') {
 //   node('CPU-SPOT') {
 //     ws(per_exec_ws('flashinfer-lint')) {
@@ -226,187 +245,47 @@ stage('Unittest') {
     failFast: true,
     // CUDA 12.6 Tests
     'AOT-Build-Import-x86-64-cu126': {
-      try {
-        run_unittest_CPU_AOT_COMPILE('CPU-LARGE-SPOT', 'cu126')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          run_unittest_CPU_AOT_COMPILE('CPU-LARGE', 'cu126')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu126',
+        { node_type -> run_unittest_CPU_AOT_COMPILE(node_type, 'cu126') })
     },
     'AOT-Build-Import-aarch64-cu126': {
-      try {
-        run_unittest_CPU_AOT_COMPILE('ARM-LARGE-SPOT', 'cu126')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          run_unittest_CPU_AOT_COMPILE('ARM-LARGE', 'cu126')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu126',
+        { node_type -> run_unittest_CPU_AOT_COMPILE(node_type, 'cu126') })
     },
     // CUDA 12.8 Tests
     'AOT-Build-Import-x86-64-cu128': {
-      try {
-        run_unittest_CPU_AOT_COMPILE('CPU-LARGE-SPOT', 'cu128')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          run_unittest_CPU_AOT_COMPILE('CPU-LARGE', 'cu128')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu128',
+        { node_type -> run_unittest_CPU_AOT_COMPILE(node_type, 'cu128') })
     },
     'AOT-Build-Import-aarch64-cu128': {
-      try {
-        run_unittest_CPU_AOT_COMPILE('ARM-LARGE-SPOT', 'cu128')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          run_unittest_CPU_AOT_COMPILE('ARM-LARGE', 'cu128')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu128',
+        { node_type -> run_unittest_CPU_AOT_COMPILE(node_type, 'cu128') })
     },
     // CUDA 12.9 Tests
     'AOT-Build-Import-x86-64-cu129': {
-      try {
-        run_unittest_CPU_AOT_COMPILE('CPU-LARGE-SPOT', 'cu129')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          run_unittest_CPU_AOT_COMPILE('CPU-LARGE', 'cu129')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu129',
+        { node_type -> run_unittest_CPU_AOT_COMPILE(node_type, 'cu129') })
     },
     'AOT-Build-Import-aarch64-cu129': {
-      try {
-        run_unittest_CPU_AOT_COMPILE('ARM-LARGE-SPOT', 'cu129')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          run_unittest_CPU_AOT_COMPILE('ARM-LARGE', 'cu129')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu129',
+        { node_type -> run_unittest_CPU_AOT_COMPILE(node_type, 'cu129') })
     },
     // JIT unittest only for cu129
     'JIT-Unittest-1-cu129': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 1, 'cu129')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 1, 'cu129')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-1-cu129',
+        { node_type -> shard_run_unittest_GPU(node_type, 1, 'cu129') })
     },
     'JIT-Unittest-2-cu129': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 2, 'cu129')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 2, 'cu129')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-2-cu129',
+        { node_type -> shard_run_unittest_GPU(node_type, 2, 'cu129') })
     },
     'JIT-Unittest-3-cu129': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 3, 'cu129')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 3, 'cu129')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-3-cu129',
+        { node_type -> shard_run_unittest_GPU(node_type, 3, 'cu129') })
     },
     'JIT-Unittest-4-cu129': {
-      try {
-        shard_run_unittest_GPU('GPU-G5-SPOT', 4, 'cu129')
-      } catch (hudson.AbortException abortEx) {
-        echo "Received normal AbortException, exit now: " + abortEx.toString()
-        throw abortEx
-      } catch (Throwable ex) {
-        echo 'Exception during SPOT run ' + ex.toString()
-        if (is_last_build()) {
-          echo 'Exception during SPOT run ' + ex.toString() + ' retry on-demand'
-          currentBuild.result = 'SUCCESS'
-          shard_run_unittest_GPU('GPU-G5', 4, 'cu129')
-        } else {
-          echo 'Exit since it is not last build'
-          throw ex
-        }
-      }
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-4-cu129',
+        { node_type -> shard_run_unittest_GPU(node_type, 4, 'cu129') })
     }
   )
 }

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h
@@ -91,10 +91,12 @@ struct TllmToCutlassTypeAdapter<__nv_fp8_e5m2> {
 #endif
 
 #if defined(ENABLE_FP4)
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 template <>
 struct TllmToCutlassTypeAdapter<__nv_fp4_e2m1> {
   using type = cutlass::float_e2m1_t;
 };
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -130,10 +132,12 @@ struct CutlassToTllmTypeAdapter<cutlass::float_e5m2_t> {
 #endif
 
 #if defined(ENABLE_FP4)
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 template <>
 struct CutlassToTllmTypeAdapter<cutlass::float_e2m1_t> {
   using type = __nv_fp4_e2m1;
 };
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h
@@ -18,7 +18,9 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 #include <cuda_fp4.h>
+#endif
 #include <cuda_fp8.h>
 
 #include "cutlass/bfloat16.h"

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -272,6 +272,8 @@ class MoeGemmRunner {
   static constexpr bool use_wfp4a16 =
       std::is_same_v<WeightType, __nv_fp4_e2m1> && std::is_same_v<T, half>;
 #endif
+#else
+  static constexpr bool use_wfp4a16 = false;
 #endif
 
 #if defined(ENABLE_FP8)

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -32,7 +32,9 @@
 #include "tensorrt_llm/cutlass_extensions/include/cutlass_extensions/gemm_configs.h"
 
 #ifdef ENABLE_FP4
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 #include <cuda_fp4.h>
+#endif
 #endif
 
 namespace tensorrt_llm::kernels::cutlass_kernels {

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -264,12 +264,14 @@ class MoeGemmRunner {
  public:
   MoeGemmRunner();
 
+#if defined(ENABLE_FP4)
 #if defined(ENABLE_BF16)
   static constexpr bool use_wfp4a16 = std::is_same_v<WeightType, __nv_fp4_e2m1> &&
                                       (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>);
 #else
   static constexpr bool use_wfp4a16 =
       std::is_same_v<WeightType, __nv_fp4_e2m1> && std::is_same_v<T, half>;
+#endif
 #endif
 
 #if defined(ENABLE_FP8)

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -527,12 +527,16 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
   using ScaleBiasType = BackBoneType;
   using Self = CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType>;
 
+#if defined(ENABLE_FP4)
 #if defined(ENABLE_BF16)
   static constexpr bool use_wfp4a16 = std::is_same_v<WeightType, __nv_fp4_e2m1> &&
                                       (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>);
 #else
   static constexpr bool use_wfp4a16 =
       std::is_same_v<WeightType, __nv_fp4_e2m1> && std::is_same_v<T, half>;
+#endif
+#else
+  static constexpr bool use_wfp4a16 = false;
 #endif
 
 #if defined(ENABLE_FP8)

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_kernels_bf16_fp4.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_kernels_bf16_fp4.cu
@@ -17,7 +17,7 @@
 #include "tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h"
 
 namespace tensorrt_llm::kernels::cutlass_kernels {
-#ifdef ENABLE_BF16
+#if defined(ENABLE_BF16) && defined(ENABLE_FP4)
 template class MoeGemmRunner<__nv_bfloat16, __nv_fp4_e2m1, __nv_bfloat16>;
 #endif
 }  // namespace tensorrt_llm::kernels::cutlass_kernels

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_kernels_fp16_fp4.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_kernels_fp16_fp4.cu
@@ -17,5 +17,7 @@
 #include "tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h"
 
 namespace tensorrt_llm::kernels::cutlass_kernels {
+#if defined(ENABLE_FP4)
 template class MoeGemmRunner<half, __nv_fp4_e2m1, half>;
-}
+#endif
+}  // namespace tensorrt_llm::kernels::cutlass_kernels

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
@@ -96,7 +96,9 @@ struct genericMoeGemmKernelLauncher {
 
     static_assert(cutlass::platform::is_same<T, WeightType>::value ||
                   cutlass::platform::is_same<WeightType, uint8_t>::value ||
+#if defined(ENABLE_FP4)
                   cutlass::platform::is_same<WeightType, __nv_fp4_e2m1>::value ||
+#endif
                   cutlass::platform::is_same<WeightType, cutlass::uint4b_t>::value);
 
     static_assert(arch::kMinComputeCapability < 90,
@@ -675,13 +677,18 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
                        "Hopper configuration provided for non-Hopper architecture");
 
   if (sm_ >= 75 && sm_ < 80) {
+#ifdef ENABLE_FP4
     if constexpr (!std::is_same_v<WeightType, __nv_fp4_e2m1>) {
       dispatchMoeGemmToCutlass<T, WeightType, ScaleBiasType, cutlass::arch::Sm75, EpilogueTag>(
           inputs, multi_processor_count_);
     } else {
       TLLM_THROW("FP4 data type is not supported on SM < 90");
     }
+#else
+    TLLM_THROW("FP4 data type is not supported on SM < 90");
+#endif
   } else if (sm_ >= 80 && sm_ < 90) {
+#ifdef ENABLE_FP4
     if constexpr (!std::is_same_v<WeightType, __nv_fp4_e2m1>) {
       if constexpr (use_fp8 || use_w4afp8) {
 #if defined(ENABLE_FP8)
@@ -700,6 +707,9 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
     } else {
       TLLM_THROW("FP4 data type is not supported on SM < 90");
     }
+#else
+    TLLM_THROW("FP4 data type is not supported on SM < 90");
+#endif
   } else if (sm_ >= 90) {
     // For SM120+ FP8 MoE, redirect to SM89 (Ada) FP8 kernel implementations.
     if constexpr (use_fp8) {

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws.h
@@ -113,6 +113,7 @@ void dispatchMoeGemmSelectBiasTmaWarpSpecialized(TmaWarpSpecializedGroupedGemmIn
   }
 #endif
   else {
+#ifdef ENABLE_FP4
     auto getFunc = [&]() {
       if constexpr (std::is_same_v<T, __nv_fp8_e4m3> && std::is_same_v<WeightType, __nv_fp4_e2m1>) {
         TLLM_CHECK_WITH_INFO(hopper_input.fpX_block_scaling_type ==
@@ -131,6 +132,9 @@ void dispatchMoeGemmSelectBiasTmaWarpSpecialized(TmaWarpSpecializedGroupedGemmIn
       }
     };
     getFunc()(hopper_input, num_experts, multi_processor_count, stream, occupancy, workspace_size);
+#else
+    TLLM_THROW("FP4 data type is not supported on this architecture and CUDA version");
+#endif
   }
 }
 

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws_mixed_dtype.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws_mixed_dtype.h
@@ -156,10 +156,16 @@ void sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass(
   // We also only instantiate configs here where threadblockShapeM == warpShapeM since those usually
   // perform the best for mixed type gemms.
 
+#if defined(ENABLE_FP4)
   constexpr int Ntile = (std::is_same_v<WeightType, __nv_fp4_e2m1>) ? 64 : 128;
   constexpr int Ktile =
       (std::is_same_v<WeightType, __nv_fp4_e2m1>) ? 128 : 128 * PackedScalesNum / sizeof(T);
   TLLM_CHECK(sizeof(T) == (std::is_same_v<WeightType, __nv_fp4_e2m1>) ? 2 : 1);
+#else
+  constexpr int Ntile = 128;
+  constexpr int Ktile = 128 * PackedScalesNum / sizeof(T);
+  TLLM_CHECK(sizeof(T) == 2);
+#endif
 
   using _Ntile = Int<Ntile>;
   using _Ktile = Int<Ktile>;
@@ -240,7 +246,11 @@ void sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass(
 template <typename T, typename WeightType, typename OutputType>
 size_t calcMaxWorkspaceSizeTmaWarpSpecializedMixedInput(int num_experts, int sm_count_) {
   size_t count = 0;
+#ifdef ENABLE_FP4
   constexpr int Ktile = (std::is_same_v<WeightType, __nv_fp4_e2m1>) ? 256 : 512;
+#else
+  constexpr int Ktile = 512;
+#endif
   using _Ktile = Int<Ktile>;
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_tma_warp_specialized_traits.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_tma_warp_specialized_traits.h
@@ -68,8 +68,13 @@ constexpr bool isValidHopperMOESpecialisation() {
   return (cutlass::platform::is_same<T, WeightType>::value ||
           (cutlass::platform::is_same<cutlass::uint4b_t, WeightType>::value &&
            cutlass::platform::is_same<T, __nv_fp8_e4m3>::value) ||
+#ifdef ENABLE_FP4
           (cutlass::platform::is_same<__nv_fp4_e2m1, WeightType>::value &&
-           !cutlass::platform::is_same<T, __nv_fp8_e4m3>::value))
+           !cutlass::platform::is_same<T, __nv_fp8_e4m3>::value)
+#else
+          false
+#endif
+              )
 
 #ifdef ENABLE_FP4
          && !cutlass::platform::is_same<T, __nv_fp4_e2m1>::value

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
@@ -23,7 +23,9 @@
 #include <ATen/Tensor.h>
 #include <ATen/cuda/EmptyTensor.h>
 #include <cuda_fp16.h>
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 #include <cuda_fp4.h>
+#endif
 #include <cuda_fp8.h>
 
 #include <cstdint>

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
@@ -369,16 +369,16 @@ at::Tensor mxfp4_dequantize_host(at::Tensor weight, at::Tensor scale, int64_t gr
   TORCH_CHECK(weight.size(1) * 2 == scale.size(1) * group_size,
               "weight and scale must have the same number of columns");
 
+  uint8_t* weight_packed_ptr = weight.data_ptr<uint8_t>();
+  __nv_fp8_e8m0* scale_ptr = reinterpret_cast<__nv_fp8_e8m0*>(scale.data_ptr<uint8_t>());
+
   int const n = weight.size(0);
   int const k = weight.size(1) * 2;
 
   at::Tensor dequant_weight =
       at::empty({n, k}, at::dtype(at::ScalarType::Float).device(at::kCPU).requires_grad(false));
 
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
   float* dequant_weight_ptr = dequant_weight.data_ptr<float>();
-  uint8_t* weight_packed_ptr = weight.data_ptr<uint8_t>();
-  __nv_fp8_e8m0* scale_ptr = reinterpret_cast<__nv_fp8_e8m0*>(scale.data_ptr<uint8_t>());
 
   float fp4_lut[] = {0.0, 0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
                      0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0};
@@ -400,9 +400,6 @@ at::Tensor mxfp4_dequantize_host(at::Tensor weight, at::Tensor scale, int64_t gr
     dequant_weight_ptr[2 * packed_idx] = weight_low * scale_;
     dequant_weight_ptr[2 * packed_idx + 1] = weight_high * scale_;
   }
-#else
-  TLLM_THROW("CUDA 12.8 is required for e8m0.");
-#endif
 
   return dequant_weight;
 }

--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -33,7 +33,9 @@
 #endif
 
 #if defined(FLASHINFER_ENABLE_FP4_E2M1)
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 #include <cuda_fp4.h>
+#endif
 #endif
 
 #ifndef FLASHINFER_EXT_MODULE_INITED

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -332,13 +332,13 @@ def gen_all_modules(
 
     if add_moe:
         jit_specs.append(gen_gemm_module())
-        jit_specs.append(gen_fp4_quantization_module())
         if has_sm90:
             jit_specs.append(gen_gemm_sm90_module())
             jit_specs.append(gen_cutlass_fused_moe_sm90_module())
         if has_sm100:
             jit_specs.append(gen_cutlass_fused_moe_sm100_module())
             jit_specs.append(gen_gemm_sm100_module())
+            jit_specs.append(gen_fp4_quantization_module())
 
     if add_comm:
         from .comm import gen_trtllm_comm_module, gen_vllm_comm_module

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -343,7 +343,6 @@ def gen_all_modules(
             jit_specs.append(gen_fp4_quantization_sm100_module())
             jit_specs.append(gen_cutlass_fused_moe_sm100_module())
             jit_specs.append(gen_gemm_sm100_module())
-            jit_specs.append(gen_fp4_quantization_module())
 
     if add_comm:
         from .comm import gen_trtllm_comm_module, gen_vllm_comm_module

--- a/flashinfer/fp4_quantization.py
+++ b/flashinfer/fp4_quantization.py
@@ -24,6 +24,7 @@ import torch
 from .jit import JitSpec
 from .jit import env as jit_env
 from .jit import gen_jit_spec, sm100a_nvcc_flags, sm90a_nvcc_flags
+from .jit.cpp_ext import is_cuda_version_at_least
 from .utils import (
     device_support_pdl,
     get_shuffle_matrix_a_row_indices,
@@ -87,12 +88,12 @@ def gen_fp4_quantization_module(nvcc_flags: List[str], device_arch: str) -> JitS
         + [
             "-DENABLE_BF16",
             "-DENABLE_FP8",
-            "-DENABLE_FP4",
+            "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
         ],
         extra_cflags=[
             "-DENABLE_BF16",
             "-DENABLE_FP8",
-            "-DENABLE_FP4",
+            "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
         ],
         extra_include_paths=[
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal",

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -32,6 +32,7 @@ from ..autotuner import (
 from ..jit import JitSpec
 from ..jit import env as jit_env
 from ..jit import gen_jit_spec, setup_cubin_loader, sm100a_nvcc_flags, sm90a_nvcc_flags
+from ..jit.cpp_ext import is_cuda_version_at_least
 from ..jit.cubin_loader import get_cubin
 from ..jit.cutlass_gemm.generate_kernels import generate_gemm_operations
 from ..utils import (
@@ -273,7 +274,7 @@ def gen_cutlass_fused_moe_sm90_module(use_fast_build: bool = False) -> JitSpec:
         "-DCOMPILE_HOPPER_TMA_GROUPED_GEMMS",
         "-DENABLE_BF16",
         "-DENABLE_FP8",
-        "-DENABLE_FP4",
+        "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
         "-DUSING_OSS_CUTLASS_MOE_GEMM",
     ]
     return gen_cutlass_fused_moe_module(nvcc_flags, "90", use_fast_build)

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -23,7 +23,7 @@ from . import env as jit_env
 
 
 @functools.cache
-def _get_cuda_version() -> Version:
+def get_cuda_version() -> Version:
     if CUDA_HOME is None:
         nvcc = "nvcc"
     else:
@@ -35,6 +35,10 @@ def _get_cuda_version() -> Version:
             f"Could not parse CUDA version from nvcc --version output: {txt}"
         )
     return Version(matches[0])
+
+
+def is_cuda_version_at_least(version_str: str) -> bool:
+    return get_cuda_version() >= Version(version_str)
 
 
 def _get_glibcxx_abi_build_flags() -> List[str]:
@@ -97,7 +101,7 @@ def generate_ninja_build_for_op(
         "--compiler-options=-fPIC",
         "--expt-relaxed-constexpr",
     ]
-    cuda_version = _get_cuda_version()
+    cuda_version = get_cuda_version()
     # enable -static-global-template-stub when cuda version >= 12.8
     if cuda_version >= Version("12.8"):
         cuda_cflags += [

--- a/flashinfer/jit/cutlass_gemm/generate_kernels.py
+++ b/flashinfer/jit/cutlass_gemm/generate_kernels.py
@@ -2,8 +2,21 @@ import enum
 import os
 from itertools import chain, product
 
-from .cutlass_library import *
-from .cutlass_library import enum_auto, DataTypeNames, DataTypeSize, DataType
+from .cutlass_library import (
+    enum_auto,
+    DataTypeNames,
+    DataTypeSize,
+    DataType,
+    DataTypeTag,
+    GemmKind,
+    GemmKindNames,
+    KernelScheduleType,
+    KernelScheduleTag,
+    KernelScheduleSuffixes,
+    EpilogueScheduleType,
+    EpilogueScheduleTag,
+    EpilogueScheduleSuffixes,
+)
 from ..cpp_ext import is_cuda_version_at_least
 
 

--- a/flashinfer/jit/cutlass_gemm/generate_kernels.py
+++ b/flashinfer/jit/cutlass_gemm/generate_kernels.py
@@ -3,6 +3,8 @@ import os
 from itertools import chain, product
 
 from .cutlass_library import *
+from .cutlass_library import enum_auto, DataTypeNames, DataTypeSize, DataType
+from ..cpp_ext import is_cuda_version_at_least
 
 
 ################################################################################
@@ -586,10 +588,20 @@ def generate_sm90_mixed_type_grouped_gemm_operations(is_arch_enabled):
         (DataType.e4m3, DataType.u4, DataType.f16, DataType.f16, DataType.f16),
         (DataType.e4m3, DataType.u4, DataType.bf16, DataType.bf16, DataType.bf16),
     ]
-    supported_dtypes_fp4 = [
-        (DataType.f16, DataType.e2m1, DataType.ue8m0, DataType.f16, DataType.f16),
-        (DataType.bf16, DataType.e2m1, DataType.ue8m0, DataType.bf16, DataType.bf16),
-    ]
+
+    if is_cuda_version_at_least("12.8"):
+        supported_dtypes_fp4 = [
+            (DataType.f16, DataType.e2m1, DataType.ue8m0, DataType.f16, DataType.f16),
+            (
+                DataType.bf16,
+                DataType.e2m1,
+                DataType.ue8m0,
+                DataType.bf16,
+                DataType.bf16,
+            ),
+        ]
+    else:
+        supported_dtypes_fp4 = []
 
     quant_ops = [TrtLlm_QuantOp.finegrained_scale_only]
 

--- a/include/flashinfer/cutlass_utils.cuh
+++ b/include/flashinfer/cutlass_utils.cuh
@@ -42,7 +42,9 @@
 #include "cutlass/util/reference/device/tensor_fill.h"
 #include "cutlass/util/tensor_view_io.h"
 #if defined(FLASHINFER_ENABLE_FP4_E2M1)
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
 #include <cuda_fp4.h>
+#endif
 #endif
 
 namespace flashinfer {

--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -7,11 +7,12 @@ set -x
 export TORCH_CUDA_ARCH_LIST=$(python3 -c '
 import torch
 cuda_ver = torch.version.cuda
-arches = ["7.5", "8.0", "8.9", "9.0+PTX", "10.0+PTX"]
+arches = ["7.5", "8.0", "8.9", "9.0+PTX"]
 if cuda_ver is not None:
     try:
         major, minor = map(int, cuda_ver.split(".")[:2])
         if (major, minor) >= (12, 8):
+            arches.append("10.0+PTX")
             arches.append("12.0+PTX")
     except Exception:
         pass

--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -14,4 +14,4 @@ pip install dist/*.whl
 # test import
 mkdir -p tmp
 cd tmp
-python -c "from flashinfer.page import gen_page_module; p = gen_page_module().aot_path; print(p); assert p.exists();"
+python -c "import flashinfer"

--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -4,7 +4,19 @@ set -eo pipefail
 set -x
 : ${MAX_JOBS:=$(nproc)}
 : ${CUDA_VISIBLE_DEVICES:=""}
-export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0+PTX 10.0+PTX 12.0+PTX"
+export TORCH_CUDA_ARCH_LIST=$(python3 -c '
+import torch
+cuda_ver = torch.version.cuda
+arches = ["7.5", "8.0", "8.9", "9.0+PTX", "10.0+PTX"]
+if cuda_ver is not None:
+    try:
+        major, minor = map(int, cuda_ver.split(".")[:2])
+        if (major, minor) >= (12, 8):
+            arches.append("12.0+PTX")
+    except Exception:
+        pass
+print(" ".join(arches))
+')
 
 python -c "import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI)"
 python -m flashinfer.aot --add-comm True --add-moe True


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

As reported in https://github.com/flashinfer-ai/flashinfer/pull/1557#issuecomment-3217441569, our UT do not cover the cuda 12.6 environment, this PR fixes the issue by adding cu126/cu128/cu129 UT to CI.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/1557#issuecomment-3217441569

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @yongwww @zhyncs 
