### PR TITLE
fix: use correct SMEM capacity for SM120 consumer Blackwell GPUs

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
@@ -41,6 +41,7 @@ from cutlass.cutlass_dsl import Int32
 
 from .custom_pipeline import PipelineCpAsyncUmma
 from .utils import (
+    get_blackwell_smem_arch,
     TRTLLM_ENABLE_PDL,
     fmin,
     griddepcontrol_launch_dependents,
@@ -514,7 +515,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             num_threads=self.threads_per_warp,
         )
 
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes(
+            get_blackwell_smem_arch()
+        )
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm.py
@@ -53,6 +53,7 @@ import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
 from .utils import (
+    get_blackwell_smem_arch,
     TRTLLM_ENABLE_PDL,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
@@ -177,7 +178,9 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
             barrier_id=4,
             num_threads=self.threads_per_warp,
         )
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes(
+            get_blackwell_smem_arch()
+        )
         # TMEM offset for final accumulator
         self.tmem_final_offset = 384
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -38,6 +38,7 @@ import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
 from .utils import (
+    get_blackwell_smem_arch,
     TRTLLM_ENABLE_PDL,
     atomic_add_func,
     blk_reduce_bf16,
@@ -440,7 +441,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             barrier_id=4,
             num_threads=self.threads_per_warp,
         )
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes(
+            get_blackwell_smem_arch()
+        )
         # TMEM offset for final accumulator
         self.tmem_final_offset = 384
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
@@ -39,6 +39,7 @@ from cutlass._mlir.dialects import math
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
 from .utils import (
+    get_blackwell_smem_arch,
     TRTLLM_ENABLE_PDL,
     fmin,
     griddepcontrol_launch_dependents,
@@ -262,7 +263,9 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
             num_threads=self.threads_per_warp,
         )
 
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes(
+            get_blackwell_smem_arch()
+        )
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
@@ -58,6 +58,25 @@ from cutlass.cutlass_dsl import T, dsl_user_op
 TRTLLM_ENABLE_PDL = os.environ.get("TRTLLM_ENABLE_PDL", "1") == "1"
 
 
+def get_blackwell_smem_arch() -> str:
+    """Return the correct SM architecture string for SMEM capacity lookup.
+
+    SM100 (B200/B300 data center) has 227KB shared memory.
+    SM120/SM121 (RTX PRO 6000/RTX 5090 consumer) has 99KB shared memory.
+
+    Using the wrong capacity causes _compute_stages to over-allocate pipeline
+    stages that don't fit in physical SMEM, degrading performance on SM120.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        return "sm_100"  # fallback
+    major, minor = torch.cuda.get_device_capability()
+    if major == 12:
+        return "sm_120"
+    return "sm_100"
+
+
 # WAR for CuTeDSL make_ptr implementation
 class _Pointer(Pointer):
     """Represents a runtime pointer that can interoperate with various data structures,


### PR DESCRIPTION
## Summary

SM120 consumer Blackwell GPUs (RTX PRO 6000, RTX 5090, RTX 5080) have **99KB** shared memory, but the CuTe DSL MoE kernels hardcode `"sm_100"` for the SMEM capacity lookup, which returns **227KB** (the SM100/B200 capacity). This causes `_compute_stages()` to compute pipeline stage counts based on 2.3x more SMEM than physically available on SM120.

## The Bug

```python
# In all 4 Blackwell CuTe DSL grouped GEMM kernels:
self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
#                                                         ^^^^^^
# SM100 (B200/B300) = 227KB SMEM
# SM120 (RTX PRO 6000, RTX 5090) = 99KB SMEM
```

SMEM capacity by architecture:
| GPU | SM | SMEM |
|-----|-----|------|
| B200, B300, GB200 | SM100 | 227KB |
| RTX PRO 6000 | SM120 | 99KB |
| RTX 5090 | SM120 | 99KB |
| RTX 5080 | SM120 | 99KB |

## The Fix

Add `get_blackwell_smem_arch()` helper in `blackwell/utils.py` that auto-detects SM120 vs SM100 via `torch.cuda.get_device_capability()` and returns the correct architecture string. All 4 affected kernel files now use dynamic detection.

## Files Changed

- `flashinfer/fused_moe/cute_dsl/blackwell/utils.py` — new `get_blackwell_smem_arch()` helper
- `flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm.py`
- `flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py`
- `flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py`
- `flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py`

## Impact

This fix is only relevant for SM120 consumer Blackwell GPUs. SM100 data center GPUs are unaffected (the helper returns `"sm_100"` for them, preserving existing behavior).

On SM120, `_compute_stages()` will now correctly compute 3-5 pipeline stages instead of requesting 7-12 stages that overflow 99KB SMEM. This should improve MoE GEMM throughput for users running NVFP4 models (Qwen3.5-397B, DeepSeek, etc.) on RTX PRO 6000 and RTX 5090 hardware.

## Testing

Tested on 4x NVIDIA RTX PRO 6000 Blackwell (SM120, 96GB GDDR7) with Qwen3.5-397B-A17B-NVFP4:
- `get_smem_capacity_in_bytes("sm_100")` returns 232448 (227KB)
- `get_smem_capacity_in_bytes("sm_120")` returns 101376 (99KB)
- `get_blackwell_smem_arch()` correctly returns `"sm_120"` on this hardware

## Related

- CUTLASS #3096 — SM120 NVFP4 MoE patches (K=64 tile shapes)
- FlashInfer #2725 — SM120 MoE capability check fix
- FlashInfer #2786 — K=64 CUTLASS kernel tiles for SM120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Blackwell GPU kernel shared-memory configuration to dynamically detect device architecture capabilities at runtime instead of using fixed settings, enhancing compatibility across different GPU compute capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->