### PR TITLE
jit: add `-lcuda` to default ldflags

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -387,7 +387,6 @@ def gen_cutlass_fused_moe_module(
         ],
         extra_cuda_cflags=nvcc_flags,
         extra_cflags=["-DFAST_BUILD"] if use_fast_build else [],
-        extra_ldflags=["-lcuda"],
         extra_include_paths=[
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal" / "include",
@@ -1010,7 +1009,6 @@ def gen_trtllm_gen_fused_moe_sm100_module() -> JitSpec:
             f'-DTLLM_GEN_BMM_CUBIN_PATH=\\"{ArtifactPath.TRTLLM_GEN_BMM}\\"',
         ]
         + nvcc_flags,
-        extra_ldflags=["-lcuda"],
         extra_include_paths=[
             # link "include" sub-directory in cache
             jit_env.FLASHINFER_CUBIN_DIR / include_path,

--- a/flashinfer/gemm.py
+++ b/flashinfer/gemm.py
@@ -230,7 +230,6 @@ def gen_gemm_sm100_module_cutlass_fp4() -> JitSpec:
         extra_cflags=[
             "-DFAST_BUILD",
         ],
-        extra_ldflags=["-lcuda"],
     )
 
 
@@ -277,7 +276,6 @@ def gen_gemm_sm120_module_cutlass_fp4() -> JitSpec:
         extra_cflags=[
             "-DFAST_BUILD",
         ],
-        extra_ldflags=["-lcuda"],
     )
 
 
@@ -328,7 +326,6 @@ def gen_gemm_sm100_module_cutlass_fp8() -> JitSpec:
         extra_cflags=[
             "-DFAST_BUILD",
         ],
-        extra_ldflags=["-lcuda"],
     )
 
 
@@ -647,7 +644,6 @@ def gen_trtllm_gen_gemm_module() -> JitSpec:
         + sm100a_nvcc_flags,
         # link "include" sub-directory in cache
         extra_include_paths=[jit_env.FLASHINFER_CUBIN_DIR / include_path],
-        extra_ldflags=["-lcuda"],
     )
 
 

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1586,7 +1586,6 @@ def gen_trtllm_gen_fmha_module():
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_fmha_kernel_launcher.cu",
             jit_env.FLASHINFER_CSRC_DIR / "fmhaReduction.cu",
         ],
-        extra_ldflags=["-lcuda"],
         # link "include" sub-directory in cache
         extra_include_paths=[jit_env.FLASHINFER_CUBIN_DIR / include_path],
         extra_cuda_cflags=[
@@ -1691,7 +1690,6 @@ def gen_cudnn_fmha_module():
     return gen_jit_spec(
         "fmha_cudnn_gen",
         [jit_env.FLASHINFER_CSRC_DIR / "cudnn_sdpa_kernel_launcher.cu"],
-        extra_ldflags=["-lcuda"],
         extra_cuda_cflags=[
             f'-DCUDNN_SDPA_CUBIN_PATH=\\"{ArtifactPath.CUDNN_SDPA}\\"',
         ],

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -166,6 +166,7 @@ def generate_ninja_build_for_op(
         "-L$cuda_home/lib64",
         "-L$cuda_home/lib64/stubs",
         "-lcudart",
+        "-lcuda",
     ]
 
     extra_ldflags = parse_env_flags("FLASHINFER_EXTRA_LDFLAGS")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR add `-lcuda` to default ldflags instead of making it optional.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
