### PR TITLE
bugfix: fix multi-gpu/node unit-test: skip when there aren't enough GPUs in test_trtllm_mnnvl_allreduce

### DIFF
--- a/tests/test_trtllm_mnnvl_allreduce.py
+++ b/tests/test_trtllm_mnnvl_allreduce.py
@@ -1,5 +1,4 @@
 # Check torch version:
-import sys
 from typing import Tuple
 
 import pytest
@@ -179,9 +178,7 @@ def test_mnnvl_allreduce_full(
 
     # Ensure we have exactly 2 ranks for this test
     if world_size < 2:
-        if rank == 0:
-            print(f"ERROR: This test requires at least 2 MPI ranks, got {world_size}")
-        sys.exit(1)
+        pytest.skip(f"This test requires at least 2 MPI ranks, got {world_size}")
 
     mapping = Mapping(
         world_size=world_size,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

Similar to PR1600, `test_trtllm_mnnvl_allreduce.py` should skip if MPI rank is too small instead of failing the unit test.

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
