### PR TITLE
feat: add warp-level persistent qk norm

### DIFF
--- a/csrc/flashinfer_norm_binding.cu
+++ b/csrc/flashinfer_norm_binding.cu
@@ -19,8 +19,6 @@ using tvm::ffi::Tensor;
 
 void rmsnorm(Tensor out, Tensor input, Tensor weight, double eps, bool enable_pdl);
 
-void qk_rmsnorm(Tensor out, Tensor input, Tensor weight, double eps, bool enable_pdl);
-
 void fused_add_rmsnorm(Tensor input, Tensor residual, Tensor weight, double eps, bool enable_pdl);
 
 void gemma_rmsnorm(Tensor out, Tensor input, Tensor weight, double eps, bool enable_pdl);
@@ -29,7 +27,6 @@ void gemma_fused_add_rmsnorm(Tensor input, Tensor residual, Tensor weight, doubl
                              bool enable_pdl);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(rmsnorm, rmsnorm);
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(qk_rmsnorm, qk_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_add_rmsnorm, fused_add_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(gemma_rmsnorm, gemma_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(gemma_fused_add_rmsnorm, gemma_fused_add_rmsnorm);

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -54,7 +54,7 @@ def rmsnorm(
     Parameters
     ----------
     input: torch.Tensor
-        Input tensor, shape (batch_size, hidden_size).
+        Input tensor, 2D shape (batch_size, hidden_size) or 3D shape (batch_size, num_heads, hidden_size).
     weight: torch.Tensor
         Weight tensor, shape (hidden_size,).
     eps: float
@@ -68,55 +68,13 @@ def rmsnorm(
     Returns
     -------
     output: torch.Tensor
-        Normalized tensor, shape (batch_size, hidden_size).
+        Normalized tensor, 2D shape (batch_size, hidden_size) or 3D shape (batch_size, num_heads, hidden_size).
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
     if out is None:
         out = torch.empty_like(input)
     _rmsnorm(out, input, weight, eps, enable_pdl)
-    return out
-
-
-def qk_rmsnorm(
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    eps: float = 1e-6,
-    out: Optional[torch.Tensor] = None,
-    enable_pdl: Optional[bool] = None,
-) -> torch.Tensor:
-    r"""Root mean square normalization.
-
-    ``out[i] = (input[i] / RMS(input)) * weight[i]``
-
-    Parameters
-    ----------
-    input: torch.Tensor
-        Input tensor, shape (batch_size, num_heads, hidden_size).
-    weight: torch.Tensor
-        Weight tensor, shape (hidden_size,).
-    eps: float
-        Epsilon for numerical stability.
-    out: Optional[torch.Tensor]
-        The output tensor, if specified, the kernel will update this tensor inplace.
-    enable_pdl: bool
-        Whether to enable `programmatic dependent launch
-        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
-
-    Returns
-    -------
-    output: torch.Tensor
-        Normalized tensor, shape (batch_size, num_heads, hidden_size).
-    """
-    if enable_pdl is None:
-        enable_pdl = device_support_pdl(input.device)
-    if out is None:
-        out = torch.empty(
-            (input.size(0), input.size(1), input.size(2)),
-            device=input.device,
-            dtype=input.dtype,
-        )
-    _qk_rmsnorm(out, input, weight, eps, enable_pdl)
     return out
 
 
@@ -135,30 +93,6 @@ def _rmsnorm(
 
 @register_fake_op("flashinfer::rmsnorm")
 def _rmsnorm_fake(
-    out: torch.Tensor,
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    eps: float,
-    enable_pdl: Optional[bool],
-) -> None:
-    pass
-
-
-@register_custom_op("flashinfer::qk_rmsnorm", mutates_args=("out",))
-def _qk_rmsnorm(
-    out: torch.Tensor,
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    eps: float,
-    enable_pdl: Optional[bool],
-) -> None:
-    if enable_pdl is None:
-        enable_pdl = device_support_pdl(input.device)
-    get_norm_module().qk_rmsnorm(out, input, weight, eps, enable_pdl)
-
-
-@register_fake_op("flashinfer::qk_rmsnorm")
-def _qk_rmsnorm_fake(
     out: torch.Tensor,
     input: torch.Tensor,
     weight: torch.Tensor,

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -117,9 +117,9 @@ def test_qknorm(
     y_ref = llama_rms_norm(x, w)
     if specify_out:
         y = torch.empty_like(x)
-        flashinfer.norm.qk_rmsnorm(x, w, out=y, enable_pdl=enable_pdl)
+        flashinfer.norm.rmsnorm(x, w, out=y, enable_pdl=enable_pdl)
     else:
-        y = flashinfer.norm.qk_rmsnorm(x, w, enable_pdl=enable_pdl)
+        y = flashinfer.norm.rmsnorm(x, w, enable_pdl=enable_pdl)
 
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Recent models are using QK normalization right before RoPE and core self-attention (e.g., Qwen-3, Wan). Existing RMSNorm implementation in FlashInfer falls short on optimal for:
1. Extra shared memory reduction step.
2. Do not support non-contiguous layout on the middle dimension. E.g., q maybe [batch_size, :num_qo_heads, head_dim].

This PR implements a persistent version of RMSNorm, where each head is unrolled with each warp.
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
