### PR TITLE
Use 6-hour timeout for flashinfer-jit-cache wheel build (release + nightly)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -179,7 +179,7 @@ jobs:
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
-        timeout-minutes: 300
+        timeout-minutes: 360
 
       - name: Display wheel size
         run: du -h flashinfer-jit-cache/dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
-        timeout-minutes: 180
+        timeout-minutes: 360
 
       - name: Display wheel size
         run: du -h flashinfer-jit-cache/dist/*


### PR DESCRIPTION
Align release and nightly JIT-cache wheel jobs on timeout-minutes: 360
so long AOT compiles are less likely to hit the job limit.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased build timeout limits in CI/CD workflows to improve build reliability and prevent premature timeouts during the wheel-building process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->