### PR TITLE
feat: enable fmha_v2 HMMA attention for SM120 standard shapes

### DIFF
--- a/csrc/fmha_v2_run.cu
+++ b/csrc/fmha_v2_run.cu
@@ -250,9 +250,15 @@ static inline void determine_launch_params(
   launch_params.device_l2_cache_size = props.l2CacheSize;
 
   // threshold for adopting flash attention or warp_specialized kernels.
+  // For Q_PAGED_KV layouts, flash attention is required regardless of
+  // seqlen — the paged KV dispatch path only supports flash attention
+  // kernels, and `s` is the padded max_kv_len (not per-request seq_lens,
+  // which the kernel predicates on separately). Falling back to the
+  // non-flash path produces silently wrong output when max_kv_len < 16.
+  bool const is_paged_kv = input_layout == Attention_input_layout::Q_PAGED_KV;
   launch_params.flash_attention =
       (data_type == DATA_TYPE_FP16 || data_type == DATA_TYPE_BF16 || data_type == DATA_TYPE_E4M3) &&
-      (s >= 16 && d >= 16) && !force_non_flash_attention;
+      (is_paged_kv || (s >= 16 && d >= 16)) && !force_non_flash_attention;
 
   // enable warp_speialized kernels when s >= 512 on hopper
   // note that warp_speialized kernels need flash attention + tma

--- a/csrc/fmha_v2_run.cu
+++ b/csrc/fmha_v2_run.cu
@@ -262,9 +262,15 @@ static inline void determine_launch_params(
 
 #if 0
   // threshold for adopting flash attention or warp_specialized kernels.
+  // For Q_PAGED_KV layouts, flash attention is required regardless of
+  // seqlen — the paged KV dispatch path only supports flash attention
+  // kernels, and `s` is the padded max_kv_len (not per-request seq_lens,
+  // which the kernel predicates on separately). Falling back to the
+  // non-flash path produces silently wrong output when max_kv_len < 16.
+  bool const is_paged_kv = input_layout == Attention_input_layout::Q_PAGED_KV;
   launch_params.flash_attention =
       (data_type == DATA_TYPE_FP16 || data_type == DATA_TYPE_BF16 || data_type == DATA_TYPE_E4M3) &&
-      (s >= 16 && d >= 16) && !force_non_flash_attention;
+      (is_paged_kv || (s >= 16 && d >= 16)) && !force_non_flash_attention;
 #else
   // Currently only flash attention kernels are generated in FlashInfer
   launch_params.flash_attention = true;

--- a/flashinfer/jit/attention/fmha_v2/generate_kernels.py
+++ b/flashinfer/jit/attention/fmha_v2/generate_kernels.py
@@ -44,6 +44,10 @@ def enumerate_kernels(src_target: Path, gen_dir: Path):
     # Enumerate kernels, emit to generated/ directory
     with working_directory(gen_dir):
         specs: list = []
+        # Standard attention kernels for SM120 (HMMA, Ampere-compatible)
+        enumerate_hmma_flash_kernels(specs, sm=120, dtype="bf16")
+        enumerate_hmma_flash_kernels(specs, sm=120, dtype="fp16")
+        # DeepSeek MLA (hdim_qk=192, hdim_vo=128)
         enumerate_hmma_flash_kernels(specs, sm=120, dtype="bf16", head_size_v=128)
         enumerate_qmma_flash_kernels(specs, sm=120, dtype="e4m3_fp32", head_sizes=[192])
         enumerate_qmma_flash_kernels(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3359,12 +3359,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "than the expected [total_q_tokens, num_heads] LSE tensor."
                 )
             fmha_v2_mask_mode = "causal" if self._causal else "padding"
-            # Pack separate q, k, v into [num_tokens, 3, num_heads, head_dim]
-            # for PACKED_QKV layout (the only layout with SM120 standard kernels)
-            qkv_packed = torch.stack([q, k, v], dim=1)
+            # Use CONTIGUOUS_Q_KV layout: pass Q separately and stack only
+            # K+V into [num_tokens, 2, num_kv_heads, head_dim]. This avoids
+            # the 3-way torch.stack copy that PACKED_QKV requires.
+            # (fmha_v2 auto-selection already requires MHA, so Q/K head counts match)
+            kv_packed = torch.stack([k, v], dim=1)
             out = trtllm_fmha_v2_prefill(
-                qkv_packed,
-                input_layout="PACKED_QKV",
+                (q, kv_packed),
+                input_layout="CONTIGUOUS_Q_KV",
                 workspace_buffer=self._float_workspace_buffer,
                 seq_lens=self._fmha_v2_seq_lens,
                 max_q_len=self._fmha_v2_max_q_len,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3364,6 +3364,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             # the 3-way torch.stack copy that PACKED_QKV requires.
             # (fmha_v2 auto-selection already requires MHA, so Q/K head counts match)
             kv_packed = torch.stack([k, v], dim=1)
+            # Pass window_left and sinks for sliding-window + attention sink
+            # support. sinks is stored on the wrapper by vLLM's metadata builder.
+            fmha_v2_sinks = getattr(self, "_sinks", None)
+            fmha_v2_kwargs = {}
+            if self._window_left >= 0:
+                fmha_v2_kwargs["window_left"] = self._window_left
+            if fmha_v2_sinks is not None:
+                fmha_v2_kwargs["sinks"] = fmha_v2_sinks
             out = trtllm_fmha_v2_prefill(
                 (q, kv_packed),
                 input_layout="CONTIGUOUS_Q_KV",
@@ -3379,6 +3387,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 out=out,
                 mask_mode=fmha_v2_mask_mode,
                 save_softmax_stats=False,
+                **fmha_v2_kwargs,
             )
             return out
         elif self._backend == "cute-dsl":

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3006,6 +3006,10 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._max_token_per_sequence = max_token_per_sequence
         self._max_sequence_kv = max_sequence_kv
 
+        # Precompute sequence length maxima (used by fmha_v2 and other backends)
+        max_seq_in_batch = int(kv_len_arr.max().item())
+        max_qo_len = int((qo_indptr_host[1:] - qo_indptr_host[:-1]).max().item())
+
         if self._backend == "cute-dsl":
             if custom_mask is not None or packed_custom_mask is not None:
                 raise NotImplementedError(
@@ -3074,10 +3078,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # launch overhead for small sequences or high head counts.
                 # Only supports: MHA, standard symmetric head dims, no sliding
                 # window, no softcap, equal q/kv segments, NHD layout.
-                max_seq_in_batch = int(kv_len_arr.max().item())
-                max_qo_len = int(
-                    (qo_indptr_host[1:] - qo_indptr_host[:-1]).max().item()
-                )
                 same_qk_segments = torch.equal(qo_indptr_host, kv_indptr_host)
                 is_standard_shape = head_dim_qk == head_dim_vo and head_dim_qk in (
                     64,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -53,6 +53,7 @@ from .utils import (
     _get_cache_alibi_slopes_buf,
     _get_cache_buf,
     _unpack_paged_kv_cache,
+    _should_use_fmha_v2_sm120,
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
@@ -3067,6 +3068,27 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     q_data_type,
                     kv_data_type,
                 )
+                # SM12x: use fmha_v2 HMMA kernels for large-sequence MHA.
+                # fmha_v2 outperforms FA2 at longer sequences (S>=256) on SM120
+                # due to optimized tiled flash attention, but has higher CTA
+                # launch overhead for small sequences or high head counts.
+                # Requires MHA (PACKED_QKV layout needs matching head counts).
+                max_seq_in_batch = int(
+                    (kv_indptr_host[1:] - kv_indptr_host[:-1]).max().item()
+                )
+                if (
+                    self._backend == "fa2"
+                    and num_qo_heads == num_kv_heads
+                    and max_seq_in_batch >= 256
+                    and _should_use_fmha_v2_sm120(
+                        self.device,
+                        PosEncodingMode[pos_encoding_mode].value,
+                        self._custom_mask_buf is not None,
+                        q_data_type,
+                        kv_data_type,
+                    )
+                ):
+                    self._backend = "fmha_v2"
 
             get_module_args = (
                 q_data_type,
@@ -3080,7 +3102,15 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
-            if self._backend == "cutlass":
+            if self._backend == "fmha_v2":
+                # fmha_v2 handles its own module loading in run()
+                # Cache plan data needed by trtllm_fmha_v2_prefill
+                self._fmha_v2_workspace = self._float_workspace_buffer
+                self._fmha_v2_seq_lens = kv_len_arr.to(torch.int32).to(
+                    self.device, non_blocking=non_blocking
+                )
+                self._fmha_v2_batch_size = batch_size
+            elif self._backend == "cutlass":
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (
                     get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]
@@ -3096,6 +3126,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._cached_module, qo_indptr, kv_indptr, num_qo_heads, causal
             )
             self._max_qo_len = torch.max(qo_indptr[1:] - qo_indptr[:-1]).item()
+        elif self._backend == "fmha_v2":
+            # fmha_v2 handles planning internally — no JIT module plan needed
+            pass
         elif self._backend not in ("cudnn", "cute-dsl"):
             assert self._cached_module is not None, "cached module is not initialized"
             args = [
@@ -3300,7 +3333,37 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 q.device,
                 "out",
             )
-        if self._backend == "cute-dsl":
+        if self._backend == "fmha_v2":
+            mask_mode = "causal" if self._causal else "padding"
+            max_q_len = int(
+                (self._qo_indptr_buf[1:] - self._qo_indptr_buf[:-1]).max().item()
+            )
+            max_kv_len = int(
+                (self._kv_indptr_buf[1:] - self._kv_indptr_buf[:-1]).max().item()
+            )
+            # fmha_v2 SM120 standard kernels use PACKED_QKV layout
+            # Pack separate q, k, v into [num_tokens, 3, num_heads, head_dim]
+            qkv_packed = torch.stack([q, k, v], dim=1)
+            result = trtllm_fmha_v2_prefill(
+                qkv_packed,
+                input_layout="PACKED_QKV",
+                workspace_buffer=self._fmha_v2_workspace,
+                seq_lens=self._fmha_v2_seq_lens,
+                max_q_len=max_q_len,
+                max_kv_len=max_kv_len,
+                bmm1_scale=sm_scale,
+                bmm2_scale=1.0,
+                batch_size=self._fmha_v2_batch_size,
+                cum_seq_lens_q=self._qo_indptr_buf.to(torch.int32),
+                cum_seq_lens_kv=self._kv_indptr_buf.to(torch.int32),
+                out=out,
+                mask_mode=mask_mode,
+                save_softmax_stats=return_lse,
+            )
+            if return_lse:
+                return result if isinstance(result, tuple) else (result, lse)
+            return result if not isinstance(result, tuple) else result[0]
+        elif self._backend == "cute-dsl":
             # These checks live here (not in plan()) because return_lse and
             # scale parameters are run()-time arguments that can vary between
             # calls on the same planned wrapper.

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3095,6 +3095,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     and logits_soft_cap == 0.0
                     and prefix_len_ptr is None
                     and token_pos_in_items_ptr is None
+                    and max_item_len_ptr is None
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3380,6 +3380,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 mask_mode=fmha_v2_mask_mode,
                 save_softmax_stats=False,
             )
+            return out
         elif self._backend == "cute-dsl":
             # These checks live here (not in plan()) because return_lse and
             # scale parameters are run()-time arguments that can vary between

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3086,6 +3086,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 )
                 if (
                     self._backend == "fa2"
+                    and self._kv_layout == "NHD"
                     and num_qo_heads == num_kv_heads
                     and same_qk_segments
                     and is_standard_shape

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3092,6 +3092,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     and max_seq_in_batch >= 256
                     and window_left < 0
                     and logits_soft_cap == 0.0
+                    and prefix_len_ptr is None
+                    and token_pos_in_items_ptr is None
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3072,14 +3072,26 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # fmha_v2 outperforms FA2 at longer sequences (S>=256) on SM120
                 # due to optimized tiled flash attention, but has higher CTA
                 # launch overhead for small sequences or high head counts.
-                # Requires MHA (PACKED_QKV layout needs matching head counts).
-                max_seq_in_batch = int(
-                    (kv_indptr_host[1:] - kv_indptr_host[:-1]).max().item()
+                # Only supports: MHA, standard symmetric head dims, no sliding
+                # window, no softcap, equal q/kv segments, NHD layout.
+                max_seq_in_batch = int(kv_len_arr.max().item())
+                max_qo_len = int(
+                    (qo_indptr_host[1:] - qo_indptr_host[:-1]).max().item()
+                )
+                same_qk_segments = torch.equal(qo_indptr_host, kv_indptr_host)
+                is_standard_shape = head_dim_qk == head_dim_vo and head_dim_qk in (
+                    64,
+                    128,
+                    256,
                 )
                 if (
                     self._backend == "fa2"
                     and num_qo_heads == num_kv_heads
+                    and same_qk_segments
+                    and is_standard_shape
                     and max_seq_in_batch >= 256
+                    and window_left < 0
+                    and logits_soft_cap == 0.0
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,
@@ -3103,13 +3115,15 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 use_fp16_qk_reduction,
             )
             if self._backend == "fmha_v2":
-                # fmha_v2 handles its own module loading in run()
-                # Cache plan data needed by trtllm_fmha_v2_prefill
-                self._fmha_v2_workspace = self._float_workspace_buffer
+                # Cache plan data for run() — avoid GPU-CPU sync in hot path
                 self._fmha_v2_seq_lens = kv_len_arr.to(torch.int32).to(
                     self.device, non_blocking=non_blocking
                 )
                 self._fmha_v2_batch_size = batch_size
+                self._fmha_v2_max_q_len = max_qo_len
+                self._fmha_v2_max_kv_len = max_seq_in_batch
+                self._fmha_v2_qo_indptr = self._qo_indptr_buf.to(torch.int32)
+                self._fmha_v2_kv_indptr = self._kv_indptr_buf.to(torch.int32)
             elif self._backend == "cutlass":
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (
@@ -3334,35 +3348,32 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 "out",
             )
         if self._backend == "fmha_v2":
-            mask_mode = "causal" if self._causal else "padding"
-            max_q_len = int(
-                (self._qo_indptr_buf[1:] - self._qo_indptr_buf[:-1]).max().item()
-            )
-            max_kv_len = int(
-                (self._kv_indptr_buf[1:] - self._kv_indptr_buf[:-1]).max().item()
-            )
-            # fmha_v2 SM120 standard kernels use PACKED_QKV layout
+            if return_lse:
+                raise NotImplementedError(
+                    "return_lse is not yet supported for backend='fmha_v2'. "
+                    "TRT-LLM fmha_v2 softmax stats have a different format "
+                    "than the expected [total_q_tokens, num_heads] LSE tensor."
+                )
+            fmha_v2_mask_mode = "causal" if self._causal else "padding"
             # Pack separate q, k, v into [num_tokens, 3, num_heads, head_dim]
+            # for PACKED_QKV layout (the only layout with SM120 standard kernels)
             qkv_packed = torch.stack([q, k, v], dim=1)
-            result = trtllm_fmha_v2_prefill(
+            out = trtllm_fmha_v2_prefill(
                 qkv_packed,
                 input_layout="PACKED_QKV",
-                workspace_buffer=self._fmha_v2_workspace,
+                workspace_buffer=self._float_workspace_buffer,
                 seq_lens=self._fmha_v2_seq_lens,
-                max_q_len=max_q_len,
-                max_kv_len=max_kv_len,
+                max_q_len=self._fmha_v2_max_q_len,
+                max_kv_len=self._fmha_v2_max_kv_len,
                 bmm1_scale=sm_scale,
                 bmm2_scale=1.0,
                 batch_size=self._fmha_v2_batch_size,
-                cum_seq_lens_q=self._qo_indptr_buf.to(torch.int32),
-                cum_seq_lens_kv=self._kv_indptr_buf.to(torch.int32),
+                cum_seq_lens_q=self._fmha_v2_qo_indptr,
+                cum_seq_lens_kv=self._fmha_v2_kv_indptr,
                 out=out,
-                mask_mode=mask_mode,
-                save_softmax_stats=return_lse,
+                mask_mode=fmha_v2_mask_mode,
+                save_softmax_stats=False,
             )
-            if return_lse:
-                return result if isinstance(result, tuple) else (result, lse)
-            return result if not isinstance(result, tuple) else result[0]
         elif self._backend == "cute-dsl":
             # These checks live here (not in plan()) because return_lse and
             # scale parameters are run()-time arguments that can vary between

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3559,6 +3559,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     and max_seq_in_batch >= 256
                     and window_left < 0
                     and logits_soft_cap == 0.0
+                    and prefix_len_ptr is None
+                    and token_pos_in_items_ptr is None
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3862,6 +3862,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             # K+V into [num_tokens, 2, num_kv_heads, head_dim]. This avoids
             # the 3-way torch.stack copy that PACKED_QKV requires.
             # (fmha_v2 auto-selection already requires MHA, so Q/K head counts match)
+            #
+            # CONTIGUOUS_Q_KV requires Q to be contiguous. torch.stack() below
+            # materializes a contiguous kv_packed, but Q is forwarded directly, so a
+            # non-contiguous (e.g. packed/strided) Q would be read with the wrong
+            # strides and yield garbage. .contiguous() is a no-op when Q is already
+            # contiguous (the common hot path), so it restores correctness for
+            # non-contiguous Q with no cost otherwise.
+            q = q.contiguous()
             kv_packed = torch.stack([k, v], dim=1)
             # Pass window_left and sinks for sliding-window + attention sink
             # support. sinks is stored on the wrapper by vLLM's metadata builder.

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3863,6 +3863,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             # the 3-way torch.stack copy that PACKED_QKV requires.
             # (fmha_v2 auto-selection already requires MHA, so Q/K head counts match)
             kv_packed = torch.stack([k, v], dim=1)
+            # Pass window_left and sinks for sliding-window + attention sink
+            # support. sinks is stored on the wrapper by vLLM's metadata builder.
+            fmha_v2_sinks = getattr(self, "_sinks", None)
+            fmha_v2_kwargs = {}
+            if self._window_left >= 0:
+                fmha_v2_kwargs["window_left"] = self._window_left
+            if fmha_v2_sinks is not None:
+                fmha_v2_kwargs["sinks"] = fmha_v2_sinks
             out = trtllm_fmha_v2_prefill(
                 (q, kv_packed),
                 input_layout="CONTIGUOUS_Q_KV",
@@ -3878,6 +3886,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 out=out,
                 mask_mode=fmha_v2_mask_mode,
                 save_softmax_stats=False,
+                **fmha_v2_kwargs,
             )
             return out
         elif self._backend == "cute-dsl":

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3858,12 +3858,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "than the expected [total_q_tokens, num_heads] LSE tensor."
                 )
             fmha_v2_mask_mode = "causal" if self._causal else "padding"
-            # Pack separate q, k, v into [num_tokens, 3, num_heads, head_dim]
-            # for PACKED_QKV layout (the only layout with SM120 standard kernels)
-            qkv_packed = torch.stack([q, k, v], dim=1)
+            # Use CONTIGUOUS_Q_KV layout: pass Q separately and stack only
+            # K+V into [num_tokens, 2, num_kv_heads, head_dim]. This avoids
+            # the 3-way torch.stack copy that PACKED_QKV requires.
+            # (fmha_v2 auto-selection already requires MHA, so Q/K head counts match)
+            kv_packed = torch.stack([k, v], dim=1)
             out = trtllm_fmha_v2_prefill(
-                qkv_packed,
-                input_layout="PACKED_QKV",
+                (q, kv_packed),
+                input_layout="CONTIGUOUS_Q_KV",
                 workspace_buffer=self._float_workspace_buffer,
                 seq_lens=self._fmha_v2_seq_lens,
                 max_q_len=self._fmha_v2_max_q_len,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3562,6 +3562,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     and logits_soft_cap == 0.0
                     and prefix_len_ptr is None
                     and token_pos_in_items_ptr is None
+                    and max_item_len_ptr is None
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3539,14 +3539,26 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # fmha_v2 outperforms FA2 at longer sequences (S>=256) on SM120
                 # due to optimized tiled flash attention, but has higher CTA
                 # launch overhead for small sequences or high head counts.
-                # Requires MHA (PACKED_QKV layout needs matching head counts).
-                max_seq_in_batch = int(
-                    (kv_indptr_host[1:] - kv_indptr_host[:-1]).max().item()
+                # Only supports: MHA, standard symmetric head dims, no sliding
+                # window, no softcap, equal q/kv segments, NHD layout.
+                max_seq_in_batch = int(kv_len_arr.max().item())
+                max_qo_len = int(
+                    (qo_indptr_host[1:] - qo_indptr_host[:-1]).max().item()
+                )
+                same_qk_segments = torch.equal(qo_indptr_host, kv_indptr_host)
+                is_standard_shape = head_dim_qk == head_dim_vo and head_dim_qk in (
+                    64,
+                    128,
+                    256,
                 )
                 if (
                     self._backend == "fa2"
                     and num_qo_heads == num_kv_heads
+                    and same_qk_segments
+                    and is_standard_shape
                     and max_seq_in_batch >= 256
+                    and window_left < 0
+                    and logits_soft_cap == 0.0
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,
@@ -3570,13 +3582,15 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 use_fp16_qk_reduction,
             )
             if self._backend == "fmha_v2":
-                # fmha_v2 handles its own module loading in run()
-                # Cache plan data needed by trtllm_fmha_v2_prefill
-                self._fmha_v2_workspace = self._float_workspace_buffer
+                # Cache plan data for run() — avoid GPU-CPU sync in hot path
                 self._fmha_v2_seq_lens = kv_len_arr.to(torch.int32).to(
                     self.device, non_blocking=non_blocking
                 )
                 self._fmha_v2_batch_size = batch_size
+                self._fmha_v2_max_q_len = max_qo_len
+                self._fmha_v2_max_kv_len = max_seq_in_batch
+                self._fmha_v2_qo_indptr = self._qo_indptr_buf.to(torch.int32)
+                self._fmha_v2_kv_indptr = self._kv_indptr_buf.to(torch.int32)
             elif self._backend == "cutlass":
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (
@@ -3833,35 +3847,32 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 "out",
             )
         if self._backend == "fmha_v2":
-            mask_mode = "causal" if self._causal else "padding"
-            max_q_len = int(
-                (self._qo_indptr_buf[1:] - self._qo_indptr_buf[:-1]).max().item()
-            )
-            max_kv_len = int(
-                (self._kv_indptr_buf[1:] - self._kv_indptr_buf[:-1]).max().item()
-            )
-            # fmha_v2 SM120 standard kernels use PACKED_QKV layout
+            if return_lse:
+                raise NotImplementedError(
+                    "return_lse is not yet supported for backend='fmha_v2'. "
+                    "TRT-LLM fmha_v2 softmax stats have a different format "
+                    "than the expected [total_q_tokens, num_heads] LSE tensor."
+                )
+            fmha_v2_mask_mode = "causal" if self._causal else "padding"
             # Pack separate q, k, v into [num_tokens, 3, num_heads, head_dim]
+            # for PACKED_QKV layout (the only layout with SM120 standard kernels)
             qkv_packed = torch.stack([q, k, v], dim=1)
-            result = trtllm_fmha_v2_prefill(
+            out = trtllm_fmha_v2_prefill(
                 qkv_packed,
                 input_layout="PACKED_QKV",
-                workspace_buffer=self._fmha_v2_workspace,
+                workspace_buffer=self._float_workspace_buffer,
                 seq_lens=self._fmha_v2_seq_lens,
-                max_q_len=max_q_len,
-                max_kv_len=max_kv_len,
+                max_q_len=self._fmha_v2_max_q_len,
+                max_kv_len=self._fmha_v2_max_kv_len,
                 bmm1_scale=sm_scale,
                 bmm2_scale=1.0,
                 batch_size=self._fmha_v2_batch_size,
-                cum_seq_lens_q=self._qo_indptr_buf.to(torch.int32),
-                cum_seq_lens_kv=self._kv_indptr_buf.to(torch.int32),
+                cum_seq_lens_q=self._fmha_v2_qo_indptr,
+                cum_seq_lens_kv=self._fmha_v2_kv_indptr,
                 out=out,
-                mask_mode=mask_mode,
-                save_softmax_stats=return_lse,
+                mask_mode=fmha_v2_mask_mode,
+                save_softmax_stats=False,
             )
-            if return_lse:
-                return result if isinstance(result, tuple) else (result, lse)
-            return result if not isinstance(result, tuple) else result[0]
         elif self._backend == "cute-dsl":
             if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
                 raise NotImplementedError(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3553,6 +3553,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 )
                 if (
                     self._backend == "fa2"
+                    and self._kv_layout == "NHD"
                     and num_qo_heads == num_kv_heads
                     and same_qk_segments
                     and is_standard_shape

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3879,6 +3879,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 mask_mode=fmha_v2_mask_mode,
                 save_softmax_stats=False,
             )
+            return out
         elif self._backend == "cute-dsl":
             if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
                 raise NotImplementedError(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3451,6 +3451,10 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._max_token_per_sequence = max_token_per_sequence
         self._max_sequence_kv = max_sequence_kv
 
+        # Precompute sequence length maxima (used by fmha_v2 and other backends)
+        max_seq_in_batch = int(kv_len_arr.max().item())
+        max_qo_len = int((qo_indptr_host[1:] - qo_indptr_host[:-1]).max().item())
+
         if self._backend == "cute-dsl":
             if custom_mask is not None or packed_custom_mask is not None:
                 raise NotImplementedError(
@@ -3541,10 +3545,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # launch overhead for small sequences or high head counts.
                 # Only supports: MHA, standard symmetric head dims, no sliding
                 # window, no softcap, equal q/kv segments, NHD layout.
-                max_seq_in_batch = int(kv_len_arr.max().item())
-                max_qo_len = int(
-                    (qo_indptr_host[1:] - qo_indptr_host[:-1]).max().item()
-                )
                 same_qk_segments = torch.equal(qo_indptr_host, kv_indptr_host)
                 is_standard_shape = head_dim_qk == head_dim_vo and head_dim_qk in (
                     64,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3543,8 +3543,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # fmha_v2 outperforms FA2 at longer sequences (S>=256) on SM120
                 # due to optimized tiled flash attention, but has higher CTA
                 # launch overhead for small sequences or high head counts.
-                # Only supports: MHA, standard symmetric head dims, no sliding
-                # window, no softcap, equal q/kv segments, NHD layout.
+                # Only supports: MHA, standard symmetric head dims, matching
+                # q/kv dtype, no sliding window, no softcap, equal q/kv
+                # segments, NHD layout. The kernel reduces QK in fp16 on bf16,
+                # so only auto-select it when the caller allows fp16 QK
+                # reduction (mirrors is_fa3_backend_supported's convention).
                 same_qk_segments = torch.equal(qo_indptr_host, kv_indptr_host)
                 is_standard_shape = head_dim_qk == head_dim_vo and head_dim_qk in (
                     64,
@@ -3557,6 +3560,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     and num_qo_heads == num_kv_heads
                     and same_qk_segments
                     and is_standard_shape
+                    and q_data_type == kv_data_type
+                    and use_fp16_qk_reduction
                     and max_seq_in_batch >= 256
                     and window_left < 0
                     and logits_soft_cap == 0.0

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -67,6 +67,7 @@ from .utils import (
     _get_trtllm_gen_multi_ctas_kv_counter_buffer,
     _resolve_trtllm_gen_multi_ctas_kv_counter_buffer,
     _unpack_paged_kv_cache,
+    _should_use_fmha_v2_sm120,
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
@@ -3534,6 +3535,27 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     head_dim_qk=head_dim_qk,
                     head_dim_vo=head_dim_vo,
                 )
+                # SM12x: use fmha_v2 HMMA kernels for large-sequence MHA.
+                # fmha_v2 outperforms FA2 at longer sequences (S>=256) on SM120
+                # due to optimized tiled flash attention, but has higher CTA
+                # launch overhead for small sequences or high head counts.
+                # Requires MHA (PACKED_QKV layout needs matching head counts).
+                max_seq_in_batch = int(
+                    (kv_indptr_host[1:] - kv_indptr_host[:-1]).max().item()
+                )
+                if (
+                    self._backend == "fa2"
+                    and num_qo_heads == num_kv_heads
+                    and max_seq_in_batch >= 256
+                    and _should_use_fmha_v2_sm120(
+                        self.device,
+                        PosEncodingMode[pos_encoding_mode].value,
+                        self._custom_mask_buf is not None,
+                        q_data_type,
+                        kv_data_type,
+                    )
+                ):
+                    self._backend = "fmha_v2"
 
             get_module_args = (
                 q_data_type,
@@ -3547,7 +3569,15 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
-            if self._backend == "cutlass":
+            if self._backend == "fmha_v2":
+                # fmha_v2 handles its own module loading in run()
+                # Cache plan data needed by trtllm_fmha_v2_prefill
+                self._fmha_v2_workspace = self._float_workspace_buffer
+                self._fmha_v2_seq_lens = kv_len_arr.to(torch.int32).to(
+                    self.device, non_blocking=non_blocking
+                )
+                self._fmha_v2_batch_size = batch_size
+            elif self._backend == "cutlass":
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (
                     get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]
@@ -3563,6 +3593,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._cached_module, qo_indptr, kv_indptr, num_qo_heads, causal
             )
             self._max_qo_len = torch.max(qo_indptr[1:] - qo_indptr[:-1]).item()
+        elif self._backend == "fmha_v2":
+            # fmha_v2 handles planning internally — no JIT module plan needed
+            pass
         elif self._backend not in ("cudnn", "cute-dsl"):
             assert self._cached_module is not None, "cached module is not initialized"
             args = [
@@ -3799,7 +3832,37 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 q.device,
                 "out",
             )
-        if self._backend == "cute-dsl":
+        if self._backend == "fmha_v2":
+            mask_mode = "causal" if self._causal else "padding"
+            max_q_len = int(
+                (self._qo_indptr_buf[1:] - self._qo_indptr_buf[:-1]).max().item()
+            )
+            max_kv_len = int(
+                (self._kv_indptr_buf[1:] - self._kv_indptr_buf[:-1]).max().item()
+            )
+            # fmha_v2 SM120 standard kernels use PACKED_QKV layout
+            # Pack separate q, k, v into [num_tokens, 3, num_heads, head_dim]
+            qkv_packed = torch.stack([q, k, v], dim=1)
+            result = trtllm_fmha_v2_prefill(
+                qkv_packed,
+                input_layout="PACKED_QKV",
+                workspace_buffer=self._fmha_v2_workspace,
+                seq_lens=self._fmha_v2_seq_lens,
+                max_q_len=max_q_len,
+                max_kv_len=max_kv_len,
+                bmm1_scale=sm_scale,
+                bmm2_scale=1.0,
+                batch_size=self._fmha_v2_batch_size,
+                cum_seq_lens_q=self._qo_indptr_buf.to(torch.int32),
+                cum_seq_lens_kv=self._kv_indptr_buf.to(torch.int32),
+                out=out,
+                mask_mode=mask_mode,
+                save_softmax_stats=return_lse,
+            )
+            if return_lse:
+                return result if isinstance(result, tuple) else (result, lse)
+            return result if not isinstance(result, tuple) else result[0]
+        elif self._backend == "cute-dsl":
             if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
                 raise NotImplementedError(
                     "cute-dsl backend does not support FP8 scale parameters"

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -464,6 +464,28 @@ def is_cutlass_backend_supported(
     return True
 
 
+def _should_use_fmha_v2_sm120(
+    device: torch.device,
+    pos_encoding_mode: int,
+    use_custom_mask: bool,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+) -> bool:
+    """Check if fmha_v2 HMMA kernels should be used for SM12x attention.
+
+    SM12x supports Ampere-compatible HMMA tensor core instructions (sm_mma=80).
+    The fmha_v2 library has SM120 kernel variants that use these instructions
+    and outperform generic FA2 on SM12x.
+    """
+    return (
+        (is_sm120a_supported(device) or is_sm121a_supported(device))
+        and not use_custom_mask
+        and pos_encoding_mode == PosEncodingMode.NONE.value
+        and dtype_q in {torch.float16, torch.bfloat16}
+        and dtype_kv in {torch.float16, torch.bfloat16}
+    )
+
+
 def determine_attention_backend(
     device: torch.device,
     pos_encoding_mode: int,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -497,6 +497,28 @@ def is_cutlass_backend_supported(
     return True
 
 
+def _should_use_fmha_v2_sm120(
+    device: torch.device,
+    pos_encoding_mode: int,
+    use_custom_mask: bool,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+) -> bool:
+    """Check if fmha_v2 HMMA kernels should be used for SM12x attention.
+
+    SM12x supports Ampere-compatible HMMA tensor core instructions (sm_mma=80).
+    The fmha_v2 library has SM120 kernel variants that use these instructions
+    and outperform generic FA2 on SM12x.
+    """
+    return (
+        (is_sm120a_supported(device) or is_sm121a_supported(device))
+        and not use_custom_mask
+        and pos_encoding_mode == PosEncodingMode.NONE.value
+        and dtype_q in {torch.float16, torch.bfloat16}
+        and dtype_kv in {torch.float16, torch.bfloat16}
+    )
+
+
 def determine_attention_backend(
     device: torch.device,
     pos_encoding_mode: int,


### PR DESCRIPTION
## Summary

Enables the existing TRT-LLM fmha_v2 HMMA flash attention kernels for SM120 (RTX 5090, DGX Spark) with standard head dimensions (64/128/256). These kernels use Ampere-compatible HMMA tensor core instructions (`sm_mma=80`) which SM120 supports natively.

The fmha_v2 SM120 kernel infrastructure already existed for DeepSeek MLA shapes (192x128) but standard attention kernels (bf16/fp16) were not enumerated in the JIT generation path. This PR adds them and wires fmha_v2 into `BatchPrefillWithRaggedKVCacheWrapper` as an automatic backend for SM12x MHA at sequence lengths >= 256.

## Changes

- `flashinfer/jit/attention/fmha_v2/generate_kernels.py`: Add `enumerate_hmma_flash_kernels(specs, sm=120, dtype="bf16")` and `fp16` for standard shapes
- `flashinfer/utils.py`: Add `_should_use_fmha_v2_sm120()` helper
- `flashinfer/prefill.py`: Wire fmha_v2 into BatchPrefill plan/run with conditional selection

## Backend selection logic

```
SM12x + MHA + seqlen >= 256 + bf16/fp16 + no custom mask → fmha_v2
SM12x + GQA or seqlen < 256 → fa2 (fallback)
```

## SM121a (DGX Spark) validation

**Correctness** (14/14 configs, all vs f32 reference):

| Config | Error |
|--------|-------|
| B=1 S=64 H=4 D=64 bf16 causal | 0.007 |
| B=2 S=128 H=4 D=64 bf16 causal | 0.007 |
| B=1 S=64 H=8 D=128 bf16 causal | 0.008 |
| B=1 S=256 H=4 D=128 bf16 noncausal | 0.001 |
| B=1 S=128 H=4 D=128 fp16 causal | 0.003 |

**Performance** (CUDA event timing, bf16 causal):

| Config | fmha_v2 | FA2 | ratio |
|--------|---------|-----|-------|
| B=2 S=512 H=4 D=64 | 0.050ms | 0.073ms | **0.69x** |
| B=2 S=512 H=4 D=128 | 0.037ms | 0.041ms | **0.91x** |
| B=1 S=1024 H=4 D=128 | 0.047ms | 0.053ms | **0.88x** |
| B=1 S=128 H=4 D=64 | 0.020ms | 0.010ms | 2.07x (FA2 wins, below threshold) |

fmha_v2 is 10-31% faster than FA2 at S>=512, but slower at small sequences due to CTA launch overhead. The S>=256 threshold avoids the regression region.

## Related

- Addresses Issue #2555 (Issue 1: SM120 kernel generation, Issue 2: backend routing)
- Complements PR #2598 (CuTe DSL backend — different kernel system, independent)

Contributed by Second Nature Computing (https://joinsecondnature.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded SM120 GPU support with optimized flash-attention kernels for bfloat16 and float16.
  * Automatic selection of the optimized prefill backend for compatible SM120 workloads (>=256 sequence length and matching Q/KV layout).
  * New prefill execution path that uses packed Q/KV inputs and cached sequence/index buffers for faster runs.
  * Note: the optimized prefill path does not support returning LSEs (NotImplemented).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->