### PR TITLE
feat(fmha): add precomputed scheduler support

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -88,7 +88,9 @@ void trtllm_paged_attention_launcher(
     int64_t sparse_mla_top_k, float skip_softmax_threshold_scale_factor, bool skips_softmax,
     bool uses_shared_paged_kv_idx, int64_t sm_count, bool enable_pdl, int64_t workspace_size,
     int64_t k_sf_stride_heads, int64_t k_sf_stride_batch, int64_t v_sf_stride_heads,
-    int64_t v_sf_stride_batch, cudaStream_t stream) {
+    int64_t v_sf_stride_batch, void const* precomputed_work_descriptors,
+    int32_t const* precomputed_work_descriptor_offsets,
+    cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads must be a multiple of num_kv_heads, got num_kv_heads: " << num_kv_heads
@@ -178,10 +180,21 @@ void trtllm_paged_attention_launcher(
     // one tokenQ in those cases, so dense mask works the same as causal mask.
     runner_params.mMaskType = TrtllmGenAttentionMaskType::Causal;
     runner_params.mKernelType = FmhaKernelType::Generation;
-    bool use_multi_block = true;
-    runner_params.mTileScheduler =
-        use_multi_block ? TileScheduler::Static : TileScheduler::Persistent;
-    runner_params.mMultiCtasKvMode = use_multi_block;
+
+    bool const use_precomputed = (precomputed_work_descriptors != nullptr);
+    if (use_precomputed) {
+      // Precomputed scheduler: metadata-driven, split-KV for load balancing.
+      runner_params.mTileScheduler = TileScheduler::Precomputed;
+      runner_params.mMultiCtasKvMode = false;
+      runner_params.ptrPrecomputedWorkDescriptors = precomputed_work_descriptors;
+      runner_params.ptrPrecomputedWorkDescriptorOffsets = precomputed_work_descriptor_offsets;
+    } else {
+      // Standard Static + multiCtasKv path.
+      bool use_multi_block = true;
+      runner_params.mTileScheduler =
+          use_multi_block ? TileScheduler::Static : TileScheduler::Persistent;
+      runner_params.mMultiCtasKvMode = use_multi_block;
+    }
 
     runner_params.cumSeqLensQPtr = cum_seq_lens_q;
     runner_params.cumSeqLensKvPtr = nullptr;
@@ -191,7 +204,7 @@ void trtllm_paged_attention_launcher(
     size_t num_semaphores =
         round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
     // semaphores be at the first 8MB of workspace buffer: counter | scratch
-    // todo(Yingyi): add softmax buffer later for lse return
+    // For precomputed: counter area reused as split_counter, scratch as partial buffers.
     runner_params.multiCtasKvCounterPtr = float_allocator.aligned_alloc<int32_t>(
         num_semaphores * sizeof(uint32_t), 16, "trtllm_gen_counter_workspace");
     // scratch takes the rest of the workspace buffer
@@ -244,7 +257,9 @@ void trtllm_paged_attention_decode(
     int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> cum_seq_lens_q, Optional<TensorView> key_block_scales,
     Optional<TensorView> value_block_scales, Optional<float> skip_softmax_threshold_scale_factor,
-    Optional<bool> uses_shared_paged_kv_idx) {
+    Optional<bool> uses_shared_paged_kv_idx,
+    Optional<TensorView> precomputed_work_descriptors,
+    Optional<TensorView> precomputed_work_descriptor_offsets) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
@@ -352,6 +367,15 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
+  // precomputed descriptors
+  void const* precomputed_work_descriptors_ptr = precomputed_work_descriptors.has_value()
+                                                   ? precomputed_work_descriptors.value().data_ptr()
+                                                   : nullptr;
+  int32_t const* precomputed_work_descriptor_offsets_ptr =
+      precomputed_work_descriptor_offsets.has_value()
+          ? static_cast<int32_t const*>(precomputed_work_descriptor_offsets.value().data_ptr())
+          : nullptr;
+
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr,
@@ -364,7 +388,8 @@ void trtllm_paged_attention_decode(
       bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
       sparse_mla_top_k, skip_softmax_threshold_scale_factor_value, skips_softmax,
       uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
-      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
+      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch,
+      precomputed_work_descriptors_ptr, precomputed_work_descriptor_offsets_ptr, stream);
 }
 
 void trtllm_paged_attention_context(
@@ -376,7 +401,8 @@ void trtllm_paged_attention_context(
     int64_t window_left, TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv, int64_t sm_count,
     bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> key_block_scales, Optional<TensorView> value_block_scales,
-    Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx) {
+    Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx,
+    Optional<TensorView> precomputed_work_descriptors, Optional<TensorView> precomputed_work_descriptor_offsets) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
@@ -474,6 +500,17 @@ void trtllm_paged_attention_context(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
+  // precomputed descriptors
+  void const* precomputed_work_descriptors_ptr = precomputed_work_descriptors.has_value()
+                                                    ? precomputed_work_descriptors.value().data_ptr()
+                                                    : nullptr;
+  int32_t const* precomputed_work_descriptor_offsets_ptr = precomputed_work_descriptor_offsets.has_value()
+                                                              ? static_cast<int32_t const*>(
+                                                                    precomputed_work_descriptor_offsets
+                                                                        .value()
+                                                                        .data_ptr())
+                                                              : nullptr;
+
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr,
@@ -487,7 +524,8 @@ void trtllm_paged_attention_context(
       bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left,
       sum_seq_q, /*sparse_mla_top_k=*/0, skip_softmax_threshold_scale_factor_value, skips_softmax,
       uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
-      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, stream);
+      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch,
+      precomputed_work_descriptors_ptr, precomputed_work_descriptor_offsets_ptr, stream);
 }
 
 void trtllm_ragged_attention_launcher(
@@ -666,6 +704,48 @@ void trtllm_ragged_attention(TensorView out, TensorView query, TensorView key, T
       skip_softmax_threshold_scale_factor_value, skips_softmax, workspace_size, stream);
 }
 
+// Query the kernel configuration for a given set of parameters without launching.
+// Writes [tileSizeKv, stepKv, tileSizeQ, numSmParts] into config_out (int64 tensor, shape [4]).
+// Takes dummy tensors (can be empty, size 0) just to carry dtype info.
+void trtllm_get_kernel_config(
+    TensorView config_out, TensorView q_dummy, TensorView kv_dummy, TensorView o_dummy,
+    int64_t num_qo_heads, int64_t num_kv_heads, int64_t head_dim_qk, int64_t head_dim_vo,
+    int64_t page_size, int64_t sm_count, int64_t batch_size, int64_t max_seq_len,
+    int64_t max_q_len, int64_t window_left) {
+  auto q_data_type = dl_dtype_to_tllm_data_type(q_dummy.dtype());
+  auto kv_data_type = dl_dtype_to_tllm_data_type(kv_dummy.dtype());
+  auto o_data_type = dl_dtype_to_tllm_data_type(o_dummy.dtype());
+
+  auto fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, o_data_type);
+  TllmGenFmhaRunnerParams runner_params;
+
+  runner_params.mQkvLayout = QkvLayout::PagedKv;
+  runner_params.mMaskType = TrtllmGenAttentionMaskType::Causal;
+  runner_params.mKernelType = FmhaKernelType::Generation;
+  runner_params.mTileScheduler = TileScheduler::Precomputed;
+  runner_params.mMultiCtasKvMode = false;
+  runner_params.mHeadDimQk = head_dim_qk;
+  runner_params.mHeadDimV = head_dim_vo;
+  runner_params.mNumHeadsQ = num_qo_heads;
+  runner_params.mNumHeadsKv = num_kv_heads;
+  runner_params.mNumHeadsQPerKv = num_qo_heads / num_kv_heads;
+  runner_params.mBatchSize = batch_size;
+  runner_params.mMaxSeqLenKv = max_seq_len;
+  runner_params.mMaxSeqLenQ = max_q_len;
+  runner_params.mNumTokensPerPage = page_size;
+  runner_params.mMultiProcessorCount = sm_count;
+  runner_params.mAttentionWindowSize = window_left == -1 ? INT_MAX : window_left + 1;
+  runner_params.mChunkedAttentionSize = INT_MAX;
+  runner_params.mUsesSharedPagedKvIdx = true;
+
+  auto config = fmha_runner->getConfig(runner_params);
+  auto* out = static_cast<int64_t*>(config_out.data_ptr());
+  out[0] = config.tileSizeKv;
+  out[1] = config.stepKv;
+  out[2] = config.tileSizeQ;
+  out[3] = config.numSmParts;
+}
+
 namespace trtllm_cubin_loader {
 #include <flashinfer/cubin_loader.h>
 }
@@ -673,5 +753,6 @@ namespace trtllm_cubin_loader {
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_paged_attention_decode, trtllm_paged_attention_decode);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_paged_attention_context, trtllm_paged_attention_context);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_ragged_attention, trtllm_ragged_attention);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_get_kernel_config, trtllm_get_kernel_config);
 
 }  // namespace flashinfer

