### PR TITLE
test: Skip sm90 test in test_jit_warmup.py if not on sm90

### DIFF
--- a/tests/utils/test_jit_warmup.py
+++ b/tests/utils/test_jit_warmup.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import torch
+import pytest
 
 import flashinfer
 from flashinfer.utils import PosEncodingMode
@@ -57,6 +58,10 @@ def test_warmpup_llama():
     )
 
 
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] != 9,
+    reason="fa3 backend is only supported on SM90",
+)
 def test_warmpup_llama_sm90():
     flashinfer.jit.build_jit_specs(
         [


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`test_jit_warmup.py` contains two tests `test_warmpup_llama` and `test_warmpup_llama_sm90` where the _sm90 variant is the first one plus an additional fa3 prefill compilation only supported on SM90.

While under general circumstances, this test should pass on non-sm90 cards, it might fail if the environment contains an incomplete `flashinfer-jit-cache` that is missing sm90 kernels and `FLASHINFER_CUDA_ARCH_LIST` is not correctly set to include 9.0a. 

Since:
1. This can interfere with unit testing by causing unexpected failures on non SM90 cards and
2. On non SM90 cards, there is no additional gain from testing sm90 kernel compilation

current PR disables it.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test execution conditions to ensure tests run only on supported hardware configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->