### PR TITLE
improve CUTLASS FP8 SM120 groupwise GEMM with ping pong

### DIFF
--- a/csrc/gemm_groupwise_sm120.cu
+++ b/csrc/gemm_groupwise_sm120.cu
@@ -31,8 +31,7 @@ using namespace flashinfer;
                                    SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, \
                                    ...)                                                           \
   [&]() -> bool {                                                                                 \
-    /* SM120/SM121 Cooperative schedule uses 128x128x128 tile shape */                            \
-    /* TODO (yongwww): PingPong schedule (64x128x128) will need additional dispatch logic */      \
+    /* SM120/SM121 uses K=128 for both Cooperative (128x128x128) and PingPong (64x128x128). */    \
     constexpr int SCALE_GRANULARITY_K = 128;                                                      \
     if (scale_granularity_k != 128) {                                                             \
       TVM_FFI_ICHECK(false)                                                                       \

--- a/csrc/gemm_groupwise_sm120.cu
+++ b/csrc/gemm_groupwise_sm120.cu
@@ -31,7 +31,6 @@ using namespace flashinfer;
                                    SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, \
                                    ...)                                                           \
   [&]() -> bool {                                                                                 \
-    /* SM120/SM121 uses K=128 for both Cooperative (128x128x128) and PingPong (64x128x128). */    \
     constexpr int SCALE_GRANULARITY_K = 128;                                                      \
     if (scale_granularity_k != 128) {                                                             \
       TVM_FFI_ICHECK(false)                                                                       \
@@ -40,7 +39,6 @@ using namespace flashinfer;
              "equal tile shape K dimension (128 for both Cooperative and PingPong schedules).";   \
       return false;                                                                               \
     }                                                                                             \
-    /* Support (1,128,128) and (128,128,128) as per SM100's approach */                           \
     if (scale_granularity_m == 1 && scale_granularity_n == 128) {                                 \
       constexpr int SCALE_GRANULARITY_M = 1;                                                      \
       constexpr int SCALE_GRANULARITY_N = 128;                                                    \

--- a/include/flashinfer/gemm/gemm_groupwise_sm120.cuh
+++ b/include/flashinfer/gemm/gemm_groupwise_sm120.cuh
@@ -29,13 +29,90 @@
 #include "cutlass/epilogue/collective/collective_builder.hpp"
 #include "cutlass/gemm/collective/collective_builder.hpp"
 #include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
 #include "cutlass/gemm/kernel/gemm_universal.hpp"
 #include "cutlass/util/packed_stride.hpp"
 
 namespace flashinfer {
 namespace gemm {
 
-// SM120 uses Cooperative schedule with 128x128x128 tile shape
+template <typename Gemm, typename ScaleConfig, typename DTypeIn, typename DTypeOut>
+cudaError_t RunSm120GroupwiseGemm(void* float_buffer, size_t float_buffer_size_in_bytes,
+                                  DTypeIn* A_ptr, DTypeIn* B_ptr, float* SFA_ptr, float* SFB_ptr,
+                                  DTypeOut* D_ptr, int m, int n, int k, int l,
+                                  cudaStream_t stream) {
+  using namespace cute;
+
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+
+  auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, l));
+  auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, l));
+  auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, l));
+  auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(m, n, l));
+
+  auto layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(m, n, k, l));
+  auto layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(m, n, k, l));
+
+  // For beta=0 case, C and D can be the same buffer.
+  DTypeOut* C_ptr = D_ptr;
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {m, n, k, l},
+      {A_ptr, stride_A, B_ptr, stride_B, SFA_ptr, layout_SFA, SFB_ptr, layout_SFB},
+      {{}, C_ptr, stride_C, D_ptr, stride_D}};
+
+  arguments.epilogue.thread.alpha = 1.0f;
+  arguments.epilogue.thread.beta = 0.0f;
+
+  Gemm gemm;
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  if (workspace_size > float_buffer_size_in_bytes) {
+    return cudaErrorInsufficientDriver;
+  }
+
+  void* kernel_workspace = nullptr;
+  if (workspace_size > 0) {
+    kernel_workspace = float_buffer;
+  }
+
+  cutlass::Status status = gemm.initialize(arguments, kernel_workspace);
+  if (status != cutlass::Status::kSuccess) {
+    return cudaErrorNotSupported;
+  }
+
+  status = gemm.run(stream);
+  if (status != cutlass::Status::kSuccess) {
+    return cudaErrorUnknown;
+  }
+
+  return cudaSuccess;
+}
+
+template <typename PingpongGemm, typename CooperativeGemm, typename ScaleConfig, typename DTypeIn,
+          typename DTypeOut>
+cudaError_t TrySm120PingpongThenCooperative(void* float_buffer, size_t float_buffer_size_in_bytes,
+                                            DTypeIn* A_ptr, DTypeIn* B_ptr, float* SFA_ptr,
+                                            float* SFB_ptr, DTypeOut* D_ptr, int m, int n, int k,
+                                            int l, cudaStream_t stream) {
+  // Try pingpong first; fallback to cooperative when pingpong is unsupported for this problem.
+  auto status = RunSm120GroupwiseGemm<PingpongGemm, ScaleConfig>(
+      float_buffer, float_buffer_size_in_bytes, A_ptr, B_ptr, SFA_ptr, SFB_ptr, D_ptr, m, n, k, l,
+      stream);
+  if (status == cudaErrorNotSupported || status == cudaErrorInsufficientDriver) {
+    return RunSm120GroupwiseGemm<CooperativeGemm, ScaleConfig>(
+        float_buffer, float_buffer_size_in_bytes, A_ptr, B_ptr, SFA_ptr, SFB_ptr, D_ptr, m, n, k, l,
+        stream);
+  }
+
+  return status;
+}
+
+// SM120 supports cooperative (128x128x128) and pingpong (64x128x128) schedules.
 template <int ScaleGranularityM, int ScaleGranularityN, int ScaleGranularityK, bool ScaleMajorK,
           typename DTypeIn, typename DTypeOut>
 cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buffer_size_in_bytes,
