### PR TITLE
[fix] Fix barrier deadlock in fmha_v2 fp8+head_dim=256 transpose_v_tile

### DIFF
--- a/csrc/fmha_v2/fmha/hopper/arrive_wait.h
+++ b/csrc/fmha_v2/fmha/hopper/arrive_wait.h
@@ -68,13 +68,13 @@ namespace fmha {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline __device__ void named_barrier_arrive(uint32_t BARRIER_ID, uint32_t NUM_THREADS) {
   if (NUM_THREADS > 1) {
-    asm volatile("bar.arrive %0, %1;" : : "r"(BARRIER_ID), "r"(NUM_THREADS));
+    asm volatile("barrier.cta.arrive %0, %1;" : : "r"(BARRIER_ID), "r"(NUM_THREADS));
   }
 }
 
 inline __device__ void named_barrier_wait(uint32_t BARRIER_ID, uint32_t NUM_THREADS) {
   if (NUM_THREADS > 1) {
-    asm volatile("bar.sync %0, %1;" ::"r"(BARRIER_ID), "r"(NUM_THREADS));
+    asm volatile("barrier.cta.sync %0, %1;" ::"r"(BARRIER_ID), "r"(NUM_THREADS));
   }
 }
 

--- a/csrc/fmha_v2/fmha/warpspec/circular_buffer.h
+++ b/csrc/fmha_v2/fmha/warpspec/circular_buffer.h
@@ -126,24 +126,30 @@ class CircularBufferReader {
   }
 
   /* Peek at the head */
-  inline __device__ int peek() {
-    return _entryProducedBarriers.bar_peek(_rptr, (_phase >> _rptr) & 1);
+  inline __device__ int peek(int ptr) {
+    return _entryProducedBarriers.bar_peek(ptr, (_phase >> ptr) & 1);
   }
+
+  inline __device__ int peek() { return peek(_rptr); }
 
   /* Wait for the head to be ready */
-  inline __device__ int wait() {
-    _entryProducedBarriers.bar_wait(_rptr, (_phase >> _rptr) & 1);
-    return _rptr;
+  inline __device__ int wait(int ptr) {
+    _entryProducedBarriers.bar_wait(ptr, (_phase >> ptr) & 1);
+    return ptr;
   }
 
+  inline __device__ int wait() { return wait(_rptr); }
+
   /* Advance the head pointer */
-  inline __device__ void advance() {
-    _phase ^= (1 << _rptr);
-    _rptr += 1;
+  inline __device__ void advance(int ptr) {
+    _phase ^= (1 << ptr);
+    _rptr = ptr + 1;
     if (_rptr >= DEPTH) {
       _rptr = 0;
     }
   }
+
+  inline __device__ void advance() { advance(_rptr); }
 
   inline __device__ int ptr() { return _rptr; }
 
@@ -165,10 +171,12 @@ class CircularBufferReader {
   /* Simplification of complete and advance for cases
      where they don't need to be reordered/separated for performance
   */
-  inline __device__ void pop(int tid0) {
-    complete(tid0, _rptr);
-    advance();
+  inline __device__ void pop(int tid0, int ptr) {
+    complete(tid0, ptr);
+    advance(ptr);
   }
+
+  inline __device__ void pop(int tid0) { pop(tid0, _rptr); }
 
   /* Overrides for pointer and phase.  Used for shared buffers */
   inline __device__ void setPtr(int ptr) { _rptr = ptr; }

--- a/csrc/fmha_v2/fmha/warpspec/compute.h
+++ b/csrc/fmha_v2/fmha/warpspec/compute.h
@@ -510,8 +510,12 @@ struct Compute {
       mutex.arrive();
     }
     if constexpr (ENABLE_MUTEX && Kernel_traits::ELEMENT_BYTES == 1) {
-      // Wait until another warpgroup has already executed QGMMA.
-      mutex.named_bar_wait();
+      // Synchronize warpgroups after BMM1 via mbarrier rendezvous.
+      // Replaces the predicated bar.sync 2, 256 pattern (named_bar_wait/named_bar_arrive)
+      // which is UB per PTX spec (bar.sync = barrier.sync.aligned requires all CTA threads
+      // to execute the same instruction) and was flagged by compute-sanitizer synccheck.
+      mutex.arrive();
+      mutex.wait();
     }
 
     // Fragment p for BMM2 input
@@ -538,10 +542,6 @@ struct Compute {
 
     // Softmax Exp, max/sum, and update scales. If returns false we skip the rest.
     if (!softmax.compute_and_update_scale<IS_FIRST_COL>(p_max, p_sum, skip_softmax_vote)) {
-      if constexpr (ENABLE_MUTEX && Kernel_traits::ELEMENT_BYTES == 1) {
-        // Notify another warpgroup to execute QGMMA.
-        mutex.named_bar_arrive();
-      }
       // Need to wait V, otherwise compute-sanitizer synccheck will fail.
       int ready2 = cbr_v.peek();
       if (!ready2) {
@@ -564,11 +564,6 @@ struct Compute {
 
     // Update flash attention scales and pack it for BMM2
     softmax.pack<IS_FIRST_COL>(ctile_o, frag_p);
-
-    if constexpr (ENABLE_MUTEX && Kernel_traits::ELEMENT_BYTES == 1) {
-      // Notify another warpgroup to execute QGMMA.
-      mutex.named_bar_arrive();
-    }
 
     // Wait until v buffer is ready.
     int ready = cbr_v.peek();

--- a/csrc/fmha_v2/fmha/warpspec/dma.h
+++ b/csrc/fmha_v2/fmha/warpspec/dma.h
@@ -99,7 +99,7 @@ struct DMA {
   static_assert(STEP_KV % K_ == 0);
   using Transposer =
       Transposer<typename Kernel_traits::Traits_o, typename Kernel_traits::Cta_tile_o, K_,
-                 (STEP_KV > 128 || SLIDING_OR_CHUNKED_ATTENTION) ? 1 : 2 /* UNROLL */>;
+                 (STEP_KV >= 128 || SLIDING_OR_CHUNKED_ATTENTION) ? 1 : 2 /* UNROLL */>;
 
   struct Device {
     // Only the warpgroup leader initiates mbarriers & TMA operations.
@@ -494,15 +494,19 @@ struct DMA {
   if constexpr (DMA_GROUP_TRANSPOSE_V) {                                                         \
     v_barrier_id =                                                                               \
         cbw_v_scratch.tmaReserve(elect_one_, (TILE_SIZE_V) * Kernel_traits::ELEMENT_BYTES);      \
-    v_barrier_ptr = cbw_v_scratch.barrier_ptr(v_barrier_id);                                     \
     v_smem = shared->smem_v_scratch.data();                                                      \
   } else {                                                                                       \
     v_barrier_id = cbw_v.tmaReserve(elect_one_, (TILE_SIZE_V) * Kernel_traits::ELEMENT_BYTES);   \
-    v_barrier_ptr = cbw_v.barrier_ptr(v_barrier_id);                                             \
     v_smem = shared->smem_v.data();                                                              \
   }                                                                                              \
                                                                                                  \
-  named_barrier_wait(SYNC_BARRIER, NUM_THREADS_IN_DMA_GROUP);
+  named_barrier_wait(SYNC_BARRIER, NUM_THREADS_IN_DMA_GROUP);                                    \
+                                                                                                 \
+  if constexpr (DMA_GROUP_TRANSPOSE_V) {                                                         \
+    v_barrier_ptr = cbw_v_scratch.barrier_ptr(v_barrier_id);                                     \
+  } else {                                                                                       \
+    v_barrier_ptr = cbw_v.barrier_ptr(v_barrier_id);                                             \
+  }
 
     // Load k,v tiles from gmem to smem by TMA.
     template <typename BufferWriter, typename BufferWriterScratch>
@@ -605,14 +609,22 @@ struct DMA {
       Transposer transposer(threadIdx.x % NUM_THREADS_IN_DMA_GROUP);
 
       // Src buffer available
-      int ready = cbr_v_scratch.peek();
+      int ready = cbr_v_scratch.peek(v_scratch_barrier_id);
       if (!ready) {
-        cbr_v_scratch.wait();
+        cbr_v_scratch.wait(v_scratch_barrier_id);
       }
-      uint32_t smem_v_src = __cvta_generic_to_shared(&shared->smem_v_scratch[v_scratch_barrier_id]);
+      uint32_t smem_v_src =
+          __cvta_generic_to_shared(&shared->smem_v_scratch[v_scratch_barrier_id * TILE_SIZE_V]);
 
       // Dst buffer available
       int v_barrier_id = cbw_v.threadReserve();
+      // NOTE(bobboli): Sync all DMA threads after consumer-bar wait to prevent phase-flip race.
+      // Without this, thread 0 can race ahead, commit V (triggering compute to consume the slot
+      // and flip the consumed-barrier phase), then wrap around in threadReserve() with a new
+      // expected phase, while slow DMA warps are still waiting on the old expected phase of the
+      // now-flipped barrier -> deadlock at bar.sync 1, 128 in transpose_v_tile. Same hazard as
+      // described for push_with_sync (see comment near run_packed_qkv).
+      named_barrier_wait(SYNC_BARRIER, NUM_THREADS_IN_DMA_GROUP);
       uint32_t smem_v_dst = __cvta_generic_to_shared(&shared->smem_v[v_barrier_id * TILE_SIZE_V]);
 
 // Explicitly transpose the v buffer in smem for fp8.
@@ -671,7 +683,7 @@ struct DMA {
       fence_view_async_shared();                                   // Commit STSM
       named_barrier_wait(SYNC_BARRIER, NUM_THREADS_IN_DMA_GROUP);  // Sync before signaling
       cbw_v.threadCommit(elect_one_, v_barrier_id);                // Signal readiness
-      cbr_v_scratch.pop(elect_one_);                               // Advance to next phase
+      cbr_v_scratch.pop(elect_one_, v_scratch_barrier_id);         // Advance to next phase
     }
 
     inline __device__ void get_next_tile_id(int local_wid, int tiw, uint32_t smem_tile_id,

--- a/csrc/fmha_v2/fmha/warpspec/dma.h
+++ b/csrc/fmha_v2/fmha/warpspec/dma.h
@@ -147,6 +147,33 @@ struct DMA {
       return std::make_pair(kv_idx_start, kv_idx_end);
     }
 
+    static inline __device__ int compute_dynamic_q_tiles_per_head(int actual_q_seqlen) {
+      return (actual_q_seqlen + STEP_Q * NUM_COMPUTE_GROUPS - 1) / (STEP_Q * NUM_COMPUTE_GROUPS);
+    }
+
+    static inline __device__ bool decode_exact_dynamic_tile_id(
+        bert::Fused_multihead_attention_params_v2 const& params, uint32_t tile_id, int& bidb,
+        int& bidh, int& q_step_offset) {
+      int remaining = static_cast<int>(tile_id);
+
+#pragma unroll 1
+      for (int batch_idx = 0; batch_idx < params.b; ++batch_idx) {
+        int const actual_q_seqlen =
+            params.cu_q_seqlens[batch_idx + 1] - params.cu_q_seqlens[batch_idx];
+        int const q_tiles_per_head = compute_dynamic_q_tiles_per_head(actual_q_seqlen);
+        int const batch_tiles = q_tiles_per_head * params.h;
+        if (remaining < batch_tiles) {
+          bidb = batch_idx;
+          bidh = remaining / q_tiles_per_head;
+          q_step_offset = (remaining % q_tiles_per_head) * NUM_COMPUTE_GROUPS;
+          return true;
+        }
+        remaining -= batch_tiles;
+      }
+
+      return false;
+    }
+
     ////////////////////////////////////////////////////////////////////////////////////////////
 
     // Packed contiguous QKV input.
@@ -181,20 +208,27 @@ struct DMA {
           bidh = tile_id_ % params.h;
           bidb = tile_id_ / params.h;
         } else {
-          // Balanced dynamic scheduling
-          if (CAUSAL_MASK && !SLIDING_OR_CHUNKED_ATTENTION && params.use_balanced_scheduling) {
-            q_step_offset = (params.num_tiles_per_head - 1 - tile_id_ / (params.b * params.h)) *
-                            NUM_COMPUTE_GROUPS;
-            tmp = tile_id_ % (params.b * params.h);
-            bidh = tmp / params.b;
-            bidb = tmp % params.b;
+          if constexpr (DMA_GROUP_TRANSPOSE_V) {
             q_steps = NUM_COMPUTE_GROUPS;
-          } else {  // Unbalanced dynamic scheduling
-            bidb = tile_id_ / (params.h * params.num_tiles_per_head);
-            tmp = tile_id_ % (params.h * params.num_tiles_per_head);
-            bidh = tmp / params.num_tiles_per_head;
-            q_step_offset = tmp % params.num_tiles_per_head * NUM_COMPUTE_GROUPS;
-            q_steps = NUM_COMPUTE_GROUPS;
+            if (!decode_exact_dynamic_tile_id(params, tile_id_, bidb, bidh, q_step_offset)) {
+              break;
+            }
+          } else {
+            // Balanced dynamic scheduling
+            if (CAUSAL_MASK && !SLIDING_OR_CHUNKED_ATTENTION && params.use_balanced_scheduling) {
+              q_step_offset = (params.num_tiles_per_head - 1 - tile_id_ / (params.b * params.h)) *
+                              NUM_COMPUTE_GROUPS;
+              tmp = tile_id_ % (params.b * params.h);
+              bidh = tmp / params.b;
+              bidb = tmp % params.b;
+              q_steps = NUM_COMPUTE_GROUPS;
+            } else {  // Unbalanced dynamic scheduling
+              bidb = tile_id_ / (params.h * params.num_tiles_per_head);
+              tmp = tile_id_ % (params.h * params.num_tiles_per_head);
+              bidh = tmp / params.num_tiles_per_head;
+              q_step_offset = tmp % params.num_tiles_per_head * NUM_COMPUTE_GROUPS;
+              q_steps = NUM_COMPUTE_GROUPS;
+            }
           }
         }
 
@@ -330,6 +364,13 @@ struct DMA {
         if (SCHEDULING_MODE == 0) {
           bidh = tile_id_ % params.h;
           bidb = tile_id_ / params.h;
+        } else if constexpr (DMA_GROUP_TRANSPOSE_V) {
+          q_steps = NUM_COMPUTE_GROUPS;
+          int q_step_offset;
+          if (!decode_exact_dynamic_tile_id(params, tile_id_, bidb, bidh, q_step_offset)) {
+            break;
+          }
+          local_q_tile_offset = q_step_offset * STEP_Q;
         } else if (SCHEDULING_MODE == 1) {
           bidb = tile_id_ / (params.h * params.num_tiles_per_head);
           tmp = tile_id_ % (params.h * params.num_tiles_per_head);

--- a/csrc/fmha_v2/fmha/warpspec/kernel_traits.h
+++ b/csrc/fmha_v2/fmha/warpspec/kernel_traits.h
@@ -139,8 +139,9 @@ struct Kernel_traits {
                              std::is_same<Element_data_type, fmha::e5m2_t>::value)
   };
 
-  // The number of smem scratch buffer for staging V transpose for Hopper QGMMA
-  enum { V_SCRATCH_BUFFERS = DMA_GROUP_TRANSPOSE_V ? 1 : 0 };
+  // Reuse the KV double-buffer depth for fp8 V transpose scratch so the DMA producer/consumer do
+  // not immediately wrap the same slot on every iteration.
+  enum { V_SCRATCH_BUFFERS = DMA_GROUP_TRANSPOSE_V ? KV_BUFFERS : 0 };
 
   // The number of compute warpgroups (128 threads per warpgroup).
   enum { NUM_COMPUTE_GROUPS = NUM_COMPUTE_GROUPS_ };

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -236,6 +236,8 @@ def generate_kernel_spec(
     #   FP8:  round_up to multiples of 128 -> D in {32, 64, 128, 256}
     #         (head_size=160 pads to D=256 for FP8 vs D=192 for FP16)
     #
+    effective_output_dtype = output_dtype if output_dtype is not None else dtype
+
     if warp_specialization:
         spec["warp_specialization"] = True
         spec["sm_mma"] = 90
@@ -269,7 +271,16 @@ def generate_kernel_spec(
                 spec["kv_loop_step"] = 256
             else:
                 # D=256 (FP8 pads head_size>128 to 256 due to 128-byte alignment):
-                # smem = 32 + 64 + 64 + 32 = ~192KB with KV_BUF=2
+                # base smem = 32 + 64 + 64 + 32 = ~192KB with KV_BUF=2.
+                #
+                # FP8->FP8 output kernels add two output staging buffers in shared memory
+                # (kernel_traits.h:514-523), which pushes STEP_KV=128 over H100's 228KB
+                # dynamic shared-memory budget and causes cudaFuncSetAttribute(...)
+                # to fail with cudaErrorInvalidValue. Keep STEP_KV=128 for numerical
+                # stability, but drop KV buffering depth to 1 for fp8 output so the
+                # kernel fits H100's smem budget.
+                if effective_output_dtype in ["e4m3", "e4m3_fp32"]:
+                    spec["kv_tile_buffers"] = 1
                 spec["kv_loop_step"] = 128
         else:
             raise ValueError(f"Unsupported dtype: {dtype}")

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -186,7 +186,9 @@ def generate_kernel_spec(
 
     # Override class defaults that always differ
     spec["flash_attention"] = True  # Class default is False
-    spec["scheduling_mode"] = 1  # Class default is 0
+    # Warp-specialized fp8 kernels use an exact dynamic tile decode in the DMA path, so they can
+    # stay on the persistent scheduler even when a launch mixes different q-tile counts.
+    spec["scheduling_mode"] = 1
 
     # # SM-specific configuration
     # if warp_specialization:

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -3,11 +3,8 @@ import torch
 import math
 from typing import Optional, Tuple, Union
 
-pytestmark = pytest.mark.skip(
-    reason="todo(jimmyzho): temporarily skip this test due to hangs"
-)
-
 import flashinfer
+
 from flashinfer.prefill import fmha_v2_prefill_deepseek
 from tests.utils_fp8 import to_float8
 from flashinfer.utils import is_sm12x_supported, is_sm120a_supported
@@ -843,8 +840,6 @@ def test_trtllm_fmha_v2_prefill(
         pytest.skip("Skip due to bug in fp8 sliding window")
     if mask_mode == "SLIDING_WINDOW":
         pytest.skip("todo(jimmyzho): temporarily skip sliding window test due to hang")
-    if dtype == torch.float8_e4m3fn and o_dtype == torch.float8_e4m3fn:
-        pytest.skip("todo(jimmyzho): temporarily skip fp8 tests due to hang")
     run_trtllm_fmha_v2_prefill_case(
         input_layout=input_layout,
         batch_size=batch_size,


### PR DESCRIPTION
## Summary

This PR fixes the SM90 FP8 `fmha_v2` deadlock on the warp-specialized QGMMA path and re-enables FP8-output prefill coverage.

Cleaned commit stack:

1. `fix(fmha_v2): fix fp8 transpose barrier pipeline on SM90`
2. `fix(fmha_v2): fix fp8 persistent scheduler for ragged q-tiles`
3. `test(fmha_v2): enable fp8 output prefill coverage`

## Root Causes

There were three separate issues:

- FP8 transpose / barrier / scratch-slot correctness bug in the DMA path
- FP8 persistent-scheduler bug on mixed-length launches, caused by decoding work from a uniform `num_tiles_per_head` and skipping invalid tiles later
- Separate H100 shared-memory budget issue for FP8-output `head_dim=256`

## What Changed

- Fixed the FP8 transpose / barrier pipeline on SM90
- Kept FP8 on persistent scheduling, but switched the FP8 transpose path to exact dynamic tile decode from `cu_q_seqlens`
- Reduced `kv_tile_buffers` to `1` for SM90 FP8-output `head_dim > 128`
- Removed stale test skips that were masking the fixed behavior

## Validation

Validated locally on H100 / SM90:

- FP8 mixed-length `PACKED_QKV` repro: `racecheck` clean, `synccheck` clean
- FP8 ragged `PACKED_QKV` repro: `racecheck` clean, `synccheck` clean
- FP8 mixed-length `CONTIGUOUS_Q_KV` repro: `racecheck` clean, `synccheck` clean
- FP16 control: `racecheck` clean
- Overnight stress: `50000` rounds completed without hanging
- Focused FP8-output causal matrix: `96 passed, 16 skipped` (`SEPARATE_Q_K_V` unsupported cases only)
