### PR TITLE
README: update for Jetson Thor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ High-Performance GPU Kernels for Inference
 | Ampere | SM 8.0, 8.6 | A100, A10, RTX 30 series |
 | Ada Lovelace | SM 8.9 | L4, L40, RTX 40 series |
 | Hopper | SM 9.0 | H100, H200 |
-| Blackwell | SM 10.0, 10.3 | B200, B300 |
-| Blackwell | SM 12.0, 12.1 | RTX 50 series, DGX Spark, Jetson Thor |
+| Blackwell | SM 10.0, 10.3, 11.0 | B200, B300, Jetson Thor |
+| Blackwell | SM 12.0, 12.1 | RTX 50 series, DGX Spark |
 
 > **Note:** Not all features are supported across all compute capabilities.
 


### PR DESCRIPTION
Tegra Thor was formerly sm_101 and is sm_110 in CUDA 13.0 onwards.

It uses the tcgen05 tensor core design with tensor memory instead of the `mma.sync` one present on sm_12x.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated GPU support matrix for Blackwell architecture with expanded compute capability coverage
  * Reorganized supported GPU examples, including refined placement of Jetson Thor and RTX 50 series GPUs across architecture configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->