### PR TITLE
Fix #1641: Use `/usr/local/cuda` as default `CUDA_HOME` if possible, like `torch.utils.cpp_extension.CUDA_HOME`

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -47,11 +47,16 @@ def get_cuda_path() -> str:
         return cuda_home
     # get output of "which nvcc"
     nvcc_path = subprocess.run(["which", "nvcc"], capture_output=True)
-    if nvcc_path.returncode != 0:
-        raise RuntimeError("Could not find nvcc")
-    cuda_home = os.path.dirname(
-        os.path.dirname(nvcc_path.stdout.decode("utf-8").strip())
-    )
+    if nvcc_path.returncode == 0:
+        cuda_home = os.path.dirname(
+            os.path.dirname(nvcc_path.stdout.decode("utf-8").strip())
+        )
+    else:
+        cuda_home = "/usr/local/cuda"  # This default value is from: https://github.com/pytorch/pytorch/blob/ceb11a584d6b3fdc600358577d9bf2644f88def9/torch/utils/cpp_extension.py#L115
+        if not os.path.exists(cuda_home):
+            raise RuntimeError(
+                f"Could not find nvcc and default {cuda_home=} doesn't exist"
+            )
     return cuda_home
 
 


### PR DESCRIPTION
Fix #1641: Use `/usr/local/cuda` as default `CUDA_HOME` if possible, like `torch.utils.cpp_extension.CUDA_HOME`

## 📌 Description
Before 1641, `torch.utils.cpp_extension.CUDA_HOME` was used, and it sets a default of `/usr/loca/cuda` if it cannot find `nvcc`. This pr re-integrates that logic back into sglang, so in environments where `CUDA_HOME` and `CUDA_PATH` aren't defined explicitly, said default is used. 

See:
https://github.com/flashinfer-ai/flashinfer/pull/1641#discussion_r2443007672

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] All tests are passing (`unittest`, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CUDA path detection to automatically fall back to the default installation directory when the CUDA compiler is not found in system PATH, with validation to ensure the selected path exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->