### PR TITLE
Feat [GDN]: Added Negative Index Padding for BF16 decode & MTP

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -789,304 +789,309 @@ def gated_delta_rule_decode_kernel_seqlen1(
         cutlass.Float32, cute.make_layout((32, 4), stride=(1, 32))
     )
 
-    h_global = gH[(pool_batch_idx, value_head_idx, None, None)]
-
-    # Launch first 2 async loads
-    load_h_chunk_async(h_sh_chunk0, h_global, tidx, 0)
-    nvvm.cp_async_commit_group()
-    load_h_chunk_async(h_sh_chunk1, h_global, tidx, 32)
-    nvvm.cp_async_commit_group()
-
-    # L2 normalization
-    q_head = gQ[(batch_idx, 0, query_head_idx, None)]
-    k_head = gK[(batch_idx, 0, query_head_idx, None)]
-
-    warp_idx = tidx // 32
-    lane_idx = tidx % 32
-
-    # Use shared helper for Q/K normalization (only warp 0 does the work)
-    if warp_idx == 0:
-        normalize_and_store_qk_to_smem(q_head, k_head, q_sh, k_sh, lane_idx, scale, eps)
-
-    cute.arch.sync_threads()
-
-    # Load V
-    v_head = gV[(batch_idx, 0, value_head_idx, None)]
+    # Allocations moved before guard (compile-time layout ops / safe batch_idx indexing)
     v_sh = smem.allocate_tensor(cutlass.Float32, 128)
-    v_sh[tidx] = v_head[tidx].to(cutlass.Float32)
-
-    # Registers: h_chunk + k_chunk (persistent) + qk_temp (reused for Q)
     h_chunk = cute.make_rmem_tensor((32,), cutlass.Float32)
     k_chunk = cute.make_rmem_tensor((32,), cutlass.Float32)  # PERSISTENT K!
     qk_temp = cute.make_rmem_tensor((32,), cutlass.Float32)
 
+    warp_idx = tidx // 32
+    lane_idx = tidx % 32
     k_base = warp_idx * 32
-
-    # Load K ONCE - keep for entire kernel
-    for i in cutlass.range_constexpr(32):
-        k_chunk[i] = k_sh[k_base + i]
-
-    h_out = gH[(pool_batch_idx, value_head_idx, None, None)]
     o_head = gO[(batch_idx, 0, value_head_idx, None)]
 
-    # ========================================================================
-    # CHUNK 0
-    # ========================================================================
-    nvvm.cp_async_wait_group(1)
-    cute.arch.sync_threads()
+    # Only process valid batch entries (pool_batch_idx >= 0)
+    if pool_batch_idx >= 0:
+        h_global = gH[(pool_batch_idx, value_head_idx, None, None)]
 
-    pred = cutlass.Float32(0.0)
-    pred2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
-            h_sh_chunk0[lane_idx, k_base + i].to(cutlass.Float32),
-            h_sh_chunk0[lane_idx, k_base + i + 1].to(cutlass.Float32),
-            g_exp,
-            g_exp,
-        )
-    for i in cutlass.range_constexpr(0, 32, 2):
-        pred, pred2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
-        )
-    pred = pred + pred2
+        # Launch first 2 async loads
+        load_h_chunk_async(h_sh_chunk0, h_global, tidx, 0)
+        nvvm.cp_async_commit_group()
+        load_h_chunk_async(h_sh_chunk1, h_global, tidx, 32)
+        nvvm.cp_async_commit_group()
 
-    pred_sh[lane_idx, warp_idx] = pred
-    cute.arch.sync_threads()
-    pred_final = (
-        pred_sh[lane_idx, 0]
-        + pred_sh[lane_idx, 1]
-        + pred_sh[lane_idx, 2]
-        + pred_sh[lane_idx, 3]
-    )
+        # L2 normalization
+        q_head = gQ[(batch_idx, 0, query_head_idx, None)]
+        k_head = gK[(batch_idx, 0, query_head_idx, None)]
 
-    v_val = (v_sh[lane_idx] - pred_final) * beta
+        # Use shared helper for Q/K normalization (only warp 0 does the work)
+        if warp_idx == 0:
+            normalize_and_store_qk_to_smem(q_head, k_head, q_sh, k_sh, lane_idx, scale, eps)
 
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair(
-            k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
-        )
+        cute.arch.sync_threads()
 
-    # Load Q for output computation
-    for i in cutlass.range_constexpr(32):
-        qk_temp[i] = q_sh[k_base + i]
+        # Load V
+        v_head = gV[(batch_idx, 0, value_head_idx, None)]
+        v_sh[tidx] = v_head[tidx].to(cutlass.Float32)
 
-    out = cutlass.Float32(0.0)
-    out2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        out, out2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
-        )
-    out = out + out2
+        # Load K ONCE - keep for entire kernel
+        for i in cutlass.range_constexpr(32):
+            k_chunk[i] = k_sh[k_base + i]
 
-    out_sh[lane_idx, warp_idx] = out
-    cute.arch.sync_threads()
-    out_final = (
-        out_sh[lane_idx, 0]
-        + out_sh[lane_idx, 1]
-        + out_sh[lane_idx, 2]
-        + out_sh[lane_idx, 3]
-    )
+        h_out = gH[(pool_batch_idx, value_head_idx, None, None)]
 
-    write_h_chunk_to_smem(h_chunk, h_sh_chunk0, lane_idx, k_base)
-    if warp_idx == 0:
-        o_head[lane_idx] = out_final.to(cutlass.BFloat16)
+        # ====================================================================
+        # CHUNK 0
+        # ====================================================================
+        nvvm.cp_async_wait_group(1)
+        cute.arch.sync_threads()
 
-    # ========================================================================
-    # CHUNK 1
-    # ========================================================================
-    nvvm.cp_async_wait_group(0)
-    cute.arch.sync_threads()
+        pred = cutlass.Float32(0.0)
+        pred2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
+                h_sh_chunk0[lane_idx, k_base + i].to(cutlass.Float32),
+                h_sh_chunk0[lane_idx, k_base + i + 1].to(cutlass.Float32),
+                g_exp,
+                g_exp,
+            )
+        for i in cutlass.range_constexpr(0, 32, 2):
+            pred, pred2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
+            )
+        pred = pred + pred2
 
-    load_h_chunk_async(h_sh_chunk2, h_global, tidx, 64)
-    nvvm.cp_async_commit_group()
-    load_h_chunk_async(h_sh_chunk3, h_global, tidx, 96)
-    nvvm.cp_async_commit_group()
-
-    store_h_smem_to_gmem(h_sh_chunk0, h_out, tidx, 0)
-
-    pred = cutlass.Float32(0.0)
-    pred2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
-            h_sh_chunk1[lane_idx, k_base + i].to(cutlass.Float32),
-            h_sh_chunk1[lane_idx, k_base + i + 1].to(cutlass.Float32),
-            g_exp,
-            g_exp,
-        )
-    for i in cutlass.range_constexpr(0, 32, 2):
-        pred, pred2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
-        )
-    pred = pred + pred2
-
-    pred_sh[lane_idx, warp_idx] = pred
-    cute.arch.sync_threads()
-    pred_final = (
-        pred_sh[lane_idx, 0]
-        + pred_sh[lane_idx, 1]
-        + pred_sh[lane_idx, 2]
-        + pred_sh[lane_idx, 3]
-    )
-
-    v_val = (v_sh[32 + lane_idx] - pred_final) * beta
-
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair(
-            k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+        pred_sh[lane_idx, warp_idx] = pred
+        cute.arch.sync_threads()
+        pred_final = (
+            pred_sh[lane_idx, 0]
+            + pred_sh[lane_idx, 1]
+            + pred_sh[lane_idx, 2]
+            + pred_sh[lane_idx, 3]
         )
 
-    for i in cutlass.range_constexpr(32):
-        qk_temp[i] = q_sh[k_base + i]
+        v_val = (v_sh[lane_idx] - pred_final) * beta
 
-    out = cutlass.Float32(0.0)
-    out2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        out, out2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
-        )
-    out = out + out2
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair(
+                k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+            )
 
