### PR TITLE
backinteg: nvidia-nvshmem-cu12 3.6.5 seems broken

### DIFF
--- a/flashinfer-jit-cache/pyproject.toml
+++ b/flashinfer-jit-cache/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "packaging>=24", "wheel", "torch", "ninja", "requests", "numpy", "nvidia-ml-py", "nvidia-nvshmem-cu12", "apache-tvm-ffi>=0.1,<0.2"]
+requires = ["setuptools>=77", "packaging>=24", "wheel", "torch", "ninja", "requests", "numpy", "nvidia-ml-py", "nvidia-nvshmem-cu12<3.6", "apache-tvm-ffi>=0.1,<0.2"]
 build-backend = "build_backend"
 backend-path = ["."]
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU-related build dependency constraint to specify a supported version range, improving build compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->