### PR TITLE
ci: Add no isolation for flashinfer-jit-cache build script

### DIFF
--- a/scripts/build_flashinfer_jit_cache_whl.sh
+++ b/scripts/build_flashinfer_jit_cache_whl.sh
@@ -49,6 +49,8 @@ export LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:$LD_LI
 
 echo "::group::Install build system"
 pip install --upgrade build
+# Install build dependencies for --no-isolation that may not be in the current environment.
+pip install --upgrade "setuptools>=77" wheel
 echo "::endgroup::"
 
 # Clean any previous builds


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix NVSHMEM version mismatch in jit-cache wheel build by using `--no-isolation` flag.

The `test_nvshmem.py` tests were failing on cu129 configurations with: `NVSHMEM device library version does not match with NVSHMEM host library version`

This occurred only when precompiled kernels were successfully built and used.

**Root Cause**
When building the `flashinfer-jit-cache` wheel, `python -m build --wheel` creates an isolated environment and installs `nvidia-nvshmem-cu12` from PyPI (latest version). The compiled NVSHMEM module gets linked against this version's device library.

At test time, the runtime environment has a different NVSHMEM version (installed by torch), causing a device/host library version mismatch.

**Fix**
Use `--no-isolation` to build with the existing environment's NVSHMEM version, ensuring the compiled module matches the runtime environment.


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-build step to ensure required build tooling is present before packaging.
  * Switched wheel creation to run without isolation so host environment dependencies are used.
  * Updated build commentary to clarify the non-isolated build behavior and expected tooling versions.
  * Minor scripting adjustments to support the new non-isolated build invocation and reduce version mismatch risk.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->