### PR TITLE
Make verbose build-command logging opt-in

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -316,12 +316,13 @@ def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:
     workdir.mkdir(parents=True, exist_ok=True)
     command = [
         "ninja",
-        "-v",
         "-C",
         str(workdir.resolve()),
         "-f",
         str(ninja_file.resolve()),
     ]
+    if os.environ.get("FLASHINFER_VERBOSE_BUILD_COMMANDS", "0") == "1":
+        command += ["-v"]
     num_workers = _get_num_workers()
     if num_workers is not None:
         command += ["-j", str(num_workers)]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

- Logging of full build commands is too verbose to have it enabled by default (e.g., >>10MB of log when building flashinfer-jit-cache).
- This PR disables logging of full build commands unless the environment variable FLASHINFER_VERBOSE_BUILD_COMMANDS=1 is set.

**EDIT: Sorry it seems that this doesn't work as expected in non-interactive terminals. Changed to draft while I investigate further.**

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process now produces less verbose output by default. Set the `FLASHINFER_VERBOSE_BUILD_COMMANDS` environment variable to enable detailed build logs when troubleshooting is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->