### PR TITLE
test: Fix MNNVL tests to skip when container lacks SYS_PTRACE capability

### DIFF
--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared test utilities for comm tests.
+"""
+
+import ctypes
+import os
+
+from flashinfer.comm.mnnvl import MnnvlMemory
+
+
+def _check_pidfd_permissions() -> bool:
+    """Check if pidfd_getfd syscall is available and permitted.
+
+    This is required for MNNVL in containers - the SYS_PTRACE capability
+    must be available for cross-process file descriptor sharing.
+    """
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        syscall = libc.syscall
+        SYS_pidfd_open = 434
+        SYS_pidfd_getfd = 438
+
+        # Try to open our own process and get our own fd
+        my_pid = os.getpid()
+        pidfd = syscall(SYS_pidfd_open, my_pid, 0)
+        if pidfd < 0:
+            return False
+
+        # Try pidfd_getfd on stdin (fd=0) - this tests the permission
+        # We don't actually need the result, just checking if it's permitted
+        test_fd = syscall(SYS_pidfd_getfd, pidfd, 0, 0)
+        os.close(pidfd)
+
+        if test_fd < 0:
+            err = ctypes.get_errno()
+            if err == 1:  # EPERM - permission denied (container issue)
+                return False
+            # Other errors (like EBADF) are OK - permission check passed
+        else:
+            os.close(test_fd)
+
+        return True
+    except Exception:
+        return False
+
+
+def mnnvl_available() -> bool:
+    """Check if MNNVL is fully available (hardware + container permissions)."""
+    return MnnvlMemory.supports_mnnvl() and _check_pidfd_permissions()

--- a/tests/comm/test_mnnvl_memory.py
+++ b/tests/comm/test_mnnvl_memory.py
@@ -22,12 +22,14 @@ from flashinfer.comm.mapping import Mapping
 from flashinfer.comm.mnnvl import MnnvlMemory, MpiComm
 from flashinfer.comm.trtllm_alltoall import MnnvlMoe, MoEAlltoallInfo
 
+from .conftest import mnnvl_available
+
 pynvml.nvmlInit()
 
 
 @pytest.mark.skipif(
-    not MnnvlMemory.supports_mnnvl(),
-    reason="Mnnvl memory is not supported on this platform",
+    not mnnvl_available(),
+    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
 )
 class TestMnnvlMemory:
     @pytest.fixture(autouse=True)
@@ -60,8 +62,8 @@ class TestMnnvlMemory:
         return (size + align_size - 1) // align_size * align_size
 
     @pytest.mark.skipif(
-        not MnnvlMemory.supports_mnnvl(),
-        reason="Mnnvl memory is not supported on this platform",
+        not mnnvl_available(),
+        reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
     )
     def test_mnnvl_memory(self):
         # allocate un-aligned memory
@@ -118,8 +120,8 @@ class TestMnnvlMemory:
         del tensor1
 
     @pytest.mark.skipif(
-        not MnnvlMemory.supports_mnnvl(),
-        reason="Mnnvl memory is not supported on this platform",
+        not mnnvl_available(),
+        reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
     )
     def test_moe_alltoall_multi_rank_single_gpu(self):
         torch.cuda.set_device(self.local_rank)

--- a/tests/comm/test_mnnvl_moe_alltoall.py
+++ b/tests/comm/test_mnnvl_moe_alltoall.py
@@ -23,6 +23,8 @@ from flashinfer.comm import MoeAlltoAll
 from flashinfer.comm.mapping import Mapping
 from flashinfer.comm.mnnvl import MnnvlMemory
 
+from .conftest import mnnvl_available
+
 
 class MPIExit(Exception):
     pass
@@ -569,8 +571,10 @@ def moe_a2a_dispatch_test_impl(distribution, top_k):
 
     try:
         MnnvlMemory.initialize()
-        if not MnnvlMemory.supports_mnnvl():
-            pytest.skip("MNNVL not supported on this system")
+        if not mnnvl_available():
+            pytest.skip(
+                "MNNVL not supported on this system or container lacks SYS_PTRACE capability"
+            )
     except Exception:
         pytest.skip("MNNVL not supported on this system")
 
@@ -668,8 +672,10 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
 
     try:
         MnnvlMemory.initialize()
-        if not MnnvlMemory.supports_mnnvl():
-            pytest.skip("MNNVL not supported on this system")
+        if not mnnvl_available():
+            pytest.skip(
+                "MNNVL not supported on this system or container lacks SYS_PTRACE capability"
+            )
     except Exception:
         pytest.skip("MNNVL not supported on this system")
 

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -18,9 +18,10 @@ import pytest
 import torch
 import pynvml
 from flashinfer.comm.mapping import Mapping
-from flashinfer.comm.mnnvl import MnnvlMemory
 
 import flashinfer.comm.trtllm_moe_alltoall as trtllm_moe_alltoall
+
+from .conftest import mnnvl_available
 
 pynvml.nvmlInit()
 
@@ -94,8 +95,8 @@ def make_payload(num_tokens, vector_dim, dtype):
     SINGLE_GPU_PARAMS,
 )
 @pytest.mark.skipif(
-    not MnnvlMemory.supports_mnnvl(),
-    reason="Mnnvl memory is not supported on this platform",
+    not mnnvl_available(),
+    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
 )
 def test_moe_alltoall_single_gpu(num_tokens, vector_dim, num_experts, top_k):
     """Test MOE alltoall communication on single GPU."""
@@ -559,8 +560,8 @@ def test_moe_combine_multi_rank_single_gpu(
 
 
 @pytest.mark.skipif(
-    not MnnvlMemory.supports_mnnvl(),
-    reason="Mnnvl memory is not supported on this platform",
+    not mnnvl_available(),
+    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
 )
 def test_moe_workspace_size_per_rank():
     """Test the workspace size per rank for the MoeAlltoAll operation."""


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

MNNVL tests were failing in containerized environments with `pidfd_getfd` permission errors instead of being skipped. The existing `MnnvlMemory.supports_mnnvl()` only checked for NVLink hardware but not container permissions. This PR adds a proactive permission check for the `pidfd_getfd` syscall (which requires `SYS_PTRACE` capability) and consolidates it into a shared `mnnvl_available()` helper, ensuring tests skip gracefully when running in containers without proper capabilities.
Changes:
* `Add tests/comm/conftest.py` with shared `_check_pidfd_permissions()` and `mnnvl_available()` helpers
* Update skip conditions in `test_mnnvl_memory.py`, `test_mnnvl_moe_alltoall.py`, and `test_trtllm_moe_alltoall.py` to use `mnnvl_available()`


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved MNNVL memory test infrastructure with centralized availability checks that verify system capability requirements (SYS_PTRACE) for containerized environments.
  * Tests now skip more gracefully when required capabilities are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->