--- a/csrc/trtllm_precomputed_sched.cu
+++ b/csrc/trtllm_precomputed_sched.cu
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Precomputed scheduler metadata generator.
+// Adapted from trtllm-gen FmhaPrecomputedSched.cpp — takes host seqLens directly (no D2H sync).
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+#include <flashinfer/trtllm/fmha/kernelParams.h>
+#include "tvm/ffi/error.h"
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer {
+
+static int hostCeilDiv(int a, int b) { return (a + b - 1) / b; }
+
+// CPU metadata generator for the precomputed scheduler.
+// Algorithm: variance-aware greedy bin-packing of KV blocks across SM partitions.
+//
+// Takes host-side seqLens directly (no D2H copy needed when called from vllm/flashinfer
+// where seq_lens_cpu is already available).
+//
+// Outputs:
+//   workDescriptorsOut[]: dense PrecomputedWorkDescriptor array (H2D copied to device)
+//   workDescriptorOffsetsOut[]: per-partition offsets [numSmParts+1] (H2D copied to device)
+static void runPrecomputedSchedFromHost(
+    int32_t const* seqLensHost,               // [batchSize] on host
+    PrecomputedWorkDescriptor* workDescPtrD,   // [maxDescs] on device, output
+    int32_t* workDescOffsetsPtrD,              // [numSmParts+1] on device, output
+    int32_t batchSize,
+    int32_t numSmParts,
+    int32_t blockSizeN,
+    int32_t attentionWindowSize,
+    int32_t tileSizeKv,
+    cudaStream_t stream) {
+  int const N = batchSize;
+  int const P = numSmParts;
+
+  if (N == 0) {
+    cudaMemsetAsync(workDescOffsetsPtrD, 0, (P + 1) * sizeof(int32_t), stream);
+    return;
+  }
+
+  // ---- Step 1: Compute numBlocks + statistics ----
+  static constexpr int kFixedOverhead = 1;
+
+  std::vector<int> numBlocks(N);
+  int totalWeightedBlocks = 0;
+  int maxBlocks = 0, minBlocks = INT32_MAX;
+
+  for (int i = 0; i < N; ++i) {
+    int seqLen = seqLensHost[i];
+    if (attentionWindowSize > 0 && seqLen > attentionWindowSize) {
+      int skippedSeqLen = std::max(0, seqLen - attentionWindowSize - 1);
+      int numSkippedTokens = (skippedSeqLen / tileSizeKv) * tileSizeKv;
+      seqLen = seqLen - numSkippedTokens;
+    }
+    numBlocks[i] = (seqLen > 0) ? hostCeilDiv(seqLen, blockSizeN) : 1;
+    totalWeightedBlocks += numBlocks[i] + kFixedOverhead;
+    maxBlocks = std::max(maxBlocks, numBlocks[i]);
+    minBlocks = std::min(minBlocks, numBlocks[i]);
+  }
+
+  // ---- Step 1.5: Compute effective partition count ----
+  // Port of espUpperBound from fmhaKernels.cuh computeCtaAndClusterConfig().
+  // Prevents over-splitting when total work is small relative to numSmParts.
+  // The kernel always launches P (= rawNumSmParts) CTAs for stable grid Z;
+  // partitions P_active..P-1 receive empty descriptor ranges and exit immediately.
+  static constexpr int kMinBlocksPerPartition = 6;
+  int64_t totalWeightForEsp =
+      static_cast<int64_t>(N) * (maxBlocks + kMinBlocksPerPartition);
+  int espUpperBound =
+      std::max(1, static_cast<int>(totalWeightForEsp / kMinBlocksPerPartition));
+  int const P_active = std::min(P, espUpperBound);
+
+  // ---- Step 2: Payload selection (uses P_active for work distribution) ----
+  int const basePayload = hostCeilDiv(totalWeightedBlocks, P_active) + kFixedOverhead;
+  int const maxPiecesPayload = hostCeilDiv(maxBlocks, kMaxNumPieces) + kFixedOverhead;
+  int const maxCost = maxBlocks + kFixedOverhead;
+  int const minCost = minBlocks + kFixedOverhead;
+
+  bool const isNearUniform = (maxCost <= 2 * minCost);
+  int payload;
+  if (isNearUniform) {
+    int const reqsPerPart = hostCeilDiv(N, P_active);
+    int const avgCost = hostCeilDiv(totalWeightedBlocks, N);
+    payload = reqsPerPart * avgCost + kFixedOverhead;
+  } else {
+    payload = std::max(basePayload, maxPiecesPayload);
+  }
+
+  // ---- Step 3: Two-pass greedy scan ----
+  struct PartBound {
+    int beginReq, endReq;
+    int beginBlock, endBlock;
+    int beginSplitIdx;
+  };
+  std::vector<PartBound> partBounds(P_active);
+  std::vector<int> numSplitsPrefix(N + 1, 0);
+
+  // Pass 1: greedy scan → partition boundaries + numSplitsPrefix.
+  {
+    int curReq = 0, curBlock = 0, curSplitIdx = 0, cumSplits = 0;
+
+    for (int p = 0; p < P_active; ++p) {
+      PartBound& pb = partBounds[p];
+      pb.beginReq = curReq;
+      pb.beginBlock = curBlock;
+      pb.beginSplitIdx = curSplitIdx;
+
+      int remainPayload = payload;
+
+      while (curReq < N) {
+        int remainBlocks = numBlocks[curReq] - curBlock;
+
+        if (remainPayload >= remainBlocks + kFixedOverhead) {
+          cumSplits += (curSplitIdx > 0) ? (curSplitIdx + 1) : 0;
+          numSplitsPrefix[curReq + 1] = cumSplits;
+          remainPayload -= remainBlocks + kFixedOverhead;
+          curReq++;
+          curBlock = 0;
+          curSplitIdx = 0;
+        } else {
+          int blocksFit = remainPayload - kFixedOverhead;
+          if (blocksFit > 0) {
+            blocksFit = std::min(blocksFit, remainBlocks);
+            curBlock += blocksFit;
+            curSplitIdx++;
+          }
+          break;
+        }
+      }
+
+      if (curReq >= N && curReq == pb.beginReq && curBlock == 0) {
+        pb.endReq = pb.beginReq - 1;
+        pb.endBlock = 0;
+      } else if (curBlock > 0 && curReq < N) {
+        pb.endReq = curReq;
+        pb.endBlock = curBlock;
+      } else if (curReq > pb.beginReq) {
+        pb.endReq = curReq - 1;
+        pb.endBlock = numBlocks[curReq - 1];
+      } else {
+        pb.endReq = pb.beginReq;
+        pb.endBlock = pb.beginBlock;
+      }
+    }
+  }
+
+  // Pass 2: generate descriptors (numSplitsPrefix is now complete).
+  int const maxDescs = N + P;
+  std::vector<PrecomputedWorkDescriptor> descsHost;
+  descsHost.reserve(maxDescs);
+  std::vector<int32_t> offsetsHost(P + 1, 0);
+
+  for (int p = 0; p < P_active; ++p) {
+    offsetsHost[p] = static_cast<int32_t>(descsHost.size());
+
+    PartBound const& pb = partBounds[p];
+    if (pb.beginReq > pb.endReq)
+      continue;
+
+    for (int req = pb.beginReq; req <= pb.endReq; ++req) {
+      int startBlock, endBlock;
+      bool isSplit;
+      int localPieceIdx = 0;
+
+      if (req == pb.beginReq && req == pb.endReq) {
+        startBlock = pb.beginBlock;
+        endBlock = pb.endBlock;
+        isSplit = (pb.beginBlock > 0) || (pb.endBlock < numBlocks[req]);
+        localPieceIdx = pb.beginSplitIdx;
+      } else if (req == pb.beginReq) {
+        startBlock = pb.beginBlock;
+        endBlock = numBlocks[req];
+        isSplit = (pb.beginBlock > 0);
+        localPieceIdx = pb.beginSplitIdx;
+      } else if (req == pb.endReq) {
+        startBlock = 0;
+        endBlock = pb.endBlock;
+        isSplit = (pb.endBlock < numBlocks[req]);
+        localPieceIdx = 0;
+      } else {
+        startBlock = 0;
+        endBlock = numBlocks[req];
+        isSplit = false;
+        localPieceIdx = 0;
+      }
+
+      int32_t si = 0;
+      if (isSplit) {
+        int splitBeginIdx = numSplitsPrefix[req];
+        int numPieces = numSplitsPrefix[req + 1] - splitBeginIdx;
+        int splitGlobalIdx = splitBeginIdx + localPieceIdx;
+        si = packSplitInfo(1, splitGlobalIdx, numPieces, splitBeginIdx);
+      }
+
+      PrecomputedWorkDescriptor desc;
+      desc.reqIdx = req;
+      desc.startBlock = startBlock;
+      desc.endBlock = endBlock;
+      desc.splitInfo = si;
+      descsHost.push_back(desc);
+    }
+  }
+  // Fill offsets for inactive partitions (P_active..P): all point to end of descriptors.
+  int32_t totalDescsVal = static_cast<int32_t>(descsHost.size());
+  for (int p = P_active; p <= P; ++p) {
+    offsetsHost[p] = totalDescsVal;
+  }
+
+  // ---- Step 4: H2D copy results (async on stream, no sync needed) ----
+  int totalDescs = static_cast<int>(descsHost.size());
+  cudaMemcpyAsync(workDescPtrD, descsHost.data(),
+                  totalDescs * sizeof(PrecomputedWorkDescriptor), cudaMemcpyHostToDevice, stream);
+  cudaMemcpyAsync(workDescOffsetsPtrD, offsetsHost.data(), (P + 1) * sizeof(int32_t),
+                  cudaMemcpyHostToDevice, stream);
+}
+
+// TVM-FFI entry point for precomputed metadata computation.
+void trtllm_compute_precomputed_metadata(TensorView seq_lens_cpu, TensorView work_descriptors_out,
+                                         TensorView work_descriptor_offsets_out,
+                                         int64_t batch_size, int64_t block_size_n,
+                                         int64_t num_sm_parts, int64_t attention_window_size,
+                                         int64_t tile_size_kv) {
+  TVM_FFI_ICHECK_EQ(seq_lens_cpu.device().device_type, kDLCPU)
+      << "seq_lens_cpu must be a CPU tensor";
+  TVM_FFI_ICHECK_EQ(work_descriptors_out.device().device_type, kDLCUDA)
+      << "work_descriptors_out must be a CUDA tensor";
+
+  auto stream = get_stream(work_descriptors_out.device());
+
+  runPrecomputedSchedFromHost(
+      static_cast<int32_t const*>(seq_lens_cpu.data_ptr()),
+      reinterpret_cast<PrecomputedWorkDescriptor*>(work_descriptors_out.data_ptr()),
+      static_cast<int32_t*>(work_descriptor_offsets_out.data_ptr()),
+      static_cast<int32_t>(batch_size), static_cast<int32_t>(num_sm_parts),
+      static_cast<int32_t>(block_size_n), static_cast<int32_t>(attention_window_size),
+      static_cast<int32_t>(tile_size_kv), stream);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_compute_precomputed_metadata,
+                               trtllm_compute_precomputed_metadata);
+
+}  // namespace flashinfer

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1193,6 +1193,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         q_len_per_req: Optional[int] = 1,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        precomputed_work_descriptors: Optional[torch.Tensor] = None,
+        precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
     ) -> torch.Tensor: ...
 
     @overload
