### PR TITLE
fix: Eliminate the usage of CUDA ARCH macro in host function.

### DIFF
--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -449,48 +449,44 @@ inline __device__ T blockReduceSum(T val) {
 // Return (block_size, cluster_size, loads_per_thread)
 std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerThread) {
   // Start with preferred block_size and cluster_size
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  int clusterSize = 8;
-#else
-  int clusterSize = 1;
-#endif
+  static const int kSMVersionMajor = flashinfer::GetCudaComputeCapability().first;
+  int clusterSize = kSMVersionMajor >= 9 ? 8 : 1;
   int blockSize = 128;
   // ========================== Adjust the grid configuration ==========================
   int threadsNeeded = ceil_div(dim, eltsPerThread);
   int loadsPerThread = 1;
 
   blockSize = ceil_div(threadsNeeded, clusterSize);
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  while (threadsNeeded % clusterSize != 0 && clusterSize > 1) {
-    clusterSize /= 2;
+  if (kSMVersionMajor >= 9) {
+    while (threadsNeeded % clusterSize != 0 && clusterSize > 1) {
+      clusterSize /= 2;
+    }
+    blockSize = ceil_div(threadsNeeded, clusterSize);
+    while (blockSize < 128 && clusterSize >= 2) {
+      blockSize *= 2;
+      clusterSize /= 2;
+    }
+    int smCount = GetCudaMultiProcessorCount();
+    while (numTokens * clusterSize > smCount && clusterSize > 1 && blockSize <= 512) {
+      blockSize *= 2;
+      clusterSize /= 2;
+    }
   }
-  blockSize = ceil_div(threadsNeeded, clusterSize);
-  while (blockSize < 128 && clusterSize >= 2) {
-    blockSize *= 2;
-    clusterSize /= 2;
-  }
-  int smCount = GetCudaMultiProcessorCount();
-  while (numTokens * clusterSize > smCount && clusterSize > 1 && blockSize <= 512) {
-    blockSize *= 2;
-    clusterSize /= 2;
-  }
-#endif
-
   // Trying to scale up use multiple loads or CGA
   while (blockSize > 1024) {
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    if (clusterSize < 8) {
-      clusterSize = clusterSize << 1;
+    if (kSMVersionMajor >= 9) {
+      if (clusterSize < 8) {
+        clusterSize = clusterSize << 1;
+      } else {
+        break;
+      }
     } else {
-      break;
+      if (loadsPerThread < 8) {
+        loadsPerThread += 1;
+      } else {
+        break;
+      }
     }
-#else
-    if (loadsPerThread < 8) {
-      loadsPerThread += 1;
-    } else {
-      break;
-    }
-#endif
     blockSize = ceil_div(threadsNeeded, clusterSize * loadsPerThread);
   }
   return {blockSize, clusterSize, loadsPerThread};
@@ -658,18 +654,11 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   int const tokenDim = params.tokenDim;
   int const eltsPerThread = sizeof(float4) / sizeof(T);
 
+  static const int kSMVersionMajor = flashinfer::GetCudaComputeCapability().first;
+
   auto [blockSize, clusterSize, loadsPerThread] =
       adjustGridConfig(numTokens, tokenDim, eltsPerThread);
   dim3 grid(numTokens, clusterSize, 1);
-
-  FLASHINFER_CHECK(blockSize <= 1024 && loadsPerThread == 1,
-                   "Hidden Dimension %d exceeds the maximum supported hidden dimension (%d)",
-                   tokenDim,
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-                   1024 * 8 * eltsPerThread);
-#else
-                   1024 * eltsPerThread);
-#endif
 
   FLASHINFER_LOG_DEBUG(
       "[MNNVL AllReduceOneShot] Dispatch: grid size: (%d, %d, 1), block_size: %d, cluster_size: "
@@ -679,15 +668,17 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       numTokens, clusterSize, blockSize, clusterSize, loadsPerThread,
       ceil_div(tokenDim, eltsPerThread));
 
+  FLASHINFER_CHECK(blockSize <= 1024 && loadsPerThread == 1,
+                   "Hidden Dimension %d exceeds the maximum supported hidden dimension (%d)",
+                   tokenDim, 1024 * (kSMVersionMajor >= 9 ? 8 : 1) * eltsPerThread);
+
   cudaLaunchAttribute attrs[2];
   attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
   attrs[0].val.programmaticStreamSerializationAllowed = params.launchWithPdl ? 1 : 0;
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   attrs[1].id = cudaLaunchAttributeClusterDimension;
   attrs[1].val.clusterDim.x = 1;
   attrs[1].val.clusterDim.y = clusterSize;
   attrs[1].val.clusterDim.z = 1;
-#endif
 
   cudaLaunchConfig_t config{
       .gridDim = grid,
@@ -695,11 +686,7 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       .dynamicSmemBytes = 0,
       .stream = params.stream,
       .attrs = attrs,
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-      .numAttrs = 2,
-#else
-      .numAttrs = 1,
-#endif
+      .numAttrs = kSMVersionMajor >= 9 ? 2 : 1,
   };
 
 #define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, RMSNORM)                                              \
@@ -1123,6 +1110,7 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
 
   // Launch the rmsnorm lamport kernel if fusion is enabled
   if (params.rmsNormFusion) {
+    static const int kSMVersionMajor = flashinfer::GetCudaComputeCapability().first;
     auto gridConfig = adjustGridConfig(numTokens, tokenDim, numEltsPerThread);
     int rnBlockSize = std::get<0>(gridConfig);
     int rnClusterSize = std::get<1>(gridConfig);
@@ -1138,15 +1126,11 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
     rnConfig.attrs = rnAttrs;
     rnAttrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
     rnAttrs[0].val.programmaticStreamSerializationAllowed = params.launchWithPdl ? 1 : 0;
-#ifndef DISABLE_CGA
     rnAttrs[1].id = cudaLaunchAttributeClusterDimension;
     rnAttrs[1].val.clusterDim.x = 1;
     rnAttrs[1].val.clusterDim.y = rnClusterSize;
     rnAttrs[1].val.clusterDim.z = 1;
-    rnConfig.numAttrs = 2;
-#else
-    rnConfig.numAttrs = 1;
-#endif
+    rnConfig.numAttrs = kSMVersionMajor >= 9 ? 2 : 1;
 
     bool const rnUseCGA = rnClusterSize > 1;
     int const dimPadded = round_up(tokenDim, numEltsPerThread * rnNumThreads);

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -654,7 +654,7 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   int const tokenDim = params.tokenDim;
   int const eltsPerThread = sizeof(float4) / sizeof(T);
 
-  static const int kSMVersionMajor = flashinfer::GetCudaComputeCapability().first;
+  static const int kSMVersionMajor = GetCudaComputeCapability().first;
 
   auto [blockSize, clusterSize, loadsPerThread] =
       adjustGridConfig(numTokens, tokenDim, eltsPerThread, kSMVersionMajor);
@@ -1114,7 +1114,7 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
 
   // Launch the rmsnorm lamport kernel if fusion is enabled
   if (params.rmsNormFusion) {
-    static const int kSMVersionMajor = flashinfer::GetCudaComputeCapability().first;
+    static const int kSMVersionMajor = GetCudaComputeCapability().first;
     auto gridConfig = adjustGridConfig(numTokens, tokenDim, numEltsPerThread, kSMVersionMajor);
     int rnBlockSize = std::get<0>(gridConfig);
     int rnClusterSize = std::get<1>(gridConfig);

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -438,7 +438,7 @@ def run_mnnvl_ar_full(
 )
 @pytest.mark.parametrize("fusion", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("hidden_size", [2880, 5120, 7168, 8192])
+@pytest.mark.parametrize("hidden_size", [2880, 5120, 7168, 8192, 16384])
 def test_mnnvl_allreduce_refactored(
     monkeypatch, seq_lens: list[int], fusion: bool, dtype: torch.dtype, hidden_size: int
 ):
@@ -451,7 +451,7 @@ def test_mnnvl_allreduce_refactored(
 @pytest.mark.parametrize("seq_lens", [[1], [4], [15], [27, 11, 24], [127]])
 @pytest.mark.parametrize("fusion", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("hidden_size", [2048, 4096, 5120, 7168, 8192])
+@pytest.mark.parametrize("hidden_size", [2048, 4096, 5120, 7168, 8192, 16384])
 def test_mnnvl_allreduce_legacy(
     monkeypatch, seq_lens: list[int], fusion: bool, dtype: torch.dtype, hidden_size: int
 ):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR fixed an dispatching issue caused by using `__CUDA_ARCH__` macro in host function. Specifically, this macro might not be defined for some build recipe, causing the fallback path always being executed and disable CGA. The fix is to use runtime API to obtain the SM version in host dispatch function.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved runtime GPU capability detection to pick optimal execution and tuning paths based on SM version, with fallbacks for older hardware.
  * Added conditional runtime synchronization and attribute selection to improve correctness and performance across architectures.
  * Minor public API signature updated to accept GPU capability input for runtime selection.

* **Tests**
  * Expanded test coverage to include larger hidden-dimension configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->