### PR TITLE
Deprecation for gated_delta_rule_mtp's intermediate_states_buffer=True

### DIFF
--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -31,6 +31,8 @@ from typing import Optional, Tuple
 
 import torch
 
+from .jit.core import logger
+
 try:
     from .api_logging import flashinfer_api
 
@@ -487,7 +489,7 @@ def gated_delta_rule_mtp(
     scale: Optional[float] = None,
     output: Optional[torch.Tensor] = None,
     intermediate_states_buffer: Optional[torch.Tensor] = None,
-    disable_state_update: bool = False,
+    disable_state_update: Optional[bool] = None,
     use_qk_l2norm: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
@@ -523,8 +525,15 @@ def gated_delta_rule_mtp(
         intermediate_states_buffer (Optional[torch.Tensor]):
             Buffer for caching intermediate states, shape ``[pool_size, T, HV, V, K]``.
             If None, intermediate states are not cached.
-        disable_state_update (bool):
-            If True, the initial state is not updated. Default: ``True``.
+        disable_state_update (Optional[bool]):
+            If True, the initial state is not updated. Currently defaults to ``True``.
+            Please pass this argument explicitly — the default will change to ``False``
+            in FlashInfer 0.7.0.
+
+            .. deprecated::
+                The implicit default of ``True`` is deprecated and will change to
+                ``False`` in version 0.7.0. Pass ``disable_state_update=True`` or
+                ``disable_state_update=False`` explicitly to silence the warning.
         use_qk_l2norm (bool):
             Whether to apply L2 normalization to q and k. Default: ``True``.
 
@@ -539,6 +548,16 @@ def gated_delta_rule_mtp(
         - State layout is K-last: [pool_size, HV, V, K]
         - Optimized for speculative decoding verification scenarios
     """
+    # Handle deprecation of disable_state_update default value
+    if disable_state_update is None:
+        logger.warning_once(
+            "gated_delta_rule_mtp(): the 'disable_state_update' parameter currently "
+            "defaults to True, but this default will change to False in FlashInfer "
+            "0.7.0. Please pass disable_state_update=True or "
+            "disable_state_update=False explicitly to suppress this warning."
+        )
+        disable_state_update = True
+
     # Validate input shapes
     B, T, H, K = q.shape
     _, _, HV, V = v.shape


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * A deprecation notice has been introduced that alerts users when relying on default behavior. The current default is scheduled to change in a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->