### PR TITLE
bugfix: add check for empty MoE tactics and allow sm121 to use sm120 config

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_sm100_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_sm100_binding.cu
@@ -220,6 +220,11 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
 
     mProfiler = std::make_shared<kernels::GemmProfilerBackend>();
     mAllProfiles = mKernelRunner->getTactics();
+    TVM_FFI_ICHECK(!mAllProfiles.empty())
+        << "No valid tactics available for fused moe op with the requested input combination "
+           "Activation: "
+        << DLDataTypeToString(mActivationDtype) << ", Weight: " << DLDataTypeToString(mWeightDtype)
+        << ", Output: " << DLDataTypeToString(mOutputDtype);
   }
 
   void runMoe(Tensor output, Tensor input, Tensor token_selected_experts,

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
@@ -728,14 +728,11 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
       if (inputs.gemm_config.sm_version >= 90) {
         bool is_same_sm = inputs.gemm_config.sm_version == sm_;
         // gemm_config.sm_version indicates the kernel pipeline, which is always 100 for 100, 103,
-        // 110, 120, 121. Below checks confirm the cutlass pipeline matches the device major
-        // version.
+        // 110 below logging helps confirming the cutlass pipeline matches the device major version
         bool is_sm110 = inputs.gemm_config.sm_version == 100 && sm_ == 110;
         bool is_sm103 = inputs.gemm_config.sm_version == 100 && sm_ == 103;
-        // SM120 and SM121 are architecturally identical, accept configs from either
-        bool is_sm120 =
-            (inputs.gemm_config.sm_version == 100 || inputs.gemm_config.sm_version == 120) &&
-            (sm_ == 120 || sm_ == 121);
+        // SM120 and SM121 are architecturally identical
+        bool is_sm120 = (inputs.gemm_config.sm_version == 120) && (sm_ == 120 || sm_ == 121);
         TLLM_CHECK_WITH_INFO(is_same_sm || is_sm110 || is_sm103 || is_sm120,
                              "Using SM %d configuration for SM %d device",
                              inputs.gemm_config.sm_version, sm_);

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
@@ -726,12 +726,20 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
       // We allow both tma warp specialized and SM80 configurations to coexist because for some
       // cases with small numbers of tokens SM80 is faster. We check here to see which is selected
       if (inputs.gemm_config.sm_version >= 90) {
-        bool is_same_sm = inputs.gemm_config.sm_version == sm_;
-        // gemm_config.sm_version indicates the kernel pipeline, which is always 100 for 100, 103,
-        // 110 below logging helps confirming the cutlass pipeline matches the device major version
-        bool is_sm110 = inputs.gemm_config.sm_version == 100 && sm_ == 110;
-        bool is_sm103 = inputs.gemm_config.sm_version == 100 && sm_ == 103;
-        TLLM_CHECK_WITH_INFO(is_same_sm || is_sm110 || is_sm103,
+        // Check if the kernel config is compatible with the device architecture
+        // - SM100: compatible with 100/103/110/120/121
+        // - SM120 and SM121: architecturally identical, fully interchangeable
+        auto is_compatible = [](int config_sm, int device_sm) -> bool {
+          if (config_sm == device_sm) return true;
+          if (config_sm == 100 &&
+              (device_sm == 103 || device_sm == 110 || device_sm == 120 || device_sm == 121))
+            return true;
+          // SM120 and SM121 are interchangeable
+          if (config_sm == 120 && device_sm == 121) return true;
+          return false;
+        };
+
+        TLLM_CHECK_WITH_INFO(is_compatible(inputs.gemm_config.sm_version, sm_),
                              "Using SM %d configuration for SM %d device",
                              inputs.gemm_config.sm_version, sm_);
         TLLM_CHECK_WITH_INFO(inputs.biases != nullptr || hopper_inputs.ptr_c == nullptr,

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -1093,8 +1093,8 @@ def dequant_mxfp4_batches(
     ("alpha", "beta", "limit"), [(None, None, None), (0.5, 0.0, 7.0), (1.702, 1.0, 7.0)]
 )
 @pytest.mark.skipif(
-    torch.cuda.get_device_capability()[0] not in [10, 11, 12],
-    reason="MXFP8xMXFP4 is only supported on SM100, SM110 and SM120",
+    torch.cuda.get_device_capability()[0] not in [10, 11],
+    reason="MXFP8xMXFP4 is only supported on SM100 and SM110",
 )
 def test_moe_mxfp8_mxfp4(
     batch_size,


### PR DESCRIPTION
## 📌 Description

- Add safety check for empty tactics to provide clear error message
- Allow SM121 devices to use SM120 kernel configurations
- Mark test_moe_mxfp8_mxfp4 as xfail (kernel not yet implemented) for sm120/121

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc: @djmmoss @yzh119 @bkryu @cyx-6  @nv-yunzheq 
