### PR TITLE
fix: restore SM120 CUTLASS MoE tile candidate removed by #2927 (test_trtllm_cutlass_fused_moe.py)

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -587,30 +587,28 @@ std::vector<CutlassGemmConfig> get_candidate_configs_sm110(
 
 std::vector<CutlassGemmConfig> get_candidate_configs_sm120(
     CutlassGemmConfig::CandidateConfigTypeParam const config) {
-#ifdef FAST_BUILD
-  return {CutlassGemmConfig{CutlassTileConfigSM120::CtaShape128x128x64B, MainloopScheduleType::AUTO,
-                            EpilogueScheduleType::AUTO, ClusterShape::ClusterShape_1x1x1}};
-#else
   if ((config & CutlassGemmConfig::FP4_ONLY) == 0) {
     if (config & CutlassGemmConfig::GROUPED_GEMM) {
       TLLM_THROW("Not Implemented: SM120 group GEMM only supports nvfp4.");
     }
     TLLM_THROW("Not Implemented: SM120 GEMM only supports nvfp4.");
   }
-  // {tile_enum, M, N}
-  static constexpr std::pair<CutlassTileConfigSM120, std::array<int, 2>> all_tiles[] = {
-      {CutlassTileConfigSM120::CtaShape128x256x64B, {128, 256}},
-      {CutlassTileConfigSM120::CtaShape128x128x256B, {128, 128}},
-      {CutlassTileConfigSM120::CtaShape256x128x128B, {256, 128}},
-  };
-  std::vector<CutlassGemmConfig> result;
-  for (auto const& [tile_enum, mn] : all_tiles) {
-    result.push_back(CutlassGemmConfig{tile_enum, MainloopScheduleType::AUTO,
-                                       EpilogueScheduleType::AUTO,
-                                       ClusterShape::ClusterShape_1x1x1});
-  }
-  return result;
-#endif
+  // Only tiles that satisfy ALL of:
+  //   1. Present in the dispatch table (SHAPE_CASE in moe_gemm_template_dispatch_tma_ws.h)
+  //   2. Pass are_tile_shapes_supported_sm120() constexpr check
+  //   3. Have compiled kernel templates (generate_sm120_grouped_gemm_operations)
+  //
+  // 128x128x128B is the only tile meeting all three criteria.  Its nominal SMEM
+  // (2 stages × (128+128) × 256 bytes = 128 KB) exceeds SM120's 100 KB budget,
+  // but CUTLASS StageCountAutoCarveout reduces the stage count to 1, bringing
+  // actual SMEM to ~64 KB.  can_implement() accepts it at runtime.
+  //
+  // K=64 tiles (128x128x64, 128x256x64, 256x128x64) are in the dispatch table
+  // but cannot be compiled for FP4 on SM120 (TMA layout static_assert failure),
+  // so they are intentionally excluded here.
+  return {CutlassGemmConfig{CutlassTileConfigSM120::CtaShape128x128x128B,
+                            MainloopScheduleType::AUTO, EpilogueScheduleType::AUTO,
+                            ClusterShape::ClusterShape_1x1x1}};
 }
 
 std::vector<CutlassGemmConfig> get_candidate_configs(

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -500,12 +500,6 @@ def test_moe_nvfp4(
             f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})"
         )
 
-    if torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip(
-            "CUTLASS MoE NVFP4 has no valid tile config on SM120/121 "
-            "(K=64 tiles in dispatch but missing from are_tile_shapes_supported_sm120)"
-        )
-
     torch.manual_seed(42)
     quant_blocksize = 16
     round_up = lambda x, y: (x + y - 1) // y * y
@@ -1284,9 +1278,6 @@ def test_moe_mxfp8_mxfp4(
         pytest.skip(
             f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})"
         )
-
-    if torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("CUTLASS MoE MXFP8xMXFP4 has no valid tile config on SM120/121")
 
     torch.manual_seed(42)
     e = num_experts


### PR DESCRIPTION
## Summary

  Fix SM120 CUTLASS MoE test failures caused by #2927 removing viable tile candidates.

  ## Root cause

  Overestimated SMEM usage (e.g. 128KB instead of actual 48-64KB for `128x128x128B`) and removed all viable tiles for FP8×FP4 (MXFP8×MXFP4).

  ## Changes

  - `cutlass_heuristic.cpp`: Restore `128x128x128B` as SM120 candidate. This fixes FP8×FP4 which had zero usable tiles after #2927.

  ## Note

  A follow-up PR will restore the three K=64B tiles (`128x128x64B`, `128x256x64B`, `256x128x64B`) which are valid for FP4×FP4 — `K=64` packed bytes maps to `TileK=128` elements for FP4, reusing existing codegen  instantiations and enabling 2-stage double buffering.

  ## Test plan

  - [x] Full `test_trtllm_cutlass_fused_moe.py` on RTX PRO 6000 (SM120): **23 passed, 14 skipped, 0 failed**