### PR TITLE
Fix ImportError in AllReduceFusionWorkspace destructor during Python shutdown

### DIFF
--- a/flashinfer/comm/workspace_base.py
+++ b/flashinfer/comm/workspace_base.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
 from abc import ABC, abstractmethod
-from typing import Optional, Any
+from typing import Any, Optional
 
 import torch
 
@@ -69,8 +70,6 @@ class AllReduceFusionWorkspace(ABC):
         distributed/CUDA resources.
         """
         if not self._destroyed:
-            import warnings
-
             warnings.warn(
                 f"{self.__class__.__name__} was not explicitly destroyed. "
                 f"Call workspace.destroy() or use AllReduceFusionContext to ensure "


### PR DESCRIPTION


<!-- .github/pull_request_template.md -->

## 📌 Description
 vLLM has integrated the latest flashinfer.

However, when vLLM shuts down, flashinfer throws the following error:
```
(Worker pid=2113423) (Worker_TP2 pid=2113423) Exception ignored in: <function AllReduceFusionWorkspace.__del__ at 0x7ff5d5ffd940>
(Worker pid=2113423) (Worker_TP2 pid=2113423) Traceback (most recent call last):
(Worker pid=2113423) (Worker_TP2 pid=2113423)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/flashinfer/comm/workspace_base.py", line 72, in __del__
(Worker pid=2113423) (Worker_TP2 pid=2113423) ImportError: sys.meta_path is None, Python is likely shutting down
(Worker pid=2113421) (Worker_TP0 pid=2113421) Exception ignored in: <function AllReduceFusionWorkspace.__del__ at 0x7f0d30f2d940>
(Worker pid=2113421) (Worker_TP0 pid=2113421) Traceback (most recent call last):
(Worker pid=2113421) (Worker_TP0 pid=2113421)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/flashinfer/comm/workspace_base.py", line 72, in __del__
(Worker pid=2113421) (Worker_TP0 pid=2113421) ImportError: sys.meta_path is None, Python is likely shutting down
(Worker pid=2113424) (Worker_TP3 pid=2113424) Exception ignored in: <function AllReduceFusionWorkspace.__del__ at 0x7f8630109940>
(Worker pid=2113424) (Worker_TP3 pid=2113424) Traceback (most recent call last):
(Worker pid=2113424) (Worker_TP3 pid=2113424)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/flashinfer/comm/workspace_base.py", line 72, in __del__
(Worker pid=2113424) (Worker_TP3 pid=2113424) ImportError: sys.meta_path is None, Python is likely shutting down
(Worker pid=2113422) (Worker_TP1 pid=2113422) Exception ignored in: <function AllReduceFusionWorkspace.__del__ at 0x7f9179e09940>
(Worker pid=2113422) (Worker_TP1 pid=2113422) Traceback (most recent call last):
(Worker pid=2113422) (Worker_TP1 pid=2113422)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/flashinfer/comm/workspace_base.py", line 72, in __del__
(Worker pid=2113422) (Worker_TP1 pid=2113422) ImportError: sys.meta_path is None, Python is likely shutting down

```
 






It can be observed that the vLLM Python process is exiting, and `__del__` is being triggered. At that point, the import system has already been torn down, so `warnings` can no longer be imported.
 
 
 
 
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization and cleanup with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->