### PR TITLE
docs: Fix installation instructions for CUDA-specific package URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Nightly builds are available for testing the latest features:
 
 ```bash
 # Core and cubin packages
-pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/
+pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps # Install the nightly package from custom index, without installing dependencies
+pip install flashinfer-python  # Install flashinfer-python's dependencies from PyPI
 pip install -U --pre flashinfer-cubin --index-url https://flashinfer.ai/whl/nightly/
 # JIT cache package (replace cu129 with your CUDA version: cu128, cu129, or cu130)
 pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu129

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -106,7 +106,8 @@ Nightly builds are available for testing the latest features:
 .. code-block:: bash
 
     # Core and cubin packages
-    pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/
+    pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps # Install the nightly package from custom index, without installing dependencies
+    pip install flashinfer-python  # Install flashinfer-python's dependencies from PyPI
     pip install -U --pre flashinfer-cubin --index-url https://flashinfer.ai/whl/nightly/
     # JIT cache package (replace cu129 with your CUDA version: cu128, cu129, or cu130)
     pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu129


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We forgot to include cuda specific suffix for `flashinfer-jit-cache` package installation instructions, this PR fixes the issue.

Also update the installation guide for nightly packages, for flashinfer-python package:
* first install flashinfer-python nightly from custom index, without installing dependencies (the dependencies such as torch are not available on our self-hosted index).
* the install flashinfer-python's dependency from pypi

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
