### PR TITLE
ci: migrate release workflows to ci-infra runners

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -127,7 +127,7 @@ jobs:
         cuda: ["12.8", "12.9", "13.0"]
         arch: ['x86_64', 'aarch64']
 
-    runs-on: [self-hosted, "${{ matrix.arch == 'aarch64' && 'arm64' || matrix.arch }}"]
+    runs-on: [self-hosted, linux, "${{ matrix.arch == 'aarch64' && 'arm64' || 'x64' }}", cpu, on-demand]
 
     steps:
       - name: Display Machine Information
@@ -281,7 +281,7 @@ jobs:
       matrix:
         cuda: ["12.9", "13.0"]
         test-shard: [1, 2, 3, 4, 5]
-    runs-on: [self-hosted, G5, X64]
+    runs-on: [self-hosted, linux, x64, gpu, sm86, on-demand]
 
     steps:
       - name: Display Machine Information

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -32,7 +32,7 @@ jobs:
           echo "Generated version tag: ${DATE_SHA}"
 
   build:
-    runs-on: [self-hosted, x86_64]
+    runs-on: [self-hosted, linux, x64, cpu, on-demand]
     needs: generate-tag
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         cuda: ["12.8", "12.9", "13.0"]
         arch: ['x86_64', 'aarch64']
 
-    runs-on: [self-hosted, "${{ matrix.arch == 'aarch64' && 'arm64' || matrix.arch }}"]
+    runs-on: [self-hosted, linux, "${{ matrix.arch == 'aarch64' && 'arm64' || 'x64' }}", cpu, on-demand]
 
     steps:
       - name: Display Machine Information


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Migrate self-hosted runner labels from the old always-on EC2 instances to the new ephemeral runners managed by ci-infra. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to optimize resource allocation and execution environments across multiple release workflows, improving build and test scheduling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->