### PR TITLE
bugfix: use torch cached default generators

### DIFF
--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -24,18 +24,19 @@ from .jit.sampling import gen_sampling_module
 from .utils import (
     _get_cache_buf,
     device_support_pdl,
+    get_default_generators,
     register_custom_op,
     register_fake_op,
 )
 
 
 def get_seed_and_offset(
-    increment: int, generator: Optional[torch.Generator] = None
+    increment: int,
+    generator: Optional[torch.Generator] = None,
+    device: Optional[torch.device] = None,
 ) -> Tuple[int, int]:
     if generator is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        generator = torch.Generator(device=device)
-        generator.seed()
+        generator = get_default_generators(device)
     # add mutex if multi-trheading needed
     state = generator.get_state()
     seed, offset = state.view(torch.int64)
@@ -101,7 +102,9 @@ def get_sampling_module():
         out_dtype = indices.dtype if indices is not None else torch.int32
         samples = torch.empty(batch_size, dtype=out_dtype, device=device)
         if seed is None or offset is None:
-            seed, offset = get_seed_and_offset(batch_size * logits.size(1), generator)
+            seed, offset = get_seed_and_offset(
+                batch_size * logits.size(1), generator, device
+            )
         module.sampling_from_logits(
             logits,
             samples,
@@ -140,7 +143,7 @@ def get_sampling_module():
         out_dtype = indices.dtype if indices is not None else torch.int32
         samples = torch.empty(batch_size, dtype=out_dtype, device=device)
         if seed is None or offset is None:
-            seed, offset = get_seed_and_offset(batch_size, generator)
+            seed, offset = get_seed_and_offset(batch_size, generator, device)
         module.sampling_from_probs(
             probs,
             samples,
@@ -186,7 +189,7 @@ def get_sampling_module():
         out_dtype = indices.dtype if indices is not None else torch.int32
         samples = torch.empty(batch_size, dtype=out_dtype, device=device)
         if seed is None or offset is None:
-            seed, offset = get_seed_and_offset(batch_size * 32, generator)
+            seed, offset = get_seed_and_offset(batch_size * 32, generator, device)
         module.top_p_sampling_from_probs(
             probs,
             samples,
@@ -233,7 +236,7 @@ def get_sampling_module():
         out_dtype = indices.dtype if indices is not None else torch.int32
         samples = torch.empty(batch_size, dtype=out_dtype, device=device)
         if seed is None or offset is None:
-            seed, offset = get_seed_and_offset(batch_size * 32, generator)
+            seed, offset = get_seed_and_offset(batch_size * 32, generator, device)
         module.top_k_sampling_from_probs(
             probs,
             samples,
@@ -282,7 +285,7 @@ def get_sampling_module():
         out_dtype = indices.dtype if indices is not None else torch.int32
         samples = torch.empty(batch_size, dtype=out_dtype, device=device)
         if seed is None or offset is None:
-            seed, offset = get_seed_and_offset(batch_size, generator)
+            seed, offset = get_seed_and_offset(batch_size, generator, device)
         module.min_p_sampling_from_probs(
             probs,
             samples,
@@ -320,7 +323,7 @@ def get_sampling_module():
         out_dtype = indices.dtype if indices is not None else torch.int32
         samples = torch.empty(batch_size, dtype=out_dtype, device=device)
         if seed is None or offset is None:
-            seed, offset = get_seed_and_offset(batch_size * 32, generator)
+            seed, offset = get_seed_and_offset(batch_size * 32, generator, device)
         module.top_k_top_p_sampling_from_probs(
             probs,
             samples,
@@ -481,7 +484,7 @@ def get_sampling_module():
         output_token_ids = torch.empty((b, n + 1), dtype=torch.int32, device=device)
         if seed is None or offset is None:
             seed, offset = get_seed_and_offset(
-                draft_probs.size(0) * (draft_probs.size(1) + 1), generator
+                draft_probs.size(0) * (draft_probs.size(1) + 1), generator, device
             )
         module.chain_speculative_sampling(
             draft_probs,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -1182,3 +1182,9 @@ def backend_requirement(
         return wrapper
 
     return decorator
+
+
+@functools.cache
+def get_default_generators(device: torch.device):
+    torch.cuda.init()
+    return torch.cuda.default_generators[device.index]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Fixed the #2284. In the past, before #1641, the flashinfer used torch default generator `at::cuda::detail::getDefaultCUDAGenerator()` while #1641 will create one new generator instance at a time. This PR recovers the default generator from torch.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sampling now uses a device-aware default random generator, ensuring consistent and correct sampling behavior across CPU and GPU when no generator is provided.

* **Chores**
  * Small public API update to accept a device context so sampling routines derive RNG state from the correct device.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->