### PR TITLE
fix: support both pip and uv pip for finding flashinfer-python package

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/deep_gemm/compiler.cuh
+++ b/csrc/nv_internal/tensorrt_llm/deep_gemm/compiler.cuh
@@ -124,8 +124,9 @@ std::string getNvccCompiler() {
 std::vector<std::filesystem::path> getJitIncludeDirs() {
   static std::vector<std::filesystem::path> includeDirs;
   if (includeDirs.empty()) {
-    // Command to execute
-    char const* cmd = "pip show flashinfer-python 2>/dev/null";
+    // Command to execute - try pip first, fallback to uv pip
+    char const* cmd =
+        "pip show flashinfer-python 2>/dev/null || uv pip show flashinfer-python 2>/dev/null";
 
     // Buffer to store the output
     std::array<char, 128> buffer;


### PR DESCRIPTION
Update getJitIncludeDirs() to try pip first, then fallback to uv pip if pip is not available. This ensures compatibility with both standard pip and uv pip package managers when locating the flashinfer-python installation for JIT compilation include paths.

The command now uses shell OR operator (||) to attempt pip first, and only falls back to uv pip if the first command fails.
```
pytest -xs tests/moe/test_trtllm_cutlass_fused_moe.py::test_moe_fp8_block_scaling
============================================================================================================================================================ test session starts =============================================================================================================================================================
platform linux -- Python 3.10.12, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/scratch.dmoss_gpu_1/repos/flashinfer
configfile: pytest.ini
collected 1 item                                                                                                                                                                                                                                                                                                                             

tests/moe/test_trtllm_cutlass_fused_moe.py [TensorRT-LLM][INFO] Compiling JIT runtime gemm_swapAB_256_128_128_16_128_2_82_8_1_GroupedWithOffset with options: 
[TensorRT-LLM][INFO] -std=c++17 
[TensorRT-LLM][INFO] --gpu-architecture=sm_90a 
[TensorRT-LLM][INFO] --ptxas-options=-allow-expensive-optimizations=true 
[TensorRT-LLM][INFO] --ptxas-options=--register-usage-level=10 
[TensorRT-LLM][INFO] --diag-suppress=161,174,177,940 
[TensorRT-LLM][INFO] -D__FORCE_INCLUDE_CUDA_FP16_HPP_FROM_FP16_H__=1 
[TensorRT-LLM][INFO] -D__FORCE_INCLUDE_CUDA_BF16_HPP_FROM_BF16_H__=1 
[TensorRT-LLM][INFO] -O3 
[TensorRT-LLM][INFO] -cubin 
[TensorRT-LLM][INFO] --expt-relaxed-constexpr 
[TensorRT-LLM][INFO] --expt-extended-lambda 
[TensorRT-LLM][INFO] --compiler-options=-fPIC,-O3,-Wno-deprecated-declarations,-Wno-abi 
[TensorRT-LLM][INFO] -I/home/scratch.dmoss_gpu_1/repos/flashinfer/flashinfer/data/csrc/nv_internal/tensorrt_llm 
[TensorRT-LLM][INFO] 

[TensorRT-LLM][INFO] Generated kernel code:

#ifdef __CUDACC_RTC__
#ifndef NVRTC_JIT_COMPILATION
#define NVRTC_JIT_COMPILATION
#endif

#include <deep_gemm/nvrtc_std.cuh>

#else

#include <string>
#include <cuda.h>

#endif

#include <cuda_bf16.h>
#include <cuda_fp8.h>
#include <deep_gemm/nvrtc_cutlass.cuh>
#include <deep_gemm/fp8_gemm_impl.cuh>

using namespace deep_gemm;

using SchedulerType =
typename SchedulerSelectorSwapAB<GemmType::GroupedWithOffset, 256, 128, 128, 16, 128, 2, 1>::type;

__global__ void dummy_kernel() {
  void *ptr = (void *)&fp8_gemm_kernel_swapAB<256, 128, 128, 16, 128, 2, 8, 128, 128, 1, SchedulerType, GroupedWithOffsetSchedulerInputSwapAB>;
}

[TensorRT-LLM][INFO] NVCC compilation took 3064 ms
[TensorRT-LLM][INFO] Compilation log:

[TensorRT-LLM][INFO] Successfully copied kernel files to cache directory: /home/dmoss/.tensorrt_llm/cache/gemm_swapAB_256_128_128_16_128_2_82_8_1_GroupedWithOffset
[TensorRT-LLM][INFO] Compiling JIT runtime gemm_swapAB_128_128_128_16_128_2_82_8_1_GroupedWithOffset with options: 
[TensorRT-LLM][INFO] -std=c++17 
[TensorRT-LLM][INFO] --gpu-architecture=sm_90a 
[TensorRT-LLM][INFO] --ptxas-options=-allow-expensive-optimizations=true 
[TensorRT-LLM][INFO] --ptxas-options=--register-usage-level=10 
[TensorRT-LLM][INFO] --diag-suppress=161,174,177,940 
[TensorRT-LLM][INFO] -D__FORCE_INCLUDE_CUDA_FP16_HPP_FROM_FP16_H__=1 
[TensorRT-LLM][INFO] -D__FORCE_INCLUDE_CUDA_BF16_HPP_FROM_BF16_H__=1 
[TensorRT-LLM][INFO] -O3 
[TensorRT-LLM][INFO] -cubin 
[TensorRT-LLM][INFO] --expt-relaxed-constexpr 
[TensorRT-LLM][INFO] --expt-extended-lambda 
[TensorRT-LLM][INFO] --compiler-options=-fPIC,-O3,-Wno-deprecated-declarations,-Wno-abi 
[TensorRT-LLM][INFO] -I/home/scratch.dmoss_gpu_1/repos/flashinfer/flashinfer/data/csrc/nv_internal/tensorrt_llm 
[TensorRT-LLM][INFO] 

[TensorRT-LLM][INFO] Generated kernel code:

#ifdef __CUDACC_RTC__
#ifndef NVRTC_JIT_COMPILATION
#define NVRTC_JIT_COMPILATION
#endif

#include <deep_gemm/nvrtc_std.cuh>

#else

#include <string>
#include <cuda.h>

#endif

#include <cuda_bf16.h>
#include <cuda_fp8.h>
#include <deep_gemm/nvrtc_cutlass.cuh>
#include <deep_gemm/fp8_gemm_impl.cuh>

using namespace deep_gemm;

using SchedulerType =
typename SchedulerSelectorSwapAB<GemmType::GroupedWithOffset, 128, 128, 128, 16, 128, 2, 1>::type;

__global__ void dummy_kernel() {
  void *ptr = (void *)&fp8_gemm_kernel_swapAB<128, 128, 128, 16, 128, 2, 8, 128, 128, 1, SchedulerType, GroupedWithOffsetSchedulerInputSwapAB>;
}

[TensorRT-LLM][INFO] NVCC compilation took 1479 ms
[TensorRT-LLM][INFO] Compilation log:

[TensorRT-LLM][INFO] Successfully copied kernel files to cache directory: /home/dmoss/.tensorrt_llm/cache/gemm_swapAB_128_128_128_16_128_2_82_8_1_GroupedWithOffset
.

============================================================================================================================================================= 1 passed in 9.02s ==============================================================================================================================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package detection compatibility for alternative package management tool installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->