### PR TITLE
Second part of refactoring the routing part

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -64,9 +64,15 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
   // Determine which path to use based on token count
   static int const smMajor = tensorrt_llm::common::getSMVersion() / 10;
   bool const useStaticBlock = data.mNumTokens <= routingCustom::BlockKernelMaxNumTokens;
+  // Use the dispatched tier size (not raw mNumExperts).
+  // Example: 512 experts with topK=22 skips Tier<512,8> and lands on
+  // Tier<1024,32>, so queryDispatchedMaxExperts() returns 1024 while
+  // mNumExperts is 512.  The dynblock kernel sizes smem proportional to
+  // maxExperts; using the raw count would exceed the smem budget.
+  int32_t const dispatchedMaxExperts = routingCustom::queryDispatchedMaxExperts(data);
   bool const useDynBlock = !useStaticBlock &&
                            data.mNumTokens <= routingCustom::DynBlockKernelMaxNumTokens &&
-                           data.mNumExperts <= routingCustom::DynBlockKernelMaxNumExperts;
+                           dispatchedMaxExperts <= routingCustom::DynBlockKernelMaxNumExperts;
   // runPostTopKPipeline only handles pre-computed topK (mPtrTopKIds or mPtrTopKPacked),
   // never raw scores. The cluster kernel's routingPermutation uses thread-per-expanded-index
   // for both input types (LoadExpertIdxFromGlobal=true), so the capacity is

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -69,7 +69,9 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
   // Tier<1024,32>, so queryDispatchedMaxExperts() returns 1024 while
   // mNumExperts is 512.  The dynblock kernel sizes smem proportional to
   // maxExperts; using the raw count would exceed the smem budget.
