### PR TITLE
support returning lse for trtllm-gen backend attention

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -77,12 +77,12 @@ void trtllm_paged_attention_launcher(
     void* out, void* out_scale_factor, void* query, void* key_cache, void* value_cache,
     void* workspace_buffer, int* block_tables, const void* k_block_scales_ptr,
     const void* v_block_scales_ptr, int* seq_lens, int* cum_seq_lens_q, int* cum_seq_lens_kv,
-    float* attention_sinks, Data_type q_data_type, Data_type kv_data_type, Data_type o_data_type,
-    TllmPagedAttentionMode mode, int64_t batch_size, int64_t max_q_len, int64_t max_kv_len,
-    int64_t num_pages_in_mem_pool, int64_t num_qo_heads, int64_t num_kv_heads, int64_t head_dim_qk,
-    int64_t head_dim_vo, int64_t page_size, int64_t q_stride_tokens, int64_t q_stride_heads,
-    int64_t kv_stride_keys_values, int64_t kv_stride_heads, int64_t kv_stride_batch,
-    int64_t max_num_blocks_per_seq, double bmm1_scale, double bmm2_scale,
+    float* attention_sinks, float* lse, Data_type q_data_type, Data_type kv_data_type,
+    Data_type o_data_type, TllmPagedAttentionMode mode, int64_t batch_size, int64_t max_q_len,
+    int64_t max_kv_len, int64_t num_pages_in_mem_pool, int64_t num_qo_heads, int64_t num_kv_heads,
+    int64_t head_dim_qk, int64_t head_dim_vo, int64_t page_size, int64_t q_stride_tokens,
+    int64_t q_stride_heads, int64_t kv_stride_keys_values, int64_t kv_stride_heads,
+    int64_t kv_stride_batch, int64_t max_num_blocks_per_seq, double bmm1_scale, double bmm2_scale,
     const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
     int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t window_left, int64_t sum_seq_q,
     int64_t sparse_mla_top_k, float skip_softmax_threshold_scale_factor, bool skips_softmax,
@@ -153,6 +153,7 @@ void trtllm_paged_attention_launcher(
   runner_params.mSumOfSeqLensQ = sum_seq_q;
   runner_params.mUsesSharedPagedKvIdx = uses_shared_paged_kv_idx;
   runner_params.ptrAttentionSinks = attention_sinks;
+  runner_params.lsePtr = lse;
   runner_params.enable_pdl = enable_pdl;
 
   // The sparse MLA parameters.
@@ -171,6 +172,13 @@ void trtllm_paged_attention_launcher(
 
     runner_params.cumSeqLensQPtr = cum_seq_lens_q;
     runner_params.cumSeqLensKvPtr = cum_seq_lens_kv;
+
+    // Context mode uses single-CTA persistent scheduling (mMultiCtasKvMode=false),
+    // so counter/scratch are not needed. Only allocate softmaxStatsPtr for LSE.
+    if (lse != nullptr) {
+      runner_params.softmaxStatsPtr = float_allocator.aligned_alloc<float2>(
+          sizeof(float2) * num_qo_heads * sum_seq_q, 16, "trtllm_gen_softmax_workspace");
+    }
   } else {
     // Generation.
     // Note that kernel names are still labeled as using a dense mask even when maskType is
@@ -190,10 +198,13 @@ void trtllm_paged_attention_launcher(
     size_t max_num_qo_heads = 256;  // todo(Yingyi): get from dlfw, in total 8MB
     size_t num_semaphores =
         round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-    // semaphores be at the first 8MB of workspace buffer: counter | scratch
-    // todo(Yingyi): add softmax buffer later for lse return
+    // semaphores: counter | softmax (if lse) | scratch
     runner_params.multiCtasKvCounterPtr = float_allocator.aligned_alloc<int32_t>(
         num_semaphores * sizeof(uint32_t), 16, "trtllm_gen_counter_workspace");
+    if (lse != nullptr) {
+      runner_params.softmaxStatsPtr = float_allocator.aligned_alloc<float2>(
+          sizeof(float2) * num_qo_heads * sum_seq_q, 16, "trtllm_gen_softmax_workspace");
+    }
     // scratch takes the rest of the workspace buffer
     runner_params.multiCtasKvScratchPtr =
         float_allocator.aligned_alloc<void>(0, 16, "trtllm_gen_scratch_workspace");
@@ -244,7 +255,7 @@ void trtllm_paged_attention_decode(
     int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> cum_seq_lens_q, Optional<TensorView> key_block_scales,
     Optional<TensorView> value_block_scales, Optional<float> skip_softmax_threshold_scale_factor,
-    Optional<bool> uses_shared_paged_kv_idx) {
+    Optional<bool> uses_shared_paged_kv_idx, Optional<TensorView> lse) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
@@ -327,6 +338,7 @@ void trtllm_paged_attention_decode(
         << "attention_sinks must be a float tensor";
     attention_sinks_ptr = static_cast<float*>(attention_sinks.value().data_ptr());
   }
+  float* lse_ptr = lse.has_value() ? static_cast<float*>(lse.value().data_ptr()) : nullptr;
   auto maybe_bmm1_scale_value = bmm1_scale.as<double>();
   auto maybe_bmm2_scale_value = bmm2_scale.as<double>();
   auto maybe_bmm1_scale_log2_tensor = bmm1_scale.as<ffi::Tensor>();
@@ -356,10 +368,10 @@ void trtllm_paged_attention_decode(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr,
       v_block_scales_ptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
-      /*cum_seq_lens_kv*/ nullptr, attention_sinks_ptr, q_data_type, kv_data_type, o_data_type,
-      TllmPagedAttentionMode::ForGen, batch_size, max_q_len, max_kv_len, num_pages_in_mem_pool,
-      num_qo_heads, num_kv_heads, head_dim_q, head_dim_o, page_size, q_stride_tokens,
-      q_stride_heads, kv_stride_keys_values, kv_stride_heads, kv_stride_batch,
+      /*cum_seq_lens_kv*/ nullptr, attention_sinks_ptr, lse_ptr, q_data_type, kv_data_type,
+      o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len, max_kv_len,
+      num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q, head_dim_o, page_size,
+      q_stride_tokens, q_stride_heads, kv_stride_keys_values, kv_stride_heads, kv_stride_batch,
       max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr,
       bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
       sparse_mla_top_k, skip_softmax_threshold_scale_factor_value, skips_softmax,
@@ -376,7 +388,8 @@ void trtllm_paged_attention_context(
     int64_t window_left, TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv, int64_t sm_count,
     bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> key_block_scales, Optional<TensorView> value_block_scales,
-    Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx) {
+    Optional<float> skip_softmax_threshold_scale_factor, Optional<bool> uses_shared_paged_kv_idx,
+    Optional<TensorView> lse) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
@@ -448,6 +461,7 @@ void trtllm_paged_attention_context(
         << "attention_sinks must be a float tensor";
     attention_sinks_ptr = static_cast<float*>(attention_sinks.value().data_ptr());
   }
+  float* lse_ptr = lse.has_value() ? static_cast<float*>(lse.value().data_ptr()) : nullptr;
 
   auto maybe_bmm1_scale_value = bmm1_scale.as<double>();
   auto maybe_bmm2_scale_value = bmm2_scale.as<double>();
@@ -480,7 +494,7 @@ void trtllm_paged_attention_context(
       v_block_scales_ptr, static_cast<int*>(seq_lens.data_ptr()),
       /*cum_seq_lens_q=*/static_cast<int*>(cum_seq_lens_q.data_ptr()),
       /*cum_seq_lens_kv=*/static_cast<int*>(cum_seq_lens_kv.data_ptr()), attention_sinks_ptr,
-      q_data_type, kv_data_type, o_data_type, TllmPagedAttentionMode::Context, batch_size,
+      lse_ptr, q_data_type, kv_data_type, o_data_type, TllmPagedAttentionMode::Context, batch_size,
       max_q_len, max_kv_len, num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q,
       head_dim_o, page_size, q_stride_tokens, q_stride_heads, kv_stride_keys_values,
       kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2031,6 +2031,7 @@ class TrtllmGenDecodeModule:
         window_left: int = -1,
         enable_pdl: bool = None,
         out: Optional[torch.Tensor] = None,
+        lse: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         key_block_scales: Optional[torch.Tensor] = None,
         value_block_scales: Optional[torch.Tensor] = None,
@@ -2081,6 +2082,7 @@ class TrtllmGenDecodeModule:
             value_block_scales,
             skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx,
+            lse,
         )
         return out
 
@@ -2147,7 +2149,6 @@ def get_trtllm_gen_decode_module(*args):
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
     ) -> None:
-        assert maybe_lse is None
         assert paged_kv_cache is not None
         assert num_qo_heads is not None
         assert num_kv_heads is not None
@@ -2171,6 +2172,7 @@ def get_trtllm_gen_decode_module(*args):
             window_left,
             enable_pdl,
             out=o,
+            lse=maybe_lse,
             sinks=sinks,
             key_block_scales=key_block_scales,
             value_block_scales=value_block_scales,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -264,6 +264,7 @@ def get_trtllm_gen_prefill_module():
         workspace_size: int,
         window_left: int = -1,
         out: Optional[torch.Tensor] = None,
+        lse: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         key_block_scales: Optional[torch.Tensor] = None,
         value_block_scales: Optional[torch.Tensor] = None,
@@ -306,6 +307,7 @@ def get_trtllm_gen_prefill_module():
             value_block_scales,
             skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx,
+            lse,
         )
         return out
 
@@ -679,7 +681,6 @@ def get_batch_prefill_module(backend, *args):
         uses_shared_paged_kv_idx: bool = True,
     ) -> None:
         if backend == "trtllm-gen":
-            assert maybe_lse is None
             assert num_qo_heads is not None
             assert num_kv_heads is not None
             assert block_tables is not None
@@ -709,6 +710,7 @@ def get_batch_prefill_module(backend, *args):
                 workspace_size,
                 window_left,
                 out=o,
+                lse=maybe_lse,
                 sinks=sinks,
                 key_block_scales=key_block_scales,
                 value_block_scales=value_block_scales,

--- a/tests/attention/test_decode_prefill_lse.py
+++ b/tests/attention/test_decode_prefill_lse.py
@@ -14,9 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import pytest
 import torch
 
 import flashinfer
+from flashinfer.utils import get_compute_capability
+from flashinfer.quantization.fp4_quantization import nvfp4_quantize_paged_kv_cache
+from tests.utils_fp8 import to_float8
 
 
 def test_mlc_failed_case():
@@ -69,6 +73,199 @@ def test_mlc_failed_case():
 
     torch.testing.assert_close(lse_1, lse_1_tc, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(o_1, o_1_tc, rtol=1e-3, atol=1e-3)
+
+
+# ── trtllm-gen: return_lse for paged decode + prefill ───────────────
+# Reference: BF16 FA2 backend (return_lse always worked).
+# Covers all Q/KV/O dtype combos supported by trtllm-gen cubins.
+
+FP8 = torch.float8_e4m3fn
+_DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp8": FP8}
+
+# (q_dtype, kv_dtype, o_dtype) from trtllm-gen cubins
+_DECODE_DTYPES = [
+    ("bf16", "bf16", "bf16"),
+    ("fp16", "fp16", "fp16"),
+    ("bf16", "fp8", "bf16"),
+    ("fp16", "fp8", "fp16"),
+    ("fp8", "fp8", "bf16"),
+    ("fp8", "fp8", "fp16"),
+    ("fp8", "fp8", "fp8"),
+    ("fp8", "nvfp4", "fp8"),
+]
+_PREFILL_DTYPES = [
+    ("bf16", "bf16", "bf16"),
+    ("fp16", "fp16", "fp16"),
+    ("fp8", "fp8", "bf16"),
+    ("fp8", "fp8", "fp16"),
+    ("fp8", "fp8", "fp8"),
+    ("fp8", "nvfp4", "fp8"),
+]
+
+
+def _quantize(q_bf16, k_bf16, v_bf16, q_dtype, kv_dtype):
+    """Quantize Q/K/V and return (q, kv, run_kwargs)."""
+    if q_dtype == "fp8":
+        q, q_s = to_float8(q_bf16)
+        q_s = q_s.item()
+    else:
+        q, q_s = q_bf16.to(_DTYPES[q_dtype]), 1.0
+
+    if kv_dtype == "nvfp4":
+        kv, sf, k_s, v_s = nvfp4_quantize_paged_kv_cache(
+            k_bf16, v_bf16, kv_layout="HND"
+        )
+    elif kv_dtype == "fp8":
+        k, k_s = to_float8(k_bf16)
+        v, v_s = to_float8(v_bf16)
+        kv, sf = (k, v), None
+        k_s, v_s = k_s.item(), v_s.item()
+    else:
+        dt = _DTYPES[kv_dtype]
+        kv, k_s, v_s, sf = (k_bf16.to(dt), v_bf16.to(dt)), 1.0, 1.0, None
+
+    kw = {"q_scale": q_s, "k_scale": k_s, "v_scale": v_s}
+    if sf is not None:
+        kw["kv_cache_sf"] = sf
+    return q, kv, kw
+
+
+def _test_trtllm_return_lse(mode, q_dtype, kv_dtype, o_dtype):
+    cc = get_compute_capability(torch.device("cuda"))
+    if cc[0] < 10:
+        pytest.skip("trtllm-gen requires SM100+")
+
+    B, Hq, Hkv, D = 4, 32, 8, 128
+    page_size = 64 if kv_dtype == "nvfp4" else 16
+    kv_len, qo_len = 256, (1 if mode == "decode" else 16)
+    device = "cuda"
+    npps = (kv_len + page_size - 1) // page_size
+    total_pages = npps * B
+    # decode q: [B, Hq, D], prefill q: [B * qo_len, Hq, D]
+    q_shape = (B, Hq, D) if mode == "decode" else (B * qo_len, Hq, D)
+    q_bf16 = torch.randn(*q_shape, dtype=torch.bfloat16, device=device)
+    k_bf16 = torch.randn(
+        total_pages, Hkv, page_size, D, dtype=torch.bfloat16, device=device
+    )
+    v_bf16 = torch.randn(
+        total_pages, Hkv, page_size, D, dtype=torch.bfloat16, device=device
+    )
+
+    kv_indptr = torch.arange(B + 1, dtype=torch.int32, device=device) * npps
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full((B,), page_size, dtype=torch.int32, device=device)
+    qo_indptr = torch.arange(B + 1, dtype=torch.int32, device=device) * qo_len
+
+    ws = lambda: torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+    kv_plan_dtype = torch.uint8 if kv_dtype == "nvfp4" else _DTYPES[kv_dtype]
+
+    if mode == "decode":
+        # Reference: BF16 FA2
+        ref = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            ws(), "HND", use_tensor_cores=True
+        )
+        ref.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            Hq,
+            Hkv,
+            D,
+            page_size,
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+        ref_o, ref_lse = ref.run(q_bf16, (k_bf16, v_bf16), return_lse=True)
+
+        # Test: trtllm-gen
+        q, kv, run_kw = _quantize(q_bf16, k_bf16, v_bf16, q_dtype, kv_dtype)
+        test = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            ws(), "HND", backend="trtllm-gen"
+        )
+        test.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            Hq,
+            Hkv,
+            D,
+            page_size,
+            q_data_type=q.dtype,
+            kv_data_type=kv_plan_dtype,
+            o_data_type=_DTYPES[o_dtype],
+        )
+        test_o, test_lse = test.run(q, kv, return_lse=True, **run_kw)
+    else:
+        # Reference: BF16 FA2 causal
+        ref = flashinfer.BatchPrefillWithPagedKVCacheWrapper(ws(), "HND")
+        ref.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            Hq,
+            Hkv,
+            D,
+            page_size,
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+            causal=True,
+        )
+        ref_o, ref_lse = ref.run(q_bf16, (k_bf16, v_bf16), return_lse=True)
+
+        # Test: trtllm-gen
+        q, kv, run_kw = _quantize(q_bf16, k_bf16, v_bf16, q_dtype, kv_dtype)
+        test = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            ws(), "HND", backend="trtllm-gen"
+        )
+        test.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            Hq,
+            Hkv,
+            D,
+            page_size,
+            q_data_type=q.dtype,
+            kv_data_type=kv_plan_dtype,
+            o_data_type=_DTYPES[o_dtype],
+            causal=True,
+        )
+        test_o, test_lse = test.run(q, kv, return_lse=True, **run_kw)
+
+    # Assert LSE relative error < 5%
+    lse_rel = (ref_lse.float() - test_lse.float()).abs() / ref_lse.float().abs().clamp(
+        min=1e-6
+    )
+    assert lse_rel.mean().item() < 0.05, (
+        f"LSE mean_rel_err {lse_rel.mean().item():.4f} >= 0.05"
+    )
+
+    # Assert output cosine similarity > 0.95
+    cos = torch.nn.functional.cosine_similarity(
+        ref_o.float().reshape(1, -1),
+        test_o.float().reshape(1, -1),
+    ).item()
+    assert cos > 0.95, f"Output cos_sim {cos:.4f} < 0.95"
+
+
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    _DECODE_DTYPES,
+    ids=[f"{q}_{kv}_{o}" for q, kv, o in _DECODE_DTYPES],
+)
+def test_trtllm_decode_return_lse(q_dtype, kv_dtype, o_dtype):
+    _test_trtllm_return_lse("decode", q_dtype, kv_dtype, o_dtype)
+
+
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    _PREFILL_DTYPES,
+    ids=[f"{q}_{kv}_{o}" for q, kv, o in _PREFILL_DTYPES],
+)
+def test_trtllm_prefill_return_lse(q_dtype, kv_dtype, o_dtype):
+    _test_trtllm_return_lse("prefill", q_dtype, kv_dtype, o_dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

support returning lse for trtllm-gen backend attention

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for returning log-sum-exp (LSE) statistics from paged decode and prefill operations, enabling greater flexibility in attention output configurations.

* **Tests**
  * Added comprehensive test coverage validating LSE computation across FP16, BF16, and FP8 data types with reference implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->