### PR TITLE
Add deprecation and removal policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,6 @@ When incrementing a version and creating a release, follow a "right-shifted" ver
 
 Like the vLLM scheme, this versioning scheme is similar to [SemVer](https://semver.org/) for compatibility purposes, except that backwards compatibility is only guaranteed for a limited number of minor releases (see the [vLLM deprecation policy](https://docs.vllm.ai/en/latest/contributing/deprecation_policy) for details).
 
-To reduce disruption during deprecation and removal, we prefer "keyword only" (after `, / ,`) for parameters that are likely to come and go (e.g. perf parameters).
+To reduce disruption during deprecation and removal, we prefer "keyword only" (after an `*`, see [PEP-3102](https://peps.python.org/pep-3102/)) for parameters that are likely to come and go (e.g. perf parameters).
 
 [^1]: We have not followed this strictly through v0.4.0. But after v0.4.0, the versioning should follow this "right-shifted" versioning scheme.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

There has been some confusion about when we can break the API. This is an attempt to better document our approach (essentially, we intend to follow the [vLLM policy](https://docs.vllm.ai/en/latest/contributing/deprecation_policy)).

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

N/A - this only touches `CONTRIBUTING.md`

## Reviewer Notes

Is this the policy we want?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified release versioning: compatibility is guaranteed only for a limited number of minor releases and follows a SemVer-like note with a deprecation policy reference.
  * Added contributor guidance recommending use of keyword-only parameters for arguments that may be deprecated.
  * Added a footnote on historical adherence and continuation of the right-shifted versioning scheme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->