-  int32_t const dispatchedMaxExperts = routingCustom::queryDispatchedMaxExperts(data);
+  // Use customData (routingCustom::Data) since queryDispatchedMaxExperts
+  // requires routingCustom::Data, not the template DataType.
+  int32_t const dispatchedMaxExperts = routingCustom::queryDispatchedMaxExperts(customData);
   bool const useDynBlock = !useStaticBlock &&
                            data.mNumTokens <= routingCustom::DynBlockKernelMaxNumTokens &&
                            dispatchedMaxExperts <= routingCustom::DynBlockKernelMaxNumExperts;

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -20,6 +20,7 @@ namespace moe::dev::routing {
 namespace routingCustom {
 // Forward declarations of launch functions
 void launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
+void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
 void launchClusterKernel(Data const& data, void* stream);
 void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream);
 void launchInitExpertCounts(Data const& data, uint32_t numThreadsHist, void* stream);
@@ -36,7 +37,7 @@ void launchOffsetsKernel(Data const& data, int numBlocksOffsets, uint32_t numThr
 // routing-method-specific logic, so all methods can use the same workflow.
 // This function handles all path selection: single-block, single-cluster, coop, multi-kernel.
 template <typename DataType>
-void runPostTopKPipeline(DataType const& data, uint32_t /*numThreadsHist*/, void* stream) {
+void runPostTopKPipeline(DataType const& data, void* stream) {
   // Convert to routingCustom::Data for launching (kernels are shared)
   routingCustom::Data customData;
   // Copy base fields
@@ -62,24 +63,23 @@ void runPostTopKPipeline(DataType const& data, uint32_t /*numThreadsHist*/, void
 
   // Determine which path to use based on token count
   static int const smMajor = tensorrt_llm::common::getSMVersion() / 10;
-  bool const useSingleBlock = data.mNumTokens <= routingCustom::BlockKernelMaxNumTokens;
-  // Use the larger threshold (MaxNumTokensSingleCluster) since runPostTopKPipeline
-  // processes pre-computed topK data (mPtrTopKPacked/mPtrTopKIds), not raw scores.
+  bool const useStaticBlock = data.mNumTokens <= routingCustom::BlockKernelMaxNumTokens;
+  bool const useDynBlock = !useStaticBlock &&
+                           data.mNumTokens <= routingCustom::DynBlockKernelMaxNumTokens &&
+                           data.mNumExperts <= routingCustom::DynBlockKernelMaxNumExperts;
+  // runPostTopKPipeline only handles pre-computed topK (mPtrTopKIds or mPtrTopKPacked),
+  // never raw scores. The cluster kernel's routingPermutation uses thread-per-expanded-index
+  // for both input types (LoadExpertIdxFromGlobal=true), so the capacity is
+  // NumBlocksPerCluster * NumThreads = 8192 tokens.
   bool const useSingleCluster =
       (smMajor >= 9) && (data.mNumTokens <= routingCustom::MaxNumTokensSingleCluster);
 
-  // PDL overlap control: the LAST routing kernel must disable overlap so the consumer
-  // GEMM (which may lack cudaGridDependencySynchronize) can't start early.
-  // Use a separate copy for the last kernel to avoid mutating customData.
-  routingCustom::Data lastKernelData = customData;
-  lastKernelData.mPdlOverlapWithNext = false;
-
-  if (useSingleBlock) {
-    // Single-block path: fuses all steps (histogram, offsets, permutation)
-    routingCustom::launchBlockKernel(lastKernelData, numThreadsHist, stream);
+  if (useDynBlock) {
+    routingCustom::launchDynBlockKernel(customData, numThreadsHist, stream);
+  } else if (useStaticBlock) {
+    routingCustom::launchBlockKernel(customData, numThreadsHist, stream);
   } else if (useSingleCluster) {
-    // Single-cluster path: uses distributed shared memory
-    routingCustom::launchClusterKernel(lastKernelData, stream);
+    routingCustom::launchClusterKernel(customData, stream);
   } else {
     // Check if we can use the coop path (more efficient for medium token counts)
     // Requires SM90+ (grid-sync), numExperts <= 1024.
@@ -108,7 +108,7 @@ void runPostTopKPipeline(DataType const& data, uint32_t /*numThreadsHist*/, void
       // Coop path: cooperative launch fuses histogram + offsets (more efficient).
       // The coop kernel atomicAdds to mPtrExpertCounts, so we must zero it first.
       routingCustom::launchInitExpertCounts(customData, numThreadsHist, stream);
-      routingCustom::launchCoopKernel(lastKernelData, numBlocksCoop, numThreadsHist, stream);
+      routingCustom::launchCoopKernel(customData, numBlocksCoop, numThreadsHist, stream);
     } else {
       // Large-token path: multi-kernel pipeline
       FLASHINFER_CHECK(data.mPtrExpertCounts != nullptr,
@@ -129,16 +129,15 @@ void runPostTopKPipeline(DataType const& data, uint32_t /*numThreadsHist*/, void
           std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
 
       routingCustom::launchHistogramKernel(customData, numBlocksHistogram, numThreadsHist, stream);
-      routingCustom::launchOffsetsKernel(lastKernelData, numBlocksOffsets, numThreadsHist, stream);
+      routingCustom::launchOffsetsKernel(customData, numBlocksOffsets, numThreadsHist, stream);
     }
   }
 }
 
 // Explicit instantiations for the three routing method Data types
-template void runPostTopKPipeline<routingCustom::Data>(routingCustom::Data const&, uint32_t, void*);
-template void runPostTopKPipeline<routingDeepSeek::Data>(routingDeepSeek::Data const&, uint32_t,
-                                                         void*);
-template void runPostTopKPipeline<routingLlama4::Data>(routingLlama4::Data const&, uint32_t, void*);
+template void runPostTopKPipeline<routingCustom::Data>(routingCustom::Data const&, void*);
+template void runPostTopKPipeline<routingDeepSeek::Data>(routingDeepSeek::Data const&, void*);
+template void runPostTopKPipeline<routingLlama4::Data>(routingLlama4::Data const&, void*);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -289,6 +289,324 @@ void launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
+// Warp-level exclusive scan for the dynamic block kernel.
+// Computes dual prefix sums across all threads in the block using a two-level scan:
+// first within each warp, then across warps.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int NumExpertWarps>
+__device__ __forceinline__ void warpExclusiveScan(int32_t val1, int32_t val2, int32_t laneIdx,
+                                                  int32_t warpIdx, int32_t* warpTotals1,
+                                                  int32_t* warpTotals2, int32_t& prefix1,
+                                                  int32_t& prefix2, int32_t& totalSum1) {
+  static_assert(NumExpertWarps <= WarpSize,
+                "NumExpertWarps must fit in one warp for the cross-warp scan");
+
+  int32_t inc1 = val1, inc2 = val2;
+#pragma unroll
+  for (int j = 1; j < WarpSize; j *= 2) {
+    int32_t n1 = __shfl_up_sync(0xffffffff, inc1, j);
+    int32_t n2 = __shfl_up_sync(0xffffffff, inc2, j);
+    if (laneIdx >= j) {
+      inc1 += n1;
+      inc2 += n2;
+    }
+  }
+
+  if (warpIdx < NumExpertWarps && laneIdx == WarpSize - 1) {
+    warpTotals1[warpIdx] = inc1;
+    warpTotals2[warpIdx] = inc2;
+  }
+  __syncthreads();
+
+  if (warpIdx == 0) {
+    int32_t wt1 = (laneIdx < NumExpertWarps) ? warpTotals1[laneIdx] : 0;
+    int32_t wt2 = (laneIdx < NumExpertWarps) ? warpTotals2[laneIdx] : 0;
+#pragma unroll
+    for (int j = 1; j < NumExpertWarps; j *= 2) {
+      int32_t n1 = __shfl_up_sync(0xffffffff, wt1, j);
+      int32_t n2 = __shfl_up_sync(0xffffffff, wt2, j);
+      if (laneIdx >= j) {
+        wt1 += n1;
+        wt2 += n2;
+      }
+    }
+    if (laneIdx < NumExpertWarps) {
+      warpTotals1[laneIdx] = wt1;
+      warpTotals2[laneIdx] = wt2;
+    }
+  }
+  __syncthreads();
+
+  totalSum1 = warpTotals1[NumExpertWarps - 1];
+  int32_t wp1 = (warpIdx > 0 && warpIdx < NumExpertWarps) ? warpTotals1[warpIdx - 1] : 0;
+  int32_t wp2 = (warpIdx > 0 && warpIdx < NumExpertWarps) ? warpTotals2[warpIdx - 1] : 0;
+  prefix1 = inc1 - val1 + wp1;
+  prefix2 = inc2 - val2 + wp2;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// 1b. Dynamic block kernel — single-block kernel with dynamic shared memory.
+//     Handles ≤DynBlockKernelMaxNumTokens tokens and ≤DynBlockKernelMaxNumExperts experts.
+//     Extends the static block kernel to more tokens by using dynamic smem and loop-based
+//     warp-per-token processing instead of fixed warpIdx mapping.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void routingIndicesDynBlockKernel(KernelParams params) {
+  using OutputT = typename KernelParams::OutputT;
+  using InputT = typename KernelParams::InputT;
+  using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
+  using TypePacked = PackedScoreIdx<BaseType>;
+  static constexpr int MaxNumExperts = KernelParams::MaxNumExperts;
+  static constexpr int NumThreadsExperts = MaxNumExperts <= 1024 ? MaxNumExperts : 1024;
+  static constexpr int ExpertsPerThread = MaxNumExperts / NumThreadsExperts;
+  static constexpr int NumExpertWarps = NumThreadsExperts / WarpSize;
+  static constexpr int VecSize = MaxNumExperts / WarpSize;
+
+  static_assert(MaxNumExperts % WarpSize == 0);
+  static_assert(MaxNumExperts % NumThreadsExperts == 0);
+
+  int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
+  int32_t const laneIdx = cutlass::arch::LaneId();
+  int32_t const numWarps = blockDim.x / WarpSize;
+
+  extern __shared__ char dynSmem[];
+  int const numSlots = params.mNumTokens * MaxNumExperts;
+  int8_t* smemKIdx = reinterpret_cast<int8_t*>(dynSmem);
+  int16_t* smemOffset = reinterpret_cast<int16_t*>(dynSmem + numSlots);
+  char* warpBase = dynSmem + numSlots + numSlots * 2;
+  warpBase = reinterpret_cast<char*>((reinterpret_cast<uintptr_t>(warpBase) + 127) & ~127);
+  int32_t* warpTotals = reinterpret_cast<int32_t*>(warpBase);
+  int32_t* warpTotals2 = warpTotals + NumExpertWarps;
+
+  auto block = cg::this_thread_block();
+  auto warp = cg::tiled_partition<WarpSize>(block);
+
+  for (int i = threadIdx.x; i < numSlots; i += blockDim.x) {
+    smemKIdx[i] = int8_t{-1};
+  }
+  __syncthreads();
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  if (params.mUsePdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  // Phase 1: TopK — one warp per token (loop when numTokens > numWarps)
+  for (int tokenIdx = warpIdx; tokenIdx < params.mNumTokens; tokenIdx += numWarps) {
+    if (params.mPtrTopKIds != nullptr) {
+      if (laneIdx < params.mTopK) {
+        auto expertIdx = params.mPtrTopKIds[tokenIdx * params.mTopK + laneIdx];
+        if (expertIdx > -1 && expertIdx < params.mNumExperts) {
+          smemKIdx[tokenIdx * MaxNumExperts + expertIdx] = static_cast<int8_t>(laneIdx);
+        } else if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+          params.mPtrExpandedIdxToPermutedIdx[tokenIdx * params.mTopK + laneIdx] = int32_t{-1};
+        }
+      }
+    } else if (params.mPtrScores != nullptr) {
+      BaseType warpTopKScore[KernelParams::MaxNumTopExperts];
+      int32_t warpTopKExpertIdx[KernelParams::MaxNumTopExperts];
+
+      auto scoreOff = tokenIdx * params.mNumExperts;
+      KernelParams::ExpertSelectPolicy::template apply<BaseType, InputT, VecSize,
+                                                       KernelParams::MaxNumTopExperts>(
+          warp, warpTopKScore, warpTopKExpertIdx, laneIdx, params.mNumExperts, params.mTopK,
+          params.mPtrScores + scoreOff, params);
+
+      if (laneIdx < params.mTopK) {
+        smemKIdx[tokenIdx * MaxNumExperts + warpTopKExpertIdx[laneIdx]] =
+            static_cast<int8_t>(laneIdx);
+        if (params.mPtrTopKWeights != nullptr) {
+          params.mPtrTopKWeights[tokenIdx * params.mTopK + laneIdx] =
+              OutputT{warpTopKScore[laneIdx]};
+        }
+      }
+    } else if (params.mPtrTopKPacked != nullptr) {
+      if (laneIdx < params.mTopK) {
+        auto expandedIdx = tokenIdx * params.mTopK + laneIdx;
+        auto scoreIdx = params.mPtrTopKPacked[expandedIdx];
+        int const expertIdx = static_cast<int>(scoreIdx.idx);
+        if (expertIdx >= 0 && expertIdx < params.mNumExperts) {
+          smemKIdx[tokenIdx * MaxNumExperts + expertIdx] = static_cast<int8_t>(laneIdx);
+          if (params.mPtrTopKWeights != nullptr) {
+            params.mPtrTopKWeights[expandedIdx] = static_cast<OutputT>(scoreIdx.score);
+          }
+        } else if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  // Phase 2: Histogram — count tokens per expert
+  int accExpertCount[ExpertsPerThread];
+  if (threadIdx.x < NumThreadsExperts) {
+#pragma unroll
+    for (int e = 0; e < ExpertsPerThread; e++) {
+      int expert = threadIdx.x * ExpertsPerThread + e;
+      auto localExpIdx = expert - params.mLocalExpertsStartIdx;
+      auto isLocal = localExpIdx >= 0 && localExpIdx < params.mNumLocalExperts &&
+                     (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
+      accExpertCount[e] = 0;
+      if (isLocal) {
+        int offset = expert;
+        for (int j = 0; j < params.mNumTokens; j++) {
+          if (smemKIdx[offset] >= 0) {
+            smemOffset[offset] = static_cast<int16_t>(accExpertCount[e]);
+            accExpertCount[e]++;
+          }
+          offset += MaxNumExperts;
+        }
+      }
+    }
+  } else {
+#pragma unroll
+    for (int e = 0; e < ExpertsPerThread; e++) {
+      accExpertCount[e] = 0;
+    }
+  }
+
+  // Phase 3: Prefix-scan (merged dual warp-level scan)
+  int32_t numCtaPerExpert[ExpertsPerThread];
+  int32_t tmpCountPerExpert[ExpertsPerThread];
+  int32_t ctaOffsetPerExpert[ExpertsPerThread];
+  int32_t expertScanCountsPerExpert[ExpertsPerThread];
+  int32_t numNonExitingCtas;
+  {
+#pragma unroll
+    for (int e = 0; e < ExpertsPerThread; e++) {
+      if (threadIdx.x < NumThreadsExperts) {
+        if (params.mIsPow2) {
+          numCtaPerExpert[e] = divUpLog2<int32_t>(accExpertCount[e], params.mPaddingLog2);
+          tmpCountPerExpert[e] = divUpMulLog2<int32_t>(accExpertCount[e], params.mPaddingLog2);
+        } else {
+          numCtaPerExpert[e] = divUpTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
+          tmpCountPerExpert[e] = divUpMulTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
+        }
+      } else {
+        numCtaPerExpert[e] = 0;
+        tmpCountPerExpert[e] = 0;
+      }
+    }
+
+    int32_t localPrefix1[ExpertsPerThread], localPrefix2[ExpertsPerThread];
+    int32_t threadTotal1 = 0, threadTotal2 = 0;
+#pragma unroll
+    for (int e = 0; e < ExpertsPerThread; e++) {
+      localPrefix1[e] = threadTotal1;
+      localPrefix2[e] = threadTotal2;
+      threadTotal1 += numCtaPerExpert[e];
+      threadTotal2 += tmpCountPerExpert[e];
+    }
+
+    int32_t threadPrefix1, threadPrefix2;
+    warpExclusiveScan<NumExpertWarps>(threadTotal1, threadTotal2, laneIdx, warpIdx, warpTotals,
+                                      warpTotals2, threadPrefix1, threadPrefix2, numNonExitingCtas);
+
+#pragma unroll
+    for (int e = 0; e < ExpertsPerThread; e++) {
+      ctaOffsetPerExpert[e] = threadPrefix1 + localPrefix1[e];
+      expertScanCountsPerExpert[e] = threadPrefix2 + localPrefix2[e];
+    }
+  }
+
+  // Phase 4: CTA configs
+  if (threadIdx.x < NumThreadsExperts) {
+#pragma unroll
+    for (int e = 0; e < ExpertsPerThread; e++) {
+      int expert = threadIdx.x * ExpertsPerThread + e;
+      auto localExpIdx = expert - params.mLocalExpertsStartIdx;
+      auto isLocal = localExpIdx >= 0 && localExpIdx < params.mNumLocalExperts &&
+                     (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
+      if (isLocal) {
+        for (int cta = 0; cta < numCtaPerExpert[e]; ++cta) {
+          int32_t const mappedLocalIdx =
+              (expert - params.mLocalExpertsStartIdx) >> params.mLocalExpertsStrideLog2;
+          params.mPtrCtaIdxXyToBatchIdx[ctaOffsetPerExpert[e] + cta] = mappedLocalIdx;
+          int32_t mnLimit1, mnLimit2;
+          if (params.mIsPow2) {
+            mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mPaddingLog2);
+            mnLimit2 =
+                mulLog2<int32_t>(ctaOffsetPerExpert[e], params.mPaddingLog2) + accExpertCount[e];
+          } else {
+            mnLimit1 = mulTileN<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mTileTokensDim);
+            mnLimit2 =
+                mulTileN<int32_t>(ctaOffsetPerExpert[e], params.mTileTokensDim) + accExpertCount[e];
+          }
+          params.mPtrCtaIdxXyToMnLimit[ctaOffsetPerExpert[e] + cta] = min(mnLimit1, mnLimit2);
+        }
+      }
+    }
+  }
+
+  if (threadIdx.x == 0) {
+    int32_t permutedIdxSize;
+    if (params.mIsPow2) {
+      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
+    } else {
+      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
+    }
+    params.mPtrPermutedIdxSize[0] = permutedIdxSize;
+    params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
+  }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  if (params.mUsePdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#endif
+
+  // Phase 5: Permutation
+  if (threadIdx.x < NumThreadsExperts) {
+    for (int tokenIdx = 0; tokenIdx < params.mNumTokens; tokenIdx++) {
+#pragma unroll
+      for (int e = 0; e < ExpertsPerThread; e++) {
+        int expert = threadIdx.x * ExpertsPerThread + e;
+        int offset = tokenIdx * MaxNumExperts + expert;
+        if (smemKIdx[offset] >= 0) {
+          auto localExpIdx = expert - params.mLocalExpertsStartIdx;
+          auto isLocal = localExpIdx >= 0 && localExpIdx < params.mNumLocalExperts &&
+                         (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
+
+          int const expandedIdx = tokenIdx * params.mTopK + smemKIdx[offset];
+          int const offsetWithinExpert = static_cast<int>(smemOffset[offset]);
+          int const offsetForExpert = expertScanCountsPerExpert[e];
+          int const permutedIdx = isLocal ? offsetForExpert + offsetWithinExpert : int32_t{-1};
+
+          if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+            params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
+          }
+          if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocal) {
+            params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
+          }
+          if (params.mPtrPermutedIdxToTokenIdx != nullptr && isLocal) {
+            params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;
+          }
+        }
+      }
+    }
+  }
+}
+
+void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
+  int32_t const maxExperts = queryDispatchedMaxExperts(data);
+  int const numSlots = data.mNumTokens * maxExperts;
+  int const smemSize = numSlots + numSlots * 2 + 128 +
+                       2 * (maxExperts / WarpSize) * static_cast<int>(sizeof(int32_t));
+  int const threads =
+      std::min(std::max(data.mNumTokens * static_cast<int>(WarpSize), maxExperts), 1024);
+
+  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesDynBlockKernel, 1, threads, smemSize, stream);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
 // 2. Cluster kernel — single-cluster fused kernel for ≤256 tokens (SM90+).
 //    Uses distributed shared memory across 8 blocks in a cluster.
 //
@@ -543,9 +861,7 @@ void run(Data const& data, void* stream) {
           << "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for "
              "custom routing.";
     }
-    uint32_t const numThreadsHist =
-        std::min(1024u, static_cast<uint32_t>(getMaxNumExperts(data.mNumExperts)));
-    runPostTopKPipeline(data, numThreadsHist, stream);
+    runPostTopKPipeline(data, stream);
     return;
   }
 
@@ -565,7 +881,10 @@ void run(Data const& data, void* stream) {
       << "Routing kernel expects #experts " << data.mNumExperts << " to be a multiple of 4.";
 
   static int const smMajor = tensorrt_llm::common::getSMVersion() / 10;
-  bool const useSingleBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
+  bool const useStaticBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
+  bool const useDynBlock = !useStaticBlock && data.mNumTokens <= DynBlockKernelMaxNumTokens &&
+                           data.mNumExperts <= DynBlockKernelMaxNumExperts;
+  bool const useSingleBlock = useStaticBlock || useDynBlock;
   bool const useSingleCluster =
       (smMajor >= 9) && (data.mNumTokens <= MaxNumTokensSingleClusterScores);
 
@@ -579,36 +898,20 @@ void run(Data const& data, void* stream) {
   uint32_t const numThreadsHist =
       std::min(1024u, static_cast<uint32_t>(getMaxNumExperts(data.mNumExperts)));
 
-  // PDL overlap control: intermediate routing kernels allow the next routing kernel to overlap
-  // (mPdlOverlapWithNext = mUsePdl). The LAST routing kernel disables overlap so the consumer
-  // GEMM (which may not have cudaGridDependencySynchronize for routing data) can't start early.
   // We need a mutable copy since `data` is const.
   Data mutableData = data;
-  bool const pdl = data.mUsePdl;
 
-  if (useSingleBlock) {
-    //@TODO: For now we use the single block kernel for cases with token number no larger than 4.
-    // We will future tune this threshold based on the performance.
-    mutableData.mPdlOverlapWithNext = false;  // Last kernel — don't let consumer overlap
+  if (useDynBlock) {
+    launchDynBlockKernel(mutableData, numThreadsHist, stream);
+  } else if (useStaticBlock) {
     launchBlockKernel(mutableData, numThreadsHist, stream);
   } else if (useSingleCluster) {
-    mutableData.mPdlOverlapWithNext = false;  // Last kernel — don't let consumer overlap
     launchClusterKernel(mutableData, stream);
   } else {
-    // mPtrScores path: compute topK first via fused scores+histogram kernel,
-    // then use coop or multi-kernel pipeline for histogram + offsets.
     uint32_t const maxNumBlocks = 1024;
 
-    // Step 1: Compute topK from raw scores and write packed results to mPtrTopKPacked.
-    mutableData.mPdlOverlapWithNext = pdl;  // Intermediate — allow next routing kernel to
-                                            // overlap
     launchHistogramScoresKernel(mutableData, maxNumBlocks, numThreadsHist, stream);
 
-    // Step 2+3: Histogram + Offsets — try coop path first, fall back to multi-kernel.
-    // Coop kernel fuses histogram + offsets into a single cooperative launch.
-    // Requires SM90+ (grid-sync), numExperts <= 1024, and enough SM capacity.
-    // Note: NumTop8Experts is used for template instantiation but does NOT limit runtime topK —
-    // the coop kernel uses hardcoded MaxExpandedIdxPerThread=64 and runtime params.mTopK.
     bool const canUseCoop =
         (smMajor >= 9) && (data.mNumExperts <= 1024) && (data.mPtrPermutedIdxSize != nullptr);
     bool useCoop = false;
@@ -622,15 +925,9 @@ void run(Data const& data, void* stream) {
     }
 
     if (useCoop) {
-      // Coop path: 2 kernels (scores+topK → coop histogram+offsets) instead of 3.
-      mutableData.mPdlOverlapWithNext = pdl;  // Intermediate — allow next routing kernel to overlap
       launchInitExpertCounts(mutableData, numThreadsHist, stream);
-      mutableData.mPdlOverlapWithNext = false;  // Last kernel — don't let consumer overlap
       launchCoopKernel(mutableData, numBlocksCoop, numThreadsHist, stream);
     } else {
-      // Multi-kernel path: 3 kernels (scores+topK → histogram → offsets).
-      // Note: histogramScoresKernel already zeroes expert counts, so no initExpertCounts
-      // needed.
       uint32_t const expandedIdxSize = data.mNumTokens * data.mTopK;
       uint32_t const histogramEltsPerBlock = 8 * numThreadsHist;
       uint32_t const offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * numThreadsHist;
@@ -640,9 +937,7 @@ void run(Data const& data, void* stream) {
       int const numBlocksOffsets =
           std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
 
-      mutableData.mPdlOverlapWithNext = pdl;  // Intermediate — allow next routing kernel to overlap
       launchHistogramKernel(mutableData, numBlocksHistogram, numThreadsHist, stream);
-      mutableData.mPdlOverlapWithNext = false;  // Last kernel — don't let consumer overlap
       launchOffsetsKernel(mutableData, numBlocksOffsets, numThreadsHist, stream);
     }
   }

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -259,9 +259,11 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
                        (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
 
         int const expandedIdx = tokenIdx * params.mTopK + smemKIdx[offset];
-        int const offsetWithinExpert = static_cast<int>(smemOffset[offset]);
-        int const offsetForExpert = expertScanCountsPerExpert[e];
-        int const permutedIdx = isLocal ? offsetForExpert + offsetWithinExpert : int32_t{-1};
+        // Only load smemOffset for local experts; the histogram phase only
+        // writes it for local experts, so remote entries are uninitialized.
+        int const permutedIdx =
+            isLocal ? expertScanCountsPerExpert[e] + static_cast<int>(smemOffset[offset])
+                    : int32_t{-1};
 
         if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
           params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
@@ -580,9 +582,11 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
               (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
 
           int const expandedIdx = tokenIdx * params.mTopK + smemKIdx[offset];
-          int const offsetWithinExpert = static_cast<int>(smemOffset[offset]);
-          int const offsetForExpert = expertScanCountsPerExpert[e];
-          int const permutedIdx = isLocal ? offsetForExpert + offsetWithinExpert : int32_t{-1};
+          // Only load smemOffset for local experts; Phase 2 only writes it
+          // for local experts, so remote entries are uninitialized.
+          int const permutedIdx =
+              isLocal ? expertScanCountsPerExpert[e] + static_cast<int>(smemOffset[offset])
+                      : int32_t{-1};
 
           if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
             params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
@@ -893,8 +897,16 @@ void run(Data const& data, void* stream) {
 
   static int const smMajor = tensorrt_llm::common::getSMVersion() / 10;
   bool const useStaticBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
+  // Gate on the dispatched tier size, not the raw expert count.
+  // Example: a model with 512 experts and topK=22 skips Tier<512,8> (topK too
+  // large) and falls through to Tier<1024,32>.  queryDispatchedMaxExperts()
+  // returns 1024 while mNumExperts is only 512.  The dynblock kernel sizes
+  // shared memory proportional to maxExperts, so using the raw count (512 <=
+  // 512, passes) would let it enter a 1024-expert specialization that exceeds
+  // the smem budget.
+  int32_t const dispatchedMaxExperts = queryDispatchedMaxExperts(data);
   bool const useDynBlock = !useStaticBlock && data.mNumTokens <= DynBlockKernelMaxNumTokens &&
-                           data.mNumExperts <= DynBlockKernelMaxNumExperts;
+                           dispatchedMaxExperts <= DynBlockKernelMaxNumExperts;
   bool const useSingleBlock = useStaticBlock || useDynBlock;
   bool const useSingleCluster =
       (smMajor >= 9) && (data.mNumTokens <= MaxNumTokensSingleClusterScores);

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -184,8 +184,6 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
     } else {
       numCtaPerExpert[e] = divUpTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
     }
-    // Expand from CGA count to CTA count to keep the semantic stable with downstream kernels
-    numCtaPerExpert[e] *= params.mClusterSizeInBatchDim;
   }
   int32_t ctaOffsetPerExpert[ExpertsPerThread];
   int32_t numNonExitingCtas;
@@ -224,13 +222,13 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
         int32_t mnLimit1;
         int32_t mnLimit2;
         if (params.mIsPow2) {
-          int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
-          mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, ctaPaddingLog2);
-          mnLimit2 = mulLog2<int32_t>(ctaOffsetPerExpert[e], ctaPaddingLog2) + accExpertCount[e];
+          mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mPaddingLog2);
+          mnLimit2 =
+              mulLog2<int32_t>(ctaOffsetPerExpert[e], params.mPaddingLog2) + accExpertCount[e];
         } else {
-          int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
-          mnLimit1 = (ctaOffsetPerExpert[e] + cta + 1) * ctaTile;
-          mnLimit2 = ctaOffsetPerExpert[e] * ctaTile + accExpertCount[e];
+          mnLimit1 = mulTileN<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mTileTokensDim);
+          mnLimit2 =
+              mulTileN<int32_t>(ctaOffsetPerExpert[e], params.mTileTokensDim) + accExpertCount[e];
         }
         params.mPtrCtaIdxXyToMnLimit[ctaOffsetPerExpert[e] + cta] = min(mnLimit1, mnLimit2);
       }
@@ -241,10 +239,9 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
   if (threadIdx.x == 0) {
     int32_t permutedIdxSize;
     if (params.mIsPow2) {
-      permutedIdxSize =
-          mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
+      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
     } else {
-      permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
     }
     params.mPtrPermutedIdxSize[0] = permutedIdxSize;
     params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
@@ -500,7 +497,6 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
           numCtaPerExpert[e] = divUpTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
           tmpCountPerExpert[e] = divUpMulTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
         }
-        numCtaPerExpert[e] *= params.mClusterSizeInBatchDim;
       } else {
         numCtaPerExpert[e] = 0;
         tmpCountPerExpert[e] = 0;
@@ -544,13 +540,13 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
           params.mPtrCtaIdxXyToBatchIdx[ctaOffsetPerExpert[e] + cta] = mappedLocalIdx;
           int32_t mnLimit1, mnLimit2;
           if (params.mIsPow2) {
-            int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
-            mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, ctaPaddingLog2);
-            mnLimit2 = mulLog2<int32_t>(ctaOffsetPerExpert[e], ctaPaddingLog2) + accExpertCount[e];
+            mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mPaddingLog2);
+            mnLimit2 =
+                mulLog2<int32_t>(ctaOffsetPerExpert[e], params.mPaddingLog2) + accExpertCount[e];
           } else {
-            int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
-            mnLimit1 = (ctaOffsetPerExpert[e] + cta + 1) * ctaTile;
-            mnLimit2 = ctaOffsetPerExpert[e] * ctaTile + accExpertCount[e];
+            mnLimit1 = mulTileN<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mTileTokensDim);
+            mnLimit2 =
+                mulTileN<int32_t>(ctaOffsetPerExpert[e], params.mTileTokensDim) + accExpertCount[e];
           }
           params.mPtrCtaIdxXyToMnLimit[ctaOffsetPerExpert[e] + cta] = min(mnLimit1, mnLimit2);
         }
@@ -561,10 +557,9 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
   if (threadIdx.x == 0) {
     int32_t permutedIdxSize;
     if (params.mIsPow2) {
-      permutedIdxSize =
-          mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
+      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
     } else {
-      permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
     }
     params.mPtrPermutedIdxSize[0] = permutedIdxSize;
     params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -451,7 +451,8 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
     for (int e = 0; e < ExpertsPerThread; e++) {
       int expert = threadIdx.x * ExpertsPerThread + e;
       auto localExpIdx = expert - params.mLocalExpertsStartIdx;
-      auto isLocal = localExpIdx >= 0 && localExpIdx < params.mNumLocalExperts &&
+      auto isLocal = localExpIdx >= 0 &&
+                     localExpIdx < (params.mNumLocalExperts << params.mLocalExpertsStrideLog2) &&
                      (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
       accExpertCount[e] = 0;
       if (isLocal) {
@@ -489,6 +490,7 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
           numCtaPerExpert[e] = divUpTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
           tmpCountPerExpert[e] = divUpMulTileN<int32_t>(accExpertCount[e], params.mTileTokensDim);
         }
+        numCtaPerExpert[e] *= params.mClusterSizeInBatchDim;
       } else {
         numCtaPerExpert[e] = 0;
         tmpCountPerExpert[e] = 0;
@@ -522,7 +524,8 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
     for (int e = 0; e < ExpertsPerThread; e++) {
       int expert = threadIdx.x * ExpertsPerThread + e;
       auto localExpIdx = expert - params.mLocalExpertsStartIdx;
-      auto isLocal = localExpIdx >= 0 && localExpIdx < params.mNumLocalExperts &&
+      auto isLocal = localExpIdx >= 0 &&
+                     localExpIdx < (params.mNumLocalExperts << params.mLocalExpertsStrideLog2) &&
                      (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
       if (isLocal) {
         for (int cta = 0; cta < numCtaPerExpert[e]; ++cta) {
@@ -531,13 +534,13 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
           params.mPtrCtaIdxXyToBatchIdx[ctaOffsetPerExpert[e] + cta] = mappedLocalIdx;
           int32_t mnLimit1, mnLimit2;
           if (params.mIsPow2) {
-            mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mPaddingLog2);
-            mnLimit2 =
-                mulLog2<int32_t>(ctaOffsetPerExpert[e], params.mPaddingLog2) + accExpertCount[e];
+            int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
+            mnLimit1 = mulLog2<int32_t>(ctaOffsetPerExpert[e] + cta + 1, ctaPaddingLog2);
+            mnLimit2 = mulLog2<int32_t>(ctaOffsetPerExpert[e], ctaPaddingLog2) + accExpertCount[e];
           } else {
-            mnLimit1 = mulTileN<int32_t>(ctaOffsetPerExpert[e] + cta + 1, params.mTileTokensDim);
-            mnLimit2 =
-                mulTileN<int32_t>(ctaOffsetPerExpert[e], params.mTileTokensDim) + accExpertCount[e];
+            int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
+            mnLimit1 = (ctaOffsetPerExpert[e] + cta + 1) * ctaTile;
+            mnLimit2 = ctaOffsetPerExpert[e] * ctaTile + accExpertCount[e];
           }
           params.mPtrCtaIdxXyToMnLimit[ctaOffsetPerExpert[e] + cta] = min(mnLimit1, mnLimit2);
         }
@@ -548,19 +551,14 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
   if (threadIdx.x == 0) {
     int32_t permutedIdxSize;
     if (params.mIsPow2) {
-      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
+      permutedIdxSize =
+          mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
     } else {
-      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
+      permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
     }
     params.mPtrPermutedIdxSize[0] = permutedIdxSize;
     params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
   }
-
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  if (params.mUsePdl) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
-#endif
 
   // Phase 5: Permutation
   if (threadIdx.x < NumThreadsExperts) {
@@ -571,8 +569,10 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
         int offset = tokenIdx * MaxNumExperts + expert;
         if (smemKIdx[offset] >= 0) {
           auto localExpIdx = expert - params.mLocalExpertsStartIdx;
-          auto isLocal = localExpIdx >= 0 && localExpIdx < params.mNumLocalExperts &&
-                         (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
+          auto isLocal =
+              localExpIdx >= 0 &&
+              localExpIdx < (params.mNumLocalExperts << params.mLocalExpertsStrideLog2) &&
+              (localExpIdx & ((1 << params.mLocalExpertsStrideLog2) - 1)) == 0;
 
           int const expandedIdx = tokenIdx * params.mTopK + smemKIdx[offset];
           int const offsetWithinExpert = static_cast<int>(smemOffset[offset]);
@@ -592,6 +592,12 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
       }
     }
   }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  if (params.mUsePdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#endif
 }
 
 void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -89,12 +89,14 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
   if (params.mPtrTopKIds != nullptr) {
     if (validToken) {
       if (laneIdx < params.mTopK) {
-        auto expertIdx = params.mPtrTopKIds[warpIdx * params.mTopK + laneIdx];
+        auto const expandedIdx = warpIdx * params.mTopK + laneIdx;
+        if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
+        }
+        auto expertIdx = params.mPtrTopKIds[expandedIdx];
         if (expertIdx > -1 && expertIdx < params.mNumExperts) {
           int offset = warpIdx * MaxNumExperts + expertIdx;
           smemKIdx[offset] = static_cast<int8_t>(laneIdx);
-        } else if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
-          params.mPtrExpandedIdxToPermutedIdx[warpIdx * params.mTopK + laneIdx] = int32_t{-1};
         }
       }
     }
@@ -122,6 +124,13 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
     if (validToken) {
       if (laneIdx < params.mTopK) {
         auto const expandedIdx = warpIdx * params.mTopK + laneIdx;
+        // Pre-initialize to -1: when duplicate expert IDs appear, multiple
+        // lanes race on the same smemKIdx slot and only one wins.  Losing
+        // lanes would skip the else-branch below, leaving their entry as
+        // uninitialized garbage.  Writing -1 up front makes every entry safe.
+        if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
+        }
         auto const scoreIdx = params.mPtrTopKPacked[expandedIdx];
         int const expertIdx = static_cast<int>(scoreIdx.idx);
         if (expertIdx >= 0 && expertIdx < params.mNumExperts) {
@@ -130,8 +139,6 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
           if (params.mPtrTopKWeights != nullptr) {
             params.mPtrTopKWeights[expandedIdx] = static_cast<OutputT>(scoreIdx.score);
           }
-        } else if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
-          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
         }
       }
     }
@@ -401,11 +408,13 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
   for (int tokenIdx = warpIdx; tokenIdx < params.mNumTokens; tokenIdx += numWarps) {
     if (params.mPtrTopKIds != nullptr) {
       if (laneIdx < params.mTopK) {
-        auto expertIdx = params.mPtrTopKIds[tokenIdx * params.mTopK + laneIdx];
+        auto const expandedIdx = tokenIdx * params.mTopK + laneIdx;
+        if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
+        }
+        auto expertIdx = params.mPtrTopKIds[expandedIdx];
         if (expertIdx > -1 && expertIdx < params.mNumExperts) {
           smemKIdx[tokenIdx * MaxNumExperts + expertIdx] = static_cast<int8_t>(laneIdx);
-        } else if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
-          params.mPtrExpandedIdxToPermutedIdx[tokenIdx * params.mTopK + laneIdx] = int32_t{-1};
         }
       }
     } else if (params.mPtrScores != nullptr) {
@@ -428,7 +437,10 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
       }
     } else if (params.mPtrTopKPacked != nullptr) {
       if (laneIdx < params.mTopK) {
-        auto expandedIdx = tokenIdx * params.mTopK + laneIdx;
+        auto const expandedIdx = tokenIdx * params.mTopK + laneIdx;
+        if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
+          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
+        }
         auto scoreIdx = params.mPtrTopKPacked[expandedIdx];
         int const expertIdx = static_cast<int>(scoreIdx.idx);
         if (expertIdx >= 0 && expertIdx < params.mNumExperts) {
@@ -436,8 +448,6 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
           if (params.mPtrTopKWeights != nullptr) {
             params.mPtrTopKWeights[expandedIdx] = static_cast<OutputT>(scoreIdx.score);
           }
-        } else if (params.mPtrExpandedIdxToPermutedIdx != nullptr) {
-          params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = int32_t{-1};
         }
       }
     }

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
@@ -477,8 +477,7 @@ void run(Data& data, void* stream) {
                        "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for "
                        "DeepSeek routing.");
     }
-    int const numThreadsHist = routingCustom::getMaxNumExperts(data.mNumExperts);
-    runPostTopKPipeline(data, numThreadsHist, stream);
+    runPostTopKPipeline(data, stream);
     return;
   }
 
@@ -525,12 +524,10 @@ void run(Data& data, void* stream) {
 
   int const numBlocks = data.mNumTokens;
   int const numThreadsHist = getMaxNumExperts(data.mNumExperts);
-  bool const pdl = data.mUsePdl;
 
   // Step 1: Run DeepSeek-specific topK computation (writes to mPtrTopKPacked)
   int const numThreadsMain =
       std::max(data.mNumExpertGroups * WarpSize, getMaxNumExperts(data.mNumExperts));
-  data.mPdlOverlapWithNext = pdl;  // Intermediate — allow permutation pipeline to overlap
   launchMainKernel(data, numBlocks, numThreadsMain, stream);
 
   // Step 2: Permutation pipeline (reads from mPtrTopKPacked written by step 1)
@@ -540,29 +537,21 @@ void run(Data& data, void* stream) {
       FLASHINFER_CHECK(data.mPtrExpertCounts != nullptr,
                        "When #tokens is large, `mPtrExpertCounts` is a required input.");
     } else {
-      data.mPtrExpertCounts =
-          nullptr;  // Set it to nullptr for single-cluster code path, as it won't be used
+      data.mPtrExpertCounts = nullptr;
     }
 
-    // Number of blocks we can use in the cooperative kernel
     static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
-    // WAR: Reserve 8 SMs for overlapping kernels.
     int const numBlocksCoop = smCount - 8;
-    // Maximum number of tokens supported by the kernel using a cooperative launch.
     int const maxTokensCoop = (numBlocksCoop * numThreadsHist * 64) / data.mTopK;
 
     if (useSingleCluster) {
-      data.mPdlOverlapWithNext = false;  // Last kernel
       launchClusterKernel(data, numThreadsHist, stream);
     } else if (data.mNumTokens <= maxTokensCoop) {
-      data.mPdlOverlapWithNext = false;  // Last kernel
       launchCoopKernel(data, numBlocksCoop, numThreadsHist, stream);
     } else {
       const int32_t expandedIdxSize = data.mNumTokens * data.mTopK;
       const int32_t histogramEltsPerBlock = 8 * numThreadsHist;
       const int32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * numThreadsHist;
-
-      // Limit grid size (both kernels use a grid-stride loop).
       const int32_t maxNumBlocks = 1024;
 
       int const numBlocksHistogram = std::min(
@@ -570,9 +559,7 @@ void run(Data& data, void* stream) {
       int const numBlocksOffsets =
           std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
 
-      data.mPdlOverlapWithNext = pdl;  // Intermediate
       launchHistogramKernel(data, numBlocksHistogram, numThreadsHist, stream);
-      data.mPdlOverlapWithNext = false;  // Last kernel
       launchOffsetsKernel(data, numBlocksOffsets, numThreadsHist, stream);
     }
   }

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
@@ -506,8 +506,7 @@ void run(Data const& data, void* stream) {
           "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for Llama4 "
           "routing.");
     }
-    int const numThreadsHist = routingCustom::getMaxNumExperts(data.mNumExperts);
-    runPostTopKPipeline(data, numThreadsHist, stream);
+    runPostTopKPipeline(data, stream);
     return;
   }
   FLASHINFER_CHECK(

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
@@ -198,8 +198,7 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
     }
     numCta += num;
   }
-  // Expand from CGA count to CTA count to keep the semantic stable with downstream kernels
-  numCta *= params.mClusterSizeInBatchDim;
+
   // second, we perform the exclusive sum across the warp
   int32_t ctaOffset;
   int32_t numNonExitingCtas;
@@ -217,7 +216,7 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
     } else {
       finalNumCta = divUpTileN<int32_t>(count, params.mTileTokensDim);
     }
