### PR TITLE
ci: fail fast if multi-node test script runs on fewer than 2 nodes

### DIFF
--- a/scripts/task_test_multi_node_comm_kernels.sh
+++ b/scripts/task_test_multi_node_comm_kernels.sh
@@ -14,6 +14,14 @@ source "${SCRIPT_DIR}/setup_test_env.sh"
 # echo "Cache cleaned."
 # echo ""
 
+# Ensure we're actually running on multiple nodes
+SLURM_NODES="${SLURM_NNODES:-1}"
+if [ "$SLURM_NODES" -lt 2 ]; then
+    echo "ERROR: Multi-node tests require at least 2 nodes, but SLURM_NNODES=${SLURM_NODES}."
+    echo "Check that the CI job sets SLURM_NODES >= 2."
+    exit 1
+fi
+
 # Disable sanity testing for multi-node tests (always run full suite)
 # shellcheck disable=SC2034  # Used by common_test_functions.sh
 DISABLE_SANITY_TEST=true

--- a/scripts/task_test_multi_node_comm_kernels.sh
+++ b/scripts/task_test_multi_node_comm_kernels.sh
@@ -15,10 +15,9 @@ source "${SCRIPT_DIR}/setup_test_env.sh"
 # echo ""
 
 # Ensure we're actually running on multiple nodes
-SLURM_NODES="${SLURM_NNODES:-1}"
-if [ "$SLURM_NODES" -lt 2 ]; then
-    echo "ERROR: Multi-node tests require at least 2 nodes, but SLURM_NNODES=${SLURM_NODES}."
-    echo "Check that the CI job sets SLURM_NODES >= 2."
+if [ "${SLURM_NNODES:-1}" -lt 2 ]; then
+    echo "ERROR: Multi-node tests require at least 2 nodes, but SLURM_NNODES=${SLURM_NNODES:-1}." >&2
+    echo "Check that the CI job sets SLURM_NNODES >= 2." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Adds an early SLURM_NNODES check to task_test_multi_node_comm_kernels.sh so that a misconfigured CI job fails loudly instead of silently skipping all 240 tests.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a preflight validation for the multi-node communication kernels test to ensure the environment is configured for multiple nodes before running, preventing invalid test execution and providing a clear error message when requirements aren't met.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/2964)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->