### PR TITLE
Ensure -gencode flags are in deterministic order (for ccache)

### DIFF
--- a/flashinfer/compilation_context.py
+++ b/flashinfer/compilation_context.py
@@ -64,5 +64,5 @@ class CompilationContext:
             )
         return [
             f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
-            for major, minor in supported_cuda_archs
+            for major, minor in sorted(supported_cuda_archs)
         ] + self.COMMON_NVCC_FLAGS


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
- Currently the `-gencode` flags are generated in a non-deterministic order due to the iteration over the `set()` data structure.
- This MR fixes the order to be deterministic.
- This is important when using ccache, as its hashing is sensitive to the order of these flags.

cc @yzh119 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic CUDA compilation flag generation to ensure consistent and reproducible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->