### PR TITLE
docker: add image tags with date-SHA suffix

### DIFF
--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -51,6 +51,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: flashinfer

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'docker/**'
+    # paths:
+    #   - 'docker/**'
 
 jobs:
   generate-tag:

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -4,13 +4,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      date_sha: ${{ steps.generate_tag.outputs.date_sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate version tag
+        id: generate_tag
+        run: |
+          DATE_SHA=$(date +'%Y%m%d')-$(git rev-parse --short HEAD)
+          echo "date_sha=${DATE_SHA}" >> $GITHUB_OUTPUT
+          echo "Generated version tag: ${DATE_SHA}"
+
   build:
     runs-on: ubuntu-latest
+    needs: generate-tag
     strategy:
       matrix:
         cuda: [cu126, cu128, cu129, cu130]
         arch: [amd64, arm64]
     steps:
+      - uses: actions/checkout@v4
+
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -21,8 +38,6 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
-
-      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -44,7 +59,7 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           push: true
           tags: |
-            flashinfer/flashinfer-ci-${{ matrix.cuda }}:${{ matrix.arch }}
+            flashinfer/flashinfer-ci-${{ matrix.cuda }}:${{ matrix.arch }}-${{ needs.generate-tag.outputs.date_sha }}
           cache-from: type=registry,ref=flashinfer/flashinfer-ci-${{ matrix.cuda }}:buildcache-${{ matrix.arch }}
           cache-to: type=registry,ref=flashinfer/flashinfer-ci-${{ matrix.cuda }}:buildcache-${{ matrix.arch }},mode=max
           provenance: false
@@ -52,7 +67,7 @@ jobs:
 
   create-manifests:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [generate-tag, build]
     strategy:
       matrix:
         cuda: [cu126, cu128, cu129, cu130]
@@ -67,7 +82,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create and push multi-arch manifest for ${{ matrix.cuda }}
+        env:
+          DATE_SHA: ${{ needs.generate-tag.outputs.date_sha }}
         run: |
-          docker buildx imagetools create -t flashinfer/flashinfer-ci-${{ matrix.cuda }}:latest \
-            flashinfer/flashinfer-ci-${{ matrix.cuda }}:amd64 \
-            flashinfer/flashinfer-ci-${{ matrix.cuda }}:arm64
+          docker buildx imagetools create \
+            -t flashinfer/flashinfer-ci-${{ matrix.cuda }}:${DATE_SHA} \
+            -t flashinfer/flashinfer-ci-${{ matrix.cuda }}:latest \
+            flashinfer/flashinfer-ci-${{ matrix.cuda }}:amd64-${DATE_SHA} \
+            flashinfer/flashinfer-ci-${{ matrix.cuda }}:arm64-${DATE_SHA}

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -10,8 +10,9 @@ on:
   pull_request:
     branches:
       - main
-    # paths:
-    #   - 'docker/**'
+    paths:
+      - 'docker/**'
+      - '.github/workflows/release-ci-docker.yml'
 
 jobs:
   generate-tag:

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -2,11 +2,16 @@ name: Release CI Docker
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
   pull_request:
     branches:
       - main
-    # paths:
-    #   - 'docker/**'
+    paths:
+      - 'docker/**'
 
 jobs:
   generate-tag:

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -10,8 +10,8 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'docker/**'
+    # paths:
+    #   - 'docker/**'
 
 jobs:
   generate-tag:
@@ -72,7 +72,7 @@ jobs:
           tags: |
             flashinfer/flashinfer-ci-${{ matrix.cuda }}:${{ matrix.arch }}-${{ needs.generate-tag.outputs.date_sha }}
           cache-from: type=registry,ref=flashinfer/flashinfer-ci-${{ matrix.cuda }}:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=flashinfer/flashinfer-ci-${{ matrix.cuda }}:buildcache-${{ matrix.arch }},mode=max
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=flashinfer/flashinfer-ci-{0}:buildcache-{1},mode=max', matrix.cuda, matrix.arch) || '' }}
           provenance: false
           sbom: false
 

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -2,6 +2,11 @@ name: Release CI Docker
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
 
 jobs:
   generate-tag:
@@ -57,7 +62,7 @@ jobs:
           context: docker
           file: docker/Dockerfile.${{ matrix.cuda }}
           platforms: linux/${{ matrix.arch }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             flashinfer/flashinfer-ci-${{ matrix.cuda }}:${{ matrix.arch }}-${{ needs.generate-tag.outputs.date_sha }}
           cache-from: type=registry,ref=flashinfer/flashinfer-ci-${{ matrix.cuda }}:buildcache-${{ matrix.arch }}
@@ -66,6 +71,7 @@ jobs:
           sbom: false
 
   create-manifests:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [generate-tag, build]
     strategy:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,56 @@ def unpack_lib(name, libs) {
      """
 }
 
+def should_skip_build() {
+  // Skip build if changes are only in documentation/config directories
+  def skip_patterns = [
+    'README.md',
+    '.github/',
+    'docs/',
+    'docker/',
+    'licenses/',
+    'LICENSE',
+    'NOTICE',
+    'version.txt'
+  ]
+
+  if (env.CHANGE_ID) {
+    // This is a PR build, check changed files
+    def changedFiles = []
+    try {
+      changedFiles = sh(
+        script: 'git diff --name-only origin/${CHANGE_TARGET}...HEAD',
+        returnStdout: true
+      ).trim().split('\n')
+    } catch (Exception e) {
+      echo "Could not determine changed files: ${e.toString()}"
+      return false
+    }
+
+    if (changedFiles.size() == 0) {
+      return false
+    }
+
+    // Check if all changed files match skip patterns
+    def allSkippable = changedFiles.every { file ->
+      skip_patterns.any { pattern ->
+        if (pattern.endsWith('/')) {
+          file.startsWith(pattern)
+        } else {
+          file == pattern
+        }
+      }
+    }
+
+    if (allSkippable) {
+      echo "Skipping build - all changes are in documentation/config files: ${changedFiles}"
+      return true
+    }
+  }
+
+  return false
+}
+
 def cancel_previous_build() {
   // cancel previous build if it is not on main.
   if (env.BRANCH_NAME != 'main') {
@@ -243,6 +293,12 @@ def shard_run_unittest_GPU(node_type, shard_id, cuda_version) {
 }
 
 stage('Unittest') {
+  if (should_skip_build()) {
+    echo "Skipping tests - only documentation/config files changed"
+    Utils.markStageSkippedForConditional('Unittest')
+    return
+  }
+
   cancel_previous_build()
   parallel(
     failFast: true,


### PR DESCRIPTION
Previously, FlashInfer CI Docker images only maintained a 'latest' tag, making it difficult to rollback to older images when regressions occur. This PR add the tag with date-sha.

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
