### PR TITLE
fix: autotuner cache key mismatch for trtllm-gen FP8 block scale MoE and FP8 routed MoE

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -449,10 +449,10 @@ class AutoTuner:
             # Expect no cache miss in inference. Thus, any cache miss should be recorded.
             if not is_cache_hit:
                 logger.debug(
-                    f"[AutoTunner]: Using fallback tactic for {custom_op} with input shapes {input_shapes}"
+                    f"[AutoTuner]: Using fallback tactic for {custom_op} with input shapes {input_shapes}"
                 )
                 logger.debug(
-                    f"[AutoTunner]: Generated key{AutoTuner._get_cache_key(custom_op, runners[0], input_shapes, tuning_config)}"
+                    f"[AutoTuner]: Generated key{AutoTuner._get_cache_key(custom_op, runners[0], input_shapes, tuning_config)}"
                 )
             return runner, tactic
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -991,7 +991,7 @@ class MoETuningSetup:
     #         4=hidden_states, 5=hidden_states_scale
     _ALL_IDX = (0, 1, 2, 3, 4, 5)
     _ROUTING_IDX = (0, 1, 4, 5)  # skip topk_ids/expert_weights
-    _PRECOMPUTED_IDX = (0, 2, 3, 4, 5)  # skip routing_logits
+    _PRECOMPUTED_IDX = (0, 2, 4, 5)  # skip routing_logits and expert_weights
     _NO_SCALE_IDX = (0, 1, 2, 3, 4)  # no hidden_states_scale
 
     _routing_inits = [
@@ -1004,7 +1004,6 @@ class MoETuningSetup:
     _precomputed_inits = [
         dynamic_tensor_initializers[0],
         dynamic_tensor_initializers[2],
-        dynamic_tensor_initializers[3],
         dynamic_tensor_initializers[4],
         dynamic_tensor_initializers[5],
     ]
@@ -1031,12 +1030,12 @@ class MoETuningSetup:
     )
     tuning_config_precomputed_routing = _make_tuning_config(
         _PRECOMPUTED_IDX,
-        (0, 0, 0, 0, 0),
+        (0, 0, 0, 0),
         _precomputed_inits,
     )
     tuning_config_precomputed_routing_deepseek_fp8 = _make_tuning_config(
         _PRECOMPUTED_IDX,
-        (0, 0, 0, 0, 1),
+        (0, 0, 0, 1),
         _precomputed_inits,
     )
     tuning_config_no_hidden_states_scales = _make_tuning_config(
@@ -1047,12 +1046,13 @@ class MoETuningSetup:
 
     @classmethod
     @functools.lru_cache(maxsize=None)
-    def refine_tuning_config(cls, tune_max_num_tokens: int):
+    def refine_tuning_config(cls, tune_max_num_tokens: int, **kwargs):
         mk = lambda idx, dim_idx, inits: cls._make_tuning_config(
             idx,
             dim_idx,
             inits,
             tune_max_num_tokens,
+            **kwargs,
         )
         routing_inits = [cls.dynamic_tensor_initializers[i] for i in cls._ROUTING_IDX]
         precomputed_inits = [
@@ -1086,12 +1086,12 @@ class MoETuningSetup:
         )
         cls.tuning_config_precomputed_routing = mk(
             cls._PRECOMPUTED_IDX,
-            (0, 0, 0, 0, 0),
+            (0, 0, 0, 0),
             precomputed_inits,
         )
         cls.tuning_config_precomputed_routing_deepseek_fp8 = mk(
             cls._PRECOMPUTED_IDX,
-            (0, 0, 0, 0, 1),
+            (0, 0, 0, 1),
             precomputed_inits,
         )
 
@@ -1193,7 +1193,7 @@ def get_trtllm_moe_sm100_module():
                 hidden_states,
                 *extra_inputs,
             ) = inputs
-            num_tokens = routing_logits.shape[0]
+            num_tokens = hidden_states.shape[0]
 
             instance_key = (
                 self.dtype_act,
@@ -1234,7 +1234,7 @@ def get_trtllm_moe_sm100_module():
                 hidden_states,
                 *extra_inputs,
             ) = inputs
