### PR TITLE
fix: torch.compile(fullgraph=True) compatibility for norm ops

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -344,24 +344,19 @@ else:
         device_types: Optional[Union[str, Sequence[str]]] = None,
         schema: Optional[str] = None,
     ) -> Callable:
-        # NOTE(Zihao): torch.library.custom_op has significant overhead as mentioned in the following link
-        # https://github.com/vllm-project/vllm/blob/36e76700453924c8d421db99af70a88a1df835cd/vllm/utils.py#L1660-L1674
-
-        # return torch.library.custom_op(
-        #     name,
-        #     fn,
-        #     mutates_args=mutates_args,
-        #     device_types=device_types,
-        #     schema=schema,
-        # )
-        return lambda x: x
+        return torch.library.custom_op(
+            name,
+            fn,
+            mutates_args=mutates_args,
+            device_types=device_types,
+            schema=schema,
+        )
 
     def register_fake_op(
         name: str,
         fn: Optional[Callable] = None,
     ) -> Callable:
-        # return torch.library.register_fake(name, fn)
-        return lambda x: x
+        return torch.library.register_fake(name, fn)
 
 
 def determine_gemm_backend(device: torch.device) -> str:

--- a/tests/norm/test_norm_torch_compile.py
+++ b/tests/norm/test_norm_torch_compile.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for norm functions compatibility with torch.compile.
+
+Verifies that rmsnorm / fused_add_rmsnorm / gemma_rmsnorm /
+gemma_fused_add_rmsnorm can be traced by Dynamo with fullgraph=True
+(i.e. no graph breaks, no posix.stat issues).
+"""
+
+import pytest
+import torch
+from torch.torch_version import TorchVersion
+from torch.torch_version import __version__ as torch_version
+
+if TorchVersion(torch_version) < TorchVersion("2.4"):
+    pytest.skip("torch.compile support requires torch >= 2.4", allow_module_level=True)
+
+import flashinfer
+
+
+def _rmsnorm_ref(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    orig = x.dtype
+    x = x.float()
+    x = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    return (x * w.float()).to(orig)
+
+
+def _gemma_rmsnorm_ref(
+    x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
+) -> torch.Tensor:
+    orig = x.dtype
+    x = x.float()
+    x = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    return (x * (w.float() + 1.0)).to(orig)
+
+
+def _fused_add_rmsnorm_ref(
+    x: torch.Tensor, residual: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
+):
+    residual = residual + x
+    orig = residual.dtype
+    r = residual.float()
+    r = r * torch.rsqrt(r.pow(2).mean(-1, keepdim=True) + eps)
+    return (r * w.float()).to(orig), residual
+
+
+def _gemma_fused_add_rmsnorm_ref(
+    x: torch.Tensor, residual: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
+):
+    residual = residual + x
+    orig = residual.dtype
+    r = residual.float()
+    r = r * torch.rsqrt(r.pow(2).mean(-1, keepdim=True) + eps)
+    return (r * (w.float() + 1.0)).to(orig), residual
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+@pytest.mark.parametrize("hidden_size", [128, 4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_rmsnorm_torch_compile(batch_size, hidden_size, dtype):
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    w = torch.ones(hidden_size, dtype=dtype, device="cuda")
+
+    # warmup: trigger JIT compilation before torch.compile tracing
+    flashinfer.rmsnorm(x, w)
+
+    compiled = torch.compile(flashinfer.rmsnorm, fullgraph=True, backend="eager")
+    out = compiled(x, w)
+    ref = _rmsnorm_ref(x, w)
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+@pytest.mark.parametrize("hidden_size", [128, 4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rmsnorm_torch_compile(batch_size, hidden_size, dtype):
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x)
+    w = torch.ones(hidden_size, dtype=dtype, device="cuda")
+
+    # warmup
+    flashinfer.fused_add_rmsnorm(x.clone(), residual.clone(), w)
+
+    def fn(x, residual, w):
+        flashinfer.fused_add_rmsnorm(x, residual, w)
+        return x, residual
+
+    compiled = torch.compile(fn, fullgraph=True, backend="eager")
+    x2, r2 = x.clone(), residual.clone()
+    out_x, out_r = compiled(x2, r2, w)
+
+    ref_x, ref_r = _fused_add_rmsnorm_ref(x.clone(), residual.clone(), w)
+    torch.testing.assert_close(out_x, ref_x, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(out_r, ref_r, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("hidden_size", [128, 4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gemma_rmsnorm_torch_compile(batch_size, hidden_size, dtype):
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    w = torch.zeros(hidden_size, dtype=dtype, device="cuda")  # gemma: (w+1)*norm
+
+    # warmup
+    flashinfer.gemma_rmsnorm(x, w)
+
+    compiled = torch.compile(flashinfer.gemma_rmsnorm, fullgraph=True, backend="eager")
+    out = compiled(x, w)
+    ref = _gemma_rmsnorm_ref(x, w)
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("hidden_size", [128, 4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gemma_fused_add_rmsnorm_torch_compile(batch_size, hidden_size, dtype):
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x)
+    w = torch.zeros(hidden_size, dtype=dtype, device="cuda")
+
+    # warmup
+    flashinfer.gemma_fused_add_rmsnorm(x.clone(), residual.clone(), w)
+
+    def fn(x, residual, w):
+        flashinfer.gemma_fused_add_rmsnorm(x, residual, w)
+        return x, residual
+
+    compiled = torch.compile(fn, fullgraph=True, backend="eager")
+    x2, r2 = x.clone(), residual.clone()
+    out_x, out_r = compiled(x2, r2, w)
+
+    ref_x, ref_r = _gemma_fused_add_rmsnorm_ref(x.clone(), residual.clone(), w)
+    torch.testing.assert_close(out_x, ref_x, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(out_r, ref_r, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
  ## 📌 Description
  https://github.com/flashinfer-ai/flashinfer/issues/2733

`register_custom_op` / `register_fake_op` in `utils.py` were no-ops, causing JIT-backed FlashInfer ops to behave like plain Python functions. Under `torch.compile(fullgraph=True)`, Dynamo would trace into the Python implementation and hit `Path.exists() -> posix.stat`, which it cannot trace, breaking compilation.

  This PR re-enables `torch.library.custom_op` and
  `torch.library.register_fake` so Dynamo treats these ops as opaque custom ops
  instead of entering the Python body.

  It also removes the now-unnecessary `@torch.compiler.disable` from
  `get_norm_module` in `norm.py`, and adds
  `tests/norm/test_norm_torch_compile.py` with 40 regression cases covering:

  - `flashinfer.rmsnorm`
  - `flashinfer.fused_add_rmsnorm`
  - `flashinfer.gemma_rmsnorm`
  - `flashinfer.gemma_fused_add_rmsnorm`

  all under `torch.compile(fullgraph=True)`.

  Scope note: the regression coverage added in this PR is for norm ops.

  ## 🔍 Related Issues

  Fixes #<issue_number>

  ## 🚀 Pull Request Checklist

  Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

  ### ✅ Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
  - [x] I have installed the hooks with `pre-commit install`.
  - [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

  > If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

  ## 🧪 Tests

  - [x] Tests have been added or updated as needed.
  - [x] All tests are passing (`unittest`, etc.).
    - `pytest tests/norm/test_norm_torch_compile.py -v`
    - `40 passed`

  ## Reviewer Notes

  This PR fixes the `torch.compile(fullgraph=True)` regression for the norm path.
  The custom-op registration change is shared infrastructure, but the added
  regression coverage in this PR is norm-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive torch.compile compatibility tests for multiple RMSNorm variants across various batch sizes, hidden dimensions, and data types (float16, bfloat16), validating compiled execution against reference results.

* **Improvements**
  * Replaced previous stub behavior with direct PyTorch library integration for custom/fake operation registration, improving runtime alignment with PyTorch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->