### PR TITLE
Fix CUTLASS FP8 gemm correctness issue on SM120/SM121 for shapes where N is not divisible by ScaleGranularityN.

### DIFF
--- a/include/flashinfer/gemm/gemm_groupwise_sm120.cuh
+++ b/include/flashinfer/gemm/gemm_groupwise_sm120.cuh
@@ -156,12 +156,13 @@ cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buf
 
   // Pass workspace pointer only if needed
   void* kernel_workspace = nullptr;
-  if (workspace_size > 0) {
+  if (workspace_size > 0) {  // Only provide a pointer if workspace is actually needed
     kernel_workspace = float_buffer;
   }
 
   status = gemm.initialize(arguments, kernel_workspace);
   if (status != cutlass::Status::kSuccess) {
+    // Don't continue if initialization failed
     return cudaErrorNotSupported;
   }
 

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -8,9 +8,9 @@ from tests.utils_fp8 import to_float8
 
 
 @pytest.mark.parametrize("b", [1, 16])
-@pytest.mark.parametrize("m", [48, 128])
-@pytest.mark.parametrize("n", [80, 64])
-@pytest.mark.parametrize("k", [64, 256])
+@pytest.mark.parametrize("m", [1, 48, 128])
+@pytest.mark.parametrize("n", [64, 80, 10304])
+@pytest.mark.parametrize("k", [64, 256, 2688])
 @pytest.mark.parametrize("input_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("mat2_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16])
@@ -18,14 +18,6 @@ from tests.utils_fp8 import to_float8
 @pytest.mark.parametrize("auto_tuning", [True, False])
 def test_bmm_fp8(b, m, n, k, input_dtype, mat2_dtype, res_dtype, backend, auto_tuning):
     compute_capability = get_compute_capability(torch.device("cuda"))
-    if compute_capability[0] == 12 and backend in [
-        "cutlass",
-        "auto",
-    ]:
-        # TODO(yongwwww): enable all test cases for SM120/121 CUTLASS bmm_fp8 backend
-        pytest.xfail(
-            "Not all test cases for CUTLASS bmm_fp8 on SM120/121 are passing at this moment"
-        )
     if backend == "cutlass" and compute_capability[0] not in [10, 11, 12]:
         pytest.skip(
             "bmm_fp8 with cutlass backend is only supported on SM100, SM110, and SM120/121 GPUs."


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The SM120 CUTLASS blockwise gemm kernel requires dimensions like N to be multiples of 128 due to hardware constraints (https://github.com/NVIDIA/cutlass/blob/3f4c086d09bd1dc55defb955862f333893bbb28b/include/cutlass/gemm/collective/sm120_mma_tma_blockwise_scaling.hpp#L345C5-L346). 

We met the shape  `a: torch.Size([1, 1, 2688]), b: torch.Size([1, 2688, 10304]), scale_a: torch.Size([]), scale_b: torch.Size([]), out: torch.Size([1, 1, 10304]), workspace_buffer: torch.Size([33554432])` from Nemotron-Nano-v3, where 10304 is not a multiple of 128, the cutlass gemm does not work for it properly. In this PR, we add a pad and slice to get it work.


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * FP8 matrix operations on SM120/SM121 GPUs now support arbitrary input dimensions, removing the previous K dimension minimum requirement and enabling broader use cases.

* **Tests**
  * Expanded test coverage for FP8 matrix operations with additional parameter combinations and improved hardware compatibility validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->