### PR TITLE
fix vllm graph register and add test

### DIFF
--- a/include/flashinfer/comm/vllm_custom_all_reduce.cuh
+++ b/include/flashinfer/comm/vllm_custom_all_reduce.cuh
@@ -44,7 +44,7 @@ struct cuda_error : public std::runtime_error {
 namespace vllm {
 
 constexpr int kMaxBlocks = 36;
-CUpointer_attribute rangeStartAddrAttr = CU_POINTER_ATTRIBUTE_RANGE_START_ADDR;
+constexpr CUpointer_attribute rangeStartAddrAttr = CU_POINTER_ATTRIBUTE_RANGE_START_ADDR;
 
 // Counter may overflow, but it's fine since unsigned int overflow is
 // well-defined behavior.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The all-reduce buffers are incorrectly registered during the cuda graph capture phase when using vLLM custom all reduce. The base_ptr is not initialized and leads to illegal memory access error.
vLLM's implementation with proper memory initialization - https://github.com/vllm-project/vllm/blob/0d21b9b51eccabfa1f8114eab2df61d75459bee7/csrc/custom_all_reduce.cuh#L452

This PR ensures that the memory pointer is initialized correctly and adds tests for vLLM custom all reduce during cuda graph capture

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
