### PR TITLE
docs: Fix inaccurate API docstrings for attention prefill

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1471,7 +1471,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             mask will be used in attention computation.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2``,``fa3`` or ``cudnn``. Defaults to ``auto``.
+            The implementation backend, could be ``auto``/``fa2``/``fa3``/``cudnn`` or ``trtllm-gen``.
+            Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
 
@@ -1920,6 +1921,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         self._block_tables = block_tables
         if self._backend == "trtllm-gen":
+            if not causal:
+                raise NotImplementedError(
+                    "Non-causal attention is not supported for trtllm-gen backend with paged KV cache. "
+                    "Please use causal=True or choose a different backend (e.g., fa2, fa3, cudnn)."
+                )
             assert logits_soft_cap == 0.0
             if self._block_tables is None:
                 blocks_per_seq = [
@@ -2457,7 +2463,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             will be used in attention computation.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2``/``fa3`` or ``trtllm-gen``.
+            The implementation backend, could be ``auto``/``fa2``/``fa3`` or ``cutlass``.
             Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR addresses the documentation issues and adds proper validation for unsupported configurations in the attention prefill wrappers raised in #1709.
Changes
* `BatchPrefillWithPagedKVCacheWrapper`: 
  * Updated docstring to include `trtllm-gen` as a valid backend option, which was 
  * Added validation for non-causal attention with `trtllm-gen` backend: The kernel only supports causal attention. Previously, using `causal=False` would silently run causal attention anyway (causing incorrect outputs). Now it raises a clear NotImplementedError.
supported but undocumented.
* `BatchPrefillWithRaggedKVCacheWrapper`: Fixed docstring to list `cutlass` instead of `trtllm-gen` as a backend option. 
    * The `cutlass` backend is supported but was missing from docs, while `trtllm-gen` raises NotImplementedError for ragged KV cache.


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

#1709

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trtllm-gen and cutlass backend options

* **Documentation**
  * Clarified available backends and default configurations
  * Improved error guidance for unsupported backend combinations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->