### PR TITLE
feat: Add DiT-oriented kernels where Qk (Bmm1) type can be reinterpreted into Int8 or BFloat16

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -44,20 +44,25 @@ enum class TllmPagedAttentionMode {
 
 class TllmGenFmhaRunnerCache {
  public:
-  using Key = std::tuple<Data_type, Data_type, Data_type>;
+  using Key = std::tuple<Data_type, Data_type, Data_type, Data_type, int, int, int, int>;
 
-  static std::shared_ptr<TllmGenFmhaRunner> get(Data_type q_data_type, Data_type kv_data_type,
-                                                Data_type o_data_type) {
+  static std::shared_ptr<TllmGenFmhaRunner> get(Data_type q_data_type, Data_type k_data_type,
+                                                Data_type v_data_type, Data_type o_data_type,
+                                                int num_elts_sage_q = 0, int num_elts_sage_k = 0,
+                                                int num_elts_sage_p = 0, int num_elts_sage_v = 0) {
     static std::unordered_map<Key, std::shared_ptr<TllmGenFmhaRunner>, KeyHash> cache;
     static std::mutex cache_mutex;
-    Key key = std::make_tuple(q_data_type, kv_data_type, o_data_type);
+    Key key = std::make_tuple(q_data_type, k_data_type, v_data_type, o_data_type, num_elts_sage_q,
+                              num_elts_sage_k, num_elts_sage_p, num_elts_sage_v);
 
     std::lock_guard<std::mutex> lock(cache_mutex);
     auto it = cache.find(key);
     if (it != cache.end()) {
       return it->second;
     } else {
-      auto runner = std::make_shared<TllmGenFmhaRunner>(q_data_type, kv_data_type, o_data_type);
+      auto runner = std::make_shared<TllmGenFmhaRunner>(
+          q_data_type, k_data_type, v_data_type, o_data_type, num_elts_sage_q, num_elts_sage_k,
+          num_elts_sage_p, num_elts_sage_v);
       cache.emplace(key, runner);
       return runner;
     }
@@ -68,7 +73,10 @@ class TllmGenFmhaRunnerCache {
     std::size_t operator()(const Key& k) const {
       return std::hash<int>()(static_cast<int>(std::get<0>(k))) ^
              (std::hash<int>()(static_cast<int>(std::get<1>(k))) << 1) ^
-             (std::hash<int>()(static_cast<int>(std::get<2>(k))) << 2);
+             (std::hash<int>()(static_cast<int>(std::get<2>(k))) << 2) ^
+             (std::hash<int>()(static_cast<int>(std::get<3>(k))) << 3) ^
+             (std::hash<int>()(std::get<4>(k)) << 4) ^ (std::hash<int>()(std::get<5>(k)) << 5) ^
+             (std::hash<int>()(std::get<6>(k)) << 6) ^ (std::hash<int>()(std::get<7>(k)) << 7);
     }
   };
 };
@@ -96,7 +104,9 @@ void trtllm_paged_attention_launcher(
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  auto fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, o_data_type);
+  // For paged attention, K and V have the same dtype (kv_data_type).
+  auto fmha_runner =
+      TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type, o_data_type);
   TllmGenFmhaRunnerParams runner_params;
 
   // Common params
@@ -225,6 +235,8 @@ inline Data_type dl_dtype_to_tllm_data_type(const DLDataType dtype) {
     return Data_type::DATA_TYPE_E4M3;
   } else if (dtype == dl_float8_e5m2) {
     return Data_type::DATA_TYPE_E5M2;
+  } else if (dtype == dl_int8) {
+    return Data_type::DATA_TYPE_INT8;
   } else if (dtype == dl_uint8) {
     // fp4 tensor is not supported in torch and use uint8_t as container.
     return Data_type::DATA_TYPE_E2M1;
@@ -493,14 +505,17 @@ void trtllm_paged_attention_context(
 void trtllm_ragged_attention_launcher(
     void* out, void* query, void* key, void* value, void* workspace_buffer, int* seq_lens,
     int* cum_seq_lens_q, int* cum_seq_lens_kv, float* attention_sinks, float* lse,
-    Data_type q_data_type, Data_type kv_data_type, Data_type o_data_type, int64_t max_q_len,
-    int64_t max_kv_len, int64_t num_qo_heads, int64_t num_kv_heads, int64_t head_dim_qk,
-    int64_t head_dim_v, int64_t sum_seq_q, int64_t sum_seq_kv, double bmm1_scale, double bmm2_scale,
-    const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
-    int64_t batch_size, int64_t window_left, int64_t sm_count, bool enable_pdl, bool is_causal,
-    int64_t k_stride_keys_values, int64_t k_stride_heads, int64_t k_stride_batch,
-    int64_t v_stride_keys_values, int64_t v_stride_heads, int64_t v_stride_batch,
-    float skip_softmax_threshold_scale_factor, bool skips_softmax, int64_t workspace_size,
+    Data_type q_data_type, Data_type k_data_type, Data_type v_data_type, Data_type o_data_type,
+    int64_t max_q_len, int64_t max_kv_len, int64_t num_qo_heads, int64_t num_kv_heads,
+    int64_t head_dim_qk, int64_t head_dim_v, int64_t sum_seq_q, int64_t sum_seq_kv,
+    double bmm1_scale, double bmm2_scale, const float* bmm1_scale_log2_ptr,
+    const float* bmm2_scale_ptr, double o_sf_scale, int64_t batch_size, int64_t window_left,
+    int64_t sm_count, bool enable_pdl, bool is_causal, int64_t k_stride_keys_values,
+    int64_t k_stride_heads, int64_t k_stride_batch, int64_t v_stride_keys_values,
+    int64_t v_stride_heads, int64_t v_stride_batch, float skip_softmax_threshold_scale_factor,
+    bool skips_softmax, int64_t workspace_size, const float* sage_attn_sfs_q,
+    const float* sage_attn_sfs_k, const float* sage_attn_sfs_p, const float* sage_attn_sfs_v,
+    int num_elts_sage_q, int num_elts_sage_k, int num_elts_sage_p, int num_elts_sage_v,
     cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
@@ -508,7 +523,9 @@ void trtllm_ragged_attention_launcher(
             << " and num_qo_heads: " << num_qo_heads;
     FLASHINFER_ERROR(err_msg.str());
   }
-  auto fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, o_data_type);
+  auto fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, k_data_type, v_data_type, o_data_type,
+                                                 num_elts_sage_q, num_elts_sage_k, num_elts_sage_p,
+                                                 num_elts_sage_v);
   TllmGenFmhaRunnerParams runner_params;
 
   runner_params.qPtr = query;
@@ -576,6 +593,12 @@ void trtllm_ragged_attention_launcher(
   runner_params.mSkipsSoftmaxWhenPossible = skips_softmax;
   runner_params.mSkipSoftmaxThresholdScaleFactor = skip_softmax_threshold_scale_factor;
 
+  // SageAttention scaling factors.
+  runner_params.ptrSageAttnSfsQ = sage_attn_sfs_q;
+  runner_params.ptrSageAttnSfsK = sage_attn_sfs_k;
+  runner_params.ptrSageAttnSfsP = sage_attn_sfs_p;
+  runner_params.ptrSageAttnSfsV = sage_attn_sfs_v;
+
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
   if (!foundKernels) {
     std::ostringstream err_msg;
@@ -586,16 +609,18 @@ void trtllm_ragged_attention_launcher(
   fmha_runner->run(runner_params);
 }
 
-void trtllm_ragged_attention(TensorView out, TensorView query, TensorView key, TensorView value,
-                             TensorView workspace_buffer, TensorView seq_lens, int64_t max_q_len,
-                             int64_t max_kv_len, Variant<double, ffi::Tensor> bmm1_scale,
-                             Variant<double, ffi::Tensor> bmm2_scale, double o_sf_scale,
-                             int64_t batch_size, int64_t window_left, TensorView cum_seq_lens_q,
-                             TensorView cum_seq_lens_kv, int64_t sm_count, bool enable_pdl,
-                             bool is_causal, int64_t workspace_size,
-                             Optional<TensorView> attention_sinks,
-                             Optional<float> skip_softmax_threshold_scale_factor,
-                             Optional<TensorView> lse) {
+void trtllm_ragged_attention(
+    TensorView out, TensorView query, TensorView key, TensorView value, TensorView workspace_buffer,
+    TensorView seq_lens, int64_t max_q_len, int64_t max_kv_len,
+    Variant<double, ffi::Tensor> bmm1_scale, Variant<double, ffi::Tensor> bmm2_scale,
+    double o_sf_scale, int64_t batch_size, int64_t window_left, TensorView cum_seq_lens_q,
+    TensorView cum_seq_lens_kv, int64_t sm_count, bool enable_pdl, bool is_causal,
+    int64_t workspace_size, Optional<TensorView> attention_sinks,
+    Optional<float> skip_softmax_threshold_scale_factor, Optional<TensorView> lse,
+    Optional<TensorView> sage_attn_sfs_q, Optional<TensorView> sage_attn_sfs_k,
+    Optional<TensorView> sage_attn_sfs_p, Optional<TensorView> sage_attn_sfs_v,
+    int64_t num_elts_per_sage_attn_blk_q, int64_t num_elts_per_sage_attn_blk_k,
+    int64_t num_elts_per_sage_attn_blk_p, int64_t num_elts_per_sage_attn_blk_v) {
   float* attention_sinks_ptr = nullptr;
   if (attention_sinks.has_value()) {
     TVM_FFI_ICHECK_EQ(attention_sinks.value().dtype(), dl_float32)
@@ -613,7 +638,8 @@ void trtllm_ragged_attention(TensorView out, TensorView query, TensorView key, T
   TVM_FFI_ICHECK_EQ(value.ndim(), 3) << "value must be a 3D tensor";
 
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
-  auto kv_data_type = dl_dtype_to_tllm_data_type(key.dtype());
+  auto k_data_type = dl_dtype_to_tllm_data_type(key.dtype());
+  auto v_data_type = dl_dtype_to_tllm_data_type(value.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
   const auto stream = get_stream(query.device());
   int num_qo_heads = query.size(1);
@@ -628,6 +654,20 @@ void trtllm_ragged_attention(TensorView out, TensorView query, TensorView key, T
   int v_stride_keys_values = value.stride(0);
   int v_stride_heads = value.stride(1);
   int v_stride_batch = value.numel();
+
+  // SageAttention scaling factor pointers.
+  const float* sage_attn_sfs_q_ptr =
+      sage_attn_sfs_q.has_value() ? static_cast<const float*>(sage_attn_sfs_q.value().data_ptr())
+                                  : nullptr;
+  const float* sage_attn_sfs_k_ptr =
+      sage_attn_sfs_k.has_value() ? static_cast<const float*>(sage_attn_sfs_k.value().data_ptr())
+                                  : nullptr;
+  const float* sage_attn_sfs_p_ptr =
+      sage_attn_sfs_p.has_value() ? static_cast<const float*>(sage_attn_sfs_p.value().data_ptr())
+                                  : nullptr;
+  const float* sage_attn_sfs_v_ptr =
+      sage_attn_sfs_v.has_value() ? static_cast<const float*>(sage_attn_sfs_v.value().data_ptr())
+                                  : nullptr;
 
   auto maybe_bmm1_scale_value = bmm1_scale.as<double>();
   auto maybe_bmm2_scale_value = bmm2_scale.as<double>();
@@ -658,12 +698,17 @@ void trtllm_ragged_attention(TensorView out, TensorView query, TensorView key, T
       out.data_ptr(), query.data_ptr(), key.data_ptr(), value.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(seq_lens.data_ptr()),
       static_cast<int*>(cum_seq_lens_q.data_ptr()), static_cast<int*>(cum_seq_lens_kv.data_ptr()),
-      attention_sinks_ptr, lse_ptr, q_data_type, kv_data_type, o_data_type, max_q_len, max_kv_len,
-      num_qo_heads, num_kv_heads, head_dim_qk, head_dim_v, sum_seq_q, sum_seq_kv, bmm1_scale_value,
-      bmm2_scale_value, bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale, batch_size, window_left,
-      sm_count, enable_pdl, is_causal, k_stride_keys_values, k_stride_heads, k_stride_batch,
-      v_stride_keys_values, v_stride_heads, v_stride_batch,
-      skip_softmax_threshold_scale_factor_value, skips_softmax, workspace_size, stream);
+      attention_sinks_ptr, lse_ptr, q_data_type, k_data_type, v_data_type, o_data_type, max_q_len,
+      max_kv_len, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_v, sum_seq_q, sum_seq_kv,
+      bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale,
+      batch_size, window_left, sm_count, enable_pdl, is_causal, k_stride_keys_values,
+      k_stride_heads, k_stride_batch, v_stride_keys_values, v_stride_heads, v_stride_batch,
+      skip_softmax_threshold_scale_factor_value, skips_softmax, workspace_size, sage_attn_sfs_q_ptr,
+      sage_attn_sfs_k_ptr, sage_attn_sfs_p_ptr, sage_attn_sfs_v_ptr,
+      static_cast<int>(num_elts_per_sage_attn_blk_q),
+      static_cast<int>(num_elts_per_sage_attn_blk_k),
+      static_cast<int>(num_elts_per_sage_attn_blk_p),
+      static_cast<int>(num_elts_per_sage_attn_blk_v), stream);
 }
 
 namespace trtllm_cubin_loader {

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "134850621dbbd55ed6b0c3fa7c29b968136c05ef/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "1d876ee612888821b168c25ffa75a9dcbb963aaa/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "39a9d28268f43475a757d5700af135e1e58c9849/batched_gemm-5ee61af-2b9855b/"
     )
@@ -157,7 +157,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "2be32ce1949ab0b1e637c27f128b77c41d6753a36cb9c0e1a97acb2d3d44ae5f"
+        "1abeea012a8779c6df5b84332fad43c6cfc3b257fe5ab883c8ea501464010d16"
     )
     TRTLLM_GEN_BMM: str = (
         "db06db7f36a2a9395a2041ff6ac016fe664874074413a2ed90797f91ef17e0f6"

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3795,6 +3795,13 @@ def trtllm_ragged_attention_deepseek(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    sage_attn_sfs: Tuple[
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+    ] = (None, None, None, None),
+    num_elts_per_sage_attn_blk: Tuple[int, int, int, int] = (0, 0, 0, 0),
     backend: str = "trtllm-gen",
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
@@ -3875,7 +3882,7 @@ def trtllm_ragged_attention_deepseek(
     if out is None:
         # FP8 inputs produce bfloat16 output by default (TRT-LLM kernels
         # do not support FP8 output for ragged attention)
-        if query.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        if query.dtype in (torch.float8_e4m3fn, torch.float8_e5m2, torch.int8):
             out_dtype = torch.bfloat16
         else:
             out_dtype = query.dtype
@@ -3938,6 +3945,9 @@ def trtllm_ragged_attention_deepseek(
         assert not isinstance(bmm2_scale, torch.Tensor), (
             "cute-dsl backend does not support device tensor bmm2_scale"
         )
+        assert sum(num_elts_per_sage_attn_blk) == 0, (
+            "cute-dsl backend does not support sage attention scale factors"
+        )
         _bmm1 = bmm1_scale
         _bmm2 = bmm2_scale
 
@@ -3975,6 +3985,12 @@ def trtllm_ragged_attention_deepseek(
             assert bmm2_scale.dtype == torch.float32
 
         workspace_size = workspace_buffer.numel() * workspace_buffer.element_size()
+        sage_attn_sfs_q, sage_attn_sfs_k, sage_attn_sfs_p, sage_attn_sfs_v = (
+            sage_attn_sfs
+        )
+        num_elts_sage_q, num_elts_sage_k, num_elts_sage_p, num_elts_sage_v = (
+            num_elts_per_sage_attn_blk
+        )
         run_func(
             out,
             query,
@@ -3998,6 +4014,14 @@ def trtllm_ragged_attention_deepseek(
             attention_sinks,
             skip_softmax_threshold_scale_factor,
             lse,
+            sage_attn_sfs_q,
+            sage_attn_sfs_k,
+            sage_attn_sfs_p,
+            sage_attn_sfs_v,
+            num_elts_sage_q,
+            num_elts_sage_k,
+            num_elts_sage_p,
+            num_elts_sage_v,
         )
 
     if return_lse:

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -20,7 +20,6 @@
 
 #include <cfloat>
 #include <cstdint>
-#include <cstring>
 #include <cuda/std/cfloat>
 #include <iterator>
 #include <memory>
@@ -101,10 +100,17 @@ class TllmGenFmhaKernel {
 
   // Ctor.
   TllmGenFmhaKernel(KernelMeta const* pMetaStart, unsigned int nMetaCount, Data_type dtypeQ,
-                    Data_type dtypeKv, Data_type dtypeOut, unsigned int smArch)
+                    Data_type dtypeK, Data_type dtypeV, Data_type dtypeOut, unsigned int smArch,
+                    int numEltsPerSageAttnBlkQ = 0, int numEltsPerSageAttnBlkK = 0,
+                    int numEltsPerSageAttnBlkP = 0, int numEltsPerSageAttnBlkV = 0)
       : mDtypeQ(dtypeQ),
-        mDtypeKv(dtypeKv),
+        mDtypeK(dtypeK),
+        mDtypeV(dtypeV),
         mDtypeOut(dtypeOut),
+        mNumEltsPerSageAttnBlkQ(numEltsPerSageAttnBlkQ),
+        mNumEltsPerSageAttnBlkK(numEltsPerSageAttnBlkK),
+        mNumEltsPerSageAttnBlkP(numEltsPerSageAttnBlkP),
+        mNumEltsPerSageAttnBlkV(numEltsPerSageAttnBlkV),
         mKernelMeta(pMetaStart),
         mKernelMetaCount(nMetaCount),
         mSM(smArch) {}
@@ -113,15 +119,13 @@ class TllmGenFmhaKernel {
     for (unsigned int i = 0; i < mKernelMetaCount; ++i) {
       auto const& kernelMeta = mKernelMeta[i];
       IKL_LOG_DEBUG("Checking tllmgen attention kernel %s", kernelMeta.mFuncName);
-      // Skip SageAttention kernels: they share the same hashID as their non-sage
-      // counterparts (sage block sizes are not part of the hash), which causes
-      // false "hash conflict" failures. SageAttention is not exposed through the
-      // flashinfer interface, so dropping these entries is safe.
-      if (kernelMeta.mFuncName != nullptr && std::strstr(kernelMeta.mFuncName, "Sage") != nullptr) {
-        continue;
-      }
       if (isSMCompatible(mSM, kernelMeta.mSM) && kernelMeta.mDataTypeQ == mDtypeQ &&
-          kernelMeta.mDataTypeKv == mDtypeKv && kernelMeta.mDataTypeO == mDtypeOut) {
+          kernelMeta.mDataTypeK == mDtypeK && kernelMeta.mDataTypeV == mDtypeV &&
+          kernelMeta.mDataTypeO == mDtypeOut &&
+          kernelMeta.mNumEltsPerSageAttnBlkQ == mNumEltsPerSageAttnBlkQ &&
+          kernelMeta.mNumEltsPerSageAttnBlkK == mNumEltsPerSageAttnBlkK &&
+          kernelMeta.mNumEltsPerSageAttnBlkP == mNumEltsPerSageAttnBlkP &&
+          kernelMeta.mNumEltsPerSageAttnBlkV == mNumEltsPerSageAttnBlkV) {
         // Store metadata for later use.
         IKL_LOG_DEBUG("Adding tllmgen attention kernel %s", kernelMeta.mFuncName);
         // Check for hash conflicts.
@@ -241,14 +245,31 @@ class TllmGenFmhaKernel {
     auto kernelParams = KernelParams::setKernelParams(
         params, kernelMeta, ctaLaunchParams.mMaxNumCtasQ, ctaLaunchParams.mMaxNumCtasKv);
 
+    // Override SageAttention parameters.
+    auto sageParamEncode = [](int blockSize) -> int32_t {
+      FLASHINFER_CHECK((blockSize & (blockSize - 1)) == 0,
+                       "SageAttention block size must be a power of 2.");
+      return blockSize == 0 ? 0 : __builtin_ctz(static_cast<unsigned int>(blockSize));
+    };
+    kernelParams.ptrSageAttnSfsQ = params.ptrSageAttnSfsQ;
+    kernelParams.ptrSageAttnSfsK = params.ptrSageAttnSfsK;
+    kernelParams.ptrSageAttnSfsP = params.ptrSageAttnSfsP;
+    kernelParams.ptrSageAttnSfsV = params.ptrSageAttnSfsV;
+    kernelParams.mLogNumEltsPerSageAttnBlkQ = sageParamEncode(kernelMeta.mNumEltsPerSageAttnBlkQ);
+    kernelParams.mLogNumEltsPerSageAttnBlkK = sageParamEncode(kernelMeta.mNumEltsPerSageAttnBlkK);
+    kernelParams.mLogNumEltsPerSageAttnBlkP = sageParamEncode(kernelMeta.mNumEltsPerSageAttnBlkP);
+    kernelParams.mLogNumEltsPerSageAttnBlkV = sageParamEncode(kernelMeta.mNumEltsPerSageAttnBlkV);
+
     void* kernelParamsList[] = {&kernelParams};
     CUlaunchAttribute launch_attribute[3];
     CUlaunchConfig launch_config;
     buildLaunchConfig(launch_config, launch_attribute, kernelMeta, ctaLaunchParams, params);
 
     // Debug info.
-    IKL_LOG_DEBUG("TRTLLM-Gen launch info (in TllmGenFmhaKernel %s, %s, %s, %d): kernelName = %s",
-                  toStr(mDtypeQ), toStr(mDtypeKv), toStr(mDtypeOut), mSM, kernelMeta.mFuncName);
+    IKL_LOG_DEBUG(
+        "TRTLLM-Gen launch info (in TllmGenFmhaKernel %s, %s, %s, %s, %d): kernelName = %s",
+        toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut), mSM,
+        kernelMeta.mFuncName);
     IKL_LOG_DEBUG(
         "TRTLLM-Gen launch info: maxSeqLenQ = %d, "
         "maxSeqLenKv = %d, "
@@ -757,7 +778,7 @@ class TllmGenFmhaKernel {
     int& tileSizeQ = selectKernelParams.mTileSizeQ;
 
     // Mixed precision kernels don't work with groupsTokensHeadsQ = true for now.
-    if (mDtypeQ != mDtypeKv) {
+    if (mDtypeQ != mDtypeK || mDtypeQ != mDtypeV) {
       tileSizeQ = params.mNumHeadsQPerKv <= 8 ? 8 : 16;
       kernelType = FmhaKernelType::SwapsMmaAbForGeneration;
       return;
@@ -851,9 +872,9 @@ class TllmGenFmhaKernel {
         ", sparseMla=" + std::to_string(params.mSparseMla) +
         ", skipsSoftmax=" + std::to_string(selectKernelParams.mSkipsSoftmaxWhenPossible);
     IKL_LOG_DEBUG(
-        "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %d) %s",
-        getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeKv), toStr(mDtypeOut), mSM,
-        info.c_str());
+        "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
+        getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut),
+        mSM, info.c_str());
 
     return std::make_pair(
         hashID(static_cast<int>(params.mQkvLayout), static_cast<int>(selectKernelParams.mMaskType),
@@ -933,7 +954,9 @@ class TllmGenFmhaKernel {
     return std::make_pair(func, kernelMeta);
   }
 
-  Data_type mDtypeQ, mDtypeKv, mDtypeOut;
+  Data_type mDtypeQ, mDtypeK, mDtypeV, mDtypeOut;
+  int mNumEltsPerSageAttnBlkQ, mNumEltsPerSageAttnBlkK, mNumEltsPerSageAttnBlkP,
+      mNumEltsPerSageAttnBlkV;
   KernelMeta const* mKernelMeta;
   unsigned int mKernelMetaCount;
   unsigned int mSM;
@@ -956,20 +979,35 @@ class TllmFmhaKernelFactory {
   using KernelType = TllmGenFmhaKernel;
 
   KernelType const* getKernels(const typename KernelType::KernelMeta* pKernelList,
-                               unsigned int nbKernels, Data_type dtypeQ, Data_type dtypeKv,
-                               Data_type dtypeOut, unsigned int sm) {
+                               unsigned int nbKernels, Data_type dtypeQ, Data_type dtypeK,
+                               Data_type dtypeV, Data_type dtypeOut, unsigned int sm,
+                               int numEltsPerSageAttnBlkQ = 0, int numEltsPerSageAttnBlkK = 0,
+                               int numEltsPerSageAttnBlkP = 0, int numEltsPerSageAttnBlkV = 0) {
     static std::mutex s_mutex;
     std::lock_guard<std::mutex> lg(s_mutex);
 
-    auto const id = hashID(dtypeQ, dtypeKv, dtypeOut, sm);
+    auto const id = hashID(dtypeQ, dtypeK, dtypeV, dtypeOut, sm, numEltsPerSageAttnBlkQ,
+                           numEltsPerSageAttnBlkK, numEltsPerSageAttnBlkP, numEltsPerSageAttnBlkV);
     auto const findIter = mKernels.find(id);
     if (findIter == mKernels.end()) {
-      KernelType* newKernel = new KernelType{pKernelList, nbKernels, dtypeQ, dtypeKv, dtypeOut, sm};
+      KernelType* newKernel = new KernelType{pKernelList,
+                                             nbKernels,
+                                             dtypeQ,
+                                             dtypeK,
+                                             dtypeV,
+                                             dtypeOut,
+                                             sm,
+                                             numEltsPerSageAttnBlkQ,
+                                             numEltsPerSageAttnBlkK,
+                                             numEltsPerSageAttnBlkP,
+                                             numEltsPerSageAttnBlkV};
       newKernel->loadKernels();
       mKernels.insert(std::make_pair(id, std::unique_ptr<KernelType>(newKernel)));
       IKL_LOG_DEBUG(
-          "Loading new kernel for dtypeQ=%s, dtypeKv=%s, dtypeOut=%s, sm=%d with %d loaded kernels",
-          toStr(dtypeQ), toStr(dtypeKv), toStr(dtypeOut), sm, newKernel->getNumLoadedKernels());
+          "Loading new kernel for dtypeQ=%s, dtypeK=%s, dtypeV=%s, dtypeOut=%s, sm=%d with %d "
+          "loaded kernels",
+          toStr(dtypeQ), toStr(dtypeK), toStr(dtypeV), toStr(dtypeOut), sm,
+          newKernel->getNumLoadedKernels());
       return newKernel;
     }
     return findIter->second.get();
@@ -990,23 +1028,46 @@ class TllmFmhaKernelFactory {
  private:
   TllmFmhaKernelFactory() = default;
 
-  inline uint64_t hashID(Data_type dtypeQ, Data_type dtypeKv, Data_type dtypeOut,
-                         unsigned int sm) const {
+  inline uint64_t hashID(Data_type dtypeQ, Data_type dtypeK, Data_type dtypeV, Data_type dtypeOut,
+                         unsigned int sm, int numEltsPerSageAttnBlkQ, int numEltsPerSageAttnBlkK,
+                         int numEltsPerSageAttnBlkP, int numEltsPerSageAttnBlkV) const {
+    // Encode sage block sizes as log2(size)+1 (0 when unused) to fit in 4 bits each.
+    auto const sageEncode = [](int n) -> uint64_t {
+      return n > 0 ? static_cast<uint64_t>(log2f(static_cast<float>(n))) + 1 : 0;
+    };
+    // Bit layout:
+    // Bits  0-15: sm
+    // Bits 16-19: dtypeQ
+    // Bits 20-23: dtypeK
+    // Bits 24-27: dtypeV
+    // Bits 28-31: dtypeOut
+    // Bits 32-35: numEltsPerSageAttnBlkQ (log2+1 encoding)
+    // Bits 36-39: numEltsPerSageAttnBlkK
+    // Bits 40-43: numEltsPerSageAttnBlkP
+    // Bits 44-47: numEltsPerSageAttnBlkV
     return static_cast<uint64_t>(sm) | static_cast<uint64_t>(dtypeQ) << 16 |
-           static_cast<uint64_t>(dtypeKv) << 20 | static_cast<uint64_t>(dtypeOut) << 24;
+           static_cast<uint64_t>(dtypeK) << 20 | static_cast<uint64_t>(dtypeV) << 24 |
+           static_cast<uint64_t>(dtypeOut) << 28 | sageEncode(numEltsPerSageAttnBlkQ) << 32 |
+           sageEncode(numEltsPerSageAttnBlkK) << 36 | sageEncode(numEltsPerSageAttnBlkP) << 40 |
+           sageEncode(numEltsPerSageAttnBlkV) << 44;
   }
 
   std::unordered_map<uint64_t, const std::unique_ptr<KernelType>> mKernels;
 };
 
-inline TllmGenFmhaKernel const* getTllmFmhaKernels(Data_type dtypeQ, Data_type dtypeKv,
-                                                   Data_type dtypeOut, unsigned int sm) {
+inline TllmGenFmhaKernel const* getTllmFmhaKernels(Data_type dtypeQ, Data_type dtypeK,
+                                                   Data_type dtypeV, Data_type dtypeOut,
+                                                   unsigned int sm, int numEltsPerSageAttnBlkQ = 0,
+                                                   int numEltsPerSageAttnBlkK = 0,
+                                                   int numEltsPerSageAttnBlkP = 0,
+                                                   int numEltsPerSageAttnBlkV = 0) {
 #ifndef EXCLUDE_SM_100
   return TllmFmhaKernelFactory::Get().getKernels(
       tensorrt_llm::kernels::sTllmGenFmhaKernelMetaInfos,
       sizeof(tensorrt_llm::kernels::sTllmGenFmhaKernelMetaInfos) /
           sizeof(tensorrt_llm::kernels::sTllmGenFmhaKernelMetaInfos[0]),
-      dtypeQ, dtypeKv, dtypeOut, sm);
+      dtypeQ, dtypeK, dtypeV, dtypeOut, sm, numEltsPerSageAttnBlkQ, numEltsPerSageAttnBlkK,
+      numEltsPerSageAttnBlkP, numEltsPerSageAttnBlkV);
 #else
   return nullptr;
 #endif  // EXCLUDE_SM_100

--- a/include/flashinfer/trtllm/fmha/fmhaRunner.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaRunner.cuh
@@ -24,21 +24,38 @@
 
 class TllmGenFmhaRunner {
  public:
-  // Constructor.
-  explicit TllmGenFmhaRunner(Data_type dtypeQ, Data_type dtypeKv, Data_type dtypeOut)
-      : mSM(getSMVersion()), mDtypeQ(dtypeQ), mDtypeKv(dtypeKv), mDtypeOut(dtypeOut) {
+  // Constructor with separate K and V types (for DiT where Q/K and V may differ).
+  explicit TllmGenFmhaRunner(Data_type dtypeQ, Data_type dtypeK, Data_type dtypeV,
+                             Data_type dtypeOut, int numEltsPerSageAttnBlkQ = 0,
+                             int numEltsPerSageAttnBlkK = 0, int numEltsPerSageAttnBlkP = 0,
+                             int numEltsPerSageAttnBlkV = 0)
+      : mSM(getSMVersion()),
+        mDtypeQ(dtypeQ),
+        mDtypeK(dtypeK),
+        mDtypeV(dtypeV),
+        mDtypeOut(dtypeOut) {
     FLASHINFER_CHECK(mSM == kSM_100 || mSM == kSM_103, "Unsupported architecture");
-    FLASHINFER_CHECK(
-        mDtypeQ == DATA_TYPE_E4M3 || mDtypeQ == DATA_TYPE_FP16 || mDtypeQ == DATA_TYPE_BF16,
-        "Unsupported Q data type: " + std::string(toStr(mDtypeQ)));
-    FLASHINFER_CHECK(mDtypeKv == DATA_TYPE_E4M3 || mDtypeKv == DATA_TYPE_E2M1 ||
-                         mDtypeKv == DATA_TYPE_FP16 || mDtypeKv == DATA_TYPE_BF16,
-                     "Unsupported Kv data type: " + std::string(toStr(mDtypeKv)));
+    FLASHINFER_CHECK(mDtypeQ == DATA_TYPE_E4M3 || mDtypeQ == DATA_TYPE_FP16 ||
+                         mDtypeQ == DATA_TYPE_BF16 || mDtypeQ == DATA_TYPE_INT8,
+                     "Unsupported Q data type: " + std::string(toStr(mDtypeQ)));
+    FLASHINFER_CHECK(mDtypeK == DATA_TYPE_E4M3 || mDtypeK == DATA_TYPE_E2M1 ||
+                         mDtypeK == DATA_TYPE_FP16 || mDtypeK == DATA_TYPE_BF16 ||
+                         mDtypeK == DATA_TYPE_INT8,
+                     "Unsupported K data type: " + std::string(toStr(mDtypeK)));
+    FLASHINFER_CHECK(mDtypeV == DATA_TYPE_E4M3 || mDtypeV == DATA_TYPE_E2M1 ||
+                         mDtypeV == DATA_TYPE_FP16 || mDtypeV == DATA_TYPE_BF16,
+                     "Unsupported V data type: " + std::string(toStr(mDtypeV)));
     FLASHINFER_CHECK(mDtypeOut == DATA_TYPE_E4M3 || mDtypeOut == DATA_TYPE_FP16 ||
                          mDtypeOut == DATA_TYPE_BF16 || mDtypeOut == DATA_TYPE_E2M1,
                      "Unsupported Output data type: " + std::string(toStr(mDtypeOut)));
-    mKernel = getTllmFmhaKernels(mDtypeQ, mDtypeKv, mDtypeOut, mSM);
+    mKernel =
+        getTllmFmhaKernels(mDtypeQ, mDtypeK, mDtypeV, mDtypeOut, mSM, numEltsPerSageAttnBlkQ,
+                           numEltsPerSageAttnBlkK, numEltsPerSageAttnBlkP, numEltsPerSageAttnBlkV);
   }
+
+  // Convenience constructor for standard kernels where K and V have the same type.
+  explicit TllmGenFmhaRunner(Data_type dtypeQ, Data_type dtypeKv, Data_type dtypeOut)
+      : TllmGenFmhaRunner(dtypeQ, dtypeKv, dtypeKv, dtypeOut) {}
 
   TllmGenFmhaRunner() = default;
 
@@ -58,7 +75,7 @@ class TllmGenFmhaRunner {
 
  private:
   // The input/output datatype.
-  Data_type mDtypeQ, mDtypeKv, mDtypeOut;
+  Data_type mDtypeQ, mDtypeK, mDtypeV, mDtypeOut;
   // The SM version.
   int mSM;
   // The class that stores all the kernels.

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -225,6 +225,12 @@ struct TllmGenFmhaRunnerParams {
   // The LSE buffer.
   float* lsePtr;
 
+  // SageAttention scaling factors (null when SageAttention is not used).
+  float const* ptrSageAttnSfsQ;
+  float const* ptrSageAttnSfsK;
+  float const* ptrSageAttnSfsP;
+  float const* ptrSageAttnSfsV;
+
   // Attention sink
   float const* ptrAttentionSinks{nullptr};
   // The output buffer.

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -537,7 +537,7 @@ struct KernelParams {
     if (dtypeElt == DATA_TYPE_E2M1) {
       tmaDataFormat =
           unpack4b ? CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B : CU_TENSOR_MAP_DATA_TYPE_UINT8;
-    } else if (dtypeElt == DATA_TYPE_E4M3) {
+    } else if (dtypeElt == DATA_TYPE_E4M3 || dtypeElt == DATA_TYPE_INT8) {
       tmaDataFormat = CU_TENSOR_MAP_DATA_TYPE_UINT8;
     } else if (dtypeElt == DATA_TYPE_FP16) {
       tmaDataFormat = CU_TENSOR_MAP_DATA_TYPE_FLOAT16;
@@ -635,7 +635,7 @@ struct KernelParams {
     memset(&params, 0, sizeof(KernelParams));
 
     // Get the device pointers for TMA descriptors.
-    auto [qPtr, kPtr, vPtr] = getDevicePtrs(options, get_size_in_bits(kernelMeta.mDataTypeKv));
+    auto [qPtr, kPtr, vPtr] = getDevicePtrs(options, get_size_in_bits(kernelMeta.mDataTypeK));
 
     // The maximum headDim of K and V.
     // Note that contiguousKv or pagedKv will pad K and V to maxHeadDimKv.
@@ -666,14 +666,14 @@ struct KernelParams {
                                  ? std::min(options.mNumTokensPerPage, kernelMeta.mTileSizeKv)
                                  : kernelMeta.mTileSizeKv;
     // The number of elements in 128B for Q.
-    int32_t numEltsIn128BKv = (128 * 8) / get_size_in_bits(kernelMeta.mDataTypeKv);
+    int32_t numEltsIn128BKv = (128 * 8) / get_size_in_bits(kernelMeta.mDataTypeK);
     // The number of head elts (per token) in each block of shared memory (see above explanation).
 
     // HeadDim will be split into multiple headDimStages (128) if maxHeadDimKv > 128.
     int32_t numEltsInClampedHeadDimKv = std::min({numEltsIn128BKv, maxHeadDimKv, 128});
 
     // Do we have to transform K/V before MMA?
-    bool const transformsKv{kernelMeta.mDataTypeKv != kernelMeta.mDataTypeQ};
+    bool const transformsKv{kernelMeta.mDataTypeK != kernelMeta.mDataTypeQ};
     // Whether store transformed K/V in TMEM.
     bool const isSwapsMmaAb =
         isSwapsMmaAbForGenerationKernel(static_cast<FmhaKernelType>(kernelMeta.mKernelType));
@@ -692,19 +692,18 @@ struct KernelParams {
     int32_t const reshapeFactorKv{
         canReshapeTmaKv
             ? std::max(
-                  1,
-                  std::min(
-                      {128 / maxHeadDimKv,
-                       128 / (maxHeadDimKv *
-                              static_cast<int32_t>(get_size_in_bits(kernelMeta.mDataTypeKv)) / 8),
-                       numKeysPerTile}))
+                  1, std::min(
+                         {128 / maxHeadDimKv,
+                          128 / (maxHeadDimKv *
+                                 static_cast<int32_t>(get_size_in_bits(kernelMeta.mDataTypeK)) / 8),
+                          numKeysPerTile}))
             : 1};
     // Shape/stride for gmem tensor Kv.
     auto [shapeK, strideK] =
-        makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeKv,
+        makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeK,
                              /*isK*/ true, storeTransformedKvInTmem, reshapeFactorKv);
     auto [shapeV, strideV] =
-        makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeKv,
+        makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeV,
                              /*isK*/ false, storeTransformedKvInTmem, reshapeFactorKv);
     // Note that for FP4 KV input, elements are stored as uint8_t, each packs 2 FP4 elements.
     auto const numEltsDivisor =
@@ -722,13 +721,23 @@ struct KernelParams {
       strideK = std::vector<uint64_t>{1, static_cast<uint64_t>(options.mHeadDimQk)};
       tileShapeKv[1] = 1;
     }
+    // K and V might use different tileShapes.
+    std::vector<uint32_t> tileShapeK(tileShapeKv);
+    std::vector<uint32_t> tileShapeV(tileShapeKv);
+    if (!storeTransformedKvInTmem && kernelMeta.mDataTypeK != kernelMeta.mDataTypeV) {
+      // tileShapeKv is in dtypeK elements. When dtypeV != dtypeK, we need to express tileShapeV in
+      // terms of dtypeV elements so the V TMA descriptor transfers the same number of bytes as K to
+      // match barrier expectations.
+      tileShapeV[0] = tileShapeV[0] * get_size_in_bits(kernelMeta.mDataTypeK) /
+                      get_size_in_bits(kernelMeta.mDataTypeV);
+    }
 
     // Build tma descriptor for K.
     params.tmaK_ = buildNdTmaDescriptor(
-        options, kernelMeta.mDataTypeKv, shapeK, strideK, tileShapeKv, const_cast<void*>(kPtr),
+        options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK, const_cast<void*>(kPtr),
         /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
     params.tmaV_ = buildNdTmaDescriptor(
-        options, kernelMeta.mDataTypeKv, shapeV, strideV, tileShapeKv, const_cast<void*>(vPtr),
+        options, kernelMeta.mDataTypeV, shapeV, strideV, tileShapeV, const_cast<void*>(vPtr),
         /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
 
     // If the KV dtype is E2m1, additional scaling factors are needed for dequant.

--- a/tests/attention/test_trtllm_ragged_dit.py
+++ b/tests/attention/test_trtllm_ragged_dit.py
@@ -1,0 +1,409 @@
+"""
+Tests for DiT (Diffusion Transformer) oriented ragged attention kernels.
+
+Covers three variants:
+1. Q/K/V all FP8 E4M3 (standard case)
+2. Q/K in BF16, V in FP8 E4M3 (DiT: BMM1 in BF16, BMM2 in FP8)
+3. Q/K in INT8, V in FP8 E4M3, with SageAttention scaling factors
+
+All tests run on SM100/SM103 only (Blackwell).
+"""
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.utils import get_compute_capability
+
+
+GPU_DEVICE = "cuda:0"
+CC_MAJOR, CC_MINOR = get_compute_capability(torch.device(GPU_DEVICE))
+WORKSPACE_SIZE = 256 * 1024 * 1024
+
+
+def _get_workspace():
+    return torch.zeros(WORKSPACE_SIZE, dtype=torch.uint8, device=GPU_DEVICE)
+
+
+def _to_float8(x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn):
+    """Quantize float tensor to FP8 and return (quantized, inv_scale)."""
+    finfo = torch.finfo(dtype)
+    amax = x.abs().amax().clamp(min=1e-12)
+    scale = finfo.max / amax * 0.1
+    x_sat = (x * scale).clamp(min=finfo.min, max=finfo.max)
+    return x_sat.to(dtype), scale.float().reciprocal()
+
+
+def _to_int8_blocked(x: torch.Tensor, block_size: int):
+    """
+    Quantize float tensor to INT8 with per-block scaling.
+
+    x: [tokens, heads, head_dim]
+    block_size: number of elements per block along tokens
+
+    Returns:
+        x_q: INT8 tensor same shape as x
+        sfs: float32 per-block scales [heads * (tokens // block_size)]
+              (inverse scales / dequant scales)
+    """
+    tokens, heads, head_dim = x.shape
+    assert tokens % block_size == 0
+    num_blocks = tokens // block_size
+    x_blocks = x.reshape(num_blocks, block_size, heads, head_dim)
+    amax = (
+        x_blocks.abs()
+        .amax(dim=-1, keepdim=True)
+        .amax(dim=1, keepdim=True)
+        .clamp(min=1e-12)
+    )
+    scale = 127.0 / amax  # per-block quantization scale
+    x_sat = (x_blocks * scale).round().clamp(-128, 127)
+    x_q = x_sat.reshape(tokens, heads, head_dim).to(torch.int8)
+    # inv_scale (dequant scale): 1/scale = amax / 127
+    inv_scale = (amax / 127.0).reshape(num_blocks, heads).T.flatten().contiguous()
+    return x_q, inv_scale
+
+
+def _ragged_reference_bf16(
+    q: torch.Tensor,  # [total_q, heads, head_dim_qk] in float32
+    k: torch.Tensor,  # [total_kv, heads, head_dim_qk] in float32
+    v: torch.Tensor,  # [total_kv, heads, head_dim_vo] in float32
+    q_lens: torch.Tensor,  # [batch]
+    kv_lens: torch.Tensor,  # [batch]
+    scale: float,
+    causal: bool,
+):
+    """
+    Compute ragged (variable-length) attention in float32 for reference.
+    Returns output [total_q, heads, head_dim_vo].
+    """
+    batch = q_lens.shape[0]
+    q_cpu = q.float().cpu()
+    k_cpu = k.float().cpu()
+    v_cpu = v.float().cpu()
+    q_lens_cpu = q_lens.cpu().tolist()
+    kv_lens_cpu = kv_lens.cpu().tolist()
+
+    out_chunks = []
+    q_offset = 0
+    kv_offset = 0
+    for b in range(batch):
+        sq = int(q_lens_cpu[b])
+        skv = int(kv_lens_cpu[b])
+        q_b = q_cpu[q_offset : q_offset + sq]  # [sq, H, Dqk]
+        k_b = k_cpu[kv_offset : kv_offset + skv]  # [skv, H, Dqk]
+        v_b = v_cpu[kv_offset : kv_offset + skv]  # [skv, H, Dvo]
+
+        # [H, sq, Dqk] @ [H, Dqk, skv] -> [H, sq, skv]
+        attn = (q_b.permute(1, 0, 2) @ k_b.permute(1, 2, 0)) * scale
+
+        if causal:
+            mask = torch.ones(sq, skv, dtype=torch.bool)
+            mask = torch.tril(mask, diagonal=skv - sq)
+            attn.masked_fill_(~mask.unsqueeze(0), float("-inf"))
+
+        attn = torch.softmax(attn, dim=-1)
+        # [H, sq, skv] @ [H, skv, Dvo] -> [H, sq, Dvo]
+        out_b = attn @ v_b.permute(1, 0, 2)
+        out_chunks.append(out_b.permute(1, 0, 2))  # [sq, H, Dvo]
+
+        q_offset += sq
+        kv_offset += skv
+
+    return torch.cat(out_chunks, dim=0).to(GPU_DEVICE)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Q/K/V all FP8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    CC_MAJOR != 10, reason="DiT attention tests require SM100/SM103 (Blackwell)."
+)
+@pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("s_qo,s_kv", [(512, 512), (256, 512)])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("head_dim", [128])
+def test_trtllm_ragged_dit_qkv_fp8(
+    causal: bool,
+    batch_size: int,
+    s_qo: int,
+    s_kv: int,
+    num_heads: int,
+    head_dim: int,
+):
+    torch.manual_seed(42)
+    device = GPU_DEVICE
+
+    q_lens = torch.full((batch_size,), s_qo, dtype=torch.int32, device=device)
+    kv_lens = torch.full((batch_size,), s_kv, dtype=torch.int32, device=device)
+    total_q = int(q_lens.sum())
+    total_kv = int(kv_lens.sum())
+
+    q_f = torch.randn(total_q, num_heads, head_dim, device=device)
+    k_f = torch.randn(total_kv, num_heads, head_dim, device=device)
+    v_f = torch.randn(total_kv, num_heads, head_dim, device=device)
+
+    q_fp8, q_inv_scale = _to_float8(q_f)
+    k_fp8, k_inv_scale = _to_float8(k_f)
+    v_fp8, v_inv_scale = _to_float8(v_f)
+
+    scale = 1.0 / math.sqrt(head_dim)
+    bmm1_scale = scale * q_inv_scale * k_inv_scale
+    bmm2_scale = v_inv_scale
+
+    qo_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
+    )
+    kv_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
+    )
+
+    workspace = _get_workspace()
+
+    out_trtllm, lse = flashinfer.prefill.trtllm_ragged_attention_deepseek(
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        workspace,
+        kv_lens,
+        s_qo,
+        s_kv,
+        float(bmm1_scale),
+        float(bmm2_scale),
+        -1,
+        batch_size,
+        -1,
+        qo_indptr,
+        kv_indptr,
+        False,
+        causal,
+        True,
+    )
+
+    assert out_trtllm.shape == (total_q, num_heads, head_dim)
+    assert out_trtllm.dtype == torch.bfloat16
+
+    # Reference
+    out_ref = _ragged_reference_bf16(
+        q_f,
+        k_f,
+        v_f,
+        q_lens,
+        kv_lens,
+        scale,
+        causal,
+    )
+    torch.testing.assert_close(
+        out_trtllm.float(),
+        out_ref.float(),
+        atol=0.05,
+        rtol=0.05,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Q/K in BF16, V in FP8 E4M3 (DiT mixed-dtype)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    CC_MAJOR != 10, reason="DiT attention tests require SM100/SM103 (Blackwell)."
+)
+@pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("s_qo,s_kv", [(512, 512), (256, 512)])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("head_dim", [128])
+def test_trtllm_ragged_dit_qk_bf16_v_fp8(
+    causal: bool,
+    batch_size: int,
+    s_qo: int,
+    s_kv: int,
+    num_heads: int,
+    head_dim: int,
+):
+    torch.manual_seed(42)
+    device = GPU_DEVICE
+
+    q_lens = torch.full((batch_size,), s_qo, dtype=torch.int32, device=device)
+    kv_lens = torch.full((batch_size,), s_kv, dtype=torch.int32, device=device)
+    total_q = int(q_lens.sum())
+    total_kv = int(kv_lens.sum())
+
+    q_bf16 = torch.randn(
+        total_q, num_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    k_bf16 = torch.randn(
+        total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    v_f = torch.randn(total_kv, num_heads, head_dim, device=device)
+    v_fp8, v_inv_scale = _to_float8(v_f)
+
+    scale = 1.0 / math.sqrt(head_dim)
+    bmm1_scale = scale  # Q/K are BF16 (no quantization scale)
+    bmm2_scale = v_inv_scale
+
+    qo_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
+    )
+    kv_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
+    )
+
+    workspace = _get_workspace()
+
+    out_trtllm, lse = flashinfer.prefill.trtllm_ragged_attention_deepseek(
+        q_bf16,
+        k_bf16,
+        v_fp8,
+        workspace,
+        kv_lens,
+        s_qo,
+        s_kv,
+        float(bmm1_scale),
+        float(bmm2_scale),
+        -1,
+        batch_size,
+        -1,
+        qo_indptr,
+        kv_indptr,
+        False,
+        causal,
+        True,
+    )
+
+    assert out_trtllm.shape == (total_q, num_heads, head_dim)
+    assert out_trtllm.dtype == torch.bfloat16
+
+    # Reference
+    out_ref = _ragged_reference_bf16(
+        q_bf16,
+        k_bf16,
+        v_f,
+        q_lens,
+        kv_lens,
+        scale,
+        causal,
+    )
+    torch.testing.assert_close(
+        out_trtllm.float(),
+        out_ref.float(),
+        atol=0.05,
+        rtol=0.05,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Q/K in INT8, V in FP8 E4M3, with SageAttention block scaling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    (CC_MAJOR, CC_MINOR) != (10, 0),
+    reason="DiT attention tests with int8 input require SM100.",
+)
+@pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("s_qo,s_kv", [(256, 256), (512, 2048)])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("sage_blk_q", [1])
+@pytest.mark.parametrize("sage_blk_k", [4, 16])
+def test_trtllm_ragged_dit_sage_qk_int8_v_fp8(
+    causal: bool,
+    batch_size: int,
+    s_qo: int,
+    s_kv: int,
+    num_heads: int,
+    head_dim: int,
+    sage_blk_q: int,
+    sage_blk_k: int,
+):
+    torch.manual_seed(42)
+    device = GPU_DEVICE
+
+    q_lens = torch.full((batch_size,), s_qo, dtype=torch.int32, device=device)
+    kv_lens = torch.full((batch_size,), s_kv, dtype=torch.int32, device=device)
+    total_q = int(q_lens.sum())
+    total_kv = int(kv_lens.sum())
+
+    q_f = torch.randn(total_q, num_heads, head_dim, device=device)
+    k_f = torch.randn(total_kv, num_heads, head_dim, device=device)
+    v_f = torch.randn(total_kv, num_heads, head_dim, device=device)
+
+    # Per-block INT8 quantization for Q and K
+    q_int8, q_sfs = _to_int8_blocked(q_f.cpu(), sage_blk_q)
+    k_int8, k_sfs = _to_int8_blocked(k_f.cpu(), sage_blk_k)
+    q_int8 = q_int8.to(device)
+    k_int8 = k_int8.to(device)
+    q_sfs = q_sfs.to(device)
+    k_sfs = k_sfs.to(device)
+
+    sage_blk_v = 1
+    v_fp8, v_inv_scale = _to_float8(v_f)
+    v_sfs = torch.ones((num_heads * head_dim), device=device)
+
+    # For SageAttention, bmm1_scale encodes 1/sqrt(head_dim) only;
+    # per-block Q/K dequant is handled via sage_attn_sfs_q/k
+    scale = 1.0 / math.sqrt(head_dim)
+    # INT8 range is [-127,127] so per-block inv_scale is amax/127;
+    # the effective per-block scale that the kernel uses is
+    # sfs_q[i] * sfs_k[j] * (1/sqrt(head_dim)), but bmm1_scale here is 1.0
+    # because the kernel multiplies by sfs_q * sfs_k internally.
+    bmm1_scale = 1.0 / math.sqrt(head_dim)
+    bmm2_scale = float(v_inv_scale)
+
+    qo_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
+    )
+    kv_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
+    )
+
+    workspace = _get_workspace()
+
+    out_trtllm, lse = flashinfer.prefill.trtllm_ragged_attention_deepseek(
+        q_int8,
+        k_int8,
+        v_fp8,
+        workspace,
+        kv_lens,
+        s_qo,
+        s_kv,
+        bmm1_scale,
+        bmm2_scale,
+        -1,
+        batch_size,
+        -1,
+        qo_indptr,
+        kv_indptr,
+        False,
+        causal,
+        True,
+        sage_attn_sfs=(q_sfs, k_sfs, None, v_sfs),
+        num_elts_per_sage_attn_blk=(sage_blk_q, sage_blk_k, 0, sage_blk_v),
+    )
+
+    assert out_trtllm.shape == (total_q, num_heads, head_dim)
+    assert out_trtllm.dtype == torch.bfloat16
+
+    out_ref = _ragged_reference_bf16(
+        q_f,
+        k_f,
+        v_f,
+        q_lens,
+        kv_lens,
+        scale,
+        causal,
+    )
+    torch.testing.assert_close(
+        out_trtllm.float(),
+        out_ref.float(),
+        atol=0.1,
+        rtol=0.1,
+    )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR adds support for DiT-oriented TRTLLM kernels with 3 variants:
- Qk in BFloat16 → Bmm1 in BFloat16
  + V in E4m3 → Bmm2 in E4m3
- Qk in Int8 with SageAttention scaling factors →  Bmm1 in Int8
  + V in E4m3 → Bmm2 in E4m3
- Qk in E4m3 with SageAttention scaling factors →  Bmm1 in E4m3
  + V in E4m3 → Bmm2 in E4m3

To integrate, the following changes are made to FlashInfer:
- Our artifactory will produce ~~a separate `kernelMetaInfoVx.h` file~~ refreshed `kernelMetaInfo.h` file with separated `dtypeK` and `dtypeV` traits.
- This PR patches `FmhaKernels` to support the new DiT kernels. `trtllm_ragged_attention_launcher` is updated as the entry point to these kernels.
  + ~~A compatibility layer was added as `fmhaKernelMetaAdapter.h`~~ API unification has taken place. This PR was refreshed with compatibility layers removed.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional SageAttention support (scaling-factor tensors + per-block counts) for ragged ~~& paged~~ attention; query/key reinterpretation for mixed dtypes and INT8 input handling; expanded kernel parameterization for improved FMHA paths.

* **Tests**
  * Added end-to-end ragged attention tests covering SageAttention and mixed-dtype scenarios.

* **Documentation**
  * Published ragged attention entry in the public API reference.

* **Chores**
  * Updated runtime artifact path and checksum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->