### PR TITLE
test: skip unsupported mm_mxfp8 configurations on SM12x

### DIFF
--- a/tests/gemm/test_mm_mxfp8.py
+++ b/tests/gemm/test_mm_mxfp8.py
@@ -84,6 +84,15 @@ def _run_mm_mxfp8(
     use_8x4_sf_layout_for_a=False,
 ):
     _skip_if_unsupported(backend)
+
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    is_sm12x = compute_capability[0] == 12
+
+    if is_sm12x and not is_sf_swizzled_layout:
+        pytest.skip(
+            "SM12x only supports swizzled 1D scales; no backend handles non-swizzled layout."
+        )
+
     if backend == "trtllm":
         if not is_sf_swizzled_layout:
             pytest.skip("trtllm must have swizzled scales")
@@ -298,6 +307,12 @@ def test_mm_mxfp8_find_minimum_cosine_similarity(is_sf_swizzled_layout):
     """Sweep value scales and enforce a minimum cosine similarity."""
     _skip_if_unsupported()
 
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability[0] == 12 and not is_sf_swizzled_layout:
+        pytest.skip(
+            "SM12x only supports swizzled 1D scales; no backend handles non-swizzled layout."
+        )
+
     m, n, k = 256, 4096, 4096
 
     value_scales = [0.001, 0.01, 0.02, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 50.0, 100.0]
@@ -496,6 +511,12 @@ def test_mm_mxfp8_llm_full_layer_simulation():
 def test_mm_mxfp8_scale_contiguity_requirement():
     """Test behavior with non-contiguous scale tensors."""
     _skip_if_unsupported()
+
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability[0] == 12:
+        pytest.skip(
+            "SM12x only supports swizzled 1D scales; this test uses non-swizzled 2D scales."
+        )
 
     m, n, k = 256, 4096, 4096
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- On SM12x GPUs, only the CUTLASS backend is available for `mm_mxfp8`, and it requires 1D swizzled scales (`SfLayout.layout_128x4`). The `trtllm` and `cute-dsl` backends do not support SM12x at all.
- The backend requirement checks in `gemm_base.py` already enforce this correctly, but several test cases in `test_mm_mxfp8.py` were not skipping these unsupported configurations, causing them to hit `BackendSupportedError` / `ValueError` instead of being gracefully skipped.
- Add SM12x skip guards to `_run_mm_mxfp8`, `test_mm_mxfp8_find_minimum_cosine_similarity`, and  `test_mm_mxfp8_scale_contiguity_requirement` so that non-swizzled scale layout tests are skipped on SM12x.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

#2902

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Improved test reliability by adding runtime CUDA compute capability detection for SM12x GPUs, with conditional skips for non-swizzled scale layouts across multiple test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->