-    out_sh[lane_idx, warp_idx] = out
-    cute.arch.sync_threads()
-    out_final = (
-        out_sh[lane_idx, 0]
-        + out_sh[lane_idx, 1]
-        + out_sh[lane_idx, 2]
-        + out_sh[lane_idx, 3]
-    )
+        # Load Q for output computation
+        for i in cutlass.range_constexpr(32):
+            qk_temp[i] = q_sh[k_base + i]
 
-    write_h_chunk_to_smem(h_chunk, h_sh_chunk1, lane_idx, k_base)
-    if warp_idx == 0:
-        o_head[32 + lane_idx] = out_final.to(cutlass.BFloat16)
+        out = cutlass.Float32(0.0)
+        out2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            out, out2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
+            )
+        out = out + out2
 
-    # ========================================================================
-    # CHUNK 2
-    # ========================================================================
-    nvvm.cp_async_wait_group(1)
-    cute.arch.sync_threads()
-
-    store_h_smem_to_gmem(h_sh_chunk1, h_out, tidx, 32)
-
-    pred = cutlass.Float32(0.0)
-    pred2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
-            h_sh_chunk2[lane_idx, k_base + i].to(cutlass.Float32),
-            h_sh_chunk2[lane_idx, k_base + i + 1].to(cutlass.Float32),
-            g_exp,
-            g_exp,
-        )
-    for i in cutlass.range_constexpr(0, 32, 2):
-        pred, pred2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
-        )
-    pred = pred + pred2
-
-    pred_sh[lane_idx, warp_idx] = pred
-    cute.arch.sync_threads()
-    pred_final = (
-        pred_sh[lane_idx, 0]
-        + pred_sh[lane_idx, 1]
-        + pred_sh[lane_idx, 2]
-        + pred_sh[lane_idx, 3]
-    )
-
-    v_val = (v_sh[64 + lane_idx] - pred_final) * beta
-
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair(
-            k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+        out_sh[lane_idx, warp_idx] = out
+        cute.arch.sync_threads()
+        out_final = (
+            out_sh[lane_idx, 0]
+            + out_sh[lane_idx, 1]
+            + out_sh[lane_idx, 2]
+            + out_sh[lane_idx, 3]
         )
 
-    for i in cutlass.range_constexpr(32):
-        qk_temp[i] = q_sh[k_base + i]
+        write_h_chunk_to_smem(h_chunk, h_sh_chunk0, lane_idx, k_base)
+        if warp_idx == 0:
+            o_head[lane_idx] = out_final.to(cutlass.BFloat16)
 
-    out = cutlass.Float32(0.0)
-    out2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        out, out2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
-        )
-    out = out + out2
+        # ====================================================================
+        # CHUNK 1
+        # ====================================================================
+        nvvm.cp_async_wait_group(0)
+        cute.arch.sync_threads()
 
-    out_sh[lane_idx, warp_idx] = out
-    cute.arch.sync_threads()
-    out_final = (
-        out_sh[lane_idx, 0]
-        + out_sh[lane_idx, 1]
-        + out_sh[lane_idx, 2]
-        + out_sh[lane_idx, 3]
-    )
+        load_h_chunk_async(h_sh_chunk2, h_global, tidx, 64)
+        nvvm.cp_async_commit_group()
+        load_h_chunk_async(h_sh_chunk3, h_global, tidx, 96)
+        nvvm.cp_async_commit_group()
 
-    write_h_chunk_to_smem(h_chunk, h_sh_chunk2, lane_idx, k_base)
-    if warp_idx == 0:
-        o_head[64 + lane_idx] = out_final.to(cutlass.BFloat16)
+        store_h_smem_to_gmem(h_sh_chunk0, h_out, tidx, 0)
 
-    # ========================================================================
-    # CHUNK 3
-    # ========================================================================
-    nvvm.cp_async_wait_group(0)
-    cute.arch.sync_threads()
+        pred = cutlass.Float32(0.0)
+        pred2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
+                h_sh_chunk1[lane_idx, k_base + i].to(cutlass.Float32),
+                h_sh_chunk1[lane_idx, k_base + i + 1].to(cutlass.Float32),
+                g_exp,
+                g_exp,
+            )
+        for i in cutlass.range_constexpr(0, 32, 2):
+            pred, pred2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
+            )
+        pred = pred + pred2
 
-    store_h_smem_to_gmem(h_sh_chunk2, h_out, tidx, 64)
-
-    pred = cutlass.Float32(0.0)
-    pred2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
-            h_sh_chunk3[lane_idx, k_base + i].to(cutlass.Float32),
-            h_sh_chunk3[lane_idx, k_base + i + 1].to(cutlass.Float32),
-            g_exp,
-            g_exp,
-        )
-    for i in cutlass.range_constexpr(0, 32, 2):
-        pred, pred2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
-        )
-    pred = pred + pred2
-
-    pred_sh[lane_idx, warp_idx] = pred
-    cute.arch.sync_threads()
-    pred_final = (
-        pred_sh[lane_idx, 0]
-        + pred_sh[lane_idx, 1]
-        + pred_sh[lane_idx, 2]
-        + pred_sh[lane_idx, 3]
-    )
-
-    v_val = (v_sh[96 + lane_idx] - pred_final) * beta
-
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair(
-            k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+        pred_sh[lane_idx, warp_idx] = pred
+        cute.arch.sync_threads()
+        pred_final = (
+            pred_sh[lane_idx, 0]
+            + pred_sh[lane_idx, 1]
+            + pred_sh[lane_idx, 2]
+            + pred_sh[lane_idx, 3]
         )
 
-    for i in cutlass.range_constexpr(32):
-        qk_temp[i] = q_sh[k_base + i]
+        v_val = (v_sh[32 + lane_idx] - pred_final) * beta
 
-    out = cutlass.Float32(0.0)
-    out2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        out, out2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair(
+                k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+            )
+
+        for i in cutlass.range_constexpr(32):
+            qk_temp[i] = q_sh[k_base + i]
+
+        out = cutlass.Float32(0.0)
+        out2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            out, out2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
+            )
+        out = out + out2
+
+        out_sh[lane_idx, warp_idx] = out
+        cute.arch.sync_threads()
+        out_final = (
+            out_sh[lane_idx, 0]
+            + out_sh[lane_idx, 1]
+            + out_sh[lane_idx, 2]
+            + out_sh[lane_idx, 3]
         )
-    out = out + out2
 
-    out_sh[lane_idx, warp_idx] = out
-    cute.arch.sync_threads()
-    out_final = (
-        out_sh[lane_idx, 0]
-        + out_sh[lane_idx, 1]
-        + out_sh[lane_idx, 2]
-        + out_sh[lane_idx, 3]
-    )
+        write_h_chunk_to_smem(h_chunk, h_sh_chunk1, lane_idx, k_base)
+        if warp_idx == 0:
+            o_head[32 + lane_idx] = out_final.to(cutlass.BFloat16)
 
-    write_h_chunk_to_smem(h_chunk, h_sh_chunk3, lane_idx, k_base)
-    if warp_idx == 0:
-        o_head[96 + lane_idx] = out_final.to(cutlass.BFloat16)
+        # ====================================================================
+        # CHUNK 2
+        # ====================================================================
+        nvvm.cp_async_wait_group(1)
+        cute.arch.sync_threads()
 
