### PR TITLE
ci: increase nightly release build timeout

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -175,7 +175,7 @@ jobs:
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
-        timeout-minutes: 240
+        timeout-minutes: 300
 
       - name: Display wheel size
         run: du -h flashinfer-jit-cache/dist/*


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Recently, we found the nightly release build could exceed the limit of 3h, for example this failure in https://github.com/flashinfer-ai/flashinfer/actions/runs/21104624306/job/60693883830. It would be good to increase the limit.
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration to improve build reliability.
  * Increased CI build timeout to reduce intermittent build failures and timeouts during packaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->