### PR TITLE
Fix: CUDA illegal memory access in MoE three-step sort fallback (num_tokens > 256)

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -3800,6 +3800,9 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, IsMX
 
     if (!fused_prologue_result) {
       TLLM_LOG_TRACE("Falling back to unfused prologue");
+      // Fix: zero-init permutation arrays before three-step fallback
+      // The three-step path may not populate all entries (e.g. tokens not matching local experts)
+      cudaMemsetAsync(unpermuted_row_to_permuted_row, -1, expanded_num_rows * sizeof(int), stream);
       threeStepBuildExpertMapsSortFirstToken(
           token_selected_experts, permuted_token_selected_experts_, permuted_row_to_unpermuted_row_,
           unpermuted_row_to_permuted_row, expert_first_token_offset_, blocked_expert_counts_,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Fixes a CUDA illegal memory access crash in cutlass_fused_moe with use_deepseek_fp8_block_scale=True when num_tokens > 256.

Root Cause

When num_tokens > 256, the fused single-block sort kernel (fusedBuildExpertMapsSortFirstTokenKernel, max BLOCK_SIZE=256) cannot handle the batch and falls back to threeStepBuildExpertMapsSortFirstToken.

The three-step fallback's blockExpertPrefixSumKernel uses break after finding the first match of a given expert in a token's top_k list. When a token has duplicate expert selections in its top_k (e.g., experts=[5, 88, 88, 65, ...]), only the first occurrence is recorded — the second slot's entry in unpermuted_row_to_permuted_row is never written.

finalizeMoeRoutingKernel then reads these uninitialized entries as row indices into the GEMM output buffer, causing wild pointer dereferences and CUDA illegal memory access.

Fix

Zero-initialize unpermuted_row_to_permuted_row with -1 before the three-step fallback runs. This is safe because finalizeMoeRoutingKernel checks expert_id validity before accessing the permutation array — entries with -1 produce valid (though redundant) expert lookups that are handled correctly.
```
cudaMemsetAsync(unpermuted_row_to_permuted_row, -1, expanded_num_rows * sizeof(int), stream);
```
Performance Impact

None. cudaMemsetAsync is fully async (no CPU-GPU sync), CUDA-graph compatible, and memsets <16KB on the GPU (<1 us). It only runs on the fallback path (num_tokens > 256).

## Test plan

### 1. Serve with FlashInfer MoE (the fixed path)

```bash
export VLLM_USE_FLASHINFER_SAMPLER=1
export VLLM_USE_FLASHINFER_MOE_FP8=1

vllm serve /scratch_omniml_data_3/hf-local/Qwen/Qwen3.5-397B-A17B-FP8 \
  --tensor-parallel-size 4 --enable-expert-parallel \
  --async-scheduling --max-num-seqs 512 \
  --max-num-batched-tokens 4096 --max-model-len 4096 \
  --gpu-memory-utilization 0.9 --no-enable-prefix-caching \
  --trust-remote-code --port 8001 \
  --compilation-config '{"compile_sizes":[1,2,4,8,16,32,64,128,256,512],"cudagraph_capture_sizes":[1,2,4,8,16,32,64,128,256,512]}'
```

### 2. Serve with Triton MoE (baseline for accuracy comparison)

```bash
export VLLM_USE_FLASHINFER_SAMPLER=1

vllm serve /scratch_omniml_data_3/hf-local/Qwen/Qwen3.5-397B-A17B-FP8 \
  --tensor-parallel-size 4 --enable-expert-parallel \
  --async-scheduling --max-num-seqs 512 \
  --max-num-batched-tokens 4096 --max-model-len 4096 \
  --gpu-memory-utilization 0.9 --no-enable-prefix-caching \
  --trust-remote-code --port 8001 \
  --compilation-config '{"compile_sizes":[1,2,4,8,16,32,64,128,256,512],"cudagraph_capture_sizes":[1,2,4,8,16,32,64,128,256,512]}' \
  --kernel-config '{"moe_backend": "triton"}'
```

### 3. Accuracy test (lm_eval GSM8K)

```bash
lm_eval --model local-completions \
    --model_args base_url=http://localhost:8001/v1/completions,model=/scratch_omniml_data_3/hf-local/Qwen/Qwen3.5-397B-A17B-FP8,num_concurrent=128,tokenized_requests=False \
    --tasks gsm8k \
    --batch_size 128
```

### 4. Results

#### FlashInfer MoE (with fix) 

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8165|±  |0.0107|
|     |       |strict-match    |     5|exact_match|↑  |0.7991|±  |0.0110|
```

#### Triton MoE (baseline) 

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8036|±  |0.0109|
|     |       |strict-match    |     5|exact_match|↑  |0.7976|±  |0.0111|
```
#### Summary

| Backend | GSM8K (flexible) | GSM8K (strict) | Crash at CONC 16+? |
|---|---|---|---|
| FlashInfer MoE (before fix) | N/A (crash) | N/A (crash) | Yes |
| FlashInfer MoE (after fix) | **0.8165** | **0.7991** | No |
| Triton MoE (baseline) | **0.8036** | **0.7976** | No |

### Perf

<img width="1517" height="412" alt="image" src="https://github.com/user-attachments/assets/89ffca81-920c-4d1d-9772-4f2d06f7aef9" />

Memset overhead per step = 94 layers × 2 us = 188 us = 0.188 ms
Step time = 50 ms
Slowdown = 0.188 / 50 = 0.38%

~0.4% slowdown — negligible. And this only happens on the three-step path (num_tokens > 256). For decode steps with fewer tokens, the fused path runs and there's zero overhead.


## 🔍 Related Issues

<!-- Link any related issues here -->
https://github.com/vllm-project/vllm/issues/39244

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixture-of-experts backend stability and reliability when processing edge cases with tokens not matched to local expert assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->