### PR TITLE
Fix bmm_fp8 cublasLt handle usage in autotuned cublas runner  #26381

### DIFF
--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -17,11 +17,43 @@
 #include <driver_types.h>
 
 #include <flashinfer/gemm/bmm_fp8.cuh>
+#include <unordered_map>
 
 #include "tvm_ffi_utils.h"
 
+namespace {
+
+struct ThreadLocalCublasLtHandles {
+  ~ThreadLocalCublasLtHandles() {
+    // Best-effort cleanup during thread teardown.
+    for (auto& [_, handle] : handles) {
+      if (handle != nullptr) {
+        (void)cublasLtDestroy(handle);
+      }
+    }
+  }
+
+  std::unordered_map<int, cublasLtHandle_t> handles;
+};
+
+cublasLtHandle_t get_cublaslt_handle(int device_id) {
+  static thread_local ThreadLocalCublasLtHandles cache;
+
+  if (auto it = cache.handles.find(device_id); it != cache.handles.end()) {
+    return it->second;
+  }
+
+  ffi::CUDADeviceGuard device_guard(device_id);
+  cublasLtHandle_t handle = nullptr;
+  FLASHINFER_CUBLAS_CHECK(cublasLtCreate(&handle));
+  cache.handles.emplace(device_id, handle);
+  return handle;
+}
+
+}  // namespace
+
 void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, TensorView B_scale,
