### PR TITLE
fix: Add fused MOE and GEMM AOT modules for SM121

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -512,15 +512,12 @@ def gen_all_modules(
             jit_specs.append(gen_fp4_quantization_sm110_module())
         if has_sm120:
             jit_specs.append(gen_fp4_quantization_sm120_module())
-            jit_specs.append(gen_cutlass_fused_moe_sm120_module())
-            jit_specs.append(gen_gemm_sm120_module())
-            jit_specs.append(gen_gemm_sm120_module_cutlass_fp4())
         if has_sm121:
             jit_specs.append(gen_fp4_quantization_sm121_module())
-            # SM121 shares the same CUTLASS kernels as SM120 for fused MOE and GEMM.
+        if has_sm120 or has_sm121:
+            # SM120 and SM121 share the same CUTLASS kernels for fused MOE and GEMM.
             # The SM120 module generators use supported_major_versions=[12] which
-            # compiles for all SM12x targets. Dedup at end of gen_all_modules()
-            # prevents duplicate modules when both has_sm120 and has_sm121 are True.
+            # compiles for all SM12x targets.
             jit_specs.append(gen_cutlass_fused_moe_sm120_module())
             jit_specs.append(gen_gemm_sm120_module())
             jit_specs.append(gen_gemm_sm120_module_cutlass_fp4())


### PR DESCRIPTION
## Summary

- Add `gen_cutlass_fused_moe_sm120_module()`, `gen_gemm_sm120_module()`, and `gen_gemm_sm120_module_cutlass_fp4()` to the `if has_sm121:` block in `aot.py`
- SM121 (DGX Spark / GB10) AOT builds now include fused MOE and GEMM modules

## Problem

SM121 was missing fused_moe, gemm, and fp4_gemm_cutlass modules in the AOT pre-compilation path. Only `gen_fp4_quantization_sm121_module()` was generated for SM121 systems, while the JIT runtime path already correctly dispatches SM121 to SM120 modules for all three operations.

This means AOT-prebuilt packages (e.g. `flashinfer-jit-cache`) targeting SM121 would be missing fused MOE and GEMM kernels, forcing fallback to JIT compilation at runtime.

## Fix

Reuse the SM120 module generators under `if has_sm121:` since SM120 and SM121 share the same CUTLASS kernels. The SM120 generators already use `supported_major_versions=[12]` which compiles for all SM12x targets. The dedup at the end of `gen_all_modules()` prevents duplicate modules when both `has_sm120` and `has_sm121` are True.

## Validation (DGX Spark, SM121a)

```
=== SM capabilities detected ===
  sm121: True

=== BEFORE fix: SM121 AOT modules ===
  fp4_quantization_121
  Total SM12x modules: 1

=== AFTER fix: SM121 AOT modules ===
  fp4_quantization_121
  fused_moe_120
  gemm_sm120
  fp4_gemm_cutlass_sm120
  Total SM12x modules: 4
```

JIT runtime dispatch confirmed: `get_cutlass_fused_moe_module("121")`, `get_gemm_sm120_module()`, and `get_cutlass_fp4_gemm_module(12, 1)` all correctly route SM121 to the SM120 modules at runtime.

Contributed by Second Nature Computing (https://joinsecondnature.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved SM120/SM121 support: generation of fused MOE, GEMM, and FP4-quantization kernel modules now occurs under a unified condition for SM120 or SM121, with FP4 quantization included alongside other SM121 modules earlier in the pipeline. Automatic deduplication remains to prevent redundant kernels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->