### PR TITLE
bugfix: increase workspace to make trtllm gen attention unit test pass

### DIFF
--- a/tests/test_trtllm_gen_attention.py
+++ b/tests/test_trtllm_gen_attention.py
@@ -19,7 +19,7 @@ GPU_DEVICE = "cuda:0"
 
 global_workspace_buffer = None  # can.be empty initialized
 global_trtllm_gen_fmha_workspace_buffer = None  # must be zero initialized
-workspace_size = 128 * 1024 * 1024
+workspace_size = 256 * 1024 * 1024
 
 
 def flip_coin(*args, **kwargs):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Increase the workspace size from 128 to 256 to make sure `tests/test_trtllm_gen_attention.py` pass

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
