### PR TITLE
Support cc common check decorator for empty backends

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -975,13 +975,12 @@ def backend_requirement(
                 return False
 
         def is_compute_capability_supported(cc):
-            # Handle empty backend_checks case
+            # In case there is only 1 implicit backend, the compute capability support needs to be added to the common check
             if not has_backend_choices():
                 # No backend-specific checks, only check common_check
                 if not hasattr(common_check, "is_compute_capability_supported"):
                     raise ValueError(
-                        f"Invalid is_compute_capability_supported call: {common_check.__name__} \
-                        does not have is_compute_capability_supported decorator"
+                        f"Invalid is_compute_capability_supported call: {common_check.__name__} does not have is_compute_capability_supported decorator"
                     )
                 return common_check.is_compute_capability_supported(cc)
             else:
@@ -1018,7 +1017,7 @@ def backend_requirement(
         def has_backend(backend: str) -> bool:
             # Whether the given backend exists in the API
             return backend in backend_checks
-        
+
         # @brief: Wrapper function that calls the orignal, decorated function, after applying a number of checks.
         # @note that here we manually apply defaults to the arguments in the wrapper function when doing validation.
         @functools.wraps(func)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend/compute-capability validation with clearer errors and correct fallback when backend-specific checks are absent.

* **New Features**
  * Decorated functions expose runtime attributes to query backend availability and choices.
  * Default-backend behavior: kernels use a default when none is passed.

* **Compatibility**
  * Expanded supported compute-capability set and raised minimum cuDNN package requirements.

* **Tests**
  * Added tests for empty-backend common-checks and default-backend behavior.

* **Chores**
  * Version bumped to 0.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->