@@ -69,12 +146,13 @@ cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buf
   using ElementAccumulator = float;
   using ElementCompute = float;
 
-  // SM120 uses fixed 128x128x128 tile shape (Cooperative schedule)
-  // TODO (yongwww): add PingPong schedule (64x128x128)
-  using MmaTileShape_MNK = Shape<_128, _128, _128>;
+  using CooperativeMmaTileShape_MNK = Shape<_128, _128, _128>;
+  using PingpongMmaTileShape_MNK = Shape<_64, _128, _128>;
   using ClusterShape_MNK = Shape<_1, _1, _1>;
 
-  // SM120's Sm120BlockwiseScaleConfig takes UMMA::Major parameters based on ScaleMajorK
+  // Pingpong tile M=64 requires ScaleGranularityM to divide 64.
+  constexpr bool kCanUsePingpong = (64 % ScaleGranularityM == 0);
+
   using ScaleConfig = std::conditional_t<
       ScaleMajorK,
       cutlass::detail::Sm120BlockwiseScaleConfig<ScaleGranularityM, ScaleGranularityN,
@@ -83,95 +161,64 @@ cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buf
                                                  ScaleGranularityK, UMMA::Major::MN,
                                                  UMMA::Major::MN>>;
 
-  // Use decltype like SM100 does for consistency
   using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
   using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
 
-  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
-      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, MmaTileShape_MNK, ClusterShape_MNK,
-      cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator, ElementCompute, ElementC,
-      LayoutC, AlignmentC, ElementD, LayoutD, AlignmentD,
+  using CooperativeCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, CooperativeMmaTileShape_MNK,
+      ClusterShape_MNK, cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator,
+      ElementCompute, ElementC, LayoutC, AlignmentC, ElementD, LayoutD, AlignmentD,
       cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
 
-  // SM120 uses automatic stage count with epilogue carveout
-  using StageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-      sizeof(typename CollectiveEpilogue::SharedStorage))>;
+  using CooperativeStageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+      sizeof(typename CooperativeCollectiveEpilogue::SharedStorage))>;
 
-  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+  using CooperativeCollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
       cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, ElementA,
       cute::tuple<LayoutA, LayoutSFA>, AlignmentA, ElementB, cute::tuple<LayoutB, LayoutSFB>,
