### PR TITLE
feat(kda): add recurrent KDA decode kernel with per-K gating

### DIFF
--- a/benchmarks/bench_recurrent_kda.py
+++ b/benchmarks/bench_recurrent_kda.py
@@ -35,9 +35,9 @@ from flashinfer.testing import bench_gpu_time
 
 # Import the recurrent KDA kernel
 try:
-    from flashinfer.kda_kernels import recurrent_kda
+    from flashinfer.kda_decode import _RECURRENT_KDA_AVAILABLE, recurrent_kda
 
-    RECURRENT_KDA_AVAILABLE = True
+    RECURRENT_KDA_AVAILABLE = _RECURRENT_KDA_AVAILABLE
 except ImportError:
     RECURRENT_KDA_AVAILABLE = False
 
@@ -233,7 +233,7 @@ def run_recurrent_kda_benchmark(args, dtype):
     """Run recurrent KDA decode benchmarks."""
     if not RECURRENT_KDA_AVAILABLE:
         print("Error: recurrent KDA kernel is not available.")
-        print("Make sure flashinfer.kda_kernels.recurrent_kda is importable.")
+        print("Make sure flashinfer.kda_decode.recurrent_kda is importable.")
         return
 
     invalid_seq_lens = [t for t in args.seq_len if t < 1]

--- a/benchmarks/bench_recurrent_kda.py
+++ b/benchmarks/bench_recurrent_kda.py
@@ -1,0 +1,364 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Recurrent KDA (Key-Driven Attention) Benchmark
+
+Benchmarks recurrent KDA decode with per-K-dimension gating. T=1 uses the
+standard decode path; T>1 uses fused speculative decode with
+num_spec_tokens=T-1.
+KDA differs from GDN by having gate g[B, T, HV, K] instead of a scalar gate.
+
+Usage:
+    python benchmarks/bench_recurrent_kda.py --batch-size 1 4 16 64 128 256
+    python benchmarks/bench_recurrent_kda.py --head-size 64 --batch-size 1 32 128
+    python benchmarks/bench_recurrent_kda.py --seq-len 1 2 3 4 --batch-size 1 32
+"""
+
+import argparse
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from flashinfer.testing import bench_gpu_time
+
+# Import the recurrent KDA kernel
+try:
+    from flashinfer.kda_kernels import recurrent_kda
+
+    RECURRENT_KDA_AVAILABLE = True
+except ImportError:
+    RECURRENT_KDA_AVAILABLE = False
+
+
+# ============================================================================
+# FLOPs and Bytes Calculation
+# ============================================================================
+
+
+def recurrent_kda_flops(
+    batch_size: int,
+    num_q_heads: int,
+    _num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    seq_len: int = 1,
+) -> int:
+    """
+    Calculate FLOPs for KDA (Key-Driven Attention) decode.
+
+    8 * K * V FLOPs per token per head:
+    1. k @ state (prediction):    2 * K * V
+    2. outer(k, v_new) update:    2 * K * V
+    3. q @ state (output):        2 * K * V
+    4. Per-K gate application:    2 * K * V  (K*V element-wise multiply + K exp() calls)
+
+    Note: K = V = head_size for KDA. State ops are per-HV (value) head.
+    """
+    total_flops = 8 * seq_len * batch_size * num_v_heads * head_size * head_size
+    return total_flops
+
+
+def recurrent_kda_bytes(
+    batch_size: int,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    seq_len: int = 1,
+) -> int:
+    """
+    Calculate memory bytes for recurrent KDA.
+
+    Includes:
+    - Q, K, V tensors: [B, T, H, K] - dtype
+    - G tensor (per-K gate): [B, T, HV, K] - dtype (extra vs GDN)
+    - Beta: [B, T, HV] - dtype
+    - State read: [B, HV, V, K] - bf16 storage for logical [K, V]
+    - State write: [B*T, HV, V, K] for spec decode, [B, HV, V, K] for T=1
+    - Output: [B, T, HV, V] - dtype
+    """
+    elem_size = torch.tensor([], dtype=dtype).element_size()
+    state_dtype_bytes = 2  # BF16 state
+
+    # Input tensors: q/k use H (query heads), v uses HV (value heads)
+    q_bytes = batch_size * seq_len * num_q_heads * head_size * elem_size
+    k_bytes = batch_size * seq_len * num_k_heads * head_size * elem_size
+    v_bytes = batch_size * seq_len * num_v_heads * head_size * elem_size
+
+    # Per-K gate: [B, T, HV, K]
+    g_bytes = batch_size * seq_len * num_v_heads * head_size * elem_size
+
+    # Beta: [B, T, HV]
+    beta_bytes = batch_size * seq_len * num_v_heads * elem_size
+
+    # Output: [B, T, HV, V]
+    o_bytes = batch_size * seq_len * num_v_heads * head_size * elem_size
+
+    # State: read one initial slot per sequence and write one checkpoint per token.
+    state_write_slots = batch_size if seq_len == 1 else batch_size * seq_len
+    state_bytes = (
+        (batch_size + state_write_slots)
+        * num_v_heads
+        * head_size
+        * head_size
+        * state_dtype_bytes
+    )
+
+    total_bytes = (
+        q_bytes + k_bytes + v_bytes + g_bytes + beta_bytes + o_bytes + state_bytes
+    )
+    return total_bytes
+
+
+# ============================================================================
+# Benchmark Function
+# ============================================================================
+
+
+def bench_recurrent_kda(
+    batch_size: int,
+    seq_len: int,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    warmup_iters: int = 10,
+    bench_iters: int = 100,
+):
+    """Benchmark recurrent KDA decode. T>1 maps to fused speculative decode."""
+    if not RECURRENT_KDA_AVAILABLE:
+        raise RuntimeError("recurrent KDA kernel is not available")
+
+    if seq_len < 1:
+        raise ValueError(f"seq_len must be >= 1, got {seq_len}")
+    if num_k_heads != num_q_heads:
+        raise ValueError(
+            "recurrent KDA uses one K head per Q head; "
+            f"got num_q_heads={num_q_heads}, num_k_heads={num_k_heads}"
+        )
+
+    # Create inputs
+    T = seq_len
+    q = torch.randn(batch_size, T, num_q_heads, head_size, dtype=dtype, device="cuda")
+    k = torch.randn(batch_size, T, num_q_heads, head_size, dtype=dtype, device="cuda")
+    v = torch.randn(batch_size, T, num_v_heads, head_size, dtype=dtype, device="cuda")
+
+    # KDA-specific: per-K log-space gate [B, T, HV, K]
+    g = F.logsigmoid(
+        torch.randn(batch_size, T, num_v_heads, head_size, device="cuda")
+    ).to(dtype)
+
+    # Beta: [B, T, HV] (pre-sigmoided)
+    beta = torch.randn(batch_size, T, num_v_heads, dtype=dtype, device="cuda").sigmoid()
+
+    state_slots = batch_size if T == 1 else batch_size * T
+    # State pool storage for logical [K, V] states. Spec decode writes one
+    # checkpoint slot per token.
+    state = torch.randn(
+        state_slots,
+        num_v_heads,
+        head_size,
+        head_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    # Scale factor
+    scale = 1.0 / (head_size**0.5)
+
+    num_spec_tokens = None if T == 1 else T - 1
+
+    # Benchmark with bench_gpu_time (CUPTI for accurate kernel timing)
+    kernel_times_ms = bench_gpu_time(
+        lambda: recurrent_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=state,
+            scale=scale,
+            use_qk_l2norm_in_kernel=True,
+            num_spec_tokens=num_spec_tokens,
+        ),
+        enable_cupti=True,
+        dry_run_iters=warmup_iters,
+        repeat_iters=bench_iters,
+    )
+
+    # Calculate metrics
+    kernel_median_ms = np.median(kernel_times_ms)
+    flops = recurrent_kda_flops(
+        batch_size, num_q_heads, num_k_heads, num_v_heads, head_size, seq_len
+    )
+    bytes_accessed = recurrent_kda_bytes(
+        batch_size, num_q_heads, num_k_heads, num_v_heads, head_size, dtype, seq_len
+    )
+
+    kernel_tflops = flops / kernel_median_ms / 1e9 if kernel_median_ms > 0 else 0
+    kernel_tb_per_sec = (
+        bytes_accessed / kernel_median_ms / 1e9 if kernel_median_ms > 0 else 0
+    )
+
+    return {
+        "batch_size": batch_size,
+        "seq_len": seq_len,
+        "mode": "decode" if T == 1 else "spec",
+        "kernel_median_us": kernel_median_ms * 1000,
+        "kernel_tflops": kernel_tflops,
+        "kernel_tb_per_sec": kernel_tb_per_sec,
+    }
+
+
+# ============================================================================
+# Runner
+# ============================================================================
+
+
+def run_recurrent_kda_benchmark(args, dtype):
+    """Run recurrent KDA decode benchmarks."""
+    if not RECURRENT_KDA_AVAILABLE:
+        print("Error: recurrent KDA kernel is not available.")
+        print("Make sure flashinfer.kda_kernels.recurrent_kda is importable.")
+        return
+
+    invalid_seq_lens = [t for t in args.seq_len if t < 1]
+    if invalid_seq_lens:
+        print("Error: --seq-len values must be >= 1")
+        return
+    valid_seq_lens = args.seq_len
+
+    print("\n" + "=" * 100)
+    print(f"Recurrent KDA Benchmark (T={valid_seq_lens})")
+    print(
+        f"Config: q_heads={args.num_q_heads}, k_heads={args.num_k_heads}, "
+        f"v_heads={args.num_v_heads}, head_size={args.head_size}, "
+        f"dtype={args.dtype}"
+    )
+    print("=" * 100)
+    print()
+    print(
+        f"{'batch':>6} {'T':>4} {'mode':>8} {'time(us)':>10} "
+        f"{'TFLOPS':>10} {'TB/s':>10}"
+    )
+    print("-" * 100)
+
+    all_results = []
+    for batch_size in args.batch_size:
+        for seq_len in valid_seq_lens:
+            try:
+                result = bench_recurrent_kda(
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    num_q_heads=args.num_q_heads,
+                    num_k_heads=args.num_k_heads,
+                    num_v_heads=args.num_v_heads,
+                    head_size=args.head_size,
+                    dtype=dtype,
+                    warmup_iters=args.warmup,
+                    bench_iters=args.iters,
+                )
+                all_results.append(result)
+
+                print(
+                    f"{result['batch_size']:>6} {result['seq_len']:>4} "
+                    f"{result['mode']:>8} "
+                    f"{result['kernel_median_us']:>10.2f} "
+                    f"{result['kernel_tflops']:>10.2f} "
+                    f"{result['kernel_tb_per_sec']:>10.2f}"
+                )
+            except Exception as e:
+                mode = "decode" if seq_len == 1 else "spec"
+                print(
+                    f"{batch_size:>6} {seq_len:>4} {mode:>8} "
+                    f"{'ERROR':>10} - {type(e).__name__}: {e}"
+                )
+
+    print("-" * 100)
+    print()
+
+    # Summary by T value
+    for t in valid_seq_lens:
+        t_results = [r for r in all_results if r["seq_len"] == t]
+        if t_results:
+            avg_time = np.mean([r["kernel_median_us"] for r in t_results])
+            avg_tflops = np.mean([r["kernel_tflops"] for r in t_results])
+            print(
+                f"T={t}: Average time={avg_time:.2f}us, Average TFLOPS={avg_tflops:.2f}"
+            )
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recurrent KDA Benchmark",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python benchmarks/bench_recurrent_kda.py --batch-size 1 4 16 64 128 256
+  python benchmarks/bench_recurrent_kda.py --head-size 64 --batch-size 1 32 128
+  python benchmarks/bench_recurrent_kda.py --seq-len 1 2 3 4 --batch-size 1 32
+""",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        nargs="+",
+        default=[1, 4, 16, 64, 128, 256],
+        help="Batch sizes to benchmark",
+    )
+    parser.add_argument("--num-q-heads", type=int, default=16)
+    parser.add_argument("--num-k-heads", type=int, default=16)
+    parser.add_argument("--num-v-heads", type=int, default=32)
+    parser.add_argument("--head-size", type=int, default=128, choices=[64, 128])
+    parser.add_argument(
+        "--dtype", type=str, choices=["float16", "bfloat16"], default="bfloat16"
+    )
+    parser.add_argument(
+        "--seq-len",
+        type=int,
+        nargs="+",
+        default=[1],
+        help="Sequence lengths to benchmark; T=1 is standard decode, T>1 is spec decode",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=10,
+        help="Number of warmup iterations",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=100,
+        help="Number of benchmark iterations",
+    )
+    args = parser.parse_args()
+
+    # Resolve dtype
+    dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
+    dtype = dtype_map[args.dtype]
+
+    run_recurrent_kda_benchmark(args, dtype)
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -112,6 +112,7 @@ from .grouped_mm import grouped_mm_bf16 as grouped_mm_bf16
 from .grouped_mm import grouped_mm_fp8 as grouped_mm_fp8
 from .grouped_mm import grouped_mm_mxfp8 as grouped_mm_mxfp8
 from .grouped_mm import grouped_mm_fp4 as grouped_mm_fp4
+from .kda_decode import recurrent_kda as recurrent_kda
 from .mla import BatchMLAPagedAttentionWrapper as BatchMLAPagedAttentionWrapper
 from .norm import fused_add_rmsnorm as fused_add_rmsnorm
 from .norm import fused_add_rmsnorm_quant as fused_add_rmsnorm_quant

--- a/flashinfer/kda_decode.py
+++ b/flashinfer/kda_decode.py
@@ -1,0 +1,90 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Key-Driven Attention Decode - API Layer
+=======================================
+
+This file provides the public API for recurrent KDA decode operations.
+Kernel implementations are in flashinfer/kda_kernels/.
+"""
+
+from typing import Optional
+
+import torch
+
+from .api_logging import flashinfer_api
+
+try:
+    from .kda_kernels.recurrent_kda import run_recurrent_kda as _run_recurrent_kda
+
+    _RECURRENT_KDA_AVAILABLE = True
+except (ImportError, RuntimeError):
+    _run_recurrent_kda = None
+    _RECURRENT_KDA_AVAILABLE = False
+
+
+@flashinfer_api
+def recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: Optional[torch.Tensor] = None,
+    dt_bias: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_gate_in_kernel: bool = False,
+    lower_bound: Optional[float] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    ssm_state_indices: Optional[torch.Tensor] = None,
+    num_spec_tokens: Optional[int] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    r"""Recurrent KDA (Key-Driven Attention) decode kernel.
+
+    This is the public API layer for the CuTe DSL implementation in
+    ``flashinfer.kda_kernels.recurrent_kda``. It supports single-token decode,
+    fused speculative decode, GQA, optional cu_seqlens packing, and the same
+    gate modes as the backend implementation.
+    """
+    if _run_recurrent_kda is None:
+        raise NotImplementedError("recurrent KDA backend is unavailable")
+
+    return _run_recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        lower_bound=lower_bound,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=num_accepted_tokens,
+        output=output,
+    )

--- a/flashinfer/kda_kernels/__init__.py
+++ b/flashinfer/kda_kernels/__init__.py
@@ -20,17 +20,21 @@ Per-K-dimension gating variant of GDN. Gate g[B,T,HV,K] applied per-lane
 instead of GDN's scalar broadcast.
 
 Exported:
-- recurrent_kda: Recurrent KDA standard decode and speculative decode kernels
+- run_recurrent_kda: Recurrent KDA standard decode and speculative decode backend
 """
 
 try:
-    from .recurrent_kda import recurrent_kda
+    from .recurrent_kda import run_recurrent_kda
+
+    recurrent_kda = run_recurrent_kda
 
     _has_cute_dsl = True
-except ImportError:
+except (ImportError, RuntimeError):
     _has_cute_dsl = False
+    run_recurrent_kda = None  # type: ignore
     recurrent_kda = None  # type: ignore
 
 __all__ = [
     "recurrent_kda",
+    "run_recurrent_kda",
 ]

