### PR TITLE
Fix deep_gemm artifact load path

### DIFF
--- a/flashinfer/deep_gemm.py
+++ b/flashinfer/deep_gemm.py
@@ -934,8 +934,9 @@ def load_all():
         if cubin_name in RUNTIME_CACHE:
             continue
         symbol, sha256 = KERNEL_MAP[cubin_name]
-        get_cubin(ArtifactPath.DEEPGEMM + cubin_name, sha256)
-        path = FLASHINFER_CUBIN_DIR / f"{ArtifactPath.DEEPGEMM + cubin_name}.cubin"
+        cubin_name = cubin_name + ".cubin"
+        get_cubin(ArtifactPath.DEEPGEMM + "/" + cubin_name, sha256)
+        path = FLASHINFER_CUBIN_DIR / f"{ArtifactPath.DEEPGEMM + "/" + cubin_name}"
         assert path.exists()
         RUNTIME_CACHE[cubin_name] = SM100FP8GemmRuntime(str(path), symbol)
 
@@ -948,8 +949,9 @@ def load(name: str, code: str) -> SM100FP8GemmRuntime:
     if cubin_name in RUNTIME_CACHE:
         return RUNTIME_CACHE[cubin_name]
     symbol, sha256 = KERNEL_MAP[cubin_name]
-    get_cubin(ArtifactPath.DEEPGEMM + cubin_name, sha256)
-    path = FLASHINFER_CUBIN_DIR / f"{ArtifactPath.DEEPGEMM + cubin_name}.cubin"
+    cubin_name = cubin_name + ".cubin"
+    get_cubin(ArtifactPath.DEEPGEMM + "/" + cubin_name, sha256)
+    path = FLASHINFER_CUBIN_DIR / f"{ArtifactPath.DEEPGEMM + "/" + cubin_name}"
     assert path.exists()
     RUNTIME_CACHE[cubin_name] = SM100FP8GemmRuntime(str(path), symbol)
     return RUNTIME_CACHE[cubin_name]
@@ -1490,11 +1492,11 @@ class KernelMap:
         self.indice = None
 
     def init_indices(self):
-        indice_path = ArtifactPath.DEEPGEMM + "kernel_map.json"
+        indice_path = ArtifactPath.DEEPGEMM + "/" + "kernel_map.json"
         assert get_cubin(indice_path, self.sha256), (
             "cubin kernel map file not found, nor downloaded with matched sha256"
         )
-        path = FLASHINFER_CUBIN_DIR / f"{indice_path}.json"
+        path = FLASHINFER_CUBIN_DIR / f"{indice_path}"
         assert path.exists()
         with open(path, "r") as f:
             self.indice = json.load(f)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

fix path strings when calling get_cubin for deep_gemm artifacts

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