-    cute.arch.sync_threads()
-    store_h_smem_to_gmem(h_sh_chunk3, h_out, tidx, 96)
+        store_h_smem_to_gmem(h_sh_chunk1, h_out, tidx, 32)
+
+        pred = cutlass.Float32(0.0)
+        pred2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
+                h_sh_chunk2[lane_idx, k_base + i].to(cutlass.Float32),
+                h_sh_chunk2[lane_idx, k_base + i + 1].to(cutlass.Float32),
+                g_exp,
+                g_exp,
+            )
+        for i in cutlass.range_constexpr(0, 32, 2):
+            pred, pred2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
+            )
+        pred = pred + pred2
+
+        pred_sh[lane_idx, warp_idx] = pred
+        cute.arch.sync_threads()
+        pred_final = (
+            pred_sh[lane_idx, 0]
+            + pred_sh[lane_idx, 1]
+            + pred_sh[lane_idx, 2]
+            + pred_sh[lane_idx, 3]
+        )
+
+        v_val = (v_sh[64 + lane_idx] - pred_final) * beta
+
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair(
+                k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+            )
+
+        for i in cutlass.range_constexpr(32):
+            qk_temp[i] = q_sh[k_base + i]
+
+        out = cutlass.Float32(0.0)
+        out2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            out, out2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
+            )
+        out = out + out2
+
+        out_sh[lane_idx, warp_idx] = out
+        cute.arch.sync_threads()
+        out_final = (
+            out_sh[lane_idx, 0]
+            + out_sh[lane_idx, 1]
+            + out_sh[lane_idx, 2]
+            + out_sh[lane_idx, 3]
+        )
+
+        write_h_chunk_to_smem(h_chunk, h_sh_chunk2, lane_idx, k_base)
+        if warp_idx == 0:
+            o_head[64 + lane_idx] = out_final.to(cutlass.BFloat16)
+
+        # ====================================================================
+        # CHUNK 3
+        # ====================================================================
+        nvvm.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        store_h_smem_to_gmem(h_sh_chunk2, h_out, tidx, 64)
+
+        pred = cutlass.Float32(0.0)
+        pred2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
+                h_sh_chunk3[lane_idx, k_base + i].to(cutlass.Float32),
+                h_sh_chunk3[lane_idx, k_base + i + 1].to(cutlass.Float32),
+                g_exp,
+                g_exp,
+            )
+        for i in cutlass.range_constexpr(0, 32, 2):
+            pred, pred2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
+            )
+        pred = pred + pred2
+
+        pred_sh[lane_idx, warp_idx] = pred
+        cute.arch.sync_threads()
+        pred_final = (
+            pred_sh[lane_idx, 0]
+            + pred_sh[lane_idx, 1]
+            + pred_sh[lane_idx, 2]
+            + pred_sh[lane_idx, 3]
+        )
+
+        v_val = (v_sh[96 + lane_idx] - pred_final) * beta
+
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair(
+                k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+            )
+
+        for i in cutlass.range_constexpr(32):
+            qk_temp[i] = q_sh[k_base + i]
+
+        out = cutlass.Float32(0.0)
+        out2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            out, out2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
+            )
+        out = out + out2
+
+        out_sh[lane_idx, warp_idx] = out
+        cute.arch.sync_threads()
+        out_final = (
+            out_sh[lane_idx, 0]
+            + out_sh[lane_idx, 1]
+            + out_sh[lane_idx, 2]
+            + out_sh[lane_idx, 3]
+        )
+
+        write_h_chunk_to_smem(h_chunk, h_sh_chunk3, lane_idx, k_base)
+        if warp_idx == 0:
+            o_head[96 + lane_idx] = out_final.to(cutlass.BFloat16)
+
+        cute.arch.sync_threads()
+        store_h_smem_to_gmem(h_sh_chunk3, h_out, tidx, 96)
+
+    else:
+        # Negative index = padding slot. Zero the output, skip all computation.
+        o_head[tidx] = cutlass.BFloat16(0.0)
 
 
 # ==============================================================================
@@ -1216,262 +1221,272 @@ def gated_delta_rule_decode_kernel_seqlen234_unified(
             alpha3, beta_raw3, dt_bias_val, A_log_val, softplus_beta, softplus_threshold
         )
 
-    # Upfront H loading
-    h_global = gH[(pool_batch_idx, value_head_idx, None, None)]
-    load_h_chunk_async(h_sh_chunk0, h_global, tidx, 0)
-    nvvm.cp_async_commit_group()
-    load_h_chunk_async(h_sh_chunk1, h_global, tidx, 32)
-    nvvm.cp_async_commit_group()
-    load_h_chunk_async(h_sh_chunk2, h_global, tidx, 64)
-    nvvm.cp_async_commit_group()
-    load_h_chunk_async(h_sh_chunk3, h_global, tidx, 96)
-    nvvm.cp_async_commit_group()
-
-    # Q/K normalization - tokens 0, 1 always
-    q_head0 = gQ[(batch_idx, 0, query_head_idx, None)]
-    k_head0 = gK[(batch_idx, 0, query_head_idx, None)]
-    q_head1 = gQ[(batch_idx, 1, query_head_idx, None)]
-    k_head1 = gK[(batch_idx, 1, query_head_idx, None)]
-
-    if warp_idx == 0:
-        normalize_and_store_qk_to_smem(
-            q_head0, k_head0, q_sh0, k_sh0, lane_idx, scale, eps
-        )
-    if warp_idx == 1:
-        normalize_and_store_qk_to_smem(
-            q_head1, k_head1, q_sh1, k_sh1, lane_idx, scale, eps
-        )
-
-    # Token 2 Q/K normalization - only for NUM_TOKENS >= 3
-    if NUM_TOKENS >= 3:
-        q_head2 = gQ[(batch_idx, 2, query_head_idx, None)]
-        k_head2 = gK[(batch_idx, 2, query_head_idx, None)]
-        if warp_idx == 2:
-            normalize_and_store_qk_to_smem(
-                q_head2, k_head2, q_sh2, k_sh2, lane_idx, scale, eps
-            )
-
-    # Token 3 Q/K normalization - only for NUM_TOKENS = 4
-    if NUM_TOKENS == 4:
-        q_head3 = gQ[(batch_idx, 3, query_head_idx, None)]
-        k_head3 = gK[(batch_idx, 3, query_head_idx, None)]
-        if warp_idx == 3:
-            normalize_and_store_qk_to_smem(
-                q_head3, k_head3, q_sh3, k_sh3, lane_idx, scale, eps
-            )
-
-    cute.arch.sync_threads()
-
-    # V loading - tokens 0, 1 always
-    v_head0 = gV[(batch_idx, 0, value_head_idx, None)]
-    v_head1 = gV[(batch_idx, 1, value_head_idx, None)]
-    load_v_to_smem(v_head0, v_sh0, tidx)
-    load_v_to_smem(v_head1, v_sh1, tidx)
-
-    # Token 2 V loading - only for NUM_TOKENS >= 3
-    if NUM_TOKENS >= 3:
-        v_head2 = gV[(batch_idx, 2, value_head_idx, None)]
-        load_v_to_smem(v_head2, v_sh2, tidx)
-
-    # Token 3 V loading - only for NUM_TOKENS = 4
-    if NUM_TOKENS == 4:
-        v_head3 = gV[(batch_idx, 3, value_head_idx, None)]
-        load_v_to_smem(v_head3, v_sh3, tidx)
-
-    # Output pointers - tokens 0, 1 always
-    h_out = gH[(pool_batch_idx, value_head_idx, None, None)]
+    # Output pointers moved before guard (safe, uses batch_idx)
     o_head0 = gO[(batch_idx, 0, value_head_idx, None)]
     o_head1 = gO[(batch_idx, 1, value_head_idx, None)]
 
-    # Token 2 output pointer
     o_head2 = o_head1  # Default for T=2
     if NUM_TOKENS >= 3:
         o_head2 = gO[(batch_idx, 2, value_head_idx, None)]
 
-    # Token 3 output pointer
     o_head3 = o_head2  # Default for T=2,3
     if NUM_TOKENS == 4:
         o_head3 = gO[(batch_idx, 3, value_head_idx, None)]
 
-    # Process V-CHUNK 0
-    nvvm.cp_async_wait_group(3)
-    cute.arch.sync_threads()
-    process_vchunk_unified_234(
-        h_sh_chunk0,
-        h_sh_chunk0,
-        h_out,
-        h_chunk,
-        kq_chunk,
-        k_sh0,
-        k_sh1,
-        k_sh2,
-        k_sh3,
-        q_sh0,
-        q_sh1,
-        q_sh2,
-        q_sh3,
-        v_sh0,
-        v_sh1,
-        v_sh2,
-        v_sh3,
-        reduce_sh,
-        o_head0,
-        o_head1,
-        o_head2,
-        o_head3,
-        g_exp0,
-        g_exp1,
-        g_exp2,
-        g_exp3,
-        beta0,
-        beta1,
-        beta2,
-        beta3,
-        0,
-        0,
-        cutlass.Int32(0),
-        tidx,
-        warp_idx,
-        lane_idx,
-        k_base,
-        NUM_TOKENS,
-    )
+    # Only process valid batch entries (pool_batch_idx >= 0)
+    if pool_batch_idx >= 0:
+        # Upfront H loading
+        h_global = gH[(pool_batch_idx, value_head_idx, None, None)]
+        load_h_chunk_async(h_sh_chunk0, h_global, tidx, 0)
+        nvvm.cp_async_commit_group()
+        load_h_chunk_async(h_sh_chunk1, h_global, tidx, 32)
+        nvvm.cp_async_commit_group()
+        load_h_chunk_async(h_sh_chunk2, h_global, tidx, 64)
+        nvvm.cp_async_commit_group()
+        load_h_chunk_async(h_sh_chunk3, h_global, tidx, 96)
+        nvvm.cp_async_commit_group()
 