-      AlignmentB, ElementAccumulator, MmaTileShape_MNK, ClusterShape_MNK, StageCount,
-      cutlass::gemm::KernelScheduleSm120Blockwise>::CollectiveOp;
+      AlignmentB, ElementAccumulator, CooperativeMmaTileShape_MNK, ClusterShape_MNK,
+      CooperativeStageCount, cutlass::gemm::KernelScheduleSm120Blockwise>::CollectiveOp;
 
-  using GemmKernel =
-      cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CollectiveMainloop,
-                                           CollectiveEpilogue, void>;
+  using CooperativeGemmKernel =
+      cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CooperativeCollectiveMainloop,
+                                           CooperativeCollectiveEpilogue, void>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using CooperativeGemm = cutlass::gemm::device::GemmUniversalAdapter<CooperativeGemmKernel>;
 
-  using StrideA = typename Gemm::GemmKernel::StrideA;
-  using StrideB = typename Gemm::GemmKernel::StrideB;
-  using StrideC = typename Gemm::GemmKernel::StrideC;
-  using StrideD = typename Gemm::GemmKernel::StrideD;
+  // Guard pingpong type instantiation behind if constexpr so the CUTLASS builder's
+  // static_assert (tile_M % ScaleGranularityM == 0) is never triggered for
+  // ScaleGranularityM=128 with tile_M=64.
+  if constexpr (kCanUsePingpong) {
+    using PingpongCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, PingpongMmaTileShape_MNK,
+        ClusterShape_MNK, cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator,
+        ElementCompute, ElementC, LayoutC, AlignmentC, ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
 
-  auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, l));
-  auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, l));
-  auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, l));
-  auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(m, n, l));
+    using PingpongStageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+        sizeof(typename PingpongCollectiveEpilogue::SharedStorage))>;
 
-  auto layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(m, n, k, l));
-  auto layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(m, n, k, l));
+    using PingpongCollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, ElementA,
+        cute::tuple<LayoutA, LayoutSFA>, AlignmentA, ElementB, cute::tuple<LayoutB, LayoutSFB>,
+        AlignmentB, ElementAccumulator, PingpongMmaTileShape_MNK, ClusterShape_MNK,
+        PingpongStageCount,
+        cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120>::CollectiveOp;
 
-  // For beta=0 case, C and D can be the same buffer
-  DTypeOut* C_ptr = D_ptr;  // Use D as both input and output when beta=0
+    using PingpongGemmKernel =
+        cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, PingpongCollectiveMainloop,
+                                             PingpongCollectiveEpilogue, void>;
 
-  typename Gemm::Arguments arguments{
-      cutlass::gemm::GemmUniversalMode::kGemm,
-      {m, n, k, l},
-      {A_ptr, stride_A, B_ptr, stride_B, SFA_ptr, layout_SFA, SFB_ptr, layout_SFB},
-      {{}, C_ptr, stride_C, D_ptr, stride_D}};  // C and D point to same buffer when beta=0
+    using PingpongGemm = cutlass::gemm::device::GemmUniversalAdapter<PingpongGemmKernel>;
 
-  // Set alpha and beta for the epilogue
-  arguments.epilogue.thread.alpha = 1.0f;
-  arguments.epilogue.thread.beta = 0.0f;
-
-  // Check device compute capability first
-  int device_id = 0;
-  cudaGetDevice(&device_id);
-  cudaDeviceProp props;
-  cudaGetDeviceProperties(&props, device_id);
-
-  Gemm gemm;
-
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    return cudaErrorNotSupported;
+    return TrySm120PingpongThenCooperative<PingpongGemm, CooperativeGemm, ScaleConfig>(
+        float_buffer, float_buffer_size_in_bytes, A_ptr, B_ptr, SFA_ptr, SFB_ptr, D_ptr, m, n, k, l,
+        stream);
+  } else {
+    return RunSm120GroupwiseGemm<CooperativeGemm, ScaleConfig>(
+        float_buffer, float_buffer_size_in_bytes, A_ptr, B_ptr, SFA_ptr, SFB_ptr, D_ptr, m, n, k, l,
+        stream);
   }
