### PR TITLE
gemm: Enabled alpha with the mx_fp4 format

### DIFF
--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -1652,6 +1652,7 @@ def build_cudnn_gemm_block_scale_dequantize_graph(
     o_type,
     block_size,
     device,
+    alpha,
     use_nvfp4,
 ):
     _check_cudnn_availability()
@@ -1704,8 +1705,7 @@ def build_cudnn_gemm_block_scale_dequantize_graph(
 
         c_final_cudnn_tensor = c_tensor
 
-        # if use_nvfp4 is True, we need to multiply the output by the global scale
-        if use_nvfp4:
+        if alpha is not None:
             global_scale_cudnn_tensor = graph.tensor(
                 name="global_scale",
                 dim=(1, 1, 1),
@@ -1734,7 +1734,7 @@ def build_cudnn_gemm_block_scale_dequantize_graph(
 
         # WAR: The alpha (contains the global scale) is not supported by the cuBLAS backend (eng0)
         # in older cuDNN versions, so we deselect it.
-        if use_nvfp4 and not _is_cublas_fp4_available_in_cudnn():
+        if (alpha is not None) and (not _is_cublas_fp4_available_in_cudnn()):
             graph.deselect_engines(["eng0"])
         graph.check_support()
         graph.build_plans()
@@ -1743,7 +1743,14 @@ def build_cudnn_gemm_block_scale_dequantize_graph(
 
 
 def execute_cudnn_gemm_fp4_graph(
-    graph, a, b, a_descale, b_descale, alpha, c_final, workspace_buffer, use_nvfp4
+    graph,
+    a,
+    b,
+    a_descale,
+    b_descale,
+    alpha,
+    c_final,
+    workspace_buffer,
 ):
     variant_pack = {
         UIDs.A_UID.value: a.view(_get_native_fp4_dtype()),
@@ -1753,7 +1760,7 @@ def execute_cudnn_gemm_fp4_graph(
         UIDs.O_UID.value: c_final,
     }
 
-    if use_nvfp4:
+    if alpha is not None:
         variant_pack[UIDs.ALPHA_UID.value] = alpha.view(torch.float)
 
     if workspace_buffer.numel() < graph.get_workspace_size():
@@ -1998,6 +2005,7 @@ def mm_fp4(
     block_size: int = 16,
     use_8x4_sf_layout: bool = False,
     backend: Literal["cudnn", "trtllm", "cutlass"] = "cudnn",
+    use_nvfp4: bool = False,
 ) -> torch.Tensor:
     r"""MM FP4
 
@@ -2016,7 +2024,7 @@ def mm_fp4(
         Block scale tensor for B, shape (k, n // block_size), float8_e4m3fn or uint8.
 
     alpha: Optional[torch.Tensor]
-        Global scale tensor, float scalar in case of nvfp4 quantization. None in case of mxfp4 quantization.
+        Global scale tensor, float scalar.
 
     out_dtype: torch.dtype
         Output dtype, bf16 or fp16.
@@ -2032,6 +2040,9 @@ def mm_fp4(
 
     backend: Literal["cudnn", "trtllm", "cutlass"]
         Backend to use, defaults to "cudnn".
+
+    use_nvfp4: bool
+        Whether to use nvfp4 quantization or mxfp4 quantization, defaults to False.
 
     Notes
     -----
@@ -2057,9 +2068,6 @@ def mm_fp4(
     >>> out.shape
     torch.Size([48, 256])
     """
-    # nvfp4 quantization if alpha provided, mxfp4 quantization if no alpha provided
-    use_nvfp4 = alpha is not None
-
     # pre-check the input tensor, block scale tensor and alpha tensor
     if a.ndim != 2 or b.ndim != 2:
         raise ValueError(f"mm_fp4 accepts 2d tensors, got {a.shape} and {b.shape}")
@@ -2147,12 +2155,13 @@ def mm_fp4(
             _torch_data_type_to_cudnn_data_type(out_dtype),
             block_size,
             a.device,
+            alpha,
             use_nvfp4,
         )
 
         # execute the fp4 cudnn graph
         execute_cudnn_gemm_fp4_graph(
-            graph, a, b, a_descale, b_descale, alpha, out, workspace_buffer, use_nvfp4
+            graph, a, b, a_descale, b_descale, alpha, out, workspace_buffer
         )
     elif backend == "trtllm":
         if out_dtype != torch.bfloat16:

--- a/tests/test_mm_fp4.py
+++ b/tests/test_mm_fp4.py
@@ -18,17 +18,19 @@ from flashinfer import (
 @pytest.mark.parametrize("backend", ["trtllm", "cudnn", "cutlass"])
 @pytest.mark.parametrize("use_128x4_sf_layout", [False, True])
 @pytest.mark.parametrize("auto_tuning", [False, True])
-@pytest.mark.parametrize("fp4_type", ["nvfp4", "mxfp4"])
+@pytest.mark.parametrize("fp4_type", ["nvfp4", "mxfp4", "mxfp4_alpha"])
 def test_mm_fp4(
     m, n, k, res_dtype, backend, use_128x4_sf_layout, auto_tuning, fp4_type
 ):
+    use_nvfp4 = fp4_type == "nvfp4"
+
     if backend == "trtllm" and res_dtype == torch.float16:
         pytest.skip("Skipping test for trtllm fp4 with float16")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
     if auto_tuning and backend == "cudnn":
         pytest.skip("Skipping test for cudnn fp4 with auto_tuning=True")
-    if fp4_type == "mxfp4" and backend != "cudnn":
+    if not use_nvfp4 and backend != "cudnn":
         pytest.skip("mx_fp4 is only supported for cudnn backend")
 
     input = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
@@ -41,9 +43,8 @@ def test_mm_fp4(
     # for trtllm, we need to shuffle mat2 because we swap A, B.
     do_shuffle_b = backend == "trtllm"
 
-    use_nvfp4 = fp4_type == "nvfp4"
     block_size = 16 if use_nvfp4 else 32
-    alpha = None  # None in case of mxfp4
+    has_alpha = fp4_type == "mxfp4_alpha" or fp4_type == "nvfp4"
 
     if use_nvfp4:
         input_fp4, input_inv_s = nvfp4_quantize(
@@ -55,10 +56,11 @@ def test_mm_fp4(
             sfLayout=SfLayout.layout_128x4,
             do_shuffle=do_shuffle_b,
         )
-        alpha = 1.0 / (global_sf_input * global_sf_mat2)
     else:
         input_fp4, input_inv_s = mxfp4_quantize(input)
         mat2_fp4, mat2_inv_s = mxfp4_quantize(mat2)
+
+    alpha = 1.0 / (global_sf_input * global_sf_mat2) if has_alpha else None
 
     reference = torch.mm(input, mat2.T)
 
@@ -76,6 +78,7 @@ def test_mm_fp4(
             block_size=block_size,
             use_8x4_sf_layout=not use_128x4_sf_layout,
             backend=backend,
+            use_nvfp4=use_nvfp4,
         )
 
     cos_sim = F.cosine_similarity(reference.reshape(-1), res.reshape(-1), dim=0)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

While the mx_fp4 format uses per-block scales only, some cases do benefit from having a global scale to avoid truncating the range. This PR enables this and makes the following changes:
* construct the cuDNN graph with a global scale if one is provided
* Adjust the mm_fp4 API with an explicit use_nvfp4 bool: previously the API could use the presence of an "alpha" factor to distinguish between nvfp4 (required global scale) and mx_fp4 formats. Now we have an explicit parameter to indicate this: use_nvfp4.

## 🔍 Related Issues

This change was decided after a feedback discussion with the requester of [issue #1592](https://github.com/flashinfer-ai/flashinfer/issues/1592).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
