### PR TITLE
fix: Add cutlass as an mm_fp4 backend in compute capability 12.0 in benchmark code

### DIFF
--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -240,7 +240,7 @@ routine_cc_to_supported_backends = {
         "9.0": [],
         "10.0": ["cudnn", "trtllm", "cutlass"],
         "10.3": ["cudnn", "trtllm", "cutlass"],
-        "12.0": ["cudnn"],
+        "12.0": ["cudnn", "cutlass"],
     },
     # MOE
     "trtllm_fp4_block_scale_moe": {


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Previously `backend='cutlass'` was not available to be benchmarked in `flashinfer_benchmark.py` for compute capability 12.0 while the kernel actually has been available. Current PR marks the backend as available.

Example output of being runnable after PR:
```
# python3 flashinfer_benchmark.py --routine mm_fp4 --m 1024 --n 7168 --k 512 --out_dtype bfloat16 --backends cudnn cutlass trtllm --use_128x4_sf_layout --use_nvfp4 --refcheck -vv                                                  
[INFO] args = Namespace(routine='mm_fp4', no_cuda_graph=False, use_cupti=False, refcheck=True, allow_output_mismatch=False, random_seed=42, verbose=2, output_path=None, num_iters=30, dry_run_iters=5, case_tag=None, generate_repro_command=False, repro_command='', batch_size=1, m=1024, n=7168, k=512, tile_size=128, group_size=1, scale_major_mode='MN', input_dtype='fp8_e4m3', mat2_dtype='fp8_e4m3', out_dtype='bfloat16', mma_sm=1, backends=['cudnn', 'cutlass', 'trtllm'], use_128x4_sf_layout=True, use_nvfp4=True, autotune=False)
[INFO] Running testMmFp4
[INFO] FlashInfer version: 0.4.1
[VVERBOSE] gpu_name = 'NVIDIA_RTX_PRO_6000_Blackwell_Server_Edition'
[WARNING] trtllm for routine mm_fp4 is not supported on compute capability 12.0. Skipping.
[VVERBOSE] input_fp4.shape = torch.Size([1024, 256])
[VVERBOSE] input_fp4.dtype = torch.uint8
[VVERBOSE] mat2_fp4.shape = torch.Size([7168, 256])
[VVERBOSE] mat2_fp4.dtype = torch.uint8
[PERF] cudnn          :: median time 0.014 ms; std 0.000 ms; achieved tflops 535.891 TFLOPs/sec; achieved tb_per_sec 1.196 TB/sec
[PERF] cutlass        :: median time 0.015 ms; std 0.000 ms; achieved tflops 515.203 TFLOPs/sec; achieved tb_per_sec 1.150 TB/sec
```

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded backend support for benchmarking routines on compute capability 12.0, adding compatibility with additional processing backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->