### PR TITLE
[fp8_blockwise]Fix int32 overflow in TRTLLM fused MoE activation kernel

### DIFF
--- a/csrc/trtllm_fused_moe_dev_kernel.cu
+++ b/csrc/trtllm_fused_moe_dev_kernel.cu
@@ -265,9 +265,11 @@ __global__ void activationDeepSeekKernel(KernelParams params) {
           // Use int64_t to avoid overflow when permutedIdx * innerDim > INT32_MAX
           int64_t const baseIdx = (int64_t)permutedIdx * params.innerDim + hiddenIdx;
 
-          int64_t const scale1Idx = (int64_t)permutedIdx + (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
-          int64_t const scale2Idx = (int64_t)permutedIdx + (int64_t)totalNumPaddedTokens *
-                                                  ((hiddenIdx / 128) + (params.innerDim / 2 / 128));
+          int64_t const scale1Idx =
+              (int64_t)permutedIdx + (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
+          int64_t const scale2Idx =
+              (int64_t)permutedIdx +
+              (int64_t)totalNumPaddedTokens * ((hiddenIdx / 128) + (params.innerDim / 2 / 128));
 
           scale1Arr[tokenInCtaIdx] = params.inDqSfsPtr[scale1Idx];
           scale2Arr[tokenInCtaIdx] = params.inDqSfsPtr[scale2Idx];
@@ -306,8 +308,8 @@ __global__ void activationDeepSeekKernel(KernelParams params) {
             float scaleOut =
                 fmaxf(aMaxArr[tokenInCtaIdx] / E4m3MaxVal, std::numeric_limits<float>::min());
             s_scaleOutArr[tokenInCtaIdx] = scaleOut;
-            int64_t const scaleOut_idx =
-                (int64_t)permutedIdxArr[tokenInCtaIdx] + (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
+            int64_t const scaleOut_idx = (int64_t)permutedIdxArr[tokenInCtaIdx] +
+                                         (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
             params.outDqSfsPtr[scaleOut_idx] = scaleOut;
           }
         }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix CUDA Illegal Memory Access (IMA) caused by int32 overflow in activationKernel and activationDeepSeekKernel in the TRTLLM fused MoE pipeline.

Root cause: The index computation `permutedIdx * params.innerDim + hiddenIdx` uses int32 arithmetic. With large MoE configurations (e.g. 256 global experts, topK=8, DP=2, EP=2), the values can exceed INT32_MAX:
- num_tokens = 65536 (max_num_batched_tokens * DP)
- totalNumPaddedTokens up to 524,288  65536 * 8, worst case all tokens route to local experts)
- innerDim =   2 * intermediate_size, suppose its >5k
- 524,287 * innerDim may be > INT32_MAX (2,147,483,647)


The overflow produces a negative index, causing out-of-bounds memory access.
Fix: Cast permutedIdx to int64_t before the multiplication in both
activationKernel (line 82) and activationDeepSeekKernel (line 337).

The overflow may also cause issue in other places, e.g. https://github.com/flashinfer-ai/flashinfer/pull/2643, but I don't have time to validate https://github.com/flashinfer-ai/flashinfer/pull/2643 yet.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x ] I have installed the hooks with `pre-commit install`.
- [ x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

Verified locally with the same model, works 

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed integer overflow issues in tensor indexing calculations, enabling proper support for larger tensor dimensions without overflow errors. Improves stability for large-scale tensor processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->