### PR TITLE
chore: Refactor benchmark imports to be lazy-loaded

### DIFF
--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -1,17 +1,13 @@
 import argparse
 import sys
 
-from routines.attention import parse_attention_args, run_attention_test
+# Only import utilities at module level - routine modules are imported lazily
+# to avoid loading unnecessary dependencies (e.g., mpi4py for non-MPI benchmarks)
 from routines.flashinfer_benchmark_utils import (
     benchmark_apis,
     full_output_columns,
     output_column_dict,
 )
-from routines.gemm import parse_gemm_args, run_gemm_test
-from routines.moe import parse_moe_args, run_moe_test
-from routines.moe_comm import parse_moe_comm_args, run_moe_comm_test
-from routines.norm import parse_norm_args, run_norm_test
-from routines.quantization import parse_quantization_args, run_quantization_test
 
 
 def run_test(args):
@@ -23,17 +19,30 @@ def run_test(args):
     """
 
     ## Depending on routine type, route to corresponding test routine
+    ## Imports are done lazily to avoid loading unnecessary dependencies
     if args.routine in benchmark_apis["attention"]:
+        from routines.attention import run_attention_test
+
         res = run_attention_test(args)
     elif args.routine in benchmark_apis["gemm"]:
+        from routines.gemm import run_gemm_test
+
         res = run_gemm_test(args)
     elif args.routine in benchmark_apis["moe"]:
+        from routines.moe import run_moe_test
+
         res = run_moe_test(args)
     elif args.routine in benchmark_apis["moe_comm"]:
+        from routines.moe_comm import run_moe_comm_test
+
         res = run_moe_comm_test(args)
     elif args.routine in benchmark_apis["norm"]:
+        from routines.norm import run_norm_test
+
         res = run_norm_test(args)
     elif args.routine in benchmark_apis["quantization"]:
+        from routines.quantization import run_quantization_test
+
         res = run_quantization_test(args)
     else:
         raise ValueError(f"Unsupported routine: {args.routine}")
@@ -165,17 +174,30 @@ def parse_args(line=sys.argv[1:]):
     )
 
     ## Check routine and pass on to routine-specific argument parser
+    ## Imports are done lazily to avoid loading unnecessary dependencies
     if args.routine in benchmark_apis["attention"]:
+        from routines.attention import parse_attention_args
+
         args = parse_attention_args(line, parser)
     elif args.routine in benchmark_apis["gemm"]:
+        from routines.gemm import parse_gemm_args
+
         args = parse_gemm_args(line, parser)
     elif args.routine in benchmark_apis["moe"]:
+        from routines.moe import parse_moe_args
+
         args = parse_moe_args(line, parser)
     elif args.routine in benchmark_apis["moe_comm"]:
+        from routines.moe_comm import parse_moe_comm_args
+
         args = parse_moe_comm_args(line, parser)
     elif args.routine in benchmark_apis["norm"]:
+        from routines.norm import parse_norm_args
+
         args = parse_norm_args(line, parser)
     elif args.routine in benchmark_apis["quantization"]:
+        from routines.quantization import parse_quantization_args
+
         args = parse_quantization_args(line, parser)
     else:
         raise ValueError(f"Unsupported routine: {args.routine}")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

**No changes to library code. Will not launch internal CI**

#2354 added moe_comm microbenchmarks to the benchmark harness. However, the PR causes failures in non-MPI enabled environments because `flashinfer_benchmark.py` blindly imports routines for all modules.

Current PR refactors `flashinfer_benchmark.py` to use lazy imports for routine modules instead of importing all modules at startup. This avoids loading unnecessary dependencies when running specific benchmarks. Users without MPI installed can now run all non-MPI benchmarks without import errors.


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized benchmark execution for improved efficiency with deferred loading of benchmark routines, reducing unnecessary resource consumption during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->