### PR TITLE
fix: Support non-power-of-2 dimensions in act_and_mul kernels

### DIFF
--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -57,6 +57,13 @@ def get_act_and_mul_module(act_func_name: str):
     return SimpleNamespace(**{fname: _act_and_mul})
 
 
+def _check_act_and_mul_input(input: torch.Tensor) -> None:
+    if input.shape[-1] % 2 != 0:
+        raise ValueError(
+            "The last dimension of the input must be even (2 * hidden_size)."
+        )
+
+
 def _check_shape(input: torch.Tensor, output: torch.Tensor) -> None:
     assert input.ndim == output.ndim, f"{input.ndim} != {output.ndim}"
     assert input.shape[:-1] == output.shape[:-1], (
@@ -94,10 +101,7 @@ def silu_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] % 2 != 0:
-        raise ValueError(
-            "The last dimension of the input must be even (2 * hidden_size)."
-        )
+    _check_act_and_mul_input(input)
     if out is not None:
         _check_shape(input, out)
     else:
@@ -141,10 +145,7 @@ def gelu_tanh_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] % 2 != 0:
-        raise ValueError(
-            "The last dimension of the input must be even (2 * hidden_size)."
-        )
+    _check_act_and_mul_input(input)
     if out is not None:
         _check_shape(input, out)
     else:
@@ -184,10 +185,7 @@ def gelu_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] % 2 != 0:
-        raise ValueError(
-            "The last dimension of the input must be even (2 * hidden_size)."
-        )
+    _check_act_and_mul_input(input)
     if out is not None:
         _check_shape(input, out)
     else:

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -94,8 +94,10 @@ def silu_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
-        raise ValueError("The pointers must be multiple of 16 bytes.")
+    if input.shape[-1] % 2 != 0:
+        raise ValueError(
+            "The last dimension of the input must be even (2 * hidden_size)."
+        )
     if out is not None:
         _check_shape(input, out)
     else:
@@ -139,8 +141,10 @@ def gelu_tanh_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
-        raise ValueError("The pointers must be multiple of 16 bytes.")
+    if input.shape[-1] % 2 != 0:
+        raise ValueError(
+            "The last dimension of the input must be even (2 * hidden_size)."
+        )
     if out is not None:
         _check_shape(input, out)
     else:
@@ -180,8 +184,10 @@ def gelu_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
-        raise ValueError("The pointers must be multiple of 16 bytes.")
+    if input.shape[-1] % 2 != 0:
+        raise ValueError(
+            "The last dimension of the input must be even (2 * hidden_size)."
+        )
     if out is not None:
         _check_shape(input, out)
     else:

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -33,6 +33,50 @@ using namespace flashinfer;
 
 {{ act_func_def }}
 
+// Macro to dispatch kernel launch by vec_size template parameter.
+// Defined outside DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16 because preprocessor
+// directives (#define) cannot appear inside macro arguments.
+#define DISPATCH_VEC_SIZE(vec_size, c_type, config, out, input, d, ...)         \
+  switch (vec_size) {                                                          \
+    case 16: {                                                                 \
+      auto kernel = flashinfer::activation::act_and_mul_kernel<                \
+          c_type, __VA_ARGS__, 16>;                                            \
+      cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out),           \
+                         static_cast<c_type*>(input), d);                      \
+      break;                                                                   \
+    }                                                                          \
+    case 8: {                                                                  \
+      auto kernel = flashinfer::activation::act_and_mul_kernel<                \
+          c_type, __VA_ARGS__, 8>;                                             \
+      cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out),           \
+                         static_cast<c_type*>(input), d);                      \
+      break;                                                                   \
+    }                                                                          \
+    case 4: {                                                                  \
+      auto kernel = flashinfer::activation::act_and_mul_kernel<                \
+          c_type, __VA_ARGS__, 4>;                                             \
+      cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out),           \
+                         static_cast<c_type*>(input), d);                      \
+      break;                                                                   \
+    }                                                                          \
+    case 2: {                                                                  \
+      auto kernel = flashinfer::activation::act_and_mul_kernel<                \
+          c_type, __VA_ARGS__, 2>;                                             \
+      cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out),           \
+                         static_cast<c_type*>(input), d);                      \
+      break;                                                                   \
+    }                                                                          \
+    case 1: {                                                                  \
+      auto kernel = flashinfer::activation::act_and_mul_kernel<                \
+          c_type, __VA_ARGS__, 1>;                                             \
+      cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out),           \
+                         static_cast<c_type*>(input), d);                      \
+      break;                                                                   \
+    }                                                                          \
+    default:                                                                   \
+      TVM_FFI_ICHECK(false) << "Unsupported vec_size: " << vec_size;           \
+  }
+
 void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
   int d = input.size(input.ndim() -1) / 2;
   int64_t num_tokens = input.numel() / input.size(input.ndim() -1);
