### PR TITLE
perf: add fp4 GEMM tile configs and streamK scheduler for SM120

### DIFF
--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -104,9 +104,11 @@ def gen_gemm_sm120_module_cutlass_fp4() -> JitSpec:
     with open(jit_env.FLASHINFER_CSRC_DIR / "fp4_gemm_cutlass_sm120.jinja") as f:
         kernel_inst_templ = jinja2.Template(f.read())
         dtype_list = ["__nv_bfloat16", "half"]
-        # SM120/121 uses only 128x128x128 tile configuration with implied 1x1x1 cluster shape
+        # SM120/121 tile configurations with implied 1x1x1 cluster shape
         cta_m_n_k_list = [
             (128, 128, 128),
+            (128, 128, 256),
+            (256, 128, 128),
         ]
         for cta_m, cta_n, cta_k in cta_m_n_k_list:
             for dtype in dtype_list:

--- a/include/flashinfer/gemm/cutlass_gemm_configs.h
+++ b/include/flashinfer/gemm/cutlass_gemm_configs.h
@@ -322,6 +322,7 @@ struct CutlassGemmConfig {
   bool enableCudaKernel = false;
   int sm_version = 80;  // Use 80 as a catch all for <90
   bool is_tma_warp_specialized = false;
+  bool use_stream_k = false;  // SM120: false = DP scheduler (default), true = StreamK scheduler
 
   CutlassGemmConfig() = default;
 
@@ -352,15 +353,18 @@ struct CutlassGemmConfig {
         sm_version(100),
         is_tma_warp_specialized(true) {}
 
+  // SM120 constructor with optional StreamK scheduler
+  // use_stream_k: false = DP scheduler (default), true = StreamK scheduler (auto heuristic)
   CutlassGemmConfig(CutlassTileConfigSM120 tile_config_sm120,
                     MainloopScheduleType mainloop_schedule, EpilogueScheduleType epilogue_schedule,
-                    ClusterShape cluster_shape)
+                    ClusterShape cluster_shape, bool use_stream_k = false)
       : tile_config_sm120(tile_config_sm120),
         mainloop_schedule(mainloop_schedule),
         epilogue_schedule(epilogue_schedule),
         cluster_shape(cluster_shape),
         sm_version(120),
-        is_tma_warp_specialized(true) {}
+        is_tma_warp_specialized(true),
+        use_stream_k(use_stream_k) {}
 
   int getTileConfigAsInt() const {
     if (sm_version == 120) return (int)tile_config_sm120;
@@ -383,6 +387,10 @@ struct CutlassGemmConfig {
              << "\n\tmainloop sched: " << (int)mainloop_schedule
              << "\n\tepi sched: " << (int)epilogue_schedule
              << "\n\tenable cuda kernel: " << (enableCudaKernel ? "true" : "false");
+      // SM120 specific: StreamK scheduler option
+      if (sm_version == 120) {
+        tactic << "\n\tscheduler: " << (use_stream_k ? "StreamK (auto heuristic)" : "DP (default)");
+      }
     } else if (tile_config_sm80 != flashinfer::gemm::CutlassTileConfig::ChooseWithHeuristic) {
       assert(sm_version < 90 && "Invalid cutlass GEMM config");
       tactic << "\n\tstyle=compatible"

--- a/include/flashinfer/gemm/fp4_gemm_template_sm120.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm120.h
@@ -31,6 +31,7 @@
 #include "cutlass/gemm/collective/collective_builder.hpp"
 #include "cutlass/gemm/device/gemm_universal_adapter.h"
 #include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/tile_scheduler.hpp"
 #include "flashinfer/arch_condition.h"
 #include "flashinfer/cutlass_utils.cuh"
 
@@ -81,6 +82,118 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
                                     int k, int batch_count, CutlassGemmConfig gemmConfig,
                                     char* workspace, size_t const workspaceBytes,
                                     cudaStream_t stream, int* occupancy);
+
+template <typename T, typename CTA_M_, typename CTA_N_, typename CTA_K_, typename CGA_M_,
+          typename CGA_N_, typename CGA_K_, typename XSM_>
+size_t genericFp4GemmKernelLauncherStreamK(void* D, void const* A, void const* B,
+                                           void const* input_sf, void const* weight_sf,
+                                           float const* global_sf, int m, int n, int k,
+                                           int batch_count, CutlassGemmConfig gemmConfig,
+                                           char* workspace, size_t const workspaceBytes,
+                                           cudaStream_t stream, int* occupancy);
+
+// ============================================================================
+// Common helper functions to reduce code duplication
+// ============================================================================
+
+// Unified prepareGemmArgs - works for both DP and StreamK schedulers
+template <typename Gemm>
+inline typename Gemm::Arguments prepareGemmArgsImpl(void* D, void const* A, void const* B,
+                                                    void const* input_sf, void const* weight_sf,
+                                                    float const* global_sf, int m, int n, int k,
+                                                    int batch_count) {
+  using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  using ElementC = void;
+  using ElementD = typename Gemm::ElementD;
+  using ElementCompute = float;
+
+  typename Gemm::Arguments operator_args;
+  operator_args.mode = cutlass::gemm::GemmUniversalMode::kGemm;
+  operator_args.epilogue.thread.alpha_ptr = static_cast<ElementCompute const*>(global_sf);
+  operator_args.problem_shape = cute::make_shape(m, n, k, batch_count);
+
+  operator_args.mainloop.ptr_A = static_cast<cutlass::float_e2m1_t const*>(A);
+  operator_args.mainloop.ptr_B = static_cast<cutlass::float_e2m1_t const*>(B);
+  operator_args.mainloop.ptr_SFA = static_cast<cutlass::float_ue4m3_t const*>(input_sf);
+  operator_args.mainloop.ptr_SFB = static_cast<cutlass::float_ue4m3_t const*>(weight_sf);
+  operator_args.epilogue.ptr_C = static_cast<ElementC const*>(D);
+  operator_args.epilogue.ptr_D = static_cast<ElementD*>(D);
+
+  int const stride_A = batch_count == 1 ? 0 : m * k;
+  int const stride_B = batch_count == 1 ? 0 : n * k;
+  int const stride_C = batch_count == 1 ? 0 : m * n;
+
+  operator_args.mainloop.dA =
+      cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideA>(k, stride_A);
+  operator_args.mainloop.dB =
+      cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideB>(k, stride_B);
+  operator_args.epilogue.dC =
+      cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideC>(n, stride_C);
+  operator_args.epilogue.dD = operator_args.epilogue.dC;
+
+  operator_args.mainloop.layout_SFA =
+      Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(operator_args.problem_shape);
+  operator_args.mainloop.layout_SFB =
+      Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(operator_args.problem_shape);
+
+  if constexpr (!std::is_const_v<decltype(operator_args.scheduler.max_swizzle_size)>) {
+    operator_args.scheduler.max_swizzle_size = 1;
+  }
+  if constexpr (!std::is_const_v<decltype(operator_args.scheduler.raster_order)>) {
+    using Enum_t = decltype(operator_args.scheduler.raster_order);
+    operator_args.scheduler.raster_order = Enum_t::Heuristic;
+  }
+  operator_args.hw_info.cluster_shape = dim3(1, 1, 1);
+  operator_args.hw_info.cluster_shape_fallback = dim3(1, 1, 1);
+
+  return operator_args;
+}
+
+// Unified runGemm - works for both DP and StreamK schedulers
+template <typename Gemm>
+inline size_t runFp4GemmImpl(void* D, void const* A, void const* B, void const* input_sf,
+                             void const* weight_sf, float const* global_sf, int m, int n, int k,
+                             int batch_count, char* workspace, size_t const workspaceBytes,
+                             cudaStream_t stream, const char* scheduler_name) {
+  Gemm gemm;
+  auto args =
+      prepareGemmArgsImpl<Gemm>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count);
+
+  // Return workspace size query
+  if (!A && !B && !D) {
+    return gemm.get_workspace_size(args);
+  }
+
+  if (gemm.get_workspace_size(args) > workspaceBytes) {
+    throw std::runtime_error(std::string("[FP4 gemm Runner") + scheduler_name + "] " +
+                             "Requested workspace size insufficient. Required " +
+                             std::to_string(gemm.get_workspace_size(args)) + ", got " +
+                             std::to_string(workspaceBytes));
+  }
+
+  auto can_implement = gemm.can_implement(args);
+  if (can_implement != cutlass::Status::kSuccess) {
+    throw std::runtime_error(std::string("[FP4 gemm Runner") + scheduler_name + "] " +
+                             "FP4 Gemm cutlass kernel will fail for params. Error: " +
+                             std::string(cutlass::cutlassGetStatusString(can_implement)));
+  }
+
+  auto initStatus = gemm.initialize(args, workspace, stream);
+  if (initStatus != cutlass::Status::kSuccess) {
+    throw std::runtime_error(std::string("[FP4 gemm Runner") + scheduler_name + "] " +
+                             "Failed to initialize cutlass FP4 gemm on sm120. Error: " +
+                             std::string(cutlass::cutlassGetStatusString(initStatus)));
+  }
+
+  auto runStatus = gemm.run(args, workspace, stream, nullptr, /*enablePDL=*/true);
+  if (runStatus != cutlass::Status::kSuccess) {
+    throw std::runtime_error(std::string("[FP4 gemm Runner") + scheduler_name + "] " +
+                             "Failed to run cutlass FP4 gemm on sm120. Error: " +
+                             std::string(cutlass::cutlassGetStatusString(runStatus)));
+  }
+
+  return gemm.get_workspace_size(args);
+}
 
 #ifdef PLACEHOLDER_KERNELS
 
@@ -146,75 +259,35 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         cutlass::gemm::collective::StageCount<2>, /* Fixed 2 stages for SM120 */                           \
         cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;                                      \
                                                                                                            \
-    /* Match example 79 - no wrapper needed */                                                             \
-    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<                                               \
-        cute::Shape<int, int, int, int>,               /* Indicates ProblemShape */                        \
-        CollectiveMainloop, CollectiveEpilogue, void>; /* No persistent scheduler for SM120 */             \
+    /* Two scheduler options for different workloads */                                                    \
+    /* See: https://github.com/NVIDIA/cutlass/blob/main/examples/79_blackwell_geforce_gemm */              \
                                                                                                            \
-    using Gemm = typename cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;                         \
+    /* Option 1: Default scheduler (void) - Data Parallel, good for regular shapes */                      \
+    using GemmKernelDefault = cutlass::gemm::kernel::GemmUniversal<                                        \
+        cute::Shape<int, int, int, int>,               /* Indicates ProblemShape */                        \
+        CollectiveMainloop, CollectiveEpilogue, void>; /* Default DP scheduler */                          \
+                                                                                                           \
+    /* Option 2: StreamK scheduler - better load balancing for small M/N, large K */                       \
+    using GemmKernelStreamK = cutlass::gemm::kernel::GemmUniversal<                                        \
+        cute::Shape<int, int, int, int>, /* Indicates ProblemShape */                                      \
+        CollectiveMainloop, CollectiveEpilogue,                                                            \
+        cutlass::gemm::StreamKScheduler>; /* StreamK scheduler */                                          \
+                                                                                                           \
+    using GemmDefault = typename cutlass::gemm::device::GemmUniversalAdapter<GemmKernelDefault>;           \
+    using GemmStreamK = typename cutlass::gemm::device::GemmUniversalAdapter<GemmKernelStreamK>;           \
+    using Gemm = GemmDefault; /* Default alias for compatibility */                                        \
   };                                                                                                       \
                                                                                                            \
