### PR TITLE
[Test] Optimize test_trtllm_gen_fused_moe.py

### DIFF
--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -49,6 +49,10 @@ from flashinfer.fused_moe.core import (
 from flashinfer.utils import get_compute_capability
 
 
+# Max num tokens to tune for trtllm-gen fused moe
+TUNE_MAX_NUM_TOKENS = 4096
+
+
 def check_cuda(err):
     """Unified CUDA error checking function used throughout the file."""
     if err != runtime.cudaError_t.cudaSuccess:
@@ -208,7 +212,7 @@ class CUDAGraphMoE:
             routing_method_type=self.config["routing_method_type"],
             gated_act_type=self.config["gated_act_type"],
             do_finalize=True,
-            tune_max_num_tokens=4096,
+            tune_max_num_tokens=TUNE_MAX_NUM_TOKENS,
         )
         return output  # Extract tensor from tuple
 
@@ -800,7 +804,7 @@ class FP8BlockScaleMoe(Moe):
                 use_shuffled_weight=static_data["use_shuffled_weight"],
                 weight_layout=static_data["weight_layout"],
                 enable_pdl=enable_pdl,
-                tune_max_num_tokens=4096,
+                tune_max_num_tokens=TUNE_MAX_NUM_TOKENS,
             )
         return output.to(torch.float)
 
@@ -977,7 +981,7 @@ class FP8PerTensorMoe(Moe):
                 == RoutingMethodType.Llama4,  # Use_routing_scales_on_input
                 None,
                 routing_method_type,
-                tune_max_num_tokens=4096,
+                tune_max_num_tokens=TUNE_MAX_NUM_TOKENS,
             )
 
         return output.to(torch.float)
@@ -1129,7 +1133,7 @@ class BF16Moe(Moe):
                 use_shuffled_weight=static_data["use_shuffled_weight"],
                 weight_layout=static_data["weight_layout"],
                 routing_method_type=routing_method_type,
-                tune_max_num_tokens=4096,
+                tune_max_num_tokens=TUNE_MAX_NUM_TOKENS,
             )
         return output.to(torch.float)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Currently `test_llm_gen_fused_moe` took long time, make some optimization to speed up
- Add autotuner choice to turn on/off autotuner in test
- Optimize token count for better coverage
- Optimize `check_accuracy` to speed up
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Add configurable autotune flag (enabled/disabled) across MoE test paths and parametrized cases; propagate it through runtime/test flows
  * Ensure autotune-aware kernel invocations respect a max-token tuning limit (4096)
  * Clear tuner state between runs to improve cache isolation
* **Bug Fixes**
  * Tighten accuracy checks to enforce finiteness and use isclose-based matching with early exit when thresholds met
<!-- end of auto-generated comment: release notes by coderabbit.ai -->