### PR TITLE
feat: RMSNorm/Fused RMSNorm + FP8 Quantization kernels

### DIFF
--- a/csrc/flashinfer_norm_binding.cu
+++ b/csrc/flashinfer_norm_binding.cu
@@ -17,8 +17,14 @@
 
 void rmsnorm(TensorView out, TensorView input, TensorView weight, double eps, bool enable_pdl);
 
+void rmsnorm_quant(TensorView out, TensorView input, TensorView weight, double scale, double eps,
+                   bool enable_pdl);
+
 void fused_add_rmsnorm(TensorView input, TensorView residual, TensorView weight, double eps,
                        bool enable_pdl);
+
+void fused_add_rmsnorm_quant(TensorView output, TensorView input, TensorView residual,
+                             TensorView weight, double scale, double eps, bool enable_pdl);
 
 void gemma_rmsnorm(TensorView out, TensorView input, TensorView weight, double eps,
                    bool enable_pdl);
@@ -29,7 +35,9 @@ void gemma_fused_add_rmsnorm(TensorView input, TensorView residual, TensorView w
 void layernorm(Tensor out, Tensor input, Tensor gamma, Tensor beta, double eps);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(rmsnorm, rmsnorm);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(rmsnorm_quant, rmsnorm_quant);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_add_rmsnorm, fused_add_rmsnorm);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_add_rmsnorm_quant, fused_add_rmsnorm_quant);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(gemma_rmsnorm, gemma_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(gemma_fused_add_rmsnorm, gemma_fused_add_rmsnorm);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(layernorm, layernorm);

--- a/csrc/norm.cu
+++ b/csrc/norm.cu
@@ -77,6 +77,43 @@ void rmsnorm(TensorView output, TensorView input, TensorView weight, double eps,
   }
 }
 
