### PR TITLE
[Fmha] revert blackwell ultra optimization that causes deadlocks.

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "e7afc4134bb53eaab63fb85163d5943fb190621c/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "55bba55929d4093682e32d817bd11ffb0441c749/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "b55211623be7f5697c5262ffd8361fc06c147bc9/batched_gemm-b3c1646-c111d7c/"
     )
@@ -155,7 +155,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "5bd87798e560a63e883902fc5468146ffff0d3551bf337d2f81bd02893e9dc39"
+        "f2c0aad1e74391c4267a2f9a20ec819358b59e04588385cffb452ed341500b99"
     )
     TRTLLM_GEN_BMM: str = (
         "0af823880730c4f0b3832d2208fab035946694b83444410b9309db5613d60195"

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -416,7 +416,8 @@ struct KernelParams {
   //     strides are read from the tensor and passed to the TMA descriptor.
   template <class FmhaOptions>
   static auto makeTmaShapeStrideKv(FmhaOptions const& options, KernelParams const& params,
-                                   Data_type dtypeKv, bool isK, bool storeTransformedKvInTmem) {
+                                   Data_type dtypeKv, bool isK, bool storeTransformedKvInTmem,
+                                   int reshapeFactor) {
     // The shape elements.
     auto [numKeys, numHeadsQPerKv, batchSize] = makeShapeKv(options, params);
     // The stride elements.
@@ -435,19 +436,26 @@ struct KernelParams {
     // dimension (it's stride is always 0). For V, the headDim dimension is already the first
     // dimension so no swapping is needed.
 
-    // Therefore, the resulting TMA layout is 4D: (headDim, numKeys, numHeadsKv, batchSize):(1,
-    // strideKeys, strideHeads, strideBatch)
+    // The TMA layout is 4D:
+    // Shape:  (headDim, numKeys, numHeadsKv, batchSize)
+    // Stride: (1, strideKeys, strideHeads, strideBatch)
+    //
+    // We reshape by a factor r so the headDim is 128B+, reducing the number of TMA read requests:
+    // Shape:  (headDim * r, numKeys / r, numHeadsKv, batchSize)
+    // Stride: (1, strideKeys * r, strideHeads, strideBatch)
 
     // Note that for FP4 KV input, elements are stored as uint8_t, each packs 2 FP4 elements.
     // The column index and strides needs to divide by 2.
     auto const colIdxDivisor = dtypeKv == DATA_TYPE_E2M1 ? 2 : 1;
     auto shape = std::vector<uint64_t>{
-        storeTransformedKvInTmem ? headDim : static_cast<uint64_t>(headDim / colIdxDivisor),
-        static_cast<uint64_t>(numKeys), static_cast<uint64_t>(options.mNumHeadsKv),
+        (storeTransformedKvInTmem ? headDim : static_cast<uint64_t>(headDim / colIdxDivisor)) *
+            reshapeFactor,
+        static_cast<uint64_t>(numKeys / reshapeFactor), static_cast<uint64_t>(options.mNumHeadsKv),
         static_cast<uint64_t>(batchSize)};
-    auto stride = std::vector<uint64_t>{1, static_cast<uint64_t>(strideKeys / colIdxDivisor),
-                                        static_cast<uint64_t>(strideHeads / colIdxDivisor),
-                                        static_cast<uint64_t>(strideBatch / colIdxDivisor)};
+    auto stride =
+        std::vector<uint64_t>{1, static_cast<uint64_t>(strideKeys / colIdxDivisor * reshapeFactor),
+                              static_cast<uint64_t>(strideHeads / colIdxDivisor),
+                              static_cast<uint64_t>(strideBatch / colIdxDivisor)};
 
     return std::make_tuple(shape, stride);
   }
@@ -466,7 +474,7 @@ struct KernelParams {
   //     sfStrideHeads and sfStrideBatch must each be a multiple of 16.
   template <class FmhaOptions>
   static auto makeTmaShapeStrideKvSf(FmhaOptions const& options, KernelParams const& params,
-                                     bool isK) {
+                                     bool isK, int reshapeFactor) {
     // The shape elements.
     auto [numKeys, numHeadsQPerKv, batchSize] = makeShapeKv(options, params);
 
@@ -484,19 +492,20 @@ struct KernelParams {
     int32_t sfStrideBatch = isK ? options.kSfStrideBatch : options.vSfStrideBatch;
 
     // The KV shape is: (headDim, numKeys, numHeadsKv, batchSize)
-    // Therefore, the KV SF shape should be (headDim / NumEltsPerSf, numKeys, numHeadsKv,
-    // batchSize). Considering the TMA requires box width to be multiple of 16B, without changing
-    // the underlying layout, we reshape into (16, numKeys * headDim / NumEltsPerSf / 16,
-    // numHeadsKv, batchSize)
+    // The KV SF shape is: (headDim / NumEltsPerSf, numKeys, numHeadsKv, batchSize).
+    // Considering the TMA requires box width to be multiple of 16B, and ideally >= 128B, we reshape
+    // with a factor into: (headDim / NumEltsPerSf * r, numKeys / r, numHeadsKv, batchSize)
 
     // Note that it only works for pagedKv layout.
     FLASHINFER_CHECK(isPagedKv(options.mQkvLayout), "The qkvLayout is not supported.");
 
     auto shape = std::vector<uint64_t>{
-        16, static_cast<uint64_t>(numKeys * headDim / NumEltsPerSf / 16),
-        static_cast<uint64_t>(options.mNumHeadsKv), static_cast<uint64_t>(batchSize)};
-    auto stride = std::vector<uint64_t>{1, 16, static_cast<uint64_t>(sfStrideHeads),
-                                        static_cast<uint64_t>(sfStrideBatch)};
+        static_cast<uint64_t>(headDim / NumEltsPerSf * reshapeFactor),
+        static_cast<uint64_t>(numKeys / reshapeFactor), static_cast<uint64_t>(options.mNumHeadsKv),
+        static_cast<uint64_t>(batchSize)};
+    auto stride = std::vector<uint64_t>{
+        1, static_cast<uint64_t>(headDim / NumEltsPerSf * reshapeFactor),
+        static_cast<uint64_t>(sfStrideHeads), static_cast<uint64_t>(sfStrideBatch)};
 
     return std::make_tuple(shape, stride);
   }
@@ -695,20 +704,39 @@ struct KernelParams {
     bool const storeTransformedKvInTmem{kernelMeta.mDataTypeKv == DATA_TYPE_E2M1 &&
                                         kernelMeta.mDataTypeQ == DATA_TYPE_E4M3 &&
                                         maxHeadDimKv >= 128 && isSwapsMmaAb};
-    // Shape/stride for gmem tensor Kv.
-    auto [shapeK, strideK] = makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeKv,
-                                                  /*isK*/ true, storeTransformedKvInTmem);
-    auto [shapeV, strideV] = makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeKv,
-                                                  /*isK*/ false, storeTransformedKvInTmem);
     // Whether swizzle is needed for K/V.
     bool const swizzleKv{storeTransformedKvInTmem || !transformsKv};
+    // Whether we can reshape the TMA box for K/V to widen it to 128B.
+    bool const canReshapeTmaKv{isPagedKv(options.mQkvLayout) &&
+                               options.mHeadDimQk == options.mHeadDimV && !swizzleKv};
+    // The reshape factor for K/V TMA box: aim for 128B box width.
+    //   - 128 / maxHeadDimKv: keeps first-dim tile <= 128 elts (CU_TENSOR_MAP_SWIZZLE_128B limit).
+    //   - 128 / (maxHeadDimKv * bytesPerElt): factor needed to reach 128B box width.
+    //   - numKeysPerTile: can't reshape more rows than the tile covers.
+    int32_t const reshapeFactorKv{
+        canReshapeTmaKv
+            ? std::max(
+                  1,
+                  std::min(
+                      {128 / maxHeadDimKv,
+                       128 / (maxHeadDimKv *
+                              static_cast<int32_t>(get_size_in_bits(kernelMeta.mDataTypeKv)) / 8),
+                       numKeysPerTile}))
+            : 1};
+    // Shape/stride for gmem tensor Kv.
+    auto [shapeK, strideK] =
+        makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeKv,
+                             /*isK*/ true, storeTransformedKvInTmem, reshapeFactorKv);
+    auto [shapeV, strideV] =
+        makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeKv,
+                             /*isK*/ false, storeTransformedKvInTmem, reshapeFactorKv);
     // Note that for FP4 KV input, elements are stored as uint8_t, each packs 2 FP4 elements.
     auto const numEltsDivisor =
         kernelMeta.mDataTypeKv == DATA_TYPE_E2M1 && !storeTransformedKvInTmem ? 2 : 1;
     // The tileShapes for K/V.
     std::vector<uint32_t> tileShapeKv(shapeK.size(), 1);
-    tileShapeKv[0] = numEltsInClampedHeadDimKv / numEltsDivisor;
-    tileShapeKv[1] = numKeysPerTile;
+    tileShapeKv[0] = numEltsInClampedHeadDimKv / numEltsDivisor * reshapeFactorKv;
+    tileShapeKv[1] = numKeysPerTile / reshapeFactorKv;
 
     // If sparse MLA is enabled, the shape and stride for K need to be updated for 2D layout
     // (numTokensKvInPagedKv, headDimQk).
@@ -731,18 +759,22 @@ struct KernelParams {
     if (kernelMeta.mDataTypeKv == DATA_TYPE_E2M1) {
       // The number of elements per SF.
       int32_t NumEltsPerSf = 16;
+      // The reshape factor for K/V SF: aim for box width 128B, limit to numKeysPerTile.
+      int32_t const reshapeFactorKvSf =
+          std::min(128 / (maxHeadDimKv / NumEltsPerSf), numKeysPerTile);
       // Compute the shape and stride for SF tensor.
       // FIXME: assume K and V uses the same shape.
-      auto [shapeKvSf, strideKvSf] = makeTmaShapeStrideKvSf(options, params, /*isK*/ true);
+      auto [shapeKvSf, strideKvSf] =
+          makeTmaShapeStrideKvSf(options, params, /*isK*/ true, reshapeFactorKvSf);
 
       // The tileShapes for K/V.
       std::vector<uint32_t> tileShapeKvSf(shapeKvSf.size(), 1);
-      tileShapeKvSf[0] = 16;
-      tileShapeKvSf[1] = numKeysPerTile * maxHeadDimKv / NumEltsPerSf / 16;
+      tileShapeKvSf[0] = maxHeadDimKv / NumEltsPerSf * reshapeFactorKvSf;
+      tileShapeKvSf[1] = numKeysPerTile / reshapeFactorKvSf;
 
-      // The tile box is reshaped from (headDim / NumEltsPerSf, tileSizeKv) into (16, tileSizeKv *
-      // headDim / NumEltsPerSf / 16). See makeTmaShapeStrideKvSf for details. Build tma descriptor
-      // for K SF.
+      // The tile box is reshaped from (headDim / NumEltsPerSf, tileSizeKv) into
+      // (headDim / NumEltsPerSf * reshapeFactorKvSf, tileSizeKv / reshapeFactorKvSf).
+      // Build tma descriptor for K SF.
       params.tmaKSf_ = buildNdTmaDescriptor(options, DATA_TYPE_E4M3, shapeKvSf, strideKvSf,
                                             tileShapeKvSf, const_cast<void*>(options.kSfBasePtr),
                                             /*swizzled = */ false);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated TRTLLM GEN FMHA artifact references and associated checksums used for download and verification.

* **Refactor**
  * Improved kernel tile-shape handling for paged K/V cache and refined scaling-factor tensor layout to optimize TMA transfers and memory access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->