### PR TITLE
ci: add docker-tags.yml to specify the docker image tag used in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,17 @@
 //
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
-// These are set at runtime from data in ci/jenkins/docker-images.yml, update
+
+// Read docker tags from configuration file
+def dockerTags = readYaml file: 'ci/docker-tags.yml'
+
+// These are set at runtime from data in ci/docker-tags.yml, update
 // image tags in that file
 // Now supports multiple CUDA versions
-docker_run_cu126 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu126:latest"
-docker_run_cu128 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu128:latest"
-docker_run_cu129 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu129:latest"
-docker_run_cu130 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu130:latest"
+docker_run_cu126 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu126:${dockerTags['flashinfer/flashinfer-ci-cu126']}"
+docker_run_cu128 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu128:${dockerTags['flashinfer/flashinfer-ci-cu128']}"
+docker_run_cu129 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu129:${dockerTags['flashinfer/flashinfer-ci-cu129']}"
+docker_run_cu130 = "bash ci/bash.sh flashinfer/flashinfer-ci-cu130:${dockerTags['flashinfer/flashinfer-ci-cu130']}"
 
 def per_exec_ws(folder) {
   return "workspace/exec_${env.EXECUTOR_NUMBER}/" + folder

--- a/ci/docker-tags.yml
+++ b/ci/docker-tags.yml
@@ -1,0 +1,4 @@
+flashinfer/flashinfer-ci-cu126: 20251002-52089b5
+flashinfer/flashinfer-ci-cu128: 20251002-52089b5
+flashinfer/flashinfer-ci-cu129: 20251002-52089b5
+flashinfer/flashinfer-ci-cu130: 20251002-52089b5


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Followup of #1839 , this PR created a `docker-tags.yml` (placed under `ci/`) file to specify the tag used for each docker image, format:
```
image: tag
```
Each tag is composed of date and git-hash.

For public/gitlab CI, we can read from this file to specify the CI docker version.

The docker file update and unittest on new container are decoupled, after we upgrade dockerfile, the ci will still be running in earlier tag until we update the `docker-tags.yml`.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes
cc @bkryu @nvmbreughe @yongwww 