-    finalNumCta *= params.mClusterSizeInBatchDim;
+
     auto expertIdx = threadIdx.x * ExpertsPerThread + ii;
     // during the scan for expert offsets, we can already write out
     // both `mPtrCtaIdxXyToBatchIdx` and `mPtrCtaIdxXyToMnLimit`
@@ -227,13 +226,11 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
       int32_t mnLimit1;
       int32_t mnLimit2;
       if (params.mIsPow2) {
-        int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
-        mnLimit1 = mulLog2<int32_t>(ctaOffsetExp + cta + 1, ctaPaddingLog2);
-        mnLimit2 = mulLog2<int32_t>(ctaOffsetExp, ctaPaddingLog2) + count;
+        mnLimit1 = mulLog2<int32_t>(ctaOffsetExp + cta + 1, params.mPaddingLog2);
+        mnLimit2 = mulLog2<int32_t>(ctaOffsetExp, params.mPaddingLog2) + count;
       } else {
-        int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
-        mnLimit1 = (ctaOffsetExp + cta + 1) * ctaTile;
-        mnLimit2 = ctaOffsetExp * ctaTile + count;
+        mnLimit1 = mulTileN<int32_t>(ctaOffsetExp + cta + 1, params.mTileTokensDim);
+        mnLimit2 = mulTileN<int32_t>(ctaOffsetExp, params.mTileTokensDim) + count;
       }
       params.mPtrCtaIdxXyToMnLimit[ctaOffsetExp + cta] = min(mnLimit1, mnLimit2);
     }