+void rmsnorm_quant(TensorView output, TensorView input, TensorView weight, double scale, double eps,
+                   bool enable_pdl) {
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(output);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
+  CHECK_DEVICE(input, weight);
+  CHECK_DIM(1, weight);  // weight: (hidden_size)
+
+  auto input_ndim = input.ndim();
+  if (input_ndim == 2) {
+    // Normal RMSNorm: [batch_size, hidden_size]
+    // Use CTA parallelization for better parallelism
+    CHECK_DIM(2, output);
+    TVM_FFI_ICHECK_EQ(input.size(1), weight.size(0));
+    unsigned int batch_size = input.size(0);
+    unsigned int hidden_size = input.size(1);
+    TVM_FFI_ICHECK_EQ(output.size(0), batch_size);
+    TVM_FFI_ICHECK_EQ(output.size(1), hidden_size);
+    ffi::CUDADeviceGuard device_guard(input.device().device_id);
+    const cudaStream_t stream = get_stream(input.device());
+
+    DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
+      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(output.dtype(), o_type, [&] {
+        cudaError_t status = norm::RMSNormQuant(
+            static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(weight.data_ptr()),
+            static_cast<o_type*>(output.data_ptr()), batch_size, hidden_size, input.stride(0),
+            output.stride(0), static_cast<float>(scale), eps, enable_pdl, stream);
+        TVM_FFI_ICHECK(status == cudaSuccess)
+            << "RMSNormQuant failed with error code " << cudaGetErrorString(status);
+        return true;
+      });
+    });
+  } else {
+    TVM_FFI_ICHECK(false) << "Unsupported input dimension: " << input_ndim;
+  }
+}
+
 void fused_add_rmsnorm(TensorView input, TensorView residual, TensorView weight, double eps,
                        bool enable_pdl) {
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
@@ -104,6 +141,42 @@ void fused_add_rmsnorm(TensorView input, TensorView residual, TensorView weight,
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "FusedAddRMSNorm failed with error code " << cudaGetErrorString(status);
     return true;
+  });
+}
+
+void fused_add_rmsnorm_quant(TensorView output, TensorView input, TensorView residual,
+                             TensorView weight, double scale, double eps, bool enable_pdl) {
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(residual);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(weight);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(output);
+  CHECK_DEVICE(input, residual);
+  CHECK_DEVICE(input, weight);
+  CHECK_DEVICE(input, output);
+  CHECK_DIM(2, input);     // input: (batch_size, hidden_size)
+  CHECK_DIM(2, residual);  // residual: (batch_size, hidden_size)
+  CHECK_DIM(1, weight);    // weight: (hidden_size)
+  CHECK_DIM(2, output);
+  unsigned int batch_size = input.size(0);
+  unsigned int hidden_size = input.size(1);
+  TVM_FFI_ICHECK_EQ(residual.size(0), batch_size);
+  TVM_FFI_ICHECK_EQ(residual.size(1), hidden_size);
+  TVM_FFI_ICHECK_EQ(weight.size(0), hidden_size);
+  ffi::CUDADeviceGuard device_guard(input.device().device_id);
+  const cudaStream_t stream = get_stream(input.device());
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
+    return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(output.dtype(), o_type, [&] {
+      cudaError_t status = norm::FusedAddRMSNormQuant(
+          static_cast<c_type*>(input.data_ptr()), static_cast<c_type*>(residual.data_ptr()),
+          static_cast<c_type*>(weight.data_ptr()), static_cast<o_type*>(output.data_ptr()),
+          batch_size, hidden_size, input.stride(0), residual.stride(0), output.stride(0), scale,
+          eps, enable_pdl, stream);
+
+      TVM_FFI_ICHECK(status == cudaSuccess)
+          << "FusedAddRMSNormQuant failed with error code " << cudaGetErrorString(status);
+      return true;
+    });
   });
 }
 

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -93,6 +93,58 @@ def _rmsnorm_fake(
 
 
 @flashinfer_api
+@register_custom_op("flashinfer::rmsnorm_quant", mutates_args=("out",))
+def rmsnorm_quant(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: float,
+    eps: float = 1e-6,
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    r"""Root mean square normalization.
+
+    ``out[i] = (input[i] / RMS(input)) * weight[i]``
+
+    Parameters
+    ----------
+    out: torch.Tensor
+        The output tensor, will quantize the output to the dtype of this tensor.
+    input: torch.Tensor
+        Input tensor, 2D shape (batch_size, hidden_size).
+    weight: torch.Tensor
+        Weight tensor, shape (hidden_size,).
+    scale: float
+        Scale factor for quantization.
+    eps: float
+        Epsilon for numerical stability.
+    enable_pdl: bool
+        Whether to enable `programmatic dependent launch
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
+
+    Returns
+    -------
+    output: torch.Tensor
+        Normalized tensor, 2D shape (batch_size, hidden_size).
+    """
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(input.device)
+    get_norm_module().rmsnorm_quant(out, input, weight, scale, eps, enable_pdl)
+
+
+@register_fake_op("flashinfer::rmsnorm_quant")
+def _rmsnorm_quant_fake(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: float,
+    eps: float,
+    enable_pdl: Optional[bool],
+) -> None:
+    pass
+
+
+@flashinfer_api
 @register_custom_op("flashinfer::fused_add_rmsnorm", mutates_args=("input", "residual"))
 def fused_add_rmsnorm(
     input: torch.Tensor,
@@ -133,6 +185,65 @@ def _fused_add_rmsnorm_fake(
     input: torch.Tensor,
     residual: torch.Tensor,
     weight: torch.Tensor,
+    eps: float = 1e-6,
+    enable_pdl: Optional[bool] = None,
+) -> None:
+    pass
+
+
+@flashinfer_api
+@register_custom_op(
+    "flashinfer::fused_add_rmsnorm_quant", mutates_args=("out", "residual")
+)
+def fused_add_rmsnorm_quant(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: float,
+    eps: float = 1e-6,
+    enable_pdl: Optional[bool] = None,
+) -> None:
+    r"""Fused add root mean square normalization.
+
+    Step 1:
+    ``residual[i] += input[i]``
+
+    Step 2:
+    ``input[i] = (residual[i] / RMS(residual)) * weight[i]``
+
+    Parameters
+    ----------
+    out: torch.Tensor
+        The output tensor, will quantize the output to the dtype of this tensor.
+    input: torch.Tensor
+        Input tensor, shape (batch_size, hidden_size).
+    residual: torch.Tensor
+        Residual tensor, shape (batch_size, hidden_size).
+    weight: torch.Tensor
+        Weight tensor, shape (hidden_size,).
+    scale: float
+        Scale factor for quantization.
+    eps: float
+        Epsilon for numerical stability.
+    enable_pdl: bool
+        Whether to enable `programmatic dependent launch
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
+    """
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(input.device)
+    get_norm_module().fused_add_rmsnorm_quant(
+        out, input, residual, weight, scale, eps, enable_pdl
+    )
+
+
+@register_fake_op("flashinfer::fused_add_rmsnorm_quant")
+def _fused_add_rmsnorm_quant_fake(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: float,
     eps: float = 1e-6,
     enable_pdl: Optional[bool] = None,
 ) -> None:

--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -16,6 +16,7 @@
 #ifndef FLASHINFER_NORM_CUH_
 #define FLASHINFER_NORM_CUH_
 
+#include <cstdint>
 #include <numeric>
 
 #include "flashinfer/trtllm/common/cudaTypeUtils.cuh"
@@ -140,6 +141,121 @@ cudaError_t RMSNorm(T* input, T* weight, T* output, uint32_t batch_size, uint32_
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, weight, output, d, stride_input,
                                             stride_output, weight_bias, eps));
+  });
+  return cudaSuccess;
+}
+
+template <uint32_t VEC_SIZE, typename T, typename O>
+__global__ void RMSNormQuantKernel(T* __restrict__ input, T* __restrict__ weight,
+                                   O* __restrict__ output, const uint32_t d,
+                                   const uint32_t stride_input, const uint32_t stride_output,
+                                   float weight_bias, float scale, float eps) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  // NOTE(Zihao): it's guaranteed that num_warps should be smaller than 32
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = ceil_div(d, VEC_SIZE * num_threads);
+  const float scale_inv = 1.0f / scale;
+  extern __shared__ float smem[];
+
+  float sum_sq = 0.f;
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    vec_t<T, VEC_SIZE> input_vec;
+    input_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.load(input + bx * stride_input + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      sum_sq += float(input_vec[j]) * float(input_vec[j]);
+    }
+  }
+
+  // first, warp reduce sum
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq += math::shfl_xor_sync(sum_sq, offset);
+  }
+
+  smem[ty] = sum_sq;
+  __syncthreads();
+  // then, cross warp reduce sum using only the first warp
+  if (ty == 0) {
+    sum_sq = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq += math::shfl_xor_sync(sum_sq, offset);
+    }
+    smem[0] = sum_sq;
+  }
+  __syncthreads();
+
+  float rms_rcp = math::rsqrt(smem[0] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    vec_t<T, VEC_SIZE> input_vec;
+    vec_t<T, VEC_SIZE> weight_vec;
+    vec_t<float, VEC_SIZE> output_vec;
+    input_vec.fill(0.f);
+    weight_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.load(input + bx * stride_input + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+      weight_vec.load(weight + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      output_vec[j] =
+          float(input_vec[j]) * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
+      output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
+    }
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +
+                            thread_id * VEC_SIZE);
+    }
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <typename T, typename O>
+cudaError_t RMSNormQuant(T* input, T* weight, O* output, uint32_t batch_size, uint32_t d,
+                         uint32_t stride_input, uint32_t stride_output, float scale,
+                         float eps = 1e-5, bool enable_pdl = false, cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
+  const uint32_t num_warps = ceil_div(block_size, 32);
+  dim3 nblks(batch_size);
+  dim3 nthrs(32, num_warps);
+  const uint32_t smem_size = num_warps * sizeof(float);
+  float weight_bias = 0.f;
+
+  cudaLaunchConfig_t config;
+  config.gridDim = nblks;
+  config.blockDim = nthrs;
+  config.dynamicSmemBytes = smem_size;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = enable_pdl;
+  config.numAttrs = 1;
+  config.attrs = attrs;
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    auto kernel = RMSNormQuantKernel<VEC_SIZE, T, O>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, weight, output, d, stride_input,
+                                            stride_output, weight_bias, scale, eps));
   });
   return cudaSuccess;
 }