-             TensorView workspace_buffer, int64_t cublas_handle) {
+             TensorView workspace_buffer) {
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
@@ -44,9 +76,9 @@ void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, Tenso
         auto k = A.size(2);
         auto n = B.size(2);
 
-        auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
         ffi::CUDADeviceGuard device_guard(A.device().device_id);
         auto stream = get_stream(A.device());
+        auto lt_handle = get_cublaslt_handle(A.device().device_id);
 
         auto status = flashinfer::bmm_fp8::bmm_fp8_internal_cublaslt(
             workspace_buffer.data_ptr(), workspace_buffer.numel(),

--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -17,11 +17,43 @@
 #include <driver_types.h>
 
 #include <flashinfer/gemm/bmm_fp8.cuh>
+#include <unordered_map>
 
 #include "tvm_ffi_utils.h"
 
+namespace {
+
+struct ThreadLocalCublasLtHandles {
+  ~ThreadLocalCublasLtHandles() {
+    // Best-effort cleanup during thread teardown.
+    for (auto& [_, handle] : handles) {
+      if (handle != nullptr) {
+        (void)cublasLtDestroy(handle);
+      }
+    }
+  }
+
+  std::unordered_map<int, cublasLtHandle_t> handles;
+};
+
+cublasLtHandle_t get_cublaslt_handle(int device_id) {
+  static thread_local ThreadLocalCublasLtHandles cache;
+
+  if (auto it = cache.handles.find(device_id); it != cache.handles.end()) {
+    return it->second;
+  }
+
+  ffi::CUDADeviceGuard device_guard(device_id);
+  cublasLtHandle_t handle = nullptr;
+  FLASHINFER_CUBLAS_CHECK(cublasLtCreate(&handle));
+  cache.handles.emplace(device_id, handle);
+  return handle;
+}
+
+}  // namespace
+
 void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, TensorView B_scale,
-             TensorView workspace_buffer, int64_t cublas_handle) {
+             TensorView workspace_buffer) {
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
@@ -44,9 +76,9 @@ void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, Tenso
         auto k = A.size(2);
         auto n = B.size(2);
 
-        auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
         ffi::CUDADeviceGuard device_guard(A.device().device_id);
         auto stream = get_stream(A.device());
+        auto lt_handle = get_cublaslt_handle(A.device().device_id);
 
         auto status = flashinfer::bmm_fp8::bmm_fp8_internal_cublaslt(
             workspace_buffer.data_ptr(),
@@ -64,8 +96,7 @@ void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, Tenso
 }
 
 int64_t bmm_fp8_get_algos(TensorView A, TensorView B, TensorView D, TensorView A_scale,
-                          TensorView B_scale, TensorView workspace_buffer, int64_t cublas_handle,
-                          TensorView algo_buffer) {
+                          TensorView B_scale, TensorView workspace_buffer, TensorView algo_buffer) {
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
@@ -87,8 +118,8 @@ int64_t bmm_fp8_get_algos(TensorView A, TensorView B, TensorView D, TensorView A
         auto k = A.size(2);
         auto n = B.size(2);
 
-        auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
         ffi::CUDADeviceGuard device_guard(A.device().device_id);
+        auto lt_handle = get_cublaslt_handle(A.device().device_id);
 
         int max_algos = static_cast<int>(algo_buffer.numel() * get_element_size(algo_buffer) /
                                          flashinfer::bmm_fp8::kAlgoBytes);
@@ -105,8 +136,8 @@ int64_t bmm_fp8_get_algos(TensorView A, TensorView B, TensorView D, TensorView A
 }
 
 void bmm_fp8_run_with_algo(TensorView A, TensorView B, TensorView D, TensorView A_scale,
-                           TensorView B_scale, TensorView workspace_buffer, int64_t cublas_handle,
-                           TensorView algo_buffer, int64_t algo_idx) {
+                           TensorView B_scale, TensorView workspace_buffer, TensorView algo_buffer,
+                           int64_t algo_idx) {
   CHECK_CUDA(A);
   CHECK_CUDA(B);
   CHECK_CUDA(D);
@@ -132,9 +163,9 @@ void bmm_fp8_run_with_algo(TensorView A, TensorView B, TensorView D, TensorView 
         auto k = A.size(2);
         auto n = B.size(2);
 
-        auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
         ffi::CUDADeviceGuard device_guard(A.device().device_id);
         auto stream = get_stream(A.device());
+        auto lt_handle = get_cublaslt_handle(A.device().device_id);
 
         auto status = flashinfer::bmm_fp8::bmm_fp8_run_with_algo<b_type, a_type, d_type>(
             workspace_buffer.data_ptr(),

--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -23,16 +23,10 @@
 
 namespace {
 
+// Handles are deliberately never destroyed. A thread_local destructor on the
+// main thread may run after CUDA teardown has started, making cublasLtDestroy
+// unsafe. This follows PyTorch's handle-pool convention.
 struct ThreadLocalCublasLtHandles {
-  ~ThreadLocalCublasLtHandles() {
-    // Best-effort cleanup during thread teardown.
-    for (auto& [_, handle] : handles) {
-      if (handle != nullptr) {
-        (void)cublasLtDestroy(handle);
-      }
-    }
-  }
-
   std::unordered_map<int, cublasLtHandle_t> handles;
 };
 

--- a/csrc/flashinfer_gemm_binding.cu
+++ b/csrc/flashinfer_gemm_binding.cu
@@ -17,7 +17,7 @@
 #include "tvm_ffi_utils.h"
 
 void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, TensorView B_scale,
-             TensorView workspace_buffer, int64_t cublas_handle);
+             TensorView workspace_buffer);
 
 void CutlassSegmentGEMM(TensorView workspace_buffer, TensorView all_problems, TensorView x_ptr,
                         TensorView w_ptr, TensorView y_ptr, TensorView x_ld, TensorView w_ld,

--- a/csrc/flashinfer_gemm_binding.cu
+++ b/csrc/flashinfer_gemm_binding.cu
@@ -17,15 +17,14 @@
 #include "tvm_ffi_utils.h"
 
 void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, TensorView B_scale,
-             TensorView workspace_buffer, int64_t cublas_handle);
+             TensorView workspace_buffer);
 
 int64_t bmm_fp8_get_algos(TensorView A, TensorView B, TensorView D, TensorView A_scale,
-                          TensorView B_scale, TensorView workspace_buffer, int64_t cublas_handle,
-                          TensorView algo_buffer);
+                          TensorView B_scale, TensorView workspace_buffer, TensorView algo_buffer);
 
 void bmm_fp8_run_with_algo(TensorView A, TensorView B, TensorView D, TensorView A_scale,
-                           TensorView B_scale, TensorView workspace_buffer, int64_t cublas_handle,
-                           TensorView algo_buffer, int64_t algo_idx);
+                           TensorView B_scale, TensorView workspace_buffer, TensorView algo_buffer,
+                           int64_t algo_idx);
 
 void CutlassSegmentGEMM(TensorView workspace_buffer, TensorView all_problems, TensorView x_ptr,
                         TensorView w_ptr, TensorView y_ptr, TensorView x_ld, TensorView w_ld,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -125,11 +125,8 @@ def get_gemm_module():
                 do_preparation: bool = False,
                 **kwargs,
             ) -> torch.Tensor:
-                cublas_handle = torch.cuda.current_blas_handle()
                 a, b, scale_a, scale_b, out, workspace_buffer = inputs
-                module.bmm_fp8(
-                    a, b, out, scale_a, scale_b, workspace_buffer, cublas_handle
-                )
+                module.bmm_fp8(a, b, out, scale_a, scale_b, workspace_buffer)
                 return out
 
         return CublasFp8GemmRunner()

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -236,8 +236,6 @@ def get_gemm_module():
                     dtype=torch.uint8,
                     device="cpu",
                 )
-                with torch.cuda.device(a.device):
-                    cublas_handle = torch.cuda.current_blas_handle()
                 count = module.bmm_fp8_get_algos(
                     a,
                     b,
@@ -245,7 +243,6 @@ def get_gemm_module():
                     scale_a,
                     scale_b,
                     workspace_buffer,
-                    cublas_handle,
                     algo_buf,
                 )
                 result = (algo_buf, count)
@@ -268,8 +265,6 @@ def get_gemm_module():
                 **kwargs,
             ) -> torch.Tensor:
                 a, b, scale_a, scale_b, out, workspace_buffer = inputs
-                with torch.cuda.device(a.device):
-                    cublas_handle = torch.cuda.current_blas_handle()
                 # The cuBLASLt algo list is enumerated per-shape, so a tactic
                 # tuned at a different (bucketed) M may be out of range here.
                 # Fall back to the heuristic default (the tactic==-1 path) on an
@@ -284,14 +279,11 @@ def get_gemm_module():
                             scale_a,
                             scale_b,
                             workspace_buffer,
-                            cublas_handle,
                             algo_buf,
                             tactic,
                         )
                         return out
