### PR TITLE
Fix trtllm-gen attention illegal memory access

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1988,7 +1988,7 @@ def get_trtllm_gen_decode_module(*args):
             q.contiguous(),  # NOTE(Siyuan): without contiguous, the result is incorrect
             paged_k_cache,
             paged_v_cache,
-            int_workspace_buffer,
+            float_workspace_buffer,
             block_tables,
             kv_lens_buffer,
             max_kv_len,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR fixes illegal memory access of trtllm-gen attention kernels. It changes the workspace buffer from `int_workspace_buffer` to `float_workspace_buffer`. `int_workspace_buffer` is a fixed sized buffer and not initialized to zero, which should not be used.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

Issue #1928 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory allocation in the decode module to improve computation accuracy and stability during text generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->