### PR TITLE
chore: add script to run unittests/benchmarks on Modal GPU runners

### DIFF
--- a/scripts/modal_runner.py
+++ b/scripts/modal_runner.py
@@ -116,6 +116,7 @@ def _run_flashinfer_command(command: str) -> str:
     # Run the user command
     print(f"=== Running command: {command} ===")
     import shlex
+
     result = subprocess.run(
         shlex.split(command),
         text=True,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

[Modal](https://modal.com/) provides serverless GPU (B200/H100/etc) execution environments for running functions remotely. This PR implements the script to run flashinfer unittests/benchmarks on Modal, it's helpful for development environment without GPUs (agent/CI/etc).

## Example Usage

```bash
modal run scripts/modal_runner.py --gpu H100 --command "pytest tests/attention/test_hopper.py -v"
```

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a containerized remote GPU runner for testing and benchmarking with selectable GPU targets, a local entrypoint to trigger runs, a persistent JIT cache to speed repeated runs, automatic bootstrapping of missing third-party dependencies, workspace mounting with build/cache exclusions, streamed logs from remote execution, and error reporting on non-zero exits for reliable, repeatable test/benchmark execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->