### PR TITLE
feat: add Relu2 (squared ReLU) activation support in CUTLASS MoE backend

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/cutlass_extensions/include/cutlass_extensions/epilogue_helpers.h
+++ b/csrc/nv_internal/tensorrt_llm/cutlass_extensions/include/cutlass_extensions/epilogue_helpers.h
@@ -50,6 +50,8 @@ struct EpilogueOpDefaultReLU {};
 
 struct EpilogueOpDefaultFtGelu {};
 
+struct EpilogueOpDefaultRelu2 {};
+
 struct EpilogueOpDefault {};
 
 template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator,
@@ -115,6 +117,13 @@ struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, Epilog
   using Op = cutlass::epilogue::thread::LinearCombination<ElementType, ElementsPerVectorAccess,
                                                           ElementAccumulator, ElementAccumulator,
                                                           DefaultScaleMode>;
+};
+
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
+struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpDefaultRelu2> {
+  using Op = cutlass::epilogue::thread::LinearCombinationGeneric<
+      cutlass::epilogue::thread::Relu2, ElementType, ElementsPerVectorAccess, ElementAccumulator,
+      ElementAccumulator, DefaultScaleMode>;
 };
 
 }  // namespace cutlass_extensions

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
@@ -1035,6 +1035,9 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType, IsMXFPX>::moeGemmBi
     case ActivationType::Geglu:
       runGemm<cutlass_extensions::EpilogueOpDefaultFtGelu>(inputs, hopper_inputs);
       break;
+    case ActivationType::Relu2:
+      runGemm<cutlass_extensions::EpilogueOpDefaultRelu2>(inputs, hopper_inputs);
+      break;
     case ActivationType::InvalidType:
       TLLM_THROW("Activation type for fpA_intB must be valid.");
       break;


### PR DESCRIPTION
## Summary

Add **Relu2 (squared ReLU) activation** support for the CUTLASS MoE GEMM path, enabling models that use Relu2 as their MoE gate activation (e.g. Nemotron-H MTP draft model) to run through the FlashInfer CUTLASS backend instead of throwing `InvalidType` at runtime.

## Problem

Two pieces were missing:

1. `epilogue_helpers.h` had no `EpilogueOpDefaultRelu2` tag struct or `Epilogue` partial specialization, so there was no CUTLASS epilogue type for Relu2.
2. `moeGemmBiasAct()` in `moe_gemm_template_dispatch.h` had no `case ActivationType::Relu2`, causing it to fall through to `InvalidType` and throw.

The `Relu2` functor itself (`relu(x)²`) already existed in `fused_activations.h` — this PR just wires it into the epilogue dispatch.

## Changes

- **`epilogue_helpers.h`**: Added `EpilogueOpDefaultRelu2` tag struct and a corresponding `Epilogue<..., EpilogueOpDefaultRelu2>` partial specialization that instantiates the existing `Relu2Op` functor via `LinearCombinationGeneric`.
- **`moe_gemm_template_dispatch.h`**: Added `case ActivationType::Relu2` to `moeGemmBiasAct()`, dispatching to the new epilogue type.

## Test plan

- [ ] Existing MoE tests pass: `pytest tests/moe/`
- [ ] Relu2-specific tests: `pytest tests/moe/test_trtllm_gen_fused_moe.py -k Relu2`
- [ ] Manual: run a Relu2 MoE model (e.g. Nemotron-H MTP) through vLLM with FlashInfer CUTLASS backend and verify no `InvalidType` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Relu2 activation function support for model computation kernels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->