-            num_tokens = routing_logits.shape[0]
+            num_tokens = hidden_states.shape[0]
 
             extra_input_idx = 0
             if trtllm_gen_dtype_has_scale(self.dtype_act):

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -946,56 +946,209 @@ def cutlass_fused_moe(
 # trtllmgen-moe-fp8
 
 
+class MoETuningSetup:
+    """Tuning config definitions for SM100"""
+
+    dynamic_tensor_initializers = [
+        lambda shapes, dtype, device: torch.empty(
+            shapes, device=device, dtype=dtype
+        ),  # output buffer, [num_tokens, hidden_size]
+        lambda shapes, dtype, device: torch.rand(
+            shapes, device=device, dtype=dtype
+        ),  # routing_logits, [num_tokens, num_experts]
+        lambda shapes, dtype, device: torch.empty(
+            shapes, device=device, dtype=dtype
+        ),  # topk_ids buffer. empty since routing_logits is used. [num_tokens, topk]
+        lambda shapes, dtype, device: torch.empty(
+            shapes, device=device, dtype=dtype
+        ),  # expert_weights buffer. empty since routing_logits is used. [num_tokens, topk]
+        lambda shapes, dtype, device: torch.randn(shapes, device=device).to(
+            dtype
+        ),  # hidden_states, [num_tokens, hidden_size]
+        lambda shapes, dtype, device: torch.ones(shapes, device=device).to(
+            dtype
+        ),  # hidden_states_scale, [num_tokens, hidden_size // sf_vec_size]
+    ]
+
+    @staticmethod
+    def _make_tuning_config(
+        input_idx, dim_idx, initializers, max_tokens=8192, **kwargs
+    ):
+        return TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    input_idx,
+                    dim_idx,
+                    get_last_power_of_2_num_tokens_buckets(max_tokens, 1),
+                    lambda x, m=max_tokens: min(last_positive_power_of_2(x), m),
+                    initializers,
+                ),
+            ),
+            **kwargs,
+        )
+
+    # Inputs: 0=output, 1=routing_logits, 2=topk_ids, 3=expert_weights,
+    #         4=hidden_states, 5=hidden_states_scale
+    _ALL_IDX = (0, 1, 2, 3, 4, 5)
+    _ROUTING_IDX = (0, 1, 4, 5)  # skip topk_ids/expert_weights
+    _PRECOMPUTED_IDX = (0, 2, 3, 4, 5)  # skip routing_logits
+    _NO_SCALE_IDX = (0, 1, 2, 3, 4)  # no hidden_states_scale
+
+    _routing_inits = [
+        dynamic_tensor_initializers[0],
+        dynamic_tensor_initializers[1],
+        dynamic_tensor_initializers[4],
+        dynamic_tensor_initializers[5],
+    ]
+
+    _precomputed_inits = [
+        dynamic_tensor_initializers[0],
+        dynamic_tensor_initializers[2],
+        dynamic_tensor_initializers[3],
+        dynamic_tensor_initializers[4],
+        dynamic_tensor_initializers[5],
+    ]
+
+    tuning_config_with_hidden_states_scales = _make_tuning_config(
+        _ALL_IDX,
+        (0, 0, 0, 0, 0, 0),
+        dynamic_tensor_initializers,
+    )
+    tuning_config_with_hidden_states_scales_deepseek_fp8 = _make_tuning_config(
+        _ALL_IDX,
+        (0, 0, 0, 0, 0, 1),
+        dynamic_tensor_initializers,
+    )
+    tuning_config_routing_from_logits = _make_tuning_config(
+        _ROUTING_IDX,
+        (0, 0, 0, 0),
+        _routing_inits,
+    )
+    tuning_config_routing_from_logits_deepseek_fp8 = _make_tuning_config(
+        _ROUTING_IDX,
+        (0, 0, 0, 1),
+        _routing_inits,
+    )
+    tuning_config_precomputed_routing = _make_tuning_config(
+        _PRECOMPUTED_IDX,
+        (0, 0, 0, 0, 0),
+        _precomputed_inits,
+    )
+    tuning_config_precomputed_routing_deepseek_fp8 = _make_tuning_config(
+        _PRECOMPUTED_IDX,
+        (0, 0, 0, 0, 1),
+        _precomputed_inits,
+    )
+    tuning_config_no_hidden_states_scales = _make_tuning_config(
+        _NO_SCALE_IDX,
+        (0, 0, 0, 0, 0),
+        dynamic_tensor_initializers[:5],
+    )
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def refine_tuning_config(cls, tune_max_num_tokens: int):
+        mk = lambda idx, dim_idx, inits: cls._make_tuning_config(
+            idx,
+            dim_idx,
+            inits,
+            tune_max_num_tokens,
+        )
+        routing_inits = [cls.dynamic_tensor_initializers[i] for i in cls._ROUTING_IDX]
+        precomputed_inits = [
+            cls.dynamic_tensor_initializers[i] for i in cls._PRECOMPUTED_IDX
+        ]
+
+        cls.tuning_config_with_hidden_states_scales = mk(
+            cls._ALL_IDX,
+            (0, 0, 0, 0, 0, 0),
+            cls.dynamic_tensor_initializers,
+        )
+        cls.tuning_config_with_hidden_states_scales_deepseek_fp8 = mk(
+            cls._ALL_IDX,
+            (0, 0, 0, 0, 0, 1),
+            cls.dynamic_tensor_initializers,
+        )
+        cls.tuning_config_no_hidden_states_scales = mk(
+            cls._NO_SCALE_IDX,
+            (0, 0, 0, 0, 0),
+            cls.dynamic_tensor_initializers[:5],
+        )
+        cls.tuning_config_routing_from_logits = mk(
+            cls._ROUTING_IDX,
+            (0, 0, 0, 0),
+            routing_inits,
+        )
+        cls.tuning_config_routing_from_logits_deepseek_fp8 = mk(
+            cls._ROUTING_IDX,
+            (0, 0, 0, 1),
+            routing_inits,
+        )
+        cls.tuning_config_precomputed_routing = mk(
+            cls._PRECOMPUTED_IDX,
+            (0, 0, 0, 0, 0),
+            precomputed_inits,
+        )
+        cls.tuning_config_precomputed_routing_deepseek_fp8 = mk(
+            cls._PRECOMPUTED_IDX,
+            (0, 0, 0, 0, 1),
+            precomputed_inits,
+        )
+
+    @classmethod
+    def select_fp8_tuning_config(cls, has_routing_logits, fp8_quantization_type):
+        """Return the correct tuning config for the given FP8 MoE call parameters."""
+        is_deepseek = fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8
+        if has_routing_logits:
+            return (
+                cls.tuning_config_routing_from_logits_deepseek_fp8
+                if is_deepseek
+                else cls.tuning_config_routing_from_logits
+            )
+        else:
+            return (
+                cls.tuning_config_precomputed_routing_deepseek_fp8
+                if is_deepseek
+                else cls.tuning_config_precomputed_routing
+            )
+
+    @staticmethod
+    def build_fp8_moe_inputs(
+        routing_logits,
+        hidden_states,
+        hidden_states_scale,
+        output,
+        topk_ids=None,
+        expert_weights=None,
+    ):
+        if routing_logits is not None:
+            routing_dtype = routing_logits.dtype
+            topk_ids = torch.empty(0, dtype=torch.int32, device=hidden_states.device)
+            expert_weights = torch.empty(
+                0, dtype=routing_dtype, device=hidden_states.device
+            )
+        else:
+            if expert_weights is None:
+                expert_weights = torch.empty(
+                    0, dtype=torch.bfloat16, device=hidden_states.device
+                )
+        return [
+            output,
+            routing_logits,
+            topk_ids,
+            expert_weights,
+            hidden_states,
+            hidden_states_scale,
+        ]
+
+
 @functools.cache
 def get_trtllm_moe_sm100_module():
     module = gen_trtllm_gen_fused_moe_sm100_module()
     moe_op = module.build_and_load()
     setup_cubin_loader(str(module.get_library_path()))
 
