### PR TITLE
Add GQA group_size 5, 6, 7 to DISPATCH_GQA_GROUP_SIZE

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -147,6 +147,15 @@
   } else if (group_size == 4) {                              \
     constexpr size_t GROUP_SIZE = 4;                         \
     __VA_ARGS__                                              \
+  } else if (group_size == 5) {                              \
+    constexpr size_t GROUP_SIZE = 5;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 6) {                              \
+    constexpr size_t GROUP_SIZE = 6;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 7) {                              \
+    constexpr size_t GROUP_SIZE = 7;                         \
+    __VA_ARGS__                                              \
   } else if (group_size == 8) {                              \
     constexpr size_t GROUP_SIZE = 8;                         \
     __VA_ARGS__                                              \


### PR DESCRIPTION
## Summary

`DISPATCH_GQA_GROUP_SIZE` only handles group sizes 1, 2, 3, 4, 8. Any other value hits a runtime error:

```
RuntimeError: Unsupported group_size: 6
```

This breaks several popular models with non-power-of-2 GQA ratios:

| Model | Q heads | KV heads | group_size |
|-------|---------|----------|------------|
| Qwen3.5-27B | 24 | 4 | **6** |
| InternLM2.5-20B | 48 | 8 | **6** |
| Qwen2.5-7B | 28 | 4 | **7** |
| Yi-1.5-34B | 56 | 8 | **7** |

This PR adds explicit `constexpr` cases for group sizes 5, 6, and 7, so all sizes 1-8 are supported. Each adds one template instantiation per call site, matching the existing dispatch pattern.

## Why this hasn't been reported widely

Most users access FlashInfer through vLLM or SGLang, which use `BatchDecodeWithPagedKVCacheWrapper`. That wrapper handles GQA at the Python level and doesn't go through `DISPATCH_GQA_GROUP_SIZE`. The error only manifests when calling the lower-level C++ kernel dispatch directly (e.g., custom attention backends or quantized KV cache implementations that bypass the Python wrapper).

## Test plan

- [x] Verified Qwen3.5-27B (group_size=6) runs correctly after fix
- [ ] CI: existing unit tests should pass (no behavior change for sizes 1-4, 8)

AI-assisted: Claude Opus 4.6 assisted with code generation and model survey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended support for additional group sizes (5, 6, and 7) in grouped query attention operations that were previously unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->