### PR TITLE
Bump tvm ffi version to 0.1.4

### DIFF
--- a/csrc/batch_attention.cu
+++ b/csrc/batch_attention.cu
@@ -48,7 +48,7 @@ Array<int64_t> BatchPagedAttentionPlan(TensorView float_workspace_buffer,
 
   HolisticPlanInfo<2> plan_info;
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   cudaError_t status = TwoStageHolisticPlan<IdType>(
@@ -102,7 +102,7 @@ void BatchPagedAttentionRun(TensorView float_workspace_buffer, TensorView int_wo
     v_stride_n = v_cache.stride(2);
   }
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
 
   DISPATCH_context(

--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -53,7 +53,7 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlan(
       << "CUDA cores template only supports equal head dim for QK and VO, please use tensor "
          "cores template for different head dim";
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
   DISPATCH_context(
       DTypeQ, DTypeKV, DTypeO, IdType, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
@@ -130,7 +130,7 @@ void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
   }
   kv_cache_strides = k_strides.data();
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
 
   DISPATCH_context(

--- a/csrc/batch_decode_mla_cute_sm80.cu
+++ b/csrc/batch_decode_mla_cute_sm80.cu
@@ -23,7 +23,7 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlanMLA(ffi::TensorView float_workspac
       int_workspace_buffer.size(0) * get_element_size(int_workspace_buffer);
 
   DecodePlanInfo plan_info;
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   auto work_estimation_func = BatchDecodeWithPagedKVCacheWorkEstimationDispatchedMlaCuteSM80<
@@ -103,7 +103,7 @@ void BatchDecodeWithPagedKVCacheRunMLA(
   }
   params.padded_batch_size = plan_info.padded_batch_size;
 
-  cudaSetDevice(paged_ckv_cache.device().device_id);
+  ffi::CUDADeviceGuard device_guard(paged_ckv_cache.device().device_id);
   const cudaStream_t stream = get_stream(paged_ckv_cache.device());
   cudaError_t status = BatchDecodeWithPagedKVCacheDispatchedMlaCuteSM80<HEAD_DIM_CKV, HEAD_DIM_KPE,
                                                                         QO_TILE_LEN, Params>(

--- a/csrc/batch_decode_mla_plan.cu
+++ b/csrc/batch_decode_mla_plan.cu
@@ -15,7 +15,7 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlanMLA(TensorView float_workspace_buf
                                                   TensorView indptr, int64_t batch_size,
                                                   int64_t num_qo_heads, int64_t page_size,
                                                   bool enable_cuda_graph) {
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   size_t float_workspace_size_in_bytes =

--- a/csrc/batch_decode_mla_run.cu
+++ b/csrc/batch_decode_mla_run.cu
@@ -35,7 +35,7 @@ void BatchDecodeWithPagedKVCacheRunMLA(
   void* float_buffer = static_cast<void*>(float_workspace_buffer.data_ptr());
   void* int_buffer = static_cast<void*>(int_workspace_buffer.data_ptr());
 
-  cudaSetDevice(q_nope.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q_nope.device().device_id);
   const cudaStream_t stream = get_stream(q_nope.device());
 
   paged_kv_mla_t<DTypeKV, IdType> paged_kv(

--- a/csrc/batch_mla_plan.cu
+++ b/csrc/batch_mla_plan.cu
@@ -38,7 +38,7 @@ Array<int64_t> BatchMLAPagedAttentionPlan(TensorView float_workspace_buffer,
 
   int batch_size = kv_len.size(0);
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   cudaError_t status =

--- a/csrc/batch_mla_run.cu
+++ b/csrc/batch_mla_run.cu
@@ -56,7 +56,7 @@ void BatchMLAPagedAttentionRun(TensorView float_workspace_buffer, TensorView int
   unsigned int o_stride_n = o.stride(0);
   unsigned int o_stride_h = o.stride(1);
 
-  cudaSetDevice(q_nope.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q_nope.device().device_id);
   const cudaStream_t stream = get_stream(q_nope.device());
 
   DISPATCH_context(

--- a/csrc/batch_mla_sm90_plan.cu
+++ b/csrc/batch_mla_sm90_plan.cu
@@ -38,7 +38,7 @@ Array<int64_t> BatchMLAPagedAttentionSM90Plan(TensorView float_workspace_buffer,
 
   int batch_size = kv_len.size(0);
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   cudaError_t status =

--- a/csrc/batch_mla_sm90_run.cu
+++ b/csrc/batch_mla_sm90_run.cu
@@ -56,7 +56,7 @@ void BatchMLAPagedAttentionSM90Run(TensorView float_workspace_buffer,
   unsigned int o_stride_n = o.stride(0);
   unsigned int o_stride_h = o.stride(1);
 
-  cudaSetDevice(q_nope.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q_nope.device().device_id);
   const cudaStream_t stream = get_stream(q_nope.device());
 
   DISPATCH_context(

--- a/csrc/batch_pod.cu
+++ b/csrc/batch_pod.cu
@@ -100,7 +100,7 @@ void batch_pod_with_kv_cache_tensor(
   }
   kv_cache_strides_p = k_strides_p.data();
 
-  cudaSetDevice(float_workspace_buffer_p.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer_p.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer_p.device());
 
   // Decode setup (TensorView decode = batched prefill)
@@ -152,7 +152,7 @@ void batch_pod_with_kv_cache_tensor(
   kv_cache_strides_d = k_strides_d.data();
 
   // Already handled by prefill
-  // cudaSetDevice(float_workspace_buffer_d.device().device_id);
+  // ffi::CUDADeviceGuard device_guard(float_workspace_buffer_d.device().device_id);
   // const cudaStream_t stream = get_stream(float_workspace_buffer_d.device());
 
   DISPATCH_context(

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -58,7 +58,7 @@ Array<int64_t> BatchPrefillWithKVCachePlan(
 
   PrefillPlanInfo plan_info;
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
   cudaError_t status = PrefillPlan<IdType>(
       float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
@@ -114,7 +114,7 @@ void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
 
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   DISPATCH_context(
@@ -247,7 +247,7 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
         << "k/v strides differs at " << i;
   }
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   DISPATCH_context(

--- a/csrc/batch_prefill_fp8_sm90.cu
+++ b/csrc/batch_prefill_fp8_sm90.cu
@@ -50,7 +50,7 @@ Array<int64_t> BatchPrefillWithKVCacheSM90Plan(
 
   flashinfer::PrefillPlanSM90Info plan_info;
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   cudaError_t status = PrefillSM90Plan(
@@ -111,7 +111,7 @@ void BatchPrefillWithPagedKVCacheSM90Run(
   void* float_buffer_ptr = float_workspace_buffer.data_ptr();
   void* int_buffer_ptr = int_workspace_buffer.data_ptr();
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
   bool use_swa = window_left != -1;

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -56,7 +56,7 @@ Array<int64_t> BatchPrefillWithKVCacheSM90Plan(
 
   flashinfer::PrefillPlanSM90Info plan_info;
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
   cudaError_t status = PrefillSM90Plan(
@@ -97,7 +97,7 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
 
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
   bool use_swa = window_left != -1;
@@ -193,7 +193,7 @@ void BatchPrefillWithPagedKVCacheSM90Run(
   void* float_buffer_ptr = float_workspace_buffer.data_ptr();
   void* int_buffer_ptr = int_workspace_buffer.data_ptr();
 
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
   bool use_swa = window_left != -1;

--- a/csrc/blackwell_fmha_plan.cu
+++ b/csrc/blackwell_fmha_plan.cu
@@ -21,7 +21,7 @@ void blackwell_fmha_plan(TensorView qo_segment_offsets, TensorView kv_segment_of
                          TensorView work_indptr, TensorView qo_tile_indices,
                          TensorView head_indices, TensorView batch_indices, int64_t qo_tile_size,
                          int64_t num_heads, int64_t num_buckets, bool causal) {
-  cudaSetDevice(qo_segment_offsets.device().device_id);
+  ffi::CUDADeviceGuard device_guard(qo_segment_offsets.device().device_id);
   const cudaStream_t stream = get_stream(qo_tile_indices.device());
   int batch_size = qo_segment_offsets.size(0) - 1;
 

--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -45,7 +45,7 @@ void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, Tenso
         auto n = B.size(2);
 
         auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
-        cudaSetDevice(A.device().device_id);
+        ffi::CUDADeviceGuard device_guard(A.device().device_id);
         auto stream = get_stream(A.device());
 
         auto status = flashinfer::bmm_fp8::bmm_fp8_internal_cublaslt(

--- a/csrc/cascade.cu
+++ b/csrc/cascade.cu
@@ -41,7 +41,7 @@ void merge_state(TensorView v_a, TensorView s_a, TensorView v_b, TensorView s_b,
   unsigned int num_heads = v_a.size(1);
   unsigned int head_dim = v_a.size(2);
 
-  cudaSetDevice(v_a.device().device_id);
+  ffi::CUDADeviceGuard device_guard(v_a.device().device_id);
   auto stream = get_stream(v_a.device());
 
   bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(v_a.dtype(), c_type, [&] {
@@ -85,7 +85,7 @@ void merge_state_in_place(TensorView v, TensorView s, TensorView v_other, Tensor
   unsigned int num_heads = v.size(1);
   unsigned int head_dim = v.size(2);
 
-  cudaSetDevice(v.device().device_id);
+  ffi::CUDADeviceGuard device_guard(v.device().device_id);
   auto stream = get_stream(v.device());
   bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(v.dtype(), c_type, [&] {
     cudaError_t status = MergeStateInPlace(
@@ -114,7 +114,7 @@ void merge_states(TensorView v, TensorView s, TensorView v_merged, TensorView s_
   unsigned int num_heads = v.size(2);
   unsigned int head_dim = v.size(3);
 
-  cudaSetDevice(v.device().device_id);
+  ffi::CUDADeviceGuard device_guard(v.device().device_id);
   auto stream = get_stream(v.device());
   bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(v.dtype(), c_type, [&] {
     cudaError_t status = MergeStates(

--- a/csrc/cutlass_mla.cu
+++ b/csrc/cutlass_mla.cu
@@ -23,7 +23,7 @@ using namespace flashinfer::attention;
 void CutlassMLAPagedAttention(ffi::TensorView workspace, ffi::TensorView out, ffi::TensorView lse,
                               ffi::TensorView q_nope_pe, ffi::TensorView ckv_kpe_cache,
                               ffi::TensorView kv_lens, ffi::TensorView page_table) {
-  cudaSetDevice(q_nope_pe.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q_nope_pe.device().device_id);
   const cudaStream_t stream = get_stream(q_nope_pe.device());
 
   int device_index = q_nope_pe.device().device_id;

--- a/csrc/fmha_cutlass_sm100.cu
+++ b/csrc/fmha_cutlass_sm100.cu
@@ -96,7 +96,7 @@ void FMHACutlassSM100Run(ffi::TensorView workspace_buffer, ffi::TensorView q, ff
   int v_stride_n = v.stride(0);
   int v_stride_h = v.stride(1);
 
-  cudaSetDevice(qo_segment_offsets.device().device_id);
+  ffi::CUDADeviceGuard device_guard(qo_segment_offsets.device().device_id);
   const cudaStream_t stream = get_stream(o.device());
 
   DISPATCH_context(DTypeIn, DTypeOut, HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE, [&] {

--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -91,7 +91,7 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
                                      int64_t scale_granularity_m, int64_t scale_granularity_n,
                                      int64_t scale_granularity_k, std::string scale_major_mode,
                                      int64_t mma_sm) {
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(C.device());
   DISPATCH_SCALE_MAJOR_K(scale_major_mode, SCALE_MAJOR_K, [&] {
     return DISPATCH_MMA_SM(mma_sm, MMA_SM, [&] {

--- a/csrc/gemm_groupwise_sm120.cu
+++ b/csrc/gemm_groupwise_sm120.cu
@@ -86,7 +86,7 @@ void CutlassGemmGroupwiseScaledSM120(TensorView float_workspace_buffer, TensorVi
                                      TensorView SFA, TensorView SFB, TensorView C,
                                      int64_t scale_granularity_m, int64_t scale_granularity_n,
                                      int64_t scale_granularity_k, std::string scale_major_mode) {
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   auto stream = get_stream(C.device());
 
   // Ensure scales are contiguous

--- a/csrc/group_gemm.cu
+++ b/csrc/group_gemm.cu
@@ -25,7 +25,7 @@ void CutlassSegmentGEMM(TensorView workspace_buffer, TensorView all_problems, Te
                         TensorView y_ld, TensorView empty_x_data, bool weight_column_major) {
   unsigned int batch_size = x_ptr.size(0);
 
-  cudaSetDevice(workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(workspace_buffer.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(empty_x_data.dtype(), c_type, [&] {
     using cutlass_t = cutlass_dtype_t<c_type>;

--- a/csrc/group_gemm_fp8_groupwise_sm100.cu
+++ b/csrc/group_gemm_fp8_groupwise_sm100.cu
@@ -91,7 +91,7 @@ void CutlassGroupGemmFP8GroupwiseScaledSM100(
     TensorView SFA, TensorView SFB, TensorView D, TensorView m_indptr, int64_t n, int64_t k,
     int64_t scale_granularity_m, int64_t scale_granularity_n, int64_t scale_granularity_k,
     std::string scale_major_mode, int64_t mma_sm) {
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   auto stream = get_stream(D.device());
   int num_groups = m_indptr.size(0) - 1;
   int max_m = SFA.size(1);

--- a/csrc/group_gemm_fp8_groupwise_sm120.cu
+++ b/csrc/group_gemm_fp8_groupwise_sm120.cu
@@ -85,7 +85,7 @@ void CutlassGroupGemmFP8GroupwiseScaledSM120(
     TensorView SFA, TensorView SFB, TensorView D, TensorView m_indptr, int64_t n, int64_t k,
     int64_t scale_granularity_m, int64_t scale_granularity_n, int64_t scale_granularity_k,
     std::string scale_major_mode) {
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   auto stream = get_stream(D.device());
   int num_groups = m_indptr.size(0) - 1;
 

--- a/csrc/group_gemm_mxfp4_groupwise_sm100.cu
+++ b/csrc/group_gemm_mxfp4_groupwise_sm100.cu
@@ -133,7 +133,7 @@ void CutlassGroupGemmMXFP4GroupwiseScaledSM100(TensorView int_workspace_buffer,
                                                TensorView D, TensorView m_indptr, int64_t n,
                                                int64_t k, int64_t mma_sm, int64_t tile_m,
                                                int64_t tile_n, int64_t tile_k, bool swap_ab) {
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   auto stream = get_stream(A.device());
   int num_groups = m_indptr.size(0) - 1;
   DISPATCH_DLPACK_INPUT_OUTPUT_DTYPE(

--- a/csrc/group_gemm_sm90.cu
+++ b/csrc/group_gemm_sm90.cu
@@ -53,7 +53,7 @@ void CutlassSegmentGEMMSM90(TensorView float_workspace_buffer, TensorView int_wo
                             TensorView y_stride, TensorView empty_x_data, TensorView empty_y_data,
                             bool weight_column_major) {
   unsigned int batch_size = x_ptr.size(0);
-  cudaSetDevice(float_workspace_buffer.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
   DISPATCH_DLPACK_INPUT_OUTPUT_DTYPE(
       empty_x_data.dtype(), empty_y_data.dtype(), c_type_in, c_type_out, [&] {

--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -36,7 +36,7 @@ void rmsnorm(TensorView output, TensorView input, TensorView weight, double eps,
     unsigned int hidden_size = input.size(1);
     TVM_FFI_ICHECK_EQ(output.size(0), batch_size);
     TVM_FFI_ICHECK_EQ(output.size(1), hidden_size);
-    cudaSetDevice(input.device().device_id);
+    ffi::CUDADeviceGuard device_guard(input.device().device_id);
     const cudaStream_t stream = get_stream(input.device());
 
     DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
@@ -60,7 +60,7 @@ void rmsnorm(TensorView output, TensorView input, TensorView weight, double eps,
     TVM_FFI_ICHECK_EQ(output.size(1), num_heads);
     TVM_FFI_ICHECK_EQ(output.size(2), hidden_size);
 
-    cudaSetDevice(input.device().device_id);
+    ffi::CUDADeviceGuard device_guard(input.device().device_id);
     const cudaStream_t stream = get_stream(input.device());
     DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
       cudaError_t status = norm::QKRMSNorm(
@@ -92,7 +92,7 @@ void fused_add_rmsnorm(TensorView input, TensorView residual, TensorView weight,
   TVM_FFI_ICHECK_EQ(residual.size(0), batch_size);
   TVM_FFI_ICHECK_EQ(residual.size(1), hidden_size);
   TVM_FFI_ICHECK_EQ(weight.size(0), hidden_size);
-  cudaSetDevice(input.device().device_id);
+  ffi::CUDADeviceGuard device_guard(input.device().device_id);
   const cudaStream_t stream = get_stream(input.device());
 
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
@@ -119,7 +119,7 @@ void gemma_rmsnorm(TensorView output, TensorView input, TensorView weight, doubl
   unsigned int hidden_size = input.size(1);
   TVM_FFI_ICHECK_EQ(output.size(0), batch_size);
   TVM_FFI_ICHECK_EQ(output.size(1), hidden_size);
-  cudaSetDevice(input.device().device_id);
+  ffi::CUDADeviceGuard device_guard(input.device().device_id);
   const cudaStream_t stream = get_stream(input.device());
 
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
@@ -148,7 +148,7 @@ void gemma_fused_add_rmsnorm(TensorView input, TensorView residual, TensorView w
   TVM_FFI_ICHECK_EQ(residual.size(0), batch_size);
   TVM_FFI_ICHECK_EQ(residual.size(1), hidden_size);
   TVM_FFI_ICHECK_EQ(weight.size(0), hidden_size);
-  cudaSetDevice(input.device().device_id);
+  ffi::CUDADeviceGuard device_guard(input.device().device_id);
   const cudaStream_t stream = get_stream(input.device());
 
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
@@ -177,7 +177,7 @@ void layernorm(Tensor output, Tensor input, Tensor gamma, Tensor beta, double ep
   unsigned int hidden_size = input.size(1);
   TVM_FFI_ICHECK_EQ(output.size(0), batch_size);
   TVM_FFI_ICHECK_EQ(output.size(1), hidden_size);
-  cudaSetDevice(input.device().device_id);
+  ffi::CUDADeviceGuard device_guard(input.device().device_id);
   const cudaStream_t stream = get_stream(input.device());
   // TODO(kaixih): This is currently our only use case; Add more if needed.
   TVM_FFI_ICHECK_EQ(input.dtype(), dl_bfloat16) << "input must be bfloat16";

--- a/csrc/page.cu
+++ b/csrc/page.cu
@@ -88,7 +88,7 @@ void append_paged_kv_cache(TensorView append_key, TensorView append_value, Tenso
   TVM_FFI_ICHECK_EQ(append_value.size(1), num_heads);
   TVM_FFI_ICHECK_EQ(append_value.size(2), head_dim);
 
-  cudaSetDevice(append_key.device().device_id);
+  ffi::CUDADeviceGuard device_guard(append_key.device().device_id);
   const cudaStream_t stream = get_stream(append_key.device());
   bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE(paged_k_cache.dtype(), c_type, [&] {
     paged_kv_t<c_type, int32_t> paged_kv(
@@ -122,7 +122,7 @@ void block_sparse_indices_to_vector_sparse_offsets(
   CHECK_INPUT(vector_sparse_indptr);
   CHECK_INPUT(kv_len_arr);
 
-  cudaSetDevice(block_sparse_indices.device().device_id);
+  ffi::CUDADeviceGuard device_guard(block_sparse_indices.device().device_id);
   const cudaStream_t stream = get_stream(block_sparse_indices.device());
 
   cudaError_t status = BlockSparseIndicesToVectorSparseOffset(
@@ -190,7 +190,7 @@ void append_paged_mla_kv_cache(TensorView append_ckv, TensorView append_kpe,
   TVM_FFI_ICHECK_EQ(append_ckv.size(1), ckv_dim);
   TVM_FFI_ICHECK_EQ(append_kpe.size(1), kpe_dim);
 
-  cudaSetDevice(append_ckv.device().device_id);
+  ffi::CUDADeviceGuard device_guard(append_ckv.device().device_id);
   const cudaStream_t stream = get_stream(append_ckv.device());
   bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE(ckv_cache.dtype(), c_type, [&] {
     paged_kv_mla_t<c_type, int32_t> paged_mla_kv(

--- a/csrc/pod.cu
+++ b/csrc/pod.cu
@@ -133,7 +133,7 @@ void pod_with_kv_cache_tensor(
   }
   kv_cache_strides_d = k_strides_d.data();
 
-  cudaSetDevice(float_workspace_buffer_d.device().device_id);
+  ffi::CUDADeviceGuard device_guard(float_workspace_buffer_d.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer_d.device());
 
   DISPATCH_context(

--- a/csrc/renorm.cu
+++ b/csrc/renorm.cu
@@ -29,7 +29,7 @@ void top_p_renorm_probs(TensorView probs, TensorView renorm_probs,
   unsigned int vocab_size = probs.size(1);
   bool has_top_p_arr = maybe_top_p_arr.has_value();
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::TopPRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
@@ -47,7 +47,7 @@ void top_k_renorm_probs(TensorView probs, TensorView renorm_probs,
   unsigned int vocab_size = probs.size(1);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::TopKRenormProb<float>(
       static_cast<float*>(probs.data_ptr()), static_cast<float*>(renorm_probs.data_ptr()),
@@ -66,7 +66,7 @@ void top_k_mask_logits(TensorView logits, TensorView mask_logits,
   unsigned int vocab_size = logits.size(1);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
 
-  cudaSetDevice(logits.device().device_id);
+  ffi::CUDADeviceGuard device_guard(logits.device().device_id);
   auto stream = get_stream(logits.device());
   cudaError_t status = sampling::TopKMaskLogits<float>(
       static_cast<float*>(logits.data_ptr()), static_cast<float*>(mask_logits.data_ptr()),

--- a/csrc/rope.cu
+++ b/csrc/rope.cu
@@ -51,7 +51,7 @@ void apply_rope(TensorView q, TensorView k, TensorView q_rope, TensorView k_rope
   size_t k_rope_stride_h = k_rope.stride(1);
   TVM_FFI_ICHECK_EQ(indptr.dtype(), offsets.dtype());
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
     return DISPATCH_DLPACK_IDTYPE_TO_CTYPE(indptr.dtype(), c_idtype, [&] {
@@ -94,7 +94,7 @@ void apply_rope_pos_ids(TensorView q, TensorView k, TensorView q_rope, TensorVie
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
     return DISPATCH_DLPACK_IDTYPE_TO_CTYPE(pos_ids.dtype(), c_idtype, [&] {
@@ -144,7 +144,7 @@ void apply_rope_pos_ids_cos_sin_cache(TensorView q, TensorView k, TensorView q_r
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
     return DISPATCH_DLPACK_IDTYPE_TO_CTYPE(pos_ids.dtype(), c_idtype, [&] {
@@ -196,7 +196,7 @@ void apply_llama31_rope(TensorView q, TensorView k, TensorView q_rope, TensorVie
   size_t k_rope_stride_h = k_rope.stride(1);
   TVM_FFI_ICHECK_EQ(indptr.dtype(), offsets.dtype());
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
     return DISPATCH_DLPACK_IDTYPE_TO_CTYPE(indptr.dtype(), c_idtype, [&] {
@@ -242,7 +242,7 @@ void apply_llama31_rope_pos_ids(TensorView q, TensorView k, TensorView q_rope, T
   size_t k_rope_stride_n = k_rope.stride(0);
   size_t k_rope_stride_h = k_rope.stride(1);
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
     return DISPATCH_DLPACK_IDTYPE_TO_CTYPE(pos_ids.dtype(), c_idtype, [&] {
@@ -393,7 +393,7 @@ void rope_quantize(TensorView q_rope_in, TensorView k_rope_in, TensorView q_nope
     k_nope_out_stride_h = k_nope_out.stride(1);
   }
 
-  cudaSetDevice(q_rope_in.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q_rope_in.device().device_id);
   const cudaStream_t stream = get_stream(q_rope_in.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q_rope_in.dtype(), c_type, [&] {
     return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(q_rope_out.dtype(), c_quant_type, [&] {
@@ -542,7 +542,7 @@ void rope_quantize_append_paged_kv_cache(
     v_in_stride_h = v_in.stride(1);
   }
 
-  cudaSetDevice(q_rope_in.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q_rope_in.device().device_id);
   const cudaStream_t stream = get_stream(q_rope_in.device());
 
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q_rope_in.dtype(), c_type, [&] {

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -32,7 +32,7 @@ void softmax(TensorView workspace_buffer, TensorView logits, TensorView output,
 
   bool has_temperature_arr = maybe_temperature_arr.has_value();
 
-  cudaSetDevice(logits.device().device_id);
+  ffi::CUDADeviceGuard device_guard(logits.device().device_id);
   auto stream = get_stream(logits.device());
   cudaError_t status = sampling::OnlineSoftmax<float>(
       static_cast<float*>(logits.data_ptr()), static_cast<float*>(output.data_ptr()), batch_size,
@@ -51,7 +51,7 @@ void sampling_from_logits(TensorView logits, TensorView output, Optional<TensorV
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = logits.size(1);
 
-  cudaSetDevice(logits.device().device_id);
+  ffi::CUDADeviceGuard device_guard(logits.device().device_id);
   auto stream = get_stream(logits.device());
   cudaError_t status = sampling::SamplingFromLogits(
       static_cast<float*>(logits.data_ptr()), static_cast<int*>(output.data_ptr()),
@@ -68,7 +68,7 @@ void sampling_from_probs(TensorView probs, TensorView output, Optional<TensorVie
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = probs.size(1);
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::SamplingFromProb(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
@@ -88,7 +88,7 @@ void top_p_sampling_from_probs(TensorView probs, TensorView output,
   unsigned int vocab_size = probs.size(1);
   bool has_top_p_arr = maybe_top_p_arr.has_value();
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::TopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
@@ -112,7 +112,7 @@ void top_k_sampling_from_probs(TensorView probs, TensorView output,
   unsigned int vocab_size = probs.size(1);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::TopKSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()), static_cast<int*>(output.data_ptr()),
@@ -136,7 +136,7 @@ void min_p_sampling_from_probs(TensorView probs, TensorView output,
   unsigned int vocab_size = probs.size(1);
   bool has_min_p_arr = maybe_min_p_arr.has_value();
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::MinPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()),
@@ -164,7 +164,7 @@ void top_k_top_p_sampling_from_probs(TensorView probs, TensorView output,
   bool has_top_k_arr = maybe_top_k_arr.has_value();
   bool has_top_p_arr = maybe_top_p_arr.has_value();
 
-  cudaSetDevice(probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
   cudaError_t status = sampling::TopKTopPSamplingFromProb<float, int>(
       static_cast<float*>(probs.data_ptr()),
@@ -201,7 +201,7 @@ void chain_speculative_sampling(TensorView draft_probs, TensorView draft_token_i
   TVM_FFI_ICHECK_EQ(batch_size, output_accepted_token_num.size(0));
   TVM_FFI_ICHECK_EQ(batch_size, output_emitted_draft_token_num.size(0));
 
-  cudaSetDevice(draft_probs.device().device_id);
+  ffi::CUDADeviceGuard device_guard(draft_probs.device().device_id);
   auto stream = get_stream(draft_probs.device());
   cudaError_t status = sampling::ChainSpeculativeSampling<float, int>(
       static_cast<float*>(draft_probs.data_ptr()), static_cast<int*>(draft_token_ids.data_ptr()),

--- a/csrc/single_decode.cu
+++ b/csrc/single_decode.cu
@@ -62,7 +62,7 @@ void single_decode_with_kv_cache(TensorView q, TensorView k, TensorView v, Tenso
       << "num_qo_heads(" << num_qo_heads << ") must be divisible by num_kv_heads(" << num_kv_heads
       << ")";
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
 
   TVM_FFI_ICHECK_EQ(head_dim_qk, head_dim_vo)

--- a/csrc/single_prefill.cu
+++ b/csrc/single_prefill.cu
@@ -68,7 +68,7 @@ void single_prefill_with_kv_cache(ffi::TensorView q, ffi::TensorView k, ffi::Ten
 
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
 
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
 
   DISPATCH_context(

--- a/csrc/single_prefill_fp8_sm90.cu
+++ b/csrc/single_prefill_fp8_sm90.cu
@@ -42,7 +42,7 @@ void single_prefill_with_kv_cache_sm90(ffi::TensorView q, ffi::TensorView k, ffi
   unsigned int qo_len = q.size(0);
 
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
 

--- a/csrc/single_prefill_sm90.cu
+++ b/csrc/single_prefill_sm90.cu
@@ -42,7 +42,7 @@ void single_prefill_with_kv_cache_sm90(ffi::TensorView q, ffi::TensorView k, ffi
   unsigned int qo_len = q.size(0);
 
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
-  cudaSetDevice(q.device().device_id);
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   const MaskMode mask_mode = static_cast<MaskMode>(mask_mode_code);
 

--- a/csrc/trtllm_allreduce.cu
+++ b/csrc/trtllm_allreduce.cu
@@ -96,7 +96,7 @@ void trtllm_custom_all_reduce(TensorView in, TensorView out, int64_t tp_size, in
                               Optional<TensorView> lamport_peer_comm_buffer_ptrs_1,
                               Optional<TensorView> lamport_peer_comm_buffer_ptrs_2) {
   AllReduceFusionOp fusion_op = static_cast<AllReduceFusionOp>(fusion_op_code);
-  cudaSetDevice(in.device().device_id);
+  ffi::CUDADeviceGuard device_guard(in.device().device_id);
   auto stream = get_stream(in.device());
 
   // TODO(zihao): review dispatch type - support fp16, bf16 only

--- a/csrc/trtllm_allreduce_fusion.cu
+++ b/csrc/trtllm_allreduce_fusion.cu
@@ -37,7 +37,7 @@ void trtllm_allreduce_fusion(TensorView allreduce_in, int64_t world_size, int64_
                              Optional<TensorView> quant_out, Optional<TensorView> scale_out,
                              Optional<TensorView> rms_gamma, Optional<double> rms_eps,
                              Optional<TensorView> scale_factor, Optional<int64_t> layout_code) {
-  cudaSetDevice(allreduce_in.device().device_id);
+  ffi::CUDADeviceGuard device_guard(allreduce_in.device().device_id);
   // todo(Yingyi): add dispatch for float and bfloat16
 
   DISPATCH_FLOATING_TYPES_FOR_ALLREDUCE(allreduce_in.dtype(), c_type, [&] {

--- a/csrc/trtllm_mnnvl_allreduce.cu
+++ b/csrc/trtllm_mnnvl_allreduce.cu
@@ -30,7 +30,7 @@ void trtllm_mnnvl_all_reduce(TensorView in, int64_t multicast_buffer_ptr, int64_
                              int64_t buffer_M, TensorView buffer_flags_mnnvl, int64_t nranks,
                              int64_t rank, bool wait_for_results, bool launch_with_pdl,
                              Optional<TensorView> out) {
-  cudaSetDevice(in.device().device_id);
+  ffi::CUDADeviceGuard device_guard(in.device().device_id);
   auto stream = get_stream(in.device());
 
   DISPATCH_FLOATING_TYPES_FOR_MNNVL_ALLREDUCE(in.dtype(), c_type, [&] {
@@ -74,7 +74,7 @@ void trtllm_mnnvl_all_reduce(TensorView in, int64_t multicast_buffer_ptr, int64_
 void trtllm_mnnvl_rmsnorm(int64_t multicast_buffer_ptr, TensorView prenorm_output,
                           TensorView normed_output, TensorView gamma, double epsilon,
                           TensorView residual, TensorView buffer_flags, bool launch_with_pdl) {
-  cudaSetDevice(prenorm_output.device().device_id);
+  ffi::CUDADeviceGuard device_guard(prenorm_output.device().device_id);
   auto stream = get_stream(prenorm_output.device());
 
   DISPATCH_FLOATING_TYPES_FOR_MNNVL_ALLREDUCE(prenorm_output.dtype(), c_type, [&] {

--- a/csrc/trtllm_moe_allreduce_fusion.cu
+++ b/csrc/trtllm_moe_allreduce_fusion.cu
@@ -32,7 +32,7 @@ void trtllm_moe_allreduce_fusion(
     TensorView moe_reduction_token_input, Optional<int64_t> layout_code,
     Optional<TensorView> moe_allreduce_out, Optional<TensorView> residual_out,
     Optional<TensorView> norm_out, Optional<TensorView> quant_out, Optional<TensorView> scale_out) {
-  cudaSetDevice(moe_reduction_active_experts_token_input.device().device_id);
+  ffi::CUDADeviceGuard device_guard(moe_reduction_active_experts_token_input.device().device_id);
   auto stream = get_stream(moe_reduction_active_experts_token_input.device());
 
   DISPATCH_FLOATING_TYPES_FOR_ALLREDUCE(

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -18,6 +18,7 @@
 #include <tvm/ffi/dtype.h>
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/cuda/device_guard.h>
 #include <tvm/ffi/function.h>
 
 #include "dlpack/dlpack.h"

--- a/csrc/vllm_custom_all_reduce.cu
+++ b/csrc/vllm_custom_all_reduce.cu
@@ -66,7 +66,7 @@ bool _is_weak_contiguous(TensorView t) {
 void all_reduce(fptr_t _fa, TensorView inp, TensorView out, fptr_t _reg_buffer,
                 int64_t reg_buffer_sz_bytes, int64_t num_ctas) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
-  cudaSetDevice(inp.device().device_id);
+  ffi::CUDADeviceGuard device_guard(inp.device().device_id);
   auto stream = get_stream(inp.device());
 
   TVM_FFI_ICHECK_EQ(inp.dtype(), out.dtype());

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license-files = ["LICENSE", "LICENSE*.txt"]
 flashinfer = "flashinfer.__main__:cli"
 
 [build-system]
-requires = ["setuptools>=77", "packaging>=24", "apache-tvm-ffi>=0.1,<0.2"]
+requires = ["setuptools>=77", "packaging>=24", "apache-tvm-ffi>=0.1.4,<0.2"]
 build-backend = "build_backend"
 backend-path = ["."]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-tvm-ffi>=0.1,<0.2
+apache-tvm-ffi>=0.1.4,<0.2
 click
 einops
 ninja


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Bump tvm ffi version to 0.1.4 and use `ffi::CUDADeviceGuard` instead of `cudaSetDevice`.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved GPU device management across CUDA operations for more reliable multi-GPU support and automatic resource cleanup.

* **Chores**
  * Updated `apache-tvm-ffi` dependency to version 0.1.4 or later.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->