### PR TITLE
Fix: Skip invalid GQA tile candidates with stepQ < headsQPerKv.

### DIFF
--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -626,6 +626,13 @@ class TllmGenFmhaKernel {
       // Load the kernel.
       std::tie(func, kernelMeta) = loadKernel(params, selectKernelParamsCopy);
 
+      // Handle the exception where computeCtaAndClusterConfig results in numTokensPerCtaQ == 0.
+      if (kernelMeta.mGroupsTokensHeadsQ) {
+        if (kernelMeta.mStepQ < params.mNumHeadsQPerKv) {
+          continue; // Skip this candidate as it's invalid
+        }
+      }
+
       // Compute the number of CTAs.
       computeCtaAndClusterConfig(ctaLaunchParams, params, kernelMeta, selectKernelParamsCopy);
 


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

Skip candidates where kernelMeta.mStepQ < params.mNumHeadsQPerKv in GQA tile selection to avoid numTokensPerCtaQ=0, resulting divide-by-zero crash.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel configuration validation to prevent invalid token and head grouping combinations, enhancing system stability and avoiding potential runtime errors in certain processing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->