### PR TITLE
bugfix: fix version tag validation in release_pypi_sdist.yml workflow

### DIFF
--- a/.github/workflows/release_pypi_sdist.yml
+++ b/.github/workflows/release_pypi_sdist.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Validate tag format
         run: |
-          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[a-z0-9]+)?$ ]]; then
+          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.?[a-z0-9]+)?$ ]]; then
             echo "Error: Tag '${{ inputs.tag }}' does not match the expected format (e.g., v1.2.3 or v1.2.3.post1 or v1.2.3rc1)"
             exit 1
           fi


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Versions such as `.post*` are excluded from the regular expression pattern.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
