### PR TITLE
Enable setting user in CI containers

### DIFF
--- a/docker/Dockerfile.cu126
+++ b/docker/Dockerfile.cu126
@@ -32,6 +32,6 @@ RUN conda install -n py312 -y mpi4py mpich
 
 # Configure pip for user-site installations (allows arbitrary users to install packages)
 # This enables 'pip install --user' and 'pip install -e .' to work for any user
-RUN mkdir -p /opt/pip-user && chmod 777 /opt/pip-user
+RUN mkdir -p /opt/pip-user && chmod 1777 /opt/pip-user
 ENV PYTHONUSERBASE=/opt/pip-user
 ENV PATH="/opt/pip-user/bin:$PATH"

--- a/docker/Dockerfile.cu128
+++ b/docker/Dockerfile.cu128
@@ -32,6 +32,6 @@ RUN conda install -n py312 -y mpi4py mpich
 
 # Configure pip for user-site installations (allows arbitrary users to install packages)
 # This enables 'pip install --user' and 'pip install -e .' to work for any user
-RUN mkdir -p /opt/pip-user && chmod 777 /opt/pip-user
+RUN mkdir -p /opt/pip-user && chmod 1777 /opt/pip-user
 ENV PYTHONUSERBASE=/opt/pip-user
 ENV PATH="/opt/pip-user/bin:$PATH"

--- a/docker/Dockerfile.cu129
+++ b/docker/Dockerfile.cu129
@@ -35,6 +35,6 @@ RUN conda install -n py312 -y mpi4py mpich
 
 # Configure pip for user-site installations (allows arbitrary users to install packages)
 # This enables 'pip install --user' and 'pip install -e .' to work for any user
-RUN mkdir -p /opt/pip-user && chmod 777 /opt/pip-user
+RUN mkdir -p /opt/pip-user && chmod 1777 /opt/pip-user
 ENV PYTHONUSERBASE=/opt/pip-user
 ENV PATH="/opt/pip-user/bin:$PATH"

--- a/docker/Dockerfile.cu130
+++ b/docker/Dockerfile.cu130
@@ -35,6 +35,6 @@ RUN conda install -n py312 -y mpi4py mpich
 
 # Configure pip for user-site installations (allows arbitrary users to install packages)
 # This enables 'pip install --user' and 'pip install -e .' to work for any user
-RUN mkdir -p /opt/pip-user && chmod 777 /opt/pip-user
+RUN mkdir -p /opt/pip-user && chmod 1777 /opt/pip-user
 ENV PYTHONUSERBASE=/opt/pip-user
 ENV PATH="/opt/pip-user/bin:$PATH"


### PR DESCRIPTION


<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Previously, pip install -e . would fail with permission errors when trying to write to /opt/conda site-packages. Configure PYTHONUSERBASE to redirect user installations to /opt/pip-user, allowing editable installs while keeping shared dependencies in read-only conda environment.

This makes it easier to clean up files after CI runs on systems where the runner doesn't have `sudo` access, since the current container requires running as `root` and leaves behind a bunch of `root`/`nobody`-owned files when building.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker images for cu126, cu128, cu129 and cu130 to enable user-level pip package installations without requiring root. Users can now run standard and editable pip installs in user space during image builds and runtime, improving flexibility for development workflows and reducing the need for elevated permissions across all supported CUDA variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->