@@ -391,6 +507,140 @@ cudaError_t FusedAddRMSNorm(T* input, T* residual, T* weight, uint32_t batch_siz
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, residual, weight, d,
                                             stride_input, stride_residual, weight_bias, eps));
+  });
+
+  return cudaSuccess;
+}
+
+template <uint32_t VEC_SIZE, typename T, typename O>
+__global__ void FusedAddRMSNormQuantKernel(T* __restrict__ input, T* __restrict__ residual,
+                                           T* __restrict__ weight, O* __restrict__ output,
+                                           const uint32_t d, const uint32_t stride_input,
+                                           const uint32_t stride_residual,
+                                           const uint32_t stride_output, float weight_bias,
+                                           float scale, float eps) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = ceil_div(d, VEC_SIZE * num_threads);
+  const float scale_inv = 1.0f / scale;
+  extern __shared__ float smem[];
+  float* smem_x = smem + ceil_div(num_warps, 4) * 4;
+
+  float sum_sq = 0.f;
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    vec_t<T, VEC_SIZE> input_vec;
+    input_vec.fill(0.f);
+    vec_t<T, VEC_SIZE> residual_vec;
+    residual_vec.fill(0.f);
+    vec_t<float, VEC_SIZE> x_vec;
+    x_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.load(input + bx * stride_input + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+      residual_vec.load(residual + bx * stride_residual + i * num_threads * VEC_SIZE +
+                        thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      float x = float(input_vec[j]);
+      x += float(residual_vec[j]);
+      sum_sq += x * x;
+      residual_vec[j] = (T)x;
+      x_vec[j] = x;
+    }
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      residual_vec.store(residual + bx * stride_residual + i * num_threads * VEC_SIZE +
+                         thread_id * VEC_SIZE);
+      x_vec.store(smem_x + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+  }
+
+  // first, warp reduce sum
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq += math::shfl_xor_sync(sum_sq, offset);
+  }
+
+  smem[ty] = sum_sq;
+  __syncthreads();
+  // then, cross warp reduce sum using only the first warp
+  if (ty == 0) {
+    sum_sq = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq += math::shfl_xor_sync(sum_sq, offset);
+    }
+    smem[0] = sum_sq;
+  }
+  __syncthreads();
+
+  float rms_rcp = math::rsqrt(smem[0] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    vec_t<float, VEC_SIZE> output_vec;
+    vec_t<T, VEC_SIZE> weight_vec;
+    vec_t<float, VEC_SIZE> x_vec;
+    output_vec.fill(0.f);
+    weight_vec.fill(0.f);
+    x_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      weight_vec.load(weight + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+      x_vec.load(smem_x + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      output_vec[j] = x_vec[j] * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
+      output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
+    }
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +
+                            thread_id * VEC_SIZE);
+    }
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <typename T, typename O>
+cudaError_t FusedAddRMSNormQuant(T* input, T* residual, T* weight, O* output, uint32_t batch_size,
+                                 uint32_t d, uint32_t stride_input, uint32_t stride_residual,
+                                 uint32_t stride_output, float scale, float eps = 1e-5,
+                                 bool enable_pdl = false, cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
+  const uint32_t num_warps = ceil_div(block_size, 32);
+  dim3 nblks(batch_size);
+  dim3 nthrs(32, num_warps);
+  const uint32_t smem_size = (ceil_div(num_warps, 4) * 4 + d) * sizeof(float);
+  float weight_bias = 0.f;
+
+  cudaLaunchConfig_t config;
+  config.gridDim = nblks;
+  config.blockDim = nthrs;
+  config.dynamicSmemBytes = smem_size;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = enable_pdl;
+  config.numAttrs = 1;
+  config.attrs = attrs;
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    auto kernel = FusedAddRMSNormQuantKernel<VEC_SIZE, T, O>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, input, residual, weight, output, d,
+                                            stride_input, stride_residual, stride_output,
+                                            weight_bias, scale, eps));
   });
 
   return cudaSuccess;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