@@ -1213,6 +1215,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         q_len_per_req: Optional[int] = 1,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        precomputed_work_descriptors: Optional[torch.Tensor] = None,
+        precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
     @flashinfer_api
@@ -1233,6 +1237,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         q_len_per_req: Optional[int] = 1,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        precomputed_work_descriptors: Optional[torch.Tensor] = None,
+        precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         r"""Compute batch decode attention between query and paged kv cache.
 
@@ -1460,6 +1466,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     value_block_scales,
                     skip_softmax_threshold_scale_factor,
                     True,  # uses_shared_paged_kv_idx
+                    precomputed_work_descriptors,
+                    precomputed_work_descriptor_offsets,
                 ]
 
             self._cached_module.paged_run(*run_args)
@@ -2036,6 +2044,8 @@ class TrtllmGenDecodeModule:
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        precomputed_work_descriptors: Optional[torch.Tensor] = None,
+        precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if out is None:
             out = torch.empty_like(query)
@@ -2081,6 +2091,8 @@ class TrtllmGenDecodeModule:
             value_block_scales,
             skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx,
+            precomputed_work_descriptors,
+            precomputed_work_descriptor_offsets,
         )
         return out
 
@@ -2146,6 +2158,8 @@ def get_trtllm_gen_decode_module(*args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        precomputed_work_descriptors: Optional[torch.Tensor] = None,
+        precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
     ) -> None:
         assert maybe_lse is None
         assert paged_kv_cache is not None
@@ -2176,6 +2190,8 @@ def get_trtllm_gen_decode_module(*args):
             value_block_scales=value_block_scales,
             skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+            precomputed_work_descriptors=precomputed_work_descriptors,
+            precomputed_work_descriptor_offsets=precomputed_work_descriptor_offsets,
         )
 
     @register_fake_op(f"flashinfer::{uri}_paged_run")
@@ -2219,6 +2235,8 @@ def get_trtllm_gen_decode_module(*args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        precomputed_work_descriptors: Optional[torch.Tensor] = None,
+        precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
     ) -> None:
         pass
 
@@ -2259,6 +2277,8 @@ def trtllm_batch_decode_with_kv_cache(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
+    precomputed_work_descriptors: Optional[torch.Tensor] = None,
+    precomputed_work_descriptor_offsets: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, FP4Tensor]:
     """
     Parameters
