### PR TITLE
unittest: fix failed unittest on hopper

### DIFF
--- a/tests/test_helpers/jit_utils.py
+++ b/tests/test_helpers/jit_utils.py
@@ -160,6 +160,9 @@ def gen_prefill_attention_modules(
             dtype_q=q_dtype,
             dtype_kv=kv_dtype,
         ):
+            if q_dtype != kv_dtype:
+                continue  # fa3 template do not support mixed precision
+
             jit_specs.append(
                 flashinfer.prefill.gen_single_prefill_module(
                     "fa3",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Some invalid configuration are generated in JIT warmup (mixed precision) function `gen_prefill_attention_modules`.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to enhance compatibility handling for specific hardware acceleration scenarios, improving test robustness for mixed-precision configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->