### PR TITLE
fix: use float instead of double in sampling binary search to avoid FP64 bottleneck on SM103

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -53,6 +53,26 @@ namespace sampling {
 
 using namespace cub;
 
+// IEEE-754 compliant arithmetic via inline PTX (no .ftz modifier).
+// Under -use_fast_math, the compiler emits .ftz variants that flush subnormal
+// results to zero.  These helpers bypass that for operations where subnormal
+// correctness matters (see #769, #774).
+__device__ __forceinline__ float ieee_mul(float a, float b) {
+  float r;
+  asm("mul.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+  return r;
+}
+__device__ __forceinline__ float ieee_add(float a, float b) {
+  float r;
+  asm("add.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+  return r;
+}
+__device__ __forceinline__ float ieee_div(float a, float b) {
+  float r;
+  asm("div.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+  return r;
+}
+
 #define DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, ...) \
   if (deterministic) {                                            \
     constexpr bool DETERMINISTIC = true;                          \
@@ -884,12 +904,9 @@ __global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, bool* v
       }
       sampled_id = temp_storage.last_valid_id;
     }
-    // float is safe here: pivot_0 is loaded from the probs array and *0.5f
-    // produces FMUL.FTZ, but both operands are probabilities in [0,1] so the
-    // result is always a normal float (FTZ never activates).  The count-based
-    // break above provides a second termination path.  See #769 / #774.
+    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
     float pivot_0 = probs[row_idx * d + sampled_id];
-    float pivot_1 = (pivot_0 + high) * 0.5f;
+    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
 
     ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
     ValueCount<float> threadlocal_gt_pivot_0{0, 0}, threadlocal_gt_pivot_1{0, 0};
@@ -1018,12 +1035,9 @@ __global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, bool* v
       }
       sampled_id = temp_storage.last_valid_id;
     }
-    // float is safe here: pivot_0 is loaded from the probs array and *0.5f
-    // produces FMUL.FTZ, but both operands are probabilities in [0,1] so the
-    // result is always a normal float (FTZ never activates).  The count-based
-    // break above provides a second termination path.  See #769 / #774.
+    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
     float pivot_0 = probs[row_idx * d + sampled_id];
-    float pivot_1 = (pivot_0 + high) * 0.5f;
+    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
 
     float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
     float threadlocal_aggregate_gt_pivot_0 = 0;
@@ -1245,12 +1259,9 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, 
         return;
       }
     }
-    // float is safe here: pivot_0 is loaded from the probs array and *0.5f
-    // produces FMUL.FTZ, but both operands are probabilities in [0,1] so the
-    // result is always a normal float (FTZ never activates).  The count-based
-    // break above provides a second termination path.  See #769 / #774.
+    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
     float pivot_0 = probs[row_idx * d + sampled_id];
-    float pivot_1 = (pivot_0 + high) * 0.5f;
+    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
 
     ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
     ValueCount<float> threadlocal_aggregate_gt_pivot_0{0, 0};
