### PR TITLE
fix(jit): GEMM kernels produce NaN under concurrency — missing GDC flags cause PDL synchronization barriers to compile as no-ops

### DIFF
--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -91,6 +91,8 @@ def gen_gemm_sm100_module_cutlass_fp4() -> JitSpec:
         + [
             "-DENABLE_BF16",
             "-DENABLE_FP4",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
         ],
         extra_cflags=[
             "-DFAST_BUILD",
@@ -158,6 +160,8 @@ def gen_gemm_sm103_module_cutlass_fp4() -> JitSpec:
         + [
             "-DENABLE_BF16",
             "-DENABLE_FP4",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
         ],
         extra_cflags=[
             "-DFAST_BUILD",
@@ -206,6 +210,8 @@ def gen_gemm_sm120_module_cutlass_fp4() -> JitSpec:
         + [
             "-DENABLE_BF16",
             "-DENABLE_FP4",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
         ],
         extra_cflags=[
             "-DFAST_BUILD",
@@ -256,6 +262,8 @@ def gen_gemm_sm100_module_cutlass_fp8() -> JitSpec:
         extra_cuda_cflags=nvcc_flags
         + [
             "-DENABLE_BF16",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
         ],
         extra_cflags=[
             "-DFAST_BUILD",
@@ -349,6 +357,8 @@ def gen_gemm_sm100_module_cutlass_mxfp8() -> JitSpec:
         extra_cuda_cflags=nvcc_flags
         + [
             "-DENABLE_BF16",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
         ],
         extra_cflags=[
             "-DFAST_BUILD",
@@ -516,7 +526,11 @@ def gen_gemm_sm120_module() -> JitSpec:
     return gen_jit_spec(
         "gemm_sm120",
         source_paths,
-        extra_cuda_cflags=nvcc_flags,
+        extra_cuda_cflags=nvcc_flags
+        + [
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
+        ],
     )
 
 


### PR DESCRIPTION
## Summary

All CUTLASS GEMM templates use `enablePDL=true` (Programmatic Dependent Launch), but the JIT compilation is missing `-DCUTLASS_ENABLE_GDC_FOR_SM100=1` and `-DCUTLASS_ENABLE_GDC_FOR_SM90=1` compile flags. Without these flags, `wait_on_dependent_grids()` and `launch_dependent_grids()` in CUTLASS `grid_dependency_control.h` compile as **empty no-ops**, eliminating the synchronization barriers needed for safe PDL execution.

## Root Cause

In `cutlass/include/cutlass/arch/grid_dependency_control.h`:

```cpp
CUTLASS_DEVICE void wait_on_dependent_grids() {
#if (defined(CUTLASS_GDC_ENABLED))  // only defined when CUTLASS_ENABLE_GDC_FOR_SM100 is set
  asm volatile("griddepcontrol.wait;");
#endif
}
```

The `CUTLASS_GDC_ENABLED` macro is only defined when `CUTLASS_ENABLE_GDC_FOR_SM100` is passed as a compile flag. Without it, PDL launches kernels with overlap enabled at the host level (`cudaLaunchAttributeProgrammaticStreamSerialization`), but the device-side synchronization barriers are compiled out — creating a race condition.

## Symptoms

On SM120 (Blackwell RTX PRO 6000 / RTX 5090) with high concurrency (64+ simultaneous requests in SGLang with TP=8):
- CUTLASS FP4 GEMM intermittently fails to write output tiles
- Unwritten tiles contain uninitialized memory (NaN/garbage)
- NaN blocks are always contiguous and 128-aligned, matching CTA tile boundaries
- `CUDA_LAUNCH_BLOCKING=1` eliminates the bug (confirms race condition)
- cudnn backend is unaffected (does not use CUTLASS PDL)
- Retry with identical inputs produces correct output

## Fix

Add `-DCUTLASS_ENABLE_GDC_FOR_SM100=1` and `-DCUTLASS_ENABLE_GDC_FOR_SM90=1` to all affected GEMM JIT modules:
- `fp4_gemm_cutlass` (SM100)
- `fp4_gemm_cutlass_sm103` (SM103)
- `fp4_gemm_cutlass_sm120` (SM120)
- `fp8_gemm_cutlass` (SM100)
- `mxfp8_gemm_cutlass` (SM100)
- `gemm_sm120` (SM120 FP8 groupwise)

The `tgv_gemm` module already had `DCUTLASS_ENABLE_GDC_FOR_SM100`.

Note: `DCUTLASS_ENABLE_GDC_FOR_SM90` is needed because the SM120 CUTLASS kernel (`sm120_gemm_tma_warpspecialized_cooperative_asymmetric_dma.hpp`) guards `launch_dependent_grids()` with `#ifdef CUTLASS_ENABLE_GDC_FOR_SM90` instead of `SM100` (upstream CUTLASS bug).

## Verification

| Configuration | Result |
|---|---|
| PDL=true, no GDC flags (current) | **NaN crash** under high concurrency |
| PDL=false (workaround) | OK |
| PDL=true + GDC flags (this PR) | **OK** — tested with 64 concurrent requests, multiple SGLang restarts from JIT cache |
| `CUDA_LAUNCH_BLOCKING=1` | OK (confirms race condition) |

## Environment

- Hardware: 8x NVIDIA RTX PRO 6000 Blackwell (SM120, 96GB)
- FlashInfer 0.6.4, CUTLASS 4.4.1
- SGLang with TP=8, EAGLE-v2, GLM-5-NVFP4-MTP model
- PyTorch 2.12.0.dev, CUDA 12.8+

## Related

- #2708
- https://github.com/sgl-project/sglang/issues/20043
- https://github.com/sgl-project/sglang/pull/20047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated CUDA compilation configuration for SM100 and SM90 GPU architectures, enhancing build optimization and extending hardware compatibility for GPU acceleration workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->