### PR TITLE
feature: make the LSE returned by MLA support base 2 or e  #2113

### DIFF
--- a/csrc/batch_mla_binding.cu
+++ b/csrc/batch_mla_binding.cu
@@ -31,7 +31,8 @@ void BatchMLAPagedAttentionRun(TensorView float_workspace_buffer, TensorView int
                                Array<int64_t> plan_info_vec, TensorView q_nope, TensorView q_pe,
                                TensorView ckv_cache, TensorView kpe_cache, TensorView kv_indices,
                                TensorView o, Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                               int64_t num_heads, int64_t page_size, double sm_scale);
+                               int64_t num_heads, int64_t page_size, double sm_scale,
+                               bool return_lse_base_on_e);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, BatchMLAPagedAttentionPlan);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, BatchMLAPagedAttentionRun);

--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -31,7 +31,8 @@ void BatchMLAPagedAttentionRun(TensorView float_workspace_buffer, TensorView int
                                Array<int64_t> plan_info_vec, TensorView q_nope, TensorView q_pe,
                                TensorView ckv_cache, TensorView kpe_cache, TensorView kv_indices,
                                TensorView o, Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                               int64_t num_heads, int64_t page_size, double sm_scale) {
+                               int64_t num_heads, int64_t page_size, double sm_scale,
+                               bool return_lse_base_on_e) {
   // q_nope: [n, num_heads, head_dim_ckv]
   // q_pe: [n, num_heads, head_dim_kpe]
   // ckv_cache: [num_pages, page_size, head_dim_ckv]
@@ -112,6 +113,7 @@ void BatchMLAPagedAttentionRun(TensorView float_workspace_buffer, TensorView int
         params.o_stride_h = o_stride_h;
 
         params.sm_scale = sm_scale;
+        params.return_lse_base_on_e = return_lse_base_on_e;
 
         cudaError_t status = mla::BatchMLAPagedAttention<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
             params, plan_info.num_blks_x, plan_info.num_blks_y, stream);

--- a/csrc/batch_mla_sm90_binding.cu
+++ b/csrc/batch_mla_sm90_binding.cu
@@ -32,8 +32,8 @@ void BatchMLAPagedAttentionSM90Run(TensorView float_workspace_buffer,
                                    TensorView q_nope, TensorView q_pe, TensorView ckv_cache,
                                    TensorView kpe_cache, TensorView kv_indices, TensorView o,
                                    Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                                   int64_t num_heads, int64_t page_size,
-                                   double sm_scale ADDITIONAL_FUNC_PARAMS);
+                                   int64_t num_heads, int64_t page_size, double sm_scale,
+                                   bool return_lse_base_on_e ADDITIONAL_FUNC_PARAMS);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, BatchMLAPagedAttentionSM90Plan);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, BatchMLAPagedAttentionSM90Run);

