### PR TITLE
bugfix: remove the filelock cleanup logic in cubin_loader.py

### DIFF
--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -106,12 +106,6 @@ def download_file(
         )
         return False
 
-    finally:
-        # Clean up the lock file
-        if os.path.exists(lock_path):
-            os.remove(lock_path)
-            logger.info(f"Lock file {lock_path} removed.")
-
 
 def load_cubin(cubin_path, sha256) -> bytes:
     """


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR removes cleanup of filelock files after downloading cubins, it may cause race conditions in concurrent environments where multiple processes might be downloading the same cubin simultaneously.

The filelock library already has robust internal mechanisms to handle lock cleanup. By removing the manual cleanup in  the finally block, we allow filelock to manage its own lock files correctly. This prevents race conditions where one process might delete a lock file while another process is still using it, especially in concurrent download scenarios.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @nvpohanh @joker-eph @wenscarl 
