### PR TITLE
cicd: Add sanity test script

### DIFF
--- a/scripts/task_test_blackwell_kernels.sh
+++ b/scripts/task_test_blackwell_kernels.sh
@@ -317,7 +317,7 @@ else
             TOTAL_IN_FILE=$(echo "$ALL_NODE_IDS" | wc -l)
             TOTAL_TEST_CASES=$((TOTAL_TEST_CASES + TOTAL_IN_FILE))
 
-             # Sample every Nth test with random offset
+            # Sample every Nth test with random offset
             SAMPLED_NODE_IDS=$(echo "$ALL_NODE_IDS" | awk "NR % $SAMPLE_RATE == $SAMPLE_OFFSET")
             # Fallback: if no tests sampled (offset missed all tests), take the first test
             if [ -z "$SAMPLED_NODE_IDS" ] || [ $(echo "$SAMPLED_NODE_IDS" | wc -l) -eq 0 ]; then


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR adds a sanity test script to use towards testing more CTK versions. This adds `--sanity-test ` flag as an option to `[scripts/task_test_blackwell_kernels.sh](https://github.com/flashinfer-ai/flashinfer/blob/main/scripts/task_test_blackwell_kernels.sh)`, our current unit testing script. But instead of running every test combination, it samples every Nth test in each test suite. N is determined by `SAMPLE_RATE`. The default value is 5, which is 20% coverage (`${SAMPLE_RATE:=5}`).

Example output for `bash scripts/task_test_blackwell_kernels.sh --dry-run --sanity-test`:
```
[1] Collecting tests from: tests/attention/test_alibi.py
  Total test cases: 216
  Sampled test cases: 44 (every 5th test)
  Sample of tests that would run:
    tests/attention/test_alibi.py::test_single_decode_alibi[128-4-1]
    tests/attention/test_alibi.py::test_single_decode_alibi[128-8-9]
    tests/attention/test_alibi.py::test_single_decode_alibi[128-32-81]
    tests/attention/test_alibi.py::test_single_decode_alibi[256-4-729]
    tests/attention/test_alibi.py::test_single_decode_alibi[256-32-1]
    ... and 39 more

[2] Collecting tests from: tests/attention/test_attention_sink.py
  Total test cases: 1504
  Sampled test cases: 301 (every 5th test)
  Sample of tests that would run:
    tests/attention/test_attention_sink.py::test_attention_sink[fa2-True--1-8-32-1-1-dtype0]
    tests/attention/test_attention_sink.py::test_attention_sink[fa2-True--1-8-32-1-16-dtype1]
    tests/attention/test_attention_sink.py::test_attention_sink[fa2-True--1-8-32-4-16-dtype0]
    tests/attention/test_attention_sink.py::test_attention_sink[fa2-True--1-8-32-16-4-dtype1]
    tests/attention/test_attention_sink.py::test_attention_sink[fa2-True--1-8-32-128-4-dtype0]
    ... and 296 more

(.... etc...., [3] through [82]....) 

[83] Collecting tests from: tests/utils/test_sampling.py
  Total test cases: 921
  Sampled test cases: 185 (every 5th test)
  Sample of tests that would run:
    tests/utils/test_sampling.py::test_softmax[True-True-1.0-normal_distribution(std=1)-111-1]
    tests/utils/test_sampling.py::test_softmax[True-True-1.0-normal_distribution(std=1)-32000-989]
    tests/utils/test_sampling.py::test_softmax[True-True-1.0-normal_distribution(std=5)-111-99]
    tests/utils/test_sampling.py::test_softmax[True-True-1.0-normal_distribution(std=5)-128256-1]
    tests/utils/test_sampling.py::test_softmax[True-True-1.0-gumbel_distribution(beta=0.1)-111-989]
    ... and 180 more

[84] Collecting tests from: tests/utils/test_triton_cascade.py
  Total test cases: 4
  Sampled test cases: 1 (every 5th test)
  Sample of tests that would run:
    tests/utils/test_triton_cascade.py::test_merge_state[128-32-2048]

```

## 🔍 Related Issues

As discussed in weekly meeting and on slack.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Sanity Test mode that runs a sampled subset of tests instead of the full suite.
  * New CLI option to enable sanity-mode and configure sample rate (with a random offset) to vary samples.
  * Dry-run now previews per-file sampled tests and reports estimated coverage and sampling details.
  * Actual sanity runs execute only sampled tests and produce per-run summaries with coverage metrics and failed-test lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->