### PR TITLE
fix(jit): enable GDC for CUTLASS GEMM PDL — SM100 flag only

### DIFF
--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -436,7 +436,10 @@ def gen_gemm_sm100_module() -> JitSpec:
     return gen_jit_spec(
         "gemm_sm100",
         source_paths,
-        extra_cuda_cflags=nvcc_flags,
+        extra_cuda_cflags=nvcc_flags
+        + [
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+        ],
     )
 
 


### PR DESCRIPTION
## Summary

Re-applies #2716 (reverted in #2737) with the fix for the AOT build failure.

**Only `-DCUTLASS_ENABLE_GDC_FOR_SM100=1`** is added. The `-DCUTLASS_ENABLE_GDC_FOR_SM90=1` flag that broke AOT builds is intentionally omitted.

## Why the original PR broke AOT

`sm90_gemm_tma_warpspecialized_cooperative.hpp:794` has a direct `#ifdef CUTLASS_ENABLE_GDC_FOR_SM90` guard (not `CUTLASS_GDC_ENABLED`) that calls `scheduler.is_last_tile()`. When compiling SM120 kernels with that flag, the SM120 scheduler (`PersistentTileSchedulerSm100StreamK`) doesn't have `is_last_tile()` → compilation error.

## Why SM100 flag alone is sufficient

CUTLASS 4.2.1 `grid_dependency_control.h` defines `CUTLASS_GDC_ENABLED` for the entire SM100 family (SM100/101/103/120/121) when `CUTLASS_ENABLE_GDC_FOR_SM100` is set. This enables `griddepcontrol.wait` and `griddepcontrol.launch_dependents` device-side barriers for all affected architectures.

## Why this is needed

All affected GEMM kernels hardcode `enablePDL=true`, which enables host-side kernel overlap. Without the GDC compile flag, the device-side synchronization barriers compile as no-ops → race condition → NaN/garbage output tiles under concurrency.

## Affected modules

- `fp4_gemm_cutlass` (SM100)
- `fp4_gemm_cutlass_sm103` (SM103)
- `fp4_gemm_cutlass_sm120` (SM120)
- `fp8_gemm_cutlass` (SM100)
- `mxfp8_gemm_cutlass` (SM100)
- `gemm_sm120` (SM120 FP8 groupwise)

(`tgv_gemm` already had the SM100 flag.)

## Test plan

- [ ] AOT build with `FLASHINFER_CUDA_ARCH_LIST="12.1a"` (the exact config that broke before)
- [ ] AOT build with full arch list `"7.5 8.0 8.9 9.0a 10.0a 12.0a"`
- [ ] FP4 GEMM correctness under concurrent streams on SM120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA compilation configurations for matrix multiplication kernels across multiple data format variants (FP4, FP8, MXFP8, BF16) supporting additional GPU architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->