### PR TITLE
Protect against null clusterUuid in mnnvl.py

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -859,12 +859,11 @@ def is_mnnvl_fabric_supported(device_idx: int) -> bool:
         handle = pynvml.nvmlDeviceGetHandleByIndex(device_idx)
         fabric_info = pynvml.c_nvmlGpuFabricInfoV_t()
         pynvml.nvmlDeviceGetGpuFabricInfoV(handle, ctypes.byref(fabric_info))
-        if (
+        return (
             fabric_info.state >= pynvml.NVML_GPU_FABRIC_STATE_COMPLETED
+            and fabric_info.clusterUuid
             and fabric_info.clusterUuid[0] != 0
-        ):
-            return True
-        return False
+        )
     finally:
         pynvml.nvmlShutdown()
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Guard against empty clusterUuid in is_mnnvl_fabric_supported().

On single-node cluster with NVSwitch, clusterUuid is all-zero bytes (no multi-node NVLink cluster), per nvidia-smi [documentation](https://docs.nvidia.com/deploy/nvidia-smi/index.html). In code, ctypes truncates at the first null byte, producing an empty string. The existing fabric_info.clusterUuid[0] != 0 check then raises IndexError: string index out of range, crashing all TP workers at startup.

The clusterUuid check itself is correct — cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC requires an active multi-node NVLink domain (non-zero ClusterUUID). The bug is only in failing to handle the empty-string edge case from ctypes.

Fix: Add a len() guard so an empty clusterUuid safely returns False, falling back to PosixFDHandleExchanger for single-node topologies.

## 🔍 Related Issues

Filed issue [flashinfer-2633](https://github.com/flashinfer-ai/flashinfer/issues/2633). This may have been why VLLM rolled back flashinfer from 0.6.4 to 0.6.3.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes
This is a trivial fix. I tested it in e2e tests, which passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of GPU fabric support to reduce incorrect status reporting and improve stability in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->