### PR TITLE
docker: upgrade cuDNN to latest version in CI install script

### DIFF
--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -31,8 +31,8 @@ pip3 install responses pytest scipy build cuda-python nvidia-nvshmem-cu12
 # Install cudnn package based on CUDA version
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
   pip3 install --upgrade cuda-python==13.0
-  pip3 install "nvidia-cudnn-cu13>=9.14.0.64"
+  pip3 install --upgrade nvidia-cudnn-cu13
 else
   pip3 install --upgrade cuda-python==12.*
-  pip3 install "nvidia-cudnn-cu12>=9.14.0.64"
+  pip3 install --upgrade nvidia-cudnn-cu12
 fi


### PR DESCRIPTION
Replace minimum version constraint with --upgrade flag to ensure CI containers always get the latest cuDNN version, fixing inconsistency between cu12 and cu13 containers.

Fixes #2929

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated NVIDIA cuDNN packages in Docker installation to the latest available versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->