### PR TITLE
Do not use the limited API with free-threaded Python

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -88,8 +88,9 @@ def generate_ninja_build_for_op(
     common_cflags = [
         "-DTORCH_EXTENSION_NAME=$name",
         "-DTORCH_API_INCLUDE_EXTENSION_H",
-        "-DPy_LIMITED_API=0x03090000",
     ]
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        common_cflags.append("-DPy_LIMITED_API=0x03090000")
     common_cflags += _get_pybind11_abi_build_flags()
     common_cflags += _get_glibcxx_abi_build_flags()
     if extra_include_dirs is not None:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ import os
 import platform
 import re
 import subprocess
+import sysconfig
 from pathlib import Path
 from typing import List, Mapping
 
@@ -103,11 +104,15 @@ class AotDistribution(Distribution):
         return enable_aot
 
 
+bdist_wheel_options = {}
+if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+    bdist_wheel_options["py_limited_api"] = "cp39"
+
 setuptools.setup(
     version=get_version(),
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     install_requires=install_requires,
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": bdist_wheel_options},
     distclass=AotDistribution,
 )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR disabled the limited C API when using free-threaded Python. This makes it possible to build a wheel and use FlashInfer with the free-threaded build of CPython.

## 🔍 Related Issues

Fixes #1686.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
