### PR TITLE
fix: vectorize get_shuffle_matrix_a_row_indices to eliminate CPU contention

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -840,16 +840,14 @@ def get_shuffle_matrix_a_row_indices(
     # row_indices[new_row] = old_row
     # so row_indices is an array of size M telling us from which old_row
     # the new_row should be taken.
+    # Vectorized: avoids a slow Python for-loop over M rows (CPU contention
+    # when many ranks call this simultaneously on large weight matrices).
+    old_rows = torch.arange(M, dtype=torch.long)
+    row_map_tensor = torch.tensor(row_map, dtype=torch.long)
+    mapped_rows = row_map_tensor[old_rows % shuffle_block_size]
+    new_rows = (old_rows // shuffle_block_size) * shuffle_block_size + mapped_rows
     row_indices = torch.empty(M, dtype=torch.long)
-
-    for old_row in range(M):
-        block_idx = old_row // shuffle_block_size
-        row_in_block = old_row % shuffle_block_size
-        mapped_row_in_block = row_map[row_in_block]
-
-        new_row = block_idx * shuffle_block_size + mapped_row_in_block
-
-        row_indices[new_row] = old_row
+    row_indices[new_rows] = old_rows
 
     return row_indices
 


### PR DESCRIPTION
## Problem

Closes #2934.

`get_shuffle_matrix_a_row_indices` in `flashinfer/utils.py` used a Python `for` loop iterating over all `M` rows of the weight matrix to build the shuffle index permutation. For large models this loop is slow (~0.5s per call on large weight matrices), and when multiple tensor-parallel ranks finish loading their weight shards at the same time, all ranks hit this CPU-bound loop simultaneously. This causes severe CPU contention — ranks that happen to start earlier monopolize the CPU cores and the stragglers are delayed by up to ~30 minutes, even though the final permutation is identical across all ranks (same `M`, same `shuffle_block_size`, same `row_map`).

The false dependency between ranks compounds the problem: all ranks are computing the same result independently, yet they serialize on CPU.

## Fix

Replace the Python for-loop with vectorized PyTorch tensor operations:

```python
# Before: O(M) Python loop — slow and causes CPU contention
for old_row in range(M):
    block_idx = old_row // shuffle_block_size
    row_in_block = old_row % shuffle_block_size
    mapped_row_in_block = row_map[row_in_block]
    new_row = block_idx * shuffle_block_size + mapped_row_in_block
    row_indices[new_row] = old_row

# After: vectorized — equivalent logic, no Python loop
old_rows = torch.arange(M, dtype=torch.long)
row_map_tensor = torch.tensor(row_map, dtype=torch.long)
mapped_rows = row_map_tensor[old_rows % shuffle_block_size]
new_rows = (old_rows // shuffle_block_size) * shuffle_block_size + mapped_rows
row_indices[new_rows] = old_rows
```

The logic is identical — only the implementation changes from a scalar Python loop to bulk tensor operations, which is orders of magnitude faster for large `M`. After the fix, the function takes around 0.05s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal tensor operations to improve performance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->