### PR TITLE
feat(gdn): port pooled decode kernel to f16 backend

### DIFF
--- a/benchmarks/bench_gdn_decode.py
+++ b/benchmarks/bench_gdn_decode.py
@@ -28,7 +28,7 @@ Kernels benchmarked:
 - FlashInfer Nontranspose [B, HV, K, V] (K-major layout)
 - Triton Pretranspose [B, HV, V, K]
 - Triton Nontranspose [B, HV, K, V]
-- gdn_decode_klast_bf16_state [B, HV, V, K] (K-fast layout, T=1..4, bf16 state)
+- gdn_decode_klast_bf16_state [B, HV, V, K] (K-last layout, T=1..4, bf16 state)
   from flashinfer.cute_dsl.gated_delta_rule
 
 Usage:
@@ -2168,7 +2168,7 @@ def run_all_layouts_benchmark(args, dtype, use_qk_l2norm):
     print("  TR-PreTr  = Triton Pretranspose [B, HV, V, K]")
     print("  TR-NonTr  = Triton Nontranspose [B, HV, K, V]")
     print(
-        "  KlastBf16 = gdn_decode_klast_bf16_state [B, HV, V, K] (K-fast layout, T=1..4, bf16 state)"
+        "  KlastBf16 = gdn_decode_klast_bf16_state [B, HV, V, K] (K-last layout, T=1..4, bf16 state)"
     )
     print("  FI/TR speedup > 1.0 means FlashInfer is faster than Triton")
     print(
@@ -2251,7 +2251,7 @@ def bench_gdn_decode_klast_bf16_state(
     dt_bias = torch.randn(num_sab_heads, dtype=dtype, device="cuda")
     b = torch.randn(batch_size, T, num_sab_heads, dtype=dtype, device="cuda")
 
-    # Initial state: [B, HV, V, K] (K-fast layout, BF16)
+    # Initial state: [B, HV, V, K] (K-last layout, BF16)
     state = torch.randn(
         batch_size,
         num_sab_heads,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1119,7 +1119,7 @@ def gated_delta_rule_decode_kernel_seqlen234_unified(
     gb: cute.Tensor,  # [B, T=2/3/4, HV]
     gA_log: cute.Tensor,  # [HV]
     gdt_bias: cute.Tensor,  # [HV]
-    gH: cute.Tensor,  # [B, HV, V=128, K=128] - K-fast layout
+    gH: cute.Tensor,  # [B, HV, V=128, K=128] - K-last layout
     gO: cute.Tensor,  # [B, T=2/3/4, HV, V=128]
     scale: cutlass.Float32,
     softplus_beta: cutlass.Float32,
@@ -2008,7 +2008,7 @@ def gated_delta_rule(
         k: Key tensor [B, T, H, K]
         v: Value tensor [B, T, HV, V]
         b: Beta gate input [B, T, HV]
-        initial_state_source: H state [B, HV, V, K] or [pool_size, HV, V, K] (K-fast layout), modified in-place
+        initial_state_source: H state [B, HV, V, K] or [pool_size, HV, V, K] (K-last layout), modified in-place
         initial_state_indices: Optional int32 pool indices [B] for indirect state access.
             Values must be in [-1, pool_size). -1 = padding slot (output zeros, state
             untouched). No runtime bounds checking is performed.

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -668,7 +668,7 @@ def _test_gdn_decode_klast_bf16_state_kernel(
         # NOTE: Do NOT pre-normalize K here. Both the kernel (use_qk_l2norm_in_kernel=True)
         # and reference will apply L2 normalization internally after GQA expansion.
 
-        # gdn_decode_klast_bf16_state kernel expects [B, HV, V, K] (K-fast layout) in BF16.
+        # gdn_decode_klast_bf16_state kernel expects [B, HV, V, K] (K-last layout) in BF16.
         # Use the same bf16 initial state for both kernel and reference so we
         # compare the bf16 h state path.
         input_state_kernel = torch.randn(


### PR DESCRIPTION
## 📌 Description
This PR ports the pooled decode kernel (originally from #2521) to the new F16 backend introduced in #2498. It enables zero-copy state updates using indirect indexing, eliminating the need for manual gather/scatter operations in SGLang.
Key changes:
- Ported `feat/gdn-decode-pooled` commits to the latest `main` (post-F16 merge).
indexing logic.
  - Updated docstrings and shape validation to handle both `[B, HV, V, K]` (direct) and `[pool_size, HV, V, K]` (pooled) state layouts.
  - Ensured compatibility with the new `gdn_decode_klast_bf16_state` backend.
## 🔍 Related Issues
- Port of #2521 (feat/gdn-decode-pooled)
- Builds on top of #2498 (F16 kernel backend)
## 🚀 Pull Request Checklist
Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.
### ✅ Pre-commit Checks
- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.
> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).
## 🧪 Tests
- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
## Reviewer Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional pool-indexed state mode: supply per-batch indices to read/write shared state slots.
  * New hybrid/linear attention backend integrations for improved stateful decode workflows.

* **Improvements**
  * Consistent pooled vs per-batch state handling across decode paths.
  * Stronger validation for state shapes, dtypes and indexing to prevent invalid reads/writes.

* **Tools**
  * Local and Python benchmarking scripts for pooled vs gather/scatter throughput.

* **Tests**
  * New tests validating pooled-state decode correctness and padding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->