### PR TITLE
fix: RMSNorm/FusedRMSNorm + Quant kernels cuda graph fixes

### DIFF
--- a/csrc/flashinfer_norm_binding.cu
+++ b/csrc/flashinfer_norm_binding.cu
@@ -17,14 +17,14 @@
 
 void rmsnorm(TensorView out, TensorView input, TensorView weight, double eps, bool enable_pdl);
 
-void rmsnorm_quant(TensorView out, TensorView input, TensorView weight, double scale, double eps,
-                   bool enable_pdl);
+void rmsnorm_quant(TensorView out, TensorView input, TensorView weight, TensorView scale,
+                   double eps, bool enable_pdl);
 
 void fused_add_rmsnorm(TensorView input, TensorView residual, TensorView weight, double eps,
                        bool enable_pdl);
 
 void fused_add_rmsnorm_quant(TensorView output, TensorView input, TensorView residual,
-                             TensorView weight, double scale, double eps, bool enable_pdl);
+                             TensorView weight, TensorView scale, double eps, bool enable_pdl);
 
 void gemma_rmsnorm(TensorView out, TensorView input, TensorView weight, double eps,
                    bool enable_pdl);

--- a/docs/api/norm.rst
+++ b/docs/api/norm.rst
@@ -11,7 +11,9 @@ Kernels for normalization layers.
     :toctree: ../generated
 
     rmsnorm
+    rmsnorm_quant
     fused_add_rmsnorm
+    fused_add_rmsnorm_quant
     gemma_rmsnorm
     gemma_fused_add_rmsnorm
     layernorm

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -98,13 +98,13 @@ def rmsnorm_quant(
     out: torch.Tensor,
     input: torch.Tensor,
     weight: torch.Tensor,
-    scale: float,
+    scale: torch.Tensor,
     eps: float = 1e-6,
     enable_pdl: Optional[bool] = None,
-) -> torch.Tensor:
-    r"""Root mean square normalization.
+) -> None:
+    r"""Root mean square normalization + fp8 quantization.
 
-    ``out[i] = (input[i] / RMS(input)) * weight[i]``
+    ``out[i] = ((input[i] / RMS(input)) * weight[i]).to(fp8)``
 
     Parameters
     ----------
@@ -114,18 +114,13 @@ def rmsnorm_quant(
         Input tensor, 2D shape (batch_size, hidden_size).
     weight: torch.Tensor
         Weight tensor, shape (hidden_size,).
-    scale: float
-        Scale factor for quantization.
+    scale: torch.Tensor
+        Scale factor for quantization, shape (1,).
     eps: float
         Epsilon for numerical stability.
     enable_pdl: bool
         Whether to enable `programmatic dependent launch
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
-
-    Returns
-    -------
-    output: torch.Tensor
-        Normalized tensor, 2D shape (batch_size, hidden_size).
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
@@ -137,7 +132,7 @@ def _rmsnorm_quant_fake(
     out: torch.Tensor,
     input: torch.Tensor,
     weight: torch.Tensor,
-    scale: float,
+    scale: torch.Tensor,
     eps: float,
     enable_pdl: Optional[bool],
 ) -> None:
@@ -200,17 +195,17 @@ def fused_add_rmsnorm_quant(
     input: torch.Tensor,
     residual: torch.Tensor,
     weight: torch.Tensor,
-    scale: float,
+    scale: torch.Tensor,
     eps: float = 1e-6,
     enable_pdl: Optional[bool] = None,
 ) -> None:
-    r"""Fused add root mean square normalization.
+    r"""Fused add root mean square normalization + fp8 quantization.
 
     Step 1:
     ``residual[i] += input[i]``
 
     Step 2:
-    ``input[i] = (residual[i] / RMS(residual)) * weight[i]``
+    ``input[i] = ((residual[i] / RMS(residual)) * weight[i]).to(fp8)``
 
     Parameters
     ----------
@@ -222,8 +217,8 @@ def fused_add_rmsnorm_quant(
         Residual tensor, shape (batch_size, hidden_size).
     weight: torch.Tensor
         Weight tensor, shape (hidden_size,).
-    scale: float
-        Scale factor for quantization.
+    scale: torch.Tensor
+        Scale factor for quantization, shape (1,).
     eps: float
         Epsilon for numerical stability.
     enable_pdl: bool
@@ -243,7 +238,7 @@ def _fused_add_rmsnorm_quant_fake(
     input: torch.Tensor,
     residual: torch.Tensor,
     weight: torch.Tensor,
-    scale: float,
+    scale: torch.Tensor,
     eps: float = 1e-6,
     enable_pdl: Optional[bool] = None,
 ) -> None:

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -149,7 +149,9 @@ def test_norm_quant(
 
     y_ref = llama_rms_norm_quant(x, w, quant_scale)
     y = torch.empty_like(x, dtype=torch.float8_e4m3fn, device="cuda")
-    flashinfer.norm.rmsnorm_quant(y, x, w, quant_scale, enable_pdl=enable_pdl)
+    flashinfer.norm.rmsnorm_quant(
+        y, x, w, torch.tensor(quant_scale, device="cuda"), enable_pdl=enable_pdl
+    )
 
     torch.testing.assert_close(y_ref.float(), y.float(), rtol=1, atol=1)
 
@@ -250,7 +252,13 @@ def test_fused_add_rmsnorm_quant(
     residual_fused = residual.clone()
     y = torch.empty_like(x, dtype=torch.float8_e4m3fn, device="cuda")
     flashinfer.norm.fused_add_rmsnorm_quant(
-        y, x_fused, residual_fused, weight, quant_scale, eps, enable_pdl=enable_pdl
+        y,
+        x_fused,
+        residual_fused,
+        weight,
+        torch.tensor(quant_scale, device="cuda"),
+        eps,
+        enable_pdl=enable_pdl,
     )
 
     torch.testing.assert_close(y.float(), x_native.float(), rtol=1, atol=1)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

follow up on #2243 

quant_scale being a float causes cuda graph capture to fail, by making it a tensor it fixes cuda graph capture for fusion passes in sglang.

also added docs for the fused kernels.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Sglang's fusion pass MR: https://github.com/sgl-project/sglang/pull/10549

Some performance numbers from sglang on an RTX 5090 running llama 3.1 8b fp8 on a 16 prompt benchmark

| server config | throughput (tok/sec |
|--------|--------|
| cuda graph | 503.25 |
| cuda graph + torch compile | 600.37 |
| cuda graph + torch compile + fusion (vllm kernels) | 612.58 |
| cuda graph + torch compile + fusion (flashinfer kernels) | 619.11 |

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalization routines updated to accept the scale parameter as a tensor (single-element) instead of a scalar, changing how quantized normalization is invoked.

* **Documentation**
  * API docs and docstrings updated to describe FP8 quantization behavior and the tensor-shaped scale parameter.

* **Tests**
  * Tests updated to pass scale as a CUDA tensor to match the new signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->