### PR TITLE
Fix MXFP8 fc1 weight shape check for non-gated activations

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -901,8 +901,8 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
-          << fc1_n_mult << ", hidden_size // 4"
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size * " << fc1_n_mult
+          << ", hidden_size // 4"
              " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
@@ -1010,8 +1010,8 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
-          << fc1_n_mult << ", hidden_size // 4"
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size * " << fc1_n_mult
+          << ", hidden_size // 4"
              " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
@@ -1071,8 +1071,8 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
-          << fc1_n_mult << ", hidden_size // 4"
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size * " << fc1_n_mult
+          << ", hidden_size // 4"
              " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";

--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -895,13 +895,14 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  2 &&
+                  (isGatedActivation(base_activation_type) ? 2 : 1) &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // 4 "
-             "// block_scale_vector_size)";
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
+          << (isGatedActivation(base_activation_type) ? 2 : 1) << ", hidden_size // 4"
+             " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
       TVM_FFI_ICHECK(
@@ -1002,13 +1003,14 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  2 &&
+                  (isGatedActivation(base_activation_type) ? 2 : 1) &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // 4 "
-             "// block_scale_vector_size)";
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
+          << (isGatedActivation(base_activation_type) ? 2 : 1) << ", hidden_size // 4"
+             " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
       TVM_FFI_ICHECK(fc2_act_global.ndim() == 0 || fc2_act_global.size(0) == num_experts_on_rank)
@@ -1061,13 +1063,14 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  2 &&
+                  (isGatedActivation(base_activation_type) ? 2 : 1) &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // 4 "
-             "// block_scale_vector_size)";
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
+          << (isGatedActivation(base_activation_type) ? 2 : 1) << ", hidden_size // 4"
+             " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
       TVM_FFI_ICHECK(

--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -890,18 +890,19 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       CHECK_DIM(1, fc1_global);
       CHECK_DIM(3, fc2_weight_block);
       CHECK_DIM(1, fc2_global);
+      int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  (isGatedActivation(base_activation_type) ? 2 : 1) &&
+                  fc1_n_mult &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
           << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
-          << (isGatedActivation(base_activation_type) ? 2 : 1) << ", hidden_size // 4"
+          << fc1_n_mult << ", hidden_size // 4"
              " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
@@ -998,18 +999,19 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       CHECK_DIM(3, fc2_weight_block);
       CHECK_DIM(1, fc2_global);
       // Check shapes
+      int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  (isGatedActivation(base_activation_type) ? 2 : 1) &&
+                  fc1_n_mult &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
           << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
-          << (isGatedActivation(base_activation_type) ? 2 : 1) << ", hidden_size // 4"
+          << fc1_n_mult << ", hidden_size // 4"
              " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
@@ -1058,18 +1060,19 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       CHECK_DIM(1, fc1_global);
       CHECK_DIM(3, fc2_weight_block);
       CHECK_DIM(1, fc2_global);
+      int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  (isGatedActivation(base_activation_type) ? 2 : 1) &&
+                  fc1_n_mult &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
           << "fc1 weight block size must be (num_experts_on_rank, inter_size * "
-          << (isGatedActivation(base_activation_type) ? 2 : 1) << ", hidden_size // 4"
+          << fc1_n_mult << ", hidden_size // 4"
              " // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";


### PR DESCRIPTION
Fixes #2731.

The MXFP8 quantization path in `getQuantParams()` hardcodes `inter_size * 2` for the fc1 weight block N-dimension check, assuming gated activations (where gate + up weights are concatenated). This causes the check to fail for non-gated activations where the multiplier should be 1.

Replace the hardcoded `* 2` with `* (isGatedActivation(base_activation_type) ? 2 : 1)` in all three MXFP8 `getQuantParams` overloads. Also updated the error messages to show the actual expected multiplier.

This matches the existing pattern in the NVFP4 path (line ~1131) which already correctly guards the `* 2` with an `isGatedActivation` check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal size validation to account for gated activations by using the proper multiplier when certain quantization formats are used.
  * Updated validation error messages to report the adjusted expected size when gated activations affect parameter layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->