### PR TITLE
Add sm90 guard to fence.acquire

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -762,7 +762,11 @@ __global__ void moeA2ACombineKernel(
         return;
       }
     }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     asm volatile("fence.acquire.sys;");
+#else
+    __threadfence_system();
+#endif
   }
   __syncthreads();
 #endif


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

The sm90 guard is needed to build flashinfer-jit-cache with later versions of the cuda 13.x toolkit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory synchronization in Mixture of Experts (MoE) communication kernels to ensure visibility of model state across execution steps, reducing rare correctness and stability issues during inference.
  * Added architecture-aware synchronization so MoE workloads behave consistently and reliably across different GPU generations, improving performance predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->