### PR TITLE
benchmark: add cupti support to benchmark

### DIFF
--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -76,6 +76,12 @@ def parse_args(line=sys.argv[1:]):
         help="Disable CUDA graph to execute kernels outside of the graph.",
     )
     parser.add_argument(
+        "--use_cupti",
+        action="store_true",
+        default=False,
+        help="Use CUPTI for timing GPU kernels when available.",
+    )
+    parser.add_argument(
         "--refcheck",
         action="store_true",
         default=False,

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -8,7 +8,6 @@ from flashinfer.testing.utils import (
     attention_tb_per_sec_with_actual_seq_lens,
     attention_tflops_per_sec_with_actual_seq_lens,
     bench_gpu_time,
-    bench_gpu_time_with_cudagraph,
 )
 
 from .flashinfer_benchmark_utils import (
@@ -506,27 +505,18 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
             if cur_backend == "fa2":
                 has_reference_output = True
                 reference_output = outputs[cur_backend]
-        if is_cuda_graph_compatible and cur_backend != "fa2":
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                num_iters_within_graph=20,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=False,
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=False,
-            )
+        # Unified benchmark entry: prefer graph if compatible and not using CUPTI
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend_wrapper(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=False,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+        )
 
     # Perform reference check
     tested_backends = list(outputs.keys())
@@ -966,27 +956,17 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
             if cur_backend == "fa2":
                 has_reference_output = True
                 reference_output = outputs[cur_backend]
-        if is_cuda_graph_compatible and cur_backend != "fa2":
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                num_iters_within_graph=20,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=False,
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=False,
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend_wrapper(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=False,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+        )
 
     # Perform reference check
     tested_backends = list(outputs.keys())
@@ -1363,27 +1343,17 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
             if cur_backend == "fa2":
                 has_reference_output = True
                 reference_output = outputs[cur_backend]
-        if is_cuda_graph_compatible and cur_backend != "fa2":
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                num_iters_within_graph=20,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend_wrapper(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=False,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+        )
 
     # Perform reference check
     tested_backends = list(outputs.keys())
@@ -1712,27 +1682,17 @@ def testBatchMLAPagedAttentionWrapper(args):
             if cur_backend == "fa2":
                 has_reference_output = True
                 reference_output = outputs[cur_backend]
-        if is_cuda_graph_compatible and cur_backend != "fa2":
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                num_iters_within_graph=20,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=False,
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend_wrapper(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=False,
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend_wrapper(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=False,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+        )
 
     # Perform reference check
     tested_backends = list(outputs.keys())

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -71,6 +71,7 @@ output_column_dict = {
     "general": [
         "refcheck",
         "no_cuda_graph",
+        "use_cupti",
         "allow_output_mismatch",
         "random_seed",
         "case_tag",

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -8,7 +8,6 @@ from einops import einsum
 import flashinfer
 from flashinfer.testing.utils import (
     bench_gpu_time,
-    bench_gpu_time_with_cudagraph,
     dequantize_fp8,
     quantize_fp8,
 )
@@ -269,26 +268,17 @@ def testGemmFp8NtGroupwise(args):
     for cur_backend in backends:
         if run_refcheck:
             outputs[cur_backend] = run_backend(cur_backend).detach()
-        if is_cuda_graph_compatible:
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,  # GEMMs are very MMA-heavy, so prefer sleep to reduce throttling.
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,  # GEMMs are very MMA-heavy, so prefer sleep to reduce throttling.
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=True,  # GEMMs are very MMA-heavy, so prefer sleep to reduce throttling.
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+        )
 
     tested_backends = list(outputs.keys())
     tested_outputs = list(outputs.values())
@@ -451,26 +441,17 @@ def testGroupGemmFp8NtGroupwise(args):
     for cur_backend in backends:
         if run_refcheck:
             outputs[cur_backend] = run_backend(cur_backend).detach()
-        if is_cuda_graph_compatible:
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,  # GEMMs are very MMA-heavy, so prefer sleep to reduce throttling.
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,  # GEMMs are very MMA-heavy, so prefer sleep to reduce throttling.
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=True,  # GEMMs are very MMA-heavy, so prefer sleep to reduce throttling.
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+        )
 
     tested_backends = list(outputs.keys())
     tested_outputs = list(outputs.values())
@@ -626,27 +607,17 @@ def testBmmFp8(args):
     for cur_backend in backends:
         if run_refcheck:
             outputs[cur_backend] = run_backend(cur_backend).detach()
-        if is_cuda_graph_compatible:
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                num_iters_within_graph=20,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=True,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+        )
 
     tested_backends = list(outputs.keys())
     tested_outputs = list(outputs.values())
@@ -844,27 +815,17 @@ def testMmFp4(args):
     for cur_backend in backends:
         if run_refcheck:
             outputs[cur_backend] = run_backend(cur_backend).detach()
-        if is_cuda_graph_compatible:
-            backend_times[cur_backend] = bench_gpu_time_with_cudagraph(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                num_iters_within_graph=20,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,
-            )
-        else:
-            backend_times[cur_backend] = bench_gpu_time(
-                fn=lambda: run_backend(cur_backend),
-                dry_run_iters=args.dry_run_iters,
-                repeat_iters=args.num_iters,
-                l2_flush=True,
-                l2_flush_size_mb=256,
-                l2_flush_device=device,
-                sleep_after_run=True,
-            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=lambda: run_backend(cur_backend),
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            l2_flush=True,
+            l2_flush_size_mb=256,
+            l2_flush_device=device,
+            sleep_after_run=True,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+        )
 
     tested_backends = list(outputs.keys())
     tested_outputs = list(outputs.values())

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -734,7 +734,7 @@ def testTrtllmFp4BlockScaleMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time_with_cupti(
+        times = bench_gpu_time(
             fn=run_fp4_moe,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,
@@ -1067,7 +1067,7 @@ def testCutlassFusedMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time_with_cupti(
+        times = bench_gpu_time(
             fn=run_cutlass,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,
@@ -1344,7 +1344,7 @@ def testTrtllmFp8BlockScaleMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time_with_cupti(
+        times = bench_gpu_time(
             fn=run_fp8_block_moe,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,
@@ -1553,7 +1553,7 @@ def testTrtllmFp8PerTensorScaleMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time_with_cupti(
+        times = bench_gpu_time(
             fn=run_fp8_per_tensor_moe,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -17,6 +17,7 @@ from flashinfer.fused_moe import (
 from flashinfer import fp4_quantize, shuffle_matrix_a
 from flashinfer.testing.utils import (
     bench_gpu_time,
+    bench_gpu_time_with_cupti,
     bench_gpu_time_with_cudagraph,
 )
 
@@ -733,7 +734,7 @@ def testTrtllmFp4BlockScaleMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time(
+        times = bench_gpu_time_with_cupti(
             fn=run_fp4_moe,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,
@@ -1066,7 +1067,7 @@ def testCutlassFusedMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time(
+        times = bench_gpu_time_with_cupti(
             fn=run_cutlass,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,
@@ -1343,7 +1344,7 @@ def testTrtllmFp8BlockScaleMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time(
+        times = bench_gpu_time_with_cupti(
             fn=run_fp8_block_moe,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,
@@ -1552,7 +1553,7 @@ def testTrtllmFp8PerTensorScaleMoe(args):
             sleep_after_run=False,
         )
     else:
-        times = bench_gpu_time(
+        times = bench_gpu_time_with_cupti(
             fn=run_fp8_per_tensor_moe,
             dry_run_iters=args.dry_run_iters,
             repeat_iters=args.num_iters,

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -17,8 +17,6 @@ from flashinfer.fused_moe import (
 from flashinfer import fp4_quantize, shuffle_matrix_a
 from flashinfer.testing.utils import (
     bench_gpu_time,
-    bench_gpu_time_with_cupti,
-    bench_gpu_time_with_cudagraph,
 )
 
 from .flashinfer_benchmark_utils import (
@@ -722,27 +720,17 @@ def testTrtllmFp4BlockScaleMoe(args):
                 run_fp4_moe()
 
     # Benchmark timing
-    if is_cuda_graph_compatible:
-        times = bench_gpu_time_with_cudagraph(
-            fn=run_fp4_moe,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            num_iters_within_graph=20,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
-    else:
-        times = bench_gpu_time(
-            fn=run_fp4_moe,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
+    times = bench_gpu_time(
+        fn=run_fp4_moe,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.num_iters,
+        l2_flush=True,
+        l2_flush_size_mb=256,
+        l2_flush_device=device,
+        sleep_after_run=False,
+        enable_cupti=args.use_cupti,
+        use_cuda_graph=is_cuda_graph_compatible,
+    )
 
     # Compute performance metrics
     median_time = np.median(times)
@@ -1055,27 +1043,17 @@ def testCutlassFusedMoe(args):
                 run_cutlass()
 
     # Measure
-    if is_cuda_graph_compatible:
-        times = bench_gpu_time_with_cudagraph(
-            fn=run_cutlass,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            num_iters_within_graph=20,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
-    else:
-        times = bench_gpu_time(
-            fn=run_cutlass,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
+    times = bench_gpu_time(
+        fn=run_cutlass,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.num_iters,
+        l2_flush=True,
+        l2_flush_size_mb=256,
+        l2_flush_device=device,
+        sleep_after_run=False,
+        enable_cupti=args.use_cupti,
+        use_cuda_graph=is_cuda_graph_compatible,
+    )
 
     median_time = np.median(times)
     std_time = np.std(times)
@@ -1332,27 +1310,17 @@ def testTrtllmFp8BlockScaleMoe(args):
         )
 
     # Benchmark timing
-    if is_cuda_graph_compatible:
-        times = bench_gpu_time_with_cudagraph(
-            fn=run_fp8_block_moe,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            num_iters_within_graph=20,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
-    else:
-        times = bench_gpu_time(
-            fn=run_fp8_block_moe,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
+    times = bench_gpu_time(
+        fn=run_fp8_block_moe,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.num_iters,
+        l2_flush=True,
+        l2_flush_size_mb=256,
+        l2_flush_device=device,
+        sleep_after_run=False,
+        enable_cupti=args.use_cupti,
+        use_cuda_graph=is_cuda_graph_compatible,
+    )
 
     # Compute performance metrics
     median_time = np.median(times)
@@ -1541,27 +1509,17 @@ def testTrtllmFp8PerTensorScaleMoe(args):
         )
 
     # Benchmark timing
-    if is_cuda_graph_compatible:
-        times = bench_gpu_time_with_cudagraph(
-            fn=run_fp8_per_tensor_moe,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            num_iters_within_graph=20,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
-    else:
-        times = bench_gpu_time(
-            fn=run_fp8_per_tensor_moe,
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
-            sleep_after_run=False,
-        )
+    times = bench_gpu_time(
+        fn=run_fp8_per_tensor_moe,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.num_iters,
+        l2_flush=True,
+        l2_flush_size_mb=256,
+        l2_flush_device=device,
+        sleep_after_run=False,
+        enable_cupti=args.use_cupti,
+        use_cuda_graph=is_cuda_graph_compatible,
+    )
 
     # Compute performance metrics
     median_time = np.median(times)

--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -46,4 +46,6 @@ GPU Benchmarking
     :toctree: ../generated
 
     bench_gpu_time
+    bench_gpu_time_with_cuda_event
     bench_gpu_time_with_cudagraph
+    bench_gpu_time_with_cupti

--- a/flashinfer/testing/__init__.py
+++ b/flashinfer/testing/__init__.py
@@ -22,6 +22,8 @@ from .utils import (
     attention_tflops_per_sec,
     attention_tflops_per_sec_with_actual_seq_lens,
     bench_gpu_time,
+    bench_gpu_time_with_cupti,
+    bench_gpu_time_with_cuda_event,
     bench_gpu_time_with_cudagraph,
     set_seed,
     sleep_after_kernel_run,

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -679,7 +679,7 @@ def bench_gpu_time_with_cupti(
         if int(cupti_version.split(".")[0]) < 13:
             raise Exception("CUPTI needs to be >= 13.0.0.")
         from functools import partial
-    except ... as e:
+    except (ModuleNotFoundError, Exception) as e:
         if isinstance(e, ModuleNotFoundError):
             warnings.warn("CUPTI is not installed. Falling back to use cuda events.")
         else:

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -642,12 +642,11 @@ def bench_gpu_time_with_cupti(
     """
     Benchmark GPU time using by using CUPTI to measure the kernel execution time.
     """
-    import warnings
     try:
         from cupti import cupti
         from functools import partial
     except ImportError:
-        warnings.warn("CUPTI is not installed. Falling back to bench_gpu_time.")
+        print("CUPTI is not installed. Falling back to bench_gpu_time.")
         return bench_gpu_time(
             fn, dry_run_iters, repeat_iters, dry_run_time_ms, repeat_time_ms,
             l2_flush, l2_flush_size_mb, l2_flush_device, sleep_after_run

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -686,27 +686,27 @@ def bench_gpu_time_with_cupti(
             warnings.warn(f"{e} Falling back to use cuda events.")
         if use_cuda_graph:
             return bench_gpu_time_with_cudagraph(
-                fn,
-                dry_run_iters,
-                repeat_iters,
-                dry_run_time_ms,
-                repeat_time_ms,
-                l2_flush,
-                l2_flush_size_mb,
-                l2_flush_device,
-                sleep_after_run,
+                fn = fn,
+                dry_run_iters = dry_run_iters,
+                repeat_iters =repeat_iters,
+                dry_run_time_ms =dry_run_time_ms,
+                repeat_time_ms =repeat_time_ms,
+                l2_flush = l2_flush,
+                l2_flush_size_mb = l2_flush_size_mb,
+                l2_flush_device = l2_flush_device,
+                sleep_after_run =sleep_after_run,
             )
         else:
             return bench_gpu_time_with_cuda_event(
-                fn,
-                dry_run_iters,
-                repeat_iters,
-                dry_run_time_ms,
-                repeat_time_ms,
-                l2_flush,
-                l2_flush_size_mb,
-                l2_flush_device,
-                sleep_after_run,
+                fn =fn,
+                dry_run_iters = dry_run_iters,
+                repeat_iters = repeat_iters,
+                dry_run_time_ms = dry_run_time_ms,
+                repeat_time_ms = repeat_time_ms,
+                l2_flush = l2_flush,
+                l2_flush_size_mb = l2_flush_size_mb,
+                l2_flush_device = l2_flush_device,
+                sleep_after_run = sleep_after_run,
             )
 
     # CUPTI buffer callbacks

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -677,13 +677,13 @@ def bench_gpu_time_with_cupti(
         from importlib.metadata import version as importlib_metadata_version
         cupti_version = importlib_metadata_version("cupti-python")
         if int(cupti_version.split(".")[0]) < 13:
-            raise Exception("CUPTI needs to be >= 13.0.0. Falling back to use cuda events.")
+            raise Exception("CUPTI needs to be >= 13.0.0.")
         from functools import partial
-    except (ImportError, Exception) as e:
-        if isinstance(e, ImportError):
+    except ... as e:
+        if isinstance(e, ModuleNotFoundError):
             warnings.warn("CUPTI is not installed. Falling back to use cuda events.")
         else:
-            warnings.warn(f"{e}")
+            warnings.warn(f"{e} Falling back to use cuda events.")
         if use_cuda_graph:
             return bench_gpu_time_with_cudagraph(
                 fn,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add CUPTI support for more accurate benchmarking. 
Require cupti-python>=13.0.0. Off by default

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
