### PR TITLE
[Fmha] support nvfp4 output keepsMmaAb generation kernels

### DIFF
--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -356,7 +356,7 @@ class TllmGenFmhaKernel {
       } else {
         // Compute numTokensPerCtaQ where each CTA must process complete numGroupedHeadsQ.
         // Note that each CTA must process complete numHeadsQPerKv.
-        int numTokensPerCtaQ = kernelMeta.mStepQ / params.mNumHeadsQPerKv;
+        int numTokensPerCtaQ = std::max(1, kernelMeta.mStepQ / params.mNumHeadsQPerKv);
         // Group both headsQ and tokensQ into one CTA.
         numCtasPerSeqQ = flashinfer::ceil_div(params.mMaxSeqLenQ, numTokensPerCtaQ);
       }
@@ -773,8 +773,11 @@ class TllmGenFmhaKernel {
       kernelType = FmhaKernelType::KeepsMmaAbForGeneration;
     }
 
-    // Use an experimental kernel-timing model to select the best tileSizeQ.
-    selectTileSizeQForGqaGeneration(params, selectKernelParams);
+    // When maxSeqLenQ > 1, use an experimental kernel-timing model to select the best kernel that
+    // groups both tokensQ and headsQ into one CTA.
+    if (params.mMaxSeqLenQ > 1) {
+      selectTileSizeQForGqaGeneration(params, selectKernelParams);
+    }
   }
 
   // Select a kernel based on the heuristic.

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -701,6 +701,7 @@ def _test_trtllm_batch_prefill(
         )
         plan_params["q_data_type"] = q.dtype
         plan_params["kv_data_type"] = kv_cache.dtype
+        plan_params["o_data_type"] = DTYPE_MAP[o_dtype]
         wrapper_trtllm_gen.plan(**plan_params)
         output_wrapper = wrapper_trtllm_gen.run(
             q_input,
@@ -1160,6 +1161,7 @@ def _test_trtllm_batch_decode(
         )
         plan_params["q_data_type"] = q.dtype
         plan_params["kv_data_type"] = kv_cache.dtype
+        plan_params["o_data_type"] = DTYPE_MAP[o_dtype]
         wrapper_trtllm_gen.plan(**plan_params)
         output_wrapper = wrapper_trtllm_gen.run(
             q_input,
@@ -1249,7 +1251,7 @@ def _test_trtllm_batch_decode(
 @pytest.mark.parametrize("enable_pdl", [True, False, None])
 @pytest.mark.parametrize("enable_sink", [True, False])
 @pytest.mark.parametrize("max_in_kv_len", [110])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("non_contiguous_query", [False, True])
 @pytest.mark.parametrize("skips_softmax", [False, True])
 @pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
@@ -1721,8 +1723,8 @@ def make_query_non_contiguous(
         (4, 3, 64, 2, 1, 128),
         (4, 4, 64, 4, 1, 128),
         (4, 5, 64, 4, 8, 128),
-        # Iterate over head_dim 64, 128, 256 for these configs to simplify
-        *[(bs, 4, 64, 4, 16, hd) for bs in [4, 8, 16, 32] for hd in [64, 128, 256]],
+        # Iterate over head_dim 128, 256 for these configs to simplify
+        *[(bs, 4, 64, 4, 16, hd) for bs in [4, 8, 16, 32] for hd in [128, 256]],
         (128, 1, 64, 2, 5, 128),
         (128, 2, 32, 4, 1, 128),
         (128, 3, 16, 4, 8, 128),


### PR DESCRIPTION
- Update cubin artifact path/checksum to new build with nvfp4 output support
- Fix kernel selection: remove E2M1 output dtype condition from mixed-precision path, allowing nvfp4 output to use GQA generation kernel selection heuristics
- Always invoke selectTileSizeQForGqaGeneration (not just for maxSeqLenQ > 1)
- Add mUsesSharedPagedKvIdx field to KernelParams for vLLM/FlashInfer paged KV index
- Remove speculative-decode skip for nvfp4 output in tests
- Expand test coverage: head_dim [64, 128, 256], additional batch configs

AI-assisted

<!-- .github/pull_request_template.md -->

## 📌 Description

## Qwen3-480B (num_qo_heads=96, num_kv_heads=8, head_dim_qk=128, head_dim_vo=128)

### Speedup (baseline / opt)

| s_qo | bs=8  | bs=16 | bs=32 | bs=40 | bs=64 |
|------|-------|-------|-------|-------|-------|
| 2    | 1.23x | 1.32x | 1.26x | 1.15x | 1.28x |
| 4    | 2.21x | 2.49x | 2.16x | 1.89x | 1.93x |
| 8    | 3.41x | 3.32x | 3.00x | 2.81x | 2.94x |

---

## GPT-OSS (num_qo_heads=64, num_kv_heads=8, head_dim_qk=64, head_dim_vo=64)

### Speedup (baseline / opt)

| s_qo | bs=8  | bs=16 | bs=32 | bs=40 | bs=64 |
|------|-------|-------|-------|-------|-------|
| 2    | 1.65x | 1.78x | 1.77x | 1.52x | 1.62x |
| 4    | 2.50x | 2.65x | 2.41x | 2.06x | 2.41x |
| 8    | 4.79x | 5.05x | 5.12x | 4.45x | 4.98x |

---

## Summary

Speedup scales strongly with `s_qo` (speculative decode query length):

- At `s_qo=2`: **1.1–1.8x** speedup across both models
- At `s_qo=4`: **1.9–2.6x** speedup
- At `s_qo=8`: **2.8–5.1x** speedup (peak **5.12x** on GPT-OSS, bs=32)


## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/2632

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixed-precision/type gating and generation-kernel selection for attention, enhancing consistency in numeric handling and kernel choice.

* **Tests**
  * Expanded decode test coverage to head dimensions 64, 128, 256.
  * Removed prior data-type restrictions in speculative decoding tests for more complete validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->