-    class MoERunner(TunableRunner):
-        dynamic_tensor_initializers = [
-            lambda shapes, dtype, device: torch.empty(
-                shapes, device=device, dtype=dtype
-            ),  # output buffer, [num_tokens, hidden_size]
-            lambda shapes, dtype, device: torch.rand(
-                shapes, device=device, dtype=dtype
-            ),  # routing_logits, [num_tokens, num_experts]
-            lambda shapes, dtype, device: torch.empty(
-                shapes, device=device, dtype=dtype
-            ),  # topk_ids buffer. empty since routing_logits is used. [num_tokens, topk]
-            lambda shapes, dtype, device: torch.empty(
-                shapes, device=device, dtype=dtype
-            ),  # expert_weights buffer. empty since routing_logits is used. [num_tokens, topk]
-            lambda shapes, dtype, device: torch.randn(shapes, device=device).to(
-                dtype
-            ),  # hidden_states, [num_tokens, hidden_size]
-            lambda shapes, dtype, device: torch.ones(shapes, device=device).to(
-                dtype
-            ),  # hidden_states_scale, [num_tokens, hidden_size // sf_vec_size]
-        ]
-        # their first dimension is num_tokens which will be tuned
-        tuning_config_with_hidden_states_scales = TuningConfig(
-            dynamic_tensor_specs=(
-                DynamicTensorSpec(
-                    (0, 1, 2, 3, 4, 5),
-                    (0, 0, 0, 0, 0, 0),
-                    get_last_power_of_2_num_tokens_buckets(8192, 1),
-                    lambda x: min(last_positive_power_of_2(x), 8192),
-                    dynamic_tensor_initializers,
-                ),
-            )
-        )
-        tuning_config_no_hidden_states_scales = TuningConfig(
-            dynamic_tensor_specs=(
-                DynamicTensorSpec(
-                    (0, 1, 2, 3, 4),
-                    (0, 0, 0, 0, 0),
-                    get_last_power_of_2_num_tokens_buckets(8192, 1),
-                    lambda x: min(last_positive_power_of_2(x), 8192),
-                    dynamic_tensor_initializers[:5],
-                ),
-            ),
-        )
+    class MoERunner(MoETuningSetup, TunableRunner):
         # cache the valid tactics to reduce the overhead of instantiating the runner
         # TODO(siyuan): directly cache the runners
         valid_tactics_dict = dict()
