### PR TITLE
hotfix: change MAX_JOBS in aot ci

### DIFF
--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -3,22 +3,29 @@
 set -eo pipefail
 set -x
 
-# Set MAX_JOBS based on architecture
+# Set MAX_JOBS based on architecture and available memory
 ARCH=$(uname -m)
-if [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" ]]; then
-  MAX_JOBS=64
-elif [[ "$ARCH" == "aarch64" ]]; then
-  MAX_JOBS=32
-else
-  # Fallback to dynamic calculation for other architectures
-  MEM_AVAILABLE_GB=$(free -g | awk '/^Mem:/ {print $7}')
-  NPROC=$(nproc)
-  MAX_JOBS=$(( MEM_AVAILABLE_GB / 4 ))
+MEM_AVAILABLE_GB=$(free -g | awk '/^Mem:/ {print $7}')
+NPROC=$(nproc)
+
+# Calculate base MAX_JOBS based on memory (4GB per job)
+BASE_MAX_JOBS=$(( MEM_AVAILABLE_GB / 4 ))
+if (( BASE_MAX_JOBS < 1 )); then
+  BASE_MAX_JOBS=1
+elif (( NPROC < BASE_MAX_JOBS )); then
+  BASE_MAX_JOBS=$NPROC
+fi
+
+# Apply architecture-specific scaling
+if [[ "$ARCH" == "aarch64" ]]; then
+  # Use half the jobs on aarch64 compared to x86_64
+  MAX_JOBS=$(( BASE_MAX_JOBS / 2 ))
   if (( MAX_JOBS < 1 )); then
     MAX_JOBS=1
-  elif (( NPROC < MAX_JOBS )); then
-    MAX_JOBS=$NPROC
   fi
+else
+  # x86_64, amd64, and other architectures use full capacity
+  MAX_JOBS=$BASE_MAX_JOBS
 fi
 
 : ${CUDA_VISIBLE_DEVICES:=""}


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

aarch64 instance tend to use more memory than x86_64, hardcode MAX_JOBS to half of x86_64's

## 🔍 Related Issues

#1612 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
