### PR TITLE
fix: check for ptr before calling close_mnnvl_memory

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -353,7 +353,9 @@ class MnnvlMemory:  # type: ignore[no-redef]
 
     def __del__(self):
         if not sys.is_finalizing():
-            MnnvlMemory.close_mnnvl_memory(self.ptr)
+            # When open_mnnvl_memory fails, self.ptr may not be set. In that case, we should not call close_mnnvl_memory.
+            if hasattr(self, "ptr"):
+                MnnvlMemory.close_mnnvl_memory(self.ptr)
 
     def as_torch_strided_tensor(self, dtype):
         num_segments = MnnvlMemory.comm.Get_size()


### PR DESCRIPTION
## 📌 Description

When `MnnvlMemory.open_mnnvl_memory(self.mapping, size)` fails, `self.ptr` is not set. The deleter then fails to call `MnnvlMemory.close_mnnvl_memory(self.ptr)` resulting in:
```
(Worker_DP1_EP1 pid=94008) Exception ignored in: <function MnnvlMemory.__del__ at 0xfffc1b855e40>
(Worker_DP1_EP1 pid=94008) Traceback (most recent call last):
(Worker_DP1_EP1 pid=94008)   File "/workspace/flashinfer/flashinfer/comm/mnnvl.py", line 356, in __del__
(Worker_DP1_EP1 pid=94008)     MnnvlMemory.close_mnnvl_memory(self.ptr)
(Worker_DP1_EP1 pid=94008)                                    ^^^^^^^^
(Worker_DP1_EP1 pid=94008) AttributeError: 'MnnvlMemory' object has no attribute 'ptr'
```

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved destructor cleanup to verify the presence of the underlying resource before attempting to release it. This prevents release attempts when initialization fails, reducing crashes and resource errors during object construction and improving overall stability and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->