### PR TITLE
fix: semaphoress must be at the fixed range in workspace buffer on trtllm_gen attention

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -155,7 +155,7 @@ void trtllm_paged_attention_launcher(
     size_t max_num_qo_heads = 256;  // todo(Yingyi): get from dlfw, in total 8MB
     size_t num_semaphores =
         round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-    // semaphores be at the last 8MB of 128 MB, workspace buffer:  counter | scratch
+    // semaphores be at the last 8MB of 128 MB, workspace buffer:  scratch | counter
     runner_params.multiCtasKvScratchPtr = reinterpret_cast<void*>(workspace_buffer);
     runner_params.multiCtasKvCounterPtr =
         reinterpret_cast<int32_t*>(static_cast<char*>(workspace_buffer) + kMaxWorkspaceBufferSize -
@@ -385,7 +385,7 @@ void trtllm_ragged_attention_launcher(
   size_t max_num_qo_heads = 256;
   size_t num_semaphores =
       round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-  // semaphores be at the last 8MB of 128 MB, workspace buffer: softmax | counter | scratch
+  // semaphores be at the last 8MB of 128 MB, workspace buffer: softmax | scratch | counter
   runner_params.multiCtasKvScratchPtr =
       reinterpret_cast<void*>(static_cast<char*>(workspace_buffer) +
                               sizeof(float2) * num_qo_heads * runner_params.mSumOfSeqLensQ);

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -155,11 +155,10 @@ void trtllm_paged_attention_launcher(
     size_t max_num_qo_heads = 256;  // todo(Yingyi): get from dlfw, in total 8MB
     size_t num_semaphores =
         round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-    // semaphores be at the last 8MB of 128 MB, workspace buffer:  scratch | counter
-    runner_params.multiCtasKvScratchPtr = reinterpret_cast<void*>(workspace_buffer);
-    runner_params.multiCtasKvCounterPtr =
-        reinterpret_cast<int32_t*>(static_cast<char*>(workspace_buffer) + kMaxWorkspaceBufferSize -
-                                   num_semaphores * sizeof(uint32_t));
+    // semaphores be at the first 8MB of 128 MB, workspace buffer: counter | scratch
+    runner_params.multiCtasKvScratchPtr = reinterpret_cast<void*>(
+        static_cast<char*>(workspace_buffer) + num_semaphores * sizeof(uint32_t));
+    runner_params.multiCtasKvCounterPtr = reinterpret_cast<int32_t*>(workspace_buffer);
   }
 
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
@@ -385,14 +384,13 @@ void trtllm_ragged_attention_launcher(
   size_t max_num_qo_heads = 256;
   size_t num_semaphores =
       round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-  // semaphores be at the last 8MB of 128 MB, workspace buffer: softmax | scratch | counter
-  runner_params.multiCtasKvScratchPtr =
-      reinterpret_cast<void*>(static_cast<char*>(workspace_buffer) +
-                              sizeof(float2) * num_qo_heads * runner_params.mSumOfSeqLensQ);
-  runner_params.multiCtasKvCounterPtr =
-      reinterpret_cast<int32_t*>(static_cast<char*>(workspace_buffer) + kMaxWorkspaceBufferSize -
-                                 num_semaphores * sizeof(uint32_t));
-  runner_params.softmaxStatsPtr = reinterpret_cast<float2*>(workspace_buffer);
+  // semaphores be at the first 8MB of 128 MB, workspace buffer: counter | softmax | scratch
+  runner_params.multiCtasKvCounterPtr = reinterpret_cast<int32_t*>(workspace_buffer);
+  runner_params.softmaxStatsPtr = reinterpret_cast<float2*>(static_cast<char*>(workspace_buffer) +
+                                                            num_semaphores * sizeof(uint32_t));
+  runner_params.multiCtasKvScratchPtr = reinterpret_cast<void*>(
+      static_cast<char*>(workspace_buffer) + num_semaphores * sizeof(uint32_t) +
+      sizeof(float2) * num_qo_heads * runner_params.mSumOfSeqLensQ);
 
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
   if (!foundKernels) {

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -39,8 +39,8 @@ enum class TllmPagedAttentionMode {
 // 128MB: max workspace buffer size for trtllm-gen fixed at python api side
 constexpr size_t kMaxWorkspaceBufferSize = 128 * 1024 * 1024;
 
-// #include <memory>
-// #include <mutex>
+#include <memory>
+#include <mutex>
 
 class TllmGenFmhaRunnerCache {
  public:

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -36,9 +36,6 @@ enum class TllmPagedAttentionMode {
   ForGen,
 };
 
-// 128MB: max workspace buffer size for trtllm-gen fixed at python api side
-constexpr size_t kMaxWorkspaceBufferSize = 128 * 1024 * 1024;
-
 #include <memory>
 #include <mutex>
 
@@ -155,7 +152,7 @@ void trtllm_paged_attention_launcher(
     size_t max_num_qo_heads = 256;  // todo(Yingyi): get from dlfw, in total 8MB
     size_t num_semaphores =
         round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-    // semaphores be at the first 8MB of 128 MB, workspace buffer: counter | scratch
+    // semaphores be at the first 8MB of workspace buffer: counter | scratch
     runner_params.multiCtasKvScratchPtr = reinterpret_cast<void*>(
         static_cast<char*>(workspace_buffer) + num_semaphores * sizeof(uint32_t));
     runner_params.multiCtasKvCounterPtr = reinterpret_cast<int32_t*>(workspace_buffer);
@@ -384,7 +381,7 @@ void trtllm_ragged_attention_launcher(
   size_t max_num_qo_heads = 256;
   size_t num_semaphores =
       round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-  // semaphores be at the first 8MB of 128 MB, workspace buffer: counter | softmax | scratch
+  // semaphores be at the first 8MB of workspace buffer: counter | softmax | scratch
   runner_params.multiCtasKvCounterPtr = reinterpret_cast<int32_t*>(workspace_buffer);
   runner_params.softmaxStatsPtr = reinterpret_cast<float2*>(static_cast<char*>(workspace_buffer) +
                                                             num_semaphores * sizeof(uint32_t));


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

**workspace_buffer arrangement**
- on main branch
paged_attention: counter (fixed 8MB at head) | scratch
ragged_attention: softmax | counter (8MB, but not at the fixed address range) | scratch

- on PR branch:
counter (fixed 8MB at head) | softmax | scratch

The range of semaphores must be fixed across multiple execution, since we are not clearing the buffer by zeros explicitly any more. 

related PR: https://github.com/flashinfer-ai/flashinfer/pull/1463

And https://github.com/flashinfer-ai/flashinfer/pull/1566 (WIP) depends on this.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