@@ -57,27 +101,8 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
     config.numAttrs = 1;
     config.attrs = attrs;
 
-#define DISPATCH_VEC_SIZE(VS)                                                                 \
-  case VS: {                                                                                  \
-    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}, VS>;\
-    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),                 \
-                       static_cast<c_type*>(input.data_ptr()), d);                            \
-    break;                                                                                    \
-  }
-
-    switch (vec_size) {
-      // VS=16 is currently unreachable (fp16/bf16 give initial vec_size=8);
-      // retained for future fp8 (sizeof=1) support.
-      DISPATCH_VEC_SIZE(16)
-      DISPATCH_VEC_SIZE(8)
-      DISPATCH_VEC_SIZE(4)
-      DISPATCH_VEC_SIZE(2)
-      DISPATCH_VEC_SIZE(1)
-      default:
-        TVM_FFI_ICHECK(false) << "Unsupported vec_size: " << vec_size;
-    }
-
-#undef DISPATCH_VEC_SIZE
+    DISPATCH_VEC_SIZE(vec_size, c_type, config, out.data_ptr(), input.data_ptr(), d,
+                      {{ act_func_name }});
 
     cudaError_t err = cudaGetLastError();
     TVM_FFI_ICHECK(err == cudaSuccess) << "Failed to launch kernel: " << cudaGetErrorString(err);
@@ -85,6 +110,8 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
     return true;
   });
 }
