### PR TITLE
Remove compute capability restrictions from routerGemm and fused_topk_deepseek

### DIFF
--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -5,12 +5,9 @@ from types import SimpleNamespace
 import torch
 from flashinfer.utils import (
     register_custom_op,
-    supported_compute_capability,
-    backend_requirement,
 )
 
 
-@supported_compute_capability([89, 90, 100, 103, 120, 121])
 def _check_dsv3_fused_routing_supported(
     scores,
     bias,
@@ -116,7 +113,6 @@ def get_dsv3_fused_routing_module():
     )
 
 
-@backend_requirement({}, common_check=_check_dsv3_fused_routing_supported)
 @flashinfer_api
 def fused_topk_deepseek(
     scores: torch.Tensor,
@@ -167,7 +163,7 @@ def fused_topk_deepseek(
             (num_tokens, topk) for the selected expert indices. Must be int32 or int64.
             This tensor is mutated in-place.
         launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to True.
+            Device-side Launch (SM90+ only). Defaults to True.
 
     Returns:
         None: Results are written directly to `topk_values` and `topk_indices` tensors.
@@ -175,14 +171,23 @@ def fused_topk_deepseek(
     Note:
         - The kernel uses float32 internally for all computations to ensure numerical
           precision, even when inputs are float16 or bfloat16.
-        - This implementation is optimized for Hopper (compute capability 90, 100),
-          Ada (compute capability 89), and Blackwell (compute capability 120, 121)
-          architectures.
+        - Persistent Device-side Launch (PDL) is supported on SM90+ architectures.
         - The "NoAux" prefix indicates this variant does not compute auxiliary losses
           (e.g., load balancing loss) during routing.
         - The "Tc" suffix indicates the use of Tensor Core optimizations in the
           underlying CUDA kernel.
     """
+    _check_dsv3_fused_routing_supported(
+        scores,
+        bias,
+        n_group,
+        topk_group,
+        topk,
+        routed_scaling_factor,
+        topk_values,
+        topk_indices,
+        launch_with_pdl,
+    )
     get_dsv3_fused_routing_module().NoAuxTc(
         scores,
         bias,

--- a/flashinfer/gemm/routergemm_dsv3.py
+++ b/flashinfer/gemm/routergemm_dsv3.py
@@ -5,8 +5,6 @@ from types import SimpleNamespace
 import torch
 from flashinfer.utils import (
     register_custom_op,
-    supported_compute_capability,
-    backend_requirement,
 )
 
 
@@ -64,8 +62,6 @@ def _mm_M1_16_K7168_shape_checks(
     return True
 
 
-# TODO: other compute capabilities may be supported but are untested
-@supported_compute_capability([100])
 def _mm_M1_16_K7168_N256_shape_checks(mat_a, mat_b, out, launch_with_pdl):
     return _mm_M1_16_K7168_shape_checks(
         mat_a,
@@ -77,8 +73,6 @@ def _mm_M1_16_K7168_N256_shape_checks(mat_a, mat_b, out, launch_with_pdl):
     )
 
 
-# TODO: other compute capabilities may be supported but are untested
-@supported_compute_capability([100])
 def _mm_M1_16_K7168_N128_shape_checks(mat_a, mat_b, out, launch_with_pdl):
     return _mm_M1_16_K7168_shape_checks(
         mat_a,
@@ -124,7 +118,6 @@ def get_dsv3_router_gemm_module():
     )
 
 
-@backend_requirement({}, common_check=_mm_M1_16_K7168_N128_shape_checks)
 @flashinfer_api
 def mm_M1_16_K7168_N128(
     mat_a: torch.Tensor,
@@ -155,7 +148,7 @@ def mm_M1_16_K7168_N128(
             routing scores. Must be bfloat16, row-major (contiguous). This tensor is
             mutated in-place.
         launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to False.
+            Device-side Launch (SM90+ only). Defaults to False.
 
     Returns:
         None: The result is written directly to the `out` tensor.
@@ -165,16 +158,16 @@ def mm_M1_16_K7168_N128(
             expected Mistral Large 3 router configuration.
 
     Note:
-        This kernel is specialized for compute capability 10.0 (Blackwell architecture).
         The specific problem size optimization makes this significantly faster than
         general-purpose GEMM implementations for the router operation.
+        Persistent Device-side Launch (PDL) is supported on SM90+ architectures.
     """
+    _mm_M1_16_K7168_N128_shape_checks(mat_a, mat_b, out, launch_with_pdl)
     get_dsv3_router_gemm_module().mm_M1_16_K7168_N128(
         mat_a, mat_b, out, launch_with_pdl
     )
 
 
-@backend_requirement({}, common_check=_mm_M1_16_K7168_N256_shape_checks)
 @flashinfer_api
 def mm_M1_16_K7168_N256(
     mat_a: torch.Tensor,
@@ -205,7 +198,7 @@ def mm_M1_16_K7168_N256(
             routing scores. Must be float32, row-major (contiguous). This tensor is
             mutated in-place.
         launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to False.
+            Device-side Launch (SM90+ only). Defaults to False.
 
     Returns:
         None: The result is written directly to the `out` tensor.
@@ -215,10 +208,11 @@ def mm_M1_16_K7168_N256(
             expected DeepSeek-V3 router configuration.
 
     Note:
-        This kernel is specialized for compute capability 10.0 (Blackwell architecture).
         The specific problem size optimization makes this significantly faster than
         general-purpose GEMM implementations for the router operation.
+        Persistent Device-side Launch (PDL) is supported on SM90+ architectures.
     """
+    _mm_M1_16_K7168_N256_shape_checks(mat_a, mat_b, out, launch_with_pdl)
     get_dsv3_router_gemm_module().mm_M1_16_K7168_N256(
         mat_a, mat_b, out, launch_with_pdl
     )

--- a/tests/model_optimizations/test_dsv3_router_gemm.py
+++ b/tests/model_optimizations/test_dsv3_router_gemm.py
@@ -2,7 +2,6 @@ import torch
 import pytest
 from flashinfer.dsv3_ops import mm_M1_16_K7168_N128, mm_M1_16_K7168_N256
 import torch.nn.functional as F
-from flashinfer.utils import get_compute_capability
 
 
 # Positive tests
@@ -19,11 +18,6 @@ from flashinfer.utils import get_compute_capability
 def test_dsv3_router_gemm_op(
     num_tokens, num_experts, hidden_dim, launch_with_pdl, output_dtype, fn_to_test
 ):
-    compute_capability = get_compute_capability(torch.device("cuda"))
-    compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
-    if compute_capability_number != 100:
-        pytest.skip("DSv3 Router GEMM is only supported on SM100")
-
     mat_a = torch.randn(num_tokens, hidden_dim, device="cuda", dtype=torch.bfloat16)
     mat_b = torch.randn(
         num_experts, hidden_dim, device="cuda", dtype=torch.bfloat16
@@ -238,11 +232,6 @@ def test_dsv3_router_gemm_op_negative(
     mat_b_transpose,
     expected_error,
 ):
-    compute_capability = get_compute_capability(torch.device("cuda"))
-    compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
-    if compute_capability_number != 100:
-        pytest.skip("DSv3 Router GEMM is only supported on SM100")
-
     mat_a = torch.randn(num_tokens, hidden_dim, device="cuda", dtype=mat_a_dtype)
     mat_b = torch.randn(num_experts, hidden_dim, device="cuda", dtype=mat_b_dtype)
     if mat_b_transpose:


### PR DESCRIPTION
## Summary
- Remove `@supported_compute_capability` and `@backend_requirement` decorators from `routerGemm` (`mm_M1_16_K7168_N128`, `mm_M1_16_K7168_N256`) and `fused_topk_deepseek` APIs
- Both kernels use standard CUDA operations with SM90+ PDL features guarded by `#if __CUDA_ARCH__ >= 900`, so they work on all GPU architectures
- `routerGemm` was previously restricted to SM100 only; `fused_topk_deepseek` was restricted to SM89/90/100/103/120/121
- Shape/config validation is now called directly in the function body instead of via decorator
- Router GEMM tests no longer skip on non-SM100 GPUs

## Test plan
- [ ] Run `pytest tests/model_optimizations/test_dsv3_router_gemm.py` on non-SM100 GPU (e.g. A100, H100)
- [ ] Run `pytest tests/model_optimizations/test_dsv3_fused_routing.py` on non-SM100 GPU
- [ ] Verify negative tests still raise ValueError for invalid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal validation logic for DSv3 routing and GEMM kernels, moving validation checks to explicit runtime calls instead of decorator-based checks while maintaining the same functional behavior.

* **Tests**
  * Updated test execution to run unconditionally on all CUDA devices, removing hardware-specific conditional skipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->