### PR TITLE
feat: Add FP8/NVFP4 quant fusion for MNNVL Allreduce

### DIFF
--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -1,11 +1,17 @@
 from .cuda_ipc import CudaRTLibrary, create_shared_buffer, free_shared_buffer
 from .dlpack_utils import pack_strided_memory
 from .mapping import Mapping
+
+# Shared type definitions (canonical source: _types.py, re-exported via allreduce.py)
+from .allreduce import AllReduceFusionPattern as AllReduceFusionPattern
+from .allreduce import QuantizationSFLayout as QuantizationSFLayout
+from .allreduce import get_pattern_traits as get_pattern_traits
+from ._types import QuantFusionType as QuantFusionType
+
+# Legacy trtllm types (for backwards compatibility)
 from .trtllm_ar import AllReduceFusionOp as AllReduceFusionOp
-from .trtllm_ar import AllReduceFusionPattern as AllReduceFusionPattern
 from .trtllm_ar import AllReduceStrategyConfig as AllReduceStrategyConfig
 from .trtllm_ar import AllReduceStrategyType as AllReduceStrategyType
-from .trtllm_ar import QuantizationSFLayout as QuantizationSFLayout
 from .trtllm_ar import (
     compute_fp4_swizzled_layout_sf_size as compute_fp4_swizzled_layout_sf_size,
 )

