### PR TITLE
fix(moe): make hidden_states_scale optional in trtllm_fp4_block_scale_moe

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -3344,7 +3344,6 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         topk_weights: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
         hidden_states: torch.Tensor,
-        hidden_states_scale: Optional[torch.Tensor],
         gemm1_weights: torch.Tensor,
         gemm1_weights_scale: torch.Tensor,
         gemm1_bias: Optional[torch.Tensor],
@@ -3383,6 +3382,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         # routing_method_type -- which stay schema-expressible if
         # register_custom_op is ever re-enabled.
         hidden_states_scale_layout: Optional[int] = None,
+        hidden_states_scale: Optional[torch.Tensor] = None,
     ) -> List[torch.Tensor]:
         if routing_logits is None:
             assert topk_ids is not None, (
@@ -3471,6 +3471,16 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         dtype_weights = deduce_trtllm_gen_tensor_dtype(
             gemm1_weights, gemm1_weights_scale
         )
+        if (
+            dtype_act == DtypeTrtllmGen.Bfloat16
+            and dtype_weights != DtypeTrtllmGen.MxE2m1
+        ):
+            raise ValueError(
+                "trtllm_fp4_block_scale_moe with bf16 hidden_states requires MxE2m1 "
+                f"(MXFP4) weights, but got weights dtype {dtype_weights.name}. "
+                "For BF16 weights, use trtllm_bf16_moe instead; for NVFP4 weights, "
+                "pass NVFP4-quantized hidden_states with hidden_states_scale."
+            )
         moe_runner = TrtllmMoERunner(
             moe_op,
             top_k=top_k,
@@ -3674,7 +3684,6 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         topk_weights: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
         hidden_states: torch.Tensor,
-        hidden_states_scale: Optional[torch.Tensor],
         gemm1_weights: torch.Tensor,
         gemm1_weights_scale: torch.Tensor,
         gemm1_bias: Optional[torch.Tensor],
@@ -3708,6 +3717,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         routing_replay_out: Optional[torch.Tensor] = None,
         valid_hidden_size: Optional[int] = None,
         valid_intermediate_size: Optional[int] = None,
+        hidden_states_scale_layout: Optional[int] = None,
+        hidden_states_scale: Optional[torch.Tensor] = None,
     ):
         # Acknowledge mutation-only and fallback-only controls without executing the native op.
         _ = routing_replay_out, valid_intermediate_size
@@ -6164,7 +6175,6 @@ def trtllm_fp4_block_scale_moe(
     routing_logits: torch.Tensor,
     routing_bias: Optional[torch.Tensor],
     hidden_states: torch.Tensor,
-    hidden_states_scale: Optional[torch.Tensor],
     gemm1_weights: torch.Tensor,
     gemm1_weights_scale: torch.Tensor,
     gemm1_bias: Optional[torch.Tensor],
@@ -6198,6 +6208,7 @@ def trtllm_fp4_block_scale_moe(
     valid_hidden_size: Optional[int] = None,
     valid_intermediate_size: Optional[int] = None,
     hidden_states_scale_layout: Optional[SfLayout] = None,
+    hidden_states_scale: Optional[torch.Tensor] = None,
 ) -> List[torch.Tensor]:
     r"""FP4 block-scaled MoE operation.
 
@@ -6214,14 +6225,6 @@ def trtllm_fp4_block_scale_moe(
         Hidden states of shape ``[seq_len, hidden_size // 2]`` (NVFP4) or
         ``[seq_len, hidden_size]`` (MXFP8 / bfloat16).  Supports bfloat16,
         MXFP8, and NVFP4 (packed into uint8).
-    hidden_states_scale : Optional[torch.Tensor]
-        Block scales for MXFP8 / NVFP4 hidden states of shape
-        ``[seq_len, hidden_size // (32 if mxfp8 else 16)]``.  Dtype is float8.
-        The equivalent flat ``[seq_len * hidden_size // (32 if mxfp8 else 16)]``
-        buffer returned by :func:`~flashinfer.mxfp8_quantize` with
-        ``is_sf_swizzled_layout=False`` (the linear layout) is also accepted.
-        Declare which layout the buffer is in with
-        ``hidden_states_scale_layout``; only the linear layout is supported.
     gemm1_weights : torch.Tensor
         ``[num_experts, M, hidden_size // 2]`` packed FP4 FC1 weights, dtype
         ``uint8``.  ``M`` is ``2 * intermediate_size`` for gated activations and
@@ -6362,6 +6365,18 @@ def trtllm_fp4_block_scale_moe(
         Valid (unpadded) intermediate dimension.  When provided,
         ``intermediate_size`` is treated as padded and only the valid region is
         computed.  Default ``None`` (use the full ``intermediate_size``).
+    hidden_states_scale : Optional[torch.Tensor]
+        Block scales for MXFP8 / NVFP4 hidden states of shape
+        ``[seq_len, hidden_size // (32 if mxfp8 else 16)]``.  Dtype is float8.
+        The equivalent flat ``[seq_len * hidden_size // (32 if mxfp8 else 16)]``
+        buffer returned by :func:`~flashinfer.mxfp8_quantize` with
+        ``is_sf_swizzled_layout=False`` (the linear layout) is also accepted.
+        Declare which layout the buffer is in with
+        ``hidden_states_scale_layout``; only the linear layout is supported.
+        Must be ``None`` (the default) for bfloat16 ``hidden_states``, which
+        carry no block scales; bfloat16 activations require MXFP4
+        (``MxE2m1``) weights.
+
     Returns
     -------
     List[torch.Tensor]
@@ -6392,7 +6407,6 @@ def trtllm_fp4_block_scale_moe(
         None,
         routing_bias,
         hidden_states,
-        hidden_states_scale,
         gemm1_weights,
         gemm1_weights_scale,
         gemm1_bias,
@@ -6427,6 +6441,7 @@ def trtllm_fp4_block_scale_moe(
         valid_hidden_size,
         valid_intermediate_size,
         hidden_states_scale_layout,
+        hidden_states_scale=hidden_states_scale,
     )
 
 
@@ -6676,7 +6691,6 @@ def trtllm_fp4_block_scale_routed_moe(
         topk_weights,
         routing_bias,
         hidden_states,
-        hidden_states_scale,
         gemm1_weights,
         gemm1_weights_scale,
         gemm1_bias,
@@ -6711,6 +6725,7 @@ def trtllm_fp4_block_scale_routed_moe(
         valid_hidden_size,
         valid_intermediate_size,
         hidden_states_scale_layout,
+        hidden_states_scale=hidden_states_scale,
     )
 
 

--- a/tests/moe/test_bf16_hidden_states_moe.py
+++ b/tests/moe/test_bf16_hidden_states_moe.py
@@ -1,0 +1,128 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Regression tests for bfloat16 ``hidden_states`` in ``trtllm_fp4_block_scale_moe``.
+
+Covers the two failures reported in issue #2657:
+
+1. ``hidden_states_scale`` was annotated ``Optional[torch.Tensor]`` but carried no
+   default, so omitting it — the correct thing to do for bfloat16 activations, which
+   have no block scales — raised ``TypeError`` instead of running.
+2. Pairing bfloat16 activations with non-MXFP4 weights tripped a raw ``TVM_FFI_ICHECK``
+   inside ``FP4BlockScaleLauncher::check_moe`` ("Only MxE2m1 weights are supported ...")
+   at kernel-launch time. The constraint is real, but the diagnostic should be raised
+   in Python, before the kernel launches.
+"""
+
+import inspect
+
+import pytest
+import torch
+
+from flashinfer.fused_moe import trtllm_fp4_block_scale_moe
+from flashinfer.utils import is_sm100a_supported
+
+
+def test_hidden_states_scale_is_optional():
+    """``hidden_states_scale`` must be omissible (issue #2657, error 1).
+
+    A signature-level check, so it guards the regression on any machine — no
+    Blackwell GPU and no JIT build required.
+    """
+    param = inspect.signature(trtllm_fp4_block_scale_moe).parameters.get(
+        "hidden_states_scale"
+    )
+    assert param is not None, "hidden_states_scale parameter is missing"
+    assert param.default is None, (
+        "hidden_states_scale must default to None so bf16 callers can omit it; "
+        f"got default {param.default!r}"
+    )
+    assert param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_bf16_hidden_states_with_non_mxfp4_weights_raises():
+    """bf16 activations + NVFP4 (``E2m1``) weights must fail in Python (issue #2657, error 2).
+
+    ``E2m1`` weight scales are one per 16 elements; ``MxE2m1`` (MXFP4) uses one per 32.
+    Building the scale tensor with the //16 shape therefore selects the unsupported
+    combination, which must surface as a ValueError rather than a C++ check failure.
+    """
+    device = torch.device("cuda")
+    if not is_sm100a_supported(device):
+        pytest.skip("trtllm_fp4_block_scale_moe requires SM100a and CUDA 12.8+.")
+
+    num_tokens, hidden_size, intermediate_size = 8, 128, 128
+    num_experts, top_k = 2, 1
+
+    hidden_states = torch.randn(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=device
+    )
+    routing_logits = torch.zeros(
+        num_tokens, num_experts, dtype=torch.float32, device=device
+    )
+
+    def _fp4_weights(out_features, in_features):
+        weights = torch.randint(
+            0,
+            256,
+            (num_experts, out_features, in_features // 2),
+            dtype=torch.uint8,
+            device=device,
+        )
+        # //16 -> deduced as E2m1 (NVFP4), which bf16 activations do not support.
+        scale = torch.ones(
+            num_experts,
+            out_features,
+            in_features // 16,
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        return weights, scale
+
+    gemm1_weights, gemm1_weights_scale = _fp4_weights(
+        2 * intermediate_size, hidden_size
+    )
+    gemm2_weights, gemm2_weights_scale = _fp4_weights(hidden_size, intermediate_size)
+
+    with pytest.raises(ValueError, match="MxE2m1"):
+        trtllm_fp4_block_scale_moe(
+            routing_logits=routing_logits,
+            routing_bias=None,
+            hidden_states=hidden_states,
+            gemm1_weights=gemm1_weights,
+            gemm1_weights_scale=gemm1_weights_scale,
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=gemm2_weights,
+            gemm2_weights_scale=gemm2_weights_scale,
+            gemm2_bias=None,
+            output1_scale_scalar=None,
+            output1_scale_gate_scalar=None,
+            output2_scale_scalar=None,
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            # hidden_states_scale deliberately omitted: bf16 activations carry no
+            # block scales, and omitting it must not raise TypeError.
+        )

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -184,7 +184,6 @@ def _run_trtllm_gen_routed_fused_moe_case(
         routing_logits,
         None,  # routing_bias
         hidden_states,
-        hidden_states_scale,
         w13,
         w13_scale,
         None,  # w13_bias
@@ -210,6 +209,7 @@ def _run_trtllm_gen_routed_fused_moe_case(
         enable_pdl,
         activation_type.value,  # act_type
         None,
+        hidden_states_scale=hidden_states_scale,
     )[0].to(torch.float)
 
     if routing_method_type == RoutingMethodType.Renormalize:

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -1349,6 +1349,7 @@ try:
     out2_scale = torch.full((E_loc_fp4,), scale_val**2, device=device)
 
     _fp4_moe_common = dict(
+        hidden_states_scale=hs_fp4_scale,
         num_experts=E_tot_fp4,
         intermediate_size=I_fp4,
         local_expert_offset=0,
@@ -1359,7 +1360,6 @@ try:
         routing_logits_fp4,
         None,  # routing_bias
         hs_fp4,
-        hs_fp4_scale,
         w13_fp4,
         w13_fp4_scale,
         None,  # gemm1_bias


### PR DESCRIPTION
`hidden_states_scale` was typed as `Optional[torch.Tensor]` but had no default value, causing a `TypeError` when callers omitted it with bf16 hidden_states (issue #2657 error 2). Move the parameter to the end of both the public API and the registered op so it properly defaults to None.

Add a Python-level validation check: when hidden_states dtype is bfloat16, gemm1_weights must be in MxE2m1 (MXFP4) format — the underlying kernel only supports that combination. Previously the C++ assertion fired with an opaque error; now a clear ValueError is raised with guidance to use trtllm_bf16_moe for all-BF16 cases.

Update docstring to document the parameter's position and constraints.

Fixes #2657

AI-assisted

<!-- .github/pull_request_template.md -->

## 📌 Description
`trtllm_fp4_block_scale_moe` documented `hidden_states_scale` as optional but it had no default value, causing a TypeError when omitted with bf16 hidden_states. This moves the parameter to the end of both the public API and the registered op so it defaults to None, and adds a clear Python-level validation error when bf16 activations are paired with non-MxE2m1 weights.

## 🔍 Related Issues
Fixes #2657
https://github.com/flashinfer-ai/flashinfer/issues/2657

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

The signature change moves `hidden_states_scale` to a keyword argument at the end of the parameter list (matching the pattern already used in the inner registered op). Existing callers passing it positionally will need to update, but the previous behavior was broken anyway. Happy to adjust if the team prefers a different approach.

Tests added in tests/moe/test_bf16_hidden_states_moe.py. The signature test runs without a GPU; the validation test requires SM100 and was not run locally due to hardware unavailability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * FP4 block-scale MoE operations now support optional hidden-state scaling, allowing calls without explicitly providing a scaling parameter.

* **Bug Fixes**
  * Added validation for BF16 hidden states with incompatible weight formats, providing clearer guidance when an unsupported configuration is used.

* **Tests**
  * Added regression coverage for optional hidden-state scaling and BF16 hidden-state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->