### PR TITLE
ci: CI build workflow should always pull fresh and do not cache

### DIFF
--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -61,10 +61,10 @@ jobs:
           file: docker/Dockerfile.${{ matrix.cuda }}
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name != 'pull_request' }}
+          pull: true  # Always pull the latest base image
+          no-cache: true  # Disable all caching
           tags: |
             flashinfer/flashinfer-ci-${{ matrix.cuda }}:${{ matrix.arch }}-${{ needs.generate-tag.outputs.date_sha }}
-          cache-from: type=registry,ref=flashinfer/flashinfer-ci-${{ matrix.cuda }}:buildcache-${{ matrix.arch }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=flashinfer/flashinfer-ci-{0}:buildcache-{1},mode=max', matrix.cuda, matrix.arch) || '' }}
           provenance: false
           sbom: false
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

#2453 

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build workflow to always pull the latest base image and disable caching during release builds, ensuring fresher container images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->