### PR TITLE
ci: limit aot parallel build jobs based on available memory

### DIFF
--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -9,8 +9,7 @@ NPROC=$(nproc)
 MAX_JOBS=$(( MEM_AVAILABLE_GB / 4 ))
 if (( MAX_JOBS < 1 )); then
   MAX_JOBS=1
-fi
-if (( NPROC < MAX_JOBS )); then
+elif (( NPROC < MAX_JOBS )); then
   MAX_JOBS=$NPROC
 fi
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Prior to this PR, MAX_JOBS defaulted to nproc, which could cause OOM errors on systems with many cores but limited memory. In the PR, we limit the jobs based on the available memory size. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
