### PR TITLE
test: Force upgrade cudnn backend for blackwell attention kernel UT

### DIFF
--- a/scripts/task_test_blackwell_kernels.sh
+++ b/scripts/task_test_blackwell_kernels.sh
@@ -5,7 +5,7 @@ set -x
 : ${JUNIT_DIR:=$(realpath ./junit)}
 
 pip install -e . -v
-pip install --upgrade nvidia-cudnn-cu12
+pip install --upgrade "nvidia-cudnn-cu12>=9.11.0.98"
 
 EXIT_CODE=0
 scripts_to_run=(

--- a/scripts/task_test_blackwell_kernels.sh
+++ b/scripts/task_test_blackwell_kernels.sh
@@ -5,6 +5,7 @@ set -x
 : ${JUNIT_DIR:=$(realpath ./junit)}
 
 pip install -e . -v
+pip install --upgrade nvidia-cudnn-cu12
 
 EXIT_CODE=0
 scripts_to_run=(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Following tests need higher version of nvidia-cudnn-cu12 package:
test_cudnn_prefill_deepseek.py
test_cudnn_prefill.py

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