+  /* Type aliases for DP and StreamK schedulers */                                                         \
   using Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_ =                                                     \
       DeviceGemmFp4GemmSm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_:: \
-          Gemm;                                                                                            \
+          GemmDefault;                                                                                     \
                                                                                                            \
-  inline typename Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_::Arguments                                  \
-      prepareGemmArgs_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_(                                                \
-          void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,              \
-          float const* global_sf, int m, int n, int k, int batch_count) {                                  \
-    using Gemm = Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_;                                             \
-    using Sm1xxBlkScaledConfig =                                                                           \
-        typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;                               \
-    /* Note: For nv_float4_t, scale factors are handled internally */                                      \
-    using ElementC = void;                                                                                 \
-    using ElementD = typename Gemm::ElementD;                                                              \
-    using ElementCompute = float;                                                                          \
+  using Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_StreamK =                                           \
+      DeviceGemmFp4GemmSm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_:: \
+          GemmStreamK;                                                                                     \
                                                                                                            \
-    typename Gemm::Arguments operator_args;                                                                \
-    operator_args.mode = cutlass::gemm::GemmUniversalMode::kGemm;                                          \
-    auto& fusion_args = operator_args.epilogue.thread;                                                     \
-    fusion_args.alpha_ptr = static_cast<ElementCompute const*>(global_sf);                                 \
-                                                                                                           \
-    operator_args.problem_shape = cute::make_shape(m, n, k, batch_count);                                  \
-                                                                                                           \
-    /* For nv_float4_t, data and scale factors are stored separately */                                    \
-    operator_args.mainloop.ptr_A = static_cast<cutlass::float_e2m1_t const*>(A);                           \
-    operator_args.mainloop.ptr_B = static_cast<cutlass::float_e2m1_t const*>(B);                           \
-    operator_args.mainloop.ptr_SFA = static_cast<cutlass::float_ue4m3_t const*>(input_sf);                 \
-    operator_args.mainloop.ptr_SFB = static_cast<cutlass::float_ue4m3_t const*>(weight_sf);                \
-    operator_args.epilogue.ptr_C = static_cast<ElementC const*>(D);                                        \
-    operator_args.epilogue.ptr_D = static_cast<ElementD*>(D);                                              \
-                                                                                                           \
-    int const stride_A = batch_count == 1 ? 0 : m * k;                                                     \
-    int const stride_B = batch_count == 1 ? 0 : n * k;                                                     \
-    int const stride_C = batch_count == 1 ? 0 : m * n;                                                     \
-                                                                                                           \
-    operator_args.mainloop.dA =                                                                            \
-        cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideA>(k, stride_A);                        \
-    operator_args.mainloop.dB =                                                                            \
-        cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideB>(k, stride_B);                        \
-    operator_args.epilogue.dC =                                                                            \
-        cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideC>(n, stride_C);                        \
-    operator_args.epilogue.dD = operator_args.epilogue.dC;                                                 \
-                                                                                                           \
-    operator_args.mainloop.layout_SFA =                                                                    \
-        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(operator_args.problem_shape);                         \
-    operator_args.mainloop.layout_SFB =                                                                    \
-        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(operator_args.problem_shape);                         \
-                                                                                                           \
-    if constexpr (!std::is_const_v<decltype(operator_args.scheduler.max_swizzle_size)>) {                  \
-      operator_args.scheduler.max_swizzle_size = 1;                                                        \
-    }                                                                                                      \
-    if constexpr (!std::is_const_v<decltype(operator_args.scheduler.raster_order)>) {                      \
-      using Enum_t = decltype(operator_args.scheduler.raster_order);                                       \
-      operator_args.scheduler.raster_order = Enum_t::Heuristic;                                            \
-    }                                                                                                      \
-    operator_args.hw_info.cluster_shape = dim3(1, 1, 1); /* SM120 requires 1x1x1 */                        \
-    operator_args.hw_info.cluster_shape_fallback = dim3(1, 1, 1);                                          \
-                                                                                                           \
-    return operator_args;                                                                                  \
-  }                                                                                                        \
-                                                                                                           \
+  /* DP scheduler launcher - uses common helper functions */                                               \
   template <>                                                                                              \
   size_t                                                                                                   \
   genericFp4GemmKernelLauncher<T, cute::Int<CTA_M_>, cute::Int<CTA_N_>, cute::Int<CTA_K_>,                 \
