### PR TITLE
bugfix: show-config command

### DIFF
--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -114,7 +114,7 @@ def show_config_cmd():
     click.secho("=== Downloaded Cubins ===", fg="yellow")
 
     status = get_artifacts_status()
-    num_downloaded = sum(1 for _, _, exists in status if exists)
+    num_downloaded = sum(1 for _, exists in status if exists)
     total_cubins = len(status)
 
     click.secho(f"Downloaded {num_downloaded}/{total_cubins} cubins", fg="cyan")
@@ -137,10 +137,10 @@ def list_cubins_cmd():
     """List downloaded cubins"""
     status = get_artifacts_status()
     table_data = []
-    for name, extension, exists in status:
+    for file_name, exists in status:
         status_str = "Downloaded" if exists else "Missing"
         color = "green" if exists else "red"
-        table_data.append([f"{name}{extension}", click.style(status_str, fg=color)])
+        table_data.append([file_name, click.style(status_str, fg=color)])
 
     click.echo(tabulate(table_data, headers=["Cubin", "Status"], tablefmt="github"))
     click.secho("", fg="white")

--- a/tests/cli/test_cli_show_config.py
+++ b/tests/cli/test_cli_show_config.py
@@ -1,0 +1,29 @@
+from click.testing import CliRunner
+
+from flashinfer.__main__ import cli
+
+
+def test_show_config_cmd_smoke(monkeypatch):
+    # Avoid network/FS/GPU dependencies by monkeypatching helpers
+    monkeypatch.setattr(
+        "flashinfer.__main__.get_artifacts_status",
+        lambda: (("foo.cubin", True), ("bar.cubin", False)),
+    )
+    monkeypatch.setattr(
+        "flashinfer.__main__._ensure_modules_registered",
+        lambda: [],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show-config"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+
+    # Basic sections present
+    assert "=== Torch Version Info ===" in out
+    assert "=== Environment Variables ===" in out
+    assert "=== Artifact Path ===" in out
+    assert "=== Downloaded Cubins ===" in out
+
+    # Uses our monkeypatched data
+    assert "Downloaded 1/2 cubins" in out

--- a/tests/cli/test_cli_show_config.py
+++ b/tests/cli/test_cli_show_config.py
@@ -4,16 +4,6 @@ from flashinfer.__main__ import cli
 
 
 def test_show_config_cmd_smoke(monkeypatch):
-    # Avoid network/FS/GPU dependencies by monkeypatching helpers
-    monkeypatch.setattr(
-        "flashinfer.__main__.get_artifacts_status",
-        lambda: (("foo.cubin", True), ("bar.cubin", False)),
-    )
-    monkeypatch.setattr(
-        "flashinfer.__main__._ensure_modules_registered",
-        lambda: [],
-    )
-
     runner = CliRunner()
     result = runner.invoke(cli, ["show-config"])
     assert result.exit_code == 0, result.output
@@ -24,6 +14,3 @@ def test_show_config_cmd_smoke(monkeypatch):
     assert "=== Environment Variables ===" in out
     assert "=== Artifact Path ===" in out
     assert "=== Downloaded Cubins ===" in out
-
-    # Uses our monkeypatched data
-    assert "Downloaded 1/2 cubins" in out


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

I believe the show-config command line option was broken by #1794, because it change the return type of `get_artifacts_status` from a list of size 3 tuples to a tuple of size 2 tuples. This code in `__main__.py` expects the former:

```
    status = get_artifacts_status()
    num_downloaded = sum(1 for _, _, exists in status if exists)
    total_cubins = len(status)
```

This PR has a fix and a test to protect against future breaks.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Is this the right place to add CLI tests? Note that I've added a `tests/cli` subdirectory.
