### PR TITLE
enable_pdl_and_bias_for_cudnn_backend

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2680,7 +2680,7 @@ def _get_3d_shape_stride_from_vector(vector: torch.Tensor, dim: int = 0):
 
 def _get_bf16_3d_shape_stride(tensor: torch.Tensor):
     """Expand 2d tensor to 3d tensor for cuDNN"""
-    if tensor.dim() != 2 and tensor.shape.dim() != 3:
+    if tensor.dim() != 2 and tensor.dim() != 3:
         raise ValueError(f"Expected 2D or 3D tensor, got {tensor.dim()}D tensor")
     shape = list(tensor.shape)
     stride = list(tensor.stride())


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. Enable bias for bf16 gemm cudnn backend
2. Enable bf16 gemm cudnn backend when pdl is enabled

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BF16 GEMM now supports optional bias in both standard and override-shape cuDNN paths for fused bias-add acceleration.

* **Bug Fixes**
  * Removed runtime rejection of bias; bias is accepted and correctly routed through execution.
  * Expanded supported cuDNN BF16 compute capability range for broader hardware compatibility.
  * Backend selection heuristic improved to better choose optimized implementations when bias/padding-like flags are present.

* **Other**
  * Enhanced stride/contiguity checks and 3D bias-shape derivation; cache/key logic updated to account for bias presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->