### PR TITLE
feat: Support for inferring out_dtype from out.dtype for TRTLLM attention kernel

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2133,7 +2133,8 @@ def trtllm_batch_decode_with_kv_cache(
         assert o_sf_vec_size is None
         out_scale_factor = None
         o_sf_start_index = 0
-        out_dtype = out_dtype or query.dtype
+        if out_dtype is None:
+            out_dtype = out.dtype if out is not None else query.dtype
         out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
         if out_dtype not in (query.dtype, torch.float16, torch.bfloat16):
             raise ValueError(f"Unsupported out_dtype: {out_dtype}")

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3391,10 +3391,11 @@ def trtllm_batch_context_with_kv_cache(
         assert o_sf_vec_size is None
         out_scale_factor = None
         o_sf_start_index = 0
-        out_dtype = out_dtype or query.dtype
+        if out_dtype is None:
+            out_dtype = out.dtype if out is not None else query.dtype
+        out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
         if out_dtype not in (query.dtype, torch.float16, torch.bfloat16):
             raise ValueError(f"Unsupported out_dtype: {out_dtype}")
-        out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
         check_shape_dtype_device(out, query.shape, out_dtype, query.device, "out")
     else:
         raise ValueError(f"Invalid out_dtype: {out_dtype}")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Instead of directly use `query.dtype` as `out_dtype`, we could infer the `out_dtype` from `out.dtype` if `out` is passed into the API.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

tests/test_trtllm_gen_attention.py::test_trtllm_batch_prefill:
`==== 972 passed, 4 warnings in 47.94s ====`
tests/test_trtllm_gen_attention.py::test_trtllm_batch_decode:
`==== 2592 passed, 15 warnings in 88.27s (0:01:28) ====`

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
