### PR TITLE
[mxfp8 etc.]Fix int32 overflow in TRTLLM fused MoE permute/finalize kernels

### DIFF
--- a/csrc/trtllm_fused_moe_dev_kernel.cu
+++ b/csrc/trtllm_fused_moe_dev_kernel.cu
@@ -586,7 +586,7 @@ __global__ void permuteKernel(KernelParams params) {
       for (int k = 0; k < params.topK; k++) {
         int const expandedIdx = tokenIdx * params.topK + k;
         int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
-        params.outPtr[permutedIdx * params.hiddenDim + hiddenIdx] = data;
+        params.outPtr[(int64_t)permutedIdx * params.hiddenDim + hiddenIdx] = data;
       }
     }
     if (params.useDeepSeekFp8) {
@@ -597,7 +597,7 @@ __global__ void permuteKernel(KernelParams params) {
           int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
 
           int const idx_in = tokenIdx + params.numTokens * scaleIdx;
-          int const idx_out = permutedIdx + params.totalNumPaddedTokens[0] * scaleIdx;
+          int64_t const idx_out = (int64_t)permutedIdx + (int64_t)params.totalNumPaddedTokens[0] * scaleIdx;
 
           params.outDqSfsPtr[idx_out] = params.inDqSfsPtr[idx_in];
         }
@@ -662,9 +662,9 @@ __global__ void finalizeKernel(KernelParams params) {
         if (params.expertWeightsPtr != nullptr) {
           TypeExpW const scale = params.expertWeightsPtr[expandedIdx];
           data +=
-              float{scale} * float{params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]};
+              float{scale} * float{params.inPtr[(int64_t)permutedIdx * params.hiddenDimPadded + hiddenIdx]};
         } else {
-          data += float{params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]};
+          data += float{params.inPtr[(int64_t)permutedIdx * params.hiddenDimPadded + hiddenIdx]};
         }
       }
 
@@ -926,14 +926,14 @@ __global__ void finalizeDeepSeekKernel(KernelParams params) {
           continue;
         }
         int const totalNumPaddedTokens = params.totalNumPaddedTokens[0];
-        int const scaleIdx = permutedIdx + totalNumPaddedTokens * (hiddenIdx / 128);
+        int64_t const scaleIdx = (int64_t)permutedIdx + (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
         float const blockScale = params.inDqSfsPtr ? params.inDqSfsPtr[scaleIdx] : 1;
 
         float const expertProb = (float)params.expertWeightsPtr[tokenIdx * params.topK + k];
 
         float const scale = expertProb * blockScale;
         acc += scale *
-               static_cast<float>(params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]);
+               static_cast<float>(params.inPtr[(int64_t)permutedIdx * params.hiddenDimPadded + hiddenIdx]);
       }
 
       // The largest (finite) value that can be represented using E4m3.


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

Extend the int32 overflow fix from https://github.com/flashinfer-ai/flashinfer/pull/2642 to the remaining standalone
kernels in trtllm_fused_moe_dev_kernel.cu: `permuteKernel`, `finalizeKernel`,
and `finalizeDeepSeekKernel`.

The same root cause applies — `permutedIdx * dimension` can exceed INT32_MAX
with large MoE configurations. This PR fixes all remaining overflow sites:

- `permuteKernel`: `permutedIdx * hiddenDim` (line 642)
- `permuteKernel` (DeepSeek scale path): `permutedIdx + totalNumPaddedTokens * scaleIdx` (line 653)
- `finalizeKernel`: `permutedIdx * hiddenDimPadded` (lines 718, 720)
- `finalizeDeepSeekKernel`: `permutedIdx + totalNumPaddedTokens * (hiddenIdx / 128)` (line 982)
- `finalizeDeepSeekKernel`: `permutedIdx * hiddenDimPadded` (line 989)


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests
**We suspect this may be the root cause for our another IMA, not validated yet**


- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
