### PR TITLE
skip per-pr for draft PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -23,7 +23,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   workflow_dispatch:
     inputs:
       skip_aot:
@@ -67,6 +67,13 @@ jobs:
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "authorized=true" >> "$GITHUB_OUTPUT"
             echo "Not a PR, authorized"
+            exit 0
+          fi
+
+          # Skip draft PRs to save CI capacity
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "Draft PR, skipping CI"
             exit 0
           fi
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Saves testing capacity not running per-pr testing on draft PRs

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to better handle draft pull requests. Tests are now automatically skipped for draft PRs and execute when marked as ready for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->