-                module.bmm_fp8(
-                    a, b, out, scale_a, scale_b, workspace_buffer, cublas_handle
-                )
+                module.bmm_fp8(a, b, out, scale_a, scale_b, workspace_buffer)
                 return out
 
         return CublasFp8GemmRunner()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues
 https://github.com/vllm-project/vllm/issues/26381
Root cause:
torch.cuda.current_blas_handle() returns cublasHandle_t, but bmm_fp8 reinterpreted it as cublasLtHandle_t before calling cublasLt APIs. This can fail in autotune/profiling paths on Blackwell.
<!-- Link any related issues here -->
on vllm side 
before: https://paste.ubuntu.com/p/npS2tkZY2c/
after : https://paste.ubuntu.com/p/c6Ys69PqvR/

and :  
```
 CUDA_VISIBLE_DEVICES=4,5,6,7 \
VLLM_DISABLE_COMPILE_CACHE=1 \
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
python examples/basic/offline_inference/generate.py \
  --model redhatai/meta-Llama-3.1-8B-FP8 \
  --tensor-parallel-size 4 \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-tokens 32 \
  --temperature 0
```
:https://paste.ubuntu.com/p/rPYcXQSwPC/


<img width="1115" height="510" alt="image" src="https://github.com/user-attachments/assets/ee05e9d9-fa6a-4ea4-bd89-082df63828a7" />

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor

* Simplified FP8 batch matrix multiplication interfaces by removing the need to provide an external cuBLAS handle.
* Improved FP8 GEMM execution by automatically managing and reusing cuBLAS resources for each GPU device.
* Updated FP8 algorithm selection and execution workflows to use this internal resource management consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->