### PR TITLE
Fix autotune profile min shape bigger than max shape.

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -637,6 +637,11 @@ class AutoTuner:
                 )
             else:
                 opt_shapes = spec.gen_tuning_buckets
+
+            # Normalize candidate buckets to be monotonically non-decreasing and non-empty
+            opt_shapes = tuple(sorted(set(opt_shapes)))
+            assert len(opt_shapes) > 0, "Empty tuning buckets are not allowed"
+
             opt_shapes_max = {
                 v1: v2
                 for v1, v2 in zip(opt_shapes, tuple(opt_shapes[1:]) + (float("inf"),))


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The code assume the `opt_shapes` got from `spec.gen_tuning_buckets` is non-decreasing order, but actually the tuning config like [HERE](https://github.com/flashinfer-ai/flashinfer/blob/f21f94abab89a3c5193e38cfdc0edae3c9dd790c/flashinfer/fused_moe/core.py#L531) can use decreasing order, which make the min shape bigger than max shape.

Since current code base don't use the min max value. So it didn't bring issue yet.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