-    # Process V-CHUNK 1
-    nvvm.cp_async_wait_group(2)
-    cute.arch.sync_threads()
-    process_vchunk_unified_234(
-        h_sh_chunk1,
-        h_sh_chunk0,
-        h_out,
-        h_chunk,
-        kq_chunk,
-        k_sh0,
-        k_sh1,
-        k_sh2,
-        k_sh3,
-        q_sh0,
-        q_sh1,
-        q_sh2,
-        q_sh3,
-        v_sh0,
-        v_sh1,
-        v_sh2,
-        v_sh3,
-        reduce_sh,
-        o_head0,
-        o_head1,
-        o_head2,
-        o_head3,
-        g_exp0,
-        g_exp1,
-        g_exp2,
-        g_exp3,
-        beta0,
-        beta1,
-        beta2,
-        beta3,
-        32,
-        0,
-        cutlass.Int32(1),
-        tidx,
-        warp_idx,
-        lane_idx,
-        k_base,
-        NUM_TOKENS,
-    )
+        # Q/K normalization - tokens 0, 1 always
+        q_head0 = gQ[(batch_idx, 0, query_head_idx, None)]
+        k_head0 = gK[(batch_idx, 0, query_head_idx, None)]
+        q_head1 = gQ[(batch_idx, 1, query_head_idx, None)]
+        k_head1 = gK[(batch_idx, 1, query_head_idx, None)]
 
-    # Process V-CHUNK 2
-    nvvm.cp_async_wait_group(1)
-    cute.arch.sync_threads()
-    process_vchunk_unified_234(
-        h_sh_chunk2,
-        h_sh_chunk1,
-        h_out,
-        h_chunk,
-        kq_chunk,
-        k_sh0,
-        k_sh1,
-        k_sh2,
-        k_sh3,
-        q_sh0,
-        q_sh1,
-        q_sh2,
-        q_sh3,
-        v_sh0,
-        v_sh1,
-        v_sh2,
-        v_sh3,
-        reduce_sh,
-        o_head0,
-        o_head1,
-        o_head2,
-        o_head3,
-        g_exp0,
-        g_exp1,
-        g_exp2,
-        g_exp3,
-        beta0,
-        beta1,
-        beta2,
-        beta3,
-        64,
-        32,
-        cutlass.Int32(1),
-        tidx,
-        warp_idx,
-        lane_idx,
-        k_base,
-        NUM_TOKENS,
-    )
+        if warp_idx == 0:
+            normalize_and_store_qk_to_smem(
+                q_head0, k_head0, q_sh0, k_sh0, lane_idx, scale, eps
+            )
+        if warp_idx == 1:
+            normalize_and_store_qk_to_smem(
+                q_head1, k_head1, q_sh1, k_sh1, lane_idx, scale, eps
+            )
 
-    # Process V-CHUNK 3
-    nvvm.cp_async_wait_group(0)
-    cute.arch.sync_threads()
-    process_vchunk_unified_234(
-        h_sh_chunk3,
-        h_sh_chunk2,
-        h_out,
-        h_chunk,
-        kq_chunk,
-        k_sh0,
-        k_sh1,
-        k_sh2,
-        k_sh3,
-        q_sh0,
-        q_sh1,
-        q_sh2,
-        q_sh3,
-        v_sh0,
-        v_sh1,
-        v_sh2,
-        v_sh3,
-        reduce_sh,
-        o_head0,
-        o_head1,
-        o_head2,
-        o_head3,
-        g_exp0,
-        g_exp1,
-        g_exp2,
-        g_exp3,
-        beta0,
-        beta1,
-        beta2,
-        beta3,
-        96,
-        64,
-        cutlass.Int32(1),
-        tidx,
-        warp_idx,
-        lane_idx,
-        k_base,
-        NUM_TOKENS,
-    )
+        # Token 2 Q/K normalization - only for NUM_TOKENS >= 3
+        if NUM_TOKENS >= 3:
+            q_head2 = gQ[(batch_idx, 2, query_head_idx, None)]
+            k_head2 = gK[(batch_idx, 2, query_head_idx, None)]
+            if warp_idx == 2:
+                normalize_and_store_qk_to_smem(
+                    q_head2, k_head2, q_sh2, k_sh2, lane_idx, scale, eps
+                )
 
-    # Final H store
-    cute.arch.sync_threads()
-    store_h_smem_to_gmem(h_sh_chunk3, h_out, tidx, 96)
+        # Token 3 Q/K normalization - only for NUM_TOKENS = 4
+        if NUM_TOKENS == 4:
+            q_head3 = gQ[(batch_idx, 3, query_head_idx, None)]
+            k_head3 = gK[(batch_idx, 3, query_head_idx, None)]
+            if warp_idx == 3:
+                normalize_and_store_qk_to_smem(
+                    q_head3, k_head3, q_sh3, k_sh3, lane_idx, scale, eps
+                )
+
+        cute.arch.sync_threads()
+
+        # V loading - tokens 0, 1 always
+        v_head0 = gV[(batch_idx, 0, value_head_idx, None)]
+        v_head1 = gV[(batch_idx, 1, value_head_idx, None)]
+        load_v_to_smem(v_head0, v_sh0, tidx)
+        load_v_to_smem(v_head1, v_sh1, tidx)
+
+        # Token 2 V loading - only for NUM_TOKENS >= 3
+        if NUM_TOKENS >= 3:
+            v_head2 = gV[(batch_idx, 2, value_head_idx, None)]
+            load_v_to_smem(v_head2, v_sh2, tidx)
+
+        # Token 3 V loading - only for NUM_TOKENS = 4
+        if NUM_TOKENS == 4:
+            v_head3 = gV[(batch_idx, 3, value_head_idx, None)]
+            load_v_to_smem(v_head3, v_sh3, tidx)
+
+        h_out = gH[(pool_batch_idx, value_head_idx, None, None)]
+
+        # Process V-CHUNK 0
+        nvvm.cp_async_wait_group(3)
+        cute.arch.sync_threads()
+        process_vchunk_unified_234(
+            h_sh_chunk0,
+            h_sh_chunk0,
+            h_out,
+            h_chunk,
+            kq_chunk,
+            k_sh0,
+            k_sh1,
+            k_sh2,
+            k_sh3,
+            q_sh0,
+            q_sh1,
+            q_sh2,
+            q_sh3,
+            v_sh0,
+            v_sh1,
+            v_sh2,
+            v_sh3,
+            reduce_sh,
+            o_head0,
+            o_head1,
+            o_head2,
+            o_head3,
+            g_exp0,
+            g_exp1,
+            g_exp2,
+            g_exp3,
+            beta0,
+            beta1,
+            beta2,
+            beta3,
+            0,
+            0,
+            cutlass.Int32(0),
+            tidx,
+            warp_idx,
+            lane_idx,
+            k_base,
+            NUM_TOKENS,
+        )
+
+        # Process V-CHUNK 1
+        nvvm.cp_async_wait_group(2)
+        cute.arch.sync_threads()
+        process_vchunk_unified_234(
+            h_sh_chunk1,
+            h_sh_chunk0,
+            h_out,
+            h_chunk,
+            kq_chunk,
+            k_sh0,
+            k_sh1,
+            k_sh2,
+            k_sh3,
+            q_sh0,
+            q_sh1,
+            q_sh2,
+            q_sh3,
+            v_sh0,
+            v_sh1,
+            v_sh2,
+            v_sh3,
+            reduce_sh,
+            o_head0,
+            o_head1,
+            o_head2,
+            o_head3,
+            g_exp0,
+            g_exp1,
+            g_exp2,
+            g_exp3,
+            beta0,
+            beta1,
+            beta2,
+            beta3,
+            32,
+            0,
+            cutlass.Int32(1),
+            tidx,
+            warp_idx,
+            lane_idx,
+            k_base,
+            NUM_TOKENS,
+        )
+
+        # Process V-CHUNK 2
+        nvvm.cp_async_wait_group(1)
+        cute.arch.sync_threads()
+        process_vchunk_unified_234(
+            h_sh_chunk2,
+            h_sh_chunk1,
+            h_out,
+            h_chunk,
+            kq_chunk,
+            k_sh0,
+            k_sh1,
+            k_sh2,
+            k_sh3,
+            q_sh0,
+            q_sh1,
+            q_sh2,
+            q_sh3,
+            v_sh0,
+            v_sh1,
+            v_sh2,
+            v_sh3,
+            reduce_sh,
+            o_head0,
+            o_head1,
+            o_head2,
+            o_head3,
+            g_exp0,
+            g_exp1,
+            g_exp2,
+            g_exp3,
+            beta0,
+            beta1,
+            beta2,
+            beta3,
+            64,
+            32,
+            cutlass.Int32(1),
+            tidx,
+            warp_idx,
+            lane_idx,
+            k_base,
+            NUM_TOKENS,
+        )
+
+        # Process V-CHUNK 3
+        nvvm.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+        process_vchunk_unified_234(
+            h_sh_chunk3,
+            h_sh_chunk2,
+            h_out,
+            h_chunk,
+            kq_chunk,
+            k_sh0,
+            k_sh1,
+            k_sh2,
+            k_sh3,
+            q_sh0,
+            q_sh1,
+            q_sh2,
+            q_sh3,
+            v_sh0,
+            v_sh1,
+            v_sh2,
+            v_sh3,
+            reduce_sh,
+            o_head0,
+            o_head1,
+            o_head2,
+            o_head3,
+            g_exp0,
+            g_exp1,
+            g_exp2,
+            g_exp3,
+            beta0,
+            beta1,
+            beta2,
+            beta3,
+            96,
+            64,
+            cutlass.Int32(1),
+            tidx,
+            warp_idx,
+            lane_idx,
+            k_base,
+            NUM_TOKENS,
+        )
+
+        # Final H store
+        cute.arch.sync_threads()
+        store_h_smem_to_gmem(h_sh_chunk3, h_out, tidx, 96)
+
+    else:
+        # Negative index = padding slot. Zero the output for all tokens.
+        o_head0[tidx] = cutlass.BFloat16(0.0)
+        o_head1[tidx] = cutlass.BFloat16(0.0)
+        if NUM_TOKENS >= 3:
+            o_head2[tidx] = cutlass.BFloat16(0.0)
+        if NUM_TOKENS == 4:
+            o_head3[tidx] = cutlass.BFloat16(0.0)
 
 
 # ==============================================================================
