### PR TITLE
DRAFT: Support Kimi-K2 for TRT: templatize number of experts

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -808,8 +808,9 @@ std::vector<at::Tensor> trtllm_fp4_block_scale_moe_launcher(
   //     {args.num_tokens, args.top_k}, routing_bias_dtype, hidden_states.device(), std::nullopt);
   // at::Tensor expert_indexes = at::detail::empty_cuda(
   //     {args.num_tokens, args.top_k}, at::ScalarType::Int, hidden_states.device(), std::nullopt);
+  int constexpr MAX_NUM_EXPERTS = 384;
   at::Tensor expert_count_histogram = at::detail::empty_cuda(
-      {2 * 256},
+      {2 * MAX_NUM_EXPERTS},
       at::ScalarType::Int,  // 256 is the max number of threads per block and max number of experts
       hidden_states.device(), std::nullopt);
 

--- a/csrc/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/trtllm_fused_moe_routing_deepseek.cu
@@ -22,8 +22,6 @@ namespace routingDeepSeek {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static constexpr int NumThreads = 256;
-static constexpr int NumWarps = NumThreads / WarpSize;
 static constexpr int NumTopGroupScores = 2;
 static constexpr int MaxNumTopExperts = 8;
 static constexpr int MaxNumTopGroups = 4;
@@ -33,6 +31,8 @@ __global__ void routingMainKernel(KernelParams params) {
   // declare types
   using OutputT = typename KernelParams::OutputT;
   using InputT = typename KernelParams::InputT;
+  static constexpr int NumThreads = KernelParams::NumExperts;  // DeepSeek uses 1 thread per expert
+  static constexpr int NumWarps = NumThreads / WarpSize;
 
   // declare shared memory structure
   // number of experts is bounded by number of threads
@@ -62,19 +62,19 @@ __global__ void routingMainKernel(KernelParams params) {
 
   // load bias already; each warp represents one expert group
   auto threadExpert = threadIdx.x;
-  bool expertSelected = threadExpert < params.mNumExperts;
+  bool expertSelected = threadExpert < KernelParams::NumExperts;
   if constexpr (KernelParams::UseGroups) {
     threadExpert = warpIdx * params.mNumExpertsPerGroup + laneIdx;
     expertSelected = laneIdx < params.mNumExpertsPerGroup;
   }
-  auto scoreIdx = int64_t{blockIdx.x} * int64_t{params.mNumExperts} + threadExpert;
+  auto scoreIdx = int64_t{blockIdx.x} * int64_t{KernelParams::NumExperts} + threadExpert;
   auto biasVal = expertSelected ? params.mPtrRoutingBias[threadExpert] : invalidScore;
 
   // initialize the mPtrExpertCounts
   if (params.mPtrExpertCounts) {
     int32_t globalThreadIdx = blockIdx.x * NumThreads + threadIdx.x;
     int32_t globalThreadStride = gridDim.x * NumThreads;
-    int32_t expertCountsNum = 2 * params.mNumExperts;
+    int32_t expertCountsNum = 2 * KernelParams::NumExperts;
     initArr(globalThreadIdx, expertCountsNum, globalThreadStride, params.mPtrExpertCounts, 0);
   }
 
@@ -164,7 +164,7 @@ __global__ void routingMainKernel(KernelParams params) {
         auto expertIdx = ii * WarpSize + laneIdx;
         expertIdxGroup[ii] = expertIdx;
         expertScoreGroup[ii] =
-            expertIdx < params.mNumExperts ? smemScoreBias[expertIdx] : invalidScoreFloat;
+            expertIdx < KernelParams::NumExperts ? smemScoreBias[expertIdx] : invalidScoreFloat;
       }
     }
 
@@ -204,9 +204,11 @@ __global__ void routingMainKernel(KernelParams params) {
 
 template <typename KernelParams>
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(NumThreads)
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(KernelParams::NumExperts)
     routingIndicesClusterKernel(KernelParams params) {
   using OutputT = typename KernelParams::OutputT;
+  static constexpr int NumThreads = KernelParams::NumExperts;  // DeepSeek uses 1 thread per expert
+  static constexpr int NumWarps = NumThreads / WarpSize;
 
   int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
   int32_t const clusterBlockRank = blockIdx.x;
@@ -230,7 +232,9 @@ __global__ void routingIndicesClusterKernel(KernelParams params) {
 
 template <typename KernelParams>
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __launch_bounds__(NumThreads) routingIndicesCoopKernel(KernelParams params) {
+__global__ void __launch_bounds__(KernelParams::NumExperts) routingIndicesCoopKernel(KernelParams params) {
+  static constexpr int NumThreads = KernelParams::NumExperts;  // DeepSeek uses 1 thread per expert
+  static constexpr int NumWarps = NumThreads / WarpSize;
   // number of experts is bounded by number of threads
   __shared__ int32_t __attribute((aligned(128))) smemExpertCount[NumThreads];
   __shared__ int32_t __attribute((aligned(128))) smemExpertOffset[NumThreads];
@@ -322,7 +326,7 @@ __global__ void __launch_bounds__(NumThreads) routingIndicesCoopKernel(KernelPar
   int32_t const localExpertCount = smemExpertCount[threadIdx.x];
 
   int32_t blockExpertOffset = 0;
-  if (threadIdx.x < params.mNumExperts) {
+  if (threadIdx.x < KernelParams::NumExperts) {
     blockExpertOffset = atomicAdd(&params.mPtrExpertCounts[threadIdx.x], localExpertCount);
   }
 
@@ -330,7 +334,7 @@ __global__ void __launch_bounds__(NumThreads) routingIndicesCoopKernel(KernelPar
   grid.sync();
 
   // Get total count for this expert.
-  int32_t count = (threadIdx.x < params.mNumExperts) ? params.mPtrExpertCounts[threadIdx.x] : 0;
+  int32_t count = (threadIdx.x < KernelParams::NumExperts) ? params.mPtrExpertCounts[threadIdx.x] : 0;
 
   // Note: the scan is redundant in all CTAs, but doing it in only 1 CTA would be worse for latency.
 
@@ -408,7 +412,14 @@ __global__ void routingIndicesCoopKernel(KernelParams params) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void run(Data& data, void* stream) {
+template <int NumExperts>
+void runImpl(Data& data, void* stream) {
+  static constexpr int NumThreads = NumExperts;  // DeepSeek: 1 thread per expert
+  static constexpr int NumWarps = NumThreads / WarpSize;
+
+  // Validate that the template parameter matches the data
+  TORCH_CHECK(data.mNumExperts == NumExperts, "DeepSeek routing kernel expects exactly ",
+              NumExperts, " experts, got ", data.mNumExperts);
   TORCH_CHECK(data.mPtrExpertIdx != nullptr || data.mPtrPermutedIdxSize != nullptr ||
                   data.mPtrExpertWeights != nullptr,
               "Routing kernel requires at least one output parameter");
@@ -480,7 +491,8 @@ void run(Data& data, void* stream) {
   LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
                                  /*coopLaunch=*/false, routingMainKernel, numBlocks, NumThreads,
                                  /*smemSize=*/0,  // No dynamic smem
-                                 stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
+                                 stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true,
+                                 NumExperts);
 
   if (data.mPtrPermutedIdxSize != nullptr) {
     if (useSingleCluster) {
@@ -488,13 +500,15 @@ void run(Data& data, void* stream) {
                                      /*coopLaunch=*/false, routingIndicesClusterKernel,
                                      NumBlocksPerCluster, NumThreads,
                                      /*smemSize=*/0,  // No dynamic smem
-                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
+                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true,
+                                     NumExperts);
     } else if (data.mNumTokens <= maxTokensCoop) {
       LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
                                      /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
                                      NumThreads,
                                      /*smemSize=*/0,  // No dynamic smem
-                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
+                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true,
+                                     NumExperts);
     } else {
       const int32_t expandedIdxSize = data.mNumTokens * data.mTopK;
 
@@ -513,13 +527,25 @@ void run(Data& data, void* stream) {
                                      /*coopLaunch=*/false, routingIndicesHistogramKernel,
                                      numBlocksHistogram, NumThreads,
                                      /*smemSize=*/0,  // No dynamic smem
-                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
+                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true,
+                                     NumExperts);
       LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
                                      /*coopLaunch=*/false, routingIndicesOffsetsKernel,
                                      numBlocksOffsets, NumThreads,
                                      /*smemSize=*/0,  // No dynamic smem
-                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
+                                     stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true,
+                                     NumExperts);
     }
+  }
+}
+
+void run(Data& data, void* stream) {
+  if (data.mNumExperts == 256) {
+    runImpl<256>(data, stream);
+  } else if (data.mNumExperts == 384) {
+    runImpl<384>(data, stream);
+  } else {
+    TORCH_CHECK(false, "Unsupported number of experts: ", data.mNumExperts);
   }
 }
 

--- a/include/flashinfer/trtllm/fused_moe/DevKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/DevKernel.h
@@ -111,16 +111,16 @@ namespace moe::dev {
     TORCH_WARN("Unsupported pair");                                                                \
   }
 
-#define LAUNCH_ROUTING(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,     \
-                       NumExperts)                                                            \
-  if (data.mDtypeExpW == tg::Dtype::Fp32) {                                                   \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, NumExperts), kernel, numBlocks,     \
-               numThreads, smemSize, stream);                                                 \
-  } else if (data.mDtypeExpW == tg::Dtype::Bfloat16) {                                        \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, NumExperts),        \
-               kernel, numBlocks, numThreads, smemSize, stream);                              \
-  } else {                                                                                    \
-    TORCH_WARN("Unsupported dtypeExpW");                                                      \
+#define LAUNCH_ROUTING(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,      \
+                       NumExperts)                                                             \
+  if (data.mDtypeExpW == tg::Dtype::Fp32) {                                                    \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, NumExperts), kernel, numBlocks,      \
+               numThreads, smemSize, stream);                                                  \
+  } else if (data.mDtypeExpW == tg::Dtype::Bfloat16) {                                         \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, NumExperts), kernel, \
+               numBlocks, numThreads, smemSize, stream);                                       \
+  } else {                                                                                     \
+    TORCH_WARN("Unsupported dtypeExpW");                                                       \
   }
 
 #define LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, \

--- a/include/flashinfer/trtllm/fused_moe/DevKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/DevKernel.h
@@ -111,37 +111,38 @@ namespace moe::dev {
     TORCH_WARN("Unsupported pair");                                                                \
   }
 
-#define LAUNCH_ROUTING(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream)     \
+#define LAUNCH_ROUTING(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,     \
+                       NumExperts)                                                            \
   if (data.mDtypeExpW == tg::Dtype::Fp32) {                                                   \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float), kernel, numBlocks, numThreads,     \
