### PR TITLE
cicd: add a github workflow for xfails report script

### DIFF
--- a/.github/workflows/update-codeowners.yml
+++ b/.github/workflows/update-codeowners.yml
@@ -73,10 +73,6 @@ jobs:
             chore: update CODEOWNERS based on git history
 
             Auto-generated CODEOWNERS update based on commit activity over the last ${{ env.DAYS_BACK }} days.
-
-            🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-            Co-Authored-By: Claude <noreply@anthropic.com>
           branch: auto-update-codeowners
           base: main
           delete-branch: true

--- a/.github/workflows/update-xfails-report.yml
+++ b/.github/workflows/update-xfails-report.yml
@@ -67,10 +67,6 @@ jobs:
             chore: update xfails report
 
             Auto-generated xfails report based on current test suite markers.
-
-            🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-            Co-Authored-By: Claude <noreply@anthropic.com>
           branch: auto-update-xfails-report
           base: main
           delete-branch: true


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds workflow that runs weekly on Mondays (and can be triggered manually) to execute scripts/xfails_tracker.py, which scans the test suite for xfail markers and outputs a comprehensive report to reports/xfails_report.txt. If the report has changed, it automatically creates a pull request to commit the updated report to the repository.

## 🔍 Related Issues

cont. testing item from november roadmap

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated weekly report generation that detects changes and opens pull requests to incorporate updates.
  * Updated automation to remove generated-attribution boilerplate from automated commit/PR messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->