--- a/flashinfer/comm/_types.py
+++ b/flashinfer/comm/_types.py
@@ -1,0 +1,187 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Shared type definitions for AllReduce fusion operations.
+
+This module contains the canonical definitions for:
+- AllReduceFusionPattern: Fusion pattern enumeration
+- QuantFusionType: Quantization type enumeration (FP8, FP4, etc.)
+- QuantizationSFLayout: Scale factor layout enumeration
+- FusionPatternTraits: Traits dataclass for pattern capabilities
+
+These types are shared across different backend implementations (TensorRT-LLM, MNNVL).
+"""
+
+from dataclasses import dataclass
+
+
+# ============================================================================
+# FUSION PATTERNS
+# ============================================================================
+
+
+class AllReduceFusionPattern:
+    """
+    Fusion patterns for AllReduce operations.
+
+    Matches the C++ AllReduceFusionPattern enum in trtllm_allreduce_fusion.cuh.
+    """
+
+    # Basic all-reduce pattern
+    kAllReduce = 0
+    # All-reduce followed by residual add and RMS norm
+    kARResidualRMSNorm = 1
+    # All-reduce followed by residual add, RMS norm and FP8 quantization
+    kARResidualRMSNormFP8Quant = 2
+    # All-reduce followed by residual add, RMS norm and FP4 quantization
+    kARResidualRMSNormFP4Quant = 3
+    # All-reduce followed by residual add, RMS norm and FP8 quantization, with norm output
+    kARResidualRMSNormOutFP8Quant = 4
+    # All-reduce followed by residual add, RMS norm and FP4 quantization, with norm output
+    kARResidualRMSNormOutFP4Quant = 5
+
+
+# ============================================================================
+# QUANTIZATION TYPES
+# ============================================================================
+
+
+class QuantFusionType:
+    """
+    Quantization types for fused AllReduce operations.
+
+    Matches the C++ QuantType enum in trtllm_allreduce_fusion.cuh.
+    """
+
+    NONE = 0
+    FP8 = 1
+    NVFP4 = 2
+
+
+class QuantizationSFLayout:
+    """
+    Scale factor layout for quantization.
+
+    Matches the C++ QuantizationSFLayout enum in trtllm_allreduce_fusion.cuh.
+    """
+
+    # Block scale factors are stored in swizzled layout for cutlass FP4 kernel.
+    # Scale factor blocks are organized in 512-byte blocks in global memory,
+    # with each block having 128x4 FP8 values.
+    SWIZZLED_128x4 = 0
+    SWIZZLED_8x4 = 1
+    # Block scale factors are stored in linear layout (row-major).
+    LINEAR = 2
+
+
+# ============================================================================
+# FUSION PATTERN TRAITS
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class FusionPatternTraits:
+    """
+    Traits for AllReduceFusionPattern.
+
+    Mirrors the C++ FusionPatternTraits template in trtllm_allreduce_fusion.cuh.
+    Provides a single source of truth for pattern capabilities.
+    """
+
+    has_allreduce_out: bool
+    has_residual: bool
+    has_residual_out: bool
+    has_rmsnorm: bool
+    has_norm_out: bool
+    quant_type: int  # QuantFusionType constant
+
+    @property
+    def has_quant(self) -> bool:
+        """Returns True if this pattern includes quantization."""
+        return self.quant_type != QuantFusionType.NONE
+
+
+# Single source of truth - mirrors the C++ DEFINE_FUSION_PATTERN_TRAITS macros
+_PATTERN_TRAITS: dict[int, FusionPatternTraits] = {
+    AllReduceFusionPattern.kAllReduce: FusionPatternTraits(
+        has_allreduce_out=True,
+        has_residual=False,
+        has_residual_out=False,
+        has_rmsnorm=False,
+        has_norm_out=False,
+        quant_type=QuantFusionType.NONE,
+    ),
+    AllReduceFusionPattern.kARResidualRMSNorm: FusionPatternTraits(
+        has_allreduce_out=False,
+        has_residual=True,
+        has_residual_out=True,
+        has_rmsnorm=True,
+        has_norm_out=True,
+        quant_type=QuantFusionType.NONE,
+    ),
+    AllReduceFusionPattern.kARResidualRMSNormFP8Quant: FusionPatternTraits(
+        has_allreduce_out=False,
+        has_residual=True,
+        has_residual_out=True,
+        has_rmsnorm=True,
+        has_norm_out=False,
+        quant_type=QuantFusionType.FP8,
+    ),
+    AllReduceFusionPattern.kARResidualRMSNormFP4Quant: FusionPatternTraits(
+        has_allreduce_out=False,
+        has_residual=True,
+        has_residual_out=True,
+        has_rmsnorm=True,
+        has_norm_out=False,
+        quant_type=QuantFusionType.NVFP4,
+    ),
+    AllReduceFusionPattern.kARResidualRMSNormOutFP8Quant: FusionPatternTraits(
+        has_allreduce_out=False,
+        has_residual=True,
+        has_residual_out=True,
+        has_rmsnorm=True,
+        has_norm_out=True,
+        quant_type=QuantFusionType.FP8,
+    ),
+    AllReduceFusionPattern.kARResidualRMSNormOutFP4Quant: FusionPatternTraits(
+        has_allreduce_out=False,
+        has_residual=True,
+        has_residual_out=True,
+        has_rmsnorm=True,
+        has_norm_out=True,
+        quant_type=QuantFusionType.NVFP4,
+    ),
+}
+
+
+def get_pattern_traits(pattern: int) -> FusionPatternTraits:
+    """
+    Get traits for an AllReduceFusionPattern.
+
+    Args:
+        pattern: AllReduceFusionPattern constant (0-5)
+
+    Returns:
+        FusionPatternTraits with all trait flags for the pattern
+
+    Example:
+        >>> traits = get_pattern_traits(AllReduceFusionPattern.kARResidualRMSNormFP8Quant)
+        >>> traits.has_quant  # True
+        >>> traits.has_rmsnorm  # True
+        >>> traits.quant_type  # QuantFusionType.FP8
+    """
+    return _PATTERN_TRAITS[pattern]

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -62,38 +62,9 @@ class AllReduceFusionOp:
     MOE_FINALIZE_ALLREDUCE_RESIDUAL_RMS_NORM = 9
 
 
-class AllReduceFusionPattern:
-    # NOTE: for trtllm_allreduce_fusion
-    # Basic all-reduce pattern
-    kAllReduce = 0
-    # All-reduce followed by residual add and RMS norm
-    kARResidualRMSNorm = 1
-    # All-reduce followed by residual add, RMS norm and FP8 quantization
-    kARResidualRMSNormFP8Quant = 2
-    # All-reduce followed by residual add, RMS norm and FP4 quantization
-    kARResidualRMSNormFP4Quant = 3
-    # All-reduce followed by residual add, RMS norm and FP8 quantization, with norm output
-    kARResidualRMSNormOutFP8Quant = 4
-    # All-reduce followed by residual add, RMS norm and FP4 quantization, with norm output
-    kARResidualRMSNormOutFP4Quant = 5
-
-
-class QuantizationSFLayout:
-    # Block scale factors are stored in swizzled layout for cutlass FP4 kernel. Scale factor
-    # blocks are organized in 512-byte blocks in global memory, with each block having 128x4 FP8
-    # values. The SF matrix dimensions are therefore padded - rows to the nearest multiple of 128 and
-    # columns to the nearest multiple of 4.
-    #
-    # The scale factor block rows map to data block rows in an interleaved pattern:
-    # For a scale factor row 'i', it maps to data block row: (i % 4) * 32 + (i / 4)
-    # Column 'j' in the scale factor block corresponds to scaling the j-th block in the data tensor.
-    #
-    # Please refer to https://nvbugs/4165523 for more details about the swizzled layout.
-    SWIZZLED_128x4 = 0
-    SWIZZLED_8x4 = 1
-    # Block scale factors are stored in linear layout (row-major). This is used in some trtllm-gen
-    # kernels standard.
-    LINEAR = 2
+# Import shared types from canonical location (_types.py) and re-export for backwards compatibility
+from ._types import AllReduceFusionPattern
+from ._types import QuantizationSFLayout
 
 
 @functools.cache

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -623,7 +623,10 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
         if quant_out is None:
             # TODO: PyTorch supports fp4x2 dtype, do we want to use that?
             quant_out = torch.empty(
-                input.shape[0], input.shape[1] // 2, dtype=torch.uint8
+                input.shape[0],
+                input.shape[1] // 2,
+                dtype=torch.uint8,
+                device=input.device,
             )
         # TODO: Do we need further check on the shape?
         elif len(quant_out.shape) != 2:

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -347,7 +347,7 @@ def get_trtllm_mnnvl_comm_module():
             residual_out,
             gamma,
             epsilon,
-            quant_type,
+            0 if quant_type is None else quant_type.value,
             quant_out,
             sf_out,
             output_scale,

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -1768,7 +1768,8 @@ __global__ __launch_bounds__(1024) void rmsNormLamport_fusion(
         *reinterpret_cast<float4*>(&outputNorm[blockLoadOffset + threadLoadOffset]) = r_out.packed;
       }
       if constexpr (QType == QuantType::kFP8) {
-        quant::quant_fp8<T, float4, kELTS_PER_LOAD>(r_out, quantOut, outputScale, threadOffset);
+        quant::quant_fp8<T, float4, kELTS_PER_LOAD>(r_out, quantOut, outputScale,
+                                                    blockLoadOffset + threadLoadOffset);
       } else if constexpr (QType == QuantType::kFP4) {
         quant::quant_nvfp4<T, float4, kELTS_PER_LOAD>(r_out, quantOut, scalingFactorOut,
                                                       outputScale, token, dim,

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -1170,9 +1170,8 @@ inline __device__ void quant_nvfp4(PackedVec<PackedType, T> packed_accum, void* 
   // Get the target pointer to the SF output.
   auto sf_out =
       cvt_quant_to_fp4_get_sf_out_offset<uint32_t, details::CVT_FP4_SF_VEC_SIZE / ELTS_PER_THREAD>(
-          std::nullopt, token_idx, packed_idx, std::nullopt,
-          token_dim / details::CVT_FP4_SF_VEC_SIZE, reinterpret_cast<uint32_t*>(sf_out_ptr),
-          sf_layout);
+          std::nullopt, token_idx, packed_idx, std::nullopt, token_dim /* numCols, don't divide*/,
+          reinterpret_cast<uint32_t*>(sf_out_ptr), sf_layout);
 
   // Calculate the offset in packed item granularity for the quant output
   uint32_t quant_out_offset = token_idx * token_dim / ELTS_PER_THREAD + packed_idx;

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -17,6 +17,11 @@
 #include <cooperative_groups.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <vector_types.h>
+#if CUDA_VERSION >= 12080
+#include <cuda_fp4.h>
+#endif
+#include <cuda_fp8.h>
 #include <cuda_pipeline.h>
 #include <cuda_runtime.h>
 
@@ -24,10 +29,20 @@
 #include <type_traits>
 
 #include "../exception.h"
+#include "../fp4_layout.cuh"
 #include "../logging.h"
 #include "../utils.cuh"
+#include "../vec_dtypes.cuh"
+
 namespace flashinfer {
 namespace trtllm_mnnvl_allreduce {
+
+// TODO: Same; This enum defination is duplicated
+enum class QuantType : int {
+  kNone = 0,
+  kFP8 = 1,
+  kFP4 = 2,
+};
 
 struct AllReduceFusionParams {
   int nRanks;
@@ -38,16 +53,21 @@ struct AllReduceFusionParams {
   void* bufferPtrLocal;
   void* multicastPtr;
   uint32_t* bufferFlags;
-  bool rmsNormFusion;
-  bool launchWithPdl;
+  bool rmsNormFusion = false;
+  bool launchWithPdl = false;
 
   void const* input;
-  void const* residualIn;
-  void const* gamma;
-  double epsilon;
+  void const* residualIn = nullptr;
+  void const* gamma = nullptr;
+  double epsilon = 1e-5;
+  float* outputScale = nullptr;
+  QuantizationSFLayout sfLayout = QuantizationSFLayout::SWIZZLED_128x4;
+  QuantType quantType = QuantType::kNone;
 
-  void* residualOut;
-  void* output;
+  void* residualOut = nullptr;
+  void* output = nullptr;
+  void* quantOut = nullptr;
+  void* scalingFactorOut = nullptr;
   cudaStream_t stream = nullptr;
 };
 
@@ -493,21 +513,666 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
 }
 };  // namespace utils
 
-using utils::blockReduceSum;
 using utils::fromFloat;
+using utils::PackedVec;
+using utils::toFloat;
+
+// TODO: These code are shared with trtllm_allreduce_fusion.cuh, and moe_allreduce_fusion; Should we
+// move them to a shared header?
+namespace quant {
+
+namespace details {
+
+static constexpr int CVT_FP4_ELTS_PER_THREAD = 8;
+static constexpr int CVT_FP4_SF_VEC_SIZE = 16;
+static constexpr int kBytesPerAccess = 16;
+static constexpr int kOneShotMaxToken = 128;
+static constexpr int kBarrierFlagCount = 256;
+
+}  // namespace details
+
+namespace maths {
+// // ============================== Cast ==============================
+template <typename T_OUT, typename T_IN>
+__device__ inline T_OUT cuda_cast(T_IN val) {
+  return val;
+}
+
+template <>
+__device__ inline float2 cuda_cast<float2, int2>(int2 val) {
+  return make_float2(val.x, val.y);
+}
+
+template <>
+__device__ inline float2 cuda_cast<float2, float>(float val) {
+  return make_float2(val, val);
+}
+
+template <>
+__device__ inline float2 cuda_cast<float2, half2>(half2 val) {
+  return __half22float2(val);
+}
+
+template <>
+__device__ inline half2 cuda_cast<half2, float2>(float2 val) {
+  return __float22half2_rn(val);
+}
+
+template <>
+__device__ inline half2 cuda_cast<half2, float>(float val) {
+  return __float2half2_rn(val);
+}
+
+template <>
+__device__ inline half2 cuda_cast<half2, half>(half val) {
+  return __half2half2(val);
+}
+
+template <>
+__device__ inline int8_t cuda_cast<int8_t, half>(half val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  union {
+    half fp16;
+    int16_t int16_in;
+  };
+
+  fp16 = val;
+  asm volatile("cvt.rni.sat.s8.f16 %0, %1;" : "=h"(int16) : "h"(int16_in));
+  return int8[0];
+}
+
+template <>
+__device__ inline int16_t cuda_cast<int16_t, half2>(half2 val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int8[0] = cuda_cast<int8_t>(val.x);
+  int8[1] = cuda_cast<int8_t>(val.y);
+  return int16;
+}
+
+template <>
+__device__ inline int8_t cuda_cast<int8_t, float>(float val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=h"(int16) : "f"(val));
+  return int8[0];
+}
+
+template <>
+__device__ inline int16_t cuda_cast<int16_t, float2>(float2 val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int8[0] = cuda_cast<int8_t>(val.x);
+  int8[1] = cuda_cast<int8_t>(val.y);
+  return int16;
+}
+
+template <>
+__device__ inline half2 cuda_cast<half2, int16_t>(int16_t val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int16 = val;
+  return make_half2(int8[0], int8[1]);
+}
+
+template <>
+__device__ inline float2 cuda_cast<float2, int16_t>(int16_t val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int16 = val;
+  return make_float2(int8[0], int8[1]);
+}
+
+template <>
+__device__ inline __nv_bfloat16 cuda_cast(int32_t val) {
+  return static_cast<float>(val);
+}
+
+template <>
+__device__ inline __nv_bfloat16 cuda_cast(int8_t val) {
+  return static_cast<float>(val);
+}
+
+template <>
+__device__ inline int8_t cuda_cast(__nv_bfloat16 val) {
+  return static_cast<float>(val);
+}
+
+template <>
+__device__ inline float cuda_cast<float, __nv_bfloat16>(__nv_bfloat16 val) {
+  return __bfloat162float(val);
+}
+
+inline __device__ float2 bf1622float2(const __nv_bfloat162 val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float2 f_val;
+  f_val.x = __low2float(val);
+  f_val.y = __high2float(val);
+  return f_val;
+#else
+  return __bfloat1622float2(val);
+#endif
+}
+
+template <>
+__device__ inline float2 cuda_cast<float2, __nv_bfloat162>(__nv_bfloat162 val) {
+  return bf1622float2(val);
+}
+
+template <>
+__device__ inline half cuda_cast<half, __nv_bfloat16>(__nv_bfloat16 val) {
+  return __float2half(__bfloat162float(val));
+}
+
+inline __device__ int16_t bf1622int16(__nv_bfloat162 val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float2 f_val;
+  f_val.x = max(min(__low2float(val), 127.f), -128.f);
+  f_val.y = max(min(__high2float(val), 127.f), -128.f);
+
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int8[0] = static_cast<int8_t>(static_cast<short>(f_val.x));
+  int8[1] = static_cast<int8_t>(static_cast<short>(f_val.y));
+  return int16;
+#else
+  val = __hmin2(val, make_bfloat162(127., 127.));
+  val = __hmax2(val, make_bfloat162(-128., -128.));
+
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int8[0] = static_cast<int8_t>(static_cast<short>(val.x));
+  int8[1] = static_cast<int8_t>(static_cast<short>(val.y));
+  return int16;
+#endif
+}
+
+template <>
+__device__ inline int16_t cuda_cast<int16_t, __nv_bfloat162>(__nv_bfloat162 val) {
+  return bf1622int16(val);
+}
+
+template <>
+__device__ inline __nv_bfloat16 cuda_cast<__nv_bfloat16, float>(float val) {
+  return __float2bfloat16(val);
+}
+
+template <>
+__device__ inline __nv_bfloat16 cuda_cast<__nv_bfloat16, half>(half val) {
+  return __float2bfloat16(__half2float(val));
+}
+
+inline __device__ __nv_bfloat162 bf162bf162(const __nv_bfloat16 val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  __nv_bfloat162 val2;
+  val2.x = val;
+  val2.y = val;
+  return val2;
+#else
+  return __bfloat162bfloat162(val);
+#endif
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, __nv_bfloat16>(__nv_bfloat16 val) {
+  return bf162bf162(val);
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, float>(float val) {
+  return __float2bfloat162_rn(val);
+}
+
+inline __device__ __nv_bfloat162 float22bf162(const float2 val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __floats2bfloat162_rn(val.x, val.y);
+#else
+  return __float22bfloat162_rn(val);
+#endif
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, float2>(float2 val) {
+  return float22bf162(val);
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, int16_t>(int16_t val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+
+  int16 = val;
+  __nv_bfloat162 res;
+  res.x = cuda_cast<__nv_bfloat16>(int8[0]);
+  res.y = cuda_cast<__nv_bfloat16>(int8[1]);
+  return res;
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, half2>(half2 val) {
+  return float22bf162(__half22float2(val));
+}
+
+// // ============================== Abs ==============================
+template <typename T>
+__device__ inline T cuda_abs(T val) {
+  assert(false);
+  return {};
+}
+
+template <>
+__device__ inline float cuda_abs(float val) {
+  return fabs(val);
+}
+
+template <>
+__device__ inline float2 cuda_abs(float2 val) {
+  return make_float2(fabs(val.x), fabs(val.y));
+}
+
+template <>
+__device__ inline half cuda_abs(half val) {
+  return __habs(val);
+}
+
+template <>
+__device__ inline half2 cuda_abs(half2 val) {
+  return __habs2(val);
+}
+
+#if __CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)
+template <>
+__device__ inline __nv_bfloat16 cuda_abs(__nv_bfloat16 val) {
+  return __habs(val);
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_abs(__nv_bfloat162 val) {
+  return __habs2(val);
+}
+#endif
+
+// // ============================== Max ==============================
+template <typename To, typename Ti>
+__device__ inline To cuda_max(Ti val) {
+  return cuda_cast<To>(val);
+};
+
+template <>
+__device__ inline float cuda_max(float2 val) {
+  return fmaxf(val.x, val.y);
+}
+
+template <>
+__device__ inline half cuda_max(half2 val) {
+  return __hmax(val.x, val.y);
+}
+
+template <>
+__device__ inline __nv_bfloat16 cuda_max(__nv_bfloat162 val) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+  return __hmax(val.x, val.y);
+#else
+  assert(0);
+  asm volatile("brkpt;\n" ::);
+  return __nv_bfloat16(0);
+#endif
+}
+
+// Binary maximum: compute the max of two values.
+template <typename T>
+__device__ inline T cuda_max(T val1, T val2) {
+  return (val1 > val2) ? val1 : val2;
+}
+
+template <>
+__device__ inline float2 cuda_max(float2 val1, float2 val2) {
+  float2 out;
+  out.x = fmaxf(val1.x, val2.x);
+  out.y = fmaxf(val1.y, val2.y);
+  return out;
+}
+
+template <>
+__device__ inline half2 cuda_max(half2 val1, half2 val2) {
+  return __hmax2(val1, val2);
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_max(__nv_bfloat162 val1, __nv_bfloat162 val2) {
+  return __hmax2(val1, val2);
+}
+
+// // ============================== Reciprocal ==============================
+// Fast reciprocal.
+inline __device__ float reciprocal_approximate_ftz(float a) {
+  float b;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;\n" : "=f"(b) : "f"(a));
+  return b;
+}
+}  // namespace maths
+
+inline __device__ int64_t get_sf_out_offset_128x4(std::optional<int> batchIdx, int mIdx, int kIdx,
+                                                  std::optional<int> numRows, int numCols) {
+  // SF layout [numMTiles, numKTiles, 32 (mTile), 4 (mTile), 4(kTile)]
+  // --> index [mTileIdx, kTileIdx, outerMIdx, innerMIdx, innerKIdx]
+
+  // batched tensor
+  // SF layout [numBTiles, numMTiles, numKTiles, 32 (mTile), 4 (mTile), 4(kTile)]
+  // --> index [bTileIdx, mTileIdx, kTileIdx, outerMIdx, innerMIdx, innerKIdx]
+
+  int32_t innerKIdx = (kIdx % 4);
+  int64_t innerKStride = 1;
+
+  int32_t innerMIdx = (mIdx % (32 * 4)) / 32;
+  int64_t innerMStride = 4 * innerKStride;  // 4
+
+  // M tile layout [32, 4] is column-major.
+  int32_t outerMIdx = (mIdx % 32);
+  int64_t outerMStride = 4 * innerMStride;  // 16
+
+  int32_t kTileIdx = (kIdx / 4);
+  int64_t kTileStride = 32 * outerMStride;  // 512
+
+  // SF vector size 16. We round the "numCols" up to a multiple of 64.
+  int factor = details::CVT_FP4_SF_VEC_SIZE * 4;
+  int32_t numKTiles = (numCols + factor - 1) / factor;
+  int32_t mTileIdx = mIdx / (32 * 4);
+  int64_t mTileStride = numKTiles * kTileStride;
+
+  // Each SF block has 128 rows so pad rows to the multiple of 128.
+  int32_t numMTiles = (numRows.value_or(0) + 128 - 1) / 128;
+  int64_t bTileStride = numMTiles * mTileStride;
+
+  // Compute the global offset.
+  int64_t SFOffset = batchIdx.value_or(0) * bTileStride + mTileIdx * mTileStride +
+                     kTileIdx * kTileStride + outerMIdx * outerMStride + innerMIdx * innerMStride +
+                     innerKIdx * innerKStride;
+
+  return SFOffset;
+}
+
+template <class SFType, int CVT_FP4_NUM_THREADS_PER_SF>
+__device__ uint8_t* cvt_quant_to_fp4_get_sf_out_offset(std::optional<int> batchIdx, int rowIdx,
+                                                       int colIdx, std::optional<int> numRows,
+                                                       int numCols, SFType* SFout,
+                                                       QuantizationSFLayout layout) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  static_assert(CVT_FP4_NUM_THREADS_PER_SF == 1 || CVT_FP4_NUM_THREADS_PER_SF == 2);
+
+  // One pair of threads write one SF to global memory.
+  // TODO: stage through smem for packed STG.32
+  // is it better than STG.8 from 4 threads ?
+  if (threadIdx.x % CVT_FP4_NUM_THREADS_PER_SF == 0) {
+    if (layout == QuantizationSFLayout::SWIZZLED_128x4) {
+      // SF vector index (16 elements share one SF in the K dimension).
+      // numRows and numCols are unpadded.
+      int32_t kIdx = colIdx / CVT_FP4_NUM_THREADS_PER_SF;
+      int32_t mIdx = rowIdx;
+
+      auto SFOffset = get_sf_out_offset_128x4(batchIdx, mIdx, kIdx, numRows, numCols);
+      return reinterpret_cast<uint8_t*>(SFout) + SFOffset;
+    } else if (layout == QuantizationSFLayout::LINEAR) {
+      // Linear row-major layout, no padding required.
+      int32_t KTileIdx = colIdx / CVT_FP4_NUM_THREADS_PER_SF;
+
+      int32_t numKTiles = numCols / details::CVT_FP4_SF_VEC_SIZE;
+      int64_t mTileStride = numKTiles;
+
+      int64_t BTileStride = numRows.value_or(0) * mTileStride;
+
+      int64_t SFOffset = batchIdx.value_or(0) * BTileStride + rowIdx * mTileStride + KTileIdx;
+      return reinterpret_cast<uint8_t*>(SFout) + SFOffset;
+    } else {
+      return nullptr;
+    }
+  }
+#endif
+  return nullptr;
+}
+
+__forceinline__ __device__ uint32_t pack_bytes(uint8_t c0, uint8_t c1, uint8_t c2, uint8_t c3) {
+  uint32_t val0 = c0;
+  uint32_t val1 = c1;
+  uint32_t val2 = c2;
+  uint32_t val3 = c3;
+
+  return (val3 << 24) | (val2 << 16) | (val1 << 8) | val0;
+}
+
+#if CUDA_VERSION >= 12080
+// Convert 8 float32 values into 8 e2m1 values (represented as one uint32_t).
+// NOTE: bypass sm_100 requirement by __nv_cvt_float2_to_fp4x2
+inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0]), "f"(array[1]), "f"(array[2]), "f"(array[3]), "f"(array[4]), "f"(array[5]),
+        "f"(array[6]), "f"(array[7]));
+  return val;
+#else
+  uint32_t val;
+  __nv_fp4x2_storage_t vals[4];
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    vals[i] = __nv_cvt_float2_to_fp4x2(*(((float2*)array) + i), __NV_E2M1, cudaRoundNearest);
+  }
+  val = pack_bytes(vals[0], vals[1], vals[2], vals[3]);
+  return val;
+#endif
+}
+
+// Convert 4 float2 values into 8 e2m1 values (represented as one uint32_t).
+inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0].x), "f"(array[0].y), "f"(array[1].x), "f"(array[1].y), "f"(array[2].x),
+        "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
+  return val;
+#else
+  uint32_t val;
+  __nv_fp4x2_storage_t vals[4];
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    vals[i] = __nv_cvt_float2_to_fp4x2(array[i], __NV_E2M1, cudaRoundNearest);
+  }
+  val = pack_bytes(vals[0], vals[1], vals[2], vals[3]);
+  return val;
+#endif
+}
+
+// Quantizes the provided PackedVec into the uint32_t output
+template <typename T, uint32_t VEC_SIZE, bool UE8M0_SF = false>
+__device__ uint32_t cvt_warp_fp16_to_fp4(vec_t<T, VEC_SIZE>& vec, float SFScaleVal,
+                                         uint8_t* SFout) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  // Get absolute maximum values among the local 8 values.
+  auto localMax = maths::cuda_abs(get_vec2_element(vec, 0));
+
+#pragma unroll
+  for (int i = 1; i < details::CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    localMax = maths::cuda_max(localMax, maths::cuda_abs(get_vec2_element(vec, i)));
+  }
+
+  // Get the absolute maximum among all 16 values (two threads).
+  localMax = maths::cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+  // Get the final absolute maximum values.
+  float vecMax = float(maths::cuda_max(localMax.x, localMax.y));
+
+  // Get the SF (max value of the vector / max value of e2m1).
+  // maximum value of e2m1 = 6.0.
+  // TODO: use half as compute data type.
+  float SFValue = SFScaleVal * (vecMax * maths::reciprocal_approximate_ftz(6.0f));
+  // 8 bits representation of the SF.
+  uint8_t fp8SFVal;
+  // Write the SF to global memory (STG.8).
+  if constexpr (UE8M0_SF) {
+#if (__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10 >= 12080)
+    __nv_fp8_e8m0 tmp;
+    tmp.__x = __nv_cvt_float_to_e8m0(SFValue, __NV_SATFINITE, cudaRoundPosInf);
+    SFValue = static_cast<float>(tmp);
+    fp8SFVal = tmp.__x;
+#else
+#error "FP8 E8M0 support requires CUDA 12.8 or newer."
+#endif
+  } else {
+    // Here SFValue is always positive, so E4M3 is the same as UE4M3.
+    __nv_fp8_e4m3 tmp = __nv_fp8_e4m3(SFValue);
+    fp8SFVal = tmp.__x;
+    SFValue = static_cast<float>(tmp);
+  }
+  // Get the output scale.
+  // Recipe: final_scale = reciprocal(fp32(fp8(SFValue * SFScaleVal))) * reciprocal(SFScaleVal))
+  float outputScale = SFValue != 0 ? maths::reciprocal_approximate_ftz(
+                                         SFValue * maths::reciprocal_approximate_ftz(SFScaleVal))
+                                   : 0.0f;
+
+  if (SFout) {
+    // Write the SF to global memory (STG.8).
+    *SFout = fp8SFVal;
+  }
+
+  // Convert the input to float.
+  float2 fp2Vals[details::CVT_FP4_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < details::CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    if constexpr (std::is_same_v<T, half>) {
+      fp2Vals[i] = __half22float2(get_vec2_element(vec, i));
+    } else {
+      fp2Vals[i] = __bfloat1622float2(get_vec2_element(vec, i));
+    }
+    fp2Vals[i].x *= outputScale;
+    fp2Vals[i].y *= outputScale;
+  }
+
+  // Convert to e2m1 values.
+  uint32_t e2m1Vec = fp32_vec_to_e2m1(fp2Vals);
+
+  // Write the e2m1 values to global memory.
+  return e2m1Vec;
+#else
+  return 0;
+#endif
+}
+
+#endif
+
+// ============================== Quant Device Function ==============================
+template <typename T, typename PackedType, int ELTS_PER_THREAD>
+inline __device__ void quant_fp8(PackedVec<PackedType, T> packed_accum, void* quant_out_ptr,
+                                 float* output_scale, uint32_t thread_offset) {
+  static_assert(ELTS_PER_THREAD == 8 || ELTS_PER_THREAD == 4, "ELTS_PER_THREAD must be 8 or 4");
+  using QuantizedPackedType = std::conditional_t<ELTS_PER_THREAD == 8, float2, float>;
+
+  auto quant_out = reinterpret_cast<__nv_fp8_e4m3*>(quant_out_ptr);
+  PackedVec<QuantizedPackedType, __nv_fp8_e4m3> quantized_accum;
+#pragma unroll
+  for (int i = 0; i < ELTS_PER_THREAD; i++) {
+    quantized_accum.elements[i] =
+        __nv_fp8_e4m3(toFloat<T>(packed_accum.elements[i]) * (*output_scale));
+  }
+  reinterpret_cast<QuantizedPackedType*>(&quant_out[thread_offset])[0] = quantized_accum.packed;
+}
+
+template <typename T, typename PackedType, int ELTS_PER_THREAD>
+inline __device__ void quant_nvfp4(PackedVec<PackedType, T> packed_accum, void* quant_out_ptr,
+                                   void* sf_out_ptr, float* output_scale, uint32_t token_idx,
+                                   uint32_t token_dim, uint32_t packed_idx,
+                                   QuantizationSFLayout sf_layout) {
+  static_assert(
+      ELTS_PER_THREAD == 8 && (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>),
+      "NVFP4 quantization fusion is only supported for FP16/BF16!");
+  constexpr int SF_VEC_SIZE = 16;
+
+  // Cast the packed accumulator
+  auto packed_accum_ = *reinterpret_cast<vec_t<T, ELTS_PER_THREAD>>(&packed_accum);
+  // SFType is only the pointer type; It does not affect the internal logic of offset calculation.
+  // Get the target pointer to the SF output.
+  auto sf_out = cvt_quant_to_fp4_get_sf_out_offset<uint32_t, SF_VEC_SIZE / ELTS_PER_THREAD>(
+      std::nullopt, token_idx, packed_idx, std::nullopt, token_dim / SF_VEC_SIZE,
+      reinterpret_cast<uint32_t*>(sf_out_ptr), sf_layout);
+
+  // Calculate the offset in packed item granularity for the quant output
+  uint32_t quant_out_offset = token_idx * token_dim / ELTS_PER_THREAD + packed_idx;
+  // Each packedvec has 8 elements -> 1 float4 in input -> 1 uint32_t in output
+  reinterpret_cast<uint32_t*>(quant_out_ptr)[quant_out_offset] =
+      cvt_warp_fp16_to_fp4<T, SF_VEC_SIZE, false>(packed_accum_, *output_scale, sf_out);
+}
+};  // namespace quant
+
+using utils::blockReduceSum;
 using utils::isNegZero;
 using utils::LamportFlags;
 using utils::loadPacked;
 using utils::loadPackedVolatile;
-using utils::PackedVec;
-using utils::toFloat;
 
-template <uint8_t WorldSize, typename T, bool RMSNormFusion = false, typename PackedType = float4>
-__global__ void __launch_bounds__(1024)
-    oneshotAllreduceFusionKernel(T* outputPtr, T* prenormedPtr, T const* shardPtr,
-                                 T const* residualInPtr, T const* gammaPtr, T** inputPtrs,
-                                 T* mcastPtr, int const numTokens, int const tokenDim,
-                                 float epsilon, int const rank, uint32_t* bufferFlags) {
+template <uint8_t WorldSize, typename T, bool RMSNormFusion = false,
+          QuantType QType = QuantType::kNone, typename PackedType = float4>
+__global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(
+    /* output ptrs*/
+    T* outputPtr, T* prenormedPtr, void* quantOutPtr, void* scalingFactorOutPtr,
+    /* input ptrs*/
+    T const* shardPtr, T const* residualInPtr, T const* gammaPtr,
+    /* Comm buffer params */
+    T** inputPtrs, T* mcastPtr, int const rank, uint32_t* bufferFlags,
+    /* problem size parameters*/
+    int const numTokens, int const tokenDim, float epsilon, float* outputScale,
+    QuantizationSFLayout sfLayout) {
+  static_assert(QType == QuantType::kNone || RMSNormFusion,
+                "Quant-only pattern without RMSNorm is not supported!");
   constexpr int kELTS_PER_THREAD = sizeof(PackedType) / sizeof(T);
   constexpr int kLAMPORT_ELTS_PER_PACKED = sizeof(PackedType) / sizeof(float);
   constexpr uint32_t kELT_SIZE = sizeof(T);
@@ -641,7 +1306,18 @@ __global__ void __launch_bounds__(1024)
                                              toFloat<T>(gamma.elements[i]));
     }
   }
-  reinterpret_cast<PackedType*>(&outputPtr[threadOffset])[0] = packedAccum.packed;
+  if (outputPtr != nullptr) {
+    reinterpret_cast<PackedType*>(&outputPtr[threadOffset])[0] = packedAccum.packed;
+  }
+
+  if constexpr (QType == QuantType::kFP8) {
+    quant::quant_fp8<T, PackedType, kELTS_PER_THREAD>(packedAccum, quantOutPtr, outputScale,
+                                                      threadOffset);
+  } else if constexpr (QType == QuantType::kFP4) {
+    quant::quant_nvfp4<T, PackedType, kELTS_PER_THREAD>(packedAccum, quantOutPtr,
+                                                        scalingFactorOutPtr, outputScale, token,
+                                                        tokenDim, packedIdx, sfLayout);
+  }
   flag.waitAndUpdate(
       {static_cast<uint32_t>(numTokens * tokenDim * WorldSize * kELT_SIZE), 0, 0, 0});
 }
@@ -689,16 +1365,31 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       .numAttrs = kSMVersionMajor >= 9 ? 2 : 1,
   };
 
-#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, RMSNORM)                                              \
-  FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(                                                        \
-      &config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM>, output, residualOut, input, \
-      residualIn, gamma, ucPtrs, mcPtr, numTokens, tokenDim, static_cast<float>(params.epsilon),  \
-      params.rank, params.bufferFlags));
-#define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE)   \
-  if (params.rmsNormFusion) {                   \
-    LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true);  \
-  } else {                                      \
-    LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, false); \
+#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, RMSNORM, QUANT_TYPE)                               \
+  FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(                                                     \
+      &config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM, QUANT_TYPE>, output,      \
+      residualOut, params.quantOut, params.scalingFactorOut, input, residualIn, gamma, ucPtrs, \
+      mcPtr, params.rank, params.bufferFlags, numTokens, tokenDim,                             \
+      static_cast<float>(params.epsilon), params.outputScale, params.sfLayout));
+#define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE)                                 \
+  if (params.rmsNormFusion) {                                                 \
+    switch (params.quantType) {                                               \
+      case QuantType::kFP8:                                                   \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kFP8);           \
+        break;                                                                \
+      case QuantType::kFP4:                                                   \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kFP4);           \
+        break;                                                                \
+      case QuantType::kNone:                                                  \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, false, QuantType::kNone);         \
+        break;                                                                \
+      default:                                                                \
+        FLASHINFER_ERROR("Unsupported quant type! Got " +                     \
+                         std::to_string(static_cast<int>(params.quantType))); \
+        return cudaErrorInvalidValue;                                         \
+    }                                                                         \
+  } else {                                                                    \
+    LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, false, QuantType::kNone);             \
   }
 
   T** ucPtrs = reinterpret_cast<T**>(params.bufferPtrsDev);
@@ -881,14 +1572,18 @@ using utils::copyF4;
 //      1. Use CGA if supported. It expands the hidden dimension to 8k x 8 = 64k.
 //      2. Set loads_per_thread >1. Which can be used if CGA is not supported. Note that this will
 //      be limited by the shared memory size and register count.
-template <typename T_IN, typename T_OUT, int LoadsPerThread = 1>
-__global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OUT* outputNorm,
-                                                       T_IN* bufferInput, T_IN const* gamma,
-                                                       float epsilon, T_IN const* residual,
-                                                       uint32_t numTokens, uint32_t dim,
-                                                       uint32_t worldSize, uint32_t* bufferFlags) {
-  static_assert(std::is_same_v<T_IN, T_OUT>, "T_IN and T_OUT must be the same type");
-  static int const kELTS_PER_LOAD = sizeof(float4) / sizeof(T_IN);
+template <typename T, QuantType QType = QuantType::kNone, int LoadsPerThread = 1>
+__global__ __launch_bounds__(1024) void rmsNormLamport_fusion(
+    /* Output ptrs */
+    T* outputPreNorm, T* outputNorm, void* quantOut, void* scalingFactorOut,
+    /* Input ptrs */
+    T* bufferInput, T const* gamma, T const* residual,
+    /* Comm buffer params */
+    uint32_t worldSize, uint32_t* bufferFlags,
+    /* Problem parameters */
+    uint32_t numTokens, uint32_t dim, float epsilon, float* outputScale,
+    QuantizationSFLayout sfLayout) {
+  static int const kELTS_PER_LOAD = sizeof(float4) / sizeof(T);
 
   uint32_t const token = blockIdx.x;
   uint32_t const blockSize = blockDim.x;
@@ -912,13 +1607,13 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
   float rInput[LoadsPerThread * kELTS_PER_LOAD];
   uint32_t offsets[LoadsPerThread * kELTS_PER_LOAD];
 
-  uint32_t const smemBufferSize = blockSize * elemsPerThread * sizeof(T_IN);
-  T_IN* smemInput = (T_IN*)&smem[0];
-  T_IN* smemResidual = (T_IN*)&smem[smemBufferSize];
-  T_IN* smemGamma = (T_IN*)&smem[2 * smemBufferSize];
+  uint32_t const smemBufferSize = blockSize * elemsPerThread * sizeof(T);
+  T* smemInput = (T*)&smem[0];
+  T* smemResidual = (T*)&smem[smemBufferSize];
+  T* smemGamma = (T*)&smem[2 * smemBufferSize];
 
   LamportFlags<float4> flag(bufferFlags, MNNVLTwoShotStage::NUM_STAGES);
-  T_IN* input = reinterpret_cast<T_IN*>(
+  T* input = reinterpret_cast<T*>(
       flag.getCurLamportBuf(reinterpret_cast<void*>(bufferInput), MNNVLTwoShotStage::BROADCAST));
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -982,14 +1677,14 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
   for (int i = 0; i < LoadsPerThread; i++) {
     int threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
     if (blockOffset * blockChunkSize + threadLoadOffset < dim) {
-      PackedVec<float4, T_IN> inp{.packed = loadPacked<float4>(&smemInput[threadLoadOffset])};
-      PackedVec<float4, T_IN> res{.packed = loadPacked<float4>(&smemResidual[threadLoadOffset])};
+      PackedVec<float4, T> inp{.packed = loadPacked<float4>(&smemInput[threadLoadOffset])};
+      PackedVec<float4, T> res{.packed = loadPacked<float4>(&smemResidual[threadLoadOffset])};
 
-      PackedVec<float4, T_IN> inp_plus_res = inp + res;
+      PackedVec<float4, T> inp_plus_res = inp + res;
 #pragma unroll
       for (int j = 0; j < kELTS_PER_LOAD; j++) {
-        rInput[i * kELTS_PER_LOAD + j] = toFloat<T_IN>(inp_plus_res.elements[j]);
-        threadSum += toFloat<T_IN>(inp_plus_res.elements[j] * inp_plus_res.elements[j]);
+        rInput[i * kELTS_PER_LOAD + j] = toFloat<T>(inp_plus_res.elements[j]);
+        threadSum += toFloat<T>(inp_plus_res.elements[j] * inp_plus_res.elements[j]);
       }
 
       *reinterpret_cast<float4*>(&outputPreNorm[blockLoadOffset + threadLoadOffset]) =
@@ -1024,21 +1719,30 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
 
 #pragma unroll
   for (int i = 0; i < LoadsPerThread; i++) {
-    PackedVec<float4, T_OUT> r_out;
+    PackedVec<float4, T> r_out;
     uint32_t threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
-    if (blockOffset * blockChunkSize + threadLoadOffset < dim) {
-      PackedVec<float4, T_IN> gamma = {.packed = loadPacked<float4>(&smemGamma[threadLoadOffset])};
+    uint32_t token_offset = blockOffset * blockChunkSize + threadLoadOffset;
+    if (token_offset < dim) {
+      PackedVec<float4, T> gamma = {.packed = loadPacked<float4>(&smemGamma[threadLoadOffset])};
 
 #pragma unroll
       for (uint32_t j = 0; j < kELTS_PER_LOAD; j++) {
-        r_out.elements[j] = fromFloat<T_OUT>(toFloat<T_IN>(gamma.elements[j]) *
-                                             rInput[i * kELTS_PER_LOAD + j] * rcpRms);
+        r_out.elements[j] =
+            fromFloat<T>(toFloat<T>(gamma.elements[j]) * rInput[i * kELTS_PER_LOAD + j] * rcpRms);
       }
-
-      *reinterpret_cast<float4*>(&outputNorm[blockLoadOffset + threadLoadOffset]) = r_out.packed;
+      if (outputNorm != nullptr) {
+        *reinterpret_cast<float4*>(&outputNorm[blockLoadOffset + threadLoadOffset]) = r_out.packed;
+      }
+      if constexpr (QType == QuantType::kFP8) {
+        quant::quant_fp8<T, float4, kELTS_PER_LOAD>(r_out, quantOut, outputScale, threadOffset);
+      } else if constexpr (QType == QuantType::kFP4) {
+        quant::quant_nvfp4<T, float4, kELTS_PER_LOAD>(r_out, quantOut, scalingFactorOut,
+                                                      outputScale, token, dim,
+                                                      token_offset / kELTS_PER_LOAD, sfLayout);
+      }
     }
   }
-  constexpr int kELTS_SIZE = sizeof(T_IN);
+  constexpr int kELTS_SIZE = sizeof(T);
 
   // Assume the previous kernel does not modify the buffer_flags.
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -1150,15 +1854,34 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
         numTokens, rnClusterSize, rnBlockSize, rnClusterSize, rnLoadsPerThread,
         ceil_div(tokenDim, numEltsPerThread));
 
-#define RUN_RMSNORM_KERNEL(LOADS_PER_THREAD)                                                      \
-  FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(&rmsNormLamport<T, T, LOADS_PER_THREAD>,              \
-                                            cudaFuncAttributeMaxDynamicSharedMemorySize,          \
-                                            smemSize));                                           \
-  rnConfig.dynamicSmemBytes = smemSize;                                                           \
-  FLASHINFER_CUDA_CALL(                                                                           \
-      cudaLaunchKernelEx(&rnConfig, &rmsNormLamport<T, T, LOADS_PER_THREAD>, residualOut, output, \
-                         bufferInput, gamma, static_cast<float>(params.epsilon), residualIn,      \
-                         numTokens, tokenDim, params.nRanks, params.bufferFlags));
+#define RUN_RMSNORM_FUSION_KERNEL_(LOADS_PER_THREAD, QType)                                     \
+  FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(&rmsNormLamport_fusion<T, QType, LOADS_PER_THREAD>, \
+                                            cudaFuncAttributeMaxDynamicSharedMemorySize,        \
+                                            smemSize));                                         \
+  rnConfig.dynamicSmemBytes = smemSize;                                                         \
+  FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(                                                      \
+      &rnConfig, &rmsNormLamport_fusion<T, QType, LOADS_PER_THREAD>, residualOut, output,       \
+      params.quantOut, params.scalingFactorOut, bufferInput, gamma, residualIn, params.nRanks,  \
+      params.bufferFlags, numTokens, tokenDim, static_cast<float>(params.epsilon),              \
+      params.outputScale, params.sfLayout));
+
+#define RUN_RMSNORM_FUSION_KERNEL(LOADS_PER_THREAD)                               \
+  switch (params.quantType) {                                                     \
+    case QuantType::kFP8:                                                         \
+      RUN_RMSNORM_FUSION_KERNEL_(LOADS_PER_THREAD, QuantType::kFP8);              \
+      break;                                                                      \
+    case QuantType::kFP4:                                                         \
+      RUN_RMSNORM_FUSION_KERNEL_(LOADS_PER_THREAD, QuantType::kFP4);              \
+      break;                                                                      \
+    case QuantType::kNone:                                                        \
+      RUN_RMSNORM_FUSION_KERNEL_(LOADS_PER_THREAD, QuantType::kNone);             \
+      break;                                                                      \
+    default:                                                                      \
+      FLASHINFER_ERROR("[MNNVL AllReduceTwoShotRMSNorm] Unsupported quant type" + \
+                       std::to_string(static_cast<int>(params.quantType)) +       \
+                       ". Supported types: {kFP8, kFP4, kNone}");                 \
+      return cudaErrorInvalidValue;                                               \
+  }
 
     T* residualOut = reinterpret_cast<T*>(params.residualOut);
     T* output = reinterpret_cast<T*>(params.output);
@@ -1166,32 +1889,32 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
     T const* gamma = reinterpret_cast<T const*>(params.gamma);
     T const* residualIn = reinterpret_cast<T const*>(params.residualIn);
     if (rnUseCGA) {
-      RUN_RMSNORM_KERNEL(1);
+      RUN_RMSNORM_FUSION_KERNEL(1);
     } else {
       switch (rnLoadsPerThread) {
         case 1:
-          RUN_RMSNORM_KERNEL(1);
+          RUN_RMSNORM_FUSION_KERNEL(1);
           break;
         case 2:
-          RUN_RMSNORM_KERNEL(2);
+          RUN_RMSNORM_FUSION_KERNEL(2);
           break;
         case 3:
-          RUN_RMSNORM_KERNEL(3);
+          RUN_RMSNORM_FUSION_KERNEL(3);
           break;
         case 4:
-          RUN_RMSNORM_KERNEL(4);
+          RUN_RMSNORM_FUSION_KERNEL(4);
           break;
         case 5:
-          RUN_RMSNORM_KERNEL(5);
+          RUN_RMSNORM_FUSION_KERNEL(5);
           break;
         case 6:
-          RUN_RMSNORM_KERNEL(6);
+          RUN_RMSNORM_FUSION_KERNEL(6);
           break;
         case 7:
-          RUN_RMSNORM_KERNEL(7);
+          RUN_RMSNORM_FUSION_KERNEL(7);
           break;
         case 8:
-          RUN_RMSNORM_KERNEL(8);
+          RUN_RMSNORM_FUSION_KERNEL(8);
           break;
         default:
           FLASHINFER_ERROR("[MNNVL AllReduceTwoShotRMSNorm] Unsupported loads_per_thread" +
@@ -1200,7 +1923,8 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
           return cudaErrorInvalidValue;
       }  // switch (rnLoadsPerThread)
     }  // if (rnUseCGA)
-#undef RUN_RMSNORM_KERNEL
+#undef RUN_RMSNORM_FUSION_KERNEL
+#undef RUN_RMSNORM_FUSION_KERNEL_
 
   }  // if (params.rmsNormFusion)
   return cudaSuccess;

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -968,6 +968,26 @@ __forceinline__ __device__ uint32_t pack_bytes(uint8_t c0, uint8_t c1, uint8_t c
   return (val3 << 24) | (val2 << 16) | (val1 << 8) | val0;
 }
 
+// Convert single float2 pair to e2m1 (2 float32 -> 2 e2m1, returns uint8_t)
+// Optimization: allows pipelined processing to reduce register usage
+// Note: "=r" constraint always allocates 32-bit register regardless of variable type
+inline __device__ uint8_t fp32_pair_to_e2m1(float2 pair) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val32;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "mov.b32 %0, {byte0, 0, 0, 0};\n"
+      "}"
+      : "=r"(val32)
+      : "f"(pair.x), "f"(pair.y));
+  return static_cast<uint8_t>(val32 & 0xFF);  // Extract low 8 bits
+#else
+  return 0;
+#endif
+}
+
 #if CUDA_VERSION >= 12080
 // Convert 8 float32 values into 8 e2m1 values (represented as one uint32_t).
 // NOTE: bypass sm_100 requirement by __nv_cvt_float2_to_fp4x2
@@ -1039,6 +1059,8 @@ template <typename T, uint32_t VEC_SIZE, bool UE8M0_SF = false>
 __device__ uint32_t cvt_warp_fp16_to_fp4(vec_t<T, VEC_SIZE>& vec, float SFScaleVal,
                                          uint8_t* SFout) {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  // Pre-compute constant: reciprocal of 6.0 (maximum value of e2m1)
+  static constexpr float RECIPROCAL_6 = 1.0f / 6.0f;
   // Get absolute maximum values among the local 8 values.
   auto localMax = maths::cuda_abs(get_vec2_element(vec, 0));
 
@@ -1054,53 +1076,58 @@ __device__ uint32_t cvt_warp_fp16_to_fp4(vec_t<T, VEC_SIZE>& vec, float SFScaleV
 
   // Get the SF (max value of the vector / max value of e2m1).
   // maximum value of e2m1 = 6.0.
-  // TODO: use half as compute data type.
-  float SFValue = SFScaleVal * (vecMax * maths::reciprocal_approximate_ftz(6.0f));
-  // 8 bits representation of the SF.
+  // Optimization: compute quantized SF directly, avoid storing intermediate SFValue
   uint8_t fp8SFVal;
-  // Write the SF to global memory (STG.8).
+  float quantized_sf;
+
   if constexpr (UE8M0_SF) {
 #if (__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10 >= 12080)
     __nv_fp8_e8m0 tmp;
-    tmp.__x = __nv_cvt_float_to_e8m0(SFValue, __NV_SATFINITE, cudaRoundPosInf);
-    SFValue = static_cast<float>(tmp);
+    float sf_value = SFScaleVal * (vecMax * RECIPROCAL_6);
+    tmp.__x = __nv_cvt_float_to_e8m0(sf_value, __NV_SATFINITE, cudaRoundPosInf);
+    quantized_sf = static_cast<float>(tmp);
     fp8SFVal = tmp.__x;
 #else
 #error "FP8 E8M0 support requires CUDA 12.8 or newer."
 #endif
   } else {
     // Here SFValue is always positive, so E4M3 is the same as UE4M3.
-    __nv_fp8_e4m3 tmp = __nv_fp8_e4m3(SFValue);
+    __nv_fp8_e4m3 tmp = __nv_fp8_e4m3(SFScaleVal * (vecMax * RECIPROCAL_6));
     fp8SFVal = tmp.__x;
-    SFValue = static_cast<float>(tmp);
+    quantized_sf = static_cast<float>(tmp);
   }
-  // Get the output scale.
+  // Get the output scale directly (optimization: avoid storing intermediate SFValue)
   // Recipe: final_scale = reciprocal(fp32(fp8(SFValue * SFScaleVal))) * reciprocal(SFScaleVal))
-  float outputScale = SFValue != 0 ? maths::reciprocal_approximate_ftz(
-                                         SFValue * maths::reciprocal_approximate_ftz(SFScaleVal))
-                                   : 0.0f;
+  // Optimization: mathematically equivalent to SFScaleVal / quantized_sf, but more efficient
+  // (reduces 1 reciprocal call and 1 multiply operation)
+  float outputScale = quantized_sf != 0 ? SFScaleVal / quantized_sf : 0.0f;
 
   if (SFout) {
     // Write the SF to global memory (STG.8).
     *SFout = fp8SFVal;
   }
 
-  // Convert the input to float.
-  float2 fp2Vals[details::CVT_FP4_ELTS_PER_THREAD / 2];
+  // Convert the input to float and quantize (pipelined to reduce register usage).
+  // Optimization: use single float2 instead of array to reduce register pressure from 32 bytes to 8
+  // bytes
+  uint32_t e2m1Vec = 0;
 
 #pragma unroll
   for (int i = 0; i < details::CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    // Reuse single float2 register instead of array
+    float2 fp2Val;
     if constexpr (std::is_same_v<T, half>) {
-      fp2Vals[i] = __half22float2(get_vec2_element(vec, i));
+      fp2Val = __half22float2(get_vec2_element(vec, i));
     } else {
-      fp2Vals[i] = __bfloat1622float2(get_vec2_element(vec, i));
+      fp2Val = __bfloat1622float2(get_vec2_element(vec, i));
     }
-    fp2Vals[i].x *= outputScale;
-    fp2Vals[i].y *= outputScale;
-  }
+    fp2Val.x *= outputScale;
+    fp2Val.y *= outputScale;
 
-  // Convert to e2m1 values.
-  uint32_t e2m1Vec = fp32_vec_to_e2m1(fp2Vals);
+    // Convert pair immediately and pack into result
+    uint8_t e2m1Pair = fp32_pair_to_e2m1(fp2Val);
+    e2m1Vec |= (static_cast<uint32_t>(e2m1Pair) << (i * 8));
+  }
 
   // Write the e2m1 values to global memory.
   return e2m1Vec;

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -1388,7 +1388,7 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
         }                                                                            \
         break;                                                                       \
       case QuantType::kNone:                                                         \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, false, QuantType::kNone);                \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kNone);                 \
         break;                                                                       \
       default:                                                                       \
         FLASHINFER_ERROR("Unsupported quant type! Got " +                            \

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -22,7 +22,7 @@ if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
 from tests.test_helpers.comm import init_torch_distributed_from_mpi
-
+from .conftest import mnnvl_available
 # Note: torch.distributed cleanup is handled by tests/comm/conftest.py
 
 
@@ -80,7 +80,7 @@ def row_linear_residual_norm_fusion_forward(
                     workspace,
                     eps,
                     launch_with_pdl=use_pdl,
-                    strategy=trtllm_mnnvl_ar.MNNVLAllreduceFusionStrategy.ONESHOT,
+                    strategy=trtllm_mnnvl_ar.MNNVLAllreduceFusionStrategy.AUTO,
                 )
             )
 
@@ -591,6 +591,10 @@ def run_mnnvl_ar_full(
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("hidden_size", [2880, 5120, 7168, 8192, 16384])
+@pytest.mark.skipif(
+    not mnnvl_available(),
+    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+)
 def test_mnnvl_allreduce_refactored(
     monkeypatch,
     seq_lens: list[int],
@@ -612,6 +616,10 @@ def test_mnnvl_allreduce_refactored(
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("hidden_size", [2048, 4096, 5120, 7168, 8192, 16384])
+@pytest.mark.skipif(
+    not mnnvl_available(),
+    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+)
 def test_mnnvl_allreduce_legacy(
     monkeypatch,
     seq_lens: list[int],

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -1,5 +1,7 @@
 # Check torch version:
+import sys
 import traceback
+from pathlib import Path
 from typing import Tuple, Optional
 
 import pytest
@@ -13,10 +15,12 @@ from flashinfer.comm.mnnvl import TorchDistBackend
 # Use flashinfer.norm.rmsnorm as reference implementation.
 from flashinfer.norm import rmsnorm
 
-# Test helpers
-from tests.test_helpers.comm import (
-    init_torch_distributed_from_mpi,
-)
+# Add project root to path for direct script execution
+_project_root = Path(__file__).resolve().parents[2]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from tests.test_helpers.comm import init_torch_distributed_from_mpi
 
 # Note: torch.distributed cleanup is handled by tests/comm/conftest.py
 
@@ -480,3 +484,7 @@ def test_mnnvl_allreduce_legacy(
     run_mnnvl_ar_full(
         monkeypatch, seq_lens, fusion, dtype, hidden_size, legacy_api=True
     )
+
+
+if __name__ == "__main__":
+    run_mnnvl_ar_full(None, [1], True, torch.float16, 2880, legacy_api=False)

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -80,7 +80,7 @@ def row_linear_residual_norm_fusion_forward(
                     workspace,
                     eps,
                     launch_with_pdl=use_pdl,
-                    strategy=trtllm_mnnvl_ar.MNNVLAllreduceFusionStrategy.AUTO,
+                    strategy=trtllm_mnnvl_ar.MNNVLAllreduceFusionStrategy.ONESHOT,
                 )
             )
 
@@ -228,6 +228,7 @@ def row_linear_residual_norm_fusion_forward(
         )
 
 
+# TODO: Remove this legacy test when the deprecated API is removed.
 @torch.inference_mode()
 def row_linear_residual_norm_fusion_forward_legacy(
     x: torch.Tensor,
@@ -603,6 +604,7 @@ def test_mnnvl_allreduce_refactored(
     )
 
 
+# TODO: Remove this legacy test when the deprecated API is removed.
 @pytest.mark.parametrize("seq_lens", [[1], [4], [15], [27, 11, 24], [127]])
 @pytest.mark.parametrize(
     "pattern",
@@ -620,4 +622,14 @@ def test_mnnvl_allreduce_legacy(
     """Test MNNVL AllReduce with legacy API."""
     run_mnnvl_ar_full(
         monkeypatch, seq_lens, pattern, dtype, hidden_size, legacy_api=True
+    )
+
+
+if __name__ == "__main__":
+    test_mnnvl_allreduce_refactored(
+        None,
+        seq_lens=[998],
+        pattern=AllReduceFusionPattern.kAllReduce,
+        dtype=torch.float16,
+        hidden_size=16384,
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- Add FP8/NVFP4 quant fusion to MNNVL Allreduce
- Support all 5 fusion patterns defined in the unified allreduce interface.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FP8 and FP4 quantized outputs for fused AllReduce + RMSNorm, with configurable scale-factor layouts and optional output tensors.

* **Refactor**
  * Pattern-driven dispatch, consolidated trait/configuration types, and updated kernel/grid sizing to support quantized fusion paths.

* **Public API**
  * Added quantization/format enums, expanded fusion parameter fields and function signatures, and consolidated re-exports.

* **Tests**
  * Expanded tests to cover RMSNorm+quantized patterns and added quantize/dequantize helpers.

* **Stability**
  * Added runtime validation, layout/shape checks and CUDA-version guards for quantized paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->