### PR TITLE
feat: support inplace update output for get_batch_indices_positions

### DIFF
--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -174,8 +174,8 @@ def get_batch_indices_positions(
     append_paged_kv_cache
     """
     batch_size = append_indptr.size(0) - 1
-    dtype = append_indptr.dtype
     device = append_indptr.device
+    dtype = torch.int32
 
     if batch_indices is None:
         batch_indices = torch.empty((nnz,), device=device, dtype=dtype)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Support inplace update output for `get_batch_indices_positions`. User can pre-allocate `batch_indices` and `positions` to avoid additional copies.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API now accepts optional pre-allocated output buffers for batch indices and positions, enabling memory reuse while preserving previous behavior.
  * Pre-allocated buffers are validated for compatibility; automatic allocation remains the fallback.

* **Documentation**
  * Docstrings clarified to describe the new optional outputs, validation rules (shape/dtype/device), and allocation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->