### PR TITLE
[fix] Bugfix 1367: fix VariableBlockSparseAttention buffer overflow by dynamically resizing kv_lens_buffer

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -998,7 +998,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
         if self._backend == "trtllm-gen":
             assert logits_soft_cap == 0.0
             self._max_kv_len = max(kv_lens_arr_host).item()
-            self._kv_lens_buffer[: len(kv_lens_arr_host)].copy_(
+            required_size = len(kv_lens_arr_host)
+            if required_size > self._kv_lens_buffer.shape[0]:
+                self._kv_lens_buffer = torch.empty(
+                    (required_size,), dtype=torch.int32, device=self.device
+                )
+            self._kv_lens_buffer[:required_size].copy_(
                 kv_lens_arr_host, non_blocking=non_blocking
             )
             if self._block_tables is None:

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1855,7 +1855,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 )
             else:
                 kv_lens_arr_host = seq_lens.cpu().flatten()
-            self._kv_lens_buffer[: len(kv_lens_arr_host)].copy_(
+            required_size = len(kv_lens_arr_host)
+            if required_size > self._kv_lens_buffer.shape[0]:
+                self._kv_lens_buffer = torch.empty(
+                    (required_size,), dtype=torch.int32, device=self.device
+                )
+            self._kv_lens_buffer[:required_size].copy_(
                 kv_lens_arr_host, non_blocking=non_blocking
             )
             self._max_kv_len = max(kv_lens_arr_host).item()

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -418,7 +418,12 @@ class BlockSparseAttentionWrapper:
             )
 
             kv_lens_arr_host = (kv_indptr_host[1:] - kv_indptr_host[:-1]) * self.C
-            self._kv_lens_buffer[: len(kv_lens_arr_host)].copy_(
+            required_size = len(kv_lens_arr_host)
+            if required_size > self._kv_lens_buffer.shape[0]:
+                self._kv_lens_buffer = torch.empty(
+                    (required_size,), dtype=torch.int32, device=self.device
+                )
+            self._kv_lens_buffer[:required_size].copy_(
                 kv_lens_arr_host,
             )
 
@@ -961,7 +966,12 @@ class VariableBlockSparseAttentionWrapper:
         self._cached_module = get_batch_prefill_module(self._backend, *get_module_args)
 
         kv_lens_arr_host = kv_indptr_host[1:] - kv_indptr_host[:-1]  # page_size == 1
-        self._kv_lens_buffer[: len(kv_lens_arr_host)].copy_(
+        required_size = len(kv_lens_arr_host)
+        if required_size > self._kv_lens_buffer.shape[0]:
+            self._kv_lens_buffer = torch.empty(
+                (required_size,), dtype=torch.int32, device=self.device
+            )
+        self._kv_lens_buffer[:required_size].copy_(
             kv_lens_arr_host,
         )
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
This PR fixes https://github.com/flashinfer-ai/flashinfer/issues/1367.

_kv_lens_buffer is statically allocated with a hardcoded size of 32768 in __init__. When len(kv_lens_arr_host) exceeds this limit (e.g., num_kv_heads * num_blocks_per_row = 48 * 768 = 36864 for variable block sparse attention), the copy_() call in plan() raises a RuntimeError due to shape mismatch.

The fix dynamically resizes _kv_lens_buffer in plan() when the required size exceeds the current buffer capacity. The initial allocation of 32768 is preserved to avoid unnecessary reallocation for common cases.
## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential buffer overflow in key-value length handling across decode, prefill, and sparse attention operations. The system now dynamically resizes internal buffers to safely accommodate variable-length data without overflow errors, improving robustness when processing larger sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->