### PR TITLE
fallback to fa2 (instead of fa3) for unsupported configuration (bf16 Q, Fp8 KV)

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -409,10 +409,10 @@ def is_fa3_backend_supported(
     if use_fp16_qk_reductions:
         return False
     # FA3 FP8 KV cache currently requires FP8 query.
-    if dtype_kv in [torch.float8_e4m3fn, torch.float8_e5m2] and dtype_q not in [
+    if dtype_kv in {torch.float8_e4m3fn, torch.float8_e5m2} and dtype_q not in {
         torch.float8_e4m3fn,
         torch.float8_e5m2,
-    ]:
+    }:
         return False
     return True
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

When the KV cache dtype is FP8, Q dtype is BF16, GPU is hopper, and the backend is set to "auto", we should set the backend as "fa2" instead of "fa3".

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/2348

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration validation: when using an FP8 key/value cache, queries must also use FP8 to ensure FA3 backend compatibility. This prevents unsupported dtype combinations, surfaces clear validation errors earlier, and avoids runtime failures when mixing FP8 KV caches with non-FP8 queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->