### PR TITLE
docs: Document setuptools upgrade requirement for editable installs with --no-build-isolation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,11 @@ pip install --no-build-isolation -e . -v
 
 We recommend using the `--no-build-isolation` flag to ensure compatibility with your existing environment. Without it, `pip` may attempt to resolve dependencies (e.g., `torch`) from PyPI, which could pull in packages built with older CUDA versions and lead to incompatibility issues.
 
+> **Note:** When using `--no-build-isolation`, pip does not automatically install build dependencies. FlashInfer requires `setuptools>=77`. If you encounter an error like `AttributeError: module 'setuptools.build_meta' has no attribute 'prepare_metadata_for_build_editable'`, upgrade pip and setuptools first:
+> ```bash
+> python -m pip install --upgrade pip setuptools
+> ```
+
 # Code Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ python -m pip install -v .
 python -m pip install --no-build-isolation -e . -v
 ```
 
+> **Note:** When using `--no-build-isolation`, pip does not automatically install build dependencies. FlashInfer requires `setuptools>=77`. If you encounter an error like `AttributeError: module 'setuptools.build_meta' has no attribute 'prepare_metadata_for_build_editable'`, upgrade pip and setuptools first:
+> ```bash
+> python -m pip install --upgrade pip setuptools
+> ```
+
 Build optional packages:
 
 ```bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -83,6 +83,16 @@ You can follow the steps below to install FlashInfer from source code:
 
        python -m pip install --no-build-isolation -e . -v
 
+   .. note::
+      When using ``--no-build-isolation``, pip does not automatically install build
+      dependencies. FlashInfer requires ``setuptools>=77``. If you encounter an error
+      like ``AttributeError: module 'setuptools.build_meta' has no attribute
+      'prepare_metadata_for_build_editable'``, upgrade pip and setuptools first:
+
+      .. code-block:: bash
+
+          python -m pip install --upgrade pip setuptools
+
 4. (Optional) Build optional packages:
 
    Build ``flashinfer-cubin``:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

* Added a note to the installation docs (`docs/installation.rst`), `README.md`, and `CONTRIBUTING.md` warning that `--no-build-isolation` skips automatic installation of build dependencies, and that `setuptools>=77` must be present in the environment.
* When using an older pip/setuptools (e.g., pip 22.0.2), the editable install fails with `AttributeError: module 'setuptools.build_meta' has no attribute 'prepare_metadata_for_build_editable'`. The fix is `python -m pip install --upgrade pip setuptools`.


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guidance explaining that `--no-build-isolation` disables automatic build-dependency installation
  * Documented setuptools≥77 requirement with upgrade instructions to resolve dependency issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->