### PR TITLE
fix return compatibility with 0.6.6

### DIFF
--- a/flashinfer/norm/__init__.py
+++ b/flashinfer/norm/__init__.py
@@ -216,8 +216,8 @@ def _rmsnorm_quant_fake(
     scale: torch.Tensor,
     eps: float,
     enable_pdl: Optional[bool],
-) -> None:
-    pass
+) -> torch.Tensor:
+    return out
 
 
 @flashinfer_api


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/2832

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a quantization routine so it now correctly returns the output tensor instead of returning nothing.

* **Documentation**
  * Updated the function documentation to include a Returns section describing the returned tensor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->