### PR TITLE
Remove `-isystem /usr/include`

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -107,6 +107,11 @@ def generate_ninja_build_for_op(
     system_includes += [p.resolve() for p in jit_env.CUTLASS_INCLUDE_DIRS]
     system_includes.append(jit_env.SPDLOG_INCLUDE_DIR.resolve())
 
+    cuda_home = get_cuda_path()
+    if cuda_home == "/usr":
+        # NOTE: this will resolve to /usr/include, which will mess up includes. See #1793
+        system_includes.remove("$cuda_home/include")
+
     common_cflags = []
     if not sysconfig.get_config_var("Py_GIL_DISABLED"):
         common_cflags.append("-DPy_LIMITED_API=0x03090000")
@@ -181,7 +186,6 @@ def generate_ninja_build_for_op(
         cuda_cflags += extra_cuda_cflags
 
     cxx = os.environ.get("CXX", "c++")
-    cuda_home = get_cuda_path()
     nvcc = os.environ.get("FLASHINFER_NVCC", "$cuda_home/bin/nvcc")
 
     lines = [


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

If cuda home is set to `/usr`, this PR removes `-isystem $cuda_home/include`, which resolves to `-isystem /usr/include`. This breaks imports when included in gcc commands. See related issues.

## 🔍 Related Issues

Resolves #1793 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
