### PR TITLE
feat: Add `variant.OutputTransform()` to decode kernels

### DIFF
--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -357,9 +357,8 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
                                       tx, ty, tz);
 #pragma unroll
   for (size_t i = 0; i < vec_size; ++i) {
-    st_local.o[i] = variant.OutputTransform(
-        params, st_local.o[i], /*batch_idx=*/0, /*qo_idx=*/0, qo_head_idx,
-        st_local.m, st_local.d, /*scale=*/1.0f);
+    st_local.o[i] = variant.OutputTransform(params, st_local.o[i], /*batch_idx=*/0, /*qo_idx=*/0,
+                                            qo_head_idx, st_local.m, st_local.d, /*scale=*/1.0f);
   }
 
   st_local.o.cast_store(o + (kv_chunk_idx * num_qo_heads + qo_head_idx) * head_dim + tx * vec_size);
@@ -592,9 +591,8 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
                                       tz);
 #pragma unroll
   for (size_t i = 0; i < vec_size; ++i) {
-    st.o[i] = variant.OutputTransform(
-        params, st.o[i], bx, /*qo_idx=*/0, qo_head_idx,
-        st.m, st.d, /*scale=*/1.0f);
+    st.o[i] = variant.OutputTransform(params, st.o[i], bx, /*qo_idx=*/0, qo_head_idx, st.m, st.d,
+                                      /*scale=*/1.0f);
   }
 
   if (tz == 0) {
@@ -1078,9 +1076,8 @@ __global__ void BatchDecodeWithPagedKVCacheKernelMLA(Params params) {
       if (qo_head_idx[i] < num_qo_heads) {
 #pragma unroll
         for (size_t j = 0; j < vec_size_ckv; ++j) {
-          st[i].o[j] = variant.OutputTransform(
-              params, st[i].o[j], batch_idx, /*qo_idx=*/0, qo_head_idx[i],
-              st[i].m, st[i].d, /*scale=*/1.0f);
+          st[i].o[j] = variant.OutputTransform(params, st[i].o[j], batch_idx, /*qo_idx=*/0,
+                                               qo_head_idx[i], st[i].m, st[i].d, /*scale=*/1.0f);
         }
         st[i].o.cast_store(o + (batch_idx * num_qo_heads + qo_head_idx[i]) * head_dim_ckv +
                            tx * vec_size_ckv);

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -355,8 +355,11 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
   // sync local state of all warps inside a threadblock
   sync_state<vec_size, bdx, bdy, bdz>(variant, st_local, reinterpret_cast<float*>(smem), smem_md,
                                       tx, ty, tz);
-  if constexpr (variant.use_softmax) {
-    st_local.normalize();
+#pragma unroll
+  for (size_t i = 0; i < vec_size; ++i) {
+    st_local.o[i] = variant.OutputTransform(
+        params, st_local.o[i], /*batch_idx=*/0, /*qo_idx=*/0, qo_head_idx,
+        st_local.m, st_local.d, /*scale=*/1.0f);
   }
 
   st_local.o.cast_store(o + (kv_chunk_idx * num_qo_heads + qo_head_idx) * head_dim + tx * vec_size);
@@ -587,8 +590,11 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
   // sync local state of all warps inside a threadblock
   sync_state<vec_size, bdx, bdy, bdz>(variant, st, reinterpret_cast<float*>(smem), smem_md, tx, ty,
                                       tz);
-  if constexpr (variant.use_softmax) {
-    st.normalize();
+#pragma unroll
+  for (size_t i = 0; i < vec_size; ++i) {
+    st.o[i] = variant.OutputTransform(
+        params, st.o[i], bx, /*qo_idx=*/0, qo_head_idx,
+        st.m, st.d, /*scale=*/1.0f);
   }
 
   if (tz == 0) {
@@ -1070,7 +1076,12 @@ __global__ void BatchDecodeWithPagedKVCacheKernelMLA(Params params) {
 #pragma unroll
     for (int i = 0; i < tile_size_qo_heads; ++i) {
       if (qo_head_idx[i] < num_qo_heads) {
-        st[i].normalize();
+#pragma unroll
+        for (size_t j = 0; j < vec_size_ckv; ++j) {
+          st[i].o[j] = variant.OutputTransform(
+              params, st[i].o[j], batch_idx, /*qo_idx=*/0, qo_head_idx[i],
+              st[i].m, st[i].d, /*scale=*/1.0f);
+        }
         st[i].o.cast_store(o + (batch_idx * num_qo_heads + qo_head_idx[i]) * head_dim_ckv +
                            tx * vec_size_ckv);
 

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -41,7 +41,8 @@ struct SingleDecodeWithCustomMask : AttentionVariantBase {
   })
 
   REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
-    return output;
+    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
+    return output * d_rcp;
   })
 };
 """
@@ -102,7 +103,8 @@ struct FlashSigmoid : AttentionVariantBase {
   });
 
   REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
-    return output;
+    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
+    return output * d_rcp;
   })
 };
 """

--- a/tests/test_jit_example.py
+++ b/tests/test_jit_example.py
@@ -103,8 +103,7 @@ struct FlashSigmoid : AttentionVariantBase {
   });
 
   REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
-    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
-    return output * d_rcp;
+    return output;
   })
 };
 """


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

I noticed that only prefill kernels use `variant.OutputTransform()`. This PR replaces `state.normalize()` in decode kernels with `variant.OutputTransform()` to match the behavior of prefill kernels, as well as enabling customizing decode kernels.

I don't have much experience working with the FlashInfer codebase, so feedback is welcome.

My goal is to enable `v_scale` epilogue fusion for FP8 KV-cache https://github.com/flashinfer-ai/flashinfer/blob/6dff34d1b8aadec626bd507715a5f45999458329/flashinfer/decode.py#L572

<details>
<summary>Test snippet (let me know if I need to add this test somewhere)</summary>

```python
from flashinfer.decode import (
    single_decode_with_kv_cache_with_jit_module,
    BatchDecodeWithPagedKVCacheWrapper,
)
from flashinfer.jit.attention import (
    gen_customize_single_decode_module,
)
import math
import torch

source = r"""
struct ScaledOutputAttention : AttentionVariantBase {
  static constexpr bool use_softmax = true;

  uint32_t window_left, qo_len, kv_len;
  float sm_scale_log2;
  float o_scale_;

  // Create closure
  template <typename Params>
  __device__ __host__ ScaledOutputAttention(const Params& params, uint32_t batch_idx,
                                          uint8_t* smem_ptr) {
    qo_len = 1;
    kv_len = params.get_kv_len(batch_idx);
    window_left = kv_len;
    sm_scale_log2 = params.sm_scale * math::log2e;

    o_scale_ = params.o_scale;
  }

  REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
    return output * d_rcp * o_scale_;
  })
};
"""

single_decode_m = gen_customize_single_decode_module(
    "single_decode_scaled_output",  # uri
    torch.bfloat16,  # dtype_q
    torch.float8_e4m3fn,  # dtype_kv
    torch.bfloat16,  # dtype_o
    128,  # head_dim_qk
    128,  # head_dim_vo
    [],  # additional_tensor_names
    [],  # additional_tensor_dtypes
    ["sm_scale", "o_scale"],  # # additional_scalar_names
    ["double", "double"],  # additional_scalar_dtypes
    "ScaledOutputAttention",
    source,
).build_and_load()

q = torch.randn(32, 128, dtype=torch.bfloat16, device="cuda")
k = torch.randn(1024, 32, 128, device="cuda").to(torch.float8_e4m3fn)
v = torch.randn(1024, 32, 128, device="cuda").to(torch.float8_e4m3fn)
sm_scale = 1.0 / math.sqrt(128)

v_scale = torch.randn(1).item() * 10

o = single_decode_with_kv_cache_with_jit_module(
    single_decode_m, q, k, v, sm_scale, v_scale
)

s = torch.einsum("hd,nhd->hn", q.float(), k.float()) * sm_scale
p = s.softmax(dim=-1)
o_ref = torch.einsum("hn,nhd->hd", p, v.float()).mul(v_scale).bfloat16()

diff = (o.float() - o_ref.float()).abs()
print(f"Single decode: mean diff={diff.mean().item()}, max diff={diff.max().item()}")


workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
    workspace,
    jit_args=[
        "batch_decode_scaled_output",  # uri
        torch.bfloat16,  # dtype_q
        torch.float8_e4m3fn,  # dtype_kv
        torch.bfloat16,  # dtype_o
        torch.int32,  # dtype_idx
        128,  # head_dim_qk
        128,  # head_dim_vo
        [],  # additional_tensor_names
        [],  # additional_tensor_dtypes
        ["sm_scale", "o_scale"],  # # additional_scalar_names
        ["double", "double"],  # additional_scalar_dtypes
        "ScaledOutputAttention",
        source,
    ],
)
# from example
num_layers = 32
num_qo_heads = 64
num_kv_heads = 8
head_dim = 128
max_num_pages = 128
page_size = 16

batch_size = 7
kv_page_indices = torch.arange(max_num_pages).int().to("cuda:0")
kv_page_indptr = torch.tensor(
    [0, 17, 29, 44, 48, 66, 100, 128], dtype=torch.int32, device="cuda:0"
)
# 1 <= kv_last_page_len <= page_size
kv_last_page_len = torch.tensor(
    [1, 7, 14, 4, 3, 1, 16], dtype=torch.int32, device="cuda:0"
)
kv_cache = torch.randn(
    max_num_pages, 2, page_size, num_kv_heads, head_dim, device="cuda:0"
).to(torch.float8_e4m3fn)
# create auxiliary data structures for batch decode attention
decode_wrapper.plan(
    kv_page_indptr,
    kv_page_indices,
    kv_last_page_len,
    num_qo_heads,
    num_kv_heads,
    head_dim,
    page_size,
    pos_encoding_mode="NONE",
    q_data_type=torch.bfloat16,
    kv_data_type=torch.float8_e4m3fn,
)
q = torch.randn(batch_size, num_qo_heads, head_dim).bfloat16().to("cuda:0")
o = decode_wrapper.run(q, kv_cache, sm_scale, v_scale)

o_ref_list = []
for i in range(7):
    start, end = kv_page_indptr[i : i + 2].tolist()

    # [2, num_pages * page_size, num_kv_heads, head_dim]
    kv = kv_cache[start:end].transpose(0, 1).flatten(1, 2)

    # slice the last page
    kv_len = (end - start - 1) * page_size + kv_last_page_len[i].item()
    kv = kv[:, :kv_len]

    o_ref = torch.nn.functional.scaled_dot_product_attention(
        q[i].view(num_qo_heads, 1, head_dim).float(),
        kv[0].transpose(0, 1).float(),
        kv[1].transpose(0, 1).float(),
        enable_gqa=True,
    )
    o_ref = (o_ref.squeeze(1) * v_scale).to(torch.bfloat16)
    o_ref_list.append(o_ref)

o_ref = torch.stack(o_ref_list, dim=0)
diff = (o.float() - o_ref.float()).abs()
print(f"Batch decode: mean diff={diff.mean().item()}, max diff={diff.max().item()}")
```
</details>

Main branch

```
Single decode: mean diff=0.3197138011455536, max diff=1.4833984375
Batch decode: mean diff=0.6976202130317688, max diff=7.2578125
```

This PR

```
Single decode: mean diff=0.00023218360729515553, max diff=0.00390625
Batch decode: mean diff=0.0003685278061311692, max diff=0.015625
```

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
