### PR TITLE
fix: allow fmha_v2_prefill_deepseek on SM121 (DGX Spark)

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3821,8 +3821,8 @@ def fmha_v2_prefill_deepseek(
         If return_lse is True, the output will be a tuple of two tensors, the first is the output tensor, the second is the lse tensor.
         If return_lse is False, the output will be a single tensor.
     """
-    if not is_sm120a_supported(query.device):
-        raise ValueError("fmha_v2_prefill_deepseek is only supported on SM120 GPUs.")
+    if not (is_sm120a_supported(query.device) or is_sm121a_supported(query.device)):
+        raise ValueError("fmha_v2_prefill_deepseek is only supported on SM12x GPUs.")
     assert query.shape[3] == 192 and key.shape[3] == 192 and value.shape[3] == 128, (
         "currently only support deepseek r1 192 query and 128 value"
     )

--- a/tests/attention/test_fmha_v2_prefill_deepseek.py
+++ b/tests/attention/test_fmha_v2_prefill_deepseek.py
@@ -5,7 +5,7 @@ import math
 
 from flashinfer.prefill import fmha_v2_prefill_deepseek
 from tests.utils_fp8 import to_float8
-from flashinfer.utils import is_sm120a_supported
+from flashinfer.utils import is_sm120a_supported, is_sm121a_supported
 
 
 def attention_ref(
@@ -57,8 +57,11 @@ def attention_ref(
 def test_fmha_v2_prefill_deepseek(
     batch_size, num_heads, head_dim_qk, head_dim_v, seq_len, qkv_dtype, o_dtype
 ):
-    if not is_sm120a_supported(torch.device("cuda")):
-        pytest.skip("fmha_v2_prefill_deepseek is only supported on SM120 GPUs.")
+    if not (
+        is_sm120a_supported(torch.device("cuda"))
+        or is_sm121a_supported(torch.device("cuda"))
+    ):
+        pytest.skip("fmha_v2_prefill_deepseek is only supported on SM12x GPUs.")
     torch.manual_seed(42)
 
     def initialize_tensors(batch_size, num_heads, head_dim_qk, head_dim_v, seq_len):


### PR DESCRIPTION
## Summary

- `fmha_v2_prefill_deepseek()` only checked `is_sm120a_supported()` (SM12.0), excluding SM12.1 devices like NVIDIA DGX Spark (GB10)
- The JIT compilation context already handles SM12.1 via `supported_major_versions=[12]` and the kernels work correctly
- This adds `is_sm121a_supported()` to the guard check, consistent with how other SM12x checks are done in the codebase (e.g., `prefill.py:106-107`, `gemm_base.py:3757`)

## Validation

Tested on DGX Spark (GB10, SM121a, CUDA 13.0, flashinfer 0.6.2):

| Test | Result |
|------|--------|
| fmha_v2_prefill_deepseek BF16 (batch=2, seq=64, heads=128, qk=192, vo=128) | PASS, no NaN |
| fmha_v2_prefill_deepseek FP8 e4m3 (same config) | PASS, no NaN |
| Bug reproduction (original code on SM12.1) | ValueError as expected |

## Test plan

- [x] Existing `test_fmha_v2_prefill_deepseek` test updated with same fix
- [x] No impact on SM12.0 (RTX 5090) — `is_sm120a_supported` check still in place
- [x] No impact on non-SM12x GPUs — they still get the existing ValueError
- [x] Bug reproduced: original code raises `ValueError: fmha_v2_prefill_deepseek is only supported on SM120 GPUs.` on SM12.1
- [x] Fix applied to installed package (no monkeypatch): BF16 and FP8 both produce correct output

Related: #2555

*From [Second Nature Computing](https://joinsecondnature.com) — tested on NVIDIA DGX Spark.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded GPU support for Deepseek operations to include SM121A GPUs in addition to SM120A, broadening hardware compatibility and enabling execution on a wider range of SM12x GPU architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->