FP8 model inference requires multiple intermediate quantization kernels, which can be avoided by fusing norm and quantization kernels. Consumers like sglang and vllm can lower to these norm + quant fusion kernels using custom torch compile passes

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

### Reference
I have been working on adding custom fusion passes to sglang as part of the following [RFC](https://github.com/sgl-project/sglang/issues/10118) and would like to use flashinfer's norm kernels for the norm quant fusions instead of migrating vllm kernels to sglang as part of the following [MR](https://github.com/sgl-project/sglang/pull/10549)

### Implementation
I realise that existing kernels (at least for rmsnorm) can be modified to add the scale parameter as an optional parameter, thereby avoiding most code duplication. However, as an initial implementation, I have opted for a separate implementation route. This can be refactored if required.

For fused_add_rmsnorm_quant, I don't think an in-place update would be possible since dtypes for input and output differ

Currently, FP8_E3M4 numeric limits (448) have been hard-coded, as I am not aware of getting this value at compile time without including c10 headers from torch, and not sure if that is acceptable post tvm ffi migration

Following is a snippet from VLLM, and I have seen similar code for getting the FP8 numeric limits
```cpp
#include <c10/util/Float8_e4m3fn.h>

template <typename T,
          typename = std::enable_if_t<std::is_same_v<T, c10::Float8_e4m3fn> ||
                                      std::is_same_v<T, c10::Float8_e4m3fnuz> ||
                                      std::is_same_v<T, int8_t>>>
struct quant_type_max {
  static constexpr T val() { return std::numeric_limits<T>::max(); }
};
```

The best option in my mind is to introduce `include/flashinfer/fp8.h` containing something similar to the above snippet, and also support e5m2

### Tests
atol and rtol for the fp8 assertions had to be high due to the low precision nature of the data, but with tolerances of 1e-2, just a few tests fail with a single element mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quantized RMSNorm and fused quantized RMSNorm (residual-add) with configurable scale, eps, and PDL toggle.
  * Supports FP16/FP8 paths and optional per-token or per-tensor scaling; outputs are clamped for quantized formats.

* **Tests**
  * Added tests validating quantized normalization and fused-residual flows across dtypes, batch sizes, scaling modes, and PDL configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->