@@ -1093,12 +1246,13 @@ def get_trtllm_moe_sm100_module():
             assert output.shape[0] == num_tokens, (
                 "output's first dimension must be batch size."
             )
-            assert topk_ids.shape[0] == num_tokens, (
+            assert topk_ids.numel() == 0 or topk_ids.shape[0] == num_tokens, (
                 "topk_ids's first dimension must be batch size."
             )
-            assert expert_weights.shape[0] == num_tokens, (
-                "expert_weights's first dimension must be batch size."
-            )
+
+            assert (
+                expert_weights.numel() == 0 or expert_weights.shape[0] == num_tokens
+            ), "expert_weights's first dimension must be batch size."
             assert hidden_states.shape[0] == num_tokens, (
                 "hidden_states's first dimension must be batch size."
             )
@@ -1282,34 +1436,6 @@ def get_trtllm_moe_sm100_module():
                     output,
                     [-1, -1] if tactic == -1 else tactic,
                 )
-
-        @classmethod
-        @functools.lru_cache(maxsize=None)
-        def refine_tuning_config(cls, tune_max_num_tokens: int, **kwargs):
-            cls.tuning_config_with_hidden_states_scales = TuningConfig(
-                dynamic_tensor_specs=(
-                    DynamicTensorSpec(
-                        (0, 1, 2, 3, 4, 5),
-                        (0, 0, 0, 0, 0, 0),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
-                        cls.dynamic_tensor_initializers,
-                    ),
-                ),
-                **kwargs,
-            )
-            cls.tuning_config_no_hidden_states_scales = TuningConfig(
-                dynamic_tensor_specs=(
-                    DynamicTensorSpec(
-                        (0, 1, 2, 3, 4),
-                        (0, 0, 0, 0, 0),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
-                        cls.dynamic_tensor_initializers[:5],
-                    ),
-                ),
-                **kwargs,
-            )
 
     @register_custom_op(
         "flashinfer::trtllm_bf16_moe",
@@ -1664,9 +1790,6 @@ def get_trtllm_moe_sm100_module():
                 "either topk_ids or routing_logits must be provided."
             )
             assert topk_ids.dtype == torch.int32, "topk_ids must be an int32 tensor."
