### PR TITLE
Skip trtllm_alltoall tests on Thor

### DIFF
--- a/tests/comm/test_trtllm_alltoall.py
+++ b/tests/comm/test_trtllm_alltoall.py
@@ -20,11 +20,11 @@ import torch
 import flashinfer.comm.trtllm_alltoall as tllm_alltoall
 from flashinfer.utils import get_compute_capability
 
-# Skip all tests on SM110 (Thor) devices due to known issues
+# Skip all tests on SM110 (Thor) devices - these tests hang indefinitely on this architecture
 pytestmark = pytest.mark.skipif(
     torch.cuda.is_available()
     and get_compute_capability(torch.device("cuda:0"))[0] == 11,
-    reason="Skipping trtllm_alltoall tests on SM110 (Thor) devices",
+    reason="Tests hang indefinitely on SM110 (Thor) devices",
 )
 
 has_setup_max_sm_count = False


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

After adding Thor to our internal CI, we've been seeing consistent hangs in this test suite. Since this functionality likely isn't crucial for this platform, we can disable the tests to unblock the rest of the testing and get nightly Thor test results.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to skip execution on SM110/Thor CUDA devices to prevent hangs during test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->