### PR TITLE
feat: support FP8 `concat_mla_k` for FP8 MLA prefill

### DIFF
--- a/benchmarks/bench_concat_mla.py
+++ b/benchmarks/bench_concat_mla.py
@@ -6,6 +6,8 @@ This benchmark compares different implementations of the concat_mla_k operation:
 - torch_compiled: torch.compile optimized version
 - flashinfer: FlashInfer CUDA kernel
 
+Supported dtypes: bfloat16, float8_e4m3fn, float8_e5m2
+
 Usage:
 $ python bench_concat_mla.py
 """
@@ -21,45 +23,65 @@ NUM_LOCAL_HEADS = 128
 QK_NOPE_HEAD_DIM = 128
 QK_ROPE_HEAD_DIM = 64
 
+BENCHMARK_DTYPES = [
+    torch.bfloat16,
+    torch.float8_e4m3fn,
+]
 
-def create_data(num_tokens: int, device: str = "cuda"):
+
+def _is_fp8(dtype):
+    return dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+
+
+def _make_random(shape, dtype, device):
+    """Create a random tensor, handling FP8 types that don't support randn."""
+    if _is_fp8(dtype):
+        return torch.randn(shape, dtype=torch.bfloat16, device=device).to(dtype)
+    return torch.randn(shape, dtype=dtype, device=device)
+
+
+def create_data(
+    num_tokens: int, dtype: torch.dtype = torch.bfloat16, device: str = "cuda"
+):
     """Create test data with potentially non-contiguous tensors."""
     # Create containers with extra space to test strided access
