### PR TITLE
[Draft] "fix: snap weight_scale_vec_size to handle block_scale_interleave padding for SM120"

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2050,23 +2050,12 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
   }
   int64_t intermediate_size_factor =
       isGatedActivation(static_cast<ActivationType>(act_type)) ? 2 : 1;
-  int64_t logical_scale_count = static_cast<int64_t>(local_num_experts) * intermediate_size *
-                                intermediate_size_factor * hidden_size;
-  int64_t weight_scale_vec_size_raw = logical_scale_count / gemm1_weights_scale.numel();
+  int64_t weight_scale_vec_size = (static_cast<int64_t>(local_num_experts) * intermediate_size *
+                                   intermediate_size_factor * hidden_size) /
+                                  gemm1_weights_scale.numel();
 
-  // Snap to nearest valid sf_vec_size (16 or 32).
-  // The raw value may be slightly smaller than the true vec_size because
-  // block_scale_interleave pads scale columns to a multiple of 4, inflating numel().
-  int64_t weight_scale_vec_size = weight_scale_vec_size_raw > 16 ? 32 : 16;
-
-  // Round-trip validation: the unpadded scale count must not exceed actual numel
-  // (padding only adds elements, never removes them).
-  int64_t expected_unpadded = logical_scale_count / weight_scale_vec_size;
-  TVM_FFI_ICHECK(gemm1_weights_scale.numel() >= expected_unpadded)
-      << "weight scale tensor too small: numel=" << gemm1_weights_scale.numel()
-      << " but expected at least " << expected_unpadded
-      << " for sf_vec_size=" << weight_scale_vec_size;
-
+  TVM_FFI_ICHECK(weight_scale_vec_size == 16 || weight_scale_vec_size == 32)
+      << "unsupported weight_scale_vec_size.";
   auto mDtypeWeights = weight_scale_vec_size == 16 ? btg::Dtype::E2m1 : btg::Dtype::MxE2m1;
 
   if (routing_bias.has_value()) {

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -731,15 +731,7 @@ def fp4_quantize(
         is_sf_8x4_layout,
         enable_pdl,
     )
-    # Swizzled sf includes row/column padding from block_scale_interleave
-    # (rows to multiple of 128, cols to multiple of 4), so we use the padded
-    # column count and let -1 absorb the padded row count.
-    # Non-swizzled sf has exactly m * (k // sf_vec_size) elements, no padding.
-    if is_sf_swizzled_layout:
-        sf_cols = round_up(input.shape[-1] // sf_vec_size, 4)
-        sf = sf.reshape((-1, sf_cols))
-    else:
-        sf = sf.reshape((-1, input.shape[-1] // sf_vec_size))
+    sf = sf.reshape((-1, input.shape[-1] // sf_vec_size))
     if is_column_major:
         x_q = x_q.transpose(-2, -1)
         sf = sf.transpose(-2, -1)

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -22,7 +22,7 @@ import torch
 from torch.nn import functional as F
 
 import flashinfer.fused_moe as fused_moe
-from flashinfer.utils import is_sm100a_supported, is_sm12x_supported
+from flashinfer.utils import is_sm100a_supported
 from flashinfer import (
     autotune,
     fp4_quantize,
@@ -69,7 +69,7 @@ def convert_swizzled_to_linear(a_sf_swizzled: torch.Tensor, m, k, block_size):
     tmp = torch.reshape(a_sf_swizzled, (1, m_tiles, k_tiles, 32, 4, 4))
     tmp = torch.permute(tmp, (0, 1, 4, 3, 2, 5))
     out = tmp.reshape(m_tiles * 128, k_tiles * f // block_size)
-    return out[0:m, 0 : k // block_size]
+    return out[0:m, 0:k]
 
 
 def dequantize_nvfp4_to_dtype(
@@ -1918,177 +1918,6 @@ def test_moe_nvfp4_unswizzled_input_sf():
     )
 
     torch.testing.assert_close(output_swizzled, output_linear, rtol=1e-3, atol=1e-3)
-
-
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize(
-    "hidden_size, intermediate_size",
-    [
-        # hidden_size=288: 288/16=18 scale cols, round_up(18,4)=20 -> padding.
-        # Exercises the weight_scale_vec_size snap fix (issue #2847).
-        (288, 128),
-    ],
-)
-@pytest.mark.parametrize("num_experts", [2])
-@pytest.mark.parametrize("top_k", [2])
-@pytest.mark.parametrize(
-    "otype, wtype",
-    [(torch.bfloat16, torch.float8_e4m3fn)],
-)
-@pytest.mark.parametrize("quantized_input", [False])
-@pytest.mark.parametrize(
-    "activation_type",
-    [ActivationType.Swiglu],
-    ids=["swiglu"],
-)
-@pytest.mark.skipif(
-    not is_sm100a_supported(torch.device("cuda"))
-    and not is_sm12x_supported(torch.device("cuda")),
-    reason="NVFP4 is only supported on SM100+",
-)
-def test_moe_nvfp4_unaligned_hidden_size(
-    batch_size,
-    hidden_size,
-    num_experts,
-    top_k,
-    intermediate_size,
-    otype,
-    wtype,
-    quantized_input,
-    activation_type,
-):
-    """Test NVFP4 MoE with hidden_size not aligned to sf_block_size * 4.
-
-    When hidden_size/sf_block_size is not a multiple of 4, block_scale_interleave
-    pads the scale columns, inflating numel(). This caused weight_scale_vec_size
-    to be computed incorrectly (e.g. 31 instead of 32). See issue #2847.
-    """
-    if top_k > num_experts:
-        pytest.skip(
-            f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})"
-        )
-
-    torch.manual_seed(42)
-    quant_blocksize = 16
-
-    def round_up(x, y):
-        return (x + y - 1) // y * y
-
-    e = num_experts
-    m = batch_size
-    n = intermediate_size
-    k = hidden_size
-
-    w1_n = 2 * n if activation_type == ActivationType.Swiglu else n
-    w1 = torch.randn((e, w1_n, k), device="cuda", dtype=otype) / 10
-
-    sf_w1_2n = round_up(w1_n, 128)
-    sf_w1_k = round_up(k // quant_blocksize, 4)
-    w1_blockscale = torch.empty(
-        (e, sf_w1_2n, sf_w1_k), device="cuda", dtype=torch.float8_e4m3fn
-    )
-
-    w2 = torch.randn((e, k, n), device="cuda", dtype=otype) / 10
-    sf_w2_k = round_up(k, 128)
-    sf_w2_n = round_up(n // quant_blocksize, 4)
-    w2_blockscale = torch.empty(
-        (e, sf_w2_k, sf_w2_n), device="cuda", dtype=torch.float8_e4m3fn
-    )
-    w1_q = torch.empty((e, w1_n, k // 2), device="cuda", dtype=torch.uint8)
-    w2_q = torch.empty((e, k, n // 2), device="cuda", dtype=torch.uint8)
-    w1_gs = torch.empty((e,), device="cuda", dtype=torch.float32)
-    w2_gs = torch.empty((e,), device="cuda", dtype=torch.float32)
-
-    for expert in range(e):
-        w1_amax = torch.abs(w1[expert]).max().to(torch.float32)
-        w2_amax = torch.abs(w2[expert]).max().to(torch.float32)
-        w1_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w1_amax
-        w2_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w2_amax
-
-        w1_q[expert], w1_blockscale[expert] = fp4_quantize(w1[expert], w1_gs[expert])
-        w2_q[expert], w2_blockscale[expert] = fp4_quantize(w2[expert], w2_gs[expert])
-
-    x = torch.randn(m, k, dtype=otype).cuda()
-    a1_gs = torch.tensor(1.0, device="cuda", dtype=torch.float32)
-    a2_gs = torch.tensor(1.0, device="cuda", dtype=torch.float32)
-    router_logits = torch.randn(m, e, dtype=otype).cuda()
-    routing_weights, selected_experts = compute_routing(router_logits, top_k)
-
-    quant_scales = [
-        a1_gs,
-        w1_blockscale.view(torch.int32),
-        1.0 / (a1_gs * w1_gs),
-        a2_gs,
-        w2_blockscale.view(torch.int32),
-        1.0 / (a2_gs * w2_gs),
-    ]
-
-    hidden_states = x
-    input_sf = None
-    if quantized_input:
-        hidden_states, input_sf = fp4_quantize(x, a1_gs)
-    flash_output = torch.zeros_like(x)
-    _ = fused_moe.cutlass_fused_moe(
-        hidden_states,
-        selected_experts.to(torch.int),
-        routing_weights,
-        w1_q.contiguous().view(torch.long),
-        w2_q.contiguous().view(torch.long),
-        otype,
-        quant_scales=quant_scales,
-        input_sf=input_sf,
-        output=flash_output,
-        activation_type=activation_type,
-    )
-
-    # Ref check
-    a_fp4, a_scale_interleaved = fp4_quantize(x, a1_gs)
-    a_in_dtype = dequantize_nvfp4_to_dtype(
-        a_fp4,
-        a_scale_interleaved,
-        a1_gs,
-        dtype=otype,
-        device=x.device,
-        block_size=quant_blocksize,
-    )
-
-    w1_d = torch.empty((e, w1_n, k), device="cuda", dtype=otype)
-    w2_d = torch.empty((e, k, n), device="cuda", dtype=otype)
-
-    for idx in range(0, e):
-        w1_d[idx] = dequantize_nvfp4_to_dtype(
-            w1_q[idx],
-            w1_blockscale[idx],
-            w1_gs[idx],
-            dtype=w1.dtype,
-            device=w1.device,
-            block_size=quant_blocksize,
-        )
-        w2_d[idx] = dequantize_nvfp4_to_dtype(
-            w2_q[idx],
-            w2_blockscale[idx],
-            w2_gs[idx],
-            dtype=w2.dtype,
-            device=w2.device,
-            block_size=quant_blocksize,
-        )
-
-    ref_output = torch_moe_nvfp4(
-        a_in_dtype,
-        w1_d,
-        w2_d,
-        top_k,
-        routing_weights,
-        selected_experts,
-        activation_type,
-    )
-    torch.testing.assert_close(ref_output, flash_output, rtol=2e-1, atol=2e-1)
-
-
-# NOTE: No MXFP8xMXFP4 unaligned-hidden_size test here because the MXFP4 MoE
-# kernel requires hidden_size % 128 == 0, and when that holds, hidden_size / 32
-# is always a multiple of 4, so the block_scale_interleave column-padding that
-# triggers the weight_scale_vec_size bug cannot occur.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[PEND Reverts] flashinfer-ai/flashinfer#2898 as ci failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Optimizations**
  * Streamlined MOE weight scaling computation for improved kernel efficiency
  * Simplified FP4 quantization tensor reshaping logic

* **Tests**
  * Removed test coverage for unaligned hidden size configurations in MOE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->