@@ -222,48 +295,23 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
       void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,                  \
       float const* global_sf, int m, int n, int k, int batch_count, CutlassGemmConfig gemmConfig,          \
       char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {                 \
-    using ElementOutput__ =                                                                                \
-        typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value,                \
-                                                cutlass::half_t, T>::type;                                 \
-    using ElementOutput_ = typename cutlass::platform::conditional<                                        \
-        cutlass::platform::is_same<ElementOutput__, float>::value, float, ElementOutput__>::type;          \
-    using ElementOutput = typename cutlass::platform::conditional<                                         \
-        cutlass::platform::is_same<ElementOutput_, SafeBF16>::value, cutlass::bfloat16_t,                  \
-        ElementOutput_>::type;                                                                             \
-                                                                                                           \
     using Fp4GemmOperator = Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_;                                  \
-    Fp4GemmOperator gemm;                                                                                  \
-    auto args = prepareGemmArgs_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_(                                      \
-        D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count);                                    \
-    /* // Return workspace size */                                                                         \
-    if (!A && !B && !D) {                                                                                  \
-      return gemm.get_workspace_size(args);                                                                \
-    }                                                                                                      \
-    if (gemm.get_workspace_size(args) > workspaceBytes) {                                                  \
-      std::string errMsg("Requested workspace size insufficient. Required " +                              \
-                         std::to_string(gemm.get_workspace_size(args)) + ", got " +                        \
-                         std::to_string(workspaceBytes));                                                  \
-      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                             \
-    }                                                                                                      \
-    auto can_implement = gemm.can_implement(args);                                                         \
-    if (can_implement != cutlass::Status::kSuccess) {                                                      \
-      std::string errMsg = "FP4 Gemm cutlass kernel will fail for params. Error: " +                       \
-                           std::string(cutlass::cutlassGetStatusString(can_implement));                    \
-      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                             \
-    }                                                                                                      \
-    auto initStatus = gemm.initialize(args, workspace, stream);                                            \
-    if (initStatus != cutlass::Status::kSuccess) {                                                         \
-      std::string errMsg = "Failed to initialize cutlass FP4 gemm on sm120. Error: " +                     \
-                           std::string(cutlass::cutlassGetStatusString(initStatus));                       \
-      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                             \
-    }                                                                                                      \
-    auto runStatus = gemm.run(args, workspace, stream, nullptr, /*enablePDL=*/true);                       \
-    if (runStatus != cutlass::Status::kSuccess) {                                                          \
-      std::string errMsg = "Failed to run cutlass FP4 gemm on sm120. Error: " +                            \
-                           std::string(cutlass::cutlassGetStatusString(runStatus));                        \
-      throw std::runtime_error("[FP4 gemm Runner] " + errMsg);                                             \
-    }                                                                                                      \
-    return gemm.get_workspace_size(args);                                                                  \
+    return runFp4GemmImpl<Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,               \
+                                           batch_count, workspace, workspaceBytes, stream, "");            \
+  }                                                                                                        \
+                                                                                                           \
+  /* StreamK scheduler launcher - uses common helper functions */                                          \
+  template <>                                                                                              \
+  size_t genericFp4GemmKernelLauncherStreamK<T, cute::Int<CTA_M_>, cute::Int<CTA_N_>,                      \
+                                             cute::Int<CTA_K_>, cute::Int<CGA_M_>,                         \
+                                             cute::Int<CGA_N_>, cute::Int<CGA_K_>, XSM_>(                  \
+      void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,                  \
+      float const* global_sf, int m, int n, int k, int batch_count, CutlassGemmConfig gemmConfig,          \
+      char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {                 \
+    using Fp4GemmOperator = Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_StreamK;                        \
+    return runFp4GemmImpl<Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,               \
+                                           batch_count, workspace, workspaceBytes, stream,                 \
+                                           " StreamK");                                                    \
   }
 
 #endif


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add SM120 FP4 GEMM tile configs and enable streamK scheduler for configs that can be selected by autotuner.
Take the problem size m=32, n=5120, k=25600 as an example. After adding these configs, the latency of mm_fp4 kernel reduced from 0.124ms to 0.069ms on RTX PRO 6000.

```
[PERF] cutlass_autotun:: median time 0.124 ms; std 0.000 ms; achieved tflops 67.751 TFLOPs/sec; achieved tb_per_sec 0.535 TB/sec
[PERF] cutlass_autotun:: median time 0.069 ms; std 0.000 ms; achieved tflops 121.902 TFLOPs/sec; achieved tb_per_sec 0.963 TB/sec
```

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added StreamK scheduler option for SM120 FP4 GEMM operations, alongside the existing DP scheduler.
  * Expanded SM120 FP4 GEMM tile configurations with two additional options (128×128×256 and 256×128×128).
  * Extended configuration generation to support all tile shapes with both schedulers for improved optimization flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->