### PR TITLE
fix: skip version check for editable/source installs (0.0.0+unknown)

### DIFF
--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -69,8 +69,11 @@ def _get_cubin_dir():
 
         flashinfer_cubin_version = flashinfer_cubin.__version__
         # Allow bypassing version check with environment variable
+        # NOTE(yiyang): skip version check for editable/source installs where
+        # flashinfer_version falls back to "0.0.0+unknown" (no _build_meta.py).
         if (
             not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
+            and flashinfer_version != "0.0.0+unknown"
             and flashinfer_version != flashinfer_cubin_version
         ):
             raise RuntimeError(
@@ -108,9 +111,11 @@ def _get_aot_dir():
         # NOTE(Zihao): we don't use exact version match here because the version of flashinfer-jit-cache
         # contains the CUDA version suffix: e.g. 0.3.1+cu129.
         # Allow bypassing version check with environment variable
-        if not os.getenv(
-            "FLASHINFER_DISABLE_VERSION_CHECK"
-        ) and not flashinfer_jit_cache_version.startswith(flashinfer_version):
+        if (
+            not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
+            and flashinfer_version != "0.0.0+unknown"
+            and not flashinfer_jit_cache_version.startswith(flashinfer_version)
+        ):
             raise RuntimeError(
                 f"flashinfer-jit-cache version ({flashinfer_jit_cache_version}) does not match "
                 f"flashinfer version ({flashinfer_version}). "


### PR DESCRIPTION
## 📌 Description

The version check in `flashinfer/jit/env.py` raises `RuntimeError` when `flashinfer.__version__` is `"0.0.0+unknown"` (editable/source installs without `_build_meta.py`). This breaks any subprocess that imports flashinfer in CI nightly builds where `flashinfer-cubin` is a versioned package.

Skip the version check when the local version is the unknown fallback, matching the existing `FLASHINFER_DISABLE_VERSION_CHECK` escape hatch behavior.

Closes #3044

### Root Cause

`flashinfer/version.py` falls back to `"0.0.0+unknown"` when `_build_meta.py` is missing (editable/source installs). The strict equality check in `_get_cubin_dir()` (line 74) compares this against the cubin package's real version (e.g., `"0.6.7.dev20260411"`), which will never match. The `_get_aot_dir()` function has the same issue with its `startswith()` check.

### Fix

Add an inline guard `flashinfer_version != "0.0.0+unknown"` to both version checks in `_get_cubin_dir()` and `_get_aot_dir()`, so dev/editable installs skip the check automatically:

**`_get_cubin_dir()`:**
```python
if (
    not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
    and flashinfer_version != "0.0.0+unknown"
    and flashinfer_version != flashinfer_cubin_version
):
```

**`_get_aot_dir()`:**
```python
if (
    not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
    and flashinfer_version != "0.0.0+unknown"
    and not flashinfer_jit_cache_version.startswith(flashinfer_version)
):
```

### Known Limitation

`flashinfer-cubin` uses `"0.0.0"` (not `"0.0.0+unknown"`) as its dev fallback. The reverse scenario (release flashinfer + dev cubin without `version.txt`) is not guarded, but is practically unreachable since `version.txt` is always present in the source tree.

## 🔍 Related Issues

- #3044 (this fix)
- #2857 (introduced the subprocess test that surfaced this)
- #1872 (added the version check infrastructure)

## 🧪 Tests

- Existing `test_single_decode_torch_compile_cuda_graph` will pass in editable-install CI environments once this fix is applied (the test was the original reporter of this bug)
- Pre-commit hooks all pass (ruff check, ruff format, mypy, clang-format, etc.)

## Reviewer Notes

@yzh119 — This is the same file you touched in #1872. The fix adds a guard for the `"0.0.0+unknown"` fallback that `version.py` produces for editable installs, consistent with the existing `FLASHINFER_DISABLE_VERSION_CHECK` env var bypass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version validation behavior to gracefully handle development builds where version information is unavailable, preventing unnecessary validation errors while maintaining strict version checking for production builds when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->