### PR TITLE
fix: reduce smem allocation for tinygemm2 kernel in SM120

### DIFF
--- a/csrc/tinygemm2.cu
+++ b/csrc/tinygemm2.cu
@@ -401,14 +401,24 @@ namespace tinygemm2 {
 // and writes output in column-major: output[n * M + m].
 // The Python wrapper transposes this back to row-major (batch_size, output_features).
 
-void launch_tinygemm2(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC, __nv_bfloat16* bias,
-                      int batch_size, int output_features, int input_features, cudaStream_t stream,
-                      bool use_pdl) {
+// Query the max dynamic shared memory for the current device (cached per device).
+static int get_max_dynamic_smem() {
+  static int cached = -1;
+  if (cached >= 0) return cached;
+  int device;
+  cudaGetDevice(&device);
+  cudaDeviceGetAttribute(&cached, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+  return cached;
+}
+
+template <int STAGES>
+void launch_tinygemm2_impl(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC,
+                           __nv_bfloat16* bias, int batch_size, int output_features,
+                           int input_features, cudaStream_t stream, bool use_pdl) {
   static int const WARP_TILE_M = 16;
   static int const TILE_M = WARP_TILE_M;
   static int const TILE_N = 8;
   static int const TILE_K = 64;
-  static int const STAGES = 16;
   static int const STAGE_UNROLL = 4;
 
   CUtensorMap weight_map{};
@@ -489,6 +499,32 @@ void launch_tinygemm2(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC, _
     status = cudaGetLastError();
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "tinygemm_kernel launch failed: " << cudaGetErrorString(status);
+  }
+}
+
+void launch_tinygemm2(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC, __nv_bfloat16* bias,
+                      int batch_size, int output_features, int input_features, cudaStream_t stream,
+                      bool use_pdl) {
+  // Dynamic shared memory per pipeline stage (STAGE_UNROLL=4 stages per group):
+  //   STAGE_UNROLL * (TILE_M * TILE_K + TILE_N * TILE_K) * sizeof(bf16)
+  //   = 4 * (16*64 + 8*64) * 2 = 12288 bytes per STAGES increment
+  static constexpr int SMEM_PER_STAGE_GROUP = 4 * (16 * 64 + 8 * 64) * 2;  // 12288
+
+  int max_smem = get_max_dynamic_smem();
+  int max_stages = max_smem / SMEM_PER_STAGE_GROUP;
+
+  // Dispatch to the largest STAGES that fits. SM90/100f typically allows 16, SM120 allows 4.
+  if (max_stages >= 16) {
+    launch_tinygemm2_impl<16>(gA, gB, gC, bias, batch_size, output_features, input_features, stream,
+                              use_pdl);
+  } else if (max_stages >= 4) {
+    // We must keep STAGES as a multiple of 4 (one slot per compute warp).
+    launch_tinygemm2_impl<4>(gA, gB, gC, bias, batch_size, output_features, input_features, stream,
+                             use_pdl);
+  } else {
+    TVM_FFI_ICHECK(false) << "Device has insufficient shared memory for tinygemm2 kernel ("
+                          << max_smem << " bytes available, minimum " << 4 * SMEM_PER_STAGE_GROUP
+                          << " bytes required)";
   }
 }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The tinygemm2 kernel used hardcoded STAGES=16 requiring 192KB of dynamic shared memory. This exceeds SM120's (Blackwell RTX) max opt-in shared memory of ~99KB (vs SM90's 228KB), causing cudaFuncSetAttribute to fail with "invalid argument". Fix is to refactor launch_tinygemm2 to query device's max shared memory, and dispatch based on available shared memory: adjust STAGES parameter. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GPU memory constraints with clearer diagnostic messages.

* **Refactor**
  * Optimized GPU compute implementation for enhanced resource utilization and adaptive execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->