### PR TITLE
Masked batch nvfp4 quantization

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/quantization.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/quantization.h
@@ -60,7 +60,14 @@ template <typename T, int SF_VEC_SIZE>
 void invokeFP4Quantization(int b, int m, int n, T const* input, float const* globalScale,
                            int64_t* output, int32_t* SFOuput, bool useUE8M0,
                            QuantizationSFLayout layout, int multiProcessorCount,
-                           bool enable_pdl = false, cudaStream_t stream = 0);
+                           int32_t const* mask = nullptr, bool enable_pdl = false,
+                           cudaStream_t stream = 0);
+
+template <typename T, int SF_VEC_SIZE>
+void invokeSiluAndMulFP4Quantization(int b, int m, int n, T const* input, float const* globalScale,
+                                     int32_t const* mask, int64_t* output, int32_t* SFOuput,
+                                     QuantizationSFLayout layout, int multiProcessorCount,
+                                     bool enable_pdl = false, cudaStream_t stream = 0);
 
 void invokeBlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded,
                                 uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount,

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.cpp
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.cpp
@@ -72,7 +72,8 @@ void fp4_quantize(Tensor self, Optional<Tensor> const& globalScale, Tensor value
   tensorrt_llm::kernels::invokeFP4Quantization<T, SF_VEC_SIZE>(                                  \
       1, m, k, reinterpret_cast<T*>(self->data), globalScalePtr,                                 \
       reinterpret_cast<int64_t*>(valueE2M1->data), reinterpret_cast<int32_t*>(scaleFP8SF->data), \
-      sfUseUE8M0, layout, mMultiProcessorCount, enable_pdl, get_stream(self->device));
+      sfUseUE8M0, layout, mMultiProcessorCount, /*mask=*/nullptr, enable_pdl,                    \
+      get_stream(self->device));
 
   if (sfUseUE8M0) {
     if (self->dtype == dl_float16) {
@@ -130,8 +131,8 @@ void fp4_quantize(Tensor self, Optional<Tensor> const& globalScale, Tensor value
 // self_fp4: [B, M, K / 2], FLOAT4_E2M1X2
 // self_block_scale_factors:
 //   [B, ceil(M / 128) * 128 * ceil(K / sfVecSize / 4) * 4], SF_DTYPE (UE4M3 or UE8M0)
-void fp4_batched_quantize(Tensor self, Tensor globalScale, Tensor valueE2M1, Tensor scaleFP8SF,
-                          int64_t sfVecSize, bool sfUseUE8M0) {
+void fp4_batched_quantize(Tensor self, Optional<Tensor> const& mask, Tensor globalScale,
+                          Tensor valueE2M1, Tensor scaleFP8SF, int64_t sfVecSize, bool sfUseUE8M0) {
   CHECK_CUDA(self);
   CHECK_CONTIGUOUS(self);
   auto fp32_dtype = DLDataType{kDLFloat, 32, 1};
@@ -148,6 +149,12 @@ void fp4_batched_quantize(Tensor self, Tensor globalScale, Tensor valueE2M1, Ten
   int64_t k = inputShape[2];
 
   TVM_FFI_ICHECK_EQ(k % sfVecSize, 0);
+  bool use_mask = mask.has_value();
+  if (use_mask) {
+    auto const& mask_rank = mask.value().shape().size();
+    TVM_FFI_ICHECK_EQ(mask_rank, 1) << "Mask should be 1D tensor.";
+    TVM_FFI_ICHECK_EQ(mask.value().shape()[0], b);
+  }
 
   std::vector<int64_t> outputShape(inputShape.begin(), inputShape.end());
   outputShape[rank - 1] = k / 2;
@@ -159,7 +166,9 @@ void fp4_batched_quantize(Tensor self, Tensor globalScale, Tensor valueE2M1, Ten
   tensorrt_llm::kernels::invokeFP4Quantization<T, SF_VEC_SIZE>(                                  \
       b, m, k, reinterpret_cast<T*>(self->data), static_cast<float*>(globalScale->data),         \
       reinterpret_cast<int64_t*>(valueE2M1->data), reinterpret_cast<int32_t*>(scaleFP8SF->data), \
-      sfUseUE8M0, layout, mMultiProcessorCount, get_stream(self->device));
+      sfUseUE8M0, layout, mMultiProcessorCount,                                                  \
+      use_mask ? static_cast<int32_t*>(mask.value()->data) : nullptr, /*enable_pdl=*/false,      \
+      get_stream(self->device));
 
   if (self->dtype == dl_float16) {
     LAUNCH_FP4_QUANTIZE_KERNEL(half, 16)
@@ -185,5 +194,61 @@ void fp4_batched_quantize(Tensor self, Tensor globalScale, Tensor valueE2M1, Ten
 #undef LAUNCH_FP4_QUANTIZE_KERNEL
 }
 
+void silu_and_mul_fp4_batched_quantize(Tensor const& self, Tensor const& mask,
+                                       Tensor const& globalScale, Tensor valueE2M1,
+                                       Tensor scaleFP8SF, int64_t sfVecSize) {
+  // TODO(shuw): mask can be none
+  CHECK_CUDA(self);
+  CHECK_CONTIGUOUS(self);
+  auto fp32_dtype = DLDataType{kDLFloat, 32, 1};
+  CHECK_INPUT_TYPE(globalScale, fp32_dtype);
+  TVM_FFI_ICHECK_EQ(sfVecSize, 16) << "sfVecSize can only be 16";
+
+  auto const& inputShape = self.shape();
+  auto const& rank = inputShape.size();
+  auto const& mask_rank = mask.shape().size();
+
+  TVM_FFI_ICHECK_EQ(rank, 3) << "Input should be 3D tensor.";
+  TVM_FFI_ICHECK_EQ(mask_rank, 1) << "Mask should be 1D tensor.";
+
+  int64_t b = inputShape[0];
+  int64_t m = inputShape[1];
+  int64_t k_by_2 = inputShape[2];
+  int64_t k = k_by_2 / 2;
+
+  TVM_FFI_ICHECK_EQ(k % sfVecSize, 0);
+  TVM_FFI_ICHECK_EQ(mask.shape()[0], b);
+
+  std::vector<int64_t> outputShape(inputShape.begin(), inputShape.end());
+  outputShape[rank - 1] = k / 2;
+
+  const thread_local int mMultiProcessorCount = tensorrt_llm::common::getMultiProcessorCount();
+  auto layout = tensorrt_llm::QuantizationSFLayout::SWIZZLED_128x4;
+
+#define LAUNCH_SILU_AND_MUL_FP4_QUANTIZE_KERNEL(T, SF_VEC_SIZE)                               \
+  tensorrt_llm::kernels::invokeSiluAndMulFP4Quantization<T, SF_VEC_SIZE>(                     \
+      b, m, k_by_2, reinterpret_cast<T*>(self->data), static_cast<float*>(globalScale->data), \
+      static_cast<int32_t*>(mask->data), reinterpret_cast<int64_t*>(valueE2M1->data),         \
+      reinterpret_cast<int32_t*>(scaleFP8SF->data), layout, mMultiProcessorCount,             \
+      get_stream(self->device));
+
+  if (self->dtype == dl_float16) {
+    LAUNCH_SILU_AND_MUL_FP4_QUANTIZE_KERNEL(half, 16)
+  } else if (self->dtype == dl_bfloat16) {
+#ifdef ENABLE_BF16
+    LAUNCH_SILU_AND_MUL_FP4_QUANTIZE_KERNEL(__nv_bfloat16, 16)
+#else
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "BFloat16 must be enabled to quantize an bf16 tensor to fp4.";
+#endif
+  } else {
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "fp4_quantize only supports input tensor with dtypes fp16/bf16.";
+  }
+
+#undef LAUNCH_SILU_AND_MUL_FP4_QUANTIZE_KERNEL
+}
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp4_quantize, fp4_quantize);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp4_batched_quantize, fp4_batched_quantize);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(silu_and_mul_fp4_batched_quantize, silu_and_mul_fp4_batched_quantize);

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.h
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.h
@@ -33,6 +33,7 @@ void fp4_quantize(Tensor self, Optional<Tensor> const& globalScale, Tensor value
 
 void fp4_batched_quantize(Tensor self, Optional<Tensor> const& mask, Tensor globalScale,
                           Tensor valueE2M1, Tensor scaleFP8SF, int64_t sfVecSize, bool sfUseUE8M0);
+
 void silu_and_mul_fp4_batched_quantize(Tensor const& self, Tensor const& mask,
                                        Tensor const& globalScale, Tensor valueE2M1,
                                        Tensor scaleFP8SF, int64_t sfVecSize);

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.h
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.h
@@ -34,6 +34,6 @@ void fp4_quantize(Tensor self, Optional<Tensor> const& globalScale, Tensor value
 void fp4_batched_quantize(Tensor self, Optional<Tensor> const& mask, Tensor globalScale,
                           Tensor valueE2M1, Tensor scaleFP8SF, int64_t sfVecSize, bool sfUseUE8M0);
 
-void silu_and_mul_fp4_batched_quantize(Tensor const& self, Tensor const& mask,
-                                       Tensor const& globalScale, Tensor valueE2M1,
-                                       Tensor scaleFP8SF, int64_t sfVecSize);
+void silu_and_mul_nvfp4_batched_quantize(Tensor const& self, Tensor const& mask,
+                                         Tensor const& globalScale, Tensor valueE2M1,
+                                         Tensor scaleFP8SF, int64_t sfVecSize);

--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.h
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.h
@@ -31,5 +31,8 @@ void fp4_quantize(Tensor self, Optional<Tensor> const& globalScale, Tensor value
                   Tensor scaleFP8SF, int64_t sfVecSize, bool sfUseUE8M0, bool isSfSwizzledLayout,
                   bool isSf8x4Layout, bool enable_pdl);
 
-void fp4_batched_quantize(Tensor self, Tensor globalScale, Tensor valueE2M1, Tensor scaleFP8SF,
-                          int64_t sfVecSize, bool sfUseUE8M0);
+void fp4_batched_quantize(Tensor self, Optional<Tensor> const& mask, Tensor globalScale,
+                          Tensor valueE2M1, Tensor scaleFP8SF, int64_t sfVecSize, bool sfUseUE8M0);
+void silu_and_mul_fp4_batched_quantize(Tensor const& self, Tensor const& mask,
+                                       Tensor const& globalScale, Tensor valueE2M1,
+                                       Tensor scaleFP8SF, int64_t sfVecSize);

--- a/docs/api/fp4_quantization.rst
+++ b/docs/api/fp4_quantization.rst
@@ -15,8 +15,10 @@ Core Quantization Functions
 
     fp4_quantize
     nvfp4_quantize
+    nvfp4_batched_quantize
     nvfp4_block_scale_interleave
     e2m1_and_ufp8sf_scale_to_float
+    silu_and_mul_fp4_batched_quantize
 
 Matrix Shuffling Utilities
 --------------------------

--- a/docs/api/fp4_quantization.rst
+++ b/docs/api/fp4_quantization.rst
@@ -18,7 +18,7 @@ Core Quantization Functions
     nvfp4_batched_quantize
     nvfp4_block_scale_interleave
     e2m1_and_ufp8sf_scale_to_float
-    silu_and_mul_fp4_batched_quantize
+    silu_and_mul_nvfp4_batched_quantize
 
 Matrix Shuffling Utilities
 --------------------------

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -24,6 +24,9 @@ from . import jit as jit
 from .activation import gelu_and_mul as gelu_and_mul
 from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
 from .activation import silu_and_mul as silu_and_mul
+from .activation import (
+    silu_and_mul_fp4_batched_quantize as silu_and_mul_fp4_batched_quantize,
+)
 from .attention import BatchAttention as BatchAttention
 from .attention import (
     BatchAttentionWithAttentionSinkWrapper as BatchAttentionWithAttentionSinkWrapper,

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -25,7 +25,7 @@ from .activation import gelu_and_mul as gelu_and_mul
 from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
 from .activation import silu_and_mul as silu_and_mul
 from .activation import (
-    silu_and_mul_fp4_batched_quantize as silu_and_mul_fp4_batched_quantize,
+    silu_and_mul_nvfp4_batched_quantize as silu_and_mul_nvfp4_batched_quantize,
 )
 from .attention import BatchAttention as BatchAttention
 from .attention import (

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -22,7 +22,13 @@ import torch
 
 from .jit import JitSpec
 from .jit import gen_act_and_mul_module as gen_act_and_mul_module_impl
-from .utils import device_support_pdl, register_custom_op, register_fake_op
+from .utils import (
+    device_support_pdl,
+    register_custom_op,
+    register_fake_op,
+    get_compute_capability,
+)
+from .fp4_quantization import get_fp4_quantization_module
 
 silu_def_cu_str = r"""
 __device__ __forceinline__ float silu(const float& val) {
@@ -134,6 +140,39 @@ def silu_and_mul(
         enable_pdl,
     )
     return out
+
+
+def silu_and_mul_fp4_batched_quantize(
+    a,
+    mask,
+    a_global_sf,
+    sf_vec_size=16,
+):
+    """
+    Silu and multiply and quantize batched input tensor to NVFP4 format with mask.
+
+    Parameters:
+        a (torch.Tensor): Input tensor of shape [B, M, K] with dtype fp16/bf16.
+        a_global_sf (torch.Tensor): Global scale factor of shape [1] with dtype float32.
+        mask (torch.Tensor): Mask tensor to apply before quantization.
+        sf_vec_size (int, optional): Scale factor vector size. Defaults to 16.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - Quantized tensor of shape [B, M, K/2] with dtype FLOAT4_E2M1X2
+            - Scale factors tensor with shape determined by layout and sf_vec_size
+    """
+    major, minor = get_compute_capability(a.device)
+    device_arch = f"{major * 10 + minor}"
+    a_fp4, a_sf = get_fp4_quantization_module(
+        device_arch
+    ).silu_and_mul_fp4_batched_quantize_sm100(
+        a,
+        mask,
+        a_global_sf,
+        sf_vec_size,
+    )
+    return a_fp4, a_sf
 
 
 def gelu_tanh_and_mul(

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -142,7 +142,7 @@ def silu_and_mul(
     return out
 
 
-def silu_and_mul_fp4_batched_quantize(
+def silu_and_mul_nvfp4_batched_quantize(
     a,
     mask,
     a_global_sf,
@@ -166,7 +166,7 @@ def silu_and_mul_fp4_batched_quantize(
     device_arch = f"{major * 10 + minor}"
     a_fp4, a_sf = get_fp4_quantization_module(
         device_arch
-    ).silu_and_mul_fp4_batched_quantize_sm100(
+    ).silu_and_mul_nvfp4_batched_quantize_sm100(
         a,
         mask,
         a_global_sf,

--- a/flashinfer/fp4_quantization.py
+++ b/flashinfer/fp4_quantization.py
@@ -295,6 +295,7 @@ def get_fp4_quantization_module(backend: str = "100"):
     )
     def fp4_batched_quantize_sm100(
         input: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
         global_scale: Optional[torch.Tensor] = None,
         sf_vec_size: int = 16,
         sf_use_ue8m0: bool = False,
@@ -309,6 +310,7 @@ def get_fp4_quantization_module(backend: str = "100"):
         Args:
             input (torch.Tensor): Input tensor of shape [B, M, K] with dtype torch.float16,
                 torch.bfloat16, or an FP8-quantized dtype supported by the kernel.
+            mask (torch.Tensor, optional): mask tensor of shape [B] with dtype torch.int32.
             global_scale (torch.Tensor, optional): Global scale factor of shape [1] and
                 dtype float32.
             sf_vec_size (int, optional): Scale-factor vector size and alignment unit along K.
@@ -347,6 +349,7 @@ def get_fp4_quantization_module(backend: str = "100"):
         )
         module.fp4_batched_quantize(
             input,
+            mask,
             global_scale,
             out_val,
             out_sf,
@@ -358,14 +361,97 @@ def get_fp4_quantization_module(backend: str = "100"):
     @register_fake_op("flashinfer::fp4_batched_quantize_sm100")
     def _fp4_batched_quantize_sm100(
         input: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
         global_scale: Optional[torch.Tensor] = None,
         sf_vec_size: int = 16,
         sf_use_ue8m0: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        m, k = input.shape
+        b, m, k = input.shape
         return (
-            input.new_empty([m, k // 2], dtype=torch.int64),  # float4_e2m1_x2
-            input.new_empty([m * k // sf_vec_size], dtype=torch.int32),  # Scale factors
+            input.new_empty([b, m, k // 2], dtype=torch.int64),  # float4_e2m1_x2
+            input.new_empty(
+                [b, m * k // sf_vec_size], dtype=torch.int32
+            ),  # Scale factors
+        )
+
+    @register_custom_op(
+        "flashinfer::silu_and_mul_fp4_batched_quantize_sm100",
+        mutates_args=("",),
+    )
+    def silu_and_mul_fp4_batched_quantize_sm100(
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        global_scale: Optional[torch.Tensor] = None,
+        sf_vec_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize a silu and matmul with masked batched tensor to FP4 (E2M1x2) with per-block scale factors.
+
+        This function first does silu and matmul to a float/bfloat16 input tensor then convect the result
+        into a packed FP4 tensor using the E2M1 format (two 4-bit values per byte), along with
+        per-block scale factors. Scale factors are encoded as UE4M3 by default, or UE8M0
+        when requested, and an optional global scale can be applied.
+
+        Args:
+            input (torch.Tensor): Input tensor of shape [B, M, K] with dtype torch.float16,
+                torch.bfloat16, or an FP8-quantized dtype supported by the kernel.
+            mask (torch.Tensor): mask tensor of shape [B] with dtype torch.int32.
+            global_scale (torch.Tensor, optional): Global scale factor of shape [1] and
+                dtype float32.
+            sf_vec_size (int, optional): Scale-factor vector size and alignment unit along K.
+                Supported/expected values:
+                - 16 (NVFP4 path; supported)
+                - 32 (MXFP4 path; not supported yet)
+                Defaults to 16.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - self_fp4 (torch.Tensor): Packed FP4 tensor in E2M1x2 format of shape
+                [B, M, K // 2] with dtype torch.uint8 (two FP4 lanes per byte).
+                - self_block_scale_factors (torch.Tensor): Block scale factors with dtype
+                uint8 (UE4M3 or UE8M0), laid out as a flat buffer of shape
+                [B, ceil(M / 128) * 128 * ceil(K / sf_vec_size / 4) * 4].
+
+        Notes:
+            - K must be even (because outputs pack two FP4 values per byte).
+            - For best performance, K should be a multiple of sf_vec_size; the scale-factor
+            buffer is aligned to sf_vec_size along K, pads M to multiples of 128, and
+            rounds (K / sf_vec_size) up to a multiple of 4 for storage.
+            - The batch dimension B is preserved for both outputs.
+        """
+        b, m, k = input.shape
+        out_val = torch.empty(
+            (b, m, k // 4),
+            dtype=torch.uint8,
+            device=input.device,
+        )
+        out_sf = torch.empty(
+            (b, _compute_swizzled_layout_sf_size(m, k // (2 * sf_vec_size), 128)),
+            dtype=torch.uint8,
+            device=input.device,
+        )
+        module.silu_and_mul_fp4_batched_quantize(
+            input,
+            mask,
+            global_scale,
+            out_val,
+            out_sf,
+            sf_vec_size,
+        )
+        return out_val, out_sf
+
+    @register_fake_op("flashinfer::silu_and_mul_fp4_batched_quantize_sm100")
+    def _silu_and_mul_fp4_batched_quantize_sm100(
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        global_scale: Optional[torch.Tensor] = None,
+        sf_vec_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        b, m, k = input.shape
+        return (
+            input.new_empty([b, m, k // 4], dtype=torch.int64),  # float4_e2m1_x2
+            input.new_empty(
+                [b, m * k // (2 * sf_vec_size)], dtype=torch.int32
+            ),  # Scale factors
         )
 
     @register_custom_op(
@@ -432,6 +518,7 @@ def get_fp4_quantization_module(backend: str = "100"):
         e2m1_and_ufp8sf_scale_to_float_sm100=e2m1_and_ufp8sf_scale_to_float_sm100,
         mxfp4_dequantize_host=mxfp4_dequantize_host,
         fp4_batched_quantize_sm100=fp4_batched_quantize_sm100,
+        silu_and_mul_fp4_batched_quantize_sm100=silu_and_mul_fp4_batched_quantize_sm100,
     )
 
 
@@ -747,12 +834,14 @@ def nvfp4_batched_quantize(
     a,
     a_global_sf,
     sf_vec_size=16,
+    mask=None,
 ):
     """
     Quantize batched input tensor to NVFP4 format.
 
     Parameters:
         a (torch.Tensor): Input tensor of shape [B, M, K] with dtype fp16/bf16.
+        mask (torch.Tensor): Mask tensor to apply before quantization.
         a_global_sf (torch.Tensor): Global scale factor of shape [1] with dtype float32.
         sf_vec_size (int, optional): Scale factor vector size. Defaults to 16.
 
@@ -765,6 +854,7 @@ def nvfp4_batched_quantize(
     device_arch = f"{major * 10 + minor}"
     a_fp4, a_sf = get_fp4_quantization_module(device_arch).fp4_batched_quantize_sm100(
         a,
+        mask,
         a_global_sf,
         sf_vec_size,
         False,

--- a/flashinfer/fp4_quantization.py
+++ b/flashinfer/fp4_quantization.py
@@ -375,10 +375,10 @@ def get_fp4_quantization_module(backend: str = "100"):
         )
 
     @register_custom_op(
-        "flashinfer::silu_and_mul_fp4_batched_quantize_sm100",
+        "flashinfer::silu_and_mul_nvfp4_batched_quantize_sm100",
         mutates_args=("",),
     )
-    def silu_and_mul_fp4_batched_quantize_sm100(
+    def silu_and_mul_nvfp4_batched_quantize_sm100(
         input: torch.Tensor,
         mask: torch.Tensor,
         global_scale: Optional[torch.Tensor] = None,
@@ -429,7 +429,7 @@ def get_fp4_quantization_module(backend: str = "100"):
             dtype=torch.uint8,
             device=input.device,
         )
-        module.silu_and_mul_fp4_batched_quantize(
+        module.silu_and_mul_nvfp4_batched_quantize(
             input,
             mask,
             global_scale,
@@ -439,8 +439,8 @@ def get_fp4_quantization_module(backend: str = "100"):
         )
         return out_val, out_sf
 
-    @register_fake_op("flashinfer::silu_and_mul_fp4_batched_quantize_sm100")
-    def _silu_and_mul_fp4_batched_quantize_sm100(
+    @register_fake_op("flashinfer::silu_and_mul_nvfp4_batched_quantize_sm100")
+    def _silu_and_mul_nvfp4_batched_quantize_sm100(
         input: torch.Tensor,
         mask: torch.Tensor,
         global_scale: Optional[torch.Tensor] = None,
@@ -518,7 +518,7 @@ def get_fp4_quantization_module(backend: str = "100"):
         e2m1_and_ufp8sf_scale_to_float_sm100=e2m1_and_ufp8sf_scale_to_float_sm100,
         mxfp4_dequantize_host=mxfp4_dequantize_host,
         fp4_batched_quantize_sm100=fp4_batched_quantize_sm100,
-        silu_and_mul_fp4_batched_quantize_sm100=silu_and_mul_fp4_batched_quantize_sm100,
+        silu_and_mul_nvfp4_batched_quantize_sm100=silu_and_mul_nvfp4_batched_quantize_sm100,
     )
 
 

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -11,7 +11,7 @@ from flashinfer import (
     mxfp4_quantize,
     mxfp4_dequantize,
     nvfp4_batched_quantize,
-    silu_and_mul_fp4_batched_quantize,
+    silu_and_mul_nvfp4_batched_quantize,
 )
 from flashinfer.utils import is_sm100a_supported
 
@@ -377,13 +377,13 @@ def test_nvfp4_batched_quantize(
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @torch.inference_mode()
-def test_silu_and_mul_fp4_batched_quantize(
+def test_silu_and_mul_nvfp4_batched_quantize(
     dtype: torch.dtype,
     batch_shape: tuple[int, int, int],
     seed: int,
     device: str,
 ) -> None:
-    """Test silu_and_mul_fp4_batched_quantize function."""
+    """Test silu_and_mul_nvfp4_batched_quantize function."""
     if not is_sm100a_supported(torch.device(device)):
         pytest.skip("Nvfp4 Requires compute capability of 10 or above")
     torch.set_default_device(device)
@@ -399,7 +399,7 @@ def test_silu_and_mul_fp4_batched_quantize(
     tensor_amax = ref_y.abs().amax(dim=(1, 2)).to(torch.float32)
     global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
 
-    out, out_scale = silu_and_mul_fp4_batched_quantize(x, mask, global_scale)
+    out, out_scale = silu_and_mul_nvfp4_batched_quantize(x, mask, global_scale)
     ref_out, ref_out_scale = nvfp4_batched_quantize(
         ref_y,
         global_scale,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR quantizes the tensor to NVFP4 along with the associated scales, making it directly usable by FlashInfer’s grouped_gemm_nt_masked.

Note: Leave the [permutation](https://github.com/sgl-project/sglang/pull/9200/files#diff-2ca2a4489a09cea1af7ccc5c59ba92c5d6acf9feb931ed0351128bbfe1a0052eR360) to framework . 

cc @kaixih
## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
