### PR TITLE
[fmha-v2] Remove H2D transfer for bmm2 scale, enabling cuda graphs

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -121,7 +121,7 @@ def _create_scale_bmm2_d_tensor(
         return result
     else:
         # FP8, INT8, etc. use FP32 accumulation - create FP32 tensor and view as int32
-        return torch.tensor([scale_bmm2], dtype=torch.float32, device=device).view(
+        return torch.full((1,), scale_bmm2, dtype=torch.float32, device=device).view(
             torch.int32
         )
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -111,14 +111,18 @@ def _create_scale_bmm2_d_tensor(
     """
     if data_dtype == torch.float16:
         # Create int32 buffer on device, write FP16 value to lower 16 bits via view
-        result = torch.zeros(1, dtype=torch.int32, device=device)
-        result.view(torch.float16)[0] = scale_bmm2
-        return result
+        return (
+            torch.full((1,), scale_bmm2, dtype=torch.float16, device=device)
+            .view(torch.uint16)
+            .to(torch.int32)
+        )
     elif data_dtype == torch.bfloat16:
         # Create int32 buffer on device, write BF16 value to lower 16 bits via view
-        result = torch.zeros(1, dtype=torch.int32, device=device)
-        result.view(torch.bfloat16)[0] = scale_bmm2
-        return result
+        return (
+            torch.full((1,), scale_bmm2, dtype=torch.bfloat16, device=device)
+            .view(torch.uint16)
+            .to(torch.int32)
+        )
     else:
         # FP8, INT8, etc. use FP32 accumulation - create FP32 tensor and view as int32
         return torch.full((1,), scale_bmm2, dtype=torch.float32, device=device).view(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Removes a host to device transfer for setting the bmm2 scale, enabling cuda graphs. Potentially, we can also enable the API to accept a tensor for this scale, such that it can be computed elsewhere and passed in as a constant.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal performance optimizations for tensor creation; no user-visible changes.

* **Refactor**
  * Simplified and standardized tensor construction logic to improve reliability and consistency across numeric types, reducing internal complexity without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->