### PR TITLE
Give knam codeowner override for Qwen3.5 (gdn) related directories

### DIFF
--- a/scripts/codeowner_overrides.json
+++ b/scripts/codeowner_overrides.json
@@ -21,8 +21,11 @@
   "tests/norm": ["@flashinfer-ai/misc-op-owners"],
 
   "benchmarks/gdn/": ["@flashinfer-ai/misc-op-owners"],
+  "csrc/gdn_prefill_launcher.cu": ["@flashinfer-ai/misc-op-owners"],
+  "csrc/gdn_prefill_sm90_kernel_inst.jinja": ["@flashinfer-ai/misc-op-owners"],
   "flashinfer/gdn_decode.py": ["@flashinfer-ai/misc-op-owners"],
-  "flashinfer/gdn_prefill.py": ["@flashinfer-ai/misc-op-owners"],
   "flashinfer/gdn_kernels/": ["@flashinfer-ai/misc-op-owners"],
+  "flashinfer/gdn_prefill.py": ["@flashinfer-ai/misc-op-owners"],
+  "flashinfer/jit/gdn.py": ["@flashinfer-ai/misc-op-owners"],
   "tests/gdn/": ["@flashinfer-ai/misc-op-owners"]
 }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Title 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to expand coverage for GDN-related components and associated tests, ensuring clearer ownership and review routing for those areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->