### PR TITLE
Add blackwell GDN prefill impl

### DIFF
--- a/benchmarks/bench_blackwell_gdn_prefill.py
+++ b/benchmarks/bench_blackwell_gdn_prefill.py
@@ -31,9 +31,11 @@ from typing import List
 
 import torch
 import torch.nn.functional as F
+import numpy as np
+from flashinfer.testing import bench_gpu_time
 
 # Blackwell GDN prefill
-from flashinfer.gdn_kernels.blackwell_prefill.gdn import chunk_gated_delta_rule
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 # FLA baseline
 from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd as fla_base
@@ -99,53 +101,35 @@ def benchmark_gdn_fixlen(
     output_final_state = True
 
     o = torch.zeros_like(v)
-    # Warmup
-    for _ in range(warmup_iters):
-        chunk_gated_delta_rule(
-            q,
-            k,
-            v,
-            g,
-            beta,
-            None,
-            h0,
-            output_final_state,
-            None,
-            False,
-            o,
-            None,
-        )
-    torch.cuda.synchronize()
+    state_output = torch.randn(
+        (batch_size, num_v_heads, head_dim, head_dim),
+        dtype=torch.float32,
+        device=device,
+    )
 
-    # Benchmark
-    torch.cuda.reset_peak_memory_stats()
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    fn_gdn = lambda: chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        None,
+        h0,
+        output_final_state,
+        None,
+        False,
+        o,
+        state_output,
+    )
 
-    o.zero_()
+    kernel_times_ms = bench_gpu_time(
+        fn_gdn,
+        enable_cupti=True,
+        dry_run_iters=warmup_iters,
+        repeat_iters=benchmark_iters,
+    )
 
-    start_event.record()
-    for _ in range(benchmark_iters):
-        chunk_gated_delta_rule(
-            q,
-            k,
-            v,
-            g,
-            beta,
-            None,
-            h0,
-            output_final_state,
-            None,
-            False,
-            o,
-            None,
-        )
-
-    end_event.record()
-    torch.cuda.synchronize()
-
-    elapsed_ms = start_event.elapsed_time(end_event)
-    avg_latency_ms = elapsed_ms / benchmark_iters
+    avg_latency_ms = np.average(kernel_times_ms)
 
     # FLA baseline
     fla_latency_ms = None
@@ -161,19 +145,13 @@ def benchmark_gdn_fixlen(
             output_final_state=output_final_state,
         )
 
