### PR TITLE
ci: limit max_jobs for arm64 jit wheel cache build on CI

### DIFF
--- a/scripts/task_test_jit_cache_package_build_import.sh
+++ b/scripts/task_test_jit_cache_package_build_import.sh
@@ -7,7 +7,7 @@ echo "========================================"
 echo "Starting flashinfer-jit-cache test script"
 echo "========================================"
 
-# MAX_JOBS = min(nproc, max(1, MemAvailable_GB/4))
+# MAX_JOBS = min(nproc, max(1, MemAvailable_GB/(8 on aarch64, 4 otherwise)))
 MEM_AVAILABLE_GB=$(free -g | awk '/^Mem:/ {print $7}')
 NPROC=$(nproc)
 MAX_JOBS=$(( MEM_AVAILABLE_GB / $([ "$(uname -m)" = "aarch64" ] && echo 8 || echo 4) ))


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We still observe OOM for some CI jobs (especially arm64 jit wheel cache bulid tasks), this PR reduces the number of 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

cc @yongwww 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized build job allocation for ARM64 systems: the job-count calculation was adjusted to better suit aarch64 memory characteristics, ensuring more reliable and efficient parallel builds while preserving behavior on other architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->