@@ -244,10 +241,9 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
   if (cute::elect_one_sync()) {
     int32_t permutedIdxSize;
     if (params.mIsPow2) {
-      permutedIdxSize =
-          mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
+      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
     } else {
-      permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
     }
 
     params.mPtrPermutedIdxSize[0] = permutedIdxSize;
@@ -263,10 +259,9 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
   // Convert CTA-level ctaOffset back to token-space (CGA granularity)
   int32_t finalExpertOffset[ExpertsPerThread];
   if (params.mIsPow2) {
-    finalExpertOffset[0] =
-        mulLog2<int32_t>(ctaOffset >> params.mClusterSizeLog2, params.mPaddingLog2);
+    finalExpertOffset[0] = mulLog2<int32_t>(ctaOffset, params.mPaddingLog2);
   } else {
-    finalExpertOffset[0] = (ctaOffset / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+    finalExpertOffset[0] = mulTileN<int32_t>(ctaOffset, params.mTileTokensDim);
   }
 #pragma unroll
   for (int ii = 1; ii < ExpertsPerThread; ++ii) {

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -373,11 +373,7 @@ class FusedMoeLauncher {
 
     // Set dtype of score based on actual routing_logits dtype
     if (routing_logits.has_value()) {
-      if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3) {
-        TVM_FFI_ICHECK_EQ(routing_logits.value().dtype(), dl_float32)
-            << "routing_logits must be float.";
-        mDtypeScore = btg::Dtype::Fp32;
-      } else if (routing_logits.value().dtype() == dl_float32) {
+      if (routing_logits.value().dtype() == dl_float32) {
         mDtypeScore = btg::Dtype::Fp32;
       } else {
         mDtypeScore = btg::Dtype::Bfloat16;
@@ -1823,11 +1819,6 @@ Array<Tensor> trtllm_fp8_per_tensor_scale_moe(
   auto dtype = hidden_states.dtype();
   auto activation = static_cast<ActivationType>(activation_type);
 
-  if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3) {
-    TVM_FFI_ICHECK_EQ(routing_logits.dtype(), dl_float32)
-        << "routing_logits must be float for DeepSeekV3.";
-  }
-
   TVM_FFI_ICHECK(dtype == dl_float8_e4m3fn || dtype == dl_float16 || dtype == dl_bfloat16)
       << "FP8 MoE: hidden_states must be float8_e4m3fn, float16, or bfloat16.";
   TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_float8_e4m3fn)
@@ -1929,12 +1920,7 @@ Array<Tensor> trtllm_fp8_block_scale_moe(
   TVM_FFI_ICHECK(use_routing_logits || use_precomputed_routing)
       << "Either routing_logits or expert_indices must be provided.";
 
-  if (use_routing_logits) {
-    if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3) {
-      TVM_FFI_ICHECK_EQ(routing_logits.value().dtype(), dl_float32)
-          << "routing_logits must be float.";
-    }
-  }
+  (void)use_routing_logits;
   TVM_FFI_ICHECK(dtype == dl_float16 || dtype == dl_bfloat16 || dtype == dl_float8_e4m3fn)
       << "FP8 block scale MoE: hidden_states must be fp16, bf16, or fp8.";
   if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -47,17 +47,7 @@ inline int32_t computeLog2(int32_t val, std::string const& name = "") {
 
 Runner::Runner() {}
 
-Runner::Runner(int32_t tileTokensDim, int32_t clusterSizeInBatchDim)
-    : mTileTokensDim(tileTokensDim), mClusterSizeInBatchDim(clusterSizeInBatchDim) {
-  // clusterSizeInBatchDim must be a power of 2: mClusterSizeLog2 is used in shift
-  // operations (>>, <<) inside the mIsPow2 kernel branches, and a non-power-of-2
-  // value would make computeLog2() return -1, causing undefined behavior.
-  // mTileTokensDim does not need this check because non-power-of-2 tiles are
-  // handled by the !mIsPow2 branches which use multiplication/division instead.
-  FLASHINFER_CHECK(
-      clusterSizeInBatchDim > 0 && (clusterSizeInBatchDim & (clusterSizeInBatchDim - 1)) == 0,
-      "clusterSizeInBatchDim must be a power of 2, got %d", clusterSizeInBatchDim);
-}
+Runner::Runner(int32_t tileTokensDim) : mTileTokensDim(tileTokensDim) {}
 
 void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts,
                  int32_t topK, int32_t nGroup, int32_t topkGroup, int32_t localExpertOffset,
@@ -103,8 +93,6 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mTopK = topK;
     routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
     routingData.mTileTokensDim = mTileTokensDim;
-    routingData.mClusterSizeInBatchDim = mClusterSizeInBatchDim;
-    routingData.mClusterSizeLog2 = computeLog2(mClusterSizeInBatchDim);
     routingData.mLocalExpertsStartIdx = localExpertOffset;
     routingData.mLocalExpertsStrideLog2 = 0;
     routingData.mNumLocalExperts = localNumExperts;
@@ -144,8 +132,6 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mTopK = topK;
     routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
     routingData.mTileTokensDim = mTileTokensDim;
-    routingData.mClusterSizeInBatchDim = mClusterSizeInBatchDim;
-    routingData.mClusterSizeLog2 = computeLog2(mClusterSizeInBatchDim);
     routingData.mLocalExpertsStartIdx = localExpertOffset;
     routingData.mLocalExpertsStrideLog2 = 0;
     routingData.mNumLocalExperts = localNumExperts;
@@ -184,8 +170,6 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mTopK = topK;
     routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
     routingData.mTileTokensDim = mTileTokensDim;
-    routingData.mClusterSizeInBatchDim = mClusterSizeInBatchDim;
-    routingData.mClusterSizeLog2 = computeLog2(mClusterSizeInBatchDim);
     routingData.mLocalExpertsStartIdx = localExpertOffset;
     routingData.mLocalExpertsStrideLog2 = 0;
     routingData.mNumLocalExperts = localNumExperts;
@@ -223,8 +207,6 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mTopK = topK;
     routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
     routingData.mTileTokensDim = mTileTokensDim;
-    routingData.mClusterSizeInBatchDim = mClusterSizeInBatchDim;
-    routingData.mClusterSizeLog2 = computeLog2(mClusterSizeInBatchDim);
     routingData.mLocalExpertsStartIdx = localExpertOffset;
     routingData.mLocalExpertsStrideLog2 = 0;
     routingData.mNumLocalExperts = localNumExperts;
@@ -300,8 +282,6 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mTopK = topK;
     routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
     routingData.mTileTokensDim = mTileTokensDim;
-    routingData.mClusterSizeInBatchDim = mClusterSizeInBatchDim;
-    routingData.mClusterSizeLog2 = computeLog2(mClusterSizeInBatchDim);
     routingData.mLocalExpertsStartIdx = localExpertOffset;
     routingData.mLocalExpertsStrideLog2 = 0;
     routingData.mNumLocalExperts = localNumExperts;

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
@@ -820,6 +821,53 @@ def cutlass_fused_moe(
 # trtllmgen-moe-fp8
 
 
+@dataclass
+class MoEInputs:
+    """MoERunner inputs.
+
+    Field order defines the flat-list index used by the autotuner.
+    """
+
+    output: torch.Tensor
+    routing_logits: Optional[torch.Tensor]
+    topk_ids: Optional[torch.Tensor]
+    expert_weights: Optional[torch.Tensor]
+    hidden_states: torch.Tensor
+    hidden_states_scale: Optional[torch.Tensor]
+
+    _FIELDS = (
+        "output",
+        "routing_logits",
+        "topk_ids",
+        "expert_weights",
+        "hidden_states",
+        "hidden_states_scale",
+    )
+
+    # Index of the dynamic dimension for each field.
+    # hidden_states_scale is excluded: its layout differs by op (fp8 DeepSeekFp8
+    # uses [hidden_size//128, num_tokens] while fp4/MxFp8 uses [num_tokens, ...]),
+    # so _make_tuning_config infers it from the actual tensor at runtime.
+    _DYNAMIC_DIM = {
+        "output": 0,
+        "routing_logits": 0,
+        "topk_ids": 0,
+        "expert_weights": 0,
+        "hidden_states": 0,
+    }
+
+    def to_list(self) -> List[Optional[torch.Tensor]]:
+        return [getattr(self, name) for name in MoEInputs._FIELDS]
+
+    @classmethod
+    def from_list(cls, lst: List) -> "MoEInputs":
+        return cls(**{name: lst[i] for i, name in enumerate(cls._FIELDS)})
+
+    @classmethod
+    def idx(cls, name: str) -> int:
+        return cls._FIELDS.index(name)
+
+
 @functools.cache
 def get_trtllm_moe_sm100_module():
     module = gen_trtllm_gen_fused_moe_sm100_module()
@@ -827,74 +875,7 @@ def get_trtllm_moe_sm100_module():
     setup_cubin_loader(str(module.get_library_path()))
 
     class MoERunner(TunableRunner):
-        @staticmethod
-        def _init_packed_topk(shapes, dtype, device):
-            """Create valid packed topk_ids with unique expert IDs for profiling.
-
-            When skip_routing=True the autotuner feeds this tensor directly to
-            the routing kernel as packed expert indices.  Each row must contain
-            unique expert IDs so the block-kernel's histogram stays correct.
-            Format per element: (expert_id << 16) | bfloat16_weight_as_int16.
-
-            For non-routed paths (BF16 MoE with routing_logits), topk_ids is a
-            small placeholder whose dim1 != top_k; fall back to torch.empty.
-            """
-            if len(shapes) < 2 or shapes[-1] <= 1:
-                return torch.empty(shapes, device=device, dtype=dtype)
-            num_tokens, top_k = shapes[0], shapes[-1]
-            ids = (
-                torch.arange(top_k, device=device, dtype=torch.int32)
-                .unsqueeze(0)
-                .expand(num_tokens, -1)
-                .contiguous()
-            )
-            weights = torch.ones(num_tokens, top_k, dtype=torch.bfloat16, device=device)
-            return (ids << 16) | weights.view(torch.int16).to(torch.int32)
-
-        dynamic_tensor_initializers = [
-            lambda shapes, dtype, device: torch.empty(
-                shapes, device=device, dtype=dtype
-            ),  # output buffer, [num_tokens, hidden_size]
-            lambda shapes, dtype, device: torch.rand(
-                shapes, device=device, dtype=dtype
-            ),  # routing_logits, [num_tokens, num_experts]
-            lambda shapes, dtype, device: MoERunner._init_packed_topk(
-                shapes, dtype, device
-            ),  # topk_ids: valid packed data for skip_routing profiling
-            lambda shapes, dtype, device: torch.empty(
-                shapes, device=device, dtype=dtype
-            ),  # expert_weights buffer. empty since routing_logits is used. [num_tokens, topk]
-            lambda shapes, dtype, device: torch.randn(shapes, device=device).to(
-                dtype
-            ),  # hidden_states, [num_tokens, hidden_size]
-            lambda shapes, dtype, device: torch.ones(shapes, device=device).to(
-                dtype
-            ),  # hidden_states_scale, [num_tokens, hidden_size // sf_vec_size]
-        ]
-        # their first dimension is num_tokens which will be tuned
-        tuning_config_with_hidden_states_scales = TuningConfig(
-            dynamic_tensor_specs=(
-                DynamicTensorSpec(
-                    (0, 1, 2, 3, 4, 5),
-                    (0, 0, 0, 0, 0, 0),
-                    get_last_power_of_2_num_tokens_buckets(8192, 1),
-                    lambda x: min(last_positive_power_of_2(x), 8192),
-                    dynamic_tensor_initializers,
-                ),
-            )
-        )
-        tuning_config_no_hidden_states_scales = TuningConfig(
-            dynamic_tensor_specs=(
-                DynamicTensorSpec(
-                    (0, 1, 2, 3, 4),
-                    (0, 0, 0, 0, 0),
-                    get_last_power_of_2_num_tokens_buckets(8192, 1),
-                    lambda x: min(last_positive_power_of_2(x), 8192),
-                    dynamic_tensor_initializers[:5],
-                ),
-            ),
-        )
-        # cache the valid tactics to reduce the overhead of instantiating the runner
+        # Cache valid tactics to reduce the overhead of re-querying the kernel.
         # TODO(siyuan): directly cache the runners
         valid_tactics_dict = dict()
 
@@ -917,7 +898,6 @@ def get_trtllm_moe_sm100_module():
             self.dtype_act = dtype_act
             self.dtype_weights = dtype_weights
             self.fp8_quantization_type = fp8_quantization_type
-            self.top_k = top_k
             self.hidden_size = hidden_size
             self.intermediate_size = intermediate_size
             self.activation_type = ActivationType(activation_type)
@@ -925,20 +905,102 @@ def get_trtllm_moe_sm100_module():
             self.weight_layout = WeightLayout(weight_layout)
             self.use_packed_weights = use_packed_weights
 
+        def _make_tuning_config(
+            self,
+            moe_inputs: "MoEInputs",
+            tune_max_num_tokens: int = 8192,
+            **kwargs,
+        ) -> TuningConfig:
+            """Build a TuningConfig for this runner instance.
+
+            Args:
+                moe_inputs: Input parameters for this call.
+                tune_max_num_tokens: Upper bound for the num_tokens tuning buckets.
+                **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
+            """
+            num_local_experts = self.num_local_experts
+
+            def _init_packed_topk_ids(shapes, dtype, device):
+                expert_ids = torch.randint(
+                    0, num_local_experts, shapes, dtype=torch.int32, device=device
+                )
+                expert_weights = torch.ones(
+                    shapes, dtype=torch.bfloat16, device=device
+                ).view(torch.int16)
+                return (expert_ids << 16) | expert_weights
+
+            spec = {
+                "output": lambda shapes, dtype, device: torch.empty(
+                    shapes, dtype=dtype, device=device
+                ),
+                "hidden_states": lambda shapes, dtype, device: torch.randn(
+                    shapes, device=device
+                ).to(dtype),
+            }
+            if moe_inputs.routing_logits is not None:
+                spec["routing_logits"] = lambda shapes, dtype, device: torch.rand(
+                    shapes, dtype=dtype, device=device
+                )
+            if moe_inputs.topk_ids is not None:
+                spec["topk_ids"] = _init_packed_topk_ids
+            if moe_inputs.expert_weights is not None:
+                spec["expert_weights"] = lambda shapes, dtype, device: torch.ones(
+                    shapes, dtype=dtype, device=device
+                )
+            if moe_inputs.hidden_states_scale is not None:
+                spec["hidden_states_scale"] = lambda shapes, dtype, device: torch.ones(
+                    shapes, device=device
+                ).to(dtype)
+
+            sorted_inputs = sorted(
+                (MoEInputs.idx(name), name, init) for name, init in spec.items()
+            )
+            input_idx = tuple(i for i, _, _ in sorted_inputs)
+
+            num_tokens = moe_inputs.hidden_states.shape[0]
+
+            def _dynamic_dim(name: str) -> int:
+                if name == "hidden_states_scale":
+                    # DeepSeekFp8 uses [hidden_size//128, num_tokens];
+                    # all others (MxFp8, fp4, …) use [num_tokens, ...].
+                    t = moe_inputs.hidden_states_scale
+                    if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
+                        assert t.shape == (self.hidden_size // 128, num_tokens), (
+                            f"hidden_states_scale shape {tuple(t.shape)} does not match "
+                            f"expected DeepSeekFp8 layout "
+                            f"(hidden_size//128={self.hidden_size // 128}, num_tokens={num_tokens})"
+                        )
+                        return 1
+                    assert t.shape[0] == num_tokens, (
+                        f"hidden_states_scale shape {tuple(t.shape)} does not match "
+                        f"expected layout (num_tokens={num_tokens}, ...)"
+                    )
+                    return 0
+                return MoEInputs._DYNAMIC_DIM[name]
+
+            dim_idx = tuple(_dynamic_dim(name) for _, name, _ in sorted_inputs)
+            initializers = [init for _, _, init in sorted_inputs]
+
+            return TuningConfig(
+                dynamic_tensor_specs=(
+                    DynamicTensorSpec(
+                        input_idx,
+                        dim_idx,
+                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
+                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        initializers,
+                    ),
+                ),
+                **kwargs,
+            )
+
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
         ) -> List[int]:
-            (
-                output,
-                routing_logits,
-                topk_ids,
-                expert_weights,
-                hidden_states,
-                *extra_inputs,
-            ) = inputs
-            num_tokens = hidden_states.shape[0]
+            moe_inputs = MoEInputs.from_list(inputs)
+            num_tokens = moe_inputs.hidden_states.shape[0]
 
             instance_key = (
                 self.dtype_act,
@@ -971,24 +1033,19 @@ def get_trtllm_moe_sm100_module():
             do_preparation: bool = False,
             **kwargs,
         ):
-            (
-                output,
-                routing_logits,
-                topk_ids,
-                expert_weights,
-                hidden_states,
-                *extra_inputs,
-            ) = inputs
-            if kwargs.get("skip_routing", False):
-                routing_logits = None
-            num_tokens = hidden_states.shape[0]
+            moe_inputs = MoEInputs.from_list(inputs)
+            output = moe_inputs.output
+            routing_logits = moe_inputs.routing_logits
+            topk_ids = moe_inputs.topk_ids
+            expert_weights = moe_inputs.expert_weights
+            hidden_states = moe_inputs.hidden_states
+            hidden_states_scale = (
+                moe_inputs.hidden_states_scale
+                if trtllm_gen_dtype_has_scale(self.dtype_act)
+                else None
+            )
 
-            extra_input_idx = 0
-            if trtllm_gen_dtype_has_scale(self.dtype_act):
-                hidden_states_scale = extra_inputs[extra_input_idx]
-                extra_input_idx += 1
-            else:
-                hidden_states_scale = None
+            num_tokens = hidden_states.shape[0]
             # sanity checks to ensure that dynamic tensors have the correct shapes
             assert output.shape[0] == num_tokens, (
                 "output's first dimension must be batch size."
@@ -1010,10 +1067,20 @@ def get_trtllm_moe_sm100_module():
             assert hidden_states.shape[0] == num_tokens, (
                 "hidden_states's first dimension must be batch size."
             )
-            assert hidden_states_scale is None or (
-                hidden_states_scale.dim() == 2
-                and hidden_states_scale.shape[0] == num_tokens
-            ), "hidden_states_scale's first dimension must be batch size"
+            if hidden_states_scale is not None:
+                assert hidden_states_scale.dim() == 2, (
+                    "hidden_states_scale must be a 2D tensor"
+                )
+                if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
+                    assert hidden_states_scale.shape[1] == num_tokens, (
+                        f"DeepSeekFp8 hidden_states_scale shape {tuple(hidden_states_scale.shape)} "
+                        f"expects num_tokens={num_tokens} at dim 1"
+                    )
+                else:
+                    assert hidden_states_scale.shape[0] == num_tokens, (
+                        f"hidden_states_scale shape {tuple(hidden_states_scale.shape)} "
+                        f"expects num_tokens={num_tokens} at dim 0"
+                    )
             # Choose the appropriate operation based on data types
             if self.dtype_weights == DtypeTrtllmGen.Bfloat16:
                 # BF16 operations
@@ -1065,7 +1132,7 @@ def get_trtllm_moe_sm100_module():
                             device=hidden_states.device,
                         )
                     elif self.fp8_quantization_type == Fp8QuantizationType.MxFp8:
-                        current_hidden_states_scale = extra_inputs[0]
+                        current_hidden_states_scale = hidden_states_scale
 
                     else:
                         raise ValueError(
@@ -1197,34 +1264,6 @@ def get_trtllm_moe_sm100_module():
                     kwargs.get("norm_topk_prob", True),
                 )
 
-        @classmethod
-        @functools.lru_cache(maxsize=None)
-        def refine_tuning_config(cls, tune_max_num_tokens: int, **kwargs):
-            cls.tuning_config_with_hidden_states_scales = TuningConfig(
-                dynamic_tensor_specs=(
-                    DynamicTensorSpec(
-                        (0, 1, 2, 3, 4, 5),
-                        (0, 0, 0, 0, 0, 0),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
-                        cls.dynamic_tensor_initializers,
-                    ),
-                ),
-                **kwargs,
-            )
-            cls.tuning_config_no_hidden_states_scales = TuningConfig(
-                dynamic_tensor_specs=(
-                    DynamicTensorSpec(
-                        (0, 1, 2, 3, 4),
-                        (0, 0, 0, 0, 0),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
-                        cls.dynamic_tensor_initializers[:5],
-                    ),
-                ),
-                **kwargs,
-            )
-
     @register_custom_op(
         "flashinfer::trtllm_bf16_moe",
         mutates_args=(""),
@@ -1261,7 +1300,6 @@ def get_trtllm_moe_sm100_module():
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1303,13 +1341,26 @@ def get_trtllm_moe_sm100_module():
             activation_type=ActivationType.Swiglu,  # Default for BF16
         )
 
-        inputs = [output, routing_logits, topk_ids, expert_weights, hidden_states]
+        moe_inputs = MoEInputs(
+            output=output,
+            routing_logits=routing_logits,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+            hidden_states=hidden_states,
+            hidden_states_scale=None,
+        )
+        tuning_config = moe_runner._make_tuning_config(
+            moe_inputs,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_cuda_graph=True,
+            use_cold_l2_cache=True,
+        )
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_bf16_moe",
             [moe_runner],
-            MoERunner.tuning_config_no_hidden_states_scales,
-            inputs,
+            tuning_config,
+            moe_inputs.to_list(),
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             gemm2_weights=gemm2_weights,
@@ -1424,7 +1475,6 @@ def get_trtllm_moe_sm100_module():
             enable_pdl = device_support_pdl(hidden_states.device)
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1456,13 +1506,26 @@ def get_trtllm_moe_sm100_module():
             activation_type=activation_type,
         )
 
-        inputs = [output, routing_logits, topk_ids, expert_weights, hidden_states]
+        moe_inputs = MoEInputs(
+            output=output,
+            routing_logits=routing_logits,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+            hidden_states=hidden_states,
+            hidden_states_scale=None,
+        )
+        tuning_config = moe_runner._make_tuning_config(
+            moe_inputs,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_cuda_graph=True,
+            use_cold_l2_cache=True,
+        )
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp8_per_tensor_scale_moe",
             [moe_runner],
-            MoERunner.tuning_config_no_hidden_states_scales,  # FP8 per-tensor doesn't use hidden_states_scale
-            inputs,
+            tuning_config,
+            moe_inputs.to_list(),
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             output1_scales_scalar=output1_scales_scalar,
@@ -1595,9 +1658,8 @@ def get_trtllm_moe_sm100_module():
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
 
-        # Use AutoTuner to select the best tactic - follow FP4 pattern exactly
+        # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1659,20 +1721,26 @@ def get_trtllm_moe_sm100_module():
             use_shuffled_weight=use_shuffled_weight,
         )
 
-        inputs = [
-            output,
-            routing_logits,
-            topk_ids,
-            expert_weights,
-            hidden_states,
-            hidden_states_scale,
-        ]
+        moe_inputs = MoEInputs(
+            output=output,
+            routing_logits=routing_logits,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+            hidden_states=hidden_states,
+            hidden_states_scale=hidden_states_scale,
+        )
+        tuning_config = moe_runner._make_tuning_config(
+            moe_inputs,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_cuda_graph=True,
+            use_cold_l2_cache=True,
+        )
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp8_block_scale_moe",
             [moe_runner],
-            MoERunner.tuning_config_with_hidden_states_scales,  # FP8 block-scale uses hidden_states_scale
-            inputs,
+            tuning_config,
+            moe_inputs.to_list(),
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             gemm1_weights_scale=gemm1_weights_scale,
@@ -1853,9 +1921,6 @@ def get_trtllm_moe_sm100_module():
             )
 
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(
-            tune_max_num_tokens, use_cold_l2_cache=True, use_cuda_graph=True
-        )
         dtype_act = deduce_trtllm_gen_tensor_dtype(hidden_states, hidden_states_scale)
         dtype_weights = deduce_trtllm_gen_tensor_dtype(
             gemm1_weights, gemm1_weights_scale
@@ -1872,34 +1937,26 @@ def get_trtllm_moe_sm100_module():
             weight_layout=WeightLayout.MajorK,
             use_shuffled_weight=True,
         )
-        tunning_config = (
-            MoERunner.tuning_config_no_hidden_states_scales
-            if hidden_states_scale is None
-            else MoERunner.tuning_config_with_hidden_states_scales
+        moe_inputs = MoEInputs(
+            output=output,
+            routing_logits=routing_logits,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+            hidden_states=hidden_states,
+            hidden_states_scale=hidden_states_scale,
         )
-        inputs = [
-            output,
-            torch.empty(
-                num_tokens,
-                num_experts,
-                dtype=routing_dtype,
-                device=hidden_states.device,
-            )
-            if routing_logits is None
-            else routing_logits,
-            topk_ids,
-            expert_weights,
-            hidden_states,
-        ]
-        if hidden_states_scale is not None:
-            inputs.append(hidden_states_scale)
+        tuning_config = moe_runner._make_tuning_config(
+            moe_inputs,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_cold_l2_cache=True,
+            use_cuda_graph=True,
+        )
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp4_block_scale_moe",
             [moe_runner],
-            tunning_config,
-            inputs,
-            skip_routing=(routing_logits is None),
+            tuning_config,
+            moe_inputs.to_list(),
             num_experts=num_experts,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
@@ -2064,7 +2121,6 @@ def get_trtllm_moe_sm100_module():
             )
 
         tuner = AutoTuner.get()
-        MoERunner.refine_tuning_config(tune_max_num_tokens)
         dtype_act = DtypeTrtllmGen.Bfloat16
         dtype_weights = DtypeTrtllmGen.MxInt4
         moe_runner = MoERunner(
@@ -2079,20 +2135,27 @@ def get_trtllm_moe_sm100_module():
             weight_layout=WeightLayout.BlockMajorK,
             use_shuffled_weight=True,
         )
-        tunning_config = MoERunner.tuning_config_no_hidden_states_scales
-        inputs = [
-            output,
-            routing_logits,
-            topk_ids,
-            expert_weights,
-            hidden_states,
-        ]
+
+        moe_inputs = MoEInputs(
+            output=output,
+            routing_logits=routing_logits,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+            hidden_states=hidden_states,
+            hidden_states_scale=None,
+        )
+        tuning_config = moe_runner._make_tuning_config(
+            moe_inputs,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_cuda_graph=True,
+            use_cold_l2_cache=True,
+        )
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_mxint4_block_scale_moe",
             [moe_runner],
-            tunning_config,
-            inputs,
+            tuning_config,
+            moe_inputs.to_list(),
             num_experts=num_experts,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import functools
-from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
@@ -821,53 +820,6 @@ def cutlass_fused_moe(
 # trtllmgen-moe-fp8
 
 
-@dataclass
-class MoEInputs:
-    """MoERunner inputs.
-
-    Field order defines the flat-list index used by the autotuner.
-    """
-
-    output: torch.Tensor
-    routing_logits: Optional[torch.Tensor]
-    topk_ids: Optional[torch.Tensor]
-    expert_weights: Optional[torch.Tensor]
-    hidden_states: torch.Tensor
-    hidden_states_scale: Optional[torch.Tensor]
-
-    _FIELDS = (
-        "output",
-        "routing_logits",
-        "topk_ids",
-        "expert_weights",
-        "hidden_states",
-        "hidden_states_scale",
-    )
-
-    # Index of the dynamic dimension for each field.
-    # hidden_states_scale is excluded: its layout differs by op (fp8 DeepSeekFp8
-    # uses [hidden_size//128, num_tokens] while fp4/MxFp8 uses [num_tokens, ...]),
-    # so _make_tuning_config infers it from the actual tensor at runtime.
-    _DYNAMIC_DIM = {
-        "output": 0,
-        "routing_logits": 0,
-        "topk_ids": 0,
-        "expert_weights": 0,
-        "hidden_states": 0,
-    }
-
-    def to_list(self) -> List[Optional[torch.Tensor]]:
-        return [getattr(self, name) for name in MoEInputs._FIELDS]
-
-    @classmethod
-    def from_list(cls, lst: List) -> "MoEInputs":
-        return cls(**{name: lst[i] for i, name in enumerate(cls._FIELDS)})
-
-    @classmethod
-    def idx(cls, name: str) -> int:
-        return cls._FIELDS.index(name)
-
-
 @functools.cache
 def get_trtllm_moe_sm100_module():
     module = gen_trtllm_gen_fused_moe_sm100_module()
@@ -875,7 +827,74 @@ def get_trtllm_moe_sm100_module():
     setup_cubin_loader(str(module.get_library_path()))
 
     class MoERunner(TunableRunner):
-        # Cache valid tactics to reduce the overhead of re-querying the kernel.
+        @staticmethod
+        def _init_packed_topk(shapes, dtype, device):
+            """Create valid packed topk_ids with unique expert IDs for profiling.
+
+            When skip_routing=True the autotuner feeds this tensor directly to
+            the routing kernel as packed expert indices.  Each row must contain
+            unique expert IDs so the block-kernel's histogram stays correct.
+            Format per element: (expert_id << 16) | bfloat16_weight_as_int16.
+
+            For non-routed paths (BF16 MoE with routing_logits), topk_ids is a
+            small placeholder whose dim1 != top_k; fall back to torch.empty.
+            """
+            if len(shapes) < 2 or shapes[-1] <= 1:
+                return torch.empty(shapes, device=device, dtype=dtype)
+            num_tokens, top_k = shapes[0], shapes[-1]
+            ids = (
+                torch.arange(top_k, device=device, dtype=torch.int32)
+                .unsqueeze(0)
+                .expand(num_tokens, -1)
+                .contiguous()
+            )
+            weights = torch.ones(num_tokens, top_k, dtype=torch.bfloat16, device=device)
+            return (ids << 16) | weights.view(torch.int16).to(torch.int32)
+
+        dynamic_tensor_initializers = [
+            lambda shapes, dtype, device: torch.empty(
+                shapes, device=device, dtype=dtype
+            ),  # output buffer, [num_tokens, hidden_size]
+            lambda shapes, dtype, device: torch.rand(
+                shapes, device=device, dtype=dtype
+            ),  # routing_logits, [num_tokens, num_experts]
+            lambda shapes, dtype, device: MoERunner._init_packed_topk(
+                shapes, dtype, device
+            ),  # topk_ids: valid packed data for skip_routing profiling
+            lambda shapes, dtype, device: torch.empty(
+                shapes, device=device, dtype=dtype
+            ),  # expert_weights buffer. empty since routing_logits is used. [num_tokens, topk]
+            lambda shapes, dtype, device: torch.randn(shapes, device=device).to(
+                dtype
+            ),  # hidden_states, [num_tokens, hidden_size]
+            lambda shapes, dtype, device: torch.ones(shapes, device=device).to(
+                dtype
+            ),  # hidden_states_scale, [num_tokens, hidden_size // sf_vec_size]
+        ]
+        # their first dimension is num_tokens which will be tuned
+        tuning_config_with_hidden_states_scales = TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    (0, 1, 2, 3, 4, 5),
+                    (0, 0, 0, 0, 0, 0),
+                    get_last_power_of_2_num_tokens_buckets(8192, 1),
+                    lambda x: min(last_positive_power_of_2(x), 8192),
+                    dynamic_tensor_initializers,
+                ),
+            )
+        )
+        tuning_config_no_hidden_states_scales = TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    (0, 1, 2, 3, 4),
+                    (0, 0, 0, 0, 0),
+                    get_last_power_of_2_num_tokens_buckets(8192, 1),
+                    lambda x: min(last_positive_power_of_2(x), 8192),
+                    dynamic_tensor_initializers[:5],
+                ),
+            ),
+        )
+        # cache the valid tactics to reduce the overhead of instantiating the runner
         # TODO(siyuan): directly cache the runners
         valid_tactics_dict = dict()
 
