### PR TITLE
chore: rename FLASHINFER_JIT_VERBOSE to FLASHINFER_JIT_DEBUG for clarity

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -290,7 +290,10 @@ def gen_jit_spec(
     needs_device_linking: bool = False,
 ) -> JitSpec:
     check_cuda_arch()
-    verbose = os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1"
+    # Use FLASHINFER_JIT_DEBUG if set, otherwise use FLASHINFER_JIT_VERBOSE (for backward compatibility)
+    debug_env = os.environ.get("FLASHINFER_JIT_DEBUG")
+    verbose_env = os.environ.get("FLASHINFER_JIT_VERBOSE", "0")
+    debug = (debug_env if debug_env is not None else verbose_env) == "1"
 
     cflags = ["-std=c++17", "-Wno-switch-bool"]
     cuda_cflags = [
@@ -302,7 +305,7 @@ def gen_jit_spec(
         "-DFLASHINFER_ENABLE_FP8_E4M3",
         "-DFLASHINFER_ENABLE_FP8_E5M2",
     ]
-    if verbose:
+    if debug:
         cflags += ["-O0", "-g"]
         cuda_cflags += [
             "-g",
@@ -310,7 +313,6 @@ def gen_jit_spec(
             "-G",
             "-lineinfo",
             "--ptxas-options=-v",
-            "--ptxas-options=--verbose,--register-usage-level=10,--warn-on-local-memory-usage",
             "-DCUTLASS_DEBUG_TRACE_LEVEL=2",
         ]
     else:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Rename environment variable `FLASHINFER_JIT_VERBOSE` to `FLASHINFER_JIT_DEBUG` to better reflect its actual behavior.

  - `FLASHINFER_JIT_DEBUG`: Enable debug mode during compilation (disable optimization, add debug symbols)
  - The previous name `FLASHINFER_JIT_VERBOSE` implied "showing more compilation info", which was confusing
  - Maintained backward compatibility: falls back to `FLASHINFER_JIT_VERBOSE` if `FLASHINFER_JIT_DEBUG` is not set

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced FLASHINFER_JIT_DEBUG environment variable for controlling JIT debug builds with backward compatibility for legacy FLASHINFER_JIT_VERBOSE.
  * Enhanced debug build configuration with improved compiler and CUDA debugging flags. Non-debug builds continue using -O3 optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->