### PR TITLE
fix(mm_fp4): use per-call workspace buffer to prevent race condition

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -3854,9 +3854,7 @@ def mm_fp4(
             dtype=out_dtype,
         )
 
-    workspace_buffer = _get_cache_buf(
-        "mm_fp4_workspace", DEFAULT_WORKSPACE_SIZE, a.device
-    )
+    workspace_buffer = torch.empty(DEFAULT_WORKSPACE_SIZE, dtype=torch.uint8, device=a.device)
 
     # Auto-select the best backend
     if backend == "auto":


### PR DESCRIPTION
## Summary

- Replace the shared cached workspace buffer (`_get_cache_buf`) in `mm_fp4()` with a fresh `torch.empty()` allocation per call to prevent race conditions when multiple `mm_fp4()` calls execute concurrently.

## Root Cause

`_get_cache_buf` returns a globally cached singleton buffer per device. When multiple `mm_fp4()` calls run concurrently during inference (e.g., in tensor-parallel or pipeline-parallel setups), they share the same workspace buffer, causing CUTLASS kernel corruption that manifests as NaN values in 128-aligned output tiles.

## Fix

Replace:
```python
workspace_buffer = _get_cache_buf(
    "mm_fp4_workspace", DEFAULT_WORKSPACE_SIZE, a.device
)
```

With:
```python
workspace_buffer = torch.empty(DEFAULT_WORKSPACE_SIZE, dtype=torch.uint8, device=a.device)
```

Fresh allocation has zero overhead thanks to PyTorch's CUDA allocator caching — previously freed buffers of the same size are returned instantly from the free list without any `cudaMalloc`.

Fixes #2708

## Test plan

- [ ] Verify NaN values no longer appear in concurrent `mm_fp4()` calls
- [ ] Verify no performance regression (PyTorch CUDA allocator caching makes fresh allocation effectively free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Updated workspace buffer allocation strategy for matrix operations to use direct allocation instead of cached buffers, improving memory predictability and lifecycle management during tensor computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->