--- a/flashinfer/kda_kernels/__init__.py
+++ b/flashinfer/kda_kernels/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+KDA (Key-Driven Attention) Kernels - CuTe DSL Implementations
+==============================================================
+
+Per-K-dimension gating variant of GDN. Gate g[B,T,HV,K] applied per-lane
+instead of GDN's scalar broadcast.
+
+Exported:
+- recurrent_kda: Recurrent KDA standard decode and speculative decode kernels
+"""
+
+try:
+    from .recurrent_kda import recurrent_kda
+
+    _has_cute_dsl = True
+except ImportError:
+    _has_cute_dsl = False
+    recurrent_kda = None  # type: ignore
+
+__all__ = [
+    "recurrent_kda",
+]

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -1,0 +1,2270 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Recurrent KDA (Key-Driven Attention) decode kernels using CuTe DSL for SM100.
+
+Supports single-token decode (T=1) and fused speculative decode
+(T=1+num_spec_tokens) with per-key-dimension gating. The logical recurrent
+state is S[K,V] and is stored transposed in the kernel as state[...,V,K] bf16.
+Per token:
+  S = exp(g)[..., None] * S + beta * outer(k, v - k @ S)
+  o = q @ S
+
+Standard decode inputs use q,k [B,1,H,K], v [B,1,HV,V], g [B,1,HV,K],
+and beta [B,1,HV]. With cu_seqlens, tokens are packed on dim 1 as
+[1,total_tokens,...], state is [N,HV,V,K], and ssm_state_indices maps
+sequences/checkpoints to state slots.
+
+Supports GQA (H != HV), cu_seqlens, paged state indices, speculative decode,
+and compile-time gate modes (pre-computed, softplus, lower_bound * sigmoid).
+"""
+
+import functools
+import math
+import os
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+import cuda.bindings.driver as cuda
+import torch
+from cutlass import utils
+from cutlass._mlir.dialects import arith as mlir_arith
+from cutlass._mlir.dialects import math as mlir_math
+from cutlass._mlir.dialects import nvvm
+import tvm_ffi  # noqa: F401 -- TVM FFI required for zero-overhead kernel dispatch
+
+# ==============================================================================
+# CONSTANTS
+# ==============================================================================
+# SMEM H padding for bank conflict avoidance.
+# H_SMEM_STRIDE = HEAD_DIM + H_SMEM_PADDING (computed inside kernels from HEAD_DIM).
+# Constraint: (stride * 2) must have >=16 as highest power-of-2 factor for cp.async 128-bit
+# alignment.
+#   HEAD_DIM=128: stride=136 -> 272 bytes -> 272 = 16*17 -> align<16> ok
+#   HEAD_DIM=64:  stride=72  -> 144 bytes -> 144 = 16*9  -> align<16> ok
+# Bank analysis: stride=136 and stride=72 both give 4-way conflicts (acceptable).
+H_SMEM_PADDING = 8
+
+
+# ==============================================================================
+# SHARED HELPER FUNCTIONS
+# ==============================================================================
+
+
+@cute.jit
+def write_h_chunk_to_smem(h_chunk_f32, h_sh_chunk, lane_idx, k_base):
+    """Write F32 register H chunk to BF16 SMEM."""
+    for i in cutlass.range_constexpr(32):
+        h_sh_chunk[lane_idx, k_base + i] = h_chunk_f32[i].to(cutlass.BFloat16)
+
+
+@cute.jit
+def store_h_smem_to_gmem(
+    h_sh_chunk,
+    h_out,
+    tidx,
+    v_row_offset,
+    HEAD_DIM: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int] = 32,
+):
+    """Store H from SMEM to GMEM using 128-bit stores.
+
+    V_TILE_ROWS: number of V-rows in this chunk (see load_h_chunk_async).
+    """
+    copy_bits = 128
+    copy_elems = copy_bits // cutlass.BFloat16.width
+
+    from cutlass.cute.nvgpu import CopyUniversalOp
+
+    if HEAD_DIM == 64:
+        # 64 threads: (8, 8) thread layout, (8, 64) tiles, V_TILE_ROWS/8 row iters
+        thr_layout = cute.make_layout((8, 8), stride=(8, 1))
+        val_layout = cute.make_layout((1, copy_elems))
+        atom_store = cute.make_copy_atom(
+            CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=copy_bits
+        )
+        tiled_copy = cute.make_tiled_copy_tv(atom_store, thr_layout, val_layout)
+        thr_copy = tiled_copy.get_slice(tidx)
+        for row_iter in cutlass.range_constexpr(V_TILE_ROWS // 8):
+            s_tile = cute.local_tile(h_sh_chunk, (8, 64), (row_iter, 0))
+            g_tile = cute.local_tile(
+                h_out, (8, 64), (row_iter + (v_row_offset // 8), 0)
+            )
+            tS = thr_copy.partition_S(s_tile)
+            tD = thr_copy.partition_D(g_tile)
+            cute.copy(atom_store, tS, tD)
+    elif HEAD_DIM == 128:
+        # 128 threads: (16, 8) thread layout, (16, 64) tiles, V_TILE_ROWS/16 row x 2 col iters
+        thr_layout = cute.make_layout((16, 8), stride=(8, 1))
+        val_layout = cute.make_layout((1, copy_elems))
+        atom_store = cute.make_copy_atom(
+            CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=copy_bits
+        )
+        tiled_copy = cute.make_tiled_copy_tv(atom_store, thr_layout, val_layout)
+        thr_copy = tiled_copy.get_slice(tidx)
+        for row_iter in cutlass.range_constexpr(V_TILE_ROWS // 16):
+            for col_iter in cutlass.range_constexpr(2):
+                s_tile = cute.local_tile(h_sh_chunk, (16, 64), (row_iter, col_iter))
+                g_tile = cute.local_tile(
+                    h_out, (16, 64), (row_iter + (v_row_offset // 16), col_iter)
+                )
+                tS = thr_copy.partition_S(s_tile)
+                tD = thr_copy.partition_D(g_tile)
+                cute.copy(atom_store, tS, tD)
+
+
+@cute.jit
+def load_h_chunk_async(
+    h_sh_chunk,
+    h_global,
+    tidx,
+    row_offset,
+    HEAD_DIM: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int] = 32,
+):
+    """Load H chunk from GMEM to SMEM using async copy.
+
+    V_TILE_ROWS: number of V-rows in this chunk. Default 32 matches the
+    base kernel's ping-pong chunk size and vtile's standard 32-row slice.
+    V_TILE_ROWS=16 enables the finer-grained vtile variant that doubles
+    grid expansion at D=128 for very low batch.
+    """
+    copy_bits = 128
+    copy_elems = copy_bits // cutlass.BFloat16.width
+
+    if HEAD_DIM == 64:
+        # 64 threads: (8, 8) thread layout, (8, 64) tiles, V_TILE_ROWS/8 row iters
+        thr_layout = cute.make_layout((8, 8), stride=(8, 1))
+        val_layout = cute.make_layout((1, copy_elems))
+        atom_async_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(
+                cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL
+            ),
+            cutlass.BFloat16,
+            num_bits_per_copy=copy_bits,
+        )
+        tiled_copy = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
+        thr_copy = tiled_copy.get_slice(tidx)
+        for row_iter in cutlass.range_constexpr(V_TILE_ROWS // 8):
+            g_tile = cute.local_tile(
+                h_global, (8, 64), (row_iter + (row_offset // 8), 0)
+            )
+            s_tile = cute.local_tile(h_sh_chunk, (8, 64), (row_iter, 0))
+            tS = thr_copy.partition_S(g_tile)
+            tD = thr_copy.partition_D(s_tile)
+            cute.copy(atom_async_copy, tS, tD)
+    elif HEAD_DIM == 128:
+        # 128 threads: (16, 8) thread layout, (16, 64) tiles, V_TILE_ROWS/16 row x 2 col iters
+        thr_layout = cute.make_layout((16, 8), stride=(8, 1))
+        val_layout = cute.make_layout((1, copy_elems))
+        atom_async_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(
+                cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL
+            ),
+            cutlass.BFloat16,
+            num_bits_per_copy=copy_bits,
+        )
+        tiled_copy = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
+        thr_copy = tiled_copy.get_slice(tidx)
+        for row_iter in cutlass.range_constexpr(V_TILE_ROWS // 16):
+            for col_iter in cutlass.range_constexpr(2):
+                g_tile = cute.local_tile(
+                    h_global, (16, 64), (row_iter + (row_offset // 16), col_iter)
+                )
+                s_tile = cute.local_tile(h_sh_chunk, (16, 64), (row_iter, col_iter))
+                tS = thr_copy.partition_S(g_tile)
+                tD = thr_copy.partition_D(s_tile)
+                cute.copy(atom_async_copy, tS, tD)
+
+
+@cute.jit
+def load_qkvg_async(
+    q_raw_sh,
+    k_raw_sh,
+    v_raw_sh,
+    g_raw_sh,
+    q_head,
+    k_head,
+    v_head,
+    g_head,
+    tidx,
+    HEAD_DIM: cutlass.Constexpr[int],
+):
+    """Issue cp.async for Q/K/V/G bf16 vectors in a single group.
+
+    Each vector is 1D [HEAD_DIM] bf16 = HEAD_DIM*2 bytes. cute.nvgpu cpasync
+    only supports 128-bit (cp.async.cg) copies, so each participating thread
+    loads 8 bf16 (16 bytes). Thread split:
+      D=128: 16 threads/vector * 4 vectors = 64 threads (warps 0-1).
+             Warps 2-3 idle through the issue (no divergence: warp-aligned).
+      D=64:   8 threads/vector * 4 vectors = 32 threads (warp 0 only).
+             Warp 1 idle (warp-aligned).
+
+    Replaces four per-token scalar `ld.global + st.shared` chains that NCU
+    flagged as the top L1TEX scoreboard stall (~40% of warp-cycles/issue at
+    B=1, H32-D128-lb). Caller MUST `cp_async_commit_group` + `wait_group(0)`
+    + `sync_threads` before reading the `*_raw_sh` buffers.
+    """
+    copy_bits = 128
+    copy_elems = copy_bits // cutlass.BFloat16.width  # 8
+    N_THR_PER_VEC: cutlass.Constexpr[int] = HEAD_DIM // copy_elems
+    N_ISSUE_THR: cutlass.Constexpr[int] = 4 * N_THR_PER_VEC
+
+    atom_async = cute.make_copy_atom(
+        cute.nvgpu.cpasync.CopyG2SOp(
+            cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL
+        ),
+        cutlass.BFloat16,
+        num_bits_per_copy=copy_bits,
+    )
+    thr_layout = cute.make_layout((N_THR_PER_VEC,))
+    val_layout = cute.make_layout((copy_elems,))
+    tiled_copy = cute.make_tiled_copy_tv(atom_async, thr_layout, val_layout)
+
+    # Gate the upper half of the block out of the issue. The split is
+    # warp-aligned at both D=128 (warps 0-1 issue, 2-3 idle) and D=64
+    # (warp 0 issues, 1 idle) -- no intra-warp divergence.
+    if tidx < N_ISSUE_THR:
+        vec_idx = tidx // N_THR_PER_VEC
+        local_tidx = tidx % N_THR_PER_VEC
+        thr_copy = tiled_copy.get_slice(local_tidx)
+
+        if vec_idx == 0:
+            cute.copy(
+                atom_async,
+                thr_copy.partition_S(q_head),
+                thr_copy.partition_D(q_raw_sh),
+            )
+        elif vec_idx == 1:
+            cute.copy(
+                atom_async,
+                thr_copy.partition_S(k_head),
+                thr_copy.partition_D(k_raw_sh),
+            )
+        elif vec_idx == 2:
+            cute.copy(
+                atom_async,
+                thr_copy.partition_S(v_head),
+                thr_copy.partition_D(v_raw_sh),
+            )
+        else:
+            cute.copy(
+                atom_async,
+                thr_copy.partition_S(g_head),
+                thr_copy.partition_D(g_raw_sh),
+            )
+
+
+@cute.jit
+def issue_qkvg_async_for_token(
+    q_raw_sh,
+    k_raw_sh,
+    v_raw_sh,
+    g_raw_sh,
+    gQ,
+    gK,
+    gV,
+    gG,
+    batch_idx,
+    token_offset,
+    query_head_idx,
+    value_head_idx,
+    tidx,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+):
+    """Issue the per-token Q/K/V/G async staging copies with token views scoped locally."""
+    if cutlass.const_expr(USE_CU_SEQLENS == 1):
+        q_head = gQ[(0, token_offset, query_head_idx, None)]
+        k_head = gK[(0, token_offset, query_head_idx, None)]
+        v_head = gV[(0, token_offset, value_head_idx, None)]
+        g_head = gG[(0, token_offset, value_head_idx, None)]
+    else:
+        q_head = gQ[(batch_idx, 0, query_head_idx, None)]
+        k_head = gK[(batch_idx, 0, query_head_idx, None)]
+        v_head = gV[(batch_idx, 0, value_head_idx, None)]
+        g_head = gG[(batch_idx, 0, value_head_idx, None)]
+
+    load_qkvg_async(
+        q_raw_sh,
+        k_raw_sh,
+        v_raw_sh,
+        g_raw_sh,
+        q_head,
+        k_head,
+        v_head,
+        g_head,
+        tidx,
+        HEAD_DIM,
+    )
+
+
+@cute.jit
+def process_vtile_token_chunk(
+    gBeta: cute.Tensor,
+    gO: cute.Tensor,
+    batch_idx,
+    token_offset,
+    value_head_idx,
+    h_sh,
+    h_chunk,
+    lane_idx,
+    warp_idx,
+    k_base,
+    g_sh,
+    k_sh,
+    q_sh,
+    v_sh,
+    pred_sh,
+    out_sh,
+    v_offset,
+    is_active,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int] = 32,
+):
+    """Resolve per-token beta/output views right at the chunk compute site."""
+    if cutlass.const_expr(USE_CU_SEQLENS == 1):
+        beta = gBeta[(0, token_offset, value_head_idx)].to(cutlass.Float32)
+        o_head = gO[(0, token_offset, value_head_idx, None)]
+    else:
+        beta = gBeta[(batch_idx, 0, value_head_idx)].to(cutlass.Float32)
+        o_head = gO[(batch_idx, 0, value_head_idx, None)]
+
+    _process_v_chunk(
+        h_sh,
+        h_sh,
+        h_chunk,
+        lane_idx,
+        warp_idx,
+        k_base,
+        g_sh,
+        k_sh,
+        q_sh,
+        v_sh,
+        pred_sh,
+        out_sh,
+        v_offset,
+        o_head,
+        beta,
+        is_active,
+        HEAD_DIM,
+        V_TILE_ROWS,
+    )
+
+
+@cute.jit
+def store_vtile_token_state(
+    gH: cute.Tensor,
+    seq_idx,
+    value_head_idx,
+    h_sh,
+    tidx,
+    v_offset,
+    HEAD_DIM: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int] = 32,
+):
+    """Materialize the token's state output view only for the GMEM checkpoint store."""
+    h_out = gH[(seq_idx, value_head_idx, None, None)]
+    store_h_smem_to_gmem(h_sh, h_out, tidx, v_offset, HEAD_DIM, V_TILE_ROWS)
+
+
+@cute.jit
+def compute_gate_to_smem(
+    g_sh,
+    g_head,
+    k_base,
+    lane_idx,
+    A_log_val,
+    gDtBias,
+    h_K_offset,
+    lower_bound_val,
+    USE_GATE_IN_KERNEL: cutlass.Constexpr[int],
+    HAS_DT_BIAS: cutlass.Constexpr[int],
+    USE_LOWER_BOUND: cutlass.Constexpr[int],
+):
+    """Compute exp(gate) and store to SMEM. Each lane writes one element.
+
+    When USE_GATE_IN_KERNEL=0: g is pre-computed log-space gate, just exp it.
+    When USE_GATE_IN_KERNEL=1, USE_LOWER_BOUND=0:
+        g_log = -exp(A_log) * softplus(g + dt_bias); return exp(g_log)
+    When USE_GATE_IN_KERNEL=1, USE_LOWER_BOUND=1:
+        g_log = lower_bound * sigmoid(exp(A_log) * (g + dt_bias)); return exp(g_log)
+
+    Args:
+        g_sh: output SMEM tensor [HEAD_DIM] Float32
+        g_head: global gate tensor slice [K=HEAD_DIM]
+        k_base: starting K index for this warp (warp_idx * 32)
+        lane_idx: lane index within warp (0..31)
+        A_log_val: exp(A_log) for this head (Float32), precomputed outside
+        gDtBias: dt_bias tensor [H*K] Float32 (or dummy if HAS_DT_BIAS=0)
+        h_K_offset: query_head_idx * K offset into dt_bias
+        lower_bound_val: lower bound float (negative, e.g. -5.0)
+        USE_GATE_IN_KERNEL: 0 = pre-computed gate, 1 = in-kernel gate
+        HAS_DT_BIAS: 0 = no dt_bias, 1 = add dt_bias
+        USE_LOWER_BOUND: 0 = softplus formula, 1 = lower_bound * sigmoid formula
+
+    Note: the dt_bias ld.global is intentionally left inside the token loop.
+    Hoisting it to CTA entry (measured 2026-04-17) regressed +2% kernel
+    duration at H32-D128-lb B=1 -- the scalar load scheduled at CTA entry
+    has nothing to overlap with, whereas inside the loop the scheduler
+    overlaps it with other compute/SMEM work.
+    """
+    g_val = g_head[k_base + lane_idx].to(cutlass.Float32)
+    if USE_GATE_IN_KERNEL == 1:
+        if HAS_DT_BIAS == 1:
+            g_val = g_val + gDtBias[h_K_offset + k_base + lane_idx].to(cutlass.Float32)
+        if USE_LOWER_BOUND == 1:
+            LOG2_E = cutlass.Float32(1.4426950408889634)
+            neg_A_log2e = -A_log_val * LOG2_E
+            lb_log2e = lower_bound_val * LOG2_E
+            one = cutlass.Float32(1.0)
+            fm = mlir_arith.FastMathFlags.fast
+            one_ir = one.ir_value()
+            neg_A_ir = neg_A_log2e.ir_value()
+            lb_ir = lb_log2e.ir_value()
+            ag = mlir_arith.mulf(neg_A_ir, g_val.ir_value(), fastmath=fm)
+            exp_neg = mlir_math.exp2(ag, fastmath=fm)
+            denom = mlir_arith.addf(one_ir, exp_neg, fastmath=fm)
+            sig = mlir_arith.divf(one_ir, denom, fastmath=fm)
+            ls = mlir_arith.mulf(lb_ir, sig, fastmath=fm)
+            g_val = mlir_math.exp2(ls, fastmath=fm)
+        else:
+            exp_g = cute.exp(g_val, fastmath=True)
+            one = cutlass.Float32(1.0)
+            log2_v = cute.log2(one + exp_g, fastmath=True)
+            g_val = cute.exp2(-A_log_val * log2_v, fastmath=True)
+    else:
+        g_val = cute.exp(g_val, fastmath=True)
+    g_sh[k_base + lane_idx] = g_val
+
+
+@cute.jit
+def normalize_and_store_qk_to_smem(
+    q_head,
+    k_head,
+    q_sh,
+    k_sh,
+    lane_idx,
+    scale,
+    eps,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_QK_L2NORM: cutlass.Constexpr[int],
+):
+    """Optionally L2-normalize Q/K vectors, then store to shared memory."""
+    # ELEMS_PER_LANE = HEAD_DIM // 32 (2 for HD=64, 4 for HD=128)
+    q_reg = cute.make_rmem_tensor((HEAD_DIM // 32,), cutlass.Float32)
+    k_reg = cute.make_rmem_tensor((HEAD_DIM // 32,), cutlass.Float32)
+
+    for i in cutlass.range_constexpr(HEAD_DIM // 32):
+        q_reg[i] = q_head[lane_idx + i * 32].to(cutlass.Float32)
+        k_reg[i] = k_head[lane_idx + i * 32].to(cutlass.Float32)
+
+    if USE_QK_L2NORM == 1:
+        q_sum_sq = cutlass.Float32(0.0)
+        k_sum_sq = cutlass.Float32(0.0)
+        q_sum_sq2 = cutlass.Float32(0.0)
+        k_sum_sq2 = cutlass.Float32(0.0)
+
+        for i in cutlass.range_constexpr(0, HEAD_DIM // 32, 2):
+            q_sum_sq, q_sum_sq2 = cute.arch.fma_packed_f32x2(
+                src_a=(q_reg[i], q_reg[i + 1]),
+                src_b=(q_reg[i], q_reg[i + 1]),
+                src_c=(q_sum_sq, q_sum_sq2),
+            )
+            k_sum_sq, k_sum_sq2 = cute.arch.fma_packed_f32x2(
+                src_a=(k_reg[i], k_reg[i + 1]),
+                src_b=(k_reg[i], k_reg[i + 1]),
+                src_c=(k_sum_sq, k_sum_sq2),
+            )
+
+        q_sum_sq = q_sum_sq + q_sum_sq2
+        k_sum_sq = k_sum_sq + k_sum_sq2
+
+        # Butterfly shuffle: always 5 rounds (32 lanes per warp, hardware constant)
+        for i in cutlass.range_constexpr(5):
+            q_sum_sq = q_sum_sq + cute.arch.shuffle_sync_bfly(
+                q_sum_sq, offset=1 << i, mask=0xFFFFFFFF
+            )
+            k_sum_sq = k_sum_sq + cute.arch.shuffle_sync_bfly(
+                k_sum_sq, offset=1 << i, mask=0xFFFFFFFF
+            )
+
+        q_norm = cute.rsqrt(q_sum_sq + eps, fastmath=True)
+        k_norm = cute.rsqrt(k_sum_sq + eps, fastmath=True)
+        q_scale_factor = q_norm * scale
+
+        for i in cutlass.range_constexpr(HEAD_DIM // 32):
+            q_sh[lane_idx + i * 32] = q_reg[i] * q_scale_factor
+            k_sh[lane_idx + i * 32] = k_reg[i] * k_norm
+    else:
+        for i in cutlass.range_constexpr(HEAD_DIM // 32):
+            q_sh[lane_idx + i * 32] = q_reg[i] * scale
+            k_sh[lane_idx + i * 32] = k_reg[i]
+
+
+# ==============================================================================
+# SEQLEN=1 KERNEL
+# ==============================================================================
+
+
+@cute.jit
+def _process_v_chunk(
+    h_sh_src,
+    h_sh_dst,
+    h_chunk,
+    lane_idx,
+    warp_idx,
+    k_base,
+    g_sh,
+    k_sh,
+    q_sh,
+    v_sh,
+    pred_sh,
+    out_sh,
+    v_offset,
+    o_head,
+    beta,
+    is_active,
+    HEAD_DIM: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int] = 32,
+):
+    """Process one V-chunk: decay state, compute prediction, update state, write output.
+
+    h_sh_src: SMEM buffer holding this chunk's state (read)
+    h_sh_dst: SMEM buffer to write updated state back to (for GMEM store)
+    h_chunk: register tensor [32] for this chunk's state slice
+    v_offset: V-row offset for indexing v_sh and o_head.
+    V_TILE_ROWS: rows owned by this CTA (32 or 16). At 16, lanes >=16 are idle;
+        their h_chunk/pred/out values are garbage and MUST NOT write to h_sh_dst
+        or o_head (both sized by V_TILE_ROWS or HEAD_DIM respectively).
+        Caller pads v_sh by LANES_PER_WARP (=32) so idle-lane v_sh reads at
+        v_offset + lane_idx stay in-bounds.
+    """
+    # Fused decay + pred
+    pred = cutlass.Float32(0.0)
+    pred2 = cutlass.Float32(0.0)
+    for i in cutlass.range_constexpr(0, 32, 2):
+        h_chunk[i], h_chunk[i + 1] = cute.arch.fma_packed_f32x2(
+            src_a=(
+                h_sh_src[lane_idx, k_base + i].to(cutlass.Float32),
+                h_sh_src[lane_idx, k_base + i + 1].to(cutlass.Float32),
+            ),
+            src_b=(g_sh[k_base + i], g_sh[k_base + i + 1]),
+            src_c=(cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        )
+        pred, pred2 = cute.arch.fma_packed_f32x2(
+            src_a=(h_chunk[i], h_chunk[i + 1]),
+            src_b=(k_sh[k_base + i], k_sh[k_base + i + 1]),
+            src_c=(pred, pred2),
+        )
+    pred = pred + pred2
+
+    pred_sh[warp_idx, lane_idx] = pred
+    cute.arch.sync_threads()
+    pred_final = cutlass.Float32(0.0)
+    if HEAD_DIM == 64:
+        pred_final = pred_sh[0, lane_idx] + pred_sh[1, lane_idx]
+    elif HEAD_DIM == 128:
+        pred_final = (
+            pred_sh[0, lane_idx]
+            + pred_sh[1, lane_idx]
+            + pred_sh[2, lane_idx]
+            + pred_sh[3, lane_idx]
+        )
+
+    v_val = (v_sh[v_offset + lane_idx] - pred_final) * beta
+
+    # Fused update + output
+    out = cutlass.Float32(0.0)
+    out2 = cutlass.Float32(0.0)
+    for i in cutlass.range_constexpr(0, 32, 2):
+        h_chunk[i], h_chunk[i + 1] = cute.arch.fma_packed_f32x2(
+            src_a=(k_sh[k_base + i], k_sh[k_base + i + 1]),
+            src_b=(v_val, v_val),
+            src_c=(h_chunk[i], h_chunk[i + 1]),
+        )
+        out, out2 = cute.arch.fma_packed_f32x2(
+            src_a=(h_chunk[i], h_chunk[i + 1]),
+            src_b=(q_sh[k_base + i], q_sh[k_base + i + 1]),
+            src_c=(out, out2),
+        )
+    out = out + out2
+
+    out_sh[warp_idx, lane_idx] = out
+    cute.arch.sync_threads()
+    out_final = cutlass.Float32(0.0)
+    if HEAD_DIM == 64:
+        out_final = out_sh[0, lane_idx] + out_sh[1, lane_idx]
+    elif HEAD_DIM == 128:
+        out_final = (
+            out_sh[0, lane_idx]
+            + out_sh[1, lane_idx]
+            + out_sh[2, lane_idx]
+            + out_sh[3, lane_idx]
+        )
+
+    # Lanes >= V_TILE_ROWS hold garbage (no V-row assigned). Gate h_sh writeback
+    # and output write to keep them out of bounds. At V_TILE_ROWS=32 (default)
+    # the guard is trivially true for all 32 lanes -- zero behavior change.
+    if lane_idx < V_TILE_ROWS:
+        write_h_chunk_to_smem(h_chunk, h_sh_dst, lane_idx, k_base)
+        if is_active:
+            if warp_idx == 0:
+                o_head[v_offset + lane_idx] = out_final.to(cutlass.BFloat16)
+
+
+@cute.kernel
+def recurrent_kda_decode_kernel(
+    gQ: cute.Tensor,
+    gK: cute.Tensor,
+    gV: cute.Tensor,
+    gG: cute.Tensor,  # [B, T, HV, K] log-space gate (or raw input if USE_GATE_IN_KERNEL)
+    gBeta: cute.Tensor,  # [B, T, HV] pre-sigmoided
+    gH: cute.Tensor,  # state: bf16 [N,HV,V,K] (modified in-place)
+    gO: cute.Tensor,
+    gALog: cute.Tensor,  # [H] float32 (A_log per query head)
+    gDtBias: cute.Tensor,  # [H*K] float32 (dt_bias per head and K)
+    gCuSeqlens: cute.Tensor,  # [N+1] int32 -- raw cu_seqlens
+    gSsmStateIndices: cute.Tensor,  # [N*NUM_TOKENS] int32 -- flattened ssm_state_indices (2D [N,T] in spec mode, 1D [N] otherwise)
+    gNumAcceptedTokens: cute.Tensor,  # [N] int32 -- per-sequence accepted token count for spec decode initial state selection
+    scale: cutlass.Float32,
+    eps: cutlass.Float32,
+    lower_bound: cutlass.Float32,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_QK_L2NORM: cutlass.Constexpr[int],
+    USE_GATE_IN_KERNEL: cutlass.Constexpr[int],
+    HAS_DT_BIAS: cutlass.Constexpr[int],
+    USE_LOWER_BOUND: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+    NUM_TOKENS: cutlass.Constexpr[int],
+):
+    """Multi-token spec-decode kernel. One CTA per (batch, head) pair.
+
+    For NUM_TOKENS==1: behavior identical to the original T=1 kernel (zero regression).
+    For NUM_TOKENS>1: D=64 uses register-carry (h_chunk_v0/v1 persist across tokens);
+    D=128 uses GMEM round-trip (reload from previous token's output slot each iteration).
+
+    Thread mapping: HEAD_DIM threads = (HEAD_DIM // 32) warps x 32 lanes.
+    State [V,K] tiled into V-chunks of 32 rows (2 for HD=64, 4 for HD=128).
+    2 ping-pong H SMEM buffers; K/G/Q read from SMEM (broadcast).
+    """
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+
+    HV = cutlass.Int32(gV.shape[2])
+    H = cutlass.Int32(gQ.shape[2])
+
+    batch_idx = bidx // HV
+    value_head_idx = bidx % HV
+    query_head_idx = value_head_idx // (HV // H)
+
+    # cu_seqlens base offset (zero cost when USE_CU_SEQLENS=0)
+    token_base_offset = cutlass.Int32(0)
+    seq_len = cutlass.Int32(1)  # default: all entries valid when no cu_seqlens
+    if USE_CU_SEQLENS == 1:
+        token_base_offset = gCuSeqlens[batch_idx].to(cutlass.Int32)
+        seq_len = gCuSeqlens[batch_idx + 1].to(cutlass.Int32) - token_base_offset
+
+    # Precompute gate params (guarded by Constexpr, zero cost when unused)
+    A_log_val = cutlass.Float32(0.0)
+    h_K_offset = cutlass.Int32(0)
+    lower_bound_val = lower_bound
+    if USE_GATE_IN_KERNEL == 1:
+        A_log_val = cute.exp(gALog[query_head_idx].to(cutlass.Float32), fastmath=True)
+        h_K_offset = query_head_idx * HEAD_DIM
+
+    smem = utils.SmemAllocator()
+
+    # Allocate SMEM -- 2 ping-pong H buffers (D=128 reuses for chunks 2,3)
+    h_sh_a = smem.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout((32, HEAD_DIM), stride=(HEAD_DIM + H_SMEM_PADDING, 1)),
+        byte_alignment=128,
+    )
+    h_sh_b = smem.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout((32, HEAD_DIM), stride=(HEAD_DIM + H_SMEM_PADDING, 1)),
+        byte_alignment=128,
+    )
+
+    q_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+    k_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+    g_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+
+    pred_sh = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((HEAD_DIM // 32, 32))
+    )
+    out_sh = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((HEAD_DIM // 32, 32))
+    )
+    v_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+
+    warp_idx = tidx // 32
+    lane_idx = tidx % 32
+    k_base = warp_idx * 32
+
+    # Register state for V-chunks.
+    # D=64: h_chunk_v0/v1 carry state across tokens (register-carry).
+    # D=128: h_chunk is reused per V-chunk (GMEM round-trip, no persistence).
+    # All three allocated unconditionally to satisfy SCF loop-carried variable rules.
+    h_chunk_v0 = cute.make_rmem_tensor((32,), cutlass.Float32)
+    h_chunk_v1 = cute.make_rmem_tensor((32,), cutlass.Float32)
+    h_chunk = cute.make_rmem_tensor((32,), cutlass.Float32)
+
+    # Pre-initialize ALL variables assigned inside the token loop body.
+    # CuTe DSL SCF requirement: names assigned inside cutlass.range() must have
+    # initial values before the loop, even inside Constexpr-dead branches.
+    seq_idx = batch_idx
+    init_seq_idx = (
+        batch_idx  # SCF pre-init: used only at token_t==0 for nat-based initial state
+    )
+    is_active = seq_len > 0
+    token_offset = token_base_offset
+    beta = cutlass.Float32(0.0)
+    raw_slot = cutlass.Int32(0)
+    raw_slot_prev = cutlass.Int32(0)
+    seq_idx_prev = batch_idx
+    # Tensor views: SCF dummy inits (overwritten each iteration before use).
+    # gH uses batch_idx (state pool has enough slots). gG/gQ/gK/gV/gO use 0
+    # because in cu_seqlens mode dim-0 is 1 while batch_idx can exceed it.
+    h_global_in = gH[(batch_idx, value_head_idx, None, None)]
+    h_global_prev = gH[(batch_idx, value_head_idx, None, None)]
+    h_global_in_c2 = gH[(batch_idx, value_head_idx, None, None)]
+    h_global_in_c3 = gH[(batch_idx, value_head_idx, None, None)]
+    g_head = gG[(0, 0, value_head_idx, None)]
+    q_head = gQ[(0, 0, query_head_idx, None)]
+    k_head = gK[(0, 0, query_head_idx, None)]
+    v_head = gV[(0, 0, value_head_idx, None)]
+    o_head = gO[(0, 0, value_head_idx, None)]
+    h_out = gH[(batch_idx, value_head_idx, None, None)]
+
+    # ========================================================================
+    # TOKEN LOOP
+    # ========================================================================
+    for token_t in cutlass.range(NUM_TOKENS):
+        # ----------------------------------------------------------------
+        # Derive state slot for this token
+        # ----------------------------------------------------------------
+        if USE_CU_SEQLENS == 1:
+            # 1D flat indexing: for NUM_TOKENS>1, ssm_state_indices is flattened [N*T]
+            # so batch_idx * NUM_TOKENS + token_t gives the right element.
+            # For NUM_TOKENS==1, this reduces to batch_idx * 1 + 0 = batch_idx.
+            raw_slot = gSsmStateIndices[batch_idx * NUM_TOKENS + token_t].to(
+                cutlass.Int32
+            )
+            is_active = raw_slot >= 0
+            seq_idx = cutlass.Int32(0) if raw_slot < 0 else raw_slot
+
+            # Derive init_seq_idx from num_accepted_tokens for initial state selection.
+            # When num_accepted_tokens[n]=nat, the initial state is at
+            # ssm_state_indices[n, nat-1] (the checkpoint after the last accepted token
+            # from the previous spec decode round). This matches the FLA Triton kernel.
+            # For nat<=1 or NUM_TOKENS==1, nat_offset=0 -> same as current behavior.
+            # Guard with NUM_TOKENS > 1 (Constexpr) so dummy tensors are never accessed
+            # in standard decode where gNumAcceptedTokens may be a 1-element dummy.
+            if token_t == 0:
+                if NUM_TOKENS > 1:
+                    nat_raw = gNumAcceptedTokens[batch_idx].to(cutlass.Int32)
+                    nat_offset = cutlass.Int32(0) if nat_raw <= 1 else (nat_raw - 1)
+                    init_raw_slot = gSsmStateIndices[
+                        batch_idx * NUM_TOKENS + nat_offset
+                    ].to(cutlass.Int32)
+                    init_seq_idx = (
+                        cutlass.Int32(0) if init_raw_slot < 0 else init_raw_slot
+                    )
+                else:
+                    init_seq_idx = seq_idx
+        else:
+            # No cu_seqlens: batch_idx is the state slot, always active
+            seq_idx = batch_idx
+            is_active = seq_len > 0
+
+        token_offset = token_base_offset + token_t
+
+        # ----------------------------------------------------------------
+        # State loading
+        # ----------------------------------------------------------------
+        if token_t == 0:
+            # First token: async load from initial state slot (nat-selected)
+            h_global_in = gH[(init_seq_idx, value_head_idx, None, None)]
+            load_h_chunk_async(h_sh_a, h_global_in, tidx, 0, HEAD_DIM)
+            nvvm.cp_async_commit_group()
+            load_h_chunk_async(h_sh_b, h_global_in, tidx, 32, HEAD_DIM)
+            nvvm.cp_async_commit_group()
+        else:
+            if HEAD_DIM == 64:
+                # D=64 register-carry: write carried registers to SMEM
+                write_h_chunk_to_smem(h_chunk_v0, h_sh_a, lane_idx, k_base)
+                write_h_chunk_to_smem(h_chunk_v1, h_sh_b, lane_idx, k_base)
+                cute.arch.sync_threads()
+            else:
+                # D=128 GMEM round-trip: reload from previous token's output slot
+                if USE_CU_SEQLENS == 1 and NUM_TOKENS > 1:
+                    raw_slot_prev = gSsmStateIndices[
+                        batch_idx * NUM_TOKENS + token_t - 1
+                    ].to(cutlass.Int32)
+                    seq_idx_prev = (
+                        cutlass.Int32(0) if raw_slot_prev < 0 else raw_slot_prev
+                    )
+                else:
+                    seq_idx_prev = seq_idx
+                h_global_prev = gH[(seq_idx_prev, value_head_idx, None, None)]
+                load_h_chunk_async(h_sh_a, h_global_prev, tidx, 0, HEAD_DIM)
+                nvvm.cp_async_commit_group()
+                load_h_chunk_async(h_sh_b, h_global_prev, tidx, 32, HEAD_DIM)
+                nvvm.cp_async_commit_group()
+
+        # ----------------------------------------------------------------
+        # Per-token data: Q, K, V, G, beta, output pointer
+        # ----------------------------------------------------------------
+        if USE_CU_SEQLENS == 1:
+            g_head = gG[(0, token_offset, value_head_idx, None)]
+            beta = gBeta[(0, token_offset, value_head_idx)].to(cutlass.Float32)
+            q_head = gQ[(0, token_offset, query_head_idx, None)]
+            k_head = gK[(0, token_offset, query_head_idx, None)]
+            v_head = gV[(0, token_offset, value_head_idx, None)]
+            o_head = gO[(0, token_offset, value_head_idx, None)]
+        else:
+            g_head = gG[(batch_idx, 0, value_head_idx, None)]
+            beta = gBeta[(batch_idx, 0, value_head_idx)].to(cutlass.Float32)
+            q_head = gQ[(batch_idx, 0, query_head_idx, None)]
+            k_head = gK[(batch_idx, 0, query_head_idx, None)]
+            v_head = gV[(batch_idx, 0, value_head_idx, None)]
+            o_head = gO[(batch_idx, 0, value_head_idx, None)]
+
+        h_out = gH[(seq_idx, value_head_idx, None, None)]
+
+        # Q/K L2 normalization (warp 0 only)
+        if warp_idx == 0:
+            normalize_and_store_qk_to_smem(
+                q_head,
+                k_head,
+                q_sh,
+                k_sh,
+                lane_idx,
+                scale,
+                eps,
+                HEAD_DIM,
+                USE_QK_L2NORM,
+            )
+
+        cute.arch.sync_threads()
+
+        # V load
+        v_sh[tidx] = v_head[tidx].to(cutlass.Float32)
+
+        # ====================================================================
+        # CHUNK 0 (from h_sh_a)
+        # ====================================================================
+        # Wait for chunk 0 async load (D=64 t>0 has no pending async)
+        if HEAD_DIM == 64 and token_t > 0:
+            pass  # registers -> SMEM already done above + sync_threads
+        else:
+            nvvm.cp_async_wait_group(1)
+            cute.arch.sync_threads()
+
+        # Compute per-K gate to SMEM
+        compute_gate_to_smem(
+            g_sh,
+            g_head,
+            k_base,
+            lane_idx,
+            A_log_val,
+            gDtBias,
+            h_K_offset,
+            lower_bound_val,
+            USE_GATE_IN_KERNEL,
+            HAS_DT_BIAS,
+            USE_LOWER_BOUND,
+        )
+        cute.arch.sync_threads()
+
+        if HEAD_DIM == 64:
+            _process_v_chunk(
+                h_sh_a,
+                h_sh_a,
+                h_chunk_v0,
+                lane_idx,
+                warp_idx,
+                k_base,
+                g_sh,
+                k_sh,
+                q_sh,
+                v_sh,
+                pred_sh,
+                out_sh,
+                0,
+                o_head,
+                beta,
+                is_active,
+                HEAD_DIM,
+            )
+        else:
+            _process_v_chunk(
+                h_sh_a,
+                h_sh_a,
+                h_chunk,
+                lane_idx,
+                warp_idx,
+                k_base,
+                g_sh,
+                k_sh,
+                q_sh,
+                v_sh,
+                pred_sh,
+                out_sh,
+                0,
+                o_head,
+                beta,
+                is_active,
+                HEAD_DIM,
+            )
+
+        # ====================================================================
+        # CHUNK 1 (from h_sh_b)
+        # ====================================================================
+        # Wait for chunk 1 async load (D=64 t>0 has no pending async)
+        if HEAD_DIM == 64 and token_t > 0:
+            pass  # registers -> SMEM already done above
+        else:
+            nvvm.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        # Store chunk 0; for D=128 also load chunk 2 into h_sh_a (ping-pong)
+        if is_active:
+            store_h_smem_to_gmem(h_sh_a, h_out, tidx, 0, HEAD_DIM)
+        if HEAD_DIM == 128:
+            if token_t == 0:
+                h_global_in_c2 = gH[(init_seq_idx, value_head_idx, None, None)]
+            else:
+                if USE_CU_SEQLENS == 1 and NUM_TOKENS > 1:
+                    raw_slot_prev = gSsmStateIndices[
+                        batch_idx * NUM_TOKENS + token_t - 1
+                    ].to(cutlass.Int32)
+                    seq_idx_prev = (
+                        cutlass.Int32(0) if raw_slot_prev < 0 else raw_slot_prev
+                    )
+                else:
+                    seq_idx_prev = seq_idx
+                h_global_in_c2 = gH[(seq_idx_prev, value_head_idx, None, None)]
+            load_h_chunk_async(h_sh_a, h_global_in_c2, tidx, 64, HEAD_DIM)
+            nvvm.cp_async_commit_group()
+
+        if HEAD_DIM == 64:
+            _process_v_chunk(
+                h_sh_b,
+                h_sh_b,
+                h_chunk_v1,
+                lane_idx,
+                warp_idx,
+                k_base,
+                g_sh,
+                k_sh,
+                q_sh,
+                v_sh,
+                pred_sh,
+                out_sh,
+                32,
+                o_head,
+                beta,
+                is_active,
+                HEAD_DIM,
+            )
+        else:
+            _process_v_chunk(
+                h_sh_b,
+                h_sh_b,
+                h_chunk,
+                lane_idx,
+                warp_idx,
+                k_base,
+                g_sh,
+                k_sh,
+                q_sh,
+                v_sh,
+                pred_sh,
+                out_sh,
+                32,
+                o_head,
+                beta,
+                is_active,
+                HEAD_DIM,
+            )
+
+        # For HEAD_DIM=64: done after 2 chunks. Store chunk1 H and continue to next token.
+        if HEAD_DIM == 64:
+            cute.arch.sync_threads()
+            if is_active:
+                store_h_smem_to_gmem(h_sh_b, h_out, tidx, 32, HEAD_DIM)
+
+        # ====================================================================
+        # CHUNK 2 (HEAD_DIM=128 only, from h_sh_a via ping-pong)
+        # ====================================================================
+        if HEAD_DIM == 128:
+            cute.arch.sync_threads()
+
+            # Store chunk 1 (h_sh_b), load chunk 3 into h_sh_b (ping-pong)
+            if is_active:
+                store_h_smem_to_gmem(h_sh_b, h_out, tidx, 32, HEAD_DIM)
+            if token_t == 0:
+                h_global_in_c3 = gH[(init_seq_idx, value_head_idx, None, None)]
+            else:
+                if USE_CU_SEQLENS == 1 and NUM_TOKENS > 1:
+                    raw_slot_prev = gSsmStateIndices[
+                        batch_idx * NUM_TOKENS + token_t - 1
+                    ].to(cutlass.Int32)
+                    seq_idx_prev = (
+                        cutlass.Int32(0) if raw_slot_prev < 0 else raw_slot_prev
+                    )
+                else:
+                    seq_idx_prev = seq_idx
+                h_global_in_c3 = gH[(seq_idx_prev, value_head_idx, None, None)]
+            load_h_chunk_async(h_sh_b, h_global_in_c3, tidx, 96, HEAD_DIM)
+            nvvm.cp_async_commit_group()
+
+            nvvm.cp_async_wait_group(1)
+            cute.arch.sync_threads()
+
+            _process_v_chunk(
+                h_sh_a,
+                h_sh_a,
+                h_chunk,
+                lane_idx,
+                warp_idx,
+                k_base,
+                g_sh,
+                k_sh,
+                q_sh,
+                v_sh,
+                pred_sh,
+                out_sh,
+                64,
+                o_head,
+                beta,
+                is_active,
+                HEAD_DIM,
+            )
+
+            # ================================================================
+            # CHUNK 3 (HEAD_DIM=128 only, from h_sh_b via ping-pong)
+            # ================================================================
+            nvvm.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+
+            if is_active:
+                store_h_smem_to_gmem(h_sh_a, h_out, tidx, 64, HEAD_DIM)
+
+            _process_v_chunk(
+                h_sh_b,
+                h_sh_b,
+                h_chunk,
+                lane_idx,
+                warp_idx,
+                k_base,
+                g_sh,
+                k_sh,
+                q_sh,
+                v_sh,
+                pred_sh,
+                out_sh,
+                96,
+                o_head,
+                beta,
+                is_active,
+                HEAD_DIM,
+            )
+
+            cute.arch.sync_threads()
+            if is_active:
+                store_h_smem_to_gmem(h_sh_b, h_out, tidx, 96, HEAD_DIM)
+
+        # Token boundary barrier (required for BOTH D=64 and D=128):
+        # - D=64: prevents SMEM h_sh_b race between store_h_smem_to_gmem (reads h_sh_b)
+        #   in this iteration and write_h_chunk_to_smem (writes h_sh_b) at the start
+        #   of the next iteration's register-carry prelude.
+        # - D=128: per bar.sync (PTX ISA) all pending memory transactions from all threads
+        #   complete before any thread proceeds, ensuring st.global stores are visible to
+        #   the subsequent cp.async reloads in the next iteration's GMEM round-trip.
+        cute.arch.sync_threads()
+
+
+# ==============================================================================
+# V-TILED KERNEL (experimental: one V-chunk per CTA)
+# ==============================================================================
+# Unlike `recurrent_kda_decode_kernel` which runs one CTA per (batch, head) and
+# processes all V rows sequentially with a 2- or 4-way SMEM ping-pong, this
+# variant runs one CTA per (batch, head, v_tile) with a single 32-row V-chunk
+# per CTA. Expands the grid by HEAD_DIM/32 (2x for D=64, 4x for D=128) to help
+# saturate SMs at small batch sizes where `grid = B * HV` under-subscribes the
+# GPU (at B=4, HV=16, D=128: 64 CTAs on ~148 SMs, NCU measured 6% occupancy).
+#
+# Trade-offs:
+# - Wins at small B (more CTAs land on more SMs).
+# - Loses the intra-CTA async overlap between chunks (each CTA has only one).
+# - Duplicates Q/K L2 norm, gate computation, and per-token metadata reads
+#   across the NUM_V_TILES CTAs per (batch, head) -- small compared to the
+#   state update work.
+# - h register-carry applies uniformly for D=64 and D=128 here (each CTA owns
+#   only 32 rows, fits cleanly in registers). D=128 gets a bonus: no GMEM
+#   round-trip at token boundaries (the original kernel pays this cost).
+
+
+@cute.kernel
+def recurrent_kda_decode_vtile_kernel(
+    gQ: cute.Tensor,
+    gK: cute.Tensor,
+    gV: cute.Tensor,
+    gG: cute.Tensor,
+    gBeta: cute.Tensor,
+    gH: cute.Tensor,
+    gO: cute.Tensor,
+    gALog: cute.Tensor,
+    gDtBias: cute.Tensor,
+    gCuSeqlens: cute.Tensor,
+    gSsmStateIndices: cute.Tensor,
+    gNumAcceptedTokens: cute.Tensor,
+    scale: cutlass.Float32,
+    eps: cutlass.Float32,
+    lower_bound: cutlass.Float32,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_QK_L2NORM: cutlass.Constexpr[int],
+    USE_GATE_IN_KERNEL: cutlass.Constexpr[int],
+    HAS_DT_BIAS: cutlass.Constexpr[int],
+    USE_LOWER_BOUND: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+    NUM_TOKENS: cutlass.Constexpr[int],
+    NUM_V_TILES: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int],
+):
+    """V-tiled decode: one CTA per (batch, head, v_tile). Grid = B*HV*NUM_V_TILES.
+
+    V_TILE_ROWS: 32 (standard, NUM_V_TILES=HEAD_DIM/32) or 16 (finer-grained,
+        NUM_V_TILES=HEAD_DIM/16). V_TILE_ROWS=16 doubles grid at D=128 for
+        very-low-batch shapes at the cost of 50% idle lanes in the state
+        reductions (warps-per-CTA stays 4, so scheduler warp-parallelism
+        is preserved -- the Round 2A ILP rejection concern doesn't apply).
+    """
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+
+    HV = cutlass.Int32(gV.shape[2])
+    H = cutlass.Int32(gQ.shape[2])
+
+    # Decode block_idx -> (batch_idx, value_head_idx, v_tile_idx)
+    v_tile_idx = bidx % NUM_V_TILES
+    bh = bidx // NUM_V_TILES
+    value_head_idx = bh % HV
+    batch_idx = bh // HV
+    query_head_idx = value_head_idx // (HV // H)
+
+    # Absolute V-row offset of this CTA's chunk in the full V vector
+    v_offset = v_tile_idx * V_TILE_ROWS
+
+    # cu_seqlens base offset (zero cost when USE_CU_SEQLENS=0)
+    token_base_offset = cutlass.Int32(0)
+    seq_len = cutlass.Int32(1)
+    if USE_CU_SEQLENS == 1:
+        token_base_offset = gCuSeqlens[batch_idx].to(cutlass.Int32)
+        seq_len = gCuSeqlens[batch_idx + 1].to(cutlass.Int32) - token_base_offset
+
+    # Precompute gate params (guarded by Constexpr, zero cost when unused)
+    A_log_val = cutlass.Float32(0.0)
+    h_K_offset = cutlass.Int32(0)
+    lower_bound_val = lower_bound
+    if USE_GATE_IN_KERNEL == 1:
+        A_log_val = cute.exp(gALog[query_head_idx].to(cutlass.Float32), fastmath=True)
+        h_K_offset = query_head_idx * HEAD_DIM
+
+    smem = utils.SmemAllocator()
+
+    # Single SMEM h buffer -- no ping-pong, only one chunk per CTA.
+    # Physical row count is always 32 (=LANES_PER_WARP), even at V_TILE_ROWS=16.
+    # _process_v_chunk reads h_sh[lane_idx, k_base+i] for all 32 lanes (the
+    # per-lane FMA loop is unpredicated so block-wide syncs stay well-formed);
+    # idle lanes at V_TILE_ROWS=16 read rows 16-31 which would OOB past the
+    # SMEM allocation (measured: IMA at D=64 V_TILE=16 due to OOB past dynamic
+    # SMEM total). Allocating 32 rows always trades ~2KB SMEM for safety and
+    # keeps the helpers parameterized on V_TILE_ROWS only for their valid-row
+    # count (load/store stride by V_TILE_ROWS*16 rows, etc.).
+    h_sh = smem.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout((32, HEAD_DIM), stride=(HEAD_DIM + H_SMEM_PADDING, 1)),
+        byte_alignment=128,
+    )
+
+    q_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+    k_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+    g_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM)
+    pred_sh = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((HEAD_DIM // 32, 32))
+    )
+    out_sh = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((HEAD_DIM // 32, 32))
+    )
+    # v_sh padded by one warp width so idle lanes (lane_idx >= V_TILE_ROWS) can
+    # read v_sh[v_offset + lane_idx] without going OOB. Max index at
+    # V_TILE_ROWS=16: (NUM_V_TILES-1)*16 + 31 = HEAD_DIM+15; pad to HEAD_DIM+32.
+    # Negligible SMEM cost (~128 bytes) and keeps _process_v_chunk branchless
+    # on the v_val computation path (the block-wide syncs inside can't be
+    # skipped by idle lanes).
+    v_sh = smem.allocate_tensor(cutlass.Float32, HEAD_DIM + 32)
+
+    # bf16 staging buffers for cp.async'd Q/K/V/G. 16-byte aligned so 64-bit
+    # cp.async destinations are 8B-aligned.
+    q_raw_sh = smem.allocate_tensor(cutlass.BFloat16, HEAD_DIM, byte_alignment=16)
+    k_raw_sh = smem.allocate_tensor(cutlass.BFloat16, HEAD_DIM, byte_alignment=16)
+    v_raw_sh = smem.allocate_tensor(cutlass.BFloat16, HEAD_DIM, byte_alignment=16)
+    g_raw_sh = smem.allocate_tensor(cutlass.BFloat16, HEAD_DIM, byte_alignment=16)
+
+    warp_idx = tidx // 32
+    lane_idx = tidx % 32
+    k_base = warp_idx * 32
+
+    # Single register-resident h chunk. Carried across tokens for both D=64 and
+    # D=128 (the v-tiled structure lets D=128 carry cleanly since each CTA owns
+    # only 32 rows, unlike the base kernel which must GMEM-round-trip at D=128).
+    h_chunk = cute.make_rmem_tensor((32,), cutlass.Float32)
+
+    # SCF pre-inits (see CuTe DSL loop-carried variable rules in the base kernel)
+    seq_idx = batch_idx
+    init_seq_idx = batch_idx
+    is_active = seq_len > 0
+    token_offset = token_base_offset
+    raw_slot = cutlass.Int32(0)
+
+    for token_t in cutlass.range(NUM_TOKENS):
+        # ----------------------------------------------------------------
+        # Resolve state slot + initial state slot
+        # ----------------------------------------------------------------
+        if USE_CU_SEQLENS == 1:
+            raw_slot = gSsmStateIndices[batch_idx * NUM_TOKENS + token_t].to(
+                cutlass.Int32
+            )
+            is_active = raw_slot >= 0
+            seq_idx = cutlass.Int32(0) if raw_slot < 0 else raw_slot
+
+            # nat-based initial state (matches base kernel and FLA Triton semantics)
+            if token_t == 0:
+                if NUM_TOKENS > 1:
+                    nat_raw = gNumAcceptedTokens[batch_idx].to(cutlass.Int32)
+                    nat_offset = cutlass.Int32(0) if nat_raw <= 1 else (nat_raw - 1)
+                    init_raw_slot = gSsmStateIndices[
+                        batch_idx * NUM_TOKENS + nat_offset
+                    ].to(cutlass.Int32)
+                    init_seq_idx = (
+                        cutlass.Int32(0) if init_raw_slot < 0 else init_raw_slot
+                    )
+                else:
+                    init_seq_idx = seq_idx
+        else:
+            seq_idx = batch_idx
+            is_active = seq_len > 0
+
+        token_offset = token_base_offset + token_t
+
+        # ----------------------------------------------------------------
+        # Batched async gmem->smem issue.
+        #   Token 0: H state slice + Q/K/V/G per-token vectors.
+        #   Token >0: Q/K/V/G only (H is register-carried from prior iter).
+        # All into one commit group so a single wait_group(0) drains them.
+        # ----------------------------------------------------------------
+        if token_t == 0:
+            load_h_chunk_async(
+                h_sh,
+                gH[(init_seq_idx, value_head_idx, None, None)],
+                tidx,
+                v_offset,
+                HEAD_DIM,
+                V_TILE_ROWS,
+            )
+        issue_qkvg_async_for_token(
+            q_raw_sh,
+            k_raw_sh,
+            v_raw_sh,
+            g_raw_sh,
+            gQ,
+            gK,
+            gV,
+            gG,
+            batch_idx,
+            token_offset,
+            query_head_idx,
+            value_head_idx,
+            tidx,
+            HEAD_DIM,
+            USE_CU_SEQLENS,
+        )
+        nvvm.cp_async_commit_group()
+
+        # Register-carry writeback for token>0 overlaps the cp.async issue
+        # above (targets h_sh; cp.async targets disjoint *_raw_sh buffers).
+        # Previous iter's token-boundary sync guarantees store_h_smem_to_gmem
+        # finished reading h_sh before we clobber it here. Guard so idle lanes
+        # at V_TILE_ROWS=16 don't write OOB into h_sh (sized (V_TILE_ROWS, K)).
+        if token_t > 0:
+            if lane_idx < V_TILE_ROWS:
+                write_h_chunk_to_smem(h_chunk, h_sh, lane_idx, k_base)
+
+        # Drain all async loads + publish h_sh register-carry writeback in a
+        # single cross-thread sync.
+        nvvm.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        # ----------------------------------------------------------------
+        # Consume bf16 staging buffers. Reads are cross-warp (e.g., warp 3
+        # wrote g_raw_sh, warp 0 reads g_raw_sh[0..31]); the sync above
+        # makes them visible.
+        # ----------------------------------------------------------------
+        # Q/K L2 norm (warp 0 only; duplicated across v-tile CTAs but
+        # negligible -- ~HEAD_DIM flops vs. state update's ~32*HEAD_DIM).
+        if warp_idx == 0:
+            normalize_and_store_qk_to_smem(
+                q_raw_sh,
+                k_raw_sh,
+                q_sh,
+                k_sh,
+                lane_idx,
+                scale,
+                eps,
+                HEAD_DIM,
+                USE_QK_L2NORM,
+            )
+
+        # V: bf16 staging -> f32 working buffer. Same-thread read/write;
+        # cross-warp visibility is resolved by the next sync_threads().
+        v_sh[tidx] = v_raw_sh[tidx].to(cutlass.Float32)
+
+        # Per-K gate: each warp reads its own g_raw_sh[k_base..k_base+31]
+        # slice. Writes go to g_sh at disjoint per-warp offsets.
+        compute_gate_to_smem(
+            g_sh,
+            g_raw_sh,
+            k_base,
+            lane_idx,
+            A_log_val,
+            gDtBias,
+            h_K_offset,
+            lower_bound_val,
+            USE_GATE_IN_KERNEL,
+            HAS_DT_BIAS,
+            USE_LOWER_BOUND,
+        )
+        cute.arch.sync_threads()
+
+        # Process this CTA's single V-chunk. h_chunk registers come out holding
+        # the updated state for this chunk (used by next token's register-carry).
+        process_vtile_token_chunk(
+            gBeta,
+            gO,
+            batch_idx,
+            token_offset,
+            value_head_idx,
+            h_sh,
+            h_chunk,
+            lane_idx,
+            warp_idx,
+            k_base,
+            g_sh,
+            k_sh,
+            q_sh,
+            v_sh,
+            pred_sh,
+            out_sh,
+            v_offset,
+            is_active,
+            HEAD_DIM,
+            USE_CU_SEQLENS,
+            V_TILE_ROWS,
+        )
+
+        cute.arch.sync_threads()
+
+        # Checkpoint: store updated state to GMEM slot for this token
+        if is_active:
+            store_vtile_token_state(
+                gH,
+                seq_idx,
+                value_head_idx,
+                h_sh,
+                tidx,
+                v_offset,
+                HEAD_DIM,
+                V_TILE_ROWS,
+            )
+
+        # Token boundary barrier: ensure h_sh GMEM store completes before next
+        # iteration's register-carry write clobbers h_sh.
+        cute.arch.sync_threads()
+
+
+# ==============================================================================
+# LAUNCH WRAPPERS
+# ==============================================================================
+
+
+@cute.jit
+def recurrent_kda_launch(
+    mQ: cute.Tensor,
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mG: cute.Tensor,
+    mBeta: cute.Tensor,
+    mH: cute.Tensor,
+    mO: cute.Tensor,
+    mALog: cute.Tensor,
+    mDtBias: cute.Tensor,
+    mCuSeqlens: cute.Tensor,
+    mSsmStateIndices: cute.Tensor,
+    mNumAcceptedTokens: cute.Tensor,
+    scale: cutlass.Float32,
+    eps: cutlass.Float32,
+    lower_bound: cutlass.Float32,
+    stream: cuda.CUstream,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_QK_L2NORM: cutlass.Constexpr[int],
+    USE_GATE_IN_KERNEL: cutlass.Constexpr[int],
+    HAS_DT_BIAS: cutlass.Constexpr[int],
+    USE_LOWER_BOUND: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+    NUM_TOKENS: cutlass.Constexpr[int],
+):
+    batch_size = mQ.shape[0]
+    if USE_CU_SEQLENS == 1:
+        batch_size = mCuSeqlens.shape[0] - 1
+    HV = mV.shape[2]
+
+    recurrent_kda_decode_kernel(
+        mQ,
+        mK,
+        mV,
+        mG,
+        mBeta,
+        mH,
+        mO,
+        mALog,
+        mDtBias,
+        mCuSeqlens,
+        mSsmStateIndices,
+        mNumAcceptedTokens,
+        scale,
+        eps,
+        lower_bound,
+        HEAD_DIM,
+        USE_QK_L2NORM,
+        USE_GATE_IN_KERNEL,
+        HAS_DT_BIAS,
+        USE_LOWER_BOUND,
+        USE_CU_SEQLENS,
+        NUM_TOKENS,
+    ).launch(
+        grid=[batch_size * HV, 1, 1],
+        block=[HEAD_DIM, 1, 1],
+        stream=stream,
+    )
+
+
+@cute.jit
+def recurrent_kda_vtile_launch(
+    mQ: cute.Tensor,
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mG: cute.Tensor,
+    mBeta: cute.Tensor,
+    mH: cute.Tensor,
+    mO: cute.Tensor,
+    mALog: cute.Tensor,
+    mDtBias: cute.Tensor,
+    mCuSeqlens: cute.Tensor,
+    mSsmStateIndices: cute.Tensor,
+    mNumAcceptedTokens: cute.Tensor,
+    scale: cutlass.Float32,
+    eps: cutlass.Float32,
+    lower_bound: cutlass.Float32,
+    stream: cuda.CUstream,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_QK_L2NORM: cutlass.Constexpr[int],
+    USE_GATE_IN_KERNEL: cutlass.Constexpr[int],
+    HAS_DT_BIAS: cutlass.Constexpr[int],
+    USE_LOWER_BOUND: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+    NUM_TOKENS: cutlass.Constexpr[int],
+    NUM_V_TILES: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int],
+):
+    batch_size = mQ.shape[0]
+    if USE_CU_SEQLENS == 1:
+        batch_size = mCuSeqlens.shape[0] - 1
+    HV = mV.shape[2]
+
+    recurrent_kda_decode_vtile_kernel(
+        mQ,
+        mK,
+        mV,
+        mG,
+        mBeta,
+        mH,
+        mO,
+        mALog,
+        mDtBias,
+        mCuSeqlens,
+        mSsmStateIndices,
+        mNumAcceptedTokens,
+        scale,
+        eps,
+        lower_bound,
+        HEAD_DIM,
+        USE_QK_L2NORM,
+        USE_GATE_IN_KERNEL,
+        HAS_DT_BIAS,
+        USE_LOWER_BOUND,
+        USE_CU_SEQLENS,
+        NUM_TOKENS,
+        NUM_V_TILES,
+        V_TILE_ROWS,
+    ).launch(
+        grid=[batch_size * HV * NUM_V_TILES, 1, 1],
+        block=[HEAD_DIM, 1, 1],
+        stream=stream,
+    )
+
+
+@cute.jit
+def recurrent_kda_vtile_spec_decode_launch(
+    mQ: cute.Tensor,
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mG: cute.Tensor,
+    mBeta: cute.Tensor,
+    mH: cute.Tensor,
+    mO: cute.Tensor,
+    mALog: cute.Tensor,
+    mDtBias: cute.Tensor,
+    mCuSeqlens: cute.Tensor,
+    mSsmStateIndices: cute.Tensor,
+    mNumAcceptedTokens: cute.Tensor,
+    scale: cutlass.Float32,
+    eps: cutlass.Float32,
+    lower_bound: cutlass.Float32,
+    stream: cuda.CUstream,
+    HEAD_DIM: cutlass.Constexpr[int],
+    USE_QK_L2NORM: cutlass.Constexpr[int],
+    USE_GATE_IN_KERNEL: cutlass.Constexpr[int],
+    HAS_DT_BIAS: cutlass.Constexpr[int],
+    USE_LOWER_BOUND: cutlass.Constexpr[int],
+    USE_CU_SEQLENS: cutlass.Constexpr[int],
+    NUM_TOKENS: cutlass.Constexpr[int],
+    NUM_V_TILES: cutlass.Constexpr[int],
+    V_TILE_ROWS: cutlass.Constexpr[int],
+):
+    """Dedicated compile surface for D128 multi-token vtile tuning."""
+    recurrent_kda_vtile_launch(
+        mQ,
+        mK,
+        mV,
+        mG,
+        mBeta,
+        mH,
+        mO,
+        mALog,
+        mDtBias,
+        mCuSeqlens,
+        mSsmStateIndices,
+        mNumAcceptedTokens,
+        scale,
+        eps,
+        lower_bound,
+        stream,
+        HEAD_DIM,
+        USE_QK_L2NORM,
+        USE_GATE_IN_KERNEL,
+        HAS_DT_BIAS,
+        USE_LOWER_BOUND,
+        USE_CU_SEQLENS,
+        NUM_TOKENS,
+        NUM_V_TILES,
+        V_TILE_ROWS,
+    )
+
+
+# ==============================================================================
+# PUBLIC API
+# ==============================================================================
+
+_dummy_cache = {}  # device -> dict of pre-allocated dummy tensors
+_num_sms_cache = {}  # device -> int, SM count (used by auto-dispatch)
+# Keeps the D128 spec-decode vtile kernel within the tuned occupancy/register budget.
+_VTILE_SPEC_D128_MAXRREGCOUNT = 72
+
+
+def _get_num_sms(device):
+    if device not in _num_sms_cache:
+        _num_sms_cache[device] = torch.cuda.get_device_properties(
+            device
+        ).multi_processor_count
+    return _num_sms_cache[device]
+
+
+@functools.cache
+def _get_compiled_kernel(
+    HEAD_DIM,
+    USE_QK_L2NORM,
+    USE_GATE_IN_KERNEL,
+    HAS_DT_BIAS,
+    USE_LOWER_BOUND,
+    USE_CU_SEQLENS,
+    NUM_TOKENS=1,
+):
+    """Cache compiled kernel for given configuration."""
+    B, H, HV, N = cute.sym_int(), cute.sym_int(), cute.sym_int(), cute.sym_int()
+    K, V = HEAD_DIM, HEAD_DIM
+
+    def make_fake(shape, dtype=cute.BFloat16):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            shape,
+            assumed_align=32,
+            stride_order=tuple(reversed(range(len(shape)))),
+        )
+
+    T_dim = cute.sym_int() if USE_CU_SEQLENS == 1 else 1
+    HV_state, ALog_sym, HK_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+    CuSeqlens_sym, SsiB_sym, Nat_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+
+    # State tensor: use make_fake_tensor with a free symbolic stride[0] to support
+    # vLLM's block-based cache where stride[0] = page_size_bytes // dtype_size
+    # (includes conv_state padding, so it's NOT compact = HV * V * K).
+    # stride[1:] are standard row-major within each block.
+    S_batch = cute.sym_int64(divisibility=16)
+    state_fake = cute.runtime.make_fake_tensor(
+        cute.BFloat16,
+        shape=(N, HV_state, V, K),
+        stride=(S_batch, V * K, K, 1),
+        assumed_align=32,
+    )
+
+    # Gate tensor: use make_fake_tensor with free symbolic strides for batch and
+    # token dims to support non-contiguous gates from split()/view() on fused
+    # projection outputs (e.g. vLLM [B, T, total_proj_dim].split(..., dim=-1)).
+    # HV and K strides remain compact since split() only affects outer dims.
+    G_batch_stride = cute.sym_int64(divisibility=16)
+    G_token_stride = cute.sym_int64(divisibility=16)
+    gate_fake = cute.runtime.make_fake_tensor(
+        cute.BFloat16,
+        shape=(B, T_dim, HV, K),
+        stride=(G_batch_stride, G_token_stride, K, 1),
+        assumed_align=32,
+    )
+
+    return cute.compile(
+        recurrent_kda_launch,
+        make_fake((B, T_dim, H, K)),  # q
+        make_fake((B, T_dim, H, K)),  # k
+        make_fake((B, T_dim, HV, V)),  # v
+        gate_fake,  # g (free batch/token strides for non-contiguous views)
+        make_fake((B, T_dim, HV)),  # beta
+        state_fake,  # state (free stride[0] for block-based cache)
+        make_fake((B, T_dim, HV, V)),  # output
+        make_fake((ALog_sym,), dtype=cute.Float32),  # A_log
+        make_fake((HK_sym,), dtype=cute.Float32),  # dt_bias
+        make_fake((CuSeqlens_sym,), dtype=cute.Int32),  # cu_seqlens
+        make_fake((SsiB_sym,), dtype=cute.Int32),  # ssm_state_indices (flattened 1D)
+        make_fake((Nat_sym,), dtype=cute.Int32),  # num_accepted_tokens [N]
+        cutlass.Float32(0.0),  # scale
+        cutlass.Float32(0.0),  # eps
+        cutlass.Float32(0.0),  # lower_bound
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        HEAD_DIM,
+        USE_QK_L2NORM,
+        USE_GATE_IN_KERNEL,
+        HAS_DT_BIAS,
+        USE_LOWER_BOUND,
+        USE_CU_SEQLENS,
+        NUM_TOKENS,
+        options="--enable-tvm-ffi --generate-line-info",
+    )
+
+
+@functools.cache
+def _get_compiled_vtile_kernel(
+    HEAD_DIM,
+    USE_QK_L2NORM,
+    USE_GATE_IN_KERNEL,
+    HAS_DT_BIAS,
+    USE_LOWER_BOUND,
+    USE_CU_SEQLENS,
+    NUM_TOKENS=1,
+    V_TILE_ROWS=32,
+):
+    """Cache compiled v-tiled kernel. NUM_V_TILES = HEAD_DIM / V_TILE_ROWS.
+
+    V_TILE_ROWS=32: standard (one CTA owns 32 V-rows).
+    V_TILE_ROWS=16: finer-grained grid at D=128 for very-low-batch; 2x grid
+        vs V_TILE_ROWS=32 at cost of 50% idle lanes in state reductions.
+    """
+    B, H, HV, N = cute.sym_int(), cute.sym_int(), cute.sym_int(), cute.sym_int()
+    K, V = HEAD_DIM, HEAD_DIM
+    NUM_V_TILES = HEAD_DIM // V_TILE_ROWS
+
+    def make_fake(shape, dtype=cute.BFloat16):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            shape,
+            assumed_align=32,
+            stride_order=tuple(reversed(range(len(shape)))),
+        )
+
+    T_dim = cute.sym_int() if USE_CU_SEQLENS == 1 else 1
+    HV_state, ALog_sym, HK_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+    CuSeqlens_sym, SsiB_sym, Nat_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+
+    S_batch = cute.sym_int64(divisibility=16)
+    state_fake = cute.runtime.make_fake_tensor(
+        cute.BFloat16,
+        shape=(N, HV_state, V, K),
+        stride=(S_batch, V * K, K, 1),
+        assumed_align=32,
+    )
+
+    G_batch_stride = cute.sym_int64(divisibility=16)
+    G_token_stride = cute.sym_int64(divisibility=16)
+    gate_fake = cute.runtime.make_fake_tensor(
+        cute.BFloat16,
+        shape=(B, T_dim, HV, K),
+        stride=(G_batch_stride, G_token_stride, K, 1),
+        assumed_align=32,
+    )
+
+    return cute.compile(
+        recurrent_kda_vtile_launch,
+        make_fake((B, T_dim, H, K)),  # q
+        make_fake((B, T_dim, H, K)),  # k
+        make_fake((B, T_dim, HV, V)),  # v
+        gate_fake,  # g
+        make_fake((B, T_dim, HV)),  # beta
+        state_fake,  # state
+        make_fake((B, T_dim, HV, V)),  # output
+        make_fake((ALog_sym,), dtype=cute.Float32),  # A_log
+        make_fake((HK_sym,), dtype=cute.Float32),  # dt_bias
+        make_fake((CuSeqlens_sym,), dtype=cute.Int32),  # cu_seqlens
+        make_fake((SsiB_sym,), dtype=cute.Int32),  # ssm_state_indices (flattened)
+        make_fake((Nat_sym,), dtype=cute.Int32),  # num_accepted_tokens
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        HEAD_DIM,
+        USE_QK_L2NORM,
+        USE_GATE_IN_KERNEL,
+        HAS_DT_BIAS,
+        USE_LOWER_BOUND,
+        USE_CU_SEQLENS,
+        NUM_TOKENS,
+        NUM_V_TILES,
+        V_TILE_ROWS,
+        options="--enable-tvm-ffi --generate-line-info",
+    )
+
+
+@functools.cache
+def _get_compiled_vtile_spec_decode_d128_kernel(
+    USE_QK_L2NORM,
+    USE_GATE_IN_KERNEL,
+    HAS_DT_BIAS,
+    USE_LOWER_BOUND,
+    USE_CU_SEQLENS,
+    NUM_TOKENS,
+    V_TILE_ROWS=32,
+):
+    """Dedicated D128 multi-token vtile compile surface with a moderate register cap."""
+    HEAD_DIM = 128
+    B, H, HV, N = cute.sym_int(), cute.sym_int(), cute.sym_int(), cute.sym_int()
+    K, V = HEAD_DIM, HEAD_DIM
+    NUM_V_TILES = HEAD_DIM // V_TILE_ROWS
+
+    def make_fake(shape, dtype=cute.BFloat16):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            shape,
+            assumed_align=32,
+            stride_order=tuple(reversed(range(len(shape)))),
+        )
+
+    T_dim = cute.sym_int() if USE_CU_SEQLENS == 1 else 1
+    HV_state, ALog_sym, HK_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+    CuSeqlens_sym, SsiB_sym, Nat_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+
+    S_batch = cute.sym_int64(divisibility=16)
+    state_fake = cute.runtime.make_fake_tensor(
+        cute.BFloat16,
+        shape=(N, HV_state, V, K),
+        stride=(S_batch, V * K, K, 1),
+        assumed_align=32,
+    )
+
+    G_batch_stride = cute.sym_int64(divisibility=16)
+    G_token_stride = cute.sym_int64(divisibility=16)
+    gate_fake = cute.runtime.make_fake_tensor(
+        cute.BFloat16,
+        shape=(B, T_dim, HV, K),
+        stride=(G_batch_stride, G_token_stride, K, 1),
+        assumed_align=32,
+    )
+
+    return cute.compile[
+        cute.EnableTVMFFI,
+        cute.GenerateLineInfo,
+        cute.PtxasOptions(f"--maxrregcount {_VTILE_SPEC_D128_MAXRREGCOUNT}"),
+    ](
+        recurrent_kda_vtile_spec_decode_launch,
+        make_fake((B, T_dim, H, K)),  # q
+        make_fake((B, T_dim, H, K)),  # k
+        make_fake((B, T_dim, HV, V)),  # v
+        gate_fake,  # g
+        make_fake((B, T_dim, HV)),  # beta
+        state_fake,  # state
+        make_fake((B, T_dim, HV, V)),  # output
+        make_fake((ALog_sym,), dtype=cute.Float32),  # A_log
+        make_fake((HK_sym,), dtype=cute.Float32),  # dt_bias
+        make_fake((CuSeqlens_sym,), dtype=cute.Int32),  # cu_seqlens
+        make_fake((SsiB_sym,), dtype=cute.Int32),  # ssm_state_indices (flattened)
+        make_fake((Nat_sym,), dtype=cute.Int32),  # num_accepted_tokens
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        HEAD_DIM,
+        USE_QK_L2NORM,
+        USE_GATE_IN_KERNEL,
+        HAS_DT_BIAS,
+        USE_LOWER_BOUND,
+        USE_CU_SEQLENS,
+        NUM_TOKENS,
+        NUM_V_TILES,
+        V_TILE_ROWS,
+    )
+
+
+def recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: Optional[torch.Tensor] = None,
+    dt_bias: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_gate_in_kernel: bool = False,
+    lower_bound: Optional[float] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    ssm_state_indices: Optional[torch.Tensor] = None,
+    num_spec_tokens: Optional[int] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    r"""Recurrent KDA (Key-Driven Attention) decode kernel.
+
+    This implements the decode phase of KDA linear attention with per-key-dimension
+    gating, processing one token at a time and updating the recurrent state in-place.
+    The logical recurrent state ``S`` is ``[K, V]`` and is stored transposed as
+    ``[V, K]`` in the kernel. Per token:
+    ``S = exp(g)[..., None] * S + beta * outer(k, v - k @ S)`` and
+    ``o = q @ S``.
+
+    Args:
+        q (torch.Tensor):
+            Current query of shape ``[B, 1, H, K]``, or ``[1, total_tokens, H, K]``
+            when using ``cu_seqlens``. Must be bfloat16.
+        k (torch.Tensor):
+            Current key of shape ``[B, 1, H, K]``. Must be bfloat16.
+        v (torch.Tensor):
+            Current value of shape ``[B, 1, HV, V]``. Must be bfloat16.
+            GQA is applied when ``HV != H``.
+        g (torch.Tensor):
+            Per-K-dimension gate of shape ``[B, 1, HV, K]``. Must be bfloat16.
+            Log-space if pre-computed, raw input if ``use_gate_in_kernel=True``.
+        beta (torch.Tensor):
+            Delta-rule learning rate of shape ``[B, 1, HV]``. Must be bfloat16.
+            Pre-sigmoided.
+        A_log (Optional[torch.Tensor]):
+            Log decay parameter of shape ``[H]``. Must be float32.
+            Required when ``use_gate_in_kernel=True``.
+        dt_bias (Optional[torch.Tensor]):
+            Per-head-K decay bias of shape ``[H*K]``. Must be float32.
+        scale (Optional[float]):
+            Scale factor for queries. If None, defaults to ``1 / sqrt(K)``.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape ``[N, HV, V, K]``. Must be bfloat16.
+            If None, zero-initialized. Updated in-place. For batched spec decode
+            without ``cu_seqlens``, ``N`` is the packed checkpoint-slot count
+            ``B * (1 + num_spec_tokens)`` when ``ssm_state_indices`` is omitted.
+        output_final_state (bool):
+            Whether to return the final state. Default: ``False``.
+        use_qk_l2norm_in_kernel (bool):
+            Whether to apply L2 normalization to Q and K. Default: ``True``.
+        use_gate_in_kernel (bool):
+            Whether to compute the gate inside the kernel from ``A_log`` and ``g``.
+            Default: ``False``.
+        lower_bound (Optional[float]):
+            If set, uses ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``
+            gate formula instead of softplus. Must be negative.
+        cu_seqlens (Optional[torch.Tensor]):
+            Cumulative sequence lengths of shape ``[N+1]``. Must be int32.
+        ssm_state_indices (Optional[torch.Tensor]):
+            State cache indices. Shape ``[N]`` int32 for standard decode, or
+            ``[N, 1+S]`` int32 for spec decode (``num_spec_tokens`` must also be
+            set). The wrapper flattens 2D indices to ``[N*(1+S)]`` before
+            passing to the kernel.
+        num_spec_tokens (Optional[int]):
+            Number of speculative tokens (S). When set, processes 1+S tokens in a single
+            fused kernel launch. If ``cu_seqlens`` is provided, requires 2D
+            ``ssm_state_indices`` ``[N, 1+S]``. If ``cu_seqlens`` is not provided,
+            the wrapper auto-builds the packed format from ``[B, 1+S, ...]`` inputs
+            (batched spec-decode shim). Must be >= 1.
+        num_accepted_tokens (Optional[torch.Tensor]):
+            Per-sequence accepted token count from the previous spec decode round.
+            Shape ``[N]`` int32. When provided, the kernel loads initial state from
+            ``ssm_state_indices[n, num_accepted_tokens[n] - 1]`` instead of
+            ``ssm_state_indices[n, 0]``, matching the FLA Triton kernel's behavior.
+            Kernel still writes all T=1+S checkpoint slots. Caller contract:
+            ``num_accepted_tokens >= 1`` (the bonus token is always accepted).
+            If ``None``, initial state is loaded from ``ssm_state_indices[n, 0]``
+            (backward compatible).
+        output (Optional[torch.Tensor]):
+            Pre-allocated output tensor. Shape ``[B, 1, HV, V]`` for standard
+            decode, ``[1, N*(1+S), HV, V]`` for spec decode with
+            ``cu_seqlens``, or ``[B, 1+S, HV, V]`` for batched spec decode
+            (``num_spec_tokens=S`` without ``cu_seqlens``). Must be
+            pre-allocated for CUDA graph capture; auto-allocated if ``None``.
+
+    Returns:
+        Tuple[torch.Tensor, Optional[torch.Tensor]]:
+            - output: Shape ``[B, 1, HV, V]`` (standard),
+              ``[1, N*(1+S), HV, V]`` (spec decode with ``cu_seqlens``), or
+              ``[B, 1+S, HV, V]`` (batched spec decode without
+              ``cu_seqlens``). Padded sequence positions are zero-filled
+              in spec mode.
+            - state: Updated state of shape ``[N, HV, V, K]`` if
+              ``output_final_state=True``, else ``None``. For batched spec
+              decode without ``cu_seqlens``, this is the packed checkpoint
+              state pool used by the shim.
+
+    Note:
+        - Requires SM100 (Blackwell) architecture
+        - State is bfloat16 ``[N, HV, V, K]`` and updated in-place
+        - HEAD_DIM (K=V) must be 64 or 128
+        - When using ``cu_seqlens``, batch size ``B`` must be 1
+        - Spec mode (``num_spec_tokens=S``): ``cu_seqlens`` must step by
+          ``1+S`` for every row including padded sequences (which signal via
+          ``ssm_state_indices == -1``). Guaranteed by vLLM's
+          ``GDNAttentionMetadata``; not validated at runtime (CUDA graph compat).
+        - ``KDA_USE_VTILE`` and ``KDA_V_TILE_ROWS`` are internal benchmarking
+          overrides for the auto-dispatch heuristic.
+    """
+    B, T, H, K = q.shape
+    _, _, HV, V = v.shape
+    device = q.device
+    if K != V:
+        raise ValueError(f"K must equal V, got K={K}, V={V}")
+    if K not in (64, 128):
+        raise ValueError(f"HEAD_DIM must be 64 or 128, got K={K}")
+    for name, tensor in (("q", q), ("k", k), ("v", v), ("g", g), ("beta", beta)):
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{name} must be bfloat16, got {tensor.dtype}")
+    if HV < H or HV % H != 0:
+        raise ValueError(f"HV must be a positive multiple of H, got H={H}, HV={HV}")
+
+    if use_gate_in_kernel:
+        if A_log is None:
+            raise ValueError("A_log is required when use_gate_in_kernel=True")
+        if A_log.dtype != torch.float32:
+            raise TypeError(f"A_log must be float32, got {A_log.dtype}")
+    if dt_bias is not None and dt_bias.dtype != torch.float32:
+        raise TypeError(f"dt_bias must be float32, got {dt_bias.dtype}")
+    if lower_bound is not None:
+        if not use_gate_in_kernel:
+            raise ValueError("lower_bound requires use_gate_in_kernel=True")
+        if lower_bound >= 0.0:
+            raise ValueError("lower_bound must be negative")
+
+    if (
+        num_spec_tokens is not None
+        and cu_seqlens is not None
+        and ssm_state_indices is None
+    ):
+        raise ValueError(
+            "ssm_state_indices is required when num_spec_tokens is set with cu_seqlens"
+        )
+
+    # Batched spec-decode shim: auto-converts [B,T,...] to packed [1,B*T,...] format.
+    _batched_spec_B = None
+    if num_spec_tokens is not None and cu_seqlens is None:
+        T_spec = 1 + num_spec_tokens
+        if T_spec != T:
+            raise ValueError(
+                f"q.shape[1]={T} must equal 1+num_spec_tokens={T_spec} "
+                f"when cu_seqlens is not provided"
+            )
+        if (
+            initial_state is not None
+            and ssm_state_indices is None
+            and initial_state.shape[0] < B * T_spec
+        ):
+            raise ValueError(
+                "initial_state must have at least B*(1+num_spec_tokens) slots "
+                "when batched spec decode auto-generates ssm_state_indices"
+            )
+        _batched_spec_B = B  # save original B for output reshape
+        # Reshape [B, T, ...] -> [1, B*T, ...] -- pure view, no copy
+        q = q.reshape(1, B * T_spec, H, K)
+        k = k.reshape(1, B * T_spec, H, K)
+        v = v.reshape(1, B * T_spec, HV, V)
+        g = g.reshape(1, B * T_spec, HV, K)
+        beta = beta.reshape(1, B * T_spec, HV)
+        # Auto-build cu_seqlens: [0, T, 2T, ..., B*T]
+        cu_seqlens = torch.arange(
+            0, B * T_spec + 1, step=T_spec, dtype=torch.int32, device=device
+        )
+        # Auto-build ssm_state_indices [B, T] if not provided
+        if ssm_state_indices is None:
+            ssm_state_indices = torch.arange(
+                B * T_spec, dtype=torch.int32, device=device
+            ).reshape(B, T_spec)
+        # Output pre-allocation: reshape caller-provided output if shape matches
+        if output is not None and output.shape == (B, T_spec, HV, V):
+            output = output.reshape(1, B * T_spec, HV, V)
+        # Update B, T to reflect packed format
+        B, T = 1, B * T_spec
+
+    if cu_seqlens is not None:
+        if B != 1:
+            raise ValueError(f"Batch size must be 1 with cu_seqlens, got B={B}")
+        NUM_TOKENS = 1
+        if num_spec_tokens is not None:
+            if num_spec_tokens <= 0:
+                raise ValueError(
+                    f"num_spec_tokens must be >= 1, got {num_spec_tokens}. "
+                    f"Use num_spec_tokens=None for standard decode."
+                )
+            NUM_TOKENS = 1 + num_spec_tokens
+            N = cu_seqlens.shape[0] - 1
+            if ssm_state_indices.ndim != 2 or ssm_state_indices.shape[1] != NUM_TOKENS:
+                raise ValueError(
+                    f"ssm_state_indices must be 2D [N, {NUM_TOKENS}] in spec mode, "
+                    f"got shape {list(ssm_state_indices.shape)}"
+                )
+            if ssm_state_indices.shape[0] != N:
+                raise ValueError(
+                    f"ssm_state_indices.shape[0]={ssm_state_indices.shape[0]} must equal "
+                    f"N={N} (cu_seqlens.shape[0]-1)"
+                )
+            if initial_state is not None and initial_state.shape[0] == 0:
+                raise ValueError(
+                    "initial_state must have at least 1 slot when cu_seqlens is used"
+                )
+        N = cu_seqlens.shape[0] - 1
+        cu_seqlens_i32 = cu_seqlens.to(torch.int32)
+        ssi = (
+            ssm_state_indices.to(torch.int32).contiguous().view(-1)
+            if ssm_state_indices is not None
+            else torch.arange(N, dtype=torch.int32, device=device)
+        )
+        if initial_state is None:
+            max_idx = (
+                max(0, int(ssi[ssi >= 0].max().item())) + 1 if (ssi >= 0).any() else 1
+            )
+            state = torch.zeros(max_idx, HV, V, K, device=device, dtype=torch.bfloat16)
+        else:
+            state = initial_state
+        if num_spec_tokens is not None:
+            # Spec mode: zero-init output so padded positions are well-defined.
+            # Reuse caller buffer when possible to avoid allocation (CUDA graph compat).
+            if (
+                output is not None
+                and output.shape == (1, N * NUM_TOKENS, HV, V)
+                and output.dtype == q.dtype
+                and output.device == device
+            ):
+                output.zero_()
+                out_buf = output
+            else:
+                out_buf = torch.zeros(
+                    1, N * NUM_TOKENS, HV, V, device=device, dtype=q.dtype
+                )
+        else:
+            if (
+                output is not None
+                and output.shape == v.shape
+                and output.dtype == q.dtype
+                and output.device == device
+            ):
+                output.zero_()
+                out_buf = output
+            else:
+                out_buf = torch.zeros_like(v)
+    else:
+        if T != 1:
+            raise ValueError(
+                f"Decode only supports T=1 without cu_seqlens, got T={T}. "
+                f"For multi-token decode, use cu_seqlens or num_spec_tokens."
+            )
+        if initial_state is not None and not initial_state.is_contiguous():
+            raise ValueError(
+                "non-contiguous initial_state requires cu_seqlens: without cu_seqlens "
+                "the wrapper calls .contiguous() which copies the state, so in-place "
+                "updates would be silently lost on the original tensor"
+            )
+        cu_seqlens_i32 = None
+        ssi = None
+        if initial_state is None:
+            state = torch.zeros(B, HV, V, K, device=device, dtype=torch.bfloat16)
+        elif ssm_state_indices is not None:
+            state = initial_state[ssm_state_indices].contiguous()
+        else:
+            state = initial_state.contiguous()
+        if (
+            output is not None
+            and output.shape == (B, 1, HV, V)
+            and output.dtype == q.dtype
+            and output.device == device
+        ):
+            out_buf = output
+        else:
+            out_buf = torch.empty(B, 1, HV, V, device=device, dtype=q.dtype)
+
+    # Compile kernel (cached by constexpr config)
+    USE_QK_NORM = 1 if use_qk_l2norm_in_kernel else 0
+    USE_GATE = 1 if use_gate_in_kernel else 0
+    HAS_BIAS = 1 if dt_bias is not None else 0
+    USE_LB = 1 if lower_bound is not None else 0
+    USE_CU = 1 if cu_seqlens_i32 is not None else 0
+    if cu_seqlens is None:
+        NUM_TOKENS = 1
+    # Dispatch between the base and v-tiled kernels.
+    #   - base:  grid = B*HV, one CTA per (batch, head), SMEM ping-pong over V chunks.
+    #            Wins when the grid is large enough to saturate SMs (larger B).
+    #   - vtile: grid = B*HV*(HEAD_DIM/32), one CTA per (batch, head, v_tile),
+    #            register-carry h, no ping-pong. Wins when the base grid
+    #            under-subscribes the GPU (small B) by expanding the grid 2-4x.
+    # Threshold mirrors upstream GDN's `_select_tile_v_for_batch` heuristic
+    # (flashinfer gdn_kernels/gdn_decode_bf16_state.py): switch to vtile when
+    # the base grid is below ~4 waves of SMs. Measured crossover on B200 matches
+    # (B=16 break-even, B<=4 vtile 1.5-1.7x, B>=64 base 7-20% faster).
+    # KDA_USE_VTILE=1/0 forces a specific path (for A/B tests, benchmarks).
+    # A register-resident ILP MTP port was evaluated and rejected in the
+    # original kda-cutedsl tuning notes.
+    _vtile_env = os.environ.get("KDA_USE_VTILE")
+    if _vtile_env == "1":
+        use_vtile = True
+    elif _vtile_env == "0":
+        use_vtile = False
+    else:
+        grid_seqs = cu_seqlens_i32.shape[0] - 1 if cu_seqlens_i32 is not None else B
+        base_grid = grid_seqs * HV
+        use_vtile = base_grid < 4 * _get_num_sms(device)
+
+    # V-row tile size inside vtile: 32 (standard) or 16 (finer-grained).
+    # V_TILE_ROWS=16 doubles the vtile grid at D=128 (see the parameterized
+    # load/store helpers + guards in _process_v_chunk). Measured on B200 at
+    # H32-D128-lb B=1 (2026-04-17): grid 128->256, waves/SM 0.12->0.25, SM
+    # Busy 3%->6.3%, but wall-time +3% (kernel stays latency-bound per CTA
+    # and the 2nd block per SM doesn't fully overlap). Not enabled by
+    # default; KDA_V_TILE_ROWS=16 forces it for A/B experiments.
+    _v_tile_env = os.environ.get("KDA_V_TILE_ROWS")
+    if _v_tile_env == "16":
+        V_TILE_ROWS = 16
+    else:
+        V_TILE_ROWS = 32
+
+    if use_vtile:
+        if K == 128 and NUM_TOKENS > 1:
+            compiled = _get_compiled_vtile_spec_decode_d128_kernel(
+                USE_QK_NORM,
+                USE_GATE,
+                HAS_BIAS,
+                USE_LB,
+                USE_CU,
+                NUM_TOKENS,
+                V_TILE_ROWS,
+            )
+        else:
+            compiled = _get_compiled_vtile_kernel(
+                K,
+                USE_QK_NORM,
+                USE_GATE,
+                HAS_BIAS,
+                USE_LB,
+                USE_CU,
+                NUM_TOKENS,
+                V_TILE_ROWS,
+            )
+    else:
+        compiled = _get_compiled_kernel(
+            K, USE_QK_NORM, USE_GATE, HAS_BIAS, USE_LB, USE_CU, NUM_TOKENS
+        )
+
+    # Dummy tensors for unused optional args (TVM FFI requires all args present)
+    global _dummy_cache
+    if device not in _dummy_cache:
+        _dummy_cache[device] = {
+            "f32_1": torch.zeros(1, device=device, dtype=torch.float32),
+            "i32_1": torch.zeros(1, device=device, dtype=torch.int32),
+        }
+    dc = _dummy_cache[device]
+
+    if num_accepted_tokens is not None:
+        num_accepted_tokens_i32 = (
+            num_accepted_tokens
+            if num_accepted_tokens.dtype == torch.int32
+            else num_accepted_tokens.to(torch.int32)
+        )
+    elif cu_seqlens_i32 is not None and NUM_TOKENS > 1:
+        nat_key = f"i32_ones_{cu_seqlens_i32.shape[0] - 1}"
+        if nat_key not in dc:
+            dc[nat_key] = torch.ones(
+                cu_seqlens_i32.shape[0] - 1, device=device, dtype=torch.int32
+            )
+        num_accepted_tokens_i32 = dc[nat_key]
+    else:
+        num_accepted_tokens_i32 = dc["i32_1"]
+
+    compiled(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        state,
+        out_buf,
+        A_log if A_log is not None else dc["f32_1"],
+        dt_bias if dt_bias is not None else dc["f32_1"],
+        cu_seqlens_i32 if cu_seqlens_i32 is not None else dc["i32_1"],
+        ssi if ssi is not None else dc["i32_1"],
+        num_accepted_tokens_i32,
+        scale if scale is not None else 1.0 / math.sqrt(K),
+        1e-6,
+        lower_bound if lower_bound is not None else 0.0,
+    )
+
+    # Reshape output back to [B, T, HV, V] for batched spec decode
+    if _batched_spec_B is not None:
+        T_spec = 1 + num_spec_tokens
+        out_buf = out_buf.reshape(_batched_spec_B, T_spec, HV, V)
+
+    return (out_buf, state if output_final_state else None)

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -1858,7 +1858,7 @@ def _get_compiled_vtile_spec_decode_d128_kernel(
     )
 
 
-def recurrent_kda(
+def run_recurrent_kda(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -2132,10 +2132,12 @@ def recurrent_kda(
             )
         cu_seqlens_i32 = None
         ssi = None
+        copy_back_indices = None
         if initial_state is None:
             state = torch.zeros(B, HV, V, K, device=device, dtype=torch.bfloat16)
         elif ssm_state_indices is not None:
             state = initial_state[ssm_state_indices].contiguous()
+            copy_back_indices = ssm_state_indices
         else:
             state = initial_state.contiguous()
         if (
@@ -2261,6 +2263,9 @@ def recurrent_kda(
         1e-6,
         lower_bound if lower_bound is not None else 0.0,
     )
+
+    if cu_seqlens_i32 is None and copy_back_indices is not None:
+        initial_state[copy_back_indices] = state
 
     # Reshape output back to [B, T, HV, V] for batched spec decode
     if _batched_spec_B is not None:

--- a/tests/kda/conftest.py
+++ b/tests/kda/conftest.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/kda/test_recurrent_kda.py
+++ b/tests/kda/test_recurrent_kda.py
@@ -8,9 +8,9 @@ import torch.nn.functional as F
 from flashinfer.utils import is_sm100a_supported
 
 try:
-    from flashinfer.kda_kernels import recurrent_kda
+    from flashinfer.kda_decode import _RECURRENT_KDA_AVAILABLE, recurrent_kda
 
-    _has_recurrent_kda = recurrent_kda is not None
+    _has_recurrent_kda = _RECURRENT_KDA_AVAILABLE
 except ImportError:
     recurrent_kda = None
     _has_recurrent_kda = False
@@ -437,6 +437,70 @@ def test_vllm_decode(
     ref_untouched = state_pool_bf16[unaccessed].transpose(-1, -2).float()
     # Untouched slots should not have been modified by the kernel
     assert_close("Untouched ht", ref_untouched, tri_untouched, atol=1e-2, rtol=1e-2)
+
+
+def test_standard_decode_state_indices_update_pool():
+    """Standard decode with ssm_state_indices updates the caller's state pool."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    B, H, D = 4, 8, 64
+    HV = H
+    n_slots = B * 3
+
+    q = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, 1, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, 1, HV, D, device=device)).to(dtype)
+    beta = torch.rand(B, 1, HV, dtype=dtype, device=device).sigmoid()
+    scale = D**-0.5
+
+    state_pool = torch.randn(n_slots, HV, D, D, dtype=dtype, device=device) * 0.01
+    state_indices = torch.randperm(n_slots, device=device)[:B].int()
+    untouched = torch.ones(n_slots, dtype=torch.bool, device=device)
+    untouched[state_indices.long()] = False
+
+    compact_state = state_pool[state_indices].clone()
+    ref_out, ref_state = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=compact_state,
+        output_final_state=True,
+    )
+
+    indexed_pool = state_pool.clone()
+    original_untouched = indexed_pool[untouched].clone()
+    tri_out, tri_state = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=indexed_pool,
+        output_final_state=True,
+        ssm_state_indices=state_indices,
+    )
+
+    assert_close("indexed output", ref_out.float(), tri_out.float())
+    assert_close("indexed returned state", ref_state.float(), tri_state.float())
+    assert_close(
+        "indexed state pool",
+        ref_state.float(),
+        indexed_pool[state_indices.long()].float(),
+    )
+    assert_close(
+        "indexed untouched state",
+        original_untouched.float(),
+        indexed_pool[untouched].float(),
+        atol=1e-3,
+        rtol=1e-3,
+    )
 
 
 # ==============================================================================
@@ -1055,9 +1119,7 @@ def test_spec_decode_basic(N, H, HV, D, num_spec_tokens, use_qk_l2norm_in_kernel
     )
 
     # Output comparison
-    assert_close(
-        "spec_output", ref_out.bfloat16().float(), tri_out.float(), atol=1e-1, rtol=5e-2
-    )
+    assert_close("spec_output", ref_out.float(), tri_out.float(), atol=1e-1, rtol=5e-2)
 
     # Per-token state comparison (EACH slot must match)
     assert_spec_states(
@@ -1122,7 +1184,7 @@ def test_spec_decode_gate_modes(gate_mode):
         q,
         k,
         v,
-        g_ref.bfloat16(),
+        g_ref,
         beta,
         ssm_state_indices,
         state_pool,
@@ -1153,7 +1215,7 @@ def test_spec_decode_gate_modes(gate_mode):
 
     assert_close(
         "spec_output_gate",
-        ref_out.bfloat16().float(),
+        ref_out.float(),
         tri_out.float(),
         atol=1e-1,
         rtol=5e-2,
@@ -1257,7 +1319,7 @@ def test_spec_decode_padded_cuda_graph(D):
     # Active outputs correct (first N_active*T output positions)
     assert_close(
         "padded_active_out",
-        ref_out_active.bfloat16().float(),
+        ref_out_active.float(),
         tri_out[:, : N_active * T].float(),
         atol=1e-1,
         rtol=5e-2,
@@ -1831,7 +1893,7 @@ def test_spec_decode_checkpoint_correctness():
 
     assert_close(
         "checkpoint_out",
-        ref_out.bfloat16().float(),
+        ref_out.float(),
         tri_out.float(),
         atol=1e-1,
         rtol=5e-2,
@@ -1896,9 +1958,7 @@ def test_spec_decode_non_compact_state():
         num_spec_tokens=num_spec_tokens,
     )
 
-    assert_close(
-        "nc_output", ref_out.bfloat16().float(), tri_out.float(), atol=1e-1, rtol=5e-2
-    )
+    assert_close("nc_output", ref_out.float(), tri_out.float(), atol=1e-1, rtol=5e-2)
     # Verify each per-token state checkpoint slot in the non-compact pool
     for b in range(N):
         for t in range(T):
@@ -2229,7 +2289,7 @@ def test_spec_decode_batched_auto_ssi():
     ref_out_batched = ref_out.reshape(B, T, HV, D)
     assert_close(
         "auto_ssi_out",
-        ref_out_batched.bfloat16().float(),
+        ref_out_batched.float(),
         tri_out.float(),
         atol=1e-1,
         rtol=5e-2,

--- a/tests/kda/test_recurrent_kda.py
+++ b/tests/kda/test_recurrent_kda.py
@@ -1,0 +1,2243 @@
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# Adapted for Recurrent KDA kernel testing
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.utils import is_sm100a_supported
+
+try:
+    from flashinfer.kda_kernels import recurrent_kda
+
+    _has_recurrent_kda = recurrent_kda is not None
+except ImportError:
+    recurrent_kda = None
+    _has_recurrent_kda = False
+
+try:
+    from fla.ops.kda import fused_recurrent_kda
+
+    _has_fla = True
+except ImportError:
+    _has_fla = False
+
+
+@pytest.fixture(autouse=True)
+def _require_recurrent_kda():
+    if not torch.cuda.is_available():
+        pytest.skip("Recurrent KDA requires CUDA")
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("Recurrent KDA requires SM100a (Blackwell)")
+    if not _has_recurrent_kda:
+        pytest.skip("recurrent_kda kernel not available (missing cutlass DSL deps)")
+
+
+# ==============================================================================
+# Reference implementations (inlined to avoid external dependencies)
+# ==============================================================================
+
+
+def naive_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+):
+    dtype = v.dtype
+    B, T, H, K, V = *q.shape, v.shape[-1]
+    if scale is None:
+        scale = K**-0.5
+
+    q, k, v, g, beta = map(lambda x: x.to(torch.float), [q, k, v, g, beta])
+    q = q * scale
+
+    S = k.new_zeros(B, H, K, V).to(q)
+    if initial_state is not None:
+        S += initial_state
+    o = torch.zeros_like(v)
+    for i in range(0, T):
+        q_i, k_i, v_i, g_i, b_i = q[:, i], k[:, i], v[:, i], g[:, i], beta[:, i]
+        S = S * g_i[..., None].exp()
+        S = S + torch.einsum(
+            "b h k, b h v -> b h k v",
+            b_i[..., None] * k_i,
+            v_i - (k_i[..., None] * S).sum(-2),
+        )
+        o[:, i] = torch.einsum("b h k, b h k v -> b h v", q_i, S)
+    if not output_final_state:
+        S = None
+    return o.to(dtype), S
+
+
+def naive_kda_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None = None,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    H, _ = g.shape[-2:]
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, -1)
+    g = (-A_log.view(H, 1).float().exp() * F.softplus(g.float())).to(output_dtype)
+    return g
+
+
+def naive_kda_lowerbound_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float = -5.0,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    H, _ = g.shape[-2:]
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, -1)
+    g = lower_bound * F.sigmoid(A_log.view(H, 1).exp() * g)
+    return g.to(output_dtype)
+
+
+# ==============================================================================
+# Test helpers
+# ==============================================================================
+
+
+def assert_close(prefix, ref, tri, atol=5e-3, rtol=5e-3):
+    """Assert tensors are close with bf16-appropriate tolerances."""
+    ref_f, tri_f = ref.float(), tri.float()
+    abs_diff = (ref_f - tri_f).flatten().abs().max().item()
+    assert not torch.isnan(ref).any(), f"{prefix}: NaN in ref"
+    assert not torch.isnan(tri).any(), f"{prefix}: NaN in tri"
+    torch.testing.assert_close(
+        ref_f, tri_f, atol=atol, rtol=rtol, msg=f"{prefix} diff: {abs_diff:.6f}"
+    )
+
+
+def maybe_l2norm(x: torch.Tensor, enabled: bool) -> torch.Tensor:
+    x = x.float()
+    return F.normalize(x, p=2, dim=-1) if enabled else x
+
+
+# ==============================================================================
+# Tests
+# ==============================================================================
+
+# Shared configs for vs_naive and vs_fla tests: (B, T, H, D, scale, norm, qk_l2, dtype)
+_VS_REFERENCE_CONFIGS = [
+    (1, 1, 4, 64, 1, 1, True, torch.bfloat16),
+    (1, 1, 4, 64, 1, 1, False, torch.bfloat16),
+    (4, 1, 4, 128, 0.1, 1, True, torch.bfloat16),
+    (4, 1, 4, 128, 0.1, 1, False, torch.bfloat16),
+    (16, 1, 4, 128, 0.1, 1, True, torch.bfloat16),
+]
+
+_VS_REFERENCE_PARAMS = [
+    pytest.param(*test, id="B{}-T{}-H{}-D{}-scale{}-norm{}-qk_l2{}-{}".format(*test))
+    for test in _VS_REFERENCE_CONFIGS
+]
+
+
+def _make_vs_reference_tensors(B, T, H, D, gate_logit_normalizer, dtype):
+    """Create shared tensors for vs_naive / vs_fla tests."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    g = (
+        F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float, device=device))
+        / gate_logit_normalizer
+    ).to(dtype)
+    beta = torch.randn(B, T, H, dtype=dtype, device=device).sigmoid()
+    h0_bf16 = torch.randn(B, H, D, D, dtype=torch.bfloat16, device=device) * 0.01
+    h0_f32 = h0_bf16.transpose(-1, -2).float()
+    return q, k, v, g, beta, h0_bf16, h0_f32
+
+
+@pytest.mark.parametrize(
+    (
+        "B",
+        "T",
+        "H",
+        "D",
+        "scale",
+        "gate_logit_normalizer",
+        "use_qk_l2norm_in_kernel",
+        "dtype",
+    ),
+    _VS_REFERENCE_PARAMS,
+)
+def test_recurrent_kda_vs_naive(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    use_qk_l2norm_in_kernel: bool,
+    dtype: torch.dtype,
+):
+    """Recurrent KDA kernel matches naive recurrent KDA reference."""
+    q, k, v, g, beta, h0_bf16, h0_f32 = _make_vs_reference_tensors(
+        B, T, H, D, gate_logit_normalizer, dtype
+    )
+
+    # Reference: naive recurrent (float32, pre-normalized)
+    ref, ref_ht = naive_recurrent_kda(
+        q=maybe_l2norm(q, use_qk_l2norm_in_kernel),
+        k=maybe_l2norm(k, use_qk_l2norm_in_kernel),
+        v=v.float(),
+        g=g.float(),
+        beta=beta.float(),
+        scale=scale,
+        initial_state=h0_f32.clone(),
+        output_final_state=True,
+    )
+
+    # Recurrent KDA kernel (bf16 state [B, H, V, K], optional in-kernel L2 norm)
+    tri, tri_ht = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=h0_bf16.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    assert_close("o", ref, tri)
+    # Convert Recurrent KDA bf16 [V,K] state to f32 [K,V] for comparison
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2).float())
+
+
+@pytest.mark.skipif(not _has_fla, reason="fla package not installed")
+@pytest.mark.parametrize(
+    (
+        "B",
+        "T",
+        "H",
+        "D",
+        "scale",
+        "gate_logit_normalizer",
+        "use_qk_l2norm_in_kernel",
+        "dtype",
+    ),
+    _VS_REFERENCE_PARAMS,
+)
+def test_recurrent_kda_vs_fla(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    use_qk_l2norm_in_kernel: bool,
+    dtype: torch.dtype,
+):
+    """Recurrent KDA kernel matches fla fused_recurrent_kda."""
+    q, k, v, g, beta, h0_bf16, h0_f32 = _make_vs_reference_tensors(
+        B, T, H, D, gate_logit_normalizer, dtype
+    )
+
+    # fla reference (f32 state [K,V])
+    ref, ref_ht = fused_recurrent_kda(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        g=g.float(),
+        beta=beta.float(),
+        scale=scale,
+        initial_state=h0_f32.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    # Recurrent KDA (bf16 state [B, H, V, K])
+    tri, tri_ht = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=h0_bf16.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    assert_close("o", ref, tri)
+    # Convert Recurrent KDA bf16 [V,K] state to f32 [K,V] for comparison
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2).float())
+
+
+@pytest.mark.parametrize(
+    (
+        "B",
+        "H",
+        "D",
+        "scale",
+        "gate_logit_normalizer",
+        "use_qk_l2norm_in_kernel",
+        "use_gate_in_kernel",
+        "safe_gate",
+        "dtype",
+    ),
+    [
+        pytest.param(
+            *test,
+            id="B{}-H{}-D{}-scale{}-norm{}-qk_l2{}-gate{}-safe{}-{}".format(*test),
+        )
+        for test in [
+            (16, 16, 128, 0.1, 1.0, True, False, False, torch.bfloat16),
+            (4, 16, 128, 0.1, 1.0, False, False, False, torch.bfloat16),
+            (32, 8, 64, 1.0, 1.0, True, False, False, torch.bfloat16),
+            (8, 8, 64, 1.0, 1.0, False, True, False, torch.bfloat16),
+            (7, 32, 128, 0.5, 0.5, True, False, False, torch.bfloat16),
+            (16, 16, 128, 0.1, 1.0, True, True, False, torch.bfloat16),
+            (32, 8, 64, 1.0, 1.0, True, True, False, torch.bfloat16),
+            (7, 32, 128, 0.5, 0.5, True, True, False, torch.bfloat16),
+            (7, 32, 128, 0.5, 0.5, True, True, True, torch.bfloat16),
+            (4, 32, 128, 0.5, 0.5, False, True, True, torch.bfloat16),
+        ]
+    ],
+)
+def test_vllm_decode(
+    B: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    use_qk_l2norm_in_kernel: bool,
+    use_gate_in_kernel: bool,
+    safe_gate: bool,
+    dtype: torch.dtype,
+):
+    """vLLM-style decoding: continuous batching with paged state, Recurrent KDA vs naive."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    # Setup cache pool (bf16 [V,K] for Recurrent KDA)
+    max_cache_slots = B * 3
+    state_pool_bf16 = torch.randn(
+        max_cache_slots, H, D, D, dtype=torch.bfloat16, device=device
+    )
+    state_indices = torch.randperm(max_cache_slots, device=device)[:B].int()
+
+    # Fill unaccessed slots with huge value to detect out-of-bound access
+    HUGE_VALUE = 1e4  # bf16 max is ~65504, use 1e4 as sentinel
+    unaccessed = torch.ones(max_cache_slots, dtype=torch.bool, device=device)
+    unaccessed[state_indices.long()] = False
+    state_pool_bf16[unaccessed] = HUGE_VALUE
+
+    T = 1
+    total_tokens = B * T
+
+    q = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    g = torch.randn(
+        1,
+        total_tokens,
+        H,
+        D,
+        dtype=torch.float if not use_gate_in_kernel else dtype,
+        device=device,
+    )
+
+    if use_gate_in_kernel:
+        A_log = torch.log(
+            torch.randn(1, 1, H, 1, dtype=torch.float32, device=device).uniform_(1, 16)
+        ).squeeze()
+        dt_bias = torch.randn(H * D, dtype=torch.float32, device=device)
+        lower_bound = -5.0 if safe_gate else None
+        naive_gate_fn = naive_kda_lowerbound_gate if safe_gate else naive_kda_gate
+    else:
+        g = (F.logsigmoid(g) / gate_logit_normalizer).to(dtype)
+        A_log = None
+        dt_bias = None
+        lower_bound = None
+        naive_gate_fn = None
+
+    beta = torch.randn(1, total_tokens, H, dtype=dtype, device=device).sigmoid()
+
+    cu_seqlens = torch.arange(
+        0, total_tokens + 1, step=T, device=device, dtype=torch.long
+    )
+    # Reference needs f32 [K,V] state; Recurrent KDA uses bf16 [V,K] directly
+    ref_state_pool = state_pool_bf16.transpose(-1, -2).float()
+    tri_state_pool_bf16 = state_pool_bf16.clone()
+
+    # Reference: loop over batch with naive recurrent
+    ref_outputs = []
+    for i in range(B):
+        start, end = i, i + 1
+        slot_idx = state_indices[i].item()
+
+        q_i = q[:, start:end]
+        k_i = k[:, start:end]
+        v_i = v[:, start:end]
+        g_i = g[:, start:end]
+        beta_i = beta[:, start:end]
+
+        h_init = ref_state_pool[slot_idx].unsqueeze(0)
+        gate_kwargs = dict(lower_bound=lower_bound) if safe_gate else {}
+        ref_o_i, ref_ht_i = naive_recurrent_kda(
+            q=maybe_l2norm(q_i, use_qk_l2norm_in_kernel),
+            k=maybe_l2norm(k_i, use_qk_l2norm_in_kernel),
+            v=v_i.float(),
+            g=(
+                naive_gate_fn(g_i, A_log, dt_bias, **gate_kwargs).float()
+                if use_gate_in_kernel
+                else g_i.float()
+            ),
+            beta=beta_i.float(),
+            scale=scale,
+            initial_state=h_init.clone(),
+            output_final_state=True,
+        )
+        ref_outputs.append(ref_o_i)
+        ref_state_pool[slot_idx] = ref_ht_i.squeeze(0)
+
+    ref_out = torch.cat(ref_outputs, dim=1)
+
+    # Recurrent KDA kernel with cu_seqlens + ssm_state_indices (bf16 state)
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=tri_state_pool_bf16,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        lower_bound=lower_bound,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+    )
+
+    assert_close("o", ref_out, tri_out)
+    # Convert Recurrent KDA bf16 [V,K] state to f32 [K,V] for comparison
+    tri_ht_f32 = tri_state_pool_bf16[state_indices.long()].transpose(-1, -2).float()
+    assert_close("ht", ref_state_pool[state_indices.long()], tri_ht_f32)
+
+    # Verify untouched slots (bf16 state pool)
+    tri_untouched = tri_state_pool_bf16[unaccessed].transpose(-1, -2).float()
+    ref_untouched = state_pool_bf16[unaccessed].transpose(-1, -2).float()
+    # Untouched slots should not have been modified by the kernel
+    assert_close("Untouched ht", ref_untouched, tri_untouched, atol=1e-2, rtol=1e-2)
+
+
+# ==============================================================================
+# vLLM CUDA graph padding tests
+# ==============================================================================
+
+
+@pytest.mark.parametrize(
+    ("H", "D", "use_gate_in_kernel", "use_qk_l2norm_in_kernel"),
+    [
+        pytest.param(8, 64, False, True, id="H8-D64-precomputed"),
+        pytest.param(16, 128, False, True, id="H16-D128-precomputed"),
+        pytest.param(8, 64, False, False, id="H8-D64-precomputed-no-qk-l2"),
+        pytest.param(8, 64, True, True, id="H8-D64-in-kernel"),
+        pytest.param(16, 128, True, True, id="H16-D128-in-kernel"),
+    ],
+)
+def test_vllm_padded_cuda_graph(
+    H: int, D: int, use_gate_in_kernel: bool, use_qk_l2norm_in_kernel: bool
+):
+    """vLLM CUDA graph padding: padded slots (PAD_SLOT_ID=-1, seq_len=0) must not
+    corrupt any state, and active slots must produce correct output + state.
+
+    This verifies three things:
+    1. In-kernel clamp: PAD_SLOT_ID=-1 doesn't cause IMA (negative pointer offset)
+    2. seq_len guard: state slot 0 is not corrupted by padded CTAs
+    3. Active slots: output and state match naive reference
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    B_active = 4
+    B_padded = 3  # padded slots appended to simulate CUDA graph fixed batch size
+    B_total = B_active + B_padded
+
+    # State pool: active slots randomly placed, slot 0 filled with sentinel
+    max_slots = 32
+    SENTINEL = 7.0  # visible value to detect corruption (bf16 max ~65504)
+    state_pool = torch.zeros(max_slots, H, D, D, dtype=dtype, device=device)
+    state_pool[0] = SENTINEL  # slot 0 is the clamp target for padded entries
+
+    # Assign active slots to random non-zero indices
+    active_indices = torch.randperm(max_slots - 1, device=device)[:B_active] + 1
+    state_pool[active_indices.long()] = (
+        torch.randn(B_active, H, D, D, dtype=dtype, device=device) * 0.01
+    )
+    state_pool_ref = state_pool.clone()
+
+    # Inputs: [1, B_total, H, D] packed
+    q = torch.rand(1, B_total, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, B_total, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, B_total, H, D, dtype=dtype, device=device)
+
+    if use_gate_in_kernel:
+        g = torch.randn(1, B_total, H, D, dtype=dtype, device=device)
+        A_log = torch.log(
+            torch.ones(H, dtype=torch.float32, device=device).uniform_(1, 16)
+        )
+        dt_bias = torch.randn(H * D, dtype=torch.float32, device=device)
+        lower_bound = None
+        naive_gate_fn = naive_kda_gate
+    else:
+        g = (F.logsigmoid(torch.randn(1, B_total, H, D, device=device)) / 1.0).to(dtype)
+        A_log = None
+        dt_bias = None
+        lower_bound = None
+        naive_gate_fn = None
+
+    beta = torch.rand(1, B_total, H, dtype=dtype, device=device).sigmoid()
+
+    # cu_seqlens: active tokens have 1 token each, padded tokens have 0
+    # [0, 1, 2, 3, 4, 4, 4, 4] -- last B_padded entries are duplicates
+    cu_seqlens = torch.cat(
+        [
+            torch.arange(B_active + 1, device=device, dtype=torch.int32),
+            torch.full((B_padded,), B_active, device=device, dtype=torch.int32),
+        ]
+    )
+
+    # ssm_state_indices: active -> real slots, padded -> PAD_SLOT_ID=-1
+    ssm_state_indices = torch.cat(
+        [
+            active_indices.int(),
+            torch.full((B_padded,), -1, device=device, dtype=torch.int32),
+        ]
+    )
+
+    scale = 1.0 / D**0.5
+
+    # Run kernel (in-place state update)
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=state_pool,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        lower_bound=lower_bound,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    # ---- Test A: state slot 0 must not be corrupted ----
+    slot0_after = state_pool[0]
+    assert torch.all(slot0_after == SENTINEL), (
+        f"State slot 0 corrupted! Expected all {SENTINEL}, "
+        f"got min={slot0_after.min().item():.3f} max={slot0_after.max().item():.3f}"
+    )
+
+    # ---- Test B: active slots match naive reference ----
+    ref_state_pool = state_pool_ref.transpose(-1, -2).float()  # [N, H, K, V]
+    ref_outputs = []
+    for i in range(B_active):
+        slot_idx = active_indices[i].item()
+        q_i = q[:, i : i + 1]
+        k_i = k[:, i : i + 1]
+        v_i = v[:, i : i + 1]
+        g_i = g[:, i : i + 1]
+        beta_i = beta[:, i : i + 1]
+
+        gate_kwargs = {}
+        ref_o_i, ref_ht_i = naive_recurrent_kda(
+            q=maybe_l2norm(q_i, use_qk_l2norm_in_kernel),
+            k=maybe_l2norm(k_i, use_qk_l2norm_in_kernel),
+            v=v_i.float(),
+            g=(
+                naive_gate_fn(g_i, A_log, dt_bias, **gate_kwargs).float()
+                if use_gate_in_kernel
+                else g_i.float()
+            ),
+            beta=beta_i.float(),
+            scale=scale,
+            initial_state=ref_state_pool[slot_idx].unsqueeze(0).clone(),
+            output_final_state=True,
+        )
+        ref_outputs.append(ref_o_i)
+        ref_state_pool[slot_idx] = ref_ht_i.squeeze(0)
+
+    ref_out = torch.cat(ref_outputs, dim=1)  # [1, B_active, H, D]
+
+    assert_close("active output", ref_out, tri_out[:, :B_active])
+    tri_ht = state_pool[active_indices.long()].transpose(-1, -2).float()
+    assert_close(
+        "active state",
+        ref_state_pool[active_indices.long()],
+        tri_ht,
+        atol=0.1,
+        rtol=0.05,
+    )
+
+
+@pytest.mark.parametrize(
+    ("H", "D"),
+    [
+        pytest.param(8, 64, id="H8-D64"),
+        pytest.param(16, 128, id="H16-D128"),
+    ],
+)
+def test_non_compact_state_stride(H: int, D: int):
+    """State tensor with non-compact stride[0] (simulating vLLM block-based cache
+    where page_size includes extra conv_state padding) produces correct results.
+
+    The kernel's compiled fake tensor uses a free sym_int64 stride[0], so it must
+    handle any stride divisible by 16, not just the compact HV*V*K stride.
+
+    Must use cu_seqlens path: the non-cu_seqlens path always calls .contiguous()
+    on the state tensor, so non-compact stride only matters for the cu_seqlens path
+    where state is passed directly to the kernel without copying.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    B = 4
+    HV = H  # GQA ratio 1
+    PADDING = 32  # extra elements per row to simulate page padding
+
+    # Create state pool with non-compact stride[0]: stride[0] = HV*D*D + PADDING
+    compact_stride = HV * D * D
+    padded_stride = compact_stride + PADDING
+    backing = torch.zeros(B * padded_stride, dtype=dtype, device=device)
+    state_noncompact = backing.as_strided(
+        size=(B, HV, D, D),
+        stride=(padded_stride, D * D, D, 1),
+    )
+    state_init = torch.randn(B, HV, D, D, dtype=dtype, device=device) * 0.01
+    state_noncompact.copy_(state_init)
+
+    # Compact reference (same logical values, standard [B, HV, D, D] layout)
+    state_compact = state_init.clone()
+
+    # Inputs: packed [1, B, H, D] with cu_seqlens (1 token per sequence)
+    q = torch.rand(1, B, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, B, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, B, H, D, dtype=dtype, device=device)
+    g = (F.logsigmoid(torch.randn(1, B, H, D, device=device)) / 1.0).to(dtype)
+    beta = torch.rand(1, B, H, dtype=dtype, device=device).sigmoid()
+    scale = 1.0 / D**0.5
+    cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
+    ssm_state_indices = torch.arange(B, device=device, dtype=torch.int32)
+
+    # Run kernel with non-compact state (state passed directly, no .contiguous())
+    out_nc, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_noncompact,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    # Run kernel with compact state (reference)
+    out_c, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_compact,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    assert_close("non-compact output", out_c, out_nc)
+    # Verify state was written to the non-compact tensor at the correct logical positions
+    nc_vals = state_noncompact.transpose(-1, -2).float()
+    c_vals = state_compact.transpose(-1, -2).float()
+    assert_close("non-compact state", c_vals, nc_vals, atol=0.1, rtol=0.05)
+
+
+# ==============================================================================
+# Non-contiguous gate stride tests
+# ==============================================================================
+
+
+@pytest.mark.parametrize(
+    "H, D",
+    [
+        pytest.param(8, 64, id="H8-D64"),
+        pytest.param(16, 128, id="H16-D128"),
+    ],
+)
+def test_non_contiguous_gate_stride(H: int, D: int):
+    """Gate tensor with non-contiguous strides (simulating split() on a fused
+    projection output) produces correct results.
+
+    In vLLM, a fused projection [B, T, total_proj_dim] is split along dim=-1,
+    yielding views where stride[1] = total_proj_dim != HV*K. After reshape to
+    [B, T, HV, K], the batch and token strides are non-compact while HV and K
+    strides remain compact.
+
+    Tests both the batched path and the cu_seqlens path.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    B = 4
+    HV = H  # GQA ratio 1
+    EXTRA = 256  # extra elements to simulate Q+K+V+beta in the fused projection
+
+    # --- Batched path (no cu_seqlens) ---
+    # Simulate fused projection: backing tensor has padded token stride.
+    # Use as_strided to force non-compact strides (reshape won't preserve them
+    # when T=1 since size-1 dims have ambiguous strides in PyTorch).
+    gate_dim = HV * D
+    total_proj_dim = gate_dim + EXTRA  # token stride = total_proj_dim
+    batch_stride = 1 * total_proj_dim  # B stride = T * total_proj_dim
+
+    # Allocate backing buffer large enough for all B batches with padded strides
+    backing = torch.zeros(B * batch_stride + EXTRA, dtype=dtype, device=device)
+    # Fill gate values at the correct offsets
+    g_values = F.logsigmoid(torch.randn(B, 1, HV, D, device=device)).to(dtype)
+    for b in range(B):
+        offset = b * batch_stride + EXTRA
+        backing[offset : offset + gate_dim] = g_values[b, 0].reshape(-1)
+
+    # Create non-contiguous view with explicit strides
+    g_noncontiguous = backing[EXTRA:].as_strided(
+        size=(B, 1, HV, D),
+        stride=(batch_stride, total_proj_dim, D, 1),
+    )
+    assert g_noncontiguous.stride()[1] == total_proj_dim, (
+        f"Expected non-compact token stride {total_proj_dim}, "
+        f"got {g_noncontiguous.stride()[1]}"
+    )
+    g_contiguous = g_noncontiguous.contiguous()
+
+    q = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, 1, HV, D, dtype=dtype, device=device)
+    beta = torch.rand(B, 1, HV, dtype=dtype, device=device).sigmoid()
+    scale = 1.0 / D**0.5
+    state_nc = torch.randn(B, HV, D, D, dtype=dtype, device=device) * 0.01
+    state_c = state_nc.clone()
+
+    out_nc, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g_noncontiguous,
+        beta=beta,
+        scale=scale,
+        initial_state=state_nc,
+    )
+    out_c, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g_contiguous,
+        beta=beta,
+        scale=scale,
+        initial_state=state_c,
+    )
+
+    assert_close("non-contiguous gate output (batched)", out_c, out_nc)
+    assert_close(
+        "non-contiguous gate state (batched)",
+        state_c.transpose(-1, -2).float(),
+        state_nc.transpose(-1, -2).float(),
+        atol=0.1,
+        rtol=0.05,
+    )
+
+    # --- cu_seqlens path ---
+    # Packed layout: [1, B, H/HV, D] with cu_seqlens
+    cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
+    ssm_state_indices = torch.arange(B, device=device, dtype=torch.int32)
+
+    # Same as_strided approach for packed layout [1, B, HV, D]
+    # Here dim0=1 (outer batch=1), dim1=B (sequences), non-compact stride on dim1
+    token_stride_cu = total_proj_dim  # stride for the sequence dim
+    batch_stride_cu = B * total_proj_dim  # stride for outer dim0
+    backing_cu = torch.zeros(batch_stride_cu + EXTRA, dtype=dtype, device=device)
+    g_vals_cu = F.logsigmoid(torch.randn(1, B, HV, D, device=device)).to(dtype)
+    for s in range(B):
+        offset = s * token_stride_cu + EXTRA
+        backing_cu[offset : offset + gate_dim] = g_vals_cu[0, s].reshape(-1)
+    g_nc_cu = backing_cu[EXTRA:].as_strided(
+        size=(1, B, HV, D),
+        stride=(batch_stride_cu, token_stride_cu, D, 1),
+    )
+    assert g_nc_cu.stride()[1] == total_proj_dim
+    g_c_cu = g_nc_cu.contiguous()
+
+    q_cu = torch.rand(1, B, H, D, dtype=dtype, device=device)
+    k_cu = torch.rand(1, B, H, D, dtype=dtype, device=device)
+    v_cu = torch.rand(1, B, HV, D, dtype=dtype, device=device)
+    beta_cu = torch.rand(1, B, HV, dtype=dtype, device=device).sigmoid()
+    state_nc_cu = torch.randn(B, HV, D, D, dtype=dtype, device=device) * 0.01
+    state_c_cu = state_nc_cu.clone()
+
+    out_nc_cu, _ = recurrent_kda(
+        q=q_cu,
+        k=k_cu,
+        v=v_cu,
+        g=g_nc_cu,
+        beta=beta_cu,
+        scale=scale,
+        initial_state=state_nc_cu,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+    out_c_cu, _ = recurrent_kda(
+        q=q_cu,
+        k=k_cu,
+        v=v_cu,
+        g=g_c_cu,
+        beta=beta_cu,
+        scale=scale,
+        initial_state=state_c_cu,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    assert_close("non-contiguous gate output (cu_seqlens)", out_c_cu, out_nc_cu)
+    assert_close(
+        "non-contiguous gate state (cu_seqlens)",
+        state_c_cu.transpose(-1, -2).float(),
+        state_nc_cu.transpose(-1, -2).float(),
+        atol=0.1,
+        rtol=0.05,
+    )
+
+
+# ==============================================================================
+# Speculative decoding tests (spec-decode Phase 1)
+# ==============================================================================
+
+
+def make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype=torch.bfloat16):
+    """Create packed spec-decode inputs.
+
+    Returns:
+        q, k, v, g, beta: packed [1, N*T, H/HV, D] tensors
+        cu_seqlens: [0, T, 2T, ..., N*T] int32
+        ssm_state_indices: [N, T] int32 -- unique slots, no overlap
+        state_pool: [N*T + 5, HV, D, D] bf16 -- extra slots as sentinels
+        T: NUM_TOKENS
+    """
+    T = 1 + num_spec_tokens
+    total_tokens = N * T
+
+    # All slots unique: sequence i uses slots i*T .. i*T+T-1
+    ssm_state_indices = torch.stack(
+        [
+            torch.arange(i * T, i * T + T, dtype=torch.int32, device=device)
+            for i in range(N)
+        ]
+    )  # [N, T]
+
+    # state pool: N*T active slots + 5 sentinel slots
+    n_pool = N * T + 5
+    state_pool = torch.randn(n_pool, HV, D, D, dtype=dtype, device=device) * 0.1
+
+    cu_seqlens = torch.arange(
+        0, total_tokens + 1, step=T, dtype=torch.int32, device=device
+    )
+
+    scale = D**-0.5
+    q = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, total_tokens, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(1, total_tokens, HV, D, device=device)).to(dtype)
+    beta = torch.rand(1, total_tokens, HV, dtype=dtype, device=device).sigmoid()
+
+    return q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, T
+
+
+def spec_decode_naive_reference(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    ssm_state_indices,
+    state_pool,
+    scale,
+    N,
+    T,
+    H,
+    HV,
+    num_accepted_tokens=None,
+    use_qk_l2norm_in_kernel=True,
+):
+    """Run spec decode reference: T sequential naive tokens per sequence.
+
+    Args:
+        num_accepted_tokens: Optional[list or tensor] of length N. When provided,
+            initial state for sequence b is loaded from ssm_state_indices[b, nat[b]-1]
+            instead of ssm_state_indices[b, 0]. This matches the FLA Triton kernel's
+            num_accepted_tokens behavior.
+
+    Returns:
+        ref_out: [1, N*T, HV, D] float32 -- output
+        ref_states: list of N lists of T tensors, each [HV, K, V] = [HV, D, D] float32
+    """
+    device = q.device
+    D = q.shape[-1]
+    ref_out = torch.zeros(1, N * T, HV, D, dtype=torch.float32, device=device)
+    ref_states = []  # ref_states[b][t] = [HV, D, D] float32 (K-major)
+
+    gqa_ratio = HV // H
+
+    for b in range(N):
+        seq_start = b * T
+        # Initial state: use nat-based slot selection when num_accepted_tokens provided
+        if num_accepted_tokens is not None:
+            nat_b = int(num_accepted_tokens[b])
+            init_col = max(nat_b - 1, 0)
+        else:
+            init_col = 0
+        init_slot = int(ssm_state_indices[b, init_col].item())
+        current_state = state_pool[init_slot].float().transpose(-1, -2)  # [HV, K, V]
+        # Expand to [1, HV, K, V] for naive_recurrent_kda
+        current_state_b = current_state.unsqueeze(0)
+
+        b_states = []
+        for t in range(T):
+            tok_idx = seq_start + t
+            q_t = q[:, tok_idx : tok_idx + 1, :H, :]  # [1, 1, H, D]
+            k_t = k[:, tok_idx : tok_idx + 1, :H, :]
+            v_t = v[:, tok_idx : tok_idx + 1, :HV, :]  # [1, 1, HV, D]
+            g_t = g[:, tok_idx : tok_idx + 1, :HV, :]  # [1, 1, HV, D]
+            beta_t = beta[:, tok_idx : tok_idx + 1, :HV]  # [1, 1, HV]
+
+            # For GQA (HV > H): expand q and k so each value head has its own q/k copy.
+            # naive_recurrent_kda treats all heads uniformly, so we replicate query heads.
+            if gqa_ratio > 1:
+                q_t_exp = q_t.repeat_interleave(gqa_ratio, dim=2)  # [1, 1, HV, D]
+                k_t_exp = k_t.repeat_interleave(gqa_ratio, dim=2)  # [1, 1, HV, D]
+            else:
+                q_t_exp = q_t
+                k_t_exp = k_t
+
+            o_t, ht = naive_recurrent_kda(
+                q=maybe_l2norm(q_t_exp, use_qk_l2norm_in_kernel),
+                k=maybe_l2norm(k_t_exp, use_qk_l2norm_in_kernel),
+                v=v_t.float(),
+                g=g_t.float(),
+                beta=beta_t.float(),
+                scale=scale,
+                initial_state=current_state_b.clone(),
+                output_final_state=True,
+            )
+            ref_out[0, tok_idx] = o_t[0, 0]  # [HV, D]
+            current_state_b = ht  # carry forward
+            b_states.append(ht[0].clone())  # [HV, K, V]
+        ref_states.append(b_states)
+
+    return ref_out, ref_states
+
+
+def assert_spec_states(
+    state_pool,
+    ssm_state_indices,
+    ref_states,
+    N,
+    T,
+    atol=1e-1,
+    rtol=5e-2,
+    num_accepted_tokens=None,
+):
+    """Assert each per-token checkpoint slot matches the reference state.
+
+    When num_accepted_tokens is provided, only validate slots from nat[b]-1 onward.
+    Earlier slots (0..nat-2) were computed from a different initial state and are
+    valid-but-meaningless -- vLLM's postprocess_mamba only reads from nat-1 onward.
+    """
+    for b in range(N):
+        start_t = 0
+        if num_accepted_tokens is not None:
+            start_t = max(int(num_accepted_tokens[b]) - 1, 0)
+        for t in range(start_t, T):
+            slot = int(ssm_state_indices[b, t].item())
+            # kernel: [HV, V, K] bf16 -> [HV, K, V] float for comparison
+            kernel_state = state_pool[slot].float().transpose(-1, -2)
+            ref_state = ref_states[b][t]
+            assert_close(
+                f"spec_state[b={b}, t={t}]",
+                ref_state,
+                kernel_state,
+                atol=atol,
+                rtol=rtol,
+            )
+
+
+# ------------------------------------------------------------------------------
+# 3a: test_spec_decode_basic
+# ------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("N", "H", "HV", "D", "num_spec_tokens", "use_qk_l2norm_in_kernel"),
+    [
+        pytest.param(4, 8, 8, 64, 1, True, id="N4-H8-D64-S1"),
+        pytest.param(4, 8, 8, 64, 3, True, id="N4-H8-D64-S3"),
+        pytest.param(4, 8, 8, 64, 1, False, id="N4-H8-D64-S1-no-qk-l2"),
+        pytest.param(8, 16, 16, 128, 2, True, id="N8-H16-D128-S2"),
+        pytest.param(8, 16, 16, 128, 4, True, id="N8-H16-D128-S4"),
+        pytest.param(8, 16, 16, 128, 2, False, id="N8-H16-D128-S2-no-qk-l2"),
+        pytest.param(4, 4, 8, 64, 2, True, id="N4-H4-HV8-D64-S2-GQA"),
+    ],
+)
+def test_spec_decode_basic(N, H, HV, D, num_spec_tokens, use_qk_l2norm_in_kernel):
+    """Single spec-decode call matches T sequential naive calls."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, T = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device)
+    )
+
+    # Reference
+    ref_out, ref_states = spec_decode_naive_reference(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        ssm_state_indices,
+        state_pool,
+        scale,
+        N,
+        T,
+        H,
+        HV,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    # Kernel
+    tri_state_pool = state_pool.clone()
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_state_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    # Output comparison
+    assert_close(
+        "spec_output", ref_out.bfloat16().float(), tri_out.float(), atol=1e-1, rtol=5e-2
+    )
+
+    # Per-token state comparison (EACH slot must match)
+    assert_spec_states(
+        tri_state_pool, ssm_state_indices, ref_states, N, T, atol=1e-1, rtol=5e-2
+    )
+
+
+# ------------------------------------------------------------------------------
+# 3b: test_spec_decode_gate_modes
+# ------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "gate_mode",
+    [
+        pytest.param("precomputed", id="precomputed"),
+        pytest.param("softplus", id="softplus"),
+        pytest.param("lower_bound", id="lower_bound"),
+    ],
+)
+def test_spec_decode_gate_modes(gate_mode):
+    """All 3 gate modes work correctly with spec decode."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 16, 16, 128, 2
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, T = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    if gate_mode == "precomputed":
+        use_gate_in_kernel = False
+        lower_bound = None
+        A_log = None
+        dt_bias = None
+        g_ref = g.float()
+        g_kernel = g
+    elif gate_mode == "softplus":
+        use_gate_in_kernel = True
+        lower_bound = None
+        A_log = torch.log(
+            torch.rand(H, device=device, dtype=torch.float32) + 1
+        ).squeeze()
+        dt_bias = None
+        # g is the raw input; reference computes the gate from same raw g
+        g_ref = naive_kda_gate(g, A_log).float()
+        g_kernel = g  # same raw g for kernel (gate computed internally)
+    else:  # lower_bound
+        use_gate_in_kernel = True
+        lower_bound = -5.0
+        A_log = torch.log(
+            torch.rand(H, device=device, dtype=torch.float32) + 1
+        ).squeeze()
+        dt_bias = torch.randn(H * D, dtype=torch.float32, device=device)
+        # g is the raw input; reference computes the gate from same raw g
+        g_ref = naive_kda_lowerbound_gate(g, A_log, dt_bias).float()
+        g_kernel = g  # same raw g for kernel (gate computed internally)
+
+    # Reference using the computed log-space gate
+    ref_out, ref_states = spec_decode_naive_reference(
+        q,
+        k,
+        v,
+        g_ref.bfloat16(),
+        beta,
+        ssm_state_indices,
+        state_pool,
+        scale,
+        N,
+        T,
+        H,
+        HV,
+    )
+
+    tri_state_pool = state_pool.clone()
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g_kernel,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_state_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        use_gate_in_kernel=use_gate_in_kernel,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+    )
+
+    assert_close(
+        "spec_output_gate",
+        ref_out.bfloat16().float(),
+        tri_out.float(),
+        atol=1e-1,
+        rtol=5e-2,
+    )
+    assert_spec_states(
+        tri_state_pool, ssm_state_indices, ref_states, N, T, atol=1e-1, rtol=5e-2
+    )
+
+
+# ------------------------------------------------------------------------------
+# 3c: test_spec_decode_padded_cuda_graph
+# ------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("D", [64, 128], ids=["D64", "D128"])
+def test_spec_decode_padded_cuda_graph(D):
+    """Padded slots (PAD_SLOT_ID=-1) don't corrupt state; active slots correct; padded output=0.
+
+    Slot 0 is reserved as a true PAD sentinel -- no active sequence uses it.
+    Active slots start from 1 to ensure slot 0 is only touched by PAD clamp reads
+    (which are harmless -- reads are allowed, only writes are guarded by is_active).
+    D=64 exercises the register-carry path; D=128 exercises the GMEM round-trip path.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N_active = 4
+    N_padded = 3
+    N = N_active + N_padded
+    H, HV, num_spec_tokens = 8, 8, 2
+    T = 1 + num_spec_tokens
+    dtype = torch.bfloat16
+
+    # Active slots start from 1 -- slot 0 is reserved as PAD sentinel
+    # ssm_active[i] = [1+i*T, 1+i*T+1, ..., 1+i*T+T-1]
+    ssm_active = torch.stack(
+        [
+            torch.arange(1 + i * T, 1 + i * T + T, dtype=torch.int32, device=device)
+            for i in range(N_active)
+        ]
+    )  # [N_active, T], slots 1..N_active*T
+
+    n_pool = N_active * T + 1 + 5  # slot 0 + active slots + sentinel slots
+    state_pool = torch.randn(n_pool, HV, D, D, dtype=dtype, device=device) * 0.1
+    scale = D**-0.5
+
+    # Inputs for active sequences
+    q = torch.rand(1, N_active * T, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, N_active * T, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, N_active * T, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(1, N_active * T, HV, D, device=device)).to(dtype)
+    beta = torch.rand(1, N_active * T, HV, dtype=dtype, device=device).sigmoid()
+
+    # Extend inputs for padded sequences (dummy tokens -- read unconditionally but writes guarded)
+    total_tokens = N * T
+    q_full = torch.cat(
+        [q, torch.zeros(1, N_padded * T, H, D, dtype=dtype, device=device)], dim=1
+    )
+    k_full = torch.cat(
+        [k, torch.zeros(1, N_padded * T, H, D, dtype=dtype, device=device)], dim=1
+    )
+    v_full = torch.cat(
+        [v, torch.zeros(1, N_padded * T, HV, D, dtype=dtype, device=device)], dim=1
+    )
+    g_full = torch.cat(
+        [g, torch.zeros(1, N_padded * T, HV, D, dtype=dtype, device=device)], dim=1
+    )
+    beta_full = torch.cat(
+        [beta, torch.zeros(1, N_padded * T, HV, dtype=dtype, device=device)], dim=1
+    )
+
+    cu_seqlens = torch.arange(
+        0, total_tokens + 1, step=T, dtype=torch.int32, device=device
+    )
+
+    # Padded rows: all -1 (PAD_SLOT_ID)
+    ssm_padded = torch.full((N_padded, T), -1, dtype=torch.int32, device=device)
+    ssm_state_indices = torch.cat([ssm_active, ssm_padded], dim=0)
+
+    # Reference: only for active sequences
+    ref_out_active, ref_states = spec_decode_naive_reference(
+        q, k, v, g, beta, ssm_active, state_pool, scale, N_active, T, H, HV
+    )
+
+    # Slot 0 = PAD sentinel -- record before kernel run
+    state_pool_kernel = state_pool.clone()
+    slot0_before = state_pool_kernel[0].clone()
+
+    tri_out, _ = recurrent_kda(
+        q=q_full,
+        k=k_full,
+        v=v_full,
+        g=g_full,
+        beta=beta_full,
+        scale=scale,
+        initial_state=state_pool_kernel,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+    )
+
+    # Active outputs correct (first N_active*T output positions)
+    assert_close(
+        "padded_active_out",
+        ref_out_active.bfloat16().float(),
+        tri_out[:, : N_active * T].float(),
+        atol=1e-1,
+        rtol=5e-2,
+    )
+
+    # Active states correct (each per-token checkpoint slot)
+    assert_spec_states(
+        state_pool_kernel, ssm_active, ref_states, N_active, T, atol=1e-1, rtol=5e-2
+    )
+
+    # Padded output positions are zero (spec mode allocates zeros)
+    padded_out = tri_out[:, N_active * T :]
+    assert padded_out.abs().max().item() == 0.0, (
+        f"Padded output should be zero, max={padded_out.abs().max().item()}"
+    )
+
+    # Slot 0 not corrupted by PAD clamp -- padded CTAs read slot 0 (is_active=False skips writes)
+    assert_close(
+        "slot0_not_corrupted",
+        slot0_before.float().transpose(-1, -2),
+        state_pool_kernel[0].float().transpose(-1, -2),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+# ------------------------------------------------------------------------------
+# 3d: test_spec_decode_shape_validation
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_shape_validation():
+    """ValueError raised for invalid inputs in spec mode."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 2
+    T = 3
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    def try_call(**overrides):
+        kw = dict(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=state_pool.clone(),
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_spec_tokens=num_spec_tokens,
+        )
+        kw.update(overrides)
+        return recurrent_kda(**kw)
+
+    # num_spec_tokens=0 raises
+    with pytest.raises(ValueError, match="num_spec_tokens must be >= 1"):
+        try_call(num_spec_tokens=0)
+
+    # ssm_state_indices=None raises
+    with pytest.raises(ValueError, match="ssm_state_indices is required"):
+        try_call(ssm_state_indices=None)
+
+    # 1D ssm_state_indices raises
+    with pytest.raises(ValueError, match="2D"):
+        try_call(ssm_state_indices=torch.arange(N, dtype=torch.int32, device=device))
+
+    # Wrong column count raises
+    with pytest.raises(ValueError, match="2D"):
+        try_call(
+            ssm_state_indices=torch.zeros(N, T + 1, dtype=torch.int32, device=device)
+        )
+
+    # Missing cu_seqlens activates batched spec shim -- T mismatch raises
+    with pytest.raises(ValueError, match="must equal 1\\+num_spec_tokens"):
+        try_call(cu_seqlens=None)
+
+    # Wrong row count
+    with pytest.raises(ValueError, match="shape\\[0\\]"):
+        try_call(
+            ssm_state_indices=torch.zeros(N + 1, T, dtype=torch.int32, device=device)
+        )
+
+    with pytest.raises(ValueError, match="lower_bound requires"):
+        try_call(lower_bound=-5.0)
+
+    with pytest.raises(ValueError, match="lower_bound must be negative"):
+        try_call(
+            use_gate_in_kernel=True,
+            A_log=torch.zeros(H, dtype=torch.float32, device=device),
+            lower_bound=0.0,
+        )
+
+    # Checks below (bounds, uniqueness, cu_seqlens deltas, shape mismatches) were
+    # removed from the hot path to enable CUDA graph compatibility (no D2H transfers).
+    # Use validate_spec_decode_inputs() for development-time validation.
+
+
+# ------------------------------------------------------------------------------
+# 3e-neg: test_spec_decode_cu_seqlens_validation
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_cu_seqlens_validation():
+    """Valid cu_seqlens still works; invalid delta checks were removed from the hot path."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 2
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_pool.clone(),
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+    )
+
+    assert out.shape == v.shape
+
+
+# ------------------------------------------------------------------------------
+# 3e: test_spec_decode_num_accepted_tokens
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_num_accepted_tokens():
+    """num_accepted_tokens selects initial state checkpoint; kernel outputs differ by nat."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 2
+    T = 1 + num_spec_tokens
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    # nat=1: should match no-nat (start from slot 0)
+    nat_1 = torch.ones(N, dtype=torch.int32, device=device)
+    tri_pool_none = state_pool.clone()
+    out_none, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_pool_none,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=None,
+    )
+    tri_pool_1 = state_pool.clone()
+    out_1, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_pool_1,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=nat_1,
+    )
+    assert_close("nat1_vs_none_out", out_none, out_1, atol=0, rtol=0)
+
+    # nat=T: start from last checkpoint of previous round
+    nat_T = torch.full((N,), T, dtype=torch.int32, device=device)
+    tri_pool_T = state_pool.clone()
+    out_T, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_pool_T,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=nat_T,
+    )
+    ref_out_T, ref_states_T = spec_decode_naive_reference(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        ssm_state_indices,
+        state_pool,
+        scale,
+        N,
+        T,
+        H,
+        HV,
+        num_accepted_tokens=nat_T,
+    )
+    # Only compare output from nat-1 onward (earlier tokens have wrong initial state)
+    for b in range(N):
+        start = T - 1  # nat=T -> start_t = T-1
+        for t in range(start, T):
+            tok_idx = b * T + t
+            assert_close(
+                f"nat_T_out[b={b},t={t}]",
+                ref_out_T[0, tok_idx],
+                out_T[0, tok_idx].float(),
+                atol=1e-1,
+                rtol=5e-2,
+            )
+    assert_spec_states(
+        tri_pool_T, ssm_state_indices, ref_states_T, N, T, num_accepted_tokens=nat_T
+    )
+
+
+def test_spec_decode_nat_equals_one_matches_no_nat():
+    """nat=1 for all sequences produces bit-identical output to nat=None."""
+    torch.manual_seed(123)
+    device = torch.device("cuda")
+    for D in [64, 128]:
+        H = HV = 8 if D == 64 else 16
+        N, num_spec_tokens = 4, 2
+        q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+            make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device)
+        )
+
+        pool_a, pool_b = state_pool.clone(), state_pool.clone()
+        out_none, _ = recurrent_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=pool_a,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_spec_tokens=num_spec_tokens,
+        )
+        nat_1 = torch.ones(N, dtype=torch.int32, device=device)
+        out_1, _ = recurrent_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=pool_b,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_spec_tokens=num_spec_tokens,
+            num_accepted_tokens=nat_1,
+        )
+        assert_close(f"nat1_compat_D{D}_out", out_none, out_1, atol=0, rtol=0)
+        # State pools should also be identical
+        assert_close(f"nat1_compat_D{D}_state", pool_a, pool_b, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("D", [64, 128], ids=["D64", "D128"])
+def test_spec_decode_nat_heterogeneous(D):
+    """Different nat values per sequence in the same batch."""
+    torch.manual_seed(77)
+    device = torch.device("cuda")
+    H = HV = 8 if D == 64 else 16
+    N, num_spec_tokens = 6, 3
+    T = 1 + num_spec_tokens  # T=4
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device)
+    )
+
+    # Heterogeneous nat: 1, 2, 3, 4, 1, 2
+    nat_values = [1, 2, 3, T, 1, 2]
+    nat = torch.tensor(nat_values, dtype=torch.int32, device=device)
+
+    tri_pool = state_pool.clone()
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=nat,
+    )
+    ref_out, ref_states = spec_decode_naive_reference(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        ssm_state_indices,
+        state_pool,
+        scale,
+        N,
+        T,
+        H,
+        HV,
+        num_accepted_tokens=nat,
+    )
+    # Compare output from nat-1 onward per sequence
+    for b in range(N):
+        start = nat_values[b] - 1
+        for t in range(start, T):
+            tok_idx = b * T + t
+            assert_close(
+                f"hetero_out[b={b},t={t}]",
+                ref_out[0, tok_idx],
+                tri_out[0, tok_idx].float(),
+                atol=1e-1,
+                rtol=5e-2,
+            )
+    assert_spec_states(
+        tri_pool, ssm_state_indices, ref_states, N, T, num_accepted_tokens=nat
+    )
+
+
+def test_spec_decode_nat_with_padding():
+    """Mixed active (varying nat) + padded (-1) sequences."""
+    torch.manual_seed(99)
+    device = torch.device("cuda")
+    N_active, N_padded = 3, 2
+    N = N_active + N_padded
+    H, HV, D, num_spec_tokens = 8, 8, 64, 2
+    T = 1 + num_spec_tokens
+    dtype = torch.bfloat16
+
+    # Active slots start from 1 (slot 0 reserved as PAD sentinel)
+    ssm_active = torch.stack(
+        [
+            torch.arange(1 + i * T, 1 + i * T + T, dtype=torch.int32, device=device)
+            for i in range(N_active)
+        ]
+    )
+    ssm_padded = torch.full((N_padded, T), -1, dtype=torch.int32, device=device)
+    ssm_state_indices = torch.cat([ssm_active, ssm_padded], dim=0)
+
+    n_pool = N_active * T + 1 + 5
+    state_pool = torch.randn(n_pool, HV, D, D, dtype=dtype, device=device) * 0.1
+    scale = D**-0.5
+
+    q = torch.rand(1, N_active * T, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, N_active * T, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, N_active * T, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(1, N_active * T, HV, D, device=device)).to(dtype)
+    beta = torch.rand(1, N_active * T, HV, dtype=dtype, device=device).sigmoid()
+
+    total_tokens = N * T
+    q_full = torch.cat(
+        [q, torch.zeros(1, N_padded * T, H, D, dtype=dtype, device=device)], dim=1
+    )
+    k_full = torch.cat(
+        [k, torch.zeros(1, N_padded * T, H, D, dtype=dtype, device=device)], dim=1
+    )
+    v_full = torch.cat(
+        [v, torch.zeros(1, N_padded * T, HV, D, dtype=dtype, device=device)], dim=1
+    )
+    g_full = torch.cat(
+        [g, torch.zeros(1, N_padded * T, HV, D, dtype=dtype, device=device)], dim=1
+    )
+    beta_full = torch.cat(
+        [beta, torch.zeros(1, N_padded * T, HV, dtype=dtype, device=device)], dim=1
+    )
+    cu_seqlens = torch.arange(
+        0, total_tokens + 1, step=T, dtype=torch.int32, device=device
+    )
+
+    # nat: active seqs have varying nat, padded seqs have nat=1 (doesn't matter, they're -1)
+    nat_active = torch.tensor([1, 2, T], dtype=torch.int32, device=device)
+    nat_padded = torch.ones(N_padded, dtype=torch.int32, device=device)
+    nat = torch.cat([nat_active, nat_padded])
+
+    # Reference for active sequences only
+    ref_out, ref_states = spec_decode_naive_reference(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        ssm_active,
+        state_pool,
+        scale,
+        N_active,
+        T,
+        H,
+        HV,
+        num_accepted_tokens=nat_active,
+    )
+
+    state_pool_kernel = state_pool.clone()
+    slot0_before = state_pool_kernel[0].clone()
+
+    tri_out, _ = recurrent_kda(
+        q=q_full,
+        k=k_full,
+        v=v_full,
+        g=g_full,
+        beta=beta_full,
+        scale=scale,
+        initial_state=state_pool_kernel,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=nat,
+    )
+
+    # Active states correct (from nat-1 onward)
+    assert_spec_states(
+        state_pool_kernel,
+        ssm_active,
+        ref_states,
+        N_active,
+        T,
+        num_accepted_tokens=nat_active,
+    )
+
+    # Padded output zero
+    padded_out = tri_out[:, N_active * T :]
+    assert padded_out.abs().max().item() == 0.0, (
+        f"Padded output should be zero, max={padded_out.abs().max().item()}"
+    )
+
+    # Slot 0 not corrupted
+    assert_close(
+        "slot0_not_corrupted",
+        slot0_before.float().transpose(-1, -2),
+        state_pool_kernel[0].float().transpose(-1, -2),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+@pytest.mark.parametrize(
+    "gate_mode",
+    ["precomputed", "softplus", "lower_bound"],
+    ids=["precomputed", "softplus", "lower_bound"],
+)
+def test_spec_decode_nat_gate_modes(gate_mode):
+    """All 3 gate modes with nat > 1."""
+    torch.manual_seed(55)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 2
+    T = 1 + num_spec_tokens
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    nat = torch.full((N,), 2, dtype=torch.int32, device=device)  # nat=2 for all
+
+    use_gate_in_kernel = gate_mode != "precomputed"
+    lower_bound = -5.0 if gate_mode == "lower_bound" else None
+    A_log = (
+        torch.randn(H, device=device, dtype=torch.float32)
+        if use_gate_in_kernel
+        else None
+    )
+    dt_bias = (
+        torch.randn(H * D, device=device, dtype=torch.float32)
+        if use_gate_in_kernel
+        else None
+    )
+
+    if not use_gate_in_kernel:
+        g = F.logsigmoid(torch.randn(1, N * T, HV, D, device=device)).to(dtype)
+    else:
+        g = torch.randn(1, N * T, HV, D, device=device).to(dtype) * 0.1
+
+    tri_pool = state_pool.clone()
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=nat,
+        use_gate_in_kernel=use_gate_in_kernel,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+    )
+
+    # Verify no NaN/Inf
+    assert not torch.isnan(tri_out).any(), f"NaN in output for gate_mode={gate_mode}"
+    assert not torch.isinf(tri_out).any(), f"Inf in output for gate_mode={gate_mode}"
+
+    # Verify nat=2 differs from nat=1 (proving nat actually works)
+    nat_1 = torch.ones(N, dtype=torch.int32, device=device)
+    tri_pool_1 = state_pool.clone()
+    out_1, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_pool_1,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+        num_accepted_tokens=nat_1,
+        use_gate_in_kernel=use_gate_in_kernel,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+    )
+    # Outputs should differ (different initial state)
+    diff = (tri_out.float() - out_1.float()).abs().max().item()
+    assert diff > 1e-3, f"nat=2 should differ from nat=1 for {gate_mode}, diff={diff}"
+
+
+# ------------------------------------------------------------------------------
+# 3f: test_spec_decode_checkpoint_correctness (stress test)
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_checkpoint_correctness():
+    """Stress test: N=8, H=16, D=128, S=4 -- all T checkpoint slots correct."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 8, 16, 16, 128, 4
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, T = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    ref_out, ref_states = spec_decode_naive_reference(
+        q, k, v, g, beta, ssm_state_indices, state_pool, scale, N, T, H, HV
+    )
+
+    tri_state_pool = state_pool.clone()
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_state_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+    )
+
+    assert_close(
+        "checkpoint_out",
+        ref_out.bfloat16().float(),
+        tri_out.float(),
+        atol=1e-1,
+        rtol=5e-2,
+    )
+    assert_spec_states(
+        tri_state_pool, ssm_state_indices, ref_states, N, T, atol=1e-1, rtol=5e-2
+    )
+
+
+# ------------------------------------------------------------------------------
+# 3g: test_spec_decode_non_compact_state
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_non_compact_state():
+    """Non-compact stride[0] state pool works correctly with spec decode.
+
+    Non-compact means stride[0] > HV*V*K -- slots are not contiguous in memory.
+    Strides [1:] remain standard (D*D, D, 1) within each slot.
+    This matches vLLM's paged cache where page_size includes padding.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 2
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, T = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    n_slots = state_pool.shape[0]
+
+    # Create non-compact state: stride[0] is padded (like vLLM paged cache).
+    # stride[1:] = (D*D, D, 1) must remain standard for the kernel to work correctly.
+    compact_stride = HV * D * D  # standard stride[0]
+    PADDING = 32  # extra elements between slots
+    padded_stride = compact_stride + PADDING
+    backing = torch.zeros(n_slots * padded_stride, dtype=dtype, device=device)
+    state_nc = backing.as_strided(
+        size=(n_slots, HV, D, D),
+        stride=(padded_stride, D * D, D, 1),
+    )
+    # Copy initial state values into non-compact backing
+    state_nc.copy_(state_pool)
+
+    # Reference with compact state (same initial values)
+    ref_out, ref_states = spec_decode_naive_reference(
+        q, k, v, g, beta, ssm_state_indices, state_pool, scale, N, T, H, HV
+    )
+
+    # Kernel with non-compact state (stride[0] = padded_stride, strides[1:] = standard)
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_nc,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+    )
+
+    assert_close(
+        "nc_output", ref_out.bfloat16().float(), tri_out.float(), atol=1e-1, rtol=5e-2
+    )
+    # Verify each per-token state checkpoint slot in the non-compact pool
+    for b in range(N):
+        for t in range(T):
+            slot = int(ssm_state_indices[b, t].item())
+            kernel_state = state_nc[slot].float().transpose(-1, -2)
+            assert_close(
+                f"nc_state[b={b},t={t}]",
+                ref_states[b][t],
+                kernel_state,
+                atol=1e-1,
+                rtol=5e-2,
+            )
+
+
+# ------------------------------------------------------------------------------
+# 3h: test_spec_decode_all_padded
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_all_padded():
+    """All-padded spec batch: output=0, state pool slot 0 not corrupted."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 2
+    T = 1 + num_spec_tokens
+    dtype = torch.bfloat16
+
+    total_tokens = N * T
+    cu_seqlens = torch.arange(
+        0, total_tokens + 1, step=T, dtype=torch.int32, device=device
+    )
+    ssm_state_indices = torch.full(
+        (N, T), -1, dtype=torch.int32, device=device
+    )  # all padded
+
+    q = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, total_tokens, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, total_tokens, HV, D, dtype=dtype, device=device)
+    g = torch.zeros(1, total_tokens, HV, D, dtype=dtype, device=device)
+    beta = torch.ones(1, total_tokens, HV, dtype=dtype, device=device) * 0.1
+    scale = D**-0.5
+
+    # State pool: at least 1 slot required by the wrapper guard
+    state_pool = torch.randn(1, HV, D, D, dtype=dtype, device=device) * 0.5
+    slot0_before = state_pool[0].clone()
+
+    tri_out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=num_spec_tokens,
+    )
+
+    # Output should be all zeros (spec mode allocates zeros for padded positions)
+    assert tri_out.abs().max().item() == 0.0, (
+        f"All-padded output should be zero, max={tri_out.abs().max().item()}"
+    )
+
+    # Slot 0 not corrupted
+    assert_close(
+        "allpad_slot0",
+        slot0_before.float().transpose(-1, -2),
+        state_pool[0].float().transpose(-1, -2),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+# ------------------------------------------------------------------------------
+# 3i: test_spec_decode_validate_slots_collision
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_validate_slots_collision():
+    """Cross-row slot collisions no longer validate in the hot path, but execution still works."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, HV, D, num_spec_tokens = 4, 8, 8, 64, 1
+    dtype = torch.bfloat16
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, scale, _ = (
+        make_spec_decode_inputs(N, H, HV, D, num_spec_tokens, device, dtype)
+    )
+
+    ssm_dup = ssm_state_indices.clone()
+    ssm_dup[0, 0] = 0
+    ssm_dup[1, 0] = 0
+
+    out, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_pool.clone(),
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_dup,
+        num_spec_tokens=num_spec_tokens,
+    )
+
+    assert out.shape == v.shape
+
+
+# ------------------------------------------------------------------------------
+# 3j: test_t1_cu_seqlens_all_padded
+# ------------------------------------------------------------------------------
+
+
+def test_t1_cu_seqlens_all_padded():
+    """All-padded T=1 cu_seqlens batch: correct (no-op) output, no corruption.
+    Two sub-cases: (a) initial_state=None exercises min-one-slot alloc guard;
+                   (b) initial_state provided exercises no-corruption guard.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    N, H, D = 4, 8, 64
+    dtype = torch.bfloat16
+
+    q = torch.rand(1, N, H, D, dtype=dtype, device=device)
+    k = torch.rand(1, N, H, D, dtype=dtype, device=device)
+    v = torch.rand(1, N, H, D, dtype=dtype, device=device)
+    g = torch.zeros(1, N, H, D, dtype=dtype, device=device)
+    beta = torch.ones(1, N, H, dtype=dtype, device=device) * 0.1
+    scale = D**-0.5
+
+    cu_seqlens = torch.arange(N + 1, dtype=torch.int32, device=device)
+    ssm_all_padded = torch.full((N,), -1, dtype=torch.int32, device=device)
+
+    # Sub-case (a): initial_state=None -> auto-allocation with at least 1 slot
+    out_a, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=None,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_all_padded,
+    )
+    # All-padded: output is pre-zeroed and all kernel writes are guarded.
+    assert out_a.abs().max().item() == 0.0, "Output should be zero for all-padded T=1"
+
+    # Sub-case (b): initial_state provided -- slot 0 must not be corrupted
+    state_pool = torch.randn(1, H, D, D, dtype=dtype, device=device)
+    slot0_before = state_pool[0].clone()
+
+    out_b, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_pool,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_all_padded,
+    )
+
+    # Slot 0 not corrupted
+    assert_close(
+        "t1_allpad_slot0",
+        slot0_before.float().transpose(-1, -2),
+        state_pool[0].float().transpose(-1, -2),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+# ==============================================================================
+# 4: Batched spec decode (no cu_seqlens)
+# ==============================================================================
+# The batched API (q shape [B, T, H, D] without cu_seqlens) is a thin shim that
+# reshapes inputs to the packed cu_seqlens form and reuses the same kernel.
+# Coverage below is intentionally minimal:
+#   - vs_cuseqlens: parity with the cu_seqlens path (proves the shim is a pass-through).
+#   - auto_ssi: verifies ssm_state_indices=None auto-generates identity slots.
+# The kernel-side correctness (gate modes, CUDA graph capture, various shapes) is
+# fully covered by the cu_seqlens tests above.
+
+# ------------------------------------------------------------------------------
+# 4a: test_spec_decode_batched_vs_cuseqlens
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_batched_vs_cuseqlens():
+    """Batched shim and cu_seqlens path produce identical results."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    B, H, HV, D, S = 4, 8, 8, 64, 2
+    T = 1 + S
+    scale = D**-0.5
+
+    q, k, v, g, beta, cu_seqlens, ssm_state_indices, state_pool, _, _ = (
+        make_spec_decode_inputs(B, H, HV, D, S, device, dtype)
+    )
+
+    # cu_seqlens path: inputs are [1, B*T, H, D]
+    state_pool_csl = state_pool.clone()
+    out_csl, _ = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_pool_csl,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=S,
+    )
+
+    # Batched path: reshape inputs to [B, T, H, D]
+    q_b = q.reshape(B, T, H, D)
+    k_b = k.reshape(B, T, H, D)
+    v_b = v.reshape(B, T, HV, D)
+    g_b = g.reshape(B, T, HV, D)
+    beta_b = beta.reshape(B, T, HV)
+
+    state_pool_bat = state_pool.clone()
+    out_bat, _ = recurrent_kda(
+        q=q_b,
+        k=k_b,
+        v=v_b,
+        g=g_b,
+        beta=beta_b,
+        scale=scale,
+        initial_state=state_pool_bat,
+        ssm_state_indices=ssm_state_indices,
+        num_spec_tokens=S,
+    )
+
+    # cu_seqlens output is [1, B*T, HV, D]; batched output is [B, T, HV, D]
+    assert_close(
+        "batched_vs_csl_out",
+        out_csl.reshape(B, T, HV, D).float(),
+        out_bat.float(),
+        atol=0,
+        rtol=0,
+    )
+
+    # States in both pools should be identical
+    assert_close(
+        "batched_vs_csl_state",
+        state_pool_csl.float(),
+        state_pool_bat.float(),
+        atol=0,
+        rtol=0,
+    )
+
+
+# ------------------------------------------------------------------------------
+# 4b: test_spec_decode_batched_auto_ssi
+# ------------------------------------------------------------------------------
+
+
+def test_spec_decode_batched_auto_ssi():
+    """ssm_state_indices=None: auto-generates sequential slots 0,1,...,B*T-1."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    B, H, HV, D, S = 4, 8, 8, 64, 1
+    T = 1 + S
+    scale = D**-0.5
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, D, device=device)).to(dtype)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+
+    n_pool = B * T + 5
+    state_pool = torch.randn(n_pool, HV, D, D, dtype=dtype, device=device) * 0.1
+
+    # Call with ssm_state_indices=None -- shim auto-generates arange(B*T).reshape(B, T)
+    tri_state_pool = state_pool.clone()
+    tri_out, final_state = recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=tri_state_pool,
+        output_final_state=True,
+        num_spec_tokens=S,
+        ssm_state_indices=None,
+    )
+
+    # Output shape is [B, T, HV, D]
+    assert tri_out.shape == (B, T, HV, D), (
+        f"Expected [{B},{T},{HV},{D}], got {list(tri_out.shape)}"
+    )
+
+    # Auto-generated indices: slot b*T+t for sequence b, token t
+    expected_ssi = torch.arange(B * T, dtype=torch.int32, device=device).reshape(B, T)
+
+    # Per-token states are in slots 0, 1, ..., B*T-1
+    q_packed = q.reshape(1, B * T, H, D)
+    k_packed = k.reshape(1, B * T, H, D)
+    v_packed = v.reshape(1, B * T, HV, D)
+    g_packed = g.reshape(1, B * T, HV, D)
+    beta_packed = beta.reshape(1, B * T, HV)
+
+    ref_out, ref_states = spec_decode_naive_reference(
+        q_packed,
+        k_packed,
+        v_packed,
+        g_packed,
+        beta_packed,
+        expected_ssi,
+        state_pool,
+        scale,
+        B,
+        T,
+        H,
+        HV,
+    )
+
+    ref_out_batched = ref_out.reshape(B, T, HV, D)
+    assert_close(
+        "auto_ssi_out",
+        ref_out_batched.bfloat16().float(),
+        tri_out.float(),
+        atol=1e-1,
+        rtol=5e-2,
+    )
+
+    # Verify states are in slots 0..B*T-1
+    assert_spec_states(
+        tri_state_pool, expected_ssi, ref_states, B, T, atol=1e-1, rtol=5e-2
+    )
+    assert final_state is tri_state_pool
+    assert final_state.shape == (n_pool, HV, D, D)


### PR DESCRIPTION
## Description

Add recurrent KDA (Kimi-Delta Attention) decode kernels as CuTe DSL kernels for
SM100 (Blackwell).

Per-token update:

`S = exp(g)[..., None] * S + beta * outer(k, v - k @ S)`  
`o = q @ S`

## Changes

- New `flashinfer/kda_kernels/recurrent_kda.py`
- Public `recurrent_kda()` API for standard T=1 decode and fused speculative decode with `num_spec_tokens`
- Supports GQA, `cu_seqlens`, and `ssm_state_indices` / paged state pools
- Gate modes:
  - precomputed log-space gate
  - in-kernel softplus gate
  - in-kernel `lower_bound * sigmoid(...)` gate
- Optional in-kernel Q/K L2 norm via `use_qk_l2norm_in_kernel`
- Base and v-tiled dispatch paths for low-batch occupancy
- Benchmark: `benchmarks/bench_recurrent_kda.py`
- Tests: `tests/kda/test_recurrent_kda.py`

## Benchmarks

B200/SM100, `do_bench_cudagraph`, latency in microseconds. `FLA/CuTe > 1`
means the CuTe DSL kernel is faster.

Packed paged-state decode with precomputed gates. T=1 is standard decode;
T=4 is fused speculative decode.

| Config | Batch | CuTe T=1 | FLA T=1 | FLA/CuTe T=1 | CuTe T=4 | FLA T=4 | FLA/CuTe T=4 |
|:---|---:|---:|---:|---:|---:|---:|---:|
| H8-D64 | 1 | 2.2 | 3.7 | 1.68x | 7.3 | 7.5 | 1.03x |
| H8-D64 | 2 | 2.2 | 3.6 | 1.63x | 7.2 | 7.6 | 1.05x |
| H8-D64 | 4 | 2.3 | 3.7 | 1.62x | 7.3 | 7.6 | 1.05x |
| H8-D64 | 8 | 2.4 | 3.7 | 1.57x | 7.6 | 7.9 | 1.04x |
| H8-D64 | 16 | 2.5 | 4.1 | 1.66x | 7.9 | 9.2 | 1.17x |
| H8-D64 | 32 | 2.9 | 5.2 | 1.82x | 9.0 | 11.8 | 1.32x |
| H8-D64 | 64 | 3.5 | 7.9 | 2.25x | 10.9 | 20.6 | 1.89x |
| H8-D64 | 128 | 4.9 | 12.2 | 2.49x | 15.7 | 34.5 | 2.19x |
| H16-D128 | 1 | 2.4 | 3.8 | 1.61x | 7.7 | 8.3 | 1.08x |
| H16-D128 | 2 | 2.5 | 3.9 | 1.56x | 7.9 | 8.7 | 1.09x |
| H16-D128 | 4 | 2.9 | 4.5 | 1.57x | 9.2 | 10.2 | 1.11x |
| H16-D128 | 8 | 3.8 | 5.7 | 1.52x | 11.9 | 13.4 | 1.13x |
| H16-D128 | 16 | 5.0 | 8.8 | 1.75x | 15.9 | 23.5 | 1.47x |
| H16-D128 | 32 | 8.4 | 13.8 | 1.65x | 28.0 | 46.2 | 1.65x |
| H16-D128 | 64 | 14.0 | 25.6 | 1.82x | 65.3 | 85.8 | 1.31x |
| H16-D128 | 128 | 25.2 | 55.1 | 2.19x | 109.4 | 161.9 | 1.48x |
| H32-D128 | 1 | 2.5 | 3.9 | 1.57x | 7.9 | 8.7 | 1.09x |
| H32-D128 | 2 | 2.9 | 4.5 | 1.56x | 9.2 | 10.2 | 1.12x |
| H32-D128 | 4 | 3.8 | 5.7 | 1.52x | 11.9 | 13.4 | 1.13x |
| H32-D128 | 8 | 5.0 | 8.7 | 1.75x | 16.0 | 24.1 | 1.51x |
| H32-D128 | 16 | 8.3 | 13.6 | 1.63x | 28.1 | 45.4 | 1.61x |
| H32-D128 | 32 | 13.8 | 24.7 | 1.79x | 65.2 | 85.2 | 1.31x |
| H32-D128 | 64 | 25.2 | 52.9 | 2.10x | 109.4 | 160.7 | 1.47x |
| H32-D128 | 128 | 55.1 | 103.9 | 1.89x | 197.3 | 311.5 | 1.58x |