-        for _ in range(warmup_iters):
-            fn_fla()
-        torch.cuda.synchronize()
-
-        fla_start = torch.cuda.Event(enable_timing=True)
-        fla_end = torch.cuda.Event(enable_timing=True)
-        fla_start.record()
-        for _ in range(benchmark_iters):
-            fn_fla()
-        fla_end.record()
-        torch.cuda.synchronize()
-
-        fla_latency_ms = fla_start.elapsed_time(fla_end) / benchmark_iters
+        fla_times_ms = bench_gpu_time(
+            fn_fla,
+            enable_cupti=True,
+            dry_run_iters=warmup_iters,
+            repeat_iters=benchmark_iters,
+        )
+        fla_latency_ms = np.average(fla_times_ms)
 
     result = {
         "batch_size": batch_size,
@@ -239,53 +217,29 @@ def benchmark_gdn_varlen(
     o = torch.zeros_like(v)
     state_output = torch.zeros_like(h0, dtype=torch.float32)
 
-    # Warmup
-    for _ in range(warmup_iters):
-        chunk_gated_delta_rule(
-            q,
-            k,
-            v,
-            g,
-            beta,
-            None,
-            h0,
-            True,
-            cu_seqlens_tensor,
-            False,
-            o,
-            state_output,
-        )
-    torch.cuda.synchronize()
+    fn_gdn = lambda: chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        None,
+        h0,
+        True,
+        cu_seqlens_tensor,
+        False,
+        o,
+        state_output,
+    )
 
-    # Benchmark
-    torch.cuda.reset_peak_memory_stats()
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    kernel_times_ms = bench_gpu_time(
+        fn_gdn,
+        enable_cupti=True,
+        dry_run_iters=warmup_iters,
+        repeat_iters=benchmark_iters,
+    )
 
-    o.zero_()
-    state_output.zero_()
-
-    start_event.record()
-    for _ in range(benchmark_iters):
-        chunk_gated_delta_rule(
-            q,
-            k,
-            v,
-            g,
-            beta,
-            None,
-            h0,
-            True,
-            cu_seqlens_tensor,
-            False,
-            o,
-            state_output,
-        )
-    end_event.record()
-    torch.cuda.synchronize()
-
-    elapsed_ms = start_event.elapsed_time(end_event)
-    avg_latency_ms = elapsed_ms / benchmark_iters
+    avg_latency_ms = np.average(kernel_times_ms)
 
     return {
         "num_seqs": num_seqs,

--- a/benchmarks/bench_blackwell_gdn_prefill.py
+++ b/benchmarks/bench_blackwell_gdn_prefill.py
@@ -1,0 +1,543 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Performance benchmark for GDN (Gated Delta Network) linear attention.
+
+Usage:
+    python bench_blackwell_gdn_prefill.py
+    python bench_blackwell_gdn_prefill.py --batch-size 8 --seq-len 1024
+    python bench_blackwell_gdn_prefill.py --varlen --batch-size 4 --seq-len 2048
+    python bench_blackwell_gdn_prefill.py --varlen --cu-seqlens 0 512 1024 2048
+    python bench_blackwell_gdn_prefill.py --sweep
+"""
+
+import argparse
+import sys
+from typing import List
+
+import torch
+import torch.nn.functional as F
+
+# Blacwell GDN prefill
+from flashinfer.gdn_kernels.blackwell_prefill.gdn import chunk_gated_delta_rule
+
+# FLA baseline
+from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd as fla_base
+
+
+def benchmark_gdn_fixlen(
+    batch_size: int,
+    seq_len: int,
+    num_qk_heads: int,
+    num_v_heads: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.bfloat16,
+    warmup_iters: int = 10,
+    benchmark_iters: int = 100,
+    use_initial_state: bool = True,
+) -> dict:
+    """
+    Benchmark GDN with fixed-length sequences.
+
+    Returns:
+        Dictionary with benchmark results.
+    """
+    device = "cuda"
+    torch.cuda.reset_peak_memory_stats()
+
+    # Create input tensors
+    q = torch.randn(
+        (batch_size, seq_len, num_qk_heads, head_dim), dtype=dtype, device=device
+    )
+    k = F.normalize(
+        torch.randn(
+            batch_size,
+            seq_len,
+            num_qk_heads,
+            head_dim,
+            dtype=torch.float32,
+            device=device,
+        ),
+        p=2,
+        dim=-1,
+    ).to(dtype)
+    v = torch.randn(
+        (batch_size, seq_len, num_v_heads, head_dim), dtype=dtype, device=device
+    )
+    g = F.logsigmoid(
+        torch.rand(
+            1, seq_len * batch_size, num_v_heads, dtype=torch.float32, device=device
+        )
+    )
+    beta = torch.rand(
+        1, seq_len * batch_size, num_v_heads, dtype=torch.float32, device=device
+    ).sigmoid()
+
+    if use_initial_state:
+        h0 = torch.randn(
+            (batch_size, num_v_heads, head_dim, head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+    else:
+        h0 = None
+
+    output_final_state = True
+
+    o = torch.zeros_like(v)
+    # Warmup
+    for _ in range(warmup_iters):
+        chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            None,
+            h0,
+            output_final_state,
+            None,
+            False,
+            o,
+            None,
+        )
+    torch.cuda.synchronize()
+
+    # Benchmark
+    torch.cuda.reset_peak_memory_stats()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    o.zero_()
+
+    start_event.record()
+    for _ in range(benchmark_iters):
+        chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            None,
+            h0,
+            output_final_state,
+            None,
+            False,
+            o,
+            None,
+        )
+
+    end_event.record()
+    torch.cuda.synchronize()
+
+    elapsed_ms = start_event.elapsed_time(end_event)
+    avg_latency_ms = elapsed_ms / benchmark_iters
+
+    # FLA baseline
+    fla_latency_ms = None
+    if num_qk_heads == num_v_heads:
+        fn_fla = lambda: fla_base(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            None,
+            initial_state=h0,
+            output_final_state=output_final_state,
+        )
+
+        for _ in range(warmup_iters):
+            fn_fla()
+        torch.cuda.synchronize()
+
+        fla_start = torch.cuda.Event(enable_timing=True)
+        fla_end = torch.cuda.Event(enable_timing=True)
+        fla_start.record()
+        for _ in range(benchmark_iters):
+            fn_fla()
+        fla_end.record()
+        torch.cuda.synchronize()
+
+        fla_latency_ms = fla_start.elapsed_time(fla_end) / benchmark_iters
+
+    result = {
+        "batch_size": batch_size,
+        "seq_len": seq_len,
+        "num_qk_heads": num_qk_heads,
+        "num_v_heads": num_v_heads,
+        "head_dim": head_dim,
+        "dtype": str(dtype).split(".")[-1],
+        "gdn_ms": avg_latency_ms,
+    }
+
+    if fla_latency_ms is not None:
+        result["fla_ms"] = fla_latency_ms
+        result["speedup"] = (
+            fla_latency_ms / avg_latency_ms if avg_latency_ms > 0 else float("nan")
+        )
+
+    return result
+
+
+def benchmark_gdn_varlen(
+    cu_seqlens: List[int],
+    num_qk_heads: int,
+    num_v_heads: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.bfloat16,
+    warmup_iters: int = 10,
+    benchmark_iters: int = 100,
+) -> dict:
+    """
+    Benchmark GDN with variable-length sequences.
+
+    Returns:
+        Dictionary with benchmark results.
+    """
+    device = "cuda"
+    torch.cuda.reset_peak_memory_stats()
+
+    total_len = cu_seqlens[-1]
+    num_seqs = len(cu_seqlens) - 1
+    cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
+
+    # Create input tensors
+    q = torch.randn((1, total_len, num_qk_heads, head_dim), dtype=dtype, device=device)
+    k = F.normalize(
+        torch.randn(
+            1, total_len, num_qk_heads, head_dim, dtype=torch.float32, device=device
+        ),
+        p=2,
+        dim=-1,
+    ).to(dtype)
+    v = torch.randn((1, total_len, num_v_heads, head_dim), dtype=dtype, device=device)
+    g = F.logsigmoid(
+        torch.rand(1, total_len, num_v_heads, dtype=torch.float32, device=device)
+    )
+    beta = torch.rand(
+        1, total_len, num_v_heads, dtype=torch.float32, device=device
+    ).sigmoid()
+    h0 = torch.randn(
+        (num_seqs, num_v_heads, head_dim, head_dim), dtype=torch.float32, device=device
+    )
+
+    o = torch.zeros_like(v)
+    state_output = torch.zeros_like(h0, dtype=torch.float32)
+
+    # Warmup
+    for _ in range(warmup_iters):
+        chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            None,
+            h0,
+            True,
+            cu_seqlens_tensor,
+            False,
+            o,
+            state_output,
+        )
+    torch.cuda.synchronize()
+
+    # Benchmark
+    torch.cuda.reset_peak_memory_stats()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    o.zero_()
+    state_output.zero_()
+
+    start_event.record()
+    for _ in range(benchmark_iters):
+        chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            None,
+            h0,
+            True,
+            cu_seqlens_tensor,
+            False,
+            o,
+            state_output,
+        )
+    end_event.record()
+    torch.cuda.synchronize()
+
+    elapsed_ms = start_event.elapsed_time(end_event)
+    avg_latency_ms = elapsed_ms / benchmark_iters
+
+    return {
+        "num_seqs": num_seqs,
+        "total_len": total_len,
+        "avg_seq_len": total_len // num_seqs,
+        "num_qk_heads": num_qk_heads,
+        "num_v_heads": num_v_heads,
+        "head_dim": head_dim,
+        "dtype": str(dtype).split(".")[-1],
+        "gdn_ms": avg_latency_ms,
+    }
+
+
+def benchmark_sweep(
+    warmup_iters: int = 10,
+    benchmark_iters: int = 100,
+    dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    """Run a sweep of benchmark configurations for both fixlen and varlen."""
+    head_dim = 128
+
+    fixlen_configs = [
+        # (batch_size, seq_len, num_qk_heads, num_v_heads)
+        # Typical use cases:
+        (1, 512, 96, 96),
+        (1, 1024, 96, 96),
+        (1, 4096, 96, 96),
+        (1, 8192, 96, 96),
+        (9, 512, 32, 32),
+        (9, 1024, 32, 32),
+        (9, 4096, 32, 32),
+        (9, 8192, 32, 32),
+        (33, 512, 32, 32),
+        (33, 1024, 32, 32),
+        (33, 4096, 32, 32),
+        (33, 8192, 32, 32),
+        # Full SM utilization:
+        (1, 512, 148, 148),
+        (1, 1024, 148, 148),
+        (1, 4096, 148, 148),
+        (1, 8192, 148, 148),
+    ]
+
+    varlen_configs = [
+        # (cu_seqlens, num_qk_heads, num_v_heads) — derived from fixlen_configs
+        ([sl * i for i in range(bs + 1)], nqk, nv)
+        for bs, sl, nqk, nv in fixlen_configs
+    ]
+
+    print("\n" + "#" * 80)
+    print(" BENCHMARK SWEEP")
+    print("#" * 80)
+
+    fixlen_results = []
+    for i, (bs, sl, nqk, nv) in enumerate(fixlen_configs):
+        label = f"[{i + 1}/{len(fixlen_configs)}] bs={bs}, sl={sl}, nqk={nqk}, nv={nv}"
+        print(f"  Running fixlen  {label} ...", end="", flush=True)
+        try:
+            result = benchmark_gdn_fixlen(
+                batch_size=bs,
+                seq_len=sl,
+                num_qk_heads=nqk,
+                num_v_heads=nv,
+                head_dim=head_dim,
+                dtype=dtype,
+                warmup_iters=warmup_iters,
+                benchmark_iters=benchmark_iters,
+            )
+            fixlen_results.append(result)
+            msg = f"  GDN: {result['gdn_ms']:.3f} ms"
+            if "fla_ms" in result:
+                msg += f"  FLA: {result['fla_ms']:.3f} ms  ({result['speedup']:.2f}x)"
+            print(msg)
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            torch.cuda.empty_cache()
+
+    varlen_results = []
+    for i, (cu_seqlens, nqk, nv) in enumerate(varlen_configs):
+        num_seqs = len(cu_seqlens) - 1
+        total_len = cu_seqlens[-1]
+        label = f"[{i + 1}/{len(varlen_configs)}] seqs={num_seqs}, total={total_len}, nqk={nqk}, nv={nv}"
+        print(f"  Running varlen  {label} ...", end="", flush=True)
+        try:
+            result = benchmark_gdn_varlen(
+                cu_seqlens=cu_seqlens,
+                num_qk_heads=nqk,
+                num_v_heads=nv,
+                head_dim=head_dim,
+                dtype=dtype,
+                warmup_iters=warmup_iters,
+                benchmark_iters=benchmark_iters,
+            )
+            varlen_results.append(result)
+            print(f"  GDN: {result['gdn_ms']:.3f} ms")
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            torch.cuda.empty_cache()
+
+    print_results_table(fixlen_results, "Fixed-Length Sweep Results")
+    print_results_table(varlen_results, "Variable-Length Sweep Results")
+
+
+def print_results_table(results: List[dict], title: str = "Benchmark Results"):
+    """Print benchmark results in a formatted table."""
+    if not results:
+        return
+
+    print(f"\n{'=' * 80}")
+    print(f" {title}")
+    print(f"{'=' * 80}")
+
+    # Get all keys from first result
+    keys = list(results[0].keys())
+
+    # Calculate column widths
+    widths = {}
+    for key in keys:
+        max_len = len(key)
+        for r in results:
+            val = r[key]
+            if isinstance(val, float):
+                val_str = f"{val:.4f}" if val < 100 else f"{val:.2f}"
+            else:
+                val_str = str(val)
+            max_len = max(max_len, len(val_str))
+        widths[key] = max_len + 2
+
+    # Print header
+    header = " | ".join(f"{key:^{widths[key]}}" for key in keys)
+    print(header)
+    print("-" * len(header))
+
+    # Print rows
+    for r in results:
+        row_vals = []
+        for key in keys:
+            val = r[key]
+            if isinstance(val, float):
+                val_str = f"{val:.4f}" if val < 100 else f"{val:.2f}"
+            else:
+                val_str = str(val)
+            row_vals.append(f"{val_str:^{widths[key]}}")
+        print(" | ".join(row_vals))
+
+    print(f"{'=' * 80}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GDN Performance Benchmark")
+    parser.add_argument("--batch-size", "-b", type=int, default=1, help="Batch size")
+    parser.add_argument(
+        "--seq-len", "-t", type=int, default=8192, help="Sequence length"
+    )
+    parser.add_argument(
+        "--num-qk-heads",
+        "-nqk",
+        type=int,
+        default=96,
+        help="Number of qk attention heads",
+    )
+    parser.add_argument(
+        "--num-v-heads", "-nv", type=int, default=96, help="Number of v attention heads"
+    )
+    parser.add_argument(
+        "--head-dim", "-d", type=int, default=128, help="Head dimension"
+    )
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--iters", type=int, default=100, help="Benchmark iterations")
+    parser.add_argument(
+        "--varlen", action="store_true", help="Run variable-length benchmark"
+    )
+    parser.add_argument(
+        "--cu-seqlens",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Cumulative sequence lengths for varlen mode (e.g. --cu-seqlens 0 512 1024 2048)",
+    )
+    parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help="Run a sweep of many test cases (fixlen + varlen)",
+    )
+
+    args = parser.parse_args()
+
+    if args.head_dim != 128:
+        print(f"Error: head_dim must be 128, got {args.head_dim}")
+        sys.exit(1)
+
+    print("\n" + "=" * 60)
+    print(" GDN (Gated Delta Network) Linear Attention Benchmark")
+    print(" GPU:", torch.cuda.get_device_name(0))
+    print("=" * 60)
+
+    if args.sweep:
+        benchmark_sweep(
+            warmup_iters=args.warmup,
+            benchmark_iters=args.iters,
+        )
+        return
+
+    if args.varlen:
+        if args.cu_seqlens is not None:
+            cu_seqlens = args.cu_seqlens
+            if cu_seqlens[0] != 0:
+                print(f"Error: cu_seqlens must start with 0, got {cu_seqlens[0]}")
+                sys.exit(1)
+            if len(cu_seqlens) < 2:
+                print("Error: cu_seqlens must have at least 2 elements (e.g. 0 1024)")
+                sys.exit(1)
+        else:
+            cu_seqlens = [args.seq_len * i for i in range(args.batch_size + 1)]
+        print("\nRunning variable-length benchmark:")
+        print(f"  cu_seqlens: {cu_seqlens}")
+        print(f"  num_qk_heads: {args.num_qk_heads}")
+        print(f"  num_v_heads: {args.num_v_heads}")
+        print(f"  head_dim: {args.head_dim}")
+
+        result = benchmark_gdn_varlen(
+            cu_seqlens=cu_seqlens,
+            num_qk_heads=args.num_qk_heads,
+            num_v_heads=args.num_v_heads,
+            head_dim=args.head_dim,
+            warmup_iters=args.warmup,
+            benchmark_iters=args.iters,
+        )
+        print_results_table([result], "Variable-Length Benchmark")
+    else:
+        # Fixed-length benchmark
+        print("\nRunning fixed-length benchmark:")
+        print(f"  batch_size: {args.batch_size}")
+        print(f"  seq_len: {args.seq_len}")
+        print(f"  num_qk_heads: {args.num_qk_heads}")
+        print(f"  num_v_heads: {args.num_v_heads}")
+        print(f"  head_dim: {args.head_dim}")
+        print(f"  warmup: {args.warmup}")
+        print(f"  iters: {args.iters}")
+
+        result = benchmark_gdn_fixlen(
+            batch_size=args.batch_size,
+            seq_len=args.seq_len,
+            num_qk_heads=args.num_qk_heads,
+            num_v_heads=args.num_v_heads,
+            head_dim=args.head_dim,
+            warmup_iters=args.warmup,
+            benchmark_iters=args.iters,
+        )
+
+        print_results_table([result], "Fixed-Length Benchmark")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_blackwell_gdn_prefill.py
+++ b/benchmarks/bench_blackwell_gdn_prefill.py
@@ -436,19 +436,19 @@ def print_results_table(results: List[dict], title: str = "Benchmark Results"):
 
 def main():
     parser = argparse.ArgumentParser(description="GDN Performance Benchmark")
-    parser.add_argument("--batch-size", "-b", type=int, default=1, help="Batch size")
+    parser.add_argument("--batch-size", "-b", type=int, default=4, help="Batch size")
     parser.add_argument(
-        "--seq-len", "-t", type=int, default=8192, help="Sequence length"
+        "--seq-len", "-t", type=int, default=4096, help="Sequence length"
     )
     parser.add_argument(
         "--num-qk-heads",
         "-nqk",
         type=int,
-        default=96,
+        default=32,
         help="Number of qk attention heads",
     )
     parser.add_argument(
-        "--num-v-heads", "-nv", type=int, default=96, help="Number of v attention heads"
+        "--num-v-heads", "-nv", type=int, default=32, help="Number of v attention heads"
     )
     parser.add_argument(
         "--head-dim", "-d", type=int, default=128, help="Head dimension"

--- a/benchmarks/bench_blackwell_gdn_prefill.py
+++ b/benchmarks/bench_blackwell_gdn_prefill.py
@@ -32,7 +32,7 @@ from typing import List
 import torch
 import torch.nn.functional as F
 
-# Blacwell GDN prefill
+# Blackwell GDN prefill
 from flashinfer.gdn_kernels.blackwell_prefill.gdn import chunk_gated_delta_rule
 
 # FLA baseline

--- a/benchmarks/bench_blackwell_gdn_prefill.py
+++ b/benchmarks/bench_blackwell_gdn_prefill.py
@@ -33,6 +33,7 @@ import torch
 import torch.nn.functional as F
 import numpy as np
 from flashinfer.testing import bench_gpu_time
+from flashinfer.utils import is_sm100a_supported, is_sm110a_supported
 
 # Blackwell GDN prefill
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
@@ -426,6 +427,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    device = torch.device("cuda")
+    if not (is_sm100a_supported(device) or is_sm110a_supported(device)):
+        print("Error: bench_blackwell_gdn_prefill.py requires an SM100A/SM110A GPU.")
+        sys.exit(1)
 
     if args.head_dim != 128:
         print(f"Error: head_dim must be 128, got {args.head_dim}")

--- a/benchmarks/bench_blackwell_gdn_prefill.py
+++ b/benchmarks/bench_blackwell_gdn_prefill.py
@@ -33,13 +33,18 @@ import torch
 import torch.nn.functional as F
 import numpy as np
 from flashinfer.testing import bench_gpu_time
-from flashinfer.utils import is_sm100a_supported, is_sm110a_supported
+from flashinfer.utils import get_compute_capability
 
 # Blackwell GDN prefill
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 # FLA baseline
 from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd as fla_base
+
+
+def check_compute_capability(device: torch.device) -> bool:
+    major, minor = get_compute_capability(device)
+    return (major, minor) in ((10, 0), (10, 3), (11, 0))
 
 
 def benchmark_gdn_fixlen(
@@ -429,8 +434,11 @@ def main():
     args = parser.parse_args()
 
     device = torch.device("cuda")
-    if not (is_sm100a_supported(device) or is_sm110a_supported(device)):
-        print("Error: bench_blackwell_gdn_prefill.py requires an SM100A/SM110A GPU.")
+    is_device_support = check_compute_capability(device)
+    if not is_device_support:
+        print(
+            "Error: bench_blackwell_gdn_prefill.py requires an SM100/SM103/SM110 GPU."
+        )
         sys.exit(1)
 
     if args.head_dim != 128:

--- a/flashinfer/gdn_kernels/__init__.py
+++ b/flashinfer/gdn_kernels/__init__.py
@@ -48,12 +48,6 @@ except ImportError:
     get_vec_size_mtp = None  # type: ignore
 
 
-try:
-    from .blackwell_prefill.gdn import chunk_gated_delta_rule
-except ImportError:
-    chunk_gated_delta_rule = None  # type: ignore
-
-
 __all__ = [
     "gated_delta_rule",
     "GatedDeltaRuleKernel",
@@ -62,5 +56,4 @@ __all__ = [
     "run_mtp_decode",
     "get_tile_v_mtp",
     "get_vec_size_mtp",
-    "chunk_gated_delta_rule",
 ]

--- a/flashinfer/gdn_kernels/__init__.py
+++ b/flashinfer/gdn_kernels/__init__.py
@@ -47,6 +47,13 @@ except ImportError:
     get_tile_v_mtp = None  # type: ignore
     get_vec_size_mtp = None  # type: ignore
 
+
+try:
+    from .blackwell_prefill.gdn import chunk_gated_delta_rule
+except ImportError:
+    chunk_gated_delta_rule = None  # type: ignore
+
+
 __all__ = [
     "gated_delta_rule",
     "GatedDeltaRuleKernel",
@@ -55,4 +62,5 @@ __all__ = [
     "run_mtp_decode",
     "get_tile_v_mtp",
     "get_vec_size_mtp",
+    "chunk_gated_delta_rule",
 ]

--- a/flashinfer/gdn_kernels/blackwell_prefill/__init__.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from .gdn import chunk_gated_delta_rule
+except ImportError:
+    chunk_gated_delta_rule = None  # type: ignore
+
+__all__ = ["chunk_gated_delta_rule"]

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
@@ -3782,12 +3782,18 @@ class GDN:
         initial_state_f32_iter: Optional[cute.Pointer],
         state_output: Optional[cute.Pointer],
         scale: Optional[float],
-        cum_seqlen_q: Optional[cute.Tensor] = None,
+        cum_seqlen: Optional[cute.Pointer] = None,
         stream: cuda.CUstream = None,
     ):
         """Host-side entry: build tensor layouts, TMA descriptors, smem storage, and launch the kernel."""
 
         b, s_q, s_sum, h_q, h_v, d = problem_size
+
+        cum_seqlen_q = (
+            None
+            if cum_seqlen is None
+            else cute.make_tensor(cum_seqlen, cute.make_layout((b)))
+        )
 
         h_r = h_v // h_q
         o_offset = 0 if cum_seqlen_q is None else (-s_q * d * h_r * h_q)
@@ -4570,8 +4576,9 @@ def chunk_gated_delta_rule(
     # Compile kernel with TVM FFI (cached)
     is_varlen = cu_seqlens is not None
     is_initial_state = initial_state is not None
+    cache_problem_size = problem_size[5]
     cache_key = (
-        problem_size,
+        cache_problem_size,
         q.dtype,
         is_varlen,
         is_initial_state,
@@ -4621,7 +4628,7 @@ def chunk_gated_delta_rule(
             state_tensor.iterator if state_tensor is not None else None,
             state_output_tensor.iterator if output_final_state else None,
             scale,
-            cu_seqlens_tensor,
+            cu_seqlens_tensor.iterator if cu_seqlens_tensor is not None else None,
             stream=current_stream,
         )
         cache["compiled_gdn"] = compiled_gdn
@@ -4640,7 +4647,7 @@ def chunk_gated_delta_rule(
         initial_state.data_ptr() if initial_state is not None else None,
         output_state.data_ptr() if output_final_state else None,
         scale,
-        cu_seqlens,
+        cu_seqlens.data_ptr() if is_varlen else None,
         stream=current_stream,
     )
 

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
@@ -1591,22 +1591,8 @@ class GDN:
             beta_val = sBeta0[tidx]
             gb_handle.release()
 
-            # Barrier to ensure cumsum visible, then save gate_tail before overwrite
-            cute.arch.barrier(
-                barrier_id=self.wg_sync_bar_id,
-                number_of_threads=len(self.cudacore_warp_ids) * 32,
-            )
-            gate_tail = (
-                sGateCumsum[tail_count - 1]
-                if cutlass.const_expr(need_mask)
-                else sGateCumsum[127]
-            )
-
-            # Precompute exp(cumsum_i) for factored gamma
-            tval_exp_gamma = cute.math.exp(tval, fastmath=True)
-
             self.compute_gamma_tmem(
-                tval_exp_gamma,
+                tval,
                 sGateCumsum,
                 kkt_thr_mma,
                 tGamma,
@@ -1622,6 +1608,12 @@ class GDN:
                 tKKTtKKT,
                 beta_val,
                 tGamma,
+            )
+
+            gate_tail = (
+                sGateCumsum[tail_count - 1]
+                if cutlass.const_expr(need_mask)
+                else sGateCumsum[127]
             )
             w0_handle = epi_w0_consumer.wait_and_advance()
             self.load_state_apply_gate(
@@ -2769,7 +2761,7 @@ class GDN:
         cIn = cute.make_identity_tensor((128, 128))
         tOcO = thr_mma.partition_C(cIn)
 
-        corr_tile_size = 32
+        corr_tile_size = 8
         tIn_i_layout = cute.composition(
             tIn.layout, cute.make_layout((128, corr_tile_size))
         )
@@ -3301,20 +3293,9 @@ class GDN:
         mask: cutlass.Constexpr[cutlass.Boolean] = False,
         tail_count: Int32 = 128,
     ):
-        """Build the 128x128 causal gamma matrix in TMEM: gamma[i,j] = exp(cumsum[i]) * exp(-cumsum[j]) for j <= i."""
+        """Build the 128x128 causal gamma matrix in TMEM: gamma[i,j] = exp(cumsum[i] - cumsum[j]) for j <= i."""
         tidx, _, _ = cute.arch.thread_idx()
         thread_idx = tidx % 128
-
-        cute.arch.barrier(
-            barrier_id=bar_id,
-            number_of_threads=len(self.cudacore_warp_ids) * 32,
-        )
-
-        # Precompute exp(-cumsum[j]) cooperatively and store to sGateCumsum
-        # Save gate_tail first (needed later, before we overwrite)
-        tidx_in_group = tidx % 128
-        neg_exp_val = cute.math.exp(-sGateCumsum[tidx_in_group], fastmath=True)
-        sGateCumsum[tidx_in_group] = neg_exp_val
 
         cute.arch.barrier(
             barrier_id=bar_id,
@@ -3367,7 +3348,6 @@ class GDN:
             )
             for it in cutlass.range_constexpr(corr_tile_size // frg_tile):
                 tile_offset = i * corr_tile_size + it * frg_tile
-                tile_end = tile_offset + frg_tile - 1
 
                 if (
                     (
@@ -3378,24 +3358,18 @@ class GDN:
                     if cutlass.const_expr(mask)
                     else (tile_offset <= thread_idx)
                 ):
-                    # Load precomputed exp(-cumsum[j]) from smem
-                    neg_exp_frag = sGateCumsum_frag[(None, it), i].load()
+                    curr_val_frag_ssa = sGateCumsum_frag[(None, it), i].load()
 
-                    # gamma[i,j] = exp(cumsum_i) * exp(-cumsum_j) — mul instead of exp
-                    new_val_frag = val * neg_exp_frag
+                    new_val_frag = cute.math.exp(val - curr_val_frag_ssa, fastmath=True)
 
-                    if tile_end <= thread_idx:
-                        # Fast path: entire tile below diagonal
-                        tTMEM_STORErS_frag[None, it].store(new_val_frag)
-                    else:
-                        for inner_idx in cutlass.range_constexpr(0, frg_tile):
-                            offset = tile_offset + inner_idx
-                            curr_val = new_val_frag[inner_idx]
+                    for inner_idx in cutlass.range_constexpr(0, frg_tile):
+                        offset = tile_offset + inner_idx
+                        curr_val = new_val_frag[inner_idx]
 
-                            if offset <= thread_idx:
-                                tTMEM_STORErS_frag[inner_idx, it] = curr_val
-                            else:
-                                tTMEM_STORErS_frag[inner_idx, it] = cutlass.Float32(0)
+                        if offset <= thread_idx:
+                            tTMEM_STORErS_frag[inner_idx, it] = curr_val
+                        else:
+                            tTMEM_STORErS_frag[inner_idx, it] = cutlass.Float32(0)
                 else:
                     tTMEM_STORErS_frag[None, it].store(zeros)
 

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
@@ -1,0 +1,4678 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Gated Delta Networks (GDN) chunked linear attention kernel for NVIDIA Blackwell (SM100).
+#
+# Implements the Chunk-wise Gated Delta Rule linear attention using CuTe-DSL,
+# for Blackwell Architecture.
+#
+# Key Features:
+#   - Supports Persistent & Non-persistent modes
+#   - Supports fixed-length and variable-length sequences (cu_seqlens)
+#   - Supports grouped value attention (GVA) where h_v is a multiple of h_q
+#   - Supports head dimension (128)
+#   - Supports input data types (f16/bf16)
+#   - Supports output data types (f16/bf16)
+#   - Supports initial_state to provide the initial state
+#   - Supports output_final_state flag to return the final state
+#   - State input and output are in f32 (fp16/bf16 not supported yet)
+
+import torch
+
+from typing import Optional, Type, Tuple, Union
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cute.runtime import from_dlpack
+from cutlass._mlir.dialects import nvvm
+
+import cuda.bindings.driver as cuda
+
+
+from .gdn_tile_scheduler import *
+from .gdn_helpers import *
+
+import functools
+import warnings
+
+from cutlass.cute import EnableTVMFFI
+
+
+def make_thread_cooperative_group(size: Int32):
+    # return pipeline.CooperativeGroup(pipeline.Agent.Thread, size, size) # old version
+    return pipeline.CooperativeGroup(pipeline.Agent.Thread, size)
+
+
+class GDN:
+    """Blackwell (SM100) kernel for Chunk-wise Gated Delta Rule linear attention."""
+
+    def __init__(
+        self,
+        is_persistent: bool = False,
+        chunk_size: Int32 = 128,  # Only 128 is supported in current version
+        head_dim: Int32 = 128,  # Only 128 is supported in current version
+    ):
+        self.chunk_size = chunk_size
+        self.is_persistent = is_persistent
+
+        self.head_dim = head_dim
+        self.cta_tiler = (chunk_size, chunk_size, head_dim)
+        self.gate_tiler = (chunk_size, 1)
+        self.beta_tiler = (chunk_size, 1)
+        self.state_output_tiler = (head_dim, head_dim)
+        self.o_output_tiler = (chunk_size, head_dim)
+
+        self.g_beta_dtype = cutlass.Float32
+        self.acc_dtype = cutlass.Float32
+        self.state_dtype = cutlass.Float32
+
+        self.mma_tiler = (chunk_size, chunk_size, head_dim)
+        self.qk_mma_tiler = self.mma_tiler
+        self.kkt_mma_tiler = self.mma_tiler
+        self.kst_mma_tiler = self.mma_tiler
+        self.tuw_mma_tiler = self.mma_tiler
+        self.o_intra_mma_tiler = (chunk_size, head_dim, chunk_size)
+        self.qs_mma_tiler = (chunk_size, head_dim, head_dim)
+        self.update_s_mma_tiler = (head_dim, head_dim, chunk_size)
+
+        self.epi_tile = (128, 128)
+
+        self.cluster_shape_mnk = (1, 1, 1)
+
+        self.buffer_align_bytes = 1024
+
+        self.q_stage = 1
+        self.one_stage = 1
+        self.kv_stage = 1
+        self.qk_stage = 2
+        self.gate_stage = 1
+        self.beta_stage = 1
+        self.mma_cudacore_stage = 1
+        self.mma_qk_stage = 2
+        self.epi_stage = 1
+
+        self.cudacore_warp_ids = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.load_warp_id = 5
+        self.epilogue_warp_id = 6
+        self.gb_warp_id = 7
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.cudacore_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+                self.epilogue_warp_id,
+                self.gb_warp_id,
+            )
+        )
+
+        # TMEM configuration
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        self.tmem_kkt_output = 0
+        self.tmem_qkt_output = 384
+        self.tmem_gate_qk = 384
+        self.tmem_gate_q = 448  # 448
+        self.tmem_k_input = 64
+        self.tmem_kst_output = 256
+        self.tmem_ivt_ss_l0_output = 448
+        self.tmem_ivt_ts_l0_input = 320
+        self.tmem_ivt_ts_l0_output = 448
+        self.tmem_ivt_ss_l1_output = 320
+        self.tmem_ivt_ts_l1_input = 320
+        self.tmem_ivt_ts_l1_output = 256
+        self.tmem_tuw_output = 256
+        self.tmem_o_intra_output = 256
+        self.tmem_o_inter_output = 256
+        self.tmem_update_s_output = 128
+        self.tmem_gamma = 256
+
+        self.tmem_state = 128
+
+        # Registers configuration
+        self.num_regs_cudacore = 240
+        self.num_regs_mma = 64
+        self.num_regs_other = 64
+        self.num_regs_gb = 64
+
+        # Named barrier IDs
+        self.cta_sync_bar_id = 0
+        self.tmem_alloc_sync_bar_id = 1
+        self.cudacore_mma_sync_bar_id = 2
+        self.wg_sync_bar_id = 3
+        self.epi_load_sync_bar_id = 4
+
+        # Matrix inversion using TFloat32
+        self.invert_type_ab = cutlass.TFloat32
+        self.invert_acc_type = cutlass.Float32
+        self.invert_mma_sub_l0_tiler = (64, 64, 32)
+        self.invert_mma_sub_l1_tiler = (64, 64, 64)
+        self.invert_mma_tiler = (128, 128, 64)
+        self.invert_sub_stage = 1
+        self.sub_stage = 9
+
+    @staticmethod
+    def can_implement(
+        q_shape: Tuple[int, int, int, int] | Tuple[int, Tuple[int, ...], int, int],
+        v_shape: Tuple[int, int, int, int] | Tuple[int, Tuple[int, ...], int, int],
+        in_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        g_beta_dtype: Type[cutlass.Numeric],
+        use_qk_l2norm_in_kernel: bool = False,
+    ) -> bool:
+        """
+        Check if the gdn can be implemented
+        """
+
+        can_implement = True
+
+        # Unpack parameters
+        b, s_q, h_q, d = q_shape
+        b_, _, h_v, d_ = v_shape
+
+        if use_qk_l2norm_in_kernel:
+            warnings.warn("use_qk_l2norm_in_kernel is not supported yet", stacklevel=2)
+            can_implement = False
+
+        if b != b_:
+            warnings.warn("q & k must have the same batch size", stacklevel=2)
+            can_implement = False
+
+        if d != d_:
+            warnings.warn("q & k must have the same head dimension", stacklevel=2)
+            can_implement = False
+
+        # todo: maybe support more later.
+        if d not in {128}:
+            warnings.warn("head dimension must be 128", stacklevel=2)
+            can_implement = False
+
+        if h_v % h_q != 0:
+            warnings.warn("h_v must be divisible by h_q", stacklevel=2)
+
+            can_implement = False
+
+        if isinstance(s_q, tuple) and len(s_q) != b:
+            warnings.warn(
+                "variable_seqlen s_q must have the length of batch size", stacklevel=2
+            )
+            can_implement = False
+
+        if in_dtype not in {
+            cutlass.BFloat16,
+            cutlass.Float16,
+            torch.float16,
+            torch.bfloat16,
+        }:
+            warnings.warn(
+                "in_dtype must be BFloat16 or Float16 or torch.float16 or torch.bfloat16",
+                stacklevel=2,
+            )
+            can_implement = False
+
+        if out_dtype not in {
+            cutlass.BFloat16,
+            cutlass.Float16,
+            torch.float16,
+            torch.bfloat16,
+        }:
+            warnings.warn(
+                "out_dtype must be BFloat16 or Float16 or torch.float16 or torch.bfloat16",
+                stacklevel=2,
+            )
+            can_implement = False
+
+        if g_beta_dtype not in {cutlass.Float32, torch.float32}:
+            warnings.warn(
+                "g_beta_dtype must be Float32 or torch.float32, but got {}".format(
+                    g_beta_dtype
+                ),
+                stacklevel=2,
+            )
+            can_implement = False
+
+        return can_implement
+
+    @cute.kernel
+    def kernel(
+        self,
+        qk_tiled_mma: cute.TiledMma,
+        o_intra_tiled_mma: cute.TiledMma,
+        o_intra_tiled_ts_mma_new: cute.TiledMma,
+        qs_tiled_mma: cute.TiledMma,
+        update_s_tiled_mma: cute.TiledMma,
+        kkt_tiled_mma: cute.TiledMma,
+        kst_tiled_mma: cute.TiledMma,
+        fake_state_tiled_mma: cute.TiledMma,
+        invert_sub_tiled_mma_ss_l0: cute.TiledMma,
+        invert_sub_tiled_mma_ts_l0: cute.TiledMma,
+        invert_sub_tiled_mma_ss_l1: cute.TiledMma,
+        invert_sub_tiled_mma_ts_l1: cute.TiledMma,
+        tuw_tiled_mma: cute.TiledMma,
+        tma_atom_q: cute.CopyAtom,
+        mQ_qdl: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_kdl: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_dkl: cute.Tensor,
+        tma_atom_state_f32: Optional[cute.CopyAtom],
+        mState_f32: Optional[cute.Tensor],
+        gate: cute.Tensor,
+        beta: cute.Tensor,
+        O: cute.Tensor,
+        tma_atom_state_output: Optional[cute.CopyAtom],
+        mStateOutput: Optional[cute.Tensor],
+        tma_atom_o_output: cute.CopyAtom,
+        mO_qdl: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        qk_smem_layout_staged: cute.ComposedLayout,
+        o_intra_smem_layout_staged_a: cute.ComposedLayout,
+        o_intra_smem_layout_staged_b: cute.ComposedLayout,
+        o_intra_smem_layout_staged_a_new: cute.ComposedLayout,
+        qs_smem_layout_staged_a: cute.ComposedLayout,
+        qs_smem_layout_staged_b: cute.ComposedLayout,
+        update_s_smem_layout_staged_a: cute.ComposedLayout,
+        update_s_smem_layout_staged_b: cute.ComposedLayout,
+        state_smem_layout_staged: cute.ComposedLayout,
+        state_smem_layout_f32_staged: cute.ComposedLayout,
+        state_output_smem_layout_staged: cute.ComposedLayout,
+        o_output_smem_layout_staged: cute.ComposedLayout,
+        gate_smem_layout_staged: cute.Layout,
+        beta_smem_layout_staged: cute.Layout,
+        ivt_smem_layout: cute.Layout,
+        sub_inner_smem_layout_staged: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l0_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l0_b: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l0_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l0_b: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l1_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l1_b: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l1_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l1_b: cute.ComposedLayout,
+        tuw_smem_layout_staged_a: cute.ComposedLayout,
+        tuw_smem_layout_staged_b: cute.ComposedLayout,
+        v_smem_layout_staged_b: cute.ComposedLayout,
+        scale: cutlass.Float32,
+        tile_sched_params: GdnStaticTileSchedulerParams,
+    ):
+        """Warp-specialized GDN kernel entry point."""
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        # Prefetch TMA descriptors
+        if warp_idx == self.load_warp_id:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o_output)
+            if cutlass.const_expr(tma_atom_state_f32 is not None):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_state_f32)
+            if cutlass.const_expr(tma_atom_state_output is not None):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_state_output)
+
+        # Alloc
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_qk_producer, load_qk_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.qk_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_kv_bytes,
+            barrier_storage=storage.load_qk_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.one_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.cudacore_warp_ids),
+            ),
+            tx_count=self.tma_copy_v_bytes,
+            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        load_state_producer, load_state_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.one_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len(self.cudacore_warp_ids)),
+            tx_count=self.tma_copy_state_f32_bytes,
+            barrier_storage=storage.load_state_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        mma_qk_producer0, mma_qk_consumer0 = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_qk_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            barrier_storage=storage.mma_qk_mbar_ptr0.data_ptr(),
+        ).make_participants()
+
+        mma_cudacore_producer0, mma_cudacore_consumer0 = (
+            pipeline.PipelineUmmaAsync.create(
+                num_stages=self.mma_cudacore_stage,
+                producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+                consumer_group=make_thread_cooperative_group(
+                    self.threads_per_warp * len(self.cudacore_warp_ids)
+                ),
+                barrier_storage=storage.mma_cudacore_mbar_ptr0.data_ptr(),
+            ).make_participants()
+        )
+
+        gb_w0_producer, gb_w0_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.gate_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            barrier_storage=storage.gb_w0_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        epi_w0_producer, epi_w0_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            barrier_storage=storage.epi_w0_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        w0_epi_producer, w0_epi_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(self.threads_per_warp),
+            barrier_storage=storage.w0_epi_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.data_ptr()
+
+        #  tmem barrier init
+        if warp_idx == self.gb_warp_id:
+            cute.arch.mbarrier_init(
+                tmem_dealloc_mbar_ptr,
+                self.threads_per_warp * len((*self.cudacore_warp_ids,)),
+            )
+        cute.arch.mbarrier_init_fence()
+
+        sQK = storage.sQK.get_tensor(
+            qk_smem_layout_staged.outer, swizzle=qk_smem_layout_staged.inner
+        )
+        sQ = cute.make_tensor(
+            cute.recast_ptr(
+                sQK[None, None, None, 1].iterator,
+                swizzle_=q_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            q_smem_layout_staged.outer,
+        )
+        sK = cute.make_tensor(
+            cute.recast_ptr(
+                sQK[None, None, None, 0].iterator,
+                swizzle_=k_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            k_smem_layout_staged.outer,
+        )
+        sStateInput = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sState.data_ptr(),
+                swizzle_=state_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            state_smem_layout_staged.outer,
+        )
+        sV = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sV.data_ptr(),
+                swizzle_=v_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            v_smem_layout_staged_b.outer,
+        )
+
+        sGate = storage.sGate.get_tensor(gate_smem_layout_staged)
+        sBeta = storage.sBeta.get_tensor(beta_smem_layout_staged)
+        sGateCumsum = storage.sGateCumsum.get_tensor(
+            cute.select(gate_smem_layout_staged, mode=[0, 1])
+        )
+        sSubInner = storage.sSubInner.get_tensor(sub_inner_smem_layout_staged)
+        sInvertSubSSL0A = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 6].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l0_a.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l0_a.outer,
+        )
+
+        sInvertSubSSL0B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 7].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l0_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l0_b.outer,
+        )
+        sInvertSubTSL0B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 8].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ts_l0_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ts_l0_b.outer,
+        )
+        sInvertSubSSL1A = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l1_a.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l1_a.outer,
+        )
+        sInvertSubSSL1B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 2].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l1_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l1_b.outer,
+        )
+        sInvertSubTSL1B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 6].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ts_l1_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ts_l1_b.outer,
+        )
+
+        sInvertSubReg = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 4].iterator, dtype=self.invert_type_ab
+            ),
+            cute.make_layout(((4, 128), 8)),
+        )
+
+        sStateInputF32 = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=state_smem_layout_f32_staged.inner,
+                dtype=self.state_dtype,
+            ),
+            state_smem_layout_f32_staged.outer,
+        )
+        sStateOutput = cute.make_tensor(
+            cute.recast_ptr(
+                sQK[None, None, None, 0].iterator,
+                swizzle_=state_output_smem_layout_staged.inner,
+                dtype=self.state_dtype,
+            ),
+            state_output_smem_layout_staged.outer,
+        )
+
+        sOIntraB = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 4].iterator,
+                swizzle_=o_intra_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            o_intra_smem_layout_staged_b.outer,
+        )
+        sQSB = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sState.data_ptr(),
+                swizzle_=qs_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            qs_smem_layout_staged_b.outer,
+        )
+
+        sUpdateA = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 4].iterator,
+                swizzle_=update_s_smem_layout_staged_a.inner,
+                dtype=self.i_dtype,
+            ),
+            update_s_smem_layout_staged_a.outer,
+        )
+        sUpdateB = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=update_s_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            update_s_smem_layout_staged_b.outer,
+        )
+
+        sO = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sState.data_ptr(),
+                swizzle_=o_output_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            o_output_smem_layout_staged.outer,
+        )
+        sIvt = storage.sIvt.get_tensor(ivt_smem_layout)
+
+        sTuwA = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=tuw_smem_layout_staged_a.inner,
+                dtype=self.i_dtype,
+            ),
+            tuw_smem_layout_staged_a.outer,
+        )
+        sTuwB = cute.make_tensor(
+            cute.recast_ptr(storage.sV.data_ptr(), dtype=self.k_dtype),
+            tuw_smem_layout_staged_b,
+        )
+        sTuwAStore_layout = cute.make_layout(
+            ((128, (4, 2)), 8), stride=((4, (1, 512)), 1024)
+        )
+        sTuwAStore = cute.make_tensor(
+            cute.recast_ptr(sTuwA.iterator, dtype=cutlass.Float32), sTuwAStore_layout
+        )
+
+        if warp_idx == self.epilogue_warp_id:
+            # Alloc tmem buffer
+            tmem_alloc_cols = cutlass.Int32(self.tmem_alloc_cols)
+            cute.arch.alloc_tmem(tmem_alloc_cols, storage.tmem_holding_buf)
+
+        # Ensure visibility of local mbarrier inits and tmem alloc
+        cute.arch.sync_threads()
+
+        tmem_ptr = cute.arch.retrieve_tmem_ptr(
+            self.acc_dtype,
+            alignment=16,
+            ptr_to_buffer_holding_addr=storage.tmem_holding_buf,
+        )
+
+        qk_thr_mma = qk_tiled_mma.get_slice(0)  # default 1sm
+        tSrQ = qk_thr_mma.make_fragment_A(sQK)
+        tSrK = qk_thr_mma.make_fragment_B(sQK)
+        qk_acc_shape = qk_thr_mma.partition_shape_C(
+            (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+        )
+        tQKtQK_fake = qk_thr_mma.make_fragment_C(qk_acc_shape)
+        tQKtQK = cute.make_tensor(tmem_ptr + self.tmem_qkt_output, tQKtQK_fake.layout)
+
+        kkt_thr_mma = kkt_tiled_mma.get_slice(0)  # default 1sm
+        tArK = kkt_thr_mma.make_fragment_A(sQK)
+        tArKT = kkt_thr_mma.make_fragment_B(sQK)
+        kkt_acc_shape = kkt_thr_mma.partition_shape_C(
+            (self.kkt_mma_tiler[0], self.kkt_mma_tiler[1])
+        )
+
+        fake_state_thr_mma = fake_state_tiled_mma.get_slice(0)
+
+        kst_thr_mma = kst_tiled_mma.get_slice(0)
+        tKSrK_0 = kst_thr_mma.make_fragment_A(sQK)
+        tKSrST = kst_thr_mma.make_fragment_B(sStateInput)
+        kst_acc_shape = kst_thr_mma.partition_shape_C(
+            (self.kst_mma_tiler[0], self.kst_mma_tiler[1])
+        )
+        tKStKS_fake = kst_thr_mma.make_fragment_C(kst_acc_shape)
+        tKStKS = cute.make_tensor(tmem_ptr + self.tmem_kst_output, tKStKS_fake.layout)
+        # input smem A
+        tKStK_layout = cute.composition(tKStKS.layout, cute.make_layout((128, 64)))
+        tKtK = cute.make_tensor(tmem_ptr + self.tmem_k_input, tKStK_layout)
+
+        invert_sub_thr_mma_ss_l0 = invert_sub_tiled_mma_ss_l0.get_slice(0)
+        tSrD = invert_sub_thr_mma_ss_l0.make_fragment_A(sInvertSubSSL0A)
+        tSrC = invert_sub_thr_mma_ss_l0.make_fragment_B(sInvertSubSSL0B)
+        invert_sub_acc_shape = invert_sub_thr_mma_ss_l0.partition_shape_C(
+            (self.invert_mma_sub_l0_tiler[0], self.invert_mma_sub_l0_tiler[1])
+        )
+
+        tKKTtKKT_fake = kkt_thr_mma.make_fragment_C(kkt_acc_shape)
+        tKKTtKKT = cute.make_tensor(
+            tmem_ptr + self.tmem_kkt_output, tKKTtKKT_fake.layout
+        )
+
+        tItSSL0_fake = invert_sub_thr_mma_ss_l0.make_fragment_C(invert_sub_acc_shape)
+        tItSSL0 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ss_l0_output, tItSSL0_fake.layout
+        )
+
+        # : ((128,128),1,1):((65536,1),0,0)
+        tQgate_layout = cute.make_layout(((128, 64), 1, 1), stride=((65536, 1), 0, 0))
+        tQgate = cute.make_tensor(tmem_ptr + self.tmem_gate_q, tQgate_layout)
+
+        tGamma_layout = cute.make_layout(((128, 128), 1, 1), stride=((65536, 1), 0, 0))
+        tGamma = cute.make_tensor(tmem_ptr + self.tmem_gamma, tGamma_layout)
+
+        # tStage
+        tStateF32_layout = cute.make_layout(
+            ((128, 128), 1, 1), stride=((65536, 1), 0, 0)
+        )
+        tStateF32 = cute.make_tensor(tmem_ptr + self.tmem_state, tStateF32_layout)
+
+        invert_sub_thr_mma_ts_l0 = invert_sub_tiled_mma_ts_l0.get_slice(0)
+        tInrDCL0A_fake = invert_sub_thr_mma_ts_l0.make_fragment_A(
+            invert_sub_smem_layout_staged_ts_l0_a.outer.shape
+        )
+        tInrDCL0A = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr,
+                dtype=tInrDCL0A_fake.element_type,
+            )
+            + self.tmem_ivt_ts_l0_input,
+            tInrDCL0A_fake.layout,
+        )
+
+        # input smem B
+        tSrDCL0B = invert_sub_thr_mma_ts_l0.make_fragment_B(sInvertSubTSL0B)
+
+        # output tmem C
+        tItTSL0_fake = invert_sub_thr_mma_ts_l0.make_fragment_C(invert_sub_acc_shape)
+        tItTSL0 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ts_l0_output, tItTSL0_fake.layout
+        )
+
+        invert_sub_thr_mma_ss_l1 = invert_sub_tiled_mma_ss_l1.get_slice(0)
+        tSrD_ivt_l1 = invert_sub_thr_mma_ss_l1.make_fragment_A(sInvertSubSSL1A)
+        tSrC_ivt_l1 = invert_sub_thr_mma_ss_l1.make_fragment_B(sInvertSubSSL1B)
+        invert_sub_acc_l1_shape = invert_sub_thr_mma_ss_l1.partition_shape_C(
+            (self.invert_mma_sub_l1_tiler[0], self.invert_mma_sub_l1_tiler[1])
+        )
+        tCtAcc_ivt_l1_ss_fake = invert_sub_thr_mma_ss_l1.make_fragment_C(
+            invert_sub_acc_l1_shape
+        )
+        tStO_ivt_l1_ss0 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ss_l1_output, tCtAcc_ivt_l1_ss_fake.layout
+        )
+
+        invert_sub_thr_mma_ts_l1 = invert_sub_tiled_mma_ts_l1.get_slice(0)
+        invert_acc_ts_l1_shape = invert_sub_thr_mma_ts_l1.partition_shape_C(
+            (self.invert_mma_sub_l1_tiler[0], self.invert_mma_sub_l1_tiler[1])
+        )
+        # output tmem C
+        tOtTSL1_fake = invert_sub_thr_mma_ts_l1.make_fragment_C(invert_acc_ts_l1_shape)
+        tOtTSL1 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ts_l1_output, tOtTSL1_fake.layout
+        )
+
+        tuw_thr_mma = tuw_tiled_mma.get_slice(0)
+        # input smem A
+        tTUWrA = tuw_thr_mma.make_fragment_A(sTuwA)
+        # input smem B
+        tTUWrB = tuw_thr_mma.make_fragment_B(sTuwB)
+        # output tmem C
+        tuw_acc_shape = tuw_thr_mma.partition_shape_C(
+            (self.tuw_mma_tiler[0], self.tuw_mma_tiler[1])
+        )
+        tVtTUW_fake = tuw_thr_mma.make_fragment_C(tuw_acc_shape)
+        tVtTUW = cute.make_tensor(tmem_ptr + self.tmem_tuw_output, tVtTUW_fake.layout)
+
+        o_intra_thr_mma = o_intra_tiled_mma.get_slice(0)
+        # input smem B
+        tOIntrarB = o_intra_thr_mma.make_fragment_B(sOIntraB)
+        # output tmem C
+        o_intra_acc_shape = o_intra_thr_mma.partition_shape_C(
+            (self.o_intra_mma_tiler[0], self.o_intra_mma_tiler[1])
+        )
+
+        o_intra_thr_mma_new = o_intra_tiled_ts_mma_new.get_slice(0)
+        # input smem A
+        tQKMtQKM_layout = cute.composition(tQKtQK.layout, cute.make_layout((128, 64)))
+        tQKMtQKM = cute.make_tensor(tmem_ptr + self.tmem_gate_qk, tQKMtQKM_layout)
+
+        update_s_thr_mma = update_s_tiled_mma.get_slice(0)
+        tUpdateA = update_s_thr_mma.make_fragment_A(sUpdateA)
+        tUpdateB = update_s_thr_mma.make_fragment_B(sUpdateB)
+        update_s_acc_shape = update_s_thr_mma.partition_shape_C(
+            (self.update_s_mma_tiler[0], self.update_s_mma_tiler[1])
+        )
+        tStUpdate_fake = update_s_thr_mma.make_fragment_C(update_s_acc_shape)
+        tStUpdate = cute.make_tensor(
+            tmem_ptr + self.tmem_update_s_output, tStUpdate_fake.layout
+        )
+
+        qs_thr_mma = qs_tiled_mma.get_slice(0)
+        tQSB = qs_thr_mma.make_fragment_B(sQSB)
+        qs_acc_shape = qs_thr_mma.partition_shape_C(
+            (self.qs_mma_tiler[0], self.qs_mma_tiler[1])
+        )
+        tOintertQS_fake = qs_thr_mma.make_fragment_C(qs_acc_shape)
+        tOintertQS = cute.make_tensor(
+            tmem_ptr + self.tmem_o_inter_output, tOintertQS_fake.layout
+        )
+
+        loop_count = cute.ceil_div(mO_qdl.shape[0], self.cta_tiler[0])
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Load Gate Beta
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.gb_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_gb)
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            lane_id = tidx % 32
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+
+                head_coord = curr_block_coord[2][0]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not GdnStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+
+                if not continue_cond:
+                    batch_base = cuseqlen_q
+                    gate_vals = cute.make_rmem_tensor((4), cutlass.Float32)
+                    beta_vals = cute.make_rmem_tensor((4), cutlass.Float32)
+
+                    for i in cutlass.range(loop_count, unroll=1):
+                        # step1: read gate beta
+                        for it in cutlass.range_constexpr(4):
+                            curr_idx = i * 128 + it * 32 + lane_id
+                            if curr_idx < seqlen_q:
+                                if cutlass.const_expr(cum_seqlen_q is not None):
+                                    gate_vals[it] = gate[
+                                        batch_base + curr_idx, 0, (head_coord, 0)
+                                    ]
+                                    beta_vals[it] = beta[
+                                        batch_base + curr_idx, 0, (head_coord, 0)
+                                    ]
+                                else:
+                                    gate_vals[it] = gate[
+                                        curr_idx, 0, (head_coord, batch_coord)
+                                    ]
+                                    beta_vals[it] = beta[
+                                        curr_idx, 0, (head_coord, batch_coord)
+                                    ]
+                            else:
+                                gate_vals[it] = cutlass.Float32(0)
+                                beta_vals[it] = cutlass.Float32(0)
+                        # step2: write to smem
+                        sGate0 = sGate[None, None, 0]  # assume only one stage
+                        sBeta0 = sBeta[None, None, 0]
+
+                        gb_handle = gb_w0_producer.acquire_and_advance()
+
+                        for it in cutlass.range_constexpr(4):
+                            sGate0[it * 32 + lane_id] = gate_vals[it]
+                            sBeta0[it * 32 + lane_id] = beta_vals[it]
+
+                        # step3: notify cuda core wg
+                        gb_handle.commit()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue: Store Output
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.epilogue_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not GdnStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+
+                if not continue_cond:
+                    curr_block_coord_o = curr_block_coord
+                    mO_qdl_ = mO_qdl
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        logical_offset_mO = (
+                            mO_qdl_.shape[0] - seqlen_q,
+                            0,
+                            (0, cuseqlen_q + seqlen_q),
+                        )
+                        mO_qdl_ = cute.domain_offset(logical_offset_mO, mO_qdl_)
+                        curr_block_coord_o = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], 0),
+                        )
+
+                    gO_mnl = cute.flat_divide(
+                        mO_qdl_, cute.select(self.mma_tiler, mode=[0, 1])
+                    )
+                    tOsO, tOgO_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_o_output,
+                        0,
+                        cute.make_layout(1),
+                        cute.group_modes(sO, 0, 2),
+                        cute.group_modes(gO_mnl, 0, 2),
+                    )
+                    tQgO = tOgO_qdl[None, None, 0, curr_block_coord_o[2]]
+                    w0_handle = epi_w0_producer.acquire_and_advance()
+                    w0_handle.commit()
+
+                    for i in cutlass.range(loop_count, unroll=1):
+                        w0_handle = epi_w0_producer.acquire_and_advance()
+                        cute.copy(tma_atom_o_output, tOsO[None, 0], tQgO[None, i])
+
+                        cute.arch.cp_async_bulk_commit_group()
+
+                        # Ensure O0 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+
+                        w0_handle.commit()
+
+                    if cutlass.const_expr(tma_atom_state_output is not None):
+                        gStateOutput = cute.flat_divide(
+                            mStateOutput,
+                            cute.select(self.update_s_mma_tiler, mode=[0, 1]),
+                        )
+                        tSsS, tSgS_vkl = cute.nvgpu.cpasync.tma_partition(
+                            tma_atom_state_output,
+                            0,  # no multicast
+                            cute.make_layout(1),
+                            cute.group_modes(sStateOutput, 0, 2),
+                            cute.group_modes(gStateOutput, 0, 4),
+                        )
+                        tSgS = tSgS_vkl[None, curr_block_coord[2]]
+                        w0_epi_handle = w0_epi_consumer.wait_and_advance()
+                        cute.copy(
+                            tma_atom_state_output,
+                            tSsS[None, 0],  # only 1 stage
+                            tSgS[None],
+                        )
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+                        w0_epi_handle.release()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                # The smem is reused, ensuring the State Output store is complete
+                if cutlass.const_expr(
+                    tma_atom_state_output is not None and self.is_persistent
+                ):
+                    cute.arch.barrier_arrive(
+                        barrier_id=self.epi_load_sync_bar_id,
+                        number_of_threads=self.threads_per_warp * 2,
+                    )
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD: tma load QKVS
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.load_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+                batch_coord = curr_block_coord[2][1]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not GdnStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+
+                if not continue_cond:
+                    mQ_qdl_ = mQ_qdl
+                    mK_kdl_ = mK_kdl
+                    mV_dkl_ = mV_dkl
+                    curr_block_coord_q = curr_block_coord
+                    curr_block_coord_kv = curr_block_coord
+                    curr_block_coord_state = curr_block_coord
+
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        logical_offset_mQ = (
+                            cuseqlen_q,
+                            0,
+                            (0, 0),
+                        )
+                        mQ_qdl_ = cute.domain_offset(logical_offset_mQ, mQ_qdl)
+                        curr_block_coord_q = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], Int32(0)),
+                        )
+                        logical_offset_mK = (
+                            cuseqlen_q,
+                            0,
+                            (0, 0),
+                        )
+                        logical_offset_mV = (
+                            0,
+                            cuseqlen_q,
+                            (0, 0),
+                        )
+                        mK_kdl_ = cute.domain_offset(logical_offset_mK, mK_kdl)
+                        mV_dkl_ = cute.domain_offset(logical_offset_mV, mV_dkl)
+                        curr_block_coord_kv = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], Int32(0)),
+                        )
+
+                    gQ_qdl = cute.flat_divide(
+                        mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2])
+                    )
+                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
+
+                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQK, 0, 3),
+                        cute.group_modes(tSgQ_qdl, 0, 3),
+                    )
+                    tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord_q[2]]
+
+                    gK_kdl = cute.flat_divide(
+                        mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
+                    )
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+                    tKgK = tKgK_kdl[None, None, 0, curr_block_coord_kv[2]]
+
+                    gV_kdl = cute.flat_divide(
+                        mV_dkl_, cute.select(self.tuw_mma_tiler, mode=[1, 2])
+                    )
+                    tSgV_kdl = tuw_thr_mma.partition_B(gV_kdl)
+                    tVsV, tVgV_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_kdl, 0, 3),
+                    )
+                    tVgV = tVgV_kdl[None, 0, None, curr_block_coord_kv[2]]
+
+                    if cutlass.const_expr(tma_atom_state_f32 is not None):
+                        gStateF32 = cute.flat_divide(
+                            mState_f32, cute.select(self.kst_mma_tiler, mode=[1, 2])
+                        )
+                        tKSgStateF32 = fake_state_thr_mma.partition_B(gStateF32)
+                        tSsSF32, tSgSF32_kdl = cute.nvgpu.cpasync.tma_partition(
+                            tma_atom_state_f32,
+                            0,  # no multicast
+                            cute.make_layout(1),
+                            cute.group_modes(sStateInputF32, 0, 3),
+                            cute.group_modes(tKSgStateF32, 0, 3),
+                        )
+                        tSgSF32 = tSgSF32_kdl[None, None, 0, curr_block_coord_state[2]]
+                        state_f32_handle0 = load_state_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_state_f32,
+                            tSgSF32[None, 0],
+                            tSsSF32[None, state_f32_handle0.index],
+                            tma_bar_ptr=state_f32_handle0.barrier,
+                        )
+
+                    for i in cutlass.range(loop_count, unroll=1):
+                        w0_coord = i
+                        k0_handle = load_qk_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_k,
+                            tKgK[None, w0_coord],
+                            tKsK[None, k0_handle.index],
+                            tma_bar_ptr=k0_handle.barrier,
+                        )
+
+                        q_handle = load_qk_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_q,
+                            tQgQ[None, w0_coord],
+                            tQsQ[None, q_handle.index],
+                            tma_bar_ptr=q_handle.barrier,
+                        )
+
+                        v_handle0 = load_v_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_v,
+                            tVgV[None, w0_coord],
+                            tVsV[None, v_handle0.index],
+                            tma_bar_ptr=v_handle0.barrier,
+                        )
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                if cutlass.const_expr(
+                    tma_atom_state_output is not None and self.is_persistent
+                ):
+                    cute.arch.barrier(
+                        barrier_id=self.epi_load_sync_bar_id,
+                        number_of_threads=self.threads_per_warp * 2,
+                    )
+            # dealloc tmem buffer
+            cute.arch.relinquish_tmem_alloc_permit()
+            cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
+            tmem_alloc_cols = Int32(self.tmem_alloc_cols)
+            #  Retrieving tmem ptr and make acc
+            tmem_ptr = cute.arch.retrieve_tmem_ptr(
+                cutlass.Float32,
+                alignment=16,
+                ptr_to_buffer_holding_addr=storage.tmem_holding_buf,
+            )
+            cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA: mma warp
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_mma)
+
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            tSrDC_ivt_l1_fake = invert_sub_thr_mma_ts_l1.make_fragment_A(
+                invert_sub_smem_layout_staged_ts_l1_a.outer.shape
+            )
+            tSrDC_ivt_l1 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr,
+                    dtype=tSrDC_ivt_l1_fake.element_type,
+                )
+                + self.tmem_ivt_ts_l1_input,
+                tSrDC_ivt_l1_fake.layout,
+            )
+            tSrA_ivt_l1 = invert_sub_thr_mma_ts_l1.make_fragment_B(sInvertSubTSL1B)
+
+            tOrP = o_intra_thr_mma_new.make_fragment_A(
+                o_intra_smem_layout_staged_a_new.outer
+            )
+            tOrP0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr,
+                    dtype=tOrP.element_type,
+                )
+                + self.tmem_gate_qk * 2,
+                tOrP.layout,
+            )
+
+            tQSA = o_intra_thr_mma_new.make_fragment_A(qs_smem_layout_staged_a.outer)
+            tQSA0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr,
+                    dtype=tQSA.element_type,
+                )
+                + self.tmem_gate_q * 2,
+                tQSA.layout,
+            )
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                continue_cond = False
+
+                if not continue_cond:
+                    for _i in cutlass.range(loop_count, unroll=1):
+                        k_handle0 = load_qk_consumer.wait_and_advance()
+                        qk_handle0 = mma_qk_producer0.acquire_and_advance()
+
+                        kkt_tiled_mma = self.exec_mma(
+                            kkt_tiled_mma,
+                            tKKTtKKT,
+                            tArK,
+                            tArKT,
+                            k_handle0.index,
+                            k_handle0.index,
+                        )
+
+                        qk_handle0.commit()
+
+                        q_handle = load_qk_consumer.wait_and_advance()
+
+                        qk_handle1 = mma_qk_producer0.acquire_and_advance()
+
+                        qk_tiled_mma = self.exec_mma(
+                            qk_tiled_mma,
+                            tQKtQK,
+                            tSrQ,
+                            tSrK,
+                            q_handle.index,
+                            k_handle0.index,
+                        )
+
+                        qk_handle1.commit()
+
+                        cs_handle = mma_cudacore_producer0.acquire_and_advance()
+                        cute.arch.barrier(
+                            barrier_id=self.cudacore_mma_sync_bar_id,
+                            number_of_threads=self.threads_per_warp * 5,
+                        )
+
+                        kst_tiled_mma = self.exec_mma(
+                            kst_tiled_mma,
+                            tKStKS,
+                            tKSrK_0,
+                            tKSrST,
+                            0,
+                            0,
+                        )
+
+                        cs_handle.commit()
+
+                        cs_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        invert_sub_tiled_mma_ss_l0 = self.exec_mma(
+                            invert_sub_tiled_mma_ss_l0,
+                            tItSSL0,
+                            tSrD,
+                            tSrC,
+                            0,
+                            0,
+                        )
+
+                        cs_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        invert_sub_tiled_mma_ts_l0 = self.exec_mma(
+                            invert_sub_tiled_mma_ts_l0,
+                            tItTSL0,
+                            tInrDCL0A,
+                            tSrDCL0B,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        invert_sub_tiled_mma_ss_l1 = self.exec_mma(
+                            invert_sub_tiled_mma_ss_l1,
+                            tStO_ivt_l1_ss0,
+                            tSrD_ivt_l1,
+                            tSrC_ivt_l1,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        k_handle0.release()
+
+                        invert_sub_tiled_mma_ts_l1 = self.exec_mma(
+                            invert_sub_tiled_mma_ts_l1,
+                            tOtTSL1,
+                            tSrDC_ivt_l1,
+                            tSrA_ivt_l1,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        tuw_tiled_mma = self.exec_mma(
+                            tuw_tiled_mma,
+                            tVtTUW,
+                            tTUWrA,
+                            tTUWrB,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        q_handle.release()
+
+                        tCtAcc_o_intra_acc_shape_fake = o_intra_thr_mma.make_fragment_C(
+                            o_intra_acc_shape
+                        )
+                        tStO_o_intra0 = cute.make_tensor(
+                            tmem_ptr + self.tmem_o_intra_output,
+                            tCtAcc_o_intra_acc_shape_fake.layout,
+                        )
+
+                        o_intra_tiled_ts_mma_new = self.exec_mma(
+                            o_intra_tiled_ts_mma_new,
+                            tStO_o_intra0,
+                            tOrP0,
+                            tOIntrarB,
+                            0,
+                            0,
+                        )
+
+                        qs_tiled_mma = self.exec_mma(
+                            qs_tiled_mma,
+                            tOintertQS,
+                            tQSA0,
+                            tQSB,
+                            0,
+                            0,
+                            True,
+                        )
+
+                        c0_handle.commit()
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        update_s_tiled_mma = self.exec_mma(
+                            update_s_tiled_mma,
+                            tStUpdate,
+                            tUpdateA,
+                            tUpdateB,
+                            0,
+                            0,
+                            True,
+                        )
+
+                        c0_handle.commit()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Mainloop: mainloop warp group
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < 4:
+            cute.arch.setmaxregister_increase(self.num_regs_cudacore)
+
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                if not continue_cond:
+                    gO_mnl = cute.flat_divide(
+                        O, cute.select(self.mma_tiler, mode=[0, 1])
+                    )
+                    # Use input state
+                    if cutlass.const_expr(tma_atom_state_f32 is not None):
+                        load_state_consumer.wait_and_advance()
+                        self.init_state_from_smem(
+                            kst_thr_mma,
+                            tStateF32,
+                            sStateInputF32,
+                        )
+                        load_state_consumer.release()
+                    else:
+                        self.init_state_zeros(
+                            kst_thr_mma,
+                            tStateF32,
+                        )
+
+                    # Arguments
+                    atom_args = (
+                        kkt_thr_mma,
+                        kst_thr_mma,
+                        qk_thr_mma,
+                        qs_thr_mma,
+                    )
+                    tensor_args = (
+                        sGate,
+                        sBeta,
+                        sGateCumsum,
+                        sStateInput,
+                        sIvt,
+                        sQ,
+                        sK,
+                        sV,
+                        sO,
+                        sInvertSubReg,
+                        sInvertSubSSL0A,
+                        sInvertSubSSL0B,
+                        sInvertSubSSL1B,
+                        sInvertSubTSL0B,
+                        sInvertSubSSL1A,
+                        sInvertSubTSL1B,
+                        sTuwAStore,
+                        sTuwA,
+                        sOIntraB,
+                        sUpdateB,
+                        tGamma,
+                        tKKTtKKT,
+                        tQKtQK,
+                        tQKMtQKM,
+                        tKtK,
+                        tKStKS,
+                        tItTSL0,
+                        tInrDCL0A,
+                        tOtTSL1,
+                        tVtTUW,
+                        tOintertQS,
+                        tItSSL0,
+                        tStateF32,
+                        tQgate,
+                    )
+                    pipeline_args = (
+                        gb_w0_consumer,
+                        epi_w0_consumer,
+                        mma_qk_consumer0,
+                        mma_cudacore_consumer0,
+                        load_v_consumer,
+                    )
+
+                    # Corner case
+                    tail_count = mO_qdl.shape[0] % self.cta_tiler[0]
+
+                    if tail_count == 0:
+                        value_args = (
+                            scale,
+                            loop_count,
+                            0,
+                        )
+                        (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        ) = self.main_loop(
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                            pipeline_args,
+                        )
+                    else:
+                        value_args = (
+                            scale,
+                            loop_count - 1,
+                            0,
+                        )
+                        (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        ) = self.main_loop(
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                            pipeline_args,
+                        )
+                        pipeline_args = (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        )
+                        value_args = (
+                            scale,
+                            1,
+                            loop_count - 1,
+                        )
+                        (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        ) = self.main_loop(
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                            pipeline_args,
+                            True,
+                            tail_count=tail_count,
+                        )
+
+                    # Output state
+                    if cutlass.const_expr(tma_atom_state_output is not None):
+                        w0_epi_handle = w0_epi_producer.acquire_and_advance()
+                        self.store_state_to_smem(
+                            tStUpdate, sStateOutput, update_s_thr_mma
+                        )
+                        w0_epi_handle.commit()
+
+                    w0_handle = epi_w0_consumer.wait_and_advance()
+                    w0_handle.release()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
+
+    @cute.jit
+    def main_loop(
+        self,
+        value_args: tuple,
+        atom_args: tuple,
+        tensor_args: tuple,
+        pipeline_args: tuple,
+        need_mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ) -> Tuple[
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Per-chunk mainloop executed by cudacore warps (0-3)."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        (
+            scale,
+            loop_count,
+            loop_base,
+        ) = value_args
+
+        (
+            kkt_thr_mma,
+            kst_thr_mma,
+            qk_thr_mma,
+            qs_thr_mma,
+        ) = atom_args
+
+        (
+            sGate,
+            sBeta,
+            sGateCumsum,
+            sStateInput,
+            sIvt,
+            sQ,
+            sK,
+            sV,
+            sO,
+            sInvertSubReg,
+            sInvertSubSSL0A,
+            sInvertSubSSL0B,
+            sInvertSubSSL1B,
+            sInvertSubTSL0B,
+            sInvertSubSSL1A,
+            sInvertSubTSL1B,
+            sTuwAStore,
+            sTuwA,
+            sOIntraB,
+            sUpdateB,
+            tGamma,
+            tKKTtKKT,
+            tQKtQK,
+            tQKMtQKM,
+            tKtK,
+            tKStKS,
+            tItTSL0,
+            tInrDCL0A,
+            tOtTSL1,
+            tVtTUW,
+            tOintertQS,
+            tItSSL0,
+            tStateF32,
+            tQgate,
+        ) = tensor_args
+
+        (
+            gb_w0_consumer,
+            epi_w0_consumer,
+            mma_qk_consumer0,
+            mma_cudacore_consumer0,
+            load_v_consumer,
+        ) = pipeline_args
+
+        for _i in cutlass.range(loop_base, loop_base + loop_count, unroll=1):
+            gb_handle = gb_w0_consumer.wait_and_advance()
+            sGate0 = sGate[None, None, gb_handle.index]
+            sBeta0 = sBeta[None, None, gb_handle.index]
+            tval = self.chunk_local_cumsum(sGate0, sGateCumsum, self.wg_sync_bar_id)
+            beta_val = sBeta0[tidx]
+            gb_handle.release()
+
+            self.compute_gamma_tmem(
+                tval,
+                sGateCumsum,
+                kkt_thr_mma,
+                tGamma,
+                self.wg_sync_bar_id,
+                need_mask,
+                tail_count,
+            )
+            qk_handle0 = mma_qk_consumer0.wait_and_advance()
+
+            self.apply_gamma_beta(
+                kkt_thr_mma,
+                sIvt,
+                tKKTtKKT,
+                beta_val,
+                tGamma,
+            )
+
+            gate_tail = (
+                sGateCumsum[tail_count - 1]
+                if cutlass.const_expr(need_mask)
+                else sGateCumsum[127]
+            )
+            w0_handle = epi_w0_consumer.wait_and_advance()
+            self.load_state_apply_gate(
+                kst_thr_mma,
+                tStateF32,
+                sStateInput,
+                gate_tail,
+            )
+            cute.arch.fence_proxy(
+                cute.arch.ProxyKind.async_shared,
+                space=cute.arch.SharedSpace.shared_cta,
+            )
+
+            qk_handle1 = mma_qk_consumer0.wait_and_advance()
+            self.load_qk_epi(
+                qk_thr_mma, tQKtQK, tQKMtQKM, tGamma, need_mask, tail_count
+            )
+
+            cute.arch.barrier_arrive(
+                barrier_id=self.cudacore_mma_sync_bar_id,
+                number_of_threads=self.threads_per_warp * 5,
+            )
+
+            reverse_result = cute.make_rmem_tensor((32, 1), self.acc_dtype)
+
+            self.reverse_smem_sub(reverse_result, sIvt)
+
+            self.store_ivt_smem_l0_ss_a(
+                reverse_result,
+                sInvertSubReg,
+                sInvertSubSSL0A,
+            )
+
+            self.store_ivt_smem_l0_ss_b(
+                kkt_thr_mma,
+                tKKTtKKT,
+                sInvertSubSSL0B,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            c0_handle.release()
+            v_handle0 = load_v_consumer.wait_and_advance()
+
+            tval_exp = cute.math.exp(tval)
+            self.get_uw_b(
+                kst_thr_mma, tKStKS, tval_exp, beta_val, sV, need_mask, tail_count
+            )
+            self.store_ivt_p1(
+                sInvertSubReg,
+                sInvertSubTSL0B,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            self.load_ivt_ss_l0(tItSSL0, tInrDCL0A)  # debug
+            c0_handle.release()
+            self.store_ivt_smem_l1_ss_b(
+                kkt_thr_mma,
+                tKKTtKKT,
+                sInvertSubSSL1B,
+            )
+
+            self.store_ivt_p2(
+                sInvertSubReg,
+                sInvertSubSSL1A,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+
+            self.load_ivt_ts_l0(
+                tItTSL0,
+                sInvertSubSSL1A,
+                sInvertSubTSL1B,
+            )
+
+            c0_handle.release()
+
+            self.store_k_epi(kkt_thr_mma, sK, tKtK, need_mask, tail_count)
+            self.store_ivt_p3(
+                sInvertSubReg,
+                sInvertSubTSL1B,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            c0_handle.release()
+            self.save_tmem(tItTSL0, sTuwAStore)
+            self.store_ivt_ad(sInvertSubReg, sTuwA)
+            self.store_ivt_c(sTuwAStore)
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            self.load_ivt_result(tOtTSL1, sTuwAStore)
+            c0_handle.release()
+
+            self.load_q_epi(qk_thr_mma, sQ, tQgate, tval_exp, need_mask, tail_count)
+            cute.arch.fence_proxy(
+                cute.arch.ProxyKind.async_shared,
+                space=cute.arch.SharedSpace.shared_cta,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            v_handle0.release()
+            self.load_v(tVtTUW, sOIntraB)
+            c0_handle.release()
+            self.load_k(tKtK, sUpdateB, gate_tail, tval)
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            qk_handle0.release()
+            c0_handle.release()
+            self.store_o_smem(tOintertQS, sO, qs_thr_mma, scale)
+
+            w0_handle.release()
+            qk_handle1.release()
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            c0_handle.release()
+
+        return (
+            gb_w0_consumer,
+            epi_w0_consumer,
+            mma_qk_consumer0,
+            mma_cudacore_consumer0,
+            load_v_consumer,
+        )
+
+    @cute.jit
+    def exec_mma(
+        self,
+        tiled_mma,
+        tCtAcc,
+        tCrA,
+        tCrB,
+        a_consumer_index,
+        b_consumer_index,
+        setAcc: bool = False,
+    ):
+        """Issue a tcgen05 GEMM."""
+        for kphase_idx in cutlass.range(cute.size(tCrB, mode=[2]), unroll_all=True):
+            # set accu = 1
+            tiled_mma.set(
+                tcgen05.Field.ACCUMULATE,
+                cutlass.Boolean(kphase_idx != 0 or setAcc),
+            )
+            cute.gemm(
+                tiled_mma,
+                tCtAcc,
+                tCrA[None, None, kphase_idx, a_consumer_index],
+                tCrB[None, None, kphase_idx, b_consumer_index],
+                tCtAcc,
+            )
+        return tiled_mma
+
+    @cute.jit
+    def get_uw_b(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        gate_val: cutlass.Float32,
+        beta_val: cutlass.Float32,
+        sV: cute.Tensor,
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Compute V_new = beta*V - beta*gamma*(K@S^T) in-place in smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 64
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        frg_tile = 8
+        sV_frg = cute.logical_divide(sV, cute.make_layout(frg_tile))
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+        tTMEM_LOADrS_frag = cute.logical_divide(
+            tTMEM_LOADrS, cute.make_layout(frg_tile)
+        )
+
+        if cutlass.const_expr(mask):
+            if thread_idx >= tail_count:
+                beta_val = self.g_beta_dtype(0)
+
+        combined_factor = gate_val * beta_val
+
+        each_iter = corr_tile_size // frg_tile
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+
+            # Load V from smem
+            temp_regs = cute.make_rmem_tensor(tTMEM_LOADrS_frag.shape, self.acc_dtype)
+            for it in cutlass.range_constexpr(each_iter):
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    # mul2
+                    (
+                        temp_regs[inner_idx + 0, it],
+                        temp_regs[inner_idx + 1, it],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrS_frag[inner_idx + 0, it],
+                            tTMEM_LOADrS_frag[inner_idx + 1, it],
+                        ),
+                        (-combined_factor, -combined_factor),
+                    )
+
+                    # fma2
+                    (
+                        temp_regs[inner_idx + 0, it],
+                        temp_regs[inner_idx + 1, it],
+                    ) = cute.arch.fma_packed_f32x2(
+                        (
+                            beta_val,
+                            beta_val,
+                        ),
+                        (
+                            cutlass.Float32(
+                                sV_frg[inner_idx + 0, (i * each_iter + it, thread_idx)]
+                            ),
+                            cutlass.Float32(
+                                sV_frg[inner_idx + 1, (i * each_iter + it, thread_idx)]
+                            ),
+                        ),
+                        (
+                            temp_regs[inner_idx + 0, it],
+                            temp_regs[inner_idx + 1, it],
+                        ),
+                    )
+                sV_frg[None, (i * each_iter + it, thread_idx)].store(
+                    temp_regs[None, it].load().to(self.i_dtype)
+                )
+
+    @cute.jit
+    def store_state_to_smem(
+        self,
+        tO: cute.Tensor,
+        sO: cute.Tensor,
+        thr_mma: cute.ThrMma,
+    ):
+        """Copy final state from TMEM to smem for TMA store to global."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tOcO = thr_mma.partition_C(tO)
+        tOsO = thr_mma.partition_C(sO)
+
+        corr_tile_size = 32  # must >= 8
+        tOsO_sub = cute.make_tensor(
+            cute.recast_ptr(tOsO.iterator, dtype=self.state_dtype),
+            cute.shape(tOsO)[0],
+        )
+        tOsO_tile = cute.logical_divide(
+            tOsO_sub, (None, (None, 32 // (128 // corr_tile_size)))
+        )
+
+        tIn_i_layout = cute.composition(
+            tO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        sOut_i_layout = cute.composition(
+            tOsO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tO.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(tOcO.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        smem_copy_atom = sm100_utils.get_smem_store_op(
+            self.s_output, self.state_dtype, self.acc_dtype, tiled_tmem_load
+        )
+        tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            sOut_i_sub = cute.make_tensor(
+                tOsO_tile[None, (None, (None, i))].iterator, sOut_i_layout
+            )
+            tTMEM_STOREsO_i = thr_tmem_load.partition_D(sOut_i_sub)
+            cute.copy(tiled_smem_store, tTMEM_LOADrS, tTMEM_STOREsO_i)
+
+        # fence view async shared
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def store_o_smem(
+        self,
+        tO: cute.Tensor,
+        sO: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        scale: cutlass.Float32,
+    ):
+        """Scale and convert O from TMEM (f32) to smem (f16/bf16) for TMA store."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tOcO = thr_mma.partition_C(tO)
+        tOsO = thr_mma.partition_C(sO)
+
+        corr_tile_size = 128  # must >= 8
+
+        # ((128,(8,16)),1,1,(1,1))
+        tOsO_sub = cute.make_tensor(
+            cute.recast_ptr(tOsO.iterator, dtype=self.i_dtype),
+            cute.shape(tOsO)[0],
+        )
+        tOsO_tile = cute.logical_divide(
+            tOsO_sub, (None, (None, 16 // (128 // corr_tile_size)))
+        )
+
+        tIn_i_layout = cute.composition(
+            tO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        sOut_i_layout = cute.composition(
+            tOsO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tO.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(tOcO.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_STORErS_x4_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_LOADrS.iterator, dtype=self.i_dtype),
+            tTMEM_LOADrS.layout,
+        )
+
+        smem_copy_atom = sm100_utils.get_smem_store_op(
+            self.o_layout, self.i_dtype, self.acc_dtype, tiled_tmem_load
+        )
+        tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+
+            frg_cnt = 4  # must 4
+            frg_tile = cute.size(tTMEM_LOADrS) // frg_cnt
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, cute.make_layout(frg_tile)
+            )
+            tTMEM_STORErS_x4_e_frg = cute.logical_divide(
+                tTMEM_STORErS_x4_e, cute.make_layout(frg_tile)
+            )
+
+            temp_regs = cute.make_rmem_tensor(tTMEM_LOADrS_frg.shape, self.acc_dtype)
+            for j in cutlass.range_constexpr(frg_cnt):
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    # mul2
+                    (
+                        temp_regs[inner_idx + 0, j],
+                        temp_regs[inner_idx + 1, j],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrS_frg[inner_idx + 0, j],
+                            tTMEM_LOADrS_frg[inner_idx + 1, j],
+                        ),
+                        (scale, scale),
+                    )
+                tTMEM_STORErS_x4_e_frg[None, j].store(
+                    temp_regs[None, j].load().to(self.i_dtype)
+                )
+
+            # store
+            sOut_i_sub = cute.make_tensor(
+                tOsO_tile[None, (None, (None, i))].iterator, sOut_i_layout
+            )
+            tTMEM_STOREsO_i = thr_tmem_load.partition_D(sOut_i_sub)
+            cute.copy(tiled_smem_store, tTMEM_STORErS_x4_e, tTMEM_STOREsO_i)
+
+        # fence view async shared
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def load_k(
+        self,
+        tIn: cute.Tensor,
+        sUpdateB: cute.Tensor,
+        gate: cutlass.Float32,
+        val: cutlass.Float32,
+    ):
+        """Load K from TMEM, apply per-token gate decay."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        gate_val = cute.math.exp((gate - val))
+
+        k = self.read_tmem_128(tIn)
+
+        k_f16 = cute.make_tensor(
+            cute.recast_ptr(k.iterator, dtype=self.i_dtype),
+            cute.make_layout(128),
+        )
+        k_f16_frag = cute.logical_divide(k_f16, cute.make_layout(8))
+
+        for bid in cutlass.range_constexpr(0, 2):
+            for col in cutlass.range_constexpr(0, 8):
+                load_row = thread_idx
+
+                store_row = load_row
+                store_col = bid * 8 + col
+
+                store_row_bid = store_row // 16
+                store_row_offset = store_row % 16
+                sUpdateB[
+                    ((None, store_col), store_row_offset), 0, store_row_bid, 0
+                ].store(
+                    (k_f16_frag[None, store_col].load() * gate_val).to(self.i_dtype)
+                )
+
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def init_state_zeros(
+        self,
+        thr_mma: cute.ThrMma,
+        tOutF32: cute.Tensor,
+    ):
+        """Zero-initialize the recurrent state in TMEM (no initial_state provided)."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+        corr_tile_size = 128
+
+        # Apply gate State
+        cInOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tInOut_i_layout = cute.composition(
+            tOutF32.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tInOut_i = cute.make_tensor(tOutF32.iterator, tInOut_i_layout)
+        cInOut_i = cute.make_tensor(tOcO.iterator, cInOut_i_layout)
+
+        tmem_store_atom_f32 = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store_f32 = tcgen05.make_tmem_copy(tmem_store_atom_f32, tInOut_i)
+        thr_tmem_store_f32 = tiled_tmem_store_f32.get_slice(thread_idx)
+
+        tTMEM_STOREtInOut = thr_tmem_store_f32.partition_D(tInOut_i)
+        tTMEM_STOREcInOut = thr_tmem_store_f32.partition_S(cInOut_i)
+        tTMEM_STORErInOut = cute.make_rmem_tensor(
+            tTMEM_STOREcInOut.shape, self.acc_dtype
+        )
+
+        frg_tile = 4
+        zeros = cute.zeros_like(cute.make_layout(frg_tile), self.acc_dtype)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtInOut_i = cute.make_tensor(
+                tTMEM_STOREtInOut.iterator + i * corr_tile_size,
+                tTMEM_STOREtInOut.layout,
+            )
+
+            tTMEM_STORErInOut_frg = cute.logical_divide(
+                tTMEM_STORErInOut, ((frg_tile, None), None)
+            )
+
+            each_iter = corr_tile_size // frg_tile
+            for j in cutlass.range_constexpr(each_iter):
+                tTMEM_STORErInOut_frg[((None, j), 0), 0, 0].store(zeros)
+
+            # store
+            cute.copy(tiled_tmem_store_f32, tTMEM_STORErInOut, tTMEM_STOREtInOut_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def init_state_from_smem(
+        self,
+        thr_mma: cute.ThrMma,
+        tOutF32: cute.Tensor,
+        sStateInputF32: cute.Tensor,
+    ):
+        """Load initial_state from smem (f32) into TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 128
+        cInOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tInOut_i_layout = cute.composition(
+            tOutF32.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tInOut_i = cute.make_tensor(tOutF32.iterator, tInOut_i_layout)
+        cInOut_i = cute.make_tensor(tOcO.iterator, cInOut_i_layout)
+
+        tmem_store_atom_f32 = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store_f32 = tcgen05.make_tmem_copy(tmem_store_atom_f32, tInOut_i)
+        thr_tmem_store_f32 = tiled_tmem_store_f32.get_slice(thread_idx)
+
+        tTMEM_STOREtInOut = thr_tmem_store_f32.partition_D(tInOut_i)
+        tTMEM_STOREcInOut = thr_tmem_store_f32.partition_S(cInOut_i)
+        tTMEM_STORErInOut = cute.make_rmem_tensor(
+            tTMEM_STOREcInOut.shape, self.acc_dtype
+        )
+
+        frg_tile = 4  # must 4
+        sStateInputF32_frag = cute.logical_divide(
+            sStateInputF32, (((None, frg_tile), None))
+        )
+        tTMEM_STORErInOut_frg = cute.logical_divide(
+            tTMEM_STORErInOut, ((frg_tile, None), None)
+        )
+        each_iter = corr_tile_size // frg_tile
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtInOut_i = cute.make_tensor(
+                tTMEM_STOREtInOut.iterator + i * corr_tile_size,
+                tTMEM_STOREtInOut.layout,
+            )
+
+            # Load from smem
+            idx_offset = i * corr_tile_size
+            for j in cutlass.range_constexpr(each_iter):
+                idx = idx_offset + j * frg_tile
+                bid = idx // 32
+                bid_inner = idx % 32 // 8
+                inner_idx = idx % 8 // 4
+                s_vec = sStateInputF32_frag[
+                    (thread_idx, (None, inner_idx)), 0, (bid_inner, bid), 0
+                ].load()
+                tTMEM_STORErInOut_frg[((None, j), 0), 0, 0].store(s_vec)
+
+            # store
+            cute.copy(tiled_tmem_store_f32, tTMEM_STORErInOut, tTMEM_STOREtInOut_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def load_state_apply_gate(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        sStateInput: cute.Tensor,
+        gate: cutlass.Float32,
+    ):
+        """Apply chunk-level gate decay to state in TMEM, and copy state to smem (f16) for KST GEMM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 16
+        # corr_tile_size_f32 = corr_tile_size // 2
+
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        # Apply gate State
+        # cInOut_i_layout = cute.composition(tOcO.layout, cute.make_layout((128, corr_tile_size)))
+        tInOut_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        # fp16 state
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tInOut_i = cute.make_tensor(tIn.iterator, tInOut_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tmem_store_atom_f32 = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        tiled_tmem_store_f32 = tcgen05.make_tmem_copy(tmem_store_atom_f32, tInOut_i)
+
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store_f32 = tiled_tmem_store_f32.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_STOREtInOut = thr_tmem_store_f32.partition_D(tInOut_i)
+        tTMEM_STORErInOut = cute.make_tensor(
+            cute.recast_ptr(tTMEM_LOADrS.iterator, dtype=self.acc_dtype),
+            tTMEM_LOADrS.layout,
+        )
+
+        gate_val = cute.math.exp(gate)
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_STOREtInOut_i = cute.make_tensor(
+                tTMEM_STOREtInOut.iterator + i * corr_tile_size,
+                tTMEM_STOREtInOut.layout,
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+
+            frg_tile = 16  # must <= 16
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, ((frg_tile, None), None)
+            )
+            tTMEM_STORErInOut_frg = cute.logical_divide(
+                tTMEM_STORErInOut, ((frg_tile, None), None)
+            )
+            sStateInput_frag = cute.logical_divide(
+                sStateInput, (((None, frg_tile), None))
+            )
+
+            each_iter = corr_tile_size // frg_tile
+            idx_offset = i * corr_tile_size
+            for j in cutlass.range_constexpr(each_iter):
+                s_vec = tTMEM_LOADrS_frg[((None, j), 0), 0, 0].load()
+                s_vec_f16 = s_vec.to(self.q_dtype)
+                idx = idx_offset + j * frg_tile
+                bid = idx // 64
+                bid_inner = idx % 64 // 16
+                inner_idx = idx % 16 // frg_tile
+                sStateInput_frag[
+                    (thread_idx, (None, inner_idx)), 0, (bid_inner, bid), 0
+                ].store(s_vec_f16)
+                # tTMEM_STORErInOut_frg[((None, j), 0), 0, 0].store(s_vec * gate_val)
+
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    (
+                        tTMEM_STORErInOut_frg[((inner_idx + 0, j), 0), 0, 0],
+                        tTMEM_STORErInOut_frg[((inner_idx + 1, j), 0), 0, 0],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (s_vec[inner_idx + 0], s_vec[inner_idx + 1]),
+                        (
+                            gate_val,
+                            gate_val,
+                        ),
+                    )
+            cute.copy(tiled_tmem_store_f32, tTMEM_STORErInOut, tTMEM_STOREtInOut_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def load_qk_epi(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        tOut: cute.Tensor,
+        tGamma: cute.Tensor,  # causal gate mask
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Apply gamma mask to QK^T."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        tGamma_i = cute.make_tensor(tGamma.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        # Load Gamma
+        tiled_tmem_load_gamma = tcgen05.make_tmem_copy(tmem_load_atom, tGamma_i)
+        thr_tmem_load_gamma = tiled_tmem_load_gamma.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_LOADtG = thr_tmem_load_gamma.partition_S(tGamma_i)
+        tTMEM_LOADrG = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+        tTMEM_STORErS_x4_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.i_dtype),
+            tTMEM_LOADrS.layout,
+        )
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size_f32, tTMEM_STOREtO.layout
+            )
+            tTMEM_LOADtG_i = cute.make_tensor(
+                tTMEM_LOADtG.iterator + i * corr_tile_size, tTMEM_LOADrG.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.copy(tiled_tmem_load_gamma, tTMEM_LOADtG_i, tTMEM_LOADrG)
+
+            frg_tile = 2
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, ((frg_tile, None), None)
+            )
+            tTMEM_LOADrG_frg = cute.logical_divide(
+                tTMEM_LOADrG, ((frg_tile, None), None)
+            )
+            tTMEM_STORErS_x4_e_frg = cute.logical_divide(
+                tTMEM_STORErS_x4_e, cute.make_layout(frg_tile)
+            )
+
+            each_iter = corr_tile_size // frg_tile
+            for j in cutlass.range_constexpr(each_iter):
+                for it in cutlass.range_constexpr(0, frg_tile, 2):
+                    (
+                        tTMEM_LOADrS_frg[((it + 0, j), 0), 0, 0],
+                        tTMEM_LOADrS_frg[((it + 1, j), 0), 0, 0],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrS_frg[((it + 0, j), 0), 0, 0],
+                            tTMEM_LOADrS_frg[((it + 1, j), 0), 0, 0],
+                        ),
+                        (
+                            tTMEM_LOADrG_frg[((it + 0, j), 0), 0, 0],
+                            tTMEM_LOADrG_frg[((it + 1, j), 0), 0, 0],
+                        ),
+                    )
+
+                s_vec = tTMEM_LOADrS_frg[((None, j), 0), 0, 0].load()
+                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.q_dtype))
+
+            # store
+            cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtO_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def load_q_epi(
+        self,
+        thr_mma: cute.ThrMma,
+        sQ: cute.Tensor,
+        tOut: cute.Tensor,
+        val: cutlass.Float32,  # exp(cumsum_gate) for per-token gating
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Load Q from smem, apply per-token gate."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sQ_frag = cute.logical_divide(sQ, (((None, 8), None)))
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 64
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS_f16 = thr_tmem_store.partition_S(cIn_i)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+        tTMEM_STORErS_x8 = cute.make_rmem_tensor(tTMEM_STOREcS_f16.shape, self.i_dtype)
+        tTMEM_STORErS_x8_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS.iterator, dtype=self.i_dtype),
+            tTMEM_STORErS_x8.layout,
+        )
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size_f32, tTMEM_STOREtO.layout
+            )
+
+            frg_tile = 8
+            tTMEM_STORErS_x8_e_frag = cute.logical_divide(
+                tTMEM_STORErS_x8_e, cute.make_layout(frg_tile)
+            )
+            for col in cutlass.range_constexpr(0, 8):
+                load_row = thread_idx
+                load_col = col
+                curr_val_ssa = sQ_frag[
+                    (load_row, (None, load_col % 2)), 0, (load_col // 2, i), 0
+                ].load()
+                tTMEM_STORErS_x8_e_frag[None, col].store(
+                    (curr_val_ssa * val).to(self.i_dtype)
+                )
+            # store
+            if cutlass.const_expr(mask):
+                if thread_idx >= tail_count:
+                    tTMEM_STORErS_x8_e_frag.fill(self.i_dtype(0))
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def store_k_epi(
+        self,
+        thr_mma: cute.ThrMma,
+        sK: cute.Tensor,
+        tOut: cute.Tensor,
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Load K from smem and store to TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sK_frag = cute.logical_divide(sK, (((None, 8), None)))
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 64
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS_f16 = thr_tmem_store.partition_S(cIn_i)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+        tTMEM_STORErS_x8 = cute.make_rmem_tensor(tTMEM_STOREcS_f16.shape, self.i_dtype)
+        tTMEM_STORErS_x8_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS.iterator, dtype=self.i_dtype),
+            tTMEM_STORErS_x8.layout,
+        )
+        frg_tile = 8
+        tTMEM_STORErS_x8_e_frag = cute.logical_divide(
+            tTMEM_STORErS_x8_e, cute.make_layout(frg_tile)
+        )
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size_f32, tTMEM_STOREtO.layout
+            )
+
+            for col in cutlass.range_constexpr(0, 8):
+                load_row = thread_idx
+
+                load_col = col
+                curr_val_ssa = sK_frag[
+                    (load_row, (None, load_col % 2)), 0, (load_col // 2, i), 0
+                ].load()
+                tTMEM_STORErS_x8_e_frag[None, col].store(curr_val_ssa)
+
+            # store
+            if cutlass.const_expr(mask):
+                if thread_idx >= tail_count:
+                    tTMEM_STORErS_x8_e_frag.fill(self.i_dtype(0))
+
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def reverse_smem_sub(
+        self,
+        reverse_result: cute.Tensor,
+        sIvt: cute.Tensor,
+    ):
+        """Compute the inverse of a 32x32 sub-block."""
+        lane_id = cute.arch.lane_idx()
+        sub_widx = cute.arch.warp_idx() % 4
+
+        reverse_result.fill(self.acc_dtype(0))
+
+        for row in cutlass.range_constexpr(1, 32, unroll=1):
+            for k in cutlass.range(1, row):
+                row_i_k = sIvt[(k, row), sub_widx]
+                reverse_result[row] -= reverse_result[k] * row_i_k
+            row_i_lane = self.acc_dtype(0)
+            if lane_id < row:
+                row_i_lane = sIvt[(lane_id, row), sub_widx]
+            reverse_result[row] -= row_i_lane
+        reverse_result[lane_id] = self.acc_dtype(1)
+
+    @cute.jit
+    def store_ivt_smem_l0_ss_a(
+        self,
+        reverse_result: cute.Tensor,
+        sReg: cute.Tensor,
+        sInvertSubSSL0A: cute.Tensor,
+    ):
+        """Store 32x32 sub-inverse results to smem."""
+
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+
+        # store sub result to shared memory
+        # (((4,128),8))
+        for row_bid in cutlass.range_constexpr(4):
+            for col_bid in cutlass.range_constexpr(8):
+                row_d = (lane_id // 4 + col_bid) % 8
+                row = row_bid * 8 + row_d
+                col_id = lane_id // 4
+                col_sub_id = lane_id % 4
+                sReg[(col_sub_id, sub_widx * 32 + row), col_id] = reverse_result[row]
+
+        cutlass.cute.arch.sync_warp()
+
+        if sub_widx == 1 or sub_widx == 3:
+            sub_id_row = sub_widx // 2
+            sInvertSubSSL0A_frag = cute.logical_divide(
+                sInvertSubSSL0A, ((None, 4), None)
+            )
+            for col in cutlass.range_constexpr(8):
+                sInvertSubSSL0A_frag[
+                    (sub_id_row * 32 + lane_id, (None, col % 2)), 0, col // 2, 0
+                ].store(sReg[(None, tidx % 128), col].load())
+
+    @cute.jit
+    def store_ivt_smem_l0_ss_b(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        sInvertSubSSL0B: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        # bidx, bidy, _ = cute.arch.block_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sub_widx = widx % 4
+
+        # load Tmem
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32  # must <= 32
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        # Load In
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        sub_tile_size = 8
+        tmem_frag = cute.logical_divide(tTMEM_LOADrS, ((sub_tile_size, None), None))
+        sInvertSubSSL0B_frag = cute.logical_divide(
+            sInvertSubSSL0B, ((sub_tile_size, None), None)
+        )
+
+        # tile 0
+        tile_frags = corr_tile_size // sub_tile_size
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 1:
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL0B_frag[
+                        ((None, (col_true, 0)), lane_id % 8), 0, lane_id // 8, 0
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+
+        # tile 2
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + 64 + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 3:
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL0B_frag[
+                        ((None, (col_true, 1)), lane_id % 8), 0, lane_id // 8, 0
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def store_ivt_smem_l1_ss_b(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        sInvertSubSSL1B: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        # bidx, bidy, _ = cute.arch.block_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sub_widx = widx % 4
+
+        # load Tmem
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 8
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        # Load In
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        # tile 0
+        tTMEM_LOADtO_i = cute.make_tensor(tTMEM_LOADtO.iterator, tTMEM_LOADtO.layout)
+
+        cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+        cute.arch.fence_view_async_tmem_load()
+        sub_tile_size = 8
+        tmem_frag = cute.logical_divide(tTMEM_LOADrS, ((sub_tile_size, None), None))
+        sInvertSubSSL1B_frag = cute.logical_divide(
+            sInvertSubSSL1B, ((sub_tile_size, None), None)
+        )
+        tile_frags = corr_tile_size // sub_tile_size
+        if sub_widx == 2 or sub_widx == 3:
+            sub_id_row = sub_widx - 2
+            for col in cutlass.range_constexpr(tile_frags):
+                col_true = (lane_id + col) % (tile_frags)
+                sInvertSubSSL1B_frag[
+                    ((None, (col_true, 0)), lane_id % 8),
+                    0,
+                    lane_id // 8 + sub_id_row * 4,
+                    0,
+                ].store(tmem_frag[((None, col_true), 0), 0, 0].load())
+
+        # tile 0
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 2 or sub_widx == 3:
+                sub_id_row = sub_widx - 2
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL1B_frag[
+                        ((None, (col_true, 0)), lane_id % 8),
+                        0,
+                        lane_id // 8 + sub_id_row * 4,
+                        0,
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+        # tile 1
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + 32 + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 2 or sub_widx == 3:
+                sub_id_row = sub_widx - 2
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL1B_frag[
+                        ((None, (col_true, 1)), lane_id % 8),
+                        0,
+                        lane_id // 8 + sub_id_row * 4,
+                        0,
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+
+    @cute.jit
+    def store_ivt_p1(
+        self,
+        sReg: cute.Tensor,
+        sInvertSubTSL0B: cute.Tensor,
+    ):
+        """Store sub-inverse register results p1 to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+
+        sInvertSubTSL0B_frag = cute.logical_divide(sInvertSubTSL0B, ((4, None), None))
+        if sub_widx == 0 or sub_widx == 2:
+            sub_id_row = sub_widx // 2
+            for col in cutlass.range_constexpr(8):
+                col_true = (lane_id + col) % 8
+                sInvertSubTSL0B_frag[
+                    ((None, (col_true, sub_id_row)), lane_id % 8), 0, lane_id // 8, 0
+                ].store(sReg[(None, tidx % 128), col_true].load())
+
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def store_ivt_p2(
+        self,
+        sReg: cute.Tensor,
+        sInvertSubSSL1A: cute.Tensor,
+    ):
+        """Store sub-inverse register results p2 to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+        sInvertSubSSL1A_frag = cute.logical_divide(sInvertSubSSL1A, ((None, 4), None))
+        zeros = cute.zeros_like(cute.make_layout((4, 1)), self.acc_dtype)
+        if sub_widx == 2 or sub_widx == 3:
+            sub_id_row = sub_widx - 2
+            for col in cutlass.range_constexpr(8):
+                sInvertSubSSL1A_frag[
+                    (sub_id_row * 32 + lane_id, (None, col % 2)),
+                    0,
+                    (col // 2, sub_id_row),
+                    0,
+                ].store(sReg[(None, tidx % 128), col].load())
+
+        if sub_widx == 0 or sub_widx == 1:
+            for col in cutlass.range_constexpr(4):
+                col_true = col + sub_widx * 4
+                sInvertSubSSL1A_frag[
+                    (lane_id, (None, col_true % 2)), 0, (col_true // 2, 1), 0
+                ].store(zeros)
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def store_ivt_p3(
+        self,
+        sReg: cute.Tensor,
+        sInvertSubTSL1B: cute.Tensor,
+    ):
+        """Store sub-inverse register results p3 to smem ."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+        sInvertSubTSL1B_frag = cute.logical_divide(sInvertSubTSL1B, ((4, None), None))
+        if sub_widx == 0 or sub_widx == 1:
+            sub_id_row = sub_widx
+            for col in cutlass.range_constexpr(8):
+                col_true = (lane_id + col) % 8
+                sInvertSubTSL1B_frag[
+                    ((None, (col_true, sub_id_row)), lane_id % 8),
+                    0,
+                    lane_id // 8 + 4 * sub_id_row,
+                    0,
+                ].store(sReg[(None, tidx % 128), col_true].load())
+        zeros = cute.zeros_like(cute.make_layout((4, 1)), self.acc_dtype)
+
+        if sub_widx == 2 or sub_widx == 3:
+            sub_id_row = sub_widx - 2
+            for col in cutlass.range_constexpr(4):
+                col_true = (lane_id + col + sub_id_row * 4) % 8
+                sInvertSubTSL1B_frag[
+                    ((None, (col_true, 1)), lane_id % 8), 0, lane_id // 8 + 0, 0
+                ].store(zeros)
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def load_store_tmem_tune(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        tOut: cute.Tensor,  # unused utility for TMEM round-trip debugging
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 16
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMrO = cute.make_rmem_tensor(
+            (tTMEM_LOADcO.shape, 128 // corr_tile_size), self.acc_dtype
+        )
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMrO_i_ = tTMrO[None, i]
+            tTMrO_i_layout = cute.composition(
+                tTMrO_i_.layout, cute.make_layout(tTMrO.shape[0])
+            )
+            tTMrO_i = cute.make_tensor(tTMrO_i_.iterator, tTMrO_i_layout)
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size, tTMEM_STOREtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO_i)
+
+            for j in cutlass.range_constexpr(0, cute.size(tTMrO_i), 2):
+                tTMrO_i[j], tTMrO_i[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tTMrO_i[j], tTMrO_i[j + 1]),
+                    (cutlass.Float32(1), cutlass.Float32(1)),
+                )
+
+            # store
+            cute.copy(tiled_tmem_store, tTMrO_i, tTMEM_STOREtO_i)
+
+    @cute.jit
+    def read_tmem_128(
+        self,
+        tIn: cute.Tensor,
+    ):
+        """Read a 128-element vector from TMEM into registers."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tIn_layout = cute.composition(tIn.layout, cute.make_layout((tIn.shape)))
+        tIn = cute.make_tensor(tIn.iterator, tIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tIn)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tIn)
+        tTR_cO = thr_copy_t2r.partition_D(tIn)
+
+        tTR_rO = cute.make_rmem_tensor(tTR_cO.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+        tTR_rO = cute.group_modes(tTR_rO, 1, cute.rank(tTR_rO))
+        cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
+        cute.arch.fence_view_async_tmem_load()
+
+        return tTR_rO
+
+    @cute.jit
+    def load_v(
+        self,
+        tIn: cute.Tensor,
+        sNewV: cute.Tensor,
+    ):
+        """Load V_new from TMEM, convert to f16, store to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tIn_layout = cute.composition(tIn.layout, cute.make_layout((tIn.shape)))
+        tIn = cute.make_tensor(tIn.iterator, tIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tIn)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+
+        tTR_tO = thr_copy_t2r.partition_S(tIn)
+        tTR_cO = thr_copy_t2r.partition_D(tIn)
+
+        tTR_rO = cute.make_rmem_tensor(tTR_cO.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+        tTR_rO = cute.group_modes(tTR_rO, 1, cute.rank(tTR_rO))
+        cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
+        cute.arch.fence_view_async_tmem_load()
+
+        tTR_rO_e = cute.make_rmem_tensor(tTR_cO.shape, self.i_dtype)
+        frg_cnt = 16
+        frg_tile = cute.size(tTR_rO) // frg_cnt
+        tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
+        tTR_rO_e_frg = cute.logical_divide(tTR_rO_e, cute.make_layout(frg_tile))
+        for j in cutlass.range_constexpr(frg_cnt):
+            r_vec = tTR_rO_frg[None, j].load()
+            tTR_rO_e_frg[None, j].store(r_vec.to(self.i_dtype))
+
+        sNewV_frg = cute.logical_divide(sNewV, cute.make_layout(frg_tile))
+        for it in cutlass.range_constexpr(0, 16):
+            sNewV_frg[None, (it, thread_idx)].store(tTR_rO_e_frg[None, it].load())
+
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def load_ivt_result(
+        self,
+        tIn: cute.Tensor,
+        sD: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_id = tidx % 32
+        warp_id = cute.arch.warp_idx() % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tIn_layout = cute.composition(tIn.layout, cute.make_layout((tIn.shape)))
+        tIn = cute.make_tensor(tIn.iterator, tIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)),
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tIn)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tIn)
+        tTR_cO = thr_copy_t2r.partition_D(tIn)
+
+        tTR_rO = cute.make_rmem_tensor(tTR_cO.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+        tTR_rO = cute.group_modes(tTR_rO, 1, cute.rank(tTR_rO))
+        cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
+        cute.arch.fence_view_async_tmem_load()
+
+        tTR_rO_e = cute.make_rmem_tensor(tTR_cO.shape, self.q_dtype)
+
+        frg_cnt = 2
+        frg_tile = cute.size(tTR_rO) // frg_cnt
+        tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
+        tTR_rO_e_frg = cute.logical_divide(tTR_rO_e, cute.make_layout(frg_tile))
+        for j in cutlass.range_constexpr(frg_cnt):
+            r_vec = -tTR_rO_frg[None, j].load()
+            tTR_rO_e_frg[None, j].store(r_vec.to(self.q_dtype))
+
+        tTR_rO_e_f32 = cute.recast_tensor(src=tTR_rO_e, dtype=cutlass.Float32)
+
+        for it in cutlass.range_constexpr(0, 8):
+            sD[
+                ((64 + warp_id * 16 + (lane_id // 4) + 0), (lane_id % 4, it % 2)),
+                it // 2,
+            ] = tTR_rO_e_f32[it * 2]
+            sD[
+                ((64 + warp_id * 16 + (lane_id // 4) + 8), (lane_id % 4, it % 2)),
+                it // 2,
+            ] = tTR_rO_e_f32[it * 2 + 1]
+
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def apply_gamma_beta(
+        self,
+        thr_mma: cute.ThrMma,
+        sIvt: cute.Tensor,
+        tIn: cute.Tensor,
+        beta_val: cutlass.Float32,
+        tGamma: cute.Tensor,
+    ):
+        """Apply gamma*beta to KK^T in TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_id = tidx % 32
+        warp_id = cute.arch.warp_idx() % 4
+        sub_widx = warp_id % 4
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32  # only 8  or 32
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+
+        tOut_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cIn_i_layout)
+
+        tGamma_i = cute.make_tensor(tGamma.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+
+        # Load In
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        # Load Gamma
+        tiled_tmem_load_gamma = tcgen05.make_tmem_copy(tmem_load_atom, tGamma_i)
+        thr_tmem_load_gamma = tiled_tmem_load_gamma.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_LOADtG = thr_tmem_load_gamma.partition_S(tGamma_i)
+        tTMEM_LOADrG = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_LOADrS = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS.iterator, dtype=self.acc_dtype),
+            tTMEM_LOADrG.layout,
+        )
+
+        frg_tile = 4
+
+        # Store to smem
+        # ((32, 32), 4)
+        lower_D_frag = cute.logical_divide(tTMEM_STORErS, ((4, None), None))
+        sIvt_frag = cute.logical_divide(sIvt, ((4, None), None))
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_LOADtG_i = cute.make_tensor(
+                tTMEM_LOADtG.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size, tTMEM_STOREtO.layout
+            )
+
+            cute.copy(tiled_tmem_load_gamma, tTMEM_LOADtG_i, tTMEM_LOADrG)
+            each_iter = corr_tile_size // frg_tile
+            tTMEM_LOADrG_frg = cute.logical_divide(
+                tTMEM_LOADrG, ((frg_tile, None), None)
+            )
+            for j in cutlass.range_constexpr(each_iter):
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    (
+                        tTMEM_LOADrG_frg[((inner_idx + 0, j), i), 0, 0],
+                        tTMEM_LOADrG_frg[((inner_idx + 1, j), i), 0, 0],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrG_frg[((inner_idx + 0, j), i), 0, 0],
+                            tTMEM_LOADrG_frg[((inner_idx + 1, j), i), 0, 0],
+                        ),
+                        (
+                            beta_val,
+                            beta_val,
+                        ),
+                    )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, ((frg_tile, None), None)
+            )
+
+            if (i * corr_tile_size) < ((sub_widx + 1) * 32):
+                for j in cutlass.range_constexpr(each_iter):
+                    for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                        (
+                            tTMEM_LOADrS_frg[((inner_idx + 0, j), i), 0, 0],
+                            tTMEM_LOADrS_frg[((inner_idx + 1, j), i), 0, 0],
+                        ) = cute.arch.mul_packed_f32x2(
+                            (
+                                tTMEM_LOADrS_frg[((inner_idx + 0, j), i), 0, 0],
+                                tTMEM_LOADrS_frg[((inner_idx + 1, j), i), 0, 0],
+                            ),
+                            (
+                                tTMEM_LOADrG_frg[((inner_idx + 0, j), i), 0, 0],
+                                tTMEM_LOADrG_frg[((inner_idx + 1, j), i), 0, 0],
+                            ),
+                        )
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+
+            tile_frags = corr_tile_size // 4
+            if (i * corr_tile_size) >= sub_widx * 32 and (i * corr_tile_size) < (
+                sub_widx + 1
+            ) * 32:
+                idx = (i * corr_tile_size - sub_widx * 32) // 4
+                for j in cutlass.range_constexpr(tile_frags):
+                    true_col = j + idx
+                    sIvt_frag[((None, true_col), lane_id), sub_widx].store(
+                        lower_D_frag[((None, j), 0), 0, 0].load()
+                    )
+
+    @cute.jit
+    def compute_gamma_tmem(
+        self,
+        val: cutlass.Float32,
+        sGateCumsum: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tOut: cute.Tensor,
+        bar_id: Int32,
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Build the 128x128 causal gamma matrix in TMEM: gamma[i,j] = exp(cumsum[i] - cumsum[j]) for j <= i."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % 128
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 128
+
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+
+        frg_tile = 32
+        sGateCumsum_tile = cute.flat_divide(
+            sGateCumsum, cute.make_layout(corr_tile_size)
+        )
+        sGateCumsum_frag = cute.logical_divide(sGateCumsum_tile, (frg_tile, None))
+
+        zeros = cute.zeros_like(cute.make_layout((frg_tile, 1)), self.acc_dtype)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size, tTMEM_STOREtO.layout
+            )
+
+            tTMEM_STORErS_frag = cute.logical_divide(
+                tTMEM_STORErS, cute.make_layout(frg_tile)
+            )
+            for it in cutlass.range_constexpr(corr_tile_size // frg_tile):
+                tile_offset = i * corr_tile_size + it * frg_tile
+
+                if (
+                    (
+                        tile_offset <= thread_idx
+                        and tile_offset < tail_count
+                        and thread_idx < tail_count
+                    )
+                    if cutlass.const_expr(mask)
+                    else (tile_offset <= thread_idx)
+                ):
+                    curr_val_frag_ssa = sGateCumsum_frag[(None, it), i].load()
+
+                    new_val_frag = cute.math.exp(val - curr_val_frag_ssa, fastmath=True)
+
+                    for inner_idx in cutlass.range_constexpr(0, frg_tile):
+                        offset = tile_offset + inner_idx
+                        curr_val = new_val_frag[inner_idx]
+
+                        if offset <= thread_idx:
+                            tTMEM_STORErS_frag[inner_idx, it] = curr_val
+                        else:
+                            tTMEM_STORErS_frag[inner_idx, it] = cutlass.Float32(0)
+                else:
+                    tTMEM_STORErS_frag[None, it].store(zeros)
+
+            # store
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def chunk_local_cumsum(
+        self,
+        sGate: cute.Tensor,
+        sGateCumsum: cute.Tensor,
+        bar_id: Int32,
+    ) -> cutlass.Float32:
+        """Compute inclusive prefix sum of gate values within a 128-token chunk."""
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_id = tidx % 32
+        warp_id = cute.arch.warp_idx() % 4
+        tidx_in_group = tidx % 128
+
+        val = sGate[tidx_in_group]
+        stride = 1
+        clamp_value = 0
+        while stride < 32:
+            shfl_value = cute.arch.shuffle_sync_op(
+                value=val,
+                offset=stride,
+                mask_and_clamp=clamp_value,
+                kind=nvvm.ShflKind.up,
+            )
+            if lane_id >= stride:
+                val += shfl_value
+
+            stride = stride << 1
+        if lane_id == 31:
+            sGateCumsum[warp_id] = val
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        if warp_id == 1:
+            pre_warp_val = sGateCumsum[0]
+            val = val + pre_warp_val
+        if warp_id == 2:
+            sGateCumsum_f2 = cute.flat_divide(sGateCumsum, (2, 1))
+            warp_sum = sGateCumsum_f2[None, 0, 0, 0]
+            pre_warp_val = warp_sum[0] + warp_sum[1]
+            val = val + pre_warp_val
+        if warp_id == 3:
+            sGateCumsum_f4 = cute.flat_divide(sGateCumsum, (4, 1))
+            warp_sum = sGateCumsum_f4[None, 0, 0, 0]
+            pre_warp_val = warp_sum[0] + warp_sum[1] + warp_sum[2]
+            val = val + pre_warp_val
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        sGateCumsum[tidx_in_group] = val
+
+        return val
+
+    @cute.jit
+    def save_tmem(
+        self,
+        tSIn: cute.Tensor,
+        sD: cute.Tensor,
+    ) -> cute.Tensor:
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        sub_widx = widx % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tSIn_layout = cute.composition(tSIn.layout, cute.make_layout((tSIn.shape)))
+        tSIn0 = cute.make_tensor(tSIn.iterator, tSIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)),
+            self.acc_dtype,
+        )
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tSIn0)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tSIn0)
+        tTR_cO = thr_copy_t2r.partition_D(tSIn0)
+        tTR_cO_one_iter = tTR_cO[None, 0, 0, 0]
+        tTR_rO = cute.make_rmem_tensor(tTR_cO_one_iter.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+
+        tTR_rO_e = cute.make_rmem_tensor(tTR_rO.shape, self.q_dtype)
+        frg_cnt = 2
+        frg_tile = cute.size(tTR_rO) // frg_cnt
+        tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
+        tTR_rO_e_frg = cute.logical_divide(tTR_rO_e, cute.make_layout(frg_tile))
+        tTR_rO_e_f32 = cute.recast_tensor(src=tTR_rO_e, dtype=cutlass.Float32)
+        for subtile_idx in cutlass.range_constexpr(2):
+            tTR_tO_mn = tTR_tO[(None, subtile_idx)]
+            cute.copy(tiled_copy_t2r, tTR_tO_mn, tTR_rO)
+            cute.arch.fence_view_async_tmem_load()
+
+            if (sub_widx == 0 or sub_widx == 1) and subtile_idx == 0:
+                for j in cutlass.range_constexpr(frg_cnt):
+                    r_vec = -tTR_rO_frg[None, j].load()
+                    tTR_rO_e_frg[None, j].store(r_vec.to(self.q_dtype))
+
+                for it in cutlass.range_constexpr(0, 4):
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 0
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2]
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 8
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2 + 1]
+
+            if (sub_widx == 2 or sub_widx == 3) and subtile_idx == 1:
+                for j in cutlass.range_constexpr(frg_cnt):
+                    r_vec = -tTR_rO_frg[None, j].load()
+                    tTR_rO_e_frg[None, j].store(r_vec.to(self.q_dtype))
+
+                for it in cutlass.range_constexpr(0, 4):
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 0
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2]
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 8
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2 + 1]
+
+    @cute.jit
+    def load_ivt_ts_l0(
+        self,
+        tSIn: cute.Tensor,
+        sInvertSubSSL1A: cute.Tensor,
+        sInvertSubTSL1B: cute.Tensor,
+    ) -> cute.Tensor:
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        sub_widx = widx % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tSIn_layout = cute.composition(tSIn.layout, cute.make_layout((tSIn.shape)))
+        tSIn0 = cute.make_tensor(tSIn.iterator, tSIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x128bOp(tcgen05.copy.Repetition(8)),  # todo
+            self.acc_dtype,
+        )
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tSIn0)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tSIn0)
+        tTR_cO = thr_copy_t2r.partition_D(tSIn0)
+        tTR_cO_one_iter = tTR_cO[None, 0, 0, 0]
+        tTR_rO = cute.make_rmem_tensor(tTR_cO_one_iter.shape, self.acc_dtype)
+
+        tTR_rO_s = cute.make_tensor(
+            cute.recast_ptr(tTR_rO.iterator, dtype=self.acc_dtype),
+            cute.shape(tTR_cO_one_iter)[0],
+        )
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+
+        for subtile_idx in cutlass.range_constexpr(2):
+            tTR_tO_mn = tTR_tO[(None, subtile_idx)]
+            cute.copy(tiled_copy_t2r, tTR_tO_mn, tTR_rO)
+            cute.arch.fence_view_async_tmem_load()
+
+            if (sub_widx == 0 or sub_widx == 1) and subtile_idx == 0:
+                sInvertSubTSL1B_frag = cute.logical_divide(
+                    sInvertSubTSL1B, ((4, None), None)
+                )
+                sub_id_row = sub_widx
+                for col in cutlass.range_constexpr(0, 8):
+                    col_true = (lane_id // 4 + col) % 8
+                    sInvertSubTSL1B_frag[
+                        ((lane_id % 4, (col_true, 0)), lane_id // 4),
+                        0,
+                        4 + sub_id_row * 2 + 0,
+                        0,
+                    ] = -tTR_rO_s[(0, col_true), 0]
+                    sInvertSubTSL1B_frag[
+                        ((lane_id % 4, (col_true, 0)), lane_id // 4),
+                        0,
+                        4 + sub_id_row * 2 + 1,
+                        0,
+                    ] = -tTR_rO_s[(1, col_true), 0]
+            if (sub_widx == 2 or sub_widx == 3) and subtile_idx == 1:
+                tTR_rO_s_frag_f1 = cute.logical_divide(
+                    cute.flatten(tTR_rO_s[None, 0]), (1, None)
+                )
+                sInvertSubSSL1A_frag_f1 = cute.logical_divide(
+                    sInvertSubSSL1A, ((None, 1), None)
+                )
+                sub_id_row = sub_widx - 2
+                for it in cutlass.range_constexpr(0, 8):
+                    col_offset = it % 2 * 4
+                    sInvertSubSSL1A_frag_f1[
+                        (
+                            32 + sub_id_row * 16 + 0 + lane_id // 4,
+                            (None, col_offset + lane_id % 4),
+                        ),
+                        0,
+                        (it // 2, 0),
+                        0,
+                    ].store(-tTR_rO_s_frag_f1[(None, 0), it].load())
+                    sInvertSubSSL1A_frag_f1[
+                        (
+                            32 + sub_id_row * 16 + 8 + lane_id // 4,
+                            (None, col_offset + lane_id % 4),
+                        ),
+                        0,
+                        (it // 2, 0),
+                        0,
+                    ].store(-tTR_rO_s_frag_f1[(None, 1), it].load())
+
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+
+    @cute.jit
+    def store_ivt_c(
+        self,
+        sD: cute.Tensor,
+    ):
+        """Zero out off-diagonal blocks in the assembled inverse matrix (block identity structure)."""
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        sub_widx = widx % 4
+
+        zeros = cute.zeros_like(cute.make_layout((4, 1)), self.acc_dtype)
+        for it in cutlass.range_constexpr(0, 4):
+            row = sub_widx // 2 * 32 + lane_id
+            col_block_inner = it % 2
+            col_block = 4 + (sub_widx % 2) * 2 + it // 2
+            sD[(row, (None, col_block_inner)), col_block].store(zeros[None, 0])
+        for it in cutlass.range_constexpr(0, 2):
+            row = sub_widx // 2 * 64 + lane_id
+            col_block_inner = sub_widx % 2
+            col_block = (sub_widx // 2) * 4 + 2 + it
+            sD[(row, (None, col_block_inner)), col_block].store(zeros[None, 0])
+
+    @cute.jit
+    def load_ivt_ss_l0(
+        self,
+        tSIn: cute.Tensor,
+        tSOut: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        sub_widx = widx % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tSIn_layout = cute.composition(tSIn.layout, cute.make_layout((tSIn.shape)))
+        tSIn0 = cute.make_tensor(tSIn.iterator, tSIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)),  # 4*8 = 32
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tSIn0)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tSIn0)
+        tTR_cO = thr_copy_t2r.partition_D(tSIn0)
+        tTR_cO_one_iter = tTR_cO[(None), 0, 0, 0]
+        tTR_rO = cute.make_rmem_tensor(tTR_cO_one_iter.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+
+        tSOut_layout = cute.make_layout(
+            (((16, 4), 32), 1, 1), stride=(((65536, 2097152), 1), 0, 0)
+        )
+        tSOut0 = cute.make_tensor(tSOut.iterator, tSOut_layout)
+        copy_atom_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x256bOp(tcgen05.copy.Repetition(4)),
+            self.acc_dtype,
+        )
+        tiled_copy_r2t = tcgen05.make_tmem_copy(copy_atom_r2t, tSOut0)
+        thr_copy_r2t = tiled_copy_r2t.get_slice(thread_idx)
+        tRT_cO = thr_copy_r2t.partition_S(tSOut0)
+        tRT_tO = thr_copy_r2t.partition_D(tSOut0)
+        tRT_cO_one_iter = tRT_cO[(None), None, 0, 0]  #
+        tRT_rO = cute.make_rmem_tensor(tRT_cO_one_iter.shape, self.acc_dtype)
+
+        for subtile_idx in cutlass.range_constexpr(2):
+            tTR_tO_mn = tTR_tO[(None, subtile_idx)]
+            cute.copy(tiled_copy_t2r, tTR_tO_mn, tTR_rO)
+            cute.arch.fence_view_async_tmem_load()
+
+            if (sub_widx == 0 or sub_widx == 1) and subtile_idx == 0:
+                for eid in cutlass.range_constexpr(16):
+                    tRT_rO[eid] = tTR_rO[eid]
+
+            if (sub_widx == 2 or sub_widx == 3) and subtile_idx == 1:
+                for eid in cutlass.range_constexpr(16):
+                    tRT_rO[eid] = tTR_rO[eid]
+
+        tRT_tO = cute.group_modes(tRT_tO, 2, cute.rank(tRT_tO))
+        for subtile_idx in cutlass.range_constexpr(0, 1):
+            tRT_tO_mn = tRT_tO[(None, None, subtile_idx)]
+            cute.copy(tiled_copy_r2t, tRT_rO, tRT_tO_mn)
+
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def store_ivt_ad(
+        self,
+        sReg: cute.Tensor,
+        sD: cute.Tensor,
+    ):
+        """Store diagonal block inverse (A/D blocks) from registers to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        sub_widx = widx % 4
+
+        reg_layout = cute.make_layout((4, 2))
+        result_e = cute.make_rmem_tensor(reg_layout.shape, self.acc_dtype)
+        for it in cutlass.range_constexpr(0, 4):
+            result_e[None, 0].store(sReg[(None, tidx % 128), it * 2 + 0].load())
+            result_e[None, 1].store(sReg[(None, tidx % 128), it * 2 + 1].load())
+            sD[(tidx % 128, (None, it % 2)), 0, sub_widx * 2 + it // 2, 0].store(
+                result_e[None].load().to(self.q_dtype)
+            )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_iter: cute.Pointer,
+        k_iter: cute.Pointer,
+        v_iter: cute.Pointer,
+        o_iter: cute.Pointer,
+        g_iter: cute.Pointer,
+        beta_iter: cute.Pointer,
+        problem_size: Tuple[
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+        ],
+        initial_state_f32_iter: Optional[cute.Pointer],
+        state_output: Optional[cute.Pointer],
+        scale: Optional[float],
+        cum_seqlen_q: Optional[cute.Tensor] = None,
+        stream: cuda.CUstream = None,
+    ):
+        """Host-side entry: build tensor layouts, TMA descriptors, smem storage, and launch the kernel."""
+
+        b, s_q, s_sum, h_q, h_v, d = problem_size
+
+        h_r = h_v // h_q
+        o_offset = 0 if cum_seqlen_q is None else (-s_q * d * h_r * h_q)
+        b_qk = b if cum_seqlen_q is None else s_sum
+        b_o = b if cum_seqlen_q is None else s_q * (1 + b)
+        b_v = b if cum_seqlen_q is None else s_sum
+
+        stride_b_qk = h_q * s_q * d if cum_seqlen_q is None else d * h_q
+        stride_b_vo = h_r * h_q * s_q * d if cum_seqlen_q is None else d * h_q * h_r
+
+        b_gb = b if cum_seqlen_q is None else 1
+        stride_b_gb = h_r * h_q * s_sum if cum_seqlen_q is None else 0
+        q_layout = cute.make_layout(
+            (s_sum, d, ((h_r, h_q), b_qk)),
+            stride=(d * h_q, 1, ((0, d), stride_b_qk)),
+        )
+        q = cute.make_tensor(q_iter, q_layout)
+
+        k_layout = cute.make_layout(
+            (s_sum, d, ((h_r, h_q), b_qk)),
+            stride=(d * h_q, 1, ((0, d), stride_b_qk)),
+        )
+        k = cute.make_tensor(k_iter, k_layout)
+        v_layout = cute.make_layout(
+            (d, s_sum, ((h_r, h_q), b_v)),
+            stride=(1, d * h_q * h_r, ((d, d * h_r), stride_b_vo)),
+        )
+        v = cute.make_tensor(v_iter, v_layout)
+        o_layout = cute.make_layout(
+            (s_q, d, ((h_r, h_q), b_o)),
+            stride=(d * h_r * h_q, 1, ((d, d * h_r), stride_b_vo)),
+        )
+        o = cute.make_tensor(o_iter + o_offset, o_layout)
+
+        state_layout = cute.make_layout(
+            (self.head_dim, self.head_dim, ((h_r, h_q), b)),
+            stride=(
+                self.head_dim,
+                1,
+                (
+                    (
+                        self.head_dim * self.head_dim,
+                        h_r * self.head_dim * self.head_dim,
+                    ),
+                    h_q * h_r * self.head_dim * self.head_dim,
+                ),
+            ),
+        )
+
+        state_input_f32 = (
+            None
+            if cutlass.const_expr(initial_state_f32_iter is None)
+            else cute.make_tensor(initial_state_f32_iter, state_layout)
+        )
+        state_output = (
+            None
+            if cutlass.const_expr(state_output is None)
+            else cute.make_tensor(state_output, state_layout)
+        )
+
+        gb_layout = cute.make_layout(
+            (s_sum, 1, ((h_r, h_q), b_gb)),
+            stride=(h_r * h_q, 0, ((1, h_r), stride_b_gb)),
+        )
+        gate = cute.make_tensor(g_iter, gb_layout)
+        beta = cute.make_tensor(beta_iter, gb_layout)
+
+        if cutlass.const_expr(scale is None):
+            scale = 1.0 / cute.math.sqrt(cutlass.Float32(d))
+
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = q.element_type
+        self.k_dtype = k.element_type
+        self.v_dtype = v.element_type
+        self.o_dtype = o.element_type
+        self.g_dtype = gate.element_type
+        self.beta_dtype = beta.element_type
+
+        self.i_dtype = self.q_dtype
+
+        self.tile_sched_params, grid = self._compute_grid(
+            cute.shape((s_q, d, ((h_r, h_q), b))),
+            self.cta_tiler,
+            self.is_persistent,
+        )
+
+        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.s_output = utils.LayoutEnum.ROW_MAJOR
+
+        cta_group = tcgen05.CtaGroup.ONE
+
+        qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+
+        update_s_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.update_s_mma_tiler[:2],
+        )
+
+        o_intra_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.o_intra_mma_tiler[:2],
+        )
+
+        o_intra_tiled_ts_mma_new = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.o_intra_mma_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        qs_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            cta_group,
+            self.qs_mma_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        kkt_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.k_dtype,
+            self.k_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.kkt_mma_tiler[:2],
+        )
+
+        kst_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            self.k_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.kst_mma_tiler[:2],
+        )
+
+        invert_sub_tiled_mma_ss_l0 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l0_tiler[:2],
+        )
+        invert_sub_tiled_mma_ts_l0 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l0_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        invert_sub_tiled_mma_ss_l1 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l1_tiler[:2],
+        )
+        invert_sub_tiled_mma_ts_l1 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l1_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        tuw_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.k_dtype,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.tuw_mma_tiler[:2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (qk_tiled_mma.thr_id.shape,),
+        )
+
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.q_dtype,
+            self.q_stage,
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.k_dtype,
+            self.kv_stage,
+        )
+
+        qk_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.i_dtype,
+            self.qk_stage,
+        )
+
+        state_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            kst_tiled_mma,
+            self.kst_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+        )
+
+        o_intra_smem_layout_staged_a = make_smem_layout_a_kind(
+            o_intra_tiled_mma,
+            self.o_intra_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        o_intra_smem_layout_staged_b = make_smem_layout_b_kind(
+            o_intra_tiled_mma,
+            self.o_intra_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        o_intra_smem_layout_staged_a_new = make_smem_layout_a_kind(
+            o_intra_tiled_ts_mma_new,
+            self.o_intra_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        qs_smem_layout_staged_a = sm100_utils.make_smem_layout_a(
+            qs_tiled_mma,
+            self.qs_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+        )
+
+        qs_smem_layout_staged_b = sm100_utils.make_smem_layout_b(
+            qs_tiled_mma,
+            self.qs_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+        )
+
+        update_s_smem_layout_staged_a = make_smem_layout_a_kind(
+            update_s_tiled_mma,
+            self.update_s_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        update_s_smem_layout_staged_b = make_smem_layout_b_kind(
+            update_s_tiled_mma,
+            self.update_s_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        state_output_smem_layout_staged = make_smem_layout_epi_kind(
+            self.state_dtype,
+            self.s_output,
+            self.state_output_tiler,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        o_output_smem_layout_staged = make_smem_layout_epi_kind(
+            self.i_dtype,
+            self.o_layout,
+            self.o_output_tiler,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        ivt_smem_layout = cute.make_layout(
+            ((36, 32), 4)
+        )  # padding, remove smem bank conflict
+        # ivt_smem_layout = cute.make_layout(((32, 32), 4))  # padding, remove smem bank conflict
+
+        sub_inner_smem_layout_staged = make_smem_layout_a_kind(
+            invert_sub_tiled_mma_ss_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.sub_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        invert_sub_smem_layout_staged_ss_l0_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ss_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ss_l0_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ss_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l0_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ts_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l0_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ts_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ss_l1_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ss_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ss_l1_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ss_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l1_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ts_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l1_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ts_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        # tuw
+        tuw_smem_layout_staged_a = make_smem_layout_a_kind(
+            tuw_tiled_mma,
+            self.tuw_mma_tiler,
+            self.q_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        tuw_smem_layout_staged_b = make_smem_layout_b_kind(
+            tuw_tiled_mma,
+            self.tuw_mma_tiler,
+            self.q_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        v_smem_layout_staged_b = make_smem_layout_b_kind(
+            tuw_tiled_mma,
+            self.tuw_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        # TMA
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        # TMA load for Q
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q,
+            q_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load for K
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load for V
+        v_smem_layout = cute.select(v_smem_layout_staged_b, mode=[0, 1, 2])
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            self.tuw_mma_tiler,
+            tuw_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        fake_state_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.state_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.state_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+        state_smem_layout_f32_staged = sm100_utils.make_smem_layout_b(
+            fake_state_tiled_mma,
+            self.qk_mma_tiler,
+            self.state_dtype,
+            self.one_stage,
+        )
+        state_smem_layout_f32 = cute.select(
+            state_smem_layout_f32_staged, mode=[0, 1, 2]
+        )
+        tma_atom_state_f32, tma_tensor_state_f32 = (
+            cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                state_input_f32,
+                state_smem_layout_f32,
+                self.qk_mma_tiler,
+                fake_state_tiled_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+            if cutlass.const_expr(state_input_f32 is not None)
+            else (None, None)
+        )
+
+        state_smem_layout_output = cute.select(
+            state_output_smem_layout_staged, mode=[0, 1]
+        )
+        tma_atom_state_output, tma_tensor_state_output = (
+            cutlass.cute.nvgpu.cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                state_output,
+                state_smem_layout_output,
+                cute.composition(
+                    cute.make_identity_layout(state_output.shape),
+                    self.state_output_tiler,
+                ),
+            )
+            if cutlass.const_expr(state_output is not None)
+            else (None, None)
+        )
+
+        o_cta_v_layout = cute.composition(
+            cute.make_identity_layout(o.shape), self.o_output_tiler
+        )
+        o_smem_layout_output = cute.select(o_output_smem_layout_staged, mode=[0, 1])
+        tma_atom_o_output, tma_tensor_o_output = (
+            cutlass.cute.nvgpu.cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                o,
+                o_smem_layout_output,
+                o_cta_v_layout,
+            )
+        )
+
+        gate_smem_layout_staged = cute.make_layout(
+            (self.chunk_size, 1, self.gate_stage)
+        )
+        gate_smem_layout = cute.select(gate_smem_layout_staged, mode=[0, 1])
+
+        beta_smem_layout_staged = cute.make_layout(
+            (self.chunk_size, 1, self.beta_stage)
+        )
+        beta_smem_layout = cute.select(beta_smem_layout_staged, mode=[0, 1])
+
+        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
+        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
+        state_copy_size = cute.size_in_bytes(self.i_dtype, state_smem_layout_f32)
+        state_f32_copy_size = cute.size_in_bytes(
+            self.state_dtype, state_smem_layout_f32
+        )
+        gate_copy_size = cute.size_in_bytes(self.g_dtype, gate_smem_layout)
+        beta_copy_size = cute.size_in_bytes(self.beta_dtype, beta_smem_layout)
+        self.tma_copy_q_bytes = q_copy_size
+        self.tma_copy_kv_bytes = k_copy_size
+        self.tma_copy_v_bytes = v_copy_size
+        self.tma_copy_state_bytes = state_copy_size
+        self.tma_copy_state_f32_bytes = state_f32_copy_size
+        self.tma_copy_gate_bytes = gate_copy_size
+        self.tma_copy_beta_bytes = beta_copy_size
+
+        # Shared memory storage
+        @cute.struct
+        class SharedStorage:
+            load_qk_mbar_ptr: cute.struct.MemRange[Int64, self.qk_stage * 2]
+            load_v_mbar_ptr: cute.struct.MemRange[Int64, self.one_stage * 2]
+            load_state_mbar_ptr: cute.struct.MemRange[Int64, self.one_stage * 2]
+            mma_cudacore_mbar_ptr0: cute.struct.MemRange[Int64, 2]
+            mma_qk_mbar_ptr0: cute.struct.MemRange[Int64, self.mma_qk_stage * 2]
+
+            w0_epi_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            epi_w0_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            gb_w0_mbar_ptr: cute.struct.MemRange[Int64, self.gate_stage * 2]
+
+            tmem_dealloc_mbar_ptr: cute.struct.MemRange[Int64, 1]
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.i_dtype, cute.cosize(v_smem_layout_staged_b)],
+                self.buffer_align_bytes,
+            ]
+
+            sQK: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, cute.cosize(qk_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+
+            sIvt: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(ivt_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+
+            sGate: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.g_beta_dtype, cute.cosize(gate_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sGateCumsum: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.g_beta_dtype,
+                    cute.cosize(cute.select(gate_smem_layout_staged, mode=[0, 1])),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sBeta: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.g_beta_dtype, cute.cosize(beta_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSubInner: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.invert_type_ab, cute.cosize(sub_inner_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+            sState: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.i_dtype, cute.cosize(state_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        if stream is None:
+            stream = cutlass.cuda.default_stream()
+
+        # Launch kernel
+        self.kernel(
+            qk_tiled_mma,
+            o_intra_tiled_mma,
+            o_intra_tiled_ts_mma_new,
+            qs_tiled_mma,
+            update_s_tiled_mma,
+            kkt_tiled_mma,
+            kst_tiled_mma,
+            fake_state_tiled_mma,
+            invert_sub_tiled_mma_ss_l0,
+            invert_sub_tiled_mma_ts_l0,
+            invert_sub_tiled_mma_ss_l1,
+            invert_sub_tiled_mma_ts_l1,
+            tuw_tiled_mma,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_state_f32,
+            tma_tensor_state_f32,
+            gate,
+            beta,
+            o,
+            tma_atom_state_output,
+            tma_tensor_state_output,
+            tma_atom_o_output,
+            tma_tensor_o_output,
+            cum_seqlen_q,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            qk_smem_layout_staged,
+            o_intra_smem_layout_staged_a,
+            o_intra_smem_layout_staged_b,
+            o_intra_smem_layout_staged_a_new,
+            qs_smem_layout_staged_a,
+            qs_smem_layout_staged_b,
+            update_s_smem_layout_staged_a,
+            update_s_smem_layout_staged_b,
+            state_smem_layout_staged,
+            state_smem_layout_f32_staged,
+            state_output_smem_layout_staged,
+            o_output_smem_layout_staged,
+            gate_smem_layout_staged,
+            beta_smem_layout_staged,
+            ivt_smem_layout,
+            sub_inner_smem_layout_staged,
+            invert_sub_smem_layout_staged_ss_l0_a,
+            invert_sub_smem_layout_staged_ss_l0_b,
+            invert_sub_smem_layout_staged_ts_l0_a,
+            invert_sub_smem_layout_staged_ts_l0_b,
+            invert_sub_smem_layout_staged_ss_l1_a,
+            invert_sub_smem_layout_staged_ss_l1_b,
+            invert_sub_smem_layout_staged_ts_l1_a,
+            invert_sub_smem_layout_staged_ts_l1_b,
+            tuw_smem_layout_staged_a,
+            tuw_smem_layout_staged_b,
+            v_smem_layout_staged_b,
+            scale,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @staticmethod
+    def _compute_grid(
+        o_shape: cute.Shape,
+        cta_tiler: Tuple[int, int, int],
+        is_persistent: bool,
+    ) -> Tuple[GdnStaticTileSchedulerParams, Tuple[int, int, int]]:
+        tile_sched_params = create_gdn_static_tile_scheduler_params(
+            is_persistent,
+            (
+                cute.ceil_div(cute.size(o_shape[1]), cta_tiler[2]),
+                cute.size(o_shape[2][0]),
+                cute.size(o_shape[2][1]),
+            ),
+        )
+        grid = GdnStaticTileScheduler.get_grid_shape(tile_sched_params)
+        return tile_sched_params, grid
+
+
+# ============================================================================
+# FlashInfer API Layer
+# ============================================================================
+
+
+@functools.lru_cache(maxsize=128)
+def _get_problem_size(q_shape, v_shape, cu_seqlens_tuple):
+    """Compute problem_size, cached by (q_shape, v_shape, cu_seqlens tuple).
+
+    Args:
+        q_shape: Tuple of (b, s_q, h_q, d).
+        v_shape: Tuple of (b, s_v, h_v, d).
+        cu_seqlens_tuple: Tuple of cumulative sequence lengths, or None.
+    """
+    b, s_q, h_q, d = q_shape
+    _, _, h_v, _ = v_shape
+    max_s_q = s_q
+    sum_s_q = s_q
+    if cu_seqlens_tuple is not None:
+        sum_s_q = cu_seqlens_tuple[-1]
+        b = len(cu_seqlens_tuple) - 1
+        max_s_q = max(cu_seqlens_tuple[i + 1] - cu_seqlens_tuple[i] for i in range(b))
+        return (b, max_s_q, sum_s_q, h_q, h_v, d)
+    return (b, max_s_q, sum_s_q, h_q, h_v, d)
+
+
+@functools.cache
+def _get_compiled_gdn_prefill_kernel(
+    problem_size,
+    dtype: torch.dtype,
+    is_varlen: bool,
+    is_initial_state: bool,
+    is_output_state: bool,
+    scale: float,
+):
+    """Cache compiled kernel for given configuration."""
+    return {}
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    """Public API: compile (on first call) and run the GDN chunked linear attention kernel.
+
+    Args:
+        q, k: (B, T, H_qk, D) query and key tensors (f16/bf16).
+        v:     (B, T, H_v, D) value tensor (f16/bf16). H_v must be a multiple of H_qk.
+        g:     (1, total_seq_len, H_v) gate values (f32, log-space).
+        beta:  (1, total_seq_len, H_v) beta values (f32, sigmoid-space).
+        scale: Scale factor for the attention scores. Defaults to 1/sqrt(D).
+        initial_state: (B, H_v, D, D) recurrent state (f32), or None for zero init.
+        output_final_state: If True, return the final state alongside output.
+        cu_seqlens: Cumulative sequence lengths for variable-length batching.
+        use_qk_l2norm_in_kernel: If True, use L2 norm of QK in the kernel.(Not supported yet)
+        output: Pre-allocated output tensor, or None to allocate internally.
+        output_state: Pre-allocated state output tensor, or None.
+
+    Returns:
+        output or (output, output_state) depending on output_final_state.
+    """
+
+    # Allocate output if needed
+    if output is None:
+        output = torch.empty_like(v)
+
+    # Check if supported
+    if not GDN.can_implement(
+        tuple(q.shape),
+        tuple(v.shape),
+        q.dtype,
+        output.dtype,
+        beta.dtype,
+        use_qk_l2norm_in_kernel,
+    ):
+        raise ValueError("Unsupported input shape or dtype")
+    cu_seqlens_tuple = tuple(cu_seqlens.tolist()) if cu_seqlens is not None else None
+    problem_size = _get_problem_size(tuple(q.shape), tuple(v.shape), cu_seqlens_tuple)
+
+    # Allocate output_state if needed, current alloc both case.
+    # TODO: Remove output_state when output_final_state is false.
+    if output_state is None:
+        output_state = torch.empty(
+            (problem_size[0], problem_size[4], problem_size[5], problem_size[5]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    # Compile kernel with TVM FFI (cached)
+    is_varlen = cu_seqlens is not None
+    is_initial_state = initial_state is not None
+    is_output_state = output_state is not None
+    cache_key = (
+        problem_size,
+        q.dtype,
+        is_varlen,
+        is_initial_state,
+        is_output_state,
+        scale,
+    )
+    cache = _get_compiled_gdn_prefill_kernel(*cache_key)
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    if "compiled_gdn" not in cache:
+        # GDN kernel
+        gdn = GDN()
+        q_tensor = from_dlpack(q, assumed_align=16, enable_tvm_ffi=True)
+        k_tensor = from_dlpack(k, assumed_align=16, enable_tvm_ffi=True)
+        v_tensor = from_dlpack(v, assumed_align=16, enable_tvm_ffi=True)
+        o_tensor = from_dlpack(output, assumed_align=16, enable_tvm_ffi=True)
+        gate_tensor = from_dlpack(g, assumed_align=16, enable_tvm_ffi=True)
+        beta_tensor = from_dlpack(beta, assumed_align=16, enable_tvm_ffi=True)
+        cu_seqlens_tensor = (
+            from_dlpack(cu_seqlens, assumed_align=16, enable_tvm_ffi=True)
+            if cu_seqlens is not None
+            else None
+        )
+        state_tensor = (
+            from_dlpack(initial_state, assumed_align=16, enable_tvm_ffi=True)
+            if initial_state is not None
+            else None
+        )
+        state_output_tensor = (
+            from_dlpack(output_state, assumed_align=16, enable_tvm_ffi=True)
+            if output_state is not None
+            else None
+        )
+
+        # Compile GDN kernel
+        options = EnableTVMFFI
+        compiled_gdn = cute.compile[options](
+            gdn,
+            q_tensor.iterator,
+            k_tensor.iterator,
+            v_tensor.iterator,
+            o_tensor.iterator,
+            gate_tensor.iterator,
+            beta_tensor.iterator,
+            problem_size,
+            state_tensor.iterator if state_tensor is not None else None,
+            state_output_tensor.iterator if state_output_tensor is not None else None,
+            scale,
+            cu_seqlens_tensor,
+            stream=current_stream,
+        )
+        cache["compiled_gdn"] = compiled_gdn
+
+    compiled_gdn = cache["compiled_gdn"]
+
+    # Run GDN kernel
+    compiled_gdn(
+        q.data_ptr(),
+        k.data_ptr(),
+        v.data_ptr(),
+        output.data_ptr(),
+        g.data_ptr(),
+        beta.data_ptr(),
+        problem_size,
+        initial_state.data_ptr() if initial_state is not None else None,
+        output_state.data_ptr() if output_state is not None else None,
+        scale,
+        cu_seqlens,
+        stream=current_stream,
+    )
+
+    if output_final_state:
+        return output, output_state
+    else:
+        return output

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
@@ -45,7 +45,6 @@ from cutlass._mlir.dialects import nvvm
 
 import cuda.bindings.driver as cuda
 
-
 from .gdn_tile_scheduler import (
     GdnStaticTileScheduler,
     GdnStaticTileSchedulerParams,

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
@@ -46,13 +46,23 @@ from cutlass._mlir.dialects import nvvm
 import cuda.bindings.driver as cuda
 
 
-from .gdn_tile_scheduler import *
-from .gdn_helpers import *
+from .gdn_tile_scheduler import (
+    GdnStaticTileScheduler,
+    GdnStaticTileSchedulerParams,
+    create_gdn_static_tile_scheduler,
+    create_gdn_static_tile_scheduler_params,
+)
+from .gdn_helpers import (
+    make_smem_layout_a_kind,
+    make_smem_layout_b_kind,
+    make_smem_layout_epi_kind,
+)
 
 import functools
 import warnings
 
 from cutlass.cute import EnableTVMFFI
+from cutlass import Int32, Int64
 
 
 def make_thread_cooperative_group(size: Int32):
@@ -4405,7 +4415,7 @@ class GDN:
 
         self.shared_storage = SharedStorage
 
-        if stream is None:
+        if cutlass.const_expr(stream is None):
             stream = cutlass.cuda.default_stream()
 
         # Launch kernel
@@ -4585,9 +4595,8 @@ def chunk_gated_delta_rule(
     cu_seqlens_tuple = tuple(cu_seqlens.tolist()) if cu_seqlens is not None else None
     problem_size = _get_problem_size(tuple(q.shape), tuple(v.shape), cu_seqlens_tuple)
 
-    # Allocate output_state if needed, current alloc both case.
-    # TODO: Remove output_state when output_final_state is false.
-    if output_state is None:
+    # Allocate output_state if needed
+    if output_final_state and (output_state is None):
         output_state = torch.empty(
             (problem_size[0], problem_size[4], problem_size[5], problem_size[5]),
             dtype=torch.float32,
@@ -4597,13 +4606,12 @@ def chunk_gated_delta_rule(
     # Compile kernel with TVM FFI (cached)
     is_varlen = cu_seqlens is not None
     is_initial_state = initial_state is not None
-    is_output_state = output_state is not None
     cache_key = (
         problem_size,
         q.dtype,
         is_varlen,
         is_initial_state,
-        is_output_state,
+        output_final_state,
         scale,
     )
     cache = _get_compiled_gdn_prefill_kernel(*cache_key)
@@ -4631,7 +4639,7 @@ def chunk_gated_delta_rule(
         )
         state_output_tensor = (
             from_dlpack(output_state, assumed_align=16, enable_tvm_ffi=True)
-            if output_state is not None
+            if output_final_state
             else None
         )
 
@@ -4647,7 +4655,7 @@ def chunk_gated_delta_rule(
             beta_tensor.iterator,
             problem_size,
             state_tensor.iterator if state_tensor is not None else None,
-            state_output_tensor.iterator if state_output_tensor is not None else None,
+            state_output_tensor.iterator if output_final_state else None,
             scale,
             cu_seqlens_tensor,
             stream=current_stream,
@@ -4666,7 +4674,7 @@ def chunk_gated_delta_rule(
         beta.data_ptr(),
         problem_size,
         initial_state.data_ptr() if initial_state is not None else None,
-        output_state.data_ptr() if output_state is not None else None,
+        output_state.data_ptr() if output_final_state else None,
         scale,
         cu_seqlens,
         stream=current_stream,

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn.py
@@ -1592,8 +1592,22 @@ class GDN:
             beta_val = sBeta0[tidx]
             gb_handle.release()
 
+            # Barrier to ensure cumsum visible, then save gate_tail before overwrite
+            cute.arch.barrier(
+                barrier_id=self.wg_sync_bar_id,
+                number_of_threads=len(self.cudacore_warp_ids) * 32,
+            )
+            gate_tail = (
+                sGateCumsum[tail_count - 1]
+                if cutlass.const_expr(need_mask)
+                else sGateCumsum[127]
+            )
+
+            # Precompute exp(cumsum_i) for factored gamma
+            tval_exp_gamma = cute.math.exp(tval, fastmath=True)
+
             self.compute_gamma_tmem(
-                tval,
+                tval_exp_gamma,
                 sGateCumsum,
                 kkt_thr_mma,
                 tGamma,
@@ -1610,12 +1624,6 @@ class GDN:
                 beta_val,
                 tGamma,
             )
-
-            gate_tail = (
-                sGateCumsum[tail_count - 1]
-                if cutlass.const_expr(need_mask)
-                else sGateCumsum[127]
-            )
             w0_handle = epi_w0_consumer.wait_and_advance()
             self.load_state_apply_gate(
                 kst_thr_mma,
@@ -1623,10 +1631,7 @@ class GDN:
                 sStateInput,
                 gate_tail,
             )
-            cute.arch.fence_proxy(
-                cute.arch.ProxyKind.async_shared,
-                space=cute.arch.SharedSpace.shared_cta,
-            )
+            cute.arch.fence_view_async_shared()
 
             qk_handle1 = mma_qk_consumer0.wait_and_advance()
             self.load_qk_epi(
@@ -1654,21 +1659,22 @@ class GDN:
                 sInvertSubSSL0B,
             )
 
-            c0_handle = mma_cudacore_consumer0.wait_and_advance()
-            c0_handle.release()
-            v_handle0 = load_v_consumer.wait_and_advance()
-
-            tval_exp = cute.math.exp(tval)
-            self.get_uw_b(
-                kst_thr_mma, tKStKS, tval_exp, beta_val, sV, need_mask, tail_count
-            )
             self.store_ivt_p1(
                 sInvertSubReg,
                 sInvertSubTSL0B,
             )
 
             c0_handle = mma_cudacore_consumer0.wait_and_advance()
-            self.load_ivt_ss_l0(tItSSL0, tInrDCL0A)  # debug
+            c0_handle.release()
+            v_handle0 = load_v_consumer.wait_and_advance()
+
+            tval_exp = cute.math.exp(tval, fastmath=True)
+            self.get_uw_b(
+                kst_thr_mma, tKStKS, tval_exp, beta_val, sV, need_mask, tail_count
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            self.load_ivt_ss_l0(tItSSL0, tInrDCL0A)
             c0_handle.release()
             self.store_ivt_smem_l1_ss_b(
                 kkt_thr_mma,
@@ -1708,10 +1714,6 @@ class GDN:
             c0_handle.release()
 
             self.load_q_epi(qk_thr_mma, sQ, tQgate, tval_exp, need_mask, tail_count)
-            cute.arch.fence_proxy(
-                cute.arch.ProxyKind.async_shared,
-                space=cute.arch.SharedSpace.shared_cta,
-            )
 
             c0_handle = mma_cudacore_consumer0.wait_and_advance()
             v_handle0.release()
@@ -1829,13 +1831,12 @@ class GDN:
             cute.arch.fence_view_async_tmem_load()
 
             # Load V from smem
-            temp_regs = cute.make_rmem_tensor(tTMEM_LOADrS_frag.shape, self.acc_dtype)
             for it in cutlass.range_constexpr(each_iter):
                 for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
                     # mul2
                     (
-                        temp_regs[inner_idx + 0, it],
-                        temp_regs[inner_idx + 1, it],
+                        tTMEM_LOADrS_frag[inner_idx + 0, it],
+                        tTMEM_LOADrS_frag[inner_idx + 1, it],
                     ) = cute.arch.mul_packed_f32x2(
                         (
                             tTMEM_LOADrS_frag[inner_idx + 0, it],
@@ -1846,8 +1847,8 @@ class GDN:
 
                     # fma2
                     (
-                        temp_regs[inner_idx + 0, it],
-                        temp_regs[inner_idx + 1, it],
+                        tTMEM_LOADrS_frag[inner_idx + 0, it],
+                        tTMEM_LOADrS_frag[inner_idx + 1, it],
                     ) = cute.arch.fma_packed_f32x2(
                         (
                             beta_val,
@@ -1862,12 +1863,12 @@ class GDN:
                             ),
                         ),
                         (
-                            temp_regs[inner_idx + 0, it],
-                            temp_regs[inner_idx + 1, it],
+                            tTMEM_LOADrS_frag[inner_idx + 0, it],
+                            tTMEM_LOADrS_frag[inner_idx + 1, it],
                         ),
                     )
                 sV_frg[None, (i * each_iter + it, thread_idx)].store(
-                    temp_regs[None, it].load().to(self.i_dtype)
+                    tTMEM_LOADrS_frag[None, it].load().to(self.i_dtype)
                 )
 
     @cute.jit
@@ -1935,10 +1936,7 @@ class GDN:
             cute.copy(tiled_smem_store, tTMEM_LOADrS, tTMEM_STOREsO_i)
 
         # fence view async shared
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def store_o_smem(
@@ -2016,13 +2014,12 @@ class GDN:
                 tTMEM_STORErS_x4_e, cute.make_layout(frg_tile)
             )
 
-            temp_regs = cute.make_rmem_tensor(tTMEM_LOADrS_frg.shape, self.acc_dtype)
             for j in cutlass.range_constexpr(frg_cnt):
                 for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
                     # mul2
                     (
-                        temp_regs[inner_idx + 0, j],
-                        temp_regs[inner_idx + 1, j],
+                        tTMEM_LOADrS_frg[inner_idx + 0, j],
+                        tTMEM_LOADrS_frg[inner_idx + 1, j],
                     ) = cute.arch.mul_packed_f32x2(
                         (
                             tTMEM_LOADrS_frg[inner_idx + 0, j],
@@ -2031,7 +2028,7 @@ class GDN:
                         (scale, scale),
                     )
                 tTMEM_STORErS_x4_e_frg[None, j].store(
-                    temp_regs[None, j].load().to(self.i_dtype)
+                    tTMEM_LOADrS_frg[None, j].load().to(self.i_dtype)
                 )
 
             # store
@@ -2042,10 +2039,7 @@ class GDN:
             cute.copy(tiled_smem_store, tTMEM_STORErS_x4_e, tTMEM_STOREsO_i)
 
         # fence view async shared
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def load_k(
@@ -2059,7 +2053,7 @@ class GDN:
         tidx, _, _ = cute.arch.thread_idx()
         thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
 
-        gate_val = cute.math.exp((gate - val))
+        gate_val = cute.math.exp((gate - val), fastmath=True)
 
         k = self.read_tmem_128(tIn)
 
@@ -2084,10 +2078,7 @@ class GDN:
                     (k_f16_frag[None, store_col].load() * gate_val).to(self.i_dtype)
                 )
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def init_state_zeros(
@@ -2233,8 +2224,7 @@ class GDN:
         cIn = cute.make_identity_tensor((128, 128))
         tOcO = thr_mma.partition_C(cIn)
 
-        corr_tile_size = 16
-        # corr_tile_size_f32 = corr_tile_size // 2
+        corr_tile_size = 32
 
         tIn_i_layout = cute.composition(
             tIn.layout, cute.make_layout((128, corr_tile_size))
@@ -2281,7 +2271,7 @@ class GDN:
             tTMEM_LOADrS.layout,
         )
 
-        gate_val = cute.math.exp(gate)
+        gate_val = cute.math.exp(gate, fastmath=True)
         for i in cutlass.range_constexpr(128 // corr_tile_size):
             tTMEM_LOADtO_i = cute.make_tensor(
                 tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
@@ -2759,10 +2749,7 @@ class GDN:
                         ((None, (col_true, 1)), lane_id % 8), 0, lane_id // 8, 0
                     ].store(tmem_frag[((None, j), 0), 0, 0].load())
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def store_ivt_smem_l1_ss_b(
@@ -2783,7 +2770,7 @@ class GDN:
         cIn = cute.make_identity_tensor((128, 128))
         tOcO = thr_mma.partition_C(cIn)
 
-        corr_tile_size = 8
+        corr_tile_size = 32
         tIn_i_layout = cute.composition(
             tIn.layout, cute.make_layout((128, corr_tile_size))
         )
@@ -2807,27 +2794,12 @@ class GDN:
 
         tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
 
-        # tile 0
-        tTMEM_LOADtO_i = cute.make_tensor(tTMEM_LOADtO.iterator, tTMEM_LOADtO.layout)
-
-        cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
-        cute.arch.fence_view_async_tmem_load()
         sub_tile_size = 8
         tmem_frag = cute.logical_divide(tTMEM_LOADrS, ((sub_tile_size, None), None))
         sInvertSubSSL1B_frag = cute.logical_divide(
             sInvertSubSSL1B, ((sub_tile_size, None), None)
         )
         tile_frags = corr_tile_size // sub_tile_size
-        if sub_widx == 2 or sub_widx == 3:
-            sub_id_row = sub_widx - 2
-            for col in cutlass.range_constexpr(tile_frags):
-                col_true = (lane_id + col) % (tile_frags)
-                sInvertSubSSL1B_frag[
-                    ((None, (col_true, 0)), lane_id % 8),
-                    0,
-                    lane_id // 8 + sub_id_row * 4,
-                    0,
-                ].store(tmem_frag[((None, col_true), 0), 0, 0].load())
 
         # tile 0
         for i in cutlass.range_constexpr(32 // corr_tile_size):
@@ -2892,10 +2864,7 @@ class GDN:
                     ((None, (col_true, sub_id_row)), lane_id % 8), 0, lane_id // 8, 0
                 ].store(sReg[(None, tidx % 128), col_true].load())
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def store_ivt_p2(
@@ -2927,10 +2896,7 @@ class GDN:
                 sInvertSubSSL1A_frag[
                     (lane_id, (None, col_true % 2)), 0, (col_true // 2, 1), 0
                 ].store(zeros)
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def store_ivt_p3(
@@ -2964,10 +2930,7 @@ class GDN:
                 sInvertSubTSL1B_frag[
                     ((None, (col_true, 1)), lane_id % 8), 0, lane_id // 8 + 0, 0
                 ].store(zeros)
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def load_store_tmem_tune(
@@ -3113,23 +3076,17 @@ class GDN:
         cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
         cute.arch.fence_view_async_tmem_load()
 
-        tTR_rO_e = cute.make_rmem_tensor(tTR_cO.shape, self.i_dtype)
         frg_cnt = 16
         frg_tile = cute.size(tTR_rO) // frg_cnt
         tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
-        tTR_rO_e_frg = cute.logical_divide(tTR_rO_e, cute.make_layout(frg_tile))
-        for j in cutlass.range_constexpr(frg_cnt):
-            r_vec = tTR_rO_frg[None, j].load()
-            tTR_rO_e_frg[None, j].store(r_vec.to(self.i_dtype))
 
         sNewV_frg = cute.logical_divide(sNewV, cute.make_layout(frg_tile))
         for it in cutlass.range_constexpr(0, 16):
-            sNewV_frg[None, (it, thread_idx)].store(tTR_rO_e_frg[None, it].load())
+            sNewV_frg[None, (it, thread_idx)].store(
+                tTR_rO_frg[None, it].load().to(self.i_dtype)
+            )
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def load_ivt_result(
@@ -3186,10 +3143,7 @@ class GDN:
                 it // 2,
             ] = tTR_rO_e_f32[it * 2 + 1]
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def apply_gamma_beta(
@@ -3210,7 +3164,7 @@ class GDN:
         cIn = cute.make_identity_tensor((128, 128))
         tOcO = thr_mma.partition_C(cIn)
 
-        corr_tile_size = 32  # only 8  or 32
+        corr_tile_size = 32  # 32
         tIn_i_layout = cute.composition(
             tIn.layout, cute.make_layout((128, corr_tile_size))
         )
@@ -3282,6 +3236,8 @@ class GDN:
             )
 
             cute.copy(tiled_tmem_load_gamma, tTMEM_LOADtG_i, tTMEM_LOADrG)
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
             each_iter = corr_tile_size // frg_tile
             tTMEM_LOADrG_frg = cute.logical_divide(
                 tTMEM_LOADrG, ((frg_tile, None), None)
@@ -3301,8 +3257,6 @@ class GDN:
                             beta_val,
                         ),
                     )
-            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
-            cute.arch.fence_view_async_tmem_load()
 
             tTMEM_LOADrS_frg = cute.logical_divide(
                 tTMEM_LOADrS, ((frg_tile, None), None)
@@ -3348,9 +3302,20 @@ class GDN:
         mask: cutlass.Constexpr[cutlass.Boolean] = False,
         tail_count: Int32 = 128,
     ):
-        """Build the 128x128 causal gamma matrix in TMEM: gamma[i,j] = exp(cumsum[i] - cumsum[j]) for j <= i."""
+        """Build the 128x128 causal gamma matrix in TMEM: gamma[i,j] = exp(cumsum[i]) * exp(-cumsum[j]) for j <= i."""
         tidx, _, _ = cute.arch.thread_idx()
         thread_idx = tidx % 128
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        # Precompute exp(-cumsum[j]) cooperatively and store to sGateCumsum
+        # Save gate_tail first (needed later, before we overwrite)
+        tidx_in_group = tidx % 128
+        neg_exp_val = cute.math.exp(-sGateCumsum[tidx_in_group], fastmath=True)
+        sGateCumsum[tidx_in_group] = neg_exp_val
 
         cute.arch.barrier(
             barrier_id=bar_id,
@@ -3403,6 +3368,7 @@ class GDN:
             )
             for it in cutlass.range_constexpr(corr_tile_size // frg_tile):
                 tile_offset = i * corr_tile_size + it * frg_tile
+                tile_end = tile_offset + frg_tile - 1
 
                 if (
                     (
@@ -3413,18 +3379,24 @@ class GDN:
                     if cutlass.const_expr(mask)
                     else (tile_offset <= thread_idx)
                 ):
-                    curr_val_frag_ssa = sGateCumsum_frag[(None, it), i].load()
+                    # Load precomputed exp(-cumsum[j]) from smem
+                    neg_exp_frag = sGateCumsum_frag[(None, it), i].load()
 
-                    new_val_frag = cute.math.exp(val - curr_val_frag_ssa, fastmath=True)
+                    # gamma[i,j] = exp(cumsum_i) * exp(-cumsum_j) — mul instead of exp
+                    new_val_frag = val * neg_exp_frag
 
-                    for inner_idx in cutlass.range_constexpr(0, frg_tile):
-                        offset = tile_offset + inner_idx
-                        curr_val = new_val_frag[inner_idx]
+                    if tile_end <= thread_idx:
+                        # Fast path: entire tile below diagonal
+                        tTMEM_STORErS_frag[None, it].store(new_val_frag)
+                    else:
+                        for inner_idx in cutlass.range_constexpr(0, frg_tile):
+                            offset = tile_offset + inner_idx
+                            curr_val = new_val_frag[inner_idx]
 
-                        if offset <= thread_idx:
-                            tTMEM_STORErS_frag[inner_idx, it] = curr_val
-                        else:
-                            tTMEM_STORErS_frag[inner_idx, it] = cutlass.Float32(0)
+                            if offset <= thread_idx:
+                                tTMEM_STORErS_frag[inner_idx, it] = curr_val
+                            else:
+                                tTMEM_STORErS_frag[inner_idx, it] = cutlass.Float32(0)
                 else:
                     tTMEM_STORErS_frag[None, it].store(zeros)
 
@@ -3446,19 +3418,16 @@ class GDN:
         tidx_in_group = tidx % 128
 
         val = sGate[tidx_in_group]
-        stride = 1
-        clamp_value = 0
-        while stride < 32:
+        for step in cutlass.range_constexpr(5):
+            stride = 1 << step
             shfl_value = cute.arch.shuffle_sync_op(
                 value=val,
                 offset=stride,
-                mask_and_clamp=clamp_value,
+                mask_and_clamp=0,
                 kind=nvvm.ShflKind.up,
             )
             if lane_id >= stride:
                 val += shfl_value
-
-            stride = stride << 1
         if lane_id == 31:
             sGateCumsum[warp_id] = val
 
@@ -3643,8 +3612,7 @@ class GDN:
                     sInvertSubTSL1B, ((4, None), None)
                 )
                 sub_id_row = sub_widx
-                for col in cutlass.range_constexpr(0, 8):
-                    col_true = (lane_id // 4 + col) % 8
+                for col_true in cutlass.range_constexpr(0, 8):
                     sInvertSubTSL1B_frag[
                         ((lane_id % 4, (col_true, 0)), lane_id // 4),
                         0,
@@ -3686,10 +3654,7 @@ class GDN:
                         0,
                     ].store(-tTR_rO_s_frag_f1[(None, 1), it].load())
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_view_async_shared()
 
     @cute.jit
     def store_ivt_c(

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn_helpers.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn_helpers.py
@@ -1,0 +1,177 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Type, Union
+
+import cutlass
+import cutlass.cute as cute
+
+
+def make_smem_layout_a_kind(
+    tiled_mma: cute.TiledMma,
+    mma_tiler_mnk: cute.Tile,
+    a_dtype: Type[cutlass.Numeric],
+    num_stages: int,
+    kind: cute.nvgpu.tcgen05.SmemLayoutAtomKind,
+    *,
+    loc=None,
+    ip=None,
+) -> Union[cute.Layout, cute.ComposedLayout]:
+    """This function helps with:
+    1. Get the partitioned shape of the A tensor based on the tiled_mma & MMA tiler.
+    2. Select the heuristic SMEM layout atom based on the A tensor's majorness, the data type, and the major mode size.
+    3. cute.Tile the SMEM layout atom to the MMA tile shape.
+    4. Stage the SMEM layout based on the number of stages.
+
+    :param tiled_mma: The tiled MMA used to partition tensor A
+    :type tiled_mma: cute.TiledMma
+    :param mma_tiler_mnk: The MMA tile shape
+    :type mma_tiler_mnk: cute.cute.Tile
+    :param a_dtype: The element type for tensor A
+    :type a_dtype: Type[Numeric]
+    :param num_stages: The number of pipeline stages for tensor A
+    :type num_stages: int
+    :param kind:         The kind of layout Atom
+    :type kind:          SmemLayoutAtomKind
+
+    :return: SMEM layout for tensor A
+    :rtype: Union[cute.Layout, cute.ComposedLayout]
+    """
+
+    is_k_major = (
+        tiled_mma.op.a_major_mode == cutlass.cute.nvgpu.tcgen05.OperandMajorMode.K
+    )
+    a_smem_shape = tiled_mma.partition_shape_A(
+        cute.dice(mma_tiler_mnk, (1, None, 1), loc=loc, ip=ip)
+    )
+    a_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+        kind,
+        a_dtype,
+        loc=loc,
+        ip=ip,
+    )
+    a_smem_layout_staged = cute.nvgpu.tcgen05.tile_to_mma_shape(
+        a_smem_layout_atom,
+        cute.append(a_smem_shape, num_stages, loc=loc, ip=ip),
+        order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        loc=loc,
+        ip=ip,
+    )
+    return a_smem_layout_staged
+
+
+def make_smem_layout_b_kind(
+    tiled_mma: cute.TiledMma,
+    mma_tiler_mnk: cute.Tile,
+    b_dtype: Type[cutlass.Numeric],
+    num_stages: int,
+    kind: cute.nvgpu.tcgen05.SmemLayoutAtomKind,
+    *,
+    loc=None,
+    ip=None,
+) -> Union[cute.Layout, cute.ComposedLayout]:
+    """This function helps:
+    1. Get the partitioned shape of the B tensor based on the tiled_mma & MMA tiler.
+    2. Select the heuristic SMEM layout atom based on the B tensor's majorness, the data type, and the major mode size.
+    3. cute.Tile the SMEM layout atom to the MMA tile shape.
+    4. Stage the SMEM layout based on the number of stages.
+
+    :param tiled_mma: The tiled MMA which is used to partition the B tensor.
+    :type tiled_mma: cute.TiledMma
+    :param mma_tiler_mnk: The MMA tile shape.
+    :type mma_tiler_mnk: cute.cute.Tile
+    :param b_dtype: The element type for the B tensor.
+    :type b_dtype: Type[Numeric]
+    :param num_stages: The stage of the B tensor.
+    :type num_stages: int
+    :param kind:         The kind of layout Atom
+    :type kind:          SmemLayoutAtomKind
+
+    :return: SMEM layout for the B tensor.
+    :rtype: Union[cute.Layout, cute.ComposedLayout]
+    """
+
+    is_k_major = (
+        tiled_mma.op.b_major_mode == cutlass.cute.nvgpu.tcgen05.OperandMajorMode.K
+    )
+    b_smem_shape = tiled_mma.partition_shape_B(
+        cute.dice(mma_tiler_mnk, (None, 1, 1), loc=loc, ip=ip)
+    )
+    b_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+        kind,
+        b_dtype,
+        loc=loc,
+        ip=ip,
+    )
+    b_smem_layout_staged = cute.nvgpu.tcgen05.tile_to_mma_shape(
+        b_smem_layout_atom,
+        cute.append(b_smem_shape, num_stages, loc=loc, ip=ip),
+        order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        loc=loc,
+        ip=ip,
+    )
+
+    return b_smem_layout_staged
+
+
+def make_smem_layout_epi_kind(
+    epi_dtype: Type[cutlass.Numeric],
+    epi_layout: cutlass.utils.LayoutEnum,
+    epi_tile: cute.Tile,
+    epi_stage: int,
+    kind: cute.nvgpu.tcgen05.SmemLayoutAtomKind,
+    *,
+    loc=None,
+    ip=None,
+) -> Union[cute.Layout, cute.ComposedLayout]:
+    """This function helps:
+    1. Select the heuristic SMEM layout atom based on the epilog tile shape,
+       the epilog tensor's majorness, and the element type.
+    2. cute.Tile the SMEM layout atom to the epilog tile shape.
+    3. Stage the SMEM layout based on the number of stages.
+
+    :param epi_dtype: The element type for the epilog tensor.
+    :type epi_dtype: Type[Numeric]
+    :param epi_layout: The layout enum for the epilog tensor.
+    :type epi_layout: LayoutEnum
+    :param epi_tile: The epilogue tile shape.
+    :type epi_tile: cute.cute.Tile
+    :param epi_stage: The stage of the epilog tensor.
+    :type epi_stage: int
+
+    :return: SMEM layout for epilog tensors (usually C & D which are processed in the epilog)
+    :rtype: Union[cute.Layout, cute.ComposedLayout]
+    """
+
+    epilog_shape = cute.product_each(
+        cute.shape(epi_tile, loc=loc, ip=ip), loc=loc, ip=ip
+    )
+
+    c_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+        kind,
+        epi_dtype,
+        loc=loc,
+        ip=ip,
+    )
+    epi_smem_layout_staged = cute.tile_to_shape(
+        c_smem_layout_atom,
+        cute.append(epilog_shape, epi_stage, loc=loc, ip=ip),
+        order=((1, 0, 2) if not epi_layout.is_n_major_c() else (0, 1, 2)),
+        loc=loc,
+        ip=ip,
+    )
+
+    return epi_smem_layout_staged

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn_tile_scheduler.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn_tile_scheduler.py
@@ -34,7 +34,9 @@ class GdnStaticTileSchedulerParams:
         ):
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
-        return GdnStaticTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+        return GdnStaticTileSchedulerParams(
+            *(tuple(obj_list)), loc=self._loc, ip=self._ip
+        )
 
 
 def create_gdn_static_tile_scheduler_params(

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn_tile_scheduler.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn_tile_scheduler.py
@@ -148,7 +148,12 @@ class GdnStaticTileScheduler:
         new_blk_coord = cutlass.new_from_mlir_values(self._blk_coord, values[4:7])
         new_grid_shape = cutlass.new_from_mlir_values(self._grid_shape, values[7:])
         return GdnStaticTileScheduler(
-            new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
+            new_params,
+            new_current_work_linear_idx,
+            new_blk_coord,
+            new_grid_shape,
+            loc=self._loc,
+            ip=self._ip,
         )
 
 

--- a/flashinfer/gdn_kernels/blackwell_prefill/gdn_tile_scheduler.py
+++ b/flashinfer/gdn_kernels/blackwell_prefill/gdn_tile_scheduler.py
@@ -1,0 +1,158 @@
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+
+from cutlass.cute.typing import Int32, Boolean
+
+
+class GdnStaticTileSchedulerParams:
+    def __init__(
+        self,
+        is_persistent: bool,
+        problem_shape_mbh: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.is_persistent = is_persistent
+        self.problem_shape_mbh = problem_shape_mbh
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.is_persistent, self.problem_shape_mbh]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip(
+            [self.is_persistent, self.problem_shape_mbh], self._values_pos, strict=True
+        ):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return GdnStaticTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+
+
+def create_gdn_static_tile_scheduler_params(
+    is_persistent: bool,
+    problem_shape_mbh: cute.Shape,
+) -> GdnStaticTileSchedulerParams:
+    return GdnStaticTileSchedulerParams(is_persistent, problem_shape_mbh)
+
+
+class GdnStaticTileScheduler:
+    def __init__(
+        self,
+        params: GdnStaticTileSchedulerParams,
+        current_work_linear_idx: Int32,
+        blk_coord: cute.Coord,
+        grid_shape: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self._params = params
+        self._blk_coord = blk_coord
+        self._grid_shape = grid_shape
+        self._is_persistent = params.is_persistent
+        self._current_work_linear_idx = current_work_linear_idx
+        self._problem_shape_mbh = cute.make_layout(
+            params.problem_shape_mbh, loc=loc, ip=ip
+        )
+        self._num_blocks = cute.size(self._problem_shape_mbh, loc=loc, ip=ip)
+        self._is_first_block = True
+        self.num_persistent_sm = cute.size(grid_shape, loc=loc, ip=ip)
+        self._loc = loc
+        self._ip = ip
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: GdnStaticTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cute.Shape:
+        if params.is_persistent:
+            hardware_info = cutlass.utils.HardwareInfo()
+            sm_count = hardware_info.get_device_multiprocessor_count()
+            return (
+                cutlass.min(
+                    sm_count, cute.size(params.problem_shape_mbh, loc=loc, ip=ip)
+                ),
+                1,
+                1,
+            )
+        else:
+            return params.problem_shape_mbh
+
+    @staticmethod
+    def check_valid_work_for_seqlen_q(
+        q_tiler: int,
+        current_idx: Int32,
+        seqlen_q: Int32,
+    ) -> Boolean:
+        return current_idx * q_tiler < seqlen_q
+
+    def get_current_work(self, *, loc=None, ip=None) -> utils.WorkTileInfo:
+        is_valid = (
+            self._current_work_linear_idx < self._num_blocks
+            if self._is_persistent
+            else self._is_first_block
+        )
+
+        blk_coord = (0, 0, 0)
+        if self._is_persistent:
+            blk_coord = self._problem_shape_mbh.get_hier_coord(
+                self._current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            blk_coord = self._blk_coord
+
+        # cur_tile_coord is (mid, 0, (bid, hid))
+        cur_tile_coord = (
+            blk_coord[0],
+            0,
+            (blk_coord[1], blk_coord[2]),
+        )
+
+        return utils.WorkTileInfo(cur_tile_coord, is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, advance_count=1, loc=None, ip=None):
+        if self._is_persistent:
+            self._current_work_linear_idx += advance_count * self.num_persistent_sm
+        self._is_first_block = False
+
+    def __extract_mlir_values__(self):
+        values = cutlass.extract_mlir_values(self._params)
+        values.extend(cutlass.extract_mlir_values(self._current_work_linear_idx))
+        values.extend(cutlass.extract_mlir_values(self._blk_coord))
+        values.extend(cutlass.extract_mlir_values(self._grid_shape))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 10
+        new_params = cutlass.new_from_mlir_values(self._params, values[0:3])
+        new_current_work_linear_idx = cutlass.new_from_mlir_values(
+            self._current_work_linear_idx, [values[3]]
+        )
+        new_blk_coord = cutlass.new_from_mlir_values(self._blk_coord, values[4:7])
+        new_grid_shape = cutlass.new_from_mlir_values(self._grid_shape, values[7:])
+        return GdnStaticTileScheduler(
+            new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
+        )
+
+
+def create_gdn_static_tile_scheduler(
+    params: GdnStaticTileSchedulerParams,
+    blk_coord: cute.Coord,
+    grid_shape: cute.Shape,
+) -> GdnStaticTileScheduler:
+    return GdnStaticTileScheduler(params, blk_coord[0], blk_coord, grid_shape)

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -26,6 +26,13 @@ from .utils import (
     register_fake_op,
     get_device_sm_count,
     _get_cache_buf,
+    is_sm90a_supported,
+    is_sm100a_supported,
+    is_sm110a_supported,
+)
+
+from flashinfer.gdn_kernels.blackwell_prefill import (
+    chunk_gated_delta_rule as chunk_gated_delta_rule_blackwell,
 )
 
 
@@ -82,8 +89,7 @@ def get_gdn_prefill_module():
     return SimpleNamespace(gdn_prefill=gdn_prefill)
 
 
-@flashinfer_api
-def chunk_gated_delta_rule(
+def chunk_gated_delta_rule_hopper(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -102,52 +108,6 @@ def chunk_gated_delta_rule(
     This implements the gated delta rule linear attention mechanism for efficient
     training and inference. Supports both GQA (grouped query attention) and GVA
     (grouped value attention) configurations.
-
-    Args:
-        q (torch.Tensor):
-            Queries of shape ``[total_seq_len, num_q_heads, head_size]``.
-            Must be contiguous and on CUDA.
-        k (torch.Tensor):
-            Keys of shape ``[total_seq_len, num_k_heads, head_size]``.
-            Must be contiguous and on CUDA.
-        v (torch.Tensor):
-            Values of shape ``[total_seq_len, num_v_heads, head_size]``.
-            Must be contiguous and on CUDA.
-        g (Optional[torch.Tensor]):
-            Forget gate (alpha) of shape ``[total_seq_len, num_sab_heads]`` where
-            ``num_sab_heads = max(num_q_heads, num_v_heads)``. Must be float32.
-            If None, defaults to all ones. Default: ``None``.
-        beta (Optional[torch.Tensor]):
-            Update gate (beta) of shape ``[total_seq_len, num_sab_heads]``.
-            Must be float32. If None, defaults to all ones. Default: ``None``.
-        scale (Optional[float]):
-            Scale factor for the attention scores.
-            If not provided, defaults to ``1 / sqrt(head_size)``. Default: ``None``.
-        initial_state (Optional[torch.Tensor]):
-            Initial KV state of shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
-            Must be float32. If None, starts from zero state. Default: ``None``.
-        output_final_state (bool):
-            Whether to output the final state. Default: ``False``.
-        cu_seqlens (torch.Tensor):
-            Cumulative sequence lengths of shape ``[num_seqs + 1]``, int64.
-            Required for variable-length sequences (varlen mode).
-        use_qk_l2norm_in_kernel (bool):
-            Whether to use QK L2 normalization in kernel. Default: ``False``.
-        output (Optional[torch.Tensor]):
-            Pre-allocated output tensor of shape ``[total_seq_len, num_o_heads, head_size]``
-            where ``num_o_heads = max(num_q_heads, num_v_heads)``.
-            If None, will be allocated automatically. Default: ``None``.
-        output_state (Optional[torch.Tensor]):
-            Pre-allocated output state tensor of shape
-            ``[num_seqs, num_sab_heads, head_size, head_size]``, float32.
-            Required if ``output_final_state=True``. Default: ``None``.
-
-    Returns:
-        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-            - If ``output_final_state=False``: Returns output tensor of shape
-              ``[total_seq_len, num_o_heads, head_size]``.
-            - If ``output_final_state=True``: Returns tuple of (output, final_state) where
-              final_state has shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
 
     Note:
         - Supports GQA: ``num_q_heads > num_k_heads = num_v_heads``
@@ -211,3 +171,111 @@ def chunk_gated_delta_rule(
         return output, output_state
     else:
         return output
+
+
+@flashinfer_api
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated Delta Rule (GDN) attention for prefill.
+
+    Args:
+        q (torch.Tensor):
+            Queries of shape ``[total_seq_len, num_q_heads, head_size]``.
+            Must be contiguous and on CUDA.
+        k (torch.Tensor):
+            Keys of shape ``[total_seq_len, num_k_heads, head_size]``.
+            Must be contiguous and on CUDA.
+        v (torch.Tensor):
+            Values of shape ``[total_seq_len, num_v_heads, head_size]``.
+            Must be contiguous and on CUDA.
+        g (Optional[torch.Tensor]):
+            Forget gate (alpha) of shape ``[total_seq_len, num_sab_heads]`` where
+            ``num_sab_heads = max(num_q_heads, num_v_heads)``. Must be float32.
+            If None, defaults to all ones. Default: ``None``.
+        beta (Optional[torch.Tensor]):
+            Update gate (beta) of shape ``[total_seq_len, num_sab_heads]``.
+            Must be float32. If None, defaults to all ones. Default: ``None``.
+        scale (Optional[float]):
+            Scale factor for the attention scores.
+            If not provided, defaults to ``1 / sqrt(head_size)``. Default: ``None``.
+        initial_state (Optional[torch.Tensor]):
+            Initial KV state of shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
+            Must be float32. If None, starts from zero state. Default: ``None``.
+        output_final_state (bool):
+            Whether to output the final state. Default: ``False``.
+        cu_seqlens (torch.Tensor):
+            Cumulative sequence lengths of shape ``[num_seqs + 1]``, int64.
+            Required for variable-length sequences (varlen mode).
+        use_qk_l2norm_in_kernel (bool):
+            Whether to use QK L2 normalization in kernel. Default: ``False``.
+        output (Optional[torch.Tensor]):
+            Pre-allocated output tensor of shape ``[total_seq_len, num_o_heads, head_size]``
+            where ``num_o_heads = max(num_q_heads, num_v_heads)``.
+            If None, will be allocated automatically. Default: ``None``.
+        output_state (Optional[torch.Tensor]):
+            Pre-allocated output state tensor of shape
+            ``[num_seqs, num_sab_heads, head_size, head_size]``, float32.
+            Required if ``output_final_state=True``. Default: ``None``.
+
+    Returns:
+        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+            - If ``output_final_state=False``: Returns output tensor of shape
+              ``[total_seq_len, num_o_heads, head_size]``.
+            - If ``output_final_state=True``: Returns tuple of (output, final_state) where
+              final_state has shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
+    """
+
+    if is_sm90a_supported(torch.device("cuda")):
+        return chunk_gated_delta_rule_hopper(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            output,
+            output_state,
+        )
+
+    elif is_sm100a_supported(torch.device("cuda")) or is_sm110a_supported(
+        torch.device("cuda")
+    ):
+        if g is None or beta is None:
+            raise NotImplementedError(
+                "Gate and beta must not be None on sm100a and sm110a."
+            )
+
+        return chunk_gated_delta_rule_blackwell(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            output,
+            output_state,
+        )
+    else:
+        raise NotImplementedError(
+            "chunk_gated_delta_rule only support sm90a, sm100a, sm110a."
+        )

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -27,8 +27,7 @@ from .utils import (
     get_device_sm_count,
     _get_cache_buf,
     is_sm90a_supported,
-    is_sm100a_supported,
-    is_sm103a_supported,
+    is_sm100f_supported,
     is_sm110a_supported,
     backend_requirement,
     supported_compute_capability,
@@ -278,10 +277,8 @@ def chunk_gated_delta_rule(
             output_state,
         )
 
-    elif (
-        is_sm100a_supported(torch.device("cuda"))
-        or is_sm103a_supported(torch.device("cuda"))
-        or is_sm110a_supported(torch.device("cuda"))
+    elif is_sm100f_supported(torch.device("cuda")) or is_sm110a_supported(
+        torch.device("cuda")
     ):
         if chunk_gated_delta_rule_blackwell is None:
             raise NotImplementedError("Blackwell GDN prefill backend is unavailable.")

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -27,15 +27,21 @@ from .utils import (
     get_device_sm_count,
     _get_cache_buf,
     is_sm90a_supported,
-    is_sm100f_supported,
-    is_sm110a_supported,
+    is_sm100a_supported,
     backend_requirement,
     supported_compute_capability,
+    get_compute_capability,
+    version_at_least,
 )
 
 from flashinfer.gdn_kernels.blackwell_prefill import (
     chunk_gated_delta_rule as chunk_gated_delta_rule_blackwell,
 )
+
+
+def is_sm103a_supported(device: torch.device) -> bool:
+    major, minor = get_compute_capability(device)
+    return major == 10 and minor == 3 and version_at_least(torch.version.cuda, "12.8")
 
 
 @functools.cache
@@ -175,7 +181,7 @@ def chunk_gated_delta_rule_hopper(
         return output
 
 
-@supported_compute_capability([90, 100, 103, 110])
+@supported_compute_capability([90, 100, 103])
 def _check_gdn_prefill(
     q,
     k,
@@ -277,7 +283,7 @@ def chunk_gated_delta_rule(
             output_state,
         )
 
-    elif is_sm100f_supported(torch.device("cuda")) or is_sm110a_supported(
+    elif is_sm100a_supported(torch.device("cuda")) or is_sm103a_supported(
         torch.device("cuda")
     ):
         if chunk_gated_delta_rule_blackwell is None:
@@ -285,7 +291,7 @@ def chunk_gated_delta_rule(
 
         if g is None or beta is None:
             raise NotImplementedError(
-                "Gate and beta must not be None on sm100a, sm103a and sm110a."
+                "Gate and beta must not be None on sm100a, sm103a."
             )
 
         return chunk_gated_delta_rule_blackwell(
@@ -304,5 +310,5 @@ def chunk_gated_delta_rule(
         )
     else:
         raise NotImplementedError(
-            "chunk_gated_delta_rule only support sm90a, sm100a, sm103a, sm110a."
+            "chunk_gated_delta_rule only support sm90a, sm100a, sm103a."
         )

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -29,6 +29,8 @@ from .utils import (
     is_sm90a_supported,
     is_sm100a_supported,
     is_sm110a_supported,
+    backend_requirement,
+    supported_compute_capability,
 )
 
 from flashinfer.gdn_kernels.blackwell_prefill import (
@@ -173,6 +175,28 @@ def chunk_gated_delta_rule_hopper(
         return output
 
 
+@supported_compute_capability([90, 100, 110])
+def _check_gdn_prefill(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    scale,
+    initial_state,
+    output_final_state,
+    cu_seqlens,
+    use_qk_l2norm_in_kernel,
+    output,
+    output_state,
+):
+    return True
+
+
+@backend_requirement(
+    {},
+    common_check=_check_gdn_prefill,
+)
 @flashinfer_api
 def chunk_gated_delta_rule(
     q: torch.Tensor,
@@ -203,10 +227,10 @@ def chunk_gated_delta_rule(
         g (Optional[torch.Tensor]):
             Forget gate (alpha) of shape ``[total_seq_len, num_sab_heads]`` where
             ``num_sab_heads = max(num_q_heads, num_v_heads)``. Must be float32.
-            If None, defaults to all ones. Default: ``None``.
+            If None, defaults to all ones(hopper). Default: ``None``.
         beta (Optional[torch.Tensor]):
             Update gate (beta) of shape ``[total_seq_len, num_sab_heads]``.
-            Must be float32. If None, defaults to all ones. Default: ``None``.
+            Must be float32. If None, defaults to all ones(hopper). Default: ``None``.
         scale (Optional[float]):
             Scale factor for the attention scores.
             If not provided, defaults to ``1 / sqrt(head_size)``. Default: ``None``.
@@ -256,6 +280,9 @@ def chunk_gated_delta_rule(
     elif is_sm100a_supported(torch.device("cuda")) or is_sm110a_supported(
         torch.device("cuda")
     ):
+        if chunk_gated_delta_rule_blackwell is None:
+            raise NotImplementedError("Blackwell GDN prefill backend is unavailable.")
+
         if g is None or beta is None:
             raise NotImplementedError(
                 "Gate and beta must not be None on sm100a and sm110a."

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -28,6 +28,7 @@ from .utils import (
     _get_cache_buf,
     is_sm90a_supported,
     is_sm100a_supported,
+    is_sm103a_supported,
     is_sm110a_supported,
     backend_requirement,
     supported_compute_capability,
@@ -175,7 +176,7 @@ def chunk_gated_delta_rule_hopper(
         return output
 
 
-@supported_compute_capability([90, 100, 110])
+@supported_compute_capability([90, 100, 103, 110])
 def _check_gdn_prefill(
     q,
     k,
@@ -277,15 +278,17 @@ def chunk_gated_delta_rule(
             output_state,
         )
 
-    elif is_sm100a_supported(torch.device("cuda")) or is_sm110a_supported(
-        torch.device("cuda")
+    elif (
+        is_sm100a_supported(torch.device("cuda"))
+        or is_sm103a_supported(torch.device("cuda"))
+        or is_sm110a_supported(torch.device("cuda"))
     ):
         if chunk_gated_delta_rule_blackwell is None:
             raise NotImplementedError("Blackwell GDN prefill backend is unavailable.")
 
         if g is None or beta is None:
             raise NotImplementedError(
-                "Gate and beta must not be None on sm100a and sm110a."
+                "Gate and beta must not be None on sm100a, sm103a and sm110a."
             )
 
         return chunk_gated_delta_rule_blackwell(
@@ -304,5 +307,5 @@ def chunk_gated_delta_rule(
         )
     else:
         raise NotImplementedError(
-            "chunk_gated_delta_rule only support sm90a, sm100a, sm110a."
+            "chunk_gated_delta_rule only support sm90a, sm100a, sm103a, sm110a."
         )

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -27,21 +27,13 @@ from .utils import (
     get_device_sm_count,
     _get_cache_buf,
     is_sm90a_supported,
-    is_sm100a_supported,
     backend_requirement,
     supported_compute_capability,
-    get_compute_capability,
-    version_at_least,
 )
 
 from flashinfer.gdn_kernels.blackwell_prefill import (
     chunk_gated_delta_rule as chunk_gated_delta_rule_blackwell,
 )
-
-
-def is_sm103a_supported(device: torch.device) -> bool:
-    major, minor = get_compute_capability(device)
-    return major == 10 and minor == 3 and version_at_least(torch.version.cuda, "12.8")
 
 
 @functools.cache
@@ -181,7 +173,7 @@ def chunk_gated_delta_rule_hopper(
         return output
 
 
-@supported_compute_capability([90, 100, 103])
+@supported_compute_capability([90, 100, 103, 110])
 def _check_gdn_prefill(
     q,
     k,
@@ -283,15 +275,13 @@ def chunk_gated_delta_rule(
             output_state,
         )
 
-    elif is_sm100a_supported(torch.device("cuda")) or is_sm103a_supported(
-        torch.device("cuda")
-    ):
+    else:  # sm100, sm103, sm110
         if chunk_gated_delta_rule_blackwell is None:
             raise NotImplementedError("Blackwell GDN prefill backend is unavailable.")
 
         if g is None or beta is None:
             raise NotImplementedError(
-                "Gate and beta must not be None on sm100a, sm103a."
+                "Gate and beta must not be None on sm100a, sm103a, sm110a."
             )
 
         return chunk_gated_delta_rule_blackwell(
@@ -307,8 +297,4 @@ def chunk_gated_delta_rule(
             use_qk_l2norm_in_kernel,
             output,
             output_state,
-        )
-    else:
-        raise NotImplementedError(
-            "chunk_gated_delta_rule only support sm90a, sm100a, sm103a."
         )

--- a/tests/gdn/test_gdn_prefill_blackwell.py
+++ b/tests/gdn/test_gdn_prefill_blackwell.py
@@ -24,7 +24,7 @@ from flashinfer.utils import (
 )
 
 try:
-    from flashinfer.gdn_kernels.blackwell_prefill.gdn import (
+    from flashinfer.gdn_prefill import (
         chunk_gated_delta_rule,
     )
 
@@ -66,12 +66,12 @@ def recurrent_gated_delta_rule_ref(
     for i in range(T):
         b_q = q[:, :, i]
         b_k = k[:, :, i]
-        b_v = v[:, :, i].clone()
-        h = h.clone() * g[:, :, i].exp()[..., None, None]
+        b_v = v[:, :, i]
+        h = h * g[:, :, i].exp()[..., None, None]
         b_beta = beta[:, :, i]
-        b_v = b_v - (h.clone() * b_k[..., None]).sum(-2)
+        b_v = b_v - (h * b_k[..., None]).sum(-2)
         b_v = b_v * b_beta[..., None]
-        h = h.clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
+        h = h + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
         o[:, :, i] = torch.einsum("bhd,bhdm->bhm", b_q, h)
     if not output_final_state:
         h = None
@@ -111,10 +111,10 @@ class TestGDNFixedLength:
     @pytest.mark.parametrize(
         "H,D,T,B,dtype",
         [
-            (16, 128, 256, 4, testtype),
+            (4, 128, 256, 2, testtype),
             (1, 128, 128, 2, testtype),
-            (16, 128, 256, 1, testtype),
-            (3, 128, 131, 177, testtype),
+            (4, 128, 256, 1, testtype),
+            (3, 128, 131, 151, testtype),
         ],
     )
     def test_fixlen_output(self, set_seed, H, D, T, B, dtype):
@@ -123,46 +123,43 @@ class TestGDNFixedLength:
 
         device = "cuda"
 
-        q = torch.randn((B, T, H, D), dtype=dtype)
-        k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
-            dtype
-        )
-        v = torch.randn((B, T, H, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32))
-        beta = torch.rand(1, T * B, H, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((B, H, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device)
+        k = F.normalize(
+            torch.randn(B, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T * B, H, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((B, H, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
             None,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         ref = []
         ref_ht = []
         h0_v_major = h0.transpose(-1, -2).contiguous()
         for i in range(B):
             ref_i, ref_ht_i = recurrent_gated_delta_rule_ref(
-                q=q[i].unsqueeze(0).clone(),
-                k=k[i].unsqueeze(0).clone(),
-                v=v[i].unsqueeze(0).clone(),
-                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
-                g=g[:, (i * T) : ((i + 1) * T)].clone(),
-                initial_state=h0_v_major[i].clone(),
+                q=q[i].unsqueeze(0),
+                k=k[i].unsqueeze(0),
+                v=v[i].unsqueeze(0),
+                beta=beta[:, (i * T) : ((i + 1) * T)],
+                g=g[:, (i * T) : ((i + 1) * T)],
+                initial_state=h0_v_major[i],
                 output_final_state=True,
             )
             if i == 0:
@@ -172,17 +169,15 @@ class TestGDNFixedLength:
                 ref = torch.cat((ref, ref_i), dim=0).contiguous()
                 ref_ht = torch.cat((ref_ht, ref_ht_i), dim=0).contiguous()
 
-        torch.cuda.synchronize()
-
         torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
 
     @pytest.mark.parametrize(
         "H,D,T,B,dtype",
         [
-            (16, 128, 256, 4, testtype),
+            (4, 128, 256, 2, testtype),
             (1, 128, 128, 2, testtype),
-            (16, 128, 256, 1, testtype),
-            (3, 128, 131, 177, testtype),
+            (4, 128, 256, 1, testtype),
+            (3, 128, 131, 151, testtype),
         ],
     )
     def test_fixlen_state(self, set_seed, H, D, T, B, dtype):
@@ -192,45 +187,42 @@ class TestGDNFixedLength:
 
         device = "cuda"
 
-        q = torch.randn((B, T, H, D), dtype=dtype)
-        k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
-            dtype
-        )
-        v = torch.randn((B, T, H, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32))
-        beta = torch.rand(1, T * B, H, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((B, H, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device)
+        k = F.normalize(
+            torch.randn(B, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T * B, H, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((B, H, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
             None,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         ref_ht = []
         h0_v_major = h0.transpose(-1, -2).contiguous()
         for i in range(B):
             _, ref_ht_i = recurrent_gated_delta_rule_ref(
-                q=q[i].unsqueeze(0).clone(),
-                k=k[i].unsqueeze(0).clone(),
-                v=v[i].unsqueeze(0).clone(),
-                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
-                g=g[:, (i * T) : ((i + 1) * T)].clone(),
-                initial_state=h0_v_major[i].clone(),
+                q=q[i].unsqueeze(0),
+                k=k[i].unsqueeze(0),
+                v=v[i].unsqueeze(0),
+                beta=beta[:, (i * T) : ((i + 1) * T)],
+                g=g[:, (i * T) : ((i + 1) * T)],
+                initial_state=h0_v_major[i],
                 output_final_state=True,
             )
             if i == 0:
@@ -239,11 +231,8 @@ class TestGDNFixedLength:
                 ref_ht = torch.cat((ref_ht, ref_ht_i), dim=0).contiguous()
 
         ref_ht = torch.transpose(ref_ht, -1, -2).contiguous()
-        torch.cuda.synchronize()
 
-        torch.testing.assert_close(
-            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
-        )
+        torch.testing.assert_close(ref_ht, state_output, atol=satol, rtol=srtol)
 
 
 class TestGDNVariableLength:
@@ -252,8 +241,8 @@ class TestGDNVariableLength:
     @pytest.mark.parametrize(
         "H,D,cu_seqlens,dtype",
         [
-            (16, 128, [0, 256, 500, 1000, 1013], testtype),
-            (16, 128, [0, 13, 77], testtype),
+            (2, 128, [0, 256, 500], testtype),
+            (2, 128, [0, 13, 77], testtype),
         ],
     )
     def test_varlen_output(self, set_seed, H, D, cu_seqlens, dtype):
@@ -267,34 +256,31 @@ class TestGDNVariableLength:
         T = cu_seqlens[-1]
         N = len(cu_seqlens) - 1
 
-        q = torch.randn((1, T, H, D), dtype=dtype)
-        k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
-            dtype
-        )
-        v = torch.randn((1, T, H, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32))
-        beta = torch.rand(1, T, H, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((N, H, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        q = torch.randn((1, T, H, D), dtype=dtype, device=device)
+        k = F.normalize(
+            torch.randn(1, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((1, T, H, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T, H, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((N, H, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
-            cu_seqlens_tensor.clone(),
+            cu_seqlens_tensor,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         ref = []
         h0_v_major = h0.transpose(-1, -2)
@@ -310,15 +296,14 @@ class TestGDNVariableLength:
             )
             ref.append(ref_i)
         ref = torch.cat(ref, 1)
-        torch.cuda.synchronize()
 
         torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
 
     @pytest.mark.parametrize(
         "H,D,cu_seqlens,dtype",
         [
-            (16, 128, [0, 256, 500, 1000, 1013], testtype),
-            (16, 128, [0, 13, 77], testtype),
+            (2, 128, [0, 256, 500], testtype),
+            (2, 128, [0, 13, 77], testtype),
         ],
     )
     def test_varlen_state(self, set_seed, H, D, cu_seqlens, dtype):
@@ -332,34 +317,31 @@ class TestGDNVariableLength:
         T = cu_seqlens[-1]
         N = len(cu_seqlens) - 1
 
-        q = torch.randn((1, T, H, D), dtype=dtype)
-        k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
-            dtype
-        )
-        v = torch.randn((1, T, H, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32))
-        beta = torch.rand(1, T, H, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((N, H, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        q = torch.randn((1, T, H, D), dtype=dtype, device=device)
+        k = F.normalize(
+            torch.randn(1, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((1, T, H, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T, H, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((N, H, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
-            cu_seqlens_tensor.clone(),
+            cu_seqlens_tensor,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         ref_ht = []
         h0_v_major = h0.transpose(-1, -2)
@@ -376,11 +358,8 @@ class TestGDNVariableLength:
             ref_ht.append(ref_ht_i)
         ref_ht = torch.cat(ref_ht, 0)
         ref_ht = torch.transpose(ref_ht, -1, -2)
-        torch.cuda.synchronize()
 
-        torch.testing.assert_close(
-            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
-        )
+        torch.testing.assert_close(ref_ht, state_output, atol=satol, rtol=srtol)
 
 
 class TestGDNFixedLengthGVA:
@@ -389,9 +368,8 @@ class TestGDNFixedLengthGVA:
     @pytest.mark.parametrize(
         "H_QK,H_V,D,T,B,dtype",
         [
-            (16, 32, 128, 555, 1, testtype),
-            (8, 32, 128, 256, 2, testtype),
-            (16, 64, 128, 128, 1, testtype),
+            (2, 8, 128, 555, 1, testtype),
+            (2, 8, 128, 256, 2, testtype),
         ],
     )
     def test_fixlen_gva_output(self, set_seed, H_QK, H_V, D, T, B, dtype):
@@ -401,34 +379,31 @@ class TestGDNFixedLengthGVA:
 
         device = "cuda"
 
-        q = torch.randn((B, T, H_QK, D), dtype=dtype)
+        q = torch.randn((B, T, H_QK, D), dtype=dtype, device=device)
         k = F.normalize(
-            torch.randn(B, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+            torch.randn(B, T, H_QK, D, dtype=torch.float32, device=device), p=2, dim=-1
         ).to(dtype)
-        v = torch.randn((B, T, H_V, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T * B, H_V, dtype=torch.float32))
-        beta = torch.rand(1, T * B, H_V, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((B, H_V, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        v = torch.randn((B, T, H_V, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T * B, H_V, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T * B, H_V, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((B, H_V, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
             None,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         repeat_factor = H_V // H_QK
         q = q.repeat_interleave(repeat_factor, dim=2)
@@ -438,12 +413,12 @@ class TestGDNFixedLengthGVA:
         h0_v_major = h0.transpose(-1, -2).contiguous()
         for i in range(B):
             ref_i, _ = recurrent_gated_delta_rule_ref(
-                q=q[i].unsqueeze(0).clone(),
-                k=k[i].unsqueeze(0).clone(),
-                v=v[i].unsqueeze(0).clone(),
-                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
-                g=g[:, (i * T) : ((i + 1) * T)].clone(),
-                initial_state=h0_v_major[i].clone(),
+                q=q[i].unsqueeze(0),
+                k=k[i].unsqueeze(0),
+                v=v[i].unsqueeze(0),
+                beta=beta[:, (i * T) : ((i + 1) * T)],
+                g=g[:, (i * T) : ((i + 1) * T)],
+                initial_state=h0_v_major[i],
                 output_final_state=True,
             )
             if i == 0:
@@ -451,15 +426,13 @@ class TestGDNFixedLengthGVA:
             else:
                 ref = torch.cat((ref, ref_i), dim=0).contiguous()
 
-        torch.cuda.synchronize()
         torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
 
     @pytest.mark.parametrize(
         "H_QK,H_V,D,T,B,dtype",
         [
-            (16, 32, 128, 555, 1, testtype),
-            (8, 32, 128, 128, 2, testtype),
-            (16, 64, 128, 130, 1, testtype),
+            (2, 8, 128, 555, 1, testtype),
+            (2, 8, 128, 128, 2, testtype),
         ],
     )
     def test_fixlen_gva_state(self, set_seed, H_QK, H_V, D, T, B, dtype):
@@ -469,34 +442,31 @@ class TestGDNFixedLengthGVA:
 
         device = "cuda"
 
-        q = torch.randn((B, T, H_QK, D), dtype=dtype)
+        q = torch.randn((B, T, H_QK, D), dtype=dtype, device=device)
         k = F.normalize(
-            torch.randn(B, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+            torch.randn(B, T, H_QK, D, dtype=torch.float32, device=device), p=2, dim=-1
         ).to(dtype)
-        v = torch.randn((B, T, H_V, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T * B, H_V, dtype=torch.float32))
-        beta = torch.rand(1, T * B, H_V, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((B, H_V, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        v = torch.randn((B, T, H_V, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T * B, H_V, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T * B, H_V, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((B, H_V, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
             None,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         repeat_factor = H_V // H_QK
         q = q.repeat_interleave(repeat_factor, dim=2)
@@ -506,12 +476,12 @@ class TestGDNFixedLengthGVA:
         h0_v_major = h0.transpose(-1, -2).contiguous()
         for i in range(B):
             _, ref_ht_i = recurrent_gated_delta_rule_ref(
-                q=q[i].unsqueeze(0).clone(),
-                k=k[i].unsqueeze(0).clone(),
-                v=v[i].unsqueeze(0).clone(),
-                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
-                g=g[:, (i * T) : ((i + 1) * T)].clone(),
-                initial_state=h0_v_major[i].clone(),
+                q=q[i].unsqueeze(0),
+                k=k[i].unsqueeze(0),
+                v=v[i].unsqueeze(0),
+                beta=beta[:, (i * T) : ((i + 1) * T)],
+                g=g[:, (i * T) : ((i + 1) * T)],
+                initial_state=h0_v_major[i],
                 output_final_state=True,
             )
             if i == 0:
@@ -520,11 +490,8 @@ class TestGDNFixedLengthGVA:
                 ref_ht = torch.cat((ref_ht, ref_ht_i), dim=0).contiguous()
 
         ref_ht = torch.transpose(ref_ht, -1, -2).contiguous()
-        torch.cuda.synchronize()
 
-        torch.testing.assert_close(
-            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
-        )
+        torch.testing.assert_close(ref_ht, state_output, atol=satol, rtol=srtol)
 
 
 class TestGDNVariableLengthGVA:
@@ -533,9 +500,8 @@ class TestGDNVariableLengthGVA:
     @pytest.mark.parametrize(
         "H_QK,H_V,D,cu_seqlens,dtype",
         [
-            (16, 32, 128, [0, 13, 287], testtype),
-            (8, 32, 128, [0, 256, 500, 1000], testtype),
-            (16, 64, 128, [0, 128], testtype),
+            (2, 8, 128, [0, 13, 287], testtype),
+            (2, 8, 128, [0, 256, 500, 511], testtype),
         ],
     )
     def test_varlen_gva_output(self, set_seed, H_QK, H_V, D, cu_seqlens, dtype):
@@ -549,34 +515,31 @@ class TestGDNVariableLengthGVA:
         T = cu_seqlens[-1]
         N = len(cu_seqlens) - 1
 
-        q = torch.randn((1, T, H_QK, D), dtype=dtype)
+        q = torch.randn((1, T, H_QK, D), dtype=dtype, device=device)
         k = F.normalize(
-            torch.randn(1, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+            torch.randn(1, T, H_QK, D, dtype=torch.float32, device=device), p=2, dim=-1
         ).to(dtype)
-        v = torch.randn((1, T, H_V, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T, H_V, dtype=torch.float32))
-        beta = torch.rand(1, T, H_V, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((N, H_V, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        v = torch.randn((1, T, H_V, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T, H_V, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T, H_V, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((N, H_V, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
-            cu_seqlens_tensor.clone(),
+            cu_seqlens_tensor,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         repeat_factor = H_V // H_QK
         q = q.repeat_interleave(repeat_factor, dim=2)
@@ -596,15 +559,14 @@ class TestGDNVariableLengthGVA:
             )
             ref.append(ref_i)
         ref = torch.cat(ref, 1)
-        torch.cuda.synchronize()
 
         torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
 
     @pytest.mark.parametrize(
         "H_QK,H_V,D,cu_seqlens,dtype",
         [
-            (16, 32, 128, [0, 13, 287], testtype),
-            (8, 32, 128, [0, 256, 500, 1000], testtype),
+            (2, 8, 128, [0, 13, 287], testtype),
+            (2, 8, 128, [0, 256, 500, 511], testtype),
         ],
     )
     def test_varlen_gva_state(self, set_seed, H_QK, H_V, D, cu_seqlens, dtype):
@@ -618,34 +580,31 @@ class TestGDNVariableLengthGVA:
         T = cu_seqlens[-1]
         N = len(cu_seqlens) - 1
 
-        q = torch.randn((1, T, H_QK, D), dtype=dtype)
+        q = torch.randn((1, T, H_QK, D), dtype=dtype, device=device)
         k = F.normalize(
-            torch.randn(1, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+            torch.randn(1, T, H_QK, D, dtype=torch.float32, device=device), p=2, dim=-1
         ).to(dtype)
-        v = torch.randn((1, T, H_V, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T, H_V, dtype=torch.float32))
-        beta = torch.rand(1, T, H_V, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((N, H_V, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        v = torch.randn((1, T, H_V, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T, H_V, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T, H_V, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((N, H_V, D, D), dtype=torch.float, device=device)
 
         state_output = torch.zeros_like(h0, dtype=torch.float)
 
         o, state_output = chunk_gated_delta_rule(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            g.clone(),
-            beta.clone(),
+            q,
+            k,
+            v,
+            g,
+            beta,
             None,
-            h0.clone(),
+            h0,
             True,
-            cu_seqlens_tensor.clone(),
+            cu_seqlens_tensor,
             False,
             None,
             state_output,
         )
-        torch.cuda.synchronize()
 
         repeat_factor = H_V // H_QK
         q = q.repeat_interleave(repeat_factor, dim=2)
@@ -666,11 +625,8 @@ class TestGDNVariableLengthGVA:
             ref_ht.append(ref_ht_i)
         ref_ht = torch.cat(ref_ht, 0)
         ref_ht = torch.transpose(ref_ht, -1, -2)
-        torch.cuda.synchronize()
 
-        torch.testing.assert_close(
-            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
-        )
+        torch.testing.assert_close(ref_ht, state_output, atol=satol, rtol=srtol)
 
 
 class TestGDNMultipleRuns:
@@ -679,40 +635,37 @@ class TestGDNMultipleRuns:
     def test_consecutive_runs_deterministic(self, set_seed):
         """Test that multiple consecutive runs produce identical results."""
         _skip_if_gdn_blackwell_prefill_not_available()
-        H, D, T, B = 16, 128, 256, 4
+        H, D, T, B = 3, 128, 131, 3
         dtype = testtype
         device = "cuda"
 
-        q = torch.randn((B, T, H, D), dtype=dtype)
-        k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
-            dtype
-        )
-        v = torch.randn((B, T, H, D), dtype=dtype)
-        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32))
-        beta = torch.rand(1, T * B, H, dtype=torch.float32).sigmoid()
-        h0 = torch.randn((B, H, D, D), dtype=torch.float)
-
-        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device)
+        k = F.normalize(
+            torch.randn(B, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32, device=device))
+        beta = torch.rand(1, T * B, H, dtype=torch.float32, device=device).sigmoid()
+        h0 = torch.randn((B, H, D, D), dtype=torch.float, device=device)
 
         results = []
         for _run_idx in range(3):
             state_output = torch.zeros_like(h0, dtype=torch.float)
 
             o, state_output = chunk_gated_delta_rule(
-                q.clone(),
-                k.clone(),
-                v.clone(),
-                g.clone(),
-                beta.clone(),
+                q,
+                k,
+                v,
+                g,
+                beta,
                 None,
-                h0.clone(),
+                h0,
                 True,
                 None,
                 False,
                 None,
                 state_output,
             )
-            torch.cuda.synchronize()
             results.append((o.clone(), state_output.clone()))
 
         for i in range(1, len(results)):

--- a/tests/gdn/test_gdn_prefill_blackwell.py
+++ b/tests/gdn/test_gdn_prefill_blackwell.py
@@ -18,7 +18,20 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from flashinfer.gdn_kernels.blackwell_prefill.gdn import chunk_gated_delta_rule
+from flashinfer.utils import (
+    is_sm100a_supported,
+    is_sm110a_supported,
+)
+
+try:
+    from flashinfer.gdn_kernels.blackwell_prefill.gdn import (
+        chunk_gated_delta_rule,
+    )
+
+    GDN_BLACKWELL_PREFILL_CUTEDSL = True
+except ImportError:
+    GDN_BLACKWELL_PREFILL_CUTEDSL = False
+
 
 testtype = torch.float16
 
@@ -66,6 +79,17 @@ def recurrent_gated_delta_rule_ref(
     return o, h
 
 
+def _skip_if_gdn_blackwell_prefill_not_available():
+    """Skip test if GDN Blackwell prefill CuTeDSL kernels not available or not Blackwell (SM100+) architecture."""
+    if not GDN_BLACKWELL_PREFILL_CUTEDSL:
+        pytest.skip("GDN Blackwell prefill CuTeDSL kernels not available")
+
+    if not is_sm100a_supported(torch.device("cuda")) and not is_sm110a_supported(
+        torch.device("cuda")
+    ):
+        pytest.skip("Only SM100A and SM110A are supported on this device")
+
+
 @pytest.fixture(autouse=True)
 def cuda_sync_and_cleanup():
     """Ensure CUDA operations are synchronized before and after each test."""
@@ -95,6 +119,8 @@ class TestGDNFixedLength:
     )
     def test_fixlen_output(self, set_seed, H, D, T, B, dtype):
         """Test fixed-length GDN output correctness."""
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         q = torch.randn((B, T, H, D), dtype=dtype)
@@ -161,6 +187,9 @@ class TestGDNFixedLength:
     )
     def test_fixlen_state(self, set_seed, H, D, T, B, dtype):
         """Test fixed-length GDN state output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         q = torch.randn((B, T, H, D), dtype=dtype)
@@ -229,6 +258,9 @@ class TestGDNVariableLength:
     )
     def test_varlen_output(self, set_seed, H, D, cu_seqlens, dtype):
         """Test variable-length GDN output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
@@ -291,6 +323,9 @@ class TestGDNVariableLength:
     )
     def test_varlen_state(self, set_seed, H, D, cu_seqlens, dtype):
         """Test variable-length GDN state output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
@@ -361,6 +396,9 @@ class TestGDNFixedLengthGVA:
     )
     def test_fixlen_gva_output(self, set_seed, H_QK, H_V, D, T, B, dtype):
         """Test fixed-length GVA output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         q = torch.randn((B, T, H_QK, D), dtype=dtype)
@@ -426,6 +464,9 @@ class TestGDNFixedLengthGVA:
     )
     def test_fixlen_gva_state(self, set_seed, H_QK, H_V, D, T, B, dtype):
         """Test fixed-length GVA state output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         q = torch.randn((B, T, H_QK, D), dtype=dtype)
@@ -499,6 +540,9 @@ class TestGDNVariableLengthGVA:
     )
     def test_varlen_gva_output(self, set_seed, H_QK, H_V, D, cu_seqlens, dtype):
         """Test variable-length GVA output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
@@ -565,6 +609,9 @@ class TestGDNVariableLengthGVA:
     )
     def test_varlen_gva_state(self, set_seed, H_QK, H_V, D, cu_seqlens, dtype):
         """Test variable-length GVA state output correctness."""
+
+        _skip_if_gdn_blackwell_prefill_not_available()
+
         device = "cuda"
 
         cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
@@ -631,6 +678,7 @@ class TestGDNMultipleRuns:
 
     def test_consecutive_runs_deterministic(self, set_seed):
         """Test that multiple consecutive runs produce identical results."""
+        _skip_if_gdn_blackwell_prefill_not_available()
         H, D, T, B = 16, 128, 256, 4
         dtype = testtype
         device = "cuda"

--- a/tests/gdn/test_gdn_prefill_blackwell.py
+++ b/tests/gdn/test_gdn_prefill_blackwell.py
@@ -1,0 +1,680 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.gdn_kernels.blackwell_prefill.gdn import chunk_gated_delta_rule
+
+testtype = torch.float16
+
+oatol = 1e-2 if testtype is torch.bfloat16 else 1e-3
+ortol = 1e-2 if testtype is torch.bfloat16 else 1e-3
+satol = 5e-3 if testtype is torch.bfloat16 else 1e-3
+srtol = 1e-3 if testtype is torch.bfloat16 else 1e-4
+
+
+def recurrent_gated_delta_rule_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+):
+    """Reference implementation of gated delta rule (recurrent version)."""
+    q, k, v, beta, g = map(
+        lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, beta, g]
+    )
+    B, H, T, K, V = *k.shape, v.shape[-1]
+    o = torch.zeros(B, H, T, V).to(v)
+    h = torch.zeros(B, H, K, V).to(v)
+    if initial_state is not None:
+        h = initial_state
+    if scale is None:
+        scale = 1 / (q.shape[-1] ** 0.5)
+    q = q * scale
+    for i in range(T):
+        b_q = q[:, :, i]
+        b_k = k[:, :, i]
+        b_v = v[:, :, i].clone()
+        h = h.clone() * g[:, :, i].exp()[..., None, None]
+        b_beta = beta[:, :, i]
+        b_v = b_v - (h.clone() * b_k[..., None]).sum(-2)
+        b_v = b_v * b_beta[..., None]
+        h = h.clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
+        o[:, :, i] = torch.einsum("bhd,bhdm->bhm", b_q, h)
+    if not output_final_state:
+        h = None
+    o = o.transpose(1, 2).contiguous()
+    return o, h
+
+
+@pytest.fixture(autouse=True)
+def cuda_sync_and_cleanup():
+    """Ensure CUDA operations are synchronized before and after each test."""
+    torch.cuda.synchronize()
+    yield
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+
+@pytest.fixture
+def set_seed():
+    """Set random seed for reproducibility."""
+    torch.manual_seed(42)
+
+
+class TestGDNFixedLength:
+    """Tests for fixed-length sequences."""
+
+    @pytest.mark.parametrize(
+        "H,D,T,B,dtype",
+        [
+            (16, 128, 256, 4, testtype),
+            (1, 128, 128, 2, testtype),
+            (16, 128, 256, 1, testtype),
+            (3, 128, 131, 177, testtype),
+        ],
+    )
+    def test_fixlen_output(self, set_seed, H, D, T, B, dtype):
+        """Test fixed-length GDN output correctness."""
+        device = "cuda"
+
+        q = torch.randn((B, T, H, D), dtype=dtype)
+        k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
+            dtype
+        )
+        v = torch.randn((B, T, H, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32))
+        beta = torch.rand(1, T * B, H, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((B, H, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            None,
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        ref = []
+        ref_ht = []
+        h0_v_major = h0.transpose(-1, -2).contiguous()
+        for i in range(B):
+            ref_i, ref_ht_i = recurrent_gated_delta_rule_ref(
+                q=q[i].unsqueeze(0).clone(),
+                k=k[i].unsqueeze(0).clone(),
+                v=v[i].unsqueeze(0).clone(),
+                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
+                g=g[:, (i * T) : ((i + 1) * T)].clone(),
+                initial_state=h0_v_major[i].clone(),
+                output_final_state=True,
+            )
+            if i == 0:
+                ref = ref_i
+                ref_ht = ref_ht_i
+            else:
+                ref = torch.cat((ref, ref_i), dim=0).contiguous()
+                ref_ht = torch.cat((ref_ht, ref_ht_i), dim=0).contiguous()
+
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
+
+    @pytest.mark.parametrize(
+        "H,D,T,B,dtype",
+        [
+            (16, 128, 256, 4, testtype),
+            (1, 128, 128, 2, testtype),
+            (16, 128, 256, 1, testtype),
+            (3, 128, 131, 177, testtype),
+        ],
+    )
+    def test_fixlen_state(self, set_seed, H, D, T, B, dtype):
+        """Test fixed-length GDN state output correctness."""
+        device = "cuda"
+
+        q = torch.randn((B, T, H, D), dtype=dtype)
+        k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
+            dtype
+        )
+        v = torch.randn((B, T, H, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32))
+        beta = torch.rand(1, T * B, H, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((B, H, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            None,
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        ref_ht = []
+        h0_v_major = h0.transpose(-1, -2).contiguous()
+        for i in range(B):
+            _, ref_ht_i = recurrent_gated_delta_rule_ref(
+                q=q[i].unsqueeze(0).clone(),
+                k=k[i].unsqueeze(0).clone(),
+                v=v[i].unsqueeze(0).clone(),
+                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
+                g=g[:, (i * T) : ((i + 1) * T)].clone(),
+                initial_state=h0_v_major[i].clone(),
+                output_final_state=True,
+            )
+            if i == 0:
+                ref_ht = ref_ht_i
+            else:
+                ref_ht = torch.cat((ref_ht, ref_ht_i), dim=0).contiguous()
+
+        ref_ht = torch.transpose(ref_ht, -1, -2).contiguous()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
+        )
+
+
+class TestGDNVariableLength:
+    """Tests for variable-length sequences."""
+
+    @pytest.mark.parametrize(
+        "H,D,cu_seqlens,dtype",
+        [
+            (16, 128, [0, 256, 500, 1000, 1013], testtype),
+            (16, 128, [0, 13, 77], testtype),
+        ],
+    )
+    def test_varlen_output(self, set_seed, H, D, cu_seqlens, dtype):
+        """Test variable-length GDN output correctness."""
+        device = "cuda"
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
+        T = cu_seqlens[-1]
+        N = len(cu_seqlens) - 1
+
+        q = torch.randn((1, T, H, D), dtype=dtype)
+        k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
+            dtype
+        )
+        v = torch.randn((1, T, H, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32))
+        beta = torch.rand(1, T, H, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((N, H, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            cu_seqlens_tensor.clone(),
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        ref = []
+        h0_v_major = h0.transpose(-1, -2)
+        for i in range(N):
+            ref_i, _ = recurrent_gated_delta_rule_ref(
+                q=q[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                k=k[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                v=v[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                beta=beta[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                g=g[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                initial_state=h0_v_major[i],
+                output_final_state=True,
+            )
+            ref.append(ref_i)
+        ref = torch.cat(ref, 1)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
+
+    @pytest.mark.parametrize(
+        "H,D,cu_seqlens,dtype",
+        [
+            (16, 128, [0, 256, 500, 1000, 1013], testtype),
+            (16, 128, [0, 13, 77], testtype),
+        ],
+    )
+    def test_varlen_state(self, set_seed, H, D, cu_seqlens, dtype):
+        """Test variable-length GDN state output correctness."""
+        device = "cuda"
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
+        T = cu_seqlens[-1]
+        N = len(cu_seqlens) - 1
+
+        q = torch.randn((1, T, H, D), dtype=dtype)
+        k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
+            dtype
+        )
+        v = torch.randn((1, T, H, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32))
+        beta = torch.rand(1, T, H, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((N, H, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            cu_seqlens_tensor.clone(),
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        ref_ht = []
+        h0_v_major = h0.transpose(-1, -2)
+        for i in range(N):
+            _, ref_ht_i = recurrent_gated_delta_rule_ref(
+                q=q[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                k=k[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                v=v[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                beta=beta[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                g=g[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                initial_state=h0_v_major[i],
+                output_final_state=True,
+            )
+            ref_ht.append(ref_ht_i)
+        ref_ht = torch.cat(ref_ht, 0)
+        ref_ht = torch.transpose(ref_ht, -1, -2)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
+        )
+
+
+class TestGDNFixedLengthGVA:
+    """Tests for fixed-length sequences with Grouped Value Attention (H_QK != H_V)."""
+
+    @pytest.mark.parametrize(
+        "H_QK,H_V,D,T,B,dtype",
+        [
+            (16, 32, 128, 555, 1, testtype),
+            (8, 32, 128, 256, 2, testtype),
+            (16, 64, 128, 128, 1, testtype),
+        ],
+    )
+    def test_fixlen_gva_output(self, set_seed, H_QK, H_V, D, T, B, dtype):
+        """Test fixed-length GVA output correctness."""
+        device = "cuda"
+
+        q = torch.randn((B, T, H_QK, D), dtype=dtype)
+        k = F.normalize(
+            torch.randn(B, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((B, T, H_V, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T * B, H_V, dtype=torch.float32))
+        beta = torch.rand(1, T * B, H_V, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((B, H_V, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            None,
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        repeat_factor = H_V // H_QK
+        q = q.repeat_interleave(repeat_factor, dim=2)
+        k = k.repeat_interleave(repeat_factor, dim=2)
+
+        ref = []
+        h0_v_major = h0.transpose(-1, -2).contiguous()
+        for i in range(B):
+            ref_i, _ = recurrent_gated_delta_rule_ref(
+                q=q[i].unsqueeze(0).clone(),
+                k=k[i].unsqueeze(0).clone(),
+                v=v[i].unsqueeze(0).clone(),
+                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
+                g=g[:, (i * T) : ((i + 1) * T)].clone(),
+                initial_state=h0_v_major[i].clone(),
+                output_final_state=True,
+            )
+            if i == 0:
+                ref = ref_i
+            else:
+                ref = torch.cat((ref, ref_i), dim=0).contiguous()
+
+        torch.cuda.synchronize()
+        torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
+
+    @pytest.mark.parametrize(
+        "H_QK,H_V,D,T,B,dtype",
+        [
+            (16, 32, 128, 555, 1, testtype),
+            (8, 32, 128, 128, 2, testtype),
+            (16, 64, 128, 130, 1, testtype),
+        ],
+    )
+    def test_fixlen_gva_state(self, set_seed, H_QK, H_V, D, T, B, dtype):
+        """Test fixed-length GVA state output correctness."""
+        device = "cuda"
+
+        q = torch.randn((B, T, H_QK, D), dtype=dtype)
+        k = F.normalize(
+            torch.randn(B, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((B, T, H_V, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T * B, H_V, dtype=torch.float32))
+        beta = torch.rand(1, T * B, H_V, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((B, H_V, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            None,
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        repeat_factor = H_V // H_QK
+        q = q.repeat_interleave(repeat_factor, dim=2)
+        k = k.repeat_interleave(repeat_factor, dim=2)
+
+        ref_ht = []
+        h0_v_major = h0.transpose(-1, -2).contiguous()
+        for i in range(B):
+            _, ref_ht_i = recurrent_gated_delta_rule_ref(
+                q=q[i].unsqueeze(0).clone(),
+                k=k[i].unsqueeze(0).clone(),
+                v=v[i].unsqueeze(0).clone(),
+                beta=beta[:, (i * T) : ((i + 1) * T)].clone(),
+                g=g[:, (i * T) : ((i + 1) * T)].clone(),
+                initial_state=h0_v_major[i].clone(),
+                output_final_state=True,
+            )
+            if i == 0:
+                ref_ht = ref_ht_i
+            else:
+                ref_ht = torch.cat((ref_ht, ref_ht_i), dim=0).contiguous()
+
+        ref_ht = torch.transpose(ref_ht, -1, -2).contiguous()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
+        )
+
+
+class TestGDNVariableLengthGVA:
+    """Tests for variable-length sequences with Grouped Value Attention (H_QK != H_V)."""
+
+    @pytest.mark.parametrize(
+        "H_QK,H_V,D,cu_seqlens,dtype",
+        [
+            (16, 32, 128, [0, 13, 287], testtype),
+            (8, 32, 128, [0, 256, 500, 1000], testtype),
+            (16, 64, 128, [0, 128], testtype),
+        ],
+    )
+    def test_varlen_gva_output(self, set_seed, H_QK, H_V, D, cu_seqlens, dtype):
+        """Test variable-length GVA output correctness."""
+        device = "cuda"
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
+        T = cu_seqlens[-1]
+        N = len(cu_seqlens) - 1
+
+        q = torch.randn((1, T, H_QK, D), dtype=dtype)
+        k = F.normalize(
+            torch.randn(1, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((1, T, H_V, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T, H_V, dtype=torch.float32))
+        beta = torch.rand(1, T, H_V, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((N, H_V, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            cu_seqlens_tensor.clone(),
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        repeat_factor = H_V // H_QK
+        q = q.repeat_interleave(repeat_factor, dim=2)
+        k = k.repeat_interleave(repeat_factor, dim=2)
+
+        ref = []
+        h0_v_major = h0.transpose(-1, -2)
+        for i in range(N):
+            ref_i, _ = recurrent_gated_delta_rule_ref(
+                q=q[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                k=k[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                v=v[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                beta=beta[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                g=g[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                initial_state=h0_v_major[i],
+                output_final_state=True,
+            )
+            ref.append(ref_i)
+        ref = torch.cat(ref, 1)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(ref, o.to(torch.float), atol=oatol, rtol=ortol)
+
+    @pytest.mark.parametrize(
+        "H_QK,H_V,D,cu_seqlens,dtype",
+        [
+            (16, 32, 128, [0, 13, 287], testtype),
+            (8, 32, 128, [0, 256, 500, 1000], testtype),
+        ],
+    )
+    def test_varlen_gva_state(self, set_seed, H_QK, H_V, D, cu_seqlens, dtype):
+        """Test variable-length GVA state output correctness."""
+        device = "cuda"
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, device=device)
+        T = cu_seqlens[-1]
+        N = len(cu_seqlens) - 1
+
+        q = torch.randn((1, T, H_QK, D), dtype=dtype)
+        k = F.normalize(
+            torch.randn(1, T, H_QK, D, dtype=torch.float32), p=2, dim=-1
+        ).to(dtype)
+        v = torch.randn((1, T, H_V, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T, H_V, dtype=torch.float32))
+        beta = torch.rand(1, T, H_V, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((N, H_V, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        state_output = torch.zeros_like(h0, dtype=torch.float)
+
+        o, state_output = chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            None,
+            h0.clone(),
+            True,
+            cu_seqlens_tensor.clone(),
+            False,
+            None,
+            state_output,
+        )
+        torch.cuda.synchronize()
+
+        repeat_factor = H_V // H_QK
+        q = q.repeat_interleave(repeat_factor, dim=2)
+        k = k.repeat_interleave(repeat_factor, dim=2)
+
+        ref_ht = []
+        h0_v_major = h0.transpose(-1, -2)
+        for i in range(N):
+            _, ref_ht_i = recurrent_gated_delta_rule_ref(
+                q=q[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                k=k[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                v=v[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                beta=beta[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                g=g[:, cu_seqlens[i] : cu_seqlens[i + 1]],
+                initial_state=h0_v_major[i],
+                output_final_state=True,
+            )
+            ref_ht.append(ref_ht_i)
+        ref_ht = torch.cat(ref_ht, 0)
+        ref_ht = torch.transpose(ref_ht, -1, -2)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            ref_ht, state_output.to(torch.float), atol=satol, rtol=srtol
+        )
+
+
+class TestGDNMultipleRuns:
+    """Tests for running the kernel multiple times (regression test)."""
+
+    def test_consecutive_runs_deterministic(self, set_seed):
+        """Test that multiple consecutive runs produce identical results."""
+        H, D, T, B = 16, 128, 256, 4
+        dtype = testtype
+        device = "cuda"
+
+        q = torch.randn((B, T, H, D), dtype=dtype)
+        k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(
+            dtype
+        )
+        v = torch.randn((B, T, H, D), dtype=dtype)
+        g = F.logsigmoid(torch.rand(1, T * B, H, dtype=torch.float32))
+        beta = torch.rand(1, T * B, H, dtype=torch.float32).sigmoid()
+        h0 = torch.randn((B, H, D, D), dtype=torch.float)
+
+        q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+
+        results = []
+        for _run_idx in range(3):
+            state_output = torch.zeros_like(h0, dtype=torch.float)
+
+            o, state_output = chunk_gated_delta_rule(
+                q.clone(),
+                k.clone(),
+                v.clone(),
+                g.clone(),
+                beta.clone(),
+                None,
+                h0.clone(),
+                True,
+                None,
+                False,
+                None,
+                state_output,
+            )
+            torch.cuda.synchronize()
+            results.append((o.clone(), state_output.clone()))
+
+        for i in range(1, len(results)):
+            torch.testing.assert_close(
+                results[0][0], results[i][0], atol=1e-6, rtol=1e-6
+            )
+            torch.testing.assert_close(
+                results[0][1], results[i][1], atol=1e-6, rtol=1e-6
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Gated Delta Networks (GDN) chunked linear attention kernel for NVIDIA Blackwell (SM100).
Implements the Chunk-wise Gated Delta Rule linear attention using CuTe-DSL, for Blackwell Architecture.

Key Features:
- Supports Persistent & Non-persistent modes    
- Supports fixed-length and variable-length sequences (cu_seqlens)
- Supports grouped value attention (GVA) where h_v is a multiple of h_q
- Supports head dimension (128)
- Supports input data types (f16/bf16)
- Supports output data types (f16/bf16)
- Supports initial_state to provide the initial state
- Supports output_final_state flag to return the final state
- State input and output are in f32 (fp16/bf16 not supported yet)


## Performance on B200

+ dtype: bfloat16
+ use_initial_state
+ output_final_state=True
+ Fixlen case

| batch_size | seq_len | qk_heads | v_heads | head_dim | dtype | gdn_ms | fla_ms | speedup |
|---|---:|---:|---:|---:|---|---:|---:|---:|
| 1  | 512  | 96  | 96  | 128 | bfloat16 | 0.0501 | 0.2119 | 4.2275 |
| 1  | 1024 | 96  | 96  | 128 | bfloat16 | 0.0869 | 0.2233 | 2.5696 |
| 1  | 4096 | 96  | 96  | 128 | bfloat16 | 0.3082 | 0.7741 | 2.5118 |
| 1  | 8192 | 96  | 96  | 128 | bfloat16 | 0.6009 | 1.4919 | 2.4827 |
| 9  | 512  | 32  | 32  | 128 | bfloat16 | 0.0986 | 0.3030 | 3.0740 |
| 9  | 1024 | 32  | 32  | 128 | bfloat16 | 0.1735 | 0.5529 | 3.1858 |
| 9  | 4096 | 32  | 32  | 128 | bfloat16 | 0.6189 | 2.0558 | 3.3219 |
| 9  | 8192 | 32  | 32  | 128 | bfloat16 | 1.2123 | 4.0530 | 3.3434 |
| 33 | 512  | 32  | 32  | 128 | bfloat16 | 0.3461 | 1.0199 | 2.9469 |
| 33 | 1024 | 32  | 32  | 128 | bfloat16 | 0.6159 | 1.9385 | 3.1474 |
| 33 | 4096 | 32  | 32  | 128 | bfloat16 | 2.2590 | 7.4736 | 3.3084 |
| 33 | 8192 | 32  | 32  | 128 | bfloat16 | 4.4938 | 14.8813 | 3.3115 |
| 1  | 512  | 148 | 148 | 128 | bfloat16 | 0.0521 | 0.2208 | 4.2371 |
| 1  | 1024 | 148 | 148 | 128 | bfloat16 | 0.0955 | 0.3089 | 3.2342 |
| 1  | 4096 | 148 | 148 | 128 | bfloat16 | 0.3232 | 1.1166 | 3.4551 |
| 1  | 8192 | 148 | 148 | 128 | bfloat16 | 0.6310 | 2.1957 | 3.4799 |

## Issues

+ In the current version, we do not parallelize over the sequence-length dimension, so performance is limited when both batch size and head count are small. In such cases, only part of the 148 SMs are used, so the GPU is not fully utilized.
+ Current version supports GVA only; GQA is not supported.
+ State input and output are FP32 only; FP16 is not supported in the current version.


## 🔍 Related Issues

[chunk_gated_delta_rule for Blackwell #2340](https://github.com/flashinfer-ai/flashinfer/issues/2340)



## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blackwell GPU support for GDN (Gated Delta Network) linear attention with SM-specific dispatch.
  * Built-in performance benchmark tool (fixed/variable lengths, sweep mode, formatted reports).
  * Exposes optional kernel entry for Blackwell prefill and public symbols for kernel access.

* **Tests**
  * Comprehensive GPU test suite: fixed/variable lengths, grouped-value attention variants, final-state outputs, and determinism across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->