-
-  size_t workspace_size = Gemm::get_workspace_size(arguments);
-
-  if (workspace_size > float_buffer_size_in_bytes) {
-    return cudaErrorInsufficientDriver;
-  }
-
-  // Pass workspace pointer only if needed
-  void* kernel_workspace = nullptr;
-  if (workspace_size > 0) {  // Only provide a pointer if workspace is actually needed
-    kernel_workspace = float_buffer;
-  }
-
-  status = gemm.initialize(arguments, kernel_workspace);
-  if (status != cutlass::Status::kSuccess) {
-    // Don't continue if initialization failed
-    return cudaErrorNotSupported;
-  }
-
-  status = gemm.run(stream);
-  if (status != cutlass::Status::kSuccess) {
-    return cudaErrorUnknown;
-  }
-
-  return cudaSuccess;
 #else
   return cudaErrorNotSupported;
 #endif

--- a/include/flashinfer/gemm/gemm_groupwise_sm120.cuh
+++ b/include/flashinfer/gemm/gemm_groupwise_sm120.cuh
@@ -56,7 +56,6 @@ cudaError_t RunSm120GroupwiseGemm(void* float_buffer, size_t float_buffer_size_i
   auto layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(m, n, k, l));
   auto layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(m, n, k, l));
 
