### PR TITLE
unittest: Add SM arch checks to skip unsupported tests on Hopper

### DIFF
--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -349,8 +349,8 @@ def test_trtllm_batch_prefill(
     max_kv_len,
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] in [11, 12]:
-        pytest.skip("trtllm-gen does not support SM110/SM120/SM121 GPUs.")
+    if compute_capability[0] != 10:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
     # Set up test parameters
     torch.manual_seed(0)
     head_dim = 128
@@ -918,8 +918,8 @@ def test_trtllm_gen_prefill_deepseek(
     batch_size, s_qo, s_kv, num_kv_heads, head_grp_size, causal
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] in [11, 12]:
-        pytest.skip("trtllm-gen does not support SM110/SM120/SM121 GPUs.")
+    if compute_capability[0] != 10:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
     if s_qo > s_kv:
         pytest.skip("s_qo > s_kv, skipping test as causal")
 

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -33,8 +33,8 @@ def test_trtllm_batch_decode_mla(
     enable_pdl: bool,
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] in [11, 12]:
-        pytest.skip("trtllm-gen does not support SM110/SM120/SM121 GPUs.")
+    if compute_capability[0] != 10:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
     if dynamic_scale and dtype != torch.float8_e4m3fn:
         pytest.skip("Dynamic scale is not supported for non-fp8 dtype")
 

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -17,13 +17,18 @@ from tests.utils_fp8 import to_float8
 @pytest.mark.parametrize("backend", ["cudnn", "cublas", "cutlass", "auto"])
 @pytest.mark.parametrize("auto_tuning", [True, False])
 def test_bmm_fp8(b, m, n, k, input_dtype, mat2_dtype, res_dtype, backend, auto_tuning):
-    if get_compute_capability(torch.device("cuda"))[0] == 12 and backend in [
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability[0] == 12 and backend in [
         "cutlass",
         "auto",
     ]:
         # TODO(yongwwww): enable all test cases for SM120/121 CUTLASS bmm_fp8 backend
         pytest.xfail(
             "Not all test cases for CUTLASS bmm_fp8 on SM120/121 are passing at this moment"
+        )
+    if backend == "cutlass" and compute_capability[0] not in [10, 11, 12]:
+        pytest.skip(
+            "bmm_fp8 with cutlass backend is only supported on SM100, SM110, and SM120/121 GPUs."
         )
     if input_dtype == torch.float8_e5m2 and mat2_dtype == torch.float8_e5m2:
         pytest.skip("Invalid combination: both input and mat2 are e5m2")

--- a/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
+++ b/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
@@ -256,8 +256,10 @@ def test_mxfp8_mxfp4_groupwise_group_gemm(
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     # TODO: We need to add gemm_mxfp4_nt_groupwise support for sm120/121 at some point.
-    if compute_capability[0] == 12:
-        pytest.skip("gemm_mxfp4_nt_groupwise is not supported in SM120/SM121.")
+    if compute_capability[0] not in [10]:
+        pytest.skip(
+            "gemm_mxfp4_nt_groupwise is only supported on SM100 and SM103 GPUs."
+        )
     torch.random.manual_seed(0)
     tile_size = 32
     alignment_n = 8

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -27,6 +27,12 @@ def test_mm_fp4(
     use_nvfp4 = fp4_type == "nvfp4"
 
     compute_capability = get_compute_capability(torch.device(device="cuda"))
+    compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
+    if not mm_fp4.is_backend_supported(backend, compute_capability_number):
+        pytest.skip(
+            f"Skipping test for {backend} because it is not supported on compute capability {compute_capability_number}."
+        )
+
     if backend == "trtllm":
         if res_dtype == torch.float16:
             pytest.skip("Skipping test for trtllm fp4 with float16")

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -2035,8 +2035,8 @@ def test_moe_quantization_classes(
     Each quantization class clearly shows which precision is being used.
     """
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] in [11, 12]:
-        pytest.skip("trtllm-gen does not support SM110/SM120/SM121 GPUs.")
+    if compute_capability[0] not in [10]:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
     # Skip incompatible combinations
     if gated_act_type == GatedActType.GeGlu and (
         type(moe_impl) is not FP4Moe


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

A number of unit tests fail on Hopper because they either do not have a support-check or fail based on "what is not supported" while missing SM90. Current PR adds checks based on "what is supported" and skips if not in the supported list of SMs.

Special case of `mm_fp4` where `mm_fp4.is_backend_supported(backend, compute_capability_number)` now exists and is used to skip tests if not supported.

Impacted tests:
* tests/attention/test_trtllm_gen_attention.py
* tests/attention/test_trtllm_gen_mla.py
* tests/gemm/test_bmm_fp8.py
* tests/gemm/test_mm_fp4.py
* tests/gemm/test_groupwise_scaled_gemm_fp8.py
* tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
* tests/moe/test_trtllm_gen_fused_moe.py


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x]  I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
