### PR TITLE
[fix] Fix TRTLLM MOE autotuner token bucket mismatch error

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1299,11 +1299,7 @@ def get_trtllm_moe_sm100_module():
                 num_local_experts,
                 tune_max_num_tokens,
             )
-            bucket_mapper = make_trtllm_moe_bucket_mapper(
-                top_k,
-                num_local_experts,
-                tune_max_num_tokens,
-            )
+            bucket_mapper = make_trtllm_moe_bucket_mapper(buckets)
             cls.tuning_config_with_hidden_states_scales = TuningConfig(
                 dynamic_tensor_specs=(
                     DynamicTensorSpec(

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -52,7 +52,9 @@ from ..utils import (
 )
 from .utils import (
     get_last_power_of_2_num_tokens_buckets,
+    get_trtllm_moe_num_tokens_buckets,
     last_positive_power_of_2,
+    make_trtllm_moe_bucket_mapper,
 )
 
 
@@ -1285,14 +1287,30 @@ def get_trtllm_moe_sm100_module():
 
         @classmethod
         @functools.lru_cache(maxsize=None)
-        def refine_tuning_config(cls, tune_max_num_tokens: int, **kwargs):
+        def refine_tuning_config(
+            cls,
+            tune_max_num_tokens: int,
+            top_k: int = 1,
+            num_local_experts: int = 1,
+            **kwargs,
+        ):
+            buckets = get_trtllm_moe_num_tokens_buckets(
+                top_k,
+                num_local_experts,
+                tune_max_num_tokens,
+            )
+            bucket_mapper = make_trtllm_moe_bucket_mapper(
+                top_k,
+                num_local_experts,
+                tune_max_num_tokens,
+            )
             cls.tuning_config_with_hidden_states_scales = TuningConfig(
                 dynamic_tensor_specs=(
                     DynamicTensorSpec(
                         (0, 1, 2, 3, 4, 5),
                         (0, 0, 0, 0, 0, 0),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        buckets,
+                        bucket_mapper,
                         cls.dynamic_tensor_initializers,
                     ),
                 ),
@@ -1303,8 +1321,8 @@ def get_trtllm_moe_sm100_module():
                     DynamicTensorSpec(
                         (0, 1, 2, 3, 4),
                         (0, 0, 0, 0, 0),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        buckets,
+                        bucket_mapper,
                         cls.dynamic_tensor_initializers[:5],
                     ),
                 ),
@@ -1346,7 +1364,11 @@ def get_trtllm_moe_sm100_module():
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
+        MoERunner.refine_tuning_config(
+            tune_max_num_tokens,
+            top_k=top_k,
+            num_local_experts=local_num_experts,
+        )
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1505,7 +1527,11 @@ def get_trtllm_moe_sm100_module():
             enable_pdl = device_support_pdl(hidden_states.device)
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
+        MoERunner.refine_tuning_config(
+            tune_max_num_tokens,
+            top_k=top_k,
+            num_local_experts=local_num_experts,
+        )
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1673,7 +1699,11 @@ def get_trtllm_moe_sm100_module():
 
         # Use AutoTuner to select the best tactic - follow FP4 pattern exactly
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
+        MoERunner.refine_tuning_config(
+            tune_max_num_tokens,
+            top_k=top_k,
+            num_local_experts=local_num_experts,
+        )
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1912,7 +1942,11 @@ def get_trtllm_moe_sm100_module():
 
         tuner = AutoTuner.get()
         MoERunner.refine_tuning_config(
-            tune_max_num_tokens, use_cold_l2_cache=True, use_cuda_graph=True
+            tune_max_num_tokens,
+            top_k=top_k,
+            num_local_experts=num_local_experts,
+            use_cold_l2_cache=True,
+            use_cuda_graph=True,
         )
         dtype_act = deduce_trtllm_gen_tensor_dtype(hidden_states, hidden_states_scale)
         dtype_weights = deduce_trtllm_gen_tensor_dtype(
@@ -2113,7 +2147,11 @@ def get_trtllm_moe_sm100_module():
             )
 
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
+        MoERunner.refine_tuning_config(
+            tune_max_num_tokens,
+            top_k=top_k,
+            num_local_experts=num_local_experts,
+        )
         dtype_act = DtypeTrtllmGen.Bfloat16
         dtype_weights = DtypeTrtllmGen.MxInt4
         moe_runner = MoERunner(

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import math
 import threading
 from dataclasses import dataclass
 from enum import Enum
@@ -7,6 +8,9 @@ from typing import Dict, List, Tuple
 import torch
 
 from ..utils import ceil_div, round_up
+
+TRTLLM_MOE_MIN_TILE_N = 8
+TRTLLM_MOE_MAX_TILE_N = 256
 
 is_torch_compiling_flag = False
 
@@ -213,6 +217,64 @@ def get_last_power_of_2_num_tokens_buckets(
         num_token_buckets.append(m)
         m //= 2
     return tuple(num_token_buckets)
+
+
+def get_trtllm_moe_num_tokens_buckets(
+    top_k: int,
+    num_local_experts: int,
+    tune_max_num_tokens: int,
+) -> Tuple[int, ...]:
+    """Generate autotuner buckets aligned with C++ tile selection."""
+
+    def geo_range(start, stop_pred, step_fn):
+        result = []
+        n = start
+        while stop_pred(n):
+            result.append(n)
+            n = step_fn(n)
+        return result
+
+    # Mirror C++ computeSelectedTileN: ceil(avg_tokens_per_expert) → next_pow2 → clamp
+    avg = tune_max_num_tokens * top_k / num_local_experts
+    max_tile = max(
+        TRTLLM_MOE_MIN_TILE_N,
+        min(
+            next_positive_power_of_2(max(1, math.ceil(avg))),
+            TRTLLM_MOE_MAX_TILE_N,
+        ),
+    )
+    tile_reps = [
+        max(1, tile * num_local_experts // top_k)
+        for tile in geo_range(
+            TRTLLM_MOE_MIN_TILE_N, lambda t: t <= max_tile, lambda t: t * 2
+        )
+    ]
+
+    above = geo_range(
+        tile_reps[-1] * 2, lambda n: n <= tune_max_num_tokens, lambda n: n * 2
+    )
+    below = geo_range(tile_reps[0] // 2, lambda n: n >= 1, lambda n: n // 2)
+
+    return tuple(sorted(set(tile_reps + above + below)))
+
+
+def make_trtllm_moe_bucket_mapper(
+    top_k: int,
+    num_local_experts: int,
+    tune_max_num_tokens: int,
+):
+    """Create a map_to_tuning_buckets function aligned with C++ computeSelectedTileN."""
+    import bisect
+
+    buckets = get_trtllm_moe_num_tokens_buckets(
+        top_k, num_local_experts, tune_max_num_tokens
+    )
+
+    def _map(num_tokens: int) -> int:
+        idx = bisect.bisect_right(buckets, num_tokens) - 1
+        return buckets[max(0, idx)]
+
+    return _map
 
 
 def get_fp4_shape(input_shape, sf_vec_size, is_swizzled_layout=True):

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -1,3 +1,4 @@
+import bisect
 import contextlib
 import math
 import threading
@@ -258,21 +259,17 @@ def get_trtllm_moe_num_tokens_buckets(
     return tuple(sorted(set(tile_reps + above + below)))
 
 
-def make_trtllm_moe_bucket_mapper(
-    top_k: int,
-    num_local_experts: int,
-    tune_max_num_tokens: int,
-):
-    """Create a map_to_tuning_buckets function aligned with C++ computeSelectedTileN."""
-    import bisect
+def make_trtllm_moe_bucket_mapper(buckets: Tuple[int, ...]):
+    """Create a map_to_tuning_buckets function aligned with C++ computeSelectedTileN.
 
-    buckets = get_trtllm_moe_num_tokens_buckets(
-        top_k, num_local_experts, tune_max_num_tokens
-    )
+    Accepts the pre-computed bucket tuple from get_trtllm_moe_num_tokens_buckets.
+    Uses bisect to find the largest bucket <= num_tokens.
+    """
+    sorted_buckets = tuple(sorted(buckets))
 
     def _map(num_tokens: int) -> int:
-        idx = bisect.bisect_right(buckets, num_tokens) - 1
-        return buckets[max(0, idx)]
+        idx = bisect.bisect_right(sorted_buckets, num_tokens) - 1
+        return sorted_buckets[max(0, idx)]
 
     return _map
 

--- a/tests/autotuner/test_autotuner_tile_mismatch.py
+++ b/tests/autotuner/test_autotuner_tile_mismatch.py
@@ -1,0 +1,436 @@
+"""
+Regression test for the tile_N mismatch bug (RuntimeError: unordered_map::at).
+
+The bug is in the C++ MoE kernel launcher (trtllm_fused_moe_kernel_launcher.cu).
+During autotuning, the Python autotuner profiles kernels using bucketed
+num_tokens (e.g. 256) and caches the best tactic [tile_N, config].
+During inference, the C++ launcher calls computeSelectedTileN with the
+*actual* num_tokens (e.g. 500) to build launchers_map — a subset of
+supported tile sizes. When the actual num_tokens differs from the
+bucketed value, computeSelectedTileN can produce a different tile subset,
+and the cached tile_N may not exist in launchers_map, causing
+launchers_map.at(tile_N) to throw.
+
+The C++ fix adds a fallback when the cached tile_N is missing:
+  if (launchers_map.find(tile_N) == launchers_map.end()) { fallback }
+
+The fix to _find_nearest_profile (propagating the bucketed value to all
+linked dimensions) is what exposed this latent C++ bug. Before that fix,
+only the first linked dimension was bucketed during inference, so the
+profile key never matched the tuning-time key — the autotuner always
+returned the fallback tactic (-1) and the C++ fallback path was taken.
+After the fix, cache hits occur and the cached tile_N reaches the C++
+launcher, where the missing guard causes the crash. Both fixes are needed:
+the Python fix makes the autotuner cache work correctly for MoE, and the
+C++ fix makes the launcher handle tile_N mismatches gracefully.
+"""
+
+import math
+
+import pytest
+import torch
+
+from flashinfer import autotune
+from flashinfer.autotuner import (
+    AutoTuner,
+    DynamicTensorSpec,
+    TuningConfig,
+    TunableRunner,
+)
+from flashinfer.fused_moe.utils import (
+    get_last_power_of_2_num_tokens_buckets,
+    last_positive_power_of_2,
+)
+from flashinfer.utils import get_compute_capability
+
+
+# ---------------------------------------------------------------------------
+# Helper: Python mirror of C++ computeSelectedTileN
+# (csrc/trtllm_fused_moe_kernel_launcher.cu, lines 85-107)
+# ---------------------------------------------------------------------------
+def _next_power_of_two(n: float) -> int:
+    if n <= 1:
+        return 1
+    return 1 << math.ceil(math.log2(n))
+
+
+def compute_selected_tile_n(
+    supported_tiles: list[int],
+    num_tokens: int,
+    top_k: int,
+    num_local_experts: int,
+) -> set[int]:
+    """Python equivalent of C++ computeSelectedTileN."""
+    avg = num_tokens * top_k / num_local_experts
+    tile = max(supported_tiles[0], min(supported_tiles[-1], _next_power_of_two(avg)))
+    try:
+        idx = supported_tiles.index(tile)
+    except ValueError:
+        # tile not in supported_tiles, find closest
+        idx = min(
+            range(len(supported_tiles)),
+            key=lambda i: abs(supported_tiles[i] - tile),
+        )
+    selected = {supported_tiles[idx]}
+    if idx + 1 < len(supported_tiles):
+        selected.add(supported_tiles[idx + 1])
+    if idx + 2 < len(supported_tiles):
+        selected.add(supported_tiles[idx + 2])
+    if idx > 0:
+        selected.add(supported_tiles[idx - 1])
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# TileAwareDummyRunner: returns different valid tactics depending on shapes
+# ---------------------------------------------------------------------------
+class TileAwareDummyRunner(TunableRunner):
+    """Runner whose valid tactics depend on input num_tokens, mimicking
+    the real trtllm-gen MoE runner where computeSelectedTileN filters tiles.
+
+    Each tactic is a list [tile_N, config_idx] matching the real MoE convention.
+    """
+
+    SUPPORTED_TILES = [8, 16, 32, 64]  # FP4 base tiles (no 128/256 for bf16 act)
+
+    def __init__(self, top_k: int = 8, num_local_experts: int = 64):
+        self.top_k = top_k
+        self.num_local_experts = num_local_experts
+
+    def get_valid_tactics(self, inputs, profile):
+        num_tokens = inputs[0].shape[0]
+        selected = compute_selected_tile_n(
+            self.SUPPORTED_TILES, num_tokens, self.top_k, self.num_local_experts
+        )
+        tactics = []
+        for tile in sorted(selected):
+            for cfg in range(2):  # 2 configs per tile
+                tactics.append([tile, cfg])
+        return tactics
+
+    def forward(self, inputs, tactic=-1, do_preparation=False, **kwargs):
+        return inputs[0]
+
+
+# ---------------------------------------------------------------------------
+# Shared MoE-like tuning config (mirrors the real one)
+# ---------------------------------------------------------------------------
+TUNE_MAX = 4096
+
+MOE_TUNING_CONFIG = TuningConfig(
+    dynamic_tensor_specs=(
+        DynamicTensorSpec(
+            input_idx=(0,),
+            dim_idx=(0,),
+            gen_tuning_buckets=get_last_power_of_2_num_tokens_buckets(TUNE_MAX, 1),
+            map_to_tuning_buckets=lambda x: min(last_positive_power_of_2(x), TUNE_MAX),
+        ),
+    ),
+)
+
+
+def _reset_autotuner() -> AutoTuner:
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    tuner.reset_statistics()
+    tuner.is_tuning_mode = False
+    return tuner
+
+
+# ===================================================================
+# Tests
+# ===================================================================
+
+
+def test_tile_set_differs_between_bucketed_and_actual_num_tokens():
+    """Prove that computeSelectedTileN can return different tile sets
+    for the bucketed num_tokens vs. the actual num_tokens that maps to
+    the same autotuner bucket.
+
+    This is the precondition for the unordered_map::at crash.
+    """
+    top_k = 8
+    num_experts = 64
+
+    # With the base SUPPORTED_TILES=[8,16,32,64] and top_k=8, num_experts=64,
+    # both bucketed=1024 and actual=1624 clamp to max tile 64, so the sets match.
+    # Use a wider tile range that DOES produce a mismatch:
+    tiles_small = [8, 16, 32, 64, 128]
+    actual = 500
+    bucket = last_positive_power_of_2(actual)  # 256
+    assert bucket == 256
+
+    tiles_bucket = compute_selected_tile_n(tiles_small, bucket, top_k, num_experts)
+    tiles_actual = compute_selected_tile_n(tiles_small, actual, top_k, num_experts)
+
+    # bucket=256: avg=256*8/64=32, nextPow2=32 → idx=2, selected={16,32,64,128}
+    # actual=500: avg=500*8/64=62.5, nextPow2=64 → idx=3, selected={32,64,128}
+    assert tiles_bucket != tiles_actual, (
+        f"Expected tile sets to differ for bucket={bucket} vs actual={actual}, "
+        f"got {tiles_bucket} vs {tiles_actual}"
+    )
+
+    # A tile_N valid for the bucket may not be valid for the actual
+    only_in_bucket = tiles_bucket - tiles_actual
+    assert len(only_in_bucket) > 0, (
+        "Expected at least one tile valid for bucketed but not for actual shapes"
+    )
+
+
+def test_autotuner_returns_cached_tactic_for_different_actual_shape(monkeypatch):
+    """The autotuner returns a cached tactic when num_tokens differs from
+    the tuning shape but maps to the same bucket.
+
+    Before the C++ fix, if the cached tile_N was not in
+    computeSelectedTileN(actual_num_tokens), this caused
+    RuntimeError: unordered_map::at.
+    """
+    tuner = _reset_autotuner()
+    runner = TileAwareDummyRunner(top_k=8, num_local_experts=64)
+    hidden_size = 256
+
+    def fake_profile(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
+        # Make the tactic with tile_N=16 the "best" (lowest time)
+        tile_n = tactic[0] if isinstance(tactic, list) else -1
+        return 1.0 if tile_n == 16 else 5.0
+
+    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", fake_profile)
+
+    # --- Phase 1: Tune with bucketed num_tokens ---
+    # The autotuner generates profiles for all buckets.
+    # For bucket=256, avg=256*8/64=32, tiles include {16,32,64,...},
+    # so tile_N=16 is valid and will be selected as best.
+    tune_inputs = [torch.empty((256, hidden_size), dtype=torch.float32)]
+    with autotune(tune_mode=True):
+        _, tuned_tactic = tuner.choose_one(
+            "test_tile_mismatch", [runner], MOE_TUNING_CONFIG, tune_inputs
+        )
+
+    assert isinstance(tuned_tactic, list)
+    assert tuned_tactic[0] == 16, f"Expected tile_N=16, got {tuned_tactic}"
+
+    # --- Phase 2: Inference with different actual num_tokens ---
+    # actual=500 maps to bucket=256 (same bucket) so we get a cache hit.
+    infer_inputs = [torch.empty((500, hidden_size), dtype=torch.float32)]
+    _, infer_tactic = tuner.choose_one(
+        "test_tile_mismatch", [runner], MOE_TUNING_CONFIG, infer_inputs
+    )
+
+    # The autotuner returns the CACHED tactic from tuning (tile_N=16).
+    assert infer_tactic == tuned_tactic, "Expected cache hit returning the tuned tactic"
+
+    # --- Verify the mismatch ---
+    # For actual=500: avg=500*8/64=62.5, nextPow2=64, tiles={32,64,128}
+    # tile_N=16 is NOT in this set → would crash without the C++ fix.
+    actual_tiles = compute_selected_tile_n(
+        TileAwareDummyRunner.SUPPORTED_TILES + [128],
+        500,
+        runner.top_k,
+        runner.num_local_experts,
+    )
+    assert tuned_tactic[0] not in actual_tiles, (
+        f"tile_N={tuned_tactic[0]} should NOT be in actual tiles {actual_tiles} — "
+        "this is the mismatch that caused the C++ unordered_map::at crash"
+    )
+
+
+def test_autotuner_cache_miss_returns_fallback_for_unseen_bucket():
+    """When num_tokens maps to a bucket that was never tuned,
+    the autotuner correctly returns the fallback tactic=-1."""
+    tuner = _reset_autotuner()
+    runner = TileAwareDummyRunner()
+    hidden_size = 256
+
+    # No tuning done — inference should always get fallback
+    inputs = [torch.empty((1624, hidden_size), dtype=torch.float32)]
+    _, tactic = tuner.choose_one("test_no_tune", [runner], MOE_TUNING_CONFIG, inputs)
+    assert tactic == -1, "Expected fallback tactic when no tuning was done"
+
+
+def test_different_actual_tokens_same_bucket_get_same_cached_tactic(monkeypatch):
+    """Multiple actual num_tokens that map to the same bucket should all
+    receive the same cached tactic — confirming the autotuner uses the
+    bucketed profile, not the actual shapes, for cache lookup."""
+    tuner = _reset_autotuner()
+    runner = TileAwareDummyRunner(top_k=8, num_local_experts=64)
+    hidden_size = 128
+
+    def fake_profile(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
+        tile_n = tactic[0] if isinstance(tactic, list) else -1
+        return 1.0 if tile_n == 32 else 5.0
+
+    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", fake_profile)
+
+    tune_inputs = [torch.empty((512, hidden_size), dtype=torch.float32)]
+    with autotune(tune_mode=True):
+        _, tuned_tactic = tuner.choose_one(
+            "test_same_bucket", [runner], MOE_TUNING_CONFIG, tune_inputs
+        )
+
+    assert tuned_tactic[0] == 32
+
+    # All these map to bucket 512 via last_positive_power_of_2
+    for actual in [513, 600, 700, 800, 900, 1000, 1023]:
+        assert last_positive_power_of_2(actual) == 512
+        infer_inputs = [torch.empty((actual, hidden_size), dtype=torch.float32)]
+        _, tactic = tuner.choose_one(
+            "test_same_bucket", [runner], MOE_TUNING_CONFIG, infer_inputs
+        )
+        assert tactic == tuned_tactic, (
+            f"Expected cached tactic {tuned_tactic} for num_tokens={actual}, got {tactic}"
+        )
+
+
+# ===================================================================
+# SM100 integration test — exercises the real C++ launcher
+# ===================================================================
+
+
+def _prepare_bf16_moe_weights(num_experts, intermediate_size, hidden_size, device):
+    """Prepare shuffled BF16 weights in BlockMajorK layout."""
+    from flashinfer import shuffle_matrix_a
+    from flashinfer.fused_moe import convert_to_block_layout
+
+    gemm1 = torch.randn(
+        num_experts,
+        2 * intermediate_size,
+        hidden_size,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    gemm2 = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device, dtype=torch.bfloat16
+    )
+    g1_shuffled, g2_shuffled = [], []
+    for i in range(num_experts):
+        g1_shuffled.append(
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm1[i].view(torch.uint8), 64), 128
+            )
+        )
+        g2_shuffled.append(
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm2[i].view(torch.uint8), 64), 128
+            )
+        )
+    return (
+        torch.stack(g1_shuffled).view(torch.bfloat16),
+        torch.stack(g2_shuffled).view(torch.bfloat16),
+    )
+
+
+def test_bf16_moe_tile_mismatch_no_crash_after_fix(monkeypatch):
+    """SM100 integration test: tune BF16 MoE with one num_tokens, then
+    infer with a different num_tokens that maps to the same autotuner
+    bucket but selects different C++ tiles.
+
+    Before the C++ fix this raised ``RuntimeError: unordered_map::at``.
+    After the fix the launcher falls back to a default tile gracefully.
+    """
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability[0] not in [10]:
+        pytest.skip("This test requires an SM100/SM103 (Blackwell) GPU.")
+
+    from flashinfer.fused_moe import trtllm_bf16_moe, WeightLayout
+
+    _reset_autotuner()
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+
+    # Model dimensions — keep small for speed
+    num_experts = 8
+    top_k = 2
+    hidden_size = 1024
+    intermediate_size = 1024
+
+    # Prepare weights once (they don't depend on num_tokens)
+    gemm1_weights, gemm2_weights = _prepare_bf16_moe_weights(
+        num_experts, intermediate_size, hidden_size, device
+    )
+
+    # --- Choose num_tokens that trigger the tile mismatch ---
+    # BF16 MoE supported tiles: {8, 16, 32, 64, 128}
+    # tune_num_tokens=256 (bucket): avg=256*2/8=64 → tiles={32,64,128}
+    # infer_num_tokens=500 (bucket=256): avg=500*2/8=125 → tiles={64,128}
+    # A tactic with tile_N=32 is valid for bucket but NOT for actual.
+    tune_num_tokens = 256
+    infer_num_tokens = 500
+    assert last_positive_power_of_2(infer_num_tokens) == tune_num_tokens
+
+    tune_max = 4096
+
+    def bias_tile_32(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
+        """Force tile_N=32 to be selected as the 'fastest' tactic."""
+        tile_n = tactic[0] if isinstance(tactic, list) else -1
+        return 1.0 if tile_n == 32 else 5.0
+
+    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", bias_tile_32)
+
+    # --- Phase 1: Tune with tune_num_tokens ---
+    routing_tune = torch.rand(
+        tune_num_tokens, num_experts, device=device, dtype=torch.bfloat16
+    )
+    hidden_tune = torch.randn(
+        tune_num_tokens, hidden_size, device=device, dtype=torch.bfloat16
+    )
+
+    with autotune(tune_mode=True):
+        trtllm_bf16_moe(
+            routing_logits=routing_tune,
+            routing_bias=None,
+            hidden_states=hidden_tune,
+            gemm1_weights=gemm1_weights,
+            gemm2_weights=gemm2_weights,
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=1,  # Renormalize (TopK/Default not supported for BF16)
+            use_shuffled_weight=True,
+            weight_layout=WeightLayout.BlockMajorK,
+            tune_max_num_tokens=tune_max,
+        )
+
+    # Verify the autotuner populated its cache during tuning
+    tuner = AutoTuner.get()
+    assert len(tuner.profiling_cache) > 0, (
+        "Autotuner cache should be populated after tuning"
+    )
+
+    # --- Phase 2: Inference with infer_num_tokens (same bucket, different tiles) ---
+    # Without the C++ fix, this would crash with RuntimeError: unordered_map::at
+    # because tile_N=32 is not in computeSelectedTileN(500, 2, 8) = {64, 128}.
+    routing_infer = torch.rand(
+        infer_num_tokens, num_experts, device=device, dtype=torch.bfloat16
+    )
+    hidden_infer = torch.randn(
+        infer_num_tokens, hidden_size, device=device, dtype=torch.bfloat16
+    )
+
+    # This call should NOT crash (with the C++ fix it falls back to a valid tile)
+    output = trtllm_bf16_moe(
+        routing_logits=routing_infer,
+        routing_bias=None,
+        hidden_states=hidden_infer,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=1,  # Renormalize
+        use_shuffled_weight=True,
+        weight_layout=WeightLayout.BlockMajorK,
+        tune_max_num_tokens=tune_max,
+    )
+
+    assert output.shape[0] == infer_num_tokens
+    assert output.isfinite().all(), "Output should be finite"

--- a/tests/autotuner/test_autotuner_tile_mismatch.py
+++ b/tests/autotuner/test_autotuner_tile_mismatch.py
@@ -1,29 +1,4 @@
-"""
-Regression test for the tile_N mismatch bug (RuntimeError: unordered_map::at).
-
-The bug is in the C++ MoE kernel launcher (trtllm_fused_moe_kernel_launcher.cu).
-During autotuning, the Python autotuner profiles kernels using bucketed
-num_tokens (e.g. 256) and caches the best tactic [tile_N, config].
-During inference, the C++ launcher calls computeSelectedTileN with the
-*actual* num_tokens (e.g. 500) to build launchers_map — a subset of
-supported tile sizes. When the actual num_tokens differs from the
-bucketed value, computeSelectedTileN can produce a different tile subset,
-and the cached tile_N may not exist in launchers_map, causing
-launchers_map.at(tile_N) to throw.
-
-The C++ fix adds a fallback when the cached tile_N is missing:
-  if (launchers_map.find(tile_N) == launchers_map.end()) { fallback }
-
-The fix to _find_nearest_profile (propagating the bucketed value to all
-linked dimensions) is what exposed this latent C++ bug. Before that fix,
-only the first linked dimension was bucketed during inference, so the
-profile key never matched the tuning-time key — the autotuner always
-returned the fallback tactic (-1) and the C++ fallback path was taken.
-After the fix, cache hits occur and the cached tile_N reaches the C++
-launcher, where the missing guard causes the crash. Both fixes are needed:
-the Python fix makes the autotuner cache work correctly for MoE, and the
-C++ fix makes the launcher handle tile_N mismatches gracefully.
-"""
+"""Regression tests for MoE autotuner tile/config mismatch handling."""
 
 import math
 
@@ -41,13 +16,8 @@ from flashinfer.fused_moe.utils import (
     get_last_power_of_2_num_tokens_buckets,
     last_positive_power_of_2,
 )
-from flashinfer.utils import get_compute_capability
 
 
-# ---------------------------------------------------------------------------
-# Helper: Python mirror of C++ computeSelectedTileN
-# (csrc/trtllm_fused_moe_kernel_launcher.cu, lines 85-107)
-# ---------------------------------------------------------------------------
 def _next_power_of_two(n: float) -> int:
     if n <= 1:
         return 1
@@ -81,15 +51,9 @@ def compute_selected_tile_n(
     return selected
 
 
-# ---------------------------------------------------------------------------
-# TileAwareDummyRunner: returns different valid tactics depending on shapes
-# ---------------------------------------------------------------------------
 class TileAwareDummyRunner(TunableRunner):
-    """Runner whose valid tactics depend on input num_tokens, mimicking
-    the real trtllm-gen MoE runner where computeSelectedTileN filters tiles.
-
-    Each tactic is a list [tile_N, config_idx] matching the real MoE convention.
-    """
+    """Dummy runner whose valid tactics depend on num_tokens.
+    returns different valid tactics depending on shapes."""
 
     SUPPORTED_TILES = [8, 16, 32, 64]  # FP4 base tiles (no 128/256 for bf16 act)
 
@@ -112,10 +76,7 @@ class TileAwareDummyRunner(TunableRunner):
         return inputs[0]
 
 
-# ---------------------------------------------------------------------------
-# Shared MoE-like tuning config (mirrors the real one)
-# ---------------------------------------------------------------------------
-TUNE_MAX = 4096
+TUNE_MAX = 8192
 
 MOE_TUNING_CONFIG = TuningConfig(
     dynamic_tensor_specs=(
@@ -137,94 +98,126 @@ def _reset_autotuner() -> AutoTuner:
     return tuner
 
 
-# ===================================================================
-# Tests
-# ===================================================================
+def _find_bucket_actual_tile_mismatch_case(
+    *,
+    supported_tiles: list[int],
+    top_k: int,
+    num_local_experts: int,
+    tune_max: int = TUNE_MAX,
+):
+    """Find (bucket, actual, tuned_tile) where tuned_tile is valid only for bucket."""
+    for actual in range(2, tune_max + 1):
+        bucket = min(last_positive_power_of_2(actual), tune_max)
+        if bucket == actual:
+            continue
+        tiles_bucket = compute_selected_tile_n(
+            supported_tiles, bucket, top_k, num_local_experts
+        )
+        tiles_actual = compute_selected_tile_n(
+            supported_tiles, actual, top_k, num_local_experts
+        )
+        only_in_bucket = sorted(tiles_bucket - tiles_actual)
+        if only_in_bucket:
+            return bucket, actual, only_in_bucket[0]
+    return None
 
 
-def test_tile_set_differs_between_bucketed_and_actual_num_tokens():
-    """Prove that computeSelectedTileN can return different tile sets
-    for the bucketed num_tokens vs. the actual num_tokens that maps to
-    the same autotuner bucket.
+@pytest.mark.parametrize(
+    "top_k,num_experts",
+    [
+        (2, 8),
+        (4, 16),
+        (8, 64),
+        (8, 128),  # Qwen3-VL-MoE-like (text) routing fanout/expert count
+        (10, 512),  # Qwen3.5-MoE-like (text) routing fanout/expert count
+    ],
+)
+def test_tile_set_differs_between_bucketed_and_actual_num_tokens(top_k, num_experts):
+    """Bucketed and actual shapes in the same bucket can still pick different tiles."""
+    tiles = [8, 16, 32, 64, 128]
+    case = _find_bucket_actual_tile_mismatch_case(
+        supported_tiles=tiles, top_k=top_k, num_local_experts=num_experts
+    )
+    assert case is not None, (
+        f"No mismatch case found for top_k={top_k}, experts={num_experts}"
+    )
+    bucket, actual, _ = case
+    tiles_bucket = compute_selected_tile_n(tiles, bucket, top_k, num_experts)
+    tiles_actual = compute_selected_tile_n(tiles, actual, top_k, num_experts)
 
-    This is the precondition for the unordered_map::at crash.
-    """
-    top_k = 8
-    num_experts = 64
-
-    # With the base SUPPORTED_TILES=[8,16,32,64] and top_k=8, num_experts=64,
-    # both bucketed=1024 and actual=1624 clamp to max tile 64, so the sets match.
-    # Use a wider tile range that DOES produce a mismatch:
-    tiles_small = [8, 16, 32, 64, 128]
-    actual = 500
-    bucket = last_positive_power_of_2(actual)  # 256
-    assert bucket == 256
-
-    tiles_bucket = compute_selected_tile_n(tiles_small, bucket, top_k, num_experts)
-    tiles_actual = compute_selected_tile_n(tiles_small, actual, top_k, num_experts)
-
-    # bucket=256: avg=256*8/64=32, nextPow2=32 → idx=2, selected={16,32,64,128}
-    # actual=500: avg=500*8/64=62.5, nextPow2=64 → idx=3, selected={32,64,128}
     assert tiles_bucket != tiles_actual, (
         f"Expected tile sets to differ for bucket={bucket} vs actual={actual}, "
         f"got {tiles_bucket} vs {tiles_actual}"
     )
 
-    # A tile_N valid for the bucket may not be valid for the actual
     only_in_bucket = tiles_bucket - tiles_actual
     assert len(only_in_bucket) > 0, (
         "Expected at least one tile valid for bucketed but not for actual shapes"
     )
 
 
-def test_autotuner_returns_cached_tactic_for_different_actual_shape(monkeypatch):
-    """The autotuner returns a cached tactic when num_tokens differs from
-    the tuning shape but maps to the same bucket.
-
-    Before the C++ fix, if the cached tile_N was not in
-    computeSelectedTileN(actual_num_tokens), this caused
-    RuntimeError: unordered_map::at.
-    """
+@pytest.mark.parametrize(
+    "top_k,num_experts,hidden_size",
+    [
+        (2, 8, 128),
+        (4, 16, 128),
+        (8, 64, 256),
+        (12, 128, 1024),
+        (
+            8,
+            256,
+            7168,
+        ),  # DeepSeek-v3-like MoE dimensions (lightweight autotuner-only path)
+        (8, 128, 4096),  # Qwen3-VL-MoE-like text dimensions (autotuner-only path)
+        (10, 512, 4096),  # Qwen3.5-MoE-like text dimensions (autotuner-only path)
+    ],
+)
+def test_autotuner_returns_cached_tactic_for_different_actual_shape(
+    monkeypatch, top_k, num_experts, hidden_size
+):
+    """Cache lookup uses bucketed profile, not raw runtime num_tokens."""
     tuner = _reset_autotuner()
-    runner = TileAwareDummyRunner(top_k=8, num_local_experts=64)
-    hidden_size = 256
+    runner = TileAwareDummyRunner(top_k=top_k, num_local_experts=num_experts)
+    case = _find_bucket_actual_tile_mismatch_case(
+        supported_tiles=runner.SUPPORTED_TILES,
+        top_k=top_k,
+        num_local_experts=num_experts,
+    )
+    assert case is not None, (
+        f"No mismatch case found for top_k={top_k}, experts={num_experts}"
+    )
+    tune_bucket, infer_actual, tuned_tile = case
 
     def fake_profile(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
-        # Make the tactic with tile_N=16 the "best" (lowest time)
+        # Make the chosen mismatch tile "best" so autotuner caches it.
         tile_n = tactic[0] if isinstance(tactic, list) else -1
-        return 1.0 if tile_n == 16 else 5.0
+        return 1.0 if tile_n == tuned_tile else 5.0
 
     monkeypatch.setattr(AutoTuner, "_profile_single_kernel", fake_profile)
 
-    # --- Phase 1: Tune with bucketed num_tokens ---
-    # The autotuner generates profiles for all buckets.
-    # For bucket=256, avg=256*8/64=32, tiles include {16,32,64,...},
-    # so tile_N=16 is valid and will be selected as best.
-    tune_inputs = [torch.empty((256, hidden_size), dtype=torch.float32)]
+    tune_inputs = [torch.empty((tune_bucket, hidden_size), dtype=torch.float32)]
     with autotune(tune_mode=True):
         _, tuned_tactic = tuner.choose_one(
             "test_tile_mismatch", [runner], MOE_TUNING_CONFIG, tune_inputs
         )
 
     assert isinstance(tuned_tactic, list)
-    assert tuned_tactic[0] == 16, f"Expected tile_N=16, got {tuned_tactic}"
+    assert tuned_tactic[0] == tuned_tile, (
+        f"Expected tile_N={tuned_tile} for top_k={top_k}, experts={num_experts}, "
+        f"got {tuned_tactic}"
+    )
 
-    # --- Phase 2: Inference with different actual num_tokens ---
-    # actual=500 maps to bucket=256 (same bucket) so we get a cache hit.
-    infer_inputs = [torch.empty((500, hidden_size), dtype=torch.float32)]
+    assert last_positive_power_of_2(infer_actual) == tune_bucket
+    infer_inputs = [torch.empty((infer_actual, hidden_size), dtype=torch.float32)]
     _, infer_tactic = tuner.choose_one(
         "test_tile_mismatch", [runner], MOE_TUNING_CONFIG, infer_inputs
     )
 
-    # The autotuner returns the CACHED tactic from tuning (tile_N=16).
     assert infer_tactic == tuned_tactic, "Expected cache hit returning the tuned tactic"
 
-    # --- Verify the mismatch ---
-    # For actual=500: avg=500*8/64=62.5, nextPow2=64, tiles={32,64,128}
-    # tile_N=16 is NOT in this set → would crash without the C++ fix.
     actual_tiles = compute_selected_tile_n(
-        TileAwareDummyRunner.SUPPORTED_TILES + [128],
-        500,
+        TileAwareDummyRunner.SUPPORTED_TILES,
+        infer_actual,
         runner.top_k,
         runner.num_local_experts,
     )
@@ -232,19 +225,6 @@ def test_autotuner_returns_cached_tactic_for_different_actual_shape(monkeypatch)
         f"tile_N={tuned_tactic[0]} should NOT be in actual tiles {actual_tiles} — "
         "this is the mismatch that caused the C++ unordered_map::at crash"
     )
-
-
-def test_autotuner_cache_miss_returns_fallback_for_unseen_bucket():
-    """When num_tokens maps to a bucket that was never tuned,
-    the autotuner correctly returns the fallback tactic=-1."""
-    tuner = _reset_autotuner()
-    runner = TileAwareDummyRunner()
-    hidden_size = 256
-
-    # No tuning done — inference should always get fallback
-    inputs = [torch.empty((1624, hidden_size), dtype=torch.float32)]
-    _, tactic = tuner.choose_one("test_no_tune", [runner], MOE_TUNING_CONFIG, inputs)
-    assert tactic == -1, "Expected fallback tactic when no tuning was done"
 
 
 def test_different_actual_tokens_same_bucket_get_same_cached_tactic(monkeypatch):
@@ -269,7 +249,6 @@ def test_different_actual_tokens_same_bucket_get_same_cached_tactic(monkeypatch)
 
     assert tuned_tactic[0] == 32
 
-    # All these map to bucket 512 via last_positive_power_of_2
     for actual in [513, 600, 700, 800, 900, 1000, 1023]:
         assert last_positive_power_of_2(actual) == 512
         infer_inputs = [torch.empty((actual, hidden_size), dtype=torch.float32)]
@@ -279,158 +258,3 @@ def test_different_actual_tokens_same_bucket_get_same_cached_tactic(monkeypatch)
         assert tactic == tuned_tactic, (
             f"Expected cached tactic {tuned_tactic} for num_tokens={actual}, got {tactic}"
         )
-
-
-# ===================================================================
-# SM100 integration test — exercises the real C++ launcher
-# ===================================================================
-
-
-def _prepare_bf16_moe_weights(num_experts, intermediate_size, hidden_size, device):
-    """Prepare shuffled BF16 weights in BlockMajorK layout."""
-    from flashinfer import shuffle_matrix_a
-    from flashinfer.fused_moe import convert_to_block_layout
-
-    gemm1 = torch.randn(
-        num_experts,
-        2 * intermediate_size,
-        hidden_size,
-        device=device,
-        dtype=torch.bfloat16,
-    )
-    gemm2 = torch.randn(
-        num_experts, hidden_size, intermediate_size, device=device, dtype=torch.bfloat16
-    )
-    g1_shuffled, g2_shuffled = [], []
-    for i in range(num_experts):
-        g1_shuffled.append(
-            convert_to_block_layout(
-                shuffle_matrix_a(gemm1[i].view(torch.uint8), 64), 128
-            )
-        )
-        g2_shuffled.append(
-            convert_to_block_layout(
-                shuffle_matrix_a(gemm2[i].view(torch.uint8), 64), 128
-            )
-        )
-    return (
-        torch.stack(g1_shuffled).view(torch.bfloat16),
-        torch.stack(g2_shuffled).view(torch.bfloat16),
-    )
-
-
-def test_bf16_moe_tile_mismatch_no_crash_after_fix(monkeypatch):
-    """SM100 integration test: tune BF16 MoE with one num_tokens, then
-    infer with a different num_tokens that maps to the same autotuner
-    bucket but selects different C++ tiles.
-
-    Before the C++ fix this raised ``RuntimeError: unordered_map::at``.
-    After the fix the launcher falls back to a default tile gracefully.
-    """
-    compute_capability = get_compute_capability(torch.device("cuda"))
-    if compute_capability[0] not in [10]:
-        pytest.skip("This test requires an SM100/SM103 (Blackwell) GPU.")
-
-    from flashinfer.fused_moe import trtllm_bf16_moe, WeightLayout
-
-    _reset_autotuner()
-    torch.manual_seed(42)
-    device = torch.device("cuda:0")
-
-    # Model dimensions — keep small for speed
-    num_experts = 8
-    top_k = 2
-    hidden_size = 1024
-    intermediate_size = 1024
-
-    # Prepare weights once (they don't depend on num_tokens)
-    gemm1_weights, gemm2_weights = _prepare_bf16_moe_weights(
-        num_experts, intermediate_size, hidden_size, device
-    )
-
-    # --- Choose num_tokens that trigger the tile mismatch ---
-    # BF16 MoE supported tiles: {8, 16, 32, 64, 128}
-    # tune_num_tokens=256 (bucket): avg=256*2/8=64 → tiles={32,64,128}
-    # infer_num_tokens=500 (bucket=256): avg=500*2/8=125 → tiles={64,128}
-    # A tactic with tile_N=32 is valid for bucket but NOT for actual.
-    tune_num_tokens = 256
-    infer_num_tokens = 500
-    assert last_positive_power_of_2(infer_num_tokens) == tune_num_tokens
-
-    tune_max = 4096
-
-    def bias_tile_32(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
-        """Force tile_N=32 to be selected as the 'fastest' tactic."""
-        tile_n = tactic[0] if isinstance(tactic, list) else -1
-        return 1.0 if tile_n == 32 else 5.0
-
-    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", bias_tile_32)
-
-    # --- Phase 1: Tune with tune_num_tokens ---
-    routing_tune = torch.rand(
-        tune_num_tokens, num_experts, device=device, dtype=torch.bfloat16
-    )
-    hidden_tune = torch.randn(
-        tune_num_tokens, hidden_size, device=device, dtype=torch.bfloat16
-    )
-
-    with autotune(tune_mode=True):
-        trtllm_bf16_moe(
-            routing_logits=routing_tune,
-            routing_bias=None,
-            hidden_states=hidden_tune,
-            gemm1_weights=gemm1_weights,
-            gemm2_weights=gemm2_weights,
-            num_experts=num_experts,
-            top_k=top_k,
-            n_group=None,
-            topk_group=None,
-            intermediate_size=intermediate_size,
-            local_expert_offset=0,
-            local_num_experts=num_experts,
-            routed_scaling_factor=None,
-            routing_method_type=1,  # Renormalize (TopK/Default not supported for BF16)
-            use_shuffled_weight=True,
-            weight_layout=WeightLayout.BlockMajorK,
-            tune_max_num_tokens=tune_max,
-        )
-
-    # Verify the autotuner populated its cache during tuning
-    tuner = AutoTuner.get()
-    assert len(tuner.profiling_cache) > 0, (
-        "Autotuner cache should be populated after tuning"
-    )
-
-    # --- Phase 2: Inference with infer_num_tokens (same bucket, different tiles) ---
-    # Without the C++ fix, this would crash with RuntimeError: unordered_map::at
-    # because tile_N=32 is not in computeSelectedTileN(500, 2, 8) = {64, 128}.
-    routing_infer = torch.rand(
-        infer_num_tokens, num_experts, device=device, dtype=torch.bfloat16
-    )
-    hidden_infer = torch.randn(
-        infer_num_tokens, hidden_size, device=device, dtype=torch.bfloat16
-    )
-
-    # This call should NOT crash (with the C++ fix it falls back to a valid tile)
-    output = trtllm_bf16_moe(
-        routing_logits=routing_infer,
-        routing_bias=None,
-        hidden_states=hidden_infer,
-        gemm1_weights=gemm1_weights,
-        gemm2_weights=gemm2_weights,
-        num_experts=num_experts,
-        top_k=top_k,
-        n_group=None,
-        topk_group=None,
-        intermediate_size=intermediate_size,
-        local_expert_offset=0,
-        local_num_experts=num_experts,
-        routed_scaling_factor=None,
-        routing_method_type=1,  # Renormalize
-        use_shuffled_weight=True,
-        weight_layout=WeightLayout.BlockMajorK,
-        tune_max_num_tokens=tune_max,
-    )
-
-    assert output.shape[0] == infer_num_tokens
-    assert output.isfinite().all(), "Output should be finite"

--- a/tests/autotuner/test_trtllm_moe_tile_mismatch_integration.py
+++ b/tests/autotuner/test_trtllm_moe_tile_mismatch_integration.py
@@ -1,0 +1,513 @@
+"""Integration tests for TRTLLM MoE launcher fallback and wrapper contracts."""
+
+import pytest
+import torch
+
+from flashinfer import autotune
+from flashinfer.autotuner import AutoTuner
+from flashinfer.utils import get_compute_capability
+
+TUNE_MAX = 8192
+
+
+def _reset_autotuner() -> AutoTuner:
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    tuner.reset_statistics()
+    tuner.is_tuning_mode = False
+    return tuner
+
+
+def _prepare_bf16_moe_weights(num_experts, intermediate_size, hidden_size, device):
+    """Prepare shuffled BF16 weights in BlockMajorK layout."""
+    from flashinfer import shuffle_matrix_a
+    from flashinfer.fused_moe import convert_to_block_layout
+
+    gemm1 = torch.randn(
+        num_experts,
+        2 * intermediate_size,
+        hidden_size,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    gemm2 = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device, dtype=torch.bfloat16
+    )
+    g1_shuffled, g2_shuffled = [], []
+    for i in range(num_experts):
+        g1_shuffled.append(
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm1[i].view(torch.uint8), 64), 128
+            )
+        )
+        g2_shuffled.append(
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm2[i].view(torch.uint8), 64), 128
+            )
+        )
+    return (
+        torch.stack(g1_shuffled).view(torch.bfloat16),
+        torch.stack(g2_shuffled).view(torch.bfloat16),
+    )
+
+
+def _overwrite_cached_tactic_for_op(custom_op: str, new_tactic):
+    """Overwrite cached tactics for one op key."""
+    tuner = AutoTuner.get()
+    updated = 0
+    for key, (runner_id, _tactic, profile) in list(tuner.profiling_cache.items()):
+        if key[0] == custom_op:
+            tuner.profiling_cache[key] = (runner_id, new_tactic, profile)
+            updated += 1
+    assert updated > 0, f"No autotuner cache entries found for {custom_op}"
+
+
+def _tune_bf16_moe_once(
+    *,
+    device,
+    tune_num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    hidden_size: int,
+    intermediate_size: int,
+    gemm1_weights,
+    gemm2_weights,
+    tune_max: int,
+):
+    from flashinfer.fused_moe import trtllm_bf16_moe, WeightLayout
+
+    routing_tune = torch.rand(
+        tune_num_tokens, num_experts, device=device, dtype=torch.bfloat16
+    )
+    hidden_tune = torch.randn(
+        tune_num_tokens, hidden_size, device=device, dtype=torch.bfloat16
+    )
+    with autotune(tune_mode=True):
+        trtllm_bf16_moe(
+            routing_logits=routing_tune,
+            routing_bias=None,
+            hidden_states=hidden_tune,
+            gemm1_weights=gemm1_weights,
+            gemm2_weights=gemm2_weights,
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=1,  # Renormalize
+            use_shuffled_weight=True,
+            weight_layout=WeightLayout.BlockMajorK,
+            tune_max_num_tokens=tune_max,
+        )
+
+
+def _run_bf16_moe_infer(
+    *,
+    device,
+    infer_num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    hidden_size: int,
+    intermediate_size: int,
+    gemm1_weights,
+    gemm2_weights,
+    tune_max: int,
+):
+    from flashinfer.fused_moe import trtllm_bf16_moe, WeightLayout
+
+    routing_infer = torch.rand(
+        infer_num_tokens, num_experts, device=device, dtype=torch.bfloat16
+    )
+    hidden_infer = torch.randn(
+        infer_num_tokens, hidden_size, device=device, dtype=torch.bfloat16
+    )
+    output = trtllm_bf16_moe(
+        routing_logits=routing_infer,
+        routing_bias=None,
+        hidden_states=hidden_infer,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=1,  # Renormalize
+        use_shuffled_weight=True,
+        weight_layout=WeightLayout.BlockMajorK,
+        tune_max_num_tokens=tune_max,
+    )
+    assert output.shape[0] == infer_num_tokens
+    assert output.isfinite().all(), "Output should be finite"
+
+
+def _require_sm100():
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability[0] not in [10]:
+        pytest.skip("This test requires an SM100/SM103 (Blackwell) GPU.")
+
+
+@pytest.mark.parametrize("fp8_quantization_type", ["DeepSeekFp8", "MxFp8"])
+def test_fp8_block_scale_moe_deepseek_contract_args(monkeypatch, fp8_quantization_type):
+    """Contract test: wrapper forwards DeepSeek-style routing/group arguments unchanged."""
+    from flashinfer.fused_moe import core as moe_core
+
+    captured = {}
+
+    def fake_trtllm_fp8_block_scale_moe(self, *args):
+        captured["args"] = args
+        hidden_states = args[4]
+        return [hidden_states.new_empty(hidden_states.shape, dtype=torch.bfloat16)]
+
+    fake_module = type(
+        "FakeMoeModule",
+        (),
+        {"trtllm_fp8_block_scale_moe": fake_trtllm_fp8_block_scale_moe},
+    )()
+    monkeypatch.setattr(moe_core, "get_trtllm_moe_sm100_module", lambda: fake_module)
+
+    seq_len = 8
+    hidden_size = 128
+    intermediate_size = 256
+    num_experts = 256
+    top_k = 8
+    n_group = 8
+    topk_group = 4
+    routed_scaling_factor = 2.5
+    tune_max_num_tokens = TUNE_MAX
+
+    routing_logits = torch.randn(seq_len, num_experts, dtype=torch.float32)
+    routing_bias = torch.randn(num_experts, dtype=torch.float32)
+    hidden_states = torch.randn(seq_len, hidden_size, dtype=torch.bfloat16)
+    hidden_states_scale = torch.ones(hidden_size // 128, seq_len, dtype=torch.float32)
+    gemm1_weights = torch.empty(1, dtype=torch.float32)
+    gemm1_weights_scale = torch.empty(1, dtype=torch.float32)
+    gemm2_weights = torch.empty(1, dtype=torch.float32)
+    gemm2_weights_scale = torch.empty(1, dtype=torch.float32)
+
+    quant_type = getattr(moe_core.Fp8QuantizationType, fp8_quantization_type)
+    output = moe_core.trtllm_fp8_block_scale_moe(
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
+        hidden_states=hidden_states,
+        hidden_states_scale=hidden_states_scale,
+        gemm1_weights=gemm1_weights,
+        gemm1_weights_scale=gemm1_weights_scale,
+        gemm2_weights=gemm2_weights,
+        gemm2_weights_scale=gemm2_weights_scale,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=n_group,
+        topk_group=topk_group,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=routed_scaling_factor,
+        routing_method_type=2,  # DeepSeekV3 routing mode
+        use_shuffled_weight=True,
+        weight_layout=moe_core.WeightLayout.BlockMajorK,
+        do_finalize=True,
+        enable_pdl=True,
+        tune_max_num_tokens=tune_max_num_tokens,
+        fp8_quantization_type=quant_type,
+    )
+
+    assert output.shape == hidden_states.shape
+    assert "args" in captured, (
+        "Expected wrapper to call trtllm_fp8_block_scale_moe backend"
+    )
+
+    args = captured["args"]
+    assert args[12] == top_k
+    assert args[13] == n_group
+    assert args[14] == topk_group
+    assert args[18] == routed_scaling_factor
+    assert args[19] == 2
+    assert args[20] is True
+    assert args[21] == int(moe_core.WeightLayout.BlockMajorK)
+    assert args[24] == tune_max_num_tokens
+    assert args[25] == quant_type
+
+
+def test_fp4_block_scale_moe_contract_args(monkeypatch):
+    """Contract test: FP4 wrapper forwards core MoE routing/kernel args unchanged."""
+    from flashinfer.fused_moe import core as moe_core
+
+    captured = {}
+
+    def fake_trtllm_fp4_block_scale_moe(self, *args):
+        captured["args"] = args
+        hidden_states = args[4]
+        return [hidden_states.new_empty(hidden_states.shape, dtype=torch.bfloat16)]
+
+    fake_module = type(
+        "FakeMoeModule",
+        (),
+        {"trtllm_fp4_block_scale_moe": fake_trtllm_fp4_block_scale_moe},
+    )()
+    monkeypatch.setattr(moe_core, "get_trtllm_moe_sm100_module", lambda: fake_module)
+
+    seq_len = 8
+    hidden_size = 128
+    intermediate_size = 256
+    num_experts = 128
+    top_k = 8
+    tune_max_num_tokens = TUNE_MAX
+
+    routing_logits = torch.randn(seq_len, num_experts, dtype=torch.float32)
+    hidden_states = torch.randn(seq_len, hidden_size, dtype=torch.bfloat16)
+    hidden_states_scale = torch.ones(seq_len, hidden_size // 16, dtype=torch.float32)
+    gemm1_weights = torch.empty(1, dtype=torch.uint8)
+    gemm1_weights_scale = torch.empty(1, dtype=torch.float32)
+    gemm2_weights = torch.empty(1, dtype=torch.uint8)
+    gemm2_weights_scale = torch.empty(1, dtype=torch.float32)
+
+    output = moe_core.trtllm_fp4_block_scale_moe(
+        routing_logits=routing_logits,
+        routing_bias=None,
+        hidden_states=hidden_states,
+        hidden_states_scale=hidden_states_scale,
+        gemm1_weights=gemm1_weights,
+        gemm1_weights_scale=gemm1_weights_scale,
+        gemm1_bias=None,
+        gemm1_alpha=None,
+        gemm1_beta=None,
+        gemm1_clamp_limit=None,
+        gemm2_weights=gemm2_weights,
+        gemm2_weights_scale=gemm2_weights_scale,
+        gemm2_bias=None,
+        output1_scale_scalar=None,
+        output1_scale_gate_scalar=None,
+        output2_scale_scalar=None,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=1,
+        do_finalize=True,
+        enable_pdl=True,
+        activation_type=moe_core.ActivationType.Swiglu.value,
+        output=None,
+        tune_max_num_tokens=tune_max_num_tokens,
+    )
+
+    assert output[0].shape == hidden_states.shape
+    assert "args" in captured, (
+        "Expected wrapper to call trtllm_fp4_block_scale_moe backend"
+    )
+
+    args = captured["args"]
+    assert args[18] == num_experts
+    assert args[19] == top_k
+    assert args[20] is None
+    assert args[21] is None
+    assert args[22] == intermediate_size
+    assert args[24] == num_experts
+    assert args[26] == 1
+    assert args[27] is True
+    assert args[31] == tune_max_num_tokens
+
+
+def test_bf16_moe_qwen35_contract_args(monkeypatch):
+    """Contract test: BF16 wrapper forwards Qwen3.5-style ungrouped routing args unchanged."""
+    from flashinfer.fused_moe import core as moe_core
+
+    captured = {}
+
+    def fake_trtllm_bf16_moe(self, *args):
+        captured["args"] = args
+        hidden_states = args[4]
+        return [hidden_states.new_empty(hidden_states.shape, dtype=torch.bfloat16)]
+
+    fake_module = type("FakeMoeModule", (), {"trtllm_bf16_moe": fake_trtllm_bf16_moe})()
+    monkeypatch.setattr(moe_core, "get_trtllm_moe_sm100_module", lambda: fake_module)
+
+    seq_len = 8
+    hidden_size = 128
+    intermediate_size = 1024
+    num_experts = 512
+    top_k = 10
+    tune_max_num_tokens = TUNE_MAX
+
+    routing_logits = torch.randn(seq_len, num_experts, dtype=torch.float32)
+    hidden_states = torch.randn(seq_len, hidden_size, dtype=torch.bfloat16)
+    gemm1_weights = torch.empty(1, dtype=torch.bfloat16)
+    gemm2_weights = torch.empty(1, dtype=torch.bfloat16)
+
+    output = moe_core.trtllm_bf16_moe(
+        routing_logits=routing_logits,
+        routing_bias=None,
+        hidden_states=hidden_states,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=0,
+        use_shuffled_weight=True,
+        weight_layout=moe_core.WeightLayout.BlockMajorK,
+        do_finalize=True,
+        enable_pdl=True,
+        tune_max_num_tokens=tune_max_num_tokens,
+    )
+
+    assert output.shape == hidden_states.shape
+    assert "args" in captured, "Expected wrapper to call trtllm_bf16_moe backend"
+
+    args = captured["args"]
+    assert args[7] == num_experts
+    assert args[8] == top_k
+    assert args[9] is None
+    assert args[10] is None
+    assert args[11] == intermediate_size
+    assert args[13] == num_experts
+    assert args[16] is True
+    assert args[17] == int(moe_core.WeightLayout.BlockMajorK)
+    assert args[20] == tune_max_num_tokens
+
+
+@pytest.mark.parametrize(
+    "top_k,num_experts",
+    [
+        (2, 8),
+        (4, 16),
+        (8, 128),  # Qwen3-VL-MoE-like (text)
+        (10, 128),  # Routing kernel currently supports top_k <= 10
+    ],
+)
+def test_bf16_moe_tile_mismatch_no_crash_after_fix(monkeypatch, top_k, num_experts):
+    """SM100 BF16 integration: cached mismatched tile falls back without crash."""
+    from flashinfer.fused_moe.utils import last_positive_power_of_2
+
+    _require_sm100()
+    _reset_autotuner()
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+
+    hidden_size = 1024
+    intermediate_size = 1024
+
+    gemm1_weights, gemm2_weights = _prepare_bf16_moe_weights(
+        num_experts, intermediate_size, hidden_size, device
+    )
+
+    tune_num_tokens = 256
+    infer_num_tokens = 500
+    assert last_positive_power_of_2(infer_num_tokens) == tune_num_tokens
+
+    tune_max = TUNE_MAX
+
+    def bias_tile_32(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
+        """Force tile_N=32 to be selected as the 'fastest' tactic."""
+        tile_n = tactic[0] if isinstance(tactic, list) else -1
+        return 1.0 if tile_n == 32 else 5.0
+
+    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", bias_tile_32)
+    _tune_bf16_moe_once(
+        device=device,
+        tune_num_tokens=tune_num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        tune_max=tune_max,
+    )
+
+    tuner = AutoTuner.get()
+    assert len(tuner.profiling_cache) > 0, (
+        "Autotuner cache should be populated after tuning"
+    )
+
+    _run_bf16_moe_infer(
+        device=device,
+        infer_num_tokens=infer_num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        tune_max=tune_max,
+    )
+
+
+@pytest.mark.parametrize(
+    "top_k,num_experts",
+    [
+        (2, 8),
+        (4, 16),
+        (8, 128),  # Qwen3-VL-MoE-like (text)
+        (10, 128),  # Routing kernel currently supports top_k <= 10
+    ],
+)
+@pytest.mark.parametrize(
+    "seed,stale_tactic",
+    [
+        (123, [4096, 0]),  # unsupported tile_N
+        (124, [32, 10_000_000]),  # invalid config index
+        (125, [32]),  # malformed tactic payload
+    ],
+)
+def test_bf16_moe_stale_cached_tactic_falls_back_no_crash(
+    monkeypatch, top_k, num_experts, seed, stale_tactic
+):
+    """SM100 integration: stale cache payloads should fall back without crashing."""
+    _require_sm100()
+    _reset_autotuner()
+    torch.manual_seed(seed)
+    device = torch.device("cuda:0")
+
+    hidden_size, intermediate_size = 1024, 1024
+    tune_num_tokens, infer_num_tokens = 256, 500
+    tune_max = TUNE_MAX
+
+    gemm1_weights, gemm2_weights = _prepare_bf16_moe_weights(
+        num_experts, intermediate_size, hidden_size, device
+    )
+
+    def bias_tile_32(self, runner_obj, prof_inputs, tactic, tuning_config=None, **kw):
+        tile_n = tactic[0] if isinstance(tactic, list) else -1
+        return 1.0 if tile_n == 32 else 5.0
+
+    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", bias_tile_32)
+    _tune_bf16_moe_once(
+        device=device,
+        tune_num_tokens=tune_num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        tune_max=tune_max,
+    )
+
+    _overwrite_cached_tactic_for_op("flashinfer::trtllm_bf16_moe", stale_tactic)
+    _run_bf16_moe_infer(
+        device=device,
+        infer_num_tokens=infer_num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        tune_max=tune_max,
+    )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR fixes a TRTLLM MoE autotuning bug caused by a mismatch between tuning-time token bucketing and runtime tile selection.
Previously, tuning bucketed by raw num_tokens, while runtime dispatch selected tiles from per-expert load (num_tokens * top_k / num_experts). In some cases, this mismatch could reuse a cached tactic that did not match the runtime tile regime and cause runtime failures.

For example, with num_tokens=3500, top_k=22, num_experts=1024:
`avg = (3500 * 22) / 1024 ≈ 75.2`, so the runtime tile center is 128.

Under the new bucketing logic:

Representative buckets per tile are computed as bucket_t = `floor((t * 1024) / 22) for t in {8, 16, 32, 64, 128, 256}`, giving: 372, 744, 1489, 2978, 5957, 11915
Plus the halving chain from 372: 186, 93, 46, 23, 11, 5, 2, 1
So the full bucket set is:
`[1, 2, 5, 11, 23, 46, 93, 186, 372, 744, 1489, 2978, 5957, 11915]`

With largest-<= num_tokens mapping, 3500 maps to bucket 2978 (instead of old raw-power-of-two bucket 2048), which aligns tuning buckets with runtime tile-selection semantics.
This change makes cached tactics consistent with runtime dispatch behavior and improves stability across workloads.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Mixture of Experts (MoE) auto-tuning for TRT-LLM backend with optimized token bucket allocation and expert mapping strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->