-  // For beta=0 case, C and D can be the same buffer.
   DTypeOut* C_ptr = D_ptr;
 
   typename Gemm::Arguments arguments{
@@ -99,7 +98,6 @@ cudaError_t TrySm120PingpongThenCooperative(void* float_buffer, size_t float_buf
                                             DTypeIn* A_ptr, DTypeIn* B_ptr, float* SFA_ptr,
                                             float* SFB_ptr, DTypeOut* D_ptr, int m, int n, int k,
                                             int l, cudaStream_t stream) {
-  // Try pingpong first; fallback to cooperative when pingpong is unsupported for this problem.
   auto status = RunSm120GroupwiseGemm<PingpongGemm, ScaleConfig>(
       float_buffer, float_buffer_size_in_bytes, A_ptr, B_ptr, SFA_ptr, SFB_ptr, D_ptr, m, n, k, l,
       stream);
@@ -112,7 +110,6 @@ cudaError_t TrySm120PingpongThenCooperative(void* float_buffer, size_t float_buf
   return status;
 }
 
-// SM120 supports cooperative (128x128x128) and pingpong (64x128x128) schedules.
 template <int ScaleGranularityM, int ScaleGranularityN, int ScaleGranularityK, bool ScaleMajorK,
           typename DTypeIn, typename DTypeOut>
 cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buffer_size_in_bytes,
@@ -150,7 +147,6 @@ cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buf
   using PingpongMmaTileShape_MNK = Shape<_64, _128, _128>;
   using ClusterShape_MNK = Shape<_1, _1, _1>;
 
-  // Pingpong tile M=64 requires ScaleGranularityM to divide 64.
   constexpr bool kCanUsePingpong = (64 % ScaleGranularityM == 0);
 
   using ScaleConfig = std::conditional_t<
@@ -185,9 +181,6 @@ cudaError_t CutlassGroupwiseScaledGEMMSM120(void* float_buffer, size_t float_buf
 
   using CooperativeGemm = cutlass::gemm::device::GemmUniversalAdapter<CooperativeGemmKernel>;
 
-  // Guard pingpong type instantiation behind if constexpr so the CUTLASS builder's
-  // static_assert (tile_M % ScaleGranularityM == 0) is never triggered for
-  // ScaleGranularityM=128 with tile_M=64.
   if constexpr (kCanUsePingpong) {
     using PingpongCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
         cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, PingpongMmaTileShape_MNK,


### PR DESCRIPTION
<img width="800" height="1600" alt="image" src="https://github.com/user-attachments/assets/5ffe3405-7809-47ce-a5f8-e5eed97802ab" />

Use ping-pong adapted from CUTLASS SM120 example. Optimize for any shape. Testing script: it can pass ref check

```python3
"""
Benchmark FP8 blockwise GEMM backends on SM120 (Blackwell).

Backends tested:
  - cutlass      : sgl_kernel.fp8_blockwise_scaled_mm
  - flashinfer   : flashinfer.gemm.gemm_fp8_nt_groupwise (backend="cutlass", scale_major_mode="MN")
  - triton       : sglang fp8_kernel.w8a8_block_fp8_matmul_triton

Weight shapes are from DeepSeek-V3/R1 (same as benchmark_deepgemm_fp8_gemm.py).
Timing via flashinfer CUPTI API for accurate kernel-only measurement.
"""

import argparse
import sys
from typing import List, Tuple, Optional

import torch

from flashinfer.testing.utils import bench_gpu_time

BLOCK_SIZE = [128, 128]


# ── quantisation helpers ─────────────────────────────────────────────────────

def per_token_group_quant_fp8(
    x: torch.Tensor,
    group_size: int,
) -> tuple[torch.Tensor, torch.Tensor]:
    """Per-token-group FP8 quantisation (row-major scales)."""
    assert x.dim() == 2 and x.shape[1] % group_size == 0
    m, k = x.shape
    x_view = x.reshape(m, k // group_size, group_size)
    x_amax = x_view.abs().float().amax(dim=2).clamp(min=1e-12)
    scale = x_amax / 448.0
    x_q = (x_view.float() / scale.unsqueeze(2)).to(torch.float8_e4m3fn).reshape(m, k)
    return x_q, scale  # scale shape: (m, k // group_size)


def per_block_quant_fp8(
    x: torch.Tensor,
    block_n: int = 128,
    block_k: int = 128,
) -> tuple[torch.Tensor, torch.Tensor]:
    """Per-block FP8 quantisation for weight (N, K)."""
    n, k = x.shape
    n_pad = ((n + block_n - 1) // block_n) * block_n
    k_pad = ((k + block_k - 1) // block_k) * block_k
    x_pad = torch.zeros(n_pad, k_pad, dtype=x.dtype, device=x.device)
    x_pad[:n, :k] = x
    x_view = x_pad.reshape(n_pad // block_n, block_n, k_pad // block_k, block_k)
    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(min=1e-12)
    scale = x_amax / 448.0
    x_q = (x_view.float() / scale).to(torch.float8_e4m3fn).reshape(n_pad, k_pad)
    x_q = x_q[:n, :k].contiguous()
    scale = scale.squeeze().reshape(n_pad // block_n, k_pad // block_k)
    return x_q, scale  # scale shape: (n // block_n, k // block_k)


# ── backend wrappers ─────────────────────────────────────────────────────────

def _run_cutlass(a_fp8, w_fp8_t, a_scale_col, w_scale_kb, m, n, k):
    """sgl_kernel cutlass backend: fp8_blockwise_scaled_mm.

    Expects:
      w_fp8_t:     (k, n) = weight.T
      a_scale_col: (m, k//128) column-major (stride(0)==1)
      w_scale_kb:  (k//128, n//128) column-major (stride(0)==1)
    """
    from sgl_kernel import fp8_blockwise_scaled_mm

    return fp8_blockwise_scaled_mm(
        a_fp8,
        w_fp8_t,
        a_scale_col,
        w_scale_kb,
        out_dtype=torch.bfloat16,
    )


def _run_flashinfer(a_fp8, w_fp8, a_scale_mn, w_scale_mn, m, n, k):
    """flashinfer cutlass backend: gemm_fp8_nt_groupwise."""
    from flashinfer.gemm import gemm_fp8_nt_groupwise

    return gemm_fp8_nt_groupwise(
        a_fp8,
        w_fp8,
        a_scale_mn,
        w_scale_mn,
        out_dtype=torch.bfloat16,
        backend="cutlass",
        scale_major_mode="MN",
    )


def _run_triton(a_fp8, w_fp8, a_scale, w_scale, m, n, k):
    """sglang triton backend: w8a8_block_fp8_matmul_triton."""
    from sglang.srt.layers.quantization.fp8_kernel import (
        w8a8_block_fp8_matmul_triton,
    )

    return w8a8_block_fp8_matmul_triton(
        a_fp8,
        w_fp8,
        a_scale,
        w_scale,
        BLOCK_SIZE,
        output_dtype=torch.bfloat16,
    )


# ── shapes from DeepSeek-V3/R1 ──────────────────────────────────────────────

def get_weight_shapes(tp_size: int) -> list[tuple[int, int]]:
    total = [
        (512 + 64, 7168),
        ((128 + 64) * 128, 7168),
        (128 * (128 + 128), 512),
        (7168, 16384),
        (7168, 18432),
    ]
    n_tp = [
        (18432 * 2, 7168),
        ((128 + 64) * 128, 7168),
        (128 * (128 + 128), 512),
        (24576, 1536),
        (4096, 7168),
    ]
    k_tp = [(7168, 18432), (7168, 16384), (7168, 2048)]

    shapes = []
    for n, k in total:
        shapes.append((n, k))
    for n, k in n_tp:
        shapes.append((n // tp_size, k))
    for n, k in k_tp:
        shapes.append((n, k // tp_size))
    return shapes


# ── main benchmark ───────────────────────────────────────────────────────────

def prepare_inputs(
    m,
    n,
    k,
    backend,
    a_fp8=None,
    w_fp8=None,
    a_scale=None,
    w_scale=None,
):
    """Prepare quantised inputs for a given backend.

    If pre-quantised tensors are provided, they are reused so that all
    backends can share the same inputs (useful for reference checks).
    """
    block_n, block_k = BLOCK_SIZE

    if a_fp8 is None or w_fp8 is None or a_scale is None or w_scale is None:
        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
        w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)

        a_fp8, a_scale = per_token_group_quant_fp8(x, block_k)
        w_fp8, w_scale = per_block_quant_fp8(w, block_n, block_k)

    if backend == "cutlass":
        # scales_a: shape (m, k//128) with column-major strides (stride(0)==1)
        a_scale_col = a_scale.T.contiguous().T  # (m, k//block_k) col-major
        # scales_b: shape (k//128, n//128) with stride(0)==1
        w_scale_kb = w_scale.T                  # view: (k//block_k, n//block_n) col-major
        # mat_b: (k, n) column-major view of (n, k) row-major weight
        w_fp8_t = w_fp8.T
        return (a_fp8, w_fp8_t, a_scale_col, w_scale_kb, m, n, k)
    elif backend == "flashinfer":
        # flashinfer cutlass with scale_major_mode="MN":
        #   a_scale: (k//block_k, m), w_scale: (k//block_k, n//block_n)
        a_scale_mn = a_scale.T.contiguous()    # (k//block_k, m)
        w_scale_mn = w_scale.T.contiguous()    # (k//block_k, n//block_n)
        return (a_fp8, w_fp8, a_scale_mn, w_scale_mn, m, n, k)
    elif backend == "triton":
        return (a_fp8, w_fp8, a_scale, w_scale, m, n, k)
    else:
        raise ValueError(f"Unknown backend: {backend}")


BACKEND_FN = {
    "cutlass": _run_cutlass,
    "flashinfer": _run_flashinfer,
    "triton": _run_triton,
}


def shape_supported(backend: str, n: int, k: int) -> bool:
    """Check whether the shape can be run by this backend without fallback."""
    if backend in ("cutlass", "flashinfer"):
        return n % 128 == 0 and k % 128 == 0
    return True  # triton handles arbitrary shapes


def run_benchmark(
    backends: list[str],
    tp_size: int,
    batch_sizes: list[int],
    use_cupti: bool,
    dry_run_iters: int,
    repeat_iters: int,
    refcheck: bool = False,
    m_override: int | None = None,
    n_override: int | None = None,
    k_override: int | None = None,
):
    if n_override is not None and k_override is not None:
        weight_shapes = [(n_override, k_override)]
    else:
        weight_shapes = get_weight_shapes(tp_size)

    header = f"{'m':>6} {'n':>6} {'k':>6}"
    for b in backends:
        header += f" | {b:>14} ms  {'TFLOPS':>7}"
    print(header)
    print("-" * len(header))

    for n, k in weight_shapes:
        for m in ([m_override] if m_override is not None else batch_sizes):
            line = f"{m:>6} {n:>6} {k:>6}"
            # Shared quantised inputs for all backends in this (m, n, k)
            a_fp8 = w_fp8 = a_scale = w_scale = None
            outputs: dict[str, torch.Tensor] = {}

            for backend in backends:
                if not shape_supported(backend, n, k):
                    line += f" | {'skip':>14}  {'':>7}"
                    continue

                fn = BACKEND_FN[backend]

                if a_fp8 is None:
                    # Lazily create shared quantised inputs once
                    block_n, block_k = BLOCK_SIZE
                    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
                    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
                    a_fp8, a_scale = per_token_group_quant_fp8(x, block_k)
                    w_fp8, w_scale = per_block_quant_fp8(w, block_n, block_k)

                inputs = prepare_inputs(
                    m,
                    n,
                    k,
                    backend,
                    a_fp8=a_fp8,
                    w_fp8=w_fp8,
                    a_scale=a_scale,
                    w_scale=w_scale,
                )

                # Optional numerical reference check vs triton later.
                if refcheck:
                    try:
                        with torch.no_grad():
                            y = fn(*inputs)
                        outputs[backend] = y.detach()
                    except Exception as exc:
                        print(
                            f"  [refcheck {backend} m={m} n={n} k={k}] {exc}",
                            file=sys.stderr,
                        )

                try:
                    times = bench_gpu_time(
                        fn=fn,
                        input_args=inputs,
                        dry_run_iters=dry_run_iters,
                        repeat_iters=repeat_iters,
                        enable_cupti=use_cupti,
                        cold_l2_cache=True,
                    )
                    median_ms = sorted(times)[len(times) // 2]
                    tflops = (2.0 * m * n * k) / (median_ms * 1e-3) / 1e12
                    line += f" | {median_ms:>14.4f}  {tflops:>7.2f}"
                except Exception as exc:
                    line += f" | {'ERR':>14}  {'':>7}"
                    print(f"  [{backend} m={m} n={n} k={k}] {exc}", file=sys.stderr)

            print(line)

            if refcheck and "triton" in outputs and isinstance(
                outputs["triton"], torch.Tensor
            ):
                ref = outputs["triton"]
                ref_max = ref.abs().max().item()
                denom = ref_max if ref_max != 0.0 else 1.0
                checks = []
                for backend, out in outputs.items():
                    if backend == "triton" or not isinstance(out, torch.Tensor):
                        continue
                    diff = (out - ref).abs()
                    max_abs = diff.max().item()
                    rel = max_abs / denom
                    checks.append(
                        f"{backend}: max_abs={max_abs:.3e}, rel={rel:.3e}"
                    )
                if checks:
                    print(
                        f"        [refcheck vs triton] "
                        + "; ".join(checks)
                    )


def main():
    parser = argparse.ArgumentParser(
        description="Benchmark FP8 blockwise GEMM backends on SM120"
    )
    parser.add_argument(
        "--backends",
        nargs="+",
        default=["cutlass", "flashinfer", "triton"],
        choices=["cutlass", "flashinfer", "triton"],
    )
    parser.add_argument("--tp_size", type=int, default=8)
    parser.add_argument(
        "--batch_sizes",
        nargs="+",
        type=int,
        default=[1, 4, 8, 16, 32, 64, 128, 256, 512],
    )
    parser.add_argument(
        "--m",
        type=int,
        default=None,
        help="Single M dimension (batch size). If set, overrides --batch_sizes.",
    )
    parser.add_argument(
        "--n",
        type=int,
        default=None,
        help="Single N dimension. Use together with --k to bypass predefined weight shapes.",
    )
    parser.add_argument(
        "--k",
        type=int,
        default=None,
        help="Single K dimension. Use together with --n to bypass predefined weight shapes.",
    )
    parser.add_argument(
        "--refcheck",
        action="store_true",
        help="Compare each backend's output against triton and print max abs/rel errors.",
    )
    parser.add_argument("--use_cupti", action="store_true", default=True)
    parser.add_argument("--dry_run_iters", type=int, default=5)
    parser.add_argument("--repeat_iters", type=int, default=50)
    args = parser.parse_args()

    torch.manual_seed(42)
    torch.cuda.manual_seed(42)

    gpu_name = torch.cuda.get_device_name(0).replace(" ", "_")
    print(f"GPU: {gpu_name}")
    print(f"TP:  {args.tp_size}")
    print(f"Backends: {args.backends}")
    print(f"Timing: {'CUPTI' if args.use_cupti else 'CUDA events'}")
    if args.refcheck and "triton" in args.backends:
        print("Refcheck: comparing outputs against triton backend")
    print()

    run_benchmark(
        backends=args.backends,
        tp_size=args.tp_size,
        batch_sizes=args.batch_sizes,
        use_cupti=args.use_cupti,
        dry_run_iters=args.dry_run_iters,
        repeat_iters=args.repeat_iters,
        refcheck=args.refcheck,
        m_override=args.m,
        n_override=args.n,
        k_override=args.k,
    )


if __name__ == "__main__":
    main()
```

E2E

```
# Triton baseline
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 50
channel 6: open failed: connect failed: open failed
channel 7: open failed: connect failed: open failed
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [05:14<00:00,  4.19it/s]
Accuracy: 0.906
Invalid: 0.000
Latency: 314.926 s
Output throughput: 832.479 token/s
```

```
# Cutlass, gemm relative error is higher than triton baseline (was already the case before, but the relative error is still the same). But works fine in e2e
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 50
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [04:49<00:00,  4.56it/s]
Accuracy: 0.894
Invalid: 0.000
Latency: 289.056 s
Output throughput: 944.364 token/s
```

```
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-27B-FP8 --attention-backend triton --fp8-gemm-backend flashinfer_cutlass --reasoning-parser qwen3 --tool-call-parser qwen3_coder
```
Before: various gemms willl take 906 us
<img width="1229" height="481" alt="Screenshot 2026-03-07 at 6 54 33 PM" src="https://github.com/user-attachments/assets/196295a5-998e-462f-850a-f3aa087cf59b" />

After: 648 us
<img width="879" height="368" alt="Screenshot 2026-03-07 at 6 55 04 PM" src="https://github.com/user-attachments/assets/d30f1ad9-138f-40d4-8bcf-64a7238feea6" />

And this kernel will include

```
_ZN7cutlass13device_kernelINS_4gemm6kernel13GemmUniversalIN4cute5tupleIJiiiiEEENS1_10collective13CollectiveMmaINS1_47MainloopSm120TmaWarpSpecializedBlockwiseScalingILi3ELi2ENS5_IJNS4_1CILi1EEESB_SB_EEENS1_53KernelTmaWarpSpecialized**PingpongBlockwiseScaling**Sm120ILi2EEEEENS5_IJNSA_ILi64EEENSA_ILi128EEESH_EEENS_12float_e4m3_tENS5_IJNS5_IJlSB_lEEENS4_6LayoutINS5_IJNS5_IJSB_iEEENS5_IJSH_iEEEiEEENS5_IJNS5_IJNSA_ILi0EEESB_EEENS5_IJSP_iEEEiEEEEEEEESJ_NS5_IJSK_NSL_INS5_IJSN_SN_iEEESS_EEEEENS4_8TiledMMAINS4_8MMA_AtomIJNS4_16SM120_16x8x32_TNISJ_SJ_fEEEEENSL_INS5_IJNSA_ILi2EEES13_SB_EEENS5_IJSB_S13_SP_EEEEENS5_IJSG_NSA_ILi32EEES17_EEEEENS4_13SM90_TMA_LOADENS4_14ComposedLayoutINS4_7SwizzleILi3ELi4ELi3EEENS4_18smem_ptr_flag_bitsILi8EEENSL_INS5_IJNSA_ILi8EEESH_EEENS5_IJSH_SB_EEEEEEENS4_9Copy_AtomIJNS4_17SM75_U32x4_LDSM_NEhEEENS4_8identityES1A_S1K_S1N_S1O_EENS_8epilogue10collective18CollectiveEpilogueINS1Q_22Sm90TmaWarpSpecializedILi3ELi2ELi4ELb1ELb0EEEJSI_NS5_IJSG_S17_EEENS_10bfloat16_tESK_S1W_SK_NS1Q_6fusion15FusionCallbacksINS1Q_23Sm120TmaWarpSpecializedILi3ELi2ELi4ELb1ELb0EEENS1X_17LinearCombinationIS1W_fS1W_fLNS_15FloatRoundStyleE2EEESI_S1V_JEEES1A_NS1B_INS1C_ILi2ELi4ELi3EEENS1E_ILi16EEENSL_INS5_IJS1G_S17_EEENS5_IJS17_SB_EEEEEEENS4_17SM75_U32x2_LDSM_NENS4_14SM90_TMA_STOREES2A_NS4_17SM90_U32x2_STSM_NENS1L_IJS2D_NS_6half_tEEEEvEEEvvEEEEvNT_6ParamsE
```

So it looks alright, at least to my really introductory understanding of cutlass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized groupwise matrix multiplication implementation for SM120 GPUs with multiple execution pathways for improved performance and compatibility across different hardware configurations.

* **Chores**
  * Removed obsolete comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->