@@ -1588,99 +1603,106 @@ def gated_delta_rule_decode_kernel_seqlen1_lowBS_1chunk(
         cutlass.Float32, cute.make_layout((32, 4), stride=(1, 32))
     )
 
-    h_global = gH[(pool_batch_idx, value_head_idx, None, None)]
-
-    load_h_chunk_async(h_sh_chunk, h_global, tidx, v_row_base)
-    nvvm.cp_async_commit_group()
-
-    q_head = gQ[(batch_idx, 0, query_head_idx, None)]
-    k_head = gK[(batch_idx, 0, query_head_idx, None)]
-
-    warp_idx = tidx // 32
-    lane_idx = tidx % 32
-
-    if warp_idx == 0:
-        normalize_and_store_qk_to_smem(q_head, k_head, q_sh, k_sh, lane_idx, scale, eps)
-
-    cute.arch.sync_threads()
-
-    v_head = gV[(batch_idx, 0, value_head_idx, None)]
+    # Allocations moved before guard (compile-time layout ops / safe batch_idx indexing)
     v_sh = smem.allocate_tensor(cutlass.Float32, 32)
-    if tidx < 32:
-        v_sh[tidx] = v_head[v_row_base + tidx].to(cutlass.Float32)
-
     h_chunk = cute.make_rmem_tensor((32,), cutlass.Float32)
     k_chunk = cute.make_rmem_tensor((32,), cutlass.Float32)
     qk_temp = cute.make_rmem_tensor((32,), cutlass.Float32)
 
+    warp_idx = tidx // 32
+    lane_idx = tidx % 32
     k_base = warp_idx * 32
-
-    for i in cutlass.range_constexpr(32):
-        k_chunk[i] = k_sh[k_base + i]
-
-    h_out = gH[(pool_batch_idx, value_head_idx, None, None)]
     o_head = gO[(batch_idx, 0, value_head_idx, None)]
 
-    nvvm.cp_async_wait_group(0)
-    cute.arch.sync_threads()
+    # Only process valid batch entries (pool_batch_idx >= 0)
+    if pool_batch_idx >= 0:
+        h_global = gH[(pool_batch_idx, value_head_idx, None, None)]
 
-    pred = cutlass.Float32(0.0)
-    pred2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
-            h_sh_chunk[lane_idx, k_base + i].to(cutlass.Float32),
-            h_sh_chunk[lane_idx, k_base + i + 1].to(cutlass.Float32),
-            g_exp,
-            g_exp,
+        load_h_chunk_async(h_sh_chunk, h_global, tidx, v_row_base)
+        nvvm.cp_async_commit_group()
+
+        q_head = gQ[(batch_idx, 0, query_head_idx, None)]
+        k_head = gK[(batch_idx, 0, query_head_idx, None)]
+
+        if warp_idx == 0:
+            normalize_and_store_qk_to_smem(q_head, k_head, q_sh, k_sh, lane_idx, scale, eps)
+
+        cute.arch.sync_threads()
+
+        v_head = gV[(batch_idx, 0, value_head_idx, None)]
+        if tidx < 32:
+            v_sh[tidx] = v_head[v_row_base + tidx].to(cutlass.Float32)
+
+        for i in cutlass.range_constexpr(32):
+            k_chunk[i] = k_sh[k_base + i]
+
+        h_out = gH[(pool_batch_idx, value_head_idx, None, None)]
+
+        nvvm.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        pred = cutlass.Float32(0.0)
+        pred2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair_mul(
+                h_sh_chunk[lane_idx, k_base + i].to(cutlass.Float32),
+                h_sh_chunk[lane_idx, k_base + i + 1].to(cutlass.Float32),
+                g_exp,
+                g_exp,
+            )
+        for i in cutlass.range_constexpr(0, 32, 2):
+            pred, pred2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
+            )
+        pred = pred + pred2
+
+        pred_sh[lane_idx, warp_idx] = pred
+        cute.arch.sync_threads()
+        pred_final = (
+            pred_sh[lane_idx, 0]
+            + pred_sh[lane_idx, 1]
+            + pred_sh[lane_idx, 2]
+            + pred_sh[lane_idx, 3]
         )
-    for i in cutlass.range_constexpr(0, 32, 2):
-        pred, pred2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], k_chunk[i], k_chunk[i + 1], pred, pred2
+
+        v_val = (v_sh[lane_idx] - pred_final) * beta
+
+        for i in cutlass.range_constexpr(0, 32, 2):
+            h_chunk[i], h_chunk[i + 1] = fma_pair(
+                k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
+            )
+
+        for i in cutlass.range_constexpr(32):
+            qk_temp[i] = q_sh[k_base + i]
+
+        out = cutlass.Float32(0.0)
+        out2 = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(0, 32, 2):
+            out, out2 = fma_pair(
+                h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
+            )
+        out = out + out2
+
+        out_sh[lane_idx, warp_idx] = out
+        cute.arch.sync_threads()
+        out_final = (
+            out_sh[lane_idx, 0]
+            + out_sh[lane_idx, 1]
+            + out_sh[lane_idx, 2]
+            + out_sh[lane_idx, 3]
         )
-    pred = pred + pred2
 
-    pred_sh[lane_idx, warp_idx] = pred
-    cute.arch.sync_threads()
-    pred_final = (
-        pred_sh[lane_idx, 0]
-        + pred_sh[lane_idx, 1]
-        + pred_sh[lane_idx, 2]
-        + pred_sh[lane_idx, 3]
-    )
+        write_h_chunk_to_smem(h_chunk, h_sh_chunk, lane_idx, k_base)
+        if warp_idx == 0:
+            o_head[v_row_base + lane_idx] = out_final.to(cutlass.BFloat16)
 
-    v_val = (v_sh[lane_idx] - pred_final) * beta
+        cute.arch.sync_threads()
+        store_h_smem_to_gmem(h_sh_chunk, h_out, tidx, v_row_base)
 
