### PR TITLE
fix: test_blackwell_kernels.sh script to no longer update dependencies

### DIFF
--- a/scripts/task_test_blackwell_kernels.sh
+++ b/scripts/task_test_blackwell_kernels.sh
@@ -15,7 +15,7 @@ if [[ "$1" == "--dry-run" ]] || [[ "${DRY_RUN}" == "true" ]]; then
 fi
 
 if [ "$DRY_RUN" != "true" ]; then
-    pip install -e . -v
+    pip install -e . -v --no-deps
 fi
 
 EXIT_CODE=0


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The `scripts/task_test_blackwell_kernels.sh` file for running a series tests for Blackwell currently reinstalls all dependencies recursively. This can cause issues with locally configured dependencies being inadvertently updated (e.g. nvidia-cudnn-cu12==9.13 is installed, but gets downgraded to nvidia-cudnn-cu12==9.10)

The current PR adds a `--no-deps` flag to keep all dependencies intact while only installing the FlashInfer build.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
