### PR TITLE
Fix: Missing args in allreduce_fusion MOE finalize call

### DIFF
--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -480,6 +480,7 @@ def allreduce_fusion(
     expanded_idx_to_permuted_idx: Optional[torch.Tensor] = None,
     expert_scale_factor: Optional[torch.Tensor] = None,
     shared_expert_output: Optional[torch.Tensor] = None,
+    routed_scaling_factor: Optional[float] = None,
 ) -> torch.Tensor:
     """
     AllReduce + RMSNorm fusion operation.
@@ -548,6 +549,7 @@ def allreduce_fusion(
             output row. Shape [token_num, top_k], dtype int32.
         expert_scale_factor: Router weights for each selected expert [token_num, top_k]
         shared_expert_output: Optional shared expert output to add [token_num, hidden_dim]
+        routed_scaling_factor: Optional global scaling factor for routed expert outputs
 
     Returns:
         Output tensor (typically norm_out for fusion cases, output otherwise)
@@ -717,6 +719,8 @@ def allreduce_fusion(
                 expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
                 norm_out=norm_out,
                 residual_out=residual_out,
+                quant_out=quant_out,
+                scale_out=scale_out,
                 workspace_ptrs=workspace.workspace_tensor,
                 launch_with_pdl=launch_with_pdl,
                 world_rank=workspace.rank,
@@ -724,6 +728,7 @@ def allreduce_fusion(
                 eps=rms_eps,
                 shared_expert_output=shared_expert_output,
                 expert_scale_factor=expert_scale_factor,
+                routed_scaling_factor=routed_scaling_factor,
             )
 
             return norm_out


### PR DESCRIPTION

## Problem

On main branch, `allreduce_fusion(pattern=kMoEFinalizeARResidualRMSNorm)` crashes with `TypeError: missing positional arguments`. mypy pre-commit also fails.

## Root Cause

Two PRs merged to main in sequence, modifying different ends of the same call chain:

| Order | PR | What changed | File |
|-------|-----|-------------|------|
| 1st | #2966 (Fused moe all-reduce routed scaling factor + quant support) | Added `quant_out`, `scale_out`, `routed_scaling_factor` to `trtllm_moe_finalize_allreduce_fusion()` signature | `flashinfer/comm/trtllm_ar.py` |
| 2nd | #2982 (Add MOE patterns to unified allreduce_fusion API, closes #2823) | Added `kMoEFinalizeARResidualRMSNorm` pattern that calls `trtllm_moe_finalize_allreduce_fusion()` | `flashinfer/comm/allreduce.py` |

PR #2982 was developed before #2966 merged. Git merge produced no conflict since they touched different files, but the call in `allreduce_fusion()` was left with the old signature — missing the three new positional args added by #2966.

## Impact

| Scope | Status |
|-------|--------|
| `allreduce_fusion(pattern=kMoEFinalizeARResidualRMSNorm)` (pattern 7) | **Broken** — TypeError at runtime |
| `allreduce_fusion(pattern=kMoEReductionARResidualRMSNorm)` (pattern 6) | Not affected (calls a different function) |
| `allreduce_fusion(pattern=0-5)` (standard allreduce) | Not affected |
| `trtllm_moe_finalize_allreduce_fusion()` direct callers | Not affected (low-level API is correct) |
| mypy pre-commit | **Fails** |
| `test_allreduce_fusion_moe_unified_api.py` finalize tests | **Would fail** if run on multi-GPU CI |

Practical impact is limited — pattern 7 was just added in #2982 and has no downstream consumers yet.

## Fix

`flashinfer/comm/allreduce.py`:
- Pass `quant_out`, `scale_out`, `routed_scaling_factor` to the `trtllm_moe_finalize_allreduce_fusion()` call
- Add `routed_scaling_factor: Optional[float] = None` to `allreduce_fusion()` signature
- Update docstring

No test changes needed — existing tests pass `None` for the new args (default values), which is the correct behavior for non-quantized finalize.

## PR

- Branch: `fix/moe-finalize-missing-args`
- Changes: 1 file, +5 lines
- Title: `fix: add missing args to moe_finalize call in unified allreduce_fusion API`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Mixture of Experts finalization for TRTLLM backend by introducing a configurable global scaling parameter. This enables fine-grained control over routed expert output scaling during finalization operations, improving flexibility for advanced inference configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->