-               smemSize, stream);                                                             \
-  } else if (data.mDtypeExpW == tg::Dtype::Bfloat16) {                                        \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16), kernel, numBlocks, \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, NumExperts), kernel, numBlocks,     \
                numThreads, smemSize, stream);                                                 \
+  } else if (data.mDtypeExpW == tg::Dtype::Bfloat16) {                                        \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, NumExperts),        \
+               kernel, numBlocks, numThreads, smemSize, stream);                              \
   } else {                                                                                    \
     TORCH_WARN("Unsupported dtypeExpW");                                                      \
   }
 
 #define LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, \
-                                       stream, extraFlag, forceFloatInput)                        \
+                                       stream, extraFlag, forceFloatInput, NumExperts)            \
   if (data.mDtypeExpW == tg::Dtype::Fp32 && extraFlag) {                                          \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, true), kernel, numBlocks, numThreads,   \
-               smemSize, stream);                                                                 \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, true, NumExperts), kernel, numBlocks,   \
+               numThreads, smemSize, stream);                                                     \
   } else if (data.mDtypeExpW == tg::Dtype::Fp32) {                                                \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, false), kernel, numBlocks, numThreads,  \
-               smemSize, stream);                                                                 \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, float, false, NumExperts), kernel, numBlocks,  \
+               numThreads, smemSize, stream);                                                     \
   } else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && extraFlag && forceFloatInput) {            \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, true), kernel, numBlocks,       \
