### PR TITLE
jit: defer ninja generation

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -219,11 +219,18 @@ class JitSpec:
         )
         write_if_different(ninja_path, content)
 
+    @property
+    def is_ninja_generated(self) -> bool:
+        return self.ninja_path.exists()
+
     def build(self, verbose: bool, need_lock: bool = True) -> None:
         lock = (
             FileLock(self.lock_path, thread_local=False) if need_lock else nullcontext()
         )
         with lock:
+            # Write ninja file if it doesn't exist (deferred case)
+            if not self.is_ninja_generated:
+                self.write_ninja()
             run_ninja(jit_env.FLASHINFER_JIT_DIR, self.ninja_path, verbose)
 
     def load(self, so_path: Path, class_name: str = None):
@@ -310,7 +317,6 @@ def gen_jit_spec(
         ),
         needs_device_linking=needs_device_linking,
     )
-    spec.write_ninja()
 
     # Register the spec in the global registry
     jit_spec_registry.register(spec)
@@ -336,6 +342,8 @@ def build_jit_specs(
         if skip_prebuilt and spec.aot_path.exists():
             continue
         lines.append(f"subninja {spec.ninja_path}")
+        if not spec.is_ninja_generated:
+            spec.write_ninja()
     if not lines:
         return
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Defer ninja generation till build, JitSpec generation should not rely on the existence of nvcc, this PR changes the behavior to make sure we can still `generate_jit_spec` on environments without nvcc installation.

For example:
```bash
python -m flashinfer module-status
```
would fail for no-nvcc environment, and after this PR, it should pass.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
