### PR TITLE
benchmark: Make use_cupti the default in microbenchmarks.

### DIFF
--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -79,7 +79,13 @@ def parse_args(line=sys.argv[1:]):
         "--use_cupti",
         action="store_true",
         default=False,
-        help="Use CUPTI for timing GPU kernels when available.",
+        help="[DEPRECATED] Use CUPTI for timing GPU kernels. This is now the default behavior.",
+    )
+    parser.add_argument(
+        "--use_cuda_events",
+        action="store_true",
+        default=False,
+        help="Use CUDA events for timing GPU kernels instead of CUPTI.",
     )
     parser.add_argument(
         "--refcheck",
@@ -155,6 +161,16 @@ def parse_args(line=sys.argv[1:]):
 
     if args.generate_repro_command:
         args.repro_command = "python3 flashinfer_benchmark.py " + " ".join(line)
+
+    # Deprecation warning for use_cupti
+    if args.use_cupti:
+        print(
+            "[WARNING] --use_cupti is deprecated and will be removed in a future release. CUPTI is now enabled by default."
+        )
+    # use_cupti is deprecated and will be removed in a future release. CUPTI is now enabled by default.
+    # If --use_cuda_events is passed, disable use_cupti
+    args.use_cupti = not args.use_cuda_events
+
     return args
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Currently the microbenchmarks in `flashinfer_benchmark.py` uses CUDA events to measure time. However, using CUPTI provides benefits in (a) nsys-matching accuracy; and (b) L2 cache flush implemented in the benchmark script.

The PR
* Makes `--use_cupti` the default behavior
* `--use_cupti` now does nothing and prints a deprecation warning.
* `--use_cuda_events` flag is now added for users who would like to use CUDA events.

Example outputs on 5090:
```
## Provide use_cupti
$ python3 flashinfer_benchmark.py --routine BatchDecodeWithPagedKVCacheWrapper --backends fa2_tc cudnn trtllm-native --page_size 16 --batch_size 1 --s_qo 1 --s_kv 8192 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --refcheck --q_dtype bfloat16 --kv_dtype bfloat16 --use_cupti
[WARNING] --use_cupti is deprecated and will be removed in a future release. CUPTI is now enabled by default.
[PERF] fa2_tc         :: median time 0.032 ms; std 0.001 ms; achieved tflops 8.482 TFLOPs/sec; achieved tb_per_sec 1.061 TB/sec
[PERF] cudnn          :: median time 0.030 ms; std 0.000 ms; achieved tflops 8.972 TFLOPs/sec; achieved tb_per_sec 1.123 TB/sec
[PERF] trtllm-native  :: median time 0.036 ms; std 0.001 ms; achieved tflops 7.561 TFLOPs/sec; achieved tb_per_sec 0.946 TB/sec

## Default behavior: same as use_cupti, except no warning message.
$ python3 flashinfer_benchmark.py --routine BatchDecodeWithPagedKVCacheWrapper --backends fa2_tc cudnn trtllm-native --page_size 16 --batch_size 1 --s_qo 1 --s_kv 8192 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --refcheck --q_dtype bfloat16 --kv_dtype bfloat16
[PERF] fa2_tc         :: median time 0.032 ms; std 0.001 ms; achieved tflops 8.452 TFLOPs/sec; achieved tb_per_sec 1.058 TB/sec
[PERF] cudnn          :: median time 0.030 ms; std 0.000 ms; achieved tflops 8.982 TFLOPs/sec; achieved tb_per_sec 1.124 TB/sec
[PERF] trtllm-native  :: median time 0.035 ms; std 0.001 ms; achieved tflops 7.612 TFLOPs/sec; achieved tb_per_sec 0.952 TB/sec

## Provide use_cuda_events for CUDA events
# NOTE: performance when using CUDA events is spuriously inflated due to not starting with a cold L2 cache (RTX5090 has a peak mem bandwidth of 1.79 TB/s)
$ python3 flashinfer_benchmark.py --routine BatchDecodeWithPagedKVCacheWrapper --backends fa2_tc cudnn trtllm-native --page_size 16 --batch_size 1 --s_qo 1 --s_kv 8192 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --refcheck --q_dtype bfloat16 --kv_dtype bfloat16 --use_cuda_events
[PERF] fa2_tc         :: median time 0.015 ms; std 0.000 ms; achieved tflops 18.461 TFLOPs/sec; achieved tb_per_sec 2.310 TB/sec
[PERF] cudnn          :: median time 0.017 ms; std 0.000 ms; achieved tflops 16.182 TFLOPs/sec; achieved tb_per_sec 2.025 TB/sec
[PERF] trtllm-native  :: median time 0.015 ms; std 0.000 ms; achieved tflops 18.120 TFLOPs/sec; achieved tb_per_sec 2.267 TB/sec
```


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--use_cuda_events` flag for GPU kernel timing.

* **Chores**
  * Deprecated `--use_cupti` flag; displays warning when set.
  * CUPTI timing now enabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->