### PR TITLE
docs: document MAX_JOBS env var and its interaction with FLASHINFER_N…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,6 @@ export FLASHINFER_NVCC_THREADS=4              # Threads per nvcc process (--thre
 export MAX_JOBS=4                             # Parallel ninja jobs (nvcc processes)
 export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"  # Target architectures
 # Memory note: total compilation memory ≈ MAX_JOBS × FLASHINFER_NVCC_THREADS × per-thread mem.
-# For modules with many variants (e.g. GDN prefill: 64 .cu files), cap both to avoid OOM.
 
 # Behavior
 export FLASHINFER_WORKSPACE_BASE="/scratch"   # Custom cache directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Enable debug build | `export FLASHINFER_JIT_DEBUG=1` |
 | Set target architectures | `export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"` |
 | Set parallel compilation | `export FLASHINFER_NVCC_THREADS=4` |
+| Limit parallel ninja jobs | `export MAX_JOBS=4` |
 
 ## Quick Start for Development
 
@@ -440,8 +441,11 @@ cat ~/.cache/flashinfer/0.6.0/*/cached_ops/*/build.ninja
 
 ```bash
 # Compilation
-export FLASHINFER_NVCC_THREADS=4              # Parallel compilation
+export FLASHINFER_NVCC_THREADS=4              # Threads per nvcc process (--threads=N)
+export MAX_JOBS=4                             # Parallel ninja jobs (nvcc processes)
 export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"  # Target architectures
+# Memory note: total compilation memory ≈ MAX_JOBS × FLASHINFER_NVCC_THREADS × per-thread mem.
+# For modules with many variants (e.g. GDN prefill: 64 .cu files), cap both to avoid OOM.
 
 # Behavior
 export FLASHINFER_WORKSPACE_BASE="/scratch"   # Custom cache directory


### PR DESCRIPTION
…VCC_THREADS

Add MAX_JOBS to the Quick Reference table and Environment Variables section. Document that total compilation memory pressure is MAX_JOBS × FLASHINFER_NVCC_THREADS, and both should be capped for modules with many kernel variants (e.g. GDN prefill: 64 .cu files) to avoid OOM on memory-constrained CI machines.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new `MAX_JOBS` environment variable to control parallel job execution during compilation, enabling build performance optimization.
  * Clarified existing configuration parameter behavior and added guidance on how compilation memory requirements scale with configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->