### PR TITLE
test: update fused_moe test to random scale factor

### DIFF
--- a/tests/test_trtllm_gen_fused_moe.py
+++ b/tests/test_trtllm_gen_fused_moe.py
@@ -1626,7 +1626,6 @@ def run_moe_reference_fp4(args, quant_mode: QuantMode):
 def run_moe_reference_dsfp8(args):
     """FP8 block-scale reference implementation."""
     # Generate block scales at runtime for FP8 block scaling
-    # Use deterministic scales for testing consistency
     hidden_states_scale = 2.0 * torch.rand(
         (args.hidden_size // 128, args.num_tokens), device="cuda", dtype=torch.float
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We could use rand scale factor rather than fixed constant when testing fp8_block_scaled fused_moe. 
We might use the same scale_factor random generation (by normal dist) rather than the dumped workload in bench.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
