### PR TITLE
[TVM] Default `fixed_split_size` value in TVM binding

### DIFF
--- a/tvm_binding/batch_prefill.cu
+++ b/tvm_binding/batch_prefill.cu
@@ -46,8 +46,7 @@ IntTuple BatchPrefillWithKVCachePlan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, int64_t window_left, int64_t fixed_split_size,
-    bool disable_split_kv, TVMStreamHandle cuda_stream) {
+    int64_t head_dim_vo, bool causal, int64_t window_left, TVMStreamHandle cuda_stream) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer->shape[0] * DataType(float_workspace_buffer->dtype).bytes();
   size_t int_workspace_size_in_bytes =
@@ -67,7 +66,8 @@ IntTuple BatchPrefillWithKVCachePlan(
       static_cast<IdType*>(kv_indptr->data) + kv_indptr->byte_offset / sizeof(IdType),
       total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
       enable_cuda_graph,
-      /*sizeof_dtype_o=*/2, window_left, fixed_split_size, disable_split_kv, stream);
+      /*sizeof_dtype_o=*/2, window_left, /*fixed_split_size=*/-1, /*disable_split_kv=*/false,
+      stream);
 
   CHECK(status == cudaSuccess) << "Failed to plan prefill with error: "
                                << cudaGetErrorString(status);

--- a/tvm_binding/batch_prefill_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_jit_tvm_binding.cu
@@ -16,15 +16,12 @@
 #include "batch_prefill_config.inc"
 #include "tvm_binding_utils.h"
 
-IntTuple BatchPrefillWithKVCachePlan(DLTensor* float_workspace_buffer,
-                                     DLTensor* int_workspace_buffer,
-                                     DLTensor* page_locked_int_workspace_buffer,
-                                     DLTensor* qo_indptr, DLTensor* kv_indptr, IntTuple kv_len_arr,
-                                     int64_t total_num_rows, int64_t batch_size,
-                                     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
-                                     bool enable_cuda_graph, int64_t head_dim_qk,
-                                     int64_t head_dim_vo, bool causal, int64_t window_left,
-                                     int64_t fixed_split_size, TVMStreamHandle cuda_stream);
+IntTuple BatchPrefillWithKVCachePlan(
+    DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer,
+    DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
+    IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
+    int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
+    int64_t head_dim_vo, bool causal, int64_t window_left, TVMStreamHandle cuda_stream);
 
 void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
                                       DLTensor* int_workspace_buffer, IntTuple plan_info_vec,


### PR DESCRIPTION
## 📌 Description

This PR uses the default value -1 for `fixed_split_size` introduced in PR #1675, to keep the interface consistent with the TVM side.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).