### PR TITLE
tests: xfail moe quantization classes mxfp8_bf16 UTs on sm103 

### DIFF
--- a/tests/test_trtllm_gen_fused_moe.py
+++ b/tests/test_trtllm_gen_fused_moe.py
@@ -2034,6 +2034,15 @@ def test_moe_quantization_classes(
             f"Incompatible: {moe_impl.name} + {weight_processing['use_shuffled_weight']} + {weight_processing['layout']}"
         )
 
+    # TODO(jimmzhou): enable MxFP4xBf16 on SM103
+    if (
+        type(moe_impl) is FP4Moe
+        and moe_impl.quant_mode == QuantMode.FP4_MXFP4_Bf16
+        and compute_capability[0] == 10
+        and compute_capability[1] == 3
+    ):
+        pytest.xfail("Make MxFP4xBf16 nonfunctional on SM103 to avoid B200 regression")
+
     moe_impl._cache_permute_indices = cache_permute_indices
 
     seed = 0


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Temporarily marking test_trtllm_gen_fused_moe mxfp8_bf16 cases as xfail until we converge on fix without causing regression on B200.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
