### PR TITLE
perf: skip kv-tile computation out of sliding window in FA2

### DIFF
--- a/benchmarks/bench_sliding_window.py
+++ b/benchmarks/bench_sliding_window.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+import itertools
+from dataclasses import dataclass
+
+import torch
+from triton.testing import do_bench
+
+# Optional: pin to a device via env CUDA_VISIBLE_DEVICES
+DEVICE = torch.device("cuda:0")
+
+import flashinfer
+
+
+@dataclass
+class Case:
+    batch_size: int
+    kv_len: int
+    qo_len: int
+    window_left: int
+    num_kv_heads: int
+    num_qo_heads: int
+    head_dim: int
+    page_size: int
+
+
+# Same grids as your pytest params
+BATCH_SIZES = [16]
+KV_LENS = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+QO_LENS = [1, 16]
+WINDOW_LEFTS = [128]
+NUM_KV_HEADS = [8]
+NUM_QO_HEADS = [32]
+HEAD_DIMS = [64]
+PAGE_SIZES = [16]
+
+DTYPE = torch.float16
+INDEX_DTYPE = torch.int32
+
+
+# --- FLOPs & bytes estimation helpers ----------------------------------------
+def total_attn_pairs(kv_len: int, qo_len: int, window_left: int) -> int:
+    total = 0
+    for i in range(1, qo_len + 1):
+        total += min(kv_len - i + 1, window_left)
+    return total
+
+
+def estimate_flops(
+    batch: int,
+    num_qo_heads: int,
+    head_dim: int,
+    kv_len: int,
+    qo_len: int,
+    window_left: int,
+) -> float:
+    """
+    Matmul-only FLOPs (ignoring softmax) ~ QK^T + softmax@V ≈ 4 * head_dim * total_pairs
+    """
+    pairs = total_attn_pairs(kv_len, qo_len, window_left)
+    return 4.0 * head_dim * pairs * batch * num_qo_heads
+
+
+def estimate_min_io_bytes(
+    batch: int,
+    num_kv_heads: int,
+    num_qo_heads: int,
+    head_dim: int,
+    kv_len: int,
+    qo_len: int,
+    window_left: int,
+    dtype_size: int = 2,
+) -> int:
+    """
+    A *rough* lower-bound I/O estimate (no re-reads, no intermediate buffers):
+      - Read Q: B * qo * Hq * D
+      - Read unique K, V from KV cache: B * min(kv_len, window_left) * Hk * D each
+      - Write O: B * qo * Hq * D
+    NOTE: Real kernels may read more/less due to paging, softmax stats, and reuse.
+    """
+    uniq_kv = min(kv_len, window_left)
+    q_bytes = batch * qo_len * num_qo_heads * head_dim * dtype_size
+    k_bytes = batch * uniq_kv * num_kv_heads * head_dim * dtype_size
+    v_bytes = batch * uniq_kv * num_kv_heads * head_dim * dtype_size
+    o_bytes = batch * qo_len * num_qo_heads * head_dim * dtype_size
+    return q_bytes + k_bytes + v_bytes + o_bytes
+
+
+# --- Benchmark runner ---------------------------------------------------------
+def run_one(case: Case, warmup=25, rep=100):
+    torch.cuda.synchronize()
+    # Inputs (mirror your test)
+    q = torch.randn(
+        case.batch_size * case.qo_len,
+        case.num_qo_heads,
+        case.head_dim,
+        dtype=DTYPE,
+        device=DEVICE,
+    )
+    q_indptr = (
+        torch.arange(0, case.batch_size + 1, device=DEVICE, dtype=INDEX_DTYPE)
+        * case.qo_len
+    )
+
+    num_pages_per_seq = (case.kv_len + case.page_size - 1) // case.page_size
+    total_num_pages = num_pages_per_seq * case.batch_size
+
+    k_data = torch.randn(
+        total_num_pages,
+        case.page_size,
+        case.num_kv_heads,
+        case.head_dim,
+        dtype=DTYPE,
+        device=DEVICE,
+    )
+    v_data = torch.randn(
+        total_num_pages,
+        case.page_size,
+        case.num_kv_heads,
+        case.head_dim,
+        dtype=DTYPE,
+        device=DEVICE,
+    )
+
+    kv_indptr = (
+        torch.arange(0, case.batch_size + 1, device=DEVICE, dtype=INDEX_DTYPE)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=DEVICE, dtype=INDEX_DTYPE)
+    kv_last_page_len = torch.full(
+        (case.batch_size,),
+        (case.kv_len - 1) % case.page_size + 1,
+        dtype=INDEX_DTYPE,
+        device=DEVICE,
+    )
+
+    # Workspace & wrapper
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=DEVICE)
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD", backend="fa2"
+    )
+
+    # Plan
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        case.num_qo_heads,
+        case.num_kv_heads,
+        case.head_dim,
+        case.page_size,
+        window_left=case.window_left,
+        causal=False,
+    )
+
+    # Warmup + timing
+    def _run():
+        o = wrapper.run(q, (k_data, v_data))
+        return o
+
+    # Warmup (helps stabilize clocks/caches)
+    for _ in range(warmup):
+        _ = _run()
+    torch.cuda.synchronize()
+
+    ms = do_bench(_run, rep=rep)  # returns milliseconds per run
+    torch.cuda.synchronize()
+
+    # Metrics
+    flops = estimate_flops(
+        case.batch_size,
+        case.num_qo_heads,
+        case.head_dim,
+        case.kv_len,
+        case.qo_len,
+        case.window_left,
+    )
+    bytes_min = estimate_min_io_bytes(
+        case.batch_size,
+        case.num_kv_heads,
+        case.num_qo_heads,
+        case.head_dim,
+        case.kv_len,
+        case.qo_len,
+        case.window_left,
+        dtype_size=2,
+    )
+
+    s = ms / 1e3
+    tflops = (flops / s) / 1e12
+    gbps = (bytes_min / s) / 1e9
+
+    return ms, tflops, gbps
+
+
+def main():
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+
+    configs = [
+        Case(b, kv, qo, w, hk, hq, d, ps)
+        for b, qo, w, hk, hq, d, ps, kv in itertools.product(
+            BATCH_SIZES,
+            QO_LENS,
+            WINDOW_LEFTS,
+            NUM_KV_HEADS,
+            NUM_QO_HEADS,
+            HEAD_DIMS,
+            PAGE_SIZES,
+            KV_LENS,
+        )
+    ]
+
+    # Header
+    print(
+        "batch kv_len qo_len win_left kv_heads qo_heads head_dim page_size | "
+        "latency_ms  est_TFLOPs  est_GB/s(min-IO)"
+    )
+    print("-" * 110)
+
+    for c in configs:
+        try:
+            ms, tflops, gbps = run_one(c)
+            print(
+                f"{c.batch_size:5d} {c.kv_len:6d} {c.qo_len:6d} {c.window_left:8d} "
+                f"{c.num_kv_heads:8d} {c.num_qo_heads:8d} {c.head_dim:8d} {c.page_size:9d} | "
+                f"{ms:10.3f} {tflops:10.3f} {gbps:15.3f}"
+            )
+        except Exception as e:
+            # Keep going if some configs are unsupported by the current build
+            print(
+                f"{c.batch_size:5d} {c.kv_len:6d} {c.qo_len:6d} {c.window_left:8d} "
+                f"{c.num_kv_heads:8d} {c.num_qo_heads:8d} {c.head_dim:8d} {c.page_size:9d} | "
+                f"ERROR: {type(e).__name__}: {e}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -47,7 +47,7 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal) {
+    int64_t head_dim_vo, bool causal, int64_t window_left) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -62,7 +62,8 @@ at::Tensor BatchPrefillWithKVCachePlan(
       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<IdType>(),
       kv_indptr.data_ptr<IdType>(), total_num_rows, batch_size, num_qo_heads, num_kv_heads,
-      head_dim_qk, head_dim_vo, page_size, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream);
+      head_dim_qk, head_dim_vo, page_size, enable_cuda_graph, /*sizeof_dtype_o=*/2, window_left,
+      stream);
 
   TORCH_CHECK(status == cudaSuccess,
               "Failed to plan prefill with error: ", cudaGetErrorString(status));

