### PR TITLE
Update deepgemm backend for 103a

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -117,7 +117,7 @@ class ArtifactPath:
         "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
     )
     CUDNN_SDPA: str = "4c623163877c8fef5751c9c7a59940cd2baae02e/fmha/cudnn/"
-    DEEPGEMM: str = "d25901733420c7cddc1adf799b0d4639ed1e162f/deep-gemm/"
+    DEEPGEMM: str = "51d730202c9eef782f06ecc950005331d85c5d4b/deep-gemm/"
 
 
 class MetaInfoHash:
@@ -127,7 +127,7 @@ class MetaInfoHash:
     TRTLLM_GEN_BMM: str = (
         "c98b4ce69a39fd41556d67033c30ea814ef76b0a2fe16e798e55baf0104acc34"
     )
-    DEEPGEMM: str = "69aa277b7f3663ed929e73f9c57301792b8c594dac15a465b44a5d151b6a1d50"
+    DEEPGEMM: str = "b4374f857c3066089c4ec6b5e79e785559fa2c05ce2623710b0b04bf86414a48"
     TRTLLM_GEN_GEMM: str = (
         "0345358c916d990709f9670e113e93f35c76aa22715e2d5128ec2ca8740be5ba"
     )

--- a/tests/test_groupwise_scaled_gemm_fp8.py
+++ b/tests/test_groupwise_scaled_gemm_fp8.py
@@ -186,7 +186,6 @@ def test_fp8_groupwise_group_gemm(
     torch.testing.assert_close(out, ref_c, atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.xfail(reason="Expected failures for deepgemm tests on SM > 100")
 @pytest.mark.parametrize("m", [128, 256, 512, 1024])
 @pytest.mark.parametrize("nk", [(128, 512), (512, 128), (4096, 7168), (7168, 2048)])
 @pytest.mark.parametrize("group_size", [1, 4, 8, 64, 128, 256])
@@ -230,7 +229,6 @@ def test_fp8_groupwise_group_deepgemm(
     torch.testing.assert_close(out, ref, atol=3e-2, rtol=3e-2)
 
 
-@pytest.mark.xfail(reason="Expected failures for deepgemm tests on SM > 100")
 @pytest.mark.parametrize("m", [128, 256, 512, 1024])
 @pytest.mark.parametrize("nk", [(128, 512), (512, 128), (4096, 7168), (7168, 2048)])
 @pytest.mark.parametrize("group_size", [1, 4, 8, 64, 128, 256])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix failed with KeyError: '103a' for deepGEMM backend tests (groupwise gemm): `tests/test_groupwise_scaled_gemm_fp8.py::test_fp8_groupwise_batch_deepgemm_masked` and `tests/test_groupwise_scaled_gemm_fp8.py::test_fp8_groupwise_group_deepgemm` 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
