### PR TITLE
[Spark unit test debugging] Fix for tests/gemm/test_groupwise_scaled_gemm_fp8.py

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -566,7 +566,7 @@ def is_sm120f_supported(device: torch.device) -> bool:
 
 def is_sm121a_supported(device: torch.device) -> bool:
     major, minor = get_compute_capability(device)
-    return major == 12 and minor == 1 and version_at_least(torch.version.cuda, "13.0")
+    return major == 12 and minor == 1 and version_at_least(torch.version.cuda, "12.9")
 
 
 def is_sm12x_supported(device: torch.device) -> bool:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Problem

`test_groupwise_scaled_gemm_fp8.py` fails on DGX Spark nightly CI:
- **CUDA 13.0**: All 800 SM12x tests fail with `RuntimeError: Ninja build failed` (CUTLASS compilation error)
- **CUDA 12.9**: All 800 SM12x tests fail with `ValueError: Unsupported device for FP8 GEMM: cuda:0` (dispatch gate rejects SM121)

### Root Cause 1: CUTLASS compilation error (CUDA 13.0)

`gen_gemm_sm120_module()` in `flashinfer/jit/gemm/core.py` passed `-DCUTLASS_ENABLE_GDC_FOR_SM90=1` to the SM120 GEMM build. This flag activates an `#ifdef CUTLASS_ENABLE_GDC_FOR_SM90` block in CUTLASS's SM90 cooperative kernel template (`sm90_gemm_tma_warpspecialized_cooperative.hpp:794`):

```cpp
#ifdef CUTLASS_ENABLE_GDC_FOR_SM90
if (scheduler.is_last_tile(work_tile_info)) {
    cutlass::arch::launch_dependent_grids();
}
#endif
```

The SM120 kernel reuses this SM90 template but with `PersistentTileSchedulerSm100` — which uses CLC-based scheduling and **does not have `is_last_tile`**. That method only exists on `PersistentTileSchedulerSm90`. The compilation fails with:

```
error: class "cutlass::gemm::kernel::detail::PersistentTileSchedulerSm100<...>" has no member "is_last_tile"
```

GDC (Programmatic Dependent Launch) for SM120/SM121 is already correctly handled through `-DCUTLASS_ENABLE_GDC_FOR_SM100=1` via `grid_dependency_control.h`, which explicitly covers `__CUDA_ARCH__ == 1200` and `__CUDA_ARCH__ == 1210`. The SM90 flag is unnecessary and incompatible.

### Root Cause 2: Overly strict CUDA version gate (CUDA 12.9)

`is_sm12x_supported()` in `flashinfer/utils.py` required CUDA ≥ 13.0 for SM121:

```python
min_cuda = "13.0" if minor >= 1 else "12.8"
```

This caused the runtime dispatch to reject SM121 on CUDA 12.9, falling through to `raise ValueError("Unsupported device for FP8 GEMM")`. CUDA 12.9 fully supports SM121a compilation and execution — confirmed by other Spark test suites passing on the same CI container.

### Changes

**`flashinfer/jit/gemm/core.py`** — Remove `-DCUTLASS_ENABLE_GDC_FOR_SM90=1` from the SM120 GEMM build:

```python
# Before:
extra_cuda_cflags=nvcc_flags
+ [
    "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
    "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
],

# After:
extra_cuda_cflags=nvcc_flags
+ [
    "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
],
```

**`flashinfer/utils.py`** — Lower CUDA version requirement for SM121 from 13.0 to 12.9:

```python
# Before:
min_cuda = "13.0" if minor >= 1 else "12.8"

# After:
min_cuda = "12.9" if minor >= 1 else "12.8"
```

### Test results

Full test suite (`test_groupwise_scaled_gemm_fp8.py`) on DGX Spark (GB10, SM 12.1):

| CUDA version | Before | After |
|---|---|---|
| 13.0 | 800 failed (compilation error) | 800 passed, 1358 skipped |
| 12.9 | 800 failed (ValueError dispatch gate) | 800 passed, 1358 skipped |


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CUDA compatibility for SM12x GPUs: several SM12x variants now accept CUDA 12.9 (previously required 13.0), while earlier minor SM12x variants continue to require CUDA 12.8. This adjusts supported CUDA thresholds for those devices, improving alignment of compatibility checks without altering behavior for older minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->