### PR TITLE
ci: Update sm12X minimum cuda capability to 12.9 in aot.py

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -742,8 +742,8 @@ def detect_sm_capabilities():
         "sm100": has_sm("compute_100", "12.8"),
         "sm100f": has_sm("compute_100", "12.9"),
         "sm103": has_sm("compute_103", "12.9"),
-        "sm110": has_sm("compute_110", "12.9"),
-        "sm120": has_sm("compute_120", "12.9"),
+        "sm110": has_sm("compute_110", "13.0"),
+        "sm120": has_sm("compute_120", "12.8"),
         "sm121": has_sm("compute_121", "12.9"),
     }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

[CUDA Release notes](https://docs.nvidia.com/cuda/parallel-thread-execution/#release-notes) indicate full sm120 support on CUDA 12.8 and sm121 on 12.9. Changing the version noted in `aot.py`.

The change alters the coverage in `flashinfer-jit-cache` -- today some sm120 kernels are not compiled & shipped in cuda 12.9, but are included in 13.0. The change here will insure kernels are included.


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted GPU capability detection and CUDA version requirements:
    * SM110 now requires CUDA 13.0 (raised from 12.9).
    * SM120 support expanded to CUDA 12.8 (lowered from 13.0).
    * SM121 support updated to CUDA 12.9 (from 13.0).

* **Impact**
  * Broader compatibility for SM120/SM121 on slightly older CUDA; SM110 now requires a newer CUDA runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->