### PR TITLE
[do not merge] fmhav2 hang

### DIFF
--- a/csrc/fmha_v2/fmha/warpspec/dma.h
+++ b/csrc/fmha_v2/fmha/warpspec/dma.h
@@ -213,7 +213,8 @@ struct DMA {
 
         // The cumulative packed_mask seqlens.
         // Each sequence length in the batch has to be padded to multiple of 128.
-        int sum_mask_s = params.cu_mask_rows[bidb];
+        // cu_mask_rows is NULL when not using a custom mask; guard to avoid illegal access.
+        int sum_mask_s = params.cu_mask_rows ? params.cu_mask_rows[bidb] : 0;
 
         if (SCHEDULING_MODE == 0) {
           // split work across M
@@ -357,7 +358,8 @@ struct DMA {
 
         // The cumulative packed_mask seqlens.
         // Each sequence length in the batch has to be padded to multiple of 128.
-        int sum_mask_s = params.cu_mask_rows[bidb];
+        // cu_mask_rows is NULL when not using a custom mask; guard to avoid illegal access.
+        int sum_mask_s = params.cu_mask_rows ? params.cu_mask_rows[bidb] : 0;
 
         // Prepare the tma descriptors.
         cudaTmaDesc const* desc_q = &params.tma_desc_q;

--- a/csrc/fmha_v2/fmha/warpspec/dma.h
+++ b/csrc/fmha_v2/fmha/warpspec/dma.h
@@ -613,6 +613,7 @@ struct DMA {
 
       // Dst buffer available
       int v_barrier_id = cbw_v.threadReserve();
+      named_barrier_wait(SYNC_BARRIER, NUM_THREADS_IN_DMA_GROUP);
       uint32_t smem_v_dst = __cvta_generic_to_shared(&shared->smem_v[v_barrier_id * TILE_SIZE_V]);
 
 // Explicitly transpose the v buffer in smem for fp8.

--- a/csrc/fmha_v2/fmha/warpspec/dma.h
+++ b/csrc/fmha_v2/fmha/warpspec/dma.h
@@ -99,7 +99,7 @@ struct DMA {
   static_assert(STEP_KV % K_ == 0);
   using Transposer =
       Transposer<typename Kernel_traits::Traits_o, typename Kernel_traits::Cta_tile_o, K_,
-                 (STEP_KV > 128 || SLIDING_OR_CHUNKED_ATTENTION) ? 1 : 2 /* UNROLL */>;
+                 (STEP_KV >= 128 || SLIDING_OR_CHUNKED_ATTENTION) ? 1 : 2 /* UNROLL */>;
 
   struct Device {
     // Only the warpgroup leader initiates mbarriers & TMA operations.

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -41,9 +41,11 @@ from .jit.attention import (
     gen_batch_prefill_module,
     gen_cudnn_fmha_module,
     gen_fmha_cutlass_sm100a_module,
+    gen_fmha_v2_module,
     gen_single_decode_module,
     gen_single_prefill_module,
     gen_trtllm_gen_fmha_module,
+    gen_trtllm_fmha_v2_sm120_module,
 )
 from .jit.cascade import gen_cascade_module
 from .jit.cpp_ext import get_cuda_version
@@ -206,6 +208,7 @@ def gen_attention(
     has_sm100: bool,
     add_gemma: bool,
     add_oai_oss: bool,
+    has_sm120: bool = False,
 ) -> Iterator[JitSpec]:
     head_dim_ckv = 512
     head_dim_kpe = 64
@@ -366,6 +369,28 @@ def gen_attention(
     if has_sm100:
         yield gen_mla_module()
 
+    # TRT-LLM FMHAv2 (SM90 and SM12x)
+    if has_sm90 or has_sm120:
+        fmha_v2_input_layouts = [
+            "packed_qkv",
+            "contiguous_q_kv",
+            "q_paged_kv_hnd",
+            "q_paged_kv_nhd",
+            "separate_q_k_v",
+        ]
+        for input_layout in fmha_v2_input_layouts:
+            for dtype in f16_dtype_:
+                yield gen_fmha_v2_module(input_layout, dtype)
+            # FP8 with fp16/bf16 output (not supported for separate_q_k_v)
+            if input_layout != "separate_q_k_v":
+                for f8_dtype in f8_dtype_:
+                    for o_dtype in f16_dtype_:
+                        yield gen_fmha_v2_module(input_layout, f8_dtype, o_dtype)
+
+    # TRT-LLM FMHAv2 SM120 (DeepSeek MLA prefill)
+    if has_sm120:
+        yield gen_trtllm_fmha_v2_sm120_module()
+
 
 def gen_xqa(
     input_type_: List[torch.dtype],
@@ -470,6 +495,7 @@ def gen_all_modules(
             has_sm100,
             add_gemma,
             add_oai_oss,
+            has_sm120=has_sm120 or has_sm121,
         )
     )
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4175,16 +4175,6 @@ def trtllm_fmha_v2_prefill(
                 "FP8 (e4m3) is not yet supported for FMHAv2 on SM120 (Blackwell). "
                 "Use fp16 or bf16 instead."
             )
-        if uses_sliding_window and input_layout in ("PACKED_QKV", "CONTIGUOUS_Q_KV"):
-            _num_kv_heads = (
-                num_qo_heads if input_layout == "PACKED_QKV" else k_cache.shape[2]
-            )
-            if batch_size == 16 and _num_kv_heads == 4 and head_dim_v == 256:
-                raise ValueError(
-                    "FP8 (e4m3) sliding window attention with batch_size=16, "
-                    "num_kv_heads=4, head_dim=256 is not supported for "
-                    f"{input_layout} layout due to a known issue."
-                )
     scale_softmax = 1.0 if is_e4m3 else 1.0
     softcapping_scale = (
         logits_soft_cap_scale if logits_soft_cap_scale is not None else 0.0

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -3,9 +3,9 @@ import torch
 import math
 from typing import Optional, Tuple, Union
 
-pytestmark = pytest.mark.skip(
-    reason="todo(jimmyzho): temporarily skip this test due to hangs"
-)
+# pytestmark = pytest.mark.skip(
+#     reason="todo(jimmyzho): temporarily skip this test due to hangs"
+# )
 
 import flashinfer
 from flashinfer.prefill import fmha_v2_prefill_deepseek

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -3,17 +3,62 @@ import torch
 import math
 from typing import Optional, Tuple, Union
 
-# pytestmark = pytest.mark.skip(
-#     reason="todo(jimmyzho): temporarily skip this test due to hangs"
-# )
-
 import flashinfer
 from flashinfer.prefill import fmha_v2_prefill_deepseek
 from tests.utils_fp8 import to_float8
-from flashinfer.utils import is_sm12x_supported, is_sm120a_supported
+from flashinfer.jit import build_jit_specs
+from flashinfer.jit.attention import gen_fmha_v2_module, gen_trtllm_fmha_v2_sm120_module
+from flashinfer.utils import (
+    has_flashinfer_jit_cache,
+    is_sm12x_supported,
+    is_sm90a_supported,
+    is_sm120a_supported,
+)
 
 _WORKSPACE_BUFFER_SIZE = 128 * 1024 * 1024
 _workspace_buffer: Optional[torch.Tensor] = None
+
+
+@pytest.fixture(
+    autouse=not has_flashinfer_jit_cache(),
+    scope="module",
+)
+def warmup_jit():
+    try:
+        modules = []
+        device = torch.device("cuda")
+        has_sm90 = is_sm90a_supported(device)
+        has_sm120 = is_sm120a_supported(device)
+
+        if has_sm90 or has_sm120:
+            input_layouts = [
+                "packed_qkv",
+                "contiguous_q_kv",
+                "q_paged_kv_hnd",
+                "q_paged_kv_nhd",
+                "separate_q_k_v",
+            ]
+            f16_dtypes = [torch.float16, torch.bfloat16]
+
+            for layout in input_layouts:
+                for dtype in f16_dtypes:
+                    modules.append(gen_fmha_v2_module(layout, dtype))
+                # FP8 with various output dtypes (not supported for separate_q_k_v)
+                if layout != "separate_q_k_v":
+                    for o_dtype in [torch.float8_e4m3fn] + f16_dtypes:
+                        modules.append(
+                            gen_fmha_v2_module(layout, torch.float8_e4m3fn, o_dtype)
+                        )
+
+        if has_sm120:
+            modules.append(gen_trtllm_fmha_v2_sm120_module())
+
+        build_jit_specs(modules, verbose=False)
+    except Exception as e:
+        # abort the test session if warmup fails
+        pytest.exit(str(e))
+    finally:
+        yield
 
 
 def _get_workspace_buffer() -> torch.Tensor:
@@ -832,19 +877,19 @@ def test_trtllm_fmha_v2_prefill(
     save_softmax_stats: bool,
 ) -> None:
     # skip bs=16, q_heads=4, kv_heads=4, head_dim=256, dtype=float8_e4m3fn if packed/contiguous and sliding window due to bug
-    if (
-        batch_size == 16
-        and num_kv_heads == 4
-        and head_dim == 256
-        and dtype == torch.float8_e4m3fn
-        and input_layout in ["PACKED_QKV", "CONTIGUOUS_Q_KV"]
-        and mask_mode == "SLIDING_WINDOW"
-    ):
-        pytest.skip("Skip due to bug in fp8 sliding window")
-    if mask_mode == "SLIDING_WINDOW":
-        pytest.skip("todo(jimmyzho): temporarily skip sliding window test due to hang")
-    if dtype == torch.float8_e4m3fn:
-        pytest.skip("todo(jimmyzho): temporarily skip fp8 tests due to hang")
+    # if (
+    #     batch_size == 16
+    #     and num_kv_heads == 4
+    #     and head_dim == 256
+    #     and dtype == torch.float8_e4m3fn
+    #     and input_layout in ["PACKED_QKV", "CONTIGUOUS_Q_KV"]
+    #     and mask_mode == "SLIDING_WINDOW"
+    # ):
+    #     pytest.skip("Skip due to bug in fp8 sliding window")
+    # if mask_mode == "SLIDING_WINDOW":
+    #     pytest.skip("todo(jimmyzho): temporarily skip sliding window test due to hang")
+    # if dtype == torch.float8_e4m3fn:
+    #     pytest.skip("todo(jimmyzho): temporarily skip fp8 tests due to hang")
     run_trtllm_fmha_v2_prefill_case(
         input_layout=input_layout,
         batch_size=batch_size,

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -843,7 +843,7 @@ def test_trtllm_fmha_v2_prefill(
         pytest.skip("Skip due to bug in fp8 sliding window")
     if mask_mode == "SLIDING_WINDOW":
         pytest.skip("todo(jimmyzho): temporarily skip sliding window test due to hang")
-    if dtype == torch.float8_e4m3fn and o_dtype == torch.float8_e4m3fn:
+    if dtype == torch.float8_e4m3fn:
         pytest.skip("todo(jimmyzho): temporarily skip fp8 tests due to hang")
     run_trtllm_fmha_v2_prefill_case(
         input_layout=input_layout,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader generation of attention kernel variants, including expanded SM120 support and additional FP8/FP16 output combinations.

* **Tests**
  * Re-enabled previously skipped attention tests and added a module-level warmup that prebuilds variants to fail fast on unsupported configs.

* **Bug Fixes**
  * Tuned attention transposition/unrolling behavior and added safety checks and synchronization to improve stability for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->