### PR TITLE
fix: pass bool alpha_is_not_none to create_cudnn_execution_plans_fp4_…

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1867,7 +1867,7 @@ def build_plans_cudnn_fp4_gemm_graph(
         o_type,
         block_size,
         device,
-        alpha,
+        alpha is not None,
         use_nvfp4,
     )
 


### PR DESCRIPTION
create_cudnn_execution_plans_fp4_gemm() expects a boolean value of alpha_is_not_none in its parameter. But the code mistakenly passes alpha. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal computation graph construction for FP4 operations to improve efficiency while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->