### PR TITLE
Added comments on potential race conditions for a cluster size > 1

### DIFF
--- a/include/flashinfer/attention/hopper/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/mainloop_mma.cuh
@@ -11,6 +11,7 @@
 #include <cutlass/cutlass.h>
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
+#include <cooperative_groups.h>
 
 #include "variants.cuh"
 
@@ -81,8 +82,10 @@ CUTLASS_DEVICE void mma_f16(
   if (work_idx != 0) {
     int lane_predicate = cute::elect_one_sync();
     if (cutlass::canonical_warp_idx_sync() == Ktraits::NUM_WARPS - 1 && lane_predicate) {
+    // This assumes a thread block cluster size of 1 (1 CTA/cluster).
++   // A cluster size > 1 could cause race conditions with barrier_O.arrive() below.
++   assert(cooperative_groups::this_cluster().size() == 1);
 #pragma unroll
-static_assert(cooperative_groups::this_cluster().size() == 1 && "This assumes a thread block cluster size of 1; ie 1CTA/cluster. Setting a cluster size > 1 could result in race conditions due to the type of barrier_O.arrive() used below.");
       for (uint32_t cta_id = 0; cta_id < 1; ++cta_id) {
         shared_storage.barrier_O.arrive(cta_id, lane_predicate);
       }

--- a/include/flashinfer/attention/hopper/quantization/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/quantization/mainloop_mma.cuh
@@ -80,8 +80,10 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
   if (work_idx != 0) {
     int lane_predicate = cute::elect_one_sync();
     if (cutlass::canonical_warp_idx_sync() == Ktraits::NUM_WARPS - 1 && lane_predicate) {
-#pragma unroll
-static_assert(cooperative_groups::this_cluster().size() == 1 && "This assumes a thread block cluster size of 1; ie 1CTA/cluster. Setting a cluster size > 1 could result in race conditions due to the type of barrier_O.arrive() used below.");
+    // This assumes a thread block cluster size of 1 (1 CTA/cluster).
++   // A cluster size > 1 could cause race conditions with barrier_O.arrive() below.
++   assert(cooperative_groups::this_cluster().size() == 1);
+      #pragma unroll
       for (uint32_t cta_id = 0; cta_id < 1; ++cta_id) {
         shared_storage.barrier_O.arrive(cta_id, lane_predicate);
       }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Adds comments on potential race conditions if this kernel is launched with a thread block cluster size > 1. Ideally we can also throw in an assert to ensure that the cluster size is equal to 1 (this needs including some libraries though). The race condition is because of the specific nature of arriving on an mbarrier and the CTA ID associated with it. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [✅] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [✅] I have installed the hooks with `pre-commit install`.
- [✅ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [✅] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a runtime check enforcing single-block cluster usage to prevent synchronization races and improve GPU computation reliability.

* **Documentation**
  * Clarified inline comments about expected GPU cluster configuration and synchronization assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->