### PR TITLE
Proposing a fork owner credential authorization

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,6 +46,19 @@ jobs:
             ACTOR="${{ github.actor }}"
           fi
 
+          # Fork support: allow fork owners to use their own credentials
+          if [[ "${{ github.repository }}" != "flashinfer-ai/flashinfer" ]]; then
+            if [[ "$ACTOR" == "${{ github.repository_owner }}" ]]; then
+              echo "✅ Fork owner $ACTOR authorized (using own credentials)"
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            else
+              echo "❌ $ACTOR is not the fork owner"
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           echo "Checking if $ACTOR is a member of $ORG/$TEAM team..."
 
           # Verify token is set


### PR DESCRIPTION
Added fork support to allow fork owners to use their own credentials in the workflow.

<!-- .github/pull_request_template.md -->

## 📌 Description

## Summary

Enable external contributors to use `@claude` on their forks using their own API quota.

## Changes

Added fork detection to the permission check:
- On forks: authorize the fork owner only (bypasses org team check)
- On upstream: existing team-based authorization unchanged

## Why

- Contributors can iterate with `@claude` before submitting PRs upstream
- No cost to the org—forks use their own `CLAUDE_CODE_OAUTH_TOKEN` secret
- The org team API isn't accessible from forks anyway (missing `FLASHINFER_GITHUB_TOKEN`)

## Setup for fork owners

1. Run `claude setup-token` locally (requires Pro/Max subscription)
2. Add `CLAUDE_CODE_OAUTH_TOKEN` to fork's repository secrets
3. `@claude` on issues/PRs within the fork

Tested on my fork.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow authorization logic to handle fork repositories differently, allowing fork owners to authorize using their own credentials when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->