### PR TITLE
Add layernorm op for inputs of mixed dtype

### DIFF
--- a/csrc/flashinfer_norm_binding.cu
+++ b/csrc/flashinfer_norm_binding.cu
@@ -26,7 +26,10 @@ void gemma_rmsnorm(Tensor out, Tensor input, Tensor weight, double eps, bool ena
 void gemma_fused_add_rmsnorm(Tensor input, Tensor residual, Tensor weight, double eps,
                              bool enable_pdl);
 
+void layernorm(Tensor out, Tensor input, Tensor gamma, Tensor beta, double eps);
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(rmsnorm, rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_add_rmsnorm, fused_add_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(gemma_rmsnorm, gemma_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(gemma_fused_add_rmsnorm, gemma_fused_add_rmsnorm);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(layernorm, layernorm);

--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -160,3 +160,36 @@ void gemma_fused_add_rmsnorm(Tensor input, Tensor residual, Tensor weight, doubl
     return true;
   });
 }
+
+void layernorm(Tensor output, Tensor input, Tensor gamma, Tensor beta, double eps) {
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(gamma);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(beta);
+  CHECK_DEVICE(input, gamma);
+  CHECK_DEVICE(input, beta);
+  CHECK_DIM(2, input);  // input: (batch_size, hidden_size)
+  CHECK_DIM(1, gamma);  // gamma: (hidden_size)
+  CHECK_DIM(1, beta);   // beta: (hidden_size)
+  TVM_FFI_ICHECK_EQ(input->shape[1], gamma->shape[0]);
+  TVM_FFI_ICHECK_EQ(input->shape[1], beta->shape[0]);
+  unsigned int batch_size = input->shape[0];
+  unsigned int hidden_size = input->shape[1];
+  TVM_FFI_ICHECK_EQ(output->shape[0], batch_size);
+  TVM_FFI_ICHECK_EQ(output->shape[1], hidden_size);
+  cudaSetDevice(input->device.device_id);
+  const cudaStream_t stream = get_stream(input->device);
+  // TODO(kaixih): This is currently our only use case; Add more if needed.
+  TVM_FFI_ICHECK_EQ(input->dtype, dl_bfloat16) << "input must be bfloat16";
+  TVM_FFI_ICHECK_EQ(gamma->dtype, dl_float32) << "gamma must be float32";
+  TVM_FFI_ICHECK_EQ(beta->dtype, dl_float32) << "beta must be float32";
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input->dtype, c_type, [&] {
+    cudaError_t status =
+        norm::LayerNorm(static_cast<c_type*>(input->data), static_cast<float*>(gamma->data),
+                        static_cast<float*>(beta->data), static_cast<c_type*>(output->data),
+                        batch_size, hidden_size, eps, stream);
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "LayerNorm failed with error code " << cudaGetErrorString(status);
+    return true;
+  });
+}

--- a/docs/api/norm.rst
+++ b/docs/api/norm.rst
@@ -14,3 +14,4 @@ Kernels for normalization layers.
     fused_add_rmsnorm
     gemma_rmsnorm
     gemma_fused_add_rmsnorm
+    layernorm

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -89,6 +89,7 @@ from .gemm import mm_fp4 as mm_fp4
 from .gemm import tgv_gemm_sm100 as tgv_gemm_sm100
 from .mla import BatchMLAPagedAttentionWrapper as BatchMLAPagedAttentionWrapper
 from .norm import fused_add_rmsnorm as fused_add_rmsnorm
+from .norm import layernorm as layernorm
 from .norm import gemma_fused_add_rmsnorm as gemma_fused_add_rmsnorm
 from .norm import gemma_rmsnorm as gemma_rmsnorm
 from .norm import rmsnorm as rmsnorm

--- a/flashinfer/jit/norm.py
+++ b/flashinfer/jit/norm.py
@@ -19,10 +19,15 @@ from .core import JitSpec, gen_jit_spec
 
 
 def gen_norm_module() -> JitSpec:
+    nvcc_flags = [
+        "-DENABLE_BF16",
+        "-DENABLE_FP8",
+    ]
     return gen_jit_spec(
         "norm",
         [
             jit_env.FLASHINFER_CSRC_DIR / "norm.cu",
             jit_env.FLASHINFER_CSRC_DIR / "flashinfer_norm_binding.cu",
         ],
+        extra_cuda_cflags=nvcc_flags,
     )

--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -18,6 +18,9 @@
 
 #include <numeric>
 
+#include "flashinfer/trtllm/common/cudaTypeUtils.cuh"
+#include "flashinfer/trtllm/common/cudaUtils.h"
+#include "flashinfer/trtllm/common/reduceKernelUtils.cuh"
 #include "flashinfer/utils.cuh"
 #include "math.cuh"
 #include "utils.cuh"
