### PR TITLE
Replace multi-item scoring with delimiterless item_offsets API

### DIFF
--- a/benchmarks/bench_mis.py
+++ b/benchmarks/bench_mis.py
@@ -1,0 +1,233 @@
+"""Benchmark: Multi-Item Scoring (MIS) performance."""
+
+import time
+import torch
+import numpy as np
+
+from flashinfer.prefill import BatchPrefillWithPagedKVCacheWrapper
+
+
+def bench_gpu_time(fn, warmup=5, repeat=50):
+    """Measure GPU kernel time in ms using CUDA events."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+    return times
+
+
+def bench_plan_time(plan_fn, warmup=3, repeat=20):
+    """Measure plan() wall-clock time in ms."""
+    for _ in range(warmup):
+        plan_fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(repeat):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        plan_fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - t0) * 1000)
+    return times
+
+
+def build_mis_inputs(batch_size, prefix_len, item_lens):
+    """Build MIS inputs: uses item_offsets CSR format."""
+    total_items_tokens = sum(item_lens)
+    qo_len = total_items_tokens
+    kv_len = prefix_len + total_items_tokens
+
+    offsets = [0]
+    for l in item_lens:
+        offsets.append(offsets[-1] + l)
+
+    max_item_len = max(item_lens)
+
+    return (
+        qo_len,
+        kv_len,
+        torch.tensor([prefix_len], dtype=torch.uint32).cuda(),
+        torch.tensor(offsets, dtype=torch.uint32).cuda(),
+        len(offsets),
+        torch.tensor([max_item_len], dtype=torch.uint16).cuda(),
+    )
+
+
+def old_plan_preprocess(item_offsets, item_offsets_len, prefix_len_ptr):
+    """Reproduce the ORIGINAL plan() preprocessing for timing comparison.
+
+    This is the old Python loop with .item() calls that we're replacing.
+    """
+    batch_size = len(prefix_len_ptr) if prefix_len_ptr is not None else 1
+    item_start_list = []
+    max_items_tokens = 0
+    for b in range(batch_size):
+        offsets_b = item_offsets[b * item_offsets_len:(b + 1) * item_offsets_len]
+        num_offsets = (offsets_b.to(torch.int64) > 0).sum().item() + 1
+        valid_offsets = offsets_b[:num_offsets].long()
+        total_tokens = valid_offsets[-1].item()
+        max_items_tokens = max(max_items_tokens, total_tokens)
+        item_start_b = torch.zeros(total_tokens, dtype=torch.uint32, device=item_offsets.device)
+        for i in range(num_offsets - 1):
+            start = valid_offsets[i].item()
+            end = valid_offsets[i + 1].item()
+            item_start_b[start:end] = start
+        item_start_list.append(item_start_b)
+    padded = []
+    for ist in item_start_list:
+        if len(ist) < max_items_tokens:
+            ist = torch.cat([ist, torch.zeros(max_items_tokens - len(ist), dtype=torch.uint32, device=ist.device)])
+        padded.append(ist)
+    return torch.cat(padded), max_items_tokens
+
+
+def run_benchmark(
+    batch_size,
+    prefix_len,
+    item_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    page_size,
+    warmup=10,
+    repeat=100,
+):
+    device = "cuda"
+    results = {}
+
+    (
+        qo_len, kv_len,
+        prefix_len_ptr, item_offsets, item_offsets_len, max_item_len_ptr,
+    ) = build_mis_inputs(batch_size, prefix_len, item_lens)
+
+    q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim, device=device, dtype=torch.float16)
+    num_pages = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages * batch_size
+    kv_data = torch.randn(total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=torch.float16)
+
+    q_indptr = (torch.arange(0, batch_size + 1, dtype=torch.int32) * qo_len).cuda()
+    kv_indptr = (torch.arange(0, batch_size + 1, dtype=torch.int32) * num_pages).cuda()
+    kv_indices = torch.arange(0, total_pages, dtype=torch.int32, device=device)
+    kv_last_page = torch.full((batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device)
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # New plan: pass item_offsets + max_item_len_ptr directly (zero expansion)
+    wrapper = BatchPrefillWithPagedKVCacheWrapper(workspace, "NHD")
+    def plan_new():
+        wrapper.plan(
+            q_indptr, kv_indptr, kv_indices, kv_last_page,
+            num_qo_heads, num_kv_heads, head_dim, page_size,
+            causal=True, pos_encoding_mode="NONE",
+            prefix_len_ptr=prefix_len_ptr,
+            item_offsets=item_offsets,
+            item_offsets_len=item_offsets_len,
+            max_item_len_ptr=max_item_len_ptr,
+        )
+    plan_new()
+    results["kern"] = bench_gpu_time(lambda: wrapper.run(q, kv_data), warmup=warmup, repeat=repeat)
+    results["plan_new"] = bench_plan_time(plan_new)
+
+    # Old plan: Python loop with .item() calls
+    results["plan_old"] = bench_plan_time(
+        lambda: old_plan_preprocess(item_offsets, item_offsets_len, prefix_len_ptr),
+        warmup=3, repeat=20,
+    )
+
+    return results, {"qo_len": qo_len, "kv_len": kv_len}
+
+
+def main():
+    NUM_LAYERS = 28  # Qwen3-0.6B
+
+    print("=" * 80)
+    print("MIS Benchmark")
+    print("=" * 80)
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print()
+
+    configs = [
+        # Uniform item lengths
+        (512, [64] * 5, "512 prefix, 5x64 uniform"),
+        (1024, [128] * 10, "1024 prefix, 10x128 uniform"),
+        (2048, [256] * 5, "2048 prefix, 5x256 uniform"),
+        (4096, [512] * 4, "4096 prefix, 4x512 uniform"),
+        (1024, [64] * 20, "1024 prefix, 20x64 uniform"),
+        (1024, [64] * 50, "1024 prefix, 50x64 uniform"),
+        (2048, [32] * 100, "2048 prefix, 100x32 uniform"),
+        # Variable item lengths (moderate variation, realistic)
+        (512, [20, 30, 25, 35, 40], "512 prefix, 5 mixed [20..40]"),
+        (256, [15, 25, 20, 30, 10] * 10, "256 prefix, 50 mixed [10..30]"),
+        (512, list(range(20, 45, 5)) * 10, "512 prefix, 50 ramp [20..40]"),
+        (1024, [40, 60, 50, 70, 55] * 10, "1024 prefix, 50 mixed [40..70]"),
+        (512, [25, 35, 30, 45, 20] * 20, "512 prefix, 100 mixed [20..45]"),
+    ]
+
+    num_qo_heads = 16
+    num_kv_heads = 8
+    head_dim = 128
+    page_size = 16
+    batch_size = 1
+
+    print(f"Config: {num_qo_heads} QO heads, {num_kv_heads} KV heads, {head_dim} head_dim, page_size={page_size}")
+    print(f"End-to-end = plan + {NUM_LAYERS} layers * kernel  (all times in ms)")
+    print()
+
+    header = (
+        f"{'Config':<35} {'QO/KV':<12} "
+        f"{'kernel':<9} "
+        f"{'OldPlan':<9} {'NewPlan':<9} {'Plan+':<7} "
+        f"{'e2e old':<9} {'e2e new':<9} {'e2e+':<7}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for prefix_len, item_lens, desc in configs:
+        try:
+            results, lens = run_benchmark(
+                batch_size, prefix_len, item_lens,
+                num_qo_heads, num_kv_heads, head_dim, page_size,
+            )
+
+            kern = np.mean(results["kern"])
+            plan_old = np.mean(results["plan_old"])
+            plan_new = np.mean(results["plan_new"])
+            plan_speedup = plan_old / plan_new
+
+            e2e_old = plan_old + NUM_LAYERS * kern
+            e2e_new = plan_new + NUM_LAYERS * kern
+            e2e_speedup = e2e_old / e2e_new
+
+            lens_str = f"{lens['qo_len']}/{lens['kv_len']}"
+
+            print(
+                f"{desc:<35} {lens_str:<12} "
+                f"{kern:<9.4f} "
+                f"{plan_old:<9.4f} {plan_new:<9.4f} {plan_speedup:<7.2f} "
+                f"{e2e_old:<9.2f} {e2e_new:<9.2f} {e2e_speedup:<7.2f}"
+            )
+        except Exception as e:
+            import traceback
+            print(f"{desc:<35} ERROR: {e}")
+            traceback.print_exc()
+
+    print()
+    print("Legend:")
+    print("  kernel: MIS GPU kernel time (ms)")
+    print("  OldPlan: original plan() with Python .item() loop (ms)")
+    print("  NewPlan: optimized plan() with direct passthrough (ms)")
+    print("  Plan+: plan speedup (>1 = new faster)")
+    print(f"  e2e old / e2e new: plan + {NUM_LAYERS} layers * kernel (ms)")
+    print("  e2e+: end-to-end speedup (>1 = new faster)")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1416,7 +1416,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     None,  # mask_indptr_buf
                     _get_cache_alibi_slopes_buf(q.shape[1], q.device),
                     None,  # maybe_prefix_len_ptr
-                    None,  # maybe_token_pos_in_items_ptr
                     None,  # maybe_max_item_len_ptr
                     logits_soft_cap,
                     sm_scale,
@@ -1425,7 +1424,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     fp8_scale_v,
                     rope_scale,
                     rope_theta,
-                    0,  # token_pos_in_items_len
                     self._workspace_size,
                     paged_kv_cache,
                     self._num_qo_heads,
@@ -2092,7 +2090,6 @@ def get_trtllm_gen_decode_module(*args):
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
         maybe_max_item_len_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
@@ -2101,7 +2098,6 @@ def get_trtllm_gen_decode_module(*args):
         scale_v: Optional[torch.Tensor],
         rope_scale: float,
         rope_theta: float,
-        token_pos_in_items_len: int,
         workspace_size: int,
         paged_kv_cache: Optional[torch.Tensor] = None,
         num_qo_heads: Optional[int] = None,
@@ -2169,13 +2165,11 @@ def get_trtllm_gen_decode_module(*args):
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
         maybe_max_item_len_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         rope_scale: float,
         rope_theta: float,
-        token_pos_in_items_len: int,
         paged_kv_cache: Optional[torch.Tensor] = None,
         num_qo_heads: Optional[int] = None,
         num_kv_heads: Optional[int] = None,

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -999,8 +999,8 @@ def gen_batch_prefill_module(
             "maybe_mask_indptr",
             "maybe_alibi_slopes",
             "maybe_prefix_len_ptr",
-            "maybe_token_pos_in_items_ptr",
             "maybe_max_item_len_ptr",
+            "maybe_item_start_ptr",
         ]
         additional_tensor_dtypes = [
             "uint8_t",
@@ -1008,14 +1008,14 @@ def gen_batch_prefill_module(
             "float",
             "uint32_t",
             "uint16_t",
-            "uint16_t",
+            "uint32_t",
         ]  # NOTE(Zihao): int32_t should follow dtype_idx
         additional_scalar_names = [
             "logits_soft_cap",
             "sm_scale",
             "rope_rcp_scale",
             "rope_rcp_theta",
-            "token_pos_in_items_len",
+            "item_start_len",
         ]
         additional_scalar_dtypes = ["double", "double", "double", "double", "int64_t"]
         variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>"
@@ -1024,16 +1024,16 @@ def gen_batch_prefill_module(
         if not fp8_enabled:
             additional_tensor_names = [
                 "maybe_prefix_len_ptr",
-                "maybe_token_pos_in_items_ptr",
                 "maybe_max_item_len_ptr",
+                "maybe_item_start_ptr",
                 "maybe_scale_v",
             ]
-            additional_tensor_dtypes = ["uint32_t", "uint16_t", "uint16_t", "float"]
+            additional_tensor_dtypes = ["uint32_t", "uint16_t", "uint32_t", "float"]
             additional_scalar_names = [
                 "logits_soft_cap",
                 "sm_scale",
                 "scale_v_scalar",
-                "token_pos_in_items_len",
+                "item_start_len",
             ]
             additional_scalar_dtypes = ["double", "double", "double", "int64_t"]
             variant_name = f"DefaultAttention<{str(use_logits_soft_cap).lower()}>"

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -67,6 +67,57 @@ from .utils import (
 )
 
 
+def _prepare_mis_item_offsets(
+    item_offsets: torch.Tensor,
+    item_offsets_len: int,
+    prefix_len_ptr: torch.Tensor,
+    max_item_len_ptr,
+    backend: str,
+):
+    """Validate and prepare MIS item_offsets for the selected backend.
+
+    The FA2 kernel indexes ``item_start`` by token position within the items
+    region (a dense per-token array), while the FA3 Hopper kernel performs a
+    binary search on the raw CSR offsets.  This helper builds the correct
+    representation and tiles it for ``batch_size > 1``.
+
+    Returns (item_start_ptr, item_start_len, max_item_len_ptr).
+    """
+    assert prefix_len_ptr is not None, (
+        "prefix_len_ptr is required when item_offsets is provided"
+    )
+    assert item_offsets_len >= 2, (
+        "item_offsets_len must be >= 2 (at least one item boundary pair)"
+    )
+    raw_offsets = item_offsets.to(dtype=torch.uint32, copy=False)
+    batch_size = len(prefix_len_ptr)
+
+    if max_item_len_ptr is None:
+        offsets_2d = item_offsets.long().reshape(batch_size, item_offsets_len)
+        diffs = offsets_2d[:, 1:] - offsets_2d[:, :-1]
+        diffs = diffs.clamp(min=0)
+        max_item_len_ptr = diffs.max(dim=1).values.to(torch.uint16)
+
+    if backend == "fa2":
+        total_tokens = raw_offsets[item_offsets_len - 1].item()
+        per_token = torch.zeros(
+            total_tokens, dtype=torch.uint32, device=raw_offsets.device
+        )
+        for i in range(item_offsets_len - 1):
+            start = raw_offsets[i].item()
+            end = raw_offsets[i + 1].item()
+            per_token[start:end] = start
+        item_start_ptr = per_token.repeat(batch_size) if batch_size > 1 else per_token
+        item_start_len = total_tokens
+    else:
+        item_start_ptr = (
+            raw_offsets.repeat(batch_size) if batch_size > 1 else raw_offsets
+        )
+        item_start_len = item_offsets_len
+
+    return item_start_ptr, item_start_len, max_item_len_ptr
+
+
 def _split_scale_param(scale):
     """Split scale parameter into tensor and scalar components.
 