+
+#undef DISPATCH_VEC_SIZE
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC({{ func_name }}, {{ func_name }});
 """

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -66,6 +66,7 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
   }
 
     switch (vec_size) {
+      DISPATCH_VEC_SIZE(16)
       DISPATCH_VEC_SIZE(8)
       DISPATCH_VEC_SIZE(4)
       DISPATCH_VEC_SIZE(2)

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -42,6 +42,10 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
   const cudaStream_t stream = get_stream(out.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
+    while (vec_size > 1 && d % vec_size != 0) {
+      vec_size /= 2;
+    }
+
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
     config.blockDim = std::min(d / vec_size, 1024U);
@@ -53,10 +57,24 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
     config.numAttrs = 1;
     config.attrs = attrs;
 
-    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}>;
+#define DISPATCH_VEC_SIZE(VS)                                                                 \
+  case VS: {                                                                                  \
+    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}, VS>;\
+    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),                 \
+                       static_cast<c_type*>(input.data_ptr()), d);                            \
+    break;                                                                                    \
+  }
 
-    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
-                       static_cast<c_type*>(input.data_ptr()), d);
+    switch (vec_size) {
+      DISPATCH_VEC_SIZE(8)
+      DISPATCH_VEC_SIZE(4)
+      DISPATCH_VEC_SIZE(2)
+      DISPATCH_VEC_SIZE(1)
+      default:
+        TVM_FFI_ICHECK(false) << "Unsupported vec_size: " << vec_size;
+    }
+
+#undef DISPATCH_VEC_SIZE
 
     cudaError_t err = cudaGetLastError();
     TVM_FFI_ICHECK(err == cudaSuccess) << "Failed to launch kernel: " << cudaGetErrorString(err);

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -66,6 +66,8 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
   }
 
     switch (vec_size) {
+      // VS=16 is currently unreachable (fp16/bf16 give initial vec_size=8);
+      // retained for future fp8 (sizeof=1) support.
       DISPATCH_VEC_SIZE(16)
       DISPATCH_VEC_SIZE(8)
       DISPATCH_VEC_SIZE(4)

--- a/include/flashinfer/activation.cuh
+++ b/include/flashinfer/activation.cuh
@@ -25,9 +25,8 @@ namespace flashinfer {
 
 namespace activation {
 
-template <typename T, float (*Activation)(const float&)>
+template <typename T, float (*Activation)(const float&), uint32_t vec_size>
 __global__ void act_and_mul_kernel(T* __restrict__ out, const T* __restrict__ input, const int d) {
-  constexpr uint32_t vec_size = 16 / sizeof(T);
   const int64_t token_idx = blockIdx.x;
   const int64_t thread_idx = threadIdx.x;
   const int64_t stride = blockDim.x;

--- a/tests/utils/test_activation.py
+++ b/tests/utils/test_activation.py
@@ -37,7 +37,7 @@ def warmup_jit():
     yield
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize("dim", [128, 256, 512, 1710, 2048, 3420, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -51,7 +51,7 @@ def test_fused_silu_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize("dim", [128, 256, 512, 1710, 2048, 3420, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -65,7 +65,7 @@ def test_fused_gelu_tanh_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize("dim", [128, 256, 512, 1710, 2048, 3420, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])

--- a/tests/utils/test_activation.py
+++ b/tests/utils/test_activation.py
@@ -37,7 +37,7 @@ def warmup_jit():
     yield
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 1710, 2048, 3420, 4096, 11008, 16384])
+@pytest.mark.parametrize("dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -51,7 +51,7 @@ def test_fused_silu_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 1710, 2048, 3420, 4096, 11008, 16384])
+@pytest.mark.parametrize("dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -65,7 +65,7 @@ def test_fused_gelu_tanh_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 1710, 2048, 3420, 4096, 11008, 16384])
+@pytest.mark.parametrize("dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])

--- a/tests/utils/test_activation.py
+++ b/tests/utils/test_activation.py
@@ -37,7 +37,9 @@ def warmup_jit():
     yield
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384])
+@pytest.mark.parametrize(
+    "dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384]
+)
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -51,7 +53,9 @@ def test_fused_silu_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384])
+@pytest.mark.parametrize(
+    "dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384]
+)
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -65,7 +69,9 @@ def test_fused_gelu_tanh_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384])
+@pytest.mark.parametrize(
+    "dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384]
+)
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])


### PR DESCRIPTION
## Summary

I ran into this while working with Qwen2.5-VL, which has `intermediate_size=3420` in its VIT. The `act_and_mul` kernels hardcode `vec_size = 16 / sizeof(T)` (8 for float16), but 3420 isn't divisible by 8. This causes misaligned vectorized loads when reading the second half of the input at offset `d`, since `3420 * 2 = 6840` bytes isn't 16-byte aligned.

The fix makes `vec_size` a template parameter in the kernel and dynamically reduces it at launch time until it evenly divides `d`:

```c++
uint32_t vec_size = 16 / sizeof(c_type);
while (vec_size > 1 && d % vec_size != 0) {
    vec_size /= 2;
}
```

For `d=3420` with float16, this gives `vec_size=4` (since `3420 % 4 == 0`). Standard power-of-2 dimensions are completely unaffected — they still use the maximum `vec_size`.

### Changes
- **`include/flashinfer/activation.cuh`**: Made `vec_size` an explicit template parameter instead of an internal `constexpr`
- **`flashinfer/jit/activation.py`**: Added dynamic `vec_size` reduction and switch-based dispatch to the correct template instantiation
- **`flashinfer/activation.py`**: Relaxed the alignment check from requiring 16-byte alignment to just requiring an even last dimension (the kernel now handles all valid alignments)
- **`tests/utils/test_activation.py`**: Added `3420` and `1710` to the test dim parametrize lists

### Verification

For `d=3420` with float16:
- **Before**: `vec_size=8`, byte offset at midpoint = `3420 * 2 = 6840`, `6840 % 16 = 8` — misaligned vectorized load
- **After**: `vec_size=4`, byte offset at midpoint = `3420 * 2 = 6840`, `6840 % 8 = 0` — properly aligned

Backward compatible — no change for existing power-of-2 dimensions.

Fixes #2526

Signed-off-by: Blake Ledden <bledden@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger input validation for fused activation+multiply operations: last dimension must be even, with a clear error for invalid shapes.

* **Performance Improvements**
  * Kernel dispatch now selects vectorized launch sizes to improve throughput across varied tensor dimensions.

* **Tests**
  * Activation tests expanded with additional input dimensions to increase coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->