### PR TITLE
bugfix: fix multi-gpu/node unit-test: skip when there aren't enough GPUs instead of failing

### DIFF
--- a/tests/test_create_ipc_buffer.py
+++ b/tests/test_create_ipc_buffer.py
@@ -67,6 +67,11 @@ def _run_ipc_test():
 # -------------------------------
 @pytest.mark.parametrize("world_size", [2, 4])
 def test_ipc_distributed(world_size):
+    available_gpus = torch.cuda.device_count()
+    if world_size > available_gpus:
+        pytest.skip(
+            f"world_size {world_size} is greater than available_gpus {available_gpus}"
+        )
     # Spawn self with torchrun
     script = os.path.abspath(__file__)
     result = subprocess.run(

--- a/tests/test_nvshmem_allreduce.py
+++ b/tests/test_nvshmem_allreduce.py
@@ -100,7 +100,7 @@ def multi_process_parallel(
 def test_nvshmem_allreduce(world_size):
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
-        raise ValueError(
+        pytest.skip(
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     print(f"Running test for world_size={world_size}")
@@ -109,4 +109,4 @@ def test_nvshmem_allreduce(world_size):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"NVSHMEM allreduce tp = {world_size}: OK")
+    print(f"NVSHMEM allreduce tp

--- a/tests/test_nvshmem_allreduce.py
+++ b/tests/test_nvshmem_allreduce.py
@@ -109,4 +109,4 @@ def test_nvshmem_allreduce(world_size):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"NVSHMEM allreduce tp
+    print(f"NVSHMEM allreduce tp = {world_size}: OK")

--- a/tests/test_trtllm_allreduce.py
+++ b/tests/test_trtllm_allreduce.py
@@ -278,7 +278,7 @@ def test_trtllm_custom_allreduce(world_size, dtype):
     torch.manual_seed(RANDOM_SEED)
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
-        raise ValueError(
+        pytest.skip(
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     print(f"Running test for world_size={world_size}")
@@ -289,4 +289,4 @@ def test_trtllm_custom_allreduce(world_size, dtype):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"custom allreduce tp = {world_size}: OK")
+    print(f"custom allreduce tp

--- a/tests/test_trtllm_allreduce.py
+++ b/tests/test_trtllm_allreduce.py
@@ -289,4 +289,4 @@ def test_trtllm_custom_allreduce(world_size, dtype):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"custom allreduce tp
+    print(f"custom allreduce tp = {world_size}: OK")

--- a/tests/test_trtllm_allreduce_fusion.py
+++ b/tests/test_trtllm_allreduce_fusion.py
@@ -358,7 +358,7 @@ def test_trtllm_allreduce_fusion(world_size, dtype, hidden_dim):
     torch.cuda.manual_seed_all(42)
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
-        raise ValueError(
+        pytest.skip(
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     print(f"Running test for world_size={world_size}")
@@ -370,4 +370,4 @@ def test_trtllm_allreduce_fusion(world_size, dtype, hidden_dim):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"allreduce fusion tp = {world_size}: OK")
+    print(f"allreduce fusion tp

--- a/tests/test_trtllm_allreduce_fusion.py
+++ b/tests/test_trtllm_allreduce_fusion.py
@@ -370,4 +370,4 @@ def test_trtllm_allreduce_fusion(world_size, dtype, hidden_dim):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"allreduce fusion tp
+    print(f"allreduce fusion tp = {world_size}: OK")

--- a/tests/test_trtllm_moe_allreduce_fusion.py
+++ b/tests/test_trtllm_moe_allreduce_fusion.py
@@ -468,4 +468,4 @@ def test_trtllm_moe_allreduce_fusion(world_size, dtype):
 
 
 if __name__ == "__main__":
-    test_trtllm_moe_allreduce_fus
+    test_trtllm_moe_allreduce_fusion(2, torch.float16)

--- a/tests/test_trtllm_moe_allreduce_fusion.py
+++ b/tests/test_trtllm_moe_allreduce_fusion.py
@@ -453,7 +453,7 @@ def test_trtllm_moe_allreduce_fusion(world_size, dtype):
     torch.cuda.manual_seed_all(42)
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
-        raise ValueError(
+        pytest.skip(
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     print(f"Running test for world_size={world_size}")
@@ -468,4 +468,4 @@ def test_trtllm_moe_allreduce_fusion(world_size, dtype):
 
 
 if __name__ == "__main__":
-    test_trtllm_moe_allreduce_fusion(2, torch.float16)
+    test_trtllm_moe_allreduce_fus

--- a/tests/test_trtllm_moe_allreduce_fusion_finalize.py
+++ b/tests/test_trtllm_moe_allreduce_fusion_finalize.py
@@ -309,4 +309,4 @@ def test_trtllm_moe_finalize_allreduce_fusion(world_size, dtype):
             residual,
         ),
     )
-    print(f"moe finalize allreduce fusion tp
+    print(f"moe finalize allreduce fusion tp = {world_size}: OK")

--- a/tests/test_trtllm_moe_allreduce_fusion_finalize.py
+++ b/tests/test_trtllm_moe_allreduce_fusion_finalize.py
@@ -279,7 +279,7 @@ def test_trtllm_moe_finalize_allreduce_fusion(world_size, dtype):
     torch.cuda.manual_seed_all(42)
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
-        raise ValueError(
+        pytest.skip(
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     print(f"Running test for world_size={world_size}")
@@ -309,4 +309,4 @@ def test_trtllm_moe_finalize_allreduce_fusion(world_size, dtype):
             residual,
         ),
     )
-    print(f"moe finalize allreduce fusion tp = {world_size}: OK")
+    print(f"moe finalize allreduce fusion tp

--- a/tests/test_vllm_custom_allreduce.py
+++ b/tests/test_vllm_custom_allreduce.py
@@ -128,7 +128,7 @@ def multi_process_parallel(
 def test_vllm_custom_allreduce(world_size):
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
-        raise ValueError(
+        pytest.skip(
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     print(f"Running test for world_size={world_size}")
@@ -137,4 +137,4 @@ def test_vllm_custom_allreduce(world_size):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"custom allreduce tp = {world_size}: OK")
+    print(f"custom allreduce tp

--- a/tests/test_vllm_custom_allreduce.py
+++ b/tests/test_vllm_custom_allreduce.py
@@ -137,4 +137,4 @@ def test_vllm_custom_allreduce(world_size):
         _run_correctness_worker,
         target_args=(),
     )
-    print(f"custom allreduce tp
+    print(f"custom allreduce tp = {world_size}: OK")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Tests should return "skipped" when current environment is not supported instead of returning a failure.

Current PR replaces raise errors to pytest.skip in test scripts

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