-    for i in cutlass.range_constexpr(0, 32, 2):
-        h_chunk[i], h_chunk[i + 1] = fma_pair(
-            k_chunk[i], k_chunk[i + 1], v_val, v_val, h_chunk[i], h_chunk[i + 1]
-        )
-
-    for i in cutlass.range_constexpr(32):
-        qk_temp[i] = q_sh[k_base + i]
-
-    out = cutlass.Float32(0.0)
-    out2 = cutlass.Float32(0.0)
-    for i in cutlass.range_constexpr(0, 32, 2):
-        out, out2 = fma_pair(
-            h_chunk[i], h_chunk[i + 1], qk_temp[i], qk_temp[i + 1], out, out2
-        )
-    out = out + out2
-
-    out_sh[lane_idx, warp_idx] = out
-    cute.arch.sync_threads()
-    out_final = (
-        out_sh[lane_idx, 0]
-        + out_sh[lane_idx, 1]
-        + out_sh[lane_idx, 2]
-        + out_sh[lane_idx, 3]
-    )
-
-    write_h_chunk_to_smem(h_chunk, h_sh_chunk, lane_idx, k_base)
-    if warp_idx == 0:
-        o_head[v_row_base + lane_idx] = out_final.to(cutlass.BFloat16)
-
-    cute.arch.sync_threads()
-    store_h_smem_to_gmem(h_sh_chunk, h_out, tidx, v_row_base)
+    else:
+        # Negative index = padding slot. Zero the output for this V-chunk.
+        if tidx < 32:
+            o_head[v_row_base + tidx] = cutlass.BFloat16(0.0)
 
 
 @cute.jit
