### PR TITLE
fix: 2D n_dim check in get_gemm_sm120_module_cutlass_fp8

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -638,7 +638,7 @@ def get_gemm_sm120_module_cutlass_fp8():
 
                 # Determine dimensions first to know scale granularity
                 if a.dim() == 2:
-                    n_dim = b_col_major.shape[0]
+                    n_dim = b.shape[0]
                     m_dim = a.shape[0]
                     k_dim = a.shape[1]
                     batch_size = 1


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

I tried running GLM-5-FP8 in sglang using the `flashinfer_cutlass` fp8 gemm backend optimized for `sm_120`, and ran into a problem with failing an assertion [here](https://github.com/sgl-project/sglang/blob/6c5bf53a36e1fd5e002d11dc72a151190aeac47c/python/sglang/srt/layers/quantization/fp8_utils.py#L529) because the `n` dimension is not divisible by the block size of 128. By patching the expected shapes to use ceil div instead of integer div, I was able to get past the assert, but inference resulted in gibberish.

My subsequent (AI-assisted) debugging pointed to this line of code in flashinfer as the source of the gibberish output. Because the [transpose](https://github.com/flashinfer-ai/flashinfer/blob/4781b428d7fb2b50fed56cc9e0adfd6c99ded7b5/flashinfer/gemm/gemm_base.py#L633) swaps the axes, `b_col_major.shape[0]` is `k`, not `n`. The result is that `n_dim` holds `k` for the entire remainder of the function.

Only models where `n` is not a multiple of 128 are affected. When `n` happens to be a multiple of 128, `n_padded == n_dim` regardless of whether `n_dim` actually holds `k`, so `needs_n_padding` is False, the wrapper takes the fast no-op path, and produces correct output. When `n` is not a multiple of 128 (but `k` is), the wrapper incorrectly concludes that N needs no padding since it is reading `k` (which is a multiple of 128) as `n_dim`. It therefore skips N padding entirely, passes the unpadded weight to the kernel with the wrong geometry, and the kernel produces silently wrong results with no error or exception. The failure mode is quiet because CUDA does not bounds-check kernel writes, and during CUDA graph capture the `fake_impl` intercepts the call entirely so the graph captures cleanly, but the corruption manifests at graph replay time.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dimension calculation in FP8 GEMM operations to ensure correct padding and tensor processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->