--- a/csrc/batch_prefill_fp8_sm90.cu
+++ b/csrc/batch_prefill_fp8_sm90.cu
@@ -40,7 +40,7 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal) {
+    int64_t head_dim_vo, bool causal, int64_t window_left) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =

--- a/csrc/batch_prefill_jit_pybind.cu
+++ b/csrc/batch_prefill_jit_pybind.cu
@@ -21,7 +21,7 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal);
+    int64_t head_dim_vo, bool causal, int64_t window_left);
 
 void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -45,7 +45,7 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal) {
+    int64_t head_dim_vo, bool causal, int64_t window_left) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =

--- a/csrc/batch_prefill_sm90_jit_pybind.cu
+++ b/csrc/batch_prefill_sm90_jit_pybind.cu
@@ -21,7 +21,7 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal);
+    int64_t head_dim_vo, bool causal, int64_t window_left);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1031,6 +1031,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 head_dim,
                 head_dim,
                 False,  # causal
+                window_left,
             )
         else:
             if self._jit_module is not None:

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1873,6 +1873,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 head_dim_qk,
                 head_dim_vo,
                 causal,
+                window_left,
             )
 
         self._causal = causal
@@ -2716,6 +2717,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 head_dim_qk,
                 head_dim_vo,
                 causal,
