### PR TITLE
fix: move ArtifactPath/CheckSumHash imports inside gen_moe_utils_modu…

### DIFF
--- a/flashinfer/jit/moe_utils.py
+++ b/flashinfer/jit/moe_utils.py
@@ -21,9 +21,6 @@ from .core import (
     current_compilation_context,
 )
 
-from .cubin_loader import download_trtllm_headers, get_cubin
-from ..artifacts import ArtifactPath, CheckSumHash
-
 
 def gen_moe_utils_module() -> JitSpec:
     """
@@ -36,6 +33,12 @@ def gen_moe_utils_module() -> JitSpec:
     - moeActivation: Apply activation functions with optional FP4 quantization
     - moeSort: Sort tokens by expert assignment (DeepSeekV3 routing)
     """
+    # Lazy imports to avoid circular dependency:
+    # artifacts.py imports from jit.cubin_loader, which triggers jit/__init__.py,
+    # which imports this module — so ArtifactPath/CheckSumHash aren't defined yet
+    # at module load time if these imports are at the top level.
+    from .cubin_loader import download_trtllm_headers, get_cubin
+    from ..artifacts import ArtifactPath, CheckSumHash
 
     download_trtllm_headers(
         "bmm",


### PR DESCRIPTION
…le to break circular import

artifacts.py imports from jit.cubin_loader at module level, which triggers jit/__init__.py to load, which imports gen_moe_utils_module from this file, which then tries to import ArtifactPath/CheckSumHash from artifacts — but artifacts.py hasn't finished initializing yet, so those names don't exist.

Fixes ImportError introduced in #2235.

See [Internal Pipeline](https://gitlab-master.nvidia.com/dl/flashinfer/flashinfer-ci/-/pipelines/45223374) for failure example.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization to enhance maintainability and prevent potential dependency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->