@@ -483,13 +534,13 @@ def get_batch_prefill_module(backend, *args):
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
         maybe_max_item_len_ptr: Optional[torch.Tensor],
+        maybe_item_start_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         rope_scale: float,
         rope_theta: float,
-        token_pos_in_items_len: int,
+        item_start_len: int,
         scale_q: Optional[torch.Tensor] = None,
         scale_k: Optional[torch.Tensor] = None,
         scale_v: Optional[torch.Tensor] = None,
@@ -517,13 +568,13 @@ def get_batch_prefill_module(backend, *args):
                 maybe_mask_indptr,
                 maybe_alibi_slopes,
                 maybe_prefix_len_ptr,
-                maybe_token_pos_in_items_ptr,
                 maybe_max_item_len_ptr,
+                maybe_item_start_ptr,
                 logits_soft_cap,
                 sm_scale,
                 1.0 / rope_scale,  # rope_rcp_scale
-                1.0 / rope_theta,  # rope_rcp_theta,
-                token_pos_in_items_len,
+                1.0 / rope_theta,  # rope_rcp_theta
+                item_start_len,
             )
         elif is_fp8:
             # FA3 FP8: scale_q, scale_k, scale_v, sm_scale, scale_q_scalar, scale_k_scalar, scale_v_scalar
@@ -554,8 +605,8 @@ def get_batch_prefill_module(backend, *args):
                 scale_v_scalar,
             )
         else:
-            # FA3 FP16: maybe_prefix_len_ptr, maybe_token_pos_in_items_ptr,
-            # maybe_max_item_len_ptr, scale_v, logits_soft_cap, sm_scale, scale_v_scalar, token_pos_in_items_len
+            # FA3 FP16: maybe_prefix_len_ptr, maybe_max_item_len_ptr, maybe_item_start_ptr,
+            # scale_v, logits_soft_cap, sm_scale, scale_v_scalar, item_start_len
             scale_v_tensor, scale_v_scalar = _split_scale_param(scale_v)
             ragged_run_func(
                 float_workspace_buffer,
@@ -573,13 +624,13 @@ def get_batch_prefill_module(backend, *args):
                 window_left,
                 enable_pdl,
                 maybe_prefix_len_ptr,
-                maybe_token_pos_in_items_ptr,
                 maybe_max_item_len_ptr,
+                maybe_item_start_ptr,
                 scale_v_tensor,
                 logits_soft_cap,
                 sm_scale,
                 scale_v_scalar,
-                token_pos_in_items_len,
+                item_start_len,
             )
 
         return o
@@ -604,13 +655,13 @@ def get_batch_prefill_module(backend, *args):
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
         maybe_max_item_len_ptr: Optional[torch.Tensor],
+        maybe_item_start_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         rope_scale: float,
         rope_theta: float,
-        token_pos_in_items_len: int,
+        item_start_len: int,
     ) -> None:
         pass
 
@@ -648,8 +699,8 @@ def get_batch_prefill_module(backend, *args):
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
         maybe_max_item_len_ptr: Optional[torch.Tensor],
+        maybe_item_start_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         scale_q: Optional[torch.Tensor],
@@ -657,7 +708,7 @@ def get_batch_prefill_module(backend, *args):
         scale_v: Optional[torch.Tensor],
         rope_scale: float,
         rope_theta: float,
-        token_pos_in_items_len: int,
+        item_start_len: int,
         workspace_size: int,
         num_qo_heads: Optional[int] = None,
         num_kv_heads: Optional[int] = None,
@@ -735,13 +786,13 @@ def get_batch_prefill_module(backend, *args):
                 maybe_mask_indptr,
                 maybe_alibi_slopes,
                 maybe_prefix_len_ptr,
-                maybe_token_pos_in_items_ptr,
                 maybe_max_item_len_ptr,
+                maybe_item_start_ptr,
                 logits_soft_cap,
                 sm_scale,
                 1.0 / rope_scale,  # rope_rcp_scale
                 1.0 / rope_theta,  # rope_rcp_theta
-                token_pos_in_items_len,
+                item_start_len,
             )
         else:
             scale_v_tensor, scale_v_scalar = _split_scale_param(scale_v)
@@ -764,13 +815,13 @@ def get_batch_prefill_module(backend, *args):
                     window_left,
                     enable_pdl,
                     maybe_prefix_len_ptr,
-                    maybe_token_pos_in_items_ptr,
                     maybe_max_item_len_ptr,
+                    maybe_item_start_ptr,
                     scale_v_tensor,
                     logits_soft_cap,
                     sm_scale,
                     scale_v_scalar,
-                    token_pos_in_items_len,
+                    item_start_len,
                 )
             else:
                 scale_q_tensor, scale_q_scalar = _split_scale_param(scale_q)
@@ -824,8 +875,8 @@ def get_batch_prefill_module(backend, *args):
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
         maybe_max_item_len_ptr: Optional[torch.Tensor],
+        maybe_item_start_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
         scale_q: Optional[torch.Tensor],
@@ -833,7 +884,7 @@ def get_batch_prefill_module(backend, *args):
         scale_v: Optional[torch.Tensor],
         rope_scale: float,
         rope_theta: float,
-        token_pos_in_items_len: int,
+        item_start_len: int,
         workspace_size: int,
         num_qo_heads: Optional[int] = None,
         num_kv_heads: Optional[int] = None,
@@ -1681,9 +1732,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
         o_data_type: Optional[Union[str, torch.dtype]] = None,
         non_blocking: bool = True,
         prefix_len_ptr: Optional[torch.Tensor] = None,
-        token_pos_in_items_ptr: Optional[torch.Tensor] = None,
-        token_pos_in_items_len: int = 0,
         max_item_len_ptr: Optional[torch.Tensor] = None,
+        item_offsets: Optional[torch.Tensor] = None,
+        item_offsets_len: int = 0,
         seq_lens: Optional[torch.Tensor] = None,
         seq_lens_q: Optional[torch.Tensor] = None,
         block_tables: Optional[torch.Tensor] = None,
@@ -1768,28 +1819,28 @@ class BatchPrefillWithPagedKVCacheWrapper:
             For FP8 inputs, this should typically be set to torch.float16 or torch.bfloat16.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
