### PR TITLE
fix(workspace_base): avoid ImportError during interpreter shutdown  

### DIFF
--- a/flashinfer/comm/workspace_base.py
+++ b/flashinfer/comm/workspace_base.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Optional, Any
 
 import torch
-
 
 class AllReduceFusionWorkspace(ABC):
     """Base class for AllReduce fusion workspaces."""
@@ -69,8 +69,6 @@ class AllReduceFusionWorkspace(ABC):
         distributed/CUDA resources.
         """
         if not self._destroyed:
-            import warnings
-
             warnings.warn(
                 f"{self.__class__.__name__} was not explicitly destroyed. "
                 f"Call workspace.destroy() or use AllReduceFusionContext to ensure "


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Move 'import warnings' to the top of the file to prevent ImportError when __del__ is called during Python interpreter shutdown. When the interpreter is shutting down, sys.meta_path is set to None, causing any import statement in __del__ to fail with ImportError.

This fixes the unclean shutdown error when using Ctrl-C with AR Fusion.

## 🔍 Related Issues

Fixes: vllm-project/vllm#35686
https://github.com/vllm-project/vllm/issues/35686

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal import placement to improve module initialization and code organization.
  * No user-visible behavior changes; functionality and warnings handling remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->