### PR TITLE
[Spark unit test debugging] Fix for tests/autotuner/test_autotuner_core.py 

### DIFF
--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -460,7 +460,7 @@ def test_choose_one_different_infer_tokens_same_bucket_get_same_cached_tactic(
         (random.randrange(bucket_start, bucket_end), [32, 1]) for _ in range(3)
     ]
     num_tokens_with_expected_tactic_list += [
-        (random.randrange(0, bucket_start), [16, 1]) for _ in range(3)
+        (random.randrange(1, bucket_start), [16, 1]) for _ in range(3)
     ]
     num_tokens_with_expected_tactic_list += [
         (random.randrange(bucket_end, bucket_end * 2), [64, 1]) for _ in range(3)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fixes this failure in the 3/23 nightly CICD: 
```
Running:  pytest --continue-on-collection-errors --junitxml=/tmp/junit/tests_autotuner_test_autotuner_core.py.xml "tests/autotuner/test_autotuner_core.py"
==========================================
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /tmp/flashinfer
configfile: pytest.ini
collected 31 items
tests/autotuner/test_autotuner_core.py ..............................F   [100%]
=================================== FAILURES ===================================
E   AssertionError: Expected cached tactic [16, 1] for num_tokens=0, got -1
    assert -1 == [16, 1]
----------------------------- Captured stderr call -----------------------------
2026-03-23 10:44:43,035 - INFO - autotuner.py:446 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
2026-03-23 10:44:43,038 - INFO - autotuner.py:455 - flashinfer.jit: [Autotuner]: Autotuning process ends
/tmp/flashinfer/tests/autotuner/test_autotuner_core.py:473: AssertionError: Expected cached tactic [16, 1] for num_tokens=0, got -1
=============================== warnings summary ===============================
../../opt/conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py:435
  /opt/conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py:435: UserWarning: 
      Found GPU0 NVIDIA GB10 which is of cuda capability 12.1.
      Minimum and Maximum cuda capability supported by this version of PyTorch is
      (8.0) - (12.0)
      
    queued_call()
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-- generated xml file: /tmp/junit/tests_autotuner_test_autotuner_core.py.xml ---
=========================== short test summary info ============================
FAILED tests/autotuner/test_autotuner_core.py::test_choose_one_different_infer_tokens_same_bucket_get_same_cached_tactic
=================== 1 failed, 30 passed, 1 warning in 0.23s ====================
❌ FAILED: tests/autotuner/test_autotuner_core.py
```

In test_choose_one_different_infer_tokens_same_bucket_get_same_cached_tactic, the inference token sampling range was changed from random.randrange(0, bucket_start) to random.randrange(1, bucket_start) to exclude zero-length inputs.

This removes a flaky edge case where num_tokens=0 could be generated, map to an invalid bucket, and return fallback tactic -1, causing intermittent CI failures unrelated to the bucket-caching behavior the test is meant to validate.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for autotuning functionality by expanding input scenarios tested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->