### PR TITLE
[RFC]MXFP8 autotune IMA at some batch size

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1157,7 +1157,20 @@ def get_trtllm_moe_sm100_module():
                         )
                     elif self.fp8_quantization_type == Fp8QuantizationType.MxFp8:
                         current_hidden_states_scale = extra_inputs[0]
-
+                        # During autotuner profiling, DynamicTensorSpec
+                        # creates an undersized 1D scale tensor (it
+                        # replaces dim 0 with the bucket value, but the
+                        # MXFP8 scale is 1D with size num_tokens *
+                        # hidden_size // 32). Recreate with correct size
+                        # to avoid OOB reads in the MoE GEMM kernel.
+                        padded_k = (current_hidden_size + 31) // 32 * 32
+                        sf_size = current_num_tokens * padded_k // 32
+                        if current_hidden_states_scale.numel() < sf_size:
+                            current_hidden_states_scale = torch.ones(
+                                (sf_size,),
+                                dtype=torch.uint8,
+                                device=hidden_states.device,
+                            )
                     else:
                         raise ValueError(
                             f"Unsupported FP8 quantization type: {self.fp8_quantization_type}"
@@ -1734,7 +1747,7 @@ def get_trtllm_moe_sm100_module():
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp8_block_scale_moe",
             [moe_runner],
-            MoERunner.tuning_config_with_hidden_states_scales,  # FP8 block-scale uses hidden_states_scale
+            MoERunner.tuning_config_with_hidden_states_scales,
             inputs,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

We are running vLLM with MXFP8 and will get the below flashinfer autotune error with `max_batch_size=64`. However,  `max_batch_size=128` or `max_batch_size=256` is fine. We tried with `CUDA_LAUNCH_BLOCKING=1` however it's the same stacktrace.

The current PR could avoid the error and eval accuracy is fine. However we doubt if it's the correct fix as perf regressed. 

```
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,483 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...

(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,812 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [8, 10], due to failure while profiling: CUDA error: an illegal memory access was encountered

(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) Device-side assertion tracking was not enabled by user.

(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,813 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [8, 11], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,814 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [8, 14], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,814 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [8, 15], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,814 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [16, 10], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,815 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [16, 11], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,815 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [16, 14], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,815 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [16, 15], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,815 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [32, 10], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,816 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [32, 11], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,816 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [32, 14], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,816 - WARNING - autotuner.py:490 - flashinfer.jit: [Autotuner]: Skipping tactic <flashinfer.fused_moe.core.get_trtllm_moe_sm100_module.<locals>.MoERunner object at 0xffde1df4af30> [32, 15], due to failure while profiling: Error in function 'run' at <REDACTED_PATH>/trtllm_fused_moe_routing_renormalize.cu:463: Got CUDA error. See above for details.

(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) 2026-03-13 12:01:42,820 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends

(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] WorkerProc hit an exception.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] Traceback (most recent call last):
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/multiproc_executor.py", line 927, in worker_busy_loop
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     output = func(*args, **kwargs)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/gpu_worker.py", line 594, in compile_or_warm_up_model
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     kernel_warmup(self)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/kernel_warmup.py", line 46, in kernel_warmup
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     flashinfer_autotune(worker.model_runner)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/kernel_warmup.py", line 103, in flashinfer_autotune
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     runner._dummy_run(
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/_contextlib.py", line 124, in decorate_context
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     return func(*args, **kwargs)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/gpu_model_runner.py", line 5182, in _dummy_run
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     outputs = self.model(
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/cuda_graph.py", line 241, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     return self.runnable(*args, **kwargs)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/decorators.py", line 492, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     return TorchCompileWithNoGuardsWrapper.__call__(self, *args, **kwargs)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/wrapper.py", line 225, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     return self._call_with_optional_nvtx_range(
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/wrapper.py", line 119, in _call_with_optional_nvtx_range
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     return callable_fn(*args, **kwargs)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/model.py", line 975, in forward
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/eval_frame.py", line 1266, in _fn
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/output_graph.py", line 2587, in _tf_disabled_wrapper
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/caching.py", line 206, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/graph_module.py", line 949, in call_wrapped
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/graph_module.py", line 461, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/module.py", line 1778, in _wrapped_call_impl
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/module.py", line 1789, in _call_impl
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<eval_with_key>.74", line 459, in forward
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     submod_4 = self.submod_4(...);  ... = None

(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/cuda_graph.py", line 241, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/piecewise_backend.py", line 379, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/standalone_compile.py", line 122, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/eval_frame.py", line 1266, in _fn
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/aot_autograd.py", line 1210, in forward
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/runtime_wrappers.py", line 582, in runtime_wrapper
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/utils.py", line 138, in call_func_at_runtime_with_args
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/runtime_wrappers.py", line 2311, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/runtime_wrappers.py", line 785, in wrapper
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/runtime_wrappers.py", line 989, in inner_fn
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/output_code.py", line 673, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/utils.py", line 3439, in run
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/<torchinductor_generated>.py", line 1413, in call
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     buf12 = torch.ops.vllm.moe_forward.default(buf11, buf10, None, arg10_1)
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/_ops.py", line 871, in __call__
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/default_moe_runner.py", line 85, in _moe_forward
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/default_moe_runner.py", line 678, in forward_impl
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/mxfp8_moe_method.py", line 234, in apply_monolithic
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/moe_post_norm_fi_trtllm.py", line 348, in run_fi_trtllm_moe_mxfp8_with_post_norm
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/flashinfer_utils.py", line 424, in flashinfer_fused_moe_mxfp8_routed
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/flashinfer_utils.py", line 151, in flashinfer_trtllm_fp8_block_scale_routed_moe
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/core.py", line 2618, in trtllm_fp8_block_scale_routed_moe
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/core.py", line 1709, in trtllm_fp8_block_scale_moe_op
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/autotuner.py", line 469, in choose_one
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/autotuner.py", line 775, in _prepare_input_tensors
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/autotuner.py", line 764, in _create_tensor_like
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]   File "<REDACTED_PATH>/core.py", line 969, in <lambda>
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932]     lambda shapes, dtype, device: torch.randn(shapes, device=device).to(
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] Device-side assertion tracking was not enabled by user.
(Worker pid=4178717) (Worker_DP0_EP0 pid=4178717) ERROR 03-13 12:01:42 [multiproc_executor.py:932] Traceback (most recent call last):

```


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an out-of-bounds read issue in the FP8 quantization path that could impact inference stability and correctness during MoE model execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->