### PR TITLE
Speedup MLARopeQuantize by 20-40%

### DIFF
--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -370,7 +370,7 @@ __global__ void MLARopeQuantizeKernel(
     // 2. if not interleave
     //  - cos = cos_cache[pos_id][(tx * vec_size) % (rot_dim // 2)]
     //  - sin = sin_cache[pos_id][(rot_dim // 2) + (tx * vec_size) % (rot_dim // 2)]
-    if (tx * vec_size < rotary_dim) {
+    if ((tx * vec_size < rotary_dim) and (by <= num_heads)) {
       int sin_offset = rotary_dim / 2;
       int vec_idx;
       if constexpr (interleave) {
@@ -716,7 +716,7 @@ cudaError_t MLARopeQuantize(DType* q_rope_in, DType* k_rope_in, DType* q_nope_in
 
   DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
     constexpr uint32_t rotary_dim = 64;
-    constexpr uint32_t vec_size = 16 / sizeof(DType);
+    constexpr uint32_t vec_size = 32 / sizeof(DType);
     constexpr uint32_t bdx = rotary_dim / vec_size;
     uint32_t num_threads = 128U;
     uint32_t bdy = num_threads / bdx;


### PR DESCRIPTION
This reverts commit 50f0bbfe6f411968a64e7f8ba7be1e9f909e594f.

<!-- .github/pull_request_template.md -->

## 📌 Description

baseline

```
    num_tokens  FlashInfer
0          1.0    0.002714
1          2.0    0.003126
2          4.0    0.003328
3          8.0    0.003328
4         16.0    0.003530
5         32.0    0.004144
6         64.0    0.005430
7        128.0    0.007837
8        256.0    0.012947
9        384.0    0.018074
10       512.0    0.024624
11       768.0    0.036298
```

pr

```
    num_tokens  FlashInfer
0          1.0    0.002509
1          2.0    0.002918
2          4.0    0.003046
3          8.0    0.003114
4         16.0    0.003120
5         32.0    0.003530
6         64.0    0.004352
7        128.0    0.005782
8        256.0    0.008813
9        384.0    0.013098
10       512.0    0.020736
11       768.0    0.030461
```

I am mostly interested in 768tok and 384tok.
It is still not yet SOL, but I may not have time recently to further optimize yet.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