@@ -2606,6 +2626,8 @@ def trtllm_batch_decode_with_kv_cache(
             v_block_scales,
             skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx,
+            precomputed_work_descriptors,
+            precomputed_work_descriptor_offsets,
         )
 
         return (
@@ -2958,3 +2980,144 @@ def fast_decode_plan(
     self._sm_scale = sm_scale
     self._rope_scale = rope_scale
     self._rope_theta = rope_theta
+
+
+class FmhaKernelConfig:
+    """Kernel configuration returned by trtllm_get_kernel_config."""
+
+    def __init__(self, tile_size_kv: int, step_kv: int, tile_size_q: int, num_sm_parts: int):
+        self.tile_size_kv = tile_size_kv
+        self.step_kv = step_kv
+        self.tile_size_q = tile_size_q
+        self.num_sm_parts = num_sm_parts
+
+    def __repr__(self):
+        return (
+            f"FmhaKernelConfig(tile_size_kv={self.tile_size_kv}, step_kv={self.step_kv}, "
+            f"tile_size_q={self.tile_size_q}, num_sm_parts={self.num_sm_parts})"
+        )
+
+
+def trtllm_get_kernel_config(
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    o_dtype: torch.dtype,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    page_size: int,
+    sm_count: int,
+    batch_size: int,
+    max_seq_len: int,
+    max_q_len: int = 1,
+    window_left: int = -1,
+) -> FmhaKernelConfig:
+    """Query the precomputed kernel's tile sizes and numSmParts. Call once at init, cache the result.
+
+    Parameters
+    ----------
+    q_dtype : torch.dtype
+        Query data type.
+    kv_dtype : torch.dtype
+        KV cache data type.
+    o_dtype : torch.dtype
+        Output data type.
+    num_qo_heads : int
+        Number of query/output heads.
+    num_kv_heads : int
+        Number of key/value heads.
+    head_dim_qk : int
+        Head dimension for Q and K.
+    head_dim_vo : int
+        Head dimension for V and O.
+    page_size : int
+        Page size for paged KV cache.
+    sm_count : int
+        Number of streaming multiprocessors.
+    batch_size : int
+        Batch size (used for numSmParts upper-bound computation).
+    max_seq_len : int
+        Maximum KV sequence length (used for numSmParts upper-bound computation).
+    max_q_len : int
+        Maximum query length per request (1 for standard decode, >1 for speculative decode).
+    window_left : int
+        Sliding window size (-1 for no window / full context).
+
+    Returns
+    -------
+    FmhaKernelConfig
+        Kernel configuration with tile_size_kv, step_kv, tile_size_q, num_sm_parts.
+    """
+    # Output tensor for C++ to write config into: [tileSizeKv, stepKv, tileSizeQ, numSmParts]
+    config_out = torch.zeros(4, dtype=torch.int64, device="cpu")
+    get_trtllm_gen_fmha_module().trtllm_get_kernel_config(
+        config_out,
+        torch.empty(0, dtype=q_dtype, device="cpu"),
+        torch.empty(0, dtype=kv_dtype, device="cpu"),
+        torch.empty(0, dtype=o_dtype, device="cpu"),
+        num_qo_heads,
+        num_kv_heads,
+        head_dim_qk,
+        head_dim_vo,
+        page_size,
+        sm_count,
+        batch_size,
+        max_seq_len,
+        max_q_len,
+        window_left,
+    )
+    return FmhaKernelConfig(
+        tile_size_kv=int(config_out[0].item()),
+        step_kv=int(config_out[1].item()),
+        tile_size_q=int(config_out[2].item()),
+        num_sm_parts=int(config_out[3].item()),
+    )
+
+
+def trtllm_compute_precomputed_metadata(
+    seq_lens_cpu: torch.Tensor,
+    work_descriptors_out: torch.Tensor,
+    work_descriptor_offsets_out: torch.Tensor,
+    batch_size: int,
+    block_size_n: int,
+    num_sm_parts: int,
+    attention_window_size: int = 0,
+    tile_size_kv: int = 128,
+) -> None:
+    """Compute precomputed scheduler metadata from host-side sequence lengths.
+
+    The metadata (work descriptors and per-partition offsets) is written directly
+    to the provided GPU tensors via async H2D copy. No stream synchronization is needed —
+    a subsequent kernel launch on the same stream will naturally wait.
+
+    Parameters
+    ----------
+    seq_lens_cpu : torch.Tensor
+        Sequence lengths on CPU, shape [batch_size], dtype int32.
+    work_descriptors_out : torch.Tensor
+        Output GPU tensor for work descriptors, shape [max_descs * 4], dtype int32.
+        max_descs = batch_size + num_sm_parts.
+    work_descriptor_offsets_out : torch.Tensor
+        Output GPU tensor for per-partition offsets, shape [num_sm_parts + 1], dtype int32.
+    batch_size : int
+        Number of requests in the batch.
+    block_size_n : int
+        KV block size (= step_kv from kernel config).
+    num_sm_parts : int
+        Number of SM partitions (from kernel config).
+    attention_window_size : int
+        Sliding window size (0 = no window, use full seqLen).
+    tile_size_kv : int
+        Single KV tile size (from kernel config).
+    """
+    get_trtllm_gen_fmha_module().trtllm_compute_precomputed_metadata(
+        seq_lens_cpu,
+        work_descriptors_out,
+        work_descriptor_offsets_out,
+        batch_size,
+        block_size_n,
+        num_sm_parts,
+        attention_window_size,
+        tile_size_kv,
+    )

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -306,6 +306,8 @@ def get_trtllm_gen_prefill_module():
             value_block_scales,
             skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx,
+            None,  # precomputed_work_descriptors
+            None,  # precomputed_work_descriptor_offsets
         )
         return out
 
@@ -4045,6 +4047,8 @@ def trtllm_batch_context_with_kv_cache(
         value_block_scales,
         skip_softmax_threshold_scale_factor,
         uses_shared_paged_kv_idx,
+        None,
+        None,
     )
     return (
         out

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -233,6 +233,11 @@ class TllmGenFmhaKernel {
     auto kernelParams = KernelParams::setKernelParams(
         params, kernelMeta, ctaLaunchParams.mMaxNumCtasQ, ctaLaunchParams.mMaxNumCtasKv);
 
+    // Precomputed scheduler: override logicalGridDimZ to numSmParts.
+    if (selectKernelParams.mTileScheduler == TileScheduler::Precomputed) {
+      kernelParams.logicalGridDimZ = ctaLaunchParams.mNumCtasZ;
+    }
+
     void* kernelParamsList[] = {&kernelParams};
     CUlaunchAttribute launch_attribute[3];
     CUlaunchConfig launch_config;
@@ -281,15 +286,47 @@ class TllmGenFmhaKernel {
 
     cuErrCheck(cuLaunchKernelEx(&launch_config, func, kernelParamsList, nullptr));
 
-    // Run the separate reduction kernel if needed.
-    tensorrt_llm::kernels::runFmhaReduction(kernelMeta, kernelParams, params.mMultiProcessorCount,
-                                            params.enable_pdl, params.stream);
+    // Run the separate reduction kernel if needed (not needed for precomputed — reduction is in-kernel).
+    if (selectKernelParams.mTileScheduler != TileScheduler::Precomputed) {
+      tensorrt_llm::kernels::runFmhaReduction(kernelMeta, kernelParams, params.mMultiProcessorCount,
+                                              params.enable_pdl, params.stream);
+    }
 
     if (params.lsePtr != nullptr) {
       flashinfer::ComputeLSEFromMD(params.softmaxStatsPtr, params.lsePtr,
                                    params.mSumOfSeqLensQ * params.mNumHeadsQ, params.enable_pdl,
                                    params.stream);
     }
+  }
+
+  // Query the selected kernel's configuration without launching or loading cubins.
+  // Looks up kernel metadata from the hash map (no CUDA context needed).
+  FmhaKernelConfig getConfig(RunnerParams const& params) const {
+    SelectKernelParams selectKernelParams{params};
+    CtaLaunchParams ctaLaunchParams;
+
+    static constexpr int kMaxPasses = 4;
+    KernelMeta kernelMeta{};
+    for (int pass = 0; pass < kMaxPasses; ++pass) {
+      selectKernel(params, selectKernelParams);
+      // Look up metadata without loading the cubin (no CUDA context needed).
+      auto [hashId, info] = hashFromRunnerParams(params, selectKernelParams);
+      auto findMetaIter = mKernelMetaMap.find(hashId);
+      FLASHINFER_CHECK(findMetaIter != mKernelMetaMap.end(),
+                       "Trtllm-gen precomputed kernel not found for getConfig: " + info);
+      kernelMeta = mKernelMeta[findMetaIter->second];
+      computeCtaAndClusterConfig(ctaLaunchParams, params, kernelMeta, selectKernelParams);
+      if (!selectKernelParams.mSelectNewKernel) {
+        break;
+      }
+    }
+
+    FmhaKernelConfig config{};
+    config.tileSizeQ = kernelMeta.mTileSizeQ;
+    config.tileSizeKv = kernelMeta.mTileSizeKv;
+    config.stepKv = kernelMeta.mStepKv;
+    config.numSmParts = ctaLaunchParams.mNumCtasZ;
+    return config;
   }
 
  private:
@@ -378,6 +415,26 @@ class TllmGenFmhaKernel {
     int numCtasY = numCtasForAllHeadsQ * numCtasPerHeadDim;
     // Compute the grid dimension Z.
     int numCtasZ = params.mBatchSize;
+
+    // Precomputed scheduler: grid Z = rawNumSmParts (constant for a given model config).
+    // Always use rawNumSmParts without espUpperBound capping so that grid Z is independent
+    // of mMaxSeqLenKv. This ensures metadata partition count == kernel grid Z regardless of
+    // the actual max sequence length in the batch, and provides stable grid dimensions for
+    // CUDA graph capture. The espUpperBound logic is ported to the metadata generator
+    // (runPrecomputedSchedFromHost) to prevent over-splitting; extra partitions receive
+    // empty descriptor ranges and exit immediately (see PrecomputedSchedule.h:69-83).
+    if (selectKernelParams.mTileScheduler == TileScheduler::Precomputed) {
+      int numSmParts = std::max(1, params.mMultiProcessorCount / (numCtasX * numCtasY));
+
+      ctaLaunchParams.mMaxNumCtasQ = numCtasPerSeqQ;
+      ctaLaunchParams.mMaxNumCtasKv = 1;
+      ctaLaunchParams.mNumCtasX = numCtasX;
+      ctaLaunchParams.mNumCtasY = numCtasY;
+      ctaLaunchParams.mNumCtasZ = numSmParts;
+      ctaLaunchParams.mClusterDimX = selectKernelParams.mUses2CtaMma ? 2 : 1;
+      return;
+    }
+
     // The 2CtaMma kernels will use 2 Ctas in the x dimension (only used by MLA generation kernels)
     // for heads, so numCtasPerHeadDim and numCtasForAllHeadsQ will be handled by the 2Ctas in the x
     // dimension.

--- a/include/flashinfer/trtllm/fmha/fmhaRunner.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaRunner.cuh
@@ -56,6 +56,12 @@ class TllmGenFmhaRunner {
   // Run the fmha kernel.
   void run(TllmGenFmhaRunnerParams const& runnerParams) { mKernel->run(runnerParams); }
 
+  // Query the selected kernel's configuration without launching.
+  // Returns tile sizes and numSmParts needed for precomputed metadata generation.
+  FmhaKernelConfig getConfig(TllmGenFmhaRunnerParams const& runnerParams) const {
+    return mKernel->getConfig(runnerParams);
+  }
+
  private:
   // The input/output datatype.
   Data_type mDtypeQ, mDtypeKv, mDtypeOut;

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -125,11 +125,23 @@ QKV_LAYOUT_FUNCTION(ContiguousKv)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Kernel configuration returned by getConfig() — no-launch metadata query.
+struct FmhaKernelConfig {
+  int tileSizeQ;
+  int tileSizeKv;
+  int stepKv;      // = tileSizeKv * numInstsKv (blockSizeN for precomputed scheduler)
+  int numSmParts;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 enum class TileScheduler {
   // Static scheduler (Non-persistent).
   Static = 0,
   // Persistent scheduler.
-  Persistent
+  Persistent,
+  // Precomputed scheduler (metadata-driven, split-KV for load balancing).
+  Precomputed
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -316,6 +328,12 @@ struct TllmGenFmhaRunnerParams {
   cudaStream_t stream;
   // Whether to enable PDL (Programmatic Dependent Launch).
   bool enable_pdl;
+
+  // Precomputed scheduler work descriptors (only valid when mTileScheduler == Precomputed).
+  // Dense per-request-chunk descriptors [maxTotalDescriptors = batchSize + numSmParts].
+  void const* ptrPrecomputedWorkDescriptors;
+  // Per-partition offset into work descriptors [numSmParts + 1] (prefix sum).
+  int32_t const* ptrPrecomputedWorkDescriptorOffsets;
 
   // set the attention mask type
   TllmGenFmhaRunnerParams& setAttentionMaskType(std::int8_t maskType) {

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -64,6 +64,32 @@ struct FastModDivInt32 {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 using Dtype = Data_type;
 
+// Dense per-request-chunk work descriptor for the precomputed scheduler.
+// 16-byte aligned for single 128-bit vectorized load on device.
+struct __align__(16) PrecomputedWorkDescriptor {
+  int32_t reqIdx;      // Batch index (= L_idx).
+  int32_t startBlock;  // First KV block (absolute, in blockSizeN units).
+  int32_t endBlock;    // Past-end KV block.
+  int32_t splitInfo;   // Bit-packed: isSplit(1) | splitGlobalIdx(12) | numPieces(7) | splitBeginIdx(12).
+};
+
+static_assert(sizeof(PrecomputedWorkDescriptor) == 16, "PrecomputedWorkDescriptor must be 16 bytes");
+
+// Bitfield capacity limits for splitInfo fields.
+static constexpr int32_t kMaxNumPieces = 0x7F;  // 7 bits, max 127
+
+// Pack helper for PrecomputedWorkDescriptor::splitInfo.
+// Layout (32 bits): [31:20] splitBeginIdx | [19:13] numPieces | [12:1] splitGlobalIdx | [0] isSplit
+inline int32_t packSplitInfo(
+    int32_t isSplit, int32_t splitGlobalIdx, int32_t numPieces, int32_t splitBeginIdx) {
+  return (isSplit & 1)
+       | ((splitGlobalIdx & 0xFFF) << 1)
+       | ((numPieces & 0x7F) << 13)
+       | ((splitBeginIdx & 0xFFF) << 20);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 struct KernelParams {
   // TMA descriptor for Q.
   CUtensorMap tmaQ_;
@@ -112,7 +138,7 @@ struct KernelParams {
   int32_t const* ptrPageIdxKv;
   // The partial matrix O for each CtaKv when the multiCtasKv mode is enabled.
   void* ptrPartialO;
-  // The partial softmax stats (max/sum)for each CtaKv when the multiCtasKv mode is enabled.
+  // The partial softmax stats (max/sum) for each CtaKv (multiCtasKv) or precomputed split requests.
   float2* ptrPartialStats;
   // The scaling factors for K.
   float const* ptrSageAttnSfsK;
@@ -206,6 +232,14 @@ struct KernelParams {
   // Whether the indices for K & V pages are shared as unified index.
   // true -> vLLM/FlashInfer; false -> TRT-LLM.
   bool mUsesSharedPagedKvIdx{true};
+
+  // Precomputed scheduler fields (appended at end for ABI compatibility with old cubins).
+  // Atomic counter for precomputed scheduler in-kernel combine [batchSize * numCtasQ * numHeadsKv].
+  int32_t* ptrPrecomputedSplitCounter;
+  // Dense per-request-chunk work descriptors [maxTotalDescriptors = batchSize + numSmParts].
+  PrecomputedWorkDescriptor const* ptrWorkDescriptors;
+  // Per-partition offset into ptrWorkDescriptors [numSmParts + 1] (prefix sum).
+  int32_t const* ptrWorkDescriptorOffsets;
 
   // Create the TMA shape/stride for Q.
   template <class FmhaOptions>
@@ -819,11 +853,26 @@ struct KernelParams {
     // Attention sink
     params.ptrAttentionSinks = options.ptrAttentionSinks;
 
-    // The partial buffers' pointers when the multiCtasKv mode is enabled.
-    int64_t partialStatsBufferSize = options.mMultiProcessorCount * kernelMeta.mStepQ;
+    // The partial buffers' pointers when the multiCtasKv mode or precomputed scheduler is enabled.
     params.ptrMultiCtasKvCounter = options.multiCtasKvCounterPtr;
-    params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
-    params.ptrPartialO = params.ptrPartialStats + partialStatsBufferSize;
+    if (options.mTileScheduler == TileScheduler::Precomputed) {
+      // Precomputed scheduler: reuse counter area as split counter, recompute partial layout.
+      params.ptrPrecomputedSplitCounter = options.multiCtasKvCounterPtr;
+      params.ptrWorkDescriptors = static_cast<PrecomputedWorkDescriptor const*>(
+          options.ptrPrecomputedWorkDescriptors);
+      params.ptrWorkDescriptorOffsets = options.ptrPrecomputedWorkDescriptorOffsets;
+      // Partial buffers: indexed by splitGlobalIdx (different layout from multiCtasKv).
+      // Layout: [maxTotalSplits * perSplitStatsSize] of float2, then partial O follows.
+      int64_t maxTotalSplits = options.mBatchSize + options.mMultiProcessorCount;
+      int64_t perSplitStatsSize = maxNumCtasQ * options.mNumHeadsKv * kernelMeta.mStepQ;
+      params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
+      params.ptrPartialO = params.ptrPartialStats + maxTotalSplits * perSplitStatsSize;
+    } else {
+      // Standard multiCtasKv layout.
+      int64_t partialStatsBufferSize = options.mMultiProcessorCount * kernelMeta.mStepQ;
+      params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
+      params.ptrPartialO = params.ptrPartialStats + partialStatsBufferSize;
+    }
 
     params.ptrPageIdxKv = options.kvPageIdxPtr;
     params.ptrScaleSoftmaxLog2 = options.scaleSoftmaxLog2Ptr;

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -1837,3 +1837,534 @@ def test_trtllm_batch_decode_spec(
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
     )
+
+
+# ---- Precomputed scheduler tests ----
+
+
+@pytest.mark.parametrize("kv_layout", ["HND"])
+@pytest.mark.parametrize(
+    "batch_size,page_size,num_kv_heads,head_grp_size",
+    [
+        (128, 16, 8, 8),    # TP1: 64:8
+        (128, 32, 4, 8),    # TP2: 32:4
+        (128, 64, 2, 8),    # TP4: 16:2
+        (128, 16, 1, 8),    # TP8: 8:1
+        (128, 32, 8, 16),   # 128:8, tileSizeQ=16
+        (128, 64, 4, 32),   # 128:4, tileSizeQ=32
+    ],
+)
+@pytest.mark.parametrize("window_left", [-1, 512])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    [
+        ("fp8", "fp8", "bf16"),
+    ],
+)
+@pytest.mark.parametrize("max_in_kv_len", [2048, 8192, 32768, 65536])
+@pytest.mark.parametrize("head_dim", [128])
+def test_trtllm_batch_decode_precomputed(
+    kv_layout: str,
+    batch_size: int,
+    page_size: int,
+    num_kv_heads: int,
+    head_grp_size: int,
+    window_left: int,
+    q_dtype: str,
+    kv_dtype: str,
+    o_dtype: str,
+    max_in_kv_len: int,
+    head_dim: int,
+):
+    """Test precomputed scheduler decode matches reference output."""
+    from flashinfer.decode import (
+        trtllm_batch_decode_with_kv_cache,
+        trtllm_compute_precomputed_metadata,
+        trtllm_get_kernel_config,
+    )
+
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip("trtllm-gen precomputed requires SM100/SM103 GPUs.")
+
+    num_qo_heads = num_kv_heads * head_grp_size
+    torch.manual_seed(42)
+
+    q_lens, in_kv_lens, seq_lens = generate_seq_lens_decode(
+        batch_size, 1, max_in_kv_len, None
+    )
+
+    q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
+    kv_cache, k_scale, v_scale, ref_kv_cache, kv_block_scales = create_kv_cache(
+        batch_size,
+        seq_lens,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_dtype,
+        "bf16" if q_dtype == "fp8" else q_dtype,
+        kv_layout,
+    )
+    page_table, all_page_ids, page_per_seq = create_page_table(
+        batch_size, seq_lens, page_size
+    )
+    kv_indptr = generate_cumsum_lens(page_per_seq)
+    kv_last_page_len = get_last_page_len(seq_lens, page_size)
+    kv_cache_arg, page_table_kernel, kv_block_scales_kernel = prepare_paged_kv_for_kernel(
+        kv_cache, page_table, True, kv_block_scales
+    )
+
+    workspace_buffer, workspace_buffer_ref = create_workspace_buffers(GPU_DEVICE)
+
+    create_out_tensor = flip_coin(
+        batch_size, page_size, num_kv_heads, head_grp_size, o_dtype
+    )
+    can_infer_type = q.dtype == DTYPE_MAP[o_dtype] or create_out_tensor
+    create_out_dtype = not can_infer_type or flip_coin(
+        batch_size, page_size, num_kv_heads, head_grp_size, o_dtype, q_dtype
+    )
+    out, out_dtype, o_scale, o_sf_scale, o_sf_vec_size = create_output(
+        q, o_dtype, create_out_tensor, create_out_dtype
+    )
+
+    sm_scale = float(1.0 / (head_dim**0.5))
+    bmm1_scale = q_scale * k_scale * sm_scale
+    bmm2_scale = v_scale / o_scale
+    if isinstance(bmm1_scale, torch.Tensor):
+        bmm1_scale = bmm1_scale.item()
+    if isinstance(bmm2_scale, torch.Tensor):
+        bmm2_scale = bmm2_scale.item()
+
+    max_seq_len_val = torch.max(seq_lens).item()
+    sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+
+    config = trtllm_get_kernel_config(
+        q_dtype=DTYPE_MAP[q_dtype],
+        kv_dtype=DTYPE_MAP[kv_dtype],
+        o_dtype=DTYPE_MAP[o_dtype],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        page_size=page_size,
+        sm_count=sm_count,
+        batch_size=batch_size,
+        max_seq_len=max_seq_len_val,
+        window_left=window_left,
+    )
+    assert config.step_kv > 0
+    assert config.num_sm_parts > 0
+
+    max_descs = batch_size + config.num_sm_parts
+    work_descriptors = torch.zeros(
+        max_descs * 4, dtype=torch.int32, device=GPU_DEVICE
+    )
+    work_descriptor_offsets = torch.zeros(
+        config.num_sm_parts + 1, dtype=torch.int32, device=GPU_DEVICE
+    )
+
+    attention_window_size = window_left + 1 if window_left >= 0 else 0
+    trtllm_compute_precomputed_metadata(
+        seq_lens_cpu=seq_lens.to(torch.int32),
+        work_descriptors_out=work_descriptors,
+        work_descriptor_offsets_out=work_descriptor_offsets,
+        batch_size=batch_size,
+        block_size_n=config.step_kv,
+        num_sm_parts=config.num_sm_parts,
+        attention_window_size=attention_window_size,
+        tile_size_kv=config.tile_size_kv,
+    )
+
+    output = trtllm_batch_decode_with_kv_cache(
+        q.contiguous(),
+        kv_cache_arg,
+        workspace_buffer,
+        page_table_kernel,
+        seq_lens.to(GPU_DEVICE),
+        max_seq_len_val,
+        bmm1_scale,
+        bmm2_scale,
+        window_left,
+        out=out,
+        out_dtype=out_dtype,
+        o_sf_scale=o_sf_scale,
+        o_sf_vec_size=o_sf_vec_size,
+        kv_layout=kv_layout,
+        backend="trtllm-gen",
+        o_scale=o_scale,
+        kv_block_scales=kv_block_scales_kernel,
+        precomputed_work_descriptors=work_descriptors,
+        precomputed_work_descriptor_offsets=work_descriptor_offsets,
+    )
+    torch.cuda.synchronize()
+
+    wrapper_ref = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer_ref, kv_layout, use_tensor_cores=True
+    )
+    wrapper_ref.plan(
+        indptr=kv_indptr,
+        indices=all_page_ids,
+        last_page_len=kv_last_page_len.to(GPU_DEVICE),
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        pos_encoding_mode="NONE",
+        kv_data_type=ref_kv_cache.dtype,
+        q_data_type=ref_q.dtype,
+        window_left=window_left,
+    )
+    output_ref = wrapper_ref.run(ref_q, ref_kv_cache)
+
+    if q_dtype == "fp8" and o_dtype == "fp8":
+        rtol, atol = 5e-2, 7e-2
+    elif q_dtype == "fp8":
+        rtol, atol = 4e-2, 7e-2
+    else:
+        rtol, atol = 1e-2, 1e-2
+    allowed_mismatch_rate = 5e-5
+
+    assert_close_with_mismatch_tolerance(
+        output.float() * o_scale,
+        output_ref.float(),
+        rtol=rtol,
+        atol=atol,
+        max_mismatched_elements=int(allowed_mismatch_rate * output.numel()),
+    )
+
+
+# ---- Precomputed scheduler + speculative decode tests ----
+
+
+@pytest.mark.parametrize("kv_layout", ["HND"])
+@pytest.mark.parametrize(
+    "batch_size,max_q_len,page_size,num_kv_heads,head_grp_size",
+    [
+        (4, 2, 16, 8, 8),     # small batch, 2 draft tokens
+        (4, 3, 32, 4, 8),     # small batch, 3 draft tokens
+        (4, 5, 16, 2, 8),     # small batch, 5 draft tokens
+        (128, 2, 16, 8, 8),   # TP1: 64:8, 2 draft tokens
+        (128, 3, 32, 4, 8),   # TP2: 32:4, 3 draft tokens
+        (128, 5, 16, 8, 8),   # TP1: 64:8, 5 draft tokens
+        (128, 4, 64, 2, 8),   # TP4: 16:2, 4 draft tokens
+    ],
+)
+@pytest.mark.parametrize("window_left", [-1, 512])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    [
+        ("fp8", "fp8", "bf16"),
+    ],
+)
+@pytest.mark.parametrize("max_in_kv_len", [2048, 8192])
+@pytest.mark.parametrize("head_dim", [128])
+def test_trtllm_batch_decode_precomputed_spec(
+    kv_layout: str,
+    batch_size: int,
+    max_q_len: int,
+    page_size: int,
+    num_kv_heads: int,
+    head_grp_size: int,
+    window_left: int,
+    q_dtype: str,
+    kv_dtype: str,
+    o_dtype: str,
+    max_in_kv_len: int,
+    head_dim: int,
+):
+    """Test precomputed scheduler with speculative decoding (max_q_len > 1)."""
+    from flashinfer.decode import (
+        trtllm_batch_decode_with_kv_cache,
+        trtllm_compute_precomputed_metadata,
+        trtllm_get_kernel_config,
+    )
+
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip("trtllm-gen precomputed requires SM100/SM103 GPUs.")
+
+    num_qo_heads = num_kv_heads * head_grp_size
+    torch.manual_seed(42)
+
+    # Variable-length Q: each request has random q_len in [1, max_q_len]
+    q_lens, in_kv_lens, seq_lens = generate_seq_lens_decode(
+        batch_size, None, max_in_kv_len, max_q_len
+    )
+
+    q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
+    q_indptr = generate_cumsum_lens(q_lens)
+
+    kv_cache, k_scale, v_scale, ref_kv_cache, kv_block_scales = create_kv_cache(
+        batch_size,
+        seq_lens,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_dtype,
+        "bf16" if q_dtype == "fp8" else q_dtype,
+        kv_layout,
+    )
+    page_table, all_page_ids, page_per_seq = create_page_table(
+        batch_size, seq_lens, page_size
+    )
+    kv_indptr = generate_cumsum_lens(page_per_seq)
+    kv_last_page_len = get_last_page_len(seq_lens, page_size)
+    kv_cache_arg, page_table_kernel, kv_block_scales_kernel = prepare_paged_kv_for_kernel(
+        kv_cache, page_table, True, kv_block_scales
+    )
+
+    workspace_buffer, workspace_buffer_ref = create_workspace_buffers(GPU_DEVICE)
+
+    create_out_tensor = flip_coin(
+        batch_size, page_size, num_kv_heads, head_grp_size, o_dtype
+    )
+    can_infer_type = q.dtype == DTYPE_MAP[o_dtype] or create_out_tensor
+    create_out_dtype = not can_infer_type or flip_coin(
+        batch_size, page_size, num_kv_heads, head_grp_size, o_dtype, q_dtype
+    )
+    out, out_dtype, o_scale, o_sf_scale, o_sf_vec_size = create_output(
+        q, o_dtype, create_out_tensor, create_out_dtype
+    )
+
+    sm_scale = float(1.0 / (head_dim**0.5))
+    bmm1_scale = q_scale * k_scale * sm_scale
+    bmm2_scale = v_scale / o_scale
+    if isinstance(bmm1_scale, torch.Tensor):
+        bmm1_scale = bmm1_scale.item()
+    if isinstance(bmm2_scale, torch.Tensor):
+        bmm2_scale = bmm2_scale.item()
+
+    max_seq_len_val = torch.max(seq_lens).item()
+    sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+
+    config = trtllm_get_kernel_config(
+        q_dtype=DTYPE_MAP[q_dtype],
+        kv_dtype=DTYPE_MAP[kv_dtype],
+        o_dtype=DTYPE_MAP[o_dtype],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        page_size=page_size,
+        sm_count=sm_count,
+        batch_size=batch_size,
+        max_seq_len=max_seq_len_val,
+        max_q_len=max_q_len,
+        window_left=window_left,
+    )
+    assert config.step_kv > 0
+    assert config.num_sm_parts > 0
+
+    max_descs = batch_size + config.num_sm_parts
+    work_descriptors = torch.zeros(
+        max_descs * 4, dtype=torch.int32, device=GPU_DEVICE
+    )
+    work_descriptor_offsets = torch.zeros(
+        config.num_sm_parts + 1, dtype=torch.int32, device=GPU_DEVICE
+    )
+
+    attention_window_size = window_left + 1 if window_left >= 0 else 0
+    trtllm_compute_precomputed_metadata(
+        seq_lens_cpu=seq_lens.to(torch.int32),
+        work_descriptors_out=work_descriptors,
+        work_descriptor_offsets_out=work_descriptor_offsets,
+        batch_size=batch_size,
+        block_size_n=config.step_kv,
+        num_sm_parts=config.num_sm_parts,
+        attention_window_size=attention_window_size,
+        tile_size_kv=config.tile_size_kv,
+    )
+
+    output = trtllm_batch_decode_with_kv_cache(
+        q.contiguous(),
+        kv_cache_arg,
+        workspace_buffer,
+        page_table_kernel,
+        seq_lens.to(GPU_DEVICE),
+        max_seq_len_val,
+        bmm1_scale,
+        bmm2_scale,
+        window_left,
+        out=out,
+        out_dtype=out_dtype,
+        o_sf_scale=o_sf_scale,
+        o_sf_vec_size=o_sf_vec_size,
+        kv_layout=kv_layout,
+        backend="trtllm-gen",
+        o_scale=o_scale,
+        kv_block_scales=kv_block_scales_kernel,
+        q_len_per_req=None,
+        max_q_len=max_q_len,
+        cum_seq_lens_q=q_indptr,
+        precomputed_work_descriptors=work_descriptors,
+        precomputed_work_descriptor_offsets=work_descriptor_offsets,
+    )
+    torch.cuda.synchronize()
+
+    # Diagnostic: run non-precomputed (static) trtllm-gen for comparison.
+    workspace_buffer_np = torch.zeros(workspace_size, dtype=torch.int8, device=GPU_DEVICE)
+    out_np = torch.empty_like(output)
+    trtllm_batch_decode_with_kv_cache(
+        q.contiguous(),
+        kv_cache_arg,
+        workspace_buffer_np,
+        page_table_kernel,
+        seq_lens.to(GPU_DEVICE),
+        max_seq_len_val,
+        bmm1_scale,
+        bmm2_scale,
+        window_left,
+        out=out_np,
+        out_dtype=out_dtype,
+        o_sf_scale=o_sf_scale,
+        o_sf_vec_size=o_sf_vec_size,
+        kv_layout=kv_layout,
+        backend="trtllm-gen",
+        o_scale=o_scale,
+        kv_block_scales=kv_block_scales_kernel,
+        q_len_per_req=None,
+        max_q_len=max_q_len,
+        cum_seq_lens_q=q_indptr,
+    )
+    torch.cuda.synchronize()
+
+    # Compare precomputed vs non-precomputed trtllm-gen outputs.
+    np_diff = (output.float() - out_np.float()).abs()
+    print(f"\n[DIAG] Config: bs={batch_size} max_q_len={max_q_len} nq={num_qo_heads} "
+          f"nkv={num_kv_heads} page={page_size} max_kv={max_seq_len_val} win={window_left}")
+    print(f"[DIAG] getConfig: step_kv={config.step_kv} num_sm_parts={config.num_sm_parts} "
+          f"tile_kv={config.tile_size_kv} tile_q={config.tile_size_q}")
+    print(f"[DIAG] Precomputed vs non-precomputed: max_diff={np_diff.max():.6f} "
+          f"mean_diff={np_diff.mean():.6f}")
+    # Per-request breakdown — show ALL bad requests
+    q_indptr_cpu = q_indptr.cpu()
+    bad_reqs = []
+    for i in range(batch_size):
+        s, e = q_indptr_cpu[i].item(), q_indptr_cpu[i + 1].item()
+        req_diff = np_diff[s:e].max().item()
+        if req_diff > 0.1:
+            nblocks = (seq_lens[i].item() + config.step_kv - 1) // config.step_kv
+            bad_reqs.append((i, e - s, seq_lens[i].item(), req_diff, nblocks))
+    print(f"[DIAG] Bad requests (diff>0.1): {len(bad_reqs)} / {batch_size}")
+    for i, qlen, kvlen, diff, nblk in bad_reqs[:20]:
+        print(f"[DIAG]   req[{i}]: q_len={qlen}, kv_len={kvlen}, nblocks={nblk}, max_diff={diff:.4f}")
+    # Check work descriptor offsets to see partition assignment
+    wd_offsets = work_descriptor_offsets.cpu().tolist()
+    print(f"[DIAG] Work descriptor offsets: {wd_offsets[:min(20, len(wd_offsets))]}")
+
+    # Reference: use prefill wrapper for spec decode (variable Q lengths)
+    wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer_ref, kv_layout
+    )
+    wrapper_ref.plan(
+        qo_indptr=q_indptr,
+        paged_kv_indptr=kv_indptr,
+        paged_kv_indices=all_page_ids,
+        paged_kv_last_page_len=kv_last_page_len.to(GPU_DEVICE),
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        page_size=page_size,
+        pos_encoding_mode="NONE",
+        kv_data_type=ref_kv_cache.dtype,
+        q_data_type=ref_q.dtype,
+        window_left=window_left,
+        causal=True,
+        logits_soft_cap=0.0,
+    )
+    output_ref = wrapper_ref.run(ref_q, ref_kv_cache)
+
+    if q_dtype == "fp8" and o_dtype == "fp8":
+        rtol, atol = 5e-2, 7e-2
+    elif q_dtype == "fp8":
+        rtol, atol = 4e-2, 7e-2
+    else:
+        rtol, atol = 1e-2, 1e-2
+    # Relax tolerance for spec decode (same as existing test_trtllm_batch_decode_spec)
+    rtol, atol = rtol * 2, atol * 2
+    allowed_mismatch_rate = 5e-5
+
+    # Also show non-precomputed vs reference diff for comparison
+    np_ref_diff = (out_np.float() * o_scale - output_ref.float()).abs()
+    precomp_ref_diff = (output.float() * o_scale - output_ref.float()).abs()
+    print(f"[DIAG] Non-precomputed vs reference: max_diff={np_ref_diff.max():.4f} "
+          f"mean_diff={np_ref_diff.mean():.6f}")
+    print(f"[DIAG] Precomputed vs reference: max_diff={precomp_ref_diff.max():.4f} "
+          f"mean_diff={precomp_ref_diff.mean():.6f}")
+
+    assert_close_with_mismatch_tolerance(
+        output.float() * o_scale,
+        output_ref.float(),
+        rtol=rtol,
+        atol=atol,
+        max_mismatched_elements=int(allowed_mismatch_rate * output.numel()),
+    )
+
+
+def test_trtllm_get_kernel_config():
+    """Test that getConfig returns valid kernel metadata."""
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip("trtllm-gen requires SM100/SM103 GPUs.")
+
+    from flashinfer.decode import trtllm_get_kernel_config
+
+    sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+
+    # Standard decode (max_q_len=1)
+    config = trtllm_get_kernel_config(
+        q_dtype=torch.float8_e4m3fn,
+        kv_dtype=torch.float8_e4m3fn,
+        o_dtype=torch.bfloat16,
+        num_qo_heads=64,
+        num_kv_heads=8,
+        head_dim_qk=128,
+        head_dim_vo=128,
+        page_size=16,
+        sm_count=sm_count,
+        batch_size=256,
+        max_seq_len=4096,
+    )
+    assert config.tile_size_kv in (64, 128)
+    assert config.step_kv > 0
+    assert config.tile_size_q > 0
+    assert config.num_sm_parts > 0
+    assert config.num_sm_parts <= sm_count
+
+    # Speculative decode (max_q_len=5): numSmParts should be <= standard decode
+    # because more CTAs per Q means fewer partitions.
+    config_spec = trtllm_get_kernel_config(
+        q_dtype=torch.float8_e4m3fn,
+        kv_dtype=torch.float8_e4m3fn,
+        o_dtype=torch.bfloat16,
+        num_qo_heads=64,
+        num_kv_heads=8,
+        head_dim_qk=128,
+        head_dim_vo=128,
+        page_size=16,
+        sm_count=sm_count,
+        batch_size=256,
+        max_seq_len=4096,
+        max_q_len=5,
+    )
+    assert config_spec.step_kv > 0
+    assert config_spec.num_sm_parts > 0
+    assert config_spec.num_sm_parts <= config.num_sm_parts
+
+    # Sliding window (window_left=512)
+    config_win = trtllm_get_kernel_config(
+        q_dtype=torch.float8_e4m3fn,
+        kv_dtype=torch.float8_e4m3fn,
+        o_dtype=torch.bfloat16,
+        num_qo_heads=64,
+        num_kv_heads=8,
+        head_dim_qk=128,
+        head_dim_vo=128,
+        page_size=16,
+        sm_count=sm_count,
+        batch_size=256,
+        max_seq_len=4096,
+        window_left=512,
+    )
+    assert config_win.step_kv > 0
+    assert config_win.num_sm_parts > 0


### PR DESCRIPTION
## Description

Add precomputed tile scheduler support for the TRT-LLM generation FMHA kernel (`trtllm_paged_attention_decode`).

### What's included

- **CPU metadata generator** (`csrc/trtllm_precomputed_sched.cu`): Takes host-side `seq_lens` directly (no D2H copy). Generates work descriptors + per-SM offsets using a two-tier assignment strategy (batch-even for small workloads, block-even for large).
- **C++ launcher extension** (`csrc/trtllm_fmha_kernel_launcher.cu`, `include/flashinfer/trtllm/fmha/`): Passes precomputed work descriptors and split counter through to the kernel. Partial O/stats buffer layout for split-combine.
- **Python API** (`flashinfer/decode.py`):
  - `trtllm_get_kernel_config(...)` → returns `KernelConfig(step_kv, tile_size_kv, num_sm_parts)` needed for metadata computation
  - `trtllm_compute_precomputed_metadata(...)` → CPU-side work descriptor generation
  - `trtllm_batch_decode_with_kv_cache(...)` now accepts optional `precomputed_work_descriptors` / `precomputed_work_descriptor_offsets`
- **Tests** (`tests/attention/test_trtllm_gen_attention.py`): new tests covering:
  - Standard decode (`max_q_len=1`) with precomputed vs persistent baseline
  - Speculative decode (`max_q_len=2,5`) with various TP configs (GQA 8:1, 16:2, 32:4, 64:8)
  - Split correctness for long sequences (16K+ tokens)
  - Sliding window attention + precomputed
  - `KeepsMmaAb` and `SwapsMmaAb` kernel types

### Key design decisions

- **Split-combine**: Long sequences are split across multiple SMs. Each split stores partial O (in fp16 for precision) + softmax stats to a scratch buffer; the last CTA to finish combines all partials.
- **CUDA graph compatible**: Work descriptors and offsets are pre-allocated GPU tensors updated each step — the kernel launch itself is graph-capturable.

## 🔍 Related Issues

N/A — internal performance feature for TRT-LLM FMHA decode path.

## 🚀 Pull Request Checklist

- [x] I have installed pre-commit by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- Tests have been added: `test_trtllm_batch_decode_precomputed`, `test_trtllm_batch_decode_precomputed_spec`
- All tests are passing

## Reviewer Notes

- The precomputed metadata format (work descriptors, offsets) matches TRT-LLM's `FmhaPrecomputedSched` exactly — this is ABI-critical for cubin compatibility.
- `kernelParams.h` partial buffer layout: stats buffer is `[maxTotalSplits, numCtasQ, numHeadsKv, stepQ]` of `float2`, partial O follows immediately after in the workspace.