### PR TITLE
perf: improve performance of cutlass fmha

### DIFF
--- a/include/flashinfer/attention/blackwell/collective/fmha_fusion.hpp
+++ b/include/flashinfer/attention/blackwell/collective/fmha_fusion.hpp
@@ -121,7 +121,8 @@ struct CausalMask : NoMask {
   template <class BlkCoord, class TileShape, class ProblemSize>
   CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
                                            ProblemSize const& problem_size) {
-    return min(get_trip_count(blk_coord, tile_shape, problem_size), ceil_div(get<0>(tile_shape), get<1>(tile_shape)) + 1);
+    return min(get_trip_count(blk_coord, tile_shape, problem_size),
+               ceil_div(get<0>(tile_shape), get<1>(tile_shape)) + 1);
   }
 
   template <class BlkCoord, class TileShape, class ProblemSize>

--- a/include/flashinfer/attention/blackwell/collective/sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp
+++ b/include/flashinfer/attention/blackwell/collective/sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp
@@ -960,7 +960,7 @@ struct Sm100FmhaFwdMainloopTmaWarpspecialized {
 
       // e^(scale * (old_max - new_max)
       float scale = ::exp2f(params.scale_softmax_log2 *
-                        (tTMEM_LOADVrS(kIdxOldRowMax) - tTMEM_LOADVrS(kIdxNewRowMax)));
+                            (tTMEM_LOADVrS(kIdxOldRowMax) - tTMEM_LOADVrS(kIdxNewRowMax)));
       bool warp_should_rescale = __any_sync(0xffffffff, scale != 1.f);
 
       pipeline_o.consumer_wait(pipeline_o_consumer_state);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. fix the bug in `get_unmasked_trip_count` calculation in causal attention
2. add skip correction rescale optimization in FA4.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