@@ -898,6 +917,7 @@ def get_trtllm_moe_sm100_module():
             self.dtype_act = dtype_act
             self.dtype_weights = dtype_weights
             self.fp8_quantization_type = fp8_quantization_type
+            self.top_k = top_k
             self.hidden_size = hidden_size
             self.intermediate_size = intermediate_size
             self.activation_type = ActivationType(activation_type)
@@ -905,102 +925,20 @@ def get_trtllm_moe_sm100_module():
             self.weight_layout = WeightLayout(weight_layout)
             self.use_packed_weights = use_packed_weights
 
-        def _make_tuning_config(
-            self,
-            moe_inputs: "MoEInputs",
-            tune_max_num_tokens: int = 8192,
-            **kwargs,
-        ) -> TuningConfig:
-            """Build a TuningConfig for this runner instance.
-
-            Args:
-                moe_inputs: Input parameters for this call.
-                tune_max_num_tokens: Upper bound for the num_tokens tuning buckets.
-                **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
-            """
-            num_local_experts = self.num_local_experts
-
-            def _init_packed_topk_ids(shapes, dtype, device):
-                expert_ids = torch.randint(
-                    0, num_local_experts, shapes, dtype=torch.int32, device=device
-                )
-                expert_weights = torch.ones(
-                    shapes, dtype=torch.bfloat16, device=device
-                ).view(torch.int16)
-                return (expert_ids << 16) | expert_weights
-
-            spec = {
-                "output": lambda shapes, dtype, device: torch.empty(
-                    shapes, dtype=dtype, device=device
-                ),
-                "hidden_states": lambda shapes, dtype, device: torch.randn(
-                    shapes, device=device
-                ).to(dtype),
-            }
-            if moe_inputs.routing_logits is not None:
-                spec["routing_logits"] = lambda shapes, dtype, device: torch.rand(
-                    shapes, dtype=dtype, device=device
-                )
-            if moe_inputs.topk_ids is not None:
-                spec["topk_ids"] = _init_packed_topk_ids
-            if moe_inputs.expert_weights is not None:
-                spec["expert_weights"] = lambda shapes, dtype, device: torch.ones(
-                    shapes, dtype=dtype, device=device
-                )
-            if moe_inputs.hidden_states_scale is not None:
-                spec["hidden_states_scale"] = lambda shapes, dtype, device: torch.ones(
-                    shapes, device=device
-                ).to(dtype)
-
-            sorted_inputs = sorted(
-                (MoEInputs.idx(name), name, init) for name, init in spec.items()
-            )
-            input_idx = tuple(i for i, _, _ in sorted_inputs)
-
-            num_tokens = moe_inputs.hidden_states.shape[0]
-
-            def _dynamic_dim(name: str) -> int:
-                if name == "hidden_states_scale":
-                    # DeepSeekFp8 uses [hidden_size//128, num_tokens];
-                    # all others (MxFp8, fp4, …) use [num_tokens, ...].
-                    t = moe_inputs.hidden_states_scale
-                    if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
-                        assert t.shape == (self.hidden_size // 128, num_tokens), (
-                            f"hidden_states_scale shape {tuple(t.shape)} does not match "
-                            f"expected DeepSeekFp8 layout "
-                            f"(hidden_size//128={self.hidden_size // 128}, num_tokens={num_tokens})"
-                        )
-                        return 1
-                    assert t.shape[0] == num_tokens, (
-                        f"hidden_states_scale shape {tuple(t.shape)} does not match "
-                        f"expected layout (num_tokens={num_tokens}, ...)"
-                    )
-                    return 0
-                return MoEInputs._DYNAMIC_DIM[name]
-
-            dim_idx = tuple(_dynamic_dim(name) for _, name, _ in sorted_inputs)
-            initializers = [init for _, _, init in sorted_inputs]
-
-            return TuningConfig(
-                dynamic_tensor_specs=(
-                    DynamicTensorSpec(
-                        input_idx,
-                        dim_idx,
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
-                        initializers,
-                    ),
-                ),
-                **kwargs,
-            )
-
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
         ) -> List[int]:
-            moe_inputs = MoEInputs.from_list(inputs)
-            num_tokens = moe_inputs.hidden_states.shape[0]
+            (
+                output,
+                routing_logits,
+                topk_ids,
+                expert_weights,
+                hidden_states,
+                *extra_inputs,
+            ) = inputs
+            num_tokens = hidden_states.shape[0]
 
             instance_key = (
                 self.dtype_act,
@@ -1033,19 +971,24 @@ def get_trtllm_moe_sm100_module():
             do_preparation: bool = False,
             **kwargs,
         ):
-            moe_inputs = MoEInputs.from_list(inputs)
-            output = moe_inputs.output
-            routing_logits = moe_inputs.routing_logits
-            topk_ids = moe_inputs.topk_ids
-            expert_weights = moe_inputs.expert_weights
-            hidden_states = moe_inputs.hidden_states
-            hidden_states_scale = (
-                moe_inputs.hidden_states_scale
-                if trtllm_gen_dtype_has_scale(self.dtype_act)
-                else None
-            )
-
+            (
+                output,
+                routing_logits,
+                topk_ids,
+                expert_weights,
+                hidden_states,
+                *extra_inputs,
+            ) = inputs
+            if kwargs.get("skip_routing", False):
+                routing_logits = None
             num_tokens = hidden_states.shape[0]
