### PR TITLE
fix: compilation failure in fp4Op.cpp

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp
@@ -306,7 +306,7 @@ void mxfp4_dequantize_host(Tensor weight, Tensor scale, Tensor dequant_weight, i
   CHECK_CPU_INPUT(scale, dl_uint8);
   CHECK_CONTIGUOUS(weight);
   CHECK_CONTIGUOUS(scale);
-  TVM_FFI_ICHECK_NE(weight.shape()->Product(), 0) << "weight should not be empty tensor";
+  TVM_FFI_ICHECK_NE(weight.shape().Product(), 0) << "weight should not be empty tensor";
   CHECK_INPUT_TYPE(weight, dl_uint8);
   CHECK_INPUT_TYPE(scale, dl_uint8);
 
@@ -324,7 +324,7 @@ void mxfp4_dequantize_host(Tensor weight, Tensor scale, Tensor dequant_weight, i
   float fp4_lut[] = {0.0, 0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
                      0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0};
 
-  for (int packed_idx = 0; packed_idx < weight.shape()->Product(); ++packed_idx) {
+  for (int packed_idx = 0; packed_idx < weight.shape().Product(); ++packed_idx) {
     int8_t weight_packed_data = weight_packed_ptr[packed_idx];
 
     uint8_t weight_low_ = weight_packed_data & 0xF;


### PR DESCRIPTION
Before the fix, running `pytest tests/test_fp4_quantize.py` results in:
```
E           /workspace/flashinfer/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp: In function ‘void mxfp4_dequantize_host(tvm::ffi::Tensor, tvm::ffi::Tensor, tvm::ffi::Tensor, int64_t)’:   E           /workspace/flashinfer/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp:309:35: error: base operand of ‘->’ has non-pointer type ‘tvm::ffi::ShapeView’                              E             309 |   TVM_FFI_ICHECK_NE(weight.shape()->Product(), 0) << "weight should not be empty tensor";                                                                              E                 |                                   ^~                                                                                                                                   E           /workspace/flashinfer/csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp:327:55: error: base operand of ‘->’ has non-pointer type ‘tvm::ffi::ShapeView’                              E             327 |   for (int packed_idx = 0; packed_idx < weight.shape()->Product(); ++packed_idx) {                                                                                     E                 |      
```

After the fix:
```
================================================================================= test session starts ===================================================================================platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /workspace/flashinfer
configfile: pyproject.toml
collected 59 items

tests/test_fp4_quantize.py ...........................................................                                                                                              [100%]

=================================================================================== 59 passed in 4.76s ====================================================================================
```