### PR TITLE
ci: Use stable Torch Release for cu130

### DIFF
--- a/docker/Dockerfile.cu130
+++ b/docker/Dockerfile.cu130
@@ -25,8 +25,7 @@ ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 # Install torch and other python packages
 COPY requirements.txt /install/requirements.txt
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
-# use nightly/cu130 temporarily and change to cu130 when torch releases stable version
-RUN bash /install/install_python_packages.sh nightly/cu130
+RUN bash /install/install_python_packages.sh cu130
 
 # Install mpi4py in the conda environment
 RUN conda install -n py312 -y mpi4py

--- a/docker/Dockerfile.cu130.dev
+++ b/docker/Dockerfile.cu130.dev
@@ -47,8 +47,7 @@ ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 # Install torch and other python packages
 COPY requirements.txt /install/requirements.txt
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
-# use nightly/cu130 temporarily and change to cu130 when torch releases stable version
-RUN bash /install/install_python_packages.sh nightly/cu130 && pip3 install pre-commit
+RUN bash /install/install_python_packages.sh cu130 && pip3 install pre-commit
 
 # Install mpi4py in the conda environment
 RUN conda install -n py312 -y mpi4py

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -24,8 +24,7 @@ CUDA_VERSION=${1:-cu128}
 
 # Install torch with specific CUDA version first, followed by others in requirements.txt, and then others.
 # This is to ensure that the torch version is compatible with the CUDA version.
-pip3 install torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION} --dry-run
-pip3 install torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
+pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
 pip3 install -r /install/requirements.txt
 pip3 install responses pytest scipy build cuda-python nvidia-nvshmem-cu12
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Previous PR #2167 's container build is installing torch 2.10.dev12032025, due to the cu130 Dockerfile installing unstable nightlies. We are seeing unit testing failures for torch 2.10 dev where `torch.einsum` causes a cuBLAS failure:

```
(py312) root@cc6b2de90050:/flashinfer# pip list | grep torch
pytorch-triton         3.5.1+gitbfeb0668
torch                  2.10.0.dev20251203+cu130
(py312) root@cc6b2de90050:/flashinfer# python3
>>> import torch
>>> query = torch.randn(1, 4, 128, device="cuda", dtype=torch.float16)
>>> key = torch.randn(1, 4, 128, device="cuda", dtype=torch.float16)
>>> scores = torch.einsum("qhd,khd->qkh", query.float(), key.float())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/conda/envs/py312/lib/python3.12/site-packages/torch/functional.py", line 373, in einsum
    return _VF.einsum(equation, operands)  # type: ignore[attr-defined]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: CUDA error: CUBLAS_STATUS_INVALID_VALUE when calling `cublasSgemmStridedBatched( handle, opa, opb, m, n, k, &alpha, a, lda, stridea, b, ldb, strideb, &beta, c, ldc, stridec, num_batches)`
```

 As PyTorch started releasing stable 2.9.1 for cu130, there is no longer a need to use nightlies. Local testing with the 2.9.1 resolves `einsum` failures:

```
(py312) root@fd986dc62859:/flashinfer# pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/cu130 --no-deps
Looking in indexes: https://download.pytorch.org/whl/cu130
Collecting torch
  Downloading https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (30 kB)
Downloading https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl (612.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 612.6/612.6 MB 215.8 MB/s  0:00:01
Installing collected packages: torch
  Attempting uninstall: torch
    Found existing installation: torch 2.10.0.dev20251203+cu130
    Uninstalling torch-2.10.0.dev20251203+cu130:
      Successfully uninstalled torch-2.10.0.dev20251203+cu130
Successfully installed torch-2.9.1+cu130
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
(py312) root@fd986dc62859:/flashinfer# python3
Python 3.12.11 | packaged by conda-forge | (main, Jun  4 2025, 14:45:31) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> query = torch.randn(1, 4, 128, device="cuda", dtype=torch.float16)
>>> key = torch.randn(1, 4, 128, device="cuda", dtype=torch.float16)
>>> scores = torch.einsum("qhd,khd->qkh", query.float(), key.float())
```

See [this line](https://github.com/flashinfer-ai/flashinfer/actions/runs/19940898985/job/57178116127?pr=2174#step:6:352) for the release container build job for cu130 where a stable release 2.9.1 is being fetched and installed

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package installation process for containerized deployments to enhance reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->