### PR TITLE
[feat] Faster topk algorithm

### DIFF
--- a/benchmarks/bench_topk.py
+++ b/benchmarks/bench_topk.py
@@ -870,11 +870,11 @@ def main():
                 f"{'FlashInfer':>12} {'FlashInfer(det)':>14} {'DetSlowdown':>11}"
             )
         else:
-            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12} {'Clusters':>12} {'Speedup':>10}"
+            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12} {'Clusters':>12} {'Speedup Clusters vs. Default':>29}"
         if args.compare_sglang:
             header += f" {'SGLang':>12} {'Speedup':>10}"
         print(header)
-        divider_len = 87 if args.deterministic else 90
+        divider_len = 87 if args.deterministic else 109
         if args.compare_sglang:
             divider_len += 24
         print("-" * divider_len)
@@ -907,7 +907,7 @@ def main():
                                 f"{result['flashinfer_us']:>10.2f}us"
                             )
                             if "fast_topk_us" in result:
-                                line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>9.2f}x"
+                                line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>28.2f}x"
                         if "sglang_us" in result:
                             line += (
                                 f" {result['sglang_us']:>10.2f}us "
@@ -947,11 +947,11 @@ def main():
                 f"{'FlashInfer':>12} {'FlashInfer(det)':>14} {'DetSlowdown':>11}"
             )
         else:
-            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12} {'Clusters':>12} {'Speedup':>10}"
+            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12} {'Clusters':>12} {'Speedup Clusters vs. Default':>29}"
         if args.compare_sglang:
             header += f" {'SGLang':>12} {'Speedup':>10}"
         print(header)
-        divider_len = 87 if args.deterministic else 90
+        divider_len = 87 if args.deterministic else 109
         if args.compare_sglang:
             divider_len += 24
         print("-" * divider_len)
@@ -984,7 +984,7 @@ def main():
                                 f"{result['flashinfer_us']:>10.2f}us"
                             )
                             if "fast_topk_us" in result:
-                                line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>9.2f}x"
+                                line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>28.2f}x"
                         if "sglang_us" in result:
                             line += (
                                 f" {result['sglang_us']:>10.2f}us "

--- a/benchmarks/bench_topk.py
+++ b/benchmarks/bench_topk.py
@@ -384,7 +384,9 @@ def bench_page_table_transform(
     # FlashInfer clusters
     set_topk_algo("clusters")
     measurements = bench_gpu_time(
-        lambda: flashinfer.top_k_page_table_transform(scores, src_page_table, lengths, k),
+        lambda: flashinfer.top_k_page_table_transform(
+            scores, src_page_table, lengths, k
+        ),
         enable_cupti=enable_cupti,
         dry_run_iters=10,
         repeat_iters=100,

--- a/benchmarks/bench_topk.py
+++ b/benchmarks/bench_topk.py
@@ -64,6 +64,7 @@ def bench_median_ms(fn) -> float:
         enable_cupti=True,
         dry_run_iters=10,
         repeat_iters=100,
+        use_cuda_graph=True,
     )
     return float(np.median(measurements))
 
@@ -88,6 +89,7 @@ def bench_top_k_from_scores(
     """Benchmark top-k on a pre-generated score tensor."""
     batch_size, seq_len = scores.shape
 
+    set_topk_algo("default")
     fi_ms, fi_nondeterministic_ms = bench_flashinfer_modes(
         lambda deterministic_mode: flashinfer.top_k(
             scores,
@@ -121,6 +123,12 @@ def bench_top_k_from_scores(
         result["torch_deterministic_us"] = torch_det_ms * 1e3
         result["speedup_vs_torch_deterministic"] = torch_det_ms / fi_ms
 
+    set_topk_algo("clusters")
+    fast_topk_ms = bench_median_ms(lambda: flashinfer.top_k(scores, k))
+    result["fast_topk_us"] = fast_topk_ms * 1e3
+    result["speedup_vs_flashinfer"] = fi_ms / fast_topk_ms
+    set_topk_algo("auto")
+
     # SGLang comparison (only supports k=2048 and float32)
     if (
         compare_sglang
@@ -130,7 +138,7 @@ def bench_top_k_from_scores(
     ):
         lengths = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
         sg_ms = bench_median_ms(
-            lambda: sgl_kernel.fast_topk_v2(scores, lengths, k, row_starts=None),
+            lambda: sgl_kernel.fast_topk_v2(scores, lengths, k, row_starts=None)
         )
         result["sglang_us"] = sg_ms * 1e3
         result["speedup_vs_sglang"] = sg_ms / fi_ms
@@ -345,7 +353,10 @@ def bench_page_table_transform(
         .expand(batch_size, -1)
         .contiguous()
     )
+    use_cuda_graph = True
+    enable_cupti = True
 
+    set_topk_algo("default")
     fi_ms, fi_nondeterministic_ms = bench_flashinfer_modes(
         lambda deterministic_mode: flashinfer.top_k_page_table_transform(
             scores,
@@ -370,13 +381,27 @@ def bench_page_table_transform(
             fi_ms / fi_nondeterministic_ms
         )
 
+    # FlashInfer clusters
+    set_topk_algo("clusters")
+    measurements = bench_gpu_time(
+        lambda: flashinfer.top_k_page_table_transform(scores, src_page_table, lengths, k),
+        enable_cupti=enable_cupti,
+        dry_run_iters=10,
+        repeat_iters=100,
+        use_cuda_graph=use_cuda_graph,
+    )
+    fast_topk_ms = np.median(measurements)
+    result["fast_topk_us"] = fast_topk_ms * 1e3
+    result["speedup_vs_flashinfer"] = fi_ms / fast_topk_ms
+    set_topk_algo("auto")
+
     # SGLang comparison (only supports k=2048 and float32)
     if compare_sglang and HAS_SGL_KERNEL and k == 2048 and dtype == torch.float32:
         cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda")
         sg_ms = bench_median_ms(
             lambda: sgl_kernel.fast_topk_transform_fused(
                 scores, lengths, src_page_table, cu_seqlens_q, k
-            ),
+            )
         )
         result["sglang_us"] = sg_ms * 1e3
         result["speedup_vs_sglang"] = sg_ms / fi_ms
@@ -399,7 +424,10 @@ def bench_ragged_transform(
     offsets = torch.arange(
         0, batch_size * seq_len, seq_len, device="cuda", dtype=torch.int32
     )
+    use_cuda_graph = True
+    enable_cupti = True
 
+    set_topk_algo("default")
     fi_ms, fi_nondeterministic_ms = bench_flashinfer_modes(
         lambda deterministic_mode: flashinfer.top_k_ragged_transform(
             scores,
@@ -424,12 +452,26 @@ def bench_ragged_transform(
             fi_ms / fi_nondeterministic_ms
         )
 
+    # FlashInfer clusters
+    set_topk_algo("clusters")
+    measurements = bench_gpu_time(
+        lambda: flashinfer.top_k_ragged_transform(scores, offsets, lengths, k),
+        enable_cupti=enable_cupti,
+        dry_run_iters=10,
+        repeat_iters=100,
+        use_cuda_graph=use_cuda_graph,
+    )
+    fast_topk_ms = np.median(measurements)
+    result["fast_topk_us"] = fast_topk_ms * 1e3
+    result["speedup_vs_flashinfer"] = fi_ms / fast_topk_ms
+    set_topk_algo("auto")
+
     # SGLang comparison (only supports k=2048 and float32)
     if compare_sglang and HAS_SGL_KERNEL and k == 2048 and dtype == torch.float32:
         sg_ms = bench_median_ms(
             lambda: sgl_kernel.fast_topk_transform_ragged_fused(
                 scores, lengths, offsets, k
-            ),
+            )
         )
         result["sglang_us"] = sg_ms * 1e3
         result["speedup_vs_sglang"] = sg_ms / fi_ms
@@ -826,13 +868,13 @@ def main():
                 f"{'FlashInfer':>12} {'FlashInfer(det)':>14} {'DetSlowdown':>11}"
             )
         else:
-            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12}"
+            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12} {'Clusters':>12} {'Speedup':>10}"
         if args.compare_sglang:
             header += f" {'SGLang':>12} {'Speedup':>10}"
         print(header)
-        divider_len = 87 if args.deterministic else 70
+        divider_len = 87 if args.deterministic else 90
         if args.compare_sglang:
-            divider_len += 20
+            divider_len += 24
         print("-" * divider_len)
 
         for batch_size in batch_sizes:
@@ -862,6 +904,8 @@ def main():
                                 f"{result['batch_size']:>6} {result['seq_len']:>10} {result['k']:>6} | "
                                 f"{result['flashinfer_us']:>10.2f}us"
                             )
+                            if "fast_topk_us" in result:
+                                line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>9.2f}x"
                         if "sglang_us" in result:
                             line += (
                                 f" {result['sglang_us']:>10.2f}us "
@@ -901,13 +945,13 @@ def main():
                 f"{'FlashInfer':>12} {'FlashInfer(det)':>14} {'DetSlowdown':>11}"
             )
         else:
-            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12}"
+            header = f"{'batch':>6} {'seq_len':>10} {'k':>6} | {'FlashInfer':>12} {'Clusters':>12} {'Speedup':>10}"
         if args.compare_sglang:
             header += f" {'SGLang':>12} {'Speedup':>10}"
         print(header)
-        divider_len = 87 if args.deterministic else 70
+        divider_len = 87 if args.deterministic else 90
         if args.compare_sglang:
-            divider_len += 20
+            divider_len += 24
         print("-" * divider_len)
 
         for batch_size in batch_sizes:
@@ -937,6 +981,8 @@ def main():
                                 f"{result['batch_size']:>6} {result['seq_len']:>10} {result['k']:>6} | "
                                 f"{result['flashinfer_us']:>10.2f}us"
                             )
+                            if "fast_topk_us" in result:
+                                line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>9.2f}x"
                         if "sglang_us" in result:
                             line += (
                                 f" {result['sglang_us']:>10.2f}us "

--- a/benchmarks/bench_topk.py
+++ b/benchmarks/bench_topk.py
@@ -681,13 +681,14 @@ def main():
             header = (
                 f"{'batch':>6} {'seq_len':>10} {'k':>6} | "
                 f"{'FlashInfer':>12} {'torch.topk':>12} {'Speedup':>10}"
+                f" {'Clusters':>12} {'Speedup Clusters vs. Default':>29}"
             )
         if args.compare_torch_deterministic and not args.deterministic:
             header += f" {'torch.det':>12} {'Speedup':>10}"
         if args.compare_sglang:
             header += f" {'SGLang':>12} {'Speedup':>10}"
         print(header)
-        divider_len = 96 if args.deterministic else 72
+        divider_len = 96 if args.deterministic else 115
         if args.compare_torch_deterministic and not args.deterministic:
             divider_len += 24
         if args.compare_sglang:
@@ -721,6 +722,8 @@ def main():
                         f"{result['flashinfer_us']:>12.2f}us {result['torch_us']:>10.2f}us "
                         f"{result['speedup_vs_torch']:>9.2f}x"
                     )
+                    if "fast_topk_us" in result:
+                        line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>28.2f}x"
                 if "torch_deterministic_us" in result:
                     line += (
                         f" {result['torch_deterministic_us']:>10.2f}us "
@@ -777,11 +780,12 @@ def main():
             header = (
                 f"{'case':>24} {'rows':>8} {'seq_len':>10} {'k':>6} | "
                 f"{'FlashInfer':>12} {'torch.topk':>12} {'Speedup':>10}"
+                f" {'Clusters':>12} {'Speedup Clusters vs. Default':>29}"
             )
         if args.compare_torch_deterministic and not args.deterministic:
             header += f" {'torch.det':>12} {'Speedup':>10}"
         print(header)
-        divider_len = 110 if args.deterministic else 86
+        divider_len = 110 if args.deterministic else 129
         if args.compare_torch_deterministic and not args.deterministic:
             divider_len += 24
         print("-" * divider_len)
@@ -832,6 +836,8 @@ def main():
                         f"{result['flashinfer_us']:>10.2f}us {result['torch_us']:>10.2f}us "
                         f"{result['speedup_vs_torch']:>9.2f}x"
                     )
+                    if "fast_topk_us" in result:
+                        line += f" {result['fast_topk_us']:>10.2f}us {result['speedup_vs_flashinfer']:>28.2f}x"
                 if "torch_deterministic_us" in result:
                     line += (
                         f" {result['torch_deterministic_us']:>10.2f}us "

--- a/csrc/flashinfer_fast_topk_clusters_binding.cu
+++ b/csrc/flashinfer_fast_topk_clusters_binding.cu
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdint>
+#include <flashinfer/fast_topk_clusters_exact.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Optional;
+
+void fast_topk_clusters_exact(TensorView logits, TensorView indices,
+                              Optional<TensorView> output_values, Optional<TensorView> histogram,
+                              TensorView cached_overflow, int64_t TopK, int64_t num_cached,
+                              int64_t num_clusters, bool pdl_enabled) {
+  CHECK_DIM(2, logits);   // input: (batch_size, seq_len)
+  CHECK_DIM(2, indices);  // output_indices: (batch_size, top_k)
+  const int batch_size = static_cast<int>(logits.size(0));
+  const int seq_len = static_cast<int>(logits.size(1));
+
+  const int* hist_ptr = nullptr;
+  if (histogram.has_value()) {
+    hist_ptr = static_cast<const int*>(histogram.value().data_ptr());
+  }
+
+  const void* values_ptr = nullptr;
+  if (output_values.has_value()) {
+    values_ptr = static_cast<const void*>(output_values.value().data_ptr());
+  }
+
+  const int logit_stride = static_cast<int>(logits.stride(0));
+  const int indices_stride = static_cast<int>(indices.stride(0));
+  const int n_clusters = static_cast<int>(num_clusters);
+  cudaStream_t stream = get_current_stream();
+  const int ovf_stride = static_cast<int>(cached_overflow.stride(0)) / (4 * n_clusters);
+
+  auto dtype = logits.dtype();
+
+  auto idx_dtype = indices.dtype();
+  TVM_FFI_ICHECK(idx_dtype.code == kDLInt && (idx_dtype.bits == 32 || idx_dtype.bits == 64))
+      << "indices must be int32 or int64, got code=" << idx_dtype.code
+      << " bits=" << idx_dtype.bits;
+  const bool idx_int64 = (idx_dtype.bits == 64);
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP32_FP16(dtype, c_type, [&] {
+    if (idx_int64) {
+      launch_fast_topk_clusters_exact<c_type, int64_t>(
+          static_cast<const c_type*>(logits.data_ptr()), static_cast<int64_t*>(indices.data_ptr()),
+          (c_type*)const_cast<void*>(values_ptr), seq_len, const_cast<int*>(hist_ptr),
+          static_cast<int*>(cached_overflow.data_ptr()), ovf_stride, batch_size, logit_stride,
+          indices_stride, static_cast<int>(num_cached), n_clusters, pdl_enabled,
+          static_cast<int>(TopK), stream);
+    } else {
+      launch_fast_topk_clusters_exact<c_type, int>(
+          static_cast<const c_type*>(logits.data_ptr()), static_cast<int*>(indices.data_ptr()),
+          (c_type*)const_cast<void*>(values_ptr), seq_len, const_cast<int*>(hist_ptr),
+          static_cast<int*>(cached_overflow.data_ptr()), ovf_stride, batch_size, logit_stride,
+          indices_stride, static_cast<int>(num_cached), n_clusters, pdl_enabled,
+          static_cast<int>(TopK), stream);
+    }
+    return true;
+  });
+  auto err = cudaGetLastError();
+  TVM_FFI_ICHECK(err == cudaSuccess)
+      << "launch_fast_topk_clusters_exact failed: " << cudaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fast_topk_clusters_exact, fast_topk_clusters_exact);
+
+void fast_topk_clusters_exact_page_table_transform(TensorView logits, TensorView indices,
+                                                   TensorView seq_lens, TensorView page_table,
+                                                   Optional<TensorView> histogram,
+                                                   TensorView cached_overflow, int64_t TopK,
+                                                   int64_t num_cached, int64_t num_clusters,
+                                                   bool pdl_enabled) {
+  CHECK_DIM(2, logits);
+  CHECK_DIM(2, indices);
+  CHECK_DIM(1, seq_lens);
+  CHECK_DIM(2, page_table);
+  const int batch_size = static_cast<int>(logits.size(0));
+
+  const int* hist_ptr = nullptr;
+  if (histogram.has_value()) {
+    hist_ptr = static_cast<const int*>(histogram.value().data_ptr());
+  }
+
+  const int logit_stride = static_cast<int>(logits.stride(0));
+  const int indices_stride = static_cast<int>(indices.stride(0));
+  const int page_table_stride = static_cast<int>(page_table.stride(0));
+  const int n_clusters = static_cast<int>(num_clusters);
+  const int ovf_stride = static_cast<int>(cached_overflow.stride(0)) / (4 * n_clusters);
+  cudaStream_t stream = get_current_stream();
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP32_FP16(logits.dtype(), c_type, [&] {
+    launch_fast_topk_clusters_exact_page_table_transform<c_type>(
+        static_cast<const c_type*>(logits.data_ptr()), static_cast<int*>(indices.data_ptr()),
+        static_cast<int*>(seq_lens.data_ptr()), static_cast<int*>(page_table.data_ptr()),
+        const_cast<int*>(hist_ptr), static_cast<int*>(cached_overflow.data_ptr()), ovf_stride,
+        batch_size, logit_stride, indices_stride, page_table_stride, static_cast<int>(num_cached),
+        n_clusters, pdl_enabled, static_cast<int>(TopK), stream);
+    return true;
+  });
+  auto err = cudaGetLastError();
+  TVM_FFI_ICHECK(err == cudaSuccess)
+      << "launch_fast_topk_clusters_exact_page_table_transform failed: " << cudaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fast_topk_clusters_exact_page_table_transform,
+                              fast_topk_clusters_exact_page_table_transform);
+
+void fast_topk_clusters_exact_ragged_transform(TensorView logits, TensorView indices,
+                                               TensorView seq_lens, TensorView offsets,
+                                               Optional<TensorView> histogram,
+                                               TensorView cached_overflow, int64_t TopK,
+                                               int64_t num_cached, int64_t num_clusters,
+                                               bool pdl_enabled) {
+  CHECK_DIM(2, logits);
+  CHECK_DIM(2, indices);
+  CHECK_DIM(1, seq_lens);
+  CHECK_DIM(1, offsets);
+  const int batch_size = static_cast<int>(logits.size(0));
+
+  const int* hist_ptr = nullptr;
+  if (histogram.has_value()) {
+    hist_ptr = static_cast<const int*>(histogram.value().data_ptr());
+  }
+
+  const int logit_stride = static_cast<int>(logits.stride(0));
+  const int indices_stride = static_cast<int>(indices.stride(0));
+  const int n_clusters = static_cast<int>(num_clusters);
+  const int ovf_stride = static_cast<int>(cached_overflow.stride(0)) / (4 * n_clusters);
+  cudaStream_t stream = get_current_stream();
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP32_FP16(logits.dtype(), c_type, [&] {
+    launch_fast_topk_clusters_exact_ragged_transform<c_type>(
+        static_cast<const c_type*>(logits.data_ptr()), static_cast<int*>(indices.data_ptr()),
+        static_cast<int*>(seq_lens.data_ptr()), static_cast<int*>(offsets.data_ptr()),
+        const_cast<int*>(hist_ptr), static_cast<int*>(cached_overflow.data_ptr()), ovf_stride,
+        batch_size, logit_stride, indices_stride, static_cast<int>(num_cached), n_clusters,
+        pdl_enabled, static_cast<int>(TopK), stream);
+    return true;
+  });
+  auto err = cudaGetLastError();
+  TVM_FFI_ICHECK(err == cudaSuccess)
+      << "launch_fast_topk_clusters_exact_ragged_transform failed: " << cudaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fast_topk_clusters_exact_ragged_transform,
+                              fast_topk_clusters_exact_ragged_transform);

--- a/csrc/flashinfer_fast_topk_clusters_binding.cu
+++ b/csrc/flashinfer_fast_topk_clusters_binding.cu
@@ -29,14 +29,14 @@ void fast_topk_clusters_exact(TensorView logits, TensorView indices,
   const int batch_size = static_cast<int>(logits.size(0));
   const int seq_len = static_cast<int>(logits.size(1));
 
-  const int* hist_ptr = nullptr;
+  int* hist_ptr = nullptr;
   if (histogram.has_value()) {
-    hist_ptr = static_cast<const int*>(histogram.value().data_ptr());
+    hist_ptr = (int*)histogram.value().data_ptr();
   }
 
-  const void* values_ptr = nullptr;
+  void* values_ptr = nullptr;
   if (output_values.has_value()) {
-    values_ptr = static_cast<const void*>(output_values.value().data_ptr());
+    values_ptr = (output_values.value().data_ptr());
   }
 
   const int logit_stride = static_cast<int>(logits.stride(0));
@@ -57,17 +57,15 @@ void fast_topk_clusters_exact(TensorView logits, TensorView indices,
     if (idx_int64) {
       launch_fast_topk_clusters_exact<c_type, int64_t>(
           static_cast<const c_type*>(logits.data_ptr()), static_cast<int64_t*>(indices.data_ptr()),
-          (c_type*)const_cast<void*>(values_ptr), seq_len, const_cast<int*>(hist_ptr),
-          static_cast<int*>(cached_overflow.data_ptr()), ovf_stride, batch_size, logit_stride,
-          indices_stride, static_cast<int>(num_cached), n_clusters, pdl_enabled,
-          static_cast<int>(TopK), stream);
+          (c_type*)(values_ptr), seq_len, (hist_ptr), static_cast<int*>(cached_overflow.data_ptr()),
+          ovf_stride, batch_size, logit_stride, indices_stride, static_cast<int>(num_cached),
+          n_clusters, pdl_enabled, static_cast<int>(TopK), stream);
     } else {
       launch_fast_topk_clusters_exact<c_type, int>(
           static_cast<const c_type*>(logits.data_ptr()), static_cast<int*>(indices.data_ptr()),
-          (c_type*)const_cast<void*>(values_ptr), seq_len, const_cast<int*>(hist_ptr),
-          static_cast<int*>(cached_overflow.data_ptr()), ovf_stride, batch_size, logit_stride,
-          indices_stride, static_cast<int>(num_cached), n_clusters, pdl_enabled,
-          static_cast<int>(TopK), stream);
+          (c_type*)(values_ptr), seq_len, (hist_ptr), static_cast<int*>(cached_overflow.data_ptr()),
+          ovf_stride, batch_size, logit_stride, indices_stride, static_cast<int>(num_cached),
+          n_clusters, pdl_enabled, static_cast<int>(TopK), stream);
     }
     return true;
   });

--- a/csrc/flashinfer_fast_topk_clusters_binding.cu
+++ b/csrc/flashinfer_fast_topk_clusters_binding.cu
@@ -19,6 +19,7 @@
 #include "tvm_ffi_utils.h"
 
 using tvm::ffi::Optional;
