### PR TITLE
fix: Skipping attention sink Blackwell test outside of Blackwell

### DIFF
--- a/tests/attention/test_attention_sink_blackwell.py
+++ b/tests/attention/test_attention_sink_blackwell.py
@@ -40,8 +40,8 @@ def test_blackwell_trtllm_gen_decode_attention_sink(
     head_dim,
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] in [11, 12]:
-        pytest.skip("trtllm-gen does not support SM110/SM120/SM121 GPUs.")
+    if compute_capability[0] != 10:
+        pytest.skip("trtllm-gen only supports SM100 and SM103 GPUs.")
     seed = 0
     torch.manual_seed(seed)
     device = "cuda:0"
@@ -141,8 +141,8 @@ def test_blackwell_trtllm_gen_context_attention_sink(
     head_dim,
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] in [11, 12]:
-        pytest.skip("trtllm-gen does not support SM110/SM120/SM121 GPUs.")
+    if compute_capability[0] != 10:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
     seed = 0
     torch.manual_seed(seed)
     device = "cuda:0"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`test_attention_sink_blackwell.py` checks `flashinfer.prefill.trtllm_batch_context_with_kv_cache` and `flashinfer.decode.trtllm_batch_decode_with_kv_cache` which are only supported on Blackwell SM100 and SM103.

Existing check only skips testing of SM 11x or 12x, which causes failures on Hopper SM90.

Test outputs:
* H200:
   * Before Fix: `144 failed, 1 warning in 9.20s`
   * After Fix: `144 skipped, 1 warning in 0.42s`
* B200: 
   * After Fix: `144 passed in 34.64s `

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU compatibility checks for attention sink tests to target specific GPU architectures (SM100/SM103). Tests now run exclusively on supported GPU models with updated filtering criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->