### PR TITLE
[DO NOT MERGE] add CUDA SWA block-table sanitizer

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -374,11 +374,8 @@ void trtllm_paged_attention_decode(
   TVM_FFI_ICHECK_EQ(block_tables.dtype(), dl_int32) << "block_tables must be int32";
   TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
   TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
-  TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
-      << "block_tables batch size must match seq_lens batch size";
   TVM_FFI_ICHECK_EQ(batch_size, block_tables.size(0))
       << "batch_size must match block_tables.size(0)";
-  TVM_FFI_ICHECK_EQ(batch_size, seq_lens.size(0)) << "batch_size must match seq_lens.size(0)";
   TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
   for (int i = 0; i < key_cache.ndim(); i++) {
@@ -496,11 +493,8 @@ void trtllm_paged_attention_context(
   TVM_FFI_ICHECK_EQ(block_tables.dtype(), dl_int32) << "block_tables must be int32";
   TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
   TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
-  TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
-      << "block_tables batch size must match seq_lens batch size";
   TVM_FFI_ICHECK_EQ(batch_size, block_tables.size(0))
       << "batch_size must match block_tables.size(0)";
-  TVM_FFI_ICHECK_EQ(batch_size, seq_lens.size(0)) << "batch_size must match seq_lens.size(0)";
   TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_q.ndim(), 1) << "cum_seq_lens_q must be a 1D tensor";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_q.dtype(), dl_int32) << "cum_seq_lens_q must be int32";
@@ -508,8 +502,6 @@ void trtllm_paged_attention_context(
       << "cum_seq_lens_q size must be batch_size + 1";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.ndim(), 1) << "cum_seq_lens_kv must be a 1D tensor";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.dtype(), dl_int32) << "cum_seq_lens_kv must be int32";
