### PR TITLE
unifying all reduce memory allocation for single-node and multi-node nvlink

### DIFF
--- a/flashinfer/comm/torch_symmetric_memory.py
+++ b/flashinfer/comm/torch_symmetric_memory.py
@@ -1,0 +1,15 @@
+import torch
+import torch.distributed._symmetric_memory as symm_mem
+
+
+def _alloc_symm_buffer_bytes(
+    size_bytes: int, tp_size: int, dtype: torch.dtype, device: torch.device, group_name: str
+) -> tuple[list[int], torch.Tensor]:
+    numel = size_bytes // torch.tensor([], dtype=dtype).element_size()
+    tensor = symm_mem.empty(numel, dtype=dtype, device=device)
+    handle = symm_mem.rendezvous(tensor, group=group_name)
+    ptrs: list[int] = []
+    for peer in range(tp_size):
+        buf = handle.get_buffer(peer, (numel,), dtype, storage_offset=0)
+        ptrs.append(buf.data_ptr())
+    return ptrs, tensor, handle

--- a/flashinfer/comm/torch_symmetric_memory.py
+++ b/flashinfer/comm/torch_symmetric_memory.py
@@ -1,7 +1,95 @@
+import functools
 from typing import Any
 
 import torch
 import torch.distributed._symmetric_memory as symm_mem
