### PR TITLE
docker: upgrade apache-tvm-ffi==0.1.0b15 in docker container

### DIFF
--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'docker/**'
+      - '.github/workflows/release-ci-docker.yml'
   pull_request:
     branches:
       - main

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -24,15 +24,15 @@ CUDA_VERSION=${1:-cu128}
 
 pip3 install torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
 pip3 install requests responses ninja pytest numpy scipy build nvidia-ml-py cuda-python einops nvidia-nvshmem-cu12
-pip3 install 'apache-tvm-ffi==0.1.0b11'
+pip3 install 'apache-tvm-ffi==0.1.0b15'
 pip3 install nvidia-cutlass-dsl
 pip3 install 'nvidia-cudnn-frontend>=1.13.0'
 
 # Install cudnn package based on CUDA version
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
-    pip3 install --upgrade cuda-python==13.0
-    pip3 install "nvidia-cudnn-cu13>=9.12.0.46"
+  pip3 install --upgrade cuda-python==13.0
+  pip3 install "nvidia-cudnn-cu13>=9.12.0.46"
 else
-    pip3 install --upgrade cuda-python==12.*
-    pip3 install "nvidia-cudnn-cu12>=9.11.0.98"
+  pip3 install --upgrade cuda-python==12.*
+  pip3 install "nvidia-cudnn-cu12>=9.11.0.98"
 fi


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

TVM-FFI made a new release with bugfix on potential memory leak:
https://github.com/apache/tvm-ffi/pull/87
This PR bumps the apache-tvm-ffi version in docker container.

## 🔍 Related Issues

https://github.com/apache/tvm-ffi/pull/87

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
