### PR TITLE
fix the dequantize_block in the trtllm_cutlass fuse moe test

### DIFF
--- a/tests/test_trtllm_cutlass_fused_moe.py
+++ b/tests/test_trtllm_cutlass_fused_moe.py
@@ -894,6 +894,7 @@ def dequantize_block(
         scales: Block scaling factors
         dtype: Target dtype for dequantization
         original_shape: Original shape of the tensor before padding
+        block_size_n: Block size
 
     Returns:
         torch.Tensor: Dequantized tensor


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The dequantize_block logic in test_trtllm_cutlass_fused_moe.py file is not correct. The test case is not failed due to the HIDDEN_SIZES intended set to 128, which makes the tensor multiply succeed like

```
x_quant.shape = torch.Size([1, 128])
scales.shape = torch.Size([1, 1, 128])
```

However, if we change the HIDDEN_SIZES to 256 and keep block size to 128, the tensor multiply would failed, since now the 

```
x_quant.shape = torch.Size([1, 256])
scales.shape = torch.Size([1, 2, 128])
```

With the logic in this PR, the scales will reshape to (1, 256) which is the same shape as x_quant, now the tensor multiply would succeed

```
x_quant.shape = torch.Size([1, 256])
scales.shape = torch.Size([1, 256])
```

The logic also works with batch size > 1

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
