### PR TITLE
feat: support routing replay in trtllm_fp8_block_scale_moe and fused_topk_deepseek

### DIFF
--- a/csrc/fused_moe/noAuxTcKernels.cu
+++ b/csrc/fused_moe/noAuxTcKernels.cu
@@ -30,7 +30,8 @@ __global__ void deepseek_v3_topk_kernel(InputT* scores, OutputT* topkValues, Idx
                                         int64_t const numGroup, int64_t const topkGroup,
                                         int64_t const topk, int64_t const numExperts,
                                         int64_t const numExpertsPerGroup,
-                                        double const routedScalingFactor) {
+                                        double const routedScalingFactor,
+                                        int16_t* routingReplayOut) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   asm volatile("griddepcontrol.wait;");
 #endif
@@ -213,6 +214,12 @@ __global__ void deepseek_v3_topk_kernel(InputT* scores, OutputT* topkValues, Idx
       topkValues[laneIdx] = static_cast<OutputT>(finalScore);
       topkIndices[laneIdx] = expertIdx;
     }
+
+    // Routing replay: record all top-K selected expert IDs per token.
+    // Layout: [num_tokens, topk] — same indexing as topkIndices.
+    if (laneIdx < topk && routingReplayOut != nullptr) {
+      routingReplayOut[blockIdx.x * topk + laneIdx] = static_cast<int16_t>(expertIdx);
+    }
   }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -224,7 +231,8 @@ template <typename InputT, typename BiasT, typename OutputT, typename IdxT>
 void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk_indices,
                    int64_t const num_tokens, int64_t const num_experts, int64_t const n_group,
                    int64_t const topk_group, int64_t const topk, double const routed_scaling_factor,
-                   bool const launch_with_pdl, cudaStream_t const stream) {
+                   bool const launch_with_pdl, cudaStream_t const stream,
+                   int16_t* routing_replay_out) {
   // Check if we can use the optimized deepseek_v3_topk_kernel
   bool const is_single_group = (n_group == 1) && (num_experts <= NumKimiK2Experts);
 
@@ -262,7 +270,7 @@ void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk
 
     cudaLaunchKernelEx(&config, kernel_instance, scores, topk_values, topk_indices, bias,
                        num_tokens, n_group, topk_group, topk, num_experts, num_experts / n_group,
-                       routed_scaling_factor);
+                       routed_scaling_factor, routing_replay_out);
     sync_check_cuda_error(stream);
   } else {
     // TODO: call the generic path (previous implementation) or signal unsupported config.
@@ -279,7 +287,7 @@ void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk
       InputT * scores, BiasT * bias, OutputT * topk_values, IdxT * topk_indices,        \
       int64_t const num_tokens, int64_t const num_experts, int64_t const n_group,       \
       int64_t const topk_group, int64_t const topk, double const routed_scaling_factor, \
-      bool const launch_with_pdl, cudaStream_t const stream);
+      bool const launch_with_pdl, cudaStream_t const stream, int16_t* routing_replay_out);
 
 INSTANTIATE_NOAUX_TC(float, float, float, int32_t);
 INSTANTIATE_NOAUX_TC(float, half, float, int32_t);
