### PR TITLE
tests: xfail attention sink UT for sliding window + non causal case

### DIFF
--- a/tests/test_attention_sink.py
+++ b/tests/test_attention_sink.py
@@ -635,8 +635,8 @@ def test_attention_sink_chunk_prefill(
     Simulate chunk-based processing of long sequences where current chunk
     attends to all historical tokens plus current chunk tokens
     """
-    if not causal:
-        # xfail for non-causal case
+    if not causal and window_left >= 0:
+        # xfail for non-causal + sliding window case
         pytest.xfail(
             "NOTE(Zihao): attention sink with sliding window and non-causal will fail after https://github.com/flashinfer-ai/flashinfer/pull/1661, temporarily xfail the test."
         )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The unittests for attention sink fails after #1661 under sliding window + non causal setting (not usual but we should fix in the future), temporarily mark them as xfail.

## 🔍 Related Issues

#1661 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @happierpig we should fix the behavior of non-causal + sliding window in a later PR.
