### PR TITLE
bugfix: fix regex in update wheel index script

### DIFF
--- a/scripts/update_whl_index.py
+++ b/scripts/update_whl_index.py
@@ -31,7 +31,11 @@ def get_package_info(wheel_path: pathlib.Path) -> Optional[dict]:
     wheel_name = wheel_path.name
 
     # Try flashinfer-python pattern
-    match = re.match(r"flashinfer_python-([0-9.]+(?:\.dev\d+)?)-", wheel_name)
+    # Supports PEP 440: base_version[{a|b|rc}N][.postN][.devN]
+    match = re.match(
+        r"flashinfer_python-([0-9.]+(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?)-",
+        wheel_name,
+    )
     if match:
         version = match.group(1)
         return {
@@ -41,7 +45,11 @@ def get_package_info(wheel_path: pathlib.Path) -> Optional[dict]:
         }
 
     # Try flashinfer-cubin pattern
-    match = re.match(r"flashinfer_cubin-([0-9.]+(?:\.dev\d+)?)-", wheel_name)
+    # Supports PEP 440: base_version[{a|b|rc}N][.postN][.devN]
+    match = re.match(
+        r"flashinfer_cubin-([0-9.]+(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?)-",
+        wheel_name,
+    )
     if match:
         version = match.group(1)
         return {
@@ -51,7 +59,11 @@ def get_package_info(wheel_path: pathlib.Path) -> Optional[dict]:
         }
 
     # Try flashinfer-jit-cache pattern (has CUDA suffix in version)
-    match = re.match(r"flashinfer_jit_cache-([0-9.]+(?:\.dev\d+)?\+cu\d+)-", wheel_name)
+    # Supports PEP 440: base_version[{a|b|rc}N][.postN][.devN]+cuXXX
+    match = re.match(
+        r"flashinfer_jit_cache-([0-9.]+(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?\+cu\d+)-",
+        wheel_name,
+    )
     if match:
         version = match.group(1)
         cuda_ver = get_cuda_version(wheel_name)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The regex cannot recognize release candidates (`v0.5.0rc1`) or post releases (`v1.2.3.post1`):  https://github.com/flashinfer-ai/flashinfer/actions/runs/18929490991/job/54049304551

This PR fixes the issue.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/actions/runs/18929490991/job/54049304551

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version string parsing in the wheel package indexing process to support more complex version formats, including pre-release, post-release, and development versions, ensuring compatibility with PEP 440 versioning standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->