### PR TITLE
[Do not merget yet] test: add trtllm-gen prefill tests for reproducing sm103 hang

### DIFF
--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -861,6 +861,78 @@ def test_trtllm_batch_prefill_bs1(
     )
 
 
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+@pytest.mark.parametrize(
+    "batch_size,page_size,num_kv_heads,head_grp_size",
+    [
+        (1, 16, 8, 8),
+        (32, 16, 8, 8),
+    ],
+)
+@pytest.mark.parametrize("window_left", [-1])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    [
+        ("bf16", "bf16", "bf16"),
+    ],
+)
+@pytest.mark.parametrize("enable_pdl", [None])
+@pytest.mark.parametrize("enable_sink", [False])
+@pytest.mark.parametrize(
+    "max_q_len,max_kv_len",
+    [
+        (1024, 0),
+        (1024, 1024),
+        (2048, 0),
+        (4096, 0),
+    ],
+)
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("skips_softmax", [False, True])
+@pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
+def test_trtllm_batch_prefill_full_seqlen(
+    kv_layout: str,
+    batch_size: int,
+    page_size: int,
+    num_kv_heads: int,
+    head_grp_size: int,
+    window_left: int,
+    q_dtype: str,
+    o_dtype: str,
+    kv_dtype: str,
+    enable_pdl: bool,
+    enable_sink: bool,
+    max_q_len: int,
+    max_kv_len: int,
+    head_dim: int,
+    skips_softmax: bool,
+    uses_shared_paged_kv_idx: bool,
+):
+    # Covers the sequence-length gap between test_trtllm_batch_prefill (max_q_len=511)
+    # and test_trtllm_batch_prefill_bs1 (max_q_len=8192).  The (1024, 0) case reproduces
+    # a trtllm-native hang found in benchmarks with s_qo=1024, s_kv=1024 (pure prefill,
+    # total KV = query length, no prior cached tokens).
+    _test_trtllm_batch_prefill(
+        kv_layout,
+        batch_size,
+        page_size,
+        num_kv_heads,
+        head_grp_size,
+        window_left,
+        q_dtype,
+        o_dtype,
+        kv_dtype,
+        enable_pdl,
+        enable_sink,
+        max_q_len,
+        max_kv_len,
+        False,
+        head_dim,
+        skips_softmax=skips_softmax,
+        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
+
+
 def _test_trtllm_batch_decode(
     backend: str,
     kv_layout: str,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- Adds `test_trtllm_batch_prefill_full_seqlen` to close a sequence-length coverage gap in `test_trtllm_gen_attention.py`. The existing prefill tests only exercise `max_q_len=511` (general test, batch ≥ 4) and `max_q_len=8192` (bs1 test). The 1024–4096 range was untested—precisely the range where a trtllm-native hang was discovered in benchmarks (`s_qo=1024, s_kv=1024, batch_size=1, 64 QO heads / 8 KV heads, head_dim=128, bf16`).
- The new test parametrizes `(max_q_len, max_kv_len)` over `(1024, 0)`, `(1024, 1024)`, `(2048, 0)`, and `(4096, 0)` with `batch_size ∈ {1, 32}`, both KV layouts, and both shared/separate page index modes (64 cases total). The `(1024, 0)` case is the exact reproduction of the hang (pure prefill, total KV = query length, no prior cached tokens).

Currently hangs on B300:
```
$ pytest tests/attention/test_trtllm_gen_attention.py::test_trtllm_batch_prefill_full_seqlen -v
...
collected 64 items                                                                                                                                                        

tests/attention/test_trtllm_gen_attention.py::test_trtllm_batch_prefill_full_seqlen[True-False-128-1024-0-False-None-bf16-bf16-bf16--1-1-16-8-8-HND] PASSED         [  1%]
tests/attention/test_trtllm_gen_attention.py::test_trtllm_batch_prefill_full_seqlen[True-False-128-1024-0-False-None-bf16-bf16-bf16--1-1-16-8-8-NHD] PASSED         [  3%]
tests/attention/test_trtllm_gen_attention.py::test_trtllm_batch_prefill_full_seqlen[True-False-128-1024-0-False-None-bf16-bf16-bf16--1-32-16-8-8-HND] 
```

Equivalent microbenchmark command
```
$ python3 benchmarks/flashinfer_benchmark.py --routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 trtllm-native --page_size 16 --batch_size 1 --s_qo 1024 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --random_actual_seq_len -vv --causal --q_dtype bfloat16 --kv_dtype bfloat16
```


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for attention mechanisms with additional sequence length configurations and parameter combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->