+
+            extra_input_idx = 0
+            if trtllm_gen_dtype_has_scale(self.dtype_act):
+                hidden_states_scale = extra_inputs[extra_input_idx]
+                extra_input_idx += 1
+            else:
+                hidden_states_scale = None
             # sanity checks to ensure that dynamic tensors have the correct shapes
             assert output.shape[0] == num_tokens, (
                 "output's first dimension must be batch size."
@@ -1067,20 +1010,10 @@ def get_trtllm_moe_sm100_module():
             assert hidden_states.shape[0] == num_tokens, (
                 "hidden_states's first dimension must be batch size."
             )
-            if hidden_states_scale is not None:
-                assert hidden_states_scale.dim() == 2, (
-                    "hidden_states_scale must be a 2D tensor"
-                )
-                if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
-                    assert hidden_states_scale.shape[1] == num_tokens, (
-                        f"DeepSeekFp8 hidden_states_scale shape {tuple(hidden_states_scale.shape)} "
-                        f"expects num_tokens={num_tokens} at dim 1"
-                    )
-                else:
-                    assert hidden_states_scale.shape[0] == num_tokens, (
-                        f"hidden_states_scale shape {tuple(hidden_states_scale.shape)} "
-                        f"expects num_tokens={num_tokens} at dim 0"
-                    )
+            assert hidden_states_scale is None or (
+                hidden_states_scale.dim() == 2
+                and hidden_states_scale.shape[0] == num_tokens
+            ), "hidden_states_scale's first dimension must be batch size"
             # Choose the appropriate operation based on data types
             if self.dtype_weights == DtypeTrtllmGen.Bfloat16:
                 # BF16 operations
@@ -1132,7 +1065,7 @@ def get_trtllm_moe_sm100_module():
                             device=hidden_states.device,
                         )
                     elif self.fp8_quantization_type == Fp8QuantizationType.MxFp8:
-                        current_hidden_states_scale = hidden_states_scale
+                        current_hidden_states_scale = extra_inputs[0]
 
                     else:
                         raise ValueError(
@@ -1264,6 +1197,34 @@ def get_trtllm_moe_sm100_module():
                     kwargs.get("norm_topk_prob", True),
                 )
 
+        @classmethod
+        @functools.lru_cache(maxsize=None)
+        def refine_tuning_config(cls, tune_max_num_tokens: int, **kwargs):
+            cls.tuning_config_with_hidden_states_scales = TuningConfig(
+                dynamic_tensor_specs=(
+                    DynamicTensorSpec(
+                        (0, 1, 2, 3, 4, 5),
+                        (0, 0, 0, 0, 0, 0),
+                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
+                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        cls.dynamic_tensor_initializers,
+                    ),
+                ),
+                **kwargs,
+            )
+            cls.tuning_config_no_hidden_states_scales = TuningConfig(
+                dynamic_tensor_specs=(
+                    DynamicTensorSpec(
+                        (0, 1, 2, 3, 4),
+                        (0, 0, 0, 0, 0),
+                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
+                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        cls.dynamic_tensor_initializers[:5],
+                    ),
+                ),
+                **kwargs,
+            )
+
     @register_custom_op(
         "flashinfer::trtllm_bf16_moe",
         mutates_args=(""),
@@ -1300,6 +1261,7 @@ def get_trtllm_moe_sm100_module():
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
+        MoERunner.refine_tuning_config(tune_max_num_tokens)
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1341,26 +1303,13 @@ def get_trtllm_moe_sm100_module():
             activation_type=ActivationType.Swiglu,  # Default for BF16
         )
 
-        moe_inputs = MoEInputs(
-            output=output,
-            routing_logits=routing_logits,
-            topk_ids=topk_ids,
-            expert_weights=expert_weights,
-            hidden_states=hidden_states,
-            hidden_states_scale=None,
-        )
-        tuning_config = moe_runner._make_tuning_config(
-            moe_inputs,
-            tune_max_num_tokens=tune_max_num_tokens,
-            use_cuda_graph=True,
-            use_cold_l2_cache=True,
-        )
+        inputs = [output, routing_logits, topk_ids, expert_weights, hidden_states]
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_bf16_moe",
             [moe_runner],
-            tuning_config,
-            moe_inputs.to_list(),
+            MoERunner.tuning_config_no_hidden_states_scales,
+            inputs,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             gemm2_weights=gemm2_weights,
@@ -1475,6 +1424,7 @@ def get_trtllm_moe_sm100_module():
             enable_pdl = device_support_pdl(hidden_states.device)
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
+        MoERunner.refine_tuning_config(tune_max_num_tokens)
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1506,26 +1456,13 @@ def get_trtllm_moe_sm100_module():
             activation_type=activation_type,
         )
 
-        moe_inputs = MoEInputs(
-            output=output,
-            routing_logits=routing_logits,
-            topk_ids=topk_ids,
-            expert_weights=expert_weights,
-            hidden_states=hidden_states,
-            hidden_states_scale=None,
-        )
-        tuning_config = moe_runner._make_tuning_config(
-            moe_inputs,
-            tune_max_num_tokens=tune_max_num_tokens,
-            use_cuda_graph=True,
-            use_cold_l2_cache=True,
-        )
+        inputs = [output, routing_logits, topk_ids, expert_weights, hidden_states]
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp8_per_tensor_scale_moe",
             [moe_runner],
-            tuning_config,
-            moe_inputs.to_list(),
+            MoERunner.tuning_config_no_hidden_states_scales,  # FP8 per-tensor doesn't use hidden_states_scale
+            inputs,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             output1_scales_scalar=output1_scales_scalar,
@@ -1658,8 +1595,9 @@ def get_trtllm_moe_sm100_module():
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
 
-        # Use AutoTuner to select the best tactic
+        # Use AutoTuner to select the best tactic - follow FP4 pattern exactly
         tuner = AutoTuner.get()
+        MoERunner.refine_tuning_config(tune_max_num_tokens)
 
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[-1]
@@ -1721,26 +1659,20 @@ def get_trtllm_moe_sm100_module():
             use_shuffled_weight=use_shuffled_weight,
         )
 
-        moe_inputs = MoEInputs(
-            output=output,
-            routing_logits=routing_logits,
-            topk_ids=topk_ids,
-            expert_weights=expert_weights,
-            hidden_states=hidden_states,
-            hidden_states_scale=hidden_states_scale,
-        )
-        tuning_config = moe_runner._make_tuning_config(
-            moe_inputs,
-            tune_max_num_tokens=tune_max_num_tokens,
-            use_cuda_graph=True,
-            use_cold_l2_cache=True,
-        )
+        inputs = [
+            output,
+            routing_logits,
+            topk_ids,
+            expert_weights,
+            hidden_states,
+            hidden_states_scale,
+        ]
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp8_block_scale_moe",
             [moe_runner],
-            tuning_config,
-            moe_inputs.to_list(),
+            MoERunner.tuning_config_with_hidden_states_scales,  # FP8 block-scale uses hidden_states_scale
+            inputs,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             gemm1_weights_scale=gemm1_weights_scale,
@@ -1921,6 +1853,9 @@ def get_trtllm_moe_sm100_module():
             )
 
         tuner = AutoTuner.get()
+        MoERunner.refine_tuning_config(
+            tune_max_num_tokens, use_cold_l2_cache=True, use_cuda_graph=True
+        )
         dtype_act = deduce_trtllm_gen_tensor_dtype(hidden_states, hidden_states_scale)
         dtype_weights = deduce_trtllm_gen_tensor_dtype(
             gemm1_weights, gemm1_weights_scale
@@ -1937,26 +1872,34 @@ def get_trtllm_moe_sm100_module():
             weight_layout=WeightLayout.MajorK,
             use_shuffled_weight=True,
         )
-        moe_inputs = MoEInputs(
-            output=output,
-            routing_logits=routing_logits,
-            topk_ids=topk_ids,
-            expert_weights=expert_weights,
-            hidden_states=hidden_states,
-            hidden_states_scale=hidden_states_scale,
+        tunning_config = (
+            MoERunner.tuning_config_no_hidden_states_scales
+            if hidden_states_scale is None
+            else MoERunner.tuning_config_with_hidden_states_scales
         )
-        tuning_config = moe_runner._make_tuning_config(
-            moe_inputs,
-            tune_max_num_tokens=tune_max_num_tokens,
-            use_cold_l2_cache=True,
-            use_cuda_graph=True,
-        )
+        inputs = [
+            output,
+            torch.empty(
+                num_tokens,
+                num_experts,
+                dtype=routing_dtype,
+                device=hidden_states.device,
+            )
+            if routing_logits is None
+            else routing_logits,
+            topk_ids,
+            expert_weights,
+            hidden_states,
+        ]
+        if hidden_states_scale is not None:
+            inputs.append(hidden_states_scale)
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_fp4_block_scale_moe",
             [moe_runner],
-            tuning_config,
-            moe_inputs.to_list(),
+            tunning_config,
+            inputs,
+            skip_routing=(routing_logits is None),
             num_experts=num_experts,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
@@ -2121,6 +2064,7 @@ def get_trtllm_moe_sm100_module():
             )
 
         tuner = AutoTuner.get()
+        MoERunner.refine_tuning_config(tune_max_num_tokens)
         dtype_act = DtypeTrtllmGen.Bfloat16
         dtype_weights = DtypeTrtllmGen.MxInt4
         moe_runner = MoERunner(
@@ -2135,27 +2079,20 @@ def get_trtllm_moe_sm100_module():
             weight_layout=WeightLayout.BlockMajorK,
             use_shuffled_weight=True,
         )
-
-        moe_inputs = MoEInputs(
-            output=output,
-            routing_logits=routing_logits,
-            topk_ids=topk_ids,
-            expert_weights=expert_weights,
-            hidden_states=hidden_states,
-            hidden_states_scale=None,
-        )
-        tuning_config = moe_runner._make_tuning_config(
-            moe_inputs,
-            tune_max_num_tokens=tune_max_num_tokens,
-            use_cuda_graph=True,
-            use_cold_l2_cache=True,
-        )
+        tunning_config = MoERunner.tuning_config_no_hidden_states_scales
+        inputs = [
+            output,
+            routing_logits,
+            topk_ids,
+            expert_weights,
+            hidden_states,
+        ]
 
         _, tactic = tuner.choose_one(
             "flashinfer::trtllm_mxint4_block_scale_moe",
             [moe_runner],
-            tuning_config,
-            moe_inputs.to_list(),
+            tunning_config,
+            inputs,
             num_experts=num_experts,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -499,25 +499,26 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
 // picking the first (expert, topK) pair that covers the runtime values.
 //
 // IMPORTANT: numThreads is clamped to at least min(MaxNumExperts, 1024) from the dispatched tier.
-#define LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,   \
-                                  stream, PreProc, PostProc)                                   \
-  [&](auto pt_tag_) {                                                                          \
-    using Pairs_ = typename decltype(pt_tag_)::Pairs;                                          \
-    bool dispatched_ =                                                                         \
-        dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {   \
-          constexpr int tierMaxExp_ = decltype(eTag_)::value;                                  \
-          constexpr int tierThreads_ = tierMaxExp_ <= 1024 ? tierMaxExp_ : 1024;               \
-          int const effectiveThreads_ = std::max(static_cast<int>(numThreads), tierThreads_);  \
-          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, effectiveThreads_, \
-                                       smemSize, stream, PreProc, PostProc,                    \
-                                       decltype(eTag_)::value, decltype(kTag_)::value);        \
-        });                                                                                    \
-    if (!dispatched_) {                                                                        \
-      FLASHINFER_WARN(                                                                         \
-          "No compiled tier covers numExperts=%d topK=%d for policy %s+%s. "                   \
-          "Add a Tier<%d, %d> to the corresponding PolicyTraits in RoutingCustomPolicy.cuh.",  \
-          data.mNumExperts, data.mTopK, #PreProc, #PostProc, data.mNumExperts, data.mTopK);    \
-    }                                                                                          \
+#define LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,     \
+                                  stream, PreProc, PostProc)                                     \
+  [&](auto pt_tag_) {                                                                            \
+    using Pairs_ = typename decltype(pt_tag_)::Pairs;                                            \
+    bool dispatched_ =                                                                           \
+        dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {     \
+          constexpr int tierMaxExp_ = decltype(eTag_)::value;                                    \
+          constexpr int tierThreads_ = tierMaxExp_ <= 1024 ? tierMaxExp_ : 1024;                 \
+          int const effectiveThreads_ = std::max(static_cast<int>(numThreads), tierThreads_);    \
+          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, effectiveThreads_,   \
+                                       smemSize, stream, PreProc, PostProc,                      \
+                                       decltype(eTag_)::value, decltype(kTag_)::value);          \
+        });                                                                                      \
+    if (!dispatched_) {                                                                          \
+      FLASHINFER_WARN(                                                                           \
+          "No compiled tier covers numExperts=%d topK=%d for policy %s+%s. "                     \
+          "Add a Tier<%d, %d> to the corresponding PolicyTraits in RoutingCustomPolicy.cuh.",    \
+          data.mNumExperts, data.mTopK, #PreProc, #PostProc, getMaxNumExperts(data.mNumExperts), \
+          data.mTopK);                                                                           \
+    }                                                                                            \
   }(PolicyTraits<PreProc, PostProc>{})
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -543,8 +544,8 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
       FLASHINFER_WARN(                                                                         \
           "No compiled tier covers numExperts=%d topK=%d for ExpertSelect policy %s. "         \
           "Add a Tier<%d, %d> to PolicyTraits<%s, void> in RoutingCustomPolicy.cuh.",          \
-          data.mNumExperts, data.mTopK, #ExpertSelect, data.mNumExperts, data.mTopK,           \
-          #ExpertSelect);                                                                      \
+          data.mNumExperts, data.mTopK, #ExpertSelect, getMaxNumExperts(data.mNumExperts),     \
+          data.mTopK, #ExpertSelect);                                                          \
     }                                                                                          \
   }(PolicyTraits<ExpertSelect, void>{})
 
@@ -599,27 +600,30 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
 // Maps (mPreprocessType, mPostprocessType) to compile-time (PreProc, PostProc) policy types.
 // Both LAUNCH_ROUTING_CUSTOM and queryDispatchedMaxExperts use this function,
 // so they are always in sync.
+// The callback receives (PreProc{}, PostProc{}, policyName) where policyName is a human-readable
+// string for diagnostics.
 template <typename Fn>
 inline void dispatchRoutingPolicy(Data const& data, Fn&& fn) {
   if (data.mPreprocessType == RoutingPreprocessType::SigmoidBias)
-    fn(SigmoidBiasPreprocess{}, ScaledSumNormalizePostprocess{});
+    fn(SigmoidBiasPreprocess{}, ScaledSumNormalizePostprocess{},
+       "SigmoidBiasPreprocess+ScaledSumNormalizePostprocess");
   else if (data.mPreprocessType == RoutingPreprocessType::Sigmoid)
-    fn(SigmoidPreprocess{}, SumNormalizePostprocess{});
+    fn(SigmoidPreprocess{}, SumNormalizePostprocess{}, "SigmoidPreprocess+SumNormalizePostprocess");
   else if (data.mPreprocessType == RoutingPreprocessType::Softmax &&
            data.mPostprocessType == RoutingPostprocessType::None)
-    fn(SoftmaxPreprocess{}, NoOpPostprocess{});
+    fn(SoftmaxPreprocess{}, NoOpPostprocess{}, "SoftmaxPreprocess+NoOpPostprocess");
   else if (data.mPreprocessType == RoutingPreprocessType::Softmax)
-    fn(SoftmaxPreprocess{}, SumNormalizePostprocess{});
+    fn(SoftmaxPreprocess{}, SumNormalizePostprocess{}, "SoftmaxPreprocess+SumNormalizePostprocess");
   else if (data.mPostprocessType == RoutingPostprocessType::Softmax)
-    fn(NoOpPreprocess{}, SoftmaxPostprocess{});
+    fn(NoOpPreprocess{}, SoftmaxPostprocess{}, "NoOpPreprocess+SoftmaxPostprocess");
   else
-    fn(NoOpPreprocess{}, NoOpPostprocess{});
+    fn(NoOpPreprocess{}, NoOpPostprocess{}, "NoOpPreprocess+NoOpPostprocess");
 }
 
 // Query the MaxNumExperts that the policy tier dispatch would select for the given data.
 inline int32_t queryDispatchedMaxExperts(Data const& data) {
   int32_t result = getMaxNumExperts(data.mNumExperts);
-  dispatchRoutingPolicy(data, [&](auto preProc, auto postProc) {
+  dispatchRoutingPolicy(data, [&](auto preProc, auto postProc, char const* /*policyName*/) {
     using Pairs = typename PolicyTraits<decltype(preProc), decltype(postProc)>::Pairs;
     dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
                       [&](auto eTag, auto /*kTag*/) { result = decltype(eTag)::value; });
@@ -630,9 +634,26 @@ inline int32_t queryDispatchedMaxExperts(Data const& data) {
 // Top-level dispatch: maps runtime preprocess/postprocess enums to compile-time policy types,
 // then delegates to LAUNCH_ROUTING_FOR_POLICY which reads PolicyTraits for tier support.
 #define LAUNCH_ROUTING_CUSTOM(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream) \
-  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_) {                               \
-    LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              decltype(preProc_), decltype(postProc_));                          \
+  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* policyName_) {      \
+    using PreProc_ = decltype(preProc_);                                                         \
+    using PostProc_ = decltype(postProc_);                                                       \
+    using Pairs_ = typename PolicyTraits<PreProc_, PostProc_>::Pairs;                            \
+    bool dispatched_ =                                                                           \
+        dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {     \
+          constexpr int tierMaxExp_ = decltype(eTag_)::value;                                    \
+          constexpr int tierThreads_ = tierMaxExp_ <= 1024 ? tierMaxExp_ : 1024;                 \
+          int const effectiveThreads_ = std::max(static_cast<int>(numThreads), tierThreads_);    \
+          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, effectiveThreads_,   \
+                                       smemSize, stream, PreProc_, PostProc_,                    \
+                                       decltype(eTag_)::value, decltype(kTag_)::value);          \
+        });                                                                                      \
+    if (!dispatched_) {                                                                          \
+      FLASHINFER_WARN(                                                                           \
+          "No compiled tier covers numExperts=%d topK=%d for policy %s. "                        \
+          "Add a Tier<%d, %d> to the corresponding PolicyTraits in RoutingCustomPolicy.cuh.",    \
+          data.mNumExperts, data.mTopK, policyName_, getMaxNumExperts(data.mNumExperts),         \
+          data.mTopK);                                                                           \
+    }                                                                                            \
   })
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -348,6 +348,8 @@ static constexpr int MaxNumTokensSingleCluster = NumBlocksPerCluster * NumThread
 static constexpr int MaxNumTokensSingleClusterScores = NumBlocksPerCluster * NumWarps;
 
 static constexpr int BlockKernelMaxNumTokens = 4;
