### PR TITLE
update trtllm-gen fp4 autotuner and routing

### DIFF
--- a/csrc/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/trtllm_fused_moe_routing_llama4.cu
@@ -450,7 +450,7 @@ void run(Data const& data, void* stream) {
     } else {
       // Reset the global histograms.
       CHECK_CUDA_ERROR(cudaMemsetAsync(data.mPtrExpertCounts, 0,
-                                       static_cast<size_t>(2 * NumThreads) * sizeof(int32_t),
+                                       static_cast<size_t>(2 * data.mNumExperts) * sizeof(int32_t),
                                        (cudaStream_t)stream));
     }
     LAUNCH_ROUTING(data,

--- a/csrc/trtllm_fused_moe_routing_renormalize.cu
+++ b/csrc/trtllm_fused_moe_routing_renormalize.cu
@@ -279,7 +279,7 @@ void run(Data const& data, void* stream) {
     } else {
       // Reset the global histograms.
       CHECK_CUDA_ERROR(cudaMemsetAsync(data.mPtrExpertCounts, 0,
-                                       static_cast<size_t>(2 * NumThreads) * sizeof(int32_t),
+                                       static_cast<size_t>(2 * data.mNumExperts) * sizeof(int32_t),
                                        (cudaStream_t)stream));
     }
     LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingIndicesHistogramKernel, numBlocksHistogram,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1015,7 +1015,7 @@ def get_trtllm_moe_sm100_module():
         def __init__(
             self,
             top_k: int,
-            num_experts: int,
+            num_local_experts: int,
             dtype_act: DtypeTrtllmGen,
             dtype_weights: DtypeTrtllmGen,
             use_deepseek_fp8: bool,
@@ -1024,7 +1024,7 @@ def get_trtllm_moe_sm100_module():
             gated_act_type: int,
             tile_tokens_dim: Optional[int] = None,
         ):
-            self.num_experts = num_experts
+            self.num_local_experts = num_local_experts
             self.top_k = top_k
             self.dtype_act = dtype_act
             self.dtype_weights = dtype_weights
@@ -1046,7 +1046,7 @@ def get_trtllm_moe_sm100_module():
             imbalance_factor = 1.3
             # Calculate the number of tokens per expert
             # assuming perfect distribution.
-            num_tokens_per_expert = (num_tokens * top_k) // self.num_experts
+            num_tokens_per_expert = (num_tokens * top_k) // self.num_local_experts
             # Apply the imbalance factor.
             num_tokens_per_expert = int(num_tokens_per_expert * imbalance_factor)
             # And pad the number to the next power of 2.
@@ -1084,7 +1084,7 @@ def get_trtllm_moe_sm100_module():
                 self.top_k,
                 self.hidden_size,
                 self.intermediate_size,
-                self.num_experts,
+                self.num_local_experts,
                 self.gated_act_type,
                 num_tokens,
             )
@@ -1160,13 +1160,13 @@ def get_trtllm_moe_sm100_module():
                 kwargs["output1_scale_scalar"],
                 kwargs["output1_scale_gate_scalar"],
                 kwargs["output2_scale_scalar"],
-                self.num_experts,
+                kwargs["num_experts"],
                 self.top_k,
                 kwargs["n_group"],
                 kwargs["topk_group"],
                 self.intermediate_size,
                 kwargs["local_expert_offset"],
-                kwargs["num_local_experts"],
+                self.num_local_experts,
                 kwargs["routed_scaling_factor"],
                 tile_tokens_dim,
                 kwargs["routing_method_type"],
@@ -1398,7 +1398,7 @@ def get_trtllm_moe_sm100_module():
         topk_group: Optional[int],
         intermediate_size: int,
         local_expert_offset: int,
-        local_num_experts: int,
+        num_local_experts: int,
         routed_scaling_factor: Optional[float],
         tile_tokens_dim: int,
         routing_method_type: int,
@@ -1448,7 +1448,7 @@ def get_trtllm_moe_sm100_module():
         )
         moe_runner = MoERunner(
             top_k=top_k,
-            num_experts=num_experts,
+            num_local_experts=num_local_experts,
             dtype_act=dtype_act,
             dtype_weights=dtype_weights,
             use_deepseek_fp8=False,
@@ -1481,7 +1481,7 @@ def get_trtllm_moe_sm100_module():
             [moe_runner],
             tunning_config,
             inputs,
-            num_local_experts=num_experts,
+            num_experts=num_experts,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             gemm1_weights_scale=gemm1_weights_scale,
@@ -1531,7 +1531,7 @@ def get_trtllm_moe_sm100_module():
             topk_group,
             intermediate_size,
             local_expert_offset,
-            local_num_experts,
+            num_local_experts,
             routed_scaling_factor,
             tile_tokens_dim,
             routing_method_type,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- remove `.to(torch.bfloat16)` which causes illegal memory access when using deepseek v3 routing.
- handle the case when `routing_logits` is `None` to support `trtllm_fp4_block_scale_routed_moe`
- fix the `invalid argument` error in llama and renormalize routing

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
