### PR TITLE
fix: Make attention microbenchmark correctly use page table

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -451,6 +451,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 page_size,
                 q_data_type=q_dtype,
                 data_type=kv_dtype,
+                block_tables=block_tables,
             )
 
     ## If FP8, prepare
@@ -915,6 +916,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 causal=causal,
                 q_data_type=q_dtype,
                 kv_data_type=kv_dtype,
+                block_tables=block_tables,
             )
 
     k_scale, v_scale = None, None
@@ -1782,7 +1784,12 @@ def testBatchMLAPagedAttentionWrapper(args):
     def run_backend_wrapper(backend):
         if backend in ["fa2", "fa3"]:
             return backend_wrappers[backend].run(
-                q_nope, q_pe, ckv_cache, kpe_cache, return_lse=False
+                q_nope,
+                q_pe,
+                ckv_cache,
+                kpe_cache,
+                page_table=block_tables,
+                return_lse=False,
             )
         elif backend == "cutlass":
             return backend_wrappers[backend].run(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Current microbenchmark code does not provides instantiated `block_tables` to all backends. The omission had no impact to correctness or perf because page tables are instantiated linearly when not provided, but will manifest as mismatches if it is shuffled.

The current PR simply calls the FlashInfer APIs in their intended way.

**No changes to library code**

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x]  I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in attention computation by aligning page-table parameter handling across different inference backend implementations for improved paged key-value cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->