@@ -26,6 +29,8 @@
 namespace flashinfer {
 
 namespace norm {
+
+using namespace tensorrt_llm::common;
 
 template <uint32_t VEC_SIZE, typename T>
 __global__ void RMSNormKernel(T* __restrict__ input, T* __restrict__ weight, T* __restrict__ output,
@@ -464,8 +469,265 @@ cudaError_t GemmaFusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batc
   return cudaSuccess;
 }
 
+template <typename T>
+struct QuantTypeStaticVals;
+
+template <>
+struct QuantTypeStaticVals<int8_t> {
+  static constexpr float MAX_VAL = 127.f;
+  static constexpr float MIN_SCALING_FACTOR = 0.f;
+  static constexpr float MIN_SCALING_FACTOR_RCP = FLT_MAX;
+};
+
+template <typename Tf, typename T>
+__inline__ __device__ Tf compute_layernorm(Tf val, float s_mean, float s_variance, T const* gemma,
+                                           T const* beta, int i) {
+  Tf ret = (val - s_mean) * s_variance * cuda_cast<Tf>(gemma[i]);
+  if (beta != nullptr) {
+    ret = ret + cuda_cast<Tf>(beta[i]);
+  }
+  return ret;
+}
+
+template <typename T, typename Tw, typename QuantT, bool USE_SHMEM,
+          bool USE_DIFF_OF_SQUARES = false>
+__global__ void generalLayerNorm(T const* input, Tw const* gemma, Tw const* beta, T* normed_output,
+                                 float const eps, int tokens, int hidden_dim,
+                                 float const* clamp_ptr, float const* scale_orig_quant_per_tensor,
+                                 float* scale_orig_quant_per_token, float* sum_per_token,
+                                 QuantT* normed_output_quant, bool has_fp8_min_scaling) {
+  constexpr auto num_elems_T = num_elems<T>::value;
+  using QuantT_packed_t = typename packed_as<QuantT, num_elems_T>::type;
+  using float_packed_t = typename packed_as<float, num_elems_T>::type;
+  using T_scalar = typename packed_as<T, 1>::type;
+
+  // The clamping minimum / maximum values.
+  T const clamp_min = cuda_cast<T>(clamp_ptr ? clamp_ptr[0] : -FLT_MAX);
+  T const clamp_max = cuda_cast<T>(clamp_ptr ? clamp_ptr[1] : FLT_MAX);
+
+  // The quantized data type's maximum value (upper-bound).
+  static constexpr float MAX_QUANT_VAL = QuantTypeStaticVals<QuantT>::MAX_VAL;
+  // The minimum scaling factor (lower-bound)
+  static constexpr float MIN_SCALING_FACTOR = QuantTypeStaticVals<QuantT>::MIN_SCALING_FACTOR;
+  static constexpr float MIN_SCALING_FACTOR_RCP =
+      QuantTypeStaticVals<QuantT>::MIN_SCALING_FACTOR_RCP;
+
+  extern __shared__ __align__(sizeof(float)) char _shmem[];
+  T* shmem = reinterpret_cast<T*>(_shmem);
+  __shared__ float s_mean;
+  __shared__ float s_variance;
+
+  int const tidx = threadIdx.x;
+  int const bidx = blockIdx.x;
+
+  float mean = 0.0f;
+  float variance = 0.0f;
+  float local_sum = 0.0f;
+  float local_var_sum = 0.0f;
+
+  int const n_elems = hidden_dim / num_elems_T;
+  for (int i = tidx; i < n_elems; i += blockDim.x) {
+    const T val = input[bidx * n_elems + i];
+    if constexpr (USE_SHMEM) {
+      shmem[i] = val;
+    }
+
+    const float_packed_t val_f = cuda_cast<float_packed_t>(val);
+    local_sum += cuda_sum<float>(val_f);
+    if constexpr (USE_DIFF_OF_SQUARES) {
+      local_var_sum += cuda_sum<float>(val_f * val_f);
+    }
+  }
+
+  if constexpr (USE_DIFF_OF_SQUARES) {
+    float packed[2] = {local_sum, local_var_sum};
+    blockReduceSumV2<float, 2>(packed);
+    mean = packed[0];
+    variance = packed[1];
+  } else {
+    mean = blockReduceSum(local_sum);
+  }
+
+  if (threadIdx.x == 0) {
+    mean = mean / hidden_dim;
+    s_mean = mean;
+    if constexpr (USE_DIFF_OF_SQUARES) {
+      variance = (variance / hidden_dim) - (mean * mean);  // Var[x] = E[x²] - E[x]²
+      s_variance = rsqrtf(variance + eps);
+    }
+  }
+  __syncthreads();
+
+  if constexpr (!USE_DIFF_OF_SQUARES) {
+    for (int i = tidx; i < n_elems; i += blockDim.x) {
+      const T val = USE_SHMEM ? shmem[i] : input[bidx * n_elems + i];
+      float_packed_t diff = cuda_cast<float_packed_t>(val) - s_mean;
+      local_var_sum += cuda_sum<float>(diff * diff);
+    }
+    variance = blockReduceSum(local_var_sum);
+
+    if (threadIdx.x == 0) {
+      s_variance = rsqrtf(variance / hidden_dim + eps);
+    }
+    __syncthreads();
+  }
+
+  bool const with_per_token_scaling = scale_orig_quant_per_token != nullptr;
+  bool const with_per_tensor_scaling = scale_orig_quant_per_tensor != nullptr;
+  bool const with_per_token_sum = sum_per_token != nullptr;
+
+  const float_packed_t scale_orig_quant =
+      cuda_cast<float_packed_t>(with_per_tensor_scaling ? *scale_orig_quant_per_tensor : 0.0f);
+  T_scalar amax = 1e-6f;
+  local_sum = 0.f;
+
+  for (int i = tidx; i < n_elems; i += blockDim.x) {
+    int const index = bidx * n_elems + i;
+    const float_packed_t val_f = cuda_cast<float_packed_t>(USE_SHMEM ? shmem[i] : input[index]);
+    T val = cuda_cast<T>(compute_layernorm(val_f, s_mean, s_variance, gemma, beta, i));
+
+    if (with_per_token_scaling) {
+      val = cuda_clamp(val, clamp_min, clamp_max);
+      amax = cuda_max(cuda_max<T_scalar, T>(cuda_abs(val)), amax);
+      if constexpr (USE_SHMEM) {
+        shmem[i] = val;
+      }
+    } else if (with_per_tensor_scaling) {
+      val = cuda_clamp(val, clamp_min, clamp_max);
+      reinterpret_cast<QuantT_packed_t*>(normed_output_quant)[index] =
+          cuda_cast<QuantT_packed_t>(cuda_cast<float_packed_t>(val) * scale_orig_quant);
+    } else {
+      normed_output[index] = val;
+    }
+
+    if (with_per_token_sum) {
+      local_sum += cuda_sum<float>(cuda_cast<float_packed_t>(val));
+    }
+  }
+
+  if (with_per_token_scaling) {
+    float abs_max_f = blockAllReduceMax(cuda_cast<float>(amax));
+    float const dynamic_per_token_scale =
+        has_fp8_min_scaling ? fminf(MAX_QUANT_VAL / abs_max_f, MIN_SCALING_FACTOR_RCP)
+                            : (MAX_QUANT_VAL / abs_max_f);
+    for (int i = tidx; i < n_elems; i += blockDim.x) {
+      int const index = bidx * n_elems + i;
+      float_packed_t val_f = cuda_cast<float_packed_t>(USE_SHMEM ? shmem[i] : input[index]);
+      if constexpr (!USE_SHMEM) {
+        val_f = compute_layernorm(val_f, s_mean, s_variance, gemma, beta, i);
+      }
+
+      reinterpret_cast<QuantT_packed_t*>(normed_output_quant)[index] =
+          cuda_cast<QuantT_packed_t>(val_f * cuda_cast<float_packed_t>(dynamic_per_token_scale));
+    }
+    if (tidx == 0) {
+      scale_orig_quant_per_token[bidx] =
+          has_fp8_min_scaling ? cuda_max(abs_max_f / MAX_QUANT_VAL, MIN_SCALING_FACTOR)
+                              : abs_max_f / MAX_QUANT_VAL;
+    }
+  }
+
+  if (with_per_token_sum) {
+    float packed_sum[1] = {local_sum};
+    blockReduceSumV2<float, 1>(packed_sum);
+    if (tidx == 0) {
+      sum_per_token[bidx] = packed_sum[0];
+    }
+  }
+}
+
+template <bool USE_DIFF_OF_SQUARES, typename T, typename Tw, typename QuantT>
+void dispatch_layernorm_type_square_method(
+    T const* input, Tw const* gemma, Tw const* beta, T* normed_output, float const eps, int tokens,
+    int hidden_dim, float const* clamp_ptr, float const* scale_orig_quant_per_tensor,
+    float* scale_orig_quant_per_token, float* sum_per_token, QuantT* normed_output_quant,
+    bool const has_fp8_min_scaling, dim3 const grid, dim3 const block, size_t const shmem_size,
+    cudaStream_t stream) {
+  // Do we use shared memory to cache intermediate results
+  bool use_shmem = true;
+  if (shmem_size >= (48 << 10)) {
+    cudaError_t ret =
+        cudaFuncSetAttribute(generalLayerNorm<T, Tw, QuantT, true, USE_DIFF_OF_SQUARES>,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_size);
+    // Use shared memory when the capacity is enough
+    use_shmem = (ret == cudaSuccess);
+  }
+
+  if (use_shmem) {
+    generalLayerNorm<T, Tw, QuantT, true, USE_DIFF_OF_SQUARES><<<grid, block, shmem_size, stream>>>(
+        input, gemma, beta, normed_output, eps, tokens, hidden_dim, clamp_ptr,
+        scale_orig_quant_per_tensor, scale_orig_quant_per_token, sum_per_token, normed_output_quant,
+        has_fp8_min_scaling);
+  } else {
+    generalLayerNorm<T, Tw, QuantT, false, USE_DIFF_OF_SQUARES><<<grid, block, 0, stream>>>(
+        input, gemma, beta, normed_output, eps, tokens, hidden_dim, clamp_ptr,
+        scale_orig_quant_per_tensor, scale_orig_quant_per_token, sum_per_token, normed_output_quant,
+        has_fp8_min_scaling);
+  }
+}
+
+template <typename T, typename Tw, typename QuantT>
+void dispatch_layernorm_type(T const* input, Tw const* gemma, Tw const* beta, T* normed_output,
+                             float const eps, int tokens, int hidden_dim, float const* clamp_ptr,
+                             float const* scale_orig_quant_per_tensor,
+                             float* scale_orig_quant_per_token, float* sum_per_token,
+                             QuantT* normed_output_quant, bool const has_fp8_min_scaling,
+                             dim3 const grid, dim3 const block, size_t const shmem_size,
+                             cudaStream_t stream, bool const use_diff_of_squares) {
+  if (use_diff_of_squares) {
+    dispatch_layernorm_type_square_method<true>(
+        input, gemma, beta, normed_output, eps, tokens, hidden_dim, clamp_ptr,
+        scale_orig_quant_per_tensor, scale_orig_quant_per_token, sum_per_token, normed_output_quant,
+        has_fp8_min_scaling, grid, block, shmem_size, stream);
+  } else {
+    dispatch_layernorm_type_square_method<false>(
+        input, gemma, beta, normed_output, eps, tokens, hidden_dim, clamp_ptr,
+        scale_orig_quant_per_tensor, scale_orig_quant_per_token, sum_per_token, normed_output_quant,
+        has_fp8_min_scaling, grid, block, shmem_size, stream);
+  }
+}
+
+template <typename T, typename Tw>
+cudaError_t LayerNorm(T* input, Tw* gemma, Tw* beta, T* out, uint32_t tokens, uint32_t hidden_dim,
+                      float eps = 1e-5, cudaStream_t stream = 0) {
+  dim3 grid(tokens);
+  dim3 block(min(hidden_dim, 1024));
+  // Make sure block.x is multiple of 32 for warp shuffle to work
+  block.x = 32 * ((block.x + 31) / 32);
+
+  constexpr size_t vec_size = 2;
+  const size_t shmem_size = hidden_dim * sizeof(T);
+  bool const use_vec_type = (hidden_dim % vec_size == 0) &&
+                            (std::is_same<T, half>::value || std::is_same<T, __nv_bfloat16>::value);
+
+  // Enable min_scaling factor if it is fp8 row-wise per-token quantization
+  // TODO(kaixih): add support for fp8 quantization if needed
+  bool has_fp8_min_scaling = false;
+  float* clamp_ptr = nullptr;
+  float* scale = nullptr;
+  float* dynamic_scale = nullptr;
+  float* sum_per_token = nullptr;
+  int8_t* normed_output_quant = nullptr;
+  bool use_diff_of_squares = false;
+
+  if (use_vec_type) {
+    using Tp = typename packed_as<T, vec_size>::type;
+    using Twp = typename packed_as<Tw, vec_size>::type;
+    dispatch_layernorm_type(reinterpret_cast<Tp const*>(input), reinterpret_cast<Twp const*>(gemma),
+                            reinterpret_cast<Twp const*>(beta), reinterpret_cast<Tp*>(out), eps,
+                            tokens, hidden_dim, clamp_ptr, scale, dynamic_scale, sum_per_token,
+                            normed_output_quant, has_fp8_min_scaling, grid, block, shmem_size,
+                            stream, use_diff_of_squares);
+  } else {
+    dispatch_layernorm_type(input, gemma, beta, out, eps, tokens, hidden_dim, clamp_ptr, scale,
+                            dynamic_scale, sum_per_token, normed_output_quant, has_fp8_min_scaling,
+                            grid, block, shmem_size, stream, use_diff_of_squares);
+  }
+  return cudaSuccess;
+}
+
 }  // namespace norm
 
 }  // namespace flashinfer
 
