### PR TITLE
docs: document replay command in CLI reference

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -97,3 +97,20 @@ Clear JIT compilation cache:
 .. code-block:: bash
 
    flashinfer clear-cache
+
+Replay Recorded Calls
+---------------------
+
+Replay API dumps captured by the Level 10 "Flight Recorder" logging mode:
+
+.. code-block:: bash
+
+   # Replay all recorded calls in a dump session
+   flashinfer replay --dir ./flashinfer_dumps
+
+   # Replay a single recorded call
+   flashinfer replay --dir ./flashinfer_dumps/<dump_directory>
+
+The ``replay`` command accepts either the root dump directory or a single dump
+subdirectory. For the full dump/replay workflow and Level 10 logging
+configuration, see :ref:`logging`.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR documents the `flashinfer replay` command in the CLI reference.

The `replay` command was introduced in #2206 as part of the Level 10 Flight Recorder / replay workflow, but it was not listed in `docs/cli.rst` alongside the other CLI commands. This PR adds a short `Replay Recorded Calls` section with examples for:

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CLI documentation for the `flashinfer replay` command, including instructions and examples for replaying recorded API dumps from the Level 10 "Flight Recorder" logging feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->