### PR TITLE
feat: add relu_and_mul activation

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -24,6 +24,7 @@ from .version import __git_version__ as __git_version__
 from . import jit as jit
 from .activation import gelu_and_mul as gelu_and_mul
 from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
+from .activation import relu_and_mul as relu_and_mul
 from .activation import silu_and_mul as silu_and_mul
 from .activation import (
     silu_and_mul_scaled_nvfp4_experts_quantize as silu_and_mul_scaled_nvfp4_experts_quantize,

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -195,6 +195,47 @@ def gelu_and_mul(
 
 
 @flashinfer_api
+def relu_and_mul(
+    input: torch.Tensor, out: torch.Tensor = None, enable_pdl: Optional[bool] = None
+) -> torch.Tensor:
+    r"""Fused ReLU and Mul operation.
+
+    ``relu(input[..., :hidden_size]) * input[..., hidden_size:]``
+
+    Parameters
+    ----------
+    input: torch.Tensor
+        Input tensor, shape (..., 2 * hidden_size).
+
+    out: Optional[torch.Tensor]
+        The output tensor, if specified, the kernel will update this tensor inplace.
+
+    enable_pdl: bool
+        Whether to enable `programmatic dependent launch
+        <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
+
+    Returns
+    -------
+    output: torch.Tensor
+        Output tensor, shape (..., hidden_size).
+    """
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(input.device)
+    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
+        raise ValueError("The pointers must be multiple of 16 bytes.")
+    if out is not None:
+        _check_shape(input, out)
+    else:
+        out = torch.empty(
+            input.shape[:-1] + (input.shape[-1] // 2,),
+            device=input.device,
+            dtype=input.dtype,
+        )
+    get_act_and_mul_module("relu").relu_and_mul(out, input, enable_pdl)
+    return out
+
+
+@flashinfer_api
 def silu_and_mul_scaled_nvfp4_experts_quantize(
     a,
     mask,

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -95,10 +95,17 @@ __device__ __forceinline__ float gelu_tanh(const float& val) {
 }
 """
 
+relu_def_cu_str = r"""
+__device__ __forceinline__ float relu(const float& val) {
+  return val > 0.0f ? val : 0.0f;
+}
+"""
+
 act_func_def_str = {
     "silu": silu_def_cu_str,
     "gelu": gelu_def_cu_str,
     "gelu_tanh": gelu_def_tanh_cu_str,
+    "relu": relu_def_cu_str,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ TORCH_COMPILE_FNS = [
     flashinfer.activation.silu_and_mul,
     flashinfer.activation.gelu_and_mul,
     flashinfer.activation.gelu_tanh_and_mul,
+    flashinfer.activation.relu_and_mul,
     flashinfer.cascade.merge_state,
     flashinfer.cascade.merge_state_in_place,
     flashinfer.cascade.merge_states,

--- a/tests/utils/test_activation.py
+++ b/tests/utils/test_activation.py
@@ -31,6 +31,7 @@ def warmup_jit():
             flashinfer.activation.gen_act_and_mul_module("silu"),
             flashinfer.activation.gen_act_and_mul_module("gelu"),
             flashinfer.activation.gen_act_and_mul_module("gelu_tanh"),
+            flashinfer.activation.gen_act_and_mul_module("relu"),
         ],
         verbose=False,
     )
@@ -76,6 +77,20 @@ def test_fused_gelu_mul(dim, batch_size, seq_len, enable_pdl):
         pytest.skip("PDL is only available for Hopper and later GPUs")
     y_ref = x[..., dim:] * torch.nn.functional.gelu(x[..., :dim], approximate="none")
     y = flashinfer.activation.gelu_and_mul(x, enable_pdl=enable_pdl)
+    torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
+@pytest.mark.parametrize("enable_pdl", [True, False])
+def test_fused_relu_mul(dim, batch_size, seq_len, enable_pdl):
+    x = torch.randn(batch_size, seq_len, 2 * dim).to(0).to(torch.float16)
+    major, _ = get_compute_capability(x.device)
+    if major < 9 and enable_pdl:
+        pytest.skip("PDL is only available for Hopper and later GPUs")
+    y_ref = x[..., dim:] * torch.nn.functional.relu(x[..., :dim])
+    y = flashinfer.activation.relu_and_mul(x, enable_pdl=enable_pdl)
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Add `relu_and_mul` as a new fused activation operation, following the same pattern as the existing `silu_and_mul`, `gelu_and_mul`, and `gelu_tanh_and_mul`.

The operation computes: `relu(input[..., :hidden_size]) * input[..., hidden_size:]`

ReLU activation is used in various LLM architectures, including models with non-gated MoE experts (e.g. T5-style FFN, some BLOOM variants). The TRT-LLM MoE kernel launcher already references `Relu2` as a supported non-gated activation type.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `relu_and_mul` function: a fused operation that applies ReLU activation to the first half of a tensor's last dimension and multiplies it with the second half, now available in the public API with optimized CUDA kernel implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->