### PR TITLE
increase workspace to make unit test pass

### DIFF
--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -277,7 +277,7 @@ def test_batch_paged_prefill_sliding_window(
         (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device="cuda:0"
     )
 
-    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
     wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, "NHD", backend=backend
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix tests/test_sliding_window.py unit test failure by increasing the workspace size.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
