### PR TITLE
bugfix: exclude `tests/utils/test_load_cubin_compile_race_condition.py` from pytest

### DIFF
--- a/tests/utils/test_load_cubin_compile_race_condition.py
+++ b/tests/utils/test_load_cubin_compile_race_condition.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import os
 import tempfile
+import pytest
 from pathlib import Path
 from multiprocessing import Pool
 
@@ -55,7 +56,8 @@ def worker_process(temp_dir):
     return content
 
 
-def _test_load_cubin_race_condition(num_iterations, num_processes):
+@pytest.mark.skip(reason="Incompatible with pytest due to multiprocessing usage.")
+def test_load_cubin_race_condition(num_iterations, num_processes):
     """
     Test race condition when multiple processes concurrently call get_cubin
     for the same file.
@@ -113,4 +115,4 @@ def _test_load_cubin_race_condition(num_iterations, num_processes):
 
 if __name__ == "__main__":
     # NOTE(Zihao): do not use pytest to run this test
-    _test_load_cubin_race_condition(100, 10)
+    test_load_cubin_race_condition(100, 10)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

pytest is not compatible with `test_load_cubin_compile_race_condition.py` (introduced in #1852 ) (at the moment), skip it for pytest.

## 🔍 Related Issues

#1852

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
