### PR TITLE
prefill: decouple custom-mask enablement from buffers and clear stale…

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1572,6 +1572,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buf
         self._custom_mask_buf = custom_mask_buf
         self._mask_indptr_buf = mask_indptr_buf
+        self._use_custom_mask = False
         self._max_total_num_rows: Optional[int] = None
         self._backend = backend
         self._plan_info = None
@@ -1800,6 +1801,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 mask_indptr,
                 bitorder="little",
             )
+        self._use_custom_mask = packed_custom_mask is not None
 
         self._prefix_len_ptr = prefix_len_ptr
         self._token_pos_in_items_ptr = token_pos_in_items_ptr
@@ -1914,7 +1916,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     self.device,
                     PosEncodingMode[pos_encoding_mode].value,
                     use_fp16_qk_reduction,
-                    self._custom_mask_buf is not None,  # use_custom_mask
+                    self._use_custom_mask,
                     q_data_type,
                     kv_data_type,
                 )
@@ -2195,7 +2197,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             k_cache = k_cache.transpose(-3, -2)
             v_cache = v_cache.transpose(-3, -2)
 
-        if self._custom_mask_buf is not None:
+        if self._use_custom_mask:
             mask_mode = MaskMode.CUSTOM.value
         else:
             if self._causal:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Make custom-mask behavior explicit and prevents stale mask state from affecting later runs. Clear mask buffer in non-cudagraph mode, ignore in cudagraph mode.

Repro: 
[repro_860_state_leak.py](https://github.com/user-attachments/files/25754279/repro_860_state_leak.py)
passes after these changes.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/860

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes



<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how custom attention masks are tracked and checked across batch attention paths by introducing a dedicated internal indicator.
  * Execution and planning logic now consistently derive mask usage from the same source, improving reliability.
  * Buffering behavior simplified when no custom mask is provided, reducing unnecessary memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->