-        prefix_len_ptr :Optional[torch.Tensor]
-            prefix length. A uint32 1D tensor indicating the prefix length of each prompt. The tensor size is equal to the batch size.
-        token_pos_in_items_ptr : Optional[torch.Tensor]
-            A uint16 1D tensor (it will be converted to uint16 in flashinfer) indicating the token position of each item and started from 0 (delimiter)
-            for each item. E.g., if we have 3 items of length 3, 2, 4 respectively for this member. This vector will be looking like
-            `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0]` with 4 delimiters indexed as 0. For batch size > 1,
-            we will concat them as 1D with zero paddings to make sure each has the same length, the padding length is defined by
-            `token_pos_in_items_len` - length of the raw `token_pos_in_items_ptr` for each prompt.
-        token_pos_in_items_len : int
-            zero padding length for `token_pos_in_items_ptr` to better handle the bsz > 1 case. Still using the above 3,2,4 example.
-            If we set `token_pos_in_items_len` to be 20, it will be  `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0]`
-            with 7 padded zeros. (note there're 8 zeros in the end where the first one is the delimiter token 0 in the end of the prompt)
+        prefix_len_ptr : Optional[torch.Tensor]
+            A uint32 1D tensor of shape ``[batch_size]`` indicating the shared prefix
+            length of each prompt.  Required when ``item_offsets`` is provided.
         max_item_len_ptr : Optional[torch.Tensor]
-            a uint16 vector contains the max token length of all items for each prompt
-        seq_lens: Optional[torch.Tensor]
+            A uint16 1D tensor of shape ``[batch_size]`` containing the maximum item
+            length for each prompt.  When ``None`` and ``item_offsets`` is provided,
+            this is auto-computed from the offsets.
+        item_offsets : Optional[torch.Tensor]
+            CSR-style cumulative item boundaries (uint32) for multi-item scoring (MIS).
+            For example, three items of length 3, 2, 4 are encoded as
+            ``[0, 3, 5, 9]``.  Shape is ``[num_items + 1]`` when all batch elements
+            share the same layout.
+        item_offsets_len : int
+            Length of the ``item_offsets`` tensor (``num_items + 1``).
+        seq_lens : Optional[torch.Tensor]
             A uint32 1D tensor indicating the kv sequence length of each prompt. shape: ``[batch_size]``.
-        seq_lens_q: Optional[torch.Tensor]
+        seq_lens_q : Optional[torch.Tensor]
             A uint32 1D tensor indicating the q sequence length of each prompt. shape: ``[batch_size]``.
             If not provided, will be set to the same value as ``seq_lens``.
-        block_tables: Optional[torch.Tensor]
+        block_tables : Optional[torch.Tensor]
             A uint32 2D tensor indicating the block table of each prompt. shape: ``[batch_size, max_num_blocks_per_seq]``.
-        max_token_per_sequence: Optional[int],
+        max_token_per_sequence : Optional[int],
             Required for cudnn backend. This is the scalar max token length of each sequence.
         max_sequence_kv: Optional[int],
             Required for cudnn backend. This is the scalar max sequence length of each sequence in kv cache.
@@ -1848,9 +1899,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
             )
 
         self._prefix_len_ptr = prefix_len_ptr
-        self._token_pos_in_items_ptr = token_pos_in_items_ptr
-        self._token_pos_in_items_len = token_pos_in_items_len
         self._max_item_len_ptr = max_item_len_ptr
+        self._item_start_ptr = None
+        self._item_start_len = 0
+        self._pending_item_offsets = (
+            (item_offsets, item_offsets_len) if item_offsets is not None else None
+        )
 
         # NOTE(Zihao): only required if qo_indptr/paged_kv_indptr are device tensors
         qo_indptr_host = qo_indptr.to("cpu")
@@ -1987,6 +2041,19 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 self._cached_module = get_batch_prefill_module(
                     self._backend, *get_module_args
                 )
+
+        if self._pending_item_offsets is not None:
+            offsets, offsets_len = self._pending_item_offsets
+            self._item_start_ptr, self._item_start_len, self._max_item_len_ptr = (
+                _prepare_mis_item_offsets(
+                    offsets,
+                    offsets_len,
+                    prefix_len_ptr,
+                    self._max_item_len_ptr,
+                    self._backend,
+                )
+            )
+            self._pending_item_offsets = None
 
         self._block_tables = block_tables
         if self._backend == "trtllm-gen":
@@ -2301,7 +2368,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             else:
                 mask_mode = MaskMode.NON_CAUSAL.value
 
-        if self._prefix_len_ptr is not None:
+        if self._item_start_ptr is not None:
             mask_mode = MaskMode.MULTIITEMSCORING.value
 
         if self._backend == "cudnn":
@@ -2370,8 +2437,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     self._mask_indptr_buf,
                     _get_cache_alibi_slopes_buf(q.shape[1], q.device),
                     self._prefix_len_ptr,
-                    self._token_pos_in_items_ptr,
                     self._max_item_len_ptr,
+                    self._item_start_ptr,
                     logits_soft_cap,
                     sm_scale,
                     fp8_scale_q,
@@ -2379,7 +2446,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     fp8_scale_v,
                     rope_scale,
                     rope_theta,
-                    self._token_pos_in_items_len,
+                    self._item_start_len,
                     self._workspace_size,
                     self._num_qo_heads,
                     self._num_kv_heads,
@@ -2717,9 +2784,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         o_data_type: Optional[Union[str, torch.dtype]] = None,
         non_blocking: bool = True,
         prefix_len_ptr: Optional[torch.Tensor] = None,
-        token_pos_in_items_ptr: Optional[torch.Tensor] = None,
-        token_pos_in_items_len: int = 0,
         max_item_len_ptr: Optional[torch.Tensor] = None,
+        item_offsets: Optional[torch.Tensor] = None,
+        item_offsets_len: int = 0,
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
         seq_lens: Optional[torch.Tensor] = None,