+using namespace flashinfer::sampling;
 
 void fast_topk_clusters_exact(TensorView logits, TensorView indices,
                               Optional<TensorView> output_values, Optional<TensorView> histogram,

--- a/flashinfer/jit/topk.py
+++ b/flashinfer/jit/topk.py
@@ -24,5 +24,7 @@ def gen_topk_module() -> JitSpec:
         [
             jit_env.FLASHINFER_CSRC_DIR / "topk.cu",
             jit_env.FLASHINFER_CSRC_DIR / "flashinfer_topk_binding.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "flashinfer_fast_topk_clusters_binding.cu",
         ],
+        extra_cuda_cflags=["-lineinfo"],
     )

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -1210,6 +1210,7 @@ def bench_gpu_time_with_cupti(
     for _ in range(repeat_iters):
         if _do_l2_flush:
             buffer.zero_()
+        torch.cuda.synchronize()
         start_cpu = cupti.get_timestamp()
         runner()
         end_cpu = cupti.get_timestamp()

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import os
 from types import SimpleNamespace
 from typing import Optional, Tuple
 
@@ -71,6 +72,132 @@ def get_topk_module():
     ) -> torch.Tensor:
         batch_size = input.size(0)
         return torch.empty(batch_size, top_k, dtype=torch.int32, device=input.device)
+
+    @register_custom_op(
+        "flashinfer::fast_topk_clusters_exact", mutates_args=("indices",)
+    )
+    def _fast_topk_clusters_exact(
+        logits: torch.Tensor,
+        indices: torch.Tensor,
+        output_values: Optional[torch.Tensor],
+        histogram: Optional[torch.Tensor],
+        cached_overflow: torch.Tensor,
+        top_k: int,
+        num_cached: int,
+        num_clusters: int,
+        pdl_enabled: bool,
+    ) -> None:
+        module.fast_topk_clusters_exact(
+            logits,
+            indices,
+            output_values,
+            histogram,
+            cached_overflow,
+            top_k,
+            num_cached,
+            num_clusters,
+            pdl_enabled,
+        )
+
+    @register_fake_op("flashinfer::fast_topk_clusters_exact")
+    def _fake_fast_topk_clusters_exact(
+        logits: torch.Tensor,
+        indices: torch.Tensor,
+        output_values: Optional[torch.Tensor],
+        histogram: Optional[torch.Tensor],
+        cached_overflow: torch.Tensor,
+        top_k: int,
+        num_cached: int,
+        num_clusters: int,
+        pdl_enabled: bool,
+    ) -> None:
+        pass
+
+    @register_custom_op(
+        "flashinfer::fast_topk_clusters_exact_page_table_transform", mutates_args=("indices",)
+    )
+    def _fast_topk_clusters_exact_page_table_transform(
+        logits: torch.Tensor,
+        indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        page_table: torch.Tensor,
+        histogram: Optional[torch.Tensor],
+        cached_overflow: torch.Tensor,
+        top_k: int,
+        num_cached: int,
+        num_clusters: int,
+        pdl_enabled: bool,
+    ) -> None:
+        module.fast_topk_clusters_exact_page_table_transform(
+            logits,
+            indices,
+            seq_lens,
+            page_table,
+            histogram,
+            cached_overflow,
+            top_k,
+            num_cached,
+            num_clusters,
+            pdl_enabled,
+        )
+
+    @register_fake_op("flashinfer::fast_topk_clusters_exact_page_table_transform")
+    def _fake_fast_topk_clusters_exact_page_table_transform(
+        logits: torch.Tensor,
+        indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        page_table: torch.Tensor,
+        histogram: Optional[torch.Tensor],
+        cached_overflow: torch.Tensor,
+        top_k: int,
+        num_cached: int,
+        num_clusters: int,
+        pdl_enabled: bool,
+    ) -> None:
+        pass
+
+    @register_custom_op(
+        "flashinfer::fast_topk_clusters_exact_ragged_transform", mutates_args=("indices",)
+    )
+    def _fast_topk_clusters_exact_ragged_transform(
+        logits: torch.Tensor,
+        indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        offsets: torch.Tensor,
+        histogram: Optional[torch.Tensor],
+        cached_overflow: torch.Tensor,
+        top_k: int,
+        num_cached: int,
+        num_clusters: int,
+        pdl_enabled: bool,
+    ) -> None:
+        module.fast_topk_clusters_exact_ragged_transform(
+            logits,
+            indices,
+            seq_lens,
+            offsets,
+            histogram,
+            cached_overflow,
+            top_k,
+            num_cached,
+            num_clusters,
+            pdl_enabled,
+        )
+
+    @register_fake_op("flashinfer::fast_topk_clusters_exact_ragged_transform")
+    def _fake_fast_topk_clusters_exact_ragged_transform(
+        logits: torch.Tensor,
+        indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        offsets: torch.Tensor,
+        histogram: Optional[torch.Tensor],
+        cached_overflow: torch.Tensor,
+        top_k: int,
+        num_cached: int,
+        num_clusters: int,
+        pdl_enabled: bool,
+    ) -> None:
+        pass
 
     @register_custom_op(
         "flashinfer::radix_topk_page_table_transform",
@@ -156,6 +283,9 @@ def get_topk_module():
         radix_topk_page_table_transform=radix_topk_page_table_transform,
         radix_topk_ragged_transform=radix_topk_ragged_transform,
         can_implement_filtered_topk=module.can_implement_filtered_topk,
+        fast_topk_clusters_exact=_fast_topk_clusters_exact,
+        fast_topk_clusters_exact_page_table_transform=_fast_topk_clusters_exact_page_table_transform,
+        fast_topk_clusters_exact_ragged_transform=_fast_topk_clusters_exact_ragged_transform,
     )
 
 
@@ -171,6 +301,108 @@ def can_implement_filtered_topk() -> bool:
         True if GPU supports FilteredTopK, False otherwise.
     """
     return get_topk_module().can_implement_filtered_topk()
+
+
+def get_fast_topk_clusters(batch_size: int) -> int:
+    # low batch size, allocate more clusters to get more parallelism
+    # high batch size, more parallelism available per row
+    if batch_size <= 32:
+        return 8
+    elif batch_size < 128:
+        return 4
+    elif batch_size < 256:
+        return 2
+    else:
+        return 1
+
+
+def topk_clusters_exact(logits, top_k, output_values=False, out_dtype=torch.int32, pdl=False):
+    assert out_dtype in (torch.int32, torch.int64), "out_dtype must be torch.int32 or torch.int64"
+    batch_size, max_model_len = logits.shape
+    indices = torch.empty(batch_size, top_k, dtype=out_dtype, device=logits.device)
+    num_clusters = get_fast_topk_clusters(batch_size)
+    if max_model_len < 8192:
+        num_clusters = 1
+    topk_global_overflow = max_model_len // num_clusters
+    overflow_buf = torch.empty(
+        batch_size,
+        4 * topk_global_overflow * num_clusters,
+        device=logits.device,
+        dtype=torch.int32,
+    )
+    output_vals = None
+    if output_values:
+        output_vals = torch.empty(
+            batch_size, top_k, dtype=logits.dtype, device=logits.device
+        )
+    get_topk_module().fast_topk_clusters_exact(
+        logits,
+        indices,
+        output_vals,
+        None,   # histogram
+        overflow_buf,
+        top_k,
+        4100,   # num_cached
+        num_clusters,
+        pdl,
+    )
+    return indices, output_vals
+
+
+def topk_clusters_page_table_transform(logits, seq_lens, src_page_table, top_k, pdl=False):
+    batch_size, max_model_len = logits.shape
+    indices = torch.empty(batch_size, top_k, dtype=torch.int32, device=logits.device)
+    num_clusters = get_fast_topk_clusters(batch_size)
+    if max_model_len < 8192:
+        num_clusters = 1
+    topk_global_overflow = max_model_len // num_clusters
+    overflow_buf = torch.empty(
+        batch_size,
+        4 * topk_global_overflow * num_clusters,
+        device=logits.device,
+        dtype=torch.int32,
+    )
+    get_topk_module().fast_topk_clusters_exact_page_table_transform(
+        logits,
+        indices,
+        seq_lens,
+        src_page_table,
+        None,   # histogram
+        overflow_buf,
+        top_k,
+        4196,   # num_cached
+        num_clusters,
+        pdl,
+    )
+    return indices
+
+
+def topk_clusters_ragged_transform(logits, seq_lens, offsets, top_k, pdl=False):
+    batch_size, max_model_len = logits.shape
+    indices = torch.empty(batch_size, top_k, dtype=torch.int32, device=logits.device)
+    num_clusters = get_fast_topk_clusters(batch_size)
+    if max_model_len < 8192:
+        num_clusters = 1
+    topk_global_overflow = max_model_len // num_clusters
+    overflow_buf = torch.empty(
+        batch_size,
+        4 * topk_global_overflow * num_clusters,
+        device=logits.device,
+        dtype=torch.int32,
+    )
+    get_topk_module().fast_topk_clusters_exact_ragged_transform(
+        logits,
+        indices,
+        seq_lens,
+        offsets,
+        None,   # histogram
+        overflow_buf,
+        top_k,
+        4196,   # num_cached
+        num_clusters,
+        pdl,
+    )
+    return indices
 
 
 @flashinfer_api
@@ -253,6 +485,17 @@ def top_k(
     """
     batch_size = input.size(0)
     device = input.device
+
+    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
+    if algo is None or algo == "clusters" and not deterministic:
+        indices, output_values = topk_clusters_exact(
+            input, k, output_values=True, out_dtype=torch.int64
+        )
+        if sorted:
+            sorted_values, sort_indices = torch.sort(output_values, dim=-1, descending=True)
+            sorted_indices = torch.gather(indices, dim=-1, index=sort_indices)
+            return sorted_values, sorted_indices
+        return output_values, indices
 
     # Allocate row_states buffer for multi-CTA path
     # 1MB is enough for any reasonable GPU (covers up to ~200 groups for deterministic
