### PR TITLE
Fix: Prevent race condition in cubin loader when file is being consumed

### DIFF
--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -80,7 +80,9 @@ def download_file(
             # Handle local file copy
             if os.path.exists(source):
                 try:
-                    shutil.copy(source, local_path)
+                    temp_path = f"{local_path}.tmp"
+                    shutil.copy(source, temp_path)
+                    os.replace(temp_path, local_path)  # Atomic rename
                     logger.info(f"File copied successfully: {local_path}")
                     return True
                 except Exception as e:
@@ -93,8 +95,12 @@ def download_file(
                     response = session.get(source, timeout=timeout)
                     response.raise_for_status()
 
-                    with open(local_path, "wb") as file:
+                    temp_path = f"{local_path}.tmp"
+                    with open(temp_path, "wb") as file:
                         file.write(response.content)
+
+                    # Atomic rename to prevent readers from seeing partial writes
+                    os.replace(temp_path, local_path)
 
                     logger.info(
                         f"File downloaded successfully: {source} -> {local_path}"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
There's a race condition between cubin download and compilation:

  Timeline of the race condition:
  1. Worker1: Acquires lock -> downloads cubin -> releases lock
  2. Worker1: Starts compile operation (reading the cubin file) without lock protection
  3. Worker2: Acquires lock -> detects file corruption (sha256 mismatch) -> overwrites the file Worker1 is reading!
  4. Worker1: Compilation fails or uses corrupted data

  Root cause: The critical region (lock scope) only protects the download operation, but doesn't protect the subsequent compile/load operations. We cannot simply extend the lock scope because:
  - load cubin + build op + load op are in different code paths
  - Cannot use the same lock across the entire pipeline (across C++/python)

###  Solution

  Use atomic file rename to leverage filesystem inode semantics:

  1. Download/copy to temporary file: {local_path}.tmp
  2. Atomically rename to final path: os.replace(tmp, local_path)

  Why this works:
  - os.replace() is an atomic operation
  - On Unix systems, when Worker2 replaces the file, Worker1's open file descriptor still points to the old inode
  - Worker1 can safely continue reading the old file
  - New readers (after the replace) see the new file
  - The old inode is only deleted when all file descriptors are closed

###  Changes

  - flashinfer/jit/cubin_loader.py:85: Atomic rename for local file copy
  - flashinfer/jit/cubin_loader.py:103: Atomic rename for URL downloads

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @nvpohanh @nvjullin @joker-eph 
