### PR TITLE
fix: cute dsl nvfp4 moe routing index error

### DIFF
--- a/csrc/moe_utils_binding.cu
+++ b/csrc/moe_utils_binding.cu
@@ -306,8 +306,9 @@ void moe_sort(
   routingData.mPtrCtaIdxXyToMnLimit = reinterpret_cast<int32_t*>(tile_idx_to_mn_limit_ptr);
   routingData.mPtrExpandedIdxToPermutedIdx =
       reinterpret_cast<int32_t*>(expanded_idx_to_permuted_idx_ptr);
-  routingData.mPtrPermutedIdxToTokenIdx =
+  routingData.mPtrPermutedIdxToExpandedIdx =
       reinterpret_cast<int32_t*>(permuted_idx_to_expanded_idx_ptr);
+  routingData.mPtrPermutedIdxToTokenIdx = nullptr;
   routingData.mPtrPermutedIdxSize = reinterpret_cast<int32_t*>(total_num_padded_tokens_ptr);
   routingData.mPtrNumNonExitingCtas = reinterpret_cast<int32_t*>(num_non_exiting_tiles_ptr);
 

--- a/csrc/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/trtllm_fused_moe_routing_deepseek.cu
@@ -488,6 +488,9 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
     if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
       params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
     }
+    if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert) {
+      params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
+    }
     if (params.mPtrPermutedIdxToTokenIdx != nullptr && isLocalExpert) {
       params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;
     }
@@ -549,7 +552,8 @@ void runImpl(Data& data, void* stream) {
                      "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for "
                      "DeepSeek routing.");
   }
-  if (data.mPtrExpandedIdxToPermutedIdx != nullptr || data.mPtrPermutedIdxToTokenIdx != nullptr)
+  if (data.mPtrExpandedIdxToPermutedIdx != nullptr ||
+      data.mPtrPermutedIdxToExpandedIdx != nullptr || data.mPtrPermutedIdxToTokenIdx != nullptr)
     FLASHINFER_CHECK(
         (data.mPtrTopKPacked != nullptr || data.mPtrTopKIds != nullptr) && data.mPtrPermutedIdxSize,
         "If permuted index is required, `mPtrTopKPacked` or `mPtrTopKIds` is also required");

--- a/csrc/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/trtllm_fused_moe_routing_llama4.cu
@@ -302,6 +302,10 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
       if (params.mPtrExpandedIdxToPermutedIdx != nullptr && isTokenRouted) {
         params.mPtrExpandedIdxToPermutedIdx[tokenIdx] = permutedIdx;
       }
+      // write out `mPtrPermutedIdxToExpandedIdx` if required
+      if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert && isTokenRouted) {
+        params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = tokenIdx;
+      }
       // write out `mPtrPermutedIdxToTokenIdx` if required
       if (params.mPtrPermutedIdxToTokenIdx != nullptr && isLocalExpert && isTokenRouted) {
         params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;

--- a/csrc/trtllm_fused_moe_routing_renormalize.cu
+++ b/csrc/trtllm_fused_moe_routing_renormalize.cu
@@ -244,6 +244,9 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
 
       params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
       if (isLocalExpert) {
+        if (params.mPtrPermutedIdxToExpandedIdx != nullptr) {
+          params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
+        }
         params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;
       }
     }

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -75,6 +75,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mPtrExpertCounts = expertCountHistogram;
     routingData.mPtrPermutedIdxSize = permutedIdxSize;
     routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
     routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
     routingData.mPtrTopKWeights = expertWeights;
 
@@ -113,6 +114,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mPtrExpertCounts = expertCountHistogram;
     routingData.mPtrPermutedIdxSize = permutedIdxSize;
     routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
     routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
     routingData.mPtrTopKWeights = expertWeights;
 
@@ -156,6 +158,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mPtrExpertCounts = expertCountHistogram;
     routingData.mPtrPermutedIdxSize = permutedIdxSize;
     routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
     routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
     routingData.mPtrTopKWeights = expertWeights;
 

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
@@ -409,6 +409,9 @@ __device__ void routingPermutation(KernelParams params,
     if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
       params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
     }
+    if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert) {
+      params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
+    }
     if (params.mPtrPermutedIdxToTokenIdx != nullptr && isLocalExpert) {
       params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;
     }
@@ -728,6 +731,9 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
           isLocalExpert ? (expertOffsets[ii] + smemExpertTileOffset[expertIdx]) : int32_t{-1};
       if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
         params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
