### PR TITLE
feat: add sink to flashinfer decode

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -388,6 +388,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: Literal[True] = True,
+    sinks: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
 
@@ -407,6 +408,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: bool = False,
+    sinks: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode attention with KV Cache for single request, return attention output.
 
@@ -533,6 +535,7 @@ def single_decode_with_kv_cache(
             window_left,
             None,  # packed_custom_mask
             _get_cache_alibi_slopes_buf(num_qo_heads, q.device),
+            sinks,  # maybe_s_aux
             logits_soft_cap,
             sm_scale,
             None,  # scale_q, not supported yet

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -467,8 +467,8 @@ def gen_single_decode_module(
         dtype_o,
         head_dim_qk,
         head_dim_vo,
-        ["maybe_alibi_slopes"],  # additional_tensor_names
-        ["float"],  # additional_tensor_dtypes
+        ["maybe_alibi_slopes", "maybe_s_aux"],  # additional_tensor_names
+        ["float", "float"],  # additional_tensor_dtypes
         [
             "logits_soft_cap",
             "sm_scale",
@@ -516,7 +516,11 @@ def gen_single_prefill_module(
 
     if backend == "fa2":
         assert not fp8_enabled, "fp8 tensor core is not supported in fa2 backend"
-        additional_tensor_names = ["maybe_custom_mask", "maybe_alibi_slopes", "maybe_s_aux"]
+        additional_tensor_names = [
+            "maybe_custom_mask",
+            "maybe_alibi_slopes",
+            "maybe_s_aux",
+        ]
         additional_tensor_dtypes = ["uint8_t", "float", "float"]
         additional_scalar_names = [
             "logits_soft_cap",

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -467,8 +467,8 @@ def gen_single_decode_module(
         dtype_o,
         head_dim_qk,
         head_dim_vo,
-        ["maybe_alibi_slopes", "maybe_s_aux"],  # additional_tensor_names
-        ["float", "float"],  # additional_tensor_dtypes
+        ["maybe_alibi_slopes"],  # additional_tensor_names
+        ["float"],  # additional_tensor_dtypes
         [
             "logits_soft_cap",
             "sm_scale",
@@ -516,8 +516,8 @@ def gen_single_prefill_module(
 
     if backend == "fa2":
         assert not fp8_enabled, "fp8 tensor core is not supported in fa2 backend"
-        additional_tensor_names = ["maybe_custom_mask", "maybe_alibi_slopes"]
-        additional_tensor_dtypes = ["uint8_t", "float"]
+        additional_tensor_names = ["maybe_custom_mask", "maybe_alibi_slopes", "maybe_s_aux"]
+        additional_tensor_dtypes = ["uint8_t", "float", "float"]
         additional_scalar_names = [
             "logits_soft_cap",
             "sm_scale",

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -467,8 +467,8 @@ def gen_single_decode_module(
         dtype_o,
         head_dim_qk,
         head_dim_vo,
-        ["maybe_alibi_slopes"],  # additional_tensor_names
-        ["float"],  # additional_tensor_dtypes
+        ["maybe_alibi_slopes", "maybe_s_aux"],  # additional_tensor_names
+        ["float", "float"],  # additional_tensor_dtypes
         [
             "logits_soft_cap",
             "sm_scale",
@@ -760,8 +760,8 @@ def gen_batch_decode_module(
         dtype_idx,
         head_dim_qk,
         head_dim_vo,
-        ["maybe_alibi_slopes"],  # additional_tensor_names
-        ["float"],  # additional_tensor_dtypes
+        ["maybe_alibi_slopes", "maybe_s_aux"],  # additional_tensor_names
+        ["float", "float"],  # additional_tensor_dtypes
         [
             "logits_soft_cap",
             "sm_scale",

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -277,6 +277,7 @@ def get_single_prefill_module(backend, *args):
         window_left: int,
         maybe_packed_custom_mask: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_s_aux: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         scale_q: Optional[torch.Tensor],
@@ -330,6 +331,7 @@ def get_single_prefill_module(backend, *args):
                 window_left,
                 maybe_packed_custom_mask,
                 maybe_alibi_slopes,
+                maybe_s_aux,
                 logits_soft_cap,
                 sm_scale,
                 1.0 / rope_scale,  # rope_rcp_scale
@@ -350,6 +352,7 @@ def get_single_prefill_module(backend, *args):
         window_left: int,
         maybe_packed_custom_mask: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_s_aux: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         rope_scale: float,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -237,6 +237,23 @@ def _get_cache_alibi_slopes_buf(
     return buf
 
 
+def _get_sink_buf(
+    sinks: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Convert sinks tensor to proper format for CUDA kernels.
+    
+    Args:
+        sinks: Optional tensor of shape [num_qo_heads] with sink values per head
+        
+    Returns:
+        Contiguous float32 tensor or None if sinks is None
+    """
+    if sinks is None:
+        return None
+    # Ensure it's float32 and contiguous as expected by CUDA kernels
+    return sinks.to(torch.float32).contiguous()
+
+
 def canonicalize_torch_dtype(dtype: Union[torch.dtype, str]) -> torch.dtype:
     if isinstance(dtype, str):
         return getattr(torch, dtype)

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -241,10 +241,10 @@ def _get_sink_buf(
     sinks: Optional[torch.Tensor],
 ) -> Optional[torch.Tensor]:
     """Convert sinks tensor to proper format for CUDA kernels.
-    
+
     Args:
         sinks: Optional tensor of shape [num_qo_heads] with sink values per head
-        
+
     Returns:
         Contiguous float32 tensor or None if sinks is None
     """

--- a/include/flashinfer/attention/default_decode_params.cuh
+++ b/include/flashinfer/attention/default_decode_params.cuh
@@ -37,6 +37,7 @@ struct SingleDecodeParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  float* maybe_s_aux;
   uint32_t kv_len;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
@@ -58,6 +59,7 @@ struct SingleDecodeParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        maybe_s_aux(nullptr),
         kv_len(0),
         num_qo_heads(0),
         num_kv_heads(0),
@@ -84,6 +86,7 @@ struct SingleDecodeParams {
         o(o),
         lse(nullptr),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        maybe_s_aux(nullptr),
         kv_len(seq_len),
         num_qo_heads(num_qo_heads),
         num_kv_heads(num_kv_heads),
@@ -118,6 +121,7 @@ struct BatchDecodeParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  float* maybe_s_aux;
   uint32_t padded_batch_size;
   uint32_t num_qo_heads;
   IdType q_stride_n;
@@ -142,6 +146,7 @@ struct BatchDecodeParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        maybe_s_aux(nullptr),
         padded_batch_size(0),
         num_qo_heads(0),
         q_stride_n(0),
@@ -170,6 +175,7 @@ struct BatchDecodeParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        maybe_s_aux(nullptr),
         padded_batch_size(0),
         num_qo_heads(num_qo_heads),
         q_stride_n(q_stride_n),

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -88,8 +88,7 @@ struct SinglePrefillParams {
         partition_kv(false) {}
 
   __host__ SinglePrefillParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* maybe_custom_mask,
-                               DTypeO* o, float* lse, float* maybe_alibi_slopes,
-                               float* maybe_s_aux,
+                               DTypeO* o, float* lse, float* maybe_alibi_slopes, float* maybe_s_aux,
                                uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len,
                                uint32_t kv_len, uint32_t q_stride_n, uint32_t q_stride_h,
                                uint32_t kv_stride_n, uint32_t kv_stride_h, uint32_t head_dim,
@@ -230,10 +229,9 @@ struct BatchPrefillRaggedParams {
                                     IdType* q_indptr, IdType* kv_indptr, IdType* maybe_mask_indptr,
                                     IdType* maybe_q_rope_offset, IdType* maybe_k_rope_offset,
                                     DTypeO* o, float* lse, float* maybe_alibi_slopes,
-                                    float* maybe_s_aux,
-                                    uint32_t num_qo_heads, uint32_t num_kv_heads,
-                                    uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n,
-                                    uint32_t kv_stride_h, int32_t window_left,
+                                    float* maybe_s_aux, uint32_t num_qo_heads,
+                                    uint32_t num_kv_heads, uint32_t q_stride_n, uint32_t q_stride_h,
+                                    uint32_t kv_stride_n, uint32_t kv_stride_h, int32_t window_left,
                                     float logits_soft_cap, float sm_scale, float rope_scale,
                                     float rope_theta)
       : q(q),
@@ -371,10 +369,9 @@ struct BatchPrefillPagedParams {
                                    uint8_t* maybe_custom_mask, IdType* q_indptr,
                                    IdType* maybe_mask_indptr, IdType* maybe_q_rope_offset,
                                    DTypeO* o, float* lse, float* maybe_alibi_slopes,
-                                   float* maybe_s_aux,
-                                   uint32_t num_qo_heads, IdType q_stride_n, IdType q_stride_h,
-                                   int32_t window_left, float logits_soft_cap, float sm_scale,
-                                   float rope_scale, float rope_theta)
+                                   float* maybe_s_aux, uint32_t num_qo_heads, IdType q_stride_n,
+                                   IdType q_stride_h, int32_t window_left, float logits_soft_cap,
+                                   float sm_scale, float rope_scale, float rope_theta)
       : q(q),
         paged_kv(paged_kv),
         maybe_custom_mask(maybe_custom_mask),

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -38,6 +38,7 @@ struct SinglePrefillParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  float* maybe_s_aux;
   uint_fastdiv group_size;
   uint32_t qo_len;
   uint32_t kv_len;
@@ -66,6 +67,7 @@ struct SinglePrefillParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        maybe_s_aux(nullptr),
         group_size(),
         qo_len(0),
         kv_len(0),
@@ -87,6 +89,7 @@ struct SinglePrefillParams {
 
   __host__ SinglePrefillParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* maybe_custom_mask,
                                DTypeO* o, float* lse, float* maybe_alibi_slopes,
+                               float* maybe_s_aux,
                                uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len,
                                uint32_t kv_len, uint32_t q_stride_n, uint32_t q_stride_h,
                                uint32_t kv_stride_n, uint32_t kv_stride_h, uint32_t head_dim,
@@ -99,6 +102,7 @@ struct SinglePrefillParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        maybe_s_aux(maybe_s_aux),
         group_size(num_qo_heads / num_kv_heads),
         num_qo_heads(num_qo_heads),
         num_kv_heads(num_kv_heads),
@@ -146,6 +150,7 @@ struct BatchPrefillRaggedParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  float* maybe_s_aux;
   uint_fastdiv group_size;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
@@ -190,6 +195,7 @@ struct BatchPrefillRaggedParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        maybe_s_aux(nullptr),
         group_size(),
         num_qo_heads(0),
         num_kv_heads(0),
@@ -224,6 +230,7 @@ struct BatchPrefillRaggedParams {
                                     IdType* q_indptr, IdType* kv_indptr, IdType* maybe_mask_indptr,
                                     IdType* maybe_q_rope_offset, IdType* maybe_k_rope_offset,
                                     DTypeO* o, float* lse, float* maybe_alibi_slopes,
+                                    float* maybe_s_aux,
                                     uint32_t num_qo_heads, uint32_t num_kv_heads,
                                     uint32_t q_stride_n, uint32_t q_stride_h, uint32_t kv_stride_n,
                                     uint32_t kv_stride_h, int32_t window_left,
@@ -241,6 +248,7 @@ struct BatchPrefillRaggedParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        maybe_s_aux(maybe_s_aux),
         group_size(num_qo_heads / num_kv_heads),
         num_qo_heads(num_qo_heads),
         num_kv_heads(num_kv_heads),
@@ -296,6 +304,7 @@ struct BatchPrefillPagedParams {
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
+  float* maybe_s_aux;
   uint_fastdiv group_size;
   uint32_t num_qo_heads;
   IdType q_stride_n;
@@ -332,6 +341,7 @@ struct BatchPrefillPagedParams {
         o(nullptr),
         lse(nullptr),
         maybe_alibi_slopes(nullptr),
+        maybe_s_aux(nullptr),
         group_size(),
         num_qo_heads(0),
         q_stride_n(0),
@@ -361,6 +371,7 @@ struct BatchPrefillPagedParams {
                                    uint8_t* maybe_custom_mask, IdType* q_indptr,
                                    IdType* maybe_mask_indptr, IdType* maybe_q_rope_offset,
                                    DTypeO* o, float* lse, float* maybe_alibi_slopes,
+                                   float* maybe_s_aux,
                                    uint32_t num_qo_heads, IdType q_stride_n, IdType q_stride_h,
                                    int32_t window_left, float logits_soft_cap, float sm_scale,
                                    float rope_scale, float rope_theta)
@@ -373,6 +384,7 @@ struct BatchPrefillPagedParams {
         o(o),
         lse(lse),
         maybe_alibi_slopes(maybe_alibi_slopes),
+        maybe_s_aux(maybe_s_aux),
         group_size(num_qo_heads / paged_kv.num_heads),
         num_qo_heads(num_qo_heads),
         q_stride_n(q_stride_n),

--- a/include/flashinfer/attention/variants.cuh
+++ b/include/flashinfer/attention/variants.cuh
@@ -90,6 +90,16 @@ struct DefaultAttention : AttentionVariantBase {
     }
     return mask;
   })
+
+  REGISTER_M_D_UPDATE(params, kv_tile_idx, qo_head_idx, m, d, scale, {
+    if constexpr (use_softmax) {
+      if (params.maybe_s_aux != nullptr) {
+        constexpr float LOG2_E = 1.4426950408889634f;  // log2(e)
+        float s_aux_val = params.maybe_s_aux[qo_head_idx];
+        d += math::ptx_exp2((s_aux_val - m) * LOG2_E);
+      }
+    }
+  })
 };
 
 };  // namespace flashinfer

--- a/tests/attention/test_decode_sink_attention.py
+++ b/tests/attention/test_decode_sink_attention.py
@@ -386,8 +386,12 @@ def test_single_decode_sink_attention_tensor_cores(
         k_cache_ref = k.unsqueeze(0)  # [1, kv_len, num_kv_heads, head_dim]
         v_cache_ref = v.unsqueeze(0)  # [1, kv_len, num_kv_heads, head_dim]
     else:  # HND -> transpose to NHD
-        k_cache_ref = k.transpose(0, 1).unsqueeze(0)  # [1, kv_len, num_kv_heads, head_dim]
-        v_cache_ref = v.transpose(0, 1).unsqueeze(0)  # [1, kv_len, num_kv_heads, head_dim]
+        k_cache_ref = k.transpose(0, 1).unsqueeze(
+            0
+        )  # [1, kv_len, num_kv_heads, head_dim]
+        v_cache_ref = v.transpose(0, 1).unsqueeze(
+            0
+        )  # [1, kv_len, num_kv_heads, head_dim]
 
     # Compute reference output
     out_ref = sink_attention_decode_ref(

--- a/tests/attention/test_decode_sink_attention.py
+++ b/tests/attention/test_decode_sink_attention.py
@@ -1,0 +1,304 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+
+import pytest
+import torch
+from tests.test_helpers.sink_attention_reference import sink_attention_unified
+
+import flashinfer
+from flashinfer.utils import has_flashinfer_jit_cache
+
+
+def sink_attention_decode_ref(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    sink: torch.Tensor,
+    window_left: int,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Reference implementation for decode mode sink attention."""
+    return sink_attention_unified(
+        q, k_cache, v_cache, sink, window_left, causal=True, sm_scale=sm_scale, mode="incremental"
+    )
+
+
+@pytest.fixture(
+    autouse=not has_flashinfer_jit_cache(),
+    scope="module",
+)
+def warmup_jit():
+    """Warmup JIT cache for decode kernels."""
+    # This will be built on-demand during tests
+    yield
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+@pytest.mark.parametrize("kv_len", [32, 128, 512])
+@pytest.mark.parametrize(
+    "num_qo_heads,num_kv_heads",
+    [
+        (8, 8),   # MHA: equal heads
+        (32, 8),  # GQA: 4:1 ratio
+        (32, 32), # MHA: equal heads
+    ],
+)
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("window_left", [-1])  # Only test without sliding window
+@pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("kv_layout", ["NHD"])
+def test_batch_decode_with_sink_attention(
+    batch_size,
+    kv_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    window_left,
+    page_size,
+    kv_layout,
+):
+    """Test batch decode with sink attention support."""
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    # Create query tensor: [batch_size, num_qo_heads, head_dim]
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    # Create KV cache in paged format
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+
+    if kv_layout == "NHD":
+        kv_shape = [total_num_pages, 2, page_size, num_kv_heads, head_dim]
+    else:
+        kv_shape = [total_num_pages, 2, num_kv_heads, page_size, head_dim]
+
+    kv_data_fp32 = torch.randn(*kv_shape, dtype=torch.float32, device=device)
+    kv_data = kv_data_fp32.to(dtype)
+
+    # Create page indices and metadata
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    # Create sink tensor: [num_qo_heads] float32
+    # Sink values should be on similar scale to logits (QK^T * sm_scale)
+    # For typical logits, use smaller range to match expected scale
+    sinks = torch.randn(num_qo_heads, device=device, dtype=torch.float32) * 0.5
+
+    # Create workspace buffer
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # Test with FlashInfer
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        pos_encoding_mode="NONE",
+        data_type=dtype,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+        window_left=window_left,
+    )
+
+    out = wrapper.run(q, kv_data, sinks=sinks)
+
+    # Create reference implementation
+    # Convert paged KV cache to regular format for reference
+    k_cache_ref = torch.zeros(
+        batch_size, kv_len, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+    v_cache_ref = torch.zeros(
+        batch_size, kv_len, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+
+    for b in range(batch_size):
+        page_start = b * num_pages_per_seq
+        for p in range(num_pages_per_seq):
+            page_idx = page_start + p
+            token_start = p * page_size
+            token_end = min(token_start + page_size, kv_len)
+            actual_page_len = token_end - token_start
+
+            if kv_layout == "NHD":
+                k_cache_ref[b, token_start:token_end] = kv_data_fp32[
+                    page_idx, 0, :actual_page_len
+                ].to(dtype)
+                v_cache_ref[b, token_start:token_end] = kv_data_fp32[
+                    page_idx, 1, :actual_page_len
+                ].to(dtype)
+            else:
+                k_cache_ref[b, token_start:token_end] = kv_data_fp32[
+                    page_idx, 0, :, :actual_page_len
+                ].transpose(0, 1).to(dtype)
+                v_cache_ref[b, token_start:token_end] = kv_data_fp32[
+                    page_idx, 1, :, :actual_page_len
+                ].transpose(0, 1).to(dtype)
+
+    # Compute reference output
+    out_ref = sink_attention_decode_ref(q, k_cache_ref, v_cache_ref, sinks, window_left, sm_scale)
+
+    # Compare results
+    # bfloat16 may have slightly larger numerical differences due to lower precision,
+    # differences in order of operations between reference and CUDA kernel, and
+    # GQA scenarios where multiple query heads share KV heads
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=3.5e-2)
+
+
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("kv_len", [128])
+@pytest.mark.parametrize("num_qo_heads", [32])
+@pytest.mark.parametrize("num_kv_heads", [32])
+@pytest.mark.parametrize("head_dim", [128])
+def test_batch_decode_without_sink_attention(
+    batch_size, kv_len, num_qo_heads, num_kv_heads, head_dim
+):
+    """Test that decode without sinks matches decode with zero sinks."""
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    page_size = 16
+    kv_layout = "NHD"
+
+    # Create query tensor
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    # Create KV cache
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_shape = [total_num_pages, 2, page_size, num_kv_heads, head_dim]
+    kv_data = torch.randn(*kv_shape, dtype=dtype, device=device)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        pos_encoding_mode="NONE",
+        data_type=dtype,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+    )
+
+    # Test without sinks
+    out_no_sinks = wrapper.run(q, kv_data, sinks=None)
+
+    # Test with zero sinks (should match no sinks)
+    zero_sinks = torch.zeros(num_qo_heads, device=device, dtype=torch.float32)
+    out_zero_sinks = wrapper.run(q, kv_data, sinks=zero_sinks)
+
+    # Results should be very close (zero sinks should be equivalent to no sinks)
+    # Note: Even when skipping zero sinks, there may be small numerical differences
+    # due to code path differences and floating point precision
+    # bfloat16 has lower precision, so allow slightly larger tolerance
+    torch.testing.assert_close(out_no_sinks, out_zero_sinks, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize("kv_len", [64])
+@pytest.mark.parametrize("num_qo_heads", [8])
+@pytest.mark.parametrize("num_kv_heads", [8])
+@pytest.mark.parametrize("head_dim", [64])
+def test_batch_decode_sink_attention_gqa(
+    batch_size, kv_len, num_qo_heads, num_kv_heads, head_dim
+):
+    """Test sink attention with grouped query attention (GQA)."""
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    page_size = 16
+    kv_layout = "NHD"
+
+    # Create query tensor with more heads than KV
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    # Create KV cache with fewer heads
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_shape = [total_num_pages, 2, page_size, num_kv_heads, head_dim]
+    kv_data = torch.randn(*kv_shape, dtype=dtype, device=device)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    # Sink tensor should have num_qo_heads elements
+    sinks = torch.rand(num_qo_heads, device=device, dtype=torch.float32) * 5.0
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout)
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        pos_encoding_mode="NONE",
+        data_type=dtype,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+    )
+
+    # This should work with GQA
+    out = wrapper.run(q, kv_data, sinks=sinks)
+
+    # Basic sanity check: output should have correct shape
+    assert out.shape == (batch_size, num_qo_heads, head_dim)
+    assert out.dtype == dtype
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+


### PR DESCRIPTION
This PR adds sink support to standard flashinfer decode

```bash
pytest tests/attention/test_decode_sink_attention.py -xs
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.10.12, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/scratch.dmoss_gpu_1/repos/flashinfer
configfile: pytest.ini
collected 110 items

tests/attention/test_decode_sink_attention.py ..............................................................................................................

============================================================================================================================= 110 passed in 8.82s ==============================================================================================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional auxiliary "sink" (maybe_s_aux/sinks) tensor support across prefill and decode flows, integrating sink values into attention softmax and threading auxiliary buffers through single- and batch-decode (including paged KV) paths.
  * Added input normalization helper to produce a kernel-friendly sink buffer format.

* **Tests**
  * Added comprehensive tests validating sink-attention decoding across batch/single flows, layouts, GQA scenarios, paged KV, and numerical tolerances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->