### PR TITLE
chore: improved URL handling for CUBIN/artifacts downloads

### DIFF
--- a/csrc/cudnn_sdpa_kernel_launcher.cu
+++ b/csrc/cudnn_sdpa_kernel_launcher.cu
@@ -85,15 +85,17 @@ enum PrefillType {
 };
 
 void init_cudnn_cubin(std::map<KernelType, std::string>& cubin_map) {
-  cubin_map[PREFILL] = getCubin(cudnn_sdpa_cubin_path + "cudnn_sm100_fprop_sdpa_prefill_d128_bf16",
-                                "ff14e8dcfc04d9b3a912dd44056be37d9aa8a85976e0070494ca0cce0524f2a1");
+  cubin_map[PREFILL] =
+      getCubin(cudnn_sdpa_cubin_path + "cudnn_sm100_fprop_sdpa_prefill_d128_bf16",
+               "ff14e8dcfc04d9b3a912dd44056be37d9aa8a85976e0070494ca0cce0524f2a1.cubin");
 
-  cubin_map[DECODE] = getCubin(cudnn_sdpa_cubin_path + "cudnn_sm100_fprop_sdpa_decode_d128_bf16",
-                               "e7ce0408b4c3a36c42616498228534ee64cab785ef570af5741deaf9dd1b475c");
+  cubin_map[DECODE] =
+      getCubin(cudnn_sdpa_cubin_path + "cudnn_sm100_fprop_sdpa_decode_d128_bf16",
+               "e7ce0408b4c3a36c42616498228534ee64cab785ef570af5741deaf9dd1b475c.cubin");
 
   cubin_map[PREFILL_DEEPSEEK] =
       getCubin(cudnn_sdpa_cubin_path + "cudnn_sm100_fprop_sdpa_prefill_d192_bf16",
-               "2190967b8733e193cdcecc054eeb7c2907080a158a33fe7ba2004523a4aff6f9");
+               "2190967b8733e193cdcecc054eeb7c2907080a158a33fe7ba2004523a4aff6f9.cubin");
 }
 
 auto get_cudnn_cubin(KernelType kernel_type) -> std::string {

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -23,7 +23,7 @@ set -u
 CUDA_VERSION=${1:-cu128}
 
 pip3 install torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
-pip3 install requests ninja pytest numpy scipy build nvidia-ml-py cuda-python einops nvidia-nvshmem-cu12
+pip3 install requests responses ninja pytest numpy scipy build nvidia-ml-py cuda-python einops nvidia-nvshmem-cu12
 pip3 install 'apache-tvm-ffi==0.1.0b11'
 pip3 install nvidia-cutlass-dsl
 pip3 install 'nvidia-cudnn-frontend>=1.13.0'

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -20,7 +20,6 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Generator
-from urllib.parse import urljoin
 import requests  # type: ignore[import-untyped]
 import shutil
 
@@ -28,6 +27,7 @@ from .jit.core import logger
 from .jit.cubin_loader import (
     FLASHINFER_CUBINS_REPOSITORY,
     get_cubin,
+    safe_urljoin,
     FLASHINFER_CUBIN_DIR,
 )
 
@@ -100,9 +100,9 @@ def get_cubin_file_list() -> Generator[str, None, None]:
     base = FLASHINFER_CUBINS_REPOSITORY
 
     # The meta info header files first.
-    yield urljoin(urljoin(base, ArtifactPath.TRTLLM_GEN_FMHA), "include/flashInferMetaInfo.h")
-    yield urljoin(urljoin(base, ArtifactPath.TRTLLM_GEN_GEMM), "include/flashinferMetaInfo.h")
-    yield urljoin(urljoin(base, ArtifactPath.TRTLLM_GEN_BMM), "include/flashinferMetaInfo.h")
+    yield safe_urljoin(safe_urljoin(base, ArtifactPath.TRTLLM_GEN_FMHA), "include/flashInferMetaInfo.h")
+    yield safe_urljoin(safe_urljoin(base, ArtifactPath.TRTLLM_GEN_GEMM), "include/flashinferMetaInfo.h")
+    yield safe_urljoin(safe_urljoin(base, ArtifactPath.TRTLLM_GEN_BMM), "include/flashinferMetaInfo.h")
 
     # All the actual kernel cubin's.
     for kernel in [
@@ -112,9 +112,9 @@ def get_cubin_file_list() -> Generator[str, None, None]:
         ArtifactPath.DEEPGEMM,
     ]:
         for name in get_available_cubin_files(
-                urljoin(base, kernel)
+                safe_urljoin(base, kernel)
             ):
-            yield urljoin(base, name)
+            yield safe_urljoin(base, name)
 
 
 def download_artifacts() -> None:

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from dataclasses import dataclass
 import os
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Generator
 from urllib.parse import urljoin
 import requests  # type: ignore[import-untyped]
 import shutil
@@ -34,7 +36,7 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def temp_env_var(key, value):
+def temp_env_var(key: str, value: str):
     old_value = os.environ.get(key, None)
     os.environ[key] = value
     try:
@@ -46,14 +48,13 @@ def temp_env_var(key, value):
             os.environ[key] = old_value
 
 
-def get_available_cubin_files(source, retries=3, delay=5, timeout=10):
+def get_available_cubin_files(source: str, retries: int = 3, delay: int = 5, timeout: int = 10) -> tuple[str, ...]:
     for attempt in range(1, retries + 1):
         try:
             response = requests.get(source, timeout=timeout)
             response.raise_for_status()
             hrefs = re.findall(r'\<a href=".*\.cubin">', response.text)
-            files = [(h[9:-8], ".cubin") for h in hrefs]
-            return files
+            return tuple((h[9:-8] + ".cubin") for h in hrefs)
 
         except requests.exceptions.RequestException as e:
             logger.warning(
@@ -63,23 +64,26 @@ def get_available_cubin_files(source, retries=3, delay=5, timeout=10):
             if attempt < retries:
                 logger.info(f"Retrying in {delay} seconds...")
                 time.sleep(delay)
-            else:
-                logger.error("Max retries reached. Fetch failed.")
-                return []
+    
+    # TODO: check if we really want to return an empty collection here instead of crashing.
+    logger.error("Max retries reached. Fetch failed.")
+    return tuple()
 
 
+@dataclass(frozen=True)
 class ArtifactPath:
-    TRTLLM_GEN_FMHA: str = "7206d64e67f4c8949286246d6e2e07706af5d223/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "7206d64e67f4c8949286246d6e2e07706af5d223/fmha/trtllm-gen"
     TRTLLM_GEN_BMM: str = (
-        "e6f22dcc3fdeb29ff87af2f4a2cb3d30b8d273e0/batched_gemm-45beda1-ee6a802/"
+        "e6f22dcc3fdeb29ff87af2f4a2cb3d30b8d273e0/batched_gemm-45beda1-ee6a802"
     )
     TRTLLM_GEN_GEMM: str = (
-        "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
+        "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e"
     )
-    CUDNN_SDPA: str = "4c623163877c8fef5751c9c7a59940cd2baae02e/fmha/cudnn/"
-    DEEPGEMM: str = "51d730202c9eef782f06ecc950005331d85c5d4b/deep-gemm/"
+    CUDNN_SDPA: str = "4c623163877c8fef5751c9c7a59940cd2baae02e/fmha/cudnn"
+    DEEPGEMM: str = "51d730202c9eef782f06ecc950005331d85c5d4b/deep-gemm"
 
 
+@dataclass(frozen=True)
 class MetaInfoHash:
     TRTLLM_GEN_FMHA: str = (
         "2f605255e71d673768f5bece66dde9e2e9f4c873347bfe8fefcffbf86a3c847d"
@@ -92,30 +96,28 @@ class MetaInfoHash:
         "0345358c916d990709f9670e113e93f35c76aa22715e2d5128ec2ca8740be5ba"
     )
 
+def get_cubin_file_list() -> Generator[str, None, None]:
+    base = FLASHINFER_CUBINS_REPOSITORY
 
-def get_cubin_file_list():
-    base = FLASHINFER_CUBINS_REPOSITORY.rstrip("/")
-    cubin_files = [
-        (ArtifactPath.TRTLLM_GEN_FMHA + "include/flashInferMetaInfo", ".h"),
-        (ArtifactPath.TRTLLM_GEN_GEMM + "include/flashinferMetaInfo", ".h"),
-        (ArtifactPath.TRTLLM_GEN_BMM + "include/flashinferMetaInfo", ".h"),
-    ]
+    # The meta info header files first.
+    yield urljoin(urljoin(base, ArtifactPath.TRTLLM_GEN_FMHA), "include/flashInferMetaInfo.h")
+    yield urljoin(urljoin(base, ArtifactPath.TRTLLM_GEN_GEMM), "include/flashinferMetaInfo.h")
+    yield urljoin(urljoin(base, ArtifactPath.TRTLLM_GEN_BMM), "include/flashinferMetaInfo.h")
+
+    # All the actual kernel cubin's.
     for kernel in [
         ArtifactPath.TRTLLM_GEN_FMHA,
         ArtifactPath.TRTLLM_GEN_BMM,
         ArtifactPath.TRTLLM_GEN_GEMM,
         ArtifactPath.DEEPGEMM,
     ]:
-        cubin_files += [
-            (kernel + name, extension)
-            for name, extension in get_available_cubin_files(
-                urljoin(base + "/", kernel)
-            )
-        ]
-    return cubin_files
+        for name in get_available_cubin_files(
+                urljoin(base, kernel)
+            ):
+            yield urljoin(base, name)
 
 
-def download_artifacts():
+def download_artifacts() -> None:
     from tqdm.contrib.logging import tqdm_logging_redirect
 
     # use a shared session to make use of HTTP keep-alive and reuse of
@@ -123,7 +125,7 @@ def download_artifacts():
     session = requests.Session()
 
     with temp_env_var("FLASHINFER_CUBIN_CHECKSUM_DISABLED", "1"):
-        cubin_files = get_cubin_file_list()
+        cubin_files = list(get_cubin_file_list())
         num_threads = int(os.environ.get("FLASHINFER_CUBIN_DOWNLOAD_THREADS", "4"))
         with tqdm_logging_redirect(
             total=len(cubin_files), desc="Downloading cubins"
@@ -134,8 +136,8 @@ def download_artifacts():
 
             with ThreadPoolExecutor(num_threads) as pool:
                 futures = []
-                for name, extension in cubin_files:
-                    fut = pool.submit(get_cubin, name, "", extension, session)
+                for name in cubin_files:
+                    fut = pool.submit(get_cubin, name, "", session)
                     fut.add_done_callback(update_pbar_cb)
                     futures.append(fut)
 
@@ -146,26 +148,26 @@ def download_artifacts():
         raise RuntimeError("Failed to download cubins")
 
 
-def get_artifacts_status():
+def get_artifacts_status() -> tuple[tuple[str, bool], ...]:
     """
     Check which cubins are already downloaded and return (num_downloaded, total).
     Does not download any cubins.
     """
     cubin_files = get_cubin_file_list()
-    status = []
-    for name, extension in cubin_files:
+
+    def _check_file_status(file_name: str) -> tuple[str, bool]:
         # get_cubin stores cubins in FLASHINFER_CUBIN_DIR with the same relative path
         # Remove any leading slashes from name
-        rel_path = name.lstrip("/")
-        local_path = os.path.join(FLASHINFER_CUBIN_DIR, rel_path)
-        exists = os.path.isfile(local_path + extension)
-        status.append((name, extension, exists))
-    return status
+        local_path = os.path.join(FLASHINFER_CUBIN_DIR, file_name)
+        exists = os.path.isfile(local_path)
+        return (file_name, exists)
+
+    return tuple(_check_file_status(file_name) for file_name in cubin_files)
 
 
 def clear_cubin():
     if os.path.exists(FLASHINFER_CUBIN_DIR):
-        print(f"Clearing cubin directory: {FLASHINFER_CUBIN_DIR}")
+        logger.info(f"Clearing cubin directory: {FLASHINFER_CUBIN_DIR}")
         shutil.rmtree(FLASHINFER_CUBIN_DIR)
     else:
-        print(f"Cubin directory does not exist: {FLASHINFER_CUBIN_DIR}")
+        logger.info(f"Cubin directory does not exist: {FLASHINFER_CUBIN_DIR}")

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -100,9 +100,9 @@ def get_cubin_file_list() -> Generator[str, None, None]:
     base = FLASHINFER_CUBINS_REPOSITORY
 
     # The meta info header files first.
-    yield safe_urljoin(safe_urljoin(base, ArtifactPath.TRTLLM_GEN_FMHA), "include/flashInferMetaInfo.h")
-    yield safe_urljoin(safe_urljoin(base, ArtifactPath.TRTLLM_GEN_GEMM), "include/flashinferMetaInfo.h")
-    yield safe_urljoin(safe_urljoin(base, ArtifactPath.TRTLLM_GEN_BMM), "include/flashinferMetaInfo.h")
+    yield safe_urljoin(ArtifactPath.TRTLLM_GEN_FMHA, "include/flashInferMetaInfo.h")
+    yield safe_urljoin(ArtifactPath.TRTLLM_GEN_GEMM, "include/flashinferMetaInfo.h")
+    yield safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM, "include/flashinferMetaInfo.h")
 
     # All the actual kernel cubin's.
     for kernel in [
@@ -114,7 +114,7 @@ def get_cubin_file_list() -> Generator[str, None, None]:
         for name in get_available_cubin_files(
                 safe_urljoin(base, kernel)
             ):
-            yield safe_urljoin(base, name)
+            yield safe_urljoin(kernel, name)
 
 
 def download_artifacts() -> None:

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -48,7 +48,9 @@ def temp_env_var(key: str, value: str):
             os.environ[key] = old_value
 
 
-def get_available_cubin_files(source: str, retries: int = 3, delay: int = 5, timeout: int = 10) -> tuple[str, ...]:
+def get_available_cubin_files(
+    source: str, retries: int = 3, delay: int = 5, timeout: int = 10
+) -> tuple[str, ...]:
     for attempt in range(1, retries + 1):
         try:
             response = requests.get(source, timeout=timeout)
@@ -64,7 +66,7 @@ def get_available_cubin_files(source: str, retries: int = 3, delay: int = 5, tim
             if attempt < retries:
                 logger.info(f"Retrying in {delay} seconds...")
                 time.sleep(delay)
-    
+
     # TODO: check if we really want to return an empty collection here instead of crashing.
     logger.error("Max retries reached. Fetch failed.")
     return tuple()
@@ -96,6 +98,7 @@ class MetaInfoHash:
         "0345358c916d990709f9670e113e93f35c76aa22715e2d5128ec2ca8740be5ba"
     )
 
+
 def get_cubin_file_list() -> Generator[str, None, None]:
     base = FLASHINFER_CUBINS_REPOSITORY
 
@@ -111,9 +114,7 @@ def get_cubin_file_list() -> Generator[str, None, None]:
         ArtifactPath.TRTLLM_GEN_GEMM,
         ArtifactPath.DEEPGEMM,
     ]:
-        for name in get_available_cubin_files(
-                safe_urljoin(base, kernel)
-            ):
+        for name in get_available_cubin_files(safe_urljoin(base, kernel)):
             yield safe_urljoin(kernel, name)
 
 

--- a/flashinfer/deep_gemm.py
+++ b/flashinfer/deep_gemm.py
@@ -1490,8 +1490,8 @@ class KernelMap:
         self.indice = None
 
     def init_indices(self):
-        indice_path = ArtifactPath.DEEPGEMM + "kernel_map"
-        assert get_cubin(indice_path, self.sha256, file_extension=".json"), (
+        indice_path = ArtifactPath.DEEPGEMM + "kernel_map.json"
+        assert get_cubin(indice_path, self.sha256), (
             "cubin kernel map file not found, nor downloaded with matched sha256"
         )
         path = FLASHINFER_CUBIN_DIR / f"{indice_path}.json"

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -957,9 +957,7 @@ def gen_trtllm_gen_fused_moe_sm100_module() -> JitSpec:
     header_name = "flashinferMetaInfo"
 
     # use `get_cubin` to get "flashinferMetaInfo.h"
-    metainfo = get_cubin(
-        f"{include_path}/{header_name}.h", MetaInfoHash.TRTLLM_GEN_BMM
-    )
+    metainfo = get_cubin(f"{include_path}/{header_name}.h", MetaInfoHash.TRTLLM_GEN_BMM)
     # make sure "flashinferMetaInfo.h" is downloaded or cached
     assert metainfo, f"{header_name}.h not found"
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -958,7 +958,7 @@ def gen_trtllm_gen_fused_moe_sm100_module() -> JitSpec:
 
     # use `get_cubin` to get "flashinferMetaInfo.h"
     metainfo = get_cubin(
-        f"{include_path}/{header_name}", MetaInfoHash.TRTLLM_GEN_BMM, ".h"
+        f"{include_path}/{header_name}.h", MetaInfoHash.TRTLLM_GEN_BMM
     )
     # make sure "flashinferMetaInfo.h" is downloaded or cached
     assert metainfo, f"{header_name}.h not found"

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -629,9 +629,8 @@ def gen_trtllm_gen_gemm_module() -> JitSpec:
 
     # use `get_cubin` to get "flashinferMetaInfo.h"
     metainfo = get_cubin(
-        f"{include_path}/{header_name}",
+        f"{include_path}/{header_name}.h",
         MetaInfoHash.TRTLLM_GEN_GEMM,
-        ".h",
     )
     # make sure "flashinferMetaInfo.h" is downloaded or cached
     assert metainfo, f"{header_name}.h not found"

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1574,7 +1574,7 @@ def gen_trtllm_gen_fmha_module():
 
     # use `get_cubin` to get "flashinferMetaInfo.h"
     metainfo = get_cubin(
-        f"{include_path}/{header_name}", MetaInfoHash.TRTLLM_GEN_FMHA, ".h"
+        f"{include_path}/{header_name}.h", MetaInfoHash.TRTLLM_GEN_FMHA
     )
 
     # make sure "flashinferMetaInfo.h" is downloaded or cached

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -33,14 +33,22 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",
 )
 
+
 def safe_urljoin(base, path):
     """Join URLs ensuring base is treated as a directory."""
-    if not base.endswith('/'):
-        base += '/'
+    if not base.endswith("/"):
+        base += "/"
     return urljoin(base, path)
 
+
 def download_file(
-    source: str, local_path: str, retries: int = 3, delay: int = 5, timeout: int = 10, lock_timeout: int = 30, session=None
+    source: str,
+    local_path: str,
+    retries: int = 3,
+    delay: int = 5,
+    timeout: int = 10,
+    lock_timeout: int = 30,
+    session=None,
 ):
     """
     Downloads a file from a URL or copies from a local path to a destination.

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -179,7 +179,7 @@ def setup_cubin_loader(dll_path: str) -> None:
 
     def get_cubin_callback(name: bytes, sha256: bytes):
         # Both name and sha256 are bytes (c_char_p)
-        cubin = get_cubin(name.decode("utf-8") + ".cubin", sha256.decode("utf-8"))
+        cubin = get_cubin(name.decode("utf-8"), sha256.decode("utf-8"))
         _LIB.FlashInferSetCurrentCubin(
             convert_to_ctypes_char_p(cubin), ctypes.c_int(len(cubin))
         )

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -35,7 +35,7 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
 
 
 def download_file(
-    source, local_path, retries=3, delay=5, timeout=10, lock_timeout=30, session=None
+    source: str, local_path: str, retries: int = 3, delay: int = 5, timeout: int = 10, lock_timeout: int = 30, session=None
 ):
     """
     Downloads a file from a URL or copies from a local path to a destination.
@@ -107,7 +107,7 @@ def download_file(
         return False
 
 
-def load_cubin(cubin_path, sha256) -> bytes:
+def load_cubin(cubin_path: str, sha256: str) -> bytes:
     """
     Load a cubin from the provide local path and
     ensure that the sha256 signature matches.
@@ -133,9 +133,9 @@ def load_cubin(cubin_path, sha256) -> bytes:
     return b""
 
 
-def get_cubin(name, sha256, file_extension=".cubin", session=None):
+def get_cubin(file_name: str, sha256: str, session=None) -> bytes:
     """
-    Load a cubin from the local cache directory with {name} and
+    Load a cubin from the local cache directory with {file_name} and
     ensure that the sha256 signature matches.
 
     If the kernel does not exist in the cache, it will downloaded.
@@ -143,16 +143,14 @@ def get_cubin(name, sha256, file_extension=".cubin", session=None):
     Returns:
     None on failure.
     """
-    cubin_fname = name + file_extension
-    cubin_path = FLASHINFER_CUBIN_DIR / cubin_fname
+    cubin_path = str(FLASHINFER_CUBIN_DIR / file_name)
     cubin = load_cubin(cubin_path, sha256)
     if cubin:
         return cubin
     # either the file does not exist or it is corrupted, we'll download a new one.
 
-    base = FLASHINFER_CUBINS_REPOSITORY.rstrip("/")
-    uri = urljoin(base + "/", cubin_fname)
-    logger.info(f"Fetching cubin {name} from {uri}")
+    uri = urljoin(FLASHINFER_CUBINS_REPOSITORY, file_name)
+    logger.info(f"Fetching cubin {file_name} from {uri}")
     download_file(uri, cubin_path, session=session)
     return load_cubin(cubin_path, sha256)
 
@@ -165,7 +163,7 @@ def convert_to_ctypes_char_p(data: bytes):
 dll_cubin_handlers = {}
 
 
-def setup_cubin_loader(dll_path: str):
+def setup_cubin_loader(dll_path: str) -> None:
     if dll_path in dll_cubin_handlers:
         return
 

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -177,9 +177,9 @@ def setup_cubin_loader(dll_path: str) -> None:
     # Define the correct callback type
     CALLBACK_TYPE = ctypes.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_char_p)
 
-    def get_cubin_callback(name, sha256):
+    def get_cubin_callback(name: bytes, sha256: bytes):
         # Both name and sha256 are bytes (c_char_p)
-        cubin = get_cubin(name.decode("utf-8"), sha256.decode("utf-8"))
+        cubin = get_cubin(name.decode("utf-8") + ".cubin", sha256.decode("utf-8"))
         _LIB.FlashInferSetCurrentCubin(
             convert_to_ctypes_char_p(cubin), ctypes.c_int(len(cubin))
         )

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -33,6 +33,11 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",
 )
 
+def safe_urljoin(base, path):
+    """Join URLs ensuring base is treated as a directory."""
+    if not base.endswith('/'):
+        base += '/'
+    return urljoin(base, path)
 
 def download_file(
     source: str, local_path: str, retries: int = 3, delay: int = 5, timeout: int = 10, lock_timeout: int = 30, session=None
@@ -149,7 +154,7 @@ def get_cubin(file_name: str, sha256: str, session=None) -> bytes:
         return cubin
     # either the file does not exist or it is corrupted, we'll download a new one.
 
-    uri = urljoin(FLASHINFER_CUBINS_REPOSITORY, file_name)
+    uri = safe_urljoin(FLASHINFER_CUBINS_REPOSITORY, file_name)
     logger.info(f"Fetching cubin {file_name} from {uri}")
     download_file(uri, cubin_path, session=session)
     return load_cubin(cubin_path, sha256)

--- a/include/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/BatchedGemmInterface.h
+++ b/include/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/BatchedGemmInterface.h
@@ -727,7 +727,7 @@ int32_t BatchedGemmInterface::run(BatchedGemmConfig const& config, void* workspa
     if (!fname_cubin.empty()) {
       fname_cubin[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fname_cubin[0])));
     }
-    fname_cubin = tllm_gen_bmm_cubin_path + fname_cubin;
+    fname_cubin = tllm_gen_bmm_cubin_path + fname_cubin + ".cubin";
     std::string cubin = flashinfer::trtllm_cubin_loader::getCubin(fname_cubin, sha256);
     cuModuleLoadData(&cuModule, cubin.c_str());
   };

--- a/include/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/BatchedGemmInterface.h
+++ b/include/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/BatchedGemmInterface.h
@@ -727,7 +727,7 @@ int32_t BatchedGemmInterface::run(BatchedGemmConfig const& config, void* workspa
     if (!fname_cubin.empty()) {
       fname_cubin[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fname_cubin[0])));
     }
-    fname_cubin = tllm_gen_bmm_cubin_path + fname_cubin + ".cubin";
+    fname_cubin = tllm_gen_bmm_cubin_path + "/" + fname_cubin + ".cubin";
     std::string cubin = flashinfer::trtllm_cubin_loader::getCubin(fname_cubin, sha256);
     cuModuleLoadData(&cuModule, cubin.c_str());
   };

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -572,7 +572,7 @@ class TllmGenFmhaKernel {
     };
     if (findModuleIter == mModules.end()) {
       // Load the module.
-      std::string cubin_path = tllm_gen_fmha_cubin_path + kernelMeta.mFuncName;
+      std::string cubin_path = tllm_gen_fmha_cubin_path + "/" + kernelMeta.mFuncName + ".cubin";
       std::string cubin = getCubin(cubin_path, kernelMeta.sha256);
       if (cubin.empty()) {
         throw std::runtime_error("Failed to load cubin for " + kernelName);

--- a/include/flashinfer/trtllm/gemm/trtllmGen_gemm_export/GemmInterface.h
+++ b/include/flashinfer/trtllm/gemm/trtllmGen_gemm_export/GemmInterface.h
@@ -478,7 +478,7 @@ int32_t GemmInterface::run(GemmConfig const& config, void* workspace, GemmData c
     if (!fname_cubin.empty()) {
       fname_cubin[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fname_cubin[0])));
     }
-    fname_cubin = tllm_gen_gemm_cubin_path + fname_cubin + ".cubin";
+    fname_cubin = tllm_gen_gemm_cubin_path + "/" + fname_cubin + ".cubin";
     std::string cubin = flashinfer::trtllm_cubin_loader::getCubin(fname_cubin, sha256);
     cuModuleLoadData(&cuModule, cubin.c_str());
   };

--- a/include/flashinfer/trtllm/gemm/trtllmGen_gemm_export/GemmInterface.h
+++ b/include/flashinfer/trtllm/gemm/trtllmGen_gemm_export/GemmInterface.h
@@ -478,7 +478,7 @@ int32_t GemmInterface::run(GemmConfig const& config, void* workspace, GemmData c
     if (!fname_cubin.empty()) {
       fname_cubin[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fname_cubin[0])));
     }
-    fname_cubin = tllm_gen_gemm_cubin_path + fname_cubin;
+    fname_cubin = tllm_gen_gemm_cubin_path + fname_cubin + ".cubin";
     std::string cubin = flashinfer::trtllm_cubin_loader::getCubin(fname_cubin, sha256);
     cuModuleLoadData(&cuModule, cubin.c_str());
   };

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,12 +1,12 @@
-from flashinfer.artifacts import get_artifacts_status, get_available_cubin_files, get_cubin, get_cubin_file_list
+from flashinfer.artifacts import ArtifactPath, get_available_cubin_files, get_cubin_file_list
 
 import responses
 
-from urllib.parse import urljoin
+from flashinfer.jit.cubin_loader import safe_urljoin
 
 def test_sanity_check_urllib_behavior():
-    # We use urllib's url joining, just making sure it behaves as we expect.
-    # In particular, it should handle slashes by itself.
+    # We use safe_urljoin which ensures the base is always treated as a directory
+    # by adding a trailing slash if needed before calling urljoin.
     base_with_trailing_slash = "https://example.com/some/path/"
     base_without_trailing_slash = "https://example.com/some/path"
     single_segment = "file.txt"
@@ -14,25 +14,31 @@ def test_sanity_check_urllib_behavior():
     multiple_segments = "more/path/file.txt"
     intermediate_segments = "more/path/"
 
-    joined = urljoin(base_with_trailing_slash, single_segment)
+    joined = safe_urljoin(base_with_trailing_slash, single_segment)
     assert joined == "https://example.com/some/path/file.txt"
 
-    joined = urljoin(base_without_trailing_slash, single_segment)
-    assert joined == "https://example.com/some/file.txt"
+    # safe_urljoin adds trailing slash, so base is treated as directory
+    joined = safe_urljoin(base_without_trailing_slash, single_segment)
+    assert joined == "https://example.com/some/path/file.txt"
 
-    joined = urljoin(base_with_trailing_slash, single_segment_with_leading_slash)
+    joined = safe_urljoin(base_with_trailing_slash, single_segment_with_leading_slash)
     assert joined == "https://example.com/file.txt"
 
-    joined = urljoin(base_without_trailing_slash, single_segment_with_leading_slash)
+    joined = safe_urljoin(base_without_trailing_slash, single_segment_with_leading_slash)
     assert joined == "https://example.com/file.txt"
 
-    joined = urljoin(base_with_trailing_slash, multiple_segments)
+    joined = safe_urljoin(base_with_trailing_slash, multiple_segments)
     assert joined == "https://example.com/some/path/more/path/file.txt"
 
-    joined = urljoin(urljoin(base_with_trailing_slash, intermediate_segments), single_segment)
+    joined = safe_urljoin(safe_urljoin(base_with_trailing_slash, intermediate_segments), single_segment)
     assert joined == "https://example.com/some/path/more/path/file.txt"
 
-success_response = """
+# Fake but real-enough looking URL, these tests should not actually try to reach it.
+test_cubin_repository = "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-unit-test"
+
+artifact_paths = ArtifactPath()
+
+success_gemm_response = """
 <!DOCTYPE html>
 <html>
     <head>
@@ -53,32 +59,6 @@ success_response = """
             03-Sep-2025 03:44  63.70 KB
 <a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
             03-Sep-2025 03:44  63.08 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  65.87 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  60.49 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  61.51 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin</a>
-            03-Sep-2025 03:44  72.00 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  64.52 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  61.73 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  63.99 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin</a>
-            03-Sep-2025 03:44  74.70 KB
-<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  67.12 KB
-<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x16x128u2_s6_et64x16_m64x16x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x16x128u2_s6_et64x16_m64x16x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  61.44 KB
-<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin</a>
-            03-Sep-2025 03:44  71.36 KB
-<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin</a>
-            03-Sep-2025 03:44  64.14 KB
-<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x8x128u2_s6_et64x8_m64x8x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x8x128u2_s6_et64x8_m64x8x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin</a>
-            03-Sep-2025 03:44  73.05 KB
 <a href="LICENSE">LICENSE</a>
             03-Sep-2025 03:44  11.09 KB
 <a href="target_path.txt">target_path.txt</a>
@@ -91,43 +71,157 @@ success_response = """
 </html>
 """
 
-# Fake but real-enough looking URL, these tests should not actually try to reach it.
-test_cubin_repository = "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-unit-test"
+# Expected GEMM cubin files from the mock response
+expected_gemm_cubin_files = {
+    "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+    "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+    "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+}
+
+success_fmha_response = """
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex"/>
+        <title>Index of sw-kernelinferencelibrary-public-generic-local/037e528e719ec3456a7d7d654f26b805e44c63b1/fmha/trtllm-gen</title>
+    </head>
+    <body>
+        <h1>Index of sw-kernelinferencelibrary-public-generic-local/037e528e719ec3456a7d7d654f26b805e44c63b1/fmha/trtllm-gen</h1>
+        <pre>Name                                                                                                                                   Last modified      Size</pre>
+        <hr/>
+        <pre>
+            <a href="../">../</a>
+            <a href="include/">include/</a>
+            03-Sep-2025 03:45    -
+<a href="fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP32VarSeqQ128Kv128PersistentContext.cubin">fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP32VarSeqQ128Kv128PersistentContext.cubin</a>
+            03-Sep-2025 03:45  106.09 KB
+<a href="fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP32VarSeqQ128Kv128StaticContext.cubin">fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP32VarSeqQ128Kv128StaticContext.cubin</a>
+            03-Sep-2025 03:45  99.89 KB
+<a href="fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP64VarSeqQ128Kv128PersistentContext.cubin">fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP64VarSeqQ128Kv128PersistentContext.cubin</a>
+            03-Sep-2025 03:45  102.89 KB
+<a href="LICENSE">LICENSE</a>
+            03-Sep-2025 03:45  11.09 KB
+
+        </pre>
+        <hr/>
+        <address style="font-size:small;">Artifactory/7.117.14 Server</address>
+    </body>
+</html>
+
+"""
+
+# Expected FMHA cubin files from the mock response
+expected_fmha_cubin_files = {
+    "fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP32VarSeqQ128Kv128PersistentContext.cubin",
+    "fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP32VarSeqQ128Kv128StaticContext.cubin",
+    "fmhaSm100aKernel_QE4m3KvE2m1OE4m3H128PagedKvCausalP64VarSeqQ128Kv128PersistentContext.cubin",
+}
+
+success_bmm_response = """
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex"/>
+        <title>Index of sw-kernelinferencelibrary-public-generic-local/037e528e719ec3456a7d7d654f26b805e44c63b1/batched_gemm-8704aa4-ba3b00d</title>
+    </head>
+    <body>
+        <h1>Index of sw-kernelinferencelibrary-public-generic-local/037e528e719ec3456a7d7d654f26b805e44c63b1/batched_gemm-8704aa4-ba3b00d</h1>
+        <pre>Name                                                                                                                                                                                    Last modified      Size</pre>
+        <hr/>
+        <pre>
+            <a href="../">../</a>
+            <a href="include/">include/</a>
+            03-Sep-2025 03:44    -
+<a href="Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_bN_clmp_dynBatch_sm100f.cubin">Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_bN_clmp_dynBatch_sm100f.cubin</a>
+            03-Sep-2025 03:44  108.73 KB
+<a href="Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedS_bN_clmp_dynBatch_sm100f.cubin">Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedS_bN_clmp_dynBatch_sm100f.cubin</a>
+            03-Sep-2025 03:44  89.20 KB
+<a href="Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256u2_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_bN_clmp_dynBatch_sm100f.cubin">Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256u2_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_bN_clmp_dynBatch_sm100f.cubin</a>
+            03-Sep-2025 03:44  112.02 KB
+<a href="LICENSE">LICENSE</a>
+            03-Sep-2025 03:44  11.09 KB
+<a href="target_path.txt">target_path.txt</a>
+            03-Sep-2025 03:44  29 bytes
+
+        </pre>
+        <hr/>
+        <address style="font-size:small;">Artifactory/7.117.14 Server</address>
+    </body>
+</html>
+
+"""
+
+# Expected BMM cubin files from the mock response
+expected_bmm_cubin_files = {
+    "Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_bN_clmp_dynBatch_sm100f.cubin",
+    "Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedS_bN_clmp_dynBatch_sm100f.cubin",
+    "Bmm_Bfloat16_E2m1E2m1_Fp32_t128x16x256u2_s6_et128x16_m128x16x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_bN_clmp_dynBatch_sm100f.cubin",
+}
+
+success_deepgemm_response = """
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex"/>
+        <title>Index of sw-kernelinferencelibrary-public-generic-local/51d730202c9eef782f06ecc950005331d85c5d4b/deep-gemm</title>
+    </head>
+    <body>
+        <h1>Index of sw-kernelinferencelibrary-public-generic-local/51d730202c9eef782f06ecc950005331d85c5d4b/deep-gemm</h1>
+        <pre>Name                                          Last modified      Size</pre>
+        <hr/>
+        <pre>
+            <a href="../">../</a>
+            <a href="kernel.fp8_m_grouped_gemm.007404769193.cubin">kernel.fp8_m_grouped_gemm.007404769193.cubin</a>
+            15-Sep-2025 23:32  54.94 KB
+<a href="kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin">kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin</a>
+            15-Sep-2025 23:32  103.99 KB
+<a href="kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin">kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin</a>
+            15-Sep-2025 23:32  256.61 KB
+<a href="kernel.fp8_m_grouped_gemm.0457375eb02f.cubin">kernel.fp8_m_grouped_gemm.0457375eb02f.cubin</a>
+            15-Sep-2025 23:32  75.47 KB
+<a href="kernel_map.json">kernel_map.json</a>
+            15-Sep-2025 23:32  107.83 KB
+<a href="LICENSE">LICENSE</a>
+            15-Sep-2025 23:32  11.09 KB
+
+        </pre>
+        <hr/>
+        <address style="font-size:small;">Artifactory/7.117.14 Server</address>
+    </body>
+</html>
+
+"""
+
+# Expected BMM cubin files from the mock response
+expected_deepgemm_cubin_files = {
+    "kernel.fp8_m_grouped_gemm.007d9ebdca7e.cubin",
+    "kernel.fp8_m_grouped_gemm.02acb2ba71fd.cubin",
+    "kernel.fp8_m_grouped_gemm.0457375eb02f.cubin",
+}
+
+def _mock_file_index_responses():
+    gemm_source = safe_urljoin(test_cubin_repository, artifact_paths.TRTLLM_GEN_GEMM)
+    responses.add(responses.GET, gemm_source, body=success_gemm_response, status=200)
+    fmha_source = safe_urljoin(test_cubin_repository, artifact_paths.TRTLLM_GEN_FMHA)
+    responses.add(responses.GET, fmha_source, body=success_fmha_response, status=200)
+    bmm_source = safe_urljoin(test_cubin_repository, artifact_paths.TRTLLM_GEN_BMM)
+    responses.add(responses.GET, bmm_source, body=success_bmm_response, status=200)
+    deepgemm_source = safe_urljoin(test_cubin_repository, artifact_paths.DEEPGEMM)
+    responses.add(responses.GET, deepgemm_source, body=success_deepgemm_response, status=200)
 
 @responses.activate
 def test_get_available_cubin_files():
-    gemm_path = "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
-    source = urljoin(test_cubin_repository, gemm_path)
-    responses.add(responses.GET, source, body=success_response, status=200)
+    _mock_file_index_responses()
+    source = safe_urljoin(test_cubin_repository, artifact_paths.TRTLLM_GEN_GEMM)
     available_cubin_files = get_available_cubin_files(source, retries=3, delay=0, timeout=5)
-    assert len(available_cubin_files) == 16
-    
-    # Expected cubin files from the mock response
-    expected_cubin_files = {
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin",
-        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x16x128u2_s6_et64x16_m64x16x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin",
-        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin",
-        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x8x128u2_s6_et64x8_m64x8x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin",
-    }
+    assert len(available_cubin_files) == 3
     
     # Check that all expected files are present
     actual_cubin_files = set(available_cubin_files)
-    assert actual_cubin_files == expected_cubin_files, f"Expected files: {expected_cubin_files}, but got: {actual_cubin_files}"
+    assert actual_cubin_files == expected_gemm_cubin_files, f"Expected files: {expected_gemm_cubin_files}, but got: {actual_cubin_files}"
     
     # Check that each individual expected file is in the results
-    for expected_file in expected_cubin_files:
+    for expected_file in expected_gemm_cubin_files:
         assert expected_file in available_cubin_files, f"Expected cubin file '{expected_file}' not found in results"
 
 
@@ -135,7 +229,7 @@ def test_get_available_cubin_files():
 def test_get_available_cubin_files_non_200_response():
     """Test that non-200 response codes return an empty tuple."""
     gemm_path = "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
-    source = urljoin(test_cubin_repository, gemm_path)
+    source = safe_urljoin(test_cubin_repository, gemm_path)
     
     # Test 404 Not Found
     responses.add(responses.GET, source, status=404)
@@ -155,5 +249,27 @@ def test_get_available_cubin_files_non_200_response():
     assert available_cubin_files == ()
 
 
-# def test_get_artifacts_status():
-#     pass
+@responses.activate
+def test_get_cubin_file_list(monkeypatch):
+    _mock_file_index_responses()
+    from flashinfer import artifacts
+    monkeypatch.setattr(artifacts, 'FLASHINFER_CUBINS_REPOSITORY', test_cubin_repository)
+    cubin_files = list(get_cubin_file_list())
+
+    # Check that all the cubin's are in there.
+    for expected_file in expected_gemm_cubin_files:
+        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+
+    for expected_file in expected_fmha_cubin_files:
+        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+
+    for expected_file in expected_bmm_cubin_files:
+        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+
+    for expected_file in expected_deepgemm_cubin_files:
+        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+    
+    # Check that the meta info headers are included (note the inconsistent casing in the actual function)
+    # Capitalization is inconsistent in the actual filenames, so we check for both variants.
+    meta_info_headers = [url for url in cubin_files if "include/flashInferMetaInfo.h" in url or "include/flashinferMetaInfo.h" in url]
+    assert len(meta_info_headers) == 3, f"Meta info headers count mismatch. Expected 3, got {len(meta_info_headers)}. Headers found: {meta_info_headers}"

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -33,6 +33,9 @@ def test_sanity_check_urllib_behavior():
     joined = safe_urljoin(safe_urljoin(base_with_trailing_slash, intermediate_segments), single_segment)
     assert joined == "https://example.com/some/path/more/path/file.txt"
 
+    joined = safe_urljoin(intermediate_segments, single_segment)
+    assert joined == "more/path/file.txt"
+
 # Fake but real-enough looking URL, these tests should not actually try to reach it.
 test_cubin_repository = "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-unit-test"
 
@@ -257,18 +260,22 @@ def test_get_cubin_file_list(monkeypatch):
     cubin_files = list(get_cubin_file_list())
 
     # Check that all the cubin's are in there.
-    for expected_file in expected_gemm_cubin_files:
-        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+    for expected_file_name in expected_gemm_cubin_files:
+        expected_file_path = artifact_paths.TRTLLM_GEN_GEMM + "/" + expected_file_name
+        assert any(expected_file_path in url for url in cubin_files), f"Expected cubin file '{expected_file_path}' not found in cubin file list"
 
-    for expected_file in expected_fmha_cubin_files:
-        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+    for expected_file_name in expected_fmha_cubin_files:
+        expected_file_path = artifact_paths.TRTLLM_GEN_FMHA + "/" + expected_file_name
+        assert any(expected_file_path in url for url in cubin_files), f"Expected cubin file '{expected_file_path}' not found in cubin file list"
 
-    for expected_file in expected_bmm_cubin_files:
-        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
+    for expected_file_name in expected_bmm_cubin_files:
+        expected_file_path = artifact_paths.TRTLLM_GEN_BMM + "/" + expected_file_name
+        assert any(expected_file_path in url for url in cubin_files), f"Expected cubin file '{expected_file_path}' not found in cubin file list"
 
-    for expected_file in expected_deepgemm_cubin_files:
-        assert any(expected_file in url for url in cubin_files), f"Expected cubin file '{expected_file}' not found in cubin file list"
-    
+    for expected_file_name in expected_deepgemm_cubin_files:
+        expected_file_path = artifact_paths.DEEPGEMM + "/" + expected_file_name
+        assert any(expected_file_path in url for url in cubin_files), f"Expected cubin file '{expected_file_path}' not found in cubin file list"
+
     # Check that the meta info headers are included (note the inconsistent casing in the actual function)
     # Capitalization is inconsistent in the actual filenames, so we check for both variants.
     meta_info_headers = [url for url in cubin_files if "include/flashInferMetaInfo.h" in url or "include/flashinferMetaInfo.h" in url]

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,159 @@
+from flashinfer.artifacts import get_artifacts_status, get_available_cubin_files, get_cubin, get_cubin_file_list
+
+import responses
+
+from urllib.parse import urljoin
+
+def test_sanity_check_urllib_behavior():
+    # We use urllib's url joining, just making sure it behaves as we expect.
+    # In particular, it should handle slashes by itself.
+    base_with_trailing_slash = "https://example.com/some/path/"
+    base_without_trailing_slash = "https://example.com/some/path"
+    single_segment = "file.txt"
+    single_segment_with_leading_slash = "/file.txt"
+    multiple_segments = "more/path/file.txt"
+    intermediate_segments = "more/path/"
+
+    joined = urljoin(base_with_trailing_slash, single_segment)
+    assert joined == "https://example.com/some/path/file.txt"
+
+    joined = urljoin(base_without_trailing_slash, single_segment)
+    assert joined == "https://example.com/some/file.txt"
+
+    joined = urljoin(base_with_trailing_slash, single_segment_with_leading_slash)
+    assert joined == "https://example.com/file.txt"
+
+    joined = urljoin(base_without_trailing_slash, single_segment_with_leading_slash)
+    assert joined == "https://example.com/file.txt"
+
+    joined = urljoin(base_with_trailing_slash, multiple_segments)
+    assert joined == "https://example.com/some/path/more/path/file.txt"
+
+    joined = urljoin(urljoin(base_with_trailing_slash, intermediate_segments), single_segment)
+    assert joined == "https://example.com/some/path/more/path/file.txt"
+
+success_response = """
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex"/>
+        <title>Index of sw-kernelinferencelibrary-public-generic-local/037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e</title>
+    </head>
+    <body>
+        <h1>Index of sw-kernelinferencelibrary-public-generic-local/037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e</h1>
+        <pre>Name                                                                                                                                   Last modified      Size</pre>
+        <hr/>
+        <pre>
+            <a href="../">../</a>
+            <a href="include/">include/</a>
+            03-Sep-2025 03:44    -
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  60.79 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  63.70 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  63.08 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  65.87 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  60.49 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  61.51 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin</a>
+            03-Sep-2025 03:44  72.00 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  64.52 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  61.73 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  63.99 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin</a>
+            03-Sep-2025 03:44  74.70 KB
+<a href="Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin">Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  67.12 KB
+<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x16x128u2_s6_et64x16_m64x16x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x16x128u2_s6_et64x16_m64x16x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  61.44 KB
+<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin</a>
+            03-Sep-2025 03:44  71.36 KB
+<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin</a>
+            03-Sep-2025 03:44  64.14 KB
+<a href="Gemm_Bfloat16_E4m3E4m3_Fp32_t128x8x128u2_s6_et64x8_m64x8x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin">Gemm_Bfloat16_E4m3E4m3_Fp32_t128x8x128u2_s6_et64x8_m64x8x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin</a>
+            03-Sep-2025 03:44  73.05 KB
+<a href="LICENSE">LICENSE</a>
+            03-Sep-2025 03:44  11.09 KB
+<a href="target_path.txt">target_path.txt</a>
+            03-Sep-2025 03:44  21 bytes
+
+        </pre>
+        <hr/>
+        <address style="font-size:small;">Artifactory/7.117.14 Server</address>
+    </body>
+</html>
+"""
+
+# Fake but real-enough looking URL, these tests should not actually try to reach it.
+test_cubin_repository = "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-unit-test"
+
+@responses.activate
+def test_get_available_cubin_files():
+    gemm_path = "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
+    source = urljoin(test_cubin_repository, gemm_path)
+    responses.add(responses.GET, source, body=success_response, status=200)
+    available_cubin_files = get_available_cubin_files(source, retries=3, delay=0, timeout=5)
+    assert len(available_cubin_files) == 16
+    
+    # Expected cubin files from the mock response
+    expected_cubin_files = {
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x128u2_s6_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s2_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s3_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedP2x1x2x3_sm100f.cubin",
+        "Gemm_Bfloat16_E2m1E2m1_Fp32_t128x128x256u2_s4_et128x128_m128x128x64_cga1x1x1_16dp256b_TN_transOut_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x16x128u2_s6_et64x16_m64x16x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin",
+        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x32x128u2_s6_et64x32_m64x32x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedS_sm100f.cubin",
+        "Gemm_Bfloat16_E4m3E4m3_Fp32_t128x8x128u2_s6_et64x8_m64x8x32_cga1x1x1_16dp256b_TN_transOut_noShflA_dsFp8_schedP2x2x1x3_sm100f.cubin",
+    }
+    
+    # Check that all expected files are present
+    actual_cubin_files = set(available_cubin_files)
+    assert actual_cubin_files == expected_cubin_files, f"Expected files: {expected_cubin_files}, but got: {actual_cubin_files}"
+    
+    # Check that each individual expected file is in the results
+    for expected_file in expected_cubin_files:
+        assert expected_file in available_cubin_files, f"Expected cubin file '{expected_file}' not found in results"
+
+
+@responses.activate
+def test_get_available_cubin_files_non_200_response():
+    """Test that non-200 response codes return an empty tuple."""
+    gemm_path = "037e528e719ec3456a7d7d654f26b805e44c63b1/gemm-8704aa4-f91dc9e/"
+    source = urljoin(test_cubin_repository, gemm_path)
+    
+    # Test 404 Not Found
+    responses.add(responses.GET, source, status=404)
+    available_cubin_files = get_available_cubin_files(source, retries=1, delay=0, timeout=5)
+    assert available_cubin_files == ()
+    
+    # Reset responses and test 500 Internal Server Error
+    responses.reset()
+    responses.add(responses.GET, source, status=500)
+    available_cubin_files = get_available_cubin_files(source, retries=1, delay=0, timeout=5)
+    assert available_cubin_files == ()
+    
+    # Reset responses and test 403 Forbidden
+    responses.reset()
+    responses.add(responses.GET, source, status=403)
+    available_cubin_files = get_available_cubin_files(source, retries=1, delay=0, timeout=5)
+    assert available_cubin_files == ()
+
+
+# def test_get_artifacts_status():
+#     pass


### PR DESCRIPTION
Encountered some issues when adding some cubin's. This change set and tests should ensure future contributors do not run into the same issues.

- Warp `urljoin` into a helper which joins URLs independently of the presence of a trailing slash
- Add unit tests for this utility and the functions that use it