### PR TITLE
misc: remove unused `torch.utils.cpp_extension` dependencies

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -22,7 +22,10 @@ from ..compilation_context import CompilationContext
 
 
 def torch_get_pybind11_abi_build_flags() -> List[str]:
-    if Version(torch.__version__) >= Version("2.9"):
+    # NOTE: starting from torch 2.9, this function is no longer needed
+    # torch (cuda) version format is now like 2.9.0+cu129, so we need to split the version string
+    # and check if the major version is at least 2.9
+    if Version(re.split(r"\+.*", torch.__version__)[0]) >= Version("2.9"):
         return []
     else:
         abi_cflags = []

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -15,11 +15,22 @@ from torch.utils.cpp_extension import (
     _TORCH_PATH,
     CUDA_HOME,
     _get_num_workers,
-    _get_pybind11_abi_build_flags,
 )
 
 from . import env as jit_env
 from ..compilation_context import CompilationContext
+
+
+def torch_get_pybind11_abi_build_flags() -> List[str]:
+    if Version(torch.__version__) >= Version("2.9"):
+        return []
+    else:
+        abi_cflags = []
+        for pname in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:
+            pval = getattr(torch._C, f"_PYBIND11_{pname}")
+            if pval is not None:
+                abi_cflags.append(f'-DPYBIND11_{pname}=\\"{pval}\\"')
+        return abi_cflags
 
 
 @functools.cache
@@ -91,7 +102,7 @@ def generate_ninja_build_for_op(
     ]
     if not sysconfig.get_config_var("Py_GIL_DISABLED"):
         common_cflags.append("-DPy_LIMITED_API=0x03090000")
-    common_cflags += _get_pybind11_abi_build_flags()
+    common_cflags += torch_get_pybind11_abi_build_flags()
     common_cflags += _get_glibcxx_abi_build_flags()
     if extra_include_dirs is not None:
         for extra_dir in extra_include_dirs:

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -20,10 +20,7 @@ limitations under the License.
 
 import os
 import pathlib
-import re
-import warnings
-
-from torch.utils.cpp_extension import _get_cuda_arch_flags
+from ..compilation_context import CompilationContext
 
 FLASHINFER_BASE_DIR = pathlib.Path(
     os.getenv("FLASHINFER_WORKSPACE_BASE", pathlib.Path.home().as_posix())
@@ -36,17 +33,10 @@ FLASHINFER_CUBIN_DIR = pathlib.Path(
 
 
 def _get_workspace_dir_name() -> pathlib.Path:
-    try:
-        with warnings.catch_warnings():
-            # Ignore the warning for FLASHINFER_CUDA_ARCH_LIST not set
-            warnings.filterwarnings(
-                "ignore", r".*FLASHINFER_CUDA_ARCH_LIST.*", module="torch"
-            )
-            flags = _get_cuda_arch_flags()
-        arch = "_".join(sorted(set(re.findall(r"compute_(\d+)", "".join(flags)))))
-    except Exception:
-        arch = "noarch"
-    # e.g.: $HOME/.cache/flashinfer/75_80_89_90/
+    compilation_context = CompilationContext()
+    arch = "_".join(
+        f"{major}{minor}" for major, minor in compilation_context.TARGET_CUDA_ARCHS
+    )
     return FLASHINFER_CACHE_DIR / arch
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR removes some dependencies on `torch.utils.cpp_extension":
1. After #1608 , we should no longer rely on `_get_cuda_arch_flags`, this PR fixes the issue.
2. Remove dependency on `_get_pybind11_abi_build_flags` as mentioned in https://github.com/flashinfer-ai/flashinfer/issues/1591.

After #1641 we will remove all dependencies on `torch.utils.cpp_extension`.

## 🔍 Related Issues

#1591 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