+import torch.distributed.distributed_c10d as c10d
+
+_compat_patched = False
+
+
+def _patch_group_count_reset() -> None:
+    """Prevent group_count from resetting to 0 on WORLD destruction (2.10 only).
+
+    On PyTorch 2.10, ``destroy_process_group(WORLD)`` resets
+    ``_world.group_count`` to 0.  When the WORLD group is later recreated via
+    ``init_process_group``, it receives the same name (e.g. ``"0"``) as the
+    previous incarnation.  The C++ ``group_info_map`` still holds the old
+    entry whose store is now a zombie (the underlying TCPStore server was torn
+    down with the old process group).  Because ``set_group_info`` enforces
+    single-init per name, we cannot update the stale entry.
+
+    By preserving the counter, each recreated WORLD group gets a unique name
+    (``"0"``, ``"1"``, ``"2"``, …).  ``set_group_info`` always sees a fresh
+    key, the rendezvous uses the live store, and the old zombie entries are
+    simply never looked up again.
+    """
+    global _compat_patched
+    if _compat_patched:
+        return
+    _compat_patched = True
+
+    import torch.distributed as dist
+
+    _original_destroy = dist.destroy_process_group
+
+    @functools.wraps(_original_destroy)
+    def _patched_destroy(group=None):
+        saved_count = c10d._world.group_count
+        _original_destroy(group)
+        # WORLD destruction resets group_count to 0 – restore it so the next
+        # init_process_group picks a name that is fresh in the C++ map.
+        if group is None:
+            c10d._world.group_count = saved_count
+
+    dist.destroy_process_group = _patched_destroy
+
+
+def _enable_symm_mem_compat(group_name: str) -> None:
+    """Pre-initialize symmetric memory for a process group (PyTorch 2.10 compat).
+
+    PyTorch 2.10's ``enable_symm_mem_for_group`` wraps the group store in an
+    extra ``PrefixStore("symmetric_memory-{ranks}", ...)``.  PyTorch 2.11
+    removed this indirection and resolves the group store directly in C++ via
+    ``group->getStore()``.  On 2.10 the extra layer can cause the store-based
+    handle exchange inside ``make_peer_alloc_info`` to hang on certain
+    topologies (Blackwell MNNVL fabric handles).
+
+    This helper mimics the 2.11 behaviour: it calls ``set_group_info`` with the
+    group's native store (no extra prefix) and populates the Python-side guard
+    dict so that ``enable_symm_mem_for_group`` becomes a no-op for this group.
+
+    It also patches ``destroy_process_group`` to preserve the group counter so
+    that if the WORLD group is destroyed and recreated, the new group receives a
+    unique name that does not collide with stale entries in the C++ map.
+    """
+    torch_version = tuple(int(x) for x in torch.__version__.split(".")[:2])
+    if torch_version >= (2, 11):
+        # 2.11+ resolves the store in C++ – nothing to patch.
+        return
+
+    from torch.distributed._symmetric_memory import _group_name_to_store
+    from torch._C._distributed_c10d import _SymmetricMemory
+
+    # Ensure the group counter survives WORLD destruction so recreated groups
+    # get unique names that won't collide in the C++ group_info_map.
+    _patch_group_count_reset()
+
+    if group_name in _group_name_to_store:
+        return  # Already initialised for this group name.
+
+    group = c10d._resolve_process_group(group_name)
+    # Use the store that the C++ ProcessGroup owns – identical to what 2.11's
+    # resolve_process_group(group_name)->getStore() returns.
+    current_store = c10d._get_process_group_store(group)
+
+    _group_name_to_store[group_name] = current_store
+    _SymmetricMemory.set_group_info(
+        group_name,
+        group.rank(),
+        group.size(),
+        current_store,
+    )
 
 
 def _alloc_symm_buffer_bytes(
@@ -23,6 +111,11 @@ def _alloc_symm_buffer_bytes(
     Returns:
         Tuple of (per-peer data pointers, local tensor, symmetric memory handle).
     """
+    # Ensure symmetric memory is set up with the correct store before
+    # rendezvous.  On PyTorch 2.10 this avoids an extra PrefixStore layer
+    # that can cause hangs on Blackwell/MNNVL topologies.
+    _enable_symm_mem_compat(group_name)
+
     elem_size = torch.empty(0, dtype=dtype).element_size()
     numel = size_bytes // elem_size
     tensor = symm_mem.empty(numel, dtype=dtype, device=device)

--- a/flashinfer/comm/torch_symmetric_memory.py
+++ b/flashinfer/comm/torch_symmetric_memory.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import torch
 import torch.distributed._symmetric_memory as symm_mem
 
@@ -8,7 +10,7 @@ def _alloc_symm_buffer_bytes(
     dtype: torch.dtype,
     device: torch.device,
     group_name: str,
-) -> tuple[list[int], torch.Tensor, symm_mem.SymmetricMemory]:
+) -> tuple[list[int], torch.Tensor, Any]:
     """Allocate a symmetric memory buffer and return per-peer pointers.
 
     Args:

--- a/flashinfer/comm/torch_symmetric_memory.py
+++ b/flashinfer/comm/torch_symmetric_memory.py
@@ -9,21 +9,7 @@ _compat_patched = False
 
 
 def _patch_group_count_reset() -> None:
-    """Prevent group_count from resetting to 0 on WORLD destruction (2.10 only).
-
-    On PyTorch 2.10, ``destroy_process_group(WORLD)`` resets
-    ``_world.group_count`` to 0.  When the WORLD group is later recreated via
-    ``init_process_group``, it receives the same name (e.g. ``"0"``) as the
-    previous incarnation.  The C++ ``group_info_map`` still holds the old
-    entry whose store is now a zombie (the underlying TCPStore server was torn
-    down with the old process group).  Because ``set_group_info`` enforces
-    single-init per name, we cannot update the stale entry.
-
-    By preserving the counter, each recreated WORLD group gets a unique name
-    (``"0"``, ``"1"``, ``"2"``, …).  ``set_group_info`` always sees a fresh
-    key, the rendezvous uses the live store, and the old zombie entries are
-    simply never looked up again.
-    """
+    """Prevent group_count from resetting to 0 on WORLD destruction (2.10 and below)."""
     global _compat_patched
     if _compat_patched:
         return
@@ -45,51 +31,15 @@ def _patch_group_count_reset() -> None:
     dist.destroy_process_group = _patched_destroy
 
 
-def _enable_symm_mem_compat(group_name: str) -> None:
-    """Pre-initialize symmetric memory for a process group (PyTorch 2.10 compat).
-
-    PyTorch 2.10's ``enable_symm_mem_for_group`` wraps the group store in an
-    extra ``PrefixStore("symmetric_memory-{ranks}", ...)``.  PyTorch 2.11
-    removed this indirection and resolves the group store directly in C++ via
-    ``group->getStore()``.  On 2.10 the extra layer can cause the store-based
-    handle exchange inside ``make_peer_alloc_info`` to hang on certain
-    topologies (Blackwell MNNVL fabric handles).
-
-    This helper mimics the 2.11 behaviour: it calls ``set_group_info`` with the
-    group's native store (no extra prefix) and populates the Python-side guard
-    dict so that ``enable_symm_mem_for_group`` becomes a no-op for this group.
-
-    It also patches ``destroy_process_group`` to preserve the group counter so
-    that if the WORLD group is destroyed and recreated, the new group receives a
-    unique name that does not collide with stale entries in the C++ map.
-    """
+def _enable_symm_mem_for_group(group_name: str) -> None:
+    """Enable symmetric memory for a process group (PyTorch 2.11+)."""
     torch_version = tuple(int(x) for x in torch.__version__.split(".")[:2])
     if torch_version >= (2, 11):
-        # 2.11+ resolves the store in C++ – nothing to patch.
         return
+    from torch.distributed._symmetric_memory import enable_symm_mem_for_group
 
-    from torch.distributed._symmetric_memory import _group_name_to_store
-    from torch._C._distributed_c10d import _SymmetricMemory
-
-    # Ensure the group counter survives WORLD destruction so recreated groups
-    # get unique names that won't collide in the C++ group_info_map.
     _patch_group_count_reset()
-
-    if group_name in _group_name_to_store:
-        return  # Already initialised for this group name.
-
-    group = c10d._resolve_process_group(group_name)
-    # Use the store that the C++ ProcessGroup owns – identical to what 2.11's
-    # resolve_process_group(group_name)->getStore() returns.
-    current_store = c10d._get_process_group_store(group)
-
-    _group_name_to_store[group_name] = current_store
-    _SymmetricMemory.set_group_info(
-        group_name,
-        group.rank(),
-        group.size(),
-        current_store,
-    )
+    enable_symm_mem_for_group(group_name)
 
 
 def _alloc_symm_buffer_bytes(
@@ -112,9 +62,8 @@ def _alloc_symm_buffer_bytes(
         Tuple of (per-peer data pointers, local tensor, symmetric memory handle).
     """
     # Ensure symmetric memory is set up with the correct store before
-    # rendezvous.  On PyTorch 2.10 this avoids an extra PrefixStore layer
-    # that can cause hangs on Blackwell/MNNVL topologies.
-    _enable_symm_mem_compat(group_name)
+    # rendezvous on PyTorch older than 2.11.
+    _enable_symm_mem_for_group(group_name)
 
     elem_size = torch.empty(0, dtype=dtype).element_size()
     numel = size_bytes // elem_size

--- a/flashinfer/comm/torch_symmetric_memory.py
+++ b/flashinfer/comm/torch_symmetric_memory.py
@@ -3,13 +3,30 @@ import torch.distributed._symmetric_memory as symm_mem
 
 
 def _alloc_symm_buffer_bytes(
-    size_bytes: int, tp_size: int, dtype: torch.dtype, device: torch.device, group_name: str
-) -> tuple[list[int], torch.Tensor]:
-    numel = size_bytes // torch.tensor([], dtype=dtype).element_size()
+    size_bytes: int,
+    world_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    group_name: str,
+) -> tuple[list[int], torch.Tensor, symm_mem.SymmetricMemory]:
+    """Allocate a symmetric memory buffer and return per-peer pointers.
+
+    Args:
+        size_bytes: Total buffer size in bytes.
+        world_size: Number of peers in the communication group.
+        dtype: Element type used to interpret the buffer.
+        device: CUDA device for the allocation.
+        group_name: Process group name for the rendezvous.
+
+    Returns:
+        Tuple of (per-peer data pointers, local tensor, symmetric memory handle).
+    """
+    elem_size = torch.empty(0, dtype=dtype).element_size()
+    numel = size_bytes // elem_size
     tensor = symm_mem.empty(numel, dtype=dtype, device=device)
     handle = symm_mem.rendezvous(tensor, group=group_name)
-    ptrs: list[int] = []
-    for peer in range(tp_size):
-        buf = handle.get_buffer(peer, (numel,), dtype, storage_offset=0)
-        ptrs.append(buf.data_ptr())
+    ptrs: list[int] = [
+        handle.get_buffer(peer, (numel,), dtype, storage_offset=0).data_ptr()
+        for peer in range(world_size)
+    ]
     return ptrs, tensor, handle

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -31,7 +31,7 @@ from ..utils import register_custom_op, round_up
 
 logger = logging.getLogger(__name__)
 from .cuda_ipc import create_shared_buffer, cudart, free_shared_buffer
-
+from .torch_symmetric_memory import _alloc_symm_buffer_bytes
 
 class AllReduceStrategyType:
     # NOTE: for trtllm_custom_all_reduce
@@ -399,6 +399,7 @@ OneShotMaxToken = 128
 MAX_ALL_REDUCE_BLOCKS = 24
 LamportTokenNumThreshold = 16
 
+_symm_workspace_refs: dict[int, list[torch.Tensor]] = {}
 
 @deprecated(
     "trtllm_create_ipc_workspace_for_all_reduce and trtllm_custom_all_reduce are deprecated and will be removed in the next major bump, use allreduce.py instead."
@@ -451,26 +452,40 @@ def trtllm_create_ipc_workspace_for_all_reduce(
     flag_size = FLAG_SIZE * tp_size * 2
     lamport_buffer_size = tp_size * LamportTokenNumThreshold * tp_size * hidden_dim * 2
 
+    # TODO(asamani): check this device and group
+    device = torch.device(f"cuda:{torch.cuda.current_device()}")
+    group_name = group.group_name
+    symm_refs: list[torch.Tensor] = []
     ipc_handles = list()
 
-    for size in [
-        buffer_size,
-        buffer_size,
-        flag_size,
-        flag_size,
-        lamport_buffer_size,
-        lamport_buffer_size,
-        lamport_buffer_size,
+    for size, dtype in [
+        (buffer_size, torch.float32),
+        (buffer_size, torch.float32),
+        (flag_size, torch.int32),
+        (flag_size, torch.int32),
+        (lamport_buffer_size, torch.float16),
+        (lamport_buffer_size, torch.float16),
+        (lamport_buffer_size, torch.float16),
     ]:
         # all sizes should be aligned to 1LU << 21 bytes (2MB)
         aligned_size = round_up(size, 1 << 21)
-        ipc_handles.append(create_shared_buffer(aligned_size, group))
+        ptrs, tensor, handle = _alloc_symm_buffer_bytes(
+            aligned_size,
+            tp_size,
+            dtype,
+            device,
+            group_name,
+        )
+        symm_refs.append((tensor, handle))
+        ipc_handles.append(ptrs)
 
     logger.debug(
         "rank %s allocated ipc_handles: %s",
         rank,
         [[hex(handle) for handle in sublist] for sublist in ipc_handles],
     )
+
+    _symm_workspace_refs[id(ipc_handles)] = symm_refs
 
     trtllm_lamport_initialize_all(
         ipc_handles[4][rank],
@@ -496,8 +511,7 @@ def trtllm_destroy_ipc_workspace_for_all_reduce(
     The workspace can be reused for multiple all reduce calls under the same configuration.
     """
 
-    for ipc_handle in workspace:
-        free_shared_buffer(ipc_handle, group)
+    _ = _symm_workspace_refs.pop(id(workspace), None)
 
 
 BarrierFlagCount = 256
@@ -588,39 +602,44 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
 
     lamport_buffer_size = lamport_comm_size * 3
 
+    # TODO(asamani): check this device and group
+    device = torch.device(f"cuda:{torch.cuda.current_device()}")
+    group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
+    symm_refs: list[torch.Tensor] = []
+
     # we should init 3 buffers for all reduce fusion:
     # [buffer_size, flag_size, lamport_buffer_size]
 
     ipc_handles: List[List[int]] = list()
     mem_handles: List[SymmDeviceMemory] = list()
-    for size in [buffer_size, flag_size, lamport_buffer_size]:
+    lamport_buffer_dtype = torch.float16 if not use_fp32_lamport else torch.float32
+    for size, dtype in [
+        (buffer_size, torch.float32),
+        (flag_size, torch.int32),
+        (lamport_buffer_size, lamport_buffer_dtype),
+    ]:
         # todo(review): confirm we need this alignment
         # all sizes should be aligned to 1LU << 21 bytes (2MB)
         aligned_size = round_up(size, 1 << 21)
 
-        if not use_symm_dev_mem:
-            ipc_handles.append(create_shared_buffer(aligned_size, group))
-        else:
-            # Use torch.cuda.current_device() instead of tp_rank to support
-            # base_gpu_id != 0 scenarios where the actual CUDA device index
-            # differs from the TP rank.
-            symm_mem = SymmDeviceMemory(
-                aligned_size,
-                tp_size,
-                tp_rank,
-                torch.cuda.current_device(),
-                comm_backend,
-                enable_multicast=False,
-                allocate_signal_pads=False,
-            )
-            ipc_handles.append(symm_mem.uc_ptrs)
-            mem_handles.append(symm_mem)
+        ptrs, tensor, handle = _alloc_symm_buffer_bytes(
+            aligned_size,
+            tp_size,
+            dtype,
+            device,
+            group_name,
+        )
+        symm_refs.append((tensor, handle))
+        ipc_handles.append(ptrs)
+        mem_handles.append(handle)
 
     logger.debug(
         "rank %s allocated ipc_handles: %s",
         tp_rank,
         [[hex(handle) for handle in sublist] for sublist in ipc_handles],
     )
+
+    _symm_workspace_refs[id(ipc_handles)] = symm_refs
 
     # Initialize lamport buffer
     aligned_lamport_buffer_size = round_up(lamport_buffer_size, 1 << 21)
@@ -712,8 +731,8 @@ def trtllm_destroy_ipc_workspace_for_all_reduce_fusion(
     The workspace can be reused for multiple all reduce fusion calls under the same configuration.
     """
 
-    for ipc_handle in workspace:
-        free_shared_buffer(ipc_handle, group)
+    # TODO(asamani): is this the correct way to destroy the workspace?
+    _ = _symm_workspace_refs.pop(id(workspace), None)
 
 
 # allReduce fused quant utils

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -472,8 +472,7 @@ def trtllm_create_ipc_workspace_for_all_reduce(
         (lamport_buffer_size, torch.float16),
         (lamport_buffer_size, torch.float16),
     ]:
-        # all sizes should be aligned to 1LU << 21 bytes (2MB)
-        aligned_size = round_up(size, 1 << 21)
+        aligned_size = round_up(size, 16)
         ptrs, tensor, handle = _alloc_symm_buffer_bytes(
             aligned_size,
             tp_size,
@@ -627,9 +626,7 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
         (flag_size, torch.int32),
         (lamport_buffer_size, lamport_buffer_dtype),
     ]:
-        # todo(review): confirm we need this alignment
-        # all sizes should be aligned to 1LU << 21 bytes (2MB)
-        aligned_size = round_up(size, 1 << 21)
+        aligned_size = round_up(size, 16)
 
         ptrs, tensor, handle = _alloc_symm_buffer_bytes(
             aligned_size,
@@ -651,7 +648,7 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     _symm_workspace_refs[id(ipc_handles)] = symm_refs
 
     # Initialize lamport buffer
-    aligned_lamport_buffer_size = round_up(lamport_buffer_size, 1 << 21)
+    aligned_lamport_buffer_size = round_up(lamport_buffer_size, 16)
     if use_fp32_lamport:
         trtllm_lamport_initialize(
             ipc_handles[2][tp_rank], aligned_lamport_buffer_size // 4, torch.float32

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -502,15 +502,16 @@ def trtllm_create_ipc_workspace_for_all_reduce(
 def trtllm_destroy_ipc_workspace_for_all_reduce(
     workspace: List[List[int]], group: Optional[ProcessGroup] = None
 ) -> None:
-    """
-    Note:
-    This function is used to destroy a workspace for all reduce.
-    The workspace is a list of IPC handles.
-    The workspace should be destroyed after calling trtllm_custom_all_reduce.
-    The workspace can be reused for multiple all reduce calls under the same configuration.
-    """
+    """Destroy a workspace created by trtllm_create_ipc_workspace_for_all_reduce.
 
-    _ = _symm_workspace_refs.pop(id(workspace), None)
+    Releases the symmetric memory references held internally. The workspace
+    list should not be used after this call.
+
+    Args:
+        workspace: The ipc_handles list returned by the create function.
+        group: Unused, kept for API compatibility.
+    """
+    _symm_workspace_refs.pop(id(workspace), None)
 
 
 BarrierFlagCount = 256
@@ -601,7 +602,6 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
 
     lamport_buffer_size = lamport_comm_size * 3
 
-    # TODO(asamani): check this device and group
     device = torch.device(f"cuda:{torch.cuda.current_device()}")
     group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
     symm_refs: list[torch.Tensor] = []
@@ -718,20 +718,16 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
 def trtllm_destroy_ipc_workspace_for_all_reduce_fusion(
     workspace: List[List[int]], group: Optional[ProcessGroup] = None
 ) -> None:
-    """
-    Parameters:
-    - workspace: the workspace to destroy.
-    - group: the process group to use.
+    """Destroy a workspace created by trtllm_create_ipc_workspace_for_all_reduce_fusion.
 
-    Note:
-    This function is used to destroy a workspace for all reduce fusion.
-    The workspace is a list of IPC handles.
-    The workspace should be destroyed after calling trtllm_custom_all_reduce_fusion.
-    The workspace can be reused for multiple all reduce fusion calls under the same configuration.
-    """
+    Releases the symmetric memory references held internally. The workspace
+    list should not be used after this call.
 
-    # TODO(asamani): is this the correct way to destroy the workspace?
-    _ = _symm_workspace_refs.pop(id(workspace), None)
+    Args:
+        workspace: The ipc_handles list returned by the create function.
+        group: Unused, kept for API compatibility.
+    """
+    _symm_workspace_refs.pop(id(workspace), None)
 
 
 # allReduce fused quant utils

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -30,8 +30,9 @@ from ..jit.comm import gen_trtllm_comm_module
 from ..utils import register_custom_op, round_up
 
 logger = logging.getLogger(__name__)
-from .cuda_ipc import create_shared_buffer, cudart, free_shared_buffer
+from .cuda_ipc import cudart
 from .torch_symmetric_memory import _alloc_symm_buffer_bytes
+
 
 class AllReduceStrategyType:
     # NOTE: for trtllm_custom_all_reduce
@@ -401,6 +402,7 @@ LamportTokenNumThreshold = 16
 
 _symm_workspace_refs: dict[int, list[torch.Tensor]] = {}
 
+
 @deprecated(
     "trtllm_create_ipc_workspace_for_all_reduce and trtllm_custom_all_reduce are deprecated and will be removed in the next major bump, use allreduce.py instead."
 )
@@ -453,7 +455,11 @@ def trtllm_create_ipc_workspace_for_all_reduce(
     lamport_buffer_size = tp_size * LamportTokenNumThreshold * tp_size * hidden_dim * 2
 
     device = torch.device(f"cuda:{torch.cuda.current_device()}")
-    group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
+    group_name = (
+        group.group_name
+        if group is not None
+        else torch.distributed.group.WORLD.group_name
+    )
     symm_refs: list[torch.Tensor] = []
     ipc_handles = list()
 
@@ -603,7 +609,11 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     lamport_buffer_size = lamport_comm_size * 3
 
     device = torch.device(f"cuda:{torch.cuda.current_device()}")
-    group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
+    group_name = (
+        group.group_name
+        if group is not None
+        else torch.distributed.group.WORLD.group_name
+    )
     symm_refs: list[torch.Tensor] = []
 
     # we should init 3 buffers for all reduce fusion:

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -452,9 +452,8 @@ def trtllm_create_ipc_workspace_for_all_reduce(
     flag_size = FLAG_SIZE * tp_size * 2
     lamport_buffer_size = tp_size * LamportTokenNumThreshold * tp_size * hidden_dim * 2
 
-    # TODO(asamani): check this device and group
     device = torch.device(f"cuda:{torch.cuda.current_device()}")
-    group_name = group.group_name
+    group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
     symm_refs: list[torch.Tensor] = []
     ipc_handles = list()
 

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -22,6 +22,7 @@ from .mnnvl import CommBackend, MPIBackend
 from .workspace_base import AllReduceFusionWorkspace
 from .torch_symmetric_memory import _alloc_symm_buffer_bytes
 from ..cuda_utils import checkCudaErrors
+
 try:
     # cuda-python >= 12.9 (has cuda.bindings.driver)
     from cuda.bindings import driver as cuda
@@ -35,6 +36,7 @@ except ImportError:
             "Could not import the 'cuda' module. "
             "Please install cuda-python that matches your CUDA version."
         ) from e
+
 
 def mpi_barrier():
     from mpi4py import MPI
@@ -152,7 +154,11 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         # index differs from the TP rank / local_rank.
         device = torch.device("cuda", torch.cuda.current_device())
         if isinstance(comm_backend, TorchDistBackend):
-            group = comm_backend._group if comm_backend._group is not None else torch.distributed.group.WORLD
+            group = (
+                comm_backend._group
+                if comm_backend._group is not None
+                else torch.distributed.group.WORLD
+            )
             group_name = group.group_name
         else:
             group_name = torch.distributed.group.WORLD.group_name
@@ -212,9 +218,7 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             raise ValueError(f"Unsupported dtype: {dtype}")
 
         num_elements = (allocated_size) // dsize
-        checkCudaErrors(
-            memset_func(int(self.ptrs[rank]), neg_zero, num_elements)
-        )
+        checkCudaErrors(memset_func(int(self.ptrs[rank]), neg_zero, num_elements))
 
     @functools.cache
     def is_buffer_size_sufficient(

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -19,7 +19,21 @@ from ..jit import gen_trtllm_mnnvl_comm_module
 from ..utils import register_custom_op
 from .mnnvl import McastGPUBuffer, CommBackend, MPIBackend
 from .workspace_base import AllReduceFusionWorkspace
-
+from .torch_symmetric_memory import _alloc_symm_buffer_bytes
+from ..cuda_utils import checkCudaErrors
+try:
+    # cuda-python >= 12.9 (has cuda.bindings.driver)
+    from cuda.bindings import driver as cuda
+except ImportError:
+    try:
+        # cuda-python < 12.9 (no cuda.bindings.driver, use cuda as driver)
+        # from cuda import cuda is not available in cuda-python >= 13.0
+        from cuda import cuda
+    except ImportError as e:
+        raise ImportError(
+            "Could not import the 'cuda' module. "
+            "Please install cuda-python that matches your CUDA version."
+        ) from e
 
 def mpi_barrier():
     from mpi4py import MPI
@@ -135,16 +149,26 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         # Use torch.cuda.current_device() instead of mapping.local_rank to
         # support base_gpu_id != 0 scenarios where the actual CUDA device
         # index differs from the TP rank / local_rank.
-        self.mcast_buffer_handle = McastGPUBuffer(
+        # self.mcast_buffer_handle = McastGPUBuffer(
+        #     requested_workspace_size,
+        #     mapping.tp_size,
+        #     mapping.tp_rank,
+        #     torch.device("cuda", torch.cuda.current_device()),
+        #     comm_backend,
+        # )
+        device=torch.device("cuda", mapping.local_rank)
+        #TODO (asamani): fix group based on comm_backend?
+        group = torch.distributed.group.WORLD
+        group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
+        self.ptrs, self.tensor, self.handle = _alloc_symm_buffer_bytes(
             requested_workspace_size,
             mapping.tp_size,
-            mapping.tp_rank,
-            torch.device("cuda", torch.cuda.current_device()),
-            comm_backend,
+            torch.float32, # TODO(asamani): should this always be f32 or dtype?
+            device,
+            group_name,
         )
 
-        # Get the actual usable buffer size after allocation (buf_size is updated by McastGPUBuffer)
-        allocated_size = self.mcast_buffer_handle.buf_size
+        allocated_size = self.handle.buffer_size - self.handle.signal_pad_size
         # We want the buffer size to be aligned to 16B which is the granularity for buffer management.
         self.buffer_size_bytes = (
             math.floor(allocated_size / self.NUM_LAMPORT_BUFFERS) // 16 * 16
@@ -157,7 +181,7 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         )
 
         # We use FP32 for sentinel value regardless of the real dtype
-        self.mcast_buffer_handle.lamport_initialize(mapping.tp_rank, torch.float32)
+        self.lamport_initialize(mapping.tp_rank, torch.float32, allocated_size)
         # Wait until the initialization is done
         torch.cuda.synchronize()
         comm_backend.barrier()
@@ -173,9 +197,26 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             device=torch.device("cuda", torch.cuda.current_device()),
         )
 
-        self.uc_ptrs_dev = self.mcast_buffer_handle.get_buffer_ptrs_dev()
-        self.uc_ptr_local = self.mcast_buffer_handle.get_unicast_ptr(self.rank)
-        self.mc_ptr = self.mcast_buffer_handle.get_multicast_ptr()
+        self.uc_ptrs_dev = self.handle.buffer_ptrs_dev
+        self.uc_ptr_local = self.handle.buffer_ptrs[self.rank]
+        self.mc_ptr = self.handle.multicast_ptr
+
+    def lamport_initialize(self, rank: int, dtype: torch.dtype, allocated_size: int):
+        if dtype == torch.bfloat16 or dtype == torch.float16:
+            neg_zero = 0x8000
+            dsize = 2
+            memset_func = cuda.cuMemsetD16
+        elif dtype == torch.float32:
+            neg_zero = 0x80000000
+            dsize = 4
+            memset_func = cuda.cuMemsetD32
+        else:
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+        num_elements = (allocated_size) // dsize
+        checkCudaErrors(
+            memset_func(int(self.ptrs[rank]), neg_zero, num_elements)
+        )
 
     @functools.cache
     def is_buffer_size_sufficient(
@@ -235,11 +276,13 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         if getattr(self, "_destroyed", False):
             return  # Already destroyed, nothing to do
 
-        del self.mcast_buffer_handle
         del self.buffer_flags
         del self.uc_ptrs_dev
         del self.uc_ptr_local
         del self.mc_ptr
+        del self.tensor
+        del self.handle
+        del self.ptrs
         self._destroyed = True
 
 

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -566,8 +566,11 @@ def get_allreduce_mnnvl_workspace(
         - torch.Tensor: Buffer flags tensor tracking state
         - int: Maximum number of elements that can fit in buffer
     """
+    # buffer shape: [3, 2, buffer_tokens, hidden_dim]
     stride = 3 * 2 * dtype.itemsize
     lcm_hidden_dim = 286720
+    # LCM for hidden_dim: 2048, 4096, 5120, 7168, 8192 = 286720
+    # max_num_elements must be a multiple of 286720
     TARGET_WORKSPACE_SIZE_BYTES = (
         buffer_size_in_bytes if buffer_size_in_bytes is not None else 12_000_000
     )
@@ -575,6 +578,7 @@ def get_allreduce_mnnvl_workspace(
         TARGET_WORKSPACE_SIZE_BYTES / (lcm_hidden_dim * stride)
     ) * (lcm_hidden_dim * stride)
 
+    # Redirect to the new workspace allocation logic. The new kernel needs the new flag buffer layout.
     workspace = MNNVLAllReduceFusionWorkspace(
         mapping,
         buffer_size_in_bytes=buffer_size_in_bytes,

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -168,7 +168,9 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             group_name,
         )
 
-        allocated_size = self.handle.buffer_size - self.handle.signal_pad_size
+        # handle.buffer_size is the usable data size. torch symmetric memory
+        # allocator places signal_pad on top of it, not carved from within.
+        allocated_size = self.handle.buffer_size
         # We want the buffer size to be aligned to 16B which is the granularity for buffer management.
         self.buffer_size_bytes = (
             math.floor(allocated_size / self.NUM_LAMPORT_BUFFERS) // 16 * 16

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -150,20 +150,11 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         # Use torch.cuda.current_device() instead of mapping.local_rank to
         # support base_gpu_id != 0 scenarios where the actual CUDA device
         # index differs from the TP rank / local_rank.
-        # self.mcast_buffer_handle = McastGPUBuffer(
-        #     requested_workspace_size,
-        #     mapping.tp_size,
-        #     mapping.tp_rank,
-        #     torch.device("cuda", torch.cuda.current_device()),
-        #     comm_backend,
-        # )
         device = torch.device("cuda", torch.cuda.current_device())
-        # device = torch.device("cuda", mapping.local_rank)
         if isinstance(comm_backend, TorchDistBackend):
             group = comm_backend._group if comm_backend._group is not None else torch.distributed.group.WORLD
             group_name = group.group_name
         else:
-            # MPIBackend or other — fall back to WORLD
             group_name = torch.distributed.group.WORLD.group_name
         self.ptrs, self.tensor, self.handle = _alloc_symm_buffer_bytes(
             requested_workspace_size,

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -21,21 +21,6 @@ from ..utils import register_custom_op
 from .mnnvl import CommBackend, MPIBackend
 from .workspace_base import AllReduceFusionWorkspace
 from .torch_symmetric_memory import _alloc_symm_buffer_bytes
-from ..cuda_utils import checkCudaErrors
-
-try:
-    # cuda-python >= 12.9 (has cuda.bindings.driver)
-    from cuda.bindings import driver as cuda
-except ImportError:
-    try:
-        # cuda-python < 12.9 (no cuda.bindings.driver, use cuda as driver)
-        # from cuda import cuda is not available in cuda-python >= 13.0
-        from cuda import cuda
-    except ImportError as e:
-        raise ImportError(
-            "Could not import the 'cuda' module. "
-            "Please install cuda-python that matches your CUDA version."
-        ) from e
 
 
 def mpi_barrier():
@@ -184,8 +169,8 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             f"[MNNVL Allreduce] Actual allocated size: {allocated_size} bytes, Actual buffer size per lamport buffer: {self.buffer_size_bytes} bytes, total workspace: {self.workspace_size_bytes} bytes."
         )
 
-        # We use FP32 for sentinel value regardless of the real dtype
-        self.lamport_initialize(mapping.tp_rank, torch.float32, allocated_size)
+        # lamport initialize tensor to negative zero.
+        self.tensor.fill_(-0.0)
         # Wait until the initialization is done
         torch.cuda.synchronize()
         comm_backend.barrier()
@@ -204,21 +189,6 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         self.uc_ptrs_dev = self.handle.buffer_ptrs_dev
         self.uc_ptr_local = self.handle.buffer_ptrs[self.rank]
         self.mc_ptr = self.handle.multicast_ptr
-
-    def lamport_initialize(self, rank: int, dtype: torch.dtype, allocated_size: int):
-        if dtype == torch.bfloat16 or dtype == torch.float16:
-            neg_zero = 0x8000
-            dsize = 2
-            memset_func = cuda.cuMemsetD16
-        elif dtype == torch.float32:
-            neg_zero = 0x80000000
-            dsize = 4
-            memset_func = cuda.cuMemsetD32
-        else:
-            raise ValueError(f"Unsupported dtype: {dtype}")
-
-        num_elements = (allocated_size) // dsize
-        checkCudaErrors(memset_func(int(self.ptrs[rank]), neg_zero, num_elements))
 
     @functools.cache
     def is_buffer_size_sufficient(

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -14,6 +14,7 @@ import torch
 from typing_extensions import deprecated
 
 from flashinfer.comm.mapping import Mapping
+from flashinfer.comm.mnnvl import TorchDistBackend
 
 from ..jit import gen_trtllm_mnnvl_comm_module
 from ..utils import register_custom_op
@@ -156,14 +157,18 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         #     torch.device("cuda", torch.cuda.current_device()),
         #     comm_backend,
         # )
-        device=torch.device("cuda", mapping.local_rank)
-        #TODO (asamani): fix group based on comm_backend?
-        group = torch.distributed.group.WORLD
-        group_name = group.group_name if group is not None else torch.distributed.group.WORLD.group_name
+        device = torch.device("cuda", torch.cuda.current_device())
+        # device = torch.device("cuda", mapping.local_rank)
+        if isinstance(comm_backend, TorchDistBackend):
+            group = comm_backend._group if comm_backend._group is not None else torch.distributed.group.WORLD
+            group_name = group.group_name
+        else:
+            # MPIBackend or other — fall back to WORLD
+            group_name = torch.distributed.group.WORLD.group_name
         self.ptrs, self.tensor, self.handle = _alloc_symm_buffer_bytes(
             requested_workspace_size,
             mapping.tp_size,
-            torch.float32, # TODO(asamani): should this always be f32 or dtype?
+            torch.float32,
             device,
             group_name,
         )

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -18,7 +18,7 @@ from flashinfer.comm.mnnvl import TorchDistBackend
 
 from ..jit import gen_trtllm_mnnvl_comm_module
 from ..utils import register_custom_op
-from .mnnvl import McastGPUBuffer, CommBackend, MPIBackend
+from .mnnvl import CommBackend, MPIBackend
 from .workspace_base import AllReduceFusionWorkspace
 from .torch_symmetric_memory import _alloc_symm_buffer_bytes
 from ..cuda_utils import checkCudaErrors
@@ -547,33 +547,22 @@ def get_allreduce_mnnvl_workspace(
     dtype: torch.dtype,
     comm_backend_for_handle_transfer: Optional[CommBackend] = None,
     buffer_size_in_bytes: Optional[int] = None,
-) -> Tuple[McastGPUBuffer, torch.Tensor, int]:
+) -> Tuple[MNNVLAllReduceFusionWorkspace, torch.Tensor, int]:
     """Get workspace buffers needed for multi-node NVLink all-reduce operation.
-
-    This function allocates and initializes the workspace buffers required for performing
-    multi-node NVLink all-reduce operations. It creates:
-    1. A multicast GPU buffer for communication between nodes
-    2. A flags tensor to track buffer state
-    3. Maximum number of elements that can fit in the buffer
-
-    The buffer size is calculated to efficiently handle common hidden dimensions
-    (2048, 4096, 5120, 7168, 8192) by using their LCM of 286720.
 
     Args:
         mapping: Tensor parallel mapping configuration containing rank info
         dtype: Data type of the tensors being reduced
+        comm_backend_for_handle_transfer: Communication backend for handle transfer
         buffer_size_in_bytes: Optional buffer size. Practically, assign this to 3 * 2 * dtype.itemsize * hidden_dim * max_tokens
 
     Returns:
         Tuple containing:
-        - McastGPUBuffer: Multicast buffer for inter-node communication
+        - MNNVLAllReduceFusionWorkspace: The workspace object backed by torch symmetric memory
         - torch.Tensor: Buffer flags tensor tracking state
         - int: Maximum number of elements that can fit in buffer
     """
-    # buffer shape: [3, 2, buffer_tokens, hidden_dim]
     stride = 3 * 2 * dtype.itemsize
-    # LCM for hidden_dim: 2048, 4096, 5120, 7168, 8192 = 286720
-    # max_num_elements must be a multiple of 286720
     lcm_hidden_dim = 286720
     TARGET_WORKSPACE_SIZE_BYTES = (
         buffer_size_in_bytes if buffer_size_in_bytes is not None else 12_000_000
@@ -582,21 +571,17 @@ def get_allreduce_mnnvl_workspace(
         TARGET_WORKSPACE_SIZE_BYTES / (lcm_hidden_dim * stride)
     ) * (lcm_hidden_dim * stride)
 
-    # Redirect to the new workspace allocation logic. The new kernel needs the new flag buffer layout.
     workspace = MNNVLAllReduceFusionWorkspace(
         mapping,
         buffer_size_in_bytes=buffer_size_in_bytes,
         comm_backend=comm_backend_for_handle_transfer,
     )
 
-    mcast_buffer = workspace.mcast_buffer_handle
-    buffer_flags = workspace.buffer_flags
-    # this is calculated using the legacy behavior. We do not use the actual allocated size.
     max_num_elements = workspace.buffer_size_bytes // stride
 
     return (
-        mcast_buffer,
-        buffer_flags,
+        workspace,
+        workspace.buffer_flags,
         max_num_elements,
     )
 

--- a/tests/comm/test_trtllm_allreduce_fusion.py
+++ b/tests/comm/test_trtllm_allreduce_fusion.py
@@ -115,7 +115,7 @@ def _run_correctness_worker(
                                     dist.barrier(group=group)
                                     test_passed = True
                                     print(
-                                        f"test RANK {rank}: token{token_num}-hidden_dim{hidden_dim}-dtype{dtype}-pattern{pattern_code}-layout{swizzled_layout_code}-pdl{launch_with_pdl} start"
+                                        f"test RANK {rank}: token{token_num}-hidden_dim{hidden_dim}-dtype{dtype}-pattern{pattern_code}-layout{swizzled_layout_code}-pdl{launch_with_pdl}-isOneShot{use_oneshot}-isTriggerCompletionAtEnd{trigger_completion_at_end}-isFP32Acc{fp32_acc} start"
                                     )
                                     dist.barrier(group=group)
                                     torch.cuda.synchronize()
@@ -389,11 +389,11 @@ def _run_correctness_worker(
                                     dist.barrier(group=group)
                                     if test_passed:
                                         print(
-                                            f"test RANK {rank}: token{token_num}-hidden_dim{hidden_dim}-dtype{dtype}-pattern{pattern_code}-layout{swizzled_layout_code}-pdl{launch_with_pdl} passed"
+                                            f"test RANK {rank}: token{token_num}-hidden_dim{hidden_dim}-dtype{dtype}-pattern{pattern_code}-layout{swizzled_layout_code}-pdl{launch_with_pdl}-isOneShot{use_oneshot}-isTriggerCompletionAtEnd{trigger_completion_at_end}-isFP32Acc{fp32_acc} passed"
                                         )
                                     else:
                                         print(
-                                            f"test RANK {rank}: token{token_num}-hidden_dim{hidden_dim}-dtype{dtype}-pattern{pattern_code}-layout{swizzled_layout_code}-pdl{launch_with_pdl} failed"
+                                            f"test RANK {rank}: token{token_num}-hidden_dim{hidden_dim}-dtype{dtype}-pattern{pattern_code}-layout{swizzled_layout_code}-pdl{launch_with_pdl}-isOneShot{use_oneshot}-isTriggerCompletionAtEnd{trigger_completion_at_end}-isFP32Acc{fp32_acc} failed"
                                         )
     finally:
         dist.barrier(group=group)

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -343,7 +343,7 @@ def run_mnnvl_ar_full(
 
     try:
         if legacy_api:
-            mcast_buffer_mnnvl, buffer_flags_mnnvl, max_num_elements_mnnvl = (
+            legacy_workspace, buffer_flags_mnnvl, max_num_elements_mnnvl = (
                 trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(
                     mapping,
                     dtype,
@@ -352,11 +352,9 @@ def run_mnnvl_ar_full(
                 )
             )
 
-            multicast_ptr = mcast_buffer_mnnvl.get_multicast_ptr()
-            buffer_ptrs_dev = mcast_buffer_mnnvl.get_buffer_ptrs_dev()
-            unicast_ptr = mcast_buffer_mnnvl.mcast_device_memory.get_unicast_ptr(
-                mapping.tp_rank
-            )
+            multicast_ptr = legacy_workspace.mc_ptr
+            buffer_ptrs_dev = legacy_workspace.uc_ptrs_dev
+            unicast_ptr = legacy_workspace.handle.buffer_ptrs[mapping.tp_rank]
 
         else:
             workspace = trtllm_mnnvl_ar.MNNVLAllReduceFusionWorkspace(
@@ -440,8 +438,8 @@ def run_mnnvl_ar_full(
         # Explicitly destroy workspace to avoid __del__ issues during Python shutdown
         if "workspace" in locals() and workspace is not None:
             workspace.destroy()
-        if "mcast_buffer_mnnvl" in locals():
-            del mcast_buffer_mnnvl
+        if "legacy_workspace" in locals():
+            legacy_workspace.destroy()
 
     # Final synchronization using torch.distributed barrier
     dist.barrier()

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -475,6 +475,13 @@ def test_mnnvl_allreduce_legacy(
     monkeypatch, seq_lens: list[int], fusion: bool, dtype: torch.dtype, hidden_size: int
 ):
     """Test MNNVL AllReduce with legacy API."""
+    explicit_workspace_bytes = 3 * 2 * dtype.itemsize * hidden_size * max(seq_lens)
     run_mnnvl_ar_full(
-        monkeypatch, seq_lens, fusion, dtype, hidden_size, legacy_api=True
+        monkeypatch,
+        seq_lens,
+        fusion,
+        dtype,
+        hidden_size,
+        legacy_explicit_workspace_bytes=explicit_workspace_bytes,
+        legacy_api=True,
     )

--- a/tests/comm/test_trtllm_mnnvl_allreduce_custom_comm.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce_custom_comm.py
@@ -140,17 +140,15 @@ def _run_mnnvl_ar(world_size, rank, dtype, distributed_init_port, seq_len, hidde
         # This workspace is sized for the maximum expected sequence length and can be reused within each list
         # Each parameterized list gets its own fresh workspace allocation
         explicit_workspace_bytes = 3 * 2 * dtype.itemsize * hidden_size * seq_len
-        mcast_buffer_mnnvl, buffer_flags_mnnvl, max_num_elements_mnnvl = (
+        legacy_workspace, buffer_flags_mnnvl, max_num_elements_mnnvl = (
             trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(
                 mapping, dtype, comm, explicit_workspace_bytes
             )
         )
 
-        multicast_ptr = mcast_buffer_mnnvl.get_multicast_ptr()
-        buffer_ptrs_dev = mcast_buffer_mnnvl.get_buffer_ptrs_dev()
-        unicast_ptr = mcast_buffer_mnnvl.mcast_device_memory.get_unicast_ptr(
-            mapping.tp_rank
-        )
+        multicast_ptr = legacy_workspace.mc_ptr
+        buffer_ptrs_dev = legacy_workspace.uc_ptrs_dev
+        unicast_ptr = legacy_workspace.handle.buffer_ptrs[mapping.tp_rank]
 
         # Test each sequence length with the same workspace (reusing allocated buffers within this list)
         if rank == 0:
@@ -228,8 +226,8 @@ def _run_mnnvl_ar(world_size, rank, dtype, distributed_init_port, seq_len, hidde
 
     finally:
         # Ensure cleanup happens for this list's workspace
-        if "mcast_buffer_mnnvl" in locals():
-            del mcast_buffer_mnnvl
+        if "legacy_workspace" in locals():
+            legacy_workspace.destroy()
 
     # Final synchronization and check for failures across all ranks
     comm.barrier()

--- a/tests/comm/test_trtllm_mnnvl_allreduce_custom_comm.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce_custom_comm.py
@@ -139,18 +139,14 @@ def _run_mnnvl_ar(world_size, rank, dtype, distributed_init_port, seq_len, hidde
         # Get workspace buffers using MPI rank - allocate once per seq_lens list and reuse within the list
         # This workspace is sized for the maximum expected sequence length and can be reused within each list
         # Each parameterized list gets its own fresh workspace allocation
-        explicit_workspace_bytes = 3 * 2 * dtype.itemsize * hidden_size * seq_len
-        legacy_workspace, buffer_flags_mnnvl, max_num_elements_mnnvl = (
-            trtllm_mnnvl_ar.get_allreduce_mnnvl_workspace(
-                mapping, dtype, comm, explicit_workspace_bytes
-            )
+        workspace = trtllm_mnnvl_ar.MNNVLAllReduceFusionWorkspace(
+            mapping,
+            max_num_tokens=seq_len,
+            hidden_dim=hidden_size,
+            dtype=dtype,
+            comm_backend=comm,
         )
 
-        multicast_ptr = legacy_workspace.mc_ptr
-        buffer_ptrs_dev = legacy_workspace.uc_ptrs_dev
-        unicast_ptr = legacy_workspace.handle.buffer_ptrs[mapping.tp_rank]
-
-        # Test each sequence length with the same workspace (reusing allocated buffers within this list)
         if rank == 0:
             print(
                 f"Testing seq_len={seq_len}, hidden_size={hidden_size}, dtype={dtype}"
@@ -179,7 +175,7 @@ def _run_mnnvl_ar(world_size, rank, dtype, distributed_init_port, seq_len, hidde
         allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
         reference_output = (allreduce_result,)
 
-        # Run the test with the same workspace
+        # Run the test with the workspace
         from .test_trtllm_mnnvl_allreduce import row_linear_residual_norm_fusion_forward
 
         row_linear_residual_norm_fusion_forward(
@@ -187,17 +183,10 @@ def _run_mnnvl_ar(world_size, rank, dtype, distributed_init_port, seq_len, hidde
             residual,
             norm_weight,
             eps,
-            hidden_size,
-            dtype,
             mapping,
             False,
             reference_output,
-            multicast_ptr,
-            buffer_ptrs_dev,
-            unicast_ptr,
-            max_num_elements_mnnvl,
-            buffer_flags_mnnvl,
-            comm,
+            workspace,
         )
 
         # Synchronize before next test
@@ -226,8 +215,8 @@ def _run_mnnvl_ar(world_size, rank, dtype, distributed_init_port, seq_len, hidde
 
     finally:
         # Ensure cleanup happens for this list's workspace
-        if "legacy_workspace" in locals():
-            legacy_workspace.destroy()
+        if "workspace" in locals():
+            workspace.destroy()
 
     # Final synchronization and check for failures across all ranks
     comm.barrier()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
The goal of this PR is to unify memory allocation for all reduce to use torch symmetric memory instead of custom allocators in in flashinfer.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

```
FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=.  mpirun --allow-run-as-root  -np <num_gpus> pytest tests/comm/test_allreduce_unified_api.py -vv -s
<num_gpus>:8 pass
<num_gpus>:4 pass
<num_gpus>:2 pass
```
```
FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=. pytest tests/comm/test_trtllm_allreduce_fusion.py -vv -s

pass
```
```
FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=.  mpirun --allow-run-as-root -np 4 pytest tests/comm/test_trtllm_mnnvl_allreduce.py -vv -s

<num_gpus>:4 pass

```
```
FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=. pytest tests/comm/test_trtllm_mnnvl_allreduce_custom_comm.py -vv -s

pass
```
## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enabled symmetric CUDA memory allocation for collective operations, improving stability and performance across PyTorch versions.
  * Unified workspace allocation and lifecycle for all-reduce/fusion paths, simplifying resource management and reducing teardown issues.

* **Bug Fixes**
  * Prevented a reset in distributed group tracking on older PyTorch releases, reducing failures during group teardown.

* **Tests**
  * Enhanced test logging and updated helpers to exercise the new workspace handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->