### PR TITLE
tests: bmm_fp8 for SM110

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -3394,7 +3394,7 @@ def mm_fp4(
     return out
 
 
-@supported_compute_capability([89, 90, 100, 103, 120, 121])
+@supported_compute_capability([89, 90, 100, 103, 110, 120, 121])
 def _cudnn_bmm_fp8_requirement(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -3408,7 +3408,7 @@ def _cudnn_bmm_fp8_requirement(
     return True
 
 
-@supported_compute_capability([89, 90, 100, 103, 120, 121])
+@supported_compute_capability([89, 90, 100, 103, 110, 120, 121])
 def _cublas_bmm_fp8_requirement(
     A: torch.Tensor,
     B: torch.Tensor,

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -29,7 +29,12 @@ def test_bmm_fp8(b, m, n, k, input_dtype, mat2_dtype, res_dtype, backend, auto_t
             pytest.skip("Invalid combination: cutlass does not support e5m2")
     if auto_tuning and backend != "cutlass":
         pytest.skip("Invalid combination: auto_tuning only supported for cutlass")
-
+    if compute_capability[0] == 11 and (
+        input_dtype == torch.float8_e5m2 or mat2_dtype == torch.float8_e5m2
+    ):
+        pytest.skip(
+            "Invalid combination: only cutlass supports SM110 which does not support e5m2"
+        )
     input = torch.randn([b, m, k], device="cuda", dtype=torch.bfloat16)
     input_fp8, input_inv_s = to_float8(input, dtype=input_dtype)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended FP8 batch matrix-multiplication support to NVIDIA SM110 GPU architecture.

* **Tests**
  * Added a test guard to skip FP8 e5m2 cases on SM110 with a note that SM110 FP8 is supported via the cutlass backend only (e5m2 not supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->