### PR TITLE
[Minor] Reduce num blocks of qknorm in small batch size

### DIFF
--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -369,7 +369,8 @@ cudaError_t QKRMSNorm(T* input, T* weight, T* output, uint32_t batch_size, uint3
     FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
     FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
 
-    dim3 nblks(num_blocks_per_sm * num_sms);
+    const int needed_blocks = ceil_div(batch_size * num_heads, num_warps);
+    dim3 nblks(std::min(num_blocks_per_sm * num_sms, needed_blocks));
     dim3 nthrs(32, num_warps);
     config.gridDim = nblks;
     config.blockDim = nthrs;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
In QKNorm kernel with small batch size, we can reduce the number of blocks launched. This can reduce block launching overhead especially in decode stage.

A example result on B200 where (batch_size, num_heads, head_dim) = (128, 8, 128), which is common in Qwen3 model decode stage.

Before this PR: 2.448us
After this PR: 1.584us

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GPU kernel grid size calculation to reduce unnecessary block launches and improve overall performance efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->