+      }
+      if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert) {
+        params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
       }
       if (params.mPtrPermutedIdxToTokenIdx != nullptr && isLocalExpert) {
         params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -51,6 +51,9 @@ struct DataBase {
   int32_t* mPtrExpandedIdxToPermutedIdx{nullptr};
   // optional: if `nullptr`, it is not filled
   // dim: [mTileTokensDim * mTopK + (mNumExperts × mTileTokensDim) - mNumExperts]
+  int32_t* mPtrPermutedIdxToExpandedIdx{nullptr};
+  // optional: if `nullptr`, it is not filled
+  // dim: [mTileTokensDim * mTopK + (mNumExperts × mTileTokensDim) - mNumExperts]
   // Note: this array (mPtrPermutedIdxToTokenIdx) is uninitialized
   // Any out-of-bounds values are undefined.
   int32_t* mPtrPermutedIdxToTokenIdx{nullptr};
@@ -113,6 +116,7 @@ struct KernelParamsBase {
   int32_t* mPtrExpertCounts = nullptr;
   int32_t* mPtrPermutedIdxSize = nullptr;
   int32_t* mPtrExpandedIdxToPermutedIdx = nullptr;
+  int32_t* mPtrPermutedIdxToExpandedIdx = nullptr;
   int32_t* mPtrPermutedIdxToTokenIdx = nullptr;
   int32_t* mPtrCtaIdxXyToBatchIdx = nullptr;
   int32_t* mPtrCtaIdxXyToMnLimit = nullptr;
@@ -137,6 +141,7 @@ struct KernelParamsBase {
     mPtrExpertCounts = data.mPtrExpertCounts;
     mPtrPermutedIdxSize = data.mPtrPermutedIdxSize;
     mPtrExpandedIdxToPermutedIdx = data.mPtrExpandedIdxToPermutedIdx;
+    mPtrPermutedIdxToExpandedIdx = data.mPtrPermutedIdxToExpandedIdx;
     mPtrPermutedIdxToTokenIdx = data.mPtrPermutedIdxToTokenIdx;
     mPtrCtaIdxXyToBatchIdx = data.mPtrCtaIdxXyToBatchIdx;
     mPtrCtaIdxXyToMnLimit = data.mPtrCtaIdxXyToMnLimit;

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -303,15 +303,19 @@ def create_moe_tensors(
 
 
 def check_accuracy(
-    actual: torch.Tensor, expected: torch.Tensor, percent_threshold: float = 0.925
+    actual: torch.Tensor, expected: torch.Tensor, percent_threshold: float = 0.97
 ):
-    """Check numerical accuracy with percentage-based tolerance."""
+    """Check numerical accuracy with percentage-based tolerance.
+
+    Tolerances are scaled by output magnitude to account for FP4 quantization
+    noise growing with larger hidden dimensions.
+    """
     actual = actual.float()
     expected = expected.float()
 
     output_scale = max(expected.std().item(), 0.01)
-    atol = max(0.1, 3.0 * output_scale)
-    rtol = 0.85
+    atol = max(0.05, 1.5 * output_scale)
+    rtol = 0.5
 
     abs_diff = torch.abs(actual - expected)
     rel_diff = abs_diff / (torch.abs(expected) + 1e-8)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

To fix the following bug:
When the CuteDSL MoE kernels were ported from TensorRT-LLM to FlashInfer, the mPtrPermutedIdxToExpandedIdx field was accidentally dropped from the routing kernel's DataBase struct in RoutingKernel.h. TRT-LLM's routing kernel produces three reverse-mapping outputs:

1. mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx — forward mapping
2. mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx — reverse to expanded index (token_idx * topk + k)
3. mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx — reverse to token index only

FlashInfer's port kept only #1 and #3, dropping #2. The binding in moe_utils_binding.cu then had to wire the Python buffer permuted_idx_to_expanded_idx to the only available reverse-mapping field — mPtrPermutedIdxToTokenIdx — which writes plain tokenIdx instead of expandedIdx.
The Impact
The CuteDSL kernels (GEMM1 gather, moe_output_memset, GEMM2 finalize) all expect expanded indices and derive the token index via expanded_idx // topk. When they received plain tokenIdx instead, they computed tokenIdx // topk — yielding the wrong A row for gather, wrong zero-init for memset, and wrong scatter position + wrong routing scale for finalize.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined MOE (Mixture of Experts) routing infrastructure by extending index mapping capabilities across multiple kernel implementations to improve internal data flow consistency.

* **Tests**
  * Strengthened accuracy validation thresholds from 0.925 to 0.97 with adjusted error tolerance parameters, ensuring more rigorous testing of MOE operations under FP4 quantization conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->