### PR TITLE
Fix gemm allreduce two shot

### DIFF
--- a/tests/gemm/test_cute_dsl_gemm_allreduce_two_shot.py
+++ b/tests/gemm/test_cute_dsl_gemm_allreduce_two_shot.py
@@ -401,6 +401,7 @@ def run(
 
     return exec_time  # Return execution time in microseconds
 
+
 def _run_correctness_worker(world_size, rank, distributed_init_port):
     assert rank >= 0
     torch.cuda.set_device(rank)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- Fix test_cute_dsl_gemm_allreduce_two_shot.py regression from nvidia-cutlass-dsl upgrade to 4.3.1 (removed helper functions)
- GB300 enabled for this kernel as well

need 8xB200

pytest tests/gemm/test_cute_dsl_gemm_allreduce_two_shot.py -v

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new synchronization helper functions for inter-GPU coordination: `spin_lock_multimem_arrive`, `spin_lock_atom_cas_acquire_wait`, and `sm_wise_inter_gpu_multimem_barrier`.

* **Tests**
  * Extended test coverage to support additional GPU architectures (SM10.3).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->