### PR TITLE
Pytest flags and regression fix

### DIFF
--- a/scripts/task_test_blackwell_kernels.sh
+++ b/scripts/task_test_blackwell_kernels.sh
@@ -6,6 +6,9 @@ set -eo pipefail
 : ${MAX_JOBS:=$(nproc)}
 : ${CUDA_VISIBLE_DEVICES:=0}
 
+# Pytest configuration flags
+PYTEST_FLAGS="--continue-on-collection-errors -s"
+
 # Check for dry-run mode
 DRY_RUN=false
 if [[ "$1" == "--dry-run" ]] || [[ "${DRY_RUN}" == "true" ]]; then
@@ -121,7 +124,7 @@ else
                 echo "Running: pytest $test_file"
                 TOTAL_TESTS=$((TOTAL_TESTS + 1))
 
-                if pytest "$test_file"; then
+                if pytest "$test_file" $PYTEST_FLAGS; then
                     echo "✅ PASSED: $test_file"
                     PASSED_TESTS=$((PASSED_TESTS + 1))
                 else
@@ -139,7 +142,7 @@ else
 
             TOTAL_TESTS=$((TOTAL_TESTS + 1))
 
-            if pytest "$test_dir"; then
+            if pytest "$test_dir" $PYTEST_FLAGS; then
                 echo "✅ PASSED: $test_dir"
                 PASSED_TESTS=$((PASSED_TESTS + 1))
             else


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. Updates task_test_blackwell_kernels.sh to get more details after the first pytest failure.
2. Revert a commit that regressed the unit tests (#1801)

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
