### PR TITLE
Respect explicit `FLASHINFER_CUBIN_DIR` over installed `flashinfer-cubin`

### DIFF
--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -59,11 +59,16 @@ _package_root: pathlib.Path = pathlib.Path(__file__).resolve().parents[1]
 def _get_cubin_dir():
     """
     Get the cubin directory path with the following priority:
-    1. flashinfer-cubin package if installed
-    2. Environment variable FLASHINFER_CUBIN_DIR
+    1. Environment variable FLASHINFER_CUBIN_DIR
+    2. flashinfer-cubin package if installed
     3. Default cache directory
     """
-    # First check if flashinfer-cubin package is installed
+    # Respect explicit overrides before consulting any installed cubin wheel.
+    env_dir = os.getenv("FLASHINFER_CUBIN_DIR")
+    if env_dir:
+        return pathlib.Path(env_dir)
+
+    # Then check if flashinfer-cubin package is installed
     if has_flashinfer_cubin():
         import flashinfer_cubin
 
@@ -81,11 +86,6 @@ def _get_cubin_dir():
             )
 
         return pathlib.Path(flashinfer_cubin.get_cubin_dir())
-
-    # Then check environment variable
-    env_dir = os.getenv("FLASHINFER_CUBIN_DIR")
-    if env_dir:
-        return pathlib.Path(env_dir)
 
     # Fall back to default cache directory
     return FLASHINFER_CACHE_DIR / "cubins"


### PR DESCRIPTION
## Rationale

This change makes `_get_cubin_dir()` treat `FLASHINFER_CUBIN_DIR` as the authoritative cubin source when it is explicitly set.

That is the least surprising behavior for an opt-in override and is especially important for local validation, custom cubin deployments, and debugging workflows. Today, an installed `flashinfer-cubin` wheel can override that user choice and even raise a wheel version mismatch before the requested directory is consulted.

The change is also low-risk: it only affects users who explicitly set `FLASHINFER_CUBIN_DIR`. For everyone else, the current `flashinfer-cubin` autodiscovery, version checks, and default cache fallback remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted cubin directory discovery logic to prioritize explicit environment variable configuration over alternative discovery methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->