### PR TITLE
fix: export MAX_JOBS for AOT build

### DIFF
--- a/scripts/task_test_aot_build_import.sh
+++ b/scripts/task_test_aot_build_import.sh
@@ -28,6 +28,9 @@ else
   MAX_JOBS=$BASE_MAX_JOBS
 fi
 
+# Export MAX_JOBS for PyTorch's cpp_extension to use
+export MAX_JOBS
+
 : ${CUDA_VISIBLE_DEVICES:=""}
 export TORCH_CUDA_ARCH_LIST=$(python3 -c '
 import torch


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Previously, MAX_JOBS was calculated but not exported, causing the build system to use all available CPU cores for parallel compilation.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
