### PR TITLE
trtllm non causal support

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -1279,6 +1279,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 batch_size=batch_size,
                 cum_seq_lens_q=qo_indptr,
                 cum_seq_lens_kv=kv_indptr,
+                causal=causal,
                 kv_cache_sf=kv_cache_sf,
             )
         elif backend == "cudnn-native":

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -94,9 +94,9 @@ void trtllm_paged_attention_launcher(
     const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
     int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t window_left, int64_t sum_seq_q,
     int64_t sparse_mla_top_k, float skip_softmax_threshold_scale_factor, bool skips_softmax,
-    bool uses_shared_paged_kv_idx, int64_t sm_count, bool enable_pdl, int64_t workspace_size,
-    int64_t k_sf_stride_heads, int64_t k_sf_stride_batch, int64_t v_sf_stride_heads,
-    int64_t v_sf_stride_batch, cudaStream_t stream) {
+    bool uses_shared_paged_kv_idx, int64_t sm_count, bool enable_pdl, bool is_causal,
+    int64_t workspace_size, int64_t k_sf_stride_heads, int64_t k_sf_stride_batch,
+    int64_t v_sf_stride_heads, int64_t v_sf_stride_batch, cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads must be a multiple of num_kv_heads, got num_kv_heads: " << num_kv_heads
@@ -174,7 +174,8 @@ void trtllm_paged_attention_launcher(
 
   AlignedAllocator float_allocator(workspace_buffer, workspace_size);
   if (mode == TllmPagedAttentionMode::Context) {
-    runner_params.mMaskType = TrtllmGenAttentionMaskType::Causal;
+    runner_params.mMaskType =
+        is_causal ? TrtllmGenAttentionMaskType::Causal : TrtllmGenAttentionMaskType::Dense;
     runner_params.mKernelType = FmhaKernelType::Context;
     runner_params.mTileScheduler = TileScheduler::Persistent;
     runner_params.mMultiCtasKvMode = false;
@@ -375,7 +376,7 @@ void trtllm_paged_attention_decode(
       max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr,
       bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
       sparse_mla_top_k, skip_softmax_threshold_scale_factor_value, skips_softmax,
-      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
+      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, true, workspace_size, k_sf_stride_heads,
       k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
 }
 
@@ -386,7 +387,7 @@ void trtllm_paged_attention_context(
     Variant<double, ffi::Tensor> bmm1_scale, Variant<double, ffi::Tensor> bmm2_scale,
     double o_sf_scale, int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t batch_size,
     int64_t window_left, TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv, int64_t sm_count,
-    bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
+    bool enable_pdl, bool is_causal, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> key_block_scales, Optional<TensorView> value_block_scales,
     Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
@@ -498,8 +499,8 @@ void trtllm_paged_attention_context(
       kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value,
       bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left,
       sum_seq_q, /*sparse_mla_top_k=*/0, skip_softmax_threshold_scale_factor_value, skips_softmax,
-      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
-      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
+      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, is_causal, workspace_size,
+      k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
 }
 
 void trtllm_ragged_attention_launcher(

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -390,7 +390,7 @@ void trtllm_paged_attention_context(
     bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> key_block_scales, Optional<TensorView> value_block_scales,
     Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx,
-    bool is_causal = true) {
+    bool is_causal) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
@@ -487,6 +487,11 @@ void trtllm_paged_attention_context(
   float const skip_softmax_threshold_scale_factor_value =
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
+
+  TVM_FFI_CHECK(
+      is_causal || window_left == -1,
+      "Sliding-window non-causal attention is not supported for trtllm-gen paged KV cache. "
+      "Use window_left=-1 for dense bidirectional attention.");
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -387,9 +387,10 @@ void trtllm_paged_attention_context(
     Variant<double, ffi::Tensor> bmm1_scale, Variant<double, ffi::Tensor> bmm2_scale,
     double o_sf_scale, int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t batch_size,
     int64_t window_left, TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv, int64_t sm_count,
-    bool enable_pdl, bool is_causal, int64_t workspace_size, Optional<TensorView> attention_sinks,
+    bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> key_block_scales, Optional<TensorView> value_block_scales,
-    Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx) {
+    Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx,
+    bool is_causal = true) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -94,9 +94,9 @@ void trtllm_paged_attention_launcher(
     const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
     int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t window_left, int64_t sum_seq_q,
     int64_t sparse_mla_top_k, float skip_softmax_threshold_scale_factor, bool skips_softmax,
-    bool uses_shared_paged_kv_idx, int64_t sm_count, bool enable_pdl, bool is_causal,
-    int64_t workspace_size, int64_t k_sf_stride_heads, int64_t k_sf_stride_batch,
-    int64_t v_sf_stride_heads, int64_t v_sf_stride_batch, cudaStream_t stream) {
+    bool uses_shared_paged_kv_idx, int64_t sm_count, bool enable_pdl, int64_t workspace_size,
+    int64_t k_sf_stride_heads, int64_t k_sf_stride_batch, int64_t v_sf_stride_heads,
+    int64_t v_sf_stride_batch, bool is_causal, cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads must be a multiple of num_kv_heads, got num_kv_heads: " << num_kv_heads
@@ -376,8 +376,8 @@ void trtllm_paged_attention_decode(
       max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr,
       bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
       sparse_mla_top_k, skip_softmax_threshold_scale_factor_value, skips_softmax,
-      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, true, workspace_size, k_sf_stride_heads,
-      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
+      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
+      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, true, stream);
 }
 
 void trtllm_paged_attention_context(
@@ -505,8 +505,8 @@ void trtllm_paged_attention_context(
       kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value,
       bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left,
       sum_seq_q, /*sparse_mla_top_k=*/0, skip_softmax_threshold_scale_factor_value, skips_softmax,
-      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, is_causal, workspace_size,
-      k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
+      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
+      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, is_causal, stream);
 }
 
 void trtllm_ragged_attention_launcher(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2069,7 +2069,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         self._block_tables = block_tables
         if self._backend == "trtllm-gen":
-            assert logits_soft_cap == 0.0
+            if logits_soft_cap != 0.0:
+                raise ValueError(
+                    "logits_soft_cap must be 0.0 for trtllm-gen paged KV cache"
+                )
             if not causal and window_left >= 0:
                 raise NotImplementedError(
                     "Sliding-window non-causal attention is not supported for trtllm-gen paged KV cache. "

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -274,6 +274,7 @@ def get_trtllm_gen_prefill_module():
         enable_pdl: bool,
         workspace_size: int,
         window_left: int = -1,
+        is_causal: bool = True,
         out: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         key_block_scales: Optional[torch.Tensor] = None,
@@ -311,6 +312,7 @@ def get_trtllm_gen_prefill_module():
             cum_seq_lens_kv,
             sm_count,
             enable_pdl,
+            is_causal,
             workspace_size,
             sinks,
             key_block_scales,
@@ -731,6 +733,7 @@ def get_batch_prefill_module(backend, *args):
                 enable_pdl,
                 workspace_size,
                 window_left,
+                mask_mode != MaskMode.NON_CAUSAL.value,
                 out=o,
                 sinks=sinks,
                 key_block_scales=key_block_scales,
@@ -2066,12 +2069,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         self._block_tables = block_tables
         if self._backend == "trtllm-gen":
-            if not causal:
-                raise NotImplementedError(
-                    "Non-causal attention is not supported for trtllm-gen backend with paged KV cache. "
-                    "Please use causal=True or choose a different backend (e.g., fa2, fa3, cudnn)."
-                )
             assert logits_soft_cap == 0.0
+            if not causal and window_left >= 0:
+                raise NotImplementedError(
+                    "Sliding-window non-causal attention is not supported for trtllm-gen paged KV cache. "
+                    "Use window_left=-1 for dense bidirectional attention."
+                )
             if self._block_tables is None:
                 blocks_per_seq = [
                     (seq_len + page_size - 1) // page_size
@@ -4048,6 +4051,7 @@ def trtllm_batch_context_with_kv_cache(
     cum_seq_lens_q: torch.Tensor,
     cum_seq_lens_kv: torch.Tensor,
     window_left: int = -1,
+    causal: bool = True,
     out: Optional[Union[torch.Tensor, FP4Tensor]] = None,
     out_dtype: Optional[Union[torch.dtype, str]] = None,
     o_sf_scale: Optional[float] = None,
@@ -4105,6 +4109,9 @@ def trtllm_batch_context_with_kv_cache(
     window_left : int = -1
         The left (inclusive) window size for the attention window, when set to ``-1``, the window
         size will be set to the full length of the sequence. Defaults to ``-1``.
+    causal : bool = True
+        Whether to apply a causal mask. Set to ``False`` to request dense / bidirectional attention.
+        For the TRTLLM-gen paged context path, non-causal currently requires ``window_left == -1``.
     out : Optional[Union[torch.Tensor, FP4Tensor]] = None
         output tensor, if not provided, will be allocated with ``out_dtype``, if ``out_dtype`` is not provided, will use the type of ``query``.
     out_dtype : Optional[Union[torch.dtype, str]] = None
@@ -4168,6 +4175,11 @@ def trtllm_batch_context_with_kv_cache(
 
     if enable_pdl is None:
         enable_pdl = device_support_pdl(query.device)
+    if not causal and window_left >= 0:
+        raise NotImplementedError(
+            "Sliding-window non-causal attention is not supported for trtllm-gen paged KV cache. "
+            "Use window_left=-1 for dense bidirectional attention."
+        )
 
     if isinstance(kv_cache, tuple):
         k_cache, v_cache = kv_cache
@@ -4311,6 +4323,7 @@ def trtllm_batch_context_with_kv_cache(
         cum_seq_lens_kv,
         sm_count,
         enable_pdl,
+        causal,
         workspace_size,
         sinks,
         key_block_scales,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -274,13 +274,13 @@ def get_trtllm_gen_prefill_module():
         enable_pdl: bool,
         workspace_size: int,
         window_left: int = -1,
-        is_causal: bool = True,
         out: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         key_block_scales: Optional[torch.Tensor] = None,
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        is_causal: bool = True,
     ) -> torch.Tensor:
         sm_count = get_device_sm_count(query.device)
         if out is None:
@@ -312,13 +312,13 @@ def get_trtllm_gen_prefill_module():
             cum_seq_lens_kv,
             sm_count,
             enable_pdl,
-            is_causal,
             workspace_size,
             sinks,
             key_block_scales,
             value_block_scales,
             skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx,
+            is_causal,
         )
         return out
 
@@ -733,13 +733,13 @@ def get_batch_prefill_module(backend, *args):
                 enable_pdl,
                 workspace_size,
                 window_left,
-                mask_mode != MaskMode.NON_CAUSAL.value,
                 out=o,
                 sinks=sinks,
                 key_block_scales=key_block_scales,
                 value_block_scales=value_block_scales,
                 skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
                 uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+                is_causal=mask_mode != MaskMode.NON_CAUSAL.value,
             )
         elif backend == "fa2":
             assert not is_float8(q)
@@ -4054,7 +4054,6 @@ def trtllm_batch_context_with_kv_cache(
     cum_seq_lens_q: torch.Tensor,
     cum_seq_lens_kv: torch.Tensor,
     window_left: int = -1,
-    causal: bool = True,
     out: Optional[Union[torch.Tensor, FP4Tensor]] = None,
     out_dtype: Optional[Union[torch.dtype, str]] = None,
     o_sf_scale: Optional[float] = None,
@@ -4067,6 +4066,7 @@ def trtllm_batch_context_with_kv_cache(
     ] = None,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     uses_shared_paged_kv_idx: bool = True,
+    causal: bool = True,
 ) -> Union[torch.Tensor, FP4Tensor]:
     """
     Parameters
@@ -4112,9 +4112,6 @@ def trtllm_batch_context_with_kv_cache(
     window_left : int = -1
         The left (inclusive) window size for the attention window, when set to ``-1``, the window
         size will be set to the full length of the sequence. Defaults to ``-1``.
-    causal : bool = True
-        Whether to apply a causal mask. Set to ``False`` to request dense / bidirectional attention.
-        For the TRTLLM-gen paged context path, non-causal currently requires ``window_left == -1``.
     out : Optional[Union[torch.Tensor, FP4Tensor]] = None
         output tensor, if not provided, will be allocated with ``out_dtype``, if ``out_dtype`` is not provided, will use the type of ``query``.
     out_dtype : Optional[Union[torch.dtype, str]] = None
@@ -4170,6 +4167,10 @@ def trtllm_batch_context_with_kv_cache(
         Whether the K and V page indices are shared as a unified index.
         True (default) uses vLLM/FlashInfer layout with a 2D page table.
         False uses TRT-LLM layout with a 3D page table ``[batch_size, 2, max_num_pages_per_seq]``.
+    causal : bool = True
+        Whether to apply a causal mask. This trailing parameter preserves existing positional
+        callers. Set to ``False`` to request dense / bidirectional attention. For the TRTLLM-gen
+        paged context path, non-causal currently requires ``window_left == -1``.
     Returns
     -------
     out: Union[torch.Tensor, FP4Tensor]
@@ -4326,13 +4327,13 @@ def trtllm_batch_context_with_kv_cache(
         cum_seq_lens_kv,
         sm_count,
         enable_pdl,
-        causal,
         workspace_size,
         sinks,
         key_block_scales,
         value_block_scales,
         skip_softmax_threshold_scale_factor,
         uses_shared_paged_kv_idx,
+        causal,
     )
     return (
         out

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -910,12 +910,14 @@ TRTLLM_BATCH_PREFILL_DTYPES = [
 @pytest.mark.parametrize("non_contiguous_query", [False, True])
 @pytest.mark.parametrize("skips_softmax", [False, True])
 @pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
+@pytest.mark.parametrize("causal", [True, False])
 def test_trtllm_batch_prefill(
     kv_layout: str,
     batch_size: int,
     page_size: int,
     num_kv_heads: int,
     head_grp_size: int,
+    causal: bool,
     window_left: int,
     q_dtype: str,
     o_dtype: str,
@@ -935,7 +937,7 @@ def test_trtllm_batch_prefill(
         page_size,
         num_kv_heads,
         head_grp_size,
-        True,
+        causal,
         window_left,
         q_dtype,
         o_dtype,
@@ -1008,64 +1010,6 @@ def test_trtllm_batch_prefill_bs1(
         max_kv_len,
         False,
         head_dim,
-        skips_softmax=skips_softmax,
-        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
-    )
-
-
-@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
-@pytest.mark.parametrize(
-    "batch_size,page_size,num_kv_heads,head_grp_size",
-    TRTLLM_BATCH_PREFILL_SHAPES,
-)
-@pytest.mark.parametrize(
-    "q_dtype,kv_dtype,o_dtype",
-    TRTLLM_BATCH_PREFILL_DTYPES,
-)
-@pytest.mark.parametrize("enable_pdl", [None])
-@pytest.mark.parametrize("enable_sink", [False, True])
-@pytest.mark.parametrize("max_q_len", [511])
-@pytest.mark.parametrize("max_kv_len", [2047])
-@pytest.mark.parametrize("head_dim", [128, 256])
-@pytest.mark.parametrize("non_contiguous_query", [False, True])
-@pytest.mark.parametrize("skips_softmax", [False, True])
-@pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
-def test_trtllm_batch_prefill_non_causal(
-    kv_layout: str,
-    batch_size: int,
-    page_size: int,
-    num_kv_heads: int,
-    head_grp_size: int,
-    q_dtype: str,
-    o_dtype: str,
-    kv_dtype: str,
-    enable_pdl: bool,
-    enable_sink: bool,
-    max_q_len: int,
-    max_kv_len: int,
-    head_dim: int,
-    non_contiguous_query: bool,
-    skips_softmax: bool,
-    uses_shared_paged_kv_idx: bool,
-):
-    _test_trtllm_batch_prefill(
-        kv_layout,
-        batch_size,
-        page_size,
-        num_kv_heads,
-        head_grp_size,
-        False,
-        -1,
-        q_dtype,
-        o_dtype,
-        kv_dtype,
-        enable_pdl,
-        enable_sink,
-        max_q_len,
-        max_kv_len,
-        kv_dtype in ("fp8", "nvfp4"),
-        head_dim,
-        non_contiguous_query=non_contiguous_query,
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
     )
@@ -1813,6 +1757,7 @@ def test_trtllm_batch_prefill_head_dim_512(
         page_size,
         num_kv_heads,
         head_grp_size,
+        True,
         window_left,
         q_dtype,
         o_dtype,

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -867,34 +867,40 @@ def _test_trtllm_batch_prefill(
         assert (workspace_buffer[: 8192 * 256 * 4].cpu().numpy() == 0).all()
 
 
+TRTLLM_BATCH_PREFILL_SHAPES = [
+    (4, 16, 2, 1),
+    (4, 32, 4, 5),
+    (4, 64, 4, 8),
+    (128, 16, 2, 5),
+    (128, 32, 4, 1),
+    (128, 64, 2, 8),
+    (256, 16, 4, 8),
+    (256, 32, 2, 8),
+    (256, 64, 4, 1),
+    (256, 64, 4, 5),
+]
+
+
+TRTLLM_BATCH_PREFILL_DTYPES = [
+    ("bf16", "bf16", "bf16"),
+    ("fp16", "fp16", "fp16"),
+    ("fp8", "fp8", "bf16"),
+    ("fp8", "fp8", "fp16"),
+    ("fp8", "fp8", "fp8"),
+    ("fp8", "fp8", "nvfp4"),
+    ("fp8", "nvfp4", "fp8"),
+]
+
+
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize(
     "batch_size,page_size,num_kv_heads,head_grp_size",
-    [
-        (4, 16, 2, 1),
-        (4, 32, 4, 5),
-        (4, 64, 4, 8),
-        (128, 16, 2, 5),
-        (128, 32, 4, 1),
-        (128, 64, 2, 8),
-        (256, 16, 4, 8),
-        (256, 32, 2, 8),
-        (256, 64, 4, 1),
-        (256, 64, 4, 5),
-    ],
+    TRTLLM_BATCH_PREFILL_SHAPES,
 )
 @pytest.mark.parametrize("window_left", [-1])  # todo(Siyuan): add 127 window_left
 @pytest.mark.parametrize(
     "q_dtype,kv_dtype,o_dtype",
-    [
-        ("bf16", "bf16", "bf16"),
-        ("fp16", "fp16", "fp16"),
-        ("fp8", "fp8", "bf16"),
-        ("fp8", "fp8", "fp16"),
-        ("fp8", "fp8", "fp8"),
-        ("fp8", "fp8", "nvfp4"),
-        ("fp8", "nvfp4", "fp8"),
-    ],
+    TRTLLM_BATCH_PREFILL_DTYPES,
 )
 @pytest.mark.parametrize("enable_pdl", [None])
 @pytest.mark.parametrize("enable_sink", [True, False])
@@ -1009,14 +1015,19 @@ def test_trtllm_batch_prefill_bs1(
 
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize(
-    "batch_size,page_size,num_kv_heads,head_grp_size", [(4, 32, 4, 5)]
+    "batch_size,page_size,num_kv_heads,head_grp_size",
+    TRTLLM_BATCH_PREFILL_SHAPES,
 )
-@pytest.mark.parametrize("q_dtype,kv_dtype,o_dtype", [("bf16", "bf16", "bf16")])
-@pytest.mark.parametrize("enable_pdl", [None, False, True])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    TRTLLM_BATCH_PREFILL_DTYPES,
+)
+@pytest.mark.parametrize("enable_pdl", [None])
 @pytest.mark.parametrize("enable_sink", [False, True])
-@pytest.mark.parametrize("max_q_len", [64])
-@pytest.mark.parametrize("max_kv_len", [64])
-@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("max_q_len", [511])
+@pytest.mark.parametrize("max_kv_len", [2047])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("non_contiguous_query", [False, True])
 @pytest.mark.parametrize("skips_softmax", [False, True])
 @pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
 def test_trtllm_batch_prefill_non_causal(
@@ -1033,6 +1044,7 @@ def test_trtllm_batch_prefill_non_causal(
     max_q_len: int,
     max_kv_len: int,
     head_dim: int,
+    non_contiguous_query: bool,
     skips_softmax: bool,
     uses_shared_paged_kv_idx: bool,
 ):
@@ -1053,6 +1065,7 @@ def test_trtllm_batch_prefill_non_causal(
         max_kv_len,
         kv_dtype in ("fp8", "nvfp4"),
         head_dim,
+        non_contiguous_query=non_contiguous_query,
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
     )

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -586,6 +586,7 @@ def _test_trtllm_batch_prefill(
     page_size: int,
     num_kv_heads: int,
     head_grp_size: int,
+    causal: bool,
     window_left: int,
     q_dtype: str,
     o_dtype: str,
@@ -603,6 +604,8 @@ def _test_trtllm_batch_prefill(
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] != 10:
         pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    if not causal and window_left >= 0:
+        pytest.skip("Non-causal paged trtllm-gen tests only cover dense attention")
 
     if skips_softmax and q_dtype != kv_dtype:
         pytest.skip(
@@ -676,7 +679,7 @@ def _test_trtllm_batch_prefill(
         "num_kv_heads": num_kv_heads,
         "head_dim_qk": head_dim,
         "page_size": page_size,
-        "causal": True,
+        "causal": causal,
         "pos_encoding_mode": "NONE",
         "logits_soft_cap": 0.0,
         "q_data_type": ref_q.dtype,
@@ -725,7 +728,7 @@ def _test_trtllm_batch_prefill(
             v_flat,
             sink,
             window_left,
-            True,
+            causal,
             sm_scale,
             mode="varlen",
             batch_size=batch_size,
@@ -768,6 +771,7 @@ def _test_trtllm_batch_prefill(
         q_indptr,
         kv_indptr,
         window_left,  # window_left
+        causal=causal,
         out=out,
         out_dtype=out_dtype,
         o_sf_scale=o_sf_scale,
@@ -925,6 +929,7 @@ def test_trtllm_batch_prefill(
         page_size,
         num_kv_heads,
         head_grp_size,
+        True,
         window_left,
         q_dtype,
         o_dtype,
@@ -986,6 +991,7 @@ def test_trtllm_batch_prefill_bs1(
         page_size,
         num_kv_heads,
         head_grp_size,
+        True,
         window_left,
         q_dtype,
         o_dtype,
@@ -995,6 +1001,57 @@ def test_trtllm_batch_prefill_bs1(
         max_q_len,
         max_kv_len,
         False,
+        head_dim,
+        skips_softmax=skips_softmax,
+        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
+
+
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+@pytest.mark.parametrize(
+    "batch_size,page_size,num_kv_heads,head_grp_size", [(4, 32, 4, 5)]
+)
+@pytest.mark.parametrize("q_dtype,kv_dtype,o_dtype", [("bf16", "bf16", "bf16")])
+@pytest.mark.parametrize("enable_pdl", [None, False, True])
+@pytest.mark.parametrize("enable_sink", [False, True])
+@pytest.mark.parametrize("max_q_len", [64])
+@pytest.mark.parametrize("max_kv_len", [64])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("skips_softmax", [False, True])
+@pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
+def test_trtllm_batch_prefill_non_causal(
+    kv_layout: str,
+    batch_size: int,
+    page_size: int,
+    num_kv_heads: int,
+    head_grp_size: int,
+    q_dtype: str,
+    o_dtype: str,
+    kv_dtype: str,
+    enable_pdl: bool,
+    enable_sink: bool,
+    max_q_len: int,
+    max_kv_len: int,
+    head_dim: int,
+    skips_softmax: bool,
+    uses_shared_paged_kv_idx: bool,
+):
+    _test_trtllm_batch_prefill(
+        kv_layout,
+        batch_size,
+        page_size,
+        num_kv_heads,
+        head_grp_size,
+        False,
+        -1,
+        q_dtype,
+        o_dtype,
+        kv_dtype,
+        enable_pdl,
+        enable_sink,
+        max_q_len,
+        max_kv_len,
+        kv_dtype in ("fp8", "nvfp4"),
         head_dim,
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Non-causal (dense-mask) support to trtllm_batch_context_with_kv_cache

NOTE TO REVIEWER: the new "casual" input being inserted in the middle of the public API could cause API regressions to users using positional arguments. I think the current ordering next to window_left makes more sense, but for reviewer to double check if we should instead move it to the end.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/2826

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public "causal" option for batched prefill so users can select causal vs non-causal attention; runtime execution respects this choice.

* **Bug Fixes / Validation**
  * Added runtime validation: non-causal mode disallowed with sliding-window left offset and requires logits soft-cap == 0.0 (errors raised when violated).

* **Tests**
  * Added and parameterized non-causal attention tests; updated batch-prefill tests and added runtime skips for unsupported combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->