### PR TITLE
chore: MoE benchmark effective BW fix for trtllm_block_scale_moe

### DIFF
--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -1233,6 +1233,7 @@ def testCutlassFusedMoe(args):
         weight_format=variant,
         routing_logits_dtype=router_logits.dtype,
         active_experts=int(selected_experts.unique().numel()),
+        verbose=args.verbose,
     )
 
     print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
@@ -1502,6 +1503,7 @@ def testTrtllmFp8BlockScaleMoe(args):
         weight_format="fp8",
         routing_logits_dtype=routing_logits.dtype,
         active_experts=int(selected_experts.unique().numel()),
+        verbose=args.verbose,
     )
 
     backend = "trtllm"
@@ -1733,6 +1735,7 @@ def testTrtllmFp8PerTensorScaleMoe(args):
         weight_format="fp8",
         routing_logits_dtype=routing_logits.dtype,
         active_experts=int(selected_experts.unique().numel()),
+        verbose=args.verbose,
     )
 
     backend = "trtllm"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The MoE benchmark script overestimates the num bytes loaded by assuming all experts are active. I saw effective BW exceeds 3x the peak BW of some system as a result. The fix is to calculate the routed experts (topk_ids) on the host side and count the unique number of experts, the same logic `cutlass_fused_moe` does.

While investigating the above issue, I also found data init of routing_bias using `rand()` results in very skewed expert distribution (repro cmd below gives 18 active out of 128 experts). I'd like to change it to `ones()*0.1` for smoother expert distribution (noe giving 114 out of 128), while maintaining the same load/compute behavior in the kernels.

```
python3 flashinfer_benchmark.py --routine trtllm_fp4_block_scale_moe --num_tokens 32 --hidden_size 7168 --intermediate_size 2048 --num_experts 128 --routing_method deepseek_v3 --top_k 8 --n_group 8 --topk_group 4 --routed_scaling_factor 2.5 --use_routing_bias --use_shuffled_weight --generate_repro_command -vv
```

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nvfp4 and mxfp4 quantization formats in bandwidth calculations.
  * Introduced routing support for DeepSeekV3 method.

* **Improvements**
  * Enhanced routing bias initialization for more consistent expert distribution.
  * Expanded routing computation utilities for greater flexibility.

* **Tests**
  * Updated benchmark test data to align with new routing and quantization logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->