### PR TITLE
fix: trtllm_mxint4_block_scale_moe unit test to index output list

### DIFF
--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -818,7 +818,7 @@ class MxInt4BlockScaleMoe(Moe):
                 routing_method_type=routing_method_type,
                 tune_max_num_tokens=TUNE_MAX_NUM_TOKENS,
             )
-        return output.to(torch.float)
+        return output[0].to(torch.float)
 
     def compute_reference(self, args):
         return run_moe_reference_mxint4(args)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix unit test failures caused by change in https://github.com/flashinfer-ai/flashinfer/pull/2548 to the API that now returns a list of tensors.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MoE test implementations to correctly extract return values from method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->