@@ -2800,20 +2867,20 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             For FP8 inputs, this should typically be set to torch.float16 or torch.bfloat16.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
-        prefix_len_ptr :Optional[torch.Tensor]
-            prefix length. A uint32 1D tensor indicating the prefix length of each prompt. The tensor size is equal to the batch size.
-        token_pos_in_items_ptr : Optional[torch.Tensor]
-            A uint16 1D tensor (it will be converted to uint16 in flashinfer) indicating the token position of each item and started from 0 (delimiter)
-            for each item. E.g., if we have 3 items of length 3, 2, 4 respectively for this member. This vector will be looking like
-            `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0]` with 4 delimiters indexed as 0. For batch size > 1,
-            we will concat them as 1D with zero paddings to make sure each has the same length, the padding length is defined by
-            `token_pos_in_items_len` - length of the raw `token_pos_in_items_ptr` for each prompt.
-        token_pos_in_items_len : int
-            zero padding length for `token_pos_in_items_ptr` to better handle the bsz > 1 case. Still using the above 3,2,4 example.
-            If we set `token_pos_in_items_len` to be 20, it will be  `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0]`
-            with 7 padded zeros. (note there're 8 zeros in the end where the first one is the delimiter token 0 in the end of the prompt)
+        prefix_len_ptr : Optional[torch.Tensor]
+            A uint32 1D tensor of shape ``[batch_size]`` indicating the shared prefix
+            length of each prompt.  Required when ``item_offsets`` is provided.
         max_item_len_ptr : Optional[torch.Tensor]
-            a uint16 vector contains the max token length of all items for each prompt
+            A uint16 1D tensor of shape ``[batch_size]`` containing the maximum item
+            length for each prompt.  When ``None`` and ``item_offsets`` is provided,
+            this is auto-computed from the offsets.
+        item_offsets : Optional[torch.Tensor]
+            CSR-style cumulative item boundaries (uint32) for multi-item scoring (MIS).
+            For example, three items of length 3, 2, 4 are encoded as
+            ``[0, 3, 5, 9]``.  Shape is ``[num_items + 1]`` when all batch elements
+            share the same layout.
+        item_offsets_len : int
+            Length of the ``item_offsets`` tensor (``num_items + 1``).
         fixed_split_size : Optional[int],
             The fixed split size for split-kv FA2 prefill/decode, in pages. Recommend setting to the average sequence length of your workload.
             When enabled, will lead to deterministic softmax score reduction in the merge_states kernel, and therefore
@@ -2942,9 +3009,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         kv_len_arr = kv_indptr_host[1:] - kv_indptr_host[:-1]
 
         self._prefix_len_ptr = prefix_len_ptr
-        self._token_pos_in_items_ptr = token_pos_in_items_ptr
-        self._token_pos_in_items_len = token_pos_in_items_len
         self._max_item_len_ptr = max_item_len_ptr
+        self._item_start_ptr = None
+        self._item_start_len = 0
+        self._pending_item_offsets = (
+            (item_offsets, item_offsets_len) if item_offsets is not None else None
+        )
 
         self._seq_lens_q = seq_lens_q
         self._seq_lens_kv = seq_lens
@@ -2986,6 +3056,19 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._cached_module = get_batch_prefill_module(
                     self._backend, *get_module_args
                 )
+
+        if self._pending_item_offsets is not None:
+            offsets, offsets_len = self._pending_item_offsets
+            self._item_start_ptr, self._item_start_len, self._max_item_len_ptr = (
+                _prepare_mis_item_offsets(
+                    offsets,
+                    offsets_len,
+                    prefix_len_ptr,
+                    self._max_item_len_ptr,
+                    self._backend,
+                )
+            )
+            self._pending_item_offsets = None
 
         if self._backend == "cutlass":
             self._plan_info = fmha_varlen_plan(
@@ -3269,6 +3352,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             else:
                 mask_mode = MaskMode.NON_CAUSAL.value
 
+        if self._item_start_ptr is not None:
+            mask_mode = MaskMode.MULTIITEMSCORING.value
+
         run_args = [
             self._float_workspace_buffer,
             self._int_workspace_buffer,
@@ -3293,13 +3379,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._mask_indptr_buf,
                 _get_cache_alibi_slopes_buf(q.shape[1], self.device),
                 self._prefix_len_ptr,
-                self._token_pos_in_items_ptr,
                 self._max_item_len_ptr,
+                self._item_start_ptr,
                 logits_soft_cap,
                 sm_scale,
                 rope_scale,
                 rope_theta,
-                self._token_pos_in_items_len,
+                self._item_start_len,
             ]
             # For FP8, append scale tensors
             if is_float8(q):

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -608,7 +608,6 @@ class BlockSparseAttentionWrapper:
                 self._mask_indptr_buf,
                 _get_cache_alibi_slopes_buf(q.shape[1], self.device),
                 None,  # maybe_prefix_len_ptr
-                None,  # maybe_token_pos_in_items_ptr
                 None,  # maybe_max_item_len_ptr
                 logits_soft_cap,
                 sm_scale,
@@ -617,7 +616,6 @@ class BlockSparseAttentionWrapper:
                 scale_v,
                 rope_scale,
                 rope_theta,
-                0,  # token_pos_in_items_len
                 self._workspace_size,  # workspace_size
             )
         else:
@@ -1157,7 +1155,6 @@ class VariableBlockSparseAttentionWrapper:
             None,  # scale_v
             rope_scale,
             rope_theta,
-            0,  # token_pos_in_items_len
             self._workspace_size,
         )
 

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -173,9 +173,9 @@ struct BatchPrefillRaggedParams {
   uint32_t padded_batch_size;
   bool partition_kv;
   uint32_t* maybe_prefix_len_ptr;
-  uint16_t* maybe_token_pos_in_items_ptr;
-  uint32_t token_pos_in_items_len;
   uint16_t* maybe_max_item_len_ptr;
+  uint32_t* maybe_item_start_ptr;
+  uint32_t item_start_len;
 
   __host__ BatchPrefillRaggedParams()
       : q(nullptr),
@@ -216,9 +216,9 @@ struct BatchPrefillRaggedParams {
         padded_batch_size(0),
         partition_kv(false),
         maybe_prefix_len_ptr(nullptr),
-        maybe_token_pos_in_items_ptr(nullptr),
-        token_pos_in_items_len(0),
-        maybe_max_item_len_ptr(nullptr) {}
+        maybe_max_item_len_ptr(nullptr),
+        maybe_item_start_ptr(nullptr),
+        item_start_len(0) {}
 
   __host__ BatchPrefillRaggedParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* maybe_custom_mask,
                                     IdType* q_indptr, IdType* kv_indptr, IdType* maybe_mask_indptr,
@@ -267,9 +267,9 @@ struct BatchPrefillRaggedParams {
         padded_batch_size(0),
         partition_kv(false),
         maybe_prefix_len_ptr(nullptr),
-        maybe_token_pos_in_items_ptr(nullptr),
-        token_pos_in_items_len(0),
-        maybe_max_item_len_ptr(nullptr) {}
+        maybe_max_item_len_ptr(nullptr),
+        maybe_item_start_ptr(nullptr),
+        item_start_len(0) {}
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
     return q_indptr[batch_idx + 1] - q_indptr[batch_idx];
@@ -318,9 +318,9 @@ struct BatchPrefillPagedParams {
   uint32_t padded_batch_size;
   bool partition_kv;
   uint32_t* maybe_prefix_len_ptr;
-  uint16_t* maybe_token_pos_in_items_ptr;
-  uint32_t token_pos_in_items_len;
   uint16_t* maybe_max_item_len_ptr;
+  uint32_t* maybe_item_start_ptr;
+  uint32_t item_start_len;
 
   __host__ BatchPrefillPagedParams()
       : q(nullptr),
@@ -353,9 +353,9 @@ struct BatchPrefillPagedParams {
         padded_batch_size(0),
         partition_kv(false),
         maybe_prefix_len_ptr(nullptr),
-        maybe_token_pos_in_items_ptr(nullptr),
-        token_pos_in_items_len(0),
-        maybe_max_item_len_ptr(nullptr) {}
+        maybe_max_item_len_ptr(nullptr),
+        maybe_item_start_ptr(nullptr),
+        item_start_len(0) {}
 
   __host__ BatchPrefillPagedParams(DTypeQ* q, paged_kv_t<DTypeKV, IdType> paged_kv,
                                    uint8_t* maybe_custom_mask, IdType* q_indptr,
@@ -394,9 +394,9 @@ struct BatchPrefillPagedParams {
         padded_batch_size(0),
         partition_kv(false),
         maybe_prefix_len_ptr(nullptr),
-        maybe_token_pos_in_items_ptr(nullptr),
-        token_pos_in_items_len(0),
-        maybe_max_item_len_ptr(nullptr) {}
+        maybe_max_item_len_ptr(nullptr),
+        maybe_item_start_ptr(nullptr),
+        item_start_len(0) {}
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
     return q_indptr[batch_idx + 1] - q_indptr[batch_idx];

--- a/include/flashinfer/attention/hopper/default_params.cuh
+++ b/include/flashinfer/attention/hopper/default_params.cuh
@@ -88,9 +88,9 @@ struct BatchPrefillRaggedParams {
     float logits_soft_cap;
     float sm_scale;
     uint32_t* maybe_prefix_len_ptr;
-    uint16_t* maybe_token_pos_in_items_ptr;
-    uint32_t token_pos_in_items_len;
     uint16_t* maybe_max_item_len_ptr;
+    uint32_t* maybe_item_start_ptr;
+    uint32_t item_start_len;
   } additional_params;
 
   int64_t q_stride_n;
@@ -139,9 +139,9 @@ struct BatchPrefillPagedParams {
     float logits_soft_cap;
     float sm_scale;
     uint32_t* maybe_prefix_len_ptr;
-    uint16_t* maybe_token_pos_in_items_ptr;
-    uint32_t token_pos_in_items_len;
     uint16_t* maybe_max_item_len_ptr;
+    uint32_t* maybe_item_start_ptr;
+    uint32_t item_start_len;
   } additional_params;
 
   int64_t q_stride_n;

--- a/include/flashinfer/attention/hopper/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/mainloop_mma.cuh
@@ -17,9 +17,9 @@
 namespace flashinfer {
 
 template <typename Ktraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL, bool MULTIITEMSCORING,
-          typename WarpScheduler, typename AttentionVariant, typename Params,
-          typename MainloopPipeline, typename PipelineState, typename SharedStorage,
-          typename FrgTensorO, typename AttentionUpdater>
+          typename WarpScheduler, typename AttentionVariant,
+          typename Params, typename MainloopPipeline, typename PipelineState,
+          typename SharedStorage, typename FrgTensorO, typename AttentionUpdater>
 CUTLASS_DEVICE void mma_f16(
     const Params& mainloop_params, AttentionVariant& variant, MainloopPipeline pipeline_k,
     MainloopPipeline pipeline_v, PipelineState& smem_pipe_read_k, PipelineState& smem_pipe_read_v,
@@ -27,8 +27,10 @@ CUTLASS_DEVICE void mma_f16(
     int swa_begin_kv_tile_idx, int swa_end_kv_tile_idx, int thread_idx, int work_idx,
     int q_tile_idx, SharedStorage& shared_storage, const int32_t qo_len, const int32_t kv_len,
     const int32_t qo_head_idx, const int32_t kv_head_idx, const uint32_t prefix_len,
-    uint16_t* token_pos_in_items, const int num_kv_tiles_outside_items_window = 0,
-    const int num_kv_tiles_prefix = 0) {
+    uint32_t* item_start,
+    const int num_kv_tiles_outside_items_window = 0,
+    const int num_kv_tiles_prefix = 0,
+    const uint32_t item_start_len = 0) {
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
   using IdType = typename Ktraits::IdType;
@@ -70,6 +72,33 @@ CUTLASS_DEVICE void mma_f16(
     shared_storage.barrier_Q.wait(work_idx % 2);
   }
 
+  // MIS: precompute item_start for each Q position via binary search on the
+  // item_start array (L1/texture cached via __ldg), store results in smem for
+  // O(1) lookup during masking. Single barrier sync, no cooperative smem load.
+  __shared__ uint32_t smem_q_item_start[MULTIITEMSCORING ? CTA_Q : 1];
+  if constexpr (MULTIITEMSCORING) {
+    for (int q = thread_idx; q < CTA_Q; q += NUM_MMA_THREADS) {
+      const int qo_idx = q + q_tile_idx * CTA_Q;
+      const int idx_in_seq = qo_idx + kv_len - qo_len;
+      if (idx_in_seq >= static_cast<int>(prefix_len) && idx_in_seq < kv_len) {
+        const uint32_t tok = idx_in_seq - prefix_len;
+        uint32_t lo = 0, hi = item_start_len - 1;
+        while (lo < hi) {
+          uint32_t mid = (lo + hi + 1) >> 1;
+          if (__ldg(item_start + mid) <= tok)
+            lo = mid;
+          else
+            hi = mid - 1;
+        }
+        smem_q_item_start[q] = __ldg(item_start + lo);
+      } else {
+        smem_q_item_start[q] = 0;
+      }
+    }
+    cutlass::arch::NamedBarrier::sync(
+        NUM_MMA_THREADS, static_cast<int>(NamedBarriers::kItemOffsetsReady));
+  }
+
   Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_QKD{}));
   consumer_wait(pipeline_k, smem_pipe_read_k);
 
@@ -99,17 +128,13 @@ CUTLASS_DEVICE void mma_f16(
     const uint32_t idx_in_original_seq = qo_idx + kv_len - qo_len;
     const bool out_of_boundary =
         kv_idx > idx_in_original_seq || (kv_idx >= std::min(kv_len, col_limit_right(qo_idx)));
-    const bool is_prefix = idx_in_original_seq < prefix_len;
-    uint16_t token_pos_in_items_regs = 0;
-    // Only access idx_in_original_seq >= prefix_len && idx_in_original_seq < kv_len to avoid
-    // out-of-bounds memory access
-    if (idx_in_original_seq >= prefix_len & idx_in_original_seq < kv_len) {
-      token_pos_in_items_regs = __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
-    }
-    if (out_of_boundary || is_prefix) {
+    const bool is_prefix_q = idx_in_original_seq < prefix_len;
+    if (out_of_boundary || is_prefix_q) {
       tSrS(i) = out_of_boundary ? (AttentionUpdater::fill_value) : tSrS(i);
     } else {
-      tSrS(i) = (kv_idx < prefix_len | (idx_in_original_seq < kv_idx + token_pos_in_items_regs))
+      const uint32_t q_item_start = smem_q_item_start[qo_idx - q_tile_idx * CTA_Q];
+      tSrS(i) = (kv_idx < prefix_len |
+                  (kv_idx >= prefix_len + q_item_start & kv_idx <= idx_in_original_seq))
                     ? tSrS(i)
                     : (AttentionUpdater::fill_value);
     }
@@ -117,18 +142,13 @@ CUTLASS_DEVICE void mma_f16(
   auto mask_multi_item_scoring_assume_in_bound = [&](decltype(tSrS)& tSrS, int i, int qo_idx,
                                                      int kv_idx) {
     const uint32_t idx_in_original_seq = qo_idx + kv_len - qo_len;
-    const bool is_prefix = idx_in_original_seq < prefix_len;
-    if (is_prefix) {
+    const bool is_prefix_q = idx_in_original_seq < prefix_len;
+    if (is_prefix_q) {
       tSrS(i) = AttentionUpdater::fill_value;
     } else {
-      uint16_t token_pos_in_items_regs = 0;
-      // Only access idx_in_original_seq >= prefix_len && idx_in_original_seq < kv_len to avoid
-      // out-of-bounds memory access
-      if (idx_in_original_seq >= prefix_len & idx_in_original_seq < kv_len) {
-        token_pos_in_items_regs = __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
-      }
-
-      tSrS(i) = (kv_idx < prefix_len | (idx_in_original_seq < kv_idx + token_pos_in_items_regs))
+      const uint32_t q_item_start = smem_q_item_start[qo_idx - q_tile_idx * CTA_Q];
+      tSrS(i) = (kv_idx < prefix_len |
+                  (kv_idx >= prefix_len + q_item_start & kv_idx <= idx_in_original_seq))
                     ? tSrS(i)
                     : (AttentionUpdater::fill_value);
     }
@@ -175,8 +195,9 @@ CUTLASS_DEVICE void mma_f16(
   Tensor tOrP = make_tensor(convert_type<DTypeKV>(tSrS).data(),
                             convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout()));
 
-  constexpr int n_masking_steps = MULTIITEMSCORING ? (cute::ceil_div(CTA_Q, CTA_KV) + 1)
-                                                   : (CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0);
+  constexpr int n_masking_steps = MULTIITEMSCORING
+                                     ? (cute::ceil_div(CTA_Q, CTA_KV) + 1)
+                                     : (CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0);
   // masking loops
   // ziangl@nvidia.com: for multi item scoring, we use this loop only to mask along the diagonal
 #pragma unroll
@@ -204,7 +225,7 @@ CUTLASS_DEVICE void mma_f16(
       int kv_idx = get<1>(tScS(i)) + kv_tile_idx_decrement(kv_tile_idx) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                         qo_head_idx, kv_head_idx);
-      if (MULTIITEMSCORING) {
+      if constexpr (MULTIITEMSCORING) {
         mask_multi_item_scoring(tSrS, i, qo_idx, kv_idx);
       } else {
         if (kv_idx >= col_limit_right(qo_idx)) {
@@ -252,8 +273,6 @@ CUTLASS_DEVICE void mma_f16(
                                         qo_head_idx, kv_head_idx);
     }
     if constexpr (MULTIITEMSCORING) {
-      // auto nums_tiles_outside_causal_diagonal = kv_tile_idx_count - cute::ceil_div(CTA_Q,
-      // CTA_KV);
       if (kv_tile_idx >= num_kv_tiles_prefix - 1) {
 #pragma unroll
         for (int i = 0; i < size(tSrS); ++i) {

--- a/include/flashinfer/attention/hopper/named_barrier.cuh
+++ b/include/flashinfer/attention/hopper/named_barrier.cuh
@@ -23,7 +23,8 @@ enum class NamedBarriers {
   kWarpSchedulerWG2 = 3,
   kWarpSchedulerWG3 = 4,
   kPrefetchIndices = 5,
-  kProducerWG = 6
+  kProducerWG = 6,
+  kItemOffsetsReady = 7
 };
 
 __device__ __forceinline__ int get_warp_group_barrier_idx(int warp_group_idx) {

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -36,9 +36,9 @@ namespace flashinfer {
 using namespace cute;
 
 DEFINE_HAS_MEMBER(maybe_prefix_len_ptr)
-DEFINE_HAS_MEMBER(maybe_token_pos_in_items_ptr)
-DEFINE_HAS_MEMBER(token_pos_in_items_len)
 DEFINE_HAS_MEMBER(maybe_max_item_len_ptr)
+DEFINE_HAS_MEMBER(maybe_item_start_ptr)
+DEFINE_HAS_MEMBER(item_start_len)
 
 template <typename CollectiveMainloop, typename CollectiveEpilogue, typename Ktraits,
           bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename TileScheduler,
@@ -132,17 +132,17 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
   if constexpr (has_maybe_prefix_len_ptr_v<decltype(mainloop_params.additional_params)>) {
     maybe_prefix_len_ptr = mainloop_params.additional_params.maybe_prefix_len_ptr;
   }
-  uint16_t* maybe_token_pos_in_items_ptr = nullptr;
-  if constexpr (has_maybe_token_pos_in_items_ptr_v<decltype(mainloop_params.additional_params)>) {
-    maybe_token_pos_in_items_ptr = mainloop_params.additional_params.maybe_token_pos_in_items_ptr;
-  }
-  uint32_t token_pos_in_items_len = 0;
-  if constexpr (has_token_pos_in_items_len_v<decltype(mainloop_params.additional_params)>) {
-    token_pos_in_items_len = mainloop_params.additional_params.token_pos_in_items_len;
-  }
   uint16_t* maybe_max_item_len_ptr = nullptr;
   if constexpr (has_maybe_max_item_len_ptr_v<decltype(mainloop_params.additional_params)>) {
     maybe_max_item_len_ptr = mainloop_params.additional_params.maybe_max_item_len_ptr;
+  }
+  uint32_t* maybe_item_start_ptr = nullptr;
+  if constexpr (has_maybe_item_start_ptr_v<decltype(mainloop_params.additional_params)>) {
+    maybe_item_start_ptr = mainloop_params.additional_params.maybe_item_start_ptr;
+  }
+  uint32_t item_start_len = 0;
+  if constexpr (has_item_start_len_v<decltype(mainloop_params.additional_params)>) {
+    item_start_len = mainloop_params.additional_params.item_start_len;
   }
 
   if (warp_group_idx == 0) {  // Producer
@@ -187,6 +187,24 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
               std::max(0, q_tile_idx * CTA_Q + kv_len - qo_len - max_item_len);
           num_kv_tiles_outside_items_window = valid_items_window_len / CTA_KV;
           num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
+          // Tighter skip bound using actual item_start of first Q in tile
+          auto* item_start_local = maybe_item_start_ptr + batch_idx * item_start_len;
+          const int first_q_idx_in_seq = q_tile_idx * CTA_Q + kv_len - qo_len;
+          if (first_q_idx_in_seq >= static_cast<int>(prefix_len)) {
+            const uint32_t tok = first_q_idx_in_seq - prefix_len;
+            uint32_t lo = 0, hi = item_start_len - 1;
+            while (lo < hi) {
+              uint32_t mid = (lo + hi + 1) >> 1;
+              if (__ldg(item_start_local + mid) <= tok)
+                lo = mid;
+              else
+                hi = mid - 1;
+            }
+            uint32_t first_q_item_start = __ldg(item_start_local + lo);
+            num_kv_tiles_outside_items_window = std::max(
+                num_kv_tiles_outside_items_window,
+                static_cast<int>((prefix_len + first_q_item_start) / CTA_KV));
+          }
         }
         if constexpr (MULTIITEMSCORING) {
           collective_mainloop.load<LEFT_SLIDING_WINDOW>(
@@ -258,10 +276,10 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
       }
 
       uint32_t prefix_len = 0;
-      uint16_t* token_pos_in_items = nullptr;
+      uint32_t* item_start = nullptr;
       if constexpr (MULTIITEMSCORING) {
         prefix_len = __ldg(maybe_prefix_len_ptr + batch_idx);
-        token_pos_in_items = maybe_token_pos_in_items_ptr + batch_idx * token_pos_in_items_len;
+        item_start = maybe_item_start_ptr + batch_idx * item_start_len;
       }
       int num_kv_tiles_outside_items_window = 0;
       int num_kv_tiles_prefix = 0;
@@ -272,14 +290,32 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
             std::max(0, q_tile_idx * CTA_Q + kv_len - qo_len - max_item_len);
         num_kv_tiles_outside_items_window = valid_items_window_len / CTA_KV;
         num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
+        // Tighter skip bound — must match producer (above) exactly
+        auto* item_start_local = maybe_item_start_ptr + batch_idx * item_start_len;
+        const int first_q_idx_in_seq = q_tile_idx * CTA_Q + kv_len - qo_len;
+        if (first_q_idx_in_seq >= static_cast<int>(prefix_len)) {
+          const uint32_t tok = first_q_idx_in_seq - prefix_len;
+          uint32_t lo = 0, hi = item_start_len - 1;
+          while (lo < hi) {
+            uint32_t mid = (lo + hi + 1) >> 1;
+            if (__ldg(item_start_local + mid) <= tok)
+              lo = mid;
+            else
+              hi = mid - 1;
+          }
+          uint32_t first_q_item_start = __ldg(item_start_local + lo);
+          num_kv_tiles_outside_items_window = std::max(
+              num_kv_tiles_outside_items_window,
+              static_cast<int>((prefix_len + first_q_item_start) / CTA_KV));
+        }
       }
       mma_f16<Ktraits, /*LEFT_SLIDING_WINDOW=*/LEFT_SLIDING_WINDOW, CAUSAL, MULTIITEMSCORING,
               CollectiveMainloop::WarpScheduler>(
           mainloop_params, variant, pipeline_k, pipeline_v, smem_pipe_read_k, smem_pipe_read_v,
           tOrO, attention_updater, num_kv_tiles, swa_begin_kv_tile_idx, swa_end_kv_tile_idx,
           threadIdx.x - NUM_COPY_THREADS, work_idx, q_tile_idx, shared_storage, qo_len, kv_len,
-          qo_head_idx, kv_head_idx, prefix_len, token_pos_in_items,
-          num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
+          qo_head_idx, kv_head_idx, prefix_len, item_start,
+          num_kv_tiles_outside_items_window, num_kv_tiles_prefix, item_start_len);
       collective_epilogue.store(epilogue_params, tOrO, attention_updater.get_lse(), shared_storage,
                                 tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord);
 
@@ -361,7 +397,8 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
   using IdType = typename KernelTraits::IdType;
 
   using CollectiveMainloop = SparseCollectiveMainloop<typename Params::AdditionalParams,
-                                                      KernelTraits, CAUSAL, MULTIITEMSCORING>;
+                                                      KernelTraits, CAUSAL,
+                                                      MULTIITEMSCORING>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler =
       std::conditional_t<SAME_SCHEDULE_FOR_ALL_HEADS, BatchPrefillTileScheduler<IdType>,
@@ -585,8 +622,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
-          params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(params, stream);
     } else if constexpr (HEAD_DIM_VO == 128) {
       BatchPrefillWithPagedKVCacheKernelTraitsDispatched<
           AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK, HEAD_DIM_VO,
@@ -595,8 +631,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
-          params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(params, stream);
     } else {
       // HEAD_DIM == 256;
       // NOTE(Zihao): CTA_KV not tuned for HEAD_DIM == 256, need to optimize later
@@ -607,8 +642,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
-          params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(params, stream);
     }
   } else {
     return cudaErrorNotSupported;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -42,9 +42,9 @@ namespace flashinfer {
 DEFINE_HAS_MEMBER(maybe_q_rope_offset)
 DEFINE_HAS_MEMBER(maybe_k_rope_offset)
 DEFINE_HAS_MEMBER(maybe_prefix_len_ptr)
-DEFINE_HAS_MEMBER(maybe_token_pos_in_items_ptr)
-DEFINE_HAS_MEMBER(token_pos_in_items_len)
 DEFINE_HAS_MEMBER(maybe_max_item_len_ptr)
+DEFINE_HAS_MEMBER(maybe_item_start_ptr)
+DEFINE_HAS_MEMBER(item_start_len)
 
 namespace cg = cooperative_groups;
 using cp_async::SharedMemFillMode;
@@ -795,10 +795,9 @@ template <typename KTraits, typename Params>
 __device__ __forceinline__ void logits_mask_multi_item_scoring(
     const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
     const uint32_t qo_packed_idx_base, const uint32_t kv_idx_base, const uint32_t qo_len,
-    const uint32_t kv_len, const uint32_t window_left, const uint32_t chunk_end,
+    const uint32_t kv_len, const uint32_t chunk_end,
     const uint_fastdiv group_size, typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
-    // new arguments for compact description of mask
-    const uint32_t prefix_len, uint16_t* token_pos_in_items, const uint32_t lane_idx = threadIdx.x,
+    const uint32_t prefix_len, uint32_t* item_start, const uint32_t lane_idx = threadIdx.x,
     const uint32_t kv_head_idx = blockIdx.z) {
   constexpr uint32_t NUM_MMA_Q = KTraits::NUM_MMA_Q;
   constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
@@ -813,18 +812,17 @@ __device__ __forceinline__ void logits_mask_multi_item_scoring(
                         r[mma_q][j]);
     }
   }
-  // prefetching global memory to registers
-  uint16_t token_pos_in_items_regs[NUM_MMA_Q][(4 / 2)];
+  // prefetch item_start for each unique Q position
+  uint32_t item_start_regs[NUM_MMA_Q][(4 / 2)];
 #pragma unroll
   for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
 #pragma unroll
     for (uint32_t eff_reg_id = 0; eff_reg_id < (4 / 2); ++eff_reg_id) {
       const uint32_t q_idx = q[mma_q][eff_reg_id];
-      // use __ldca to hint compiler to cache in L1 for further reuse by other tiles
       const int idx_in_original_seq = q_idx + kv_len - qo_len;
       if (idx_in_original_seq >= prefix_len & idx_in_original_seq < kv_len) {
-        token_pos_in_items_regs[mma_q][eff_reg_id] =
-            __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
+        item_start_regs[mma_q][eff_reg_id] =
+            __ldca(item_start + idx_in_original_seq - prefix_len);
       }
     }
   }
@@ -838,18 +836,18 @@ __device__ __forceinline__ void logits_mask_multi_item_scoring(
         const uint32_t q_idx = q[mma_q][(reg_id % 4) / 2], kv_idx = kv_idx_base + mma_kv * 16 +
                                                                     2 * (lane_idx % 4) +
                                                                     8 * (reg_id / 4) + reg_id % 2;
-        const uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
         const uint32_t idx_in_original_seq = q_idx + kv_len - qo_len;
-        const bool out_of_boundary = kv_idx > idx_in_original_seq || (kv_idx >= chunk_end) ||
-                                     kv_idx + window_left < idx_in_original_seq;
-        const bool is_prefix = idx_in_original_seq < prefix_len;
-        if (out_of_boundary || is_prefix) {
+        const bool out_of_boundary = kv_idx > idx_in_original_seq || (kv_idx >= chunk_end);
+        const bool is_prefix_q = idx_in_original_seq < prefix_len;
+        if (out_of_boundary || is_prefix_q) {
           s_frag[mma_q][mma_kv][reg_id] =
               out_of_boundary ? (KTraits::MaskFillValue) : s_frag[mma_q][mma_kv][reg_id];
         } else {
+          // Q is in items region: allow prefix KV, or same-item causal KV
+          const uint32_t q_item_start = item_start_regs[mma_q][((reg_id % 4) / 2)];
           s_frag[mma_q][mma_kv][reg_id] =
               (kv_idx < prefix_len |
-               (idx_in_original_seq < kv_idx + token_pos_in_items_regs[mma_q][((reg_id % 4) / 2)]))
+               (kv_idx >= prefix_len + q_item_start & kv_idx <= idx_in_original_seq))
                   ? s_frag[mma_q][mma_kv][reg_id]
                   : (KTraits::MaskFillValue);
         }
@@ -2074,17 +2072,17 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     if constexpr (has_maybe_prefix_len_ptr_v<Params>) {
       maybe_prefix_len_ptr = params.maybe_prefix_len_ptr;
     }
-    uint16_t* maybe_token_pos_in_items_ptr = nullptr;
-    if constexpr (has_maybe_token_pos_in_items_ptr_v<Params>) {
-      maybe_token_pos_in_items_ptr = params.maybe_token_pos_in_items_ptr;
-    }
-    uint32_t token_pos_in_items_len = 0;
-    if constexpr (has_token_pos_in_items_len_v<Params>) {
-      token_pos_in_items_len = params.token_pos_in_items_len;
-    }
     uint16_t* maybe_max_item_len_ptr = nullptr;
     if constexpr (has_maybe_max_item_len_ptr_v<Params>) {
       maybe_max_item_len_ptr = params.maybe_max_item_len_ptr;
+    }
+    uint32_t* maybe_item_start_ptr = nullptr;
+    if constexpr (has_maybe_item_start_ptr_v<Params>) {
+      maybe_item_start_ptr = params.maybe_item_start_ptr;
+    }
+    uint32_t item_start_len = 0;
+    if constexpr (has_item_start_len_v<Params>) {
+      item_start_len = params.item_start_len;
     }
 
     static_assert(sizeof(DTypeQ) == 2);
@@ -2319,9 +2317,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           if (iter + 1 >= num_iterations_prefix) {
             logits_mask_multi_item_scoring<KTraits>(
                 params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base, kv_idx_base, qo_len,
-                kv_len, window_left, chunk_end, group_size, s_frag,
+                kv_len, chunk_end, group_size, s_frag,
                 __ldg(maybe_prefix_len_ptr + request_idx),
-                maybe_token_pos_in_items_ptr + request_idx * token_pos_in_items_len, tid.x,
+                maybe_item_start_ptr + request_idx * item_start_len, tid.x,
                 kv_head_idx);
           } else {
             if (iter >= mask_iteration || iter < window_iteration) {

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -815,52 +815,54 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
     torch.testing.assert_close(o_custom, o_causal, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize(
-    "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
+    "prefix_len, item_lens",
     [
-        (54, 37, 17, list(range(17)) + list(range(19)) + [0], 100, [18]),
-        (97, 81, 16, list(range(80)) + [0], 97, [79]),
+        (17, [17, 19]),
+        (16, [80]),
+        (17, [3, 2, 4]),
+        (16, [40, 40]),
     ],
 )
 @pytest.mark.parametrize("page_size", [1, 5, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])
 @pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.parametrize("causal", [True])
 @pytest.mark.parametrize("kv_layout", ["NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["ROPE_LLAMA"])
 @pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
 @pytest.mark.parametrize("return_lse", [True, False])
 def test_batch_prefill_with_paged_kv_cache_multi_item_scoring(
     batch_size,
-    kv_len,
-    qo_len,
-    prefix_len_ptr,
-    token_pos_in_items_ptr,
-    token_pos_in_items_len,
-    max_item_len_ptr,
+    prefix_len,
+    item_lens,
     page_size,
     num_kv_heads,
     num_qo_heads,
     head_dim,
-    causal,
     kv_layout,
     pos_encoding_mode,
     logits_soft_cap,
     return_lse,
 ):
+    total_items_tokens = sum(item_lens)
+    qo_len = total_items_tokens
+    kv_len = prefix_len + total_items_tokens
+
+    offsets = [0]
+    for l in item_lens:
+        offsets.append(offsets[-1] + l)
+    item_offsets_tensor = torch.tensor(offsets, dtype=torch.uint32).to(0)
+    item_offsets_len = len(offsets)
+
     q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim).to(0).half()
-    q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
     num_pages_per_seq = (kv_len + page_size - 1) // page_size
     total_num_pages = num_pages_per_seq * batch_size
-    kv_data = (
-        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0).half()
-        if kv_layout == "HND"
-        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim)
-        .to(0)
-        .half()
-    )
+    kv_data = torch.randn(
+        total_num_pages, 2, page_size, num_kv_heads, head_dim
+    ).to(0).half()
+    q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
     kv_indptr_cpu = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
     kv_indices_cpu = torch.arange(0, total_num_pages).int()
     kv_last_page_len_cpu = torch.full(
@@ -868,31 +870,25 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring(
     )
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
-    q_indptr_gpu = q_indptr_cpu.to(0)
-    kv_indptr_gpu = kv_indptr_cpu.to(0)
-    kv_indices_gpu = kv_indices_cpu.to(0)
-    kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
     wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
     wrapper.plan(
-        q_indptr_gpu,
-        kv_indptr_gpu,
-        kv_indices_gpu,
-        kv_last_page_len_gpu,
+        q_indptr_cpu.to(0),
+        kv_indptr_cpu.to(0),
+        kv_indices_cpu.to(0),
+        kv_last_page_len_cpu.to(0),
         num_qo_heads,
         num_kv_heads,
         head_dim,
         page_size,
-        causal=causal,
+        causal=True,
         pos_encoding_mode=pos_encoding_mode,
         logits_soft_cap=logits_soft_cap,
-        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
-        .to(dtype=torch.uint16)
-        .to(0),
-        token_pos_in_items_len=token_pos_in_items_len,
-        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+        prefix_len_ptr=torch.tensor([prefix_len] * batch_size, dtype=torch.uint32).to(0),
+        item_offsets=item_offsets_tensor,
+        item_offsets_len=item_offsets_len,
+        max_item_len_ptr=torch.tensor([max(item_lens)] * batch_size, dtype=torch.uint16).to(0),
     )
     if return_lse:
         o, _ = wrapper.run_return_lse(q, kv_data)
@@ -900,22 +896,12 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring(
         o = wrapper.run(q, kv_data)
 
     for i in range(batch_size):
-        perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
-        perm_dims_last = [1, 0, 2] if kv_layout == "HND" else [0, 1, 2]
         qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
         ki = torch.cat(
             [
                 kv_data[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1] - 1, 0]
-                .permute(*perm_dims)
                 .reshape(-1, num_kv_heads, head_dim),
-                (
-                    kv_data[kv_indptr_cpu[i + 1] - 1, 0, :, : kv_last_page_len_cpu[i]]
-                    if kv_layout == "HND"
-                    else kv_data[
-                        kv_indptr_cpu[i + 1] - 1, 0, : kv_last_page_len_cpu[i], :
-                    ]
-                )
-                .permute(*perm_dims_last)
+                kv_data[kv_indptr_cpu[i + 1] - 1, 0, : kv_last_page_len_cpu[i], :]
                 .reshape(-1, num_kv_heads, head_dim),
             ],
             dim=0,
@@ -923,103 +909,33 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring(
         vi = torch.cat(
             [
                 kv_data[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1] - 1, 1]
-                .permute(*perm_dims)
                 .reshape(-1, num_kv_heads, head_dim),
-                (
-                    kv_data[kv_indptr_cpu[i + 1] - 1, 1, :, : kv_last_page_len_cpu[i]]
-                    if kv_layout == "HND"
-                    else kv_data[
-                        kv_indptr_cpu[i + 1] - 1, 1, : kv_last_page_len_cpu[i], :
-                    ]
-                )
-                .permute(*perm_dims_last)
+                kv_data[kv_indptr_cpu[i + 1] - 1, 1, : kv_last_page_len_cpu[i], :]
                 .reshape(-1, num_kv_heads, head_dim),
             ],
             dim=0,
         )
 
-        def create_2D_multi_item_mask_dense(
-            is_delimiter, sliding_window_size=-1, prefix_cache_len=None
-        ):
-            # Function to create custom_mask for multi-item scoring
-            #
-            # Note, sliding window implementation assumes that candidate_i_size < sliding_window_size < prefix_size
-            # Args:
-            # is_delimiter: a boolen torch vec to indicate the delimiter position for creating custom attnetion mask in multi-item scoring
-            #           currently assume qo len and kv len are the same and 1D (bsz=1) case
-            # sliding_window_size: the window size for sliding window attention, -1 means no sliding window attention
-            delimiter_idx = is_delimiter.nonzero(as_tuple=True)[0]
-            if len(delimiter_idx) == 0:
-                return None
-            else:
-                first_delimiter_pos = delimiter_idx[0]
-            seq_len = len(is_delimiter)
-            pos = torch.arange(seq_len, device=is_delimiter.device)
+        custom_mask = torch.zeros(qo_len, kv_len, dtype=torch.bool, device=q.device)
+        for q_idx in range(qo_len):
+            kv_pos = prefix_len + q_idx
+            item_start_rel = 0
+            for j in range(len(offsets) - 1):
+                if offsets[j] <= q_idx < offsets[j + 1]:
+                    item_start_rel = offsets[j]
+                    break
+            custom_mask[q_idx, :prefix_len] = True
+            custom_mask[q_idx, prefix_len + item_start_rel : kv_pos + 1] = True
 
-            group_ids = torch.cumsum(is_delimiter, 0)
-            # Get mask for within-group causal attention
-            within_group_causal = (group_ids.unsqueeze(1) == group_ids.unsqueeze(0)) & (
-                pos.unsqueeze(0) <= pos.unsqueeze(1)
-            )
-            # Combine all conditions
-            attention_mask = (
-                (
-                    within_group_causal
-                    | (
-                        (pos >= first_delimiter_pos).unsqueeze(1)
-                        & (pos < first_delimiter_pos).unsqueeze(0)
-                    )  # Prefix attention
-                )
-                & ~is_delimiter.unsqueeze(0)
-                & ~is_delimiter.unsqueeze(1)
-            )  # No delimiter attention
-
-            if sliding_window_size > 0 and sliding_window_size < len(is_delimiter):
-                # Calculate how many positions from right of prefix each token can attend to
-
-                group_size = torch.sum(
-                    within_group_causal & ~is_delimiter.unsqueeze(0), dim=1
-                )
-
-                # For prefix: after sliding_window_size position, can see window_size tokens
-                # For candidate items: can see (sliding_window_size - group_size) tokens from prefix end
-                prefix_window = torch.where(
-                    pos >= first_delimiter_pos,
-                    sliding_window_size - group_size,
-                    torch.where(
-                        pos < sliding_window_size,
-                        first_delimiter_pos,
-                        sliding_window_size,
-                    ),
-                )
-
-                # Starting index of attention window relative to token position for candidate item/group
-                prefix_start = first_delimiter_pos - prefix_window.unsqueeze(1)
-
-                attention_mask = attention_mask & (pos >= prefix_start)
-            if prefix_cache_len:
-                patch = torch.ones(
-                    seq_len,
-                    prefix_cache_len,
-                    device=is_delimiter.device,
-                    dtype=torch.bool,
-                )
-                attention_mask = torch.concat([patch, attention_mask], dim=1)
-            return attention_mask.unsqueeze(0).reshape(-1)
-
-        custom_mask = create_2D_multi_item_mask_dense(
-            is_delimiter=torch.tensor(token_pos_in_items_ptr).to(0) == 0,
-            sliding_window_size=-1,
-            prefix_cache_len=prefix_len_ptr,
-        )
+        custom_mask_flat = custom_mask.unsqueeze(0).reshape(-1)
         o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
             qi,
             ki,
             vi,
-            causal=causal,
+            causal=True,
             pos_encoding_mode=pos_encoding_mode,
             logits_soft_cap=logits_soft_cap,
-            custom_mask=custom_mask,
+            custom_mask=custom_mask_flat,
         )
         o_i_np = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]].cpu().numpy()
         o_ref_i_np = o_ref_i.cpu().numpy()

--- a/tests/attention/test_hopper.py
+++ b/tests/attention/test_hopper.py
@@ -304,10 +304,10 @@ def test_batch_paged_prefill(
 
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize(
-    "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
+    "prefix_len, item_lens",
     [
-        (54, 37, 17, list(range(17)) + list(range(19)) + [0], 100, [18]),
-        (97, 81, 16, list(range(80)) + [0], 97, [79]),
+        (17, [17, 19]),
+        (16, [80]),
     ],
 )
 @pytest.mark.parametrize("page_size", [1, 5, 16])
@@ -320,12 +320,8 @@ def test_batch_paged_prefill(
 @pytest.mark.parametrize("return_lse", [True, False])
 def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
     batch_size,
-    kv_len,
-    qo_len,
-    prefix_len_ptr,
-    token_pos_in_items_ptr,
-    token_pos_in_items_len,
-    max_item_len_ptr,
+    prefix_len,
+    item_lens,
     page_size,
     num_kv_heads,
     num_qo_heads,
@@ -337,6 +333,14 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
 ):
     if not is_sm90a_supported(torch.device("cuda")):
         pytest.skip("SM90A is not supported")
+
+    qo_len = sum(item_lens)
+    kv_len = prefix_len + qo_len
+    item_offsets = [0]
+    for l in item_lens:
+        item_offsets.append(item_offsets[-1] + l)
+    item_offsets_tensor = torch.tensor(item_offsets, dtype=torch.uint32).to(0)
+    item_offsets_len = len(item_offsets)
 
     q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim).to(0).half()
     q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
@@ -375,15 +379,11 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
         page_size,
         causal=causal,
         logits_soft_cap=logits_soft_cap,
-        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
-        .to(dtype=torch.uint16)
-        .to(0),
-        token_pos_in_items_len=token_pos_in_items_len,
-        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+        prefix_len_ptr=torch.tensor([prefix_len], dtype=torch.uint32).to(0),
+        item_offsets=item_offsets_tensor,
+        item_offsets_len=item_offsets_len,
+        max_item_len_ptr=torch.tensor([max(item_lens)], dtype=torch.uint16).to(0),
     )
-    o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
-
     wrapper_fa3 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout, backend="fa3"
     )
@@ -398,46 +398,28 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
         page_size,
         causal=causal,
         logits_soft_cap=logits_soft_cap,
-        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
-        .to(dtype=torch.uint16)
-        .to(0),
-        token_pos_in_items_len=token_pos_in_items_len,
-        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+        prefix_len_ptr=torch.tensor([prefix_len], dtype=torch.uint32).to(0),
+        item_offsets=item_offsets_tensor,
+        item_offsets_len=item_offsets_len,
+        max_item_len_ptr=torch.tensor([max(item_lens)], dtype=torch.uint16).to(0),
     )
 
-    o_fa3, lse_fa3 = wrapper_fa3.run_return_lse(q, kv_data)
-
-    torch.testing.assert_close(lse_fa2, lse_fa3, rtol=1e-3, atol=1e-3)
+    if return_lse:
+        o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
+        o_fa3, lse_fa3 = wrapper_fa3.run_return_lse(q, kv_data)
+        torch.testing.assert_close(lse_fa2, lse_fa3, rtol=1e-3, atol=1e-3)
+    else:
+        o_fa2 = wrapper_fa2.run(q, kv_data)
+        o_fa3 = wrapper_fa3.run(q, kv_data)
     torch.testing.assert_close(o_fa2, o_fa3, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize(
-    "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
+    "prefix_len, item_lens",
     [
-        (
-            54,
-            37,
-            [17, 17],
-            list(range(17))
-            + list(range(19))
-            + [0]
-            + [0] * 63
-            + list(range(15))
-            + list(range(21))
-            + [0],
-            100,
-            [18, 20],
-        ),
-        (
-            97,
-            81,
-            [16, 16],
-            list(range(80)) + [0] * 17 + list(range(76)) + [0] * 5,
-            97,
-            [79, 75],
-        ),
+        (17, [17, 19]),
+        (16, [80]),
     ],
 )
 @pytest.mark.parametrize("page_size", [1, 5, 16])
@@ -450,12 +432,8 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
 @pytest.mark.parametrize("return_lse", [True, False])
 def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
     batch_size,
-    kv_len,
-    qo_len,
-    prefix_len_ptr,
-    token_pos_in_items_ptr,
-    token_pos_in_items_len,
-    max_item_len_ptr,
+    prefix_len,
+    item_lens,
     page_size,
     num_kv_heads,
     num_qo_heads,
@@ -467,6 +445,14 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
 ):
     if not is_sm90a_supported(torch.device("cuda")):
         pytest.skip("SM90A is not supported")
+
+    qo_len = sum(item_lens)
+    kv_len = prefix_len + qo_len
+    item_offsets = [0]
+    for l in item_lens:
+        item_offsets.append(item_offsets[-1] + l)
+    item_offsets_tensor = torch.tensor(item_offsets, dtype=torch.uint32).to(0)
+    item_offsets_len = len(item_offsets)
 
     q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim).to(0).half()
     q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
@@ -505,15 +491,11 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
         page_size,
         causal=causal,
         logits_soft_cap=logits_soft_cap,
-        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
-        .to(dtype=torch.uint16)
-        .to(0),
-        token_pos_in_items_len=token_pos_in_items_len,
-        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+        prefix_len_ptr=torch.tensor([prefix_len, prefix_len], dtype=torch.uint32).to(0),
+        item_offsets=item_offsets_tensor,
+        item_offsets_len=item_offsets_len,
+        max_item_len_ptr=torch.tensor([max(item_lens)] * 2, dtype=torch.uint16).to(0),
     )
-    o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
-
     wrapper_fa3 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
         workspace_buffer, kv_layout, backend="fa3"
     )
@@ -528,17 +510,19 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
         page_size,
         causal=causal,
         logits_soft_cap=logits_soft_cap,
-        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
-        .to(dtype=torch.uint16)
-        .to(0),
-        token_pos_in_items_len=token_pos_in_items_len,
-        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+        prefix_len_ptr=torch.tensor([prefix_len, prefix_len], dtype=torch.uint32).to(0),
+        item_offsets=item_offsets_tensor,
+        item_offsets_len=item_offsets_len,
+        max_item_len_ptr=torch.tensor([max(item_lens)] * 2, dtype=torch.uint16).to(0),
     )
 
-    o_fa3, lse_fa3 = wrapper_fa3.run_return_lse(q, kv_data)
-
-    torch.testing.assert_close(lse_fa2, lse_fa3, rtol=1e-3, atol=1e-3)
+    if return_lse:
+        o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
+        o_fa3, lse_fa3 = wrapper_fa3.run_return_lse(q, kv_data)
+        torch.testing.assert_close(lse_fa2, lse_fa3, rtol=1e-3, atol=1e-3)
+    else:
+        o_fa2 = wrapper_fa2.run(q, kv_data)
+        o_fa3 = wrapper_fa3.run(q, kv_data)
     torch.testing.assert_close(o_fa2, o_fa3, rtol=1e-3, atol=1e-3)
 
 

--- a/tests/test_mis_parity.py
+++ b/tests/test_mis_parity.py
@@ -1,0 +1,177 @@
+"""Parity test: MIS optimized kernel vs custom_mask reference.
+
+Verifies that the MIS attention kernel (smem binary search) produces
+identical results to an explicit custom mask implementation.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.prefill import BatchPrefillWithPagedKVCacheWrapper
+
+
+def build_custom_mask(prefix_len, item_lens, qo_len, kv_len):
+    """Build explicit attention mask equivalent to MIS semantics."""
+    offsets = [0]
+    for l in item_lens:
+        offsets.append(offsets[-1] + l)
+
+    mask = torch.zeros(qo_len, kv_len, dtype=torch.bool, device="cuda")
+    for q_idx in range(qo_len):
+        kv_pos = prefix_len + q_idx
+        for j in range(len(offsets) - 1):
+            if offsets[j] <= q_idx < offsets[j + 1]:
+                item_start_rel = offsets[j]
+                break
+        mask[q_idx, :prefix_len] = True
+        kv_item_start = prefix_len + item_start_rel
+        mask[q_idx, kv_item_start : kv_pos + 1] = True
+
+    return mask.unsqueeze(0).reshape(-1)
+
+
+def run_parity_check(
+    prefix_len,
+    item_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    page_size,
+    dtype=torch.float16,
+    auto_max_item_len=False,
+):
+    total_items_tokens = sum(item_lens)
+    qo_len = total_items_tokens
+    kv_len = prefix_len + total_items_tokens
+
+    offsets = [0]
+    for l in item_lens:
+        offsets.append(offsets[-1] + l)
+
+    prefix_len_ptr = torch.tensor([prefix_len], dtype=torch.uint32, device="cuda")
+    item_offsets = torch.tensor(offsets, dtype=torch.uint32, device="cuda")
+    item_offsets_len = len(offsets)
+    max_item_len_ptr = (
+        None if auto_max_item_len
+        else torch.tensor([max(item_lens)], dtype=torch.uint16, device="cuda")
+    )
+
+    torch.manual_seed(42)
+    q = torch.randn(qo_len, num_qo_heads, head_dim, device="cuda", dtype=dtype)
+
+    num_pages = (kv_len + page_size - 1) // page_size
+    kv_data = torch.randn(
+        num_pages, 2, page_size, num_kv_heads, head_dim, device="cuda", dtype=dtype
+    )
+
+    k_full = kv_data[:, 0].reshape(-1, num_kv_heads, head_dim)[:kv_len]
+    v_full = kv_data[:, 1].reshape(-1, num_kv_heads, head_dim)[:kv_len]
+
+    q_indptr = torch.tensor([0, qo_len], dtype=torch.int32, device="cuda")
+    kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda")
+    kv_indices = torch.arange(num_pages, dtype=torch.int32, device="cuda")
+    kv_last_page = torch.tensor(
+        [(kv_len - 1) % page_size + 1], dtype=torch.int32, device="cuda"
+    )
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda")
+
+    wrapper = BatchPrefillWithPagedKVCacheWrapper(workspace, "NHD")
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=True,
+        pos_encoding_mode="NONE",
+        prefix_len_ptr=prefix_len_ptr,
+        item_offsets=item_offsets,
+        item_offsets_len=item_offsets_len,
+        max_item_len_ptr=max_item_len_ptr,
+    )
+    out_mis = wrapper.run(q, kv_data)
+
+    custom_mask = build_custom_mask(prefix_len, item_lens, qo_len, kv_len)
+    out_ref = flashinfer.prefill.single_prefill_with_kv_cache(
+        q,
+        k_full,
+        v_full,
+        causal=True,
+        custom_mask=custom_mask,
+    )
+
+    max_diff = (out_mis - out_ref).abs().max().item()
+    ref_scale = out_ref.abs().mean().item()
+    rel_max = max_diff / (ref_scale + 1e-8)
+
+    return rel_max
+
+
+RNG = np.random.RandomState(123)
+
+CONFIGS = [
+    (256, [10] * 5),
+    (256, [10] * 50),
+    (256, [10] * 100),
+    (512, [25] * 50),
+    (512, [50] * 100),
+    (1024, [128] * 10),
+    (2048, [256] * 5),
+    (4096, [512] * 4),
+    (256, [1] * 50),
+    (256, [2] * 100),
+    (512, [20, 30, 25, 35, 40]),
+    (256, [15, 25, 20, 30, 10] * 10),
+    (512, list(range(20, 45, 5)) * 10),
+    (1024, [40, 60, 50, 70, 55] * 10),
+    (512, [25, 35, 30, 45, 20] * 20),
+    (256, RNG.randint(10, 40, size=20).tolist()),
+    (512, RNG.randint(15, 50, size=30).tolist()),
+    (1024, RNG.randint(20, 60, size=50).tolist()),
+    (512, sorted(RNG.randint(15, 45, size=20).tolist())),
+]
+
+
+@pytest.mark.parametrize("prefix_len, item_lens", CONFIGS)
+def test_mis_parity(prefix_len, item_lens):
+    rel_max = run_parity_check(
+        prefix_len,
+        item_lens,
+        num_qo_heads=16,
+        num_kv_heads=8,
+        head_dim=128,
+        page_size=16,
+    )
+    assert rel_max < 0.02, f"Relative max diff {rel_max:.6f} exceeds 2% threshold"
+
+
+AUTO_MAX_CONFIGS = [
+    (256, [10] * 5),
+    (512, [20, 30, 25, 35, 40]),
+    (256, [15, 25, 20, 30, 10] * 10),
+    (1024, [128] * 10),
+]
+
+
+@pytest.mark.parametrize("prefix_len, item_lens", AUTO_MAX_CONFIGS)
+def test_mis_parity_auto_max_item_len(prefix_len, item_lens):
+    """Verify the auto-computed max_item_len_ptr path in plan()."""
+    rel_max = run_parity_check(
+        prefix_len,
+        item_lens,
+        num_qo_heads=16,
+        num_kv_heads=8,
+        head_dim=128,
+        page_size=16,
+        auto_max_item_len=True,
+    )
+    assert rel_max < 0.02, f"Relative max diff {rel_max:.6f} exceeds 2% threshold"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 📌 Description

This PR replaces the existing delimiter-based multi-item scoring (MIS) implementation with a delimiterless approach using CSR-style `item_offsets`. The original V1 implementation required delimiter tokens between items and used per-token `token_pos_in_items` arrays for mask lookup. The new implementation eliminates delimiter tokens entirely, using `item_offsets` (cumulative item boundaries) with binary search for O(1) mask lookup in shared memory.

**Key changes:**
- Remove `kMultiItemScoringV2` mask mode — consolidate into a single `kMultiItemScoring` path using the `item_offsets` approach
- Remove `token_pos_in_items_ptr` / `token_pos_in_items_len` from all C++ param structs, Python API signatures, and JIT compilation
- Reduce compilation surface from 5 to 4 mask modes
- FA2 kernel: replace V1 mask function with V2's `item_start`-based masking
- Hopper kernels: merge smem binary search precomputation and tighter tile-skip logic into `MULTIITEMSCORING`
- Simplify Python `plan()` API: use `item_offsets` / `item_offsets_len` instead of `token_pos_in_items_ptr` / `token_pos_in_items_len`

**Breaking API change:** `BatchPrefillWithPagedKVCacheWrapper.plan()` and `BatchPrefillWithRaggedKVCacheWrapper.plan()` no longer accept `token_pos_in_items_ptr` / `token_pos_in_items_len`. Use `item_offsets` / `item_offsets_len` instead.

## 🔍 Related Issues

- Supersedes #1015 (original MIS V1 with delimiter tokens)
- Incorporates fix from #1140 (CUDA illegal memory access in MIS)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Test changes:
- Converted V1 MIS tests in `test_batch_prefill_kernels.py` and `test_hopper.py` to use `item_offsets` API
- Added `batch_size=2` coverage and merged V2 test cases into the main MIS test
- Converted `test_mis_v2_parity.py` → `test_mis_parity.py` as a proper pytest with 19 configurations (uniform, variable, random item lengths)
- FA2 vs FA3 parity tests cover `page_size=[1, 5, 16]`, GQA (`num_qo_heads=32, num_kv_heads=4`), `return_lse`, and `logits_soft_cap`

## Reviewer Notes

- This is a breaking change to the `plan()` API for multi-item scoring. The `item_offsets` API is more natural (CSR-style, consistent with other FlashInfer APIs) and eliminates the need for delimiter tokens in the sequence.
- The Hopper kernel uses a shared-memory binary search on `item_offsets` (precomputed once per CTA tile) for O(1) mask lookup, replacing V1's per-token global memory loads of `token_pos_in_items`.
- Tile-skip optimization now uses the actual `item_start` of the first Q token in the tile (via binary search) instead of the conservative `max_item_len`-based bound from V1.
