### PR TITLE
Improve dev container conda consistency

### DIFF
--- a/docker/Dockerfile.cu126
+++ b/docker/Dockerfile.cu126
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install python
 COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
+RUN bash /install/install_python.sh /opt/conda py312
 
 # Set home directory
 WORKDIR /workspace

--- a/docker/Dockerfile.cu126.dev
+++ b/docker/Dockerfile.cu126.dev
@@ -13,34 +13,6 @@ RUN apt-get update && apt-get install -y \
     zsh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install python
-COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
-
-# Set home directory
-WORKDIR /workspace
-
-RUN echo "source activate py312" >> ~/.bashrc
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
-
-# Install torch and other python packages
-COPY install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh cu126 && pip3 install pre-commit
-
-# Install mpi4py in the conda environment
-RUN conda install -n py312 -y mpi4py
-
-# Install oh-my-zsh
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-
-# Install zsh-autosuggestions
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-
-# Configure zsh
-RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
-    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
-
 # Create a non-root user
 ARG USERNAME=devuser
 ARG USER_UID=1003
@@ -60,21 +32,37 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Ref: https://github.com/rapidsai/devcontainers/pull/373
 RUN if grep ubuntu:x:1000:1000 /etc/passwd >/dev/null; then userdel -f -r ubuntu; fi
 
-# Copy zsh configuration to the new user's home
-RUN cp -r /root/.oh-my-zsh /home/$USERNAME/.oh-my-zsh && \
-    cp /root/.zshrc /home/$USERNAME/.zshrc && \
-    chown -R $USERNAME:$USERNAME /home/$USERNAME/.oh-my-zsh && \
-    chown $USERNAME:$USERNAME /home/$USERNAME/.zshrc
-
 # Switch to non-root user
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
+# Install python
+COPY install/install_python.sh /install/install_python.sh
+RUN bash /install/install_python.sh /home/$USERNAME/conda py312
+
+RUN echo "source activate py312" >> ~/.bashrc
+ENV PATH="/home/$USERNAME/conda/bin:$PATH"
+ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
+
+# Install torch and other python packages
+COPY install/install_python_packages.sh /install/install_python_packages.sh
+RUN bash /install/install_python_packages.sh cu126 && pip3 install pre-commit
+
+# Install mpi4py in the conda environment
+RUN conda install -n py312 -y mpi4py
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Install zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+# Configure zsh
+RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
+    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
+
 # clangd
 ENV PATH="/usr/lib/llvm-19/bin:$PATH"
-# conda
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 
 # Triton
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"

--- a/docker/Dockerfile.cu128
+++ b/docker/Dockerfile.cu128
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install python
 COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
+RUN bash /install/install_python.sh /opt/conda py312
 
 # Set home directory
 WORKDIR /workspace

--- a/docker/Dockerfile.cu128.dev
+++ b/docker/Dockerfile.cu128.dev
@@ -13,34 +13,6 @@ RUN apt-get update && apt-get install -y \
     zsh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install python
-COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
-
-# Set home directory
-WORKDIR /workspace
-
-RUN echo "source activate py312" >> ~/.bashrc
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
-
-# Install torch and other python packages
-COPY install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh cu128 && pip3 install pre-commit
-
-# Install mpi4py in the conda environment
-RUN conda install -n py312 -y mpi4py
-
-# Install oh-my-zsh
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-
-# Install zsh-autosuggestions
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-
-# Configure zsh
-RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
-    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
-
 # Create a non-root user
 ARG USERNAME=devuser
 ARG USER_UID=1003
@@ -60,21 +32,37 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Ref: https://github.com/rapidsai/devcontainers/pull/373
 RUN if grep ubuntu:x:1000:1000 /etc/passwd >/dev/null; then userdel -f -r ubuntu; fi
 
-# Copy zsh configuration to the new user's home
-RUN cp -r /root/.oh-my-zsh /home/$USERNAME/.oh-my-zsh && \
-    cp /root/.zshrc /home/$USERNAME/.zshrc && \
-    chown -R $USERNAME:$USERNAME /home/$USERNAME/.oh-my-zsh && \
-    chown $USERNAME:$USERNAME /home/$USERNAME/.zshrc
-
 # Switch to non-root user
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
+# Install python
+COPY install/install_python.sh /install/install_python.sh
+RUN bash /install/install_python.sh /home/$USERNAME/conda py312
+
+RUN echo "source activate py312" >> ~/.bashrc
+ENV PATH="/home/$USERNAME/conda/bin:$PATH"
+ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
+
+# Install torch and other python packages
+COPY install/install_python_packages.sh /install/install_python_packages.sh
+RUN bash /install/install_python_packages.sh cu128 && pip3 install pre-commit
+
+# Install mpi4py in the conda environment
+RUN conda install -n py312 -y mpi4py
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Install zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+# Configure zsh
+RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
+    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
+
 # clangd
 ENV PATH="/usr/lib/llvm-19/bin:$PATH"
-# conda
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 
 # Triton
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"

--- a/docker/Dockerfile.cu129
+++ b/docker/Dockerfile.cu129
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install python
 COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
+RUN bash /install/install_python.sh /opt/conda py312
 
 # Set home directory
 WORKDIR /workspace

--- a/docker/Dockerfile.cu129.dev
+++ b/docker/Dockerfile.cu129.dev
@@ -13,34 +13,6 @@ RUN apt-get update && apt-get install -y \
     zsh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install python
-COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
-
-# Set home directory
-WORKDIR /workspace
-
-RUN echo "source activate py312" >> ~/.bashrc
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
-
-# Install torch and other python packages
-COPY install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh cu129 && pip3 install pre-commit
-
-# Install mpi4py in the conda environment
-RUN conda install -n py312 -y mpi4py
-
-# Install oh-my-zsh
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-
-# Install zsh-autosuggestions
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-
-# Configure zsh
-RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
-    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
-
 # Create a non-root user
 ARG USERNAME=devuser
 ARG USER_UID=1003
@@ -60,21 +32,37 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Ref: https://github.com/rapidsai/devcontainers/pull/373
 RUN if grep ubuntu:x:1000:1000 /etc/passwd >/dev/null; then userdel -f -r ubuntu; fi
 
-# Copy zsh configuration to the new user's home
-RUN cp -r /root/.oh-my-zsh /home/$USERNAME/.oh-my-zsh && \
-    cp /root/.zshrc /home/$USERNAME/.zshrc && \
-    chown -R $USERNAME:$USERNAME /home/$USERNAME/.oh-my-zsh && \
-    chown $USERNAME:$USERNAME /home/$USERNAME/.zshrc
-
 # Switch to non-root user
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
+# Install python
+COPY install/install_python.sh /install/install_python.sh
+RUN bash /install/install_python.sh /home/$USERNAME/conda py312
+
+RUN echo "source activate py312" >> ~/.bashrc
+ENV PATH="/home/$USERNAME/conda/bin:$PATH"
+ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
+
+# Install torch and other python packages
+COPY install/install_python_packages.sh /install/install_python_packages.sh
+RUN bash /install/install_python_packages.sh cu129 && pip3 install pre-commit
+
+# Install mpi4py in the conda environment
+RUN conda install -n py312 -y mpi4py
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Install zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+# Configure zsh
+RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
+    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
+
 # clangd
 ENV PATH="/usr/lib/llvm-19/bin:$PATH"
-# conda
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 
 # Triton
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"

--- a/docker/Dockerfile.cu130
+++ b/docker/Dockerfile.cu130
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install python
 COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
+RUN bash /install/install_python.sh /opt/conda py312
 
 # Set home directory
 WORKDIR /workspace

--- a/docker/Dockerfile.cu130.dev
+++ b/docker/Dockerfile.cu130.dev
@@ -13,35 +13,6 @@ RUN apt-get update && apt-get install -y \
     zsh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install python
-COPY install/install_python.sh /install/install_python.sh
-RUN bash /install/install_python.sh py312
-
-# Set home directory
-WORKDIR /workspace
-
-RUN echo "source activate py312" >> ~/.bashrc
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
-
-# Install torch and other python packages
-COPY install/install_python_packages.sh /install/install_python_packages.sh
-# use nightly/cu130 temporarily and change to cu130 when torch releases stable version
-RUN bash /install/install_python_packages.sh nightly/cu130 && pip3 install pre-commit
-
-# Install mpi4py in the conda environment
-RUN conda install -n py312 -y mpi4py
-
-# Install oh-my-zsh
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-
-# Install zsh-autosuggestions
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-
-# Configure zsh
-RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
-    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
-
 # Create a non-root user
 ARG USERNAME=devuser
 ARG USER_UID=1003
@@ -61,21 +32,38 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Ref: https://github.com/rapidsai/devcontainers/pull/373
 RUN if grep ubuntu:x:1000:1000 /etc/passwd >/dev/null; then userdel -f -r ubuntu; fi
 
-# Copy zsh configuration to the new user's home
-RUN cp -r /root/.oh-my-zsh /home/$USERNAME/.oh-my-zsh && \
-    cp /root/.zshrc /home/$USERNAME/.zshrc && \
-    chown -R $USERNAME:$USERNAME /home/$USERNAME/.oh-my-zsh && \
-    chown $USERNAME:$USERNAME /home/$USERNAME/.zshrc
-
 # Switch to non-root user
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
+# Install python
+COPY install/install_python.sh /install/install_python.sh
+RUN bash /install/install_python.sh /home/$USERNAME/conda py312
+
+RUN echo "source activate py312" >> ~/.bashrc
+ENV PATH="/home/$USERNAME/conda/bin:$PATH"
+ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
+
+# Install torch and other python packages
+COPY install/install_python_packages.sh /install/install_python_packages.sh
+# use nightly/cu130 temporarily and change to cu130 when torch releases stable version
+RUN bash /install/install_python_packages.sh nightly/cu130 && pip3 install pre-commit
+
+# Install mpi4py in the conda environment
+RUN conda install -n py312 -y mpi4py
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Install zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+# Configure zsh
+RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="fino-time"/' ~/.zshrc && \
+    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions)/' ~/.zshrc
+
 # clangd
 ENV PATH="/usr/lib/llvm-19/bin:$PATH"
-# conda
-ENV PATH="/opt/conda/bin:$PATH"
-ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 
 # Triton
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"

--- a/docker/install/install_python.sh
+++ b/docker/install/install_python.sh
@@ -23,6 +23,6 @@ set -o pipefail
 
 # Install python and pip. Don't modify this to add Python package dependencies,
 wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-bash Miniforge3.sh -b -p /opt/conda
+bash Miniforge3.sh -b -p $1
 
-/opt/conda/bin/conda create -n $1 python=3.12
+$1/bin/conda create -n $2 python=3.12


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Current dev container docker building installed the conda at `/opt/conda`, which is the root owned path. This PR improves the installation of conda for dev container to `/home/devuser/conda`, as setting before #1791.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
