### PR TITLE
ci: add docker cleanup before running tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -97,7 +97,7 @@ jobs:
       - Linux
       - ${{ matrix.arch }}
       - cpu
-    timeout-minutes: 300
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -108,6 +108,10 @@ jobs:
     steps:
       - name: Cleanup
         run: |
+          # Stop all Docker containers to free memory
+          docker stop $(docker ps -q) 2>/dev/null || true
+          docker rm $(docker ps -aq) 2>/dev/null || true
+          # Clean workspace and caches
           sudo rm -rf ${{ github.workspace }}/* || true
           sudo rm -rf ${{ github.workspace }}/.[!.]* || true
           rm -rf ~/.cache/flashinfer_jit || true
@@ -136,7 +140,7 @@ jobs:
     needs: setup
     if: needs.setup.outputs.skip_build != 'true' && github.event.inputs.skip_gpu != 'true'
     runs-on: [self-hosted, Linux, X64, gpu, sm86]
-    timeout-minutes: 300
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +158,6 @@ jobs:
           sudo rm -rf ${{ github.workspace }}/.[!.]* || true
           rm -rf ~/.cache/flashinfer_jit || true
           docker system prune -f || true
-          # Verify GPU is free
           nvidia-smi || true
 
       - uses: actions/checkout@v4
@@ -180,7 +183,7 @@ jobs:
     needs: setup
     if: needs.setup.outputs.skip_build != 'true' && github.event.inputs.skip_gpu != 'true'
     runs-on: [self-hosted, Linux, X64, gpu, sm75]
-    timeout-minutes: 300
+    timeout-minutes: 360
     env:
       DOCKER_IMAGE: flashinfer/flashinfer-ci-cu129:${{ needs.setup.outputs.docker_tag }}
     steps:
@@ -194,7 +197,6 @@ jobs:
           sudo rm -rf ${{ github.workspace }}/.[!.]* || true
           rm -rf ~/.cache/flashinfer_jit || true
           docker system prune -f || true
-          # Verify GPU is free
           nvidia-smi || true
 
       - uses: actions/checkout@v4

--- a/scripts/task_show_node_info.sh
+++ b/scripts/task_show_node_info.sh
@@ -40,5 +40,5 @@ ec2_metadata public-hostname
 echo "===== RUNNER INFO ====="
 df --human-readable
 lscpu
-free
+free -h
 nvidia-smi 2>/dev/null || echo "cuda not found"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Added a Docker cleanup step before tests run. This helps prevent leftover Docker containers from previous jobs when runners are reused

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD infrastructure by optimizing build pipeline timeouts and enhancing system cleanup procedures to ensure reliable test execution.
  * Enhanced development tooling with improved memory information formatting for better readability during system diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->