@@ -1994,7 +2016,7 @@ def gated_delta_rule(
     else:
         h_slot_indices = initial_state_indices
 
-    output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
+    output = torch.zeros(B, T, HV, V, device=q.device, dtype=q.dtype)
 
     q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
     k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -816,7 +816,9 @@ def gated_delta_rule_decode_kernel_seqlen1(
 
         # Use shared helper for Q/K normalization (only warp 0 does the work)
         if warp_idx == 0:
-            normalize_and_store_qk_to_smem(q_head, k_head, q_sh, k_sh, lane_idx, scale, eps)
+            normalize_and_store_qk_to_smem(
+                q_head, k_head, q_sh, k_sh, lane_idx, scale, eps
+            )
 
         cute.arch.sync_threads()
 
@@ -1625,7 +1627,9 @@ def gated_delta_rule_decode_kernel_seqlen1_lowBS_1chunk(
         k_head = gK[(batch_idx, 0, query_head_idx, None)]
 
         if warp_idx == 0:
-            normalize_and_store_qk_to_smem(q_head, k_head, q_sh, k_sh, lane_idx, scale, eps)
+            normalize_and_store_qk_to_smem(
+                q_head, k_head, q_sh, k_sh, lane_idx, scale, eps
+            )
 
         cute.arch.sync_threads()
 

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -430,6 +430,15 @@ def gdn_verify_kernel_mtp_original(
                         (flat_state_idx, v_idx, lane_in_group),
                     )
                     cute.autovec_copy(r_h, h_tile_out)
+    else:
+        # Padding slot: zero output for all V rows this group handles
+        rows_per_group: cutlass.Constexpr[int] = tile_v // num_groups
+        for row_in_group in cutlass.range_constexpr(rows_per_group):
+            v_idx = i_v * tile_v + group_idx * rows_per_group + row_in_group
+            if v_idx < V:
+                for i_t in cutlass.range_constexpr(T):
+                    if lane_in_group == 0:
+                        o[(i_n, i_t, i_hv, v_idx)] = cutlass.BFloat16(0.0)
 
 
 @cute.jit
@@ -1524,6 +1533,14 @@ def gdn_verify_kernel_mtp(
                     v_global = v_tile_base + tidx
                     if v_global < V:
                         o[(i_n, t_idx, i_hv, v_global)] = sOutput[(t_idx, tidx)]
+    else:
+        # Padding slot: zero output using cooperative writeback pattern
+        v_tile_base = i_v * tile_v
+        for t_idx in cutlass.range_constexpr(T):
+            if tidx < tile_v:
+                v_global = v_tile_base + tidx
+                if v_global < V:
+                    o[(i_n, t_idx, i_hv, v_global)] = cutlass.BFloat16(0.0)
 
 
 @cute.jit

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -260,6 +260,8 @@ def gdn_verify_kernel_mtp_original(
     )
 
     # Only process valid batch entries (cache_idx >= 0)
+    rows_per_group: cutlass.Constexpr[int] = tile_v // num_groups
+
     if cache_idx >= 0:
         # Compute k_start once (used for shared memory writes)
         k_start = lane_in_group * vec_size
@@ -351,7 +353,6 @@ def gdn_verify_kernel_mtp_original(
         cute.arch.barrier()
 
         # Each group handles tile_v/num_groups V rows
-        rows_per_group: cutlass.Constexpr[int] = tile_v // num_groups
         for row_in_group in cutlass.range_constexpr(rows_per_group):
             v_idx = i_v * tile_v + group_idx * rows_per_group + row_in_group
 
@@ -432,7 +433,6 @@ def gdn_verify_kernel_mtp_original(
                     cute.autovec_copy(r_h, h_tile_out)
     else:
         # Padding slot: zero output for all V rows this group handles
-        rows_per_group: cutlass.Constexpr[int] = tile_v // num_groups
         for row_in_group in cutlass.range_constexpr(rows_per_group):
             v_idx = i_v * tile_v + group_idx * rows_per_group + row_in_group
             if v_idx < V:

--- a/tests/gdn/test_negative_index_padding.py
+++ b/tests/gdn/test_negative_index_padding.py
@@ -1,0 +1,445 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for negative-index padding in BF16 decode and MTP kernels."""
+
+from __future__ import annotations
+
+import os
+import random
+
+import pytest
+import torch
+
+try:
+    from .reference_delta_rule import decode_delta_rule, verify_delta_rule
+except ImportError:
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).parent))
+    from reference_delta_rule import decode_delta_rule, verify_delta_rule
+
+from flashinfer.gdn_decode import gated_delta_rule_mtp
+from flashinfer.utils import get_compute_capability
+
+try:
+    from flashinfer.gdn_kernels.gdn_decode_bf16_state import (
+        gated_delta_rule as gdn_decode_klast_bf16_state,
+    )
+
+    GDN_DECODE_KLAST_BF16_STATE_AVAILABLE = True
+except ImportError:
+    GDN_DECODE_KLAST_BF16_STATE_AVAILABLE = False
+
+
+def _skip_if_not_sm90_or_later():
+    cc = get_compute_capability(torch.device("cuda"))
+    if cc[0] not in [9, 10, 11, 12]:
+        pytest.skip(f"GDN decode requires SM90+, but got SM{cc[0]}{cc[1]}")
+
+
+def _test_bf16_decode_negative_indices(
+    B: int,
+    T: int,
+    num_q_heads: int = 16,
+    num_k_heads: int = 16,
+    num_v_heads: int = 32,
+    head_size: int = 128,
+    scale: float = 1.0,
+    pool_multiplier: int = 2,
+    padding_fraction: float = 0.5,
+    seed: int = 42,
+):
+    """BF16 decode kernel must zero output for negative-index (padding) slots
+    and correctly process valid slots."""
+    _skip_if_not_sm90_or_later()
+    if not GDN_DECODE_KLAST_BF16_STATE_AVAILABLE:
+        pytest.skip("BF16 state kernel not available")
+
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    K = head_size
+    V = head_size
+    HV = num_v_heads
+    pool_size = B * pool_multiplier
+    device = torch.device("cuda")
+
+    with device:
+        q = torch.randn(B, T, num_q_heads, K, dtype=torch.bfloat16)
+        k = torch.randn(B, T, num_k_heads, K, dtype=torch.bfloat16)
+        v = torch.randn(B, T, HV, V, dtype=torch.bfloat16)
+        a = torch.randn(B, T, HV, dtype=torch.bfloat16) * 0.1
+        b = torch.randn(B, T, HV, dtype=torch.bfloat16)
+        A_log = torch.randn(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.randn(HV, dtype=torch.float32) * 0.1
+        pool = torch.randn(pool_size, HV, V, K, dtype=torch.bfloat16)
+
+        indices = torch.arange(B, dtype=torch.int32, device=device) % pool_size
+        mask = torch.rand(B, device=device) < padding_fraction
+        if B >= 2:
+            mask[0] = False
+            mask[-1] = True
+        indices[mask] = -1
+
+        valid_mask = indices >= 0
+        num_valid = valid_mask.sum().item()
+        if num_valid > 0:
+            valid_slots = torch.randperm(pool_size, device=device)[:num_valid].to(
+                torch.int32
+            )
+            indices[valid_mask] = valid_slots
+
+    pool_under_test = pool.clone()
+    output = gdn_decode_klast_bf16_state(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        b=b,
+        initial_state_source=pool_under_test,
+        initial_state_indices=indices,
+        scale=scale,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.cuda.synchronize()
+
+    invalid_mask = indices < 0
+    if invalid_mask.any():
+        padded_output = output[invalid_mask]
+        assert torch.all(padded_output == 0), (
+            f"Padding slots must produce zero output, "
+            f"but got max abs = {padded_output.abs().max().item()}"
+        )
+
+    valid_indices_local = torch.where(valid_mask)[0].cpu().numpy()
+    pool_snapshot = pool.clone()
+
+    for i in valid_indices_local:
+        pool_idx = indices[i].item()
+        for t in range(T):
+            ref_state = (
+                pool_snapshot[pool_idx].float().transpose(-2, -1).contiguous()
+            )
+            ref_o, ref_s = decode_delta_rule(
+                q[i, t].unsqueeze(0).float(),
+                k[i, t].unsqueeze(0).float(),
+                v[i, t].unsqueeze(0).float(),
+                ref_state.unsqueeze(0),
+                A_log=A_log,
+                a=a[i, t].unsqueeze(0),
+                dt_bias=dt_bias.float(),
+                b=b[i, t].unsqueeze(0),
+                scale_factor=scale,
+                use_l2_norm=True,
+            )
+            pool_snapshot[pool_idx] = ref_s.squeeze(0).transpose(-2, -1).to(
+                pool_snapshot.dtype
+            )
+
+            torch.testing.assert_close(
+                output[i, t].float(),
+                ref_o.squeeze(0).to(device),
+                atol=5e-2,
+                rtol=5e-2,
+            )
+
+        torch.testing.assert_close(
+            pool_under_test[pool_idx].float(),
+            pool_snapshot[pool_idx].float(),
+            atol=5e-2,
+            rtol=5e-2,
+        )
+
+    used_pool_indices = indices[valid_mask].unique()
+    touched = torch.zeros(pool_size, dtype=torch.bool, device=device)
+    if len(used_pool_indices) > 0:
+        touched[used_pool_indices.long()] = True
+    torch.testing.assert_close(
+        pool_under_test[~touched], pool[~touched], atol=0.0, rtol=0.0
+    )
+
+
+def _test_bf16_decode_all_padding(
+    B: int,
+    T: int,
+    num_v_heads: int = 32,
+    head_size: int = 128,
+    seed: int = 42,
+):
+    """When ALL indices are negative, output must be all zeros and pool unchanged."""
+    _skip_if_not_sm90_or_later()
+    if not GDN_DECODE_KLAST_BF16_STATE_AVAILABLE:
+        pytest.skip("BF16 state kernel not available")
+
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    K = head_size
+    V = head_size
+    HV = num_v_heads
+    pool_size = B * 2
+    device = torch.device("cuda")
+
+    with device:
+        q = torch.randn(B, T, 16, K, dtype=torch.bfloat16)
+        k = torch.randn(B, T, 16, K, dtype=torch.bfloat16)
+        v = torch.randn(B, T, HV, V, dtype=torch.bfloat16)
+        a = torch.randn(B, T, HV, dtype=torch.bfloat16) * 0.1
+        b = torch.randn(B, T, HV, dtype=torch.bfloat16)
+        A_log = torch.randn(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.randn(HV, dtype=torch.float32) * 0.1
+        pool = torch.randn(pool_size, HV, V, K, dtype=torch.bfloat16)
+        indices = torch.full((B,), -1, dtype=torch.int32, device=device)
+
+    pool_under_test = pool.clone()
+    output = gdn_decode_klast_bf16_state(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        b=b,
+        initial_state_source=pool_under_test,
+        initial_state_indices=indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.all(output == 0), (
+        f"All-padding batch must produce zero output, "
+        f"but got max abs = {output.abs().max().item()}"
+    )
+    torch.testing.assert_close(
+        pool_under_test, pool, atol=0.0, rtol=0.0,
+        msg="All-padding batch must not modify any pool state",
+    )
+
+
+@pytest.mark.parametrize("B", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("T", [1, 2, 3, 4])
+def test_bf16_decode_negative_indices(
+    B: int,
+    T: int,
+    seed: int = int(os.environ.get("SEED", "42")),
+):
+    _test_bf16_decode_negative_indices(B=B, T=T, seed=seed)
+
+
+@pytest.mark.parametrize("B", [1, 4, 8])
+@pytest.mark.parametrize("T", [1, 2, 4])
+def test_bf16_decode_all_padding(
+    B: int,
+    T: int,
+    seed: int = int(os.environ.get("SEED", "42")),
+):
+    _test_bf16_decode_all_padding(B=B, T=T, seed=seed)
+
+
+def _test_mtp_negative_indices(
+    B: int,
+    T: int,
+    num_q_heads: int = 16,
+    num_k_heads: int = 16,
+    num_v_heads: int = 32,
+    head_size: int = 128,
+    scale: float = 1.0,
+    pool_multiplier: int = 2,
+    padding_fraction: float = 0.5,
+    seed: int = 42,
+):
+    """MTP kernel must zero output for negative-index (padding) slots."""
+    _skip_if_not_sm90_or_later()
+
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    K = head_size
+    V = head_size
+    H = num_q_heads
+    HV = num_v_heads
+    pool_size = B * pool_multiplier
+    device = torch.device("cuda")
+
+    with device:
+        q = torch.randn(B, T, H, K, dtype=torch.bfloat16)
+        k = torch.randn(B, T, H, K, dtype=torch.bfloat16)
+        v = torch.randn(B, T, HV, V, dtype=torch.bfloat16)
+        a = torch.randn(B, T, HV, dtype=torch.bfloat16) * 0.1
+        b = torch.randn(B, T, HV, dtype=torch.bfloat16)
+        A_log = torch.randn(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.randn(HV, dtype=torch.float32) * 0.1
+        initial_state = torch.randn(pool_size, HV, V, K, dtype=torch.float32)
+
+        indices = torch.arange(B, dtype=torch.int32, device=device) % pool_size
+        mask = torch.rand(B, device=device) < padding_fraction
+        if B >= 2:
+            mask[0] = False
+            mask[-1] = True
+        indices[mask] = -1
+
+        valid_mask = indices >= 0
+        num_valid = valid_mask.sum().item()
+        if num_valid > 0:
+            valid_slots = torch.randperm(pool_size, device=device)[:num_valid].to(
+                torch.int32
+            )
+            indices[valid_mask] = valid_slots
+
+    state_under_test = initial_state.clone()
+
+    output_prealloc = torch.ones(B, T, HV, V, dtype=torch.bfloat16, device=device)
+    output, _ = gated_delta_rule_mtp(
+        q=q,
+        k=k,
+        v=v,
+        initial_state=state_under_test,
+        initial_state_indices=indices,
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b,
+        scale=scale,
+        output=output_prealloc,
+        use_qk_l2norm=True,
+    )
+    torch.cuda.synchronize()
+
+    invalid_mask = indices < 0
+    if invalid_mask.any():
+        padded_output = output[invalid_mask]
+        assert torch.all(padded_output == 0), (
+            f"MTP padding slots must produce zero output, "
+            f"but got max abs = {padded_output.abs().max().item()}"
+        )
+
+    valid_indices_local = torch.where(valid_mask)[0].cpu().numpy()
+    state_snapshot = initial_state.clone()
+
+    for i in valid_indices_local:
+        pool_idx = indices[i].item()
+        for t in range(T):
+            ref_state = (
+                state_snapshot[pool_idx].float().transpose(-2, -1).contiguous()
+            )
+            ref_o, ref_s = decode_delta_rule(
+                q[i, t].unsqueeze(0).float(),
+                k[i, t].unsqueeze(0).float(),
+                v[i, t].unsqueeze(0).float(),
+                ref_state.unsqueeze(0),
+                A_log=A_log,
+                a=a[i, t].unsqueeze(0),
+                dt_bias=dt_bias.float(),
+                b=b[i, t].unsqueeze(0),
+                scale_factor=scale,
+                use_l2_norm=True,
+            )
+            state_snapshot[pool_idx] = ref_s.squeeze(0).transpose(-2, -1)
+
+            torch.testing.assert_close(
+                output[i, t].float(),
+                ref_o.squeeze(0).to(device),
+                atol=5e-2,
+                rtol=5e-2,
+            )
+
+        torch.testing.assert_close(
+            state_under_test[pool_idx].float(),
+            state_snapshot[pool_idx].float(),
+            atol=5e-2,
+            rtol=5e-2,
+        )
+
+
+def _test_mtp_all_padding(
+    B: int,
+    T: int,
+    num_v_heads: int = 32,
+    head_size: int = 128,
+    seed: int = 42,
+):
+    """When ALL indices are negative, MTP output must be all zeros."""
+    _skip_if_not_sm90_or_later()
+
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    K = head_size
+    V = head_size
+    HV = num_v_heads
+    pool_size = B * 2
+    device = torch.device("cuda")
+
+    with device:
+        q = torch.randn(B, T, 16, K, dtype=torch.bfloat16)
+        k = torch.randn(B, T, 16, K, dtype=torch.bfloat16)
+        v = torch.randn(B, T, HV, V, dtype=torch.bfloat16)
+        a = torch.randn(B, T, HV, dtype=torch.bfloat16) * 0.1
+        b = torch.randn(B, T, HV, dtype=torch.bfloat16)
+        A_log = torch.randn(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.randn(HV, dtype=torch.float32) * 0.1
+        initial_state = torch.randn(pool_size, HV, V, K, dtype=torch.float32)
+        indices = torch.full((B,), -1, dtype=torch.int32, device=device)
+
+    state_under_test = initial_state.clone()
+    output_prealloc = torch.ones(B, T, HV, V, dtype=torch.bfloat16, device=device)
+    output, _ = gated_delta_rule_mtp(
+        q=q,
+        k=k,
+        v=v,
+        initial_state=state_under_test,
+        initial_state_indices=indices,
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b,
+        output=output_prealloc,
+        use_qk_l2norm=True,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.all(output == 0), (
+        f"MTP all-padding batch must produce zero output, "
+        f"but got max abs = {output.abs().max().item()}"
+    )
+    torch.testing.assert_close(
+        state_under_test, initial_state, atol=0.0, rtol=0.0,
+        msg="MTP all-padding batch must not modify any pool state",
+    )
+
+
+@pytest.mark.parametrize("B", [4, 8, 16])
+@pytest.mark.parametrize("T", [2, 3, 4])
+def test_mtp_negative_indices(
+    B: int,
+    T: int,
+    seed: int = int(os.environ.get("SEED", "42")),
+):
+    _test_mtp_negative_indices(B=B, T=T, seed=seed)
+
+
+@pytest.mark.parametrize("B", [4, 8])
+@pytest.mark.parametrize("T", [2, 4])
+def test_mtp_all_padding(
+    B: int,
+    T: int,
+    seed: int = int(os.environ.get("SEED", "42")),
+):
+    _test_mtp_all_padding(B=B, T=T, seed=seed)

--- a/tests/gdn/test_negative_index_padding.py
+++ b/tests/gdn/test_negative_index_padding.py
@@ -23,13 +23,13 @@ import pytest
 import torch
 
 try:
-    from .reference_delta_rule import decode_delta_rule, verify_delta_rule
+    from .reference_delta_rule import decode_delta_rule
 except ImportError:
     import sys
     from pathlib import Path
 
     sys.path.insert(0, str(Path(__file__).parent))
-    from reference_delta_rule import decode_delta_rule, verify_delta_rule
+    from reference_delta_rule import decode_delta_rule
 
 from flashinfer.gdn_decode import gated_delta_rule_mtp
 from flashinfer.utils import get_compute_capability
@@ -133,9 +133,7 @@ def _test_bf16_decode_negative_indices(
     for i in valid_indices_local:
         pool_idx = indices[i].item()
         for t in range(T):
-            ref_state = (
-                pool_snapshot[pool_idx].float().transpose(-2, -1).contiguous()
-            )
+            ref_state = pool_snapshot[pool_idx].float().transpose(-2, -1).contiguous()
             ref_o, ref_s = decode_delta_rule(
                 q[i, t].unsqueeze(0).float(),
                 k[i, t].unsqueeze(0).float(),
@@ -148,8 +146,8 @@ def _test_bf16_decode_negative_indices(
                 scale_factor=scale,
                 use_l2_norm=True,
             )
-            pool_snapshot[pool_idx] = ref_s.squeeze(0).transpose(-2, -1).to(
-                pool_snapshot.dtype
+            pool_snapshot[pool_idx] = (
+                ref_s.squeeze(0).transpose(-2, -1).to(pool_snapshot.dtype)
             )
 
             torch.testing.assert_close(
@@ -227,7 +225,10 @@ def _test_bf16_decode_all_padding(
         f"but got max abs = {output.abs().max().item()}"
     )
     torch.testing.assert_close(
-        pool_under_test, pool, atol=0.0, rtol=0.0,
+        pool_under_test,
+        pool,
+        atol=0.0,
+        rtol=0.0,
         msg="All-padding batch must not modify any pool state",
     )
 
@@ -336,9 +337,7 @@ def _test_mtp_negative_indices(
     for i in valid_indices_local:
         pool_idx = indices[i].item()
         for t in range(T):
-            ref_state = (
-                state_snapshot[pool_idx].float().transpose(-2, -1).contiguous()
-            )
+            ref_state = state_snapshot[pool_idx].float().transpose(-2, -1).contiguous()
             ref_o, ref_s = decode_delta_rule(
                 q[i, t].unsqueeze(0).float(),
                 k[i, t].unsqueeze(0).float(),
@@ -420,7 +419,10 @@ def _test_mtp_all_padding(
         f"but got max abs = {output.abs().max().item()}"
     )
     torch.testing.assert_close(
-        state_under_test, initial_state, atol=0.0, rtol=0.0,
+        state_under_test,
+        initial_state,
+        atol=0.0,
+        rtol=0.0,
         msg="MTP all-padding batch must not modify any pool state",
     )
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

  This PR implements negative-index padding for the remaining pooled GDN runtime paths: BF16 decode and MTP.
 
  There is already exist support for pooled state access for GDN decode through `initial_state` plus `initial_state_indices`, where each batch row maps to a slot in a persistent state pool instead of `assuming batch_idx == state_idx`.
 
  In this, a negative pooled index means:
 
  - this batch row is padding
  - there is no active sequence behind it
  - the kernel must skip all stateful work for that row
 
  The FP32 pooled decode path already had this behavior from earlier work. The BF16 fast path and MTP path did not.

  ## What this PR changes
 
 
  ### BF16 decode
 
  Adds negative-index padding handling to the BF16 VK-layout fast path:
 
 
  - T=1 main kernel
  - T=1 low-batch kernel
  - unified T=2/3/4 kernel
 
 
  For padded rows, these kernels now:
 
  - skip the normal state/gate/update path
  - explicitly zero the related output slice
  - avoid going to pooled state
 
  ### MTP
 
  Adds explicit padding output zeroing to the MTP pooled path so negative-index rows do not get stale output values.
 
 
  For padded rows, MTP now:
 
  - skips recurrent computation
  - skips state update
  - zeros output explicitly
  - preserves state-side buffers for those rows

## 🔍 Related Issues

  - #2687: Idea originally came from the proposed changes in GDN Decode/Prefill API.
  - #2521: pooled indirect state access and negative-index padding for the FP32 path.
  - #2727: non-contiguous pooled decode support.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed padding slot handling to properly zero outputs for invalid batch indices instead of undefined behavior.
  * Improved memory access safety with explicit guard checks to prevent illegal accesses.

* **Tests**
  * Added comprehensive test suite validating padding behavior across decode and multi-token processing scenarios, including all-padding edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->