### PR TITLE
[DO NOT MERGE][WIP] lint: Add clang-tidy to pre-commits

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,65 @@
+Checks: 'clang-diagnostic-*,
+clang-analyzer-*,
+cppcoreguidelines-*,
+modernize-*,
+performance-*,
+readability-*,
+bugprone-*,
+misc-*,
+-modernize-use-trailing-return-type,
+-cppcoreguidelines-avoid-magic-numbers,
+-readability-magic-numbers,
+-cppcoreguidelines-pro-type-vararg,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-avoid-c-arrays,
+-modernize-avoid-c-arrays,
+-cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+-readability-named-parameter,
+-readability-identifier-length,
+-readability-function-cognitive-complexity,
+-bugprone-easily-swappable-parameters,
+-misc-non-private-member-variables-in-classes,
+-cppcoreguidelines-non-private-member-variables-in-classes,
+-readability-braces-around-statements,
+-cppcoreguidelines-avoid-non-const-global-variables,
+-cppcoreguidelines-init-variables,
+-cppcoreguidelines-macro-usage,
+-cppcoreguidelines-owning-memory,
+-cppcoreguidelines-no-malloc,
+-modernize-use-nodiscard,
+-readability-else-after-return,
+-readability-implicit-bool-conversion,
+-readability-uppercase-literal-suffix,
+-bugprone-branch-clone,
+-bugprone-signed-char-misuse,
+-misc-unused-parameters,
+-cppcoreguidelines-special-member-functions
+'
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*/flashinfer/(include|csrc)/.*'
+FormatStyle: file
+
+CheckOptions:
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case_
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: '_'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,18 @@ repos:
         exclude: |
           (?x)^(3rdparty/.* flashinfer/jit/aot_config.py)$
 
+  # Clang-tidy linter for C++ code
+  - repo: local
+    hooks:
+      - id: clang-tidy
+        name: clang-tidy
+        entry: bash -c 'clang-tidy "$@" -- -I./include -I./csrc -std=c++17' --
+        language: system
+        types_or: [c++, c, cuda]
+        files: ^(include|csrc)/
+        exclude: ^3rdparty/
+        require_serial: true
+
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v1.17.1'  # Use the sha / tag you want to point at
       hooks:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Add clang-tidy linter for C++/CUDA codebase as part of pre-commits

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
