### PR TITLE
misc: checksum check when downloading artifacts

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -27,6 +27,7 @@ from .jit.cubin_loader import (
     FLASHINFER_CUBINS_REPOSITORY,
     get_cubin,
     FLASHINFER_CUBIN_DIR,
+    download_file,
 )
 
 
@@ -69,44 +70,72 @@ def get_available_cubin_files(source, retries=3, delay=5, timeout=10):
 
 
 class ArtifactPath:
-    TRTLLM_GEN_FMHA: str = "538f8e38ace07f701f61e26b138b2b8c70ce9e8e/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "9ef9e6243df03ab2c3fca1f0398a38cf1011d1e1/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
-        "e6f22dcc3fdeb29ff87af2f4a2cb3d30b8d273e0/batched_gemm-45beda1-ee6a802/"
+        "9ef9e6243df03ab2c3fca1f0398a38cf1011d1e1/batched_gemm-45beda1-7bdba93/"
     )
     TRTLLM_GEN_GEMM: str = (
-        "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
+        "9ef9e6243df03ab2c3fca1f0398a38cf1011d1e1/gemm-45beda1-f91dc9e/"
     )
-    CUDNN_SDPA: str = "4c623163877c8fef5751c9c7a59940cd2baae02e/fmha/cudnn/"
-    DEEPGEMM: str = "51d730202c9eef782f06ecc950005331d85c5d4b/deep-gemm/"
+    CUDNN_SDPA: str = "9ef9e6243df03ab2c3fca1f0398a38cf1011d1e1/fmha/cudnn/"
+    DEEPGEMM: str = "9ef9e6243df03ab2c3fca1f0398a38cf1011d1e1/deep-gemm/"
 
 
 class MetaInfoHash:
     TRTLLM_GEN_FMHA: str = (
-        "71f06a8fc03d28cc94ee6fc180fb7e37256a9e1c30ab2a6c0bf20a2d97af3eff"
+        "875f50e8f466120b1a59b94397835b86fad785942b4036823230465bc618b919"
     )
     TRTLLM_GEN_BMM: str = (
-        "c98b4ce69a39fd41556d67033c30ea814ef76b0a2fe16e798e55baf0104acc34"
+        "9490085267aed30a387bfff024a0605e1ca4d39dfe06a5abc159d7d7e129bdf4"
     )
     DEEPGEMM: str = "b4374f857c3066089c4ec6b5e79e785559fa2c05ce2623710b0b04bf86414a48"
     TRTLLM_GEN_GEMM: str = (
-        "0345358c916d990709f9670e113e93f35c76aa22715e2d5128ec2ca8740be5ba"
+        "7d8ef4e6d89b6990e3e90a3d3a21e96918824d819f8f897a9bfd994925b9ea67"
     )
+
+
+def get_checksums(kernels):
+    checksums = {}
+    for kernel in kernels:
+        uri = FLASHINFER_CUBINS_REPOSITORY + "/" + (kernel + "checksums.txt")
+        checksum_path = FLASHINFER_CUBIN_DIR / (kernel + "checksums.txt")
+        download_file(uri, checksum_path)
+        with open(checksum_path, "r") as f:
+            for line in f:
+                sha256, filename = line.strip().split()
+                checksums[kernel + filename] = sha256
+    return checksums
 
 
 def get_cubin_file_list():
     cubin_files = [
-        (ArtifactPath.TRTLLM_GEN_FMHA + "include/flashInferMetaInfo", ".h"),
-        (ArtifactPath.TRTLLM_GEN_GEMM + "include/flashinferMetaInfo", ".h"),
-        (ArtifactPath.TRTLLM_GEN_BMM + "include/flashinferMetaInfo", ".h"),
+        (
+            ArtifactPath.TRTLLM_GEN_FMHA + "include/flashInferMetaInfo",
+            ".h",
+            MetaInfoHash.TRTLLM_GEN_FMHA,
+        ),
+        (
+            ArtifactPath.TRTLLM_GEN_GEMM + "include/flashinferMetaInfo",
+            ".h",
+            MetaInfoHash.TRTLLM_GEN_GEMM,
+        ),
+        (
+            ArtifactPath.TRTLLM_GEN_BMM + "include/flashinferMetaInfo",
+            ".h",
+            MetaInfoHash.TRTLLM_GEN_BMM,
+        ),
     ]
-    for kernel in [
+    kernels = [
         ArtifactPath.TRTLLM_GEN_FMHA,
-        ArtifactPath.TRTLLM_GEN_BMM,
         ArtifactPath.TRTLLM_GEN_GEMM,
+        ArtifactPath.TRTLLM_GEN_BMM,
         ArtifactPath.DEEPGEMM,
-    ]:
+    ]
+    checksums = get_checksums(kernels)
+
+    for kernel in kernels:
         cubin_files += [
-            (kernel + name, extension)
+            (kernel + name, extension, checksums[kernel + name + extension])
             for name, extension in get_available_cubin_files(
                 FLASHINFER_CUBINS_REPOSITORY + "/" + kernel
             )
@@ -120,27 +149,25 @@ def download_artifacts():
     # use a shared session to make use of HTTP keep-alive and reuse of
     # HTTPS connections.
     session = requests.Session()
+    cubin_files = get_cubin_file_list()
+    num_threads = int(os.environ.get("FLASHINFER_CUBIN_DOWNLOAD_THREADS", "4"))
+    with tqdm_logging_redirect(
+        total=len(cubin_files), desc="Downloading cubins"
+    ) as pbar:
 
-    with temp_env_var("FLASHINFER_CUBIN_CHECKSUM_DISABLED", "1"):
-        cubin_files = get_cubin_file_list()
-        num_threads = int(os.environ.get("FLASHINFER_CUBIN_DOWNLOAD_THREADS", "4"))
-        with tqdm_logging_redirect(
-            total=len(cubin_files), desc="Downloading cubins"
-        ) as pbar:
+        def update_pbar_cb(_) -> None:
+            pbar.update(1)
 
-            def update_pbar_cb(_) -> None:
-                pbar.update(1)
+        with ThreadPoolExecutor(num_threads) as pool:
+            futures = []
+            for name, extension, checksum in cubin_files:
+                fut = pool.submit(get_cubin, name, checksum, extension, session)
+                fut.add_done_callback(update_pbar_cb)
+                futures.append(fut)
 
-            with ThreadPoolExecutor(num_threads) as pool:
-                futures = []
-                for name, extension in cubin_files:
-                    fut = pool.submit(get_cubin, name, "", extension, session)
-                    fut.add_done_callback(update_pbar_cb)
-                    futures.append(fut)
+            results = [fut.result() for fut in as_completed(futures)]
 
-                results = [fut.result() for fut in as_completed(futures)]
-
-        all_success = all(results)
+    all_success = all(results)
     if not all_success:
         raise RuntimeError("Failed to download cubins")
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

checks the sha256 hash when downloading cubins from artifactory, using the generated `checksum.txt` in each cubin directory.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
