### PR TITLE
ci: fix prefill attention unittests

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -2306,12 +2306,14 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
       // apply mask
       if (MASK_MODE == MaskMode::kCustom) {
         logits_mask<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-                             kv_idx_base, qo_len, kv_len, chunk_end, group_size, s_frag);
+                             kv_idx_base, qo_len, kv_len, chunk_end, group_size, s_frag, tid,
+                             kv_head_idx);
       } else {
         if constexpr (MASK_MODE != MaskMode::kMultiItemScoring) {
           if (iter >= mask_iteration || iter < window_iteration) {
             logits_mask<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-                                 kv_idx_base, qo_len, kv_len, chunk_end, group_size, s_frag);
+                                 kv_idx_base, qo_len, kv_len, chunk_end, group_size, s_frag, tid,
+                                 kv_head_idx);
           }
         } else if constexpr (MASK_MODE == MaskMode::kMultiItemScoring) {
           if (iter + 1 >= num_iterations_prefix) {
@@ -2324,7 +2326,8 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           } else {
             if (iter >= mask_iteration || iter < window_iteration) {
               logits_mask<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-                                   kv_idx_base, qo_len, kv_len, chunk_end, group_size, s_frag);
+                                   kv_idx_base, qo_len, kv_len, chunk_end, group_size, s_frag, tid,
+                                   kv_head_idx);
             }
           }
         }

--- a/scripts/task_jit_run_tests_part4.sh
+++ b/scripts/task_jit_run_tests_part4.sh
@@ -10,5 +10,6 @@ pip install -e . -v
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # avoid memory fragmentation
 pytest -s tests/test_deepseek_mla.py
 pytest -s tests/test_group_gemm.py
+pytest -s tests/test_batch_prefill_kernels.py
 # NOTE(Zihao): need to fix tile size on KV dimension for head_dim=256 on small shared memory architecture (sm89)
 # pytest -s tests/test_batch_attention.py

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -512,7 +512,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
 
 @pytest.mark.parametrize("batch_size", [12, 17, 128])
 @pytest.mark.parametrize("kv_len", [54, 97, 512, 2048])
-@pytest.mark.parametrize("qo_len", [37, 17, 127])  # , 577])
+@pytest.mark.parametrize("qo_len", [37, 17, 127, 577])
 @pytest.mark.parametrize("page_size", [1, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])
@@ -536,6 +536,8 @@ def test_batch_prefill_with_paged_kv_cache_custom_mask(
     return_lse,
     contiguous_kv,
 ):
+    if qo_len > kv_len:
+        pytest.skip("qo_len > kv_len is not supported for custom mask test")
     q = torch.randn(
         batch_size * qo_len,
         num_qo_heads,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. xfail the prefill + cudagraph UT, until we fully fix the workspace overflow issues.
2. fixes the correctness of pageattention + custom mask
3. add tests/test_batch_prefill_kernels.py to public CI

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @nvmbreughe @yongwww 
