### PR TITLE
[chore] bench_moe_deepseek.py allows adjusting expert distribution

### DIFF
--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -113,7 +113,7 @@ def interleave(x, gs=64):
     )
 
 
-def create_inputs(n, dev="cuda"):
+def create_inputs(n, dev="cuda", routing_bias_scale=0.01):
     """Create inputs for all backends (CuteDSL, CUTLASS, TRTLLM)."""
     from flashinfer.fp4_quantization import fp4_quantize
 
@@ -124,7 +124,10 @@ def create_inputs(n, dev="cuda"):
 
     # Router logits and bias
     rl = torch.randn(n, CFG.num_experts, device=dev, dtype=torch.float32)
-    rb = torch.randn(CFG.num_experts, device=dev, dtype=torch.bfloat16)
+    rb = (
+        torch.randn(CFG.num_experts, device=dev, dtype=torch.bfloat16)
+        * routing_bias_scale
+    )
 
     # Hidden states
     hb = torch.randn(n, CFG.hidden_size, device=dev, dtype=torch.bfloat16) / 10
@@ -827,6 +830,7 @@ def run_benchmark(
     use_cuda_graph=True,
     use_cupti=True,
     use_wrapper=True,
+    routing_bias_scale=0.01,
 ):
     """
     Unified benchmark for DeepSeek-V3 MoE backends.
@@ -841,6 +845,7 @@ def run_benchmark(
         use_cuda_graph: Whether to use CUDA graph for benchmarking
         use_cupti: Whether to use CUPTI for accurate GPU timing
         use_wrapper: Whether to use CuteDslMoEWrapper API (recommended)
+        routing_bias_scale: Scale for random routing bias generation
 
     Returns:
         List of BenchResult objects
@@ -852,16 +857,25 @@ def run_benchmark(
 
     # Run autotune if requested (BEFORE printing header to avoid interleaved output)
     if do_autotune:
-        run_autotune(create_inputs(max(token_counts)), verbose=verbose)
+        run_autotune(
+            create_inputs(max(token_counts), routing_bias_scale=routing_bias_scale),
+            verbose=verbose,
+        )
 
     # Print header AFTER autotune completes
     if verbose:
-        _print_header(ep_config, num_local, use_cuda_graph, use_cupti)
+        _print_header(
+            ep_config,
+            num_local,
+            use_cuda_graph,
+            use_cupti,
+            routing_bias_scale,
+        )
 
     # Run benchmarks
     results = []
     for n in token_counts:
-        row = _benchmark_single(
+        row, histogram_record = _benchmark_single(
             n,
             warmup,
             iters,
@@ -870,10 +884,11 @@ def run_benchmark(
             use_cuda_graph,
             use_cupti,
             use_wrapper=use_wrapper,
+            routing_bias_scale=routing_bias_scale,
         )
         results.extend(row)
         if verbose:
-            _print_row(row)
+            _print_row(row, histogram_record)
 
     # Print footer
     if verbose:
@@ -891,13 +906,15 @@ def _benchmark_single(
     use_cuda_graph,
     use_cupti,
     use_wrapper=True,
+    routing_bias_scale=0.01,
 ):
     """Benchmark all backends for a single token count.
 
     Args:
         use_wrapper: If True, use CuteDslMoEWrapper API for CuteDSL.
     """
-    inputs = create_inputs(n)
+    inputs = create_inputs(n, routing_bias_scale=routing_bias_scale)
+    histogram_record = _collect_expert_histogram(inputs, num_local, local_offset)
 
     # Run all three backends
     lat = {
@@ -930,14 +947,20 @@ def _benchmark_single(
                 tflops=calc_tflops(n, latency, num_local),
             )
         )
-    return results
+    return results, histogram_record
 
 
-def _print_header(ep_config, num_local, use_cuda_graph, use_cupti):
+def _print_header(
+    ep_config,
+    num_local,
+    use_cuda_graph,
+    use_cupti,
+    routing_bias_scale,
+):
     """Print benchmark header."""
-    print("\n" + "=" * 100)
+    print("\n" + "=" * 120)
     print(f"DeepSeek-V3 MoE Benchmark: CuteDSL vs CUTLASS vs TRTLLM (EP={ep_config})")
-    print("=" * 100)
+    print("=" * 120)
     print(
         f"Model: hidden={CFG.hidden_size}, intermediate={CFG.intermediate_size}, "
         f"experts={CFG.num_experts}, top_k={CFG.top_k}"
@@ -948,26 +971,35 @@ def _print_header(ep_config, num_local, use_cuda_graph, use_cupti):
     print(
         f"CUDA Graph: {'enabled' if use_cuda_graph else 'disabled'}, CUPTI: {'enabled' if use_cupti else 'disabled'}"
     )
-    print("-" * 100)
+    print(
+        f"Routing bias scale: {routing_bias_scale} "
+        f"(larger values tend to create expert imbalance)"
+    )
+    print("-" * 120)
     print(
         f"{'Tokens':>6} | "
         f"{'CuteDSL':^15} | "
         f"{'CUTLASS':^15} | "
         f"{'TRTLLM':^15} | "
         f"{'Speedup (CuteDSL/X)':^18} | "
-        f"{'Winner':^8}"
+        f"{'Winner':^8} | "
+        f"{'Active':^7} | "
+        f"{'Stats':^14}"
     )
     print(
         f"{'':>6} | "
         f"{'ms':>7} {'TFLOPS':>7} | "
         f"{'ms':>7} {'TFLOPS':>7} | "
         f"{'ms':>7} {'TFLOPS':>7} | "
-        f"{'CUTLASS':>8} {'TRTLLM':>8} |"
+        f"{'CUTLASS':>9} {'TRTLLM':>9} | "
+        f"{'':^8} | "
+        f"{'experts':^7} | "
+        f"{'min/max/median':^14}"
     )
-    print("-" * 100)
+    print("-" * 120)
 
 
-def _print_row(results):
+def _print_row(results, histogram_record):
     """Print a single row of benchmark results."""
     # Extract values by backend
     r = {r.backend: r for r in results}
@@ -980,20 +1012,70 @@ def _print_row(results):
     # Find winner
     winner = min(r.values(), key=lambda x: x.latency_ms).backend
 
+    active_experts = f"{histogram_record['active_local_experts']:>3}"
+    stats = (
+        f"{histogram_record['min_count']:>3}/"
+        f"{histogram_record['max_count']:>3}/"
+        f"{histogram_record['median_count']:>7.2f}"
+    )
     print(
         f"{cute.tokens:>6} | "
         f"{cute.latency_ms:>7.3f} {cute.tflops:>7.1f} | "
         f"{cutlass.latency_ms:>7.3f} {cutlass.tflops:>7.1f} | "
         f"{trtllm.latency_ms:>7.3f} {trtllm.tflops:>7.1f} | "
-        f"{speedup_cutlass:>7.2f}x {speedup_trtllm:>7.2f}x | "
-        f"{winner:^8}"
+        f"{speedup_cutlass:>8.2f}x {speedup_trtllm:>8.2f}x | "
+        f"{winner:^8} | "
+        f"{active_experts:>7} | "
+        f"{stats:>14}"
     )
 
 
 def _print_footer(ep_config, num_local):
     """Print benchmark footer."""
-    print("-" * 100)
+    print("-" * 120)
     print("Speedup > 1.0 means CuteDSL is faster than that backend")
+
+
+def _collect_expert_histogram(inputs, num_local, local_offset):
+    from flashinfer.fused_moe import fused_topk_deepseek
+
+    num_tokens = inputs["router_logits"].shape[0]
+    dev = inputs["router_logits"].device
+    topk_values = torch.empty(num_tokens, CFG.top_k, dtype=torch.float32, device=dev)
+    topk_indices = torch.empty(num_tokens, CFG.top_k, dtype=torch.int32, device=dev)
+
+    fused_topk_deepseek(
+        scores=inputs["router_logits"],
+        bias=inputs["routing_bias"].float(),
+        n_group=CFG.n_group,
+        topk_group=CFG.topk_group,
+        topk=CFG.top_k,
+        routed_scaling_factor=CFG.routed_scaling_factor,
+        topk_values=topk_values,
+        topk_indices=topk_indices,
+    )
+
+    expert_hist = torch.bincount(
+        topk_indices.reshape(-1).to(torch.int64), minlength=CFG.num_experts
+    )
+    local_hist = expert_hist[local_offset : local_offset + num_local]
+    local_hist_f32 = local_hist.to(torch.float32)
+    active_local_experts = int((local_hist > 0).sum().item())
+    if local_hist.numel() > 0:
+        min_count = int(local_hist.min().item())
+        max_count = int(local_hist.max().item())
+        median_count = float(torch.quantile(local_hist_f32, 0.5).item())
+    else:
+        min_count = 0
+        max_count = 0
+        median_count = 0.0
+
+    return {
+        "active_local_experts": active_local_experts,
+        "min_count": min_count,
+        "max_count": max_count,
+        "median_count": median_count,
+    }
 
 
 def main():
@@ -1037,6 +1119,12 @@ def main():
         action="store_true",
         help="Use functional API instead of CuteDslMoEWrapper for CuteDSL benchmark",
     )
+    parser.add_argument(
+        "--routing-bias-scale",
+        type=float,
+        default=0.01,
+        help="Scale for random routing bias. Larger values tend to create expert imbalance.",
+    )
     args = parser.parse_args()
 
     if not is_sm100_family():
@@ -1065,6 +1153,7 @@ def main():
         use_cuda_graph=not args.no_cuda_graph,
         use_cupti=not args.no_cupti,
         use_wrapper=not args.functional_api,
+        routing_bias_scale=args.routing_bias_scale,
     )
 
     return 0


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

- Adds `--routing-bias-scale` to indirectly affect expert balance for benchmark data initialization
- Adds `Active expert`, `Tokens/slot` stats, `TB/s` to allow for more informed decision

```
$ python benchmarks/bench_moe_deepseek.py --num-tokens 1,8,64,512,1024,2048,4096,8192 --routing-bias-scale 1
==============================================================================================================================================
DeepSeek-V3 MoE Benchmark: CuteDSL vs CUTLASS vs TRTLLM (EP=1)
==============================================================================================================================================
Model: hidden=7168, intermediate=2048, experts=256, top_k=8
EP Config: 256 local experts (simulating 1-way parallelism)
CUDA Graph: enabled, CUPTI: enabled
Routing bias scale: 1.0 (larger values tend to create expert imbalance)
----------------------------------------------------------------------------------------------------------------------------------------------
Tokens |        CuteDSL         |        CUTLASS         |         TRTLLM         | Speedup (CuteDSL/X) |  Winner  | Active  |  Tokens/slot
       |      ms  TFLOPS   TB/s |      ms  TFLOPS   TB/s |      ms  TFLOPS   TB/s |   CUTLASS    TRTLLM |          | experts | min/median/max
----------------------------------------------------------------------------------------------------------------------------------------------
     1 |   0.069    10.2    2.9 |   0.104     6.8    1.9 |   0.057    12.3    3.5 |     1.50x     0.83x |  TRTLLM  |       8 |   0/  0.0/   1
     8 |   0.103    55.0    3.9 |   0.138    40.9    2.9 |   0.087    64.5    4.6 |     1.34x     0.85x |  TRTLLM  |      16 |   0/  0.0/   8
    64 |   0.130   345.8    4.5 |   0.175   257.8    3.3 |   0.126   358.0    4.6 |     1.34x     0.97x |  TRTLLM  |      23 |   0/  0.0/  59
   512 |   0.191  1888.8    4.0 |   0.356  1013.2    2.1 |   0.244  1476.1    3.1 |     1.86x     1.28x | CuteDSL  |      27 |   0/  0.0/ 477
  1024 |   0.294  2457.6    3.0 |   0.513  1407.0    1.7 |   0.563  1280.8    1.5 |     1.75x     1.92x | CuteDSL  |      28 |   0/  0.0/ 956
  2048 |   0.492  2933.8    2.1 |   0.775  1863.2    1.4 |   0.542  2664.1    1.9 |     1.57x     1.10x | CuteDSL  |      28 |   0/  0.0/1910
  4096 |   0.971  2971.9    1.5 |   1.404  2056.1    1.0 |   0.944  3056.8    1.5 |     1.45x     0.97x |  TRTLLM  |      28 |   0/  0.0/3810
  8192 |   1.988  2902.9    1.2 |   2.628  2196.1    0.9 |   1.843  3132.0    1.3 |     1.32x     0.93x |  TRTLLM  |      37 |   0/  0.0/8192
----------------------------------------------------------------------------------------------------------------------------------------------
```

After smoothing out expert histogram, the best implementation changes. CuteDSL MoE is faster for tokens>=1024. TRTLLM high throughput cannot keep up.

```
==============================================================================================================================================
DeepSeek-V3 MoE Benchmark: CuteDSL vs CUTLASS vs TRTLLM (EP=1)
==============================================================================================================================================
Model: hidden=7168, intermediate=2048, experts=256, top_k=8
EP Config: 256 local experts (simulating 1-way parallelism)
CUDA Graph: enabled, CUPTI: enabled
Routing bias scale: 0.01 (larger values tend to create expert imbalance)
----------------------------------------------------------------------------------------------------------------------------------------------
Tokens |        CuteDSL         |        CUTLASS         |         TRTLLM         | Speedup (CuteDSL/X) |  Winner  | Active  |  Tokens/slot
       |      ms  TFLOPS   TB/s |      ms  TFLOPS   TB/s |      ms  TFLOPS   TB/s |   CUTLASS    TRTLLM |          | experts | min/median/max
----------------------------------------------------------------------------------------------------------------------------------------------
     1 |   0.069    10.2    2.9 |   0.100     7.1    2.0 |   0.055    12.8    3.6 |     1.44x     0.79x |  TRTLLM  |       8 |   0/  0.0/   1
     8 |   0.255    22.1    5.6 |   0.298    18.9    4.8 |   0.233    24.2    6.2 |     1.17x     0.91x |  TRTLLM  |      58 |   0/  0.0/   3
    64 |   0.885    50.9    6.3 |   0.955    47.2    5.9 |   0.806    55.9    7.0 |     1.08x     0.91x |  TRTLLM  |     226 |   0/  2.0/   6
   512 |   1.021   353.4    6.3 |   1.416   254.7    4.5 |   0.963   374.7    6.7 |     1.39x     0.94x |  TRTLLM  |     256 |   4/ 16.0/  30
  1024 |   1.056   683.1    6.2 |   1.511   477.5    4.3 |   1.199   601.8    5.4 |     1.43x     1.14x | CuteDSL  |     256 |  12/ 31.0/  58
  2048 |   1.102  1309.8    6.1 |   1.650   874.5    4.1 |   1.481   974.6    4.5 |     1.50x     1.34x | CuteDSL  |     256 |  30/ 65.0/ 101
  4096 |   1.589  1815.9    4.4 |   2.158  1337.6    3.3 |   3.304   873.6    2.1 |     1.36x     2.08x | CuteDSL  |     256 |  66/128.0/ 198
  8192 |   2.581  2236.1    3.0 |   3.595  1605.8    2.2 |   2.769  2084.9    2.8 |     1.39x     1.07x | CuteDSL  |     256 | 138/252.0/ 385
----------------------------------------------------------------------------------------------------------------------------------------------
```

Next actions:
- TRTLLM at token=4096 chooses tileN=64 kernel instead of more suitable tileN=128 kernel. Will have to investigate next.
- High thoughput perf in TRTLLM MoE is still pending for investigation.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--routing-bias-scale` command-line option to control routing bias scaling in benchmarks.
  * Enhanced benchmark output with expert histogram statistics (active experts count, min/max/median distributions).

* **Improvements**
  * Updated benchmark result display with additional metrics columns for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->