### PR TITLE
fix: ensure each CTA processes full numHeadsQPerKv for trtllm decode kernel

### DIFF
--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -611,8 +611,9 @@ class TllmGenFmhaKernel {
     float globalModelingKernelTime = FLT_MAX;
     // Loop over each candidate tile size.
     for (int tileSizeQ : candidateTileSizesQ) {
-      // Only consider candidates <= default tileSizeQ.
-      if (tileSizeQ > defaultTileSizeQ) {
+      // Only consider candidates <= default tileSizeQ and ensure each CTA processes full
+      // numHeadsQPerKv.
+      if (tileSizeQ > defaultTileSizeQ || tileSizeQ < params.mNumHeadsQPerKv) {
         continue;
       }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Skip candidates where kernelMeta.mStepQ < params.mNumHeadsQPerKv in GQA tile selection to avoid numTokensPerCtaQ=0, resulting divide-by-zero crash.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Refined GPU tile-size selection to enforce a lower bound on candidates, producing more consistent and often improved modeling time and resource utilization during GPU-accelerated operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->