-            routing_dtype = torch.bfloat16
-        else:
-            routing_dtype = routing_logits.dtype
 
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
@@ -1682,22 +1805,11 @@ def get_trtllm_moe_sm100_module():
         output = torch.empty(
             num_tokens, hidden_size, dtype=torch.bfloat16, device=hidden_states.device
         )
-        if routing_logits is not None:
-            # When routing_logits is provided, we must pass topk_ids/expert_weights with no allocation
-            topk_ids = torch.empty(0, dtype=torch.int32, device=hidden_states.device)
-            expert_weights = torch.empty(
-                0, dtype=routing_dtype, device=hidden_states.device
-            )
-        else:
-            # When routing_logits is provided, we either have topk_ids/expert_weights,
-            # packed into a single tensor as topk_id
-            # or have them individually as topk_ids and expert_weights respectively
-            topk_ids = topk_ids
-            expert_weights = (
-                expert_weights
-                if expert_weights is not None
-                else torch.empty(0, dtype=routing_dtype, device=hidden_states.device)
-            )
+
+        tuning_config = MoERunner.select_fp8_tuning_config(
+            routing_logits is not None,
+            fp8_quantization_type,
+        )
 
         dtype_act = (
             DtypeTrtllmGen.E4m3
@@ -1721,20 +1833,20 @@ def get_trtllm_moe_sm100_module():
             weight_layout=weight_layout,
             use_shuffled_weight=use_shuffled_weight,
         )
-
-        inputs = [
-            output,
+        inputs = MoETuningSetup.build_fp8_moe_inputs(
             routing_logits,
-            topk_ids,
-            expert_weights,
             hidden_states,
             hidden_states_scale,
-        ]
+            output,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+        )
+        _, _, topk_ids, expert_weights, _, _ = inputs
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp8_block_scale_moe",
             [moe_runner],
-            MoERunner.tuning_config_with_hidden_states_scales,  # FP8 block-scale uses hidden_states_scale
+            tuning_config,
             inputs,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,

--- a/tests/moe/test_moe_autotuner_cache_keys.py
+++ b/tests/moe/test_moe_autotuner_cache_keys.py
@@ -89,7 +89,7 @@ def test_deepseek_fp8_precomputed_routing(num_tokens):
         hidden_states_scale=torch.empty(SCALE_DIM, num_tokens),
         output=output,
         topk_ids=torch.empty(num_tokens, TOP_K, dtype=torch.int32),
-        expert_weights=torch.empty(num_tokens, TOP_K),
+        expert_weights=None,
     )
     _assert_cache_key_match(config, inputs)
 