-#endif  // FLASHINFER_NORM_CUH_
+#endif  // FLAHSINFER_NORM_CUH_

--- a/include/flashinfer/trtllm/common/cudaUtils.h
+++ b/include/flashinfer/trtllm/common/cudaUtils.h
@@ -159,4 +159,114 @@ auto constexpr ceilDiv(T numerator, U denominator) {
   return (numerator + denominator - 1) / denominator;
 }
 
+template <typename T>
+struct num_elems;
+template <>
+struct num_elems<float> {
+  static constexpr int value = 1;
+};
+template <>
+struct num_elems<float2> {
+  static constexpr int value = 2;
+};
+template <>
+struct num_elems<float4> {
+  static constexpr int value = 4;
+};
+template <>
+struct num_elems<half> {
+  static constexpr int value = 1;
+};
+template <>
+struct num_elems<half2> {
+  static constexpr int value = 2;
+};
+#ifdef ENABLE_BF16
+template <>
+struct num_elems<__nv_bfloat16> {
+  static constexpr int value = 1;
+};
+template <>
+struct num_elems<__nv_bfloat162> {
+  static constexpr int value = 2;
+};
+#endif
+#ifdef ENABLE_FP8
+template <>
+struct num_elems<__nv_fp8_e4m3> {
+  static constexpr int value = 1;
+};
+template <>
+struct num_elems<__nv_fp8x2_e4m3> {
+  static constexpr int value = 2;
+};
+#endif
+
+template <typename T, int num>
+struct packed_as;
+template <typename T>
+struct packed_as<T, 1> {
+  using type = T;
+};
+template <>
+struct packed_as<half, 2> {
+  using type = half2;
+};
+template <>
+struct packed_as<float, 2> {
+  using type = float2;
+};
+template <>
+struct packed_as<int8_t, 2> {
+  using type = int16_t;
+};
+template <>
+struct packed_as<int32_t, 2> {
+  using type = int2;
+};
+template <>
+struct packed_as<half2, 1> {
+  using type = half;
+};
+template <>
+struct packed_as<float2, 1> {
+  using type = float;
+};
+#ifdef ENABLE_BF16
+template <>
+struct packed_as<__nv_bfloat16, 2> {
+  using type = __nv_bfloat162;
+};
+template <>
+struct packed_as<__nv_bfloat162, 1> {
+  using type = __nv_bfloat16;
+};
+#endif
+#ifdef ENABLE_FP8
+template <>
+struct packed_as<__nv_fp8_e4m3, 2> {
+  using type = __nv_fp8x2_e4m3;
+};
+template <>
+struct packed_as<__nv_fp8x2_e4m3, 1> {
+  using type = __nv_fp8_e4m3;
+};
+template <>
+struct packed_as<__nv_fp8_e5m2, 2> {
+  using type = __nv_fp8x2_e5m2;
+};
+template <>
+struct packed_as<__nv_fp8x2_e5m2, 1> {
+  using type = __nv_fp8_e5m2;
+};
+#endif
+
+inline __device__ float2 operator*(float2 a, float2 b) { return make_float2(a.x * b.x, a.y * b.y); }
+inline __device__ float2 operator+(float2 a, float2 b) { return make_float2(a.x + b.x, a.y + b.y); }
+inline __device__ float2 operator-(float2 a, float2 b) { return make_float2(a.x - b.x, a.y - b.y); }
+
+inline __device__ float2 operator*(float2 a, float b) { return make_float2(a.x * b, a.y * b); }
+inline __device__ float2 operator+(float2 a, float b) { return make_float2(a.x + b, a.y + b); }
+inline __device__ float2 operator-(float2 a, float b) { return make_float2(a.x - b, a.y - b); }
+
 }  // namespace tensorrt_llm::common

