### PR TITLE
fix: missing header include in decode kernel jit binding

### DIFF
--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <flashinfer/attention/decode.cuh>
 #include <flashinfer/attention/scheduler.cuh>
 #include <flashinfer/pos_enc.cuh>
 #include <flashinfer/utils.cuh>


### PR DESCRIPTION
## 📌 Description

This commit adds the missing include of the header `decode.cuh` in the JIT binding `csrc/batch_decode.cu`, without this fix, there will be linking error when linking `batch_decode.o`, `batch_decode_kernel.o` and `batch_decode_jit_binding.o`.

The reason is that, `csrc/batch_decode.cu` relies on `scheduler.cuh` for decoding attention planning. `scheduler.cuh` declares the decode kernel of `BatchDecodeWithPagedKVCacheKernel`, which is implemented in `decode.cuh`, but does not include `decode.cuh`.  Therefore, if `csrc/batch_decode.cu` does not include `decode.cuh`, the decode kernel will be a symbol that is declared but not implemented.


## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x]  I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

N/A