--- a/tests/moe/test_moe_autotuner_cache_keys.py
+++ b/tests/moe/test_moe_autotuner_cache_keys.py
@@ -1,0 +1,149 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+from flashinfer.autotuner import AutoTuner
+from flashinfer.fused_moe.core import Fp8QuantizationType, MoETuningSetup
+
+HIDDEN_SIZE = 256
+NUM_EXPERTS = 8
+TOP_K = 2
+SCALE_DIM = HIDDEN_SIZE // 128
+
+
+def _assert_cache_key_match(config, inputs):
+    """Core assertion: at least one tuning profile must produce a cache key
+    that matches the inference cache key for the given inputs."""
+    tuner = AutoTuner()
+    inference_shapes = tuple(tuner._get_input_sizes(inputs))
+    inference_key = AutoTuner._find_nearest_profile(inference_shapes, config)
+
+    profiles = tuner._generate_optimization_profiles(config, inputs)
+    tuning_keys = {
+        AutoTuner._find_nearest_profile(p.get_opt_shapes(), config) for p in profiles
+    }
+    assert inference_key in tuning_keys, (
+        f"No tuning profile matches the inference cache key.\n"
+        f"  inference key: {inference_key}\n"
+        f"  tuning keys:   {tuning_keys}"
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [512, 4096, 8192])
+def test_deepseek_fp8_routing_from_logits(num_tokens):
+    config = MoETuningSetup.select_fp8_tuning_config(
+        has_routing_logits=True,
+        fp8_quantization_type=Fp8QuantizationType.DeepSeekFp8,
+    )
+    output = torch.empty(num_tokens, HIDDEN_SIZE)
+    inputs = MoETuningSetup.build_fp8_moe_inputs(
+        routing_logits=torch.empty(num_tokens, NUM_EXPERTS),
+        hidden_states=torch.empty(num_tokens, HIDDEN_SIZE),
+        hidden_states_scale=torch.empty(SCALE_DIM, num_tokens),
+        output=output,
+    )
+    _assert_cache_key_match(config, inputs)
+
+
+@pytest.mark.parametrize("num_tokens", [512, 4096, 8192])
+def test_mxfp8_routing_from_logits(num_tokens):
+    config = MoETuningSetup.select_fp8_tuning_config(
+        has_routing_logits=True,
+        fp8_quantization_type=Fp8QuantizationType.MxFp8,
+    )
+    output = torch.empty(num_tokens, HIDDEN_SIZE)
+    inputs = MoETuningSetup.build_fp8_moe_inputs(
+        routing_logits=torch.empty(num_tokens, NUM_EXPERTS),
+        hidden_states=torch.empty(num_tokens, HIDDEN_SIZE),
+        hidden_states_scale=torch.empty(num_tokens, SCALE_DIM),
+        output=output,
+    )
+    _assert_cache_key_match(config, inputs)
+
+
+@pytest.mark.parametrize("num_tokens", [512, 4096, 8192])
+def test_deepseek_fp8_precomputed_routing(num_tokens):
+    config = MoETuningSetup.select_fp8_tuning_config(
+        has_routing_logits=False,
+        fp8_quantization_type=Fp8QuantizationType.DeepSeekFp8,
+    )
+    output = torch.empty(num_tokens, HIDDEN_SIZE)
+    inputs = MoETuningSetup.build_fp8_moe_inputs(
+        routing_logits=None,
+        hidden_states=torch.empty(num_tokens, HIDDEN_SIZE),
+        hidden_states_scale=torch.empty(SCALE_DIM, num_tokens),
+        output=output,
+        topk_ids=torch.empty(num_tokens, TOP_K, dtype=torch.int32),
+        expert_weights=torch.empty(num_tokens, TOP_K),
+    )
+    _assert_cache_key_match(config, inputs)
+
+
+@pytest.mark.parametrize("num_tokens", [512, 4096, 8192])
+def test_no_scale_config(num_tokens):
+    config = MoETuningSetup.tuning_config_no_hidden_states_scales
+    inputs = [
+        torch.empty(num_tokens, HIDDEN_SIZE),
+        torch.empty(num_tokens, NUM_EXPERTS),
+        torch.empty(num_tokens, TOP_K, dtype=torch.int32),
+        torch.empty(num_tokens, TOP_K),
+        torch.empty(num_tokens, HIDDEN_SIZE),
+    ]
+    _assert_cache_key_match(config, inputs)
+
+
+@pytest.mark.parametrize("max_tokens", [4096, 16384])
+def test_max_tokens_respected(max_tokens):
+    """Tokens at max_tokens must still hit the cache after refine."""
+    MoETuningSetup.refine_tuning_config(max_tokens)
+    config = MoETuningSetup.select_fp8_tuning_config(
+        has_routing_logits=True,
+        fp8_quantization_type=Fp8QuantizationType.DeepSeekFp8,
+    )
+    output = torch.empty(max_tokens, HIDDEN_SIZE)
+    inputs = MoETuningSetup.build_fp8_moe_inputs(
+        routing_logits=torch.empty(max_tokens, NUM_EXPERTS),
+        hidden_states=torch.empty(max_tokens, HIDDEN_SIZE),
+        hidden_states_scale=torch.empty(SCALE_DIM, max_tokens),
+        output=output,
+    )
+    _assert_cache_key_match(config, inputs)
+
+
+def test_select_config_deepseek_with_routing():
+    config = MoETuningSetup.select_fp8_tuning_config(
+        True, Fp8QuantizationType.DeepSeekFp8
+    )
+    assert config is MoETuningSetup.tuning_config_routing_from_logits_deepseek_fp8
+
+
+def test_select_config_deepseek_precomputed():
+    config = MoETuningSetup.select_fp8_tuning_config(
+        False, Fp8QuantizationType.DeepSeekFp8
+    )
+    assert config is MoETuningSetup.tuning_config_precomputed_routing_deepseek_fp8
+
+
+def test_select_config_mxfp8_with_routing():
+    config = MoETuningSetup.select_fp8_tuning_config(True, Fp8QuantizationType.MxFp8)
+    assert config is MoETuningSetup.tuning_config_routing_from_logits
+
+
+def test_select_config_mxfp8_precomputed():
+    config = MoETuningSetup.select_fp8_tuning_config(False, Fp8QuantizationType.MxFp8)
+    assert config is MoETuningSetup.tuning_config_precomputed_routing


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The PR 
- fixes input shape mismatches to match the autotuner cache key for MoE FP8 
- enables autotuner for fp8 block scale routed moe

