### PR TITLE
feat: add CuTe DSL flash attention backend for SM120 GPUs

### DIFF
--- a/flashinfer/cute_dsl_attention.py
+++ b/flashinfer/cute_dsl_attention.py
@@ -207,6 +207,11 @@ def cute_dsl_prefill_sm120(
     if key.shape[2] != value.shape[2]:
         raise ValueError("key and value must have the same number of KV heads.")
     head_dim = query.shape[-1]
+    if key.shape[-1] != head_dim or value.shape[-1] != head_dim:
+        raise ValueError(
+            f"head_dim mismatch: query={head_dim}, key={key.shape[-1]}, "
+            f"value={value.shape[-1]}. All must match."
+        )
     if head_dim % 8 != 0:
         raise ValueError(f"head_dim must be divisible by 8, got {head_dim}.")
     if out is not None:
@@ -278,6 +283,9 @@ def cute_dsl_prefill_sm120(
     cache_key = (
         query.shape,
         key.shape,
+        _get_stride_order(query),
+        _get_stride_order(key),
+        _get_stride_order(value),
         dtype_str,
         causal,
         sm_scale,

--- a/flashinfer/cute_dsl_attention.py
+++ b/flashinfer/cute_dsl_attention.py
@@ -22,8 +22,10 @@ efficient memory movement.
 
 import functools
 import importlib
+import importlib.util
 import math
 import os
+import threading
 from typing import Optional
 
 import torch
@@ -92,8 +94,9 @@ def _get_compiled_kernel(head_dim, m_block, n_block, num_threads, is_causal, dty
 
 # Bounded cache for cute.compile() results keyed by
 # (shape, dtype, causal, sm_scale, block sizes, num_threads).
-# Using an ordered dict with manual eviction to bound memory.
+# Thread-safe with lock to prevent double-compilation under concurrency.
 _compile_cache: dict = {}
+_compile_cache_lock = threading.Lock()
 _COMPILE_CACHE_MAX_SIZE = 64
 
 
@@ -105,14 +108,22 @@ def _get_or_compile(
     if compiled is not None:
         return compiled
 
-    compiled = cute.compile(fa2_fwd, q_cute, k_cute, v_cute, o_cute, sm_scale, stream)
+    with _compile_cache_lock:
+        # Double-check after acquiring lock
+        compiled = _compile_cache.get(cache_key)
+        if compiled is not None:
+            return compiled
 
-    # Evict oldest entries if cache is full
-    if len(_compile_cache) >= _COMPILE_CACHE_MAX_SIZE:
-        oldest_key = next(iter(_compile_cache))
-        del _compile_cache[oldest_key]
+        compiled = cute.compile(
+            fa2_fwd, q_cute, k_cute, v_cute, o_cute, sm_scale, stream
+        )
 
-    _compile_cache[cache_key] = compiled
+        # Evict oldest entries if cache is full
+        if len(_compile_cache) >= _COMPILE_CACHE_MAX_SIZE:
+            oldest_key = next(iter(_compile_cache))
+            del _compile_cache[oldest_key]
+
+        _compile_cache[cache_key] = compiled
     return compiled
 
 

--- a/flashinfer/cute_dsl_attention.py
+++ b/flashinfer/cute_dsl_attention.py
@@ -1,0 +1,283 @@
+"""CuTe DSL Flash Attention v2 backend for SM120 (Blackwell GeForce / DGX Spark).
+
+This module provides an optional attention backend using NVIDIA's CuTe DSL
+(CUTLASS Python DSL) which JIT-compiles flash attention kernels specifically
+for SM120 GPUs that lack tcgen05 instructions.
+
+Requirements:
+    - ``nvidia-cutlass-dsl`` package (pip install nvidia-cutlass-dsl)
+    - ``cuda-python`` package (pip install cuda-python)
+    - CUTLASS repository with the Blackwell GeForce flash_attention_v2 example
+
+Usage::
+
+    from flashinfer.cute_dsl_attention import cute_dsl_prefill_sm120
+
+    out = cute_dsl_prefill_sm120(q, k, v, causal=True)
+
+The CuTe DSL kernel uses SM80-compatible HMMA tensor core instructions
+(mma.sync 16x8x16) which work on SM120, combined with CpAsync for
+efficient memory movement.
+"""
+
+import functools
+import importlib
+import math
+import os
+from typing import Optional
+
+import torch
+
+from .api_logging import flashinfer_api
+from .utils import is_sm120a_supported, is_sm121a_supported
+
+
+def _find_cute_dsl_fa_module():
+    """Find the CuTe DSL flash attention module.
+
+    Searches for the FlashAttentionForwardSm120 class in these locations:
+    1. CUTLASS_FA_SM120_PATH environment variable
+    2. CUTLASS repo at standard paths
+    """
+    custom_path = os.environ.get("CUTLASS_FA_SM120_PATH")
+    if custom_path and os.path.exists(custom_path):
+        return custom_path
+
+    candidates = [
+        os.path.expanduser(
+            "~/cutlass/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py"
+        ),
+        "/usr/local/cutlass/examples/python/CuTeDSL/blackwell_geforce/"
+        "flash_attention_v2.py",
+    ]
+
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+
+    return None
+
+
+def _load_fa_module(module_path: str):
+    """Load the flash attention module from a file path."""
+    spec = importlib.util.spec_from_file_location("flash_attention_v2", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@functools.lru_cache(maxsize=32)
+def _get_compiled_kernel(head_dim, m_block, n_block, num_threads, is_causal, dtype_str):
+    """Cache CuTe DSL flash attention kernel instances.
+
+    Bounded to 32 entries to prevent unbounded memory growth from
+    varied configurations.
+    """
+    module_path = _find_cute_dsl_fa_module()
+    if module_path is None:
+        raise ImportError(
+            "CuTe DSL flash attention module not found. Set CUTLASS_FA_SM120_PATH "
+            "to the path of flash_attention_v2.py from the CUTLASS repository, or "
+            "clone CUTLASS to ~/cutlass/."
+        )
+
+    fa_module = _load_fa_module(module_path)
+
+    fa2_fwd = fa_module.FlashAttentionForwardSm120(
+        head_dim, m_block, n_block, num_threads, is_causal
+    )
+
+    return fa2_fwd, fa_module
+
+
+# Bounded cache for cute.compile() results keyed by
+# (shape, dtype, causal, sm_scale, block sizes, num_threads).
+# Using an ordered dict with manual eviction to bound memory.
+_compile_cache: dict = {}
+_COMPILE_CACHE_MAX_SIZE = 64
+
+
+def _get_or_compile(
+    cache_key, fa2_fwd, cute, q_cute, k_cute, v_cute, o_cute, sm_scale, stream
+):
+    """Get a cached compiled executor or compile and cache a new one."""
+    compiled = _compile_cache.get(cache_key)
+    if compiled is not None:
+        return compiled
+
+    compiled = cute.compile(fa2_fwd, q_cute, k_cute, v_cute, o_cute, sm_scale, stream)
+
+    # Evict oldest entries if cache is full
+    if len(_compile_cache) >= _COMPILE_CACHE_MAX_SIZE:
+        oldest_key = next(iter(_compile_cache))
+        del _compile_cache[oldest_key]
+
+    _compile_cache[cache_key] = compiled
+    return compiled
+
+
+def _get_stride_order(t):
+    """Get stride order, with fallback for PyTorch < 2.7.
+
+    ``torch.Tensor.dim_order()`` was introduced in PyTorch 2.7.
+    For older versions, derive the order from actual strides.
+    """
+    if hasattr(t, "dim_order"):
+        return t.dim_order()
+    # Derive order from strides: largest stride first (dim_order convention)
+    return tuple(sorted(range(t.ndim), key=lambda i: t.stride(i), reverse=True))
+
+
+@flashinfer_api
+def cute_dsl_prefill_sm120(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    causal: bool = True,
+    sm_scale: Optional[float] = None,
+    m_block_size: int = 64,
+    n_block_size: int = 64,
+    num_threads: int = 128,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Flash Attention v2 prefill using CuTe DSL kernels on SM120 GPUs.
+
+    This function JIT-compiles a flash attention kernel using NVIDIA's CuTe DSL
+    (CUTLASS Python DSL) that runs on SM120 GPUs using SM80-compatible HMMA
+    tensor core instructions.
+
+    Parameters
+    ----------
+    query : torch.Tensor
+        Query tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
+    key : torch.Tensor
+        Key tensor with shape [batch_size, seqlen_k, num_heads, head_dim].
+    value : torch.Tensor
+        Value tensor with shape [batch_size, seqlen_k, num_heads, head_dim].
+    causal : bool
+        Whether to use causal masking.
+    sm_scale : Optional[float]
+        Softmax scale factor. If None, defaults to 1/sqrt(head_dim).
+    m_block_size : int
+        Query block tile size (default 64, can be 64 or 128).
+    n_block_size : int
+        Key/Value block tile size (default 64, can be 64 or 128).
+    num_threads : int
+        Number of threads per CTA (default 128).
+    out : Optional[torch.Tensor]
+        Pre-allocated output tensor with same shape and dtype as query.
+        If None, a new tensor is allocated.
+
+    Returns
+    -------
+    out : torch.Tensor
+        Output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
+    """
+    if not (is_sm120a_supported(query.device) or is_sm121a_supported(query.device)):
+        raise ValueError(
+            "cute_dsl_prefill_sm120 is only supported on SM12x GPUs "
+            "(RTX 5090, DGX Spark GB10)."
+        )
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"Only BF16 and FP16 are supported, got {query.dtype}.")
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError("query, key, and value must have the same dtype.")
+    if key.device != query.device or value.device != query.device:
+        raise ValueError("query, key, and value must be on the same device.")
+    if query.shape[0] != key.shape[0] or query.shape[0] != value.shape[0]:
+        raise ValueError("query, key, and value must have the same batch size.")
+    if key.shape[1] != value.shape[1]:
+        raise ValueError("key and value must have the same sequence length.")
+    if query.shape[2] != key.shape[2]:
+        raise ValueError(
+            "GQA is not yet supported; query and key must have the same "
+            "number of heads."
+        )
+    if key.shape[2] != value.shape[2]:
+        raise ValueError("key and value must have the same number of KV heads.")
+    head_dim = query.shape[-1]
+    if head_dim % 8 != 0:
+        raise ValueError(f"head_dim must be divisible by 8, got {head_dim}.")
+    if out is not None:
+        if out.shape != query.shape:
+            raise ValueError(
+                f"out shape {out.shape} must match query shape {query.shape}."
+            )
+        if out.dtype != query.dtype:
+            raise ValueError(
+                f"out dtype {out.dtype} must match query dtype {query.dtype}."
+            )
+        if out.device != query.device:
+            raise ValueError("out must be on the same device as query.")
+
+    try:
+        import cutlass.cute as cute
+        from cutlass.cute.runtime import from_dlpack
+    except ImportError as e:
+        raise ImportError(
+            "nvidia-cutlass-dsl package is required for CuTe DSL attention. "
+            "Install with: pip install nvidia-cutlass-dsl"
+        ) from e
+
+    try:
+        # cuda-python >= 12.6.2 uses cuda.bindings.driver
+        import cuda.bindings.driver as cuda_drv
+    except ImportError:
+        try:
+            # cuda-python < 12.6.2 uses cuda.cuda
+            from cuda import cuda as cuda_drv
+        except ImportError as e:
+            raise ImportError(
+                "cuda-python package is required for CuTe DSL attention. "
+                "Install with: pip install cuda-python"
+            ) from e
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    dtype_str = str(query.dtype).split(".")[-1]  # "float16" or "bfloat16"
+
+    fa2_fwd, _ = _get_compiled_kernel(
+        head_dim, m_block_size, n_block_size, num_threads, causal, dtype_str
+    )
+
+    if out is None:
+        out = torch.empty_like(query)
+
+    dtype_bits = 16  # FP16 and BF16 are both 16-bit
+    align_divisibility = 128 // dtype_bits  # 8 elements for 16-byte alignment
+
+    def to_cute_tensor(t):
+        """Convert a torch tensor to CuTe tensor with proper alignment hints."""
+        ct = from_dlpack(t, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        ct = ct.mark_compact_shape_dynamic(
+            mode=3,
+            stride_order=_get_stride_order(t),
+            divisibility=align_divisibility,
+        )
+        return ct
+
+    q_cute = to_cute_tensor(query)
+    k_cute = to_cute_tensor(key)
+    v_cute = to_cute_tensor(value)
+    o_cute = to_cute_tensor(out)
+
+    stream = cuda_drv.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    cache_key = (
+        query.shape,
+        key.shape,
+        dtype_str,
+        causal,
+        sm_scale,
+        m_block_size,
+        n_block_size,
+        num_threads,
+    )
+    compiled = _get_or_compile(
+        cache_key, fa2_fwd, cute, q_cute, k_cute, v_cute, o_cute, sm_scale, stream
+    )
+
+    compiled(q_cute, k_cute, v_cute, o_cute, sm_scale, stream)
+
+    return out

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3312,7 +3312,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 q.device,
                 "out",
             )
-<<<<<<< HEAD
         if self._backend == "cute-dsl":
             # These checks live here (not in plan()) because return_lse and
             # scale parameters are run()-time arguments that can vary between

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3080,13 +3080,25 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
+            # cute_dsl limitations: no GQA, no CUDA graphs, and seqlen_q must equal
+            # seqlen_k per sequence (full prefill only, not append/chunked).
+            if self._backend == "cute_dsl" and (
+                num_qo_heads != num_kv_heads
+                or self.is_cuda_graph_enabled
+                or not torch.equal(
+                    qo_indptr_host[1:] - qo_indptr_host[:-1],
+                    kv_indptr_host[1:] - kv_indptr_host[:-1],
+                )
+            ):
+                self._backend = "fa2"
+
             if self._backend == "cutlass":
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (
                     get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]
                 )
                 self._cached_module = get_fmha_module(*new_get_module_args)
-            elif self._backend != "cudnn":
+            elif self._backend not in ("cudnn", "cute_dsl"):
                 self._cached_module = get_batch_prefill_module(
                     self._backend, *get_module_args
                 )
@@ -3096,7 +3108,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._cached_module, qo_indptr, kv_indptr, num_qo_heads, causal
             )
             self._max_qo_len = torch.max(qo_indptr[1:] - qo_indptr[:-1]).item()
-        elif self._backend not in ("cudnn", "cute-dsl"):
+        elif self._backend not in ("cudnn", "cute_dsl"):
             assert self._cached_module is not None, "cached module is not initialized"
             args = [
                 self._float_workspace_buffer,
@@ -3300,6 +3312,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 q.device,
                 "out",
             )
+<<<<<<< HEAD
         if self._backend == "cute-dsl":
             # These checks live here (not in plan()) because return_lse and
             # scale parameters are run()-time arguments that can vary between

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -54,6 +54,7 @@ from .utils import (
     _get_cache_buf,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
+    _should_use_cute_dsl,
     determine_attention_backend,
     device_support_pdl,
     get_device_sm_count,
@@ -3067,6 +3068,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     q_data_type,
                     kv_data_type,
                 )
+                # cute_dsl is only supported by BatchPrefill, so check here
+                # rather than in determine_attention_backend (which is shared
+                # by single_prefill, decode, sparse, etc.)
+                if self._backend == "fa2" and _should_use_cute_dsl(
+                    self.device,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    self._custom_mask_buf is not None,
+                    q_data_type,
+                    kv_data_type,
+                ):
+                    self._backend = "cute_dsl"
 
             get_module_args = (
                 q_data_type,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3092,6 +3092,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             ):
                 self._backend = "fa2"
 
+            if self._backend == "cute_dsl":
+                # Cache CPU indptrs to avoid GPU→CPU sync on every run() call
+                self._qo_indptr_cpu = qo_indptr_host
+                self._kv_indptr_cpu = kv_indptr_host
+
             if self._backend == "cutlass":
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3078,7 +3078,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     q_data_type,
                     kv_data_type,
                 ):
-                    self._backend = "cute_dsl"
+                    self._backend = "cute-dsl"
 
             get_module_args = (
                 q_data_type,
@@ -3094,7 +3094,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             )
             # cute_dsl limitations: no GQA, no CUDA graphs, and seqlen_q must equal
             # seqlen_k per sequence (full prefill only, not append/chunked).
-            if self._backend == "cute_dsl" and (
+            if self._backend == "cute-dsl" and (
                 num_qo_heads != num_kv_heads
                 or self.is_cuda_graph_enabled
                 or not torch.equal(
@@ -3104,7 +3104,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             ):
                 self._backend = "fa2"
 
-            if self._backend == "cute_dsl":
+            if self._backend == "cute-dsl":
                 # Cache CPU indptrs to avoid GPU→CPU sync on every run() call
                 self._qo_indptr_cpu = qo_indptr_host
                 self._kv_indptr_cpu = kv_indptr_host
@@ -3115,7 +3115,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]
                 )
                 self._cached_module = get_fmha_module(*new_get_module_args)
-            elif self._backend not in ("cudnn", "cute_dsl"):
+            elif self._backend not in ("cudnn", "cute-dsl"):
                 self._cached_module = get_batch_prefill_module(
                     self._backend, *get_module_args
                 )
@@ -3125,7 +3125,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._cached_module, qo_indptr, kv_indptr, num_qo_heads, causal
             )
             self._max_qo_len = torch.max(qo_indptr[1:] - qo_indptr[:-1]).item()
-        elif self._backend not in ("cudnn", "cute_dsl"):
+        elif self._backend not in ("cudnn", "cute-dsl"):
             assert self._cached_module is not None, "cached module is not initialized"
             args = [
                 self._float_workspace_buffer,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3068,7 +3068,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     q_data_type,
                     kv_data_type,
                 )
-                # cute_dsl is only supported by BatchPrefill, so check here
+                # cute-dsl is only supported by BatchPrefill, so check here
                 # rather than in determine_attention_backend (which is shared
                 # by single_prefill, decode, sparse, etc.)
                 if self._backend == "fa2" and _should_use_cute_dsl(
@@ -3092,7 +3092,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
-            # cute_dsl limitations: no GQA, no CUDA graphs, and seqlen_q must equal
+            # cute-dsl limitations: no GQA, no CUDA graphs, and seqlen_q must equal
             # seqlen_k per sequence (full prefill only, not append/chunked).
             if self._backend == "cute-dsl" and (
                 num_qo_heads != num_kv_heads

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -464,6 +464,17 @@ def is_cutlass_backend_supported(
     return True
 
 
+@functools.lru_cache(maxsize=1)
+def _is_cute_dsl_available() -> bool:
+    """Check if nvidia-cutlass-dsl is available for CuTe DSL backends."""
+    try:
+        import cutlass.cute  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def determine_attention_backend(
     device: torch.device,
     pos_encoding_mode: int,
@@ -505,6 +516,15 @@ def determine_attention_backend(
         dtype_kv,
     ):
         return "fa3"
+    elif (
+        (is_sm120a_supported(device) or is_sm121a_supported(device))
+        and not use_custom_mask
+        and pos_encoding_mode == PosEncodingMode.NONE.value
+        and dtype_q in {torch.float16, torch.bfloat16}
+        and dtype_kv in {torch.float16, torch.bfloat16}
+        and _is_cute_dsl_available()
+    ):
+        return "cute_dsl"
     else:
         return "fa2"
 

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -516,17 +516,31 @@ def determine_attention_backend(
         dtype_kv,
     ):
         return "fa3"
-    elif (
+    else:
+        return "fa2"
+
+
+def _should_use_cute_dsl(
+    device: torch.device,
+    pos_encoding_mode: int,
+    use_custom_mask: bool,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+) -> bool:
+    """Check if the CuTe DSL backend should be used for SM12x attention.
+
+    This is separate from determine_attention_backend because cute_dsl is only
+    supported by BatchPrefillWithKVCacheWrapper, not by single_prefill, decode,
+    or sparse attention APIs.
+    """
+    return (
         (is_sm120a_supported(device) or is_sm121a_supported(device))
         and not use_custom_mask
         and pos_encoding_mode == PosEncodingMode.NONE.value
         and dtype_q in {torch.float16, torch.bfloat16}
         and dtype_kv in {torch.float16, torch.bfloat16}
         and _is_cute_dsl_available()
-    ):
-        return "cute_dsl"
-    else:
-        return "fa2"
+    )
 
 
 def version_at_least(version: str, base_version: str) -> bool:

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -464,17 +464,6 @@ def is_cutlass_backend_supported(
     return True
 
 
-@functools.lru_cache(maxsize=1)
-def _is_cute_dsl_available() -> bool:
-    """Check if nvidia-cutlass-dsl is available for CuTe DSL backends."""
-    try:
-        import cutlass.cute  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
 def determine_attention_backend(
     device: torch.device,
     pos_encoding_mode: int,
@@ -516,15 +505,6 @@ def determine_attention_backend(
         dtype_kv,
     ):
         return "fa3"
-    elif (
-        (is_sm120a_supported(device) or is_sm121a_supported(device))
-        and not use_custom_mask
-        and pos_encoding_mode == PosEncodingMode.NONE.value
-        and dtype_q in {torch.float16, torch.bfloat16}
-        and dtype_kv in {torch.float16, torch.bfloat16}
-        and _is_cute_dsl_available()
-    ):
-        return "cute_dsl"
     else:
         return "fa2"
 


### PR DESCRIPTION
## Summary

Adds an optional attention backend using NVIDIA's CuTe DSL (CUTLASS Python DSL) for **SM120 GPUs** (RTX 5090, DGX Spark GB10) that lack `tcgen05` instructions. The kernel uses SM80-compatible HMMA tensor core instructions (`mma.sync.aligned.m16n8k16`) which work on SM120.

This is extracted from #2561 as a standalone module, decoupled from the fmha_v2 standard attention work (which was integrated into #2446 per discussion with @jimmyzho).

### API

```python
from flashinfer.cute_dsl_attention import cute_dsl_prefill_sm120

out = cute_dsl_prefill_sm120(q, k, v, causal=True)
```

### Requirements

- `nvidia-cutlass-dsl` package (`pip install nvidia-cutlass-dsl`)
- `cuda-python` package (`pip install cuda-python`)
- CUTLASS repo with `FlashAttentionForwardSm120` example (set `CUTLASS_FA_SM120_PATH` or clone to `~/cutlass/`)

### Review feedback addressed (from #2561)

| Issue | Fix |
|-------|-----|
| Unbounded `_compile_cache` | Bounded to 64 entries with FIFO eviction |
| `num_threads` missing from cache key | Included in cache key |
| Hardcoded dev-specific paths | Removed; uses env var + standard locations only |
| Missing `@flashinfer_api` | Added |
| Missing `out` parameter | Added optional `out` parameter |
| `torch.Tensor.dim_order()` compat | Fallback for PyTorch < 2.7 via stride-derived order |
| `cuda-python` import guard | Protected with try-except; supports both cuda-python < 12.6.2 and >= 12.6.2 import paths |
| Missing input validation | Full q/k/v shape, dtype, device validation |
| `@functools.cache` unbounded | Changed to `@functools.lru_cache(maxsize=32)` |

### Validation on DGX Spark (SM121a, CUDA 13.0)

| Test | Result |
|------|--------|
| BF16 b=1 h=4 s=64 d=64 non-causal | PASS (max_diff=0.000000) |
| BF16 b=1 h=4 s=64 d=64 causal | PASS (max_diff=0.000000) |
| BF16 b=1 h=4 s=128 d=128 non-causal | PASS (max_diff=0.000977) |
| BF16 b=1 h=4 s=128 d=128 causal | PASS (max_diff=0.000001) |
| BF16 b=2 h=4 s=64 d=64 non-causal | PASS (max_diff=0.000977) |
| BF16 b=2 h=4 s=64 d=64 causal | PASS (max_diff=0.000000) |
| FP16 b=1 h=4 s=64 d=64 non-causal | PASS (max_diff=0.000122) |
| FP16 b=1 h=4 s=64 d=64 causal | PASS (max_diff=0.000244) |
| FP16 b=1 h=4 s=128 d=128 causal | PASS (max_diff=0.000244) |
| Pre-allocated `out` parameter | PASS |

### Dependencies

- This PR uses `is_sm120a_supported`/`is_sm121a_supported` individually; once #2574 merges, these can be replaced with the unified `is_sm12x_supported()` helper.

[Second Nature Computing](https://joinsecondnature.com)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CuTe DSL–based flash-attention prefill support for SM120/SM121 GPUs with JIT-compiled, cached kernels and concurrency-safe compilation.
  * Automatic backend selection to prefer CuTe DSL when compatible, with transparent fallback to alternate prefill paths for unsupported cases (grouped-query attention, CUDA graphs, differing per-sequence lengths or head mismatches).
  * Automatic tensor layout/format handling, configurable tuning knobs, robust input validation, and clear dependency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->