@@ -305,7 +313,7 @@ namespace flashinfer::trtllm_dsv3_fused_routing {
 
 void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_group, int64_t topk,
              double routed_scaling_factor, TensorView topk_values, TensorView topk_indices,
-             bool launch_with_pdl) {
+             bool launch_with_pdl, Optional<TensorView> routing_replay_out) {
   auto data_type = scores.dtype();
   auto bias_type = bias.dtype();
 
@@ -342,6 +350,19 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
   TVM_FFI_ICHECK(encode_dlpack_dtype(topk_indices.dtype()) == int32_code)
       << "topk_indices must have the same dtype as scores";
 
+  int16_t* replay_ptr = nullptr;
+  if (routing_replay_out.has_value()) {
+    auto replay = routing_replay_out.value();
+    TVM_FFI_ICHECK(replay.dim() == 2)
+        << "routing_replay_out must be a 2D Tensor [num_tokens, topk]";
+    TVM_FFI_ICHECK(replay.sizes()[0] == num_tokens)
+        << "routing_replay_out dim0 must equal num_tokens";
+    TVM_FFI_ICHECK(replay.sizes()[1] == topk) << "routing_replay_out dim1 must equal topk";
+    TVM_FFI_ICHECK(encode_dlpack_dtype(replay.dtype()) == int16_code)
+        << "routing_replay_out must be int16 dtype";
+    replay_ptr = reinterpret_cast<int16_t*>(replay.data_ptr());
+  }
+
   auto stream = get_stream(scores.device());
   using namespace tensorrt_llm::kernels;
   switch (encode_dlpack_dtype(data_type)) {
@@ -353,14 +374,14 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<half*>(scores.data_ptr()), reinterpret_cast<half*>(bias.data_ptr()),
               reinterpret_cast<half*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         case float32_code:
           invokeNoAuxTc<half, float, half, int32_t>(
               reinterpret_cast<half*>(scores.data_ptr()), reinterpret_cast<float*>(bias.data_ptr()),
               reinterpret_cast<half*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         case bfloat16_code:
           invokeNoAuxTc<half, __nv_bfloat16, half, int32_t>(
@@ -368,7 +389,7 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<__nv_bfloat16*>(bias.data_ptr()),
               reinterpret_cast<half*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         default:
           throw std::invalid_argument(
@@ -384,14 +405,14 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<float*>(bias.data_ptr()),
               reinterpret_cast<float*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         case float16_code:
           invokeNoAuxTc<float, half, float, int32_t>(
               reinterpret_cast<float*>(scores.data_ptr()), reinterpret_cast<half*>(bias.data_ptr()),
               reinterpret_cast<float*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         case bfloat16_code:
           invokeNoAuxTc<float, __nv_bfloat16, float, int32_t>(
@@ -399,7 +420,7 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<__nv_bfloat16*>(bias.data_ptr()),
               reinterpret_cast<float*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         default:
           throw std::invalid_argument(
@@ -416,7 +437,7 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<__nv_bfloat16*>(bias.data_ptr()),
               reinterpret_cast<__nv_bfloat16*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         case float16_code:
           invokeNoAuxTc<__nv_bfloat16, half, __nv_bfloat16, int32_t>(
@@ -424,7 +445,7 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<half*>(bias.data_ptr()),
               reinterpret_cast<__nv_bfloat16*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         case float32_code:
           invokeNoAuxTc<__nv_bfloat16, float, __nv_bfloat16, int32_t>(
@@ -432,7 +453,7 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
               reinterpret_cast<float*>(bias.data_ptr()),
               reinterpret_cast<__nv_bfloat16*>(topk_values.data_ptr()),
               reinterpret_cast<int32_t*>(topk_indices.data_ptr()), num_tokens, num_experts, n_group,
-              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream);
+              topk_group, topk, routed_scaling_factor, launch_with_pdl, stream, replay_ptr);
           break;
         default:
           throw std::invalid_argument(

--- a/csrc/fused_moe/noAuxTcKernels.cu
+++ b/csrc/fused_moe/noAuxTcKernels.cu
@@ -353,6 +353,10 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
   int16_t* replay_ptr = nullptr;
   if (routing_replay_out.has_value()) {
     auto replay = routing_replay_out.value();
+    TVM_FFI_ICHECK(replay.device().device_type == kDLCUDA)
+        << "routing_replay_out must be a CUDA tensor";
+    TVM_FFI_ICHECK(replay.device().device_id == scores.device().device_id)
+        << "routing_replay_out must be on the same device as scores";
     TVM_FFI_ICHECK(replay.dim() == 2)
         << "routing_replay_out must be a 2D Tensor [num_tokens, topk]";
     TVM_FFI_ICHECK(replay.sizes()[0] == num_tokens)

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -134,6 +134,9 @@ class FusedMoeLauncher {
 
   int64_t intermediate_size_factor{2};
 
+  // Optional routing replay output: [num_tokens, top_k] int16 tensor
+  Optional<TensorView> routing_replay_out;
+
  public:
   // Constructor that initializes all TensorView members
   FusedMoeLauncher(const Optional<TensorView>& routing_logits,
@@ -159,6 +162,10 @@ class FusedMoeLauncher {
         mDtypeWeights{btg::Dtype::Bfloat16},
         activation_type{ActivationType::Swiglu},
         intermediate_size_factor{2} {}
+
+  void set_routing_replay_out(const Optional<TensorView>& replay_out) {
+    routing_replay_out = replay_out;
+  }
 
  protected:
   // Initialize common data necessary for later.
@@ -375,6 +382,11 @@ class FusedMoeLauncher {
     tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
     cudaStream_t routing_stream = get_stream(hidden_states.device());
 
+    int16_t* replay_ptr = nullptr;
+    if (routing_replay_out.has_value()) {
+      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
+    }
+
     routing_runner.run(
         args->routing_logits, args->routing_bias, args->num_tokens, args->num_experts, args->top_k,
         args->n_group, args->topk_group, args->local_expert_offset, args->local_num_experts,
@@ -389,7 +401,7 @@ class FusedMoeLauncher {
         static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
         static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
         use_routing_scales_on_input, use_deep_seek_fp8,
-        static_cast<RoutingMethodType>(routing_method_type), routing_stream);
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, replay_ptr);
 
     check_moe();
     prepare_moe(moe_tactic);
@@ -1076,6 +1088,11 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
     cudaStream_t routing_stream = get_stream(hidden_states.device());
     tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
 
+    int16_t* replay_ptr = nullptr;
+    if (routing_replay_out.has_value()) {
+      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
+    }
+
     // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
     bool use_precomputed = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
     // When using pre-computed routing, pass nullptr as routing_logits to tell the
@@ -1094,7 +1111,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
         static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
         static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
         use_routing_scales_on_input, use_deep_seek_fp8,
-        static_cast<RoutingMethodType>(routing_method_type), routing_stream);
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, replay_ptr);
 
     check_moe();
     prepare_moe(moe_tactic);
@@ -1543,6 +1560,11 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
     tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
     cudaStream_t routing_stream = get_stream(hidden_states.device());
 
+    int16_t* replay_ptr = nullptr;
+    if (routing_replay_out.has_value()) {
+      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
+    }
+
     routing_runner.run(
         args->routing_logits, args->routing_bias, args->num_tokens, args->num_experts, args->top_k,
         args->n_group, args->topk_group, args->local_expert_offset, args->local_num_experts,
@@ -1557,7 +1579,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
         static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
         static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
         use_routing_scales_on_input, use_deep_seek_fp8,
-        static_cast<RoutingMethodType>(routing_method_type), routing_stream);
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, replay_ptr);
 
     check_moe();
     prepare_moe(moe_tactic);
@@ -1782,7 +1804,8 @@ Array<Tensor> trtllm_fp8_block_scale_moe(
     Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
     int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
     int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
-    bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type) {
+    bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
+    Optional<TensorView> routing_replay_out) {
   // Basic type validation
   auto dtype = hidden_states.dtype();
 
@@ -1875,6 +1898,7 @@ Array<Tensor> trtllm_fp8_block_scale_moe(
         quantization_type);
     launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
                    weight_layout);
+    launcher->set_routing_replay_out(routing_replay_out);
 
     launchers_map[curr_tile_N] = std::move(launcher);
   }

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1866,6 +1866,19 @@ Array<Tensor> trtllm_fp8_block_scale_moe(
   auto const num_tokens = hidden_states.size(0);
   auto const hidden_size = hidden_states.size(1);
 
+  if (routing_replay_out.has_value()) {
+    auto replay = routing_replay_out.value();
+    TVM_FFI_ICHECK(replay.device().device_type == kDLCUDA)
+        << "routing_replay_out must be a CUDA tensor";
+    TVM_FFI_ICHECK(replay.device().device_id == hidden_states.device().device_id)
+        << "routing_replay_out must be on the same device as hidden_states";
+    TVM_FFI_ICHECK(replay.ndim() == 2) << "routing_replay_out must be 2D [num_tokens, top_k]";
+    TVM_FFI_ICHECK(replay.size(0) == num_tokens) << "routing_replay_out dim0 must equal num_tokens";
+    TVM_FFI_ICHECK(replay.size(1) == top_k) << "routing_replay_out dim1 must equal top_k";
+    TVM_FFI_ICHECK(encode_dlpack_dtype(replay.dtype()) == int16_code)
+        << "routing_replay_out must be int16 dtype";
+  }
+
   auto supported_tile_nums = Fp8BlockScaleLauncher::getSupportedTileNums(quantization_type);
   std::set<int32_t> selected_tile_nums =
       computeSelectedTileN(supported_tile_nums, num_tokens, top_k, local_num_experts);

--- a/csrc/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/trtllm_fused_moe_routing_deepseek.cu
@@ -261,6 +261,12 @@ __global__ void routingMainKernel(KernelParams params) {
           params.mPtrTopKIds == nullptr) {
         params.mPtrTopKWeights[idxTopK] = finalScore;
       }
+
+      // Routing replay: record all top-K selected expert IDs per token.
+      // Layout: [num_tokens, topK] — same indexing as mPtrTopKPacked.
+      if (laneIdx < params.mTopK && params.mPtrRoutingReplayOut != nullptr) {
+        params.mPtrRoutingReplayOut[idxTopK] = static_cast<int16_t>(expertIdx);
+      }
     }
   }
 }

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -58,7 +58,8 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
                  int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit,
                  int32_t* numNonExitingCtas, btg::Dtype dtypeElt, btg::Dtype dtypeBias,
                  bool useRoutingScalesOnInput, bool useDeepSeekFp8,
-                 RoutingMethodType routingMethodType, cudaStream_t stream) {
+                 RoutingMethodType routingMethodType, cudaStream_t stream,
+                 int16_t* routingReplayOut) {
   if (routingMethodType == RoutingMethodType::DeepSeekV3) {
     FLASHINFER_CHECK(topK <= 22, "For DeepSeek routing method, must have topK <= 22");
     FLASHINFER_CHECK(topkGroup <= 4, "For DeepSeek routing method, must have topkGroup <= 4");
@@ -98,6 +99,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mNumLocalExperts = localNumExperts;
     routingData.mRouteScale = routedScalingFactor;
     routingData.mUseRoutingSoftmax = false;
+    routingData.mPtrRoutingReplayOut = routingReplayOut;
     moe::dev::routing::routingDeepSeek::run(routingData, stream);
   } else if (routingMethodType == RoutingMethodType::Llama4) {
     FLASHINFER_CHECK(topK == 1, "For Llama routing method, must have topK == 1");

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -53,6 +53,7 @@ constexpr int64_t float16_code = encode_dlpack_dtype(dl_float16);
 constexpr int64_t bfloat16_code = encode_dlpack_dtype(dl_bfloat16);
 constexpr int64_t float32_code = encode_dlpack_dtype(dl_float32);
 constexpr int64_t uint8_code = encode_dlpack_dtype(dl_uint8);
+constexpr int64_t int16_code = encode_dlpack_dtype(dl_int16);
 constexpr int64_t int32_code = encode_dlpack_dtype(dl_int32);
 constexpr int64_t int64_code = encode_dlpack_dtype(dl_int64);
 constexpr int64_t float8_e4m3fn_code = encode_dlpack_dtype(dl_float8_e4m3fn);

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1628,7 +1628,7 @@ def get_trtllm_moe_sm100_module():
 
     @register_custom_op(
         "flashinfer::trtllm_fp8_block_scale_moe",
-        mutates_args=(""),
+        mutates_args=("routing_replay_out",),
     )
     def trtllm_fp8_block_scale_moe_op(
         routing_logits: Optional[torch.Tensor],
@@ -1657,6 +1657,7 @@ def get_trtllm_moe_sm100_module():
         enable_pdl: Optional[bool] = None,
         tune_max_num_tokens: int = 8192,
         fp8_quantization_type: Fp8QuantizationType = Fp8QuantizationType.DeepSeekFp8,
+        routing_replay_out: Optional[torch.Tensor] = None,
     ) -> List[torch.Tensor]:
         # Determine routing mode: compute from logits or use pre-computed
         if routing_logits is None:
@@ -1781,6 +1782,7 @@ def get_trtllm_moe_sm100_module():
             enable_pdl,
             [-1, -1] if tactic == -1 else tactic,
             fp8_quantization_type,
+            routing_replay_out,
         )
 
         if do_finalize:
@@ -1824,6 +1826,7 @@ def get_trtllm_moe_sm100_module():
         enable_pdl: Optional[bool] = None,
         tune_max_num_tokens: int = 8192,
         fp8_quantization_type: Fp8QuantizationType = Fp8QuantizationType.DeepSeekFp8,
+        routing_replay_out: Optional[torch.Tensor] = None,
     ) -> List[torch.Tensor]:
         seq_len = hidden_states.shape[0]
         hidden_size = hidden_states.shape[1]
@@ -2543,6 +2546,7 @@ def trtllm_fp8_block_scale_moe(
     enable_pdl: Optional[bool] = None,
     tune_max_num_tokens: int = 8192,
     fp8_quantization_type: Fp8QuantizationType = Fp8QuantizationType.DeepSeekFp8,
+    routing_replay_out: Optional[torch.Tensor] = None,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
     """FP8 block scale MoE operation.
 
@@ -2575,6 +2579,9 @@ def trtllm_fp8_block_scale_moe(
         enable_pdl: Whether to enable Programmatic Dependent Launch (PDL). Auto-enabled for >= sm90.
         tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
         fp8_quantization_type: Type of FP8 quantization to use (default: DeepSeekFp8)
+        routing_replay_out: Optional [seq_len, top_k] int16 tensor. When provided, the
+            routing kernel writes selected expert IDs per token into this tensor during
+            routing. When None, no recording occurs (zero overhead).
     Returns:
         when do_finalize=True, returns the final MoE output.
         otherwise, returns the intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) that need further processing.
@@ -2609,6 +2616,7 @@ def trtllm_fp8_block_scale_moe(
         enable_pdl,
         tune_max_num_tokens,
         fp8_quantization_type,
+        routing_replay_out,
     )
 
     if do_finalize:

--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from flashinfer.api_logging import flashinfer_api
 from flashinfer.jit import gen_dsv3_fused_routing_module
 import functools
@@ -21,6 +23,7 @@ def _check_dsv3_fused_routing_supported(
     topk_values,
     topk_indices,
     launch_with_pdl,
+    routing_replay_out=None,
 ):
     """Validate configuration parameters for DSv3 fused routing kernel.
 
@@ -38,6 +41,18 @@ def _check_dsv3_fused_routing_supported(
     Raises:
         ValueError: If configuration is invalid or exceeds kernel limits
     """
+    if routing_replay_out is not None:
+        num_tokens = scores.shape[0]
+        if routing_replay_out.dtype != torch.int16:
+            raise ValueError(
+                f"routing_replay_out must be int16, got {routing_replay_out.dtype}"
+            )
+        if routing_replay_out.shape != (num_tokens, topk):
+            raise ValueError(
+                f"routing_replay_out shape must be ({num_tokens}, {topk}), "
+                f"got {tuple(routing_replay_out.shape)}"
+            )
+
     # Extract number of experts from scores shape
     num_experts = scores.shape[1]
 
@@ -86,7 +101,7 @@ def get_dsv3_fused_routing_module():
 
     @register_custom_op(
         "flashinfer::NoAuxTc",
-        mutates_args=["topk_values", "topk_indices"],
+        mutates_args=["topk_values", "topk_indices", "routing_replay_out"],
     )
     def NoAuxTc(
         scores: torch.Tensor,
@@ -98,6 +113,7 @@ def get_dsv3_fused_routing_module():
         topk_values: torch.Tensor,
         topk_indices: torch.Tensor,
         launch_with_pdl: bool = True,
+        routing_replay_out: Optional[torch.Tensor] = None,
     ) -> None:
         module.NoAuxTc(
             scores,
@@ -109,6 +125,7 @@ def get_dsv3_fused_routing_module():
             topk_values,
             topk_indices,
             launch_with_pdl,
+            routing_replay_out,
         )
 
     return SimpleNamespace(
@@ -128,6 +145,7 @@ def fused_topk_deepseek(
     topk_values: torch.Tensor,
     topk_indices: torch.Tensor,
     launch_with_pdl: bool = True,
+    routing_replay_out: Optional[torch.Tensor] = None,
 ) -> None:
     """Fused expert routing with top-k selection for DeepSeek-V3.
 
@@ -168,6 +186,10 @@ def fused_topk_deepseek(
             This tensor is mutated in-place.
         launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
             Device-side Launch. Defaults to True.
+        routing_replay_out (torch.Tensor, optional): Pre-allocated output tensor of shape
+            (num_tokens, topk) with dtype int16 for recording the selected expert IDs per
+            token. If None, no routing replay recording occurs (zero overhead). This tensor
+            is mutated in-place.
 
     Returns:
         None: Results are written directly to `topk_values` and `topk_indices` tensors.
@@ -193,4 +215,5 @@ def fused_topk_deepseek(
         topk_values,
         topk_indices,
         launch_with_pdl,
+        routing_replay_out,
     )

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -68,6 +68,11 @@ struct DataBase {
   // Together with mPtrTopKWeights, they form the top-k experts for each token
   int32_t* mPtrTopKIds{nullptr};
 
+  // optional: if `nullptr`, no routing replay recording occurs
+  // dim: [mNumTokens, mTopK]
+  // Records the selected expert IDs per token for replay/debugging
+  int16_t* mPtrRoutingReplayOut{nullptr};
+
   // optional: if `nullptr`, scores are used directly as input.
   // If it is given, it must represent a packed value s.t. the most significant
   // 16/32 bits represent the score without sigmoid activation and
@@ -124,6 +129,7 @@ struct KernelParamsBase {
   OutputT* mPtrTopKWeights = nullptr;
   int32_t* mPtrTopKIds = nullptr;
   InputT const* mPtrScores = nullptr;
+  int16_t* mPtrRoutingReplayOut = nullptr;
 
   // Public scalar members
   int32_t mNumTokens = 0;
@@ -149,6 +155,7 @@ struct KernelParamsBase {
     mPtrTopKWeights = static_cast<OutputT*>(data.mPtrTopKWeights);
     mPtrTopKIds = static_cast<int32_t*>(data.mPtrTopKIds);
     mPtrScores = (InputT const*)data.mPtrScores;
+    mPtrRoutingReplayOut = data.mPtrRoutingReplayOut;
 
     mNumTokens = data.mNumTokens;
     mNumExperts = data.mNumExperts;

--- a/include/flashinfer/trtllm/fused_moe/noAuxTcKernels.h
+++ b/include/flashinfer/trtllm/fused_moe/noAuxTcKernels.h
@@ -28,6 +28,7 @@ template <typename InputT, typename BiasT, typename OutputT, typename IdxT>
 void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk_indices,
                    int64_t const num_tokens, int64_t const num_experts, int64_t const n_group,
                    int64_t const topk_group, int64_t const topk, double const routed_scaling_factor,
-                   cudaStream_t const stream = 0);
+                   bool const launch_with_pdl, cudaStream_t const stream,
+                   int16_t* routing_replay_out = nullptr);
 
 }  // namespace tensorrt_llm::kernels

--- a/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/include/flashinfer/trtllm/fused_moe/runner.h
@@ -128,7 +128,7 @@ class Runner {
            int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas,
            batchedGemm::trtllm::gen::Dtype dtypeElt, batchedGemm::trtllm::gen::Dtype dtypeBias,
            bool useRoutingScalesOnInput, bool useDeepSeekFp8, RoutingMethodType routingMethodType,
-           cudaStream_t stream);
+           cudaStream_t stream, int16_t* routingReplayOut = nullptr);
 
  private:
   int32_t mTileTokensDim{8};

--- a/tests/model_optimizations/test_dsv3_fused_routing.py
+++ b/tests/model_optimizations/test_dsv3_fused_routing.py
@@ -499,3 +499,92 @@ def test_dsv3_fused_routing_op(
 
     # Validate values
     validate_values(ground_truth, sorted_vals, tokens_with_different_experts, data_type)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64])
+@pytest.mark.parametrize("num_experts", [256])
+@pytest.mark.parametrize("topk", [1, 4, 8])
+@pytest.mark.parametrize("n_group", [1, 8])
+@pytest.mark.parametrize("topk_group", [1, 4])
+@pytest.mark.parametrize("data_type", [torch.bfloat16, torch.float16])
+def test_routing_replay_out(
+    num_tokens, num_experts, topk, n_group, topk_group, data_type
+):
+    """
+    Test that routing_replay_out records the same expert IDs as topk_indices.
+
+    The routing replay feature writes selected expert IDs (int16) into an
+    optional output tensor during the fused routing kernel. This test verifies
+    that routing_replay_out matches topk_indices (as sets per token), and that
+    passing None produces identical routing results (no side effects).
+    """
+    if topk_group * n_group < topk or topk_group > n_group:
+        pytest.skip("Invalid configuration")
+    if n_group > 1:
+        if (
+            topk > 8
+            or num_experts / n_group > 32
+            or num_experts / n_group * topk_group > 128
+        ):
+            pytest.skip("Exceeds kernel limits for n_group > 1")
+    else:
+        if num_experts > 384 or topk > 8:
+            pytest.skip("Exceeds kernel limits for n_group = 1")
+
+    torch.manual_seed(42)
+    device = "cuda"
+    scores = torch.randn(num_tokens, num_experts, device=device, dtype=data_type)
+    bias = torch.randn(num_experts, device=device, dtype=data_type)
+    routed_scaling_factor = 1.0
+
+    topk_values = torch.empty(num_tokens, topk, device=device, dtype=data_type)
+    topk_indices = torch.zeros(num_tokens, topk, device=device, dtype=torch.int32)
+    routing_replay_out = torch.full(
+        (num_tokens, topk), -1, device=device, dtype=torch.int16
+    )
+
+    fused_topk_deepseek(
+        scores,
+        bias,
+        n_group,
+        topk_group,
+        topk,
+        routed_scaling_factor,
+        topk_values,
+        topk_indices,
+        launch_with_pdl=True,
+        routing_replay_out=routing_replay_out,
+    )
+
+    # routing_replay_out should contain the same expert IDs as topk_indices (per token)
+    for t in range(num_tokens):
+        replay_set = set(routing_replay_out[t].tolist())
+        indices_set = set(topk_indices[t].tolist())
+        assert replay_set == indices_set, (
+            f"Token {t}: routing_replay_out experts {replay_set} "
+            f"!= topk_indices experts {indices_set}"
+        )
+
+    # Verify None produces identical results (no side effects from replay)
+    topk_values_no_replay = torch.empty(
+        num_tokens, topk, device=device, dtype=data_type
+    )
+    topk_indices_no_replay = torch.zeros(
+        num_tokens, topk, device=device, dtype=torch.int32
+    )
+
+    fused_topk_deepseek(
+        scores,
+        bias,
+        n_group,
+        topk_group,
+        topk,
+        routed_scaling_factor,
+        topk_values_no_replay,
+        topk_indices_no_replay,
+        launch_with_pdl=True,
+        routing_replay_out=None,
+    )
+
+    torch.testing.assert_close(topk_values, topk_values_no_replay)
+    torch.testing.assert_close(topk_indices, topk_indices_no_replay)

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -528,3 +528,139 @@ def test_trtllm_gen_bf16_routed_fused_moe(
     # mismatch percentage
     mismatch_pct = (~mask).float().mean().item() * 100
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
+
+
+@pytest.mark.parametrize("num_tokens", [8, 64])
+@pytest.mark.parametrize("hidden_size", [1024, 2048])
+@pytest.mark.parametrize("intermediate_size", [1024, 2048])
+@pytest.mark.parametrize("num_experts", [8, 16])
+@pytest.mark.parametrize("top_k", [2, 4])
+def test_fp8_block_scale_moe_routing_replay(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_experts: int,
+):
+    """Test that routing_replay_out in trtllm_fp8_block_scale_moe records correct expert IDs.
+
+    Runs the full MoE kernel twice with the same inputs: once with routing_replay_out
+    and once without. Verifies that:
+    1. The MoE output is identical (replay has no side effects).
+    2. The replay tensor contains valid expert IDs in [0, num_experts).
+    3. Each token's replay IDs contain exactly top_k unique experts.
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] not in [10]:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    enable_pdl = device_support_pdl(device)
+
+    routing_logits = torch.rand(num_tokens, num_experts, device=device).to(
+        torch.bfloat16
+    )
+
+    hidden_states_bf16 = (
+        torch.randn(num_tokens, hidden_size, device=device).to(torch.bfloat16) * 0.1
+    )
+    hidden_states = hidden_states_bf16.to(torch.float8_e4m3fn)
+
+    hidden_states_scale = torch.ones(
+        hidden_size // 128, num_tokens, device=device, dtype=torch.float32
+    )
+
+    gemm1_weights = torch.randn(
+        num_experts, 2 * intermediate_size, hidden_size, device=device
+    ).to(torch.float8_e4m3fn)
+    gemm2_weights = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device
+    ).to(torch.float8_e4m3fn)
+
+    gemm1_weights_scale = torch.ones(
+        num_experts,
+        2 * intermediate_size // 128,
+        hidden_size // 128,
+        device=device,
+        dtype=torch.float32,
+    )
+    gemm2_weights_scale = torch.ones(
+        num_experts,
+        hidden_size // 128,
+        intermediate_size // 128,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    routing_replay_out = torch.full(
+        (num_tokens, top_k), -1, device=device, dtype=torch.int16
+    )
+
+    output_with_replay = trtllm_fp8_block_scale_moe(
+        routing_logits,
+        None,  # routing_bias
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        num_experts,
+        top_k,
+        None,  # n_group
+        None,  # topk_group
+        intermediate_size,
+        0,  # local_expert_offset
+        num_experts,
+        None,  # routed_scaling_factor
+        RoutingMethodType.Renormalize.value,
+        False,  # use_shuffled_weight
+        0,  # weight_layout
+        enable_pdl,
+        routing_replay_out=routing_replay_out,
+    )
+
+    output_without_replay = trtllm_fp8_block_scale_moe(
+        routing_logits,
+        None,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        num_experts,
+        top_k,
+        None,
+        None,
+        intermediate_size,
+        0,
+        num_experts,
+        None,
+        RoutingMethodType.Renormalize.value,
+        False,
+        0,
+        enable_pdl,
+        routing_replay_out=None,
+    )
+
+    # MoE output should be identical regardless of replay
+    torch.testing.assert_close(
+        output_with_replay.to(torch.float),
+        output_without_replay.to(torch.float),
+        rtol=0,
+        atol=0,
+    )
+
+    # All replay IDs should be valid expert indices
+    assert (routing_replay_out >= 0).all(), "Found negative expert IDs in replay"
+    assert (routing_replay_out < num_experts).all(), (
+        f"Found expert IDs >= {num_experts} in replay"
+    )
+
+    # Each token should have top_k unique experts
+    for t in range(num_tokens):
+        unique_experts = routing_replay_out[t].unique()
+        assert unique_experts.numel() == top_k, (
+            f"Token {t}: expected {top_k} unique experts, got {unique_experts.numel()}"
+        )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Motivation

vLLM's expert-parallel routing replay feature (`RoutedExpertsCapturer`) needs to record which experts each token is routed to during MoE inference. This works fine for the non-fused path where `BaseRouter.select_experts()` is called and `capture_fn` fires. However, the **TRTLLM-GEN fused MoE path is monolithic** — `Fp8MoEMethod.apply_monolithic()` calls FlashInfer's `trtllm_fp8_block_scale_moe` directly, bypassing the router entirely. This means `capture_fn` is never invoked and the `RoutedExpertsCapturer` never receives expert IDs from this code path.

Without this change, any vLLM deployment using the TRTLLM-GEN fused MoE backend cannot use routing replay, which is required for expert-parallel inference and load-balancing analytics.

### What this PR does

Adds an optional `routing_replay_out` parameter to FlashInfer's fused routing and MoE kernels. When a pre-allocated `int16` tensor of shape `[num_tokens, topk]` is provided, the CUDA routing kernel writes selected expert IDs per token directly into it during routing — inside the same fused kernel call that computes the MoE output. When `None` (the default), the kernel skips the write entirely with zero overhead.

**API surface (all backward-compatible, default `None`):**
- `flashinfer.fused_moe.fused_topk_deepseek(..., routing_replay_out=None)`
- `flashinfer.fused_moe.trtllm_fp8_block_scale_moe(..., routing_replay_out=None)`

**Changes across the stack:**
- **CUDA kernels**: plumb `routing_replay_out` through `deepseek_v3_topk_kernel`, `routingMainKernel`, `invokeNoAuxTc`, and all three launcher classes (`FusedMoeLauncher`, `Fp8BlockScaleLauncher`, `FP4BlockScaleLauncher`)
- **C++ bindings**: add `int16_code` constant, `Optional<TensorView>` parameter with shape/dtype validation in `NoAuxTc` and `trtllm_fp8_block_scale_moe`
- **Python API**: add `routing_replay_out` to `fused_topk_deepseek`, `trtllm_fp8_block_scale_moe`, and their `torch.compile` registrations (`custom_op`, `fake_op`, `mutates_args`)
- **Input validation**: dtype and shape checks in `_check_dsv3_fused_routing_supported`

### vLLM integration status

This feature has been tested end-to-end with vLLM's `RoutedExpertsCapturer` and the corresponding vLLM integration PR is in progress toward merging into vLLM main. The vLLM-side change is minimal (3 files, ~15 lines) — it slices the existing `_RoutedExpertsDeviceCache` buffer and passes it as `routing_replay_out`.

## 🔍 Related Issues

- vLLM expert-parallel routing replay for the TRTLLM-GEN fused MoE path

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

**New tests added:**
- `test_routing_replay_out` — standalone `fused_topk_deepseek` routing kernel: verifies `routing_replay_out` matches `topk_indices` per token and that `None` produces identical results (no side effects)
- `test_fp8_block_scale_moe_routing_replay` — end-to-end FP8 block-scale MoE: verifies replay IDs are valid, unique per token, and MoE output is bit-identical with/without replay (SM100+)

## Reviewer Notes

- All changes are backward-compatible: `routing_replay_out` defaults to `None`, so existing callers are unaffected.
- The overhead when `routing_replay_out is None` is a single pointer null-check per thread — effectively zero.
- The write when enabled is K coalesced int16 stores per token (e.g., 8 stores for DeepSeek-V3's top-8), negligible relative to the routing computation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional routing-replay output: record per-token selected expert IDs (num_tokens × topk) for replay/debug; written only when provided.

* **API**
  * Public ops and launchers accept an optional routing_replay_out tensor/pointer (int16) and propagate it through routing paths without changing default behavior.

* **Documentation**
  * Docstrings and operator metadata updated to describe routing_replay_out and its in-place semantics.

* **Tests**
  * Added tests confirming replay contents and that providing replay produces no side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->