### PR TITLE
Waive / disable test_mla_decode_kernel.py::test_mla_decode_kernel for not sm80 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,17 @@ def get_device_properties(device: torch.device):
     return torch.cuda.get_device_properties(device)
 
 
+def skip_on_gpu_arch_error(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except flashinfer.utils.GPUArchitectureError as e:
+            pytest.skip(e.msg)
+
+    return wrapper
+
+
 def clear_cuda_cache(device: torch.device) -> None:
     total_memory = get_device_properties(device).total_memory
     reserved_memory = torch.cuda.memory_reserved()

--- a/tests/test_mla_decode_kernel.py
+++ b/tests/test_mla_decode_kernel.py
@@ -7,7 +7,7 @@ from torch import nn
 
 import flashinfer
 from rope_reference import apply_rotary_emb, precompute_freqs_cis
-from flashinfer.utils import get_compute_capability
+from conftest import skip_on_gpu_arch_error
 
 
 def wmape(target: torch.Tensor, preds: torch.Tensor):
@@ -396,17 +396,11 @@ class DeepseekV2AttentionMatAbsorbDecode(nn.Module):
         return output
 
 
+@skip_on_gpu_arch_error
 @pytest.mark.parametrize("bsz", [6])
 @pytest.mark.parametrize("kv_len", [640])
 @pytest.mark.parametrize("page_size", [16])
 def test_mla_decode_kernel(bsz, kv_len, page_size):
-    major, minor = get_compute_capability(torch.device("cuda"))
-    device_arch = major * 10 + minor
-    if device_arch != 80:
-        pytest.skip(
-            "MLA decode kernel is not supported on this GPU (SM{device_arch}). Supported architecture: SM80."
-        )
-
     dev_id = 0
 
     torch.manual_seed(666)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

test_mla_decode_kernel.py::test_mla_decode_kernel uses use_tensor_cores=false, which calls the internal sm80 MLA decode kernel, which doesn't support B40 chips (sm120).

This change adds checks to the test to skip when running on B40, and in the code before calling the internal sm80 MLA decode kernel to return a better error message. 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ x] I have installed the hooks with `pre-commit install`.
- [ x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ x] Tests have been added or updated as needed.
- [x ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