@@ -1734,11 +1745,10 @@ __global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* 
   // stopping condition
   // - f(low) >= p, f(min_gt_low) == f(max_le_high) == f(high) < p
   do {
-    float pivot_0 = (high + 2 * low) / 3.f;
-    float pivot_1 = (2 * high + low) / 3.f;
-    // Guard against -use_fast_math FTZ: if div.approx.ftz.f32 flushed a pivot
-    // into low/high (e.g. subnormal result → 0), the search can't progress.
-    if (pivot_0 <= low || pivot_1 >= high) break;
+    // Use IEEE-754 arithmetic (no FTZ) to prevent -use_fast_math from flushing
+    // subnormal pivots to zero, which would stall the search (#769, #774).
+    float pivot_0 = ieee_div(ieee_add(high, ieee_mul(2.f, low)), 3.f);
+    float pivot_1 = ieee_div(ieee_add(ieee_mul(2.f, high), low), 3.f);
 
     float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
     min_gt_low = high;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

#### Summary
- Replace `double` with `float` for binary search variables (`low`, `high`, `pivot_0`, `pivot_1`) in three sampling kernels: `TopKSamplingFromProbKernel`, `TopPSamplingFromProbKernel`, `TopKTopPSamplingFromProbKernel`
- Use inline PTX IEEE-754 arithmetic (`mul.rn.f32`, `add.rn.f32`, `div.rn.f32`) for all pivot computations to guarantee no FTZ, verified via SASS inspection

#### Problem                                               
`top_k_sampling_from_probs` is ~7x slower on B300 (SM103) compared to B200 (SM100), despite identical SM count (148), similar memory bandwidth.

**Root cause**: The binary search loop in the sampling kernels used `double` for `low`, `high`, `pivot_0`, and `pivot_1`. These variables participate in comparisons (probs_vec[j] > pivot_0) across all 1024 threads in the inner loop, promoting float operands to double — hundreds of FP64 ops per iteration.

B300 (SM103) has a 1:64 FP64:FP32 throughput ratio (inference-optimized die), vs B200's 1:2. Since the prob values are already float32, the double precision was unnecessary and created a severe bottleneck on reduced-FP64 GPUs.

#### Relationship to #769 and #774

Issue #769 reported a hang in the old `top_k_top_p_sampling_from_probs` caused by `-use_fast_math` emitting `div.approx.ftz.f32`, which flushed subnormal division results to zero and stalled the binary search. PR #774 fixed this by changing `float` to `double` in three renorm/mask kernels.

The `double` in the sampling kernels was introduced one month later by PR #912, which rewrote the sampling algorithm with dual-pivot rejection sampling. PR #912 likely copied the `double` convention without it being structurally needed — the new algorithm does not share the #769 failure mechanism.

This PR uses inline PTX to guarantee no FTZ on pivot arithmetic, making double unnecessary across all four kernels. Three IEEE-754 helpers (`ieee_mul`, `ieee_add`, `ieee_div`) emit `mul.rn.f32`, `add.rn.f32`, `div.rn.f32` without the `.ftz` modifier, verified via SASS inspection on both SM100a and
  SM103a. This is strictly stronger than the original double fix — it prevents FTZ at the instruction level rather than sidestepping it via wider precision.

#### Perf results 
Geomean speedups
- `top_k_sampling_from_probs`: 1.11x on B200; 5.67x on B300
- `top_p_sampling_from_probs`: 1.09x on B200; 4.80x on B300

<details>
  <summary> Click to show collapsed perf numbers python3 benchmarks/bench_sampling.py</summary>


The following categories are not impacted and thus not shown: `naive sampling`, `sampling from softmax(logits)`, `sampling from logits`, `top-p renorm probs`, `top-k renorm probs`, `top-k mask logits`.

Perf data from impacted categories:

| category | case | B200 before | B200 after | B300 before | B300 after |
|----------|------|-------------|------------|-------------|------------|
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 188.42 us | 170.05 us | 1133.57 us | **164.88 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 147.52 us | 135.20 us | 895.97 us | **132.05 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 102.37 us | 92.19 us | 570.40 us | **91.14 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 65.57 us | 58.40 us | 336.86 us | **64.59 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 190.54 us | 172.08 us | 1217.39 us | **166.99 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 144.40 us | 131.04 us | 885.73 us | **127.97 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 98.29 us | 90.11 us | 562.11 us | **87.04 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 66.53 us | 59.36 us | 332.85 us | **65.44 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 66.53 us | 58.37 us | 183.20 us | **64.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 66.56 us | 58.43 us | 183.33 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 66.53 us | 58.46 us | 183.26 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 67.55 us | 58.43 us | 183.33 us | **64.64 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 66.50 us | 58.38 us | 181.20 us | **63.57 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 66.56 us | 58.37 us | 181.25 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 66.56 us | 59.33 us | 181.20 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 66.56 us | 58.42 us | 181.28 us | **63.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 66.54 us | 59.36 us | 187.39 us | **63.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 66.56 us | 59.30 us | 187.34 us | **64.02 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 66.54 us | 59.36 us | 187.39 us | **64.42 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 66.56 us | 59.39 us | 187.33 us | **63.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 66.50 us | 58.37 us | 185.34 us | **63.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 66.56 us | 59.36 us | 185.31 us | **63.63 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 66.56 us | 58.37 us | 185.34 us | **63.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 66.46 us | 58.83 us | 185.31 us | **65.07 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 147.60 us | 135.14 us | 898.06 us | **132.06 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 65.55 us | 59.33 us | 336.90 us | **63.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 67.58 us | 59.36 us | 336.75 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 67.55 us | 60.42 us | 199.71 us | **63.57 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 143.36 us | 131.04 us | 886.86 us | **127.41 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 66.56 us | 59.39 us | 332.85 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 66.56 us | 58.42 us | 332.75 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 66.56 us | 59.38 us | 197.66 us | **64.59 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 389.12 us | 354.27 us | 2390.02 us | **345.12 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 294.91 us | 270.27 us | 1801.20 us | **263.20 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 262.14 us | 239.55 us | 1587.20 us | **234.50 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 225.28 us | 206.82 us | 1363.97 us | **201.73 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 331.71 us | 297.09 us | 2091.01 us | **290.72 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 288.72 us | 259.07 us | 1773.52 us | **252.93 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 255.97 us | 229.46 us | 1562.58 us | **224.27 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 221.18 us | 198.69 us | 1343.50 us | **194.08 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 98.27 us | 87.98 us | 556.06 us | **84.99 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 85.98 us | 79.84 us | 433.06 us | **78.80 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 66.58 us | 58.40 us | 329.90 us | **63.44 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 66.56 us | 58.37 us | 255.04 us | **63.65 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 93.95 us | 84.02 us | 548.85 us | **82.94 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 83.94 us | 75.87 us | 424.99 us | **74.75 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 66.56 us | 58.37 us | 326.59 us | **63.52 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 66.56 us | 58.38 us | 250.88 us | **62.59 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 120.83 us | 110.58 us | 670.78 us | **109.55 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 92.21 us | 86.11 us | 461.86 us | **84.99 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 71.68 us | 67.55 us | 375.70 us | **66.56 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 66.56 us | 59.36 us | 259.10 us | **63.63 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 116.80 us | 106.50 us | 663.74 us | **105.41 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 90.11 us | 83.86 us | 453.66 us | **80.90 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 69.78 us | 65.54 us | 370.85 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 66.56 us | 59.26 us | 255.04 us | **63.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 374.88 us | 339.90 us | 2308.13 us | **328.82 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 337.86 us | 307.14 us | 2110.02 us | **300.00 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 294.94 us | 268.29 us | 1796.19 us | **263.04 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 180.19 us | 165.28 us | 1044.40 us | **160.83 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 364.48 us | 323.68 us | 2275.15 us | **315.33 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 329.63 us | 294.88 us | 2078.77 us | **287.86 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 286.74 us | 258.05 us | 1769.44 us | **252.90 us** |
| top-k sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 174.10 us | 157.70 us | 1027.12 us | **154.59 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 343.97 us | 313.34 us | 2121.70 us | **304.03 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 307.17 us | 280.58 us | 1843.14 us | **271.36 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 214.98 us | 196.64 us | 1251.23 us | **189.46 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 147.46 us | 135.14 us | 831.46 us | **132.03 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 440.22 us | 395.25 us | 2701.39 us | **381.95 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 296.96 us | 268.29 us | 1812.45 us | **260.02 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 207.81 us | 188.40 us | 1231.06 us | **182.24 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 143.28 us | 129.12 us | 818.21 us | **125.92 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 127.01 us | 116.74 us | 676.86 us | **113.63 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 93.18 us | 86.08 us | 465.89 us | **84.99 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 69.60 us | 58.88 us | 252.00 us | **65.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 69.70 us | 58.37 us | 252.86 us | **64.03 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 122.94 us | 112.51 us | 664.51 us | **109.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 89.60 us | 82.86 us | 457.73 us | **80.90 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 69.62 us | 58.88 us | 246.85 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 69.63 us | 59.36 us | 246.88 us | **63.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 198.62 us | 180.22 us | 1170.43 us | **175.14 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 113.62 us | 104.35 us | 617.47 us | **101.34 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 69.63 us | 58.37 us | 257.02 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 69.63 us | 58.37 us | 257.02 us | **63.50 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 192.54 us | 173.01 us | 1153.14 us | **168.96 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 109.57 us | 100.32 us | 609.28 us | **97.28 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 69.63 us | 58.37 us | 250.93 us | **63.52 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 68.77 us | 58.37 us | 250.88 us | **64.53 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 419.78 us | 380.93 us | 2649.06 us | **367.76 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 352.08 us | 317.39 us | 2164.62 us | **308.27 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 244.75 us | 219.04 us | 1513.47 us | **212.00 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 145.38 us | 134.58 us | 818.08 us | **132.00 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 406.05 us | 366.59 us | 2613.30 us | **353.38 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 341.95 us | 305.09 us | 2132.00 us | **295.94 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 237.42 us | 210.91 us | 1493.07 us | **203.79 us** |
| top-k sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 141.49 us | 128.99 us | 805.89 us | **125.98 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 445.97 us | 407.52 us | 2693.06 us | **394.24 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 350.14 us | 317.44 us | 2086.94 us | **310.26 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 290.85 us | 266.24 us | 1632.22 us | **259.04 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 182.24 us | 165.89 us | 1092.67 us | **160.67 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 397.41 us | 356.42 us | 2584.64 us | **345.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 337.89 us | 305.07 us | 2052.26 us | **295.97 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 282.69 us | 254.00 us | 1602.56 us | **246.85 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 176.19 us | 159.71 us | 1079.23 us | **154.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 124.83 us | 116.59 us | 656.53 us | **113.66 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 83.36 us | 77.82 us | 420.90 us | **76.80 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 65.95 us | 59.46 us | 261.04 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 65.54 us | 59.39 us | 261.12 us | **63.63 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 120.86 us | 110.67 us | 646.11 us | **108.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 80.90 us | 75.76 us | 412.77 us | **74.75 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 65.54 us | 58.46 us | 255.01 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 65.54 us | 58.72 us | 254.96 us | **63.01 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 135.10 us | 124.82 us | 775.15 us | **121.79 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 98.30 us | 92.21 us | 486.42 us | **91.10 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 65.54 us | 59.39 us | 260.99 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 65.54 us | 59.42 us | 261.02 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 131.18 us | 119.84 us | 762.88 us | **117.70 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 96.26 us | 90.08 us | 477.74 us | **87.04 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 65.54 us | 58.37 us | 255.02 us | **64.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 65.54 us | 58.38 us | 254.94 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 460.70 us | 417.76 us | 2887.73 us | **404.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 327.62 us | 296.78 us | 2031.62 us | **287.65 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 237.76 us | 219.10 us | 1417.28 us | **212.00 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 206.94 us | 190.53 us | 1229.76 us | **185.38 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 446.46 us | 401.44 us | 2844.67 us | **388.16 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 319.52 us | 284.80 us | 2005.02 us | **277.44 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 230.30 us | 209.82 us | 1396.69 us | **203.81 us** |
| top-k sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 200.64 us | 183.06 us | 1210.26 us | **179.20 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 423.78 us | 382.94 us | 2714.66 us | **371.81 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 337.95 us | 305.20 us | 2091.06 us | **294.00 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 245.78 us | 221.22 us | 1495.10 us | **215.98 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 245.71 us | 221.15 us | 1495.07 us | **214.02 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 430.14 us | 389.02 us | 2723.81 us | **377.92 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 326.50 us | 294.85 us | 2060.27 us | **283.68 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 235.62 us | 213.02 us | 1475.15 us | **205.95 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 236.08 us | 213.01 us | 1474.56 us | **205.86 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 160.80 us | 149.49 us | 869.41 us | **146.40 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 114.69 us | 104.59 us | 611.39 us | **103.33 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 87.04 us | 79.87 us | 427.01 us | **78.85 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 69.14 us | 61.46 us | 256.99 us | **64.51 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 157.68 us | 143.36 us | 854.98 us | **140.29 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 110.59 us | 101.46 us | 602.06 us | **99.33 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 82.94 us | 76.82 us | 420.80 us | **76.64 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 69.63 us | 60.38 us | 252.96 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 183.30 us | 169.92 us | 1029.02 us | **164.83 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 120.86 us | 112.61 us | 635.87 us | **109.57 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 68.72 us | 62.38 us | 261.01 us | **63.49 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 69.63 us | 62.45 us | 261.12 us | **63.94 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 179.20 us | 163.76 us | 1012.77 us | **158.72 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 118.21 us | 108.51 us | 625.66 us | **105.47 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 68.58 us | 61.39 us | 254.98 us | **63.50 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 68.61 us | 61.41 us | 255.04 us | **63.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 428.03 us | 384.99 us | 2789.26 us | **373.76 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 339.87 us | 309.22 us | 2160.69 us | **300.06 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 293.87 us | 264.14 us | 1892.32 us | **256.99 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 229.54 us | 206.85 us | 1314.82 us | **201.71 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 415.81 us | 372.59 us | 2756.58 us | **361.41 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 329.73 us | 296.94 us | 2137.12 us | **287.76 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 284.64 us | 254.94 us | 1869.87 us | **247.71 us** |
| top-k sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 219.74 us | 198.67 us | 1292.30 us | **191.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 576.50 us | 518.27 us | 3546.10 us | **501.84 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 450.53 us | 409.58 us | 2706.34 us | **396.26 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 348.13 us | 313.90 us | 2107.55 us | **305.04 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 294.75 us | 266.27 us | 1681.41 us | **260.06 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 557.14 us | 500.61 us | 3511.30 us | **484.27 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 440.24 us | 395.17 us | 2666.46 us | **381.95 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 336.02 us | 303.10 us | 2080.77 us | **294.06 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 287.76 us | 256.10 us | 1654.77 us | **250.78 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 194.67 us | 180.32 us | 1064.93 us | **177.10 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 155.68 us | 139.26 us | 805.95 us | **136.19 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 116.70 us | 104.53 us | 571.38 us | **103.42 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 110.59 us | 104.48 us | 478.05 us | **103.42 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 188.38 us | 174.11 us | 1051.73 us | **170.98 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 147.36 us | 135.14 us | 793.52 us | **132.13 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 109.12 us | 102.37 us | 564.13 us | **101.38 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 106.50 us | 102.37 us | 468.02 us | **99.41 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 202.72 us | 185.78 us | 1104.85 us | **181.25 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 145.28 us | 133.12 us | 807.90 us | **130.05 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 120.83 us | 112.67 us | 578.51 us | **109.70 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 110.62 us | 104.48 us | 472.06 us | **103.42 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 194.58 us | 178.30 us | 1090.56 us | **175.10 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 139.10 us | 128.99 us | 798.77 us | **126.02 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 116.74 us | 110.53 us | 570.45 us | **107.52 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 106.53 us | 102.37 us | 463.98 us | **99.33 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 681.95 us | 613.41 us | 4246.40 us | **592.93 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 493.62 us | 448.45 us | 2983.92 us | **433.18 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 364.51 us | 329.76 us | 2189.28 us | **321.07 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 272.40 us | 245.76 us | 1554.43 us | **238.59 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 659.36 us | 589.78 us | 4183.10 us | **568.40 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 480.32 us | 432.13 us | 2942.98 us | **416.90 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 354.30 us | 318.46 us | 2158.69 us | **310.18 us** |
| top-k sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 262.14 us | 237.50 us | 1531.81 us | **230.46 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, k: 10 | 993.31 us | 896.13 us | 6248.42 us | **868.37 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, k: 100 | 730.22 us | 658.32 us | 4516.34 us | **637.97 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, k: 1000 | 514.05 us | 464.86 us | 3129.20 us | **451.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, k: 5000 | 412.54 us | 372.72 us | 2378.78 us | **361.54 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, k: 10 | 929.92 us | 832.02 us | 5849.22 us | **806.69 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, k: 100 | 706.56 us | 634.75 us | 4459.63 us | **615.42 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, k: 1000 | 496.64 us | 449.47 us | 3087.94 us | **437.15 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, k: 5000 | 397.34 us | 360.35 us | 2342.88 us | **349.28 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, k: 10 | 268.38 us | 245.84 us | 1398.90 us | **240.61 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, k: 100 | 207.78 us | 188.42 us | 1010.80 us | **183.36 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, k: 1000 | 179.20 us | 164.86 us | 814.08 us | **162.06 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, k: 5000 | 178.08 us | 163.86 us | 811.97 us | **160.77 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, k: 10 | 258.11 us | 237.55 us | 1379.23 us | **232.45 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, k: 100 | 196.64 us | 182.26 us | 996.50 us | **179.22 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, k: 1000 | 169.95 us | 159.78 us | 801.81 us | **156.67 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, k: 5000 | 168.05 us | 159.71 us | 799.74 us | **156.67 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 10 | 372.83 us | 339.94 us | 2052.06 us | **330.83 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 100 | 237.57 us | 215.04 us | 1204.22 us | **209.89 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 1000 | 176.11 us | 163.81 us | 803.94 us | **160.75 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, k: 5000 | 176.10 us | 163.84 us | 800.59 us | **160.66 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 10 | 360.30 us | 327.86 us | 2021.34 us | **318.58 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 100 | 225.38 us | 208.83 us | 1186.90 us | **203.76 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 1000 | 167.87 us | 157.79 us | 792.66 us | **154.66 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, k: 5000 | 167.90 us | 157.70 us | 789.41 us | **154.66 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, k: 10 | 1033.34 us | 929.89 us | 6547.46 us | **899.06 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, k: 100 | 819.18 us | 737.28 us | 5151.79 us | **713.76 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, k: 1000 | 619.52 us | 555.07 us | 3791.87 us | **537.60 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, k: 5000 | 448.51 us | 405.50 us | 2625.50 us | **394.10 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, k: 10 | 1001.44 us | 896.96 us | 6464.13 us | **867.33 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, k: 100 | 795.50 us | 710.80 us | 5093.36 us | **687.22 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, k: 1000 | 599.07 us | 536.50 us | 3744.86 us | **519.30 us** |
| top-k sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, k: 5000 | 432.11 us | 391.17 us | 2590.72 us | **379.97 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 133.14 us | 122.78 us | 707.58 us | **118.00 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 68.64 us | 59.39 us | 160.80 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 69.60 us | 59.39 us | 160.80 us | **64.53 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 88.06 us | 81.92 us | 445.41 us | **78.93 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 67.60 us | 59.36 us | 157.23 us | **64.54 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 68.64 us | 58.90 us | 158.62 us | **64.10 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 68.69 us | 59.33 us | 142.46 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 69.50 us | 58.43 us | 144.32 us | **63.49 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 68.64 us | 59.34 us | 142.43 us | **64.61 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 69.15 us | 59.36 us | 142.24 us | **63.58 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 68.61 us | 59.90 us | 140.38 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 69.62 us | 59.38 us | 141.49 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 68.61 us | 59.38 us | 232.35 us | **64.50 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 68.62 us | 59.39 us | 148.48 us | **64.05 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 68.66 us | 58.37 us | 148.38 us | **63.52 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 68.61 us | 59.33 us | 230.37 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 68.64 us | 59.34 us | 145.07 us | **63.55 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 68.61 us | 59.39 us | 146.35 us | **64.62 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 68.56 us | 59.39 us | 160.70 us | **63.95 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 68.10 us | 59.31 us | 160.74 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 68.64 us | 58.37 us | 160.72 us | **64.61 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 68.64 us | 59.36 us | 158.69 us | **65.52 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 67.60 us | 59.39 us | 157.66 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 1, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 67.62 us | 59.39 us | 158.61 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 227.33 us | 206.70 us | 1180.67 us | **201.76 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 131.07 us | 120.80 us | 617.70 us | **119.71 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 87.17 us | 81.89 us | 387.97 us | **80.90 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 196.61 us | 180.22 us | 1069.09 us | **177.15 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 124.90 us | 116.70 us | 605.01 us | **115.62 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 83.94 us | 79.30 us | 379.90 us | **76.80 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 106.50 us | 98.30 us | 521.25 us | **97.28 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 96.22 us | 88.06 us | 486.50 us | **87.04 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 78.77 us | 73.73 us | 353.33 us | **72.70 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 102.37 us | 95.39 us | 512.96 us | **93.18 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 92.19 us | 85.98 us | 478.22 us | **82.94 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 75.81 us | 71.68 us | 347.10 us | **70.66 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 159.74 us | 147.46 us | 775.30 us | **144.38 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 94.21 us | 86.02 us | 513.04 us | **82.94 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 110.59 us | 102.37 us | 533.54 us | **101.34 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 153.58 us | 141.31 us | 759.94 us | **138.18 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 92.13 us | 83.97 us | 506.86 us | **80.90 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 106.59 us | 98.30 us | 524.32 us | **97.28 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 188.45 us | 172.00 us | 996.42 us | **168.90 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 95.23 us | 88.88 us | 425.09 us | **87.09 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 69.71 us | 59.38 us | 216.06 us | **64.50 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 181.10 us | 165.89 us | 977.89 us | **162.78 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 91.14 us | 86.02 us | 416.70 us | **84.99 us** |
| top-p sampling | vocab_size: 128512, batch_size: 16, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 69.63 us | 59.39 us | 211.97 us | **64.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 182.96 us | 165.89 us | 910.27 us | **162.78 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 103.95 us | 96.26 us | 508.96 us | **93.22 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 70.67 us | 67.58 us | 320.50 us | **66.56 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 186.40 us | 172.03 us | 996.46 us | **166.91 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 100.38 us | 94.14 us | 500.80 us | **91.14 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 69.63 us | 65.54 us | 314.34 us | **64.54 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 117.76 us | 108.54 us | 582.58 us | **105.47 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 117.76 us | 108.53 us | 558.10 us | **105.54 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 87.04 us | 79.87 us | 388.03 us | **78.85 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 112.64 us | 104.45 us | 573.55 us | **102.40 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 112.62 us | 104.42 us | 546.90 us | **101.47 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 82.94 us | 77.82 us | 378.85 us | **76.80 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 178.19 us | 161.81 us | 930.64 us | **157.86 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 179.18 us | 162.74 us | 934.91 us | **158.75 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 88.45 us | 81.94 us | 388.13 us | **80.90 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 170.16 us | 155.70 us | 915.55 us | **152.54 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 171.01 us | 157.66 us | 918.56 us | **153.54 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 84.99 us | 79.87 us | 379.84 us | **78.85 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 168.96 us | 153.70 us | 855.14 us | **150.56 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 95.23 us | 88.03 us | 476.16 us | **84.99 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 80.90 us | 75.78 us | 369.63 us | **74.75 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 161.84 us | 149.47 us | 840.67 us | **146.37 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 91.14 us | 84.03 us | 467.94 us | **82.94 us** |
| top-p sampling | vocab_size: 128512, batch_size: 32, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 78.85 us | 73.73 us | 361.47 us | **72.70 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 268.34 us | 245.79 us | 1404.99 us | **238.56 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 127.01 us | 116.74 us | 619.46 us | **113.66 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 84.96 us | 78.80 us | 373.82 us | **76.80 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 223.20 us | 204.77 us | 1132.45 us | **199.62 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 121.90 us | 112.64 us | 609.14 us | **109.62 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 80.90 us | 75.78 us | 367.50 us | **74.75 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 144.29 us | 133.15 us | 707.65 us | **130.03 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 115.71 us | 106.58 us | 539.65 us | **105.44 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 76.80 us | 71.68 us | 340.99 us | **70.66 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 137.30 us | 127.97 us | 697.42 us | **123.89 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 110.66 us | 104.42 us | 528.43 us | **101.38 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 74.75 us | 70.14 us | 334.91 us | **68.61 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 155.65 us | 143.33 us | 840.67 us | **138.24 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 97.28 us | 90.05 us | 487.46 us | **88.90 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 93.18 us | 88.03 us | 408.48 us | **84.99 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 149.46 us | 137.26 us | 828.42 us | **134.14 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 93.18 us | 86.02 us | 480.42 us | **84.99 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 89.09 us | 83.97 us | 399.33 us | **80.96 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 200.80 us | 184.35 us | 1088.54 us | **179.20 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 107.50 us | 100.34 us | 512.98 us | **97.31 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 93.18 us | 86.08 us | 408.58 us | **84.99 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 194.59 us | 178.42 us | 1069.02 us | **175.04 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 103.42 us | 96.26 us | 502.82 us | **95.23 us** |
| top-p sampling | vocab_size: 128512, batch_size: 64, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 89.09 us | 83.97 us | 400.42 us | **82.94 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 195.50 us | 179.92 us | 998.51 us | **175.10 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 142.32 us | 129.17 us | 750.54 us | **125.95 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 94.18 us | 88.06 us | 403.52 us | **87.04 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 210.93 us | 192.51 us | 1160.06 us | **187.42 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 136.19 us | 124.96 us | 736.43 us | **121.89 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 90.10 us | 84.02 us | 396.22 us | **82.94 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 178.94 us | 163.84 us | 875.36 us | **160.77 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 148.48 us | 137.18 us | 712.91 us | **134.14 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 103.44 us | 96.26 us | 494.50 us | **95.12 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 171.01 us | 157.70 us | 858.16 us | **154.62 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 143.39 us | 133.15 us | 697.33 us | **130.06 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 99.39 us | 94.14 us | 484.35 us | **91.14 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 173.06 us | 159.54 us | 848.90 us | **154.59 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 168.85 us | 155.62 us | 832.40 us | **150.64 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 84.10 us | 77.94 us | 366.56 us | **76.83 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 165.86 us | 153.57 us | 832.66 us | **148.54 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 161.95 us | 149.60 us | 817.73 us | **146.40 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 80.93 us | 76.77 us | 359.42 us | **74.78 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 219.20 us | 200.67 us | 1124.32 us | **195.55 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 135.20 us | 122.88 us | 730.16 us | **121.78 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 80.88 us | 75.82 us | 347.14 us | **74.75 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 210.98 us | 192.54 us | 1104.90 us | **188.42 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 131.07 us | 120.82 us | 718.02 us | **117.79 us** |
| top-p sampling | vocab_size: 128512, batch_size: 128, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 77.82 us | 73.73 us | 340.90 us | **73.73 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 315.36 us | 288.83 us | 1637.31 us | **281.65 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 182.29 us | 168.06 us | 905.12 us | **164.90 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 117.30 us | 112.59 us | 508.05 us | **109.65 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 274.43 us | 253.95 us | 1458.19 us | **246.70 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 176.16 us | 163.84 us | 889.89 us | **159.94 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 114.72 us | 108.54 us | 498.59 us | **107.55 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 217.02 us | 200.64 us | 1057.71 us | **195.65 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 182.24 us | 170.03 us | 933.97 us | **166.80 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 116.69 us | 110.53 us | 528.45 us | **107.55 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 208.96 us | 194.59 us | 1039.42 us | **189.47 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 176.05 us | 163.94 us | 921.42 us | **160.82 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 112.70 us | 107.30 us | 521.23 us | **105.46 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 233.42 us | 213.02 us | 1253.28 us | **207.97 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 188.29 us | 174.03 us | 885.70 us | **168.96 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 131.09 us | 124.82 us | 563.94 us | **121.86 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 225.39 us | 207.42 us | 1234.08 us | **203.68 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 181.09 us | 167.97 us | 868.42 us | **164.86 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 126.88 us | 120.83 us | 552.10 us | **117.82 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 264.22 us | 241.66 us | 1361.01 us | **234.53 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 161.66 us | 151.58 us | 742.43 us | **148.53 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 119.58 us | 112.64 us | 523.26 us | **111.57 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 253.98 us | 233.54 us | 1341.44 us | **228.38 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 156.61 us | 147.46 us | 731.07 us | **144.45 us** |
| top-p sampling | vocab_size: 128512, batch_size: 256, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 115.71 us | 110.61 us | 517.18 us | **107.78 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, p: 0.1 | 489.44 us | 446.46 us | 2597.89 us | **433.23 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, p: 0.5 | 273.28 us | 253.98 us | 1295.36 us | **248.83 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: True, p: 0.9 | 163.87 us | 157.70 us | 709.57 us | **154.67 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, p: 0.1 | 419.78 us | 386.00 us | 2316.22 us | **375.73 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, p: 0.5 | 264.13 us | 247.70 us | 1272.75 us | **241.66 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=1), deterministic: False, p: 0.9 | 159.74 us | 153.62 us | 700.53 us | **150.61 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, p: 0.1 | 368.66 us | 339.98 us | 1843.30 us | **332.74 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, p: 0.5 | 254.02 us | 237.57 us | 1169.33 us | **232.38 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: True, p: 0.9 | 184.42 us | 176.05 us | 812.56 us | **171.17 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, p: 0.1 | 355.36 us | 329.12 us | 1810.29 us | **320.51 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, p: 0.5 | 245.68 us | 231.42 us | 1147.89 us | **226.21 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: normal_distribution(std=5), deterministic: False, p: 0.9 | 180.16 us | 170.99 us | 797.71 us | **167.06 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.1 | 392.13 us | 362.48 us | 1968.16 us | **353.25 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.5 | 300.99 us | 280.58 us | 1421.20 us | **273.41 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: True, p: 0.9 | 193.52 us | 184.35 us | 843.86 us | **181.25 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.1 | 376.85 us | 350.22 us | 1931.41 us | **340.99 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.5 | 290.82 us | 271.41 us | 1398.85 us | **265.25 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=0.1), deterministic: False, p: 0.9 | 188.46 us | 180.14 us | 828.42 us | **176.53 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.1 | 440.30 us | 400.22 us | 2340.86 us | **390.08 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.5 | 260.61 us | 243.71 us | 1259.46 us | **238.56 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: True, p: 0.9 | 176.11 us | 167.97 us | 756.80 us | **164.86 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.1 | 423.94 us | 389.12 us | 2306.10 us | **377.86 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.5 | 251.92 us | 236.40 us | 1239.02 us | **230.46 us** |
| top-p sampling | vocab_size: 128512, batch_size: 512, distrib: gumbel_distribution(beta=1), deterministic: False, p: 0.9 | 171.95 us | 163.84 us | 745.38 us | **160.80 us** |


</details>



<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

#2837 
<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sampling internals converted to single-precision math with safer pivot computations for more consistent behavior.
* **Bug Fixes**
  * Added an early-exit guard in the sampling search to prevent stalled progress under aggressive floating-point optimizations.
* **Impact**
  * More stable and consistent sampling results with modest performance and reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->