-  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.size(0), batch_size + 1)
-      << "cum_seq_lens_kv size must be batch_size + 1";
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
   int num_qo_heads = query.size(1);
   int sum_seq_q = query.size(0);

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -43,6 +43,18 @@ enum class TllmPagedAttentionMode {
 
 namespace {
 
+#define DISPATCH_DTYPE(dtype, c_type, ...) \
+  [&]() -> bool {                          \
+    if ((dtype) == dl_int32) {             \
+      using c_type = int32_t;              \
+      return __VA_ARGS__();                \
+    } else if ((dtype) == dl_uint32) {     \
+      using c_type = uint32_t;             \
+      return __VA_ARGS__();                \
+    }                                      \
+    return false;                          \
+  }()
+
 template <typename BlockT, typename SeqLenT>
 __global__ void sanitize_trtllm_swa_block_tables_kernel(
     BlockT* block_tables, const SeqLenT* seq_lens, const int32_t* cum_seq_lens_q,
@@ -141,36 +153,18 @@ void maybe_sanitize_trtllm_swa_block_tables_inplace(
     int64_t cum_seq_lens_q_size, int64_t batch_size, int64_t max_num_blocks_per_seq,
     int64_t max_kv_len, int64_t max_q_len, int64_t page_size, int64_t window_left,
     int64_t num_pages_in_mem_pool, cudaStream_t stream) {
-  if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_int32) {
-    sanitize_trtllm_swa_block_tables_inplace<int32_t, int32_t>(
-        static_cast<int32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
-        cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
-        window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
-    return;
+  bool dispatched = DISPATCH_DTYPE(block_tables.dtype(), TBlock, [&] {
+    return DISPATCH_DTYPE(seq_lens.dtype(), TSeq, [&] {
+      sanitize_trtllm_swa_block_tables_inplace<TBlock, TSeq>(
+          static_cast<TBlock*>(block_tables.data_ptr()), static_cast<TSeq*>(seq_lens.data_ptr()),
+          cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
+          window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
+      return true;
+    });
+  });
+  if (!dispatched) {
+    FLASHINFER_ERROR("Unsupported block_tables/seq_lens dtype combination for SWA sanitization.");
   }
-  if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_uint32) {
-    sanitize_trtllm_swa_block_tables_inplace<int32_t, uint32_t>(
-        static_cast<int32_t*>(block_tables.data_ptr()), static_cast<uint32_t*>(seq_lens.data_ptr()),
-        cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
-        window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
-    return;
-  }
-  if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_int32) {
-    sanitize_trtllm_swa_block_tables_inplace<uint32_t, int32_t>(
-        static_cast<uint32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
-        cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
-        window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
-    return;
-  }
-  if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_uint32) {
-    sanitize_trtllm_swa_block_tables_inplace<uint32_t, uint32_t>(
-        static_cast<uint32_t*>(block_tables.data_ptr()),
-        static_cast<uint32_t*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr, batch_size,
-        max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left,
-        num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
-    return;
-  }
-  FLASHINFER_ERROR("Unsupported block_tables/seq_lens dtype combination for SWA sanitization.");
 }
 
 }  // namespace
@@ -374,6 +368,9 @@ void trtllm_paged_attention_decode(
   TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
   TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
       << "block_tables batch size must match seq_lens batch size";
+  TVM_FFI_ICHECK_EQ(batch_size, block_tables.size(0))
+      << "batch_size must match block_tables.size(0)";
+  TVM_FFI_ICHECK_EQ(batch_size, seq_lens.size(0)) << "batch_size must match seq_lens.size(0)";
   TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
   for (int i = 0; i < key_cache.ndim(); i++) {
@@ -491,6 +488,9 @@ void trtllm_paged_attention_context(
   TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
   TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
       << "block_tables batch size must match seq_lens batch size";
+  TVM_FFI_ICHECK_EQ(batch_size, block_tables.size(0))
+      << "batch_size must match block_tables.size(0)";
+  TVM_FFI_ICHECK_EQ(batch_size, seq_lens.size(0)) << "batch_size must match seq_lens.size(0)";
   TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_q.ndim(), 1) << "cum_seq_lens_q must be a 1D tensor";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_q.dtype(), dl_int32) << "cum_seq_lens_q must be int32";

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -496,6 +496,10 @@ void trtllm_paged_attention_context(
   TVM_FFI_ICHECK_EQ(cum_seq_lens_q.dtype(), dl_int32) << "cum_seq_lens_q must be int32";
   TVM_FFI_ICHECK_EQ(cum_seq_lens_q.size(0), batch_size + 1)
       << "cum_seq_lens_q size must be batch_size + 1";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.ndim(), 1) << "cum_seq_lens_kv must be a 1D tensor";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.dtype(), dl_int32) << "cum_seq_lens_kv must be int32";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.size(0), batch_size + 1)
+      << "cum_seq_lens_kv size must be batch_size + 1";
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
   int num_qo_heads = query.size(1);
   int sum_seq_q = query.size(0);

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -61,11 +61,10 @@ bool is_trtllm_swa_block_table_sanitize_enabled() {
 }
 
 template <typename BlockT, typename SeqLenT>
-__global__ void sanitize_trtllm_swa_block_tables_kernel(BlockT* block_tables,
-                                                        const SeqLenT* seq_lens, int64_t batch_size,
-                                                        int64_t max_num_blocks_per_seq,
-                                                        int64_t page_size, int64_t window_left,
-                                                        int64_t num_pages_in_mem_pool) {
+__global__ void sanitize_trtllm_swa_block_tables_kernel(
+    BlockT* block_tables, const SeqLenT* seq_lens, const int32_t* cum_seq_lens_q,
+    int64_t batch_size, int64_t max_num_blocks_per_seq, int64_t max_q_len, int64_t page_size,
+    int64_t window_left, int64_t num_pages_in_mem_pool) {
   const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t total_elems = batch_size * max_num_blocks_per_seq;
   if (idx >= total_elems) {
@@ -80,6 +79,17 @@ __global__ void sanitize_trtllm_swa_block_tables_kernel(BlockT* block_tables,
     seq_len = 0;
   }
 
+  // For multi-token queries, preserve every page needed by any token in the
+  // sequence. If query lengths are ragged, derive q_len from cum_seq_lens_q.
+  int64_t q_len = max_q_len;
+  if (cum_seq_lens_q != nullptr) {
+    q_len =
+        static_cast<int64_t>(cum_seq_lens_q[row + 1]) - static_cast<int64_t>(cum_seq_lens_q[row]);
+  }
+  if (q_len <= 0) {
+    q_len = 1;
+  }
+
   int64_t total_pages = (seq_len + page_size - 1) / page_size;
   if (total_pages < 0) {
     total_pages = 0;
@@ -87,7 +97,7 @@ __global__ void sanitize_trtllm_swa_block_tables_kernel(BlockT* block_tables,
     total_pages = max_num_blocks_per_seq;
   }
 
-  const int64_t window_tokens = window_left + 1;
+  const int64_t window_tokens = window_left + q_len;
   int64_t in_window_tokens = seq_len < window_tokens ? seq_len : window_tokens;
   if (in_window_tokens < 0) {
     in_window_tokens = 0;
@@ -123,14 +133,18 @@ __global__ void sanitize_trtllm_swa_block_tables_kernel(BlockT* block_tables,
 
 template <typename BlockT, typename SeqLenT>
 void sanitize_trtllm_swa_block_tables_inplace(BlockT* block_tables_ptr, const SeqLenT* seq_lens_ptr,
-                                              int64_t batch_size, int64_t max_num_blocks_per_seq,
-                                              int64_t max_kv_len, int64_t page_size,
+                                              const int32_t* cum_seq_lens_q_ptr, int64_t batch_size,
+                                              int64_t max_num_blocks_per_seq, int64_t max_kv_len,
+                                              int64_t max_q_len, int64_t page_size,
                                               int64_t window_left, int64_t num_pages_in_mem_pool,
                                               cudaStream_t stream) {
   if (!is_trtllm_swa_block_table_sanitize_enabled()) {
     return;
   }
   if (window_left < 0 || page_size <= 0 || batch_size <= 0 || max_num_blocks_per_seq <= 0) {
+    return;
+  }
+  if (max_q_len <= 0) {
     return;
   }
   if (max_kv_len <= window_left + 1) {
@@ -141,41 +155,42 @@ void sanitize_trtllm_swa_block_tables_inplace(BlockT* block_tables_ptr, const Se
   int64_t total_elems = batch_size * max_num_blocks_per_seq;
   int blocks = static_cast<int>((total_elems + kThreads - 1) / kThreads);
   sanitize_trtllm_swa_block_tables_kernel<<<blocks, kThreads, 0, stream>>>(
-      block_tables_ptr, seq_lens_ptr, batch_size, max_num_blocks_per_seq, page_size, window_left,
-      num_pages_in_mem_pool);
+      block_tables_ptr, seq_lens_ptr, cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq,
+      max_q_len, page_size, window_left, num_pages_in_mem_pool);
   FLASHINFER_CUDA_CHECK(cudaGetLastError());
 }
 
 void maybe_sanitize_trtllm_swa_block_tables_inplace(
-    TensorView block_tables, TensorView seq_lens, int64_t batch_size,
-    int64_t max_num_blocks_per_seq, int64_t max_kv_len, int64_t page_size, int64_t window_left,
-    int64_t num_pages_in_mem_pool, cudaStream_t stream) {
+    TensorView block_tables, TensorView seq_lens, const int32_t* cum_seq_lens_q_ptr,
+    int64_t batch_size, int64_t max_num_blocks_per_seq, int64_t max_kv_len, int64_t max_q_len,
+    int64_t page_size, int64_t window_left, int64_t num_pages_in_mem_pool, cudaStream_t stream) {
   if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_int32) {
     sanitize_trtllm_swa_block_tables_inplace<int32_t, int32_t>(
         static_cast<int32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
-        batch_size, max_num_blocks_per_seq, max_kv_len, page_size, window_left,
-        num_pages_in_mem_pool, stream);
+        cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
+        window_left, num_pages_in_mem_pool, stream);
     return;
   }
   if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_uint32) {
     sanitize_trtllm_swa_block_tables_inplace<int32_t, uint32_t>(
         static_cast<int32_t*>(block_tables.data_ptr()), static_cast<uint32_t*>(seq_lens.data_ptr()),
-        batch_size, max_num_blocks_per_seq, max_kv_len, page_size, window_left,
-        num_pages_in_mem_pool, stream);
+        cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
+        window_left, num_pages_in_mem_pool, stream);
     return;
   }
   if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_int32) {
     sanitize_trtllm_swa_block_tables_inplace<uint32_t, int32_t>(
         static_cast<uint32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
-        batch_size, max_num_blocks_per_seq, max_kv_len, page_size, window_left,
-        num_pages_in_mem_pool, stream);
+        cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
+        window_left, num_pages_in_mem_pool, stream);
     return;
   }
   if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_uint32) {
     sanitize_trtllm_swa_block_tables_inplace<uint32_t, uint32_t>(
         static_cast<uint32_t*>(block_tables.data_ptr()),
-        static_cast<uint32_t*>(seq_lens.data_ptr()), batch_size, max_num_blocks_per_seq, max_kv_len,
-        page_size, window_left, num_pages_in_mem_pool, stream);
+        static_cast<uint32_t*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr, batch_size,
+        max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left,
+        num_pages_in_mem_pool, stream);
     return;
   }
   FLASHINFER_ERROR("Unsupported block_tables/seq_lens dtype combination for SWA sanitization.");
@@ -457,9 +472,9 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
-  maybe_sanitize_trtllm_swa_block_tables_inplace(block_tables, seq_lens, batch_size,
-                                                 max_num_blocks_per_seq, max_kv_len, page_size,
-                                                 window_left, num_pages_in_mem_pool, stream);
+  maybe_sanitize_trtllm_swa_block_tables_inplace(
+      block_tables, seq_lens, cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len,
+      max_q_len, page_size, window_left, num_pages_in_mem_pool, stream);
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
@@ -560,9 +575,10 @@ void trtllm_paged_attention_context(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
-  maybe_sanitize_trtllm_swa_block_tables_inplace(block_tables, seq_lens, batch_size,
-                                                 max_num_blocks_per_seq, max_kv_len, page_size,
-                                                 window_left, num_pages_in_mem_pool, stream);
+  maybe_sanitize_trtllm_swa_block_tables_inplace(
+      block_tables, seq_lens, static_cast<int32_t*>(cum_seq_lens_q.data_ptr()), batch_size,
+      max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left, num_pages_in_mem_pool,
+      stream);
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -20,10 +20,7 @@
 #include <nvrtc.h>
 #include <tvm/ffi/container/variant.h>
 
-#include <algorithm>
-#include <cctype>
 #include <cstdint>
-#include <cstdlib>
 #include <flashinfer/trtllm/fmha/fmhaRunner.cuh>
 #include <flashinfer/utils.cuh>
 #include <iostream>
@@ -45,20 +42,6 @@ enum class TllmPagedAttentionMode {
 };
 
 namespace {
-
-bool is_trtllm_swa_block_table_sanitize_enabled() {
-  static const bool enabled = []() {
-    const char* env = std::getenv("FLASHINFER_TRTLLM_SWA_BLOCK_TABLE_SANITIZE");
-    if (env == nullptr) {
-      return true;
-    }
-    std::string value(env);
-    std::transform(value.begin(), value.end(), value.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    return !(value == "0" || value == "false" || value == "no" || value == "off");
-  }();
-  return enabled;
-}
 
 template <typename BlockT, typename SeqLenT>
 __global__ void sanitize_trtllm_swa_block_tables_kernel(
@@ -134,9 +117,6 @@ void sanitize_trtllm_swa_block_tables_inplace(BlockT* block_tables_ptr, const Se
                                               int64_t max_q_len, int64_t page_size,
                                               int64_t window_left, int64_t num_pages_in_mem_pool,
                                               cudaStream_t stream) {
-  if (!is_trtllm_swa_block_table_sanitize_enabled()) {
-    return;
-  }
   if (window_left < 0 || page_size <= 0 || batch_size <= 0 || max_num_blocks_per_seq <= 0) {
     return;
   }

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -362,7 +362,15 @@ void trtllm_paged_attention_decode(
     Optional<TensorView> cum_seq_lens_q, Optional<float> skip_softmax_threshold_scale_factor) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
-  TVM_FFI_ICHECK_EQ(block_tables.ndim(), 2) << "block_tables must be a 2D tensor";
+  if (sparse_mla_top_k > 0) {
+    TVM_FFI_ICHECK_EQ(block_tables.ndim(), 3) << "block_tables must be a 3D tensor for sparse MLA";
+    TVM_FFI_ICHECK_EQ(block_tables.size(1), max_q_len)
+        << "For sparse MLA, block_tables.size(1) must match max_q_len";
+    TVM_FFI_ICHECK_EQ(block_tables.size(2), sparse_mla_top_k)
+        << "For sparse MLA, block_tables.size(2) must match sparse_mla_top_k";
+  } else {
+    TVM_FFI_ICHECK_EQ(block_tables.ndim(), 2) << "block_tables must be a 2D tensor";
+  }
   TVM_FFI_ICHECK_EQ(block_tables.dtype(), dl_int32) << "block_tables must be int32";
   TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
   TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
@@ -452,10 +460,12 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
-  maybe_sanitize_trtllm_swa_block_tables_inplace(
-      block_tables, seq_lens, cum_seq_lens_q_ptr, cum_seq_lens_q_size, batch_size,
-      max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left, num_pages_in_mem_pool,
-      stream);
+  if (sparse_mla_top_k <= 0) {
+    maybe_sanitize_trtllm_swa_block_tables_inplace(
+        block_tables, seq_lens, cum_seq_lens_q_ptr, cum_seq_lens_q_size, batch_size,
+        max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left,
+        num_pages_in_mem_pool, stream);
+  }
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -91,9 +91,7 @@ __global__ void sanitize_trtllm_swa_block_tables_kernel(
   }
 
   int64_t total_pages = (seq_len + page_size - 1) / page_size;
-  if (total_pages < 0) {
-    total_pages = 0;
-  } else if (total_pages > max_num_blocks_per_seq) {
+  if (total_pages > max_num_blocks_per_seq) {
     total_pages = max_num_blocks_per_seq;
   }
 
@@ -103,9 +101,7 @@ __global__ void sanitize_trtllm_swa_block_tables_kernel(
     in_window_tokens = 0;
   }
   int64_t in_window_pages = (in_window_tokens + page_size - 1) / page_size;
-  if (in_window_pages < 0) {
-    in_window_pages = 0;
-  } else if (in_window_pages > max_num_blocks_per_seq) {
+  if (in_window_pages > max_num_blocks_per_seq) {
     in_window_pages = max_num_blocks_per_seq;
   }
 

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -47,7 +47,7 @@ template <typename BlockT, typename SeqLenT>
 __global__ void sanitize_trtllm_swa_block_tables_kernel(
     BlockT* block_tables, const SeqLenT* seq_lens, const int32_t* cum_seq_lens_q,
     int64_t batch_size, int64_t max_num_blocks_per_seq, int64_t max_q_len, int64_t page_size,
-    int64_t window_left, int64_t num_pages_in_mem_pool) {
+    int64_t window_left, int64_t num_pages_in_mem_pool, int64_t cum_seq_lens_q_size) {
   const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t total_elems = batch_size * max_num_blocks_per_seq;
   if (idx >= total_elems) {
@@ -65,7 +65,7 @@ __global__ void sanitize_trtllm_swa_block_tables_kernel(
   // For multi-token queries, preserve every page needed by any token in the
   // sequence. If query lengths are ragged, derive q_len from cum_seq_lens_q.
   int64_t q_len = max_q_len;
-  if (cum_seq_lens_q != nullptr) {
+  if (cum_seq_lens_q != nullptr && row + 1 < cum_seq_lens_q_size) {
     q_len =
         static_cast<int64_t>(cum_seq_lens_q[row + 1]) - static_cast<int64_t>(cum_seq_lens_q[row]);
   }
@@ -116,7 +116,7 @@ void sanitize_trtllm_swa_block_tables_inplace(BlockT* block_tables_ptr, const Se
                                               int64_t max_num_blocks_per_seq, int64_t max_kv_len,
                                               int64_t max_q_len, int64_t page_size,
                                               int64_t window_left, int64_t num_pages_in_mem_pool,
-                                              cudaStream_t stream) {
+                                              int64_t cum_seq_lens_q_size, cudaStream_t stream) {
   if (window_left < 0 || page_size <= 0 || batch_size <= 0 || max_num_blocks_per_seq <= 0) {
     return;
   }
@@ -132,33 +132,34 @@ void sanitize_trtllm_swa_block_tables_inplace(BlockT* block_tables_ptr, const Se
   int blocks = static_cast<int>((total_elems + kThreads - 1) / kThreads);
   sanitize_trtllm_swa_block_tables_kernel<<<blocks, kThreads, 0, stream>>>(
       block_tables_ptr, seq_lens_ptr, cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq,
-      max_q_len, page_size, window_left, num_pages_in_mem_pool);
+      max_q_len, page_size, window_left, num_pages_in_mem_pool, cum_seq_lens_q_size);
   FLASHINFER_CUDA_CHECK(cudaGetLastError());
 }
 
 void maybe_sanitize_trtllm_swa_block_tables_inplace(
     TensorView block_tables, TensorView seq_lens, const int32_t* cum_seq_lens_q_ptr,
-    int64_t batch_size, int64_t max_num_blocks_per_seq, int64_t max_kv_len, int64_t max_q_len,
-    int64_t page_size, int64_t window_left, int64_t num_pages_in_mem_pool, cudaStream_t stream) {
+    int64_t cum_seq_lens_q_size, int64_t batch_size, int64_t max_num_blocks_per_seq,
+    int64_t max_kv_len, int64_t max_q_len, int64_t page_size, int64_t window_left,
+    int64_t num_pages_in_mem_pool, cudaStream_t stream) {
   if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_int32) {
     sanitize_trtllm_swa_block_tables_inplace<int32_t, int32_t>(
         static_cast<int32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
         cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
-        window_left, num_pages_in_mem_pool, stream);
+        window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
     return;
   }
   if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_uint32) {
     sanitize_trtllm_swa_block_tables_inplace<int32_t, uint32_t>(
         static_cast<int32_t*>(block_tables.data_ptr()), static_cast<uint32_t*>(seq_lens.data_ptr()),
         cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
-        window_left, num_pages_in_mem_pool, stream);
+        window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
     return;
   }
   if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_int32) {
     sanitize_trtllm_swa_block_tables_inplace<uint32_t, int32_t>(
         static_cast<uint32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
         cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
-        window_left, num_pages_in_mem_pool, stream);
+        window_left, num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
     return;
   }
   if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_uint32) {
@@ -166,7 +167,7 @@ void maybe_sanitize_trtllm_swa_block_tables_inplace(
         static_cast<uint32_t*>(block_tables.data_ptr()),
         static_cast<uint32_t*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr, batch_size,
         max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left,
-        num_pages_in_mem_pool, stream);
+        num_pages_in_mem_pool, cum_seq_lens_q_size, stream);
     return;
   }
   FLASHINFER_ERROR("Unsupported block_tables/seq_lens dtype combination for SWA sanitization.");
@@ -368,11 +369,9 @@ void trtllm_paged_attention_decode(
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   TVM_FFI_ICHECK_EQ(block_tables.ndim(), 2) << "block_tables must be a 2D tensor";
-  TVM_FFI_ICHECK(block_tables.dtype() == dl_int32 || block_tables.dtype() == dl_uint32)
-      << "block_tables must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(block_tables.dtype(), dl_int32) << "block_tables must be int32";
   TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
-  TVM_FFI_ICHECK(seq_lens.dtype() == dl_int32 || seq_lens.dtype() == dl_uint32)
-      << "seq_lens must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
   TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
       << "block_tables batch size must match seq_lens batch size";
   TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
@@ -385,6 +384,14 @@ void trtllm_paged_attention_decode(
   int num_qo_heads = query.size(1);
   // the cum_seq_lens_q is optional, and can be nullptr when all sequences have the same query
   // length
+  int64_t cum_seq_lens_q_size = 0;
+  if (cum_seq_lens_q.has_value()) {
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().ndim(), 1) << "cum_seq_lens_q must be a 1D tensor";
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().dtype(), dl_int32) << "cum_seq_lens_q must be int32";
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().size(0), batch_size + 1)
+        << "cum_seq_lens_q size must be batch_size + 1";
+    cum_seq_lens_q_size = cum_seq_lens_q.value().size(0);
+  }
   int* cum_seq_lens_q_ptr =
       cum_seq_lens_q.has_value() ? static_cast<int*>(cum_seq_lens_q.value().data_ptr()) : nullptr;
   // Multiply by two for FP4 tensor as it is stored as UINT8 dtype. Assume the dim is even.
@@ -449,8 +456,9 @@ void trtllm_paged_attention_decode(
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
   maybe_sanitize_trtllm_swa_block_tables_inplace(
-      block_tables, seq_lens, cum_seq_lens_q_ptr, batch_size, max_num_blocks_per_seq, max_kv_len,
-      max_q_len, page_size, window_left, num_pages_in_mem_pool, stream);
+      block_tables, seq_lens, cum_seq_lens_q_ptr, cum_seq_lens_q_size, batch_size,
+      max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left, num_pages_in_mem_pool,
+      stream);
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
@@ -478,14 +486,16 @@ void trtllm_paged_attention_context(
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   TVM_FFI_ICHECK_EQ(block_tables.ndim(), 2) << "block_tables must be a 2D tensor";
-  TVM_FFI_ICHECK(block_tables.dtype() == dl_int32 || block_tables.dtype() == dl_uint32)
-      << "block_tables must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(block_tables.dtype(), dl_int32) << "block_tables must be int32";
   TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
-  TVM_FFI_ICHECK(seq_lens.dtype() == dl_int32 || seq_lens.dtype() == dl_uint32)
-      << "seq_lens must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(seq_lens.dtype(), dl_int32) << "seq_lens must be int32";
   TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
       << "block_tables batch size must match seq_lens batch size";
   TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.ndim(), 1) << "cum_seq_lens_q must be a 1D tensor";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.dtype(), dl_int32) << "cum_seq_lens_q must be int32";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.size(0), batch_size + 1)
+      << "cum_seq_lens_q size must be batch_size + 1";
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
   int num_qo_heads = query.size(1);
   int sum_seq_q = query.size(0);
@@ -552,9 +562,9 @@ void trtllm_paged_attention_context(
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
   maybe_sanitize_trtllm_swa_block_tables_inplace(
-      block_tables, seq_lens, static_cast<int32_t*>(cum_seq_lens_q.data_ptr()), batch_size,
-      max_num_blocks_per_seq, max_kv_len, max_q_len, page_size, window_left, num_pages_in_mem_pool,
-      stream);
+      block_tables, seq_lens, static_cast<int32_t*>(cum_seq_lens_q.data_ptr()),
+      cum_seq_lens_q.size(0), batch_size, max_num_blocks_per_seq, max_kv_len, max_q_len, page_size,
+      window_left, num_pages_in_mem_pool, stream);
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -20,10 +20,15 @@
 #include <nvrtc.h>
 #include <tvm/ffi/container/variant.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
 #include <flashinfer/trtllm/fmha/fmhaRunner.cuh>
 #include <flashinfer/utils.cuh>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 
 #include "tvm/ffi/error.h"
@@ -38,6 +43,145 @@ enum class TllmPagedAttentionMode {
   Context,
   ForGen,
 };
+
+namespace {
+
+bool is_trtllm_swa_block_table_sanitize_enabled() {
+  static const bool enabled = []() {
+    const char* env = std::getenv("FLASHINFER_TRTLLM_SWA_BLOCK_TABLE_SANITIZE");
+    if (env == nullptr) {
+      return true;
+    }
+    std::string value(env);
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return !(value == "0" || value == "false" || value == "no" || value == "off");
+  }();
+  return enabled;
+}
+
+template <typename BlockT, typename SeqLenT>
+__global__ void sanitize_trtllm_swa_block_tables_kernel(BlockT* block_tables,
+                                                        const SeqLenT* seq_lens, int64_t batch_size,
+                                                        int64_t max_num_blocks_per_seq,
+                                                        int64_t page_size, int64_t window_left,
+                                                        int64_t num_pages_in_mem_pool) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total_elems = batch_size * max_num_blocks_per_seq;
+  if (idx >= total_elems) {
+    return;
+  }
+
+  const int64_t row = idx / max_num_blocks_per_seq;
+  const int64_t col = idx - row * max_num_blocks_per_seq;
+
+  int64_t seq_len = static_cast<int64_t>(seq_lens[row]);
+  if (seq_len < 0) {
+    seq_len = 0;
+  }
+
+  int64_t total_pages = (seq_len + page_size - 1) / page_size;
+  if (total_pages < 0) {
+    total_pages = 0;
+  } else if (total_pages > max_num_blocks_per_seq) {
+    total_pages = max_num_blocks_per_seq;
+  }
+
+  const int64_t window_tokens = window_left + 1;
+  int64_t in_window_tokens = seq_len < window_tokens ? seq_len : window_tokens;
+  if (in_window_tokens < 0) {
+    in_window_tokens = 0;
+  }
+  int64_t in_window_pages = (in_window_tokens + page_size - 1) / page_size;
+  if (in_window_pages < 0) {
+    in_window_pages = 0;
+  } else if (in_window_pages > max_num_blocks_per_seq) {
+    in_window_pages = max_num_blocks_per_seq;
+  }
+
+  int64_t start_live = total_pages - in_window_pages;
+  if (start_live < 0) {
+    start_live = 0;
+  } else if (start_live > max_num_blocks_per_seq) {
+    start_live = max_num_blocks_per_seq;
+  }
+  if (col >= start_live) {
+    return;
+  }
+
+  const int64_t anchor_col = total_pages > 0 ? start_live : int64_t(0);
+  int64_t anchor = static_cast<int64_t>(block_tables[row * max_num_blocks_per_seq + anchor_col]);
+  if (anchor < 0) {
+    anchor = 0;
+  }
+  if (num_pages_in_mem_pool > 0 && anchor >= num_pages_in_mem_pool) {
+    anchor = num_pages_in_mem_pool - 1;
+  }
+
+  block_tables[idx] = static_cast<BlockT>(anchor);
+}
+
+template <typename BlockT, typename SeqLenT>
+void sanitize_trtllm_swa_block_tables_inplace(BlockT* block_tables_ptr, const SeqLenT* seq_lens_ptr,
+                                              int64_t batch_size, int64_t max_num_blocks_per_seq,
+                                              int64_t max_kv_len, int64_t page_size,
+                                              int64_t window_left, int64_t num_pages_in_mem_pool,
+                                              cudaStream_t stream) {
+  if (!is_trtllm_swa_block_table_sanitize_enabled()) {
+    return;
+  }
+  if (window_left < 0 || page_size <= 0 || batch_size <= 0 || max_num_blocks_per_seq <= 0) {
+    return;
+  }
+  if (max_kv_len <= window_left + 1) {
+    return;
+  }
+
+  constexpr int kThreads = 256;
+  int64_t total_elems = batch_size * max_num_blocks_per_seq;
+  int blocks = static_cast<int>((total_elems + kThreads - 1) / kThreads);
+  sanitize_trtllm_swa_block_tables_kernel<<<blocks, kThreads, 0, stream>>>(
+      block_tables_ptr, seq_lens_ptr, batch_size, max_num_blocks_per_seq, page_size, window_left,
+      num_pages_in_mem_pool);
+  FLASHINFER_CUDA_CHECK(cudaGetLastError());
+}
+
+void maybe_sanitize_trtllm_swa_block_tables_inplace(
+    TensorView block_tables, TensorView seq_lens, int64_t batch_size,
+    int64_t max_num_blocks_per_seq, int64_t max_kv_len, int64_t page_size, int64_t window_left,
+    int64_t num_pages_in_mem_pool, cudaStream_t stream) {
+  if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_int32) {
+    sanitize_trtllm_swa_block_tables_inplace<int32_t, int32_t>(
+        static_cast<int32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
+        batch_size, max_num_blocks_per_seq, max_kv_len, page_size, window_left,
+        num_pages_in_mem_pool, stream);
+    return;
+  }
+  if (block_tables.dtype() == dl_int32 && seq_lens.dtype() == dl_uint32) {
+    sanitize_trtllm_swa_block_tables_inplace<int32_t, uint32_t>(
+        static_cast<int32_t*>(block_tables.data_ptr()), static_cast<uint32_t*>(seq_lens.data_ptr()),
+        batch_size, max_num_blocks_per_seq, max_kv_len, page_size, window_left,
+        num_pages_in_mem_pool, stream);
+    return;
+  }
+  if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_int32) {
+    sanitize_trtllm_swa_block_tables_inplace<uint32_t, int32_t>(
+        static_cast<uint32_t*>(block_tables.data_ptr()), static_cast<int32_t*>(seq_lens.data_ptr()),
+        batch_size, max_num_blocks_per_seq, max_kv_len, page_size, window_left,
+        num_pages_in_mem_pool, stream);
+    return;
+  }
+  if (block_tables.dtype() == dl_uint32 && seq_lens.dtype() == dl_uint32) {
+    sanitize_trtllm_swa_block_tables_inplace<uint32_t, uint32_t>(
+        static_cast<uint32_t*>(block_tables.data_ptr()),
+        static_cast<uint32_t*>(seq_lens.data_ptr()), batch_size, max_num_blocks_per_seq, max_kv_len,
+        page_size, window_left, num_pages_in_mem_pool, stream);
+    return;
+  }
+  FLASHINFER_ERROR("Unsupported block_tables/seq_lens dtype combination for SWA sanitization.");
+}
+
+}  // namespace
 
 #include <memory>
 #include <mutex>
@@ -232,6 +376,15 @@ void trtllm_paged_attention_decode(
     Optional<TensorView> cum_seq_lens_q, Optional<float> skip_softmax_threshold_scale_factor) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
+  TVM_FFI_ICHECK_EQ(block_tables.ndim(), 2) << "block_tables must be a 2D tensor";
+  TVM_FFI_ICHECK(block_tables.dtype() == dl_int32 || block_tables.dtype() == dl_uint32)
+      << "block_tables must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
+  TVM_FFI_ICHECK(seq_lens.dtype() == dl_int32 || seq_lens.dtype() == dl_uint32)
+      << "seq_lens must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
+      << "block_tables batch size must match seq_lens batch size";
+  TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
   for (int i = 0; i < key_cache.ndim(); i++) {
     TVM_FFI_ICHECK_EQ(key_cache.size(i), value_cache.size(i));
@@ -304,6 +457,10 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
+  maybe_sanitize_trtllm_swa_block_tables_inplace(block_tables, seq_lens, batch_size,
+                                                 max_num_blocks_per_seq, max_kv_len, page_size,
+                                                 window_left, num_pages_in_mem_pool, stream);
+
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()),
@@ -329,6 +486,15 @@ void trtllm_paged_attention_context(
     Optional<float> skip_softmax_threshold_scale_factor) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
+  TVM_FFI_ICHECK_EQ(block_tables.ndim(), 2) << "block_tables must be a 2D tensor";
+  TVM_FFI_ICHECK(block_tables.dtype() == dl_int32 || block_tables.dtype() == dl_uint32)
+      << "block_tables must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1) << "seq_lens must be a 1D tensor";
+  TVM_FFI_ICHECK(seq_lens.dtype() == dl_int32 || seq_lens.dtype() == dl_uint32)
+      << "seq_lens must be int32 or uint32";
+  TVM_FFI_ICHECK_EQ(block_tables.size(0), seq_lens.size(0))
+      << "block_tables batch size must match seq_lens batch size";
+  TVM_FFI_ICHECK_GE(window_left, -1) << "window_left must be >= -1";
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
   int num_qo_heads = query.size(1);
   int sum_seq_q = query.size(0);
@@ -393,6 +559,10 @@ void trtllm_paged_attention_context(
   float const skip_softmax_threshold_scale_factor_value =
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
+
+  maybe_sanitize_trtllm_swa_block_tables_inplace(block_tables, seq_lens, batch_size,
+                                                 max_num_blocks_per_seq, max_kv_len, page_size,
+                                                 window_left, num_pages_in_mem_pool, stream);
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import functools
 import math
-import os
 from enum import Enum
 from typing import Callable, Dict, Iterable, Optional, Sequence, Tuple, Union
 
@@ -188,93 +187,6 @@ def _unpack_paged_kv_cache(
                 type(paged_kv_cache)
             )
         )
-
-
-def _sanitize_trtllm_sliding_window_block_tables(
-    block_tables: torch.Tensor,
-    seq_lens: torch.Tensor,
-    page_size: int,
-    window_left: int,
-    num_pages_in_mem_pool: Optional[int] = None,
-) -> torch.Tensor:
-    r"""Normalize TRTLLM paged-KV block tables for sliding-window attention.
-
-    TRTLLM kernels should only attend to the in-window pages for SWA. To avoid any
-    impact from out-of-window placeholder pages, this helper rewrites the prefix
-    pages (left of the in-window region) to the first in-window page id.
-
-    Notes
-    -----
-    - The transform is only applied when ``window_left >= 0``.
-    - If no sequence in the batch exceeds the window, the input is returned as-is.
-    - This helper intentionally does not modify the in-window pages.
-    """
-    if not _is_trtllm_swa_block_table_sanitize_enabled():
-        return block_tables
-    if window_left < 0 or block_tables.numel() == 0:
-        return block_tables
-    if block_tables.ndim != 2:
-        raise ValueError(
-            f"block_tables must be a 2D tensor, got shape={tuple(block_tables.shape)}"
-        )
-    if seq_lens.ndim != 1:
-        raise ValueError(
-            f"seq_lens must be a 1D tensor, got shape={tuple(seq_lens.shape)}"
-        )
-    if block_tables.size(0) != seq_lens.numel():
-        raise ValueError(
-            "block_tables and seq_lens batch size mismatch: "
-            f"{block_tables.size(0)} vs {seq_lens.numel()}"
-        )
-    if page_size <= 0:
-        raise ValueError(f"page_size must be positive, got {page_size}")
-
-    batch_size, max_num_blocks_per_seq = block_tables.shape
-    if max_num_blocks_per_seq == 0:
-        return block_tables
-
-    # Compute page counts on the same device as block_tables.
-    seq_lens_i64 = seq_lens.to(device=block_tables.device, dtype=torch.int64)
-    total_pages = (seq_lens_i64 + page_size - 1) // page_size
-    total_pages = total_pages.clamp_(min=0, max=max_num_blocks_per_seq)
-
-    window_tokens = window_left + 1
-    in_window_tokens = torch.minimum(
-        seq_lens_i64,
-        torch.full_like(seq_lens_i64, window_tokens),
-    )
-    in_window_pages = (in_window_tokens + page_size - 1) // page_size
-    in_window_pages = in_window_pages.clamp_(min=0, max=max_num_blocks_per_seq)
-
-    start_live = (total_pages - in_window_pages).clamp_(
-        min=0, max=max_num_blocks_per_seq
-    )
-
-    row_ids = torch.arange(batch_size, device=block_tables.device)
-    anchor_col = torch.where(total_pages > 0, start_live, torch.zeros_like(start_live))
-    anchor_vals = block_tables[row_ids, anchor_col]
-    if num_pages_in_mem_pool is not None and num_pages_in_mem_pool > 0:
-        anchor_vals = anchor_vals.clamp_(0, num_pages_in_mem_pool - 1)
-    else:
-        anchor_vals = anchor_vals.clamp_min_(0)
-
-    col_ids = torch.arange(
-        max_num_blocks_per_seq, device=block_tables.device
-    ).unsqueeze(0)
-    prefix_mask = col_ids < start_live.unsqueeze(1)
-    return torch.where(prefix_mask, anchor_vals.unsqueeze(1), block_tables)
-
-
-@functools.cache
-def _is_trtllm_swa_block_table_sanitize_enabled() -> bool:
-    """Return whether TRTLLM SWA block-table sanitization is enabled.
-
-    Controlled by env var ``FLASHINFER_TRTLLM_SWA_BLOCK_TABLE_SANITIZE``:
-    - enabled (default): unset, ``1``, ``true``, ``yes``, ``on``
-    - disabled: ``0``, ``false``, ``no``, ``off``
-    """
-    value = os.getenv("FLASHINFER_TRTLLM_SWA_BLOCK_TABLE_SANITIZE", "1")
-    return value.strip().lower() not in ("0", "false", "no", "off")
 
 
 def get_alibi_slopes(n_heads: int) -> torch.Tensor:

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import math
+import os
 from enum import Enum
 from typing import Callable, Dict, Iterable, Optional, Sequence, Tuple, Union
 
@@ -187,6 +188,93 @@ def _unpack_paged_kv_cache(
                 type(paged_kv_cache)
             )
         )
+
+
+def _sanitize_trtllm_sliding_window_block_tables(
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_size: int,
+    window_left: int,
+    num_pages_in_mem_pool: Optional[int] = None,
+) -> torch.Tensor:
+    r"""Normalize TRTLLM paged-KV block tables for sliding-window attention.
+
+    TRTLLM kernels should only attend to the in-window pages for SWA. To avoid any
+    impact from out-of-window placeholder pages, this helper rewrites the prefix
+    pages (left of the in-window region) to the first in-window page id.
+
+    Notes
+    -----
+    - The transform is only applied when ``window_left >= 0``.
+    - If no sequence in the batch exceeds the window, the input is returned as-is.
+    - This helper intentionally does not modify the in-window pages.
+    """
+    if not _is_trtllm_swa_block_table_sanitize_enabled():
+        return block_tables
+    if window_left < 0 or block_tables.numel() == 0:
+        return block_tables
+    if block_tables.ndim != 2:
+        raise ValueError(
+            f"block_tables must be a 2D tensor, got shape={tuple(block_tables.shape)}"
+        )
+    if seq_lens.ndim != 1:
+        raise ValueError(
+            f"seq_lens must be a 1D tensor, got shape={tuple(seq_lens.shape)}"
+        )
+    if block_tables.size(0) != seq_lens.numel():
+        raise ValueError(
+            "block_tables and seq_lens batch size mismatch: "
+            f"{block_tables.size(0)} vs {seq_lens.numel()}"
+        )
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+
+    batch_size, max_num_blocks_per_seq = block_tables.shape
+    if max_num_blocks_per_seq == 0:
+        return block_tables
+
+    # Compute page counts on the same device as block_tables.
+    seq_lens_i64 = seq_lens.to(device=block_tables.device, dtype=torch.int64)
+    total_pages = (seq_lens_i64 + page_size - 1) // page_size
+    total_pages = total_pages.clamp_(min=0, max=max_num_blocks_per_seq)
+
+    window_tokens = window_left + 1
+    in_window_tokens = torch.minimum(
+        seq_lens_i64,
+        torch.full_like(seq_lens_i64, window_tokens),
+    )
+    in_window_pages = (in_window_tokens + page_size - 1) // page_size
+    in_window_pages = in_window_pages.clamp_(min=0, max=max_num_blocks_per_seq)
+
+    start_live = (total_pages - in_window_pages).clamp_(
+        min=0, max=max_num_blocks_per_seq
+    )
+
+    row_ids = torch.arange(batch_size, device=block_tables.device)
+    anchor_col = torch.where(total_pages > 0, start_live, torch.zeros_like(start_live))
+    anchor_vals = block_tables[row_ids, anchor_col]
+    if num_pages_in_mem_pool is not None and num_pages_in_mem_pool > 0:
+        anchor_vals = anchor_vals.clamp_(0, num_pages_in_mem_pool - 1)
+    else:
+        anchor_vals = anchor_vals.clamp_min_(0)
+
+    col_ids = torch.arange(
+        max_num_blocks_per_seq, device=block_tables.device
+    ).unsqueeze(0)
+    prefix_mask = col_ids < start_live.unsqueeze(1)
+    return torch.where(prefix_mask, anchor_vals.unsqueeze(1), block_tables)
+
+
+@functools.cache
+def _is_trtllm_swa_block_table_sanitize_enabled() -> bool:
+    """Return whether TRTLLM SWA block-table sanitization is enabled.
+
+    Controlled by env var ``FLASHINFER_TRTLLM_SWA_BLOCK_TABLE_SANITIZE``:
+    - enabled (default): unset, ``1``, ``true``, ``yes``, ``on``
+    - disabled: ``0``, ``false``, ``no``, ``off``
+    """
+    value = os.getenv("FLASHINFER_TRTLLM_SWA_BLOCK_TABLE_SANITIZE", "1")
+    return value.strip().lower() not in ("0", "false", "no", "off")
 
 
 def get_alibi_slopes(n_heads: int) -> torch.Tensor:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Reported by VLLM: SWA + prefix cache enabled + hybrid KV cache manager + TRTLLM attention backend leads to corrupted generations due to incorrectly reading kv cache null blocks. This MR adds sanitization for SWA TRTLLM paged-KV block tables.

The reproducer script provided now passes with negligible performance impact.

## 🔍 Related Issues

https://nvbugspro.nvidia.com/bug/5922676

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional sanitization of sliding‑window attention block tables (CUDA + Python) to normalize left‑prefix pages; toggle via environment variable.

* **Improvements**
  * Stricter input shape/type validation and earlier error reporting in attention decode/context paths.
  * Sanitization is invoked early in attention preprocessing to improve robustness.

* **Chores**
  * Internal wiring and validation scaffolding added; no public API signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->