+static constexpr int DynBlockKernelMaxNumTokens = 16;
+static constexpr int DynBlockKernelMaxNumExperts = 512;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -431,6 +433,7 @@ struct PolicyTraits {
 };
 
 /// Softmax + None (Default: Softmax -> TopK).
+/// NOTE: Currently only covers ≤256 experts. If a model requires more, add a larger Tier here.
 template <>
 struct PolicyTraits<SoftmaxPreprocess, NoOpPostprocess> {
   using Pairs = TierList<Tier<128, 8>,  // Small expert counts (≤128 experts)
@@ -456,6 +459,7 @@ struct PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> {
 };
 
 /// Sigmoid + SumNormalize (SigmoidRenorm: Sigmoid -> TopK -> Renormalize).
+/// NOTE: Currently only covers ≤256 experts. If a model requires more, add a larger Tier here.
 template <>
 struct PolicyTraits<SigmoidPreprocess, SumNormalizePostprocess> {
   using Pairs = TierList<Tier<128, 8>,  // Small expert counts (≤128 experts)
@@ -470,11 +474,13 @@ struct PolicyTraits<SigmoidBiasPreprocess, ScaledSumNormalizePostprocess> {
                          Tier<256, 8>,  // MiniMax M2 (256 experts, topK=6)
                          Tier<384, 8>,  // Kimi K2 (384 experts)
                          Tier<512, 8>,  // DeepSeek nGroup≤1 (256 experts → E512 fallback)
-                         Tier<512, 22>  // Nemotron Super V3 (512 experts, topK=22, nGroup≤1)
+                         Tier<512, 22>,  // Nemotron Super V3 (512 experts, topK=22, nGroup≤1)
+                         Tier<1024, 32>  // Default fallback (expert count may grow beyond 512)
                          >;
 };
 
 /// None + None (TopK only: no softmax or renormalize).
+/// NOTE: Currently only covers ≤256 experts. If a model requires more, add a larger Tier here.
 template <>
 struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
   using Pairs = TierList<Tier<128, 8>,  // Small expert counts (≤128 experts)
@@ -507,7 +513,10 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
                                        decltype(eTag_)::value, decltype(kTag_)::value);        \
         });                                                                                    \
     if (!dispatched_) {                                                                        \
-      FLASHINFER_WARN("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);   \
+      FLASHINFER_WARN(                                                                         \
+          "No compiled tier covers numExperts=%d topK=%d for policy %s+%s. "                   \
+          "Add a Tier<%d, %d> to the corresponding PolicyTraits in RoutingCustomPolicy.cuh.",  \
+          data.mNumExperts, data.mTopK, #PreProc, #PostProc, data.mNumExperts, data.mTopK);    \
     }                                                                                          \
   }(PolicyTraits<PreProc, PostProc>{})
 
@@ -531,7 +540,11 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
                                             decltype(eTag_)::value, decltype(kTag_)::value);   \
         });                                                                                    \
     if (!dispatched_) {                                                                        \
-      FLASHINFER_WARN("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);   \
+      FLASHINFER_WARN(                                                                         \
+          "No compiled tier covers numExperts=%d topK=%d for ExpertSelect policy %s. "         \
+          "Add a Tier<%d, %d> to PolicyTraits<%s, void> in RoutingCustomPolicy.cuh.",          \
+          data.mNumExperts, data.mTopK, #ExpertSelect, data.mNumExperts, data.mTopK,           \
+          #ExpertSelect);                                                                      \
     }                                                                                          \
   }(PolicyTraits<ExpertSelect, void>{})
 
@@ -582,31 +595,47 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
     FLASHINFER_WARN("Unsupported numExperts");                                                     \
   }
 
+// Single source of truth for runtime → compile-time policy dispatch.
+// Maps (mPreprocessType, mPostprocessType) to compile-time (PreProc, PostProc) policy types.
+// Both LAUNCH_ROUTING_CUSTOM and queryDispatchedMaxExperts use this function,
+// so they are always in sync.
+template <typename Fn>
+inline void dispatchRoutingPolicy(Data const& data, Fn&& fn) {
+  if (data.mPreprocessType == RoutingPreprocessType::SigmoidBias)
+    fn(SigmoidBiasPreprocess{}, ScaledSumNormalizePostprocess{});
+  else if (data.mPreprocessType == RoutingPreprocessType::Sigmoid)
+    fn(SigmoidPreprocess{}, SumNormalizePostprocess{});
+  else if (data.mPreprocessType == RoutingPreprocessType::Softmax &&
+           data.mPostprocessType == RoutingPostprocessType::None)
+    fn(SoftmaxPreprocess{}, NoOpPostprocess{});
+  else if (data.mPreprocessType == RoutingPreprocessType::Softmax)
+    fn(SoftmaxPreprocess{}, SumNormalizePostprocess{});
+  else if (data.mPostprocessType == RoutingPostprocessType::Softmax)
+    fn(NoOpPreprocess{}, SoftmaxPostprocess{});
+  else
+    fn(NoOpPreprocess{}, NoOpPostprocess{});
+}
+
+// Query the MaxNumExperts that the policy tier dispatch would select for the given data.
+inline int32_t queryDispatchedMaxExperts(Data const& data) {
+  int32_t result = getMaxNumExperts(data.mNumExperts);
+  dispatchRoutingPolicy(data, [&](auto preProc, auto postProc) {
+    using Pairs = typename PolicyTraits<decltype(preProc), decltype(postProc)>::Pairs;
+    dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
+                      [&](auto eTag, auto /*kTag*/) { result = decltype(eTag)::value; });
+  });
+  return result;
+}
+
 // Top-level dispatch: maps runtime preprocess/postprocess enums to compile-time policy types,
 // then delegates to LAUNCH_ROUTING_FOR_POLICY which reads PolicyTraits for tier support.
-// Use this ONLY for kernels that call ExpertSelectPolicy::apply (block, cluster, histogramScores).
 #define LAUNCH_ROUTING_CUSTOM(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream) \
-  if (data.mPreprocessType == RoutingPreprocessType::SigmoidBias) {                              \
+  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_) {                               \
     LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              SigmoidBiasPreprocess, ScaledSumNormalizePostprocess);             \
-  } else if (data.mPreprocessType == RoutingPreprocessType::Sigmoid) {                           \
-    LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              SigmoidPreprocess, SumNormalizePostprocess);                       \
-  } else if (data.mPreprocessType == RoutingPreprocessType::Softmax &&                           \
-             data.mPostprocessType == RoutingPostprocessType::None) {                            \
-    LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              SoftmaxPreprocess, NoOpPostprocess);                               \
-  } else if (data.mPreprocessType == RoutingPreprocessType::Softmax) {                           \
-    LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              SoftmaxPreprocess, SumNormalizePostprocess);                       \
-  } else if (data.mPostprocessType == RoutingPostprocessType::Softmax) {                         \
-    LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              NoOpPreprocess, SoftmaxPostprocess);                               \
-  } else {                                                                                       \
-    LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, \
-                              NoOpPreprocess, NoOpPostprocess);                                  \
-  }                                                                                              \
-  ////////////////////////////////////////////////////////////////////////////////////////////////////
+                              decltype(preProc_), decltype(postProc_));                          \
+  })
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
 }  // namespace routingCustom
 }  // namespace moe::dev::routing

--- a/include/flashinfer/trtllm/fused_moe/RoutingDevKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingDevKernel.h
@@ -38,13 +38,7 @@
                                                                                              \
     cudaLaunchAttribute attributes[2] = {};                                                  \
     attributes[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;                   \
-    /* mUsePdl controls in-kernel sync/trigger; mPdlOverlapWithNext controls whether    */   \
-    /* the NEXT kernel in the stream is allowed to start before this one finishes.      */   \
-    /* Both must be true for overlap: mUsePdl ensures PDL is globally enabled,          */   \
-    /* mPdlOverlapWithNext is false for the last routing kernel so the consumer GEMM    */   \
-    /* (which may lack cudaGridDependencySynchronize) can't read stale routing data.    */   \
-    attributes[0].val.programmaticStreamSerializationAllowed =                               \
-        int(data.mUsePdl && data.mPdlOverlapWithNext);                                       \
+    attributes[0].val.programmaticStreamSerializationAllowed = int(data.mUsePdl);            \
     attributes[1].id = cudaLaunchAttributeCooperative;                                       \
     attributes[1].val.cooperative = int(coopLaunch);                                         \
     config.attrs = attributes;                                                               \

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
@@ -361,8 +361,6 @@ __device__ void routingPermutation(KernelParams params,
     } else {
       numCta[e] = divUpTileN<int32_t>(count[e], params.mTileTokensDim);
     }
-    // Expand from CGA count to CTA count to keep the semantic stable with downstream kernels
-    numCta[e] *= params.mClusterSizeInBatchDim;
   }
 
   int32_t ctaOffset[ExpertsPerThread];
@@ -382,13 +380,11 @@ __device__ void routingPermutation(KernelParams params,
         int32_t mnLimit1;
         int32_t mnLimit2;
         if (params.mIsPow2) {
-          int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
-          mnLimit1 = mulLog2<int32_t>(ctaOffset[e] + cta + 1, ctaPaddingLog2);
-          mnLimit2 = mulLog2<int32_t>(ctaOffset[e], ctaPaddingLog2) + count[e];
+          mnLimit1 = mulLog2<int32_t>(ctaOffset[e] + cta + 1, params.mPaddingLog2);
+          mnLimit2 = mulLog2<int32_t>(ctaOffset[e], params.mPaddingLog2) + count[e];
         } else {
-          int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
-          mnLimit1 = (ctaOffset[e] + cta + 1) * ctaTile;
-          mnLimit2 = ctaOffset[e] * ctaTile + count[e];
+          mnLimit1 = mulTileN<int32_t>(ctaOffset[e] + cta + 1, params.mTileTokensDim);
+          mnLimit2 = mulTileN<int32_t>(ctaOffset[e], params.mTileTokensDim) + count[e];
         }
         params.mPtrCtaIdxXyToMnLimit[ctaOffset[e] + cta] = min(mnLimit1, mnLimit2);
       }