**Issue1**: Could not find tuned tactic for trtllm_fp8_block_scale_moe 
```2026-02-26 09:26:35,204 - INFO - autotuner.py:444 - flashinfer.jit: [AutoTunner]: Using fallback tactic for flashinfer::trtllm_fp8_block_scale_moe with input shapes (torch.Size([1024, 4096]), torch.Size([1024, 512]), torch.Size([0]), torch.Size([0]), torch.Size([1024, 4096]), torch.Size([32, 1024]))```

Tuned with incorrect input:
op=flashinfer::trtllm_fp8_block_scale_moe, profile=((1024, 4096), (1024, 512), (**1024**,), (**1024**,), (1024, 4096), (**1024, 16384**)) -> runner_id=0, tactic=[64, 5]

**Issue2**: Crash when autotuning trtllm_fp8_block_scale_routed_moe
```    trtllm_fp8_block_scale_routed_moe(
  File "/flashinfer/flashinfer/fused_moe/core.py", line 2568, in trtllm_fp8_block_scale_routed_moe
    result = get_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/flashinfer/flashinfer/fused_moe/core.py", line 1711, in trtllm_fp8_block_scale_moe_op
    _, tactic = tuner.choose_one(
                ^^^^^^^^^^^^^^^^^
  File "/flashinfer/flashinfer/autotuner.py", line 470, in choose_one
    tensors = self._prepare_input_tensors(p, inputs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/flashinfer/flashinfer/autotuner.py", line 792, in _prepare_input_tensors
    tensor = self._create_tensor_like(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/flashinfer/flashinfer/autotuner.py", line 771, in _create_tensor_like
    dtype = origin_tensor.dtype
            ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'dtype' 
```


**Benchmark**:



| Tokens | BF16 (ms) | BF16 TFLOPS | FP8 Untuned (ms) | FP8 Untuned TFLOPS | FP8 Tuned (ms) | FP8 Tuned TFLOPS | FP8 routed Untuned (ms) | FP8 routed Untuned TFLOPS | FP8 routed Tuned (ms) | FP8 routed Tuned TFLOPS |
|--------|-----------|-------------|------------------|-------------------|-----------------|------------------|---------------------|----------------------|------------------|-------------------|
| 1024 | 1.877 | 137.32 | 1.455 | 177.07 | 1.187 | 217.07 | 1.337 | 192.80 | 1.514| 170.27 |
| 2048 | 1.952 | 263.99 | 1.692 | 304.65 | 1.425 | 361.77 | 1.548 | 333.04 | 1.662 | 310.09|
| 4096 | 2.194 | 469.85 | 2.232 | 461.79 | 2.561 | 402.43 | 2.087 | 493.88 | 1.887 | 546.16|
| 8192 | 3.594 | 573.57 | 3.458 | 596.15 | 3.439 | 599.49 | 3.355 | 614.50 | 3.582 | 575.53|
| 16384 | 5.423 | 760.37 | 6.329 | 651.47 | 5.852 | 704.53 | 6.026 | 684.17 | 5.670 | 727.18|

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in autotuner debug log messages.

* **Refactor**
  * Consolidated MoE tuning configuration and input preparation into a centralized setup, simplifying FP8/FP4 paths, reducing duplication, and improving runtime/shape validation and configurability.

* **Tests**
  * Added tests verifying autotuner cache-key behavior across quantization modes and multiple token-count scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->