+                window_left,
             )
 
         self._causal = causal

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1379,24 +1379,27 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
     const uint32_t k_stride_h = params.k_stride_h;
     const uint32_t v_stride_n = params.v_stride_n;
     const uint32_t v_stride_h = params.v_stride_h;
-    const int32_t maybe_window_left = params.window_left;
     const uint_fastdiv& group_size = params.group_size;
 
     static_assert(sizeof(DTypeQ) == 2);
     const uint32_t lane_idx = tid.x, warp_idx = get_warp_idx<KTraits>(tid.y, tid.z);
     const uint32_t num_qo_heads = num_kv_heads * group_size;
 
-    const uint32_t max_chunk_size = partition_kv ? ceil_div(kv_len, num_chunks) : kv_len;
-    const uint32_t chunk_start = partition_kv ? chunk_idx * max_chunk_size : 0;
+    auto smem = reinterpret_cast<uint8_t*>(&smem_storage);
+    AttentionVariant variant(params, /*batch_idx=*/0, smem);
+
+    const uint32_t window_left = variant.window_left;
+    const uint32_t kv_start_idx =
+        sub_if_greater_or_zero(kv_len + (bx * CTA_TILE_Q) / group_size, qo_len + window_left);
+    const uint32_t max_chunk_size =
+        partition_kv ? ceil_div(kv_len - kv_start_idx, num_chunks) : kv_len - kv_start_idx;
+    const uint32_t chunk_start =
+        partition_kv ? min(chunk_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
     const uint32_t chunk_end =
-        partition_kv ? min((chunk_idx + 1) * max_chunk_size, kv_len) : kv_len;
+        partition_kv ? min((chunk_idx + 1) * max_chunk_size + kv_start_idx, kv_len) : kv_len;
     const uint32_t chunk_size = chunk_end - chunk_start;
 
     auto block = cg::this_thread_block();
-    auto smem = reinterpret_cast<uint8_t*>(&smem_storage);
-    AttentionVariant variant(params, /*batch_idx=*/0, smem);
-    const uint32_t window_left = variant.window_left;
-
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
     alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
     DTypeQKAccum m[NUM_MMA_Q][2];
@@ -1596,6 +1599,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
   const uint32_t num_kv_heads = params.num_kv_heads;
   const uint32_t qo_len = params.qo_len;
   const uint32_t kv_len = params.kv_len;
+
+  // reducing launch CTAs
+  uint32_t window_left = min((params.window_left >= 0) ? params.window_left : kv_len, kv_len);
+
   if (kv_len < qo_len && MASK_MODE == MaskMode::kCausal) {
     std::ostringstream err_msg;
     err_msg << "When mask_mode is set to MaskMode::kCausal, kv_len must be greater than or equal "
@@ -1673,8 +1680,9 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
                                      (num_kv_heads * ceil_div(qo_len * group_size, CTA_TILE_Q));
         uint32_t num_chunks;
         if (max_num_kv_chunks > 0) {
-          uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
-          num_chunks = ceil_div(kv_len, chunk_size);
+          // Add CTA_TILE_Q to launch enough CTAs to cover the causal mask
+          uint32_t chunk_size = max(ceil_div(window_left + CTA_TILE_Q, max_num_kv_chunks), 256);
+          num_chunks = ceil_div(window_left + CTA_TILE_Q, chunk_size);
         } else {
           num_chunks = 0;
         }
@@ -1768,7 +1776,6 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     const uint32_t k_stride_h = params.k_stride_h;
     const uint32_t v_stride_n = params.v_stride_n;
     const uint32_t v_stride_h = params.v_stride_h;
-    const int32_t maybe_window_left = params.window_left;
     const uint_fastdiv& group_size = params.group_size;
 
     static_assert(sizeof(DTypeQ) == 2);
@@ -1790,13 +1797,18 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     const uint32_t qo_len = variant.qo_len, kv_len = variant.kv_len,
                    window_left = variant.window_left;
     const uint32_t kv_len_safe = kv_len > 0 ? kv_len : 1;
-    const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len;
-    const uint32_t chunk_start = partition_kv ? kv_tile_idx * max_chunk_size : 0;
-    const uint32_t chunk_end =
-        partition_kv ? min((kv_tile_idx + 1) * max_chunk_size, kv_len) : kv_len;
-    const uint32_t chunk_size = chunk_end - chunk_start;
     const uint32_t qo_upper_bound =
         min(qo_len, ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size));
+
+    // skip out-of-window kv tile by add non-zero kv_start_idx offset
+    const uint32_t kv_start_idx = sub_if_greater_or_zero(
+        kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size, qo_len + window_left);
+    const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+    const uint32_t chunk_start =
+        partition_kv ? min(kv_tile_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
+    const uint32_t chunk_end =
+        partition_kv ? min((kv_tile_idx + 1) * max_chunk_size + kv_start_idx, kv_len) : kv_len;
+    const uint32_t chunk_size = chunk_end - chunk_start;
 
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
     alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
@@ -1970,8 +1982,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     // threadblock synchronization
     threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
 
-    const uint32_t num_kv_chunks = (kv_len_safe + kv_chunk_size - 1) / kv_chunk_size;
-
+    const uint32_t num_kv_chunks =
+        ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
     // transform output
     transform_output<KTraits, Params>(params, variant, o_frag, m, d, /*batch_idx=*/request_idx,
                                       kv_tile_idx, qo_packed_idx_base, warp_idx, lane_idx,
@@ -2065,7 +2077,6 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     bool* block_valid_mask = params.block_valid_mask;
     const paged_kv_t<DTypeKV, IdType>& paged_kv = params.paged_kv;
     const bool partition_kv = params.partition_kv;
-    const int32_t maybe_window_left = params.window_left;
     const uint_fastdiv& group_size = params.group_size;
 
     uint32_t* maybe_prefix_len_ptr = nullptr;
@@ -2102,13 +2113,17 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     const uint32_t qo_len = variant.qo_len, kv_len = variant.kv_len,
                    window_left = variant.window_left;
     const uint32_t kv_len_safe = kv_len > 0 ? kv_len : 1;
-    const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len;
-    const uint32_t chunk_start = partition_kv ? kv_tile_idx * max_chunk_size : 0;
-    const uint32_t chunk_end =
-        partition_kv ? min((kv_tile_idx + 1) * max_chunk_size, kv_len) : kv_len;
-    const uint32_t chunk_size = chunk_end - chunk_start;
     const uint32_t qo_upper_bound =
         min(qo_len, ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size));
+
+    const uint32_t kv_start_idx = sub_if_greater_or_zero(
+        kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size, qo_len + window_left);
+    const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+    const uint32_t chunk_start =
+        partition_kv ? min(kv_tile_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
+    const uint32_t chunk_end =
+        partition_kv ? min((kv_tile_idx + 1) * max_chunk_size + kv_start_idx, kv_len) : kv_len;
+    const uint32_t chunk_size = chunk_end - chunk_start;
 
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
     alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
@@ -2353,7 +2368,8 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     // threadblock synchronization
     threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
 
-    const uint32_t num_kv_chunks = (kv_len_safe + kv_chunk_size - 1) / kv_chunk_size;
+    const uint32_t num_kv_chunks =
+        ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
 
     // transform output
     transform_output<KTraits, Params>(params, variant, o_frag, m, d, /*batch_idx=*/request_idx,

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -497,7 +497,7 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
                                    uint32_t total_num_rows, uint32_t batch_size,
                                    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
                                    uint32_t page_size, uint32_t max_batch_size_if_split,
-                                   bool enable_cuda_graph) {
+                                   bool enable_cuda_graph, int32_t window_left) {
   std::vector<IdType> request_indices, qo_tile_indices, kv_tile_indices, merge_indptr, o_indptr;
   merge_indptr.push_back(0);
   o_indptr.push_back(0);
@@ -554,17 +554,25 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
     }
   }
 
+  // Calculate the actual needed CTA when considering sliding window
+  std::vector<int64_t> cliped_kv_len_arr(batch_size);
+  for (uint32_t i = 0; i < batch_size; ++i) {
+    // pad CTA_TILE_Q to consider the causal kv-len
+    cliped_kv_len_arr[i] =
+        std::min(window_left >= 0 ? ceil_div(window_left + cta_tile_q, page_size) : kv_len_arr[i],
+                 kv_len_arr[i]);
+  }
+
   auto [split_kv, kv_chunk_size] =
       PrefillBinarySearchKVChunkSize(enable_cuda_graph, max_batch_size_if_split, packed_qo_len_arr,
-                                     kv_len_arr, cta_tile_q, min_kv_chunk_size);
+                                     cliped_kv_len_arr, cta_tile_q, min_kv_chunk_size);
 
   // step 3: split qo_indptr and kv_indptr
   uint32_t new_batch_size = 0;
   for (uint32_t request_idx = 0; request_idx < batch_size; ++request_idx) {
     const int64_t packed_qo_len = packed_qo_len_arr[request_idx];
-    const int64_t kv_len = std::max(int(kv_len_arr[request_idx]), 1);
     const int64_t num_tiles_q = ceil_div(packed_qo_len, cta_tile_q);
-    const int64_t num_tiles_kv = ceil_div(kv_len, kv_chunk_size);
+    const int64_t num_tiles_kv = ceil_div(cliped_kv_len_arr[request_idx], kv_chunk_size);
 
     for (uint32_t q_tile_idx = 0; q_tile_idx < num_tiles_q; ++q_tile_idx) {
       for (uint32_t kv_tile_idx = 0; kv_tile_idx < num_tiles_kv; ++kv_tile_idx) {
@@ -680,7 +688,7 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
                                IdType* qo_indptr_h, IdType* kv_indptr_h, uint32_t total_num_rows,
                                uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
                                uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
-                               bool enable_cuda_graph, uint32_t sizeof_dtype_o,
+                               bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left,
                                cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
@@ -703,7 +711,7 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
         qo_tile_indices_vec, kv_tile_indices_vec, merge_indptr_vec, o_indptr_vec] =
       PrefillSplitQOKVIndptr(qo_indptr_h, kv_indptr_h, total_num_rows, batch_size, num_qo_heads,
                              num_kv_heads, head_dim_vo, page_size, max_batch_size_if_split,
-                             enable_cuda_graph);
+                             enable_cuda_graph, window_left);
 
   plan_info.cta_tile_q = cta_tile_q;
   plan_info.total_num_rows = total_num_rows;

--- a/include/flashinfer/attention/variants.cuh
+++ b/include/flashinfer/attention/variants.cuh
@@ -61,9 +61,7 @@ struct DefaultAttention : AttentionVariantBase {
         custom_mask_ptr = params.maybe_custom_mask;
       }
     }
-    if constexpr (use_sliding_window) {
-      window_left = (params.window_left >= 0) ? params.window_left : kv_len;
-    }
+    window_left = (params.window_left >= 0) ? params.window_left : kv_len;
   }
 
   REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx, {

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -46,8 +46,8 @@ def warmup_jit():
     yield
 
 
-@pytest.mark.parametrize("seq_len", [1, 3, 19, 99, 199, 1999])
-@pytest.mark.parametrize("window_left", [3, 13, 23, 43])
+@pytest.mark.parametrize("seq_len", [1, 3, 19, 99, 199, 1177, 1999])
+@pytest.mark.parametrize("window_left", [3, 13, 23, 37, 43])
 @pytest.mark.parametrize("num_kv_heads", [1, 4])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
@@ -78,8 +78,16 @@ def test_single_decode_sliding_window(
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("backend", ["fa2", "auto"])
 def test_batch_decode_sliding_window(
-    batch_size, kv_len, window_left, num_kv_heads, num_qo_heads, head_dim, page_size
+    batch_size,
+    kv_len,
+    window_left,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    page_size,
+    backend,
 ):
     q = torch.randn(
         batch_size, num_qo_heads, head_dim, dtype=torch.float16, device="cuda:0"
@@ -112,7 +120,9 @@ def test_batch_decode_sliding_window(
     )
 
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
-    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, "NHD")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD", backend=backend
+    )
     wrapper.plan(
         kv_indptr,
         kv_indices,
@@ -207,14 +217,15 @@ def test_single_prefill_sliding_window(
     torch.testing.assert_close(o.cpu(), o_ref.cpu(), rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("batch_size", [12, 17])
-@pytest.mark.parametrize("kv_len", [54, 397])
-@pytest.mark.parametrize("qo_len", [37, 47])
-@pytest.mark.parametrize("window_left", [13, 33])
-@pytest.mark.parametrize("num_kv_heads", [1, 4])
-@pytest.mark.parametrize("num_qo_heads", [4, 8])
+@pytest.mark.parametrize("batch_size", [12, 17, 71])
+@pytest.mark.parametrize("kv_len", [54, 397, 1177, 2999])
+@pytest.mark.parametrize("qo_len", [1, 37, 47])
+@pytest.mark.parametrize("window_left", [13, 33, 111])
+@pytest.mark.parametrize("num_kv_heads", [32])
+@pytest.mark.parametrize("num_qo_heads", [32])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("backend", ["fa2", "auto"])
 def test_batch_paged_prefill_sliding_window(
     batch_size,
     kv_len,
@@ -224,6 +235,7 @@ def test_batch_paged_prefill_sliding_window(
     num_qo_heads,
     head_dim,
     page_size,
+    backend,
 ):
     q = torch.randn(
         batch_size * qo_len,
@@ -263,7 +275,9 @@ def test_batch_paged_prefill_sliding_window(
     )
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
-    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace_buffer, "NHD")
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD", backend=backend
+    )
     wrapper.plan(
         q_indptr,
         kv_indptr,
@@ -315,8 +329,16 @@ def test_batch_paged_prefill_sliding_window(
 @pytest.mark.parametrize("num_kv_heads", [1, 4])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("backend", ["fa2", "auto"])
 def test_batch_ragged_prefill_sliding_window(
-    batch_size, kv_len, qo_len, window_left, num_kv_heads, num_qo_heads, head_dim
+    batch_size,
+    kv_len,
+    qo_len,
+    window_left,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    backend,
 ):
     q = torch.randn(
         batch_size * qo_len,
@@ -346,7 +368,9 @@ def test_batch_ragged_prefill_sliding_window(
         torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * kv_len
     )
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
-    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace_buffer, "NHD")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace_buffer, "NHD", backend=backend
+    )
     wrapper.plan(
         q_indptr,
         kv_indptr,

--- a/tvm_binding/batch_prefill.cu
+++ b/tvm_binding/batch_prefill.cu
@@ -46,7 +46,7 @@ IntTuple BatchPrefillWithKVCachePlan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream) {
+    int64_t head_dim_vo, bool causal, int64_t window_left, TVMStreamHandle cuda_stream) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer->shape[0] * DataType(float_workspace_buffer->dtype).bytes();
   size_t int_workspace_size_in_bytes =
@@ -66,7 +66,7 @@ IntTuple BatchPrefillWithKVCachePlan(
       static_cast<IdType*>(kv_indptr->data) + kv_indptr->byte_offset / sizeof(IdType),
       total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
       enable_cuda_graph,
-      /*sizeof_dtype_o=*/2, stream);
+      /*sizeof_dtype_o=*/2, window_left, stream);
 
   CHECK(status == cudaSuccess) << "Failed to plan prefill with error: "
                                << cudaGetErrorString(status);

--- a/tvm_binding/batch_prefill_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_jit_tvm_binding.cu
@@ -16,14 +16,12 @@
 #include "batch_prefill_config.inc"
 #include "tvm_binding_utils.h"
 
-IntTuple BatchPrefillWithKVCachePlan(DLTensor* float_workspace_buffer,
-                                     DLTensor* int_workspace_buffer,
-                                     DLTensor* page_locked_int_workspace_buffer,
-                                     DLTensor* qo_indptr, DLTensor* kv_indptr, IntTuple kv_len_arr,
-                                     int64_t total_num_rows, int64_t batch_size,
-                                     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
-                                     bool enable_cuda_graph, int64_t head_dim_qk,
-                                     int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream);
+IntTuple BatchPrefillWithKVCachePlan(
+    DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer,
+    DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
+    IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
+    int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
+    int64_t head_dim_vo, bool causal, int64_t window_left, TVMStreamHandle cuda_stream);
 
 void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
                                       DLTensor* int_workspace_buffer, IntTuple plan_info_vec,

--- a/tvm_binding/batch_prefill_sm90.cu
+++ b/tvm_binding/batch_prefill_sm90.cu
@@ -45,7 +45,7 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream) {
+    int64_t head_dim_vo, bool causal, int64_t window_left, TVMStreamHandle cuda_stream) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer->shape[0] * DataType(float_workspace_buffer->dtype).bytes();
   size_t int_workspace_size_in_bytes =

--- a/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
@@ -21,7 +21,7 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream);
+    int64_t head_dim_vo, bool causal, int64_t window_left, TVMStreamHandle cuda_stream);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
This PR skips redundant kv-tiles loading&computation in FA2's sliding window implementation, which is used by GPT-OSS inference scenarios. Main modification:
1. Make `PrefillPlanSM80` aware of sliding window: skipping redundant attention states merge
2. Add `kv-start-idx` offsets at the start of each device kernel, to skip the window computation. As it maintains the original 0-base `kv-tile-idx`, it should be compatible w/ jit `sink-token` implementation.
<img width="717" height="320" alt="image" src="https://github.com/user-attachments/assets/a061c602-2cf9-4867-ad1b-46905ab1f44d" />

## 🔍 Related Issues
This should backup https://github.com/vllm-project/vllm/pull/23010.

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