-    k_nope_container = torch.randn(
+    k_nope_container = _make_random(
         (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM + 128),
-        dtype=torch.bfloat16,
+        dtype=dtype,
         device=device,
     )
     k_nope = k_nope_container[:, :, :QK_NOPE_HEAD_DIM]
 
-    k_rope_container = torch.randn(
+    k_rope_container = _make_random(
         (num_tokens, 1, 128 + QK_ROPE_HEAD_DIM),
-        dtype=torch.bfloat16,
+        dtype=dtype,
         device=device,
     )
     k_rope = k_rope_container[:, :, -QK_ROPE_HEAD_DIM:]
 
     k = torch.empty(
         (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM),
-        dtype=torch.bfloat16,
+        dtype=dtype,
         device=device,
     )
     return dict(k=k, k_nope=k_nope, k_rope=k_rope)
 
 
-def fn_torch(k, k_nope, k_rope):
+def fn_torch(k: torch.Tensor, k_nope: torch.Tensor, k_rope: torch.Tensor) -> None:
     """Native PyTorch implementation."""
     k[..., :QK_NOPE_HEAD_DIM] = k_nope
     k[..., QK_NOPE_HEAD_DIM:] = k_rope
 
 
 @torch.compile(dynamic=True)
-def fn_torch_compiled(k, k_nope, k_rope):
+def fn_torch_compiled(
+    k: torch.Tensor, k_nope: torch.Tensor, k_rope: torch.Tensor
+) -> None:
     """torch.compile optimized implementation."""
     return fn_torch(k, k_nope, k_rope)
 
 
-def fn_flashinfer(k, k_nope, k_rope):
+def fn_flashinfer(k: torch.Tensor, k_nope: torch.Tensor, k_rope: torch.Tensor) -> None:
     """FlashInfer CUDA kernel implementation."""
     concat_mla_k_flashinfer(k, k_nope, k_rope)
 
@@ -68,26 +90,40 @@ def execute_and_get_output(f, data):
     """Execute function and return output for correctness checking."""
     data["k"].zero_()
     f(**data)
-    assert data["k"].sum().item() != 0, "Output should not be all zeros"
+    # FP8 types don't support .sum(), so check via raw bytes
+    assert data["k"].view(torch.uint8).any(), "Output should not be all zeros"
     return data["k"].clone()
 
 
 def verify_correctness():
     """Verify that all implementations produce the same output."""
     print("Verifying correctness...")
-    torch.manual_seed(0)
-    data = create_data(num_tokens=32768)
+    for dtype in BENCHMARK_DTYPES:
+        torch.manual_seed(0)
+        data = create_data(num_tokens=32768, dtype=dtype)
 
-    output_ref = execute_and_get_output(fn_torch, data)
-    output_flashinfer = execute_and_get_output(fn_flashinfer, data)
+        output_ref = execute_and_get_output(fn_torch, data)
+        output_flashinfer = execute_and_get_output(fn_flashinfer, data)
 
-    if not torch.allclose(output_ref, output_flashinfer):
-        abs_delta = torch.abs(output_ref - output_flashinfer)
-        raise AssertionError(
-            f"FlashInfer output mismatch! "
-            f"abs_delta max={abs_delta.max().item()}, "
-            f"num_mismatches={torch.sum(abs_delta != 0).item()}"
-        )
+        # FP8 types don't support torch.allclose / subtraction directly
+        if _is_fp8(dtype):
+            matches = output_ref.view(torch.uint8) == output_flashinfer.view(
+                torch.uint8
+            )
+            if not matches.all():
+                raise AssertionError(
+                    f"[{dtype}] FlashInfer output mismatch! "
+                    f"num_mismatches={torch.sum(~matches).item()}"
+                )
+        else:
+            if not torch.allclose(output_ref, output_flashinfer):
+                abs_delta = torch.abs(output_ref - output_flashinfer)
+                raise AssertionError(
+                    f"[{dtype}] FlashInfer output mismatch! "
+                    f"abs_delta max={abs_delta.max().item()}, "
+                    f"num_mismatches={torch.sum(abs_delta != 0).item()}"
+                )
+        print(f"  {dtype}: OK")
 
     print("All implementations produce correct results!")
 
@@ -95,38 +131,44 @@ def verify_correctness():
 def benchmark():
     """Run benchmark for all implementations."""
     num_tokens_list = [2048, 4096, 8192, 16384, 32768]
-    providers = [
-        ("torch", fn_torch),
-        ("torch_compiled", fn_torch_compiled),
-        ("flashinfer", fn_flashinfer),
-    ]
 
-    # Warmup torch_compiled
-    print("Warming up torch.compile...")
-    data = create_data(num_tokens=2048)
-    for _ in range(3):
-        fn_torch_compiled(**data)
+    for dtype in BENCHMARK_DTYPES:
+        print(f"\n{'=' * 60}")
+        print(f"Benchmarking dtype={dtype}")
+        print(f"{'=' * 60}")
 
-    # Collect results
-    results = {name: [] for name, _ in providers}
+        providers = [
+            ("torch", fn_torch),
+            ("torch_compiled", fn_torch_compiled),
+            ("flashinfer", fn_flashinfer),
+        ]
 
-    for num_tokens in num_tokens_list:
-        data = create_data(num_tokens=num_tokens)
-        for name, fn in providers:
-            measurements = bench_gpu_time(lambda: fn(**data))
-            median_ms = np.median(measurements)
-            results[name].append(median_ms)
+        # Warmup torch_compiled
+        print("Warming up torch.compile...")
+        data = create_data(num_tokens=2048, dtype=dtype)
+        for _ in range(3):
+            fn_torch_compiled(**data)
 
-    # Print header
-    header = ["num_tokens"] + [name for name, _ in providers]
-    print(" ".join(f"{h:>14}" for h in header))
+        # Collect results
+        results = {name: [] for name, _ in providers}
 
-    # Print rows
-    for i, num_tokens in enumerate(num_tokens_list):
-        row = [f"{float(num_tokens):>14.1f}"]
-        for name, _ in providers:
-            row.append(f"{results[name][i]:>14.6f}")
-        print(" ".join(row))
+        for num_tokens in num_tokens_list:
+            data = create_data(num_tokens=num_tokens, dtype=dtype)
+            for name, fn in providers:
+                measurements = bench_gpu_time(lambda: fn(**data))
+                median_ms = np.median(measurements)
+                results[name].append(median_ms)
+
+        # Print header
+        header = ["num_tokens"] + [name for name, _ in providers]
+        print(" ".join(f"{h:>14}" for h in header))
+
+        # Print rows
+        for i, num_tokens in enumerate(num_tokens_list):
+            row = [f"{float(num_tokens):>14.1f}"]
+            for name, _ in providers:
+                row.append(f"{results[name][i]:>14.6f}")
+            print(" ".join(row))
 
 
 if __name__ == "__main__":

--- a/csrc/concat_mla.cu
+++ b/csrc/concat_mla.cu
@@ -84,7 +84,7 @@ void concat_mla_k(TensorView k, TensorView k_nope, TensorView k_rope) {
   ffi::CUDADeviceGuard device_guard(k.device().device_id);
   const cudaStream_t stream = get_stream(k.device());
 
-  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(k.dtype(), c_type, [&] {
+  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8(k.dtype(), c_type, [&] {
     cudaError_t status = ConcatMLAK<c_type>(
         static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(k_nope.data_ptr()),
         static_cast<c_type*>(k_rope.data_ptr()), num_tokens, k_stride_0, k_stride_1,

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -166,6 +166,21 @@ constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
     }                                                                                    \
   }()
 
+// Dispatcher for FP16/BF16/FP8 data types
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8(dlpack_dtype, c_type, ...)               \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
 #ifdef FLASHINFER_ENABLE_F32
 #define _DISPATCH_CASE_F32(c_type, ...) \
   case float32_code: {                  \

--- a/include/flashinfer/concat_mla.cuh
+++ b/include/flashinfer/concat_mla.cuh
@@ -18,6 +18,7 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
 #include "utils.cuh"
@@ -51,17 +52,79 @@ constexpr int MLA_NUM_HEAD_CHUNKS = MLA_NUM_LOCAL_HEADS / MLA_HEAD_CHUNK_SIZE;
  *
  * \tparam DType Data type (nv_bfloat16 or nv_half)
  */
+// ======================= Vector Type Selection =======================
+// Select vector types based on element size:
+// - 2-byte types (fp16/bf16): NopeVec=int2 (8B), RopeVec=int (4B)
+// - 1-byte types (fp8):       NopeVec=int  (4B), RopeVec=short (2B)
+template <typename DType, int ElemSize = sizeof(DType)>
+struct ConcatMLAVecTraits;
+
+// Specialization for 2-byte types (fp16/bf16)
+template <typename DType>
+struct ConcatMLAVecTraits<DType, 2> {
+  using NopeVec = int2;
+  using RopeVec = int;
+  // Number of DType elements per NopeVec: 8 / 2 = 4
+  static constexpr int NOPE_ELEMS_PER_VEC = sizeof(NopeVec) / sizeof(DType);
+  // Number of DType elements per RopeVec: 4 / 2 = 2
+  static constexpr int ROPE_ELEMS_PER_VEC = sizeof(RopeVec) / sizeof(DType);
+
+  static __forceinline__ __device__ NopeVec load_nope(const NopeVec* addr) {
+    return ld_na_global_v2(reinterpret_cast<const int2*>(addr));
+  }
+  static __forceinline__ __device__ void store_nope(NopeVec* addr, NopeVec val) {
+    st_na_global_v2(reinterpret_cast<int2*>(addr), val);
+  }
+  static __forceinline__ __device__ RopeVec load_rope(const RopeVec* addr) {
+    return ld_na_global_v1(reinterpret_cast<const int*>(addr));
+  }
+  static __forceinline__ __device__ void store_rope(RopeVec* addr, RopeVec val) {
+    st_na_global_v1(reinterpret_cast<int*>(addr), val);
+  }
+};
+
+// Specialization for 1-byte types (FP8)
+template <typename DType>
+struct ConcatMLAVecTraits<DType, 1> {
+  using NopeVec = int;
+  using RopeVec = short;
+  // Number of DType elements per NopeVec: 4 / 1 = 4
+  static constexpr int NOPE_ELEMS_PER_VEC = sizeof(NopeVec) / sizeof(DType);
+  // Number of DType elements per RopeVec: 2 / 1 = 2
+  static constexpr int ROPE_ELEMS_PER_VEC = sizeof(RopeVec) / sizeof(DType);
+
+  static __forceinline__ __device__ NopeVec load_nope(const NopeVec* addr) {
+    return ld_na_global_v1(reinterpret_cast<const int*>(addr));
+  }
+  static __forceinline__ __device__ void store_nope(NopeVec* addr, NopeVec val) {
+    st_na_global_v1(reinterpret_cast<int*>(addr), val);
+  }
+  static __forceinline__ __device__ RopeVec load_rope(const RopeVec* addr) {
+    return ld_na_global_v_short(reinterpret_cast<const short*>(addr));
+  }
+  static __forceinline__ __device__ void store_rope(RopeVec* addr, RopeVec val) {
+    st_na_global_v_short(reinterpret_cast<short*>(addr), val);
+  }
+};
+
 template <typename DType>
 __global__ void ConcatMLAKKernel(DType* __restrict__ k, const DType* __restrict__ k_nope,
                                  const DType* __restrict__ k_rope, const int num_tokens,
                                  const int64_t k_stride_0, const int k_stride_1,
                                  const int64_t k_nope_stride_0, const int k_nope_stride_1,
                                  const int64_t k_rope_stride_0) {
+  using Traits = ConcatMLAVecTraits<DType>;
+  using NopeVec = typename Traits::NopeVec;
+  using RopeVec = typename Traits::RopeVec;
+
   constexpr int NUM_LOCAL_HEADS = MLA_NUM_LOCAL_HEADS;
   constexpr int QK_NOPE_HEAD_DIM = MLA_QK_NOPE_HEAD_DIM;
   constexpr int QK_ROPE_HEAD_DIM = MLA_QK_ROPE_HEAD_DIM;
   constexpr int HEAD_CHUNK_SIZE = MLA_HEAD_CHUNK_SIZE;
   constexpr int NUM_HEAD_CHUNKS = MLA_NUM_HEAD_CHUNKS;
+
+  static_assert(sizeof(NopeVec) * 32 == QK_NOPE_HEAD_DIM * sizeof(DType), "nope vec mismatch");
+  static_assert(sizeof(RopeVec) * 32 == QK_ROPE_HEAD_DIM * sizeof(DType), "rope vec mismatch");
 
   const int flat_warp_id = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
   const int token_id = flat_warp_id / NUM_HEAD_CHUNKS;
@@ -70,42 +133,37 @@ __global__ void ConcatMLAKKernel(DType* __restrict__ k, const DType* __restrict_
 
   if (token_id >= num_tokens) return;
 
-  // Vector types for efficient memory access
-  // NopeVec: 8B/thread, 32 threads = 256B/row (covers nope_dim bf16 elements)
-  // RopeVec: 4B/thread, 32 threads = 128B/row (covers rope_dim bf16 elements)
-  using NopeVec = int2;
-  using RopeVec = int;
-  static_assert(sizeof(NopeVec) * 32 == QK_NOPE_HEAD_DIM * sizeof(DType), "nope vec mismatch");
-  static_assert(sizeof(RopeVec) * 32 == QK_ROPE_HEAD_DIM * sizeof(DType), "rope vec mismatch");
-
   const int head_row0 = head_chunk_id * HEAD_CHUNK_SIZE;
 
   // Source pointer for k_nope (indexed by token and head)
-  const int2* __restrict__ nope_src =
-      reinterpret_cast<const int2*>(k_nope + token_id * k_nope_stride_0 +
-                                    head_row0 * k_nope_stride_1) +
+  const NopeVec* __restrict__ nope_src =
+      reinterpret_cast<const NopeVec*>(k_nope + token_id * k_nope_stride_0 +
+                                       head_row0 * k_nope_stride_1) +
       lane_id;
 
   // Destination pointers for output k (nope part and rope part)
-  int2* __restrict__ nope_dst =
-      reinterpret_cast<int2*>(k + token_id * k_stride_0 + head_row0 * k_stride_1) + lane_id;
+  NopeVec* __restrict__ nope_dst =
+      reinterpret_cast<NopeVec*>(k + token_id * k_stride_0 + head_row0 * k_stride_1) + lane_id;
 
-  int* __restrict__ rope_dst = reinterpret_cast<int*>(k + token_id * k_stride_0 +
-                                                      head_row0 * k_stride_1 + QK_NOPE_HEAD_DIM) +
-                               lane_id;
+  RopeVec* __restrict__ rope_dst =
+      reinterpret_cast<RopeVec*>(k + token_id * k_stride_0 + head_row0 * k_stride_1 +
+                                 QK_NOPE_HEAD_DIM) +
+      lane_id;
 
-  // Stride calculations for vector types
-  const int nope_src_stride_v = (k_nope_stride_1 >> 2);  // int2 covers 4 bf16
-  const int nope_dst_stride_v = (k_stride_1 >> 2);
-  const int rope_dst_stride_v = (k_stride_1 >> 1);  // int covers 2 bf16
+  // Stride calculations for vector types (in units of the respective vector type)
+  constexpr int NOPE_ELEMS_PER_VEC = Traits::NOPE_ELEMS_PER_VEC;
+  constexpr int ROPE_ELEMS_PER_VEC = Traits::ROPE_ELEMS_PER_VEC;
+  const int nope_src_stride_v = k_nope_stride_1 / NOPE_ELEMS_PER_VEC;
+  const int nope_dst_stride_v = k_stride_1 / NOPE_ELEMS_PER_VEC;
+  const int rope_dst_stride_v = k_stride_1 / ROPE_ELEMS_PER_VEC;
 
   // Load rope value once - it's shared across all heads
-  const int* rope_base = reinterpret_cast<const int*>(k_rope + token_id * k_rope_stride_0);
-  const RopeVec rope_val = ld_na_global_v1(rope_base + lane_id);
+  const RopeVec* rope_base = reinterpret_cast<const RopeVec*>(k_rope + token_id * k_rope_stride_0);
+  const RopeVec rope_val = Traits::load_rope(rope_base + lane_id);
 
   // Prefetch first nope row and load it
   prefetch_L2(nope_src);
-  NopeVec cur = ld_na_global_v2(nope_src);
+  NopeVec cur = Traits::load_nope(nope_src);
 
 // Process all heads in this chunk with software pipelining
 #pragma unroll
@@ -113,14 +171,14 @@ __global__ void ConcatMLAKKernel(DType* __restrict__ k, const DType* __restrict_
     NopeVec next;
     if (i + 1 < HEAD_CHUNK_SIZE) {
       // Prefetch and load next row while processing current
-      const int2* next_src = nope_src + nope_src_stride_v;
+      const NopeVec* next_src = nope_src + nope_src_stride_v;
       prefetch_L2(next_src);
-      next = ld_na_global_v2(next_src);
+      next = Traits::load_nope(next_src);
     }
 
     // Write current nope and rope values
-    st_na_global_v2(nope_dst, cur);
-    st_na_global_v1(rope_dst, rope_val);
+    Traits::store_nope(nope_dst, cur);
+    Traits::store_rope(rope_dst, rope_val);
 
     // Advance pointers
     nope_src += nope_src_stride_v;

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -441,6 +441,22 @@ __forceinline__ __device__ int get_lane_id() {
 }
 
 /*!
+ * \brief Non-atomic global load for short (2 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ short ld_na_global_v_short(const short* addr) {
+  short val;
+  asm volatile("ld.global.cs.b16 %0, [%1];" : "=h"(val) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global store for short (2 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_v_short(short* addr, short val) {
+  asm volatile("st.global.cs.b16 [%0], %1;" ::"l"(addr), "h"(val));
+}
+
+/*!
  * \brief Non-atomic global load for int (4 bytes) with cache streaming hint
  */
 __forceinline__ __device__ int ld_na_global_v1(const int* addr) {

--- a/tests/model_optimizations/test_concat_mla.py
+++ b/tests/model_optimizations/test_concat_mla.py
@@ -1,0 +1,251 @@
+################################################################################
+#
+# Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+
+"""
+Test for concat_mla_k kernel.
+
+Validates that the FlashInfer CUDA kernel correctly concatenates k_nope and k_rope
+tensors for MLA attention, matching a reference PyTorch implementation.
+
+Tests cover:
+- Multiple dtypes: float16, bfloat16, float8_e4m3fn
+- Contiguous and non-contiguous (strided) inputs
+- Various token counts including edge cases
+"""
+
+from typing import Sequence
+
+import pytest
+import torch
+
+from flashinfer.concat_ops import concat_mla_k
+
+# MLA configuration constants (must match kernel expectations)
+NUM_LOCAL_HEADS = 128
+QK_NOPE_HEAD_DIM = 128
+QK_ROPE_HEAD_DIM = 64
+K_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM
+
+
+def reference_concat_mla_k(
+    k: torch.Tensor, k_nope: torch.Tensor, k_rope: torch.Tensor
+) -> None:
+    """Reference PyTorch implementation of concat_mla_k."""
+    k[..., :QK_NOPE_HEAD_DIM] = k_nope
+    k[..., QK_NOPE_HEAD_DIM:] = k_rope
+
+
+@pytest.fixture(params=[torch.float16, torch.bfloat16, torch.float8_e4m3fn])
+def dtype(request: pytest.FixtureRequest) -> torch.dtype:
+    return request.param
+
+
+@pytest.fixture(params=[1, 7, 128, 1024, 4096])
+def num_tokens(request: pytest.FixtureRequest) -> int:
+    return request.param
+
+
+def _make_random_tensor(
+    shape: Sequence[int], dtype: torch.dtype, device: str = "cuda"
+) -> torch.Tensor:
+    """Create a random tensor, handling FP8 which doesn't support randn."""
+    if dtype == torch.float8_e4m3fn:
+        # Generate in float16 then cast (fp8 doesn't support randn directly)
+        return torch.randn(shape, dtype=torch.float16, device=device).to(dtype)
+    return torch.randn(shape, dtype=dtype, device=device)
+
+
+def _to_comparable(t: torch.Tensor) -> torch.Tensor:
+    """Convert tensor to float32 for comparison (needed for fp8)."""
+    return t.float()
+
+
+class TestConcatMLAKContiguous:
+    """Test concat_mla_k with contiguous inputs."""
+
+    def test_correctness(self, dtype: torch.dtype, num_tokens: int) -> None:
+        k_nope = _make_random_tensor(
+            (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM), dtype
+        )
+        k_rope = _make_random_tensor((num_tokens, 1, QK_ROPE_HEAD_DIM), dtype)
+
+        # FlashInfer kernel output
+        k = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda"
+        )
+        concat_mla_k(k, k_nope, k_rope)
+
+        # Reference output
+        k_ref = torch.empty_like(k)
+        reference_concat_mla_k(k_ref, k_nope, k_rope)
+
+        torch.testing.assert_close(
+            _to_comparable(k), _to_comparable(k_ref), atol=0, rtol=0
+        )
+
+
+class TestConcatMLAKStrided:
+    """Test concat_mla_k with non-contiguous (strided) inputs."""
+
+    def test_strided_nope(self, dtype: torch.dtype, num_tokens: int) -> None:
+        """k_nope is a slice of a larger tensor (non-contiguous)."""
+        nope_container = _make_random_tensor(
+            (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM + 128), dtype
+        )
+        k_nope = nope_container[:, :, :QK_NOPE_HEAD_DIM]
+        assert not k_nope.is_contiguous()
+
+        k_rope = _make_random_tensor((num_tokens, 1, QK_ROPE_HEAD_DIM), dtype)
+
+        k = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda"
+        )
+        concat_mla_k(k, k_nope, k_rope)
+
+        k_ref = torch.empty_like(k)
+        reference_concat_mla_k(k_ref, k_nope, k_rope)
+
+        torch.testing.assert_close(
+            _to_comparable(k), _to_comparable(k_ref), atol=0, rtol=0
+        )
+
+    def test_strided_rope(self, dtype: torch.dtype, num_tokens: int) -> None:
+        """k_rope is a slice of a larger tensor (non-contiguous)."""
+        k_nope = _make_random_tensor(
+            (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM), dtype
+        )
+
+        rope_container = _make_random_tensor(
+            (num_tokens, 1, 128 + QK_ROPE_HEAD_DIM), dtype
+        )
+        k_rope = rope_container[:, :, -QK_ROPE_HEAD_DIM:]
+        # With num_tokens=1, the slice may still be contiguous (single-element leading dims),
+        # so only assert for num_tokens > 1
+        if num_tokens > 1:
+            assert not k_rope.is_contiguous()
+
+        k = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda"
+        )
+        concat_mla_k(k, k_nope, k_rope)
+
+        k_ref = torch.empty_like(k)
+        reference_concat_mla_k(k_ref, k_nope, k_rope)
+
+        torch.testing.assert_close(
+            _to_comparable(k), _to_comparable(k_ref), atol=0, rtol=0
+        )
+
+    def test_strided_output(self, dtype: torch.dtype, num_tokens: int) -> None:
+        """Output k is a slice of a larger tensor (non-contiguous token stride)."""
+        k_nope = _make_random_tensor(
+            (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM), dtype
+        )
+        k_rope = _make_random_tensor((num_tokens, 1, QK_ROPE_HEAD_DIM), dtype)
+
+        # Create output with extra padding between heads
+        k_container = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM + 64), dtype=dtype, device="cuda"
+        )
+        k = k_container[:, :, :K_HEAD_DIM]
+        assert not k.is_contiguous()
+
+        concat_mla_k(k, k_nope, k_rope)
+
+        k_ref = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda"
+        )
+        reference_concat_mla_k(k_ref, k_nope, k_rope)
+
+        torch.testing.assert_close(
+            _to_comparable(k), _to_comparable(k_ref), atol=0, rtol=0
+        )
+
+    def test_all_strided(self, dtype: torch.dtype, num_tokens: int) -> None:
+        """All tensors are non-contiguous slices."""
+        nope_container = _make_random_tensor(
+            (num_tokens, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM + 128), dtype
+        )
+        k_nope = nope_container[:, :, :QK_NOPE_HEAD_DIM]
+
+        rope_container = _make_random_tensor(
+            (num_tokens, 1, 128 + QK_ROPE_HEAD_DIM), dtype
+        )
+        k_rope = rope_container[:, :, -QK_ROPE_HEAD_DIM:]
+
+        k_container = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM + 64), dtype=dtype, device="cuda"
+        )
+        k = k_container[:, :, :K_HEAD_DIM]
+
+        concat_mla_k(k, k_nope, k_rope)
+
+        k_ref = torch.empty(
+            (num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda"
+        )
+        reference_concat_mla_k(k_ref, k_nope, k_rope)
+
+        torch.testing.assert_close(
+            _to_comparable(k), _to_comparable(k_ref), atol=0, rtol=0
+        )
+
+
+class TestConcatMLAKEdgeCases:
+    """Test edge cases."""
+
+    def test_zero_tokens(self) -> None:
+        """Zero token count should be a no-op."""
+        dtype = torch.bfloat16
+        k = torch.empty((0, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda")
+        k_nope = torch.empty(
+            (0, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM), dtype=dtype, device="cuda"
+        )
+        k_rope = torch.empty((0, 1, QK_ROPE_HEAD_DIM), dtype=dtype, device="cuda")
+        # Should not crash
+        concat_mla_k(k, k_nope, k_rope)
+
+    def test_single_token(self) -> None:
+        """Single token should work correctly for all dtypes."""
+        for dtype in [torch.float16, torch.bfloat16, torch.float8_e4m3fn]:
+            k_nope = _make_random_tensor((1, NUM_LOCAL_HEADS, QK_NOPE_HEAD_DIM), dtype)
+            k_rope = _make_random_tensor((1, 1, QK_ROPE_HEAD_DIM), dtype)
+            k = torch.empty(
+                (1, NUM_LOCAL_HEADS, K_HEAD_DIM), dtype=dtype, device="cuda"
+            )
+            concat_mla_k(k, k_nope, k_rope)
+
+            k_ref = torch.empty_like(k)
+            reference_concat_mla_k(k_ref, k_nope, k_rope)
+
+            torch.testing.assert_close(
+                _to_comparable(k), _to_comparable(k_ref), atol=0, rtol=0
+            )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Extends `concat_mla_k` for FP8. Adds functional tests.

Note: first draft written mostly by Claude, needs author review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 support alongside FP16/BF16 and a type-generic vector handling layer for concat operations.
  * Added short (2-byte) non-atomic global load/store helpers.

* **Performance**
  * Improved vectorized memory handling and dispatch for more efficient concat kernel execution.

* **Tests**
  * Added comprehensive correctness tests for contiguous/strided inputs, multiple dtypes, and edge cases.

* **Benchmarks**
  * Added FP8-capable benchmarking and per-dtype benchmarking/reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->