### PR TITLE
chore: guard regression with trtllm_bf16_routed_moe tests

### DIFF
--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -43,6 +43,7 @@ from flashinfer.utils import device_support_pdl
 from .test_trtllm_gen_fused_moe import (
     FP8BlockScaleMoe,
     QuantMode,
+    routing_reference_no_aux,
     routing_reference_renormalize,
     routing_reference_renormalize_naive,
     routing_reference_topk,
@@ -410,37 +411,38 @@ def test_trtllm_gen_fp8_routed_fused_moe(
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
 
 
-@pytest.mark.parametrize("num_tokens", [8, 64])
-@pytest.mark.parametrize("hidden_size", [1024, 2048])
-@pytest.mark.parametrize("intermediate_size", [1024, 2048])
-@pytest.mark.parametrize("num_experts", [8, 16])
-@pytest.mark.parametrize("top_k", [2, 4])
-@pytest.mark.parametrize(
-    "routing_method_type",
-    [
-        RoutingMethodType.Renormalize,
-    ],
-)
-def test_trtllm_gen_bf16_routed_fused_moe(
+def run_bf16_routed_equivalence_test(
     num_tokens: int,
     hidden_size: int,
     intermediate_size: int,
     top_k: int,
     num_experts: int,
     routing_method_type: RoutingMethodType,
+    routed_scaling_factor: float | None = None,
+    routing_bias: torch.Tensor | None = None,
+    n_group: int | None = None,
+    topk_group: int | None = None,
+    seed: int = 42,
 ):
     """Test Bf16 scale routed MoE matches standard routing."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] not in [10]:
         pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
-    torch.manual_seed(42)
+    torch.manual_seed(seed)
     device = torch.device("cuda:0")
     enable_pdl = device_support_pdl(device)
 
     # Generate random routing logits for reference
-    routing_logits = torch.rand(num_tokens, num_experts, device=device).to(
-        torch.bfloat16
-    )
+    if routing_method_type == RoutingMethodType.DeepSeekV3:
+        routing_logits = torch.randn(num_tokens, num_experts, device=device).to(
+            torch.float
+        )
+        if routing_bias is None:
+            routing_bias = torch.randn(num_experts, device=device, dtype=torch.bfloat16)
+    else:
+        routing_logits = torch.rand(num_tokens, num_experts, device=device).to(
+            torch.bfloat16
+        )
 
     # Generate random hidden states in FP8
     hidden_states = (
@@ -469,18 +471,18 @@ def test_trtllm_gen_bf16_routed_fused_moe(
     # Run reference with routing_logits
     reference_output = trtllm_bf16_moe(
         routing_logits=routing_logits,
-        routing_bias=None,
+        routing_bias=routing_bias,
         hidden_states=hidden_states,
         gemm1_weights=gemm1_weights,
         gemm2_weights=gemm2_weights,
         num_experts=num_experts,
         top_k=top_k,
-        n_group=None,
-        topk_group=None,
+        n_group=n_group,
+        topk_group=topk_group,
         intermediate_size=intermediate_size,
         local_expert_offset=0,
         local_num_experts=num_experts,
-        routed_scaling_factor=None,
+        routed_scaling_factor=routed_scaling_factor,
         routing_method_type=routing_method_type.value,
         use_shuffled_weight=True,
         weight_layout=WeightLayout.BlockMajorK,
@@ -501,6 +503,18 @@ def test_trtllm_gen_bf16_routed_fused_moe(
         permute_info, expert_weights_ref = routing_reference_topk(
             routing_logits, top_k, num_experts, 8
         )
+    elif routing_method_type == RoutingMethodType.DeepSeekV3:
+        permute_info, expert_weights_ref = routing_reference_no_aux(
+            routing_logits,
+            routing_bias,
+            top_k,
+            n_group,
+            topk_group,
+            routed_scaling_factor,
+            8,
+        )
+    else:
+        raise NotImplementedError(f"Unsupported routing method: {routing_method_type}")
     topk_ids = permute_info["topKIndices"].to(torch.int32)
     expert_weights = expert_weights_ref.view(num_tokens, num_experts)[
         torch.arange(num_tokens, device=device).unsqueeze(1), topk_ids
@@ -520,12 +534,12 @@ def test_trtllm_gen_bf16_routed_fused_moe(
         gemm2_weights=gemm2_weights,
         num_experts=num_experts,
         top_k=top_k,
-        n_group=None,
-        topk_group=None,
+        n_group=n_group,
+        topk_group=topk_group,
         intermediate_size=intermediate_size,
         local_expert_offset=0,
         local_num_experts=num_experts,
-        routed_scaling_factor=None,
+        routed_scaling_factor=routed_scaling_factor,
         routing_method_type=routing_method_type.value,
         use_shuffled_weight=True,
         weight_layout=WeightLayout.BlockMajorK,
@@ -538,6 +552,50 @@ def test_trtllm_gen_bf16_routed_fused_moe(
     # mismatch percentage
     mismatch_pct = (~mask).float().mean().item() * 100
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
+
+
+@pytest.mark.parametrize("num_tokens", [8, 64])
+@pytest.mark.parametrize("hidden_size", [1024, 2048])
+@pytest.mark.parametrize("intermediate_size", [1024, 2048])
+@pytest.mark.parametrize("num_experts", [8, 16])
+@pytest.mark.parametrize("top_k", [2, 4])
+@pytest.mark.parametrize(
+    "routing_method_type",
+    [
+        RoutingMethodType.Renormalize,
+    ],
+)
+def test_trtllm_gen_bf16_routed_fused_moe(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_experts: int,
+    routing_method_type: RoutingMethodType,
+):
+    run_bf16_routed_equivalence_test(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        num_experts=num_experts,
+        routing_method_type=routing_method_type,
+    )
+
+
+def test_trtllm_gen_bf16_routed_fused_moe_deepseek_routing():
+    run_bf16_routed_equivalence_test(
+        num_tokens=1,
+        hidden_size=128,
+        intermediate_size=128,
+        top_k=1,
+        num_experts=32,
+        routing_method_type=RoutingMethodType.DeepSeekV3,
+        routed_scaling_factor=2.0,
+        n_group=1,
+        topk_group=1,
+        seed=0,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

**Update: bug no longer reproducible on ToT since https://github.com/flashinfer-ai/flashinfer/pull/2803 fixed it. The only useful part left is the regression testing.**

Old title was `fix: segfault using packed topk_id/weight as trtllm_bf16_routed_moe input in DeepSeek routing`

Old description:

When deciding whether to enter the main routing kernel inside the MoE, switch the condition from `mPtrTopKIds == nullptr` to `mPtrScores != nullptr`.

`mPtrTopKIds == nullptr` is true for the "packed" pre-routed inputs so it will go down the main routing kernel path. It is the wrong code path.  As `mPtrScores` is the routing logits, the condition should be `mPtrScores != nullptr`.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

Found when integrating FlashInfer BF16 TRTLLM MoE in https://github.com/NVIDIA/TensorRT-LLM/pull/12557

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added explicit DeepSeekV3 routing coverage for MoE equivalence checks.
  * Enhanced routed-MoE test harness with configurable routing parameters and deterministic seeding to improve validation and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->