### PR TITLE
perf: prefer cuDNN first for mm_fp4 on CUDA>=13 and cuDNN>=9.15 (SM100/SM103)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5056,28 +5056,21 @@ def _heuristic_func_mm_fp4(
     - If cuda version is 12 - use cutlass.
     - If cuda version is 13 and cudnn version is less than 9.15 - use cutlass.
     - If cuda version is 13 and cudnn version is 9.15 or greater:
-      - On SM103 (B300) - use cutlass (faster based on benchmarks).
-      - On SM100 (B200) - use cudnn (faster based on benchmarks).
+      - Use cudnn first for both SM100 (B200) and SM103 (B300).
 
     """
     cuda_major = get_cuda_version().major
-    # Get compute capability to distinguish between SM100 (10.0) and SM103 (10.3)
     major, minor = get_compute_capability(a.device)
-    is_sm103 = major == 10 and minor == 3
     is_sm120 = major == 12 and minor == 0
 
     # SM120 + CUDA 13: prefer b12x (warp-level MMA, underfill tile selection)
     if is_sm120 and use_nvfp4 and cuda_major >= 13:
         return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
 
-    # If cuda version is 13 or greater and cudnn version is 9.15 or greater:
-    # On SM103 (B300), cutlass is more performant than cudnn.
-    # On SM100 (B200), cudnn is more performant than cutlass.
+    # If cuda version is 13 or greater and cudnn version is 9.15 or greater,
+    # prioritize cudnn for both SM100 (B200) and SM103 (B300).
     if CUDNN_AVAILABLE and cuda_major >= 13 and cudnn.backend_version() >= 91500:
-        if is_sm103:
-            candidate_backends = ("cutlass", "cudnn")
-        else:
-            candidate_backends = ("cudnn", "cutlass")
+        candidate_backends = ("cudnn", "cutlass")
     # Otherwise, prioritize cutlass
     else:
         candidate_backends = ("cutlass", "cudnn")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This changes `mm_fp4` auto backend selection to prefer cuDNN first (instead of CUTLASS-first on SM103) for CUDA 13 with cuDNN backend >= 9.15 on both SM100 and SM103. This is basically reverting the previous SM103-specific choice based on updated results: with `nvidia-cudnn-cu13==9.19.1.2`, cuDNN is better in most cases on SM103. See the comparison plots below.

<img width="7164" height="3075" alt="image" src="https://github.com/user-attachments/assets/356ba5bb-5a5e-42a4-996d-b4e74423ffe9" />

<img width="7164" height="3075" alt="image" src="https://github.com/user-attachments/assets/5a55347e-aa77-4149-9889-85ec850f0ae0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Streamlined backend selection for FP4 matrix multiplication on NVIDIA GPUs (CUDA 13+ with cuDNN 9.15+), consistently prioritizing cuDNN to improve performance and stability.
  * Reduced variance in backend choice, simplifying and unifying behavior across supported GPU targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->