-               numThreads, smemSize, stream);                                                     \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, true, NumExperts), kernel,      \
+               numBlocks, numThreads, smemSize, stream);                                          \
   } else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && extraFlag) {                               \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, true), kernel,          \
-               numBlocks, numThreads, smemSize, stream);                                          \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, true, NumExperts),      \
+               kernel, numBlocks, numThreads, smemSize, stream);                                  \
   } else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && forceFloatInput) {                         \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, false), kernel, numBlocks,      \
-               numThreads, smemSize, stream);                                                     \
-  } else if (data.mDtypeExpW == tg::Dtype::Bfloat16) {                                            \
-    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, false), kernel,         \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, false, NumExperts), kernel,     \
                numBlocks, numThreads, smemSize, stream);                                          \
+  } else if (data.mDtypeExpW == tg::Dtype::Bfloat16) {                                            \
+    LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, false, NumExperts),     \
+               kernel, numBlocks, numThreads, smemSize, stream);                                  \
   } else {                                                                                        \
     TORCH_WARN("Unsupported dtypeExpW");                                                          \
   }

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -254,7 +254,8 @@ struct Data : public DataBase {
   bool mApplySoftmaxAfterTopK{false};
 };
 
-template <typename InputT_, typename OutputT_, bool DoSoftmaxBeforeTopK_, int NumExperts_, bool UsePdl_>
+template <typename InputT_, typename OutputT_, bool DoSoftmaxBeforeTopK_, int NumExperts_,
+          bool UsePdl_>
 struct KernelParams : public KernelParamsBase<InputT_, OutputT_, NumExperts_, UsePdl_> {
   using InputT = InputT_;
   using OutputT = OutputT_;

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -92,10 +92,11 @@ struct DataBase {
   int32_t mNumLocalExperts;
 };
 
-template <typename InputT_, typename OutputT_, bool UsePdl_>
+template <typename InputT_, typename OutputT_, int NumExperts_, bool UsePdl_>
 struct KernelParamsBase {
   using InputT = InputT_;
   using OutputT = OutputT_;
+  static constexpr int NumExperts = NumExperts_;
   static constexpr bool UsePdl = UsePdl_;
 
   // Public pointer members
@@ -160,8 +161,8 @@ struct Data : public DataBase {
   bool mUseRoutingSoftmax;
 };
 
-template <typename InputT_, typename OutputT_, bool UseGroups_, bool UsePdl_>
-struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_> {
+template <typename InputT_, typename OutputT_, bool UseGroups_, int NumExperts_, bool UsePdl_>
+struct KernelParams : public KernelParamsBase<InputT_, OutputT_, NumExperts_, UsePdl_> {
   using InputT = InputT_;
   using OutputT = OutputT_;
 
@@ -215,8 +216,8 @@ struct Data : public DataBase {
   tg::Dtype mDtypeExpW{tg::Dtype::Bfloat16};
 };
 
-template <typename InputT_, typename OutputT_, bool UsePdl_>
-struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_> {
+template <typename InputT_, typename OutputT_, int NumExperts_, bool UsePdl_>
+struct KernelParams : public KernelParamsBase<InputT_, OutputT_, NumExperts_, UsePdl_> {
   using InputT = InputT_;
   using OutputT = OutputT_;
 
@@ -253,8 +254,8 @@ struct Data : public DataBase {
   bool mApplySoftmaxAfterTopK{false};
 };
 
-template <typename InputT_, typename OutputT_, bool DoSoftmaxBeforeTopK_, bool UsePdl_>
-struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_> {
+template <typename InputT_, typename OutputT_, bool DoSoftmaxBeforeTopK_, int NumExperts_, bool UsePdl_>
+struct KernelParams : public KernelParamsBase<InputT_, OutputT_, NumExperts_, UsePdl_> {
   using InputT = InputT_;
   using OutputT = OutputT_;
 


### PR DESCRIPTION
## Goal: Support Kimi-K2 Family of Models

The DeepSeek-v3 family of models use 256 experts, while the Kimi-K2 family of models use 384 experts. The number of experts is currently a hardcoded constant in the DeepSeek routing kernels, and must remain a compile-time constant in order to be used as the `__launchbounds__` for some kernels.

  ### Proposed Solution: Template-configurable Number of Experts

  In [include/flashinfer/trtllm/fused_moe/RoutingKernel.h](https://github.com/flashinfer-ai/flashinfer/blob/main/include/flashinfer/trtllm/fused_moe/RoutingKernel.h), change
  ```
  template <typename InputT_, typename OutputT_, bool UsePdl_>
  struct KernelParamsBase {
      ...
  }
  ```
  to
  ```
  template <typename InputT_, typename OutputT_, bool UsePdl_, int NumExperts_>
  struct KernelParamsBase {
      static constexpr bool NumExperts = NumExperts_;
      ...
  }
  ```
Then change [csrc/trtllm_fused_moe_routing_deepseek.cu](https://github.com/flashinfer-ai/flashinfer/blob/main/csrc/trtllm_fused_moe_routing_deepseek.cu), [csrc/trtllm_fused_moe_routing_renormalize.cu](https://github.com/flashinfer-ai/flashinfer/blob/main/csrc/trtllm_fused_moe_routing_renormalize.cu), [csrc/trtllm_fused_moe_routing_llama4.cu](https://github.com/flashinfer-ai/flashinfer/blob/main/csrc/trtllm_fused_moe_routing_llama4.cu), to use `KernelParams::NumExperts` as the number of experts (might need some boilerplate to "pass" it from `KernelParamsBase` to `KernelParams` as well).


  ### Benefits
  - Easy to support different numbers of experts in the future.
  - Zero runtime overhead.

  ### Costs
  - (NEW) The numbers of experts for Llama4 and `renormalize` kernels need to be known at compile time, where previously only the *max* number of experts was known at compile time. This means that `flashinfer` users passing custom numbers of experts to these kernels will have their code broken if we don't include that number of experts in the `run` logic dispatching. If this is a concern we *might* be able to keep the number of experts defined at compile time in the deepseek kernel and at runtime in the Llama4 and renormalize kernels, but this would come at the cost of some complexity.

  ### Alternatives Considered

  1. New file called `csrc/trtllm_fused_moe_routing_kimi.cu` that is an exact copy of [csrc/trtllm_fused_moe_routing_deepseek.cu](https://github.com/flashinfer-ai/flashinfer/blob/main/csrc/trtllm_fused_moe_routing_deepseek.cu) except it hardcodes 384 experts. This makes maintenance of both files more difficult, and doesn't make it easy to support different numbers of experts in the future.

  2. Make [csrc/trtllm_fused_moe_routing_deepseek.cu](https://github.com/flashinfer-ai/flashinfer/blob/main/csrc/trtllm_fused_moe_routing_deepseek.cu) accept a compiler flag defining the number of experts (`-DNUM_EXPERTS 256` and `-DNUM_EXPERTS 384`). This moves complexity to the build stage, which doesn't seem like the right place to manage it.

