### PR TITLE
Added xfail for mx_fp4 matmul on SM120

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -52,27 +52,15 @@ log2e = 1.44269504088896340736
 
 
 class GPUArchitectureError(Exception):
-    def __init__(self, msg: str):
-        self.msg = msg
-        super().__init__(self.msg)
+    """Custom exception for GPU architecture-related errors."""
 
-    def __str__(self):
-        return self.msg
-
-    def __repr__(self):
-        return self.msg
+    pass
 
 
 class LibraryError(Exception):
-    def __init__(self, msg: str):
-        self.msg = msg
-        super().__init__(self.msg)
+    """Custom exception for library-related errors."""
 
-    def __str__(self):
-        return self.msg
-
-    def __repr__(self):
-        return self.msg
+    pass
 
 
 def _expand_5d(x: torch.Tensor, kv_layout: str) -> torch.Tensor:

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -63,6 +63,18 @@ class GPUArchitectureError(Exception):
         return self.msg
 
 
+class LibraryError(Exception):
+    def __init__(self, msg: str):
+        self.msg = msg
+        super().__init__(self.msg)
+
+    def __str__(self):
+        return self.msg
+
+    def __repr__(self):
+        return self.msg
+
+
 def _expand_5d(x: torch.Tensor, kv_layout: str) -> torch.Tensor:
     if x.ndim not in [4, 5]:
         raise ValueError("x must be 4D or 5D")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

* A library bug is prevening mx_fp4 matmul on SM120
* While waiting for the patch, this test is now xfailed
* Added a LibraryError class was added to handle these issues in general

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [V] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [V] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
