### PR TITLE
Update cudnn prefill to use correct sequence strides

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -185,12 +185,13 @@ if CUDNN_AVAILABLE:
             # Create tensors from the input tensors
             if q.dim() == 3:
                 h_qo, d_qk = q.shape[1], q.shape[2]
+                s_stride, h_stride, d_stride = q.stride()
             elif q.dim() == 4:
                 h_qo, d_qk = q.shape[2], q.shape[3]
+                s_stride, h_stride, d_stride = q.stride()
             else:
                 raise ValueError(f"Invalid query tensor shape: {q.shape}")
 
-            s_stride, h_stride, d_stride = q.stride()
             cudnn_q = g.tensor(
                 name="q",
                 dim=(graph_b, h_qo, graph_s_qo, d_qk),
@@ -208,7 +209,7 @@ if CUDNN_AVAILABLE:
                     stride=(1, 1, 1, 1),
                     data_type=cudnn.data_type.FLOAT,
                 )
-                
+
                 cudnn_k_scale = g.tensor(
                     name="k_scale",
                     dim=(1, 1, 1, 1),
@@ -283,6 +284,9 @@ if CUDNN_AVAILABLE:
                     ragged_k.set_uid(UIDs.RAGGED_K_UID.value)
                     cudnn_k_cache.set_ragged_offset(ragged_k)
 
+                assert v_cache.dim() == 3, (
+                    "v_cache must have 3 dimensions since k_cache has 3 dimensions"
+                )
                 s_stride, h_stride, d_stride = v_cache.stride()
                 cudnn_v_cache = g.tensor(
                     name="v_cache",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Pass correct strides to cudnn prefill

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tensor stride handling for query, key, and value caches so strides are derived from actual tensors (including 3D/4D cases) instead of relying on hard-coded layout assumptions, reducing memory/layout errors while keeping public APIs unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->