### PR TITLE
misc: unify the macro to determine cuda version at compile time

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4118,7 +4118,7 @@ CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enable>::
 
       TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF weight_block_scale_value_int{};
 #ifdef ENABLE_FP8
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
       __nv_fp8_e8m0 tmp;
       tmp.__x = __nv_cvt_float_to_e8m0(1.0f, __NV_SATFINITE, cudaRoundPosInf);
       std::memcpy(&weight_block_scale_value_int, &tmp, sizeof(tmp));

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
+#include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 #include <cuda_fp4.h>
 #endif
 #include <cuda_fp8.h>
@@ -93,7 +94,7 @@ struct TllmToCutlassTypeAdapter<__nv_fp8_e5m2> {
 #endif
 
 #if defined(ENABLE_FP4)
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 template <>
 struct TllmToCutlassTypeAdapter<__nv_fp4_e2m1> {
   using type = cutlass::float_e2m1_t;
@@ -134,7 +135,7 @@ struct CutlassToTllmTypeAdapter<cutlass::float_e5m2_t> {
 #endif
 
 #if defined(ENABLE_FP4)
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 template <>
 struct CutlassToTllmTypeAdapter<cutlass::float_e2m1_t> {
   using type = __nv_fp4_e2m1;

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <cuda.h>
 #include <cuda_runtime_api.h>
 
 #include <array>
@@ -32,7 +33,7 @@
 #include "tensorrt_llm/cutlass_extensions/include/cutlass_extensions/gemm_configs.h"
 
 #ifdef ENABLE_FP4
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 #include <cuda_fp4.h>
 #endif
 #endif

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
@@ -22,8 +22,9 @@
 #include <ATen/ATen.h>
 #include <ATen/Tensor.h>
 #include <ATen/cuda/EmptyTensor.h>
+#include <cuda.h>
 #include <cuda_fp16.h>
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 #include <cuda_fp4.h>
 #endif
 #include <cuda_fp8.h>
@@ -375,7 +376,7 @@ at::Tensor mxfp4_dequantize_host(at::Tensor weight, at::Tensor scale, int64_t gr
   at::Tensor dequant_weight =
       at::empty({n, k}, at::dtype(at::ScalarType::Float).device(at::kCPU).requires_grad(false));
 
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
   uint8_t* weight_packed_ptr = weight.data_ptr<uint8_t>();
   __nv_fp8_e8m0* scale_ptr = reinterpret_cast<__nv_fp8_e8m0*>(scale.data_ptr<uint8_t>());
   float* dequant_weight_ptr = dequant_weight.data_ptr<float>();

--- a/csrc/pytorch_extension_utils.h
+++ b/csrc/pytorch_extension_utils.h
@@ -17,6 +17,7 @@
 #include <Python.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#include <cuda.h>
 #include <torch/library.h>
 
 #ifdef FLASHINFER_ENABLE_BF16
@@ -33,7 +34,7 @@
 #endif
 
 #if defined(FLASHINFER_ENABLE_FP4_E2M1)
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 #include <cuda_fp4.h>
 #endif
 #endif
@@ -146,8 +147,7 @@ FLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)
 #endif
 
 // Should not be used together with _DISPATCH_SF_CASE_FP8_E8M0
-#if defined(FLASHINFER_ENABLE_FP4_E2M1) && \
-    (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if defined(FLASHINFER_ENABLE_FP4_E2M1) && CUDA_VERSION >= 12080
 #define _DISPATCH_CASE_FP4_E2M1(c_type, ...) \
   case at::ScalarType::Byte: {               \
     using c_type = __nv_fp4_e2m1;            \
@@ -158,8 +158,7 @@ FLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)
 #endif
 
 // Should not be used together with _DISPATCH_CASE_FP4_E2M1
-#if defined(FLASHINFER_ENABLE_FP8_E8M0) && \
-    (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if defined(FLASHINFER_ENABLE_FP8_E8M0) && CUDA_VERSION >= 12080
 #define _DISPATCH_SF_CASE_FP8_E8M0(c_type, ...) \
   case at::ScalarType::Byte: {                  \
     using c_type = __nv_fp8_e8m0;               \

--- a/include/flashinfer/cutlass_utils.cuh
+++ b/include/flashinfer/cutlass_utils.cuh
@@ -74,7 +74,7 @@ struct cutlass_dtype<__nv_fp8_e5m2> {
   using type = cutlass::float_e5m2_t;
 };
 
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#if CUDA_VERSION >= 12080
 template <>
 struct cutlass_dtype<__nv_fp8_e8m0> {
   using type = cutlass::float_ue8m0_t;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We used to rely on two kinds of macros to determine whether cuda version >= 12.8:
```c++
#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
```
and
```c++
#if CUDA_VERSION >= 12080
```
which is misleading can cause errors mentioned in #1571 , this PR unifies the macros so that we only rely on `CUDA_VERSION` to determine cuda version at compile time.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