@@ -361,6 +604,10 @@ def top_k_page_table_transform(
     device = input.device
     num_rows = input.size(0)
 
+    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
+    if (algo is None or algo == "clusters") and row_to_batch is None and not deterministic:
+        return topk_clusters_page_table_transform(input, lengths, src_page_table, k)
+
     # Allocate row_states buffer for multi-CTA path
     row_states_buffer: Optional[torch.Tensor] = _get_cache_buf(
         f"radix_topk_row_states_{device}",
@@ -448,6 +695,10 @@ def top_k_ragged_transform(
     """
     device = input.device
     num_rows = input.size(0)
+
+    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
+    if algo is None or algo == "clusters" and not deterministic:
+        return topk_clusters_ragged_transform(input, lengths, offsets, k)
 
     # Allocate row_states buffer for multi-CTA path
     row_states_buffer: Optional[torch.Tensor] = _get_cache_buf(

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -23,7 +23,12 @@ import torch
 
 from .api_logging import flashinfer_api
 from .jit.topk import gen_topk_module
-from .utils import _get_cache_buf, register_custom_op, register_fake_op
+from .utils import (
+    _get_cache_buf,
+    register_custom_op,
+    register_fake_op,
+    get_shared_bytes_per_block_optin,
+)
 
 
 @functools.cache
@@ -306,6 +311,25 @@ def can_implement_filtered_topk() -> bool:
     return get_topk_module().can_implement_filtered_topk()
 
 
+def roundup_kbyte(x):
+    return (x + 1023) // 1024 * 1024
+
+
+@functools.cache
+def get_num_cached_for_topk(device, k):
+    regs_per_thread = 32
+    threads_per_block = 1024
+    blocks_per_sm = 65536 // (threads_per_block * regs_per_thread)
+
+    shared_per_block = (
+        get_shared_bytes_per_block_optin(device) // blocks_per_sm
+    )  # SMEM_CARVEOUT // blocks_per_sm
+
+    buffers_used = (k + 6 + 3 * 256 + 8) * 4  # other shared memory for buffers
+    # num_bytes = 2 * 2 * sizeof(int) * num_cached, double buffer on indices and values cache
+    return (shared_per_block - buffers_used - 1024) // 16
+
+
 def get_fast_topk_clusters(batch_size: int) -> int:
     # low batch size, allocate more clusters to get more parallelism
     # high batch size, more parallelism available per row
@@ -342,6 +366,8 @@ def topk_clusters_exact(
         output_vals = torch.empty(
             batch_size, top_k, dtype=logits.dtype, device=logits.device
         )
+
+    num_cached = get_num_cached_for_topk(logits.device, top_k)
     get_topk_module().fast_topk_clusters_exact(
         logits,
         indices,
@@ -349,7 +375,7 @@ def topk_clusters_exact(
         None,  # histogram
         overflow_buf,
         top_k,
-        4100,  # num_cached
+        num_cached,  # num_cached
         num_clusters,
         pdl,
     )
@@ -371,6 +397,7 @@ def topk_clusters_page_table_transform(
         device=logits.device,
         dtype=torch.int32,
     )
+    num_cached = get_num_cached_for_topk(logits.device, top_k)
     get_topk_module().fast_topk_clusters_exact_page_table_transform(
         logits,
         indices,
@@ -379,7 +406,7 @@ def topk_clusters_page_table_transform(
         None,  # histogram
         overflow_buf,
         top_k,
-        4196,  # num_cached
+        num_cached,  # num_cached
         num_clusters,
         pdl,
     )
@@ -399,6 +426,7 @@ def topk_clusters_ragged_transform(logits, seq_lens, offsets, top_k, pdl=False):
         device=logits.device,
         dtype=torch.int32,
     )
+    num_cached = get_num_cached_for_topk(logits.device, top_k)
     get_topk_module().fast_topk_clusters_exact_ragged_transform(
         logits,
         indices,
@@ -407,7 +435,7 @@ def topk_clusters_ragged_transform(logits, seq_lens, offsets, top_k, pdl=False):
         None,  # histogram
         overflow_buf,
         top_k,
-        4196,  # num_cached
+        num_cached,  # num_cached
         num_clusters,
         pdl,
     )

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -25,6 +25,7 @@ from .api_logging import flashinfer_api
 from .jit.topk import gen_topk_module
 from .utils import (
     _get_cache_buf,
+    get_compute_capability,
     register_custom_op,
     register_fake_op,
     get_shared_bytes_per_block_optin,
@@ -442,6 +443,12 @@ def topk_clusters_ragged_transform(logits, seq_lens, offsets, top_k, pdl=False):
     return indices
 
 
+def can_use_clusters_topk(device, deterministic):
+    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
+    cap = get_compute_capability(device)
+    return (algo is None or algo == "clusters") and not deterministic and cap[0] == 10
+
+
 @flashinfer_api
 def top_k(
     input: torch.Tensor,
@@ -523,8 +530,7 @@ def top_k(
     batch_size = input.size(0)
     device = input.device
 
-    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
-    if (algo is None or algo == "clusters") and not deterministic:
+    if can_use_clusters_topk(input.device, deterministic):
         indices, output_values = topk_clusters_exact(
             input, k, output_values=True, out_dtype=torch.int64
         )
@@ -643,12 +649,7 @@ def top_k_page_table_transform(
     device = input.device
     num_rows = input.size(0)
 
-    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
-    if (
-        (algo is None or algo == "clusters")
-        and row_to_batch is None
-        and not deterministic
-    ):
+    if can_use_clusters_topk(input.device, deterministic) and row_to_batch is None:
         return topk_clusters_page_table_transform(input, lengths, src_page_table, k)
 
     # Allocate row_states buffer for multi-CTA path
@@ -739,8 +740,7 @@ def top_k_ragged_transform(
     device = input.device
     num_rows = input.size(0)
 
-    algo = os.environ.get("FLASHINFER_TOPK_ALGO")
-    if (algo is None or algo == "clusters") and not deterministic:
+    if can_use_clusters_topk(input.device, deterministic):
         return topk_clusters_ragged_transform(input, lengths, offsets, k)
 
     # Allocate row_states buffer for multi-CTA path

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -496,7 +496,7 @@ def top_k(
     device = input.device
 
     algo = os.environ.get("FLASHINFER_TOPK_ALGO")
-    if algo is None or algo == "clusters" and not deterministic:
+    if (algo is None or algo == "clusters") and not deterministic:
         indices, output_values = topk_clusters_exact(
             input, k, output_values=True, out_dtype=torch.int64
         )
@@ -616,7 +616,11 @@ def top_k_page_table_transform(
     num_rows = input.size(0)
 
     algo = os.environ.get("FLASHINFER_TOPK_ALGO")
-    if (algo is None or algo == "clusters") and row_to_batch is None and not deterministic:
+    if (
+        (algo is None or algo == "clusters")
+        and row_to_batch is None
+        and not deterministic
+    ):
         return topk_clusters_page_table_transform(input, lengths, src_page_table, k)
 
     # Allocate row_states buffer for multi-CTA path
@@ -708,7 +712,7 @@ def top_k_ragged_transform(
     num_rows = input.size(0)
 
     algo = os.environ.get("FLASHINFER_TOPK_ALGO")
-    if algo is None or algo == "clusters" and not deterministic:
+    if (algo is None or algo == "clusters") and not deterministic:
         return topk_clusters_ragged_transform(input, lengths, offsets, k)
 
     # Allocate row_states buffer for multi-CTA path

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -326,7 +326,7 @@ def get_num_cached_for_topk(device, k):
         get_shared_bytes_per_block_optin(device) // blocks_per_sm
     )  # SMEM_CARVEOUT // blocks_per_sm
 
-    buffers_used = (k + 6 + 3 * 256 + 8) * 4  # other shared memory for buffers
+    buffers_used = (k + 5 + 3 * 256 + 8) * 4  # other shared memory for buffers
     # num_bytes = 2 * 2 * sizeof(int) * num_cached, double buffer on indices and values cache
     return (shared_per_block - buffers_used - 1024) // 16
 

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -74,7 +74,8 @@ def get_topk_module():
         return torch.empty(batch_size, top_k, dtype=torch.int32, device=input.device)
 
     @register_custom_op(
-        "flashinfer::fast_topk_clusters_exact", mutates_args=("indices",)
+        "flashinfer::fast_topk_clusters_exact",
+        mutates_args=("indices", "output_values", "cached_overflow"),
     )
     def _fast_topk_clusters_exact(
         logits: torch.Tensor,
@@ -114,7 +115,8 @@ def get_topk_module():
         pass
 
     @register_custom_op(
-        "flashinfer::fast_topk_clusters_exact_page_table_transform", mutates_args=("indices",)
+        "flashinfer::fast_topk_clusters_exact_page_table_transform",
+        mutates_args=("indices", "cached_overflow"),
     )
     def _fast_topk_clusters_exact_page_table_transform(
         logits: torch.Tensor,
@@ -157,7 +159,8 @@ def get_topk_module():
         pass
 
     @register_custom_op(
-        "flashinfer::fast_topk_clusters_exact_ragged_transform", mutates_args=("indices",)
+        "flashinfer::fast_topk_clusters_exact_ragged_transform",
+        mutates_args=("indices", "cached_overflow"),
     )
     def _fast_topk_clusters_exact_ragged_transform(
         logits: torch.Tensor,
@@ -316,8 +319,12 @@ def get_fast_topk_clusters(batch_size: int) -> int:
         return 1
 
 
-def topk_clusters_exact(logits, top_k, output_values=False, out_dtype=torch.int32, pdl=False):
-    assert out_dtype in (torch.int32, torch.int64), "out_dtype must be torch.int32 or torch.int64"
+def topk_clusters_exact(
+    logits, top_k, output_values=False, out_dtype=torch.int32, pdl=False
+):
+    assert out_dtype in (torch.int32, torch.int64), (
+        "out_dtype must be torch.int32 or torch.int64"
+    )
     batch_size, max_model_len = logits.shape
     indices = torch.empty(batch_size, top_k, dtype=out_dtype, device=logits.device)
     num_clusters = get_fast_topk_clusters(batch_size)
@@ -339,17 +346,19 @@ def topk_clusters_exact(logits, top_k, output_values=False, out_dtype=torch.int3
         logits,
         indices,
         output_vals,
-        None,   # histogram
+        None,  # histogram
         overflow_buf,
         top_k,
-        4100,   # num_cached
+        4100,  # num_cached
         num_clusters,
         pdl,
     )
     return indices, output_vals
 
 
-def topk_clusters_page_table_transform(logits, seq_lens, src_page_table, top_k, pdl=False):
+def topk_clusters_page_table_transform(
+    logits, seq_lens, src_page_table, top_k, pdl=False
+):
     batch_size, max_model_len = logits.shape
     indices = torch.empty(batch_size, top_k, dtype=torch.int32, device=logits.device)
     num_clusters = get_fast_topk_clusters(batch_size)
@@ -367,10 +376,10 @@ def topk_clusters_page_table_transform(logits, seq_lens, src_page_table, top_k, 
         indices,
         seq_lens,
         src_page_table,
-        None,   # histogram
+        None,  # histogram
         overflow_buf,
         top_k,
-        4196,   # num_cached
+        4196,  # num_cached
         num_clusters,
         pdl,
     )
@@ -395,10 +404,10 @@ def topk_clusters_ragged_transform(logits, seq_lens, offsets, top_k, pdl=False):
         indices,
         seq_lens,
         offsets,
-        None,   # histogram
+        None,  # histogram
         overflow_buf,
         top_k,
-        4196,   # num_cached
+        4196,  # num_cached
         num_clusters,
         pdl,
     )
@@ -492,7 +501,9 @@ def top_k(
             input, k, output_values=True, out_dtype=torch.int64
         )
         if sorted:
-            sorted_values, sort_indices = torch.sort(output_values, dim=-1, descending=True)
+            sorted_values, sort_indices = torch.sort(
+                output_values, dim=-1, descending=True
+            )
             sorted_indices = torch.gather(indices, dim=-1, index=sort_indices)
             return sorted_values, sorted_indices
         return output_values, indices

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -307,6 +307,12 @@ def get_gpu_memory_bandwidth(device: torch.device) -> float:
         pynvml.nvmlShutdown()
 
 
+@functools.cache
+def get_shared_bytes_per_block_optin(device: torch.device) -> int:
+    cap = torch.cuda.get_device_properties(device.index)
+    return cap.shared_memory_per_block_optin
+
+
 def _check_cached_qkv_data_type(
     q: torch.Tensor, k: torch.Tensor, dtype_q: torch.dtype, dtype_kv: torch.dtype
 ) -> None:

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -1,0 +1,740 @@
+
+#include <cooperative_groups.h>
+#include <cuda_fp16.h>
+
+#include <cassert>
+#include <flashinfer/vec_dtypes.cuh>
+
+namespace cg = cooperative_groups;
+using namespace flashinfer;
+
+__device__ __forceinline__ uint32_t getLaneId() {
+  uint32_t laneId;
+  asm("mov.u32 %0, %%laneid;" : "=r"(laneId));
+  return laneId;
+}
+
+template <int num_threads>
+__device__ __forceinline__ uint32_t InclusiveWarpDownScan(uint32_t val) {
+#pragma unroll
+  for (int i = 1; i <= (num_threads >> 1); i <<= 1)  // 16 = LANE_COUNT >> 1
+  {
+    const uint32_t t = __shfl_down_sync(0xffffffff, val, i, 32);
+    if (getLaneId() < num_threads - i) val += t;
+  }
+
+  return val;
+}
+
+template <auto* kernel_func, size_t smem_bytes>
+void setup_kernel_smem_once() {
+  static const cudaError_t result = []() -> cudaError_t {
+    auto func_ptr = kernel_func;
+
+    return cudaFuncSetAttribute(func_ptr, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+  }();
+}
+
+__device__ __forceinline__ int cum_sum(int* s_hist_buf) {
+  constexpr int RADIX = 256;
+  const int warp_idx = threadIdx.x / 32;
+
+  __shared__ int reduce_buf[8];
+  int val = 0;
+  if (threadIdx.x < RADIX) {
+    val = s_hist_buf[threadIdx.x];
+    val = InclusiveWarpDownScan<32>(val);
+    if (getLaneId() == 0 && warp_idx < 8) {
+      reduce_buf[warp_idx] = val;
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x < 32) {
+    int cum_val = InclusiveWarpDownScan<8>(threadIdx.x < 8 ? reduce_buf[threadIdx.x] : 0);
+    __syncwarp();
+    if (threadIdx.x < 8) {
+      reduce_buf[threadIdx.x] = cum_val;
+    }
+  }
+  __syncthreads();
+  if (warp_idx < 7) {
+    val += reduce_buf[warp_idx + 1];
+  }
+  return val;
+}
+
+struct PackedCachedData {
+  uint32_t bits;
+  int index;
+};
+
+template <typename T>
+struct OrderedBits;
+
+template <>
+struct OrderedBits<float> {
+  using DType = float;
+  using OrderedDType = uint32_t;
+  using self_t = OrderedBits<float>;
+
+  static __device__ self_t::OrderedDType to_ordered_bits(self_t::DType x) {
+    uint32_t bits = __float_as_uint(x);
+    return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+  }
+
+  static __device__ self_t::DType from_ordered_bits(self_t::OrderedDType bits) {
+    auto float_bits = (bits & 0x80000000u) ? bits ^ 0x80000000u : ~bits;
+    return __uint_as_float(float_bits);
+  }
+};
+
+template <>
+struct OrderedBits<half> {
+  using DType = half;
+  using OrderedDType = uint16_t;
+  using self_t = OrderedBits<half>;
+
+  static __device__ self_t::OrderedDType to_ordered_bits(self_t::DType x) {
+    uint16_t bits = __half_as_ushort(x);
+    uint16_t key =
+        (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+
+    return key;
+  }
+
+  static __device__ self_t::DType from_ordered_bits(self_t::OrderedDType bits) {
+    auto half_bits = (bits & 0x8000) ? bits ^ 0x8000 : ~bits;
+    return __ushort_as_half(half_bits);
+  }
+};
+
+template <>
+struct OrderedBits<nv_bfloat16> {
+  using DType = nv_bfloat16;
+  using OrderedDType = uint16_t;
+  using self_t = OrderedBits<nv_bfloat16>;
+
+  static __device__ self_t::OrderedDType to_ordered_bits(self_t::DType x) {
+    uint16_t bits = __bfloat16_as_ushort(x);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+  }
+};
+
+struct TopkResults {
+  int local_topk_num;
+  int local_topk_start;
+  int* local_topk_inds;
+};
+
+// Global overflow cache layout (per cluster section):
+//   g_bits [ ph * NClusters * overflow_stride + block_id * overflow_stride + i
+//   ] g_inds [ overflow_stride * 2 * NClusters  + same offset ]
+// Total per cluster: overflow_stride * 4 * NClusters int32 elements.
+
+template <typename T, int NClusters, bool PDL_ENABLED>
+__device__ __forceinline__ TopkResults fast_topk_cuda_v4(
+    const T* __restrict__ logits,                    // Input logits [max_num_pages * 64]
+    const int* __restrict__ pre_hist,                // Histogram of the first bin, if
+                                                     // PRE_HISTOGRAM is enabled, [256]
+    PackedCachedData* __restrict__ cached_overflow,  // [overflow_stride * 2]
+    const int overflow_stride, const int seq_len, const int num_cached, const int TopK) {
+  static_assert(sizeof(T) == 4 || sizeof(T) == 2, "the size of T must be 4 or 2 bytes");
+
+  using Ord = OrderedBits<T>;
+  constexpr int NRemainingRounds =
+      sizeof(T) - 1;  // each round takes a byte, first round is already done
+  constexpr int LShiftStart = sizeof(T) * 8 - 8;  // 24 for float, 8 for half
+  constexpr int RADIX = 256;
+
+  __shared__ int shared_hist[3][RADIX];
+
+  extern __shared__ uint8_t shared_cache[];
+  alignas(128) __shared__ int shared_final_idx_count;      // number of topk indices in s_topk_inds
+  alignas(128) __shared__ int shared_num_cached_count[2];  // number of cached indices
+  alignas(128) __shared__ int shared_threshold_bin;
+  alignas(128) __shared__ int s_cached_overflow_count[2];  // global overflow counts
+
+  uint32_t* s_cached_logit_bits = (uint32_t*)shared_cache;
+  int* s_cached_indices = (int*)(2 * num_cached + s_cached_logit_bits);
+  int* s_topk_inds = (int*)(2 * num_cached + s_cached_indices);
+
+  auto cluster = cg::this_cluster();
+  const int block_id = cluster.block_rank();
+  const bool radix_thread = threadIdx.x < RADIX;
+  constexpr bool DEBUG = false;
+  constexpr bool RUN_PHASE1 = true;
+  constexpr bool ENABLE_CLUSTER_SAFETY = true;
+
+  auto get_cached_overflow = [&](int phase) { return cached_overflow + phase * overflow_stride; };
+
+  auto get_threshold_bin = [&](int hist_idx, int& k_remaining, bool sum_hist = true) {
+    __syncthreads();
+    // first reduce cum sum locally
+    int cum_val = cum_sum(shared_hist[hist_idx]);
+    if (NClusters > 1 && sum_hist) {
+      if (radix_thread) {
+        shared_hist[hist_idx][threadIdx.x] = cum_val;
+      }
+      cluster.sync();  // now first block in cluster has its local cum sum
+
+      if (radix_thread) {
+#pragma unroll
+        for (int cl = 0; cl < NClusters - 1; cl++) {
+          cum_val += cluster.map_shared_rank(&shared_hist[hist_idx][threadIdx.x],
+                                             (cl + block_id + 1) % NClusters)[0];
+        }
+        shared_hist[2][threadIdx.x] = cum_val;
+      }
+    } else {
+      if (radix_thread) {
+        shared_hist[2][threadIdx.x] = cum_val;
+      }
+    }
+
+    __syncthreads();
+
+    int cum_val1 = threadIdx.x < RADIX - 1 ? shared_hist[2][threadIdx.x + 1] : 0;
+
+    if (radix_thread && cum_val > k_remaining && cum_val1 <= k_remaining) {
+      shared_threshold_bin = threadIdx.x;
+      if (DEBUG) {
+        printf(
+            "block_id %d: threshold_bin %d. cum_sum_thres %d, cum_sum_thres+1 "
+            "%d, topk_val %d\n",
+            block_id, threadIdx.x, cum_val, cum_val1, shared_final_idx_count);
+      }
+    }
+
+    __syncthreads();
+    const int threshold_bin = shared_threshold_bin;
+    if (threshold_bin < RADIX - 1) {
+      k_remaining -= shared_hist[2][threshold_bin + 1];
+    }
+    return threshold_bin;
+  };
+
+  if (PDL_ENABLED) cudaGridDependencySynchronize();
+
+  if (radix_thread) {
+    if (pre_hist != nullptr) {
+      shared_hist[0][threadIdx.x] = pre_hist[threadIdx.x];
+    } else {
+      shared_hist[0][threadIdx.x] = 0;
+    }
+    shared_hist[1][threadIdx.x] = 0;
+  }
+  if (threadIdx.x == 0) {
+    shared_final_idx_count = 0;
+    shared_num_cached_count[0] = 0;
+    s_cached_overflow_count[0] = 0;
+  }
+
+  if (pre_hist == nullptr) {
+    __syncthreads();
+    for (int i = threadIdx.x + block_id * 1024; i < seq_len; i += 1024 * NClusters) {
+      T res = logits[i];
+
+      auto bin = Ord::to_ordered_bits(res) >> LShiftStart;
+      atomicAdd(shared_hist[0] + bin, 1);
+    }
+  }
+
+  int top_k_remaining = TopK;
+  if (RUN_PHASE1) {
+    // get_threshold_bin synchronizes
+    // if we use the PRE_HISTOGRAM then we don't need to sum the first histogram
+    // across clusters
+    const int threshold_bin = get_threshold_bin(0, top_k_remaining, pre_hist == nullptr);
+
+    auto compute_phase1 = [&](T logit, int i) {
+      auto bits = Ord::to_ordered_bits(logit);
+      int bin = (bits >> LShiftStart);
+
+      if (bin > threshold_bin) {
+        int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+        if (topk_offset < TopK) {
+          s_topk_inds[topk_offset] = i;
+        }
+      }
+
+      if (bin == threshold_bin) {
+        int cached_offset = atomicAdd(&shared_num_cached_count[0], 1);
+        if (cached_offset < num_cached) {
+          s_cached_indices[cached_offset] = i;
+          s_cached_logit_bits[cached_offset] =
+              static_cast<uint32_t>(bits);  // widen to 32 bits if from half
+          atomicAdd(shared_hist[1] + (( bits >> (LShiftStart - 8) ) & 0xff), 1);
+        } else {
+          // Shared buffer full: spill to per-CTA global overflow cache.
+          int g_off = atomicAdd(&s_cached_overflow_count[0], 1);
+          if (g_off < overflow_stride) {
+            PackedCachedData cached_res = {static_cast<uint32_t>(bits), i};
+            get_cached_overflow(0)[g_off] = cached_res;
+            atomicAdd(shared_hist[1] + (( bits >> (LShiftStart - 8) ) & 0xff), 1);
+          }
+        }
+      }
+    };
+    if (ENABLE_CLUSTER_SAFETY && NClusters > 1) {
+      cluster.barrier_arrive();  // arrive at this point to signal that we are
+                                 // done with shared_hist[0], which we need in
+                                 // distributed shared memory to communicate
+                                 // histograms within the cluster, otherwise there
+                                 // is a race condition that produces slightly wrong
+                                 // results, for slightly better performance
+    }
+
+    int tid = block_id * 1024 + threadIdx.x;
+    constexpr int VEC_SIZE = 4;
+    vec_t<T, VEC_SIZE> score_vec;
+    int seq_len_aligned = seq_len / VEC_SIZE * VEC_SIZE;
+    for (int i = tid * VEC_SIZE; i < seq_len_aligned; i += NClusters * 1024 * VEC_SIZE) {
+      score_vec.cast_load(&logits[i]);
+      for (int j = 0; j < VEC_SIZE; j++) {
+        compute_phase1(score_vec[j], i + j);
+      }
+    }
+    for (int i = seq_len_aligned + tid; i < seq_len; i += NClusters * 1024) {
+      compute_phase1(logits[i], i);
+    }
+  }
+#pragma unroll
+  for (int t = 1; t <= NRemainingRounds; t++) {
+    const int phase = t % 2;
+    // we are now using histogram buffers at phase, and cached_offsets at phase
+    // ^ 1 clear the next stage to prepare
+
+    if (ENABLE_CLUSTER_SAFETY && NClusters > 1) {
+      cluster.barrier_wait();  // wait because we need to clear shared_hist for this
+                               // next histogram; there is a dependency between
+                               // get_threshold_bin and phase ^ 1 of the histogram
+    }
+    if (radix_thread) {
+      shared_hist[phase ^ 1][threadIdx.x] = 0;
+    }
+    if (threadIdx.x == 0) {
+      shared_num_cached_count[phase] = 0;
+      s_cached_overflow_count[phase] = 0;
+    }
+    // get_threshold_bin synchronizes the block
+    const int threshold_bin = get_threshold_bin(phase, top_k_remaining);
+    if (ENABLE_CLUSTER_SAFETY && NClusters > 1 && t < NRemainingRounds) {
+      cluster.barrier_arrive();  // same reasoning as above, for the last
+                                 // iteration there is no dependency because no
+                                 // more calls to get_threshold_bin
+    }
+    int buf_len = min(num_cached, shared_num_cached_count[phase ^ 1]);
+    int g_buf_len = min(overflow_stride, s_cached_overflow_count[phase ^ 1]);
+
+    if (DEBUG && threadIdx.x == 0) {
+      printf("block_id %d, num_cached %d, g_buf_len %d\n", block_id, buf_len, g_buf_len);
+    }
+
+    // --- Process shared cache ---
+    // using cached indices, it's a local slice so don't partition between
+    // blocks
+    for (int i = threadIdx.x; i < buf_len; i += 1024) {
+      uint32_t bits = s_cached_logit_bits[i + (phase ^ 1) * num_cached];
+      int cached_idx = s_cached_indices[i + (phase ^ 1) * num_cached];
+      int bin = (bits >> (LShiftStart - t * 8)) & 0xff;
+
+      if (bin > threshold_bin) {
+        int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+        if (topk_offset < TopK) {
+          s_topk_inds[topk_offset] = cached_idx;
+        } else {
+          break;
+        }
+      }
+      if (bin == threshold_bin && t < NRemainingRounds) {
+        int cached_offset = atomicAdd(&shared_num_cached_count[phase], 1);
+        if (cached_offset < num_cached) {
+          s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
+          s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
+          atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+        } else {
+          int g_off = atomicAdd(&s_cached_overflow_count[phase], 1);
+          if (g_off < overflow_stride) {
+            PackedCachedData data = {bits, cached_idx};
+            get_cached_overflow(phase)[g_off] = data;
+            atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+          }
+        }
+      }
+    }
+
+    // --- Process global overflow cache from previous phase ---
+    for (int i = threadIdx.x; i < g_buf_len; i += 1024) {
+      PackedCachedData data = get_cached_overflow(phase ^ 1)[i];
+      uint32_t bits = data.bits;
+      int cached_idx = data.index;
+      int bin = (bits >> (LShiftStart - t * 8)) & 0xff;
+
+      if (bin > threshold_bin) {
+        int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+        if (topk_offset < TopK) {
+          s_topk_inds[topk_offset] = cached_idx;
+        } else {
+          break;
+        }
+      }
+      if (bin == threshold_bin && t < NRemainingRounds) {
+        int cached_offset = atomicAdd(&shared_num_cached_count[phase], 1);
+        if (cached_offset < num_cached) {
+          s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
+          s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
+          atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+        } else {
+          int g_off = atomicAdd(&s_cached_overflow_count[phase], 1);
+          if (g_off < overflow_stride) {
+            get_cached_overflow(phase)[g_off] = {bits, cached_idx};
+            atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+          }
+        }
+      }
+    }
+
+    // it could be that at the last stage, we have say S topk indices, T indices
+    // above the threshold_bin and S + T < TopK. Then the rest of the topk items
+    // must come from threshold_bin
+    if (t == NRemainingRounds) {
+      if (top_k_remaining > 0) {
+        // Collect threshold_bin items from shared cache.
+        for (int i = threadIdx.x; i < buf_len; i += blockDim.x) {
+          int bin = s_cached_logit_bits[i] & 0xff;
+          int cached_idx = s_cached_indices[i];
+          if (bin == threshold_bin) {
+            int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+            if (topk_offset < TopK) {
+              s_topk_inds[topk_offset] = cached_idx;
+            } else {
+              break;
+            }
+          }
+        }
+        // Collect threshold_bin items from global overflow cache.
+        for (int i = threadIdx.x; i < g_buf_len; i += blockDim.x) {
+          auto data = get_cached_overflow(phase ^ 1)[i];
+          uint32_t bits = data.bits;
+          int cached_idx = data.index;
+          int bin = bits & 0xff;
+          if (bin == threshold_bin) {
+            int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+            if (topk_offset < TopK) {
+              s_topk_inds[topk_offset] = cached_idx;
+            } else {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+  __syncthreads();
+  // now shared_final_idx_count contains the local topK in each
+  // block in a cluster, and
+  // s_topk_inds[0:shared_final_idx_count] contains the local
+  // slice.
+  if (NClusters > 1) {
+    int topk_start = 0;
+    int topk_num = shared_final_idx_count;
+
+    cluster.sync();  // sync to get the shared_final_idx_count across CTAs in
+                     // current cluster
+
+    if (block_id > 0) {
+      if (threadIdx.x == 0) {
+        topk_start += atomicAdd(cluster.map_shared_rank(&shared_final_idx_count, 0), topk_num);
+        shared_final_idx_count = topk_start;
+      }
+      __syncthreads();
+      topk_start = shared_final_idx_count;
+    }
+
+    if (DEBUG && threadIdx.x == 0) {
+      printf("block rank %d, topk start %d, topk num %d\n", block_id, topk_start, topk_num);
+    }
+
+    cluster.sync();  // sync so CTAs don't exit when other CTAs depend on
+                     // shared_final_idx_count
+    return {min(TopK, topk_num), topk_start, s_topk_inds};
+
+  } else {
+    return {TopK, 0, s_topk_inds};
+  }
+}
+
+
+template <typename T, typename IdxT, int NClusters, bool PDL_ENABLED>
+__global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
+    fast_topk_clusters_exact_kernel(
+        const T* __restrict__ logits,  // [batchsize, max_num_pages * 64]
+        IdxT* __restrict__ output_indices, T* __restrict__ output_values, int seq_len,
+        int* __restrict__ pre_hist, int* __restrict__ cached_overflow, int overflow_stride,
+        int logit_stride, int indices_stride, int num_cached, const int TopK) {
+  int cluster_id = blockIdx.x / NClusters;
+  int logit_offset = cluster_id * logit_stride;
+  int ind_offset = cluster_id * indices_stride;
+  if (seq_len <= TopK) {
+    for (int i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK; i += 1024 * NClusters) {
+      if (i < seq_len) {
+        output_indices[ind_offset + i] = static_cast<IdxT>(i);
+      } else {
+        output_indices[ind_offset + i] = static_cast<IdxT>(-1);
+      }
+    }
+
+  } else {
+    // Each cluster gets its own overflow section of size overflow_stride * 4 *
+    // NClusters int32 elements.
+    int* block_overflow = cached_overflow + blockIdx.x * overflow_stride * 4;
+    auto topk_res = fast_topk_cuda_v4<T, NClusters, PDL_ENABLED>(
+        logits + logit_offset, (pre_hist == nullptr) ? nullptr : pre_hist + cluster_id * 256,
+        (PackedCachedData*)block_overflow, overflow_stride, seq_len, num_cached, TopK);
+
+    for (int i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
+      int offs = i + topk_res.local_topk_start;
+      if (offs < TopK) {
+        auto ind = topk_res.local_topk_inds[i];
+        output_indices[offs + ind_offset] = static_cast<IdxT>(ind);
+        if (output_values != nullptr) {
+          output_values[offs + ind_offset] = logits[logit_offset + ind];
+        }
+      }
+    }
+  }
+}
+
+
+template <typename T, int NClusters, bool PDL_ENABLED>
+__global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
+    fast_topk_clusters_exact_page_table_transform_kernel(
+        const T* __restrict__ logits,  // [batchsize, logits_stride]
+        int* __restrict__ output_indices, // [batchsize, indices_stride]
+        int* __restrict__ seq_lens, // [batchsize]
+        int* __restrict__ page_table, // [batchsize, page_table_stride]
+        int* __restrict__ pre_hist, // optional[batchsize, 256]
+        int* __restrict__ cached_overflow, // [batchsize, 4 * NClusters * overflow_stride]
+        int overflow_stride,
+        int logit_stride, int indices_stride, 
+        int page_table_stride,
+        int num_cached, const int TopK) {
+  int cluster_id = blockIdx.x / NClusters;
+  int logit_offset = cluster_id * logit_stride;
+  int ind_offset = cluster_id * indices_stride;
+  int page_table_offset = cluster_id * page_table_stride;
+  int seq_len = seq_lens[cluster_id];
+  if (seq_len <= TopK) {
+    for (int i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK; i += 1024 * NClusters) {
+      if (i < seq_len) {
+        output_indices[ind_offset + i] = page_table[page_table_offset + i];
+
+      } else {
+        output_indices[ind_offset + i] = -1;
+      }
+    }
+
+  } else {
+    // Each cluster gets its own overflow section of size overflow_stride * 4 *
+    // NClusters int32 elements.
+    int* block_overflow = cached_overflow + blockIdx.x * overflow_stride * 4;
+    auto topk_res = fast_topk_cuda_v4<T, NClusters, PDL_ENABLED>(
+        logits + logit_offset, (pre_hist == nullptr) ? nullptr : pre_hist + cluster_id * 256,
+        (PackedCachedData*)block_overflow, overflow_stride, seq_len, num_cached, TopK);
+
+    for (int i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
+      int offs = i + topk_res.local_topk_start;
+      if (offs < TopK) {
+        auto ind = topk_res.local_topk_inds[i];
+        output_indices[offs + ind_offset] = page_table[page_table_offset + ind];
+      }
+    }
+  }
+}
+
+template <typename T, int NClusters, bool PDL_ENABLED>
+__global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
+    fast_topk_clusters_exact_ragged_transform_kernel(
+        const T* __restrict__ logits,  // [batchsize, logits_stride]
+        int* __restrict__ output_indices, // [batchsize, indices_stride]
+        int* __restrict__ seq_lens, // [batchsize]
+        int* __restrict__ offsets, // [batchsize]
+        int* __restrict__ pre_hist, // optional[batchsize, 256]
+        int* __restrict__ cached_overflow, // [batchsize, 4 * NClusters * overflow_stride]
+        int overflow_stride,
+        int logit_stride, int indices_stride, 
+        int num_cached, const int TopK) {
+  int cluster_id = blockIdx.x / NClusters;
+  int logit_offset = cluster_id * logit_stride;
+  int ind_offset = cluster_id * indices_stride;
+  int seq_len = seq_lens[cluster_id];
+  int ragged_offset = offsets[cluster_id];
+  if (seq_len <= TopK) {
+    for (int i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK; i += 1024 * NClusters) {
+      if (i < seq_len) {
+        output_indices[ind_offset + i] = i + ragged_offset;
+
+      } else {
+        output_indices[ind_offset + i] = -1;
+      }
+    }
+
+  } else {
+    // Each cluster gets its own overflow section of size overflow_stride * 4 *
+    // NClusters int32 elements.
+    int* block_overflow = cached_overflow + blockIdx.x * overflow_stride * 4;
+    auto topk_res = fast_topk_cuda_v4<T, NClusters, PDL_ENABLED>(
+        logits + logit_offset, (pre_hist == nullptr) ? nullptr : pre_hist + cluster_id * 256,
+        (PackedCachedData*)block_overflow, overflow_stride, seq_len, num_cached, TopK);
+
+    for (int i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
+      int offs = i + topk_res.local_topk_start;
+      if (offs < TopK) {
+        auto ind = topk_res.local_topk_inds[i];
+        output_indices[offs + ind_offset] = ind + ragged_offset;
+      }
+    }
+  }
+}
+
+
+
+
+constexpr int MAX_SMEM_CARVEOUT = 227 * 1000;
+
+#define DISPATCH_TOPK_EXACT(kernel_name, dtype, CLUSTERS, PDL)                    \
+  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                           \
+    setup_kernel_smem_once<kernel_name<dtype, CLUSTERS, PDL>,                     \
+                           MAX_SMEM_CARVEOUT>();                                  \
+    kernel = (void*)&kernel_name<dtype, CLUSTERS, PDL>;                           \
+  }
+
+// Variant for kernels with an additional IdxT template parameter (index output dtype).
+#define DISPATCH_TOPK_EXACT_IDX(kernel_name, dtype, idx_type, CLUSTERS, PDL)     \
+  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                           \
+    setup_kernel_smem_once<kernel_name<dtype, idx_type, CLUSTERS, PDL>,           \
+                           MAX_SMEM_CARVEOUT>();                                  \
+    kernel = (void*)&kernel_name<dtype, idx_type, CLUSTERS, PDL>;                 \
+  }
+
+inline void launch_topk_cluster_kernel(void* kernel, void** args, int grid_dim, int smem_bytes,
+                                       int num_clusters, bool pdl_enabled, cudaStream_t stream) {
+  cudaLaunchConfig_t config;
+  config.numAttrs = 0;
+  cudaLaunchAttribute attribute[2];
+  attribute[config.numAttrs].id = cudaLaunchAttributeClusterDimension;
+  attribute[config.numAttrs].val.clusterDim = {(unsigned)num_clusters, 1, 1};
+  config.numAttrs += 1;
+  if (pdl_enabled) {
+    attribute[config.numAttrs].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attribute[config.numAttrs].val.programmaticStreamSerializationAllowed = 1;
+    config.numAttrs += 1;
+  }
+  config.blockDim = 1024;
+  config.dynamicSmemBytes = smem_bytes;
+  config.gridDim = grid_dim;
+  config.stream = stream;
+  config.attrs = attribute;
+  cudaLaunchKernelExC(&config, kernel, args);
+}
+
+template <typename T, typename IdxT = int>
+void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_values, int seq_len,
+                                     int* pre_hist, int* cached_overflow, int overflow_stride,
+                                     int batch_size, int logit_stride, int indices_stride,
+                                     int num_cached, int num_clusters, bool pdl_enabled, int TopK,
+                                     cudaStream_t stream) {
+  int extern_shared_mem =
+      (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
+
+  void* args[11] = {
+      &logits,          &indices,      &output_values,  &seq_len,   &pre_hist, &cached_overflow,
+      &overflow_stride, &logit_stride, &indices_stride, &num_cached, &TopK};
+
+  void* kernel = nullptr;
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 1, true);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 2, true);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 4, true);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 8, true);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 1, false);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 2, false);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 4, false);
+  DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 8, false);
+
+  if (kernel == nullptr) {
+    num_clusters = 1;
+    pdl_enabled = false;
+    DISPATCH_TOPK_EXACT_IDX(fast_topk_clusters_exact_kernel, T, IdxT, 1, false);
+  }
+
+  // cudaLaunchKernelExC requires an explicit cluster dimension attribute even for kernels
+  // annotated with __cluster_dims__; without it the launch fails with invalid argument.
+  launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
+                             num_clusters, pdl_enabled, stream);
+}
+
+template <typename T>
+void launch_fast_topk_clusters_exact_page_table_transform(
+    const T* logits, int* indices, int* seq_lens, int* page_table, int* pre_hist,
+    int* cached_overflow, int overflow_stride, int batch_size, int logit_stride,
+    int indices_stride, int page_table_stride, int num_cached, int num_clusters,
+    bool pdl_enabled, int TopK, cudaStream_t stream) {
+  int extern_shared_mem =
+      (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
+
+  void* args[12] = {&logits,          &indices,        &seq_lens,          &page_table,
+                    &pre_hist,         &cached_overflow, &overflow_stride,   &logit_stride,
+                    &indices_stride,   &page_table_stride, &num_cached,      &TopK};
+
+  void* kernel = nullptr;
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 1, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 2, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 4, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 8, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 1, false);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 2, false);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 4, false);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 8, false);
+
+  if (kernel == nullptr) {
+    num_clusters = 1;
+    pdl_enabled = false;
+    DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 1, false);
+  }
+
+  launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
+                             num_clusters, pdl_enabled, stream);
+}
+
+template <typename T>
+void launch_fast_topk_clusters_exact_ragged_transform(
+    const T* logits, int* indices, int* seq_lens, int* offsets, int* pre_hist,
+    int* cached_overflow, int overflow_stride, int batch_size, int logit_stride,
+    int indices_stride, int num_cached, int num_clusters, bool pdl_enabled, int TopK,
+    cudaStream_t stream) {
+  int extern_shared_mem =
+      (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
+
+  void* args[11] = {&logits,    &indices,         &seq_lens,        &offsets,
+                    &pre_hist,  &cached_overflow,  &overflow_stride, &logit_stride,
+                    &indices_stride, &num_cached,  &TopK};
+
+  void* kernel = nullptr;
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 1, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 2, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 4, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 8, true);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 1, false);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 2, false);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 4, false);
+  DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 8, false);
+
+  if (kernel == nullptr) {
+    num_clusters = 1;
+    pdl_enabled = false;
+    DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 1, false);
+  }
+
+  launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
+                             num_clusters, pdl_enabled, stream);
+}

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -471,11 +471,12 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
         IdxT* __restrict__ output_indices, T* __restrict__ output_values, int seq_len,
         int* __restrict__ pre_hist, int* __restrict__ cached_overflow, int overflow_stride,
         int logit_stride, int indices_stride, int num_cached, const int TopK) {
-  int cluster_id = blockIdx.x / NClusters;
-  int logit_offset = cluster_id * logit_stride;
-  int ind_offset = cluster_id * indices_stride;
+  int64_t cluster_id = blockIdx.x / NClusters;
+  int64_t logit_offset = cluster_id * logit_stride;
+  int64_t ind_offset = cluster_id * indices_stride;
   if (seq_len <= TopK) {
-    for (int i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK; i += 1024 * NClusters) {
+    for (int64_t i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK;
+         i += 1024 * NClusters) {
       if (i < seq_len) {
         output_indices[ind_offset + i] = static_cast<IdxT>(i);
       } else {
@@ -491,7 +492,7 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
         logits + logit_offset, (pre_hist == nullptr) ? nullptr : pre_hist + cluster_id * 256,
         (PackedCachedData*)block_overflow, overflow_stride, seq_len, num_cached, TopK);
 
-    for (int i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
+    for (int64_t i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
       int offs = i + topk_res.local_topk_start;
       if (offs < TopK) {
         auto ind = topk_res.local_topk_inds[i];
@@ -515,13 +516,14 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
         int* __restrict__ cached_overflow,  // [batchsize, 4 * NClusters * overflow_stride]
         int overflow_stride, int logit_stride, int indices_stride, int page_table_stride,
         int num_cached, const int TopK) {
-  int cluster_id = blockIdx.x / NClusters;
-  int logit_offset = cluster_id * logit_stride;
-  int ind_offset = cluster_id * indices_stride;
-  int page_table_offset = cluster_id * page_table_stride;
+  int64_t cluster_id = blockIdx.x / NClusters;
+  int64_t logit_offset = cluster_id * logit_stride;
+  int64_t ind_offset = cluster_id * indices_stride;
+  int64_t page_table_offset = cluster_id * page_table_stride;
   int seq_len = seq_lens[cluster_id];
   if (seq_len <= TopK) {
-    for (int i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK; i += 1024 * NClusters) {
+    for (int64_t i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK;
+         i += 1024 * NClusters) {
       if (i < seq_len) {
         output_indices[ind_offset + i] = page_table[page_table_offset + i];
 
@@ -538,7 +540,7 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
         logits + logit_offset, (pre_hist == nullptr) ? nullptr : pre_hist + cluster_id * 256,
         (PackedCachedData*)block_overflow, overflow_stride, seq_len, num_cached, TopK);
 
-    for (int i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
+    for (int64_t i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
       int offs = i + topk_res.local_topk_start;
       if (offs < TopK) {
         auto ind = topk_res.local_topk_inds[i];
@@ -559,12 +561,13 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
         int* __restrict__ cached_overflow,  // [batchsize, 4 * NClusters * overflow_stride]
         int overflow_stride, int logit_stride, int indices_stride, int num_cached, const int TopK) {
   int cluster_id = blockIdx.x / NClusters;
-  int logit_offset = cluster_id * logit_stride;
-  int ind_offset = cluster_id * indices_stride;
-  int seq_len = seq_lens[cluster_id];
-  int ragged_offset = offsets[cluster_id];
+  int64_t logit_offset = cluster_id * logit_stride;
+  int64_t ind_offset = cluster_id * indices_stride;
+  int64_t seq_len = seq_lens[cluster_id];
+  int64_t ragged_offset = offsets[cluster_id];
   if (seq_len <= TopK) {
-    for (int i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK; i += 1024 * NClusters) {
+    for (int64_t i = threadIdx.x + (blockIdx.x % NClusters) * 1024; i < TopK;
+         i += 1024 * NClusters) {
       if (i < seq_len) {
         output_indices[ind_offset + i] = i + ragged_offset;
 
@@ -581,7 +584,7 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
         logits + logit_offset, (pre_hist == nullptr) ? nullptr : pre_hist + cluster_id * 256,
         (PackedCachedData*)block_overflow, overflow_stride, seq_len, num_cached, TopK);
 
-    for (int i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
+    for (int64_t i = threadIdx.x; i < topk_res.local_topk_num; i += 1024) {
       int offs = i + topk_res.local_topk_start;
       if (offs < TopK) {
         auto ind = topk_res.local_topk_inds[i];

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -2,8 +2,7 @@
 #define FLASHINFER_TOPK_CLUSTERS_CUH_
 #include <cooperative_groups.h>
 #include <cuda_fp16.h>
-
-#include <cassert>
+#include <tvm/ffi/error.h>
 
 #include "topk_common.cuh"
 #include "vec_dtypes.cuh"
@@ -612,7 +611,7 @@ void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_v
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
 #else
-  throw std::runtime_error("fast_topk_clusters_exact requires SM 9.0 (Hopper) or newer");
+  TVM_FFI_ICHECK(false) << "fast_topk_clusters_exact requires SM 9.0 (Hopper) or newer";
 #endif
 }
 
@@ -648,8 +647,8 @@ void launch_fast_topk_clusters_exact_page_table_transform(
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
 #else
-  throw std::runtime_error(
-      "fast_topk_clusters_exact_page_table_transform requires SM 9.0 (Hopper) or newer");
+  TVM_FFI_ICHECK(false)
+      << "fast_topk_clusters_exact_page_table_transform requires SM 9.0 (Hopper) or newer";
 #endif
 }
 
@@ -684,8 +683,8 @@ void launch_fast_topk_clusters_exact_ragged_transform(
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
 #else
-  throw std::runtime_error(
-      "fast_topk_clusters_exact_ragged_transform requires SM 9.0 (Hopper) or newer");
+  TVM_FFI_ICHECK(false)
+      << "fast_topk_clusters_exact_ragged_transform requires SM 9.0 (Hopper) or newer";
 #endif
 }
 

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -74,6 +74,10 @@ struct TopkResults {
 //   ] g_inds [ overflow_stride * 2 * NClusters  + same offset ]
 // Total per cluster: overflow_stride * 4 * NClusters int32 elements.
 
+// Cluster cooperative groups (cg::this_cluster, cluster barriers, etc.) require
+// SM 9.0 (Hopper) or newer.
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 900
+
 template <typename T, int NClusters, bool PDL_ENABLED>
 __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
     const T* __restrict__ logits,                    // Input logits [max_num_pages * 64]
@@ -105,7 +109,6 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   auto cluster = cg::this_cluster();
   const int block_id = cluster.block_rank();
   const bool radix_thread = threadIdx.x < RADIX;
-  constexpr bool DEBUG = false;
   constexpr bool RUN_PHASE1 = true;
   constexpr bool ENABLE_CLUSTER_SAFETY = true;
 
@@ -141,12 +144,6 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
 
     if (radix_thread && cum_val > k_remaining && cum_val1 <= k_remaining) {
       *shared_threshold_bin = threadIdx.x;
-      if (DEBUG) {
-        printf(
-            "block_id %d: threshold_bin %d. cum_sum_thres %d, cum_sum_thres+1 "
-            "%d, topk_val %d\n",
-            block_id, threadIdx.x, cum_val, cum_val1, *shared_final_idx_count);
-      }
     }
 
     __syncthreads();
@@ -269,10 +266,6 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
     }
     int buf_len = min(num_cached, shared_num_cached_count[phase ^ 1]);
     int g_buf_len = min(overflow_stride, s_cached_overflow_count[phase ^ 1]);
-
-    if (DEBUG && threadIdx.x == 0) {
-      printf("block_id %d, num_cached %d, g_buf_len %d\n", block_id, buf_len, g_buf_len);
-    }
 
     // --- Process shared cache ---
     // using cached indices, it's a local slice so don't partition between
@@ -397,10 +390,6 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
       }
       __syncthreads();
       topk_start = *shared_final_idx_count;
-    }
-
-    if (DEBUG && threadIdx.x == 0) {
-      printf("block rank %d, topk start %d, topk num %d\n", block_id, topk_start, topk_num);
     }
 
     cluster.sync();  // sync so CTAs don't exit when other CTAs depend on
@@ -545,6 +534,8 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
   }
 }
 
+#endif  // !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 900
+
 constexpr int MAX_SMEM_CARVEOUT = 227 * 1024;
 
 #define DISPATCH_TOPK_EXACT(kernel_name, dtype, CLUSTERS, PDL) \
@@ -593,6 +584,7 @@ void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_v
                                      int batch_size, int logit_stride, int indices_stride,
                                      int num_cached, int num_clusters, bool pdl_enabled, int TopK,
                                      cudaStream_t stream) {
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 900
   int extern_shared_mem = get_shared_mem_bytes(TopK, num_cached);
 
   void* args[11] = {
@@ -619,6 +611,9 @@ void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_v
   // annotated with __cluster_dims__; without it the launch fails with invalid argument.
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
+#else
+  throw std::runtime_error("fast_topk_clusters_exact requires SM 9.0 (Hopper) or newer");
+#endif
 }
 
 template <typename T>
@@ -627,6 +622,7 @@ void launch_fast_topk_clusters_exact_page_table_transform(
     int* cached_overflow, int overflow_stride, int batch_size, int logit_stride, int indices_stride,
     int page_table_stride, int num_cached, int num_clusters, bool pdl_enabled, int TopK,
     cudaStream_t stream) {
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 900
   int extern_shared_mem = get_shared_mem_bytes(TopK, num_cached);
 
   void* args[12] = {&logits,         &indices,           &seq_lens,        &page_table,
@@ -651,6 +647,10 @@ void launch_fast_topk_clusters_exact_page_table_transform(
 
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
+#else
+  throw std::runtime_error(
+      "fast_topk_clusters_exact_page_table_transform requires SM 9.0 (Hopper) or newer");
+#endif
 }
 
 template <typename T>
@@ -658,6 +658,7 @@ void launch_fast_topk_clusters_exact_ragged_transform(
     const T* logits, int* indices, int* seq_lens, int* offsets, int* pre_hist, int* cached_overflow,
     int overflow_stride, int batch_size, int logit_stride, int indices_stride, int num_cached,
     int num_clusters, bool pdl_enabled, int TopK, cudaStream_t stream) {
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 900
   int extern_shared_mem = get_shared_mem_bytes(TopK, num_cached);
 
   void* args[11] = {
@@ -682,6 +683,10 @@ void launch_fast_topk_clusters_exact_ragged_transform(
 
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
+#else
+  throw std::runtime_error(
+      "fast_topk_clusters_exact_ragged_transform requires SM 9.0 (Hopper) or newer");
+#endif
 }
 
 }  // namespace sampling

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -1,12 +1,17 @@
-
+#ifndef FLASHINFER_TOPK_CLUSTERS_CUH_
+#define FLASHINFER_TOPK_CLUSTERS_CUH_
 #include <cooperative_groups.h>
 #include <cuda_fp16.h>
 
 #include <cassert>
-#include <flashinfer/vec_dtypes.cuh>
+
+#include "topk_common.cuh"
+#include "vec_dtypes.cuh"
+
+namespace flashinfer {
+namespace sampling {
 
 namespace cg = cooperative_groups;
-using namespace flashinfer;
 
 __device__ __forceinline__ uint32_t getLaneId() {
   uint32_t laneId;
@@ -24,15 +29,6 @@ __device__ __forceinline__ uint32_t InclusiveWarpDownScan(uint32_t val) {
   }
 
   return val;
-}
-
-template <auto* kernel_func, size_t smem_bytes>
-void setup_kernel_smem_once() {
-  static const cudaError_t result = []() -> cudaError_t {
-    auto func_ptr = kernel_func;
-
-    return cudaFuncSetAttribute(func_ptr, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
-  }();
 }
 
 __device__ __forceinline__ int cum_sum(int* s_hist_buf, int* reduce_buf) {
@@ -67,58 +63,6 @@ struct PackedCachedData {
   int index;
 };
 
-template <typename T>
-struct OrderedBits;
-
-template <>
-struct OrderedBits<float> {
-  using DType = float;
-  using OrderedDType = uint32_t;
-  using self_t = OrderedBits<float>;
-
-  static __device__ self_t::OrderedDType to_ordered_bits(self_t::DType x) {
-    uint32_t bits = __float_as_uint(x);
-    return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
-  }
-
-  static __device__ self_t::DType from_ordered_bits(self_t::OrderedDType bits) {
-    auto float_bits = (bits & 0x80000000u) ? bits ^ 0x80000000u : ~bits;
-    return __uint_as_float(float_bits);
-  }
-};
-
-template <>
-struct OrderedBits<half> {
-  using DType = half;
-  using OrderedDType = uint16_t;
-  using self_t = OrderedBits<half>;
-
-  static __device__ self_t::OrderedDType to_ordered_bits(self_t::DType x) {
-    uint16_t bits = __half_as_ushort(x);
-    uint16_t key =
-        (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
-
-    return key;
-  }
-
-  static __device__ self_t::DType from_ordered_bits(self_t::OrderedDType bits) {
-    auto half_bits = (bits & 0x8000) ? bits ^ 0x8000 : ~bits;
-    return __ushort_as_half(half_bits);
-  }
-};
-
-template <>
-struct OrderedBits<nv_bfloat16> {
-  using DType = nv_bfloat16;
-  using OrderedDType = uint16_t;
-  using self_t = OrderedBits<nv_bfloat16>;
-
-  static __device__ self_t::OrderedDType to_ordered_bits(self_t::DType x) {
-    uint16_t bits = __bfloat16_as_ushort(x);
-    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
-  }
-};
-
 struct TopkResults {
   int local_topk_num;
   int local_topk_start;
@@ -139,7 +83,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
     const int overflow_stride, const int seq_len, const int num_cached, const int TopK) {
   static_assert(sizeof(T) == 4 || sizeof(T) == 2, "the size of T must be 4 or 2 bytes");
 
-  using Ord = OrderedBits<T>;
+  using Ord = RadixTopKTraits<T>;
   constexpr int NRemainingRounds =
       sizeof(T) - 1;  // each round takes a byte, first round is already done
   constexpr int LShiftStart = sizeof(T) * 8 - 8;  // 24 for float, 8 for half
@@ -234,7 +178,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
     for (int i = threadIdx.x + block_id * 1024; i < seq_len; i += 1024 * NClusters) {
       T res = logits[i];
 
-      auto bin = Ord::to_ordered_bits(res) >> LShiftStart;
+      auto bin = Ord::ToOrdered(res) >> LShiftStart;
       atomicAdd(shared_hist + bin, 1);
     }
   }
@@ -247,7 +191,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
     const int threshold_bin = get_threshold_bin(0, top_k_remaining, pre_hist == nullptr);
 
     auto compute_phase1 = [&](T logit, int i) {
-      auto bits = Ord::to_ordered_bits(logit);
+      auto bits = Ord::ToOrdered(logit);
       int bin = (bits >> LShiftStart);
 
       if (bin > threshold_bin) {
@@ -739,3 +683,8 @@ void launch_fast_topk_clusters_exact_ragged_transform(
   launch_topk_cluster_kernel(kernel, args, batch_size * num_clusters, extern_shared_mem,
                              num_clusters, pdl_enabled, stream);
 }
+
+}  // namespace sampling
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_TOPK_CLUSTERS_CUH_

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -35,11 +35,10 @@ void setup_kernel_smem_once() {
   }();
 }
 
-__device__ __forceinline__ int cum_sum(int* s_hist_buf) {
+__device__ __forceinline__ int cum_sum(int* s_hist_buf, int* reduce_buf) {
   constexpr int RADIX = 256;
   const int warp_idx = threadIdx.x / 32;
 
-  __shared__ int reduce_buf[8];
   int val = 0;
   if (threadIdx.x < RADIX) {
     val = s_hist_buf[threadIdx.x];
@@ -146,17 +145,18 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   constexpr int LShiftStart = sizeof(T) * 8 - 8;  // 24 for float, 8 for half
   constexpr int RADIX = 256;
 
-  __shared__ int shared_hist[3][RADIX];
-
-  extern __shared__ uint8_t shared_cache[];
-  alignas(128) __shared__ int shared_final_idx_count;      // number of topk indices in s_topk_inds
-  alignas(128) __shared__ int shared_num_cached_count[2];  // number of cached indices
-  alignas(128) __shared__ int shared_threshold_bin;
-  alignas(128) __shared__ int s_cached_overflow_count[2];  // global overflow counts
+  alignas(128) extern __shared__ uint8_t shared_cache[];
 
   uint32_t* s_cached_logit_bits = (uint32_t*)shared_cache;
   int* s_cached_indices = (int*)(2 * num_cached + s_cached_logit_bits);
   int* s_topk_inds = (int*)(2 * num_cached + s_cached_indices);
+
+  int* shared_hist = s_topk_inds + TopK;
+  int* shared_final_idx_count = shared_hist + 3 * 256;
+  int* shared_num_cached_count = shared_final_idx_count + 1;
+  int* shared_threshold_bin = shared_num_cached_count + 2;
+  int* s_cached_overflow_count = shared_threshold_bin + 1;
+  int* s_cum_reduce_buf = s_cached_overflow_count + 2;
 
   auto cluster = cg::this_cluster();
   const int block_id = cluster.block_rank();
@@ -170,45 +170,45 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   auto get_threshold_bin = [&](int hist_idx, int& k_remaining, bool sum_hist = true) {
     __syncthreads();
     // first reduce cum sum locally
-    int cum_val = cum_sum(shared_hist[hist_idx]);
+    int cum_val = cum_sum(shared_hist + hist_idx * 256, s_cum_reduce_buf);
     if (NClusters > 1 && sum_hist) {
       if (radix_thread) {
-        shared_hist[hist_idx][threadIdx.x] = cum_val;
+        shared_hist[hist_idx * 256 + threadIdx.x] = cum_val;
       }
       cluster.sync();  // now first block in cluster has its local cum sum
 
       if (radix_thread) {
 #pragma unroll
         for (int cl = 0; cl < NClusters - 1; cl++) {
-          cum_val += cluster.map_shared_rank(&shared_hist[hist_idx][threadIdx.x],
+          cum_val += cluster.map_shared_rank(&shared_hist[hist_idx * 256 + threadIdx.x],
                                              (cl + block_id + 1) % NClusters)[0];
         }
-        shared_hist[2][threadIdx.x] = cum_val;
+        shared_hist[2 * 256 + threadIdx.x] = cum_val;
       }
     } else {
       if (radix_thread) {
-        shared_hist[2][threadIdx.x] = cum_val;
+        shared_hist[2 * 256 + threadIdx.x] = cum_val;
       }
     }
 
     __syncthreads();
 
-    int cum_val1 = threadIdx.x < RADIX - 1 ? shared_hist[2][threadIdx.x + 1] : 0;
+    int cum_val1 = threadIdx.x < RADIX - 1 ? shared_hist[2 * 256 + threadIdx.x + 1] : 0;
 
     if (radix_thread && cum_val > k_remaining && cum_val1 <= k_remaining) {
-      shared_threshold_bin = threadIdx.x;
+      *shared_threshold_bin = threadIdx.x;
       if (DEBUG) {
         printf(
             "block_id %d: threshold_bin %d. cum_sum_thres %d, cum_sum_thres+1 "
             "%d, topk_val %d\n",
-            block_id, threadIdx.x, cum_val, cum_val1, shared_final_idx_count);
+            block_id, threadIdx.x, cum_val, cum_val1, *shared_final_idx_count);
       }
     }
 
     __syncthreads();
-    const int threshold_bin = shared_threshold_bin;
+    const int threshold_bin = *shared_threshold_bin;
     if (threshold_bin < RADIX - 1) {
-      k_remaining -= shared_hist[2][threshold_bin + 1];
+      k_remaining -= shared_hist[2 * 256 + threshold_bin + 1];
     }
     return threshold_bin;
   };
@@ -217,14 +217,14 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
 
   if (radix_thread) {
     if (pre_hist != nullptr) {
-      shared_hist[0][threadIdx.x] = pre_hist[threadIdx.x];
+      shared_hist[threadIdx.x] = pre_hist[threadIdx.x];
     } else {
-      shared_hist[0][threadIdx.x] = 0;
+      shared_hist[threadIdx.x] = 0;
     }
-    shared_hist[1][threadIdx.x] = 0;
+    shared_hist[256 + threadIdx.x] = 0;
   }
   if (threadIdx.x == 0) {
-    shared_final_idx_count = 0;
+    *shared_final_idx_count = 0;
     shared_num_cached_count[0] = 0;
     s_cached_overflow_count[0] = 0;
   }
@@ -235,7 +235,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
       T res = logits[i];
 
       auto bin = Ord::to_ordered_bits(res) >> LShiftStart;
-      atomicAdd(shared_hist[0] + bin, 1);
+      atomicAdd(shared_hist + bin, 1);
     }
   }
 
@@ -251,7 +251,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
       int bin = (bits >> LShiftStart);
 
       if (bin > threshold_bin) {
-        int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+        int topk_offset = atomicAdd(shared_final_idx_count, 1);
         if (topk_offset < TopK) {
           s_topk_inds[topk_offset] = i;
         }
@@ -263,14 +263,14 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
           s_cached_indices[cached_offset] = i;
           s_cached_logit_bits[cached_offset] =
               static_cast<uint32_t>(bits);  // widen to 32 bits if from half
-          atomicAdd(shared_hist[1] + ((bits >> (LShiftStart - 8)) & 0xff), 1);
+          atomicAdd(shared_hist + 256 + ((bits >> (LShiftStart - 8)) & 0xff), 1);
         } else {
           // Shared buffer full: spill to per-CTA global overflow cache.
           int g_off = atomicAdd(&s_cached_overflow_count[0], 1);
           if (g_off < overflow_stride) {
             PackedCachedData cached_res = {static_cast<uint32_t>(bits), i};
             get_cached_overflow(0)[g_off] = cached_res;
-            atomicAdd(shared_hist[1] + ((bits >> (LShiftStart - 8)) & 0xff), 1);
+            atomicAdd(shared_hist + 256 + ((bits >> (LShiftStart - 8)) & 0xff), 1);
           }
         }
       }
@@ -310,7 +310,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
                                // get_threshold_bin and phase ^ 1 of the histogram
     }
     if (radix_thread) {
-      shared_hist[phase ^ 1][threadIdx.x] = 0;
+      shared_hist[(phase ^ 1) * 256 + threadIdx.x] = 0;
     }
     if (threadIdx.x == 0) {
       shared_num_cached_count[phase] = 0;
@@ -339,7 +339,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
       int bin = (bits >> (LShiftStart - t * 8)) & 0xff;
 
       if (bin > threshold_bin) {
-        int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+        int topk_offset = atomicAdd(shared_final_idx_count, 1);
         if (topk_offset < TopK) {
           s_topk_inds[topk_offset] = cached_idx;
         } else {
@@ -351,13 +351,15 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
         if (cached_offset < num_cached) {
           s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
           s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
-          atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+          atomicAdd(shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff),
+                    1);
         } else {
           int g_off = atomicAdd(&s_cached_overflow_count[phase], 1);
           if (g_off < overflow_stride) {
             PackedCachedData data = {bits, cached_idx};
             get_cached_overflow(phase)[g_off] = data;
-            atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+            atomicAdd(
+                shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
           }
         }
       }
@@ -371,7 +373,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
       int bin = (bits >> (LShiftStart - t * 8)) & 0xff;
 
       if (bin > threshold_bin) {
-        int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+        int topk_offset = atomicAdd(shared_final_idx_count, 1);
         if (topk_offset < TopK) {
           s_topk_inds[topk_offset] = cached_idx;
         } else {
@@ -383,12 +385,14 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
         if (cached_offset < num_cached) {
           s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
           s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
-          atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+          atomicAdd(shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff),
+                    1);
         } else {
           int g_off = atomicAdd(&s_cached_overflow_count[phase], 1);
           if (g_off < overflow_stride) {
             get_cached_overflow(phase)[g_off] = {bits, cached_idx};
-            atomicAdd(shared_hist[phase ^ 1] + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+            atomicAdd(
+                shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
           }
         }
       }
@@ -404,7 +408,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
           int bin = s_cached_logit_bits[i] & 0xff;
           int cached_idx = s_cached_indices[i];
           if (bin == threshold_bin) {
-            int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+            int topk_offset = atomicAdd(shared_final_idx_count, 1);
             if (topk_offset < TopK) {
               s_topk_inds[topk_offset] = cached_idx;
             } else {
@@ -419,7 +423,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
           int cached_idx = data.index;
           int bin = bits & 0xff;
           if (bin == threshold_bin) {
-            int topk_offset = atomicAdd(&shared_final_idx_count, 1);
+            int topk_offset = atomicAdd(shared_final_idx_count, 1);
             if (topk_offset < TopK) {
               s_topk_inds[topk_offset] = cached_idx;
             } else {
@@ -437,18 +441,18 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   // slice.
   if (NClusters > 1) {
     int topk_start = 0;
-    int topk_num = shared_final_idx_count;
+    int topk_num = *shared_final_idx_count;
 
     cluster.sync();  // sync to get the shared_final_idx_count across CTAs in
                      // current cluster
 
     if (block_id > 0) {
       if (threadIdx.x == 0) {
-        topk_start += atomicAdd(cluster.map_shared_rank(&shared_final_idx_count, 0), topk_num);
-        shared_final_idx_count = topk_start;
+        topk_start += atomicAdd(cluster.map_shared_rank(shared_final_idx_count, 0), topk_num);
+        *shared_final_idx_count = topk_start;
       }
       __syncthreads();
-      topk_start = shared_final_idx_count;
+      topk_start = *shared_final_idx_count;
     }
 
     if (DEBUG && threadIdx.x == 0) {
@@ -479,6 +483,9 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
          i += 1024 * NClusters) {
       if (i < seq_len) {
         output_indices[ind_offset + i] = static_cast<IdxT>(i);
+        if (output_values != nullptr) {
+          output_values[ind_offset + i] = logits[logit_offset + i];
+        }
       } else {
         output_indices[ind_offset + i] = static_cast<IdxT>(-1);
       }
@@ -594,23 +601,24 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
   }
 }
 
-constexpr int MAX_SMEM_CARVEOUT = 227 * 1000;
+constexpr int MAX_SMEM_CARVEOUT = 227 * 1024;
 
-#define DISPATCH_TOPK_EXACT(kernel_name, dtype, CLUSTERS, PDL)                      \
-  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                             \
-    setup_kernel_smem_once<kernel_name<dtype, CLUSTERS, PDL>, MAX_SMEM_CARVEOUT>(); \
-    kernel = (void*)&kernel_name<dtype, CLUSTERS, PDL>;                             \
+#define DISPATCH_TOPK_EXACT(kernel_name, dtype, CLUSTERS, PDL) \
+  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {        \
+    kernel = (void*)&kernel_name<dtype, CLUSTERS, PDL>;        \
   }
 
 // Variant for kernels with an additional IdxT template parameter (index output dtype).
-#define DISPATCH_TOPK_EXACT_IDX(kernel_name, dtype, idx_type, CLUSTERS, PDL)                  \
-  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                                       \
-    setup_kernel_smem_once<kernel_name<dtype, idx_type, CLUSTERS, PDL>, MAX_SMEM_CARVEOUT>(); \
-    kernel = (void*)&kernel_name<dtype, idx_type, CLUSTERS, PDL>;                             \
+#define DISPATCH_TOPK_EXACT_IDX(kernel_name, dtype, idx_type, CLUSTERS, PDL) \
+  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                      \
+    kernel = (void*)&kernel_name<dtype, idx_type, CLUSTERS, PDL>;            \
   }
 
 inline void launch_topk_cluster_kernel(void* kernel, void** args, int grid_dim, int smem_bytes,
                                        int num_clusters, bool pdl_enabled, cudaStream_t stream) {
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, MAX_SMEM_CARVEOUT);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributePreferredSharedMemoryCarveout, 100);
+
   cudaLaunchConfig_t config;
   config.numAttrs = 0;
   cudaLaunchAttribute attribute[2];
@@ -630,14 +638,18 @@ inline void launch_topk_cluster_kernel(void* kernel, void** args, int grid_dim, 
   cudaLaunchKernelExC(&config, kernel, args);
 }
 
+int get_shared_mem_bytes(int TopK, int num_cached) {
+  return (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int) +
+          6 * sizeof(int) + 3 * 256 * sizeof(int) + 8 * sizeof(int));
+}
+
 template <typename T, typename IdxT = int>
 void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_values, int seq_len,
                                      int* pre_hist, int* cached_overflow, int overflow_stride,
                                      int batch_size, int logit_stride, int indices_stride,
                                      int num_cached, int num_clusters, bool pdl_enabled, int TopK,
                                      cudaStream_t stream) {
-  int extern_shared_mem =
-      (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
+  int extern_shared_mem = get_shared_mem_bytes(TopK, num_cached);
 
   void* args[11] = {
       &logits,          &indices,      &output_values,  &seq_len,    &pre_hist, &cached_overflow,
@@ -671,8 +683,7 @@ void launch_fast_topk_clusters_exact_page_table_transform(
     int* cached_overflow, int overflow_stride, int batch_size, int logit_stride, int indices_stride,
     int page_table_stride, int num_cached, int num_clusters, bool pdl_enabled, int TopK,
     cudaStream_t stream) {
-  int extern_shared_mem =
-      (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
+  int extern_shared_mem = get_shared_mem_bytes(TopK, num_cached);
 
   void* args[12] = {&logits,         &indices,           &seq_lens,        &page_table,
                     &pre_hist,       &cached_overflow,   &overflow_stride, &logit_stride,
@@ -703,8 +714,7 @@ void launch_fast_topk_clusters_exact_ragged_transform(
     const T* logits, int* indices, int* seq_lens, int* offsets, int* pre_hist, int* cached_overflow,
     int overflow_stride, int batch_size, int logit_stride, int indices_stride, int num_cached,
     int num_clusters, bool pdl_enabled, int TopK, cudaStream_t stream) {
-  int extern_shared_mem =
-      (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
+  int extern_shared_mem = get_shared_mem_bytes(TopK, num_cached);
 
   void* args[11] = {
       &logits,          &indices,      &seq_lens,       &offsets,    &pre_hist, &cached_overflow,

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -263,14 +263,14 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
           s_cached_indices[cached_offset] = i;
           s_cached_logit_bits[cached_offset] =
               static_cast<uint32_t>(bits);  // widen to 32 bits if from half
-          atomicAdd(shared_hist[1] + (( bits >> (LShiftStart - 8) ) & 0xff), 1);
+          atomicAdd(shared_hist[1] + ((bits >> (LShiftStart - 8)) & 0xff), 1);
         } else {
           // Shared buffer full: spill to per-CTA global overflow cache.
           int g_off = atomicAdd(&s_cached_overflow_count[0], 1);
           if (g_off < overflow_stride) {
             PackedCachedData cached_res = {static_cast<uint32_t>(bits), i};
             get_cached_overflow(0)[g_off] = cached_res;
-            atomicAdd(shared_hist[1] + (( bits >> (LShiftStart - 8) ) & 0xff), 1);
+            atomicAdd(shared_hist[1] + ((bits >> (LShiftStart - 8)) & 0xff), 1);
           }
         }
       }
@@ -464,7 +464,6 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   }
 }
 
-
 template <typename T, typename IdxT, int NClusters, bool PDL_ENABLED>
 __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
     fast_topk_clusters_exact_kernel(
@@ -505,19 +504,16 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
   }
 }
 
-
 template <typename T, int NClusters, bool PDL_ENABLED>
 __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
     fast_topk_clusters_exact_page_table_transform_kernel(
-        const T* __restrict__ logits,  // [batchsize, logits_stride]
-        int* __restrict__ output_indices, // [batchsize, indices_stride]
-        int* __restrict__ seq_lens, // [batchsize]
-        int* __restrict__ page_table, // [batchsize, page_table_stride]
-        int* __restrict__ pre_hist, // optional[batchsize, 256]
-        int* __restrict__ cached_overflow, // [batchsize, 4 * NClusters * overflow_stride]
-        int overflow_stride,
-        int logit_stride, int indices_stride, 
-        int page_table_stride,
+        const T* __restrict__ logits,       // [batchsize, logits_stride]
+        int* __restrict__ output_indices,   // [batchsize, indices_stride]
+        int* __restrict__ seq_lens,         // [batchsize]
+        int* __restrict__ page_table,       // [batchsize, page_table_stride]
+        int* __restrict__ pre_hist,         // optional[batchsize, 256]
+        int* __restrict__ cached_overflow,  // [batchsize, 4 * NClusters * overflow_stride]
+        int overflow_stride, int logit_stride, int indices_stride, int page_table_stride,
         int num_cached, const int TopK) {
   int cluster_id = blockIdx.x / NClusters;
   int logit_offset = cluster_id * logit_stride;
@@ -555,15 +551,13 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
 template <typename T, int NClusters, bool PDL_ENABLED>
 __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
     fast_topk_clusters_exact_ragged_transform_kernel(
-        const T* __restrict__ logits,  // [batchsize, logits_stride]
-        int* __restrict__ output_indices, // [batchsize, indices_stride]
-        int* __restrict__ seq_lens, // [batchsize]
-        int* __restrict__ offsets, // [batchsize]
-        int* __restrict__ pre_hist, // optional[batchsize, 256]
-        int* __restrict__ cached_overflow, // [batchsize, 4 * NClusters * overflow_stride]
-        int overflow_stride,
-        int logit_stride, int indices_stride, 
-        int num_cached, const int TopK) {
+        const T* __restrict__ logits,       // [batchsize, logits_stride]
+        int* __restrict__ output_indices,   // [batchsize, indices_stride]
+        int* __restrict__ seq_lens,         // [batchsize]
+        int* __restrict__ offsets,          // [batchsize]
+        int* __restrict__ pre_hist,         // optional[batchsize, 256]
+        int* __restrict__ cached_overflow,  // [batchsize, 4 * NClusters * overflow_stride]
+        int overflow_stride, int logit_stride, int indices_stride, int num_cached, const int TopK) {
   int cluster_id = blockIdx.x / NClusters;
   int logit_offset = cluster_id * logit_stride;
   int ind_offset = cluster_id * indices_stride;
@@ -597,24 +591,19 @@ __global__ __launch_bounds__(1024) void __cluster_dims__(NClusters, 1, 1)
   }
 }
 
-
-
-
 constexpr int MAX_SMEM_CARVEOUT = 227 * 1000;
 
-#define DISPATCH_TOPK_EXACT(kernel_name, dtype, CLUSTERS, PDL)                    \
-  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                           \
-    setup_kernel_smem_once<kernel_name<dtype, CLUSTERS, PDL>,                     \
-                           MAX_SMEM_CARVEOUT>();                                  \
-    kernel = (void*)&kernel_name<dtype, CLUSTERS, PDL>;                           \
+#define DISPATCH_TOPK_EXACT(kernel_name, dtype, CLUSTERS, PDL)                      \
+  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                             \
+    setup_kernel_smem_once<kernel_name<dtype, CLUSTERS, PDL>, MAX_SMEM_CARVEOUT>(); \
+    kernel = (void*)&kernel_name<dtype, CLUSTERS, PDL>;                             \
   }
 
 // Variant for kernels with an additional IdxT template parameter (index output dtype).
-#define DISPATCH_TOPK_EXACT_IDX(kernel_name, dtype, idx_type, CLUSTERS, PDL)     \
-  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                           \
-    setup_kernel_smem_once<kernel_name<dtype, idx_type, CLUSTERS, PDL>,           \
-                           MAX_SMEM_CARVEOUT>();                                  \
-    kernel = (void*)&kernel_name<dtype, idx_type, CLUSTERS, PDL>;                 \
+#define DISPATCH_TOPK_EXACT_IDX(kernel_name, dtype, idx_type, CLUSTERS, PDL)                  \
+  if (num_clusters == CLUSTERS && pdl_enabled == PDL) {                                       \
+    setup_kernel_smem_once<kernel_name<dtype, idx_type, CLUSTERS, PDL>, MAX_SMEM_CARVEOUT>(); \
+    kernel = (void*)&kernel_name<dtype, idx_type, CLUSTERS, PDL>;                             \
   }
 
 inline void launch_topk_cluster_kernel(void* kernel, void** args, int grid_dim, int smem_bytes,
@@ -648,7 +637,7 @@ void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_v
       (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
 
   void* args[11] = {
-      &logits,          &indices,      &output_values,  &seq_len,   &pre_hist, &cached_overflow,
+      &logits,          &indices,      &output_values,  &seq_len,    &pre_hist, &cached_overflow,
       &overflow_stride, &logit_stride, &indices_stride, &num_cached, &TopK};
 
   void* kernel = nullptr;
@@ -676,15 +665,15 @@ void launch_fast_topk_clusters_exact(const T* logits, IdxT* indices, T* output_v
 template <typename T>
 void launch_fast_topk_clusters_exact_page_table_transform(
     const T* logits, int* indices, int* seq_lens, int* page_table, int* pre_hist,
-    int* cached_overflow, int overflow_stride, int batch_size, int logit_stride,
-    int indices_stride, int page_table_stride, int num_cached, int num_clusters,
-    bool pdl_enabled, int TopK, cudaStream_t stream) {
+    int* cached_overflow, int overflow_stride, int batch_size, int logit_stride, int indices_stride,
+    int page_table_stride, int num_cached, int num_clusters, bool pdl_enabled, int TopK,
+    cudaStream_t stream) {
   int extern_shared_mem =
       (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
 
-  void* args[12] = {&logits,          &indices,        &seq_lens,          &page_table,
-                    &pre_hist,         &cached_overflow, &overflow_stride,   &logit_stride,
-                    &indices_stride,   &page_table_stride, &num_cached,      &TopK};
+  void* args[12] = {&logits,         &indices,           &seq_lens,        &page_table,
+                    &pre_hist,       &cached_overflow,   &overflow_stride, &logit_stride,
+                    &indices_stride, &page_table_stride, &num_cached,      &TopK};
 
   void* kernel = nullptr;
   DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_page_table_transform_kernel, T, 1, true);
@@ -708,16 +697,15 @@ void launch_fast_topk_clusters_exact_page_table_transform(
 
 template <typename T>
 void launch_fast_topk_clusters_exact_ragged_transform(
-    const T* logits, int* indices, int* seq_lens, int* offsets, int* pre_hist,
-    int* cached_overflow, int overflow_stride, int batch_size, int logit_stride,
-    int indices_stride, int num_cached, int num_clusters, bool pdl_enabled, int TopK,
-    cudaStream_t stream) {
+    const T* logits, int* indices, int* seq_lens, int* offsets, int* pre_hist, int* cached_overflow,
+    int overflow_stride, int batch_size, int logit_stride, int indices_stride, int num_cached,
+    int num_clusters, bool pdl_enabled, int TopK, cudaStream_t stream) {
   int extern_shared_mem =
       (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int));
 
-  void* args[11] = {&logits,    &indices,         &seq_lens,        &offsets,
-                    &pre_hist,  &cached_overflow,  &overflow_stride, &logit_stride,
-                    &indices_stride, &num_cached,  &TopK};
+  void* args[11] = {
+      &logits,          &indices,      &seq_lens,       &offsets,    &pre_hist, &cached_overflow,
+      &overflow_stride, &logit_stride, &indices_stride, &num_cached, &TopK};
 
   void* kernel = nullptr;
   DISPATCH_TOPK_EXACT(fast_topk_clusters_exact_ragged_transform_kernel, T, 1, true);

--- a/include/flashinfer/fast_topk_clusters_exact.cuh
+++ b/include/flashinfer/fast_topk_clusters_exact.cuh
@@ -98,12 +98,12 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   int* s_cached_indices = (int*)(2 * num_cached + s_cached_logit_bits);
   int* s_topk_inds = (int*)(2 * num_cached + s_cached_indices);
 
-  int* shared_hist = s_topk_inds + TopK;
-  int* shared_final_idx_count = shared_hist + 3 * 256;
-  int* shared_num_cached_count = shared_final_idx_count + 1;
-  int* shared_threshold_bin = shared_num_cached_count + 2;
-  int* s_cached_overflow_count = shared_threshold_bin + 1;
-  int* s_cum_reduce_buf = s_cached_overflow_count + 2;
+  int* shared_hist = s_topk_inds + TopK;                      // [3 * 256]
+  int* shared_final_idx_count = shared_hist + 3 * 256;        // [1]
+  int* shared_num_cached_count = shared_final_idx_count + 1;  // [2]
+  int* shared_threshold_bin = shared_num_cached_count + 2;    // [1]
+  int* s_cum_reduce_buf = shared_threshold_bin + 1;           // [8]
+  int* s_k_remaining_counter = s_cum_reduce_buf + 8;          // [1]
 
   auto cluster = cg::this_cluster();
   const int block_id = cluster.block_rank();
@@ -165,8 +165,8 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   }
   if (threadIdx.x == 0) {
     *shared_final_idx_count = 0;
+    *s_k_remaining_counter = 0;
     shared_num_cached_count[0] = 0;
-    s_cached_overflow_count[0] = 0;
   }
 
   if (pre_hist == nullptr) {
@@ -192,9 +192,9 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
 
       if (bin > threshold_bin) {
         int topk_offset = atomicAdd(shared_final_idx_count, 1);
-        if (topk_offset < TopK) {
-          s_topk_inds[topk_offset] = i;
-        }
+        // if (topk_offset < TopK) {
+        s_topk_inds[topk_offset] = i;
+        // }
       }
 
       if (bin == threshold_bin) {
@@ -206,7 +206,7 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
           atomicAdd(shared_hist + 256 + ((bits >> (LShiftStart - 8)) & 0xff), 1);
         } else {
           // Shared buffer full: spill to per-CTA global overflow cache.
-          int g_off = atomicAdd(&s_cached_overflow_count[0], 1);
+          int g_off = cached_offset - num_cached;
           if (g_off < overflow_stride) {
             PackedCachedData cached_res = {static_cast<uint32_t>(bits), i};
             get_cached_overflow(0)[g_off] = cached_res;
@@ -254,7 +254,6 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
     }
     if (threadIdx.x == 0) {
       shared_num_cached_count[phase] = 0;
-      s_cached_overflow_count[phase] = 0;
     }
     // get_threshold_bin synchronizes the block
     const int threshold_bin = get_threshold_bin(phase, top_k_remaining);
@@ -263,8 +262,10 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
                                  // iteration there is no dependency because no
                                  // more calls to get_threshold_bin
     }
-    int buf_len = min(num_cached, shared_num_cached_count[phase ^ 1]);
-    int g_buf_len = min(overflow_stride, s_cached_overflow_count[phase ^ 1]);
+    int raw_buf_len = shared_num_cached_count[phase ^ 1];
+    int buf_len = min(num_cached, raw_buf_len);
+    int g_buf_len = min(overflow_stride, max(0, raw_buf_len - num_cached));
+    bool exceeded_k_remaining_cnt = false;
 
     // --- Process shared cache ---
     // using cached indices, it's a local slice so don't partition between
@@ -276,26 +277,44 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
 
       if (bin > threshold_bin) {
         int topk_offset = atomicAdd(shared_final_idx_count, 1);
-        if (topk_offset < TopK) {
-          s_topk_inds[topk_offset] = cached_idx;
-        } else {
-          break;
-        }
+        s_topk_inds[topk_offset] = cached_idx;
       }
-      if (bin == threshold_bin && t < NRemainingRounds) {
-        int cached_offset = atomicAdd(&shared_num_cached_count[phase], 1);
-        if (cached_offset < num_cached) {
-          s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
-          s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
-          atomicAdd(shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff),
-                    1);
-        } else {
-          int g_off = atomicAdd(&s_cached_overflow_count[phase], 1);
-          if (g_off < overflow_stride) {
-            PackedCachedData data = {bits, cached_idx};
-            get_cached_overflow(phase)[g_off] = data;
+      if (bin == threshold_bin) {
+        if (t < NRemainingRounds) {
+          int cached_offset = atomicAdd(&shared_num_cached_count[phase], 1);
+          if (cached_offset < num_cached) {
+            s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
+            s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
             atomicAdd(
                 shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
+          } else {
+            int g_off = cached_offset - num_cached;
+            if (g_off < overflow_stride) {
+              PackedCachedData data = {bits, cached_idx};
+              get_cached_overflow(phase)[g_off] = data;
+              atomicAdd(
+                  shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff),
+                  1);
+            }
+          }
+        } else {
+          // t == NRemainingRounds
+          // if top_k_remaining > 0, that means that in the final round, there's still
+          // top_k_remaining items left after considering items bigger than the threshold_bin,
+          // therefore the top_k_remaining items must be == to the threshold_bin, partitioned
+          // amongst the cluster ranks
+          if (top_k_remaining > 0 && !exceeded_k_remaining_cnt) {
+            // here just pick an arbitrary index, since it should be bit equal as we be bin ==
+            // threshold_bin in the last bin
+            int k_remaining_cnt = atomicAdd(cluster.map_shared_rank(s_k_remaining_counter, 0), 1);
+            if (k_remaining_cnt < top_k_remaining) {
+              int off = atomicAdd(shared_final_idx_count, 1);
+              s_topk_inds[off] = cached_idx;  // this should always be inbounds since the sum of
+              // shared_final_idx_count amongst the cluster ranks +
+              // top_k_remaining == TopK
+            } else {
+              exceeded_k_remaining_cnt = true;
+            }
           }
         }
       }
@@ -310,60 +329,42 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
 
       if (bin > threshold_bin) {
         int topk_offset = atomicAdd(shared_final_idx_count, 1);
-        if (topk_offset < TopK) {
-          s_topk_inds[topk_offset] = cached_idx;
-        } else {
-          break;
-        }
+        s_topk_inds[topk_offset] = cached_idx;
       }
-      if (bin == threshold_bin && t < NRemainingRounds) {
-        int cached_offset = atomicAdd(&shared_num_cached_count[phase], 1);
-        if (cached_offset < num_cached) {
-          s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
-          s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
-          atomicAdd(shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff),
-                    1);
-        } else {
-          int g_off = atomicAdd(&s_cached_overflow_count[phase], 1);
-          if (g_off < overflow_stride) {
-            get_cached_overflow(phase)[g_off] = {bits, cached_idx};
+      if (bin == threshold_bin) {
+        if (t < NRemainingRounds) {
+          int cached_offset = atomicAdd(&shared_num_cached_count[phase], 1);
+          if (cached_offset < num_cached) {
+            s_cached_indices[cached_offset + phase * num_cached] = cached_idx;
+            s_cached_logit_bits[cached_offset + phase * num_cached] = bits;
             atomicAdd(
                 shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff), 1);
-          }
-        }
-      }
-    }
-
-    // it could be that at the last stage, we have say S topk indices, T indices
-    // above the threshold_bin and S + T < TopK. Then the rest of the topk items
-    // must come from threshold_bin
-    if (t == NRemainingRounds) {
-      if (top_k_remaining > 0) {
-        // Collect threshold_bin items from shared cache.
-        for (int i = threadIdx.x; i < buf_len; i += blockDim.x) {
-          int bin = s_cached_logit_bits[i] & 0xff;
-          int cached_idx = s_cached_indices[i];
-          if (bin == threshold_bin) {
-            int topk_offset = atomicAdd(shared_final_idx_count, 1);
-            if (topk_offset < TopK) {
-              s_topk_inds[topk_offset] = cached_idx;
-            } else {
-              break;
+          } else {
+            int g_off = cached_offset - num_cached;
+            if (g_off < overflow_stride) {
+              get_cached_overflow(phase)[g_off] = {bits, cached_idx};
+              atomicAdd(
+                  shared_hist + (phase ^ 1) * 256 + (bits >> (LShiftStart - (t + 1) * 8) & 0xff),
+                  1);
             }
           }
-        }
-        // Collect threshold_bin items from global overflow cache.
-        for (int i = threadIdx.x; i < g_buf_len; i += blockDim.x) {
-          auto data = get_cached_overflow(phase ^ 1)[i];
-          uint32_t bits = data.bits;
-          int cached_idx = data.index;
-          int bin = bits & 0xff;
-          if (bin == threshold_bin) {
-            int topk_offset = atomicAdd(shared_final_idx_count, 1);
-            if (topk_offset < TopK) {
-              s_topk_inds[topk_offset] = cached_idx;
+        } else {
+          // t == NRemainingRounds
+          // if top_k_remaining > 0, that means that in the final round, there's still
+          // top_k_remaining items left after considering items bigger than the threshold_bin,
+          // therefore the top_k_remaining items must be == to the threshold_bin, partitioned
+          // amongst the cluster ranks
+          if (top_k_remaining > 0 && !exceeded_k_remaining_cnt) {
+            // here just pick an arbitrary index, since it should be bit equal as we be bin ==
+            // threshold_bin in the last bin
+            int k_remaining_cnt = atomicAdd(cluster.map_shared_rank(s_k_remaining_counter, 0), 1);
+            if (k_remaining_cnt < top_k_remaining) {
+              int off = atomicAdd(shared_final_idx_count, 1);
+              s_topk_inds[off] = cached_idx;  // this should always be inbounds since the sum of
+              // shared_final_idx_count amongst the cluster ranks +
+              // top_k_remaining == TopK
             } else {
-              break;
+              exceeded_k_remaining_cnt = true;
             }
           }
         }
@@ -378,6 +379,9 @@ __device__ __forceinline__ TopkResults fast_topk_cuda_v4(
   if (NClusters > 1) {
     int topk_start = 0;
     int topk_num = *shared_final_idx_count;
+    // if (threadIdx.x == 0)
+    //   printf("cluster id %d, topk_num %d, top_k_remaining %d\n", block_id, topk_num,
+    //          top_k_remaining);
 
     cluster.sync();  // sync to get the shared_final_idx_count across CTAs in
                      // current cluster
@@ -574,7 +578,7 @@ inline void launch_topk_cluster_kernel(void* kernel, void** args, int grid_dim, 
 
 int get_shared_mem_bytes(int TopK, int num_cached) {
   return (num_cached * 2 * sizeof(float) + num_cached * 2 * sizeof(int) + TopK * sizeof(int) +
-          6 * sizeof(int) + 3 * 256 * sizeof(int) + 8 * sizeof(int));
+          5 * sizeof(int) + 3 * 256 * sizeof(int) + 8 * sizeof(int));
 }
 
 template <typename T, typename IdxT = int>

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -25,6 +25,7 @@
 #include <numeric>
 #include <type_traits>
 
+#include "topk_common.cuh"
 #include "utils.cuh"
 #include "vec_dtypes.cuh"
 
@@ -51,92 +52,6 @@ inline size_t GetRadixTopKAvailableOrderedSmemBytes(size_t max_smem_per_block,
   return max_smem_per_block - fixed_smem_aligned - launch_headroom;
 }
 
-// ============================================================================
-// RadixTopK Type Traits - supports float, half, and bfloat16
-// OrderedType: uint32_t for float, uint16_t for half/bf16
-// NUM_ROUNDS is computed as: sizeof(OrderedType) * 8 / RADIX_BITS
-// ============================================================================
-template <typename DType>
-struct RadixTopKTraits;
-
-// Specialization for float (32-bit)
-template <>
-struct RadixTopKTraits<float> {
-  using OrderedType = uint32_t;
-
-  // Compute number of rounds based on radix bits (not hardcoded)
-  template <uint32_t RADIX_BITS>
-  static __host__ __device__ constexpr uint32_t num_rounds() {
-    return sizeof(OrderedType) * 8 / RADIX_BITS;
-  }
-
-  __device__ __forceinline__ static OrderedType ToOrdered(float val) {
-    uint32_t bits = __float_as_uint(val);
-    // For descending order: flip all bits if negative, else flip sign bit
-    return (bits & 0x80000000) ? ~bits : (bits ^ 0x80000000);
-  }
-
-  __device__ __forceinline__ static float FromOrdered(OrderedType ordered) {
-    uint32_t bits = (ordered & 0x80000000) ? (ordered ^ 0x80000000) : ~ordered;
-    return __uint_as_float(bits);
-  }
-
-  __device__ __forceinline__ static float NegInf() {
-    return -cuda::std::numeric_limits<float>::infinity();
-  }
-};
-
-// Specialization for half (16-bit)
-template <>
-struct RadixTopKTraits<half> {
-  using OrderedType = uint16_t;
-
-  template <uint32_t RADIX_BITS>
-  static __host__ __device__ constexpr uint32_t num_rounds() {
-    return sizeof(OrderedType) * 8 / RADIX_BITS;
-  }
-
-  __device__ __forceinline__ static OrderedType ToOrdered(half val) {
-    uint16_t bits = __half_as_ushort(val);
-    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits ^ 0x8000);
-  }
-
-  __device__ __forceinline__ static half FromOrdered(OrderedType ordered) {
-    uint16_t bits = (ordered & 0x8000) ? static_cast<uint16_t>(ordered ^ 0x8000)
-                                       : static_cast<uint16_t>(~ordered);
-    return __ushort_as_half(bits);
-  }
-
-  __device__ __forceinline__ static half NegInf() {
-    return __ushort_as_half(static_cast<uint16_t>(0xFC00));  // -inf in fp16
-  }
-};
-
-// Specialization for nv_bfloat16 (16-bit)
-template <>
-struct RadixTopKTraits<nv_bfloat16> {
-  using OrderedType = uint16_t;
-
-  template <uint32_t RADIX_BITS>
-  static __host__ __device__ constexpr uint32_t num_rounds() {
-    return sizeof(OrderedType) * 8 / RADIX_BITS;
-  }
-
-  __device__ __forceinline__ static OrderedType ToOrdered(nv_bfloat16 val) {
-    uint16_t bits = __bfloat16_as_ushort(val);
-    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits ^ 0x8000);
-  }
-
-  __device__ __forceinline__ static nv_bfloat16 FromOrdered(OrderedType ordered) {
-    uint16_t bits = (ordered & 0x8000) ? static_cast<uint16_t>(ordered ^ 0x8000)
-                                       : static_cast<uint16_t>(~ordered);
-    return __ushort_as_bfloat16(bits);
-  }
-
-  __device__ __forceinline__ static nv_bfloat16 NegInf() {
-    return __ushort_as_bfloat16(static_cast<uint16_t>(0xFF80));  // -inf in bf16
-  }
-};
 // ==================== Multi-CTA Top-K Implementation ====================
 
 // Acquire/Release primitives for inter-CTA synchronization

--- a/include/flashinfer/topk_common.cuh
+++ b/include/flashinfer/topk_common.cuh
@@ -1,0 +1,106 @@
+#ifndef FLASHINFER_TOPK_COMMON_CUH_
+#define FLASHINFER_TOPK_COMMON_CUH_
+
+#include <cstdint>
+#include <cstdlib>
+#include <numeric>
+#include <type_traits>
+
+
+namespace flashinfer {
+namespace sampling {
+
+
+
+
+// ============================================================================
+// RadixTopK Type Traits - supports float, half, and bfloat16
+// OrderedType: uint32_t for float, uint16_t for half/bf16
+// NUM_ROUNDS is computed as: sizeof(OrderedType) * 8 / RADIX_BITS
+// ============================================================================
+template <typename DType>
+struct RadixTopKTraits;
+
+// Specialization for float (32-bit)
+template <>
+struct RadixTopKTraits<float> {
+  using OrderedType = uint32_t;
+
+  // Compute number of rounds based on radix bits (not hardcoded)
+  template <uint32_t RADIX_BITS>
+  static __host__ __device__ constexpr uint32_t num_rounds() {
+    return sizeof(OrderedType) * 8 / RADIX_BITS;
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(float val) {
+    uint32_t bits = __float_as_uint(val);
+    // For descending order: flip all bits if negative, else flip sign bit
+    return (bits & 0x80000000) ? ~bits : (bits ^ 0x80000000);
+  }
+
+  __device__ __forceinline__ static float FromOrdered(OrderedType ordered) {
+    uint32_t bits = (ordered & 0x80000000) ? (ordered ^ 0x80000000) : ~ordered;
+    return __uint_as_float(bits);
+  }
+
+  __device__ __forceinline__ static float NegInf() {
+    return -cuda::std::numeric_limits<float>::infinity();
+  }
+};
+
+// Specialization for half (16-bit)
+template <>
+struct RadixTopKTraits<half> {
+  using OrderedType = uint16_t;
+
+  template <uint32_t RADIX_BITS>
+  static __host__ __device__ constexpr uint32_t num_rounds() {
+    return sizeof(OrderedType) * 8 / RADIX_BITS;
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(half val) {
+    uint16_t bits = __half_as_ushort(val);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits ^ 0x8000);
+  }
+
+  __device__ __forceinline__ static half FromOrdered(OrderedType ordered) {
+    uint16_t bits = (ordered & 0x8000) ? static_cast<uint16_t>(ordered ^ 0x8000)
+                                       : static_cast<uint16_t>(~ordered);
+    return __ushort_as_half(bits);
+  }
+
+  __device__ __forceinline__ static half NegInf() {
+    return __ushort_as_half(static_cast<uint16_t>(0xFC00));  // -inf in fp16
+  }
+};
+
+// Specialization for nv_bfloat16 (16-bit)
+template <>
+struct RadixTopKTraits<nv_bfloat16> {
+  using OrderedType = uint16_t;
+
+  template <uint32_t RADIX_BITS>
+  static __host__ __device__ constexpr uint32_t num_rounds() {
+    return sizeof(OrderedType) * 8 / RADIX_BITS;
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(nv_bfloat16 val) {
+    uint16_t bits = __bfloat16_as_ushort(val);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits ^ 0x8000);
+  }
+
+  __device__ __forceinline__ static nv_bfloat16 FromOrdered(OrderedType ordered) {
+    uint16_t bits = (ordered & 0x8000) ? static_cast<uint16_t>(ordered ^ 0x8000)
+                                       : static_cast<uint16_t>(~ordered);
+    return __ushort_as_bfloat16(bits);
+  }
+
+  __device__ __forceinline__ static nv_bfloat16 NegInf() {
+    return __ushort_as_bfloat16(static_cast<uint16_t>(0xFF80));  // -inf in bf16
+  }
+};
+
+}  // namespace sampling
+}  // namespace flashinfer
+
+#endif // FLASHINFER_TOPK_COMMON_CUH_

--- a/include/flashinfer/topk_common.cuh
+++ b/include/flashinfer/topk_common.cuh
@@ -1,8 +1,12 @@
 #ifndef FLASHINFER_TOPK_COMMON_CUH_
 #define FLASHINFER_TOPK_COMMON_CUH_
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 #include <cstdint>
 #include <cstdlib>
+#include <cuda/std/limits>
 #include <numeric>
 #include <type_traits>
 

--- a/include/flashinfer/topk_common.cuh
+++ b/include/flashinfer/topk_common.cuh
@@ -6,12 +6,8 @@
 #include <numeric>
 #include <type_traits>
 
-
 namespace flashinfer {
 namespace sampling {
-
-
-
 
 // ============================================================================
 // RadixTopK Type Traits - supports float, half, and bfloat16
@@ -103,4 +99,4 @@ struct RadixTopKTraits<nv_bfloat16> {
 }  // namespace sampling
 }  // namespace flashinfer
 
-#endif // FLASHINFER_TOPK_COMMON_CUH_
+#endif  // FLASHINFER_TOPK_COMMON_CUH_

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -51,6 +51,7 @@ def compute_topk_accuracy(test_indices, ref_indices, batch_size, k):
     for i in range(batch_size):
         ref_set = set(ref_indices[i].cpu().numpy())
         test_set = set(test_indices[i].cpu().numpy())
+        assert len(ref_set) == len(test_set)
         total_intersection += len(ref_set & test_set)
     return total_intersection / (batch_size * k)
 
@@ -133,7 +134,7 @@ def test_top_k(batch_size, vocab_size, k, dtype):
     accuracy = compute_topk_accuracy(indices.int(), ref_indices.int(), batch_size, k)
     # Accuracy depends on vocab size, k, and data distribution
     # Random Gaussian data can have many values close to each other at boundaries
-    min_accuracy = 0.98
+    min_accuracy = 0.97
     assert accuracy >= min_accuracy, f"Accuracy {accuracy:.4f} < {min_accuracy}"
 
 
@@ -2260,6 +2261,163 @@ def test_top_k_uint32_pointer_overflow():
         indices[row_idx : row_idx + 1].int(), ref_indices.int(), 1, k
     )
     assert accuracy >= 0.98, f"Last row accuracy {accuracy:.4f} < 0.98"
+
+
+# ===================== topk_clusters_exact Tests =====================
+
+
+def _require_sm100_or_sm103():
+    major, minor = get_compute_capability(torch.device("cuda"))
+    cc = major * 10 + minor
+    if cc not in [100, 103]:
+        pytest.skip("topk_clusters_exact requires SM100 or SM103 (Blackwell)")
+
+
+@pytest.mark.parametrize("batch_size", [1, 16, 64])
+@pytest.mark.parametrize("seq_len", [4096, 16384, 65536])
+@pytest.mark.parametrize("k", [256, 1024, 2048])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("output_values", [False, True])
+@pytest.mark.parametrize("out_dtype", [torch.int32, torch.int64])
+def test_topk_clusters_exact_correctness(batch_size, seq_len, k, dtype, output_values, out_dtype):
+    """Test topk_clusters_exact returns indices (and optionally values) matching torch.topk."""
+    _require_sm100_or_sm103()
+    if k > seq_len:
+        pytest.skip("k should be less than seq_len")
+
+    torch.manual_seed(42)
+    device = "cuda"
+    logits = torch.randn(batch_size, seq_len, device=device, dtype=dtype)
+
+    indices, values = flashinfer.topk.topk_clusters_exact(
+        logits, k, output_values=output_values, out_dtype=out_dtype
+    )
+
+    assert indices.shape == (batch_size, k)
+    assert indices.dtype == out_dtype
+
+    ref_values, ref_indices = torch.topk(logits, k, dim=-1)
+
+    if output_values:
+        assert values is not None
+        assert values.shape == (batch_size, k)
+        assert values.dtype == dtype
+        
+        abs_err = 0.125 if dtype == torch.bfloat16 else 1e-5
+        rel_err = 0.1 if dtype == torch.bfloat16 else 1e-5
+        torch.testing.assert_close(values.min(dim=-1).values, ref_values.min(dim=-1).values, rtol=rel_err, atol=abs_err)
+        torch.testing.assert_close(values.max(dim=-1).values, ref_values.max(dim=-1).values, rtol=rel_err, atol=abs_err)
+    else:
+        assert values is None
+
+    accuracy = compute_topk_accuracy(indices, ref_indices.int(), batch_size, k)
+    acc = 0.95 if dtype == torch.bfloat16 else 0.99
+    assert accuracy >= acc, f"Accuracy {accuracy:.4f} < {acc}"
+
+
+@pytest.mark.parametrize("batch_size", [1, 16])
+@pytest.mark.parametrize("seq_len", [4096, 16384])
+@pytest.mark.parametrize("k", [256, 2048])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_topk_clusters_exact_variable_seq_lens(batch_size, seq_len, k, dtype):
+    """Test topk_clusters_ragged_transform respects per-row variable seq_lens."""
+    _require_sm100_or_sm103()
+    if k > seq_len // 2:
+        pytest.skip("k should be well below seq_len")
+
+    torch.manual_seed(42)
+    device = "cuda"
+    logits = torch.randn(batch_size, seq_len, device=device, dtype=dtype)
+    # Variable lengths: half rows get seq_len, half get seq_len // 2
+    lengths_list = [seq_len if i % 2 == 0 else seq_len // 2 for i in range(batch_size)]
+    seq_lens = torch.tensor(lengths_list, device=device, dtype=torch.int32)
+    # Zero offsets: output indices are positions within each row
+    offsets = torch.zeros(batch_size, device=device, dtype=torch.int32)
+
+    indices = flashinfer.topk.topk_clusters_ragged_transform(logits, seq_lens, offsets, k)
+
+    assert indices.shape == (batch_size, k)
+    assert indices.dtype == torch.int32
+
+    # Verify all indices are within [0, row_len) for each row
+    for i in range(batch_size):
+        row_len = lengths_list[i]
+        assert torch.all(indices[i] >= 0) and torch.all(indices[i] < row_len), (
+            f"Row {i}: indices out of [0, {row_len})"
+        )
+
+    # Verify accuracy per row
+    for i in range(batch_size):
+        row_len = lengths_list[i]
+        ref = torch.topk(logits[i, :row_len], k).indices
+        test_set = set(indices[i].cpu().numpy())
+        ref_set = set(ref.cpu().numpy())
+        row_accuracy = len(test_set & ref_set) / k
+        acc = 0.95 if dtype == torch.bfloat16 else 0.99
+        assert row_accuracy >= acc, f"Row {i} accuracy {row_accuracy:.4f} < {acc}"
+
+
+@pytest.mark.parametrize("num_rows", [1, 16, 64])
+@pytest.mark.parametrize("seq_len", [4096, 16384])
+@pytest.mark.parametrize("k", [256, 1024])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_topk_clusters_page_table_transform(num_rows, seq_len, k, dtype):
+    """Test topk_clusters_page_table_transform returns correct page table entries."""
+    _require_sm100_or_sm103()
+    if k > seq_len:
+        pytest.skip("k should be less than seq_len")
+
+    torch.manual_seed(42)
+    device = "cuda"
+
+    scores = torch.randn(num_rows, seq_len, device=device, dtype=dtype)
+    src_page_table = torch.randint(
+        0, 10000, (num_rows, seq_len), device=device, dtype=torch.int32
+    )
+    lengths = torch.full((num_rows,), seq_len, device=device, dtype=torch.int32)
+
+    output = flashinfer.topk.topk_clusters_page_table_transform(
+        scores, lengths, src_page_table, k
+    )
+
+    assert output.shape == (num_rows, k)
+    assert output.dtype == torch.int32
+
+    ref_output = reference_page_table_transform(scores, src_page_table, lengths, k)
+    accuracy = compute_transform_accuracy(output, ref_output, num_rows, k)
+    
+    acc = 0.95 if dtype == torch.bfloat16 else 0.99
+    assert accuracy >= acc, f"Accuracy {accuracy:.4f} < {acc}"
+
+
+@pytest.mark.parametrize("num_rows", [1, 16, 64])
+@pytest.mark.parametrize("seq_len", [4096, 16384])
+@pytest.mark.parametrize("k", [256, 1024])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_topk_clusters_ragged_transform(num_rows, seq_len, k, dtype):
+    """Test topk_clusters_ragged_transform returns correct indices with offsets."""
+    _require_sm100_or_sm103()
+    if k > seq_len:
+        pytest.skip("k should be less than seq_len")
+
+    torch.manual_seed(42)
+    device = "cuda"
+
+    scores = torch.randn(num_rows, seq_len, device=device, dtype=dtype)
+    offsets = torch.arange(
+        0, num_rows * seq_len, seq_len, device=device, dtype=torch.int32
+    )
+    lengths = torch.full((num_rows,), seq_len, device=device, dtype=torch.int32)
+
+    output = flashinfer.topk.topk_clusters_ragged_transform(scores, lengths, offsets, k)
+
+    assert output.shape == (num_rows, k)
+    assert output.dtype == torch.int32
+
+    ref_output = reference_ragged_transform(scores, offsets, lengths, k)
+    accuracy = compute_transform_accuracy(output, ref_output, num_rows, k)
+    acc = 0.95 if dtype == torch.bfloat16 else 0.99
+    assert accuracy >= acc, f"Accuracy {accuracy:.4f} < {acc}"
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -2279,7 +2279,9 @@ def _require_sm100_or_sm103():
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("output_values", [False, True])
 @pytest.mark.parametrize("out_dtype", [torch.int32, torch.int64])
-def test_topk_clusters_exact_correctness(batch_size, seq_len, k, dtype, output_values, out_dtype):
+def test_topk_clusters_exact_correctness(
+    batch_size, seq_len, k, dtype, output_values, out_dtype
+):
     """Test topk_clusters_exact returns indices (and optionally values) matching torch.topk."""
     _require_sm100_or_sm103()
     if k > seq_len:
@@ -2302,11 +2304,21 @@ def test_topk_clusters_exact_correctness(batch_size, seq_len, k, dtype, output_v
         assert values is not None
         assert values.shape == (batch_size, k)
         assert values.dtype == dtype
-        
+
         abs_err = 0.125 if dtype == torch.bfloat16 else 1e-5
         rel_err = 0.1 if dtype == torch.bfloat16 else 1e-5
-        torch.testing.assert_close(values.min(dim=-1).values, ref_values.min(dim=-1).values, rtol=rel_err, atol=abs_err)
-        torch.testing.assert_close(values.max(dim=-1).values, ref_values.max(dim=-1).values, rtol=rel_err, atol=abs_err)
+        torch.testing.assert_close(
+            values.min(dim=-1).values,
+            ref_values.min(dim=-1).values,
+            rtol=rel_err,
+            atol=abs_err,
+        )
+        torch.testing.assert_close(
+            values.max(dim=-1).values,
+            ref_values.max(dim=-1).values,
+            rtol=rel_err,
+            atol=abs_err,
+        )
     else:
         assert values is None
 
@@ -2334,7 +2346,9 @@ def test_topk_clusters_exact_variable_seq_lens(batch_size, seq_len, k, dtype):
     # Zero offsets: output indices are positions within each row
     offsets = torch.zeros(batch_size, device=device, dtype=torch.int32)
 
-    indices = flashinfer.topk.topk_clusters_ragged_transform(logits, seq_lens, offsets, k)
+    indices = flashinfer.topk.topk_clusters_ragged_transform(
+        logits, seq_lens, offsets, k
+    )
 
     assert indices.shape == (batch_size, k)
     assert indices.dtype == torch.int32
@@ -2385,7 +2399,7 @@ def test_topk_clusters_page_table_transform(num_rows, seq_len, k, dtype):
 
     ref_output = reference_page_table_transform(scores, src_page_table, lengths, k)
     accuracy = compute_transform_accuracy(output, ref_output, num_rows, k)
-    
+
     acc = 0.95 if dtype == torch.bfloat16 else 0.99
     assert accuracy >= acc, f"Accuracy {accuracy:.4f} < {acc}"
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR implements a faster topk algorithm that uses sm90+ CTA clusters feature. This is a non-deterministic algorithm, but does not drop indices and instead overflows to global memory. Benchmark results show that it's faster than both the multi-cta topk algorithm and the filtering algorithm overall. The cases it's slower is when the overflow happens too much.
Note: Speedup is speedup of flashinfer vs torch, while Speedup Clusters vs. Default is speed up of this kernel over flashinfer.
```
====================================================================================================
top_k: Basic radix-based top-k selection (dtype=FP32, deterministic=False, pattern=random)
NOTE: default top-k sweep includes two extra large-batch/long-vocab stress cases beyond the original grid
====================================================================================================
 batch    seq_len      k |   FlashInfer   torch.topk    Speedup     Clusters  Speedup Clusters vs. Default
-------------------------------------------------------------------------------------------------------------------
     1        256    256 |         4.42us      20.64us      4.67x       1.50us                         2.94x
     1        512    256 |         5.79us      22.11us      3.82x       6.18us                         0.94x
     1        512    512 |         5.38us      21.28us      3.96x       1.54us                         3.50x
     1       1024    256 |        10.05us      27.68us      2.75x       6.40us                         1.57x
     1       1024    512 |         6.56us      24.51us      3.74x       6.40us                         1.02x
     1       1024   1024 |         5.12us      25.38us      4.96x       1.60us                         3.20x
     1       2048    256 |        10.08us      31.17us      3.09x       7.10us                         1.42x
     1       2048    512 |        11.01us      31.94us      2.90x       7.20us                         1.53x
     1       2048   1024 |         9.34us      32.03us      3.43x       7.07us                         1.32x
     1       2048   2048 |         5.79us      27.26us      4.71x       1.76us                         3.29x
     1       4096    256 |         9.12us      36.06us      3.95x       7.30us                         1.25x
     1       4096    512 |        11.42us      41.70us      3.65x       7.39us                         1.55x
     1       4096   1024 |        11.52us      41.15us      3.57x       7.58us                         1.52x
     1       4096   2048 |        10.22us      32.45us      3.17x       7.30us                         1.40x
     1       4096   4096 |         7.17us      35.78us      4.99x       2.02us                         3.56x
     1      16384    256 |        12.83us      78.53us      6.12x      11.49us                         1.12x
     1      16384    512 |        14.98us      89.09us      5.95x      12.24us                         1.22x
     1      16384   1024 |        15.95us      80.99us      5.08x      12.26us                         1.30x
     1      16384   2048 |        17.50us      93.33us      5.33x      12.51us                         1.40x
     1      16384   4096 |        21.28us      84.70us      3.98x      12.80us                         1.66x
     1      65536    256 |        33.44us      94.88us      2.84x      12.48us                         2.68x
     1      65536    512 |        34.24us      92.26us      2.69x      12.35us                         2.77x
     1      65536   1024 |        34.75us      91.52us      2.63x      12.42us                         2.80x
     1      65536   2048 |        36.58us      91.87us      2.51x      13.73us                         2.66x
     1      65536   4096 |        37.98us      92.03us      2.42x      13.92us                         2.73x
     1     131072    256 |        39.10us      99.81us      2.55x      14.69us                         2.66x
     1     131072    512 |        40.26us      98.13us      2.44x      14.72us                         2.73x
     1     131072   1024 |        39.81us      99.92us      2.51x      14.88us                         2.68x
     1     131072   2048 |        41.94us     101.50us      2.42x      14.98us                         2.80x
     1     131072   4096 |        43.62us     103.04us      2.36x      18.40us                         2.37x
     1     262144    256 |        43.46us     116.40us      2.68x      19.26us                         2.26x
     1     262144    512 |        44.46us     115.49us      2.60x      19.36us                         2.30x
     1     262144   1024 |        44.35us     114.14us      2.57x      19.34us                         2.29x
     1     262144   2048 |        45.89us     115.36us      2.51x      19.52us                         2.35x
     1     262144   4096 |        46.78us     116.83us      2.50x      19.71us                         2.37x
     1     524288    256 |        45.60us     152.27us      3.34x      28.00us                         1.63x
     1     524288    512 |        46.91us     146.75us      3.13x      28.19us                         1.66x
     1     524288   1024 |        46.34us     151.39us      3.27x      28.35us                         1.63x
     1     524288   2048 |        47.14us     149.55us      3.17x      28.58us                         1.65x
     1     524288   4096 |        47.76us     151.58us      3.17x      28.54us                         1.67x
    16        256    256 |         5.95us      20.99us      3.53x       1.50us                         3.96x
    16        512    256 |         9.98us      23.07us      2.31x       6.43us                         1.55x
    16        512    512 |         5.60us      22.82us      4.07x       1.50us                         3.72x
    16       1024    256 |        11.30us      28.86us      2.56x       6.59us                         1.71x
    16       1024    512 |         9.12us      26.37us      2.89x       6.62us                         1.38x
    16       1024   1024 |         6.21us      27.30us      4.40x       1.60us                         3.88x
    16       2048    256 |        11.65us      31.87us      2.74x       7.23us                         1.61x
    16       2048    512 |        10.62us      32.64us      3.07x       7.36us                         1.44x
    16       2048   1024 |        10.08us      30.27us      3.00x       7.30us                         1.38x
    16       2048   2048 |         6.75us      30.46us      4.51x       1.76us                         3.84x
    16       4096    256 |        11.55us      43.04us      3.73x       7.39us                         1.56x
    16       4096    512 |        12.26us      44.70us      3.65x       7.49us                         1.64x
    16       4096   1024 |        12.06us      42.21us      3.50x       7.63us                         1.58x
    16       4096   2048 |        12.10us      38.69us      3.20x       7.65us                         1.58x
    16       4096   4096 |         7.84us      41.50us      5.29x       2.02us                         3.89x
    16      16384    256 |        14.98us      92.72us      6.19x      14.18us                         1.06x
    16      16384    512 |        15.17us      96.22us      6.34x      15.38us                         0.99x
    16      16384   1024 |        17.73us      98.88us      5.58x      15.33us                         1.16x
    16      16384   2048 |        18.18us      98.50us      5.42x      15.81us                         1.15x
    16      16384   4096 |        21.63us     107.09us      4.95x      16.29us                         1.33x
    16      65536    256 |        27.73us     104.93us      3.78x      16.13us                         1.72x
    16      65536    512 |        32.16us     103.86us      3.23x      16.35us                         1.97x
    16      65536   1024 |        32.58us     103.84us      3.19x      16.16us                         2.02x
    16      65536   2048 |        35.90us     107.92us      3.01x      19.20us                         1.87x
    16      65536   4096 |        42.08us     110.78us      2.63x      19.62us                         2.15x
    16     131072    256 |        43.92us     115.10us      2.62x      20.96us                         2.10x
    16     131072    512 |        43.46us     112.86us      2.60x      21.23us                         2.05x
    16     131072   1024 |        53.47us     115.94us      2.17x      21.25us                         2.52x
    16     131072   2048 |        54.43us     116.69us      2.14x      21.25us                         2.56x
    16     131072   4096 |        48.22us     122.78us      2.55x      26.88us                         1.79x
    16     262144    256 |        49.12us     136.64us      2.78x      27.54us                         1.78x
    16     262144    512 |        49.33us     136.82us      2.77x      28.03us                         1.76x
    16     262144   1024 |        49.46us     138.70us      2.80x      28.03us                         1.76x
    16     262144   2048 |        50.59us     139.33us      2.75x      28.29us                         1.79x
    16     262144   4096 |        51.55us     142.85us      2.77x      28.77us                         1.79x
    16     524288    256 |        89.95us     181.86us      2.02x      42.38us                         2.12x
    16     524288    512 |        90.51us     178.05us      1.97x      43.17us                         2.10x
    16     524288   1024 |        90.75us     179.14us      1.97x      42.72us                         2.12x
    16     524288   2048 |        91.73us     182.66us      1.99x      43.39us                         2.11x
    16     524288   4096 |        93.60us     185.39us      1.98x      43.15us                         2.17x
    64        256    256 |         6.37us      22.05us      3.46x       1.50us                         4.24x
    64        512    256 |        10.53us      23.68us      2.25x       6.53us                         1.61x
    64        512    512 |         5.50us      23.55us      4.28x       1.54us                         3.58x
    64       1024    256 |        12.03us      31.09us      2.58x       6.70us                         1.79x
    64       1024    512 |        10.62us      27.30us      2.57x       6.77us                         1.57x
    64       1024   1024 |         6.66us      26.91us      4.04x       1.63us                         4.08x
    64       2048    256 |        11.34us      35.07us      3.09x       7.39us                         1.53x
    64       2048    512 |        10.88us      34.18us      3.14x       7.42us                         1.47x
    64       2048   1024 |        11.20us      32.42us      2.89x       7.52us                         1.49x
    64       2048   2048 |         7.39us      32.06us      4.34x       1.79us                         4.12x
    64       4096    256 |        12.67us      43.23us      3.41x       7.68us                         1.65x
    64       4096    512 |        11.71us      43.14us      3.68x       7.71us                         1.52x
    64       4096   1024 |        12.13us      46.66us      3.85x       7.87us                         1.54x
    64       4096   2048 |        11.97us      40.22us      3.36x       7.78us                         1.54x
    64       4096   4096 |         8.64us      40.93us      4.74x       2.08us                         4.15x
    64      16384    256 |        15.42us      98.59us      6.39x      14.11us                         1.09x
    64      16384    512 |        15.39us     101.60us      6.60x      15.42us                         1.00x
    64      16384   1024 |        17.98us      99.87us      5.55x      15.65us                         1.15x
    64      16384   2048 |        19.14us     102.14us      5.34x      15.97us                         1.20x
    64      16384   4096 |        22.37us     104.22us      4.66x      16.46us                         1.36x
    64      65536    256 |        27.97us     135.71us      4.85x      20.93us                         1.34x
    64      65536    512 |        32.85us     136.61us      4.16x      21.12us                         1.56x
    64      65536   1024 |        34.08us     135.14us      3.97x      21.22us                         1.61x
    64      65536   2048 |        36.93us     139.07us      3.77x      27.04us                         1.37x
    64      65536   4096 |        43.30us     141.86us      3.28x      28.35us                         1.53x
    64     131072    256 |        44.80us     178.22us      3.98x      29.41us                         1.52x
    64     131072    512 |        44.53us     174.94us      3.93x      29.57us                         1.51x
    64     131072   1024 |        54.59us     174.56us      3.20x      29.70us                         1.84x
    64     131072   2048 |        55.46us     177.73us      3.20x      30.24us                         1.83x
    64     131072   4096 |        90.98us     181.47us      1.99x      44.93us                         2.02x
    64     262144    256 |        75.17us     240.90us      3.20x      47.73us                         1.57x
    64     262144    512 |        80.53us     239.86us      2.98x      47.92us                         1.68x
    64     262144   1024 |        81.97us     241.82us      2.95x      48.13us                         1.70x
    64     262144   2048 |        98.64us     241.71us      2.45x      48.58us                         2.03x
    64     262144   4096 |       143.36us     244.83us      1.71x      49.95us                         2.87x
    64     524288    256 |       162.29us     488.82us      3.01x      84.50us                         1.92x
    64     524288    512 |       161.41us     488.70us      3.03x      84.70us                         1.91x
    64     524288   1024 |       175.39us     491.07us      2.80x      85.01us                         2.06x
    64     524288   2048 |       175.98us     494.22us      2.81x      85.89us                         2.05x
    64     524288   4096 |       227.90us     494.98us      2.17x      88.62us                         2.57x
   256        256    256 |         7.04us      23.15us      3.29x       1.82us                         3.86x
   256        512    256 |        15.12us      27.04us      1.79x       7.87us                         1.92x
   256        512    512 |         7.15us      26.37us      3.69x       1.89us                         3.79x
   256       1024    256 |        17.66us      40.45us      2.29x       8.26us                         2.14x
   256       1024    512 |        15.65us      37.55us      2.40x       8.32us                         1.88x
   256       1024   1024 |         7.58us      38.83us      5.12x       2.14us                         3.54x
   256       2048    256 |        18.66us      49.60us      2.66x       9.34us                         2.00x
   256       2048    512 |        18.66us      51.17us      2.74x       9.47us                         1.97x
   256       2048   1024 |        17.09us      46.14us      2.70x       9.66us                         1.77x
   256       2048   2048 |         8.99us      47.52us      5.28x       2.37us                         3.80x
   256       4096    256 |        19.23us      99.17us      5.16x      10.72us                         1.79x
   256       4096    512 |        19.97us      99.41us      4.98x      10.91us                         1.83x
   256       4096   1024 |        20.58us     102.10us      4.96x      11.28us                         1.82x
   256       4096   2048 |        18.34us     103.58us      5.65x      11.07us                         1.66x
   256       4096   4096 |        12.54us     114.22us      9.11x       2.82us                         4.45x
   256      16384    256 |        28.42us     131.98us      4.64x      16.19us                         1.75x
   256      16384    512 |        29.50us     135.30us      4.59x      22.11us                         1.33x
   256      16384   1024 |        31.34us     136.93us      4.37x      23.23us                         1.35x
   256      16384   2048 |        34.24us     138.99us      4.06x      24.26us                         1.41x
   256      16384   4096 |        40.64us     149.52us      3.68x      25.12us                         1.62x
   256      65536    256 |        53.92us     240.27us      4.46x      42.66us                         1.26x
   256      65536    512 |        64.16us     243.09us      3.79x      43.22us                         1.48x
   256      65536   1024 |        64.93us     243.83us      3.76x      43.97us                         1.48x
   256      65536   2048 |        71.01us     250.61us      3.53x      76.10us                         0.93x
   256      65536   4096 |       150.53us     260.10us      1.73x      83.87us                         1.79x
   256     131072    256 |        92.15us     487.68us      5.29x      81.01us                         1.14x
   256     131072    512 |        92.16us     488.58us      5.30x      81.44us                         1.13x
   256     131072   1024 |       111.23us     493.68us      4.44x      82.45us                         1.35x
   256     131072   2048 |       112.56us     495.41us      4.40x      84.58us                         1.33x
   256     131072   4096 |       259.01us     509.48us      1.97x     161.81us                         1.60x
   256     262144    256 |       178.59us     881.03us      4.93x     155.81us                         1.15x
   256     262144    512 |       192.08us     879.04us      4.58x     156.94us                         1.22x
   256     262144   1024 |       192.74us     879.60us      4.56x     158.18us                         1.22x
   256     262144   2048 |       230.40us     885.49us      3.84x     160.82us                         1.43x
   256     262144   4096 |       411.46us     898.68us      2.18x     170.59us                         2.41x
   256     524288    256 |       327.39us    1542.01us      4.71x     299.43us                         1.09x
   256     524288    512 |       327.95us    1542.65us      4.70x     300.77us                         1.09x
   256     524288   1024 |       355.35us    1544.52us      4.35x     303.06us                         1.17x
   256     524288   2048 |       357.19us    1549.56us      4.34x     305.75us                         1.17x
   256     524288   4096 |       824.29us    1568.89us      1.90x     316.91us                         2.60x
  2048     131072   1024 |       703.20us    3012.43us      4.28x     470.11us                         1.50x
  4096     200000   1024 |      1994.76us    8891.66us      4.46x    1383.16us                         1.44x

====================================================================================================
dsa_topk: DeepSeek DSA-like indexer top-k workload (dtype=FP32, deterministic=False, dsa_pattern=dsa_relu, k=2048)
====================================================================================================
                    case     rows    seq_len      k |   FlashInfer   torch.topk    Speedup     Clusters  Speedup Clusters vs. Default
---------------------------------------------------------------------------------------------------------------------------------
      decode_b1_q1_l128k        1     131072   2048 |      42.59us      98.62us      2.32x      14.98us                         2.84x
       decode_b8_q1_l64k        8      65536   2048 |      37.01us      97.70us      2.64x      14.59us                         2.54x
     decode_b32_q1_l128k       32     131072   2048 |      56.13us     135.20us      2.41x      23.01us                         2.44x
   prefill_b1_q128_l128k      128     131072   2048 |      62.02us     241.52us      3.89x      49.18us                         1.26x

====================================================================================================
top_k_page_table_transform: Fused top-k + page table gather (dtype=FP32, deterministic=False, pattern=random)
====================================================================================================
 batch    seq_len      k |   FlashInfer     Clusters  Speedup Clusters vs. Default
-------------------------------------------------------------------------------------------------------------
     1        256    256 |       2.85us       2.43us                         1.17x
     1        512    256 |       4.72us       7.04us                         0.67x
     1        512    512 |       2.94us       2.56us                         1.15x
     1       1024    256 |       7.04us       7.01us                         1.00x
     1       1024    512 |       4.45us       6.77us                         0.66x
     1       1024   1024 |       2.56us       2.24us                         1.14x
     1       2048    256 |       8.64us       7.92us                         1.09x
     1       2048    512 |       7.38us       7.87us                         0.94x
     1       2048   1024 |       7.12us       7.71us                         0.92x
     1       2048   2048 |       3.26us       2.91us                         1.12x
     1       4096    256 |       8.93us       8.26us                         1.08x
     1       4096    512 |       9.06us       8.35us                         1.08x
     1       4096   1024 |       7.95us       8.32us                         0.96x
     1       4096   2048 |       7.65us       8.00us                         0.96x
     1       4096   4096 |       4.16us       2.62us                         1.59x
     1      16384    256 |      12.26us      12.70us                         0.96x
     1      16384    512 |      13.10us      13.26us                         0.99x
     1      16384   1024 |      14.46us      13.50us                         1.07x
     1      16384   2048 |      15.46us      13.54us                         1.14x
     1      16384   4096 |      20.35us      13.73us                         1.48x
     1      65536    256 |      30.30us      13.07us                         2.32x
     1      65536    512 |      31.14us      13.12us                         2.37x
     1      65536   1024 |      31.58us      13.18us                         2.40x
     1      65536   2048 |      33.50us      14.62us                         2.29x
     1      65536   4096 |      35.33us      14.82us                         2.38x
     1     131072    256 |      35.42us      15.07us                         2.35x
     1     131072    512 |      35.87us      15.17us                         2.36x
     1     131072   1024 |      36.45us      15.33us                         2.38x
     1     131072   2048 |      38.05us      15.30us                         2.49x
     1     131072   4096 |      41.22us      19.17us                         2.15x
     1     262144    256 |      40.08us      19.78us                         2.03x
     1     262144    512 |      40.58us      20.32us                         2.00x
     1     262144   1024 |      41.15us      19.81us                         2.08x
     1     262144   2048 |      42.82us      20.02us                         2.14x
     1     262144   4096 |      45.06us      20.22us                         2.23x
     1     524288    256 |      42.75us      28.21us                         1.52x
     1     524288    512 |      42.82us      28.29us                         1.51x
     1     524288   1024 |      43.10us      28.26us                         1.53x
     1     524288   2048 |      43.71us      28.38us                         1.54x
     1     524288   4096 |      45.12us      29.31us                         1.54x
    16        256    256 |       2.75us       2.37us                         1.16x
    16        512    256 |       7.71us       7.17us                         1.08x
    16        512    512 |       2.85us       2.46us                         1.16x
    16       1024    256 |       8.19us       7.30us                         1.12x
    16       1024    512 |       6.94us       7.39us                         0.94x
    16       1024   1024 |       2.82us       2.56us                         1.10x
    16       2048    256 |       8.70us       8.08us                         1.08x
    16       2048    512 |       8.67us       8.19us                         1.06x
    16       2048   1024 |       8.19us       8.06us                         1.02x
    16       2048   2048 |       3.52us       3.20us                         1.10x
    16       4096    256 |       9.05us       8.45us                         1.07x
    16       4096    512 |      10.14us       8.50us                         1.19x
    16       4096   1024 |       9.31us       8.61us                         1.08x
    16       4096   2048 |       8.74us       8.35us                         1.05x
    16       4096   4096 |       4.50us       2.82us                         1.60x
    16      16384    256 |      12.74us      15.04us                         0.85x
    16      16384    512 |      13.38us      16.83us                         0.79x
    16      16384   1024 |      14.30us      16.80us                         0.85x
    16      16384   2048 |      16.26us      17.17us                         0.95x
    16      16384   4096 |      20.51us      17.52us                         1.17x
    16      65536    256 |      24.69us      16.86us                         1.46x
    16      65536    512 |      29.82us      16.80us                         1.78x
    16      65536   1024 |      30.69us      17.18us                         1.79x
    16      65536   2048 |      34.14us      20.29us                         1.68x
    16      65536   4096 |      39.68us      20.83us                         1.90x
    16     131072    256 |      40.78us      21.63us                         1.89x
    16     131072    512 |      41.25us      21.63us                         1.91x
    16     131072   1024 |      51.58us      21.66us                         2.38x
    16     131072   2048 |      52.78us      22.02us                         2.40x
    16     131072   4096 |      45.87us      27.94us                         1.64x
    16     262144    256 |      45.34us      28.64us                         1.58x
    16     262144    512 |      45.92us      28.70us                         1.60x
    16     262144   1024 |      46.34us      29.04us                         1.60x
    16     262144   2048 |      47.84us      29.60us                         1.62x
    16     262144   4096 |      49.70us      30.30us                         1.64x
    16     524288    256 |      86.62us      43.87us                         1.97x
    16     524288    512 |      87.30us      44.13us                         1.98x
    16     524288   1024 |      87.68us      44.35us                         1.98x
    16     524288   2048 |      89.30us      44.74us                         2.00x
    16     524288   4096 |      92.38us      45.36us                         2.04x
    64        256    256 |       2.85us       2.43us                         1.17x
    64        512    256 |       7.78us       7.39us                         1.05x
    64        512    512 |       2.91us       2.56us                         1.14x
    64       1024    256 |       8.58us       7.58us                         1.13x
    64       1024    512 |       8.06us       7.60us                         1.06x
    64       1024   1024 |       3.01us       2.66us                         1.13x
    64       2048    256 |       9.47us       8.38us                         1.13x
    64       2048    512 |       8.83us       8.35us                         1.06x
    64       2048   1024 |       8.29us       8.35us                         0.99x
    64       2048   2048 |       3.71us       3.33us                         1.12x
    64       4096    256 |       9.41us       8.74us                         1.08x
    64       4096    512 |       9.58us       8.86us                         1.08x
    64       4096   1024 |      10.34us       8.93us                         1.16x
    64       4096   2048 |       9.09us       8.61us                         1.06x
    64       4096   4096 |       4.70us       3.04us                         1.55x
    64      16384    256 |      13.06us      15.17us                         0.86x
    64      16384    512 |      13.86us      16.61us                         0.83x
    64      16384   1024 |      15.23us      16.80us                         0.91x
    64      16384   2048 |      16.45us      16.96us                         0.97x
    64      16384   4096 |      21.10us      17.44us                         1.21x
    64      65536    256 |      25.58us      21.89us                         1.17x
    64      65536    512 |      31.20us      22.02us                         1.42x
    64      65536   1024 |      31.87us      22.18us                         1.44x
    64      65536   2048 |      35.34us      28.45us                         1.24x
    64      65536   4096 |      41.31us      30.75us                         1.34x
    64     131072    256 |      42.14us      30.34us                         1.39x
    64     131072    512 |      42.80us      30.59us                         1.40x
    64     131072   1024 |      52.54us      30.85us                         1.70x
    64     131072   2048 |      54.40us      31.62us                         1.72x
    64     131072   4096 |      90.27us      49.18us                         1.84x
    64     262144    256 |      71.92us      48.66us                         1.48x
    64     262144    512 |      79.04us      48.56us                         1.63x
    64     262144   1024 |      79.22us      49.02us                         1.62x
    64     262144   2048 |      96.82us      49.54us                         1.95x
    64     262144   4096 |     146.72us      54.74us                         2.68x
    64     524288    256 |     158.80us      84.70us                         1.87x
    64     524288    512 |     158.82us      84.99us                         1.87x
    64     524288   1024 |     171.39us      85.76us                         2.00x
    64     524288   2048 |     172.91us      86.19us                         2.01x
    64     524288   4096 |     228.77us      90.02us                         2.54x
   256        256    256 |       3.74us       2.75us                         1.36x
   256        512    256 |      13.25us       8.72us                         1.52x
   256        512    512 |       3.81us       2.98us                         1.28x
   256       1024    256 |      15.84us       9.09us                         1.74x
   256       1024    512 |      13.47us       9.14us                         1.47x
   256       1024   1024 |       4.08us       3.36us                         1.21x
   256       2048    256 |      16.51us      10.29us                         1.60x
   256       2048    512 |      16.32us      10.37us                         1.57x
   256       2048   1024 |      14.53us      10.30us                         1.41x
   256       2048   2048 |       5.28us       3.97us                         1.33x
   256       4096    256 |      17.36us      11.82us                         1.47x
   256       4096    512 |      18.72us      11.97us                         1.56x
   256       4096   1024 |      18.43us      12.22us                         1.51x
   256       4096   2048 |      15.68us      11.42us                         1.37x
   256       4096   4096 |       7.52us       4.29us                         1.75x
   256      16384    256 |      26.72us      17.09us                         1.56x
   256      16384    512 |      28.35us      23.04us                         1.23x
   256      16384   1024 |      30.21us      23.97us                         1.26x
   256      16384   2048 |      33.22us      24.93us                         1.33x
   256      16384   4096 |      41.31us      26.30us                         1.57x
   256      65536    256 |      52.75us      43.46us                         1.21x
   256      65536    512 |      63.33us      44.13us                         1.44x
   256      65536   1024 |      66.08us      46.93us                         1.41x
   256      65536   2048 |      74.27us      78.90us                         0.94x
   256      65536   4096 |     152.87us      88.19us                         1.73x
   256     131072    256 |      89.89us      80.86us                         1.11x
   256     131072    512 |      90.99us      81.34us                         1.12x
   256     131072   1024 |     109.87us      82.70us                         1.33x
   256     131072   2048 |     114.05us      85.18us                         1.34x
   256     131072   4096 |     261.31us     162.07us                         1.61x
   256     262144    256 |     174.27us     154.00us                         1.13x
   256     262144    512 |     187.58us     154.53us                         1.21x
   256     262144   1024 |     189.57us     155.97us                         1.22x
   256     262144   2048 |     227.89us     158.94us                         1.43x
   256     262144   4096 |     422.98us     169.30us                         2.50x
   256     524288    256 |     322.55us     298.26us                         1.08x
   256     524288    512 |     323.62us     300.18us                         1.08x
   256     524288   1024 |     350.56us     302.34us                         1.16x
   256     524288   2048 |     354.67us     306.77us                         1.16x
   256     524288   4096 |     834.52us     316.07us                         2.64x

====================================================================================================
top_k_ragged_transform: Fused top-k + ragged index transform (dtype=FP32, deterministic=False, pattern=random)
====================================================================================================
 batch    seq_len      k |   FlashInfer     Clusters  Speedup Clusters vs. Default
-------------------------------------------------------------------------------------------------------------
     1        256    256 |       2.37us       1.76us                         1.35x
     1        512    256 |       3.58us       6.53us                         0.55x
     1        512    512 |       2.34us       1.82us                         1.28x
     1       1024    256 |       7.63us       6.94us                         1.10x
     1       1024    512 |       6.14us       6.88us                         0.89x
     1       1024   1024 |       2.75us       2.08us                         1.32x
     1       2048    256 |       6.72us       7.52us                         0.89x
     1       2048    512 |       7.97us       7.74us                         1.03x
     1       2048   1024 |       7.71us       7.68us                         1.00x
     1       2048   2048 |       2.85us       2.18us                         1.31x
     1       4096    256 |       8.22us       7.70us                         1.07x
     1       4096    512 |       7.23us       7.71us                         0.94x
     1       4096   1024 |       8.38us       7.86us                         1.07x
     1       4096   2048 |       6.83us       7.44us                         0.92x
     1       4096   4096 |       2.91us       2.30us                         1.26x
     1      16384    256 |      11.52us      11.87us                         0.97x
     1      16384    512 |      11.94us      12.51us                         0.95x
     1      16384   1024 |      12.74us      12.54us                         1.02x
     1      16384   2048 |      13.92us      12.51us                         1.11x
     1      16384   4096 |      17.50us      12.61us                         1.39x
     1      65536    256 |      30.88us      12.78us                         2.42x
     1      65536    512 |      31.14us      12.74us                         2.44x
     1      65536   1024 |      32.16us      12.74us                         2.53x
     1      65536   2048 |      33.07us      14.05us                         2.35x
     1      65536   4096 |      34.18us      14.21us                         2.41x
     1     131072    256 |      36.54us      14.94us                         2.45x
     1     131072    512 |      37.22us      14.91us                         2.50x
     1     131072   1024 |      37.41us      14.98us                         2.50x
     1     131072   2048 |      38.34us      14.98us                         2.56x
     1     131072   4096 |      39.84us      18.67us                         2.13x
     1     262144    256 |      41.28us      19.36us                         2.13x
     1     262144    512 |      41.68us      19.65us                         2.12x
     1     262144   1024 |      41.44us      19.55us                         2.12x
     1     262144   2048 |      42.88us      19.65us                         2.18x
     1     262144   4096 |      43.46us      19.49us                         2.23x
     1     524288    256 |      42.88us      28.00us                         1.53x
     1     524288    512 |      43.33us      27.97us                         1.55x
     1     524288   1024 |      43.49us      28.54us                         1.52x
     1     524288   2048 |      44.10us      28.46us                         1.55x
     1     524288   4096 |      44.13us      28.35us                         1.56x
    16        256    256 |       2.43us       1.86us                         1.31x
    16        512    256 |       6.42us       6.78us                         0.95x
    16        512    512 |       2.48us       1.92us                         1.29x
    16       1024    256 |       7.52us       6.85us                         1.10x
    16       1024    512 |       6.18us       7.01us                         0.88x
    16       1024   1024 |       2.43us       1.92us                         1.27x
    16       2048    256 |       7.87us       7.58us                         1.04x
    16       2048    512 |       7.90us       7.60us                         1.04x
    16       2048   1024 |       6.56us       7.65us                         0.86x
    16       2048   2048 |       2.53us       2.08us                         1.22x
    16       4096    256 |       8.16us       7.78us                         1.05x
    16       4096    512 |       8.35us       7.82us                         1.07x
    16       4096   1024 |       8.34us       8.00us                         1.04x
    16       4096   2048 |       7.97us       7.58us                         1.05x
    16       4096   4096 |       2.62us       2.21us                         1.19x
    16      16384    256 |      11.71us      14.37us                         0.82x
    16      16384    512 |      13.09us      15.65us                         0.84x
    16      16384   1024 |      13.12us      15.97us                         0.82x
    16      16384   2048 |      14.27us      15.84us                         0.90x
    16      16384   4096 |      17.60us      16.10us                         1.09x
    16      65536    256 |      23.79us      16.37us                         1.45x
    16      65536    512 |      28.91us      16.48us                         1.75x
    16      65536   1024 |      29.57us      16.74us                         1.77x
    16      65536   2048 |      32.03us      18.98us                         1.69x
    16      65536   4096 |      37.66us      19.46us                         1.94x
    16     131072    256 |      39.75us      20.67us                         1.92x
    16     131072    512 |      40.06us      20.80us                         1.93x
    16     131072   1024 |      49.31us      20.61us                         2.39x
    16     131072   2048 |      49.25us      20.48us                         2.40x
    16     131072   4096 |      43.62us      26.45us                         1.65x
    16     262144    256 |      45.54us      27.57us                         1.65x
    16     262144    512 |      45.63us      27.74us                         1.64x
    16     262144   1024 |      46.02us      27.65us                         1.66x
    16     262144   2048 |      46.43us      27.76us                         1.67x
    16     262144   4096 |      47.68us      28.23us                         1.69x
    16     524288    256 |      86.43us      42.54us                         2.03x
    16     524288    512 |      86.82us      42.75us                         2.03x
    16     524288   1024 |      87.07us      42.08us                         2.07x
    16     524288   2048 |      87.71us      42.38us                         2.07x
    16     524288   4096 |      89.17us      42.93us                         2.08x
    64        256    256 |       2.37us       1.79us                         1.32x
    64        512    256 |       7.46us       7.01us                         1.06x
    64        512    512 |       2.56us       1.95us                         1.31x
    64       1024    256 |       7.74us       7.14us                         1.09x
    64       1024    512 |       7.33us       7.10us                         1.03x
    64       1024   1024 |       2.53us       2.05us                         1.23x
    64       2048    256 |       8.00us       7.68us                         1.04x
    64       2048    512 |       8.03us       7.78us                         1.03x
    64       2048   1024 |       6.78us       7.71us                         0.88x
    64       2048   2048 |       2.59us       2.11us                         1.23x
    64       4096    256 |       9.20us       7.98us                         1.15x
    64       4096    512 |       8.54us       8.10us                         1.06x
    64       4096   1024 |       8.64us       8.13us                         1.06x
    64       4096   2048 |       8.29us       7.84us                         1.06x
    64       4096   4096 |       2.72us       2.27us                         1.20x
    64      16384    256 |      12.13us      14.11us                         0.86x
    64      16384    512 |      13.31us      15.36us                         0.87x
    64      16384   1024 |      14.27us      15.63us                         0.91x
    64      16384   2048 |      15.17us      15.74us                         0.96x
    64      16384   4096 |      18.10us      16.03us                         1.13x
    64      65536    256 |      25.06us      20.64us                         1.21x
    64      65536    512 |      29.25us      20.58us                         1.42x
    64      65536   1024 |      29.89us      20.67us                         1.45x
    64      65536   2048 |      32.94us      26.56us                         1.24x
    64      65536   4096 |      38.99us      27.26us                         1.43x
    64     131072    256 |      41.06us      28.88us                         1.42x
    64     131072    512 |      41.22us      28.99us                         1.42x
    64     131072   1024 |      50.37us      29.09us                         1.73x
    64     131072   2048 |      50.83us      29.22us                         1.74x
    64     131072   4096 |      86.02us      43.84us                         1.96x
    64     262144    256 |      70.35us      47.04us                         1.50x
    64     262144    512 |      76.61us      47.07us                         1.63x
    64     262144   1024 |      77.41us      47.26us                         1.64x
    64     262144   2048 |      93.22us      47.54us                         1.96x
    64     262144   4096 |     137.71us      47.97us                         2.87x
    64     524288    256 |     157.73us      83.46us                         1.89x
    64     524288    512 |     157.31us      83.46us                         1.88x
    64     524288   1024 |     169.62us      83.81us                         2.02x
    64     524288   2048 |     170.10us      84.21us                         2.02x
    64     524288   4096 |     222.91us      84.21us                         2.65x
   256        256    256 |       2.94us       2.22us                         1.32x
   256        512    256 |      12.10us       8.16us                         1.48x
   256        512    512 |       3.09us       2.27us                         1.36x
   256       1024    256 |      14.05us       8.67us                         1.62x
   256       1024    512 |      11.49us       8.67us                         1.32x
   256       1024   1024 |       3.39us       2.45us                         1.39x
   256       2048    256 |      15.84us       9.60us                         1.65x
   256       2048    512 |      14.88us       9.66us                         1.54x
   256       2048   1024 |      13.15us       9.76us                         1.35x
   256       2048   2048 |       3.74us       2.46us                         1.52x
   256       4096    256 |      16.48us      10.98us                         1.50x
   256       4096    512 |      16.16us      11.10us                         1.46x
   256       4096   1024 |      16.93us      11.33us                         1.49x
   256       4096   2048 |      14.26us      10.72us                         1.33x
   256       4096   4096 |       4.13us       2.66us                         1.55x
   256      16384    256 |      24.54us      16.35us                         1.50x
   256      16384    512 |      25.57us      22.05us                         1.16x
   256      16384   1024 |      27.52us      22.66us                         1.21x
   256      16384   2048 |      29.82us      23.07us                         1.29x
   256      16384   4096 |      35.14us      23.14us                         1.52x
   256      65536    256 |      50.02us      42.40us                         1.18x
   256      65536    512 |      59.97us      42.64us                         1.41x
   256      65536   1024 |      60.35us      43.10us                         1.40x
   256      65536   2048 |      65.46us      72.35us                         0.90x
   256      65536   4096 |     144.24us      74.11us                         1.95x
   256     131072    256 |      87.68us      79.49us                         1.10x
   256     131072    512 |      88.13us      79.78us                         1.10x
   256     131072   1024 |     106.06us      80.19us                         1.32x
   256     131072   2048 |     106.21us      80.48us                         1.32x
   256     131072   4096 |     250.90us     143.89us                         1.74x
   256     262144    256 |     172.16us     152.48us                         1.13x
   256     262144    512 |     185.03us     152.80us                         1.21x
   256     262144   1024 |     185.33us     153.22us                         1.21x
   256     262144   2048 |     220.74us     153.57us                         1.44x
   256     262144   4096 |     403.57us     154.13us                         2.62x
   256     524288    256 |     320.91us     295.36us                         1.09x
   256     524288    512 |     320.71us     296.06us                         1.08x
   256     524288   1024 |     346.91us     296.64us                         1.17x
   256     524288   2048 |     347.35us     297.58us                         1.17x
   256     524288   4096 |     815.83us     298.11us                         2.74x


```

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clustered Top‑K option with public APIs, automatic dispatch, and support for page‑table and ragged inputs.

* **Benchmarks**
  * Added "clusters" measurement path, CUDA-graph timing, and speedup-vs-default reporting in benchmark output.

* **Tests**
  * New correctness and coverage tests for clustered Top‑K gated by compute capability with dtype-specific accuracy thresholds.

* **Chores**
  * Updated JIT/build to include clustered kernels and pass CUDA compile flags; added a cached shared‑memory query utility.

* **Style**
  * Tightened test assertions, improved GPU timing sync, and adjusted benchmark output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->