### PR TITLE
hotfix: make aot wheel work without nvcc

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -64,13 +64,13 @@ def get_cuda_version() -> Version:
                 f"Could not parse CUDA version from nvcc --version output: {txt}"
             )
         return Version(matches[0])
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
         # NOTE(Zihao): when nvcc is unavailable, fall back to torch.version.cuda
         if torch.version.cuda is None:
             raise RuntimeError(
                 "nvcc not found and PyTorch is not built with CUDA support. "
                 "Could not determine CUDA version."
-            )
+            ) from e
         return Version(torch.version.cuda)
 
 

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -66,6 +66,11 @@ def get_cuda_version() -> Version:
         return Version(matches[0])
     except (FileNotFoundError, subprocess.CalledProcessError):
         # NOTE(Zihao): when nvcc is unavailable, fall back to torch.version.cuda
+        if torch.version.cuda is None:
+            raise RuntimeError(
+                "nvcc not found and PyTorch is not built with CUDA support. "
+                "Could not determine CUDA version."
+            )
         return Version(torch.version.cuda)
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Change the logic of `get_cuda_version`: when nvcc is not installed, return torch.version.cuda, this patch could unblock #1781 .

## 🔍 Related Issues

#1781 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes
cc @Flynn-Zh