### PR TITLE
bugfix: fix stub generation directory in fused_moe module

### DIFF
--- a/.claude/skills/add-cuda-kernel/SKILL.md
+++ b/.claude/skills/add-cuda-kernel/SKILL.md
@@ -234,6 +234,7 @@ def gen_scale_module(dtype_in, dtype_out):
 - No Jinja template needed for simple operations
 - Just copy source files to generation directory
 - URI uniquely identifies the module configuration
+- **NEVER write to package directories** - see "JIT Directory Rules" in `CLAUDE.md`
 
 ### (Optional) Specifying Supported CUDA Architectures
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,17 @@ FlashInfer's JIT system has three layers:
 - `sources`: List of .cu/.cpp files to compile
 - `extra_cuda_cflags`, `extra_cflags`, `extra_ldflags`: Compiler flags
 
+### JIT Directory Rules
+
+**NEVER write to package directories** - they may be read-only after installation.
+
+| Directory | Writable | Use for |
+|-----------|----------|---------|
+| `FLASHINFER_GEN_SRC_DIR` | ✓ Yes | Generated source files (Jinja output, copied .cu files) |
+| `FLASHINFER_JIT_DIR` | ✓ Yes | Compiled `.so` outputs |
+| `FLASHINFER_CSRC_DIR` | ✗ No | Read-only source templates |
+| `FLASHINFER_AOT_DIR` | ✗ No | Read-only pre-compiled binaries |
+
 ### Compilation Context: Architecture-Specific Compilation
 
 FlashInfer uses `CompilationContext` to manage CUDA architecture targets. Some kernels only work on specific GPU architectures (e.g., Hopper SM90, Blackwell SM100/SM12x).

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -16,7 +16,8 @@ from .cpp_ext import generate_ninja_build_for_op, run_ninja
 from .utils import write_if_different
 
 os.makedirs(jit_env.FLASHINFER_WORKSPACE_DIR, exist_ok=True)
-os.makedirs(jit_env.FLASHINFER_CSRC_DIR, exist_ok=True)
+# Note: Do NOT create FLASHINFER_CSRC_DIR here - it's the package directory
+# which may be read-only after installation
 
 
 class MissingJITCacheError(RuntimeError):

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -111,9 +111,10 @@ def gen_cutlass_fused_moe_module(
     """
     Generate a JitSpec for the cutlass fused moe module.
     """
+    # Use FLASHINFER_GEN_SRC_DIR (user's writable cache) instead of FLASHINFER_CSRC_DIR
+    # (package directory which may be read-only after installation)
     output_dir = (
-        jit_env.FLASHINFER_CSRC_DIR
-        / f"nv_internal/tensorrt_llm/cutlass_instantiations/{device_arch}"
+        jit_env.FLASHINFER_GEN_SRC_DIR / f"cutlass_instantiations/{device_arch}"
     )
 
     try:
@@ -205,6 +206,8 @@ def gen_cutlass_fused_moe_module(
             / "tensorrt_llm"
             / "kernels"
             / "cutlass_kernels",
+            # Include the generated output directory for header files
+            output_dir,
         ],
     )
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

bugfix to #2093, the fundamental issue is we should not write to `jit_env.FLASHINFER_CSRC_DIR` (which might be read-only) for fused-moe module, instead we should use `FLASHINFER_GEN_SRC_DIR` which is supposed to be writable.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JIT kernel generation now correctly uses user-writable cache directories instead of package directories, resolving compatibility issues in post-installation and read-only environments.

* **Documentation**
  * Updated JIT directory rules clarifying which directories are writable versus read-only. Added details on GPU auto-detection and CUDA architecture environment variable controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->