### PR TITLE
fix: use type-specific FP8 max value for clamping in RMSNorm quantization kernels

### DIFF
--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -229,7 +229,8 @@ __global__ void RMSNormQuantKernel(T* __restrict__ input, T* __restrict__ weight
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
       output_vec[j] =
           float(input_vec[j]) * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
-      output_vec[j] = fmaxf(-fp8_clamp_max<O>::value, fminf(output_vec[j], fp8_clamp_max<O>::value));
+      output_vec[j] =
+          fmaxf(-fp8_clamp_max<O>::value, fminf(output_vec[j], fp8_clamp_max<O>::value));
     }
     if ((i * num_threads + thread_id) * VEC_SIZE < d) {
       output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +
@@ -613,7 +614,8 @@ __global__ void FusedAddRMSNormQuantKernel(T* __restrict__ input, T* __restrict_
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
       output_vec[j] = x_vec[j] * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
-      output_vec[j] = fmaxf(-fp8_clamp_max<O>::value, fminf(output_vec[j], fp8_clamp_max<O>::value));
+      output_vec[j] =
+          fmaxf(-fp8_clamp_max<O>::value, fminf(output_vec[j], fp8_clamp_max<O>::value));
     }
     if ((i * num_threads + thread_id) * VEC_SIZE < d) {
       output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +


### PR DESCRIPTION
## Summary
Replace hardcoded FP8 E4M3 clamp value (448.0) with a type-aware `fp8_clamp_max<O>` trait in `RMSNormQuantKernel` and `FusedAddRMSNormQuantKernel`.

## Problem
Both kernels hardcode the E4M3 max value for output clamping:
```cpp
output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
```

However, the output type `O` is dispatched via `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8` in `csrc/norm.cu`, which handles both E4M3 (`max=448`) and E5M2 (`max=57344`). When the output dtype is E5M2, this incorrectly truncates ~99% of the representable range.

## Fix
Added `fp8_clamp_max<T>` trait with correct max values:
- `__nv_fp8_e4m3`: 448.0f
- `__nv_fp8_e5m2`: 57344.0f

Applied to both `RMSNormQuantKernel` and `FusedAddRMSNormQuantKernel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced fixed ±448.0 clamping with type-specific clamp values for FP8-like outputs.
  * Updated quantized RMS normalization paths to use the new per-output clamping constants, improving numerical consistency across precisions.
  * Clamping is now driven by output precision so bounds vary appropriately; no other algorithmic behavior was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->