### PR TITLE
fix: limit the number of nvcc threads for each kernel

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -167,7 +167,7 @@ def gen_jit_spec(
     cuda_cflags = [
         "-O3",
         "-std=c++17",
-        "--threads=4",
+        f"--threads={os.environ.get('FLASHINFER_NVCC_THREADS', '1')}",
         "-use_fast_math",
         "-DFLASHINFER_ENABLE_F16",
         "-DFLASHINFER_ENABLE_BF16",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

https://github.com/flashinfer-ai/flashinfer/commit/28741b776e6606de80f0e647c68829d12be37e22#diff-40560dd793d7f5c65e589c2ce598d1aba2cc91ff4832806968ec531427a320e2 changes the default behavior of jit compilation which will uses 32 threads per kernel in nvcc.

It's not necessary because we already parallel compile different cuda files (especiall in aot compilation) with different process (in ninja) and it will lead to out-of-memory issue for machines with limited CPU memory (e.g. our CI node with 150GB CPU memory would fail).

This PR reverts the change.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
