### PR TITLE
fix: set_log_level now properly sets logger level to enable DEBUG logs

### DIFF
--- a/include/flashinfer/logging.h
+++ b/include/flashinfer/logging.h
@@ -36,6 +36,7 @@ inline void set_log_level(spdlog::level::level_enum lvl) {
   console_sink->set_pattern(fmt);
   console_sink->set_level(lvl);
   spdlog::set_default_logger(std::make_shared<spdlog::logger>("flashinfer", console_sink));
+  spdlog::set_level(lvl);
 }
 
 }  // namespace logging


### PR DESCRIPTION
(just opening a PR for claude generated fix)

Fixed bug where `flashinfer.utils.set_log_level("debug")` didn't show DEBUG level logs.

The issue was that only the sink's log level was being set, while the logger's level remained at the default (info). In spdlog, both the logger and sink have independent log levels, and the effective level is the most restrictive of the two.

Added `spdlog::set_level(lvl)` call to ensure the logger level matches the requested level.

Fixes #2401

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging consistency by ensuring the global log level is properly synchronized with the configured logger settings, enabling more reliable log filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->