### PR TITLE
chore: Switch `pynvml` to `nvidia-ml-py`

### DIFF
--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -23,6 +23,6 @@ set -u
 CUDA_VERSION=${1:-cu128}
 
 pip3 install torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
-pip3 install requests ninja pytest numpy scipy build pynvml cuda-python einops nvidia-nvshmem-cu12
+pip3 install requests ninja pytest numpy scipy build nvidia-ml-py cuda-python einops nvidia-nvshmem-cu12
 pip3 install nvidia-cutlass-dsl
 pip3 install 'nvidia-cudnn-frontend>=1.13.0' 'nvidia-cudnn-cu12>=9.11.0.98'

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ install_requires = [
     "torch",
     "ninja",
     "requests",
-    "pynvml",
+    "nvidia-ml-py",
     "einops",
     "click",
     "tqdm",


### PR DESCRIPTION
The following warning info can be hidden by switching the package `pynvml` to `nvidia-ml-py`.
```
.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: 
FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. 
If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
```

The Usage remains the same.
Ref: https://pypi.org/project/pynvml/ and https://pypi.org/project/nvidia-ml-py/

Relevant reproducible detail:
```
$ uv pip list | grep -E "(torch|flashinfer)"
flashinfer-python                 0.3.1
torch                             2.7.1
torchaudio                        2.7.1
torchvision                       0.22.1
```