--- a/include/flashinfer/trtllm/common/reduceKernelUtils.cuh
+++ b/include/flashinfer/trtllm/common/reduceKernelUtils.cuh
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <assert.h>
+
+#include <array>
+#if ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0))
+#include <cooperative_groups/reduce.h>
+#else
+#include <cooperative_groups.h>
+#endif
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+#include <float.h>
+
+#include <type_traits>
+
+#include "flashinfer/trtllm/common/cudaTypeUtils.cuh"
+
+namespace cg = cooperative_groups;
+
+namespace tensorrt_llm {
+namespace common {
+
+template <int VPT>
+struct BytesToType;
+
+template <>
+struct BytesToType<1> {
+  using type = uint8_t;
+};
+
+template <>
+struct BytesToType<2> {
+  using type = uint16_t;
+};
+
+template <>
+struct BytesToType<4> {
+  using type = uint32_t;
+};
+
+template <>
+struct BytesToType<8> {
+  using type = uint64_t;
+};
+
+template <>
+struct BytesToType<16> {
+  using type = float4;
+};
+
+template <int Bytes>
+__device__ inline void copy(void const* local, void* data) {
+  using T = typename BytesToType<Bytes>::type;
+
+  T const* in = static_cast<T const*>(local);
+  T* out = static_cast<T*>(data);
+  *out = *in;
+}
+
+static float constexpr HALF_FLT_MAX = 65504.F;
+#define FINAL_MASK 0xffffffff
+
+template <typename T>
+__inline__ __device__ T warpReduceSum(T val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val = add<T>(val, __shfl_xor_sync(FINAL_MASK, val, mask,
+                                      32));  //__shfl_sync bf16 return float when sm < 80
+  return val;
+}
+
+/* Calculate the sum of all elements in a block */
+template <typename T>
+__inline__ __device__ T blockReduceSum(T val) {
+  static __shared__ T shared[32];
+  int lane = threadIdx.x & 0x1f;
+  int wid = threadIdx.x >> 5;
+
+  val = warpReduceSum<T>(val);
+
+  if (lane == 0) shared[wid] = val;
+
+  __syncthreads();
+
+  // Modify from blockDim.x << 5 to blockDim.x / 32. to prevent
+  // blockDim.x is not divided by 32
+  val = (threadIdx.x < (blockDim.x / 32.f)) ? shared[lane] : (T)(0.0f);
+  val = warpReduceSum<T>(val);
+
+  return val;
+}
+
+template <typename T>
+__inline__ __device__ T warpReduceMax(T val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val = max(val, __shfl_xor_sync(FINAL_MASK, val, mask, 32));
+  return val;
+}
+
+/* Calculate the maximum of all elements in a block */
+template <typename T>
+__inline__ __device__ T blockReduceMax(T val) {
+  static __shared__ T shared[32];
+  int lane = threadIdx.x & 0x1f;  // in-warp idx
+  int wid = threadIdx.x >> 5;     // warp idx
+
+  val = warpReduceMax(val);  // get maxx in each warp
+
+  if (lane == 0)  // record in-warp maxx by warp Idx
+    shared[wid] = val;
+
+  __syncthreads();
+
+  // Modify from blockDim.x << 5 to blockDim.x / 32. to prevent
+  // blockDim.x is not divided by 32
+  val = (threadIdx.x < (blockDim.x / 32.f)) ? shared[lane] : -1e20f;
+  val = warpReduceMax(val);
+
+  return val;
+}
+
+/* Calculate the maximum of all elements in a block */
+template <typename T>
+__inline__ __device__ T blockAllReduceMax(T val) {
+  static __shared__ T shared[32];
+  int lane = threadIdx.x & 0x1f;  // in-warp idx
+  int wid = threadIdx.x >> 5;     // warp idx
+
+  val = warpReduceMax(val);  // get maxx in each warp
+
+  if (lane == 0)  // record in-warp maxx by warp Idx
+    shared[wid] = val;
+
+  __syncthreads();
+
+  // Modify from blockDim.x << 5 to blockDim.x / 32. to prevent
+  // blockDim.x is not divided by 32
+  val = (lane < (blockDim.x / 32.f)) ? shared[lane] : -1e20f;
+  val = warpReduceMax(val);
+
+  return val;
+}
+
+template <typename T, int SZ>
+__inline__ __device__ typename PackType<T, SZ>::type batchWarpReduceSum(
+    typename PackType<T, SZ>::type val) {
+  using Packed = typename PackType<T, SZ>::type;
+
+  using type = std::conditional_t<sizeof(Packed) == 4, uint32_t,
+                                  std::conditional_t<sizeof(Packed) == 8, uint64_t, void>>;
+  static_assert(sizeof(Packed) == sizeof(type));
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1) {
+    //__shfl_sync bf16 return float when sm < 80
+    Packed remote;
+    *reinterpret_cast<type*>(remote.array) =
+        __shfl_xor_sync(FINAL_MASK, *reinterpret_cast<type*>(val.array), mask, 32);
+#pragma unroll SZ
+    for (int i = 0; i < SZ; i++) {
+      val.array[i] = add(val.array[i], remote.array[i]);
+    }
+  }
+  return val;
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T warpReduceSumV2(T* val) {
+#pragma unroll
+  for (int i = 0; i < NUM; i++) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+      val[i] += __shfl_xor_sync(FINAL_MASK, val[i], mask, 32);
+  }
+  return (T)(0.0f);
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T blockReduceSumV2(T* val) {
+  static __shared__ T shared[NUM][33];
+  int lane = threadIdx.x & 0x1f;
+  int wid = threadIdx.x >> 5;
+
+  warpReduceSumV2<T, NUM>(val);
+
+  if (lane == 0) {
+#pragma unroll
+    for (int i = 0; i < NUM; i++) {
+      shared[i][wid] = val[i];
+    }
+  }
+
+  __syncthreads();
+
+  bool is_mask = threadIdx.x < (blockDim.x / 32.f);
+#pragma unroll
+  for (int i = 0; i < NUM; i++) {
+    val[i] = is_mask ? shared[i][lane] : (T)(0.0f);
+  }
+  warpReduceSumV2<T, NUM>(val);
+  return (T)0.0f;
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T warpReduceMaxV2(T* val) {
+#pragma unroll
+  for (int i = 0; i < NUM; i++) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+      val[i] = max(val[i], __shfl_xor_sync(FINAL_MASK, val[i], mask, 32));
+  }
+  return (T)(0.0f);
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T blockReduceMaxV2(T* val) {
+  static __shared__ T shared[32][NUM];
+  int lane = threadIdx.x & 0x1f;  // in-warp idx
+  int wid = threadIdx.x >> 5;     // warp idx
+
+  warpReduceMaxV2<T, NUM>(val);  // get maxx in each warp
+
+  if (lane == 0)  // record in-warp maxx by warp Idx
+  {
+#pragma unroll
+    for (int i = 0; i < NUM; i++) {
+      shared[wid][i] = val[i];
+    }
+  }
+
+  __syncthreads();
+
+  // Modify from blockDim.x << 5 to blockDim.x / 32. to prevent
+  // blockDim.x is not divided by 32
+  bool is_mask = threadIdx.x < (blockDim.x / 32.f);
+#pragma unroll
+  for (int i = 0; i < NUM; i++) {
+    val[i] = is_mask ? shared[lane][i] : (T)-1e20f;
+  }
+  warpReduceMaxV2<T, NUM>(val);
+
+  return (T)0.0f;
+}
+
+template <int NUM>
+__inline__ __device__ void cgBlockReduceSumElements(float* element_list,
+                                                    float* cgBlockReduceSumElements_shm) {
+  cg::thread_block cta = cg::this_thread_block();
+  cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
+
+  int const tid = cta.thread_rank();
+  int const blockz = blockDim.x;
+  for (int i = 0; i < NUM; i++) {
+#if ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0))
+    cgBlockReduceSumElements_shm[i * blockz + tid] =
+        cg::reduce(tile, element_list[i], cg::plus<float>());
+#else
+    // TODO Add implementation here
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+      printf("[ERROR] Not support cgBlockReduceSumElements when CUDA < 11 \n");
+      assert(false);
+    }
+#endif
+  }
+  cg::sync(cta);
+  if (tid == 0) {
+#pragma unroll
+    for (int i = 0; i < NUM; i++) {
+      float beta = 0.0f;
+      for (int j = 0; j < blockz; j += 32) {
+        beta += cgBlockReduceSumElements_shm[i * blockz + j];
+      }
+      element_list[i] = beta;
+    }
+  }
+}
+
+template <typename T, int MAX_K>
+struct TopK {
+  int p[MAX_K];  // index, being -1 at the tail if the array is not full
+  T u[MAX_K];    // value in descend order, being -MAX_T_VAL if the element is invalid
+
+  __device__ __forceinline__ void insert(T const elem, int const elem_id) {
+    if (elem_id < 0) {
+      return;
+    }
+    // Condition of updating the array
+    // 1. array is not full
+    // 2. elem is greater than the smallest (last) element in the array
+    // 3. elem is equal to the smallest (last) element in the array but its elem_id is smaller
+    bool const need_update = (p[MAX_K - 1] == -1 || elem > u[MAX_K - 1] ||
+                              elem == u[MAX_K - 1] && elem_id < p[MAX_K - 1]);
+    if (!need_update) {
+      return;
+    }
+    // Find suitable index for the new element
+    int i;
+    for (i = MAX_K - 2; i >= 0; --i) {
+      bool const need_decrease = (p[i] == -1 || elem > u[i] || elem == u[i] && elem_id < p[i]);
+      if (!need_decrease) break;
+    }
+    // Move elements to correct positions
+    for (int k = MAX_K - 2; k >= i; --k) {
+      p[k + 1] = p[k];
+      u[k + 1] = u[k];
+    }
+    p[i] = elem_id;
+    u[i] = elem;
+  }
+
+  __device__ __forceinline__ void init() {
+    T const MAX_T_VAL = (std::is_same<T, half>::value) ? HALF_FLT_MAX : FLT_MAX;
+    for (int i = 0; i < MAX_K; i++) {
+      p[i] = -1;
+      u[i] = -MAX_T_VAL;
+    }
+  }
+};
+
+template <typename T, int MAX_K>
+__device__ __forceinline__ TopK<T, MAX_K> reduce_topk_op(TopK<T, MAX_K> const& a,
+                                                         TopK<T, MAX_K> const& b) {
+  TopK<T, MAX_K> res = a;
+  for (int i = 0; i < MAX_K; ++i) res.insert(b.u[i], b.p[i]);
+  return res;
+}
+
+template <typename T>
+struct TopK_2 {
+  int p = -1;
+  T u = -((std::is_same<T, half>::value) ? HALF_FLT_MAX : FLT_MAX);
+
+  __device__ __forceinline__ void insert(T elem, int elem_id) {
+    if (elem > u) {
+      u = elem;
+      p = elem_id;
+    }
+  }
+
+  __device__ __forceinline__ void init() {
+    u = -((std::is_same<T, half>::value) ? HALF_FLT_MAX : FLT_MAX);
+    p = -1;
+  }
+};
+
+template <typename T>
+__device__ __forceinline__ TopK_2<T> reduce_topk_op_2(TopK_2<T> const& a, TopK_2<T> const& b) {
+  return a.u > b.u ? a : b;
+}
+
+template <typename T>
+__device__ __forceinline__ T clamp_inf_for_half(float const input) {
+  return input;
+}
+
+template <>
+__device__ __forceinline__ half clamp_inf_for_half(float const input) {
+  // clamp inf values to enable fp16 training
+  return input > 0.0f ? (half)min(input, HALF_FLT_MAX - 1000)
+                      : (half)max(input, -HALF_FLT_MAX + 1000);
+}
+
+}  // namespace common
+}  // namespace tensorrt_llm

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 import flashinfer
 from flashinfer.utils import device_support_pdl
