### PR TITLE
Proposing issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug Report
+description: Report a bug in FlashInfer
+labels: ["bug", "needs-triage"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Attention
+        - GEMM
+        - MoE
+        - MoE Routing
+        - Communication (allreduce, alltoall)
+        - Norm (RMSNorm, etc.)
+        - Sampling / TopK
+        - Quantization (FP4, FP8, etc.)
+        - JIT Compilation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework (if applicable)
+      options:
+        - None (direct FlashInfer API)
+        - vLLM
+        - SGLang
+        - TensorRT-LLM
+        - Other
+    validations:
+      required: false
+
+  - type: input
+    id: model
+    attributes:
+      label: Model (if applicable)
+      placeholder: e.g., DeepSeek-V3, Qwen3-Coder-480B, Llama-4-Maverick
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened and what did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - FlashInfer version:
+        - PyTorch version:
+        - GPU device (e.g., H100, A100, RTX 5090):
+        - CUDA toolkit version:
+        - NVIDIA driver version:
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Tip — enable API logging to capture inputs before a crash:
+        ```
+        export FLASHINFER_LOGLEVEL=3          # detailed input/output logging
+        export FLASHINFER_LOGDEST=debug.log   # save to file (or "stdout"/"stderr")
+        ```
+        Level 5 adds tensor statistics (min/max/mean, NaN/Inf detection). For JIT issues, also set FLASHINFER_JIT_VERBOSE=1.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["feature request", "needs-triage"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Attention
+        - GEMM
+        - MoE
+        - MoE Routing
+        - Communication (allreduce, alltoall)
+        - Norm (RMSNorm, etc.)
+        - Sampling / TopK
+        - Quantization (FP4, FP8, etc.)
+        - JIT Compilation
+        - New operation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework (if applicable)
+      options:
+        - None (direct FlashInfer API)
+        - vLLM
+        - SGLang
+        - TensorRT-LLM
+        - Other
+    validations:
+      required: false
+
+  - type: input
+    id: model
+    attributes:
+      label: Model (if applicable)
+      placeholder: e.g., DeepSeek-V3, Qwen3-Coder-480B, Llama-4-Maverick
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see and why is it useful?
+    validations:
+      required: true
+
+  - type: input
+    id: gpu
+    attributes:
+      label: Target GPU (if relevant)
+      placeholder: e.g., H100/SM90, B200/SM100, RTX 5090/SM120
+    validations:
+      required: false

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,52 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by component dropdown
+        env:
+          GH_TOKEN: ${{ secrets.FLASHINFER_BOT_TOKEN }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          LABELS=""
+
+          # Match component dropdown value from issue form
+          # "MoE Routing" must be checked before "MoE"
+          if echo "$ISSUE_BODY" | grep -q "MoE Routing"; then
+            LABELS="op: moe-routing"
+          elif echo "$ISSUE_BODY" | grep -q "MoE"; then
+            LABELS="op: moe"
+          fi
+
+          if echo "$ISSUE_BODY" | grep -q "Attention"; then
+            LABELS="${LABELS:+$LABELS,}op: attention"
+          fi
+          if echo "$ISSUE_BODY" | grep -q "GEMM"; then
+            LABELS="${LABELS:+$LABELS,}op: gemm"
+          fi
+          if echo "$ISSUE_BODY" | grep -q "Communication"; then
+            LABELS="${LABELS:+$LABELS,}op: comm"
+          fi
+          if echo "$ISSUE_BODY" | grep -q "Norm"; then
+            LABELS="${LABELS:+$LABELS,}op: norm"
+          fi
+          if echo "$ISSUE_BODY" | grep -q "Sampling"; then
+            LABELS="${LABELS:+$LABELS,}op: misc"
+          fi
+          if echo "$ISSUE_BODY" | grep -q "Quantization"; then
+            LABELS="${LABELS:+$LABELS,}op: misc"
+          fi
+
+          if [ -n "$LABELS" ]; then
+            gh issue edit "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --add-label "$LABELS"
+          fi


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

 Summary

  - Add GitHub issue form templates (bug report + feature request) to guide reporters through providing component, framework, model, environment,
   and logging info
  - Add workflow to auto-apply op: labels based on the component dropdown selection
  - Bug report template auto-labels bug + needs-triage; feature request auto-labels feature request + needs-triage
  - Blank issues still allowed as fallback

  Details

  Bug report asks for:
  - Component dropdown (Attention, GEMM, MoE, MoE Routing, Comm, Norm, etc.)
  - Framework dropdown (vLLM, SGLang, TensorRT-LLM)
  - Model name (optional)
  - Description, repro steps, environment (GPU, CUDA, driver), and logs
  - Includes tips on enabling FLASHINFER_LOGLEVEL for debugging

  Feature request asks for:
  - Component and framework dropdowns
  - Model name and target GPU (optional)
  - Description

  Issue labeler workflow (issue-labeler.yml):
  - Triggers on issue open
  - Reads the component dropdown value from the issue body
  - Auto-applies the matching op: label (attention, gemm, moe, moe-routing, comm, norm, misc)

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
