### PR TITLE
perf: revert overly conservative signal updates in grouped_gemm_masked_blackwell 

### DIFF
--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -71,12 +71,14 @@ sizeof_i32 = 4
 
 
 @dsl_user_op
-def with_byte(arr: cute.typing.Tensor, index: Int32, value: Uint8, *, loc=None, ip=None) -> cute.typing.Tensor:
+def with_byte(
+    arr: cute.typing.Tensor, index: Int32, value: Uint8, *, loc=None, ip=None
+) -> cute.typing.Tensor:
     element_index = index // 4
     byte_offset = index % 4
     arr[element_index] &= ~(0xFF << (byte_offset * 8))
     arr[element_index] |= value << (byte_offset * 8)
-    assert isinstance(arr[index//4], Uint64), f"{arr[index//4]=}"
+    assert isinstance(arr[index // 4], Uint64), f"{arr[index//4]=}"
     return arr
 
 
@@ -227,9 +229,7 @@ class MaskedScheduler:
         new_num_tiles_executed = new_from_mlir_values(
             self._num_tiles_executed, [values[7]]
         )
-        new_last_batch_idx = new_from_mlir_values(
-            self._last_batch_idx, [values[8]]
-        )
+        new_last_batch_idx = new_from_mlir_values(self._last_batch_idx, [values[8]])
         return MaskedScheduler(
             self.params,
             new_num_persistent_clusters,
@@ -328,8 +328,7 @@ class MaskedScheduler:
             batch_idx += Int32(1)
 
         if cutlass.const_expr(
-            (dsm_pending_packed is not None)
-            and (self.params.dst_signals is not None)
+            (dsm_pending_packed is not None) and (self.params.dst_signals is not None)
         ):
             if self._current_batch_idx != batch_idx and self._num_tiles_executed > 0:
                 self._last_batch_idx = self._current_batch_idx
@@ -1674,7 +1673,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 assert self.num_c_stage < 256, "must be representable in 1 byte"
                 num_experts = tile_sched_params.masked_m.shape[0]
                 assert num_experts <= 64, "num_experts must be <= 64"
-            dsm_pending_packed = cute.make_fragment(cute.make_layout((1, 8), stride=(8, 1)), dtype=cutlass.Uint64)
+            dsm_pending_packed = cute.make_fragment(
+                cute.make_layout((1, 8), stride=(8, 1)), dtype=cutlass.Uint64
+            )
             dsm_pending_packed.fill(0)
             dsm_pending_idx = Int32(0)
 
@@ -1772,7 +1773,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         ):
                             dsm_counter = (dsm_counter + 1).to(Uint8)
                             will_write_signals = (
-                                read_byte(dsm_pending_packed, tile_sched._last_batch_idx)
+                                read_byte(
+                                    dsm_pending_packed, tile_sched._last_batch_idx
+                                )
                                 == dsm_counter
                             )
 
@@ -1801,7 +1804,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         lane_id = tidx % 32
                         if warp_idx == self.epilog_warp_id[0] and lane_id == 0:
                             if (
-                                read_byte(dsm_pending_packed, tile_sched._last_batch_idx)
+                                read_byte(
+                                    dsm_pending_packed, tile_sched._last_batch_idx
+                                )
                                 == dsm_counter
                             ):
                                 atomic_add_release_global(
@@ -1809,7 +1814,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                     + sizeof_i32 * tile_sched._last_batch_idx,
                                     value=1,
                                 )
-                                with_byte(dsm_pending_packed, tile_sched._last_batch_idx, 0)
+                                with_byte(
+                                    dsm_pending_packed, tile_sched._last_batch_idx, 0
+                                )
                                 dsm_pending_idx = tile_sched._last_batch_idx + 1
 
                 #
@@ -1862,13 +1869,16 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 lane_id = tidx % 32
                 if warp_idx == self.epilog_warp_id[0] and lane_id == 0:
                     while dsm_pending_idx < num_experts:
-                        if read_byte(dsm_pending_packed, dsm_pending_idx) == self.num_c_stage-1:
+                        if (
+                            read_byte(dsm_pending_packed, dsm_pending_idx)
+                            == self.num_c_stage - 1
+                        ):
                             atomic_add_release_global(
                                 tile_sched_params.dst_signals.toint()
                                 + sizeof_i32 * dsm_pending_idx,
-                             value=1,
+                                value=1,
                             )
-                        
+
                         dsm_pending_idx += 1
 
             else:

--- a/tests/gemm/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/gemm/test_cute_dsl_blockscaled_gemm.py
@@ -27,7 +27,7 @@ from flashinfer.cute_dsl.utils import (
 @pytest.mark.skipif(
     not is_cute_dsl_available(), reason="Please `pip install nvidia-cutlass-dsl`"
 )
-@pytest.mark.parametrize("lm", [(2,512), (10, 256)])
+@pytest.mark.parametrize("lm", [(2, 512), (10, 256)])
 @pytest.mark.parametrize("kn", [(7168, 4096), (2048, 7168)])
 @pytest.mark.parametrize(
     "ab_dtype,sf_dtype,c_dtype,sf_vec_size",
@@ -207,9 +207,15 @@ def test_blockscaled_gemm_python_interface(
         )
 
         if enable_dst_signals:
-            expect_signals = torch.ceil(masked_m_tensor/mma_tiler_mn[0]) * (n / mma_tiler_mn[1])
-            expect_signals = torch.where(expect_signals > sm_count, sm_count, expect_signals)
-            assert torch.all(dst_signals == expect_signals), f"{dst_signals} {expect_signals} {masked_m_tensor}"
+            expect_signals = torch.ceil(masked_m_tensor / mma_tiler_mn[0]) * (
+                n / mma_tiler_mn[1]
+            )
+            expect_signals = torch.where(
+                expect_signals > sm_count, sm_count, expect_signals
+            )
+            assert torch.all(dst_signals == expect_signals), (
+                f"{dst_signals} {expect_signals} {masked_m_tensor}"
+            )
 
     # compute ref output
     if not fuse_alpha:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Refactor the signal update mechanism in grouped_gemm_masked_blackwell.py to reduce unnecessary atomic operations, support longer signal lengths (up to 64 experts), and improve kernel performance by ~10μs+.

**Original Limitations**

1. **Signal length capped at 8:** The original implementation packed all pending signals into a single Uint64, limiting num_experts <= 8. This is insufficient for real-world MoE scenarios with dozens of experts.
2. **Excessive signal updates:** The scheduler updated signals for all experts sequentially, even when a CTA only computed a subset of groups. This caused unnecessary atomic_add_release_global operations  (~10μs overhead)

**Changes Made**

Use tile_sched._last_batch_idx to target _only_  the computed group. The CTA only updates signals of computed groups.

**Perf**

| m, k, n, topk, l | w/o signals (us) | w/ signals (Before) (us)) | w/ signals (After) (us)) |
|------------------|-------------|--------------------------|--------------------------|
| 32, 2048, 4096, 10, 8  | 7.8         | 19.4                     | 10.4                     |
| 32, 2048, 4096, 10, 16 | 12.5        | 34.8                     | 15.6                     |
| 32, 2048, 8192, 10, 8  | 12.6        | 19.9                     | 15.7                     |
| 32, 2048, 8192, 10, 16 | 27.0        | 36.3                     | 28.9                     |
| 32, 2048, 8192, 10, 32 | 48.7        | 71.0                     | 51.8                     |

**Potential Impact**
This change modifies the final value of the signal counter (e.g., dst_signals[exp_idx]) after kernel execution. As a result,  other downstream systems relies on the absolute value of these signals, may need adjustment.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouped GEMM scheduler robustness with enhanced batch synchronization and state management for more reliable execution.

* **Tests**
  * Expanded test validation with updated parameter configurations and enhanced verification logic for GEMM scheduler behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->