### PR TITLE
test: Skip test_decode_delta_rule.py 

### DIFF
--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -23,6 +23,8 @@ import random
 import torch
 import pytest
 
+pytestmark = pytest.mark.skip(reason="Temporarily skipped due to CI failures.")
+
 try:
     from .reference_delta_rule import decode_delta_rule, verify_delta_rule
 except ImportError:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`test_decode_delta_rule.py` is failing in internal and public CI, blocking any other PRs from being merged.

Disable the unit test script for now until a fix has been checked in.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled a test module pending investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->