### PR TITLE
Fix sm120 fp8 groupwise gemm

### DIFF
--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -2764,20 +2764,64 @@ def group_gemm_fp8_nt_groupwise(
 
     if is_sm120a_supported(a.device) or is_sm121a_supported(a.device):
         # SM120/121 doesn't use mma_sm parameter
-        get_gemm_sm120_module().group_gemm_fp8_nt_groupwise(
-            int_workspace_buffer,
-            float_workspace_buffer,
-            a,
-            b,
-            a_scale,
-            b_scale,
-            out,
-            m_indptr,
-            n,
-            k,
-            *scale_granularity_mnk,
-            scale_major_mode,
-        )
+        # TODO (yongwww): SM120/121 has correctness issues with multi-group scenarios
+        # Fall back to loop-based processing for now
+        use_loop_fallback = num_groups > 1
+
+        if use_loop_fallback:
+            for i in range(num_groups):
+                m_start = m_indptr[i].item()
+                m_end = m_indptr[i + 1].item()
+                group_m = m_end - m_start
+
+                a_group = a[m_start:m_end, :].contiguous()
+                b_group = b[i : i + 1, :, :].contiguous()
+
+                # Extract scales based on mode
+                if scale_major_mode == "K":
+                    a_scale_group = a_scale[m_start:m_end, :].contiguous()
+                    b_scale_group = b_scale[i : i + 1, :, :].contiguous()
+                else:  # MN mode
+                    sf_m_start = m_start // scale_granularity_mnk[0]
+                    sf_m_end = (
+                        m_end + scale_granularity_mnk[0] - 1
+                    ) // scale_granularity_mnk[0]
+                    a_scale_group = a_scale[:, sf_m_start:sf_m_end].contiguous()
+                    b_scale_group = b_scale[i : i + 1, :, :].contiguous()
+
+                group_m_indptr = torch.tensor(
+                    [0, group_m], dtype=torch.int32, device=a.device
+                )
+
+                get_gemm_sm120_module().group_gemm_fp8_nt_groupwise(
+                    int_workspace_buffer,
+                    float_workspace_buffer,
+                    a_group,
+                    b_group,
+                    a_scale_group,
+                    b_scale_group,
+                    out[m_start:m_end, :],
+                    group_m_indptr,
+                    n,
+                    k,
+                    *scale_granularity_mnk,
+                    scale_major_mode,
+                )
+        else:
+            get_gemm_sm120_module().group_gemm_fp8_nt_groupwise(
+                int_workspace_buffer,
+                float_workspace_buffer,
+                a,
+                b,
+                a_scale,
+                b_scale,
+                out,
+                m_indptr,
+                n,
+                k,
+                *scale_granularity_mnk,
+                scale_major_mode,
+            )
     elif is_sm100a_supported(a.device):
         get_gemm_sm100_module().group_gemm_fp8_nt_groupwise(
             int_workspace_buffer,

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -2779,6 +2779,9 @@ def group_gemm_fp8_nt_groupwise(
                 a_scale_group = a_scale[m_start:m_end, :].contiguous()
                 b_scale_group = b_scale[i : i + 1, :, :].contiguous()
             else:  # MN mode
+                assert m_start % scale_granularity_mnk[0] == 0, (
+                    f"m_start ({m_start}) is not aligned to scale_granularity_m ({scale_granularity_mnk[0]})"
+                )
                 sf_m_start = m_start // scale_granularity_mnk[0]
                 sf_m_end = (
                     m_end + scale_granularity_mnk[0] - 1


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Currently we saw ~200/1200 failures for fp8 groupwise gemm test on sm120/121, this fix is a workaround to use single group to pass CI check for now

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc: @yzh119 
