### PR TITLE
fix: Use compatible license field format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ name = "flashinfer-python"
 description = "FlashInfer: Kernel Library for LLM Serving"
 requires-python = ">=3.10,<4.0"
 authors = [{ name = "FlashInfer team" }]
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 readme = "README.md"
 urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 dynamic = ["dependencies", "version"]
-license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.scripts]
 flashinfer = "flashinfer.__main__:cli"


### PR DESCRIPTION
## Summary

Fixes #2544

The PEP 639 short-form `license = "Apache-2.0"` and `license-files` fields require setuptools >= 77. While `build-system.requires` specifies `setuptools>=77`, users installing from source with `--no-build-isolation` use their local setuptools, which may be older. This causes a `ValueError` during installation.

- Changed `license = "Apache-2.0"` to `license = { text = "Apache-2.0" }` (table form, compatible with both old and new setuptools)
- Removed `license-files` field (setuptools auto-discovers LICENSE files by default)

## Test plan

- [ ] Verify `python -m pip install --no-build-isolation -e .` no longer fails with a `ValueError` on older setuptools
- [ ] Verify license metadata is still correct in the built package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license metadata format in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->