### PR TITLE
perf: enable pdl for cutlass fp4 gemm

### DIFF
--- a/include/flashinfer/gemm/fp4_gemm_template_sm100.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm100.h
@@ -273,7 +273,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
                            std::string(cutlassGetStatusString(initStatus));                                  \
       throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                               \
     }                                                                                                        \
-    auto runStatus = gemm.run(args, workspace, stream, nullptr, /* enablePDL */ false);                      \
+    auto runStatus = gemm.run(args, workspace, stream, nullptr, /*enablePDL=*/true);                         \
     if (runStatus != cutlass::Status::kSuccess) {                                                            \
       std::string errMsg = "Failed to run cutlass FP4 gemm on sm100. Error: " +                              \
                            std::string(cutlassGetStatusString(runStatus));                                   \

--- a/include/flashinfer/gemm/fp4_gemm_template_sm120.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm120.h
@@ -257,7 +257,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
                            std::string(cutlass::cutlassGetStatusString(initStatus));                       \
       throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                             \
     }                                                                                                      \
-    auto runStatus = gemm.run(args, workspace, stream, nullptr, /* enablePDL */ false);                    \
+    auto runStatus = gemm.run(args, workspace, stream, nullptr, /*enablePDL=*/true);                       \
     if (runStatus != cutlass::Status::kSuccess) {                                                          \
       std::string errMsg = "Failed to run cutlass FP4 gemm on sm120. Error: " +                            \
                            std::string(cutlass::cutlassGetStatusString(runStatus));                        \


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The `enablePDL` flag is set to false, this PR turned them on.
Set to true for both because sm_100 and sm_120 should have support of pdl.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated runtime configuration for FP4 GEMM operations to enhance execution performance on SM100 and SM120 GPU architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->