### PR TITLE
Dispatch GQA group size 5, 6, 7

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -134,6 +134,15 @@
   } else if (group_size == 4) {                              \
     constexpr size_t GROUP_SIZE = 4;                         \
     __VA_ARGS__                                              \
+  } else if (group_size == 5) {                              \
+    constexpr size_t GROUP_SIZE = 5;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 6) {                              \
+    constexpr size_t GROUP_SIZE = 6;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 7) {                              \
+    constexpr size_t GROUP_SIZE = 7;                         \
+    __VA_ARGS__                                              \
   } else if (group_size == 8) {                              \
     constexpr size_t GROUP_SIZE = 8;                         \
     __VA_ARGS__                                              \


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Models like Qwen3.5-27B use 24 Q heads with 4 KV heads, producing a
GQA group_size of 6. The existing macro only handled {1, 2, 3, 4, 8},
causing "Unsupported group_size: 6" errors at batch decode plan time.

Add the missing group sizes 5, 6, and 7 so that non-power-of-2 GQA
ratios are dispatched correctly.
## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended inference engine support for additional grouped query attention configurations, enabling broader compatibility with diverse model parameters and enabling more flexible inference operations across different model architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->