### PR TITLE
[Spark unit test debugging] Fix for tests/attention/test_trtllm_gen_mla.py

### DIFF
--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -516,9 +516,15 @@ def xqa_mla(
     # Infer parameters from tensors
     batch_size = q.shape[0]
     head_dim = q.shape[-1]
+    num_q_heads = q.shape[-2]
 
-    # Calculate head_group_ratio
-    head_group_ratio = 128
+    # Calculate head_group_ratio (MLA has 1 KV head, so ratio = num_q_heads)
+    head_group_ratio = num_q_heads
+    if head_group_ratio != 128:
+        raise ValueError(
+            f"XQA MLA only supports 128 query heads (head_group_ratio=128), "
+            f"got {num_q_heads} query heads"
+        )
 
     # Calculate max_seq_len from page_table and page_size
     num_pages_per_seq = page_table.shape[-1]

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -728,6 +728,8 @@ def test_trtllm_batch_decode_mla(
 ):
     if backend == "xqa" and layer_dimensions.head_dimensions == smaller_mla_dimensions:
         pytest.skip("XQA MLA does not support smaller MLA dimensions yet.")
+    if backend == "xqa" and layer_dimensions.num_heads != 128:
+        pytest.skip("XQA MLA only supports 128 query heads (head_group_ratio=128)")
 
     trtllm_batch_decode_mla(
         layer_dimensions,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Problem: 
`test_trtllm_gen_mla.py` fails with `cudaErrorIllegalAddress` (254 failures) on the DGX Spark nightly CI when running XQA MLA tests with `layer_dimensions1` (64 query heads). 

### Root cause: 
`xqa_mla()` in `flashinfer/xqa.py` hardcoded `head_group_ratio = 128` regardless of the actual number of query heads. The XQA MLA CUDA kernel (`csrc/xqa/mla_sm120.cu`) is compiled with `HEAD_GRP_SIZE=128` — the entire MLA code path is gated on `#define IS_MLA (HEAD_GRP_SIZE == 128 && HEAD_ELEMS == 576)`. Shared memory layouts, TMA tensor maps, and warp tile shapes are all sized for exactly 128 heads at compile time.

 The hardcoded 128 was a latent bug because it didn't validate the assumption it was making. So when a model with 64 query heads was passed in:

- The TMA tensor map for Q was created assuming 128 heads per batch entry
- **Batch 0**: the kernel read 128 heads but only 64 existed, silently reading into batch 1's memory
- **Batch 1+**: the kernel read completely out of bounds of the Q tensor

This produced wrong results (only ~20% of elements within tolerance) with `CUDA_LAUNCH_BLOCKING=1`, or `cudaErrorIllegalAddress` in async mode when the out-of-bounds TMA read hit unmapped memory.

Batch 0 appeared correct by coincidence (extra data came from batch 1, but KV attention still used batch 0's page table). Single-batch runs always passed, masking the bug.

### Debugging evidence

Tested on DGX Spark (GB10, SM 12.1):

| Config | batch[0] | batch[1] |
|--------|----------|----------|
| 128 heads (ratio matches kernel) | ✅ max_diff=0 | ✅ max_diff=0 |
| 64 heads (ratio mismatches kernel) | ✅ max_diff=0 | ❌ max_diff=1.8 |

### Why not fix the kernel to support 64 heads?

The MLA code path is gated on `HEAD_GRP_SIZE == 128` in `csrc/xqa/defines.h`. The value is a compile-time constant used throughout shared memory allocation, warp tiling, and buffer sizing. Supporting other head counts would require either generalizing the kernel or compiling additional kernel variants — that's feature work beyond the scope of this fix. 

The scope of this fix is to fail clearly on unsupported head counts, instead of returning cudaErrorIllegalAddress. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * XQA MLA now enforces an exact 128 query-head requirement and will raise an error if unmet.
  * XQA MLA GPU support narrowed to recent SM12x architectures.

* **Tests**
  * MLA tests updated to skip or validate runs unless the environment provides 128 query heads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->