--- a/csrc/batch_mla_sm90_run.cu
+++ b/csrc/batch_mla_sm90_run.cu
@@ -31,8 +31,8 @@ void BatchMLAPagedAttentionSM90Run(TensorView float_workspace_buffer,
                                    TensorView q_nope, TensorView q_pe, TensorView ckv_cache,
                                    TensorView kpe_cache, TensorView kv_indices, TensorView o,
                                    Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                                   int64_t num_heads, int64_t page_size,
-                                   double sm_scale ADDITIONAL_FUNC_PARAMS) {
+                                   int64_t num_heads, int64_t page_size, double sm_scale,
+                                   bool return_lse_base_on_e ADDITIONAL_FUNC_PARAMS) {
   // q_nope: [n, num_heads, head_dim_ckv]
   // q_pe: [n, num_heads, head_dim_kpe]
   // ckv_cache: [num_pages, page_size, head_dim_ckv]
@@ -111,6 +111,7 @@ void BatchMLAPagedAttentionSM90Run(TensorView float_workspace_buffer,
         params.kpe_stride_n = kpe_stride_n;
         params.o_stride_n = o_stride_n;
         params.o_stride_h = o_stride_h;
+        params.return_lse_base_on_e = return_lse_base_on_e;
 
         ADDITIONAL_PARAMS_SETTER
 

--- a/flashinfer/mla.py
+++ b/flashinfer/mla.py
@@ -314,6 +314,7 @@ class BatchMLAPagedAttentionWrapper:
         profiler_buffer: Optional[torch.Tensor] = None,
         kv_len: Optional[torch.Tensor] = None,
         page_table: Optional[torch.Tensor] = None,
+        return_lse_base_on_e: bool = False,
     ) -> torch.Tensor: ...
 
     @overload
@@ -329,6 +330,7 @@ class BatchMLAPagedAttentionWrapper:
         profiler_buffer: Optional[torch.Tensor] = None,
         kv_len: Optional[torch.Tensor] = None,
         page_table: Optional[torch.Tensor] = None,
+        return_lse_base_on_e: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
     def run(
@@ -343,6 +345,7 @@ class BatchMLAPagedAttentionWrapper:
         profiler_buffer: Optional[torch.Tensor] = None,
         kv_len: Optional[torch.Tensor] = None,
         page_table: Optional[torch.Tensor] = None,
+        return_lse_base_on_e: bool = False,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         r"""Run the MLA attention computation.
 
@@ -441,6 +444,7 @@ class BatchMLAPagedAttentionWrapper:
             num_heads,
             page_size,
             sm_scale,
+            return_lse_base_on_e,
             *profiler_args,
         )
 

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -628,7 +628,8 @@ __device__ void DevicePersistentMergeStates(
     typename KTraits::IdType* merge_partial_packed_offset_end,
     typename KTraits::IdType* merge_partial_stride, typename KTraits::DTypeO* partial_o,
     float* partial_lse, typename KTraits::DTypeO* final_o, float* final_lse,
-    const uint32_t o_stride_n, const uint32_t o_stride_h, const uint_fastdiv& num_heads) {
+    const uint32_t o_stride_n, const uint32_t o_stride_h, const uint_fastdiv& num_heads,
+    const bool& return_lse_base_on_e) {
   constexpr uint32_t VEC_SIZE = 8;  // partial o has data type float
   constexpr uint32_t NUM_THRS_PER_ROW = KTraits::HEAD_DIM_CKV / VEC_SIZE;
   constexpr uint32_t ROWS_PER_ITERATION = (KTraits::NUM_THREADS) / NUM_THRS_PER_ROW;
@@ -660,7 +661,10 @@ __device__ void DevicePersistentMergeStates(
     st.o.cast_store(final_o +
                     (q * o_stride_n + r * o_stride_h + (thread_id % NUM_THRS_PER_ROW) * VEC_SIZE));
     if (final_lse) {
-      final_lse[q * num_heads + r] = st.get_lse() * math::loge2;
+      final_lse[q * num_heads + r] = st.get_lse();
+      if (return_lse_base_on_e) {
+        final_lse[q * num_heads + r] *= math::loge2;
+      }
     }
   }
 }
@@ -672,8 +676,8 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
                                         float (*o_frag)[8], typename KTraits::DTypeQKAccum* m,
                                         float* d, const uint32_t o_stride_n,
                                         const uint32_t o_stride_h, const uint32_t q_len,
-                                        const uint32_t packed_offset,
-                                        const uint_fastdiv& num_heads) {
+                                        const uint32_t packed_offset, const uint_fastdiv& num_heads,
+                                        const bool& return_lse_base_on_e) {
   using DTypeO = typename KTraits::DTypeO;
   constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
   constexpr uint32_t HEAD_DIM_CKV = KTraits::HEAD_DIM_CKV;
@@ -743,7 +747,10 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
         uint32_t q, r;
         num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4, q, r);
         if (lane_idx % 4 == 0 && q < q_len) {
-          final_lse[q * num_heads + r] = math::loge2 * (math::ptx_log2(d[j]) + float(m[j]));
+          final_lse[q * num_heads + r] = math::ptx_log2(d[j]) + float(m[j]);
+          if (return_lse_base_on_e) {
+            final_lse[q * num_heads + r] *= math::loge2;
+          }
         }
       }
     }
@@ -967,7 +974,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
         final_lse ? final_lse + q_indptr * num_heads : nullptr,
         (partial_indptr == -1) ? nullptr : partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
         (partial_indptr == -1) ? nullptr : partial_lse + partial_indptr, o_frag, m, d, o_stride_n,
-        o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads);
+        o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads, params.return_lse_base_on_e);
   }
 
   auto grid = cg::this_grid();
@@ -978,7 +985,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
       params.merge_packed_offset_start, params.merge_packed_offset_end,
       params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
       params.merge_partial_stride, partial_o, partial_lse, final_o, final_lse, o_stride_n,
-      o_stride_h, num_heads);
+      o_stride_h, num_heads, params.return_lse_base_on_e);
 }
 
 #define DISPATCH_SMEM_CONFIG(smem_limit_per_sm, NUM_STAGES, CTA_TILE_KV, QK_SHARD, ...) \

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -455,7 +455,8 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
                                         float* partial_lse, float(*o_frag), float* m, float* d,
                                         const uint32_t o_stride_n, const uint32_t o_stride_h,
                                         const uint32_t q_len, const uint32_t packed_offset,
-                                        const uint_fastdiv& num_heads) {
+                                        const uint_fastdiv& num_heads,
+                                        const bool& return_lse_base_on_e) {
   using DTypeO = typename KTraits::DTypeO;
   constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
   constexpr uint32_t HEAD_DIM_CKV = KTraits::HEAD_DIM_CKV;
@@ -542,7 +543,10 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
           uint32_t q, r;
           num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4, q, r);
           if (lane_idx % 4 == 0 && q < q_len) {
-            final_lse[q * num_heads + r] = math::loge2 * (math::ptx_log2(d[j]) + float(m[j]));
+            final_lse[q * num_heads + r] = math::ptx_log2(d[j]) + float(m[j]);
+            if (return_lse_base_on_e) {
+              final_lse[q * num_heads + r] *= math::loge2;
+            }
           }
         }
       }
@@ -796,7 +800,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
           final_lse ? final_lse + q_indptr * num_heads : nullptr,
           (partial_indptr == -1) ? nullptr : partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
           (partial_indptr == -1) ? nullptr : partial_lse + partial_indptr, o_frag, m, d, o_stride_n,
-          o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads);
+          o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads, params.return_lse_base_on_e);
       PROFILER_EVENT_END(variant, ProfileEventType::kWriteO);
       __syncthreads();
     }
@@ -936,7 +940,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
           final_lse ? final_lse + q_indptr * num_heads : nullptr,
           (partial_indptr == -1) ? nullptr : partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
           (partial_indptr == -1) ? nullptr : partial_lse + partial_indptr, o_frag, m, d, o_stride_n,
-          o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads);
+          o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads, params.return_lse_base_on_e);
       PROFILER_EVENT_END(variant, ProfileEventType::kWriteO);
       __syncthreads();
     }
@@ -953,7 +957,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
       params.merge_packed_offset_start, params.merge_packed_offset_end,
       params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
       params.merge_partial_stride, partial_o, partial_lse, final_o, final_lse, o_stride_n,
-      o_stride_h, num_heads);
+      o_stride_h, num_heads, params.return_lse_base_on_e);
 
   PROFILER_EVENT_END(variant, ProfileEventType::kSplitK);
 }

--- a/include/flashinfer/attention/mla_params.cuh
+++ b/include/flashinfer/attention/mla_params.cuh
@@ -71,6 +71,7 @@ struct MLAParams {
   uint32_t o_stride_h;
 
   float sm_scale;
+  bool return_lse_base_on_e;
 };
 
 };  // namespace flashinfer


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This pr adds a parameter `return_lse_base_on_e` to control the base of LSE returned by MLA. Default to `False`, which keeps the same with current implementation. If `return_lse_base_on_e` is `True`, multiply the final LSE by `loge2` to maintain consistency with the standard softmax and FA3.

## 🔍 Related Issues

#2113 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a run-time option to control whether returned log‑sum‑exp (LSE) baselines are scaled by ln(2) (default: disabled).

* **Bug Fixes**
  * Conditional scaling ensures returned LSE values are consistent when the option is enabled, improving numerical consistency.

* **Chores**
  * The new option is exposed in public APIs and bindings and is propagated through the execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->