### PR TITLE
ci: refactor PR tests to hide failed spot jobs from PR status

### DIFF
--- a/.github/workflows/pr-test-runner.yml
+++ b/.github/workflows/pr-test-runner.yml
@@ -45,6 +45,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ inputs.concurrency_key || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -252,12 +252,14 @@ jobs:
           SKIP_AOT: ${{ github.event.inputs.skip_aot || 'false' }}
           SKIP_GPU: ${{ github.event.inputs.skip_gpu || 'false' }}
           CONCURRENCY_KEY: pr-test-${{ github.ref }}
+          DISPATCH_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           # Try workflow_dispatch first (works after pr-test-runner.yml is on main)
           # Uses GITHUB_TOKEN (has actions:write) - App token doesn't have Actions permission
+          # --ref uses PR branch (to test PR changes to runner) or main (for push)
           if GH_TOKEN="$GH_ACTION_TOKEN" gh workflow run pr-test-runner.yml \
             --repo "${{ github.repository }}" \
-            --ref main \
+            --ref "$DISPATCH_REF" \
             -f pr_head_sha="$HEAD_SHA" \
             -f docker_tag="$DOCKER_TAG" \
             -f aot_check_id="$AOT_CHECK_ID" \


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Refactor PR tests to hide failed spot job checks from the PR status panel. Instead of running test jobs inline (where cancelled/failed spot attempts are visible), this PR introduces a two-workflow architecture:

- **pr-test.yml (Gateway)** - Creates custom check runs via GitHub App, then dispatches tests to a separate runner workflow
- **pr-test-runner.yml (Runner)** - Executes the actual tests (spot + on-demand rerun), updates check runs with results

`workflow_dispatch` requires the target workflow to exist on the default branch ([GitHub docs](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow)). Since `pr-test-runner.yml` is new and not yet on `main`, this PR uses `repository_dispatch` to a temporary copy in `ci-infra` for testing. An auto-switch mechanism tries `workflow_dispatch` first and falls back to `ci-infra`:

- **During this PR**: `workflow_dispatch` fails (file not on main) -> tests run via ci-infra
- **After merge**: `workflow_dispatch` succeeds -> tests run in flashinfer directly


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized PR test orchestration into a manual-triggered runner that coordinates AOT and GPU test workflows.
  * Switched to token-based orchestration to create PR check runs and dispatch external test runners for unified status reporting.
  * Added automated detection of spot-instance interruptions and conditional reruns on stable/on-demand instances.
  * Added PR authorization gating with a clear reporting path when CI authorization is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->