### PR TITLE
bugfix: Fix arg passing to TORCH_CHECK and TORCH_WARN macros

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -244,8 +244,9 @@ void TrtllmGenBatchedGemmRunner::run(
 
   TORCH_CHECK(err == 0,
               "Error occurred when running GEMM!"
-              " (numBatches: %d, GemmMNK: %d %d %d, Kernel: %s)",
-              numBatches, m, n, k, config.mFunctionName);
+              " (numBatches: ",
+              numBatches, ", GemmMNK: ", m, " ", n, " ", k, ", Kernel: ", config.mFunctionName,
+              ")");
 }
 
 void TrtllmGenBatchedGemmRunner::run(int32_t m, int32_t n, int32_t k,

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -910,7 +910,7 @@ std::vector<at::Tensor> trtllm_fp4_block_scale_moe_launcher(
   TORCH_CHECK(gemm1_weights_scale.sizes()[0] == local_num_experts,
               "gemm1_weights_scale has incorrect dim 0.");
   TORCH_CHECK(intermediate_size % sf_vec_size == 0,
-              "the second dimension of weights must be a multiple of %d.", sf_vec_size);
+              "the second dimension of weights must be a multiple of ", sf_vec_size);
   TORCH_CHECK(gemm1_weights_scale.sizes()[1] == 2 * intermediate_size,
               "gemm1_weights_scale has incorrect dim 1.");
   TORCH_CHECK(gemm1_weights_scale.sizes()[2] == args.hidden_size / sf_vec_size,
@@ -918,8 +918,7 @@ std::vector<at::Tensor> trtllm_fp4_block_scale_moe_launcher(
 
   if (gemm1_bias.has_value()) {
     TORCH_CHECK(gemm1_bias.value().scalar_type() == at::ScalarType::Float,
-                "gemm1_bias must be float, got %s.",
-                c10::toString(gemm1_bias.value().scalar_type()));
+                "gemm1_bias must be float, got ", c10::toString(gemm1_bias.value().scalar_type()));
     TORCH_CHECK(gemm1_bias.value().dim() == 2, "gemm1_bias must be 2D.");
     TORCH_CHECK(gemm1_bias.value().sizes()[0] == local_num_experts,
                 "gemm1_bias has incorrect dim 0.");
@@ -929,7 +928,7 @@ std::vector<at::Tensor> trtllm_fp4_block_scale_moe_launcher(
 
   if (gemm1_alpha.has_value()) {
     TORCH_CHECK(gemm1_alpha.value().scalar_type() == at::ScalarType::Float,
-                "gemm1_alpha must be float, got %s.",
+                "gemm1_alpha must be float, got ",
                 c10::toString(gemm1_alpha.value().scalar_type()));
     TORCH_CHECK(gemm1_alpha.value().dim() == 1, "gemm1_alpha must be 1D.");
     TORCH_CHECK(gemm1_alpha.value().sizes()[0] == local_num_experts,
@@ -937,8 +936,7 @@ std::vector<at::Tensor> trtllm_fp4_block_scale_moe_launcher(
   }
   if (gemm1_beta.has_value()) {
     TORCH_CHECK(gemm1_beta.value().scalar_type() == at::ScalarType::Float,
-                "gemm1_beta must be float, got %s.",
-                c10::toString(gemm1_beta.value().scalar_type()));
+                "gemm1_beta must be float, got ", c10::toString(gemm1_beta.value().scalar_type()));
     TORCH_CHECK(gemm1_beta.value().dim() == 1, "gemm1_beta must be 1D.");
     TORCH_CHECK(gemm1_beta.value().sizes()[0] == local_num_experts,
                 "gemm1_beta has incorrect dim 0.");

--- a/csrc/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/trtllm_fused_moe_routing_deepseek.cu
@@ -417,43 +417,38 @@ void run(Data& data, void* stream) {
                 "If permuted index is required, `mPtrExpertIdx` is also required");
   TORCH_CHECK(!data.mUseRoutingSoftmax, "Routing with softmax not implemented yet");
   TORCH_CHECK(data.mNumLimitedGroups <= MaxNumTopGroups,
-              "Routing kernel expects <= %d top groups, got %d", MaxNumTopGroups,
+              "Routing kernel expects <= ", MaxNumTopGroups, " top groups, got ",
               data.mNumLimitedGroups);
-  TORCH_CHECK(data.mTopK <= MaxNumTopExperts, "Routing kernel expects topK experts <= %d, got %d",
-              MaxNumTopExperts, data.mTopK);
-  TORCH_CHECK(data.mTopK <= WarpSize, "Routing kernel expects top K <= warp size, got %d",
+  TORCH_CHECK(data.mTopK <= MaxNumTopExperts,
+              "Routing kernel expects topK experts <= ", MaxNumTopExperts, ", got ", data.mTopK);
+  TORCH_CHECK(data.mTopK <= WarpSize, "Routing kernel expects top K <= warp size, got ",
               data.mTopK);
   TORCH_CHECK(data.mTopK * data.mNumLimitedGroups <= WarpSize,
-              "Routing kernel expects top K * top groups <= warp size (for now), got %d * %d",
-              data.mTopK, data.mNumLimitedGroups);
-  TORCH_CHECK(data.mNumExperts >= MaxNumTopExperts,
-              "Routing kernel expects %d to be at most #experts %d", MaxNumTopExperts,
-              data.mNumExperts);
-  TORCH_CHECK(data.mNumExperts <= NumThreads, "Routing kernel expects #experts %d  <= #threads %d",
-              data.mNumExperts, NumThreads);
-  TORCH_CHECK(data.mNumExpertGroups >= data.mNumLimitedGroups,
-              "Routing kernel expects top groups %d to be limited by #expert groups %d",
-              data.mNumLimitedGroups, data.mNumExpertGroups);
+              "Routing kernel expects top K * top groups <= warp size (for now), got ", data.mTopK,
+              " * ", data.mNumLimitedGroups);
+  TORCH_CHECK(data.mNumExperts >= MaxNumTopExperts, "Routing kernel expects ", MaxNumTopExperts,
+              " to be at most #experts ", data.mNumExperts);
+  TORCH_CHECK(data.mNumExperts <= NumThreads, "Routing kernel expects #experts ", data.mNumExperts,
+              " <= #threads ", NumThreads);
+  TORCH_CHECK(data.mNumExpertGroups >= data.mNumLimitedGroups, "Routing kernel expects top groups ",
+              data.mNumLimitedGroups, " to be limited by #expert groups ", data.mNumExpertGroups);
   if (data.mNumExpertGroups > 1) {
-    TORCH_CHECK(data.mNumExpertGroups <= NumWarps,
-                "Routing kernel expects #experts groups %d to be <= #warps %d",
-                data.mNumExpertGroups, NumWarps);
-    TORCH_CHECK(data.mNumExperts % data.mNumExpertGroups == 0,
-                "Routing kernel expects #experts %d to be a multiple of #expert groups %d",
-                data.mNumExperts, data.mNumExpertGroups);
+    TORCH_CHECK(data.mNumExpertGroups <= NumWarps, "Routing kernel expects #experts groups ",
+                data.mNumExpertGroups, " to be <= #warps ", NumWarps);
+    TORCH_CHECK(data.mNumExperts % data.mNumExpertGroups == 0, "Routing kernel expects #experts ",
+                data.mNumExperts, " to be a multiple of #expert groups ", data.mNumExpertGroups);
     TORCH_CHECK(data.mNumExperts / data.mNumExpertGroups <= WarpSize,
-                "Routing kernel expects #experts per group <= warp size, got %d",
+                "Routing kernel expects #experts per group <= warp size, got ",
                 data.mNumExperts / data.mNumExpertGroups);
   } else {
-    TORCH_CHECK(data.mNumExperts <= WarpSize * MaxNumTopGroups,
-                "Routing kernel expects #experts %d <= WarpSize * MaxNumTopGroups %d",
-                data.mNumExperts, WarpSize * MaxNumTopGroups);
-    TORCH_CHECK(data.mTopK <= NumWarps, "Routing kernel expects top K %d to be <= #warps %d",
-                data.mTopK, NumWarps);
+    TORCH_CHECK(data.mNumExperts <= WarpSize * MaxNumTopGroups, "Routing kernel expects #experts ",
+                data.mNumExperts, " <= WarpSize * MaxNumTopGroups ", WarpSize * MaxNumTopGroups);
+    TORCH_CHECK(data.mTopK <= NumWarps, "Routing kernel expects top K ", data.mTopK,
+                " to be <= #warps ", NumWarps);
   }
-  TORCH_CHECK(data.mNumExperts % 4 == 0,
-              "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
-  TORCH_CHECK(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got %d",
+  TORCH_CHECK(data.mNumExperts % 4 == 0, "Routing kernel expects #experts ", data.mNumExperts,
+              " to be a multiple of 4.");
+  TORCH_CHECK(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got ",
               data.mPaddingLog2);
   int const numBlocks = data.mNumTokens;
 

--- a/csrc/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/trtllm_fused_moe_routing_llama4.cu
@@ -391,16 +391,15 @@ void run(Data const& data, void* stream) {
   TORCH_CHECK(data.mPtrPermutedIdxSize != nullptr && data.mPtrCtaIdxXyToBatchIdx != nullptr &&
                   data.mPtrCtaIdxXyToMnLimit != nullptr && data.mPtrNumNonExitingCtas != nullptr,
               "Llama4 routing kernel expects permuted idx and grouped Gemm launch config buffers");
-  TORCH_CHECK(data.mTopK <= MaxNumTopExperts, "Routing kernel expects topK experts <= %d, got %d",
-              MaxNumTopExperts, data.mTopK);
-  TORCH_CHECK(data.mNumExperts <= MaxNumExperts,
-              "Routing kernel expects #experts %d to be at most max #experts %d", data.mNumExperts,
-              MaxNumExperts);
+  TORCH_CHECK(data.mTopK <= MaxNumTopExperts,
+              "Routing kernel expects topK experts <= ", MaxNumTopExperts, ", got ", data.mTopK);
+  TORCH_CHECK(data.mNumExperts <= MaxNumExperts, "Routing kernel expects #experts ",
+              data.mNumExperts, " to be at most max #experts ", MaxNumExperts);
   static_assert(MaxNumExperts <= NumThreads, "#experts must be bounded by #threads");
   static_assert(MaxNumExperts <= NumThreadsHist, "#experts must be bounded by #threads");
-  TORCH_CHECK(data.mNumExperts % 4 == 0,
-              "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
-  TORCH_CHECK(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got %d",
+  TORCH_CHECK(data.mNumExperts % 4 == 0, "Routing kernel expects #experts ", data.mNumExperts,
+              " to be a multiple of 4.");
+  TORCH_CHECK(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got ",
               data.mPaddingLog2);
 
   bool const useSingleWarp =

--- a/csrc/trtllm_fused_moe_routing_renormalize.cu
+++ b/csrc/trtllm_fused_moe_routing_renormalize.cu
@@ -229,16 +229,15 @@ void run(Data const& data, void* stream) {
   TORCH_CHECK(data.mPtrPermutedIdxSize != nullptr && data.mPtrCtaIdxXyToBatchIdx != nullptr &&
                   data.mPtrCtaIdxXyToMnLimit != nullptr && data.mPtrNumNonExitingCtas != nullptr,
               "Llama4 routing kernel expects permuted idx and grouped Gemm launch config buffers");
-  TORCH_CHECK(data.mTopK <= MaxNumTopExperts, "Routing kernel expects topK experts <= %d, got %d",
-              MaxNumTopExperts, data.mTopK);
-  TORCH_CHECK(data.mNumExperts <= MaxNumExperts,
-              "Routing kernel expects #experts %d to be at most max #experts %d", data.mNumExperts,
-              MaxNumExperts);
+  TORCH_CHECK(data.mTopK <= MaxNumTopExperts,
+              "Routing kernel expects topK experts <= ", MaxNumTopExperts, ", got ", data.mTopK);
+  TORCH_CHECK(data.mNumExperts <= MaxNumExperts, "Routing kernel expects #experts ",
+              data.mNumExperts, " to be at most max #experts ", MaxNumExperts);
   static_assert(MaxNumExperts <= NumThreads, "#experts must be bounded by #threads");
   static_assert(MaxNumExperts <= NumThreadsHist, "#experts must be bounded by #threads");
-  TORCH_CHECK(data.mNumExperts % 4 == 0,
-              "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
-  TORCH_CHECK(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got %d",
+  TORCH_CHECK(data.mNumExperts % 4 == 0, "Routing kernel expects #experts ", data.mNumExperts,
+              " to be a multiple of 4.");
+  TORCH_CHECK(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got ",
               data.mPaddingLog2);
 
   bool const useSingleCluster =

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -38,7 +38,7 @@ inline int32_t computeLog2(int32_t val, std::string const& name = "") {
   while (n >>= 1) {
     ++out;
   }
-  TORCH_CHECK((1 << out) == val, "Expected %s to be a power of 2, got %d", name.c_str(), val);
+  TORCH_CHECK((1 << out) == val, "Expected ", name, " to be a power of 2, got ", val);
   return out;
 }
 }  // namespace
@@ -93,7 +93,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
   } else if (routingMethodType == RoutingMethodType::Llama4) {
     TORCH_CHECK(topK == 1, "For Llama routing method, must have topK == 1");
     if (nGroup > 0 || topkGroup > 0) {
-      TORCH_WARN("For Llama routing method, nGroup/topkGroup is ignored, got %d/%d.", nGroup,
+      TORCH_WARN("For Llama routing method, nGroup/topkGroup is ignored, got ", nGroup, "/",
                  topkGroup);
     }
     moe::dev::routing::routingLlama4::Data routingData;
@@ -170,8 +170,9 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
 
     moe::dev::routing::routingRenormalize::run(routingData, stream);
   } else {
-    TORCH_CHECK(false, "Unimplemented routing method %s of enum %d",
-                serializeMoeRoutingMethodType(routingMethodType).c_str(), (int)routingMethodType);
+    TORCH_CHECK(false, "Unimplemented routing method ",
+                serializeMoeRoutingMethodType(routingMethodType), " of enum ",
+                (int)routingMethodType);
   }
 }
 }  // namespace Routing
@@ -202,8 +203,8 @@ tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
         .weightLayout = weightLayout};
     return options;
   } else {
-    TORCH_CHECK(false, "Unimplemented gated act type %s of enum %d",
-                MoE::serializeGatedActType(gatedActType).c_str(), (int)gatedActType);
+    TORCH_CHECK(false, "Unimplemented gated act type ", MoE::serializeGatedActType(gatedActType),
+                " of enum ", (int)gatedActType);
   }
 }
 


### PR DESCRIPTION
## 📌 Description

Fixed arg passing to `TORCH_CHECK` and `TORCH_WARN` macros, as they don't support printf style formatting.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
