### PR TITLE
Bump base container image from 13.0.0 to 13.0.1 for cu130 container

### DIFF
--- a/docker/Dockerfile.cu130
+++ b/docker/Dockerfile.cu130
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:13.0.0-devel-ubuntu24.04
+FROM nvidia/cuda:13.0.1-devel-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
This PR bumps the base image of [flashinfer-ci-cu130](https://hub.docker.com/r/flashinfer/flashinfer-ci-cu130) from [nvidia/cuda:13.0.0-devel-ubuntu24.04](https://hub.docker.com/layers/nvidia/cuda/13.0.0-devel-ubuntu24.04/images/sha256-435220c0fef35cbf712e11999f8670a83835ef3cdd18564e5e8122f83078c88c) to [nvidia/cuda:13.0.1-devel-ubuntu24.04](https://hub.docker.com/layers/nvidia/cuda/13.0.1-devel-ubuntu24.04/images/sha256-84e5f33efdccadc21599978ea7e6ed80cbe19bb432f9c339b15a66c4025ac983)

The updated base image container contains the CUDA Toolkit 13.0 Update 1

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