@@ -396,9 +392,9 @@ __device__ void routingPermutation(KernelParams params,
       // get the padded offset associated with this expert (token-space, CGA granularity)
       int32_t offset;
       if (params.mIsPow2) {
-        offset = mulLog2<int32_t>(ctaOffset[e] >> params.mClusterSizeLog2, params.mPaddingLog2);
+        offset = mulLog2<int32_t>(ctaOffset[e], params.mPaddingLog2);
       } else {
-        offset = (ctaOffset[e] / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+        offset = mulTileN<int32_t>(ctaOffset[e], params.mTileTokensDim);
       }
 
       // write expert offsets to shared
@@ -410,10 +406,9 @@ __device__ void routingPermutation(KernelParams params,
   if (clusterBlockRank == 0 && warpIdx == NumWarps - 1 && cute::elect_one_sync()) {
     int32_t permutedIdxSize;
     if (params.mIsPow2) {
-      permutedIdxSize =
-          mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
+      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
     } else {
-      permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
     }
     params.mPtrPermutedIdxSize[0] = permutedIdxSize;
     params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
@@ -641,8 +636,6 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
     } else {
       numCta[e] = divUpTileN<int32_t>(count[e], params.mTileTokensDim);
     }
-    // Expand from CGA count to CTA count to keep the semantic stable with downstream kernels
-    numCta[e] *= params.mClusterSizeInBatchDim;
   }
   int32_t ctaOffset[ExpertsPerThread];
   int32_t numNonExitingCtas;
@@ -655,9 +648,9 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
       // Get the padded offset associated with this expert (token-space, CGA granularity)
       int32_t offset;
       if (params.mIsPow2) {
-        offset = mulLog2<int32_t>(ctaOffset[e] >> params.mClusterSizeLog2, params.mPaddingLog2);
+        offset = mulLog2<int32_t>(ctaOffset[e], params.mPaddingLog2);
       } else {
-        offset = (ctaOffset[e] / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+        offset = mulTileN<int32_t>(ctaOffset[e], params.mTileTokensDim);
       }
 
       // Write expert offsets to shared
@@ -672,10 +665,9 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
   if (blockIdx.x == 0 && warpIdx == NumThreadsBlock / WarpSize - 1 && cute::elect_one_sync()) {
     int32_t permutedIdxSize;
     if (params.mIsPow2) {
-      permutedIdxSize =
-          mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
+      permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
     } else {
-      permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+      permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
     }
     params.mPtrPermutedIdxSize[0] = permutedIdxSize;
     params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
@@ -694,13 +686,11 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
         int32_t mnLimit1;
         int32_t mnLimit2;
         if (params.mIsPow2) {
-          int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
-          mnLimit1 = mulLog2<int32_t>(ctaOffset[e] + cta + 1, ctaPaddingLog2);
-          mnLimit2 = mulLog2<int32_t>(ctaOffset[e], ctaPaddingLog2) + count[e];
+          mnLimit1 = mulLog2<int32_t>(ctaOffset[e] + cta + 1, params.mPaddingLog2);
+          mnLimit2 = mulLog2<int32_t>(ctaOffset[e], params.mPaddingLog2) + count[e];
         } else {
-          int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
-          mnLimit1 = (ctaOffset[e] + cta + 1) * ctaTile;
-          mnLimit2 = ctaOffset[e] * ctaTile + count[e];
+          mnLimit1 = mulTileN<int32_t>(ctaOffset[e] + cta + 1, params.mTileTokensDim);
+          mnLimit2 = mulTileN<int32_t>(ctaOffset[e], params.mTileTokensDim) + count[e];
         }
         params.mPtrCtaIdxXyToMnLimit[ctaOffset[e] + cta] = min(mnLimit1, mnLimit2);
       }
@@ -1017,8 +1007,6 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
   } else {
     numCta = divUpTileN<int32_t>(count, params.mTileTokensDim);
   }
-  // Expand from CGA count to CTA count to keep the semantic stable with downstream kernels
-  numCta *= params.mClusterSizeInBatchDim;
 
   int32_t ctaOffset;
   int32_t numNonExitingCtas;
@@ -1032,13 +1020,11 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
     int32_t mnLimit1;
     int32_t mnLimit2;
     if (params.mIsPow2) {
-      int32_t ctaPaddingLog2 = params.mPaddingLog2 - params.mClusterSizeLog2;
-      mnLimit1 = mulLog2<int32_t>(ctaOffset + cta + 1, ctaPaddingLog2);
-      mnLimit2 = mulLog2<int32_t>(ctaOffset, ctaPaddingLog2) + count;
+      mnLimit1 = mulLog2<int32_t>(ctaOffset + cta + 1, params.mPaddingLog2);
+      mnLimit2 = mulLog2<int32_t>(ctaOffset, params.mPaddingLog2) + count;
     } else {
-      int32_t ctaTile = params.mTileTokensDim / params.mClusterSizeInBatchDim;
-      mnLimit1 = (ctaOffset + cta + 1) * ctaTile;
-      mnLimit2 = ctaOffset * ctaTile + count;
+      mnLimit1 = mulTileN<int32_t>(ctaOffset + cta + 1, params.mTileTokensDim);
+      mnLimit2 = mulTileN<int32_t>(ctaOffset, params.mTileTokensDim) + count;
     }
     params.mPtrCtaIdxXyToMnLimit[ctaOffset + cta] = min(mnLimit1, mnLimit2);
   }
@@ -1046,16 +1032,15 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
   // get the padded offset associated with this expert (token-space, CGA granularity)
   int32_t offset;
   if (params.mIsPow2) {
-    offset = mulLog2<int32_t>(ctaOffset >> params.mClusterSizeLog2, params.mPaddingLog2);
+    offset = mulLog2<int32_t>(ctaOffset, params.mPaddingLog2);
   } else {
-    offset = (ctaOffset / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+    offset = mulTileN<int32_t>(ctaOffset, params.mTileTokensDim);
   }
   int32_t permutedIdxSize;
   if (params.mIsPow2) {
-    permutedIdxSize =
-        mulLog2<int32_t>(numNonExitingCtas >> params.mClusterSizeLog2, params.mPaddingLog2);
+    permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
   } else {
-    permutedIdxSize = (numNonExitingCtas / params.mClusterSizeInBatchDim) * params.mTileTokensDim;
+    permutedIdxSize = mulTileN<int32_t>(numNonExitingCtas, params.mTileTokensDim);
   }
 
   // write out padded count

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -40,21 +40,6 @@ struct PackedScoreIdx {
 struct DataBase {
   bool mUsePdl{false};
 
-  // Controls the cudaLaunchAttributeProgrammaticStreamSerialization launch attribute.
-  // When true, the NEXT kernel in the stream is allowed to start before this kernel completes.
-  // When false (default), the next kernel waits for this kernel to finish (normal serialization).
-  //
-  // This is separate from mUsePdl because:
-  //   - mUsePdl controls IN-KERNEL behavior: cudaGridDependencySynchronize (wait for predecessor)
-  //     and cudaTriggerProgrammaticLaunchCompletion (signal successor).
-  //   - mPdlOverlapWithNext controls the LAUNCH ATTRIBUTE: whether the runtime is allowed to
-  //     dispatch the next kernel before this one finishes.
-  //
-  // The LAST routing kernel in a multi-kernel chain should set mPdlOverlapWithNext = false
-  // to prevent the consumer GEMM (which may not have cudaGridDependencySynchronize for routing
-  // data) from starting early and reading stale permutation indices.
-  bool mPdlOverlapWithNext{false};
-
   // optional: only used as an intermediate buffer when the number of tokens is large.
   // dim: max([2*NumThreads] = [512], mNumExperts*2)
   int32_t* mPtrExpertCounts{nullptr};
@@ -392,7 +377,7 @@ void run(Data const& data, void* stream);
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename DataType>
-void runPostTopKPipeline(DataType const& data, uint32_t numThreadsHist, void* stream);
+void runPostTopKPipeline(DataType const& data, void* stream);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 }  // namespace routing

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -96,14 +96,8 @@ struct DataBase {
   int32_t mNumTokens;
   int32_t mNumExperts;
   int32_t mTopK;
-  // Cluster-wide tile size in token dimension.
   int32_t mTileTokensDim;
-  // log2() of the padding size in cluster-wide tile.
   int32_t mPaddingLog2;
-  // Cluster size (e.g., 1x2, 2x1, etc.) in batch dimension.
-  int32_t mClusterSizeInBatchDim{1};
-  // log2() of the cluster size in batch dimension.
-  int32_t mClusterSizeLog2{0};
 
   /// For expert parallelization
   int32_t mLocalExpertsStartIdx;
@@ -140,8 +134,6 @@ struct KernelParamsBase {
 
   int32_t mPaddingLog2 = -1;
   int32_t mTileTokensDim = 0;
-  int32_t mClusterSizeInBatchDim = 1;
-  int32_t mClusterSizeLog2 = 0;
   int32_t mLocalExpertsStartIdx = 0;
   int32_t mLocalExpertsStrideLog2 = 0;
   int32_t mNumLocalExperts = 0;
@@ -168,8 +160,6 @@ struct KernelParamsBase {
 
     mPaddingLog2 = data.mPaddingLog2;
     mTileTokensDim = data.mTileTokensDim;
-    mClusterSizeInBatchDim = data.mClusterSizeInBatchDim;
-    mClusterSizeLog2 = data.mClusterSizeLog2;
     mLocalExpertsStartIdx = data.mLocalExpertsStartIdx;
     mLocalExpertsStrideLog2 = data.mLocalExpertsStrideLog2;
     mNumLocalExperts = data.mNumLocalExperts;

--- a/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/include/flashinfer/trtllm/fused_moe/runner.h
@@ -125,7 +125,7 @@ class Runner {
  public:
   explicit Runner();
 
-  explicit Runner(int32_t tileTokensDim, int32_t clusterSizeInBatchDim = 1);
+  explicit Runner(int32_t tileTokensDim);
 
   void run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts,
            int32_t topK, int32_t nGroups, int32_t topkGroups, int32_t localExpertOffset,
@@ -141,7 +141,6 @@ class Runner {
 
  private:
   int32_t mTileTokensDim{8};
-  int32_t mClusterSizeInBatchDim{1};
 };
 }  // namespace Routing
 

--- a/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
+++ b/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
@@ -344,7 +344,12 @@ def test_fp4_moe_autotune(
 
     with autotune(tune_mode=True):
         if routed:
-            topk_ids = torch.randint(0, num_experts, (num_tokens, top_k), device=device)
+            topk_ids = torch.stack(
+                [
+                    torch.randperm(num_experts, device=device)[:top_k]
+                    for _ in range(num_tokens)
+                ]
+            )
             topk_weights = torch.ones(
                 num_tokens, top_k, dtype=torch.bfloat16, device=device
             )
@@ -447,7 +452,12 @@ def test_fp8_moe_autotune(
 
     with autotune(tune_mode=True):
         if routed:
-            topk_ids = torch.randint(0, num_experts, (num_tokens, top_k), device=device)
+            topk_ids = torch.stack(
+                [
+                    torch.randperm(num_experts, device=device)[:top_k]
+                    for _ in range(num_tokens)
+                ]
+            )
             topk_weights = torch.ones(
                 num_tokens, top_k, dtype=torch.bfloat16, device=device
             )

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1873,7 +1873,7 @@ def routing_reference_minimax2(
     selection_scores = sigmoid_scores.clone()
     if routing_bias is not None:
         selection_scores = selection_scores + routing_bias.float()
-    topk_values, topk_idx = torch.topk(selection_scores, k=top_k, dim=-1)
+    _, topk_idx = torch.topk(selection_scores, k=top_k, dim=-1)
 
     # Weights use un-biased sigmoid scores
     raw_weights = torch.gather(sigmoid_scores, -1, topk_idx)

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -3772,6 +3772,283 @@ def test_fp8_per_tensor_autotune_valid_configs_nonefp8(
     )
 
 
+@pytest.mark.parametrize(
+    "num_tokens",
+    [5, 8, 12, 16],
+    ids=lambda t: f"T{t}",
+)
+@pytest.mark.parametrize("hidden_size", [512])
+@pytest.mark.parametrize("intermediate_size", [512])
+@pytest.mark.parametrize(
+    "moe_impl",
+    [
+        pytest.param(
+            FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_DEEPSEEK),
+            id="FP8_Block_DeepSeek",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "routing_config",
+    [
+        pytest.param(
+            {
+                "num_experts": 64,
+                "top_k": 4,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": None,
+                "has_routing_bias": False,
+                "routing_method_type": RoutingMethodType.Renormalize,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="Renormalize_64e_top4",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "weight_processing",
+    [
+        pytest.param(
+            {
+                "use_shuffled_weight": False,
+                "layout": WeightLayout.MajorK,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+            },
+            id="NoShuffle_MajorK",
+        ),
+    ],
+)
+@pytest.mark.parametrize("activation_type", [ActivationType.Swiglu])
+def test_dyn_block_kernel_routing(
+    num_tokens,
+    hidden_size,
+    intermediate_size,
+    moe_impl,
+    routing_config,
+    weight_processing,
+    activation_type,
+):
+    """Test token counts 5-16 that exercise the dynamic block kernel path (BlockKernelMaxNumTokens < tokens <= DynBlockKernelMaxNumTokens)."""
+    run_moe_test(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        moe_impl,
+        routing_config,
+        weight_processing,
+        activation_type,
+        cache_permute_indices=False,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [8])
+@pytest.mark.parametrize("hidden_size", [512])
+@pytest.mark.parametrize("intermediate_size", [512])
+@pytest.mark.parametrize(
+    "moe_impl",
+    [
+        pytest.param(
+            FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_DEEPSEEK),
+            id="FP8_Block_DeepSeek",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "routing_config",
+    [
+        pytest.param(
+            {
+                "num_experts": 1024,
+                "top_k": 8,
+                "padding": 8,
+                "n_groups": 1,
+                "top_k_groups": 1,
+                "routed_scaling": 1.0,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.DeepSeekV3,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="DeepSeekV3_1024e_top8",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "weight_processing",
+    [
+        pytest.param(
+            {
+                "use_shuffled_weight": False,
+                "layout": WeightLayout.MajorK,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+            },
+            id="NoShuffle_MajorK",
+        ),
+    ],
+)
+@pytest.mark.parametrize("activation_type", [ActivationType.Swiglu])
+def test_tier_1024_experts_routing(
+    num_tokens,
+    hidden_size,
+    intermediate_size,
+    moe_impl,
+    routing_config,
+    weight_processing,
+    activation_type,
+):
+    """Test 1024-expert routing to exercise Tier<1024, 32> in SigmoidBias+ScaledSumNormalize policy."""
+    run_moe_test(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        moe_impl,
+        routing_config,
+        weight_processing,
+        activation_type,
+        cache_permute_indices=False,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [8])
+@pytest.mark.parametrize("hidden_size", [512])
+@pytest.mark.parametrize("intermediate_size", [512])
+@pytest.mark.parametrize(
+    "moe_impl",
+    [
+        pytest.param(
+            FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_DEEPSEEK),
+            id="FP8_Block_DeepSeek",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "routing_config",
+    [
+        pytest.param(
+            {
+                "num_experts": 256,
+                "top_k": 6,
+                "padding": 8,
+                "n_groups": 8,
+                "top_k_groups": 4,
+                "routed_scaling": 2.5,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.DeepSeekV3,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="DeepSeekV3_256e",
+        ),
+        pytest.param(
+            {
+                "num_experts": 128,
+                "top_k": 8,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": None,
+                "has_routing_bias": False,
+                "routing_method_type": RoutingMethodType.Renormalize,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="Renormalize_128e",
+        ),
+        pytest.param(
+            {
+                "num_experts": 128,
+                "top_k": 8,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": None,
+                "has_routing_bias": False,
+                "routing_method_type": RoutingMethodType.Default,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="Default_128e",
+        ),
+        pytest.param(
+            {
+                "num_experts": 128,
+                "top_k": 8,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": None,
+                "has_routing_bias": False,
+                "routing_method_type": RoutingMethodType.SigmoidRenorm,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="SigmoidRenorm_128e",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "weight_processing",
+    [
+        pytest.param(
+            {
+                "use_shuffled_weight": False,
+                "layout": WeightLayout.MajorK,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+            },
+            id="NoShuffle_MajorK",
+        ),
+    ],
+)
+@pytest.mark.parametrize("activation_type", [ActivationType.Swiglu])
+@pytest.mark.parametrize(
+    "routing_logits_dtype",
+    [
+        pytest.param(torch.bfloat16, id="BF16_logits"),
+        pytest.param(torch.float32, id="FP32_logits"),
+    ],
+)
+@pytest.mark.parametrize(
+    "routing_bias_dtype",
+    [
+        pytest.param(None, id="default_bias"),
+        pytest.param(torch.float32, id="FP32_bias"),
+    ],
+)
+def test_routing_dtype_flexibility(
+    num_tokens,
+    hidden_size,
+    intermediate_size,
+    moe_impl,
+    routing_config,
+    weight_processing,
+    activation_type,
+    routing_logits_dtype,
+    routing_bias_dtype,
+):
+    """Test that routing works with both bfloat16 and float32 logits/bias across all routing methods."""
+    run_moe_test(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        moe_impl,
+        routing_config,
+        weight_processing,
+        activation_type,
+        cache_permute_indices=False,
+        routing_logits_dtype=routing_logits_dtype,
+        routing_bias_dtype=routing_bias_dtype,
+    )
+
+
 def test_fp8_block_scale_routed_activation_type_relu2_smoke():
     """Smoke test routed FP8 block-scale call path with explicit non-gated activation_type."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1862,6 +1862,32 @@ def routing_reference_sigmoid_renorm(
     return permute_info, scores
 
 
+def routing_reference_minimax2(
+    expert_logits, routing_bias, top_k, num_experts, padding
+):
+    """Sigmoid + Bias -> TopK -> ScaledSumNormalize routing reference (MiniMax2).
+    Bias affects expert selection but NOT the final weights.
+    Weights = sigmoid(logit) / (sum_of_selected_sigmoid + 1e-20).
+    """
+    sigmoid_scores = torch.sigmoid(expert_logits.float())
+    selection_scores = sigmoid_scores.clone()
+    if routing_bias is not None:
+        selection_scores = selection_scores + routing_bias.float()
+    topk_values, topk_idx = torch.topk(selection_scores, k=top_k, dim=-1)
+
+    # Weights use un-biased sigmoid scores
+    raw_weights = torch.gather(sigmoid_scores, -1, topk_idx)
+    raw_weights = raw_weights / (raw_weights.sum(dim=-1, keepdim=True) + 1e-20)
+    raw_weights = raw_weights.to(expert_logits.dtype)
+
+    scores = torch.zeros_like(sigmoid_scores, dtype=expert_logits.dtype)
+    for i in range(topk_idx.shape[0]):
+        for j in range(topk_idx.shape[1]):
+            scores[i, topk_idx[i, j]] = raw_weights[i, j]
+    permute_info = routing_reference(scores, top_k, padding)
+    return permute_info, scores
+
+
 def check_accuracy(a, b, atol, rtol, percent):
     """Unified accuracy checking function with detailed error reporting."""
     if not torch.isfinite(a).all():
@@ -2743,6 +2769,10 @@ def run_moe_test(
         permute_info, scores = routing_reference_sigmoid_renorm(
             expert_logits, top_k, num_experts, padding, norm_topk_prob=norm_topk_prob
         )
+    elif routing_method_type == RoutingMethodType.MiniMax2:
+        permute_info, scores = routing_reference_minimax2(
+            expert_logits, routing_bias, top_k, num_experts, padding
+        )
     elif routing_method_type == RoutingMethodType.Llama4:
         permute_info, scores = routing_reference_no_aux(
             expert_logits,
@@ -2999,6 +3029,28 @@ def run_moe_test(
                 "enable_autotune": False,
             },
             id="SigmoidRenorm_128e_top8",
+        ),
+        pytest.param(
+            {
+                "num_experts": 256,
+                "top_k": 6,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": None,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.MiniMax2,
+                "compatible_moe_impls": [
+                    FP8PerTensorMoe,
+                    FP8BlockScaleMoe,
+                    FP4Moe,
+                    BF16Moe,
+                    MxInt4BlockScaleMoe,
+                ],
+                "compatible_intermediate_size": [384, 768, 1024],
+                "enable_autotune": False,
+            },
+            id="MiniMax2_256e_top6",
         ),
     ],
 )
@@ -3992,6 +4044,22 @@ def test_tier_1024_experts_routing(
                 "enable_autotune": False,
             },
             id="SigmoidRenorm_128e",
+        ),
+        pytest.param(
+            {
+                "num_experts": 256,
+                "top_k": 6,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": None,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.MiniMax2,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="MiniMax2_256e",
         ),
     ],
 )


### PR DESCRIPTION
…PdlOverlapWithNext;Remove DeepSeekV3 float32 logits constraint from kernel launchers

<!-- .github/pull_request_template.md -->

## 📌 Description

1. Add dynamic block kernel (`routingIndicesDynBlockKernel`) comes from the TensorRT-LLM. https://github.com/NVIDIA/TensorRT-LLM/pull/12456/ . Made related modification by refactoring  `LAUNCH_ROUTING_CUSTOM` with `dispatchRoutingPolicy` and `queryDispatchedMaxExperts`
2. Simplify PDL (Programmatic Dependent Launch) for routing kernels, as the bug related to PDL is solved.
3. Added a default fallback tier (`Tier<1024, 32>`) to support future models with >512 experts using the DeepSeek nGroup≤1 / MiniMax2 routing policy.
4. Remove DeepSeekV3 float32 logits constraint
5. Improve policy tier dispatch error messages

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests
```
python -m pytest tests/moe/test_trtllm_gen_fused_moe.py -k "test_dyn_block_kernel_routing or test_tier_1024_experts_routing" -xvs
python3 -m pytest tests/moe/test_trtllm_gen_fused_moe.py -k "test_routing_dtype_flexibility" -xvs
```


- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic single-block routing for small token/expert workloads to improve performance.

* **Improvements**
  * Added a 1024-expert policy tier and clearer tier-dispatch diagnostics.
  * More flexible routing/logits dtype handling and simplified kernel overlap/launch synchronization.
  * Automatic histogram-thread sizing and removal of legacy cluster-size/overlap public flags.
  * Autotuner now initializes packed TopK with per-token unique expert IDs.

* **Tests**
  * Added tests for dynamic-block routing, 1024-expert tier, MiniMax2 routing, and routing dtype combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->