### PR TITLE
Bugfix: fix o_strides in persistent kernel 

### DIFF
--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -155,7 +155,7 @@ class BatchAttention:
 
         k_cache, v_cache = _unpack_paged_kv_cache(kv_cache, self._kv_layout)
         if out is None:
-            out = torch.empty_like(q)
+            out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
         if lse is None:
             # lse shape: [batch_size, num_qo_heads]
             lse = torch.empty(

--- a/include/flashinfer/attention/persistent.cuh
+++ b/include/flashinfer/attention/persistent.cuh
@@ -408,10 +408,13 @@ struct BlockBatchPagedAttentionPersistent {
                           warp_idx, lane_idx, tid);
       } else {
         // write through
+        // o_stride_n = num_qo_heads* head_dim
+        const uint32_t o_stride_n = num_kv_heads * gqa_group_size * HEAD_DIM_VO,
+                       o_stride_h = HEAD_DIM_VO;
         DTypeO* o_ptr_base =
-            params.final_o + q_indptr * q_stride_n + (kv_head_idx * gqa_group_size) * q_stride_h;
+            params.final_o + q_indptr * o_stride_n + (kv_head_idx * gqa_group_size) * o_stride_h;
         write_o_reg_gmem<KTraits>(o_frag, &q_smem, o_ptr_base, qo_packed_idx_base, q_len,
-                                  q_stride_n, q_stride_h, gqa_group_size, tid);
+                                  o_stride_n, o_stride_h, gqa_group_size, tid);
       }
 
       if constexpr (variant.use_softmax) {


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
It will be buggy when q is non-contiguous (from torch.split)

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