@@ -222,6 +223,22 @@ def test_gemma_fused_add_rmsnorm(
 
     torch.testing.assert_close(x_fused, x_native, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(residual_fused, residual_native, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 128])
+@pytest.mark.parametrize("hidden_size", [128, 129, 1024, 16384])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_layernorm(batch_size, hidden_size, dtype):
+    eps = 1e-6
+
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    gemma = torch.randn(hidden_size, dtype=torch.float32, device="cuda")
+    beta = torch.randn(hidden_size, dtype=torch.float32, device="cuda")
+
+    out = flashinfer.layernorm(x, gemma, beta, eps)
+    out_ref = F.layer_norm(x.float(), (hidden_size,), gemma, beta, eps).to(dtype)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Enable mixed-dtype LayerNorm (TRT-LLM based). PyTorch’s LayerNorm expects input, weight (gamma), and bias (beta) to share the same dtype. In practice, we often run bf16 activations with fp32 affine params for stability. This PR adopts the TRT-LLM implementation to support mixed dtypes (e.g., [bf16 inputs with fp32 gamma/beta](https://github.com/sgl-project/sglang/blob/b4408e6098ca06026d8ff0a56fa86492c0e27b99/python/sglang/srt/layers/attention/nsa/nsa_indexer.py#L99)) and exposes this behavior to users.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Note: This PR only enables support for BF16 inputs with FP32 gamma/beta. The underlying kernel actually supports more combinations of input types and even quantized outputs. However, since those paths are not required for our current use case and haven’t been thoroughly tested in this effort, I chose not to expose them in this PR. If needed, they can be added in a follow-up PR.

For the supported case, I also did a quick benchmark (below on B200):
```
# time (ms) so lower is better
m=128 k=1024 flashinfer vs pytorch: 2.97 8.04
m=128 k=2048 flashinfer vs pytorch: 3.40 9.45
m=128 k=4096 flashinfer vs pytorch: 4.00 12.30
m=512 k=1024 flashinfer vs pytorch: 6.07 8.76
m=512 k=2048 flashinfer vs pytorch: 7.87 11.08
m=512 k=4096 flashinfer vs pytorch: 9.26 17.26
m=1024 k=1024 flashinfer vs pytorch: 9.99 10.40
m=1024 k=2048 flashinfer vs pytorch: 13.02 15.41
m=1024 k=4096 flashinfer vs pytorch: 15.57 24.04
m=4096 k=1024 flashinfer vs pytorch: 34.64 25.73
m=4096 k=2048 flashinfer vs pytorch: 47.10 48.01
m=4096 k=4096 flashinfer vs pytorch: 57.02 97.66
```

Repro:
```python

import sys
import torch
import flashinfer
import torch.nn.functional as F

from triton.testing import do_bench_cudagraph

m, k = 1024, 1024
if len(sys.argv) > 2:
  m, k = int(sys.argv[1]), int(sys.argv[2])

dtype = torch.bfloat16
x = torch.randn((m, k), dtype=dtype, device='cuda')
gemma = torch.randn((k,), dtype=torch.float32, device='cuda')
beta = torch.randn((k,), dtype=torch.float32, device='cuda')
eps = 1e-6

out = flashinfer.layernorm(x, gemma, beta, eps)
out_ref = F.layer_norm(x.float(), (k,), gemma, beta, eps).to(dtype)

def check_accuracy(a, b, atol, rtol, percent):
    if torch.any(torch.isnan(a)):
        raise Exception("NaN in a")
    if torch.any(torch.isnan(b)):
        raise Exception("NaN in b")
    assert a.shape == b.shape
    left = torch.abs(a - b)
    right = atol + rtol * torch.abs(b)
    count = torch.sum(left > right)
    mismatch_percent = count / a.numel()
    print(f"{mismatch_percent=}")
    if mismatch_percent > 1 - percent:
        raise Exception("Mismatch percentage is %f for rtol %f" %
                        (mismatch_percent, rtol))

check_accuracy(out,
               out_ref,
               atol=0.01,
               rtol=0.01,
               percent=1.)

def bench_fi():
  return flashinfer.layernorm(x, gemma, beta, eps)

def bench_pt():
  return F.layer_norm(x.float(), (k,), gemma, beta, eps).to(dtype)
 
time_fi = do_bench_cudagraph(bench_fi) * 1e3
time_pt = do_bench_cudagraph(bench_pt) * 1e3

print(f"{m=} {k=} flashinfer vs pytorch: {time_fi:.2f} {time_pt:.2f}")

```

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
