### PR TITLE
Prevent MoE autotuner buffer overflow on large token buckets

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -485,10 +485,16 @@ class CuteDslMoEWrapper:
         **kwargs,
     ) -> torch.Tensor:
         """Forward implementation called by auto-tuner."""
-        # Pre-allocated buffers are sized for self.tile_size. When the tactic
-        # uses a different tile_size (e.g. during autotune), fall back to
-        # dynamic allocation to avoid buffer overflow in moe_sort.
-        use_prealloc = self.use_cuda_graph and tile_size == self.tile_size
+        # Pre-allocated buffers are sized for self.tile_size and
+        # self.max_num_tokens.  Fall back to dynamic allocation when the
+        # tactic uses a different tile_size or the batch exceeds what the
+        # buffers were sized for (e.g. autotuner probing larger buckets).
+        num_tokens = x.shape[0]
+        use_prealloc = (
+            self.use_cuda_graph
+            and tile_size == self.tile_size
+            and num_tokens <= self.max_num_tokens
+        )
         return _moe_core_impl(
             x=x,
             x_sf=x_sf,
@@ -607,7 +613,7 @@ class CuteDslMoEWrapper:
         _, best_tactic = tuner.choose_one(
             "CuteDslMoEWrapper::run",
             [self._runner],
-            CuteDslFusedMoENvfp4Runner.tuning_config,
+            self._runner.tuning_config,
             inputs,
         )
 
@@ -784,7 +790,7 @@ def cute_dsl_fused_moe_nvfp4(
     _, best_tactic = tuner.choose_one(
         "CuteDslFusedMoE::run_moe_nvfp4",
         [runner],
-        CuteDslFusedMoENvfp4Runner.tuning_config,
+        runner.tuning_config,
         inputs,
         aux_stream=aux_stream,
     )

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -246,47 +246,6 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         output_dtype: Output data type (default: torch.bfloat16).
     """
 
-    # Tensor initializers for dynamic tensors (indices 0, 1, 2, 3, 11)
-    # These create valid dummy tensors for profiling with different num_tokens
-    dynamic_tensor_initializers = [
-        # 0: x - FP4 quantized input (uint8 packed)
-        lambda shapes, dtype, device: torch.randint(
-            0, 256, shapes, dtype=torch.uint8, device=device
-        ),
-        # 1: x_sf - FP8 scale factors (uint8)
-        lambda shapes, dtype, device: torch.randint(
-            1, 128, shapes, dtype=torch.uint8, device=device
-        ),
-        # 2: token_selected_experts - expert indices (int32, 0 to num_experts-1)
-        lambda shapes, dtype, device: torch.randint(
-            0,
-            8,
-            shapes,
-            dtype=torch.int32,
-            device=device,  # num_experts=8 typical
-        ),
-        # 3: token_final_scales - routing weights (float32, softmax normalized)
-        lambda shapes, dtype, device: torch.softmax(
-            torch.randn(shapes, device=device), dim=-1
-        ).to(torch.float32),
-        # 11: moe_output - output buffer (bfloat16)
-        lambda shapes, dtype, device: torch.empty(shapes, dtype=dtype, device=device),
-    ]
-
-    # Tuning config with dynamic tensor specs for num_tokens dimension
-    # Indices 0, 1, 2, 3, 11 all have num_tokens as their first dimension
-    tuning_config = TuningConfig(
-        dynamic_tensor_specs=(
-            DynamicTensorSpec(
-                input_idx=(0, 1, 2, 3, 11),  # x, x_sf, experts, scales, moe_output
-                dim_idx=(0, 0, 0, 0, 0),  # First dimension is num_tokens for all
-                gen_tuning_buckets=get_last_power_of_2_num_tokens_buckets(8192),
-                map_to_tuning_buckets=lambda x: min(last_positive_power_of_2(x), 8192),
-                tensor_initializers=dynamic_tensor_initializers,
-            ),
-        ),
-    )
-
     def __init__(
         self,
         forward_impl: Callable,
@@ -306,6 +265,47 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         self.use_fused_finalize = use_fused_finalize
         self.output_dtype = output_dtype
         self.enable_pdl = enable_pdl
+
+        # Instance-level so dummy expert IDs span all local experts
+        # (randint(0, num_experts)) for realistic profiling.
+        self.tuning_config = TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    input_idx=(0, 1, 2, 3, 11),
+                    dim_idx=(0, 0, 0, 0, 0),
+                    gen_tuning_buckets=get_last_power_of_2_num_tokens_buckets(8192),
+                    map_to_tuning_buckets=lambda x: min(
+                        last_positive_power_of_2(x), 8192
+                    ),
+                    tensor_initializers=[
+                        # 0: x — FP4 quantized input (uint8 packed)
+                        lambda shapes, dtype, device: torch.randint(
+                            0, 256, shapes, dtype=torch.uint8, device=device
+                        ),
+                        # 1: x_sf — FP8 scale factors (uint8)
+                        lambda shapes, dtype, device: torch.randint(
+                            1, 128, shapes, dtype=torch.uint8, device=device
+                        ),
+                        # 2: token_selected_experts — expert indices [0, num_experts)
+                        lambda shapes, dtype, device: torch.randint(
+                            0,
+                            max(num_experts, 1),
+                            shapes,
+                            dtype=torch.int32,
+                            device=device,
+                        ),
+                        # 3: token_final_scales — routing weights (softmax normalized)
+                        lambda shapes, dtype, device: torch.softmax(
+                            torch.randn(shapes, device=device), dim=-1
+                        ).to(torch.float32),
+                        # 11: moe_output — output buffer
+                        lambda shapes, dtype, device: torch.empty(
+                            shapes, dtype=dtype, device=device
+                        ),
+                    ],
+                ),
+            ),
+        )
 
     def __hash__(self):
         return hash(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

CuteDslMoEWrapper pre-allocates intermediate buffers sized for
max_num_tokens, but the autotuner can probe buckets larger than that
(e.g. 8192 tokens vs 2048 max). The GEMM kernels then write past
buffer bounds, silently corrupting model weights and eventually
triggering cudaErrorIllegalAddress.

Two fixes:
- Check num_tokens <= max_num_tokens before reusing pre-allocated
  buffers; fall back to dynamic allocation when exceeded.
- Move tuning_config to instance level so dummy expert IDs span all
  local experts (randint(0, num_experts)) instead of a hardcoded 8,
  which concentrated routing and inflated permutation buffer sizes.

## 🔍 Related Issues

[feat: cuteDSL fp4 moe for better DSR1 performance.](https://github.com/flashinfer-ai/flashinfer/pull/2398)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * CUDA-graph preallocation now respects input-size limits to avoid over-allocation and improve memory behavior for larger token batches.
  * Memory gating refined to prevent oversized buffer reuse, improving inference stability under varying workloads.

* **Stability & Tuning**
  * Auto-tuner configuration is now per-run, improving tuning accuracy and consistency.
  * Runtime tuning initialization adapts to the configured expert count for more representative profiling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->