### PR TITLE
bugfix: hotfix of PR 2366 (mamba kernel)

### DIFF
--- a/include/flashinfer/mamba/selective_state_update.cuh
+++ b/include/flashinfer/mamba/selective_state_update.cuh
@@ -641,7 +641,7 @@ void invokeSelectiveStateUpdate(SelectiveStateUpdateParams& params, cudaStream_t
       using sram_t = SharedStorage<input_t, weight_t, matrixA_t, state_t, rowsPerStage, DIM, DSTATE,
                                    numStages>;
       constexpr size_t smem_size = sizeof(sram_t);
-      FLASHINFER_CUDA_CALL(
+      FLASHINFER_CUDA_CHECK(
           cudaFuncSetAttribute(scan_func, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
       scan_func<<<grid, block, smem_size, stream>>>(params, tensorState);

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -57,6 +57,13 @@
   }
 #endif
 
+#define FLASHINFER_CUDA_CHECK(func)                                                         \
+  do {                                                                                      \
+    cudaError_t e = (func);                                                                 \
+    FLASHINFER_CHECK(e == cudaSuccess, "CUDA Error: ", cudaGetErrorString(e), " (", int(e), \
+                     ") at ", __FILE__, ":", __LINE__, " in ", STR(func));                  \
+  } while (0)
+
 #define DISPATCH_USE_FP16_QK_REDUCTION(use_fp16_qk_reduction, USE_FP16_QK_REDUCTION, ...) \
   if (use_fp16_qk_reduction) {                                                            \
     FLASHINFER_ERROR("FP16_QK_REDUCTION disabled at compile time");                       \


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The commit  https://github.com/flashinfer-ai/flashinfer/pull/2366/changes/1938c5c8780b25360c16021aa0758937f19388d7 we added to #2366 cause hanging issue when running the unittests because the `FLASHINFER_CUDA_CALL` macro expects the caller environment returns a `cudaError_t` which contradicts with the structure of the lambda functions inside invokeSelectiveStateUpdate of mamba kernel. This PR fixes the issue by adding another macro `FLASHINFER_CUDA_CHECK`.

## 🔍 Related Issues

#2366 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CUDA error handling mechanisms to provide clearer error messages and enhanced diagnostics during kernel configuration and execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->