### PR TITLE
fix: handle race condition in ensure_symlink for multi-process TP workers

### DIFF
--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -238,6 +238,9 @@ def ensure_symlink(
     This is used to map C++ include paths (e.g.
     ``CUBIN_DIR/flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export``) to the
     canonical artifact directory where ``get_artifact()`` stores downloaded files.
+
+    This function is safe to call concurrently from multiple processes (e.g.
+    tensor-parallel workers) that may race to create the same symlink.
     """
     link = pathlib.Path(link)
     target = pathlib.Path(target)
@@ -250,7 +253,13 @@ def ensure_symlink(
         else:
             shutil.rmtree(link)
     link.parent.mkdir(parents=True, exist_ok=True)
-    link.symlink_to(target)
+    try:
+        link.symlink_to(target)
+    except FileExistsError:
+        # Another process created the symlink between our check and create.
+        if link.is_symlink() and link.resolve() == target.resolve():
+            return
+        raise
 
 
 def verify_symlinked_headers(


### PR DESCRIPTION
## Summary

- Fix TOCTOU race condition in `ensure_symlink()` that causes `FileExistsError` when multiple tensor-parallel workers concurrently create the same symlink

## Problem

With `--tensor-parallel-size 2` (or higher), multiple worker processes call `gen_trtllm_gen_fused_moe_sm100_module()` concurrently during startup. Both workers:

1. Check if the symlink exists → `False`
2. Call `link.symlink_to(target)`
3. The second worker crashes with `FileExistsError: [Errno 17] File exists`

This crashes the vLLM server during initialization:
```
FileExistsError: [Errno 17] File exists: '.../trtllmGen_bmm_export' -> '.../trtllm/batched_gemm/trtllmGen_bmm_export'
```

## Fix

Wrap `symlink_to()` in a `try/except FileExistsError`. If another process already created the correct symlink between our check and create, silently succeed. If the symlink points to the wrong target, re-raise.

## Test plan

- [x] Verified the fix matches the pattern used by other projects (e.g. huggingface_hub) for the same race condition
- [ ] Run vLLM with `--tensor-parallel-size 2 --moe-backend=flashinfer_trtllm` on a model like Llama-4-Scout FP8

Fixes #2980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved concurrent-safety of JIT compilation symlink creation for multi-process scenarios, preventing race conditions when multiple processes attempt simultaneous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->