### PR TITLE
chore: make cache directory flashinfer-version specific

### DIFF
--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -136,7 +136,7 @@ def _get_workspace_dir_name() -> pathlib.Path:
         f"{major}{minor}"
         for major, minor in sorted(compilation_context.TARGET_CUDA_ARCHS)
     )
-    return FLASHINFER_CACHE_DIR / arch
+    return FLASHINFER_CACHE_DIR / flashinfer_version / arch
 
 
 # use pathlib


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Some users might install different flashinfer versions under different venv/conda environments and the compiled binaries might not be compatible, this PR changes the workspace directory to be flashinfer-version specific.

## 🔍 Related Issues

#1906 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
