### PR TITLE
ci: use self-hosted runner for building docker containers

### DIFF
--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -32,7 +32,7 @@ jobs:
           echo "Generated version tag: ${DATE_SHA}"
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, x86_64]
     needs: generate-tag
     strategy:
       matrix:
@@ -40,17 +40,6 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Github default runner's disk space is too small and results in OOM issues: https://github.com/flashinfer-ai/flashinfer/actions/runs/18389642821/job/52402828516

## 🔍 Related Issues

#1901 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @nvmbreughe 
