### PR TITLE
Fp8 attention are now part of cuDNN 9.17.1

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -764,14 +764,14 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
             backends.remove("fa2")
     if "cudnn" in backends:
         remove_cudnn = False
-        # cuDNN FP8 prefill requires cuDNN >= 9.18.0 (backend version 91800)
+        # cuDNN FP8 prefill requires cuDNN >= 9.17.1 (backend version 91701)
         if q_dtype in [torch.float8_e4m3fn, torch.float8_e5m2] or kv_dtype in [
             torch.float8_e4m3fn,
             torch.float8_e5m2,
         ]:
-            if not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 91800:
+            if not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 91701:
                 print(
-                    f"[INFO] cuDNN FP8 prefill requires cuDNN >= 9.18.0. "
+                    f"[INFO] cuDNN FP8 prefill requires cuDNN >= 9.17.1. "
                     f"Current version: {CUDNN_BACKEND_VERSION}. Skipping cudnn backend."
                 )
                 remove_cudnn = True
@@ -785,9 +785,9 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
             torch.float8_e4m3fn,
             torch.float8_e5m2,
         ]:
-            if not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 91800:
+            if not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 91701:
                 print(
-                    f"[INFO] cuDNN FP8 prefill requires cuDNN >= 9.18.0. "
+                    f"[INFO] cuDNN FP8 prefill requires cuDNN >= 9.17.1. "
                     f"Current version: {CUDNN_BACKEND_VERSION}. Skipping cudnn-native backend."
                 )
                 remove_cudnn_native = True

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -176,9 +176,9 @@ if CUDNN_AVAILABLE:
         if (
             cudnn_q_data_type == cudnn.data_type.FP8_E4M3
             or cudnn_q_data_type == cudnn.data_type.FP8_E5M2
-        ) and cudnn.backend_version() < 91800:
+        ) and cudnn.backend_version() < 91701:
             raise RuntimeError(
-                f"FP8 is not supported in cuDNN backend version < 9.18.0, current version is {cudnn.backend_version()}"
+                f"FP8 is not supported in cuDNN backend version < 9.17.1, current version is {cudnn.backend_version()}"
             )
 
         with cudnn.graph(handle) as (g, _):

--- a/tests/attention/test_cudnn_prefill.py
+++ b/tests/attention/test_cudnn_prefill.py
@@ -202,8 +202,8 @@ def test_cudnn_prefill_fp8(
     return_lse,
     is_cuda_graph_compatible,
 ):
-    if cudnn.backend_version() < 91800:
-        pytest.skip("cuDNN backend version is less than 9.18.0, skipping test")
+    if cudnn.backend_version() < 91701:
+        pytest.skip("cuDNN backend version is less than 9.17.1, skipping test")
 
     head_dim = 128
     if s_qo > s_kv:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Lowered minimum cuDNN version requirement for FP8 support from 9.18.0 to 9.17.1, enabling FP8 functionality on earlier cuDNN versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->