### PR TITLE
misc: fix vector size calculation for fp4

### DIFF
--- a/csrc/activation.cu
+++ b/csrc/activation.cu
@@ -40,7 +40,7 @@ void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   auto stream = at::cuda::getCurrentCUDAStream();
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    uint32_t vec_size = 16 / sizeof(c_type);
+    uint32_t vec_size = get_vec_size_128b<c_type>();
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
     config.blockDim = std::min(d / vec_size, 1024U);
@@ -72,7 +72,7 @@ void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   auto stream = at::cuda::getCurrentCUDAStream();
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    uint32_t vec_size = 16 / sizeof(c_type);
+    uint32_t vec_size = get_vec_size_128b<c_type>();
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
     config.blockDim = std::min(d / vec_size, 1024U);
@@ -103,7 +103,7 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   auto stream = at::cuda::getCurrentCUDAStream();
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    uint32_t vec_size = 16 / sizeof(c_type);
+    uint32_t vec_size = get_vec_size_128b<c_type>();
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
     config.blockDim = std::min(d / vec_size, 1024U);

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -41,7 +41,7 @@ void {{ func_name }}(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   const c10::cuda::OptionalCUDAGuard device_guard(out.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
-    uint32_t vec_size = 16 / sizeof(c_type);
+    uint32_t vec_size = get_vec_size_128b<c_type>();
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
     config.blockDim = std::min(d / vec_size, 1024U);

--- a/include/flashinfer/activation.cuh
+++ b/include/flashinfer/activation.cuh
@@ -27,7 +27,7 @@ namespace activation {
 
 template <typename T, float (*Activation)(const float&)>
 __global__ void act_and_mul_kernel(T* __restrict__ out, const T* __restrict__ input, const int d) {
-  constexpr uint32_t vec_size = 16 / sizeof(T);
+  constexpr uint32_t vec_size = get_vec_size_128b<T>();
   const int64_t token_idx = blockIdx.x;
   const int64_t thread_idx = threadIdx.x;
   const int64_t stride = blockDim.x;

--- a/include/flashinfer/cp_async.cuh
+++ b/include/flashinfer/cp_async.cuh
@@ -154,7 +154,7 @@ __device__ __forceinline__ void load(T* smem_ptr, const T* gmem_ptr) {
     load_128b<prefetch_mode>(smem_ptr, gmem_ptr);
   } else {
     load_128b<prefetch_mode>(smem_ptr, gmem_ptr);
-    load_128b<prefetch_mode>(smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T));
+    load_128b<prefetch_mode>(smem_ptr + get_vec_size_128b<T>(), gmem_ptr + get_vec_size_128b<T>());
   }
 }
 
@@ -177,8 +177,8 @@ __device__ __forceinline__ void pred_load(T* smem_ptr, const T* gmem_ptr, bool p
     pred_load_128b<prefetch_mode, fill_mode>(smem_ptr, gmem_ptr, predicate);
   } else {
     pred_load_128b<prefetch_mode, fill_mode>(smem_ptr, gmem_ptr, predicate);
-    pred_load_128b<prefetch_mode, fill_mode>(smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T),
-                                             predicate);
+    pred_load_128b<prefetch_mode, fill_mode>(smem_ptr + get_vec_size_128b<T>(),
+                                             gmem_ptr + get_vec_size_128b<T>(), predicate);
   }
 }
 

--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -108,7 +108,7 @@ template <typename T>
 cudaError_t RMSNorm(T* input, T* weight, T* output, uint32_t batch_size, uint32_t d,
                     uint32_t stride_input, uint32_t stride_output, float eps = 1e-5,
                     bool enable_pdl = false, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+  const uint32_t vec_size = std::gcd(get_vec_size_128b<T>(), d);
 
   const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
   const uint32_t num_warps = ceil_div(block_size, 32);
@@ -236,7 +236,7 @@ template <typename T>
 cudaError_t FusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batch_size, uint32_t d,
                             uint32_t stride_input, uint32_t stride_residual, float eps = 1e-5,
                             bool enable_pdl = false, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+  const uint32_t vec_size = std::gcd(get_vec_size_128b<T>(), d);
 
   const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
   const uint32_t num_warps = ceil_div(block_size, 32);
@@ -273,7 +273,7 @@ template <typename T>
 cudaError_t GemmaRMSNorm(T* input, T* weight, T* output, uint32_t batch_size, uint32_t d,
                          uint32_t stride_input, uint32_t stride_output, float eps = 1e-5,
                          bool enable_pdl = false, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+  const uint32_t vec_size = std::gcd(get_vec_size_128b<T>(), d);
 
   const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
   const uint32_t num_warps = ceil_div(block_size, 32);
@@ -308,7 +308,7 @@ template <typename T>
 cudaError_t GemmaFusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batch_size, uint32_t d,
                                  uint32_t stride_input, uint32_t stride_residual, float eps = 1e-5,
                                  bool enable_pdl = false, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+  const uint32_t vec_size = std::gcd(get_vec_size_128b<T>(), d);
 
   const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
   const uint32_t num_warps = ceil_div(block_size, 32);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We used to rely on `16 / sizeof(T)` to calculate the vector size of a given data type to compose 128b, but it will fail for fp4 because sizeof(__nv_fp4_e2m1) is 1 (there is no native subbyte design in C++).

This PR fixes the issue by adding a function `get_vec_size_128b` which will return 32 for fp4.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
