### PR TITLE
update autotuner input tensor random range

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -62,8 +62,8 @@ class DynamicTensorSpec:
         if self.tensor_initializers is None:
             self.tensor_initializers = [
                 lambda shapes, dtype, device: (
-                    torch.randn(shapes, device=device).to(dtype) * 10 - 5
-                )
+                    torch.rand(shapes, device=device) * 10 - 5
+                ).to(dtype)
                 for _ in range(len(self.input_idx))
             ]
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Update autotuner input tensor random range from [0,1) to [-5,5) for larger range and closer to real tensor

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tensor initialization used during autotuning: values are now drawn from a symmetric range around zero ([-5, 5]) with a more uniform-like distribution, yielding more consistent and stable parameter tuning results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->