### PR TITLE
feat: Add backend="b12x" for mm_fp4 on SM120

### DIFF
--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -1147,21 +1147,18 @@ def testMmFp4(args):
         mat2_inv_s,
         mat2_inv_s_trtllm,
     ):
-        if backend in ["cudnn", "trtllm", "cutlass", "cute-dsl", "auto"]:
-            return flashinfer.gemm.mm_fp4(
-                a=input_fp4,
-                b=mat2_fp4.T if backend != "trtllm" else mat2_fp4_trtllm.T,
-                a_descale=input_inv_s,
-                b_descale=mat2_inv_s.T if backend != "trtllm" else mat2_inv_s_trtllm.T,
-                alpha=(alpha_for_cute_dsl_mxfp4 if (backend == "cute-dsl") else alpha),
-                out_dtype=res_dtype,
-                block_size=block_size,
-                use_8x4_sf_layout=not use_128x4_sf_layout,
-                backend=backend,
-                use_nvfp4=use_nvfp4,
-            )
-        else:
-            raise ValueError(f"Unsupported backend: {backend}")
+        return flashinfer.gemm.mm_fp4(
+            a=input_fp4,
+            b=mat2_fp4.T if backend != "trtllm" else mat2_fp4_trtllm.T,
+            a_descale=input_inv_s,
+            b_descale=mat2_inv_s.T if backend != "trtllm" else mat2_inv_s_trtllm.T,
+            alpha=(alpha_for_cute_dsl_mxfp4 if (backend == "cute-dsl") else alpha),
+            out_dtype=res_dtype,
+            block_size=block_size,
+            use_8x4_sf_layout=not use_128x4_sf_layout,
+            backend=backend,
+            use_nvfp4=use_nvfp4,
+        )
 
     has_reference_output = False
     if run_refcheck:

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -1040,7 +1040,14 @@ def testMmFp4(args):
     run_refcheck = args.refcheck
     use_128x4_sf_layout = args.use_128x4_sf_layout
     use_nvfp4 = args.use_nvfp4
-    autotune_supported_backends = ["cudnn", "cutlass", "trtllm", "cute-dsl", "auto"]
+    autotune_supported_backends = [
+        "cudnn",
+        "cutlass",
+        "trtllm",
+        "cute-dsl",
+        "b12x",
+        "auto",
+    ]
     res = []
 
     res_dtype = dtype_str_to_torch_dtype(args.out_dtype)

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -140,7 +140,16 @@ def parse_gemm_args(line, parser):
         required=False,
         nargs="+",
         default=["cudnn"],
-        choices=["cudnn", "cublas", "trtllm", "cutlass", "tgv", "cute-dsl", "b12x", "auto"],
+        choices=[
+            "cudnn",
+            "cublas",
+            "trtllm",
+            "cutlass",
+            "tgv",
+            "cute-dsl",
+            "b12x",
+            "auto",
+        ],
         help="Kernel backends to test. Default: cudnn",
     )
     parser.add_argument(

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -140,7 +140,7 @@ def parse_gemm_args(line, parser):
         required=False,
         nargs="+",
         default=["cudnn"],
-        choices=["cudnn", "cublas", "trtllm", "cutlass", "tgv", "cute-dsl", "auto"],
+        choices=["cudnn", "cublas", "trtllm", "cutlass", "tgv", "cute-dsl", "b12x", "auto"],
         help="Kernel backends to test. Default: cudnn",
     )
     parser.add_argument(

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -21,8 +21,10 @@ from typing import Union, Tuple
 
 import cutlass
 import cutlass._mlir.dialects.cute as _cute_ir
+import cutlass.cute as cute
 import torch
 from cutlass._mlir import ir
+from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.cute.typing import AddressSpace, Numeric, Pointer, Type
 
 
@@ -408,3 +410,162 @@ def get_mma_sf_shape(
     m_tiles = ceil_div(m, 128)
     k_tiles = ceil_div(sf_k, 4)
     return (32, 4, m_tiles, 4, k_tiles, num_groups)
+
+
+@dsl_user_op
+def sm120_make_smem_layout_sfa(
+    tiled_mma: cute.TiledMma,
+    tile_shape_mnk: cute.Tile,
+    sf_vec_size: int,
+    num_stages: int,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.Layout:
+    """Make shared memory layout for scale factors A on SM120.
+
+    Constructs the SMEM layout for SFA based on BlockScaledBasicChunk,
+    MMA tiler shape, scale factor vector size, and number of pipeline stages.
+
+    Args:
+        tiled_mma: The tiled MMA operation.
+        tile_shape_mnk: The tile shape (M, N, K).
+        sf_vec_size: Scale factor vector size (16 or 32).
+        num_stages: Number of pipeline stages.
+
+    Returns:
+        Staged shared memory layout for SFA.
+    """
+    assert sf_vec_size == 16 or sf_vec_size == 32, "sf_vec_size must be 16 or 32"
+
+    blk_mn = 128
+    blk_sf = 4
+    blk_elems = blk_mn * blk_sf
+    mma_nsf = tiled_mma.shape_mnk[2] // sf_vec_size
+
+    mn_basic_block_shape = (32, 4)
+    mn_basic_block_stride = (16, 4)
+    k_basic_block_shape = (sf_vec_size, mma_nsf)
+    k_basic_block_stride = (0, 1)
+
+    assert tile_shape_mnk[0] % (blk_mn // 2) == 0, (
+        "tile_shape_mnk[0] must be divisible by 64"
+    )
+
+    # Scale-factor tiles are quantized in 128-row blocks, so narrower MMA
+    # tiles still allocate one full SF block and consume only the live subset.
+    sfa_tile_m = max(blk_mn, ceil_div(tile_shape_mnk[0], blk_mn) * blk_mn)
+
+    sSFA_shapeM = (mn_basic_block_shape, sfa_tile_m // blk_mn)
+    sSF_strideM = (mn_basic_block_stride, blk_elems)
+
+    assert tile_shape_mnk[2] % (blk_sf * mma_nsf) == 0, (
+        "tile_shape_mnk[2] must be divisible by blk_sf * mma_nsf"
+    )
+
+    sSFA_shapeK = (
+        k_basic_block_shape,
+        blk_sf // mma_nsf,
+        tile_shape_mnk[2] // sf_vec_size // blk_sf,
+    )
+    sSF_strideK = (
+        k_basic_block_stride,
+        mma_nsf,
+        sfa_tile_m // blk_mn * blk_elems,
+    )
+
+    sSFA_shape = (sSFA_shapeM, sSFA_shapeK)
+    sSFA_stride = (sSF_strideM, sSF_strideK)
+
+    smem_layout = cute.make_layout(sSFA_shape, stride=sSFA_stride)
+
+    sfa_smem_layout_staged = cute.append(
+        smem_layout,
+        cute.make_layout(
+            num_stages, stride=cute.cosize(cute.filter_zeros(smem_layout))
+        ),
+    )
+
+    return sfa_smem_layout_staged
+
+
+@dsl_user_op
+def sm120_make_smem_layout_sfb(
+    tiled_mma: cute.TiledMma,
+    tile_shape_mnk: cute.Tile,
+    sf_vec_size: int,
+    num_stages: int,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.Layout:
+    """Make shared memory layout for scale factors B on SM120.
+
+    Constructs the SMEM layout for SFB based on BlockScaledBasicChunk,
+    MMA tiler shape, scale factor vector size, and number of pipeline stages.
+
+    Args:
+        tiled_mma: The tiled MMA operation.
+        tile_shape_mnk: The tile shape (M, N, K).
+        sf_vec_size: Scale factor vector size (16 or 32).
+        num_stages: Number of pipeline stages.
+
+    Returns:
+        Staged shared memory layout for SFB.
+    """
+    blk_mn = 128
+    blk_sf = 4
+    blk_elems = blk_mn * blk_sf
+
+    assert sf_vec_size == 16 or sf_vec_size == 32, "sf_vec_size must be 16 or 32"
+
+    assert tile_shape_mnk[1] % (blk_mn // 2) == 0, (
+        "tile_shape_mnk[1] must be divisible by 64"
+    )
+
+    assert tile_shape_mnk[2] % sf_vec_size == 0, (
+        "tile_shape_mnk[2] must be divisible by sf_vec_size"
+    )
+
+    mma_nsf = tiled_mma.shape_mnk[2] // sf_vec_size
+
+    mn_basic_block_shape = (32, 4)
+    mn_basic_block_stride = (16, 4)
+    k_basic_block_shape = (sf_vec_size, mma_nsf)
+    k_basic_block_stride = (0, 1)
+
+    # Scale-factor tiles are quantized in 128-column blocks, so narrower MMA
+    # tiles still allocate one full SF block and consume only the live subset.
+    sfb_tile_n = max(blk_mn, ceil_div(tile_shape_mnk[1], blk_mn) * blk_mn)
+
+    sSFB_shapeN = (mn_basic_block_shape, sfb_tile_n // blk_mn)
+    sSF_strideN = (mn_basic_block_stride, blk_elems)
+
+    assert tile_shape_mnk[2] % (blk_sf * mma_nsf) == 0, (
+        "tile_shape_mnk[2] must be divisible by blk_sf * mma_nsf"
+    )
+
+    sSFB_shapeK = (
+        k_basic_block_shape,
+        blk_sf // mma_nsf,
+        tile_shape_mnk[2] // sf_vec_size // blk_sf,
+    )
+    sSF_strideK = (
+        k_basic_block_stride,
+        mma_nsf,
+        sfb_tile_n // blk_mn * blk_elems,
+    )
+
+    sSFB_shape = (sSFB_shapeN, sSFB_shapeK)
+    sSFB_stride = (sSF_strideN, sSF_strideK)
+
+    smem_layout = cute.make_layout(sSFB_shape, stride=sSFB_stride)
+
+    sfb_smem_layout_staged = cute.append(
+        smem_layout,
+        cute.make_layout(
+            num_stages, stride=cute.cosize(cute.filter_zeros(smem_layout))
+        ),
+    )
+
+    return sfb_smem_layout_staged

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -462,6 +462,10 @@ def sm120_make_smem_layout_sfa(
     assert tile_shape_mnk[2] % (blk_sf * mma_nsf) == 0, (
         "tile_shape_mnk[2] must be divisible by blk_sf * mma_nsf"
     )
+    assert tile_shape_mnk[2] % (sf_vec_size * blk_sf) == 0, (
+        "tile_shape_mnk[2] must be divisible by sf_vec_size * blk_sf"
+    )
+    assert blk_sf % mma_nsf == 0, "blk_sf must be divisible by mma_nsf"
 
     sSFA_shapeK = (
         k_basic_block_shape,
@@ -544,6 +548,10 @@ def sm120_make_smem_layout_sfb(
     assert tile_shape_mnk[2] % (blk_sf * mma_nsf) == 0, (
         "tile_shape_mnk[2] must be divisible by blk_sf * mma_nsf"
     )
+    assert tile_shape_mnk[2] % (sf_vec_size * blk_sf) == 0, (
+        "tile_shape_mnk[2] must be divisible by sf_vec_size * blk_sf"
+    )
+    assert blk_sf % mma_nsf == 0, "blk_sf must be divisible by mma_nsf"
 
     sSFB_shapeK = (
         k_basic_block_shape,

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -48,10 +48,14 @@ try:
             Sm100BlockScaledPersistentDenseGemmKernel as Sm100BlockScaledPersistentDenseGemmKernel,
             create_scale_factor_tensor as create_scale_factor_tensor,
         )
+        from .kernels.dense_blockscaled_gemm_sm120 import (
+            Sm120BlockScaledDenseGemmKernel as Sm120BlockScaledDenseGemmKernel,
+        )
 
         _cute_dsl_kernels = [
             "grouped_gemm_nt_masked",
             "Sm100BlockScaledPersistentDenseGemmKernel",
+            "Sm120BlockScaledDenseGemmKernel",
             "create_scale_factor_tensor",
         ]
 except ImportError:

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -48,16 +48,24 @@ try:
             Sm100BlockScaledPersistentDenseGemmKernel as Sm100BlockScaledPersistentDenseGemmKernel,
             create_scale_factor_tensor as create_scale_factor_tensor,
         )
-        from .kernels.dense_blockscaled_gemm_sm120 import (
-            Sm120BlockScaledDenseGemmKernel as Sm120BlockScaledDenseGemmKernel,
-        )
 
         _cute_dsl_kernels = [
             "grouped_gemm_nt_masked",
             "Sm100BlockScaledPersistentDenseGemmKernel",
-            "Sm120BlockScaledDenseGemmKernel",
             "create_scale_factor_tensor",
         ]
+except ImportError:
+    pass
+
+try:
+    from flashinfer.cute_dsl.utils import is_cute_dsl_available
+
+    if is_cute_dsl_available():
+        from .kernels.dense_blockscaled_gemm_sm120 import (
+            Sm120BlockScaledDenseGemmKernel as Sm120BlockScaledDenseGemmKernel,
+        )
+
+        _cute_dsl_kernels.append("Sm120BlockScaledDenseGemmKernel")
 except ImportError:
     pass
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4379,7 +4379,7 @@ def _check_mm_fp4_problem_size(
     block_size: int = 16,
     use_8x4_sf_layout: bool = False,  # unused
     backend: Literal[
-        "cudnn", "trtllm", "cutlass", "cute-dsl", "auto"
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
     ] = "auto",  # unused
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
@@ -4439,7 +4439,7 @@ def _cudnn_gemm_fp4_requirement(
     block_size: int = 16,
     use_8x4_sf_layout: bool = False,
     backend: Literal[
-        "cudnn", "trtllm", "cutlass", "cute-dsl", "auto"
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
     ] = "auto",  # unused
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
@@ -4470,7 +4470,7 @@ def _trtllm_gemm_fp4_requirement(
     block_size: int = 16,  # unused
     use_8x4_sf_layout: bool = False,  # unused
     backend: Literal[
-        "cudnn", "trtllm", "cutlass", "cute-dsl", "auto"
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
     ] = "auto",  # unused
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
@@ -4497,7 +4497,7 @@ def _cutlass_gemm_fp4_requirement(
     block_size: int = 16,  # unused
     use_8x4_sf_layout: bool = False,
     backend: Literal[
-        "cudnn", "trtllm", "cutlass", "cute-dsl", "auto"
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
     ] = "auto",  # unused
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
@@ -4521,7 +4521,7 @@ def _cute_dsl_gemm_fp4_requirement(
     block_size: int = 16,  # unused
     use_8x4_sf_layout: bool = False,
     backend: Literal[
-        "cudnn", "trtllm", "cutlass", "cute-dsl", "auto"
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
     ] = "auto",  # unused
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
@@ -4927,7 +4927,7 @@ def _heuristic_func_mm_fp4(
     out: Optional[torch.Tensor] = None,
     block_size: int = 16,
     use_8x4_sf_layout: bool = False,
-    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "auto"] = "cudnn",
+    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"] = "cudnn",
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
 ):
@@ -5121,7 +5121,7 @@ def mm_fp4(
     use_8x4_sf_layout: bool
         Whether to use 8x4 scale factor layout or 128x4 scale factor layout, defaults to False.
 
-    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "auto"]
+    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"]
         Backend to use, defaults to ``"auto"``, which automatically selects the best
         backend between ``"cudnn"`` and ``"cutlass"`` based on the current CUDA and
         cuDNN versions. The ``"trtllm"`` and ``"cute-dsl"`` backends are never selected

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4579,7 +4579,6 @@ def _cute_dsl_gemm_fp4_runner(
 
     On SM100: uses the SM100 kernel only.
     On SM103: uses both SM100 kernel and the SM103-specific 3xFP4 kernel.
-    On SM120/SM121: uses the SM120 warp-level MMA kernel.
     The autotuner selects the best (kernel_type, tile, cluster, swap_ab, prefetch,
     use_tma_store) combination.
     """
@@ -4590,15 +4589,6 @@ def _cute_dsl_gemm_fp4_runner(
     )
 
     sm_version = sm_major * 10 + sm_minor
-
-    # SM120/SM121 kernel (warp-level MMA, no tcgen05)
-    Sm120Kernel = None
-    if sm_version == 120:
-        from .kernels.dense_blockscaled_gemm_sm120 import (
-            Sm120BlockScaledDenseGemmKernel,
-        )
-
-        Sm120Kernel = Sm120BlockScaledDenseGemmKernel
 
     # TODO(yunzheq): Re-enable SM103 kernel once cutlass-dsl package includes
     # SM103MmaMXF4Op and compatible PersistentTileSchedulerParams.
@@ -4650,51 +4640,6 @@ def _cute_dsl_gemm_fp4_runner(
             sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
 
             valid_tactics = []
-
-            # --- SM120/SM121 tactics ---
-            if sm_version == 120 and Sm120Kernel is not None:
-                batch_size = 1
-                # SM120 kernel supports tile M,N divisible by 64.
-                # Smaller tiles (64x64, 64x128, 128x64) help when
-                # small-M shapes leave SMs idle with 128x128.
-                sm120_mma_tiler_candidates = [
-                    (64, 64),
-                    (64, 128),
-                    (128, 64),
-                    (128, 128),
-                ]
-                # SM120 kernel does not support swap_ab (SF fragment
-                # partitioning assumes non-swapped layout).
-                swap_ab = False
-                for mma_tiler_mn in sm120_mma_tiler_candidates:
-                    if not Sm120Kernel.can_implement(
-                        ab_dtype,
-                        sf_dtype,
-                        sf_vec_size,
-                        c_cutlass_dtype,
-                        mma_tiler_mn,
-                        (1, 1),
-                        m,
-                        n,
-                        real_k,
-                        batch_size,
-                        "k",
-                        "k",
-                        "n",
-                    ):
-                        continue
-                    for use_prefetch in (False, True):
-                        valid_tactics.append(
-                            (
-                                mma_tiler_mn,
-                                (1, 1),
-                                swap_ab,
-                                use_prefetch,
-                                "sm120",
-                                None,
-                            )
-                        )
-                return valid_tactics
 
             # SM100 tactics (shared enumeration with mxfp8)
             sm100_base = _get_sm100_block_scaled_tactics(
@@ -4787,27 +4732,14 @@ def _cute_dsl_gemm_fp4_runner(
             batch_size = 1
 
             if tactic is None or tactic == -1:
-                if sm_version == 120:
-                    _sm_count = torch.cuda.get_device_properties(
-                        a.device
-                    ).multi_processor_count
-                    tactic = (
-                        _select_default_sm120_mma_tiler(m, n, _sm_count),
-                        (1, 1),
-                        False,
-                        False,
-                        "sm120",
-                        None,
-                    )
-                else:
-                    tactic = (
-                        _SM100_DEFAULT_MMA_TILER_MN,
-                        _SM100_DEFAULT_CLUSTER_SHAPE_MN,
-                        False,
-                        False,
-                        "sm100",
-                        None,
-                    )
+                tactic = (
+                    _SM100_DEFAULT_MMA_TILER_MN,
+                    _SM100_DEFAULT_CLUSTER_SHAPE_MN,
+                    False,
+                    False,
+                    "sm100",
+                    None,
+                )
 
             (
                 mma_tiler_mn,
@@ -4849,15 +4781,7 @@ def _cute_dsl_gemm_fp4_runner(
             )
 
             make_kernel: Any  # type varies by kernel_type
-            if kernel_type == "sm120" and Sm120Kernel is not None:
-                make_kernel = lambda: Sm120Kernel(
-                    sf_vec_size,
-                    mma_tiler_mn,
-                    cluster_shape_mn,
-                    use_prefetch,
-                    enable_pdl,
-                )
-            elif kernel_type == "sm103" and Sm103Kernel is not None:
+            if kernel_type == "sm103" and Sm103Kernel is not None:
                 make_kernel = lambda: Sm103Kernel(
                     sf_vec_size,
                     mma_tiler_mn,
@@ -4916,6 +4840,194 @@ def _cute_dsl_gemm_fp4_runner(
     return CuteDSLFp4GemmRunner()
 
 
+# Module-level kernel cache for b12x GEMM (separate from CuTe DSL SM100 cache).
+_B12X_MM_FP4_KERNEL_CACHE: dict[tuple, tuple] = {}
+
+
+def _b12x_gemm_fp4_runner(
+    sm_major: int,
+    sm_minor: int,
+    enable_pdl: bool,
+    out_dtype: torch.dtype,
+    use_nvfp4: bool,
+):
+    """Create a b12x FP4 GEMM runner for SM120.
+
+    Uses the SM120 warp-level MMA kernel with underfill tile selection.
+    """
+    import cutlass
+
+    from .kernels.dense_blockscaled_gemm_sm120 import (
+        Sm120BlockScaledDenseGemmKernel,
+    )
+
+    cutlass_dtype_attr = _TORCH_TO_CUTLASS_DTYPE_ATTR.get(out_dtype)
+    c_cutlass_dtype = (
+        getattr(cutlass, cutlass_dtype_attr) if cutlass_dtype_attr is not None else None
+    )
+    if c_cutlass_dtype is None:
+        raise ValueError(
+            f"b12x backend does not support output dtype {out_dtype}. "
+            f"Supported: torch.bfloat16, torch.float16."
+        )
+
+    class B12xFp4GemmRunner(TunableRunner):
+        """TunableRunner for b12x block-scaled FP4 dense GEMM on SM120.
+
+        Tactics are tuples:
+            (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch, kernel_type, use_tma_store)
+        where kernel_type is always "sm120" and use_tma_store is always None.
+        """
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+        ) -> list:
+            (a, b, a_descale, b_descale, alpha, _, out, _, _, _) = inputs
+            m = a.shape[0]
+            k_packed = a.shape[1]
+            n = b.shape[1]
+            real_k = k_packed * 2
+
+            sf_vec_size = 16
+            ab_dtype = cutlass.Float4E2M1FN
+            sf_dtype = cutlass.Float8E4M3FN
+            batch_size = 1
+
+            valid_tactics = []
+            sm120_mma_tiler_candidates = [
+                (64, 64),
+                (64, 128),
+                (128, 64),
+                (128, 128),
+            ]
+            swap_ab = False
+            for mma_tiler_mn in sm120_mma_tiler_candidates:
+                if not Sm120BlockScaledDenseGemmKernel.can_implement(
+                    ab_dtype,
+                    sf_dtype,
+                    sf_vec_size,
+                    c_cutlass_dtype,
+                    mma_tiler_mn,
+                    (1, 1),
+                    m,
+                    n,
+                    real_k,
+                    batch_size,
+                    "k",
+                    "k",
+                    "n",
+                ):
+                    continue
+                for use_prefetch in (False, True):
+                    valid_tactics.append(
+                        (mma_tiler_mn, (1, 1), swap_ab, use_prefetch, "sm120", None)
+                    )
+            return valid_tactics
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic=None,
+            do_preparation: bool = False,
+            **kwargs,
+        ):
+            (a, b, a_descale, b_descale, alpha_tensor, _, out, _, _, _) = inputs
+            m = a.shape[0]
+            k_packed = a.shape[1]
+            n = b.shape[1]
+            real_k = k_packed * 2
+
+            sf_vec_size = 16
+            sf_dtype = cutlass.Float8E4M3FN
+            batch_size = 1
+
+            if tactic is None or tactic == -1:
+                _sm_count = torch.cuda.get_device_properties(
+                    a.device
+                ).multi_processor_count
+                tactic = (
+                    _select_default_sm120_mma_tiler(m, n, _sm_count),
+                    (1, 1),
+                    False,
+                    False,
+                    "sm120",
+                    None,
+                )
+
+            (
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+                kernel_type,
+                use_tma_store,
+            ) = tactic
+
+            # b12x SM120 kernel does not support swap_ab
+            kernel_m, kernel_n = m, n
+            kernel_a, kernel_b = a, b.T
+            kernel_a_sf, kernel_b_sf = a_descale, b_descale.T
+
+            sf_m = (kernel_m + 127) // 128
+            sf_n = (kernel_n + 127) // 128
+            sf_k = (real_k // sf_vec_size + 3) // 4
+
+            cache_key = (
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+                kernel_type,
+                use_tma_store,
+                enable_pdl,
+                out_dtype,
+            )
+
+            make_kernel = lambda: Sm120BlockScaledDenseGemmKernel(
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                use_prefetch,
+                enable_pdl,
+            )
+
+            compiled_gemm, _ = _compile_block_scaled_gemm(
+                _B12X_MM_FP4_KERNEL_CACHE,
+                cache_key,
+                make_kernel,
+                ab_cutlass_dtype=cutlass.Uint8,
+                sf_dtype=sf_dtype,
+                c_cutlass_dtype=c_cutlass_dtype,
+                ab_assumed_align=32,
+                cluster_shape_mn=cluster_shape_mn,
+                swap_ab=swap_ab,
+                sf_m=sf_m,
+                sf_n=sf_n,
+                sf_k=sf_k,
+                batch_size=batch_size,
+            )
+
+            alpha_for_launch = _prepare_alpha_for_launch(alpha_tensor, a.device)
+
+            compiled_gemm(
+                kernel_a,
+                kernel_b,
+                out,
+                sf_m,
+                sf_n,
+                sf_k,
+                kernel_a_sf.data_ptr(),
+                kernel_b_sf.data_ptr(),
+                alpha_for_launch,
+            )
+            return out
+
+    return B12xFp4GemmRunner()
+
+
 def _heuristic_func_mm_fp4(
     suitable_backends: List[str],
     a: torch.Tensor,
@@ -4927,7 +5039,9 @@ def _heuristic_func_mm_fp4(
     out: Optional[torch.Tensor] = None,
     block_size: int = 16,
     use_8x4_sf_layout: bool = False,
-    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"] = "cudnn",
+    backend: Literal[
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
+    ] = "cudnn",
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
 ):
@@ -4949,6 +5063,11 @@ def _heuristic_func_mm_fp4(
     # Get compute capability to distinguish between SM100 (10.0) and SM103 (10.3)
     major, minor = get_compute_capability(a.device)
     is_sm103 = major == 10 and minor == 3
+    is_sm120 = major == 12 and minor == 0
+
+    # SM120: prefer b12x (warp-level MMA, underfill tile selection)
+    if is_sm120 and use_nvfp4:
+        return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
 
     # If cuda version is 13 or greater and cudnn version is 9.15 or greater:
     # On SM103 (B300), cutlass is more performant than cudnn.
@@ -5197,7 +5316,7 @@ def mm_fp4(
         "cute-dsl": lambda: _cute_dsl_gemm_fp4_runner(
             major, minor, enable_pdl, out_dtype, use_nvfp4
         ),
-        "b12x": lambda: _cute_dsl_gemm_fp4_runner(
+        "b12x": lambda: _b12x_gemm_fp4_runner(
             major, minor, enable_pdl, out_dtype, use_nvfp4
         ),
     }

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4509,7 +4509,7 @@ def _cutlass_gemm_fp4_requirement(
     return True
 
 
-@supported_compute_capability([100, 103, 120, 121])
+@supported_compute_capability([100, 103])
 def _cute_dsl_gemm_fp4_requirement(
     a: torch.Tensor,  # unused
     b: torch.Tensor,  # unused
@@ -4532,6 +4532,32 @@ def _cute_dsl_gemm_fp4_requirement(
     # preparation for 128x4 layout.
     if use_8x4_sf_layout:
         raise ValueError("cute_dsl FP4 GEMM only supports 128x4 scale factor layout.")
+    _check_cute_dsl_availability()
+    return True
+
+
+@supported_compute_capability([120])
+def _b12x_gemm_fp4_requirement(
+    a: torch.Tensor,  # unused
+    b: torch.Tensor,  # unused
+    a_descale: torch.Tensor,  # unused
+    b_descale: torch.Tensor,  # unused
+    alpha: Optional[torch.Tensor] = None,  # unused
+    out_dtype: torch.dtype = torch.bfloat16,  # unused
+    out: Optional[torch.Tensor] = None,  # unused
+    block_size: int = 16,  # unused
+    use_8x4_sf_layout: bool = False,
+    backend: Literal[
+        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
+    ] = "auto",  # unused
+    use_nvfp4: bool = True,
+    enable_pdl: bool = True,  # unused
+):
+    # b12x backend requires 128x4 scale factor layout and NVFP4 only.
+    if use_8x4_sf_layout:
+        raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
+    if not use_nvfp4:
+        raise ValueError("b12x FP4 GEMM only supports NVFP4 (sf_vec_size=16).")
     _check_cute_dsl_availability()
     return True
 
@@ -4567,7 +4593,7 @@ def _cute_dsl_gemm_fp4_runner(
 
     # SM120/SM121 kernel (warp-level MMA, no tcgen05)
     Sm120Kernel = None
-    if sm_version in (120, 121):
+    if sm_version == 120:
         from .kernels.dense_blockscaled_gemm_sm120 import (
             Sm120BlockScaledDenseGemmKernel,
         )
@@ -4626,7 +4652,7 @@ def _cute_dsl_gemm_fp4_runner(
             valid_tactics = []
 
             # --- SM120/SM121 tactics ---
-            if sm_version in (120, 121) and Sm120Kernel is not None:
+            if sm_version == 120 and Sm120Kernel is not None:
                 batch_size = 1
                 # SM120 kernel supports tile M,N divisible by 64.
                 # Smaller tiles (64x64, 64x128, 128x64) help when
@@ -4761,7 +4787,7 @@ def _cute_dsl_gemm_fp4_runner(
             batch_size = 1
 
             if tactic is None or tactic == -1:
-                if sm_version in (120, 121):
+                if sm_version == 120:
                     _sm_count = torch.cuda.get_device_properties(
                         a.device
                     ).multi_processor_count
@@ -5044,6 +5070,7 @@ _MM_MXFP8_TUNING_CONFIG = TuningConfig(
         "trtllm": _trtllm_gemm_fp4_requirement,
         "cutlass": _cutlass_gemm_fp4_requirement,
         "cute-dsl": _cute_dsl_gemm_fp4_requirement,
+        "b12x": _b12x_gemm_fp4_requirement,
     },
     common_check=_check_mm_fp4_problem_size,
     heuristic_func=_heuristic_func_mm_fp4,  # result stored in mm_fp4.suitable_auto_backends
@@ -5059,7 +5086,7 @@ def mm_fp4(
     out: Optional[torch.Tensor] = None,
     block_size: int = 16,
     use_8x4_sf_layout: bool = False,
-    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "auto"] = "auto",
+    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"] = "auto",
     use_nvfp4: bool = True,
     enable_pdl: bool = True,
 ) -> torch.Tensor:
@@ -5168,6 +5195,9 @@ def mm_fp4(
             major, minor
         ).cutlass_fp4_gemm_runner(),
         "cute-dsl": lambda: _cute_dsl_gemm_fp4_runner(
+            major, minor, enable_pdl, out_dtype, use_nvfp4
+        ),
+        "b12x": lambda: _cute_dsl_gemm_fp4_runner(
             major, minor, enable_pdl, out_dtype, use_nvfp4
         ),
     }

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -17,7 +17,7 @@ limitations under the License.
 import functools
 from enum import Enum
 from types import SimpleNamespace
-from typing import Any, List, Literal, Optional, Tuple
+from typing import List, Literal, Optional, Tuple
 
 from flashinfer.trtllm_low_latency_gemm import trtllm_low_latency_gemm
 import torch
@@ -4639,8 +4639,6 @@ def _cute_dsl_gemm_fp4_runner(
             ab_dtype = cutlass.Float4E2M1FN
             sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
 
-            valid_tactics = []
-
             # SM100 tactics (shared enumeration with mxfp8)
             sm100_base = _get_sm100_block_scaled_tactics(
                 m,
@@ -4780,7 +4778,6 @@ def _cute_dsl_gemm_fp4_runner(
                 out_dtype,
             )
 
-            make_kernel: Any  # type varies by kernel_type
             if kernel_type == "sm103" and Sm103Kernel is not None:
                 make_kernel = lambda: Sm103Kernel(
                     sf_vec_size,
@@ -5241,10 +5238,12 @@ def mm_fp4(
         Whether to use 8x4 scale factor layout or 128x4 scale factor layout, defaults to False.
 
     backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"]
-        Backend to use, defaults to ``"auto"``, which automatically selects the best
-        backend between ``"cudnn"`` and ``"cutlass"`` based on the current CUDA and
-        cuDNN versions. The ``"trtllm"`` and ``"cute-dsl"`` backends are never selected
-        when ``backend="auto"`` because they require different weight preparation.
+        Backend to use, defaults to ``"auto"``. On SM120, ``"auto"`` prefers
+        ``"b12x"`` (NVFP4 only), then ``"cutlass"``, then ``"cudnn"``. On other
+        architectures, ``"auto"`` selects between ``"cudnn"`` and ``"cutlass"``
+        based on the current CUDA and cuDNN versions. The ``"trtllm"`` and
+        ``"cute-dsl"`` backends are never auto-selected because they require
+        different weight preparation.
 
     use_nvfp4: bool
         Whether to use nvfp4 quantization or mxfp4 quantization, defaults to ``True``.

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4553,7 +4553,12 @@ def _b12x_gemm_fp4_requirement(
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
 ):
-    # b12x backend requires 128x4 scale factor layout and NVFP4 only.
+    # b12x backend requires CUDA 13+, 128x4 scale factor layout, and NVFP4 only.
+    if get_cuda_version().major < 13:
+        raise ValueError(
+            "b12x FP4 GEMM requires CUDA 13 or later. "
+            f"Current CUDA version: {get_cuda_version()}."
+        )
     if use_8x4_sf_layout:
         raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
     if not use_nvfp4:
@@ -5062,8 +5067,8 @@ def _heuristic_func_mm_fp4(
     is_sm103 = major == 10 and minor == 3
     is_sm120 = major == 12 and minor == 0
 
-    # SM120: prefer b12x (warp-level MMA, underfill tile selection)
-    if is_sm120 and use_nvfp4:
+    # SM120 + CUDA 13: prefer b12x (warp-level MMA, underfill tile selection)
+    if is_sm120 and use_nvfp4 and cuda_major >= 13:
         return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
 
     # If cuda version is 13 or greater and cudnn version is 9.15 or greater:

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -17,7 +17,7 @@ limitations under the License.
 import functools
 from enum import Enum
 from types import SimpleNamespace
-from typing import List, Literal, Optional, Tuple
+from typing import Any, List, Literal, Optional, Tuple
 
 from flashinfer.trtllm_low_latency_gemm import trtllm_low_latency_gemm
 import torch
@@ -3577,6 +3577,29 @@ _SM100_DEFAULT_MMA_TILER_MN = (128, 128)
 _SM100_DEFAULT_CLUSTER_SHAPE_MN = (1, 1)
 
 
+def _select_default_sm120_mma_tiler(m, n, sm_count):
+    """Select optimal SM120 tile shape based on problem size and SM count.
+
+    Uses narrower tiles (64x64, 64x128, 128x64) when the default 128x128
+    would leave SMs idle on small-M shapes.
+    """
+    coarse_tile = (128, 128)
+    coarse_tiles = ((m + coarse_tile[0] - 1) // coarse_tile[0]) * (
+        (n + coarse_tile[1] - 1) // coarse_tile[1]
+    )
+    if m <= 128 and coarse_tiles < max(1, sm_count // 2):
+        if n > 1536:
+            return (64, 128)
+        medium_tile = (128, 64)
+        medium_tiles = ((m + medium_tile[0] - 1) // medium_tile[0]) * (
+            (n + medium_tile[1] - 1) // medium_tile[1]
+        )
+        if medium_tiles < max(1, sm_count // 2):
+            return (64, 64)
+        return (128, 64)
+    return (128, 128)
+
+
 def _get_approximate_cta_nums(m, n, tile_mn, cluster_shape_mn):
     tile_m, tile_n = tile_mn
     cluster_m, cluster_n = cluster_shape_mn
@@ -4486,7 +4509,7 @@ def _cutlass_gemm_fp4_requirement(
     return True
 
 
-@supported_compute_capability([100, 103])
+@supported_compute_capability([100, 103, 120, 121])
 def _cute_dsl_gemm_fp4_requirement(
     a: torch.Tensor,  # unused
     b: torch.Tensor,  # unused
@@ -4530,6 +4553,7 @@ def _cute_dsl_gemm_fp4_runner(
 
     On SM100: uses the SM100 kernel only.
     On SM103: uses both SM100 kernel and the SM103-specific 3xFP4 kernel.
+    On SM120/SM121: uses the SM120 warp-level MMA kernel.
     The autotuner selects the best (kernel_type, tile, cluster, swap_ab, prefetch,
     use_tma_store) combination.
     """
@@ -4540,6 +4564,15 @@ def _cute_dsl_gemm_fp4_runner(
     )
 
     sm_version = sm_major * 10 + sm_minor
+
+    # SM120/SM121 kernel (warp-level MMA, no tcgen05)
+    Sm120Kernel = None
+    if sm_version in (120, 121):
+        from .kernels.dense_blockscaled_gemm_sm120 import (
+            Sm120BlockScaledDenseGemmKernel,
+        )
+
+        Sm120Kernel = Sm120BlockScaledDenseGemmKernel
 
     # TODO(yunzheq): Re-enable SM103 kernel once cutlass-dsl package includes
     # SM103MmaMXF4Op and compatible PersistentTileSchedulerParams.
@@ -4589,6 +4622,53 @@ def _cute_dsl_gemm_fp4_runner(
             sf_vec_size = 16 if use_nvfp4 else 32
             ab_dtype = cutlass.Float4E2M1FN
             sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
+
+            valid_tactics = []
+
+            # --- SM120/SM121 tactics ---
+            if sm_version in (120, 121) and Sm120Kernel is not None:
+                batch_size = 1
+                # SM120 kernel supports tile M,N divisible by 64.
+                # Smaller tiles (64x64, 64x128, 128x64) help when
+                # small-M shapes leave SMs idle with 128x128.
+                sm120_mma_tiler_candidates = [
+                    (64, 64),
+                    (64, 128),
+                    (128, 64),
+                    (128, 128),
+                ]
+                # SM120 kernel does not support swap_ab (SF fragment
+                # partitioning assumes non-swapped layout).
+                swap_ab = False
+                for mma_tiler_mn in sm120_mma_tiler_candidates:
+                    if not Sm120Kernel.can_implement(
+                        ab_dtype,
+                        sf_dtype,
+                        sf_vec_size,
+                        c_cutlass_dtype,
+                        mma_tiler_mn,
+                        (1, 1),
+                        m,
+                        n,
+                        real_k,
+                        batch_size,
+                        "k",
+                        "k",
+                        "n",
+                    ):
+                        continue
+                    for use_prefetch in (False, True):
+                        valid_tactics.append(
+                            (
+                                mma_tiler_mn,
+                                (1, 1),
+                                swap_ab,
+                                use_prefetch,
+                                "sm120",
+                                None,
+                            )
+                        )
+                return valid_tactics
 
             # SM100 tactics (shared enumeration with mxfp8)
             sm100_base = _get_sm100_block_scaled_tactics(
@@ -4681,14 +4761,27 @@ def _cute_dsl_gemm_fp4_runner(
             batch_size = 1
 
             if tactic is None or tactic == -1:
-                tactic = (
-                    _SM100_DEFAULT_MMA_TILER_MN,
-                    _SM100_DEFAULT_CLUSTER_SHAPE_MN,
-                    False,
-                    False,
-                    "sm100",
-                    None,
-                )
+                if sm_version in (120, 121):
+                    _sm_count = torch.cuda.get_device_properties(
+                        a.device
+                    ).multi_processor_count
+                    tactic = (
+                        _select_default_sm120_mma_tiler(m, n, _sm_count),
+                        (1, 1),
+                        False,
+                        False,
+                        "sm120",
+                        None,
+                    )
+                else:
+                    tactic = (
+                        _SM100_DEFAULT_MMA_TILER_MN,
+                        _SM100_DEFAULT_CLUSTER_SHAPE_MN,
+                        False,
+                        False,
+                        "sm100",
+                        None,
+                    )
 
             (
                 mma_tiler_mn,
@@ -4729,7 +4822,16 @@ def _cute_dsl_gemm_fp4_runner(
                 out_dtype,
             )
 
-            if kernel_type == "sm103" and Sm103Kernel is not None:
+            make_kernel: Any  # type varies by kernel_type
+            if kernel_type == "sm120" and Sm120Kernel is not None:
+                make_kernel = lambda: Sm120Kernel(
+                    sf_vec_size,
+                    mma_tiler_mn,
+                    cluster_shape_mn,
+                    use_prefetch,
+                    enable_pdl,
+                )
+            elif kernel_type == "sm103" and Sm103Kernel is not None:
                 make_kernel = lambda: Sm103Kernel(
                     sf_vec_size,
                     mma_tiler_mn,

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py
@@ -1,0 +1,1894 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is ported from the CUTLASS dense block-scaled GEMM example
+# and adapted for the current Blackwell GeForce target.
+#
+# Ported from the b12x kernel library to FlashInfer.
+
+from typing import Callable, List, Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm120_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+import cutlass.utils.hopper_helpers as sm90_utils
+import functools
+import torch
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.nvgpu.warp.mma import Field as WarpField
+
+from flashinfer.cute_dsl.utils import (
+    cutlass_to_torch_dtype,
+    get_cutlass_dtype,
+    get_max_active_clusters,
+    get_num_sm,
+    make_ptr,
+    sm120_make_smem_layout_sfa,
+    sm120_make_smem_layout_sfb,
+)
+
+
+def current_cuda_stream():
+    """Return current CUDA stream as a CUDA driver stream handle."""
+    import cuda.bindings.driver as cuda_driver
+
+    return cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+# Workaround for nvidia-cutlass-dsl 4.4.1 bug:
+# @dsl_user_op on PersistentTileSchedulerParams.__init__ renames attributes
+# (e.g. raster_along_m -> _raster_along_m, cluster_shape_major_fdd ->
+# cluster_shape_m_fdd) but __extract_mlir_values__ (used by TVM-FFI)
+# still references the original names.
+_orig_extract = utils.PersistentTileSchedulerParams.__extract_mlir_values__
+
+# Map of source-code attr name -> runtime attr name set by @dsl_user_op
+_ATTR_RENAMES = {
+    "raster_along_m": "_raster_along_m",
+    "cluster_shape_major_fdd": "cluster_shape_m_fdd",
+    "cluster_shape_minor_fdd": "cluster_shape_n_fdd",
+}
+
+
+def _patched_extract(self):
+    for src_name, dst_name in _ATTR_RENAMES.items():
+        if not hasattr(self, src_name) and hasattr(self, dst_name):
+            setattr(self, src_name, getattr(self, dst_name))
+    return _orig_extract(self)
+
+
+utils.PersistentTileSchedulerParams.__extract_mlir_values__ = _patched_extract
+
+
+class DenseGemmKernel:
+    """Implements batched matrix multiplication (C = A x SFA x B x SFB) for
+    Blackwell GeForce architecture using warp-level MMA.
+
+    Key architectural differences from the tcgen05 donor path:
+    - No TMEM, no tcgen05, no 2-CTA instructions, no multi-cluster
+    - Warp-level MMA: MmaMXF4NVF4Op atom m16n8k64, atom_layout=(4,2,1)
+    - 256 MMA threads + 32 DMA = 288 total threads
+    - PipelineTmaAsync (not PipelineTmaUmma)
+    - Manual atom unroll workaround for CuTe DSL compiler SF address space bug
+    - Cluster shape always (1,1,1)
+
+    Notes:
+        - Supported combinations:
+            * NVF4: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
+            * MXF4: A/B: Float4E2M1FN, SF: Float8E8M0FNU, sf_vec_size: 32
+        - Tile shape constraints:
+            * tile_m must be divisible by 128
+            * tile_n must be divisible by 128
+            * tile_k must be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_prefetch: bool = False,
+        enable_pdl: bool = True,
+    ):
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        # K = sf_vec_size * 8 for FP4 (each FP4 element is 0.5 bytes, sf_vec_size
+        # elements per scale factor, and we want 4 MMA k-tiles per stage)
+        tile_k = sf_vec_size * 8  # 128 for sf_vec_size=16
+        self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        self.sfa_tiles_per_block = self.sfa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.sfb_tile_shape_nk = (max(128, mma_tiler_mn[1]), tile_k)
+        self.sfb_tiles_per_block = self.sfb_tile_shape_nk[0] // mma_tiler_mn[1]
+        self.cluster_shape_mnk = (1, 1, 1)  # Always (1,1,1) on the current target
+        self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.use_prefetch = use_prefetch
+        self.enable_pdl = enable_pdl
+
+        self.tiled_mma = None
+        self.occupancy = 1
+        self.num_mma_warps = 8
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (
+            self.num_mma_warps + 1  # 1 warp for DMA
+        ) * self.num_threads_per_warp
+
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+
+        self.ab_stage = None
+        self.epi_stage = None
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+
+        self.buffer_align_bytes = 1024
+
+        self.mma_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+
+    def _setup_attributes(self):
+        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+            self.a_dtype,
+            self.acc_dtype,
+            self.sf_dtype,
+        )
+        atom_shape = (4, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
+        permutation_mnk = sm120_utils.get_permutation_mnk(
+            self.tile_shape_mnk, self.sf_vec_size, False
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+        # Bare atom for manual unroll workaround (avoids hasAuxTensor address space bug)
+        self.mma_atom = cute.make_mma_atom(mma_op)
+        # Compute atom loop bounds from tile shape and atom/layout shape
+        # MMA atom: m16, n8, k64; atom_layout: (4,2,1) -> group: m64, n16, k64
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
+
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+
+        # Compute the smem size of SFA/SFB
+        sfa_smem_layout_per_stage = sm120_make_smem_layout_sfa(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+        sfb_smem_layout_per_stage = sm120_make_smem_layout_sfb(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        # Compute stage before compute smem layout
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            sfa_smem_layout_per_stage,
+            sfb_smem_layout_per_stage,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        assert self.epi_stage > 0, (
+            "epi_stage <= 0, not enough shared memory. This configuration will be skipped."
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+            self.sf_vec_size,
+            self.tiled_mma,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        c: cute.Tensor,
+        alpha: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM operation.
+
+        Args:
+            a: Input tensor A
+            b: Input tensor B
+            sfa: Scale factor tensor for A
+            sfb: Scale factor tensor for B
+            c: Output tensor C
+            alpha: Alpha scaling factor tensor, shape (1,), float32
+            max_active_clusters: Max active clusters
+            stream: CUDA stream
+            epilogue_op: Elementwise epilogue function
+        """
+        # Setup static attributes
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.sf_dtype = sfa.element_type
+
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
+
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        self.sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa.iterator, self.sfa_layout)
+
+        self.sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b.shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb.iterator, self.sfb_layout)
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            1,
+        )
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+        )
+        tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
+            sfa_tensor,
+            self.sfa_smem_layout_staged,
+            self.sfa_tile_shape_mk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+        tma_atom_sfb, tma_tensor_sfb = self._make_tma_atoms_and_tensors(
+            sfb_tensor,
+            self.sfb_smem_layout_staged,
+            self.sfb_tile_shape_nk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        tile_sched_params, grid = self._compute_grid(
+            c,
+            self.tile_shape_mnk,
+            max_active_clusters,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype, cute.cosize(self.epi_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            self.tiled_mma,
+            self.mma_atom,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            tile_sched_params,
+            epilogue_op,
+            alpha,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+        return
+
+    def _partition_fragment_SFA(
+        self,
+        sfa_tensor: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tidx: int,
+    ):
+        thrfrg_sfa_layout = self._thrfrg_SFA(sfa_tensor.layout, thr_mma)
+        thr_tensor = cute.make_tensor(sfa_tensor.iterator, thrfrg_sfa_layout)
+        thr_vmnk = thr_mma.thr_layout_vmnk.get_flat_coord(tidx)
+        thr_vmk = (thr_vmnk[0], (thr_vmnk[1], thr_vmnk[3]))
+        partitioned_sfa = thr_tensor[thr_vmk, (None, None)]
+        partitioned_sfa = cute.group_modes(cute.flatten(partitioned_sfa), 0, 2)
+        return cute.make_fragment_like(partitioned_sfa)
+
+    def _partition_fragment_SFB(
+        self,
+        sfb_tensor: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tidx: int,
+    ):
+        thrfrg_sfb_layout = self._thrfrg_SFB(sfb_tensor.layout, thr_mma)
+        thr_tensor = cute.make_tensor(sfb_tensor.iterator, thrfrg_sfb_layout)
+        thr_vmnk = thr_mma.thr_layout_vmnk.get_flat_coord(tidx)
+        thr_vnk = (thr_vmnk[0], (thr_vmnk[2], thr_vmnk[3]))
+        partitioned_sfb = thr_tensor[thr_vnk, (None, None)]
+        partitioned_sfb = cute.group_modes(cute.flatten(partitioned_sfb), 0, 2)
+        partitioned_sfb = cute.group_modes(partitioned_sfb, 1, 3)
+        return cute.make_fragment_like(partitioned_sfb)
+
+    def _thrfrg_SFA(self, sfa_tensor, tiled_mma: cute.TiledMma):
+        assert cute.rank(sfa_tensor) >= 2
+
+        atom_shape_mnk = tiled_mma.shape_mnk
+        atom_sfa_layout = cute.make_layout(
+            shape=((2, 2, 8), 64), stride=((8, 0, 1), 16)
+        )
+        permutation_mnk = tiled_mma.permutation_mnk
+        thr_layout_vmnk = tiled_mma.thr_layout_vmnk
+
+        # Reorder the tensor for TiledAtom
+        t_tile = (permutation_mnk[0], permutation_mnk[2])
+        t_tensor = cute.logical_divide(sfa_tensor, t_tile)
+
+        # Tile the tensor for the Atom
+        a_tile = (
+            cute.make_layout((atom_shape_mnk[0])),
+            cute.make_layout((atom_shape_mnk[2])),
+        )
+        a_tensor = cute.zipped_divide(t_tensor, a_tile)
+
+        # Transform the Atom mode from (M,K) to (Thr,Val)
+        tv_tensor = cute.composition(a_tensor, (atom_sfa_layout, None))
+
+        # Tile the tensor for the Thread
+        thr_tile = (
+            None,
+            (
+                cute.make_layout(cute.size(thr_layout_vmnk[1])),
+                cute.make_layout(cute.size(thr_layout_vmnk[3])),
+            ),
+        )
+        thr_tensor = cute.zipped_divide(tv_tensor, thr_tile)
+        return thr_tensor
+
+    def _thrfrg_SFB(self, sfb_tensor, tiled_mma: cute.TiledMma):
+        assert cute.rank(sfb_tensor) >= 2
+
+        atom_shape_mnk = tiled_mma.shape_mnk
+        atom_sfb_layout = cute.make_layout(shape=((4, 8), 64), stride=((0, 1), 8))
+        permutation_mnk = tiled_mma.permutation_mnk
+        thr_layout_vmnk = tiled_mma.thr_layout_vmnk
+
+        # Reorder the tensor for TiledAtom
+        t_tile = (permutation_mnk[1], permutation_mnk[2])
+        t_tensor = cute.logical_divide(sfb_tensor, t_tile)
+
+        # Tile the tensor for the Atom
+        a_tile = (
+            cute.make_layout((atom_shape_mnk[1])),
+            cute.make_layout((atom_shape_mnk[2])),
+        )
+        a_tensor = cute.zipped_divide(t_tensor, a_tile)
+
+        # Transform the Atom mode from (N,K) to (Thr,Val)
+        tv_tensor = cute.composition(a_tensor, (atom_sfb_layout, None))
+
+        # Tile the tensor for the Thread
+        thr_tile = (
+            None,
+            (
+                cute.make_layout(cute.size(thr_layout_vmnk[2])),
+                cute.make_layout(cute.size(thr_layout_vmnk[3])),
+            ),
+        )
+        thr_tensor = cute.zipped_divide(tv_tensor, thr_tile)
+        return thr_tensor
+
+    def _get_layoutSFA_TV(self, tiled_mma: cute.TiledMma):
+        if tiled_mma.permutation_mnk is not None:
+            perm_m = tiled_mma.permutation_mnk[0]
+            perm_k = tiled_mma.permutation_mnk[2]
+            tile_m = cute.size(perm_m)
+            tile_k = cute.size(perm_k)
+        else:
+            tile_shape_mnk = tiled_mma.shape_mnk * tiled_mma.thr_layout_vmnk
+            tile_m = cute.size(tile_shape_mnk[0])
+            tile_k = cute.size(tile_shape_mnk[2])
+
+        ref_A = cute.make_layout((tile_m, tile_k))
+        thr_layout_vmnk = tiled_mma.thr_layout_vmnk
+
+        atile = (
+            None,
+            (
+                cute.make_layout(
+                    shape=(
+                        cute.size(thr_layout_vmnk[1]),
+                        cute.size(thr_layout_vmnk[2]),
+                    ),
+                    stride=(1, 0),
+                ),
+                None,
+            ),
+        )
+
+        thridx_2_thrid = cute.right_inverse(thr_layout_vmnk)
+        thrfrg_sfa = self._thrfrg_SFA(ref_A, tiled_mma)
+        layout_tv_1 = cute.composition(thrfrg_sfa, (atile, None))
+        layout_tv = cute.composition(layout_tv_1, (thridx_2_thrid, None))
+        return layout_tv
+
+    def _get_layoutSFB_TV(self, tiled_mma: cute.TiledMma):
+        if tiled_mma.permutation_mnk is not None:
+            perm_n_layout = tiled_mma.permutation_mnk[1]
+            perm_k = tiled_mma.permutation_mnk[2]
+            tile_n = cute.size(perm_n_layout)
+            tile_k = cute.size(perm_k)
+        else:
+            tile_shape_mnk = tiled_mma.shape_mnk * tiled_mma.thr_layout_vmnk
+            tile_n = cute.size(tile_shape_mnk[1])
+            tile_k = cute.size(tile_shape_mnk[2])
+
+        ref_B = cute.make_layout((tile_n, tile_k))
+        thr_layout_vmnk = tiled_mma.thr_layout_vmnk
+
+        atile = (
+            None,
+            (
+                cute.make_layout(
+                    shape=(
+                        cute.size(thr_layout_vmnk[1]),
+                        cute.size(thr_layout_vmnk[2]),
+                    ),
+                    stride=(0, 1),
+                ),
+                None,
+            ),
+        )
+
+        thridx_2_thrid = cute.right_inverse(thr_layout_vmnk)
+        thrfrg_sfb = self._thrfrg_SFB(ref_B, tiled_mma)
+        layout_tv = cute.composition(thrfrg_sfb, (atile, None))
+        layout_tv = cute.composition(layout_tv, (thridx_2_thrid, None))
+        return layout_tv
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        mma_atom: cute.MmaAtom,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        alpha: cute.Tensor,
+    ):
+        # Keep alpha in FP32 for precision
+        alpha_value = alpha[0].to(cutlass.Float32)
+
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = (
+            cute.size_in_bytes(self.a_dtype, a_smem_layout)
+            + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        )
+
+        # Allocate shared memory
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Pipeline setup
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=mainloop_pipeline_array_ptr,
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        # Generate smem tensors
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner
+        )
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        # Local_tile partition global tensors
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl,
+            self.sfa_tile_shape_mk,
+            (None, None, None),
+        )
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            self.sfb_tile_shape_nk,
+            (None, None, None),
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        # Partition for TiledMMA
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        # TMA partitions for A
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA_mkl, 0, 2),
+        )
+
+        # TMA partitions for B
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_nkl, 0, 2),
+        )
+
+        # TMA partitions for SFA
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_atom_sfa,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sSFA, 0, 2),
+            cute.group_modes(gSFA_mkl, 0, 2),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA partitions for SFB
+        tBsSFB, tBgSFB = cpasync.tma_partition(
+            tma_atom_sfb,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_nkl, 0, 2),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        # Make fragments
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCrSFA_full = self._partition_fragment_SFA(sSFA[None, None, 0], thr_mma, tidx)
+        tCrSFB_full = self._partition_fragment_SFB(sSFB[None, None, 0], thr_mma, tidx)
+
+        tCgC = thr_mma.partition_C(gC_mnl)
+        acc_shape = tCgC.shape[:3]
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        # Cluster/thread sync
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.sync_threads()
+
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        # Tile scheduler
+        tile_sched = utils.StaticPersistentTileScheduler.create(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        # Pipeline states
+        mainloop_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        mainloop_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        # MMA warp group
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            # Copy atoms for SMEM->RMEM
+            atom_copy_ldmatrix_A = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                self.a_dtype,
+            )
+            atom_copy_ldmatrix_B = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                self.b_dtype,
+            )
+            smem_tiled_copy_A = cute.make_tiled_copy_A(atom_copy_ldmatrix_A, tiled_mma)
+            smem_tiled_copy_B = cute.make_tiled_copy_B(atom_copy_ldmatrix_B, tiled_mma)
+
+            atom_copy_ldmatrix_SF = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.sf_dtype,
+            )
+            smem_tiled_copy_SFA = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                self._get_layoutSFA_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[0]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            smem_tiled_copy_SFB = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                self._get_layoutSFB_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[1]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+
+            thr_copy_ldmatrix_A = smem_tiled_copy_A.get_slice(tidx)
+            thr_copy_ldmatrix_B = smem_tiled_copy_B.get_slice(tidx)
+            tCsA_copy_view = thr_copy_ldmatrix_A.partition_S(sA)
+            tCrA_copy_view = thr_copy_ldmatrix_A.retile(tCrA)
+            tCsB_copy_view = thr_copy_ldmatrix_B.partition_S(sB)
+            tCrB_copy_view = thr_copy_ldmatrix_B.retile(tCrB)
+
+            thr_copy_ldmatrix_SFA = smem_tiled_copy_SFA.get_slice(tidx)
+            thr_copy_ldmatrix_SFB = smem_tiled_copy_SFB.get_slice(tidx)
+            tCsSFA_copy_view_full = thr_copy_ldmatrix_SFA.partition_S(sSFA)
+            tCrSFA_copy_view_full = thr_copy_ldmatrix_SFA.retile(tCrSFA_full)
+            tCsSFB_copy_view_full = thr_copy_ldmatrix_SFB.partition_S(sSFB)
+            tCrSFB_copy_view_full = thr_copy_ldmatrix_SFB.retile(tCrSFB_full)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
+                sfa_tile_offset = tile_coord_mnl[0] % self.sfa_tiles_per_block
+                sfb_tile_offset = tile_coord_mnl[1] % self.sfb_tiles_per_block
+                if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                    sSFA_tile = cute.local_tile(
+                        sSFA,
+                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                        (sfa_tile_offset, 0, None),
+                    )
+                    tCsSFA_tile_copy_view = thr_copy_ldmatrix_SFA.partition_S(sSFA_tile)
+                    tCrSFA_tile = self._partition_fragment_SFA(
+                        sSFA_tile[None, None, 0], thr_mma, tidx
+                    )
+                    tCrSFA_tile_copy_view = thr_copy_ldmatrix_SFA.retile(tCrSFA_tile)
+                else:
+                    tCsSFA_tile_copy_view = tCsSFA_copy_view_full
+                    tCrSFA_tile = tCrSFA_full
+                    tCrSFA_tile_copy_view = tCrSFA_copy_view_full
+                if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                    sSFB_tile = cute.local_tile(
+                        sSFB,
+                        cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                        (sfb_tile_offset, 0, None),
+                    )
+                    tCsSFB_tile_copy_view = thr_copy_ldmatrix_SFB.partition_S(sSFB_tile)
+                    tCrSFB_tile = self._partition_fragment_SFB(
+                        sSFB_tile[None, None, 0], thr_mma, tidx
+                    )
+                    tCrSFB_tile_copy_view = thr_copy_ldmatrix_SFB.retile(tCrSFB_tile)
+                else:
+                    tCsSFB_tile_copy_view = tCsSFB_copy_view_full
+                    tCrSFB_tile = tCrSFB_full
+                    tCrSFB_tile_copy_view = tCrSFB_copy_view_full
+                accumulators.fill(0.0)
+
+                # Pipelined MAINLOOP
+                mainloop_consumer_state.reset_count()
+
+                peek_ab_full_status = cutlass.Boolean(1)
+                if mainloop_consumer_state.count < k_tile_cnt:
+                    peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                        mainloop_consumer_state
+                    )
+
+                mainloop_pipeline.consumer_wait(
+                    mainloop_consumer_state, peek_ab_full_status
+                )
+                tCsA_p = tCsA_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsB_p = tCsB_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsSFA_p = tCsSFA_tile_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                tCsSFB_p = tCsSFB_tile_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                cute.copy(
+                    smem_tiled_copy_A,
+                    tCsA_p[None, None, 0],
+                    tCrA_copy_view[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_B,
+                    tCsB_p[None, None, 0],
+                    tCrB_copy_view[None, None, 0],
+                )
+
+                tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
+                tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
+
+                cute.copy(
+                    smem_tiled_copy_SFA,
+                    tCsSFA_p_filtered[None, None, 0],
+                    tCrSFA_copy_view_filtered[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_SFB,
+                    tCsSFB_p_filtered[None, None, 0],
+                    tCrSFB_copy_view_filtered[None, None, 0],
+                )
+
+                for _k_tile in range(0, k_tile_cnt - 1, 1, unroll=2):  # type: ignore[call-overload]
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+
+                        if k_block_idx == num_k_blocks - 1:
+                            mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                            mainloop_consumer_state.advance()
+
+                            peek_ab_full_status = cutlass.Boolean(1)
+                            peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                                mainloop_consumer_state
+                            )
+
+                            tCsA_p = tCsA_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsB_p = tCsB_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFA_p = tCsSFA_tile_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFB_p = tCsSFB_tile_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            mainloop_pipeline.consumer_wait(
+                                mainloop_consumer_state, peek_ab_full_status
+                            )
+
+                        # Manual atom unroll: avoids hasAuxTensor address space bug
+                        for _mt in range(self.num_m_tiles):
+                            for _nt in range(self.num_n_tiles):
+                                mma_atom.set(
+                                    WarpField.SFA,
+                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                )
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                )
+                                cute.gemm(
+                                    mma_atom,
+                                    accumulators[None, _mt, _nt],
+                                    tCrA[None, _mt, k_block_idx],
+                                    tCrB[None, _nt, k_block_idx],
+                                    accumulators[None, _mt, _nt],
+                                )
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+
+                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(
+                            tCrSFA_tile_copy_view
+                        )
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(
+                            tCrSFB_tile_copy_view
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFA,
+                            tCsSFA_p_filtered[None, None, k_block_next],
+                            tCrSFA_copy_view_filtered[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFB,
+                            tCsSFB_p_filtered[None, None, k_block_next],
+                            tCrSFB_copy_view_filtered[None, None, k_block_next],
+                        )
+
+                # Hoist out last k_tile
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_block_next = (
+                        0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    )
+
+                    if k_block_idx == num_k_blocks - 1:
+                        mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                        mainloop_consumer_state.advance()
+
+                    if k_block_next > 0:
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(
+                            tCrSFA_tile_copy_view
+                        )
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(
+                            tCrSFB_tile_copy_view
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFA,
+                            tCsSFA_p_filtered[None, None, k_block_next],
+                            tCrSFA_copy_view_filtered[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFB,
+                            tCsSFB_p_filtered[None, None, k_block_next],
+                            tCrSFB_copy_view_filtered[None, None, k_block_next],
+                        )
+                    # Manual atom unroll: avoids hasAuxTensor address space bug
+                    for _mt in range(self.num_m_tiles):
+                        for _nt in range(self.num_n_tiles):
+                            mma_atom.set(
+                                WarpField.SFA,
+                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                            )
+                            mma_atom.set(
+                                WarpField.SFB,
+                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                            )
+                            cute.gemm(
+                                mma_atom,
+                                accumulators[None, _mt, _nt],
+                                tCrA[None, _mt, k_block_idx],
+                                tCrB[None, _nt, k_block_idx],
+                                accumulators[None, _mt, _nt],
+                            )
+
+                # EPILOGUE
+                _is_m_major = self.c_layout.is_m_major_c()
+                if cutlass.const_expr(self.c_dtype.width == 16):
+                    copy_atom_r2s = cute.make_copy_atom(
+                        cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                        self.c_dtype,
+                    )
+                else:
+                    copy_atom_r2s = cute.make_copy_atom(
+                        cute.nvgpu.CopyUniversalOp(),
+                        self.c_dtype,
+                    )
+
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(
+                        self.c_layout.is_m_major_c(),
+                        2,
+                    ),
+                    self.c_dtype,
+                )
+
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s,
+                    tiled_copy_C_Atom,
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+
+                sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+                tcgc_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+
+                bSG_sD, bSG_gD = cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    sepi_for_tma_partition,
+                    tcgc_for_tma_partition,
+                )
+
+                epi_rest_m = bSG_gD.shape[1][0]
+                epi_rest_n = bSG_gD.shape[1][1]
+                epi_tile_m = self.epi_tile[0]
+                epi_tile_n = self.epi_tile[1]
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
+                has_multi_epi_store = cutlass.const_expr(
+                    not (self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1)
+                )
+                tma_store_producer_group = pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    self.num_mma_warps * self.num_threads_per_warp,
+                )
+                tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=self.epi_stage,
+                    producer_group=tma_store_producer_group,
+                )
+
+                for epi_m in cutlass.range_constexpr(epi_rest_m):
+                    for epi_n in cutlass.range_constexpr(epi_rest_n):
+                        MmaMPerEpiM = epi_tile_m // mma_tile_m
+                        MmaNPerEpiN = epi_tile_n // mma_tile_n
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
+                                mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                tRS_rAcc_slice = tRS_rAcc[(None, mma_m, mma_n)]
+                                for elem_idx in cutlass.range_constexpr(
+                                    cute.size(tRS_rD_slice)
+                                ):
+                                    tRS_rD_slice[elem_idx] = tRS_rAcc_slice[elem_idx]
+
+                        # Type conversion with alpha scaling
+                        tRS_rD_out = cute.make_rmem_tensor(
+                            tRS_rD_layout.shape, self.c_dtype
+                        )
+                        acc_vec = tRS_rD.load()
+                        # Multiply alpha in FP32 before converting to c_dtype
+                        # to avoid overflow when c_dtype is FP16
+                        acc_vec = epilogue_op((alpha_value * acc_vec).to(self.c_dtype))
+                        tRS_rD_out.store(acc_vec)
+
+                        # Register to shared memory
+                        epi_buffer = (epi_m * epi_rest_n + epi_n) % cute.size(
+                            tRS_sD, mode=[3]
+                        )
+                        if has_multi_epi_store:
+                            self.epilog_sync_barrier.arrive_and_wait()
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, epi_buffer)],
+                        )
+                        cute.arch.fence_proxy(
+                            "async.shared",
+                            space="cta",
+                        )
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        # Copy from shared memory to global memory
+                        gmem_coord = (epi_m, epi_n)
+                        if warp_idx == 0:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sD[(None, epi_buffer)],
+                                bSG_gD[(None, gmem_coord)],
+                            )
+                            if has_multi_epi_store:
+                                tma_store_pipeline.producer_commit()
+                                tma_store_pipeline.producer_acquire()
+
+                # Advance to the next work tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                if has_multi_epi_store:
+                    tma_store_pipeline.producer_tail()
+
+        # DMA warp group
+        elif warp_idx == self.tma_load_warp_id:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
+                tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+                sfa_tile_coord_m = tile_coord_mnl[0] // self.sfa_tiles_per_block
+                tAgSFA_mkl = tAgSFA[(None, sfa_tile_coord_m, None, tile_coord_mnl[2])]
+                sfb_tile_coord_n = tile_coord_mnl[1] // self.sfb_tiles_per_block
+                tBgSFB_nkl = tBgSFB[(None, sfb_tile_coord_n, None, tile_coord_mnl[2])]
+
+                mainloop_producer_state.reset_count()
+
+                for _k_tile in range(0, k_tile_cnt, 1, unroll=2):  # type: ignore[call-overload]
+                    mainloop_pipeline.producer_acquire(mainloop_producer_state)
+
+                    tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                    tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+
+                    tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                    tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                    tAgSFA_k = tAgSFA_mkl[(None, mainloop_producer_state.count)]
+                    tAsSFA_pipe = tAsSFA[(None, mainloop_producer_state.index)]
+
+                    tBgSFB_k = tBgSFB_nkl[(None, mainloop_producer_state.count)]
+                    tBsSFB_pipe = tBsSFB[(None, mainloop_producer_state.index)]
+
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_k,
+                        tAsA_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_k,
+                        tBsB_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_k,
+                        tAsSFA_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_k,
+                        tBsSFB_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    mainloop_pipeline.producer_commit(mainloop_producer_state)
+                    mainloop_producer_state.advance()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            mainloop_pipeline.producer_tail(mainloop_producer_state)
+        return
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk: tuple,
+        a_dtype,
+        b_dtype,
+        sf_dtype,
+        sfa_smem_layout,
+        sfb_smem_layout,
+        epi_tile: tuple,
+        c_dtype,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> tuple:
+        epi_stage_max = (tile_shape_mnk[1] // epi_tile[1]) * (
+            tile_shape_mnk[0] // epi_tile[0]
+        )
+        epi_stage = min(epi_stage_max, 4)
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_bytes = c_bytes_per_stage * epi_stage
+
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        sf_bytes_per_stage = (
+            cute.size(cute.filter_zeros(sfa_smem_layout).shape) * sf_dtype.width // 8
+            + cute.size(cute.filter_zeros(sfb_smem_layout).shape) * sf_dtype.width // 8
+        )
+        mbar_helpers_bytes = 1024
+
+        ab_stage = (
+            (smem_capacity - occupancy * 1024) // occupancy
+            - mbar_helpers_bytes
+            - epi_bytes
+        ) // (ab_bytes_per_stage + sf_bytes_per_stage)
+        ab_stage = max(1, min(ab_stage, 4))
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk: tuple,
+        epi_tile: tuple,
+        a_dtype,
+        a_layout,
+        b_dtype,
+        b_layout,
+        ab_stage: int,
+        c_dtype,
+        c_layout,
+        epi_stage: int,
+        sf_vec_size: int,
+        tiled_mma,
+    ) -> tuple:
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+
+        a_is_k_major = a_layout.is_k_major_a()
+        b_is_k_major = b_layout.is_k_major_b()
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                a_layout,
+                a_dtype,
+                a_major_mode_size,
+            ),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        sfa_smem_layout_staged = sm120_make_smem_layout_sfa(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+        sfb_smem_layout_staged = sm120_make_smem_layout_sfb(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                c_layout,
+                c_dtype,
+                c_major_mode_size,
+            ),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+
+        return (
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            sfa_smem_layout_staged,
+            sfb_smem_layout_staged,
+            epi_smem_layout_staged,
+        )
+
+    @staticmethod
+    def _compute_grid(
+        c,
+        tile_shape_mnk: tuple,
+        max_active_clusters,
+    ) -> tuple:
+        c_shape = cute.slice_(tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (1, 1, 1)
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(
+        tensor_c,
+        epi_smem_layout_staged,
+        epi_tile: tuple,
+    ) -> tuple:
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+        return tma_atom_c, tma_tensor_c
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(
+        tensor,
+        smem_layout_staged,
+        smem_tile: tuple,
+        mcast_dim: int,
+        internal_type=None,
+    ) -> tuple:
+        op = (
+            cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+            op,
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=mcast_dim,
+            internal_type=internal_type,
+        )
+        return tma_atom, tma_tensor
+
+    @staticmethod
+    def can_implement(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size: int,
+        c_dtype,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        # The current target only supports cluster (1,1)
+        if cluster_shape_mn != (1, 1):
+            return False
+        # Tile M must be divisible by 128; tile N follows 64-column warpgroup
+        # quanta, while the SF paths round narrow tiles up to full 128-element
+        # scale-factor blocks.
+        if mma_tiler_mn[0] % 64 != 0 or mma_tiler_mn[1] % 64 != 0:
+            return False
+        # The current target only supports FP4 (MmaMXF4NVF4Op)
+        if ab_dtype != cutlass.Float4E2M1FN:
+            return False
+        # SM120 warp-level MmaMXF4NVF4Op only supports sf_vec_size=16
+        # (CUTLASS DSL hardcodes sf_vec_size=16 in the MMA atom constructor)
+        if sf_vec_size != 16:
+            return False
+        if sf_dtype != cutlass.Float8E4M3FN:
+            return False
+        # Only 16-bit output types supported for now
+        if c_dtype not in (cutlass.Float16, cutlass.BFloat16):
+            return False
+        # A must be K-major, B must be K-major
+        if a_major != "k" or b_major != "k":
+            return False
+        # Alignment: K must be divisible by tile_k
+        tile_k = sf_vec_size * 8
+        if k % tile_k != 0:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # wrapper: compile-time entry point matching the SM100 interface
+    # for FlashInfer's _compile_block_scaled_gemm
+    # ------------------------------------------------------------------
+    @cute.jit
+    def wrapper(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        sf_m: cutlass.Int64,
+        sf_n: cutlass.Int64,
+        sf_k: cutlass.Int64,
+        l: cutlass.Constexpr,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        alpha_tensor: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        current_stream,
+        swap_ab: cutlass.Constexpr = False,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Wrapper matching the SM100 compile interface."""
+        m = cute.size(mA, mode=[0])
+        k_raw = cute.size(mA, mode=[1])
+        n = cute.size(mB, mode=[0])
+
+        if cutlass.const_expr(
+            mA.element_type == cutlass.Uint8 and mB.element_type == cutlass.Uint8
+        ):
+            k = k_raw * 2
+            a_ptr = cute.recast_ptr(mA.iterator, dtype=cutlass.Float4E2M1FN)
+            b_ptr = cute.recast_ptr(mB.iterator, dtype=cutlass.Float4E2M1FN)
+        elif cutlass.const_expr(mA.element_type != mB.element_type):
+            raise TypeError("Unsupported mixed input dtypes for block-scaled GEMM.")
+        else:
+            k = k_raw
+            a_ptr = mA.iterator
+            b_ptr = mB.iterator
+
+        a_tensor = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_ordered_layout((m, k, l), order=(1, 0, 2)),
+        )
+        b_tensor = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)),
+        )
+        if cutlass.const_expr(swap_ab):
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(0, 1, 2)),
+            )
+        else:
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+            )
+        sfa_tensor = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_m, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+        sfb_tensor = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_n, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+
+        self(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            alpha_tensor,
+            max_active_clusters,
+            current_stream,
+            epilogue_op,
+        )
+
+
+# Alias for FlashInfer integration
+Sm120BlockScaledDenseGemmKernel = DenseGemmKernel
+
+
+class _DenseGemmLaunch:
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+        ab_dtype: torch.dtype,
+        sf_dtype: torch.dtype,
+        c_dtype: torch.dtype,
+        alpha_dtype: torch.dtype,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        sm_count: int,
+        sm_version: str,
+    ):
+        self._m = m
+        self._n = n
+        self._k = k
+        self._l = l
+        self._a_major = a_major
+        self._b_major = b_major
+        self._c_major = c_major
+        self._ab_dtype = ab_dtype
+        self._sf_dtype = sf_dtype
+        self._c_dtype = c_dtype
+        self._alpha_dtype = alpha_dtype
+        self._sf_vec_size = sf_vec_size
+        self._mma_tiler_mn = mma_tiler_mn
+        self._cluster_shape_mn = cluster_shape_mn
+
+        if sm_version != "sm_120":
+            raise ValueError(
+                f"dense_gemm launch only supports sm_120, got {sm_version}"
+            )
+
+        if not DenseGemmKernel.can_implement(
+            ab_dtype,
+            sf_dtype,
+            sf_vec_size,
+            c_dtype,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            m,
+            n,
+            k,
+            l,
+            a_major,
+            b_major,
+            c_major,
+        ):
+            raise TypeError(
+                "dense_gemm launch is unsupported with "
+                f"{ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype}, "
+                f"{mma_tiler_mn}, {cluster_shape_mn}, {m}, {n}, {k}, {l}, "
+                f"{a_major}, {b_major}, {c_major}"
+            )
+
+        self._max_active_clusters = min(
+            get_max_active_clusters(
+                self._cluster_shape_mn[0] * self._cluster_shape_mn[1]
+            ),
+            sm_count,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        sfa_ptr: cute.Pointer,
+        sfb_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        alpha_ptr: cute.Pointer,
+        current_stream: cuda.CUstream,
+    ):
+        a_tensor = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_ordered_layout(
+                (self._m, self._k, self._l),
+                order=(0, 1, 2) if self._a_major == "m" else (1, 0, 2),
+            ),
+        )
+        b_tensor = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_ordered_layout(
+                (self._n, self._k, self._l),
+                order=(0, 1, 2) if self._b_major == "n" else (1, 0, 2),
+            ),
+        )
+        c_tensor = cute.make_tensor(
+            c_ptr,
+            layout=cute.make_ordered_layout(
+                (self._m, self._n, self._l),
+                order=(0, 1, 2) if self._c_major == "m" else (1, 0, 2),
+            ),
+        )
+        alpha_tensor = cute.make_tensor(
+            alpha_ptr,
+            layout=cute.make_ordered_layout((1,), order=(0,)),
+        )
+        sfa_tensor = cute.make_tensor(sfa_ptr, layout=cute.make_layout((1,)))
+        sfb_tensor = cute.make_tensor(sfb_ptr, layout=cute.make_layout((1,)))
+
+        DenseGemmKernel(
+            sf_vec_size=self._sf_vec_size,
+            mma_tiler_mn=self._mma_tiler_mn,
+            cluster_shape_mn=self._cluster_shape_mn,
+        )(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            alpha_tensor,
+            self._max_active_clusters,
+            current_stream,
+        )
+
+
+@functools.cache
+def _get_compiled_dense_gemm(
+    m: int,
+    n: int,
+    k: int,
+    l: int,
+    a_major: str,
+    b_major: str,
+    c_major: str,
+    ab_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    c_dtype: Type[cutlass.Numeric],
+    alpha_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    sm_count: int,
+    sm_version: str,
+) -> Callable:
+    def _make_runtime_pointers(
+        input_tensors: Optional[List[torch.Tensor]],
+    ) -> List[cute.Pointer]:
+        if input_tensors is None:
+            (
+                a_data_ptr,
+                b_data_ptr,
+                sfa_data_ptr,
+                sfb_data_ptr,
+                c_data_ptr,
+                alpha_data_ptr,
+            ) = [16 for _ in range(6)]
+        else:
+            (
+                a_tensor_gpu,
+                b_tensor_gpu,
+                sfa_tensor_gpu,
+                sfb_tensor_gpu,
+                c_tensor_gpu,
+                alpha_tensor_gpu,
+            ) = input_tensors
+            (
+                a_data_ptr,
+                b_data_ptr,
+                sfa_data_ptr,
+                sfb_data_ptr,
+                c_data_ptr,
+                alpha_data_ptr,
+            ) = (
+                a_tensor_gpu.data_ptr(),
+                b_tensor_gpu.data_ptr(),
+                sfa_tensor_gpu.data_ptr(),
+                sfb_tensor_gpu.data_ptr(),
+                c_tensor_gpu.data_ptr(),
+                alpha_tensor_gpu.data_ptr(),
+            )
+
+        return [
+            make_ptr(ab_dtype, a_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(ab_dtype, b_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(sf_dtype, sfa_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(sf_dtype, sfb_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(c_dtype, c_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(
+                alpha_dtype, alpha_data_ptr, cute.AddressSpace.gmem, assumed_align=16
+            ),
+        ]
+
+    compiled_kernel = cute.compile(
+        _DenseGemmLaunch(
+            m=m,
+            n=n,
+            k=k,
+            l=l,
+            a_major=a_major,
+            b_major=b_major,
+            c_major=c_major,
+            ab_dtype=ab_dtype,
+            sf_dtype=sf_dtype,
+            c_dtype=c_dtype,
+            alpha_dtype=alpha_dtype,
+            sf_vec_size=sf_vec_size,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            sm_count=sm_count,
+            sm_version=sm_version,
+        ),
+        *_make_runtime_pointers(None),
+        current_cuda_stream(),
+    )
+
+    def tensor_api(
+        a_tensor_gpu: torch.Tensor,
+        b_tensor_gpu: torch.Tensor,
+        sfa_tensor_gpu: torch.Tensor,
+        sfb_tensor_gpu: torch.Tensor,
+        c_tensor_gpu: Optional[torch.Tensor] = None,
+        alpha_tensor_gpu: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if c_tensor_gpu is None:
+            c_tensor_gpu = torch.empty(
+                (m, n, l),
+                dtype=cutlass_to_torch_dtype(c_dtype),
+                device=a_tensor_gpu.device,
+            )
+        if alpha_tensor_gpu is None:
+            alpha_tensor_gpu = torch.ones(
+                (1,),
+                dtype=torch.float32,
+                device=a_tensor_gpu.device,
+            )
+
+        nonlocal compiled_kernel
+        compiled_kernel(
+            *_make_runtime_pointers(
+                [
+                    a_tensor_gpu,
+                    b_tensor_gpu,
+                    sfa_tensor_gpu,
+                    sfb_tensor_gpu,
+                    c_tensor_gpu,
+                    alpha_tensor_gpu,
+                ]
+            ),
+            current_cuda_stream(),
+        )
+        return c_tensor_gpu
+
+    return tensor_api
+
+
+def _select_default_mma_tiler_mn(m: int, n: int, sm_count: int) -> Tuple[int, int]:
+    coarse_tile = (128, 128)
+    coarse_tiles = ((m + coarse_tile[0] - 1) // coarse_tile[0]) * (
+        (n + coarse_tile[1] - 1) // coarse_tile[1]
+    )
+    if m <= 128 and coarse_tiles < max(1, sm_count // 2):
+        if n > 1536:
+            return (64, 128)
+        medium_tile = (128, 64)
+        medium_tiles = ((m + medium_tile[0] - 1) // medium_tile[0]) * (
+            (n + medium_tile[1] - 1) // medium_tile[1]
+        )
+        if medium_tiles < max(1, sm_count // 2):
+            return (64, 64)
+        return (128, 64)
+    return (128, 128)
+
+
+def dense_gemm(
+    lhs: Tuple[torch.Tensor, torch.Tensor],
+    rhs: Tuple[torch.Tensor, torch.Tensor],
+    out: Optional[torch.Tensor] = None,
+    *,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    sf_vec_size: int,
+    sm_count: Optional[int] = None,
+    mma_tiler_mn: Optional[Tuple[int, int]] = None,
+    cluster_shape_mn: Tuple[int, int] = (1, 1),
+    alpha: Optional[torch.Tensor] = None,
+    alpha_dtype: Optional[str] = None,
+) -> torch.Tensor:
+    """Execute dense block-scaled GEMM for one expert-major batch stack."""
+    a_torch, sfa_torch = lhs
+    b_torch, sfb_torch = rhs
+
+    m, k, l = a_torch.shape
+    n, _, _ = b_torch.shape
+    if ab_dtype == "float4_e2m1fn":
+        k *= 2
+
+    if sm_count is None:
+        sm_count = get_num_sm(a_torch.device)
+    if mma_tiler_mn is None:
+        mma_tiler_mn = _select_default_mma_tiler_mn(m, n, sm_count)
+    if alpha_dtype is None:
+        alpha_dtype = "float32" if alpha is None else str(alpha.dtype).split(".")[-1]
+
+    return _get_compiled_dense_gemm(
+        m=m,
+        n=n,
+        k=k,
+        l=l,
+        a_major="k",
+        b_major="k",
+        c_major="n",
+        ab_dtype=get_cutlass_dtype(ab_dtype),
+        sf_dtype=get_cutlass_dtype(sf_dtype),
+        c_dtype=get_cutlass_dtype(c_dtype),
+        alpha_dtype=get_cutlass_dtype(alpha_dtype),
+        sf_vec_size=sf_vec_size,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        sm_count=sm_count,
+        sm_version="sm_120",
+    )(
+        a_tensor_gpu=a_torch,
+        b_tensor_gpu=b_torch,
+        sfa_tensor_gpu=sfa_torch,
+        sfb_tensor_gpu=sfb_torch,
+        c_tensor_gpu=out,
+        alpha_tensor_gpu=alpha,
+    )

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py
@@ -64,31 +64,6 @@ def current_cuda_stream():
     return cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
 
 
-# Workaround for nvidia-cutlass-dsl 4.4.1 bug:
-# @dsl_user_op on PersistentTileSchedulerParams.__init__ renames attributes
-# (e.g. raster_along_m -> _raster_along_m, cluster_shape_major_fdd ->
-# cluster_shape_m_fdd) but __extract_mlir_values__ (used by TVM-FFI)
-# still references the original names.
-_orig_extract = utils.PersistentTileSchedulerParams.__extract_mlir_values__
-
-# Map of source-code attr name -> runtime attr name set by @dsl_user_op
-_ATTR_RENAMES = {
-    "raster_along_m": "_raster_along_m",
-    "cluster_shape_major_fdd": "cluster_shape_m_fdd",
-    "cluster_shape_minor_fdd": "cluster_shape_n_fdd",
-}
-
-
-def _patched_extract(self):
-    for src_name, dst_name in _ATTR_RENAMES.items():
-        if not hasattr(self, src_name) and hasattr(self, dst_name):
-            setattr(self, src_name, getattr(self, dst_name))
-    return _orig_extract(self)
-
-
-utils.PersistentTileSchedulerParams.__extract_mlir_values__ = _patched_extract
-
-
 class DenseGemmKernel:
     """Implements batched matrix multiplication (C = A x SFA x B x SFB) for
     Blackwell GeForce architecture using warp-level MMA.

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py
@@ -78,12 +78,13 @@ class DenseGemmKernel:
 
     Notes:
         - Supported combinations:
-            * NVF4: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
-            * MXF4: A/B: Float4E2M1FN, SF: Float8E8M0FNU, sf_vec_size: 32
+            * NVF4 only: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
+            (MXF4 / sf_vec_size=32 is not supported — the CUTLASS DSL
+            MmaMXF4NVF4Op hardcodes sf_vec_size=16 in its constructor.)
         - Tile shape constraints:
-            * tile_m must be divisible by 128
-            * tile_n must be divisible by 128
-            * tile_k must be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
+            * tile_m must be divisible by 64
+            * tile_n must be divisible by 64
+            * tile_k = sf_vec_size * 8 = 128
     """
 
     def __init__(
@@ -1446,6 +1447,19 @@ class DenseGemmKernel:
         # Alignment: K must be divisible by tile_k
         tile_k = sf_vec_size * 8
         if k % tile_k != 0:
+            return False
+        # Reject tiles that cannot fit even one pipeline stage in SM120
+        # shared memory.  A+B are FP4 (0.5 bytes/element), SF blocks are
+        # rounded up to 128-element granularity, epilogue is 16-bit output.
+        sfa_tile_m = max(128, ((mma_tiler_mn[0] + 127) // 128) * 128)
+        sfb_tile_n = max(128, ((mma_tiler_mn[1] + 127) // 128) * 128)
+        ab_bytes = (mma_tiler_mn[0] * tile_k + mma_tiler_mn[1] * tile_k) // 2
+        # SF: 128 * 4 elements per SF block, 1 byte each
+        sf_bytes = (sfa_tile_m // 128) * 4 * 128 + (sfb_tile_n // 128) * 4 * 128
+        epi_bytes = mma_tiler_mn[0] * mma_tiler_mn[1] * 2  # 16-bit output
+        mbar_bytes = 1024
+        smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        if ab_bytes + sf_bytes + epi_bytes + mbar_bytes > smem_capacity:
             return False
         return True
 

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -32,12 +32,15 @@ def _test_mm_fp4(
     if backend == "cute-dsl":
         if not use_128x4_sf_layout:
             pytest.skip("cute_dsl backend only supports 128x4 SF layout")
-        if compute_capability[0] not in [10, 12]:
-            pytest.skip("cute_dsl backend only supports SM100/SM103/SM120/SM121 GPUs.")
-        if compute_capability[0] == 12 and not use_nvfp4:
-            pytest.skip(
-                "SM120/SM121 cute-dsl warp-level MMA only supports NVFP4 (sf_vec_size=16)."
-            )
+        if compute_capability[0] not in [10]:
+            pytest.skip("cute_dsl backend only supports SM100/SM103 GPUs.")
+    if backend == "b12x":
+        if not use_128x4_sf_layout:
+            pytest.skip("b12x backend only supports 128x4 SF layout")
+        if compute_capability[0] != 12 or compute_capability[1] != 0:
+            pytest.skip("b12x backend only supports SM120 GPUs.")
+        if not use_nvfp4:
+            pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
     if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:
@@ -108,7 +111,7 @@ def _test_mm_fp4(
 @pytest.mark.parametrize("n", [128, 256, 512])
 @pytest.mark.parametrize("k", [128, 256, 512])
 @pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("backend", ["trtllm", "cudnn", "cutlass", "cute-dsl"])
+@pytest.mark.parametrize("backend", ["trtllm", "cudnn", "cutlass", "cute-dsl", "b12x"])
 @pytest.mark.parametrize("use_128x4_sf_layout", [False, True])
 @pytest.mark.parametrize("auto_tuning", [False, True])
 @pytest.mark.parametrize("fp4_type", ["nvfp4", "mxfp4", "mxfp4_alpha"])

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -41,6 +41,8 @@ def _test_mm_fp4(
             pytest.skip("b12x backend only supports SM120 GPUs.")
         if not use_nvfp4:
             pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
+        if torch.version.cuda and int(torch.version.cuda.split(".")[0]) < 13:
+            pytest.skip("b12x backend requires CUDA 13+.")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
     if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -32,8 +32,12 @@ def _test_mm_fp4(
     if backend == "cute-dsl":
         if not use_128x4_sf_layout:
             pytest.skip("cute_dsl backend only supports 128x4 SF layout")
-        if compute_capability[0] not in [10]:
-            pytest.skip("cute_dsl backend only supports SM100/SM103 GPUs.")
+        if compute_capability[0] not in [10, 12]:
+            pytest.skip("cute_dsl backend only supports SM100/SM103/SM120/SM121 GPUs.")
+        if compute_capability[0] == 12 and not use_nvfp4:
+            pytest.skip(
+                "SM120/SM121 cute-dsl warp-level MMA only supports NVFP4 (sf_vec_size=16)."
+            )
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
     if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Summary
- Add a new `backend="b12x"` option for `mm_fp4` targeting SM120 GPUs. Supports nvfp4 only.
- Port the `b12x` block-scaled NVFP4 dense GEMM kernel using CuTe DSL. Ported from the [b12x library](https://github.com/lukealonso/b12x/tree/master)   
- On SM120, `backend="auto"` now prefers "b12x" over "cutlass" and "cudnn" for NVFP4   
- SM121 (Spark) is not yet supported pending a `nvidia-cutlass-dsl==4.5` wheel release.

### Changes
| File | Change |
|---|---|
| `flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120.py` | New SM120 kernel with `wrapper()` method for FlashInfer's TVM-FFI compile interface |
| `flashinfer/cute_dsl/utils.py` | Add `sm120_make_smem_layout_sfa/sfb` with 64-aligned tile support |
| `flashinfer/gemm/gemm_base.py` | New `_b12x_gemm_fp4_requirement`, `_b12x_gemm_fp4_runner` (separate cache and runner class), `_select_default_sm120_mma_tiler` heuristic, SM120 auto-selection in heuristic |
| `flashinfer/gemm/__init__.py` | Export `Sm120BlockScaledDenseGemmKernel` |
| `tests/gemm/test_mm_fp4.py` | Add `"b12x"` to backend parametrize with SM120-only skip |
| `benchmarks/routines/gemm.py` | Add `"b12x"` to CLI choices and autotune-supported backends, remove redundant backend guard in `run_backend` |

### Performance numbers on RTX 5090 (SM120)
Geomean speedup vs CUTLASS:
- cuDNN: **1.02x**
- b12x: **1.20x**

`b12x` performance is particularly strong on small-M (decode) shapes where the underfill tiles (64x64, 64x128) kick in — many of those show 1.3-1.6x speedup. The larger shapes are roughly at parity

<details>
  <summary>Click to view performance comparisons on between backends</summary>

| M | N | K | cuDNN (us) | CUTLASS (us) | b12x (us) | best |
|---:|---:|---:|---:|---:|---:|---|
| 1 | 512 | 7168 | 18.448 | 24.240 | 13.680 | **b12x** |
| 4 | 512 | 7168 | 18.976 | 24.400 | 13.983 | **b12x** |
| 16 | 512 | 7168 | 19.152 | 24.304 | 14.303 | **b12x** |
| 64 | 512 | 7168 | 19.088 | 24.352 | 15.360 | **b12x** |
| 256 | 512 | 7168 | 21.728 | 24.575 | 25.392 | cuDNN |
| 1024 | 512 | 7168 | 23.519 | 25.232 | 26.592 | cuDNN |
| 1 | 896 | 1024 | 7.056 | 6.512 | 4.720 | **b12x** |
| 4 | 896 | 1024 | 7.232 | 6.608 | 4.976 | **b12x** |
| 16 | 896 | 1024 | 7.232 | 6.544 | 4.944 | **b12x** |
| 64 | 896 | 1024 | 7.152 | 6.432 | 4.993 | **b12x** |
| 256 | 896 | 1024 | 7.360 | 6.640 | 6.656 | CUTLASS |
| 1024 | 896 | 1024 | 7.664 | 6.736 | 6.928 | CUTLASS |
| 1 | 896 | 5120 | 20.192 | 18.144 | 11.200 | **b12x** |
| 8 | 896 | 5120 | 18.624 | 18.208 | 11.424 | **b12x** |
| 64 | 896 | 5120 | 19.008 | 18.224 | 12.560 | **b12x** |
| 512 | 896 | 5120 | 20.192 | 18.864 | 20.032 | CUTLASS |
| 1 | 1024 | 7168 | 18.895 | 24.256 | 14.880 | **b12x** |
| 4 | 1024 | 7168 | 19.231 | 24.592 | 15.744 | **b12x** |
| 16 | 1024 | 7168 | 19.488 | 24.671 | 16.432 | **b12x** |
| 256 | 1024 | 7168 | 23.103 | 24.720 | 25.824 | cuDNN |
| 1024 | 1024 | 7168 | 28.928 | 26.160 | 28.816 | CUTLASS |
| 1 | 1280 | 8192 | 18.287 | 27.872 | 18.191 | **b12x** |
| 8 | 1280 | 8192 | 18.688 | 27.856 | 19.296 | cuDNN |
| 64 | 1280 | 8192 | 18.528 | 27.920 | 19.936 | cuDNN |
| 512 | 1280 | 8192 | 21.328 | 29.040 | 31.599 | cuDNN |
| 1 | 1792 | 5120 | 17.600 | 18.864 | 14.592 | **b12x** |
| 8 | 1792 | 5120 | 17.488 | 18.912 | 14.272 | **b12x** |
| 64 | 1792 | 5120 | 20.063 | 18.832 | 14.976 | **b12x** |
| 512 | 1792 | 5120 | 23.536 | 19.904 | 22.080 | CUTLASS |
| 1 | 2560 | 8192 | 20.304 | 29.328 | 25.520 | cuDNN |
| 8 | 2560 | 8192 | 22.288 | 29.151 | 26.064 | cuDNN |
| 64 | 2560 | 8192 | 19.472 | 29.184 | 26.272 | cuDNN |
| 512 | 2560 | 8192 | 34.128 | 30.752 | 33.871 | CUTLASS |
| 1 | 3584 | 5120 | 21.456 | 22.128 | 19.504 | **b12x** |
| 8 | 3584 | 5120 | 21.071 | 22.111 | 19.520 | **b12x** |
| 64 | 3584 | 5120 | 20.800 | 22.463 | 20.128 | **b12x** |
| 512 | 3584 | 5120 | 26.079 | 24.608 | 24.736 | CUTLASS |
| 1 | 4608 | 7168 | 29.040 | 32.512 | 28.016 | **b12x** |
| 4 | 4608 | 7168 | 28.816 | 32.560 | 28.192 | **b12x** |
| 16 | 4608 | 7168 | 32.399 | 32.992 | 28.559 | **b12x** |
| 64 | 4608 | 7168 | 24.688 | 32.479 | 28.496 | cuDNN |
| 256 | 4608 | 7168 | 35.776 | 34.255 | 35.888 | CUTLASS |
| 1024 | 4608 | 7168 | 68.367 | 71.200 | 67.919 | **b12x** |
| 1 | 5120 | 640 | 7.632 | 6.768 | 5.456 | **b12x** |
| 8 | 5120 | 640 | 7.648 | 6.624 | 5.200 | **b12x** |
| 64 | 5120 | 640 | 7.808 | 6.752 | 5.296 | **b12x** |
| 512 | 5120 | 640 | 8.928 | 8.288 | 7.504 | **b12x** |
| 1 | 5120 | 1024 | 8.240 | 7.728 | 6.272 | **b12x** |
| 8 | 5120 | 1024 | 8.079 | 7.680 | 6.176 | **b12x** |
| 64 | 5120 | 1024 | 8.160 | 7.536 | 5.952 | **b12x** |
| 512 | 5120 | 1024 | 9.136 | 10.368 | 8.784 | **b12x** |
| 1 | 5120 | 1280 | 9.968 | 9.088 | 7.456 | **b12x** |
| 8 | 5120 | 1280 | 9.680 | 9.328 | 7.504 | **b12x** |
| 64 | 5120 | 1280 | 9.775 | 9.008 | 7.280 | **b12x** |
| 512 | 5120 | 1280 | 10.848 | 11.776 | 10.128 | **b12x** |
| 1 | 5120 | 2048 | 12.816 | 12.512 | 10.032 | **b12x** |
| 8 | 5120 | 2048 | 12.640 | 12.160 | 9.888 | **b12x** |
| 64 | 5120 | 2048 | 12.816 | 11.536 | 9.872 | **b12x** |
| 512 | 5120 | 2048 | 13.872 | 14.624 | 13.232 | **b12x** |
| 1 | 5120 | 2560 | 15.024 | 14.384 | 11.760 | **b12x** |
| 8 | 5120 | 2560 | 14.816 | 14.336 | 11.968 | **b12x** |
| 64 | 5120 | 2560 | 14.944 | 13.872 | 11.584 | **b12x** |
| 512 | 5120 | 2560 | 16.400 | 16.592 | 15.887 | **b12x** |
| 1 | 5120 | 4096 | 20.608 | 19.040 | 15.584 | **b12x** |
| 8 | 5120 | 4096 | 20.527 | 18.800 | 15.984 | **b12x** |
| 64 | 5120 | 4096 | 20.784 | 19.280 | 17.168 | **b12x** |
| 512 | 5120 | 4096 | 23.696 | 23.967 | 23.376 | **b12x** |
| 1 | 5120 | 5120 | 24.303 | 23.856 | 19.823 | **b12x** |
| 8 | 5120 | 5120 | 22.415 | 23.663 | 19.840 | **b12x** |
| 64 | 5120 | 5120 | 25.568 | 23.552 | 20.560 | **b12x** |
| 512 | 5120 | 5120 | 29.328 | 30.016 | 29.152 | **b12x** |
| 1 | 5120 | 8192 | 35.887 | 33.903 | 27.616 | **b12x** |
| 8 | 5120 | 8192 | 31.424 | 34.336 | 29.200 | **b12x** |
| 64 | 5120 | 8192 | 36.224 | 34.591 | 31.696 | **b12x** |
| 512 | 5120 | 8192 | 42.111 | 43.791 | 41.440 | **b12x** |
| 1 | 5120 | 16384 | 59.119 | 58.911 | 49.968 | **b12x** |
| 8 | 5120 | 16384 | 59.103 | 58.959 | 50.175 | **b12x** |
| 64 | 5120 | 16384 | 51.456 | 58.864 | 51.407 | **b12x** |
| 512 | 5120 | 16384 | 81.375 | 84.191 | 81.871 | cuDNN |
| 1 | 7168 | 256 | 5.424 | 4.976 | 3.968 | **b12x** |
| 4 | 7168 | 256 | 5.728 | 5.168 | 3.935 | **b12x** |
| 16 | 7168 | 256 | 5.456 | 4.992 | 4.096 | **b12x** |
| 64 | 7168 | 256 | 5.855 | 5.184 | 4.240 | **b12x** |
| 256 | 7168 | 256 | 5.856 | 5.488 | 5.040 | **b12x** |
| 1024 | 7168 | 256 | 9.696 | 12.912 | 10.048 | cuDNN |
| 1 | 7168 | 512 | 7.072 | 7.008 | 5.184 | **b12x** |
| 4 | 7168 | 512 | 7.120 | 6.864 | 5.408 | **b12x** |
| 16 | 7168 | 512 | 6.976 | 6.720 | 5.120 | **b12x** |
| 64 | 7168 | 512 | 7.071 | 6.559 | 5.456 | **b12x** |
| 256 | 7168 | 512 | 7.296 | 7.104 | 6.576 | **b12x** |
| 1024 | 7168 | 512 | 15.280 | 18.000 | 14.752 | **b12x** |
| 4 | 7168 | 2304 | 15.168 | 14.800 | 11.551 | **b12x** |
| 16 | 7168 | 2304 | 14.848 | 14.479 | 11.232 | **b12x** |
| 64 | 7168 | 2304 | 14.528 | 13.712 | 11.423 | **b12x** |
| 256 | 7168 | 2304 | 15.136 | 15.840 | 14.320 | **b12x** |
| 1 | 7168 | 4608 | 25.552 | 25.792 | 19.264 | **b12x** |
| 4 | 7168 | 4608 | 25.200 | 25.184 | 18.560 | **b12x** |
| 16 | 7168 | 4608 | 27.648 | 24.320 | 19.120 | **b12x** |
| 64 | 7168 | 4608 | 25.952 | 24.383 | 22.544 | **b12x** |
| 256 | 7168 | 4608 | 27.984 | 27.328 | 26.480 | **b12x** |
| 1024 | 7168 | 4608 | 70.480 | 72.335 | 69.743 | **b12x** |
| 1 | 7168 | 5120 | 28.063 | 27.552 | 19.552 | **b12x** |
| 8 | 7168 | 5120 | 26.048 | 26.287 | 20.192 | **b12x** |
| 64 | 7168 | 5120 | 27.824 | 25.215 | 23.312 | **b12x** |
| 512 | 7168 | 5120 | 47.567 | 48.175 | 47.648 | cuDNN |
| 1 | 8192 | 1024 | 10.352 | 9.775 | 7.376 | **b12x** |
| 8 | 8192 | 1024 | 10.367 | 9.456 | 7.696 | **b12x** |
| 64 | 8192 | 1024 | 9.568 | 9.233 | 7.712 | **b12x** |
| 512 | 8192 | 1024 | 14.016 | 15.264 | 13.776 | **b12x** |
| 1 | 8192 | 2048 | 14.832 | 14.688 | 10.640 | **b12x** |
| 8 | 8192 | 2048 | 14.591 | 14.080 | 10.560 | **b12x** |
| 64 | 8192 | 2048 | 14.128 | 13.104 | 11.936 | **b12x** |
| 512 | 8192 | 2048 | 22.272 | 23.280 | 22.080 | **b12x** |
| 1 | 8192 | 3584 | 21.087 | 21.872 | 15.727 | **b12x** |
| 8 | 8192 | 3584 | 22.272 | 21.264 | 15.808 | **b12x** |
| 64 | 8192 | 3584 | 20.448 | 19.200 | 18.336 | **b12x** |
| 512 | 8192 | 3584 | 35.423 | 35.023 | 35.344 | CUTLASS |
| 1 | 8192 | 4096 | 22.880 | 23.872 | 16.416 | **b12x** |
| 8 | 8192 | 4096 | 25.312 | 23.663 | 18.352 | **b12x** |
| 64 | 8192 | 4096 | 22.176 | 21.184 | 20.624 | **b12x** |
| 512 | 8192 | 4096 | 39.392 | 38.928 | 39.552 | CUTLASS |
| 1 | 8192 | 7168 | 37.663 | 38.783 | 26.863 | **b12x** |
| 8 | 8192 | 7168 | 37.888 | 37.296 | 27.663 | **b12x** |
| 64 | 8192 | 7168 | 37.584 | 34.224 | 32.416 | **b12x** |
| 512 | 8192 | 7168 | 67.824 | 70.751 | 67.759 | **b12x** |
| 1 | 8192 | 8192 | 40.288 | 42.784 | 29.472 | **b12x** |
| 8 | 8192 | 8192 | 39.487 | 42.191 | 31.904 | **b12x** |
| 64 | 8192 | 8192 | 38.159 | 35.663 | 39.263 | CUTLASS |
| 512 | 8192 | 8192 | 76.895 | 80.655 | 77.391 | cuDNN |
| 1 | 8192 | 14336 | 69.615 | 70.624 | 52.720 | **b12x** |
| 8 | 8192 | 14336 | 69.647 | 70.175 | 53.615 | **b12x** |
| 64 | 8192 | 14336 | 61.919 | 67.904 | 58.223 | **b12x** |
| 512 | 8192 | 14336 | 124.814 | 128.014 | 124.735 | **b12x** |
| 1 | 8192 | 28672 | 134.031 | 135.231 | 100.127 | **b12x** |
| 8 | 8192 | 28672 | 133.935 | 131.982 | 102.047 | **b12x** |
| 64 | 8192 | 28672 | 108.863 | 127.887 | 122.463 | cuDNN |
| 512 | 8192 | 28672 | 233.486 | 243.533 | 232.621 | **b12x** |
| 1 | 9216 | 7168 | 41.200 | 45.840 | 29.296 | **b12x** |
| 4 | 9216 | 7168 | 41.232 | 46.031 | 29.584 | **b12x** |
| 16 | 9216 | 7168 | 39.008 | 42.911 | 32.912 | **b12x** |
| 64 | 9216 | 7168 | 37.999 | 35.135 | 33.151 | **b12x** |
| 256 | 9216 | 7168 | 42.655 | 39.839 | 41.536 | CUTLASS |
| 1024 | 9216 | 7168 | 125.534 | 128.511 | 125.279 | **b12x** |
| 1 | 10240 | 8192 | 47.807 | 50.847 | 35.328 | **b12x** |
| 8 | 10240 | 8192 | 47.535 | 51.615 | 35.887 | **b12x** |
| 64 | 10240 | 8192 | 38.944 | 38.336 | 44.496 | CUTLASS |
| 512 | 10240 | 8192 | 84.383 | 86.399 | 83.343 | **b12x** |



</details>

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

#3013 
<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "b12x" FP4 backend with SM120-optimized execution and a new SM120 block-scaled dense GEMM kernel.
  * Registered SM120 kernel for CuTe-DSL-enabled builds and added SM120-specific shared-memory layouts.

* **Enhancements**
  * Improved SM120 tiling/auto-selection heuristics for small-M and low-occupancy scenarios.

* **Tests**
  * Extended FP4 tests to include "b12x" with SM120-specific preconditions and skip logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->