### PR TITLE
bugfix: Fix test_fp4_quantize test bug

### DIFF
--- a/tests/test_fp4_quantize.py
+++ b/tests/test_fp4_quantize.py
@@ -2,7 +2,7 @@ import functools
 
 import pytest
 import torch
-from utils_fp4 import cast_from_fp4, recover_swizzled_scales, ref_fp4_quant
+from utils_fp4 import cast_from_fp4, ref_fp4_quant
 
 from flashinfer import (
     block_scale_interleave,
@@ -123,11 +123,8 @@ def test_fp4_quantization(
     else:
         out_scale = out_scale.view(torch.float8_e4m3fn).to(torch.float32)
     if is_swizzled:
-        scale_ans = recover_swizzled_scales(
-            out_scale.reshape(-1, n // sf_vec_size),
-            m,
-            n,
-            sf_vec_size,
+        scale_ans = unswizzle_sf(
+            out_scale.reshape(-1, n // sf_vec_size), m, n, sf_vec_size
         )
     else:
         scale_ans = out_scale

--- a/tests/test_fp4_quantize.py
+++ b/tests/test_fp4_quantize.py
@@ -102,7 +102,7 @@ def test_fp4_quantization(
     is_swizzled: bool,
 ) -> None:
     if not is_sm100a_supported(torch.device(device)):
-        pytest.skip("Nvfp4 Requires compute capability of 10 or above")
+        pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
     torch.set_default_device(device)
     torch.manual_seed(seed)
     m, n = shape
@@ -148,7 +148,7 @@ def test_scale_swizzling(
     device: str,
 ) -> None:
     if not is_sm100a_supported(torch.device("cuda")):
-        pytest.skip("Nvfp4 Requires compute capability of 10 or above")
+        pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
     torch.set_default_device(device)
     torch.manual_seed(seed)
     m, n = shape
@@ -184,7 +184,7 @@ def test_block_scale_interleave(
 ) -> None:
     """Test the block_scale_interleave function directly."""
     if not is_sm100a_supported(torch.device("cuda")):
-        pytest.skip("Nvfp4 Requires compute capability of 10 or above")
+        pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
     torch.set_default_device(device)
     torch.manual_seed(seed)
 
@@ -233,7 +233,7 @@ def test_e2m1_dequantization(
 ) -> None:
     """Test roundtrip: fp4_quantize -> e2m1_and_ufp8sf_scale_to_float."""
     if not is_sm100a_supported(torch.device("cuda")):
-        pytest.skip("Nvfp4 Requires compute capability of 10 or above")
+        pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
     torch.set_default_device(device)
     torch.manual_seed(seed)
 
@@ -298,7 +298,7 @@ def test_e2m1_dequantization(
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 def test_mxfp4_quantize_roundtrip(device: str):
     if not is_sm100a_supported(torch.device(device)):
-        pytest.skip("Nvfp4 Requires compute capability of 10 or above")
+        pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
     x = torch.randn((128, 64), device="cuda", dtype=torch.bfloat16) / 10
 
     quant_a, sfs = mxfp4_quantize(x)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`test_fp4_quantize` currently has failures on SM100. This PR fixes those failures by using a different unswizzling helper function. Separately, I'd like to understand why there are multiple unswizzling helpers, but to simplify things, I'm not refactoring in this PR.

I also changed the skip reasons in this test file to explicitly say that there's a min CUDA version for NVFP4, because that was an issue I had in my environment that wasn't immediately obvious from the current skip reason.

## 🔍 Related Issues

None that I know of.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ✅ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ✅ ] I have installed the hooks with `pre-commit install`.
- [ ✅ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

I've tested with:

```
pytest -q 'tests/test_fp4_quantize.py'
```

Before (in internal CI): 
```
=========================== short test summary info ============================
FAILED tests/test_fp4_quantize.py::test_fp4_quantization[True-True-cuda:0-42-shape0-dtype0] - RuntimeError: shape '[1, 2, 1, 32, 4, 4]' is invalid for input of size 512
FAILED tests/test_fp4_quantize.py::test_fp4_quantization[True-True-cuda:0-42-shape0-dtype1] - RuntimeError: shape '[1, 2, 1, 32, 4, 4]' is invalid for input of size 512
FAILED tests/test_fp4_quantize.py::test_fp4_quantization[True-True-cuda:0-42-shape2-dtype0] - RuntimeError: shape '[1, 2, 1, 32, 4, 4]' is invalid for input of size 512
FAILED tests/test_fp4_quantize.py::test_fp4_quantization[True-True-cuda:0-42-shape2-dtype1] - RuntimeError: shape '[1, 2, 1, 32, 4, 4]' is invalid for input of size 512
========================= 4 failed, 49 passed in 6.83s =========================
```

After (local testing):

```
.....................................................                                                                           [100%]
53 passed in 0.77s
```

- [ ✅ ] Tests have been added or updated as needed.
- [ ✅ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
