### PR TITLE
fix: add _check_tensor_params to check correct sampling parameters and dtype validation in decode.py

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -834,12 +834,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
         Parameters
         ----------
         indptr : torch.Tensor
-            The indptr of the paged kv cache, shape: ``[batch_size + 1]``
+            The indptr of the paged kv cache, shape: ``[batch_size + 1]``, dtype: ``torch.int32``
         indices : torch.Tensor
-            The page indices of the paged kv cache, shape: ``[kv_indptr[-1]]``
+            The page indices of the paged kv cache, shape: ``[kv_indptr[-1]]``, dtype: ``torch.int32``
         last_page_len : torch.Tensor
             The number of entries in the last page of each request in the paged kv
-            cache, shape: ``[batch_size]``
+            cache, shape: ``[batch_size]``, dtype: ``torch.int32``
         num_qo_heads : int
             The number of query/output heads
         num_kv_heads : int
@@ -895,6 +895,16 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
+        for tensor, name in [
+            (indptr, "indptr"),
+            (indices, "indices"),
+            (last_page_len, "last_page_len"),
+        ]:
+            if tensor.dtype != torch.int32:
+                raise ValueError(
+                    f"{name} must have dtype torch.int32, got {tensor.dtype}"
+                )
+
         self._workspace_size = (
             self._float_workspace_buffer.numel()
             * self._float_workspace_buffer.element_size()
@@ -1609,12 +1619,12 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         Parameters
         ----------
         indptr : torch.Tensor
-            The indptr of the paged kv cache, shape: ``[batch_size + 1]``
+            The indptr of the paged kv cache, shape: ``[batch_size + 1]``, dtype: ``torch.int32``
         indices : torch.Tensor
-            The page indices of the paged kv cache, shape: ``[qo_indptr[-1]]``
+            The page indices of the paged kv cache, shape: ``[qo_indptr[-1]]``, dtype: ``torch.int32``
         last_page_len : torch.Tensor
             The number of entries in the last page of each request in the paged kv
-            cache, shape: ``[batch_size]``
+            cache, shape: ``[batch_size]``, dtype: ``torch.int32``
         num_qo_heads : int
             The number of query/output heads
         head_dim_compressed_kv : int
@@ -1644,6 +1654,16 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         :meth:`run_return_lse` calls, auxiliary data structures will be created
         during this call and cached for multiple run calls.
         """
+        for tensor, name in [
+            (indptr, "indptr"),
+            (indices, "indices"),
+            (last_page_len, "last_page_len"),
+        ]:
+            if tensor.dtype != torch.int32:
+                raise ValueError(
+                    f"{name} must have dtype torch.int32, got {tensor.dtype}"
+                )
+
         batch_size = len(last_page_len)
         if logits_soft_cap is None:
             logits_soft_cap = 0.0

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -468,7 +468,7 @@ def _check_tensor_param(param: Any, tensor: torch.Tensor) -> None:
     if isinstance(param, torch.Tensor):
         if param.dim() == 0:
             raise ValueError(
-                f"Expected a 1D tensor or scalar for the sampling parameter, "
+                f"Expected a 1D tensor of shape (batch_size,) or scalar for the sampling parameter, "
                 f"but got a 0-dimensional tensor with shape {param.shape}. "
             )
         elif param.dim() > 1:
@@ -686,8 +686,8 @@ def top_p_sampling_from_probs(
         shape should be ``(unique_batch_size, num_classes)`` where unique_batch_size is the number of unique
         probability distributions.
     top_p: Union[torch.Tensor, float]
-        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
-        If a scalar, the same threshold is used for all requests.
+        Either a float or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
+        If a float, the same threshold is used for all requests.
         If a tensor, each request has its own threshold.
     indices: Optional[torch.Tensor]
         Optional indices tensor of shape ``(batch_size,)`` that maps each output to a row in probs.

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1252,11 +1252,6 @@ def top_k_renorm_probs(
     top_k_sampling_from_probs
     sampling_from_probs
     top_p_renorm_probs
-
-    Raises
-    ------
-    ValueError
-        If top_k is not a positive integer or a 1D tensor of shape (batch_size,).
     """
     _check_tensor_param(top_k, probs)
     return get_sampling_module().top_k_renorm_probs(

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -557,18 +557,19 @@ def test_chain_speculative_sampling(
         assert torch.all(emitted_num + 1 == (output_token_ids != -1).sum(dim=1))
 
 
-def test_check_tensor_param():
-    torch.manual_seed(42)
+@pytest.mark.parametrize("batch_size", [1, 2, 32])
+@pytest.mark.parametrize("vocab_size", [4, 16, 128])
+@pytest.mark.parametrize("K", [1, 3, 10])
+def test_check_tensor_param(batch_size, vocab_size, K):
+    if vocab_size < K:
+        pytest.skip("K should be less than or equal to vocab_size")
 
-    K = 3
-    batch_size, vocab_size = 2, 4
     pre_norm_prob = torch.rand(batch_size, vocab_size, device="cuda:0")
     prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
 
     # Test case 1: Scalar K should work fine
     result1 = flashinfer.sampling.top_k_renorm_probs(prob, K)
     assert result1.shape == prob.shape
-
     # Test case 2: 2D tensor should raise error
     with pytest.raises(ValueError, match="Expected a 1D tensor or scalar.*2D tensor"):
         flashinfer.sampling.top_k_renorm_probs(
@@ -577,7 +578,6 @@ def test_check_tensor_param():
                 [[K] * vocab_size] * batch_size, dtype=torch.int, device="cuda:0"
             ),
         )
-
     # Test case 3: 0-dimensional tensor should raise error
     with pytest.raises(
         ValueError, match="Expected a 1D tensor or scalar.*0-dimensional tensor"
@@ -585,18 +585,17 @@ def test_check_tensor_param():
         flashinfer.sampling.top_k_renorm_probs(
             prob, torch.tensor(K, dtype=torch.int, device="cuda:0")
         )
-
     # Test case 4: 1D tensor with wrong batch size should raise error
+    wrong_batch_size = batch_size + 1  # Always different from actual batch size
     with pytest.raises(
         ValueError, match="Sampling parameter tensor batch size mismatch"
     ):
         flashinfer.sampling.top_k_renorm_probs(
-            prob, torch.tensor([K], dtype=torch.int, device="cuda:0")
+            prob, torch.tensor([K] * wrong_batch_size, dtype=torch.int, device="cuda:0")
         )
-
     # Test case 5: 1D tensor with correct batch size should work
     result5 = flashinfer.sampling.top_k_renorm_probs(
-        prob, torch.tensor([K, K], dtype=torch.int, device="cuda:0")
+        prob, torch.tensor([K] * batch_size, dtype=torch.int, device="cuda:0")
     )
     assert result5.shape == prob.shape
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

This adds the `_check_tensor_params` function in `sampling.py` that is used in the different sampling functions to check that the parameters make sense for this function (see related issues). This also adds some `dtype` validation checks in `decode.py` to make sure we don't silently produce wrong results when passing in the wrong `dtype`. 

I tried to make just one small function that would cover the cases. But please let me know if there is a case I missed. Looking forward to the feedback. 

## 🔍 Related Issues

This was originally from this issue https://github.com/flashinfer-ai/flashinfer/issues/1634 that showed that we can pass relatively bogus inputs to sampling function and get wrong output. Now, when running his code, only the first case passes, which seems correct to me. The second case is passing a 2D tensor (2, 4) when the docs should indicate it should be (2,) (which passes). If it should be the other way around, let me know. The output is the same as well. 

For `dtype` validation, this was originally from https://github.com/flashinfer-ai/flashinfer/issues/1654. I add a check that is very similar to the ones I saw in `mla.py`.

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added unit tests `test_check_tensor_params_top_k`, `test_check_tensor_params_top_p`, `test_check_tensor_params_min_p` that cover different functions and three different cases. Tested the `dtype` validation changes locally.

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
