### PR TITLE
docs: add CUDA compute capability table per quantization type

### DIFF
--- a/docs/api/fp4_quantization.rst
+++ b/docs/api/fp4_quantization.rst
@@ -5,7 +5,7 @@ flashinfer.fp4_quantization
 
 .. currentmodule:: flashinfer.fp4_quantization
 
-This module provides FP4 quantization operations for LLM inference, supporting various scale factor layouts and quantization formats.
+This module provides FP4 quantization operations for LLM inference, supporting various scale factor layouts and quantization formats. See :ref:`supported_hardware` for GPU compatibility.
 
 Core Quantization Functions
 ---------------------------
@@ -28,6 +28,11 @@ GPU-accelerated quantization and dequantization for KV cache data using a linear
 
 - :func:`nvfp4_kv_dequantize`: SM80+ (Ampere and later)
 - :func:`nvfp4_kv_quantize`: SM100+ (Blackwell and later)
+
+.. seealso::
+
+   :doc:`/supported_hardware` for a complete overview of compute capability
+   requirements across all data types.
 
 .. autosummary::
     :toctree: ../generated

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    :caption: Get Started
 
    installation
+   supported_hardware
    cli
    logging
    autotuning

--- a/docs/supported_hardware.rst
+++ b/docs/supported_hardware.rst
@@ -1,0 +1,55 @@
+.. _supported_hardware:
+
+Supported Hardware
+==================
+
+FlashInfer leverages NVIDIA Tensor Core instructions that require specific GPU
+architectures. This page summarizes the minimum compute capability required for
+each quantization data type supported by FlashInfer.
+
+.. tip::
+
+   Run ``flashinfer show-config`` to check your GPU's compute capability.
+
+Quantization Data Types
+-----------------------
+
+The table below shows the minimum compute capability at which *any* backend
+supports the given data type. Some backends may require a higher capability;
+consult the per-function API documentation for exact requirements.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 20 35
+
+   * - Data Type
+     - Min Compute Capability
+     - GPU Architecture
+     - Notes
+   * - FP8 (e4m3 / e5m2)
+     - sm_89 (8.9)
+     - Ada / Hopper+
+     - cuDNN and cuBLAS backends. CUTLASS requires sm_100+.
+   * - MXFP8
+     - sm_100 (10.0)
+     - Blackwell+
+     -
+   * - NVFP4 KV dequantize
+     - sm_80 (8.0)
+     - Ampere+
+     -
+   * - NVFP4 / MXFP4 (quantize & GEMM)
+     - sm_100 (10.0)
+     - Blackwell+
+     -
+
+.. note::
+
+   This table reflects FlashInfer's current support. The per-function API
+   documentation (e.g., :doc:`/api/fp4_quantization`) is the authoritative
+   source for each operation's hardware requirements.
+
+   For the official NVIDIA hardware specifications, see the
+   `PTX ISA Reference <https://docs.nvidia.com/cuda/parallel-thread-execution/>`_
+   and the
+   `CUDA Compute Capability list <https://developer.nvidia.com/cuda-gpus>`_.

--- a/docs/supported_hardware.rst
+++ b/docs/supported_hardware.rst
@@ -4,8 +4,9 @@ Supported Hardware
 ==================
 
 FlashInfer leverages NVIDIA Tensor Core instructions that require specific GPU
-architectures. This page summarizes the minimum compute capability required for
-each quantization data type supported by FlashInfer.
+architectures. This page provides a high-level, manually maintained summary of
+the minimum compute capability required for each quantization data type
+supported by FlashInfer.
 
 .. tip::
 
@@ -15,8 +16,9 @@ Quantization Data Types
 -----------------------
 
 The table below shows the minimum compute capability at which *any* backend
-supports the given data type. Some backends may require a higher capability;
-consult the per-function API documentation for exact requirements.
+supports the given data type. Backend coverage can still vary by operation
+(``mm`` vs ``bmm``), scale layout, and CUDA/cuDNN version; consult the
+per-function API documentation for exact requirements.
 
 .. list-table::
    :header-rows: 1
@@ -31,9 +33,11 @@ consult the per-function API documentation for exact requirements.
      - Ada / Hopper+
      - cuDNN and cuBLAS backends. CUTLASS requires sm_100+.
    * - MXFP8
-     - sm_100 (10.0)
-     - Blackwell+
-     -
+      - sm_100 (10.0)
+      - Blackwell+
+      - Support is backend-specific. MXFP8 support starts at sm_100 for GEMM on
+        Blackwell, but BMM uses cuDNN on sm_100 / sm_103 and CUTLASS on sm_120 /
+        sm_121. See :doc:`/api/gemm` for per-operation backend details.
    * - NVFP4 KV dequantize
      - sm_80 (8.0)
      - Ampere+
@@ -46,8 +50,12 @@ consult the per-function API documentation for exact requirements.
 .. note::
 
    This table reflects FlashInfer's current support. The per-function API
-   documentation (e.g., :doc:`/api/fp4_quantization`) is the authoritative
-   source for each operation's hardware requirements.
+   documentation (e.g., :doc:`/api/fp4_quantization` and :doc:`/api/gemm`) is
+   the authoritative source for each operation's hardware requirements.
+
+   Compute capability is not the only requirement. FlashInfer currently
+   supports CUDA 12.6, 12.8, 13.0, and 13.1 (see :doc:`/installation`), and
+   Blackwell FP4 / MXFP4 features require CUDA 12.8+.
 
    For the official NVIDIA hardware specifications, see the
    `PTX ISA Reference <https://docs.nvidia.com/cuda/parallel-thread-execution/>`_


### PR DESCRIPTION
## 📌 Description

Closes #2406

Adds a new **"Supported Hardware"** documentation page listing the minimum CUDA compute capability required for each quantization data type in FlashInfer.

### What's missing?

There is no documentation mapping quantization data types to their minimum required CUDA compute capability. Users have to discover at runtime which GPU they need for a given quant type (e.g., `nvfp4` requires sm_100+).

### Solution

New `docs/supported_hardware.rst` page in the "Get Started" section with:

- **Summary table** — one row per quant type showing the minimum SM at which *any* backend works:

  | Data Type | Min SM | Architecture | Notes |
  |-----------|--------|-------------|-------|
  | FP8 (e4m3 / e5m2) | sm_89 | Ada / Hopper+ | cuDNN/cuBLAS backends. CUTLASS requires sm_100+. |
  | MXFP8 | sm_100 | Blackwell+ | |
  | NVFP4 KV dequantize | sm_80 | Ampere+ | |
  | NVFP4 / MXFP4 (quantize & GEMM) | sm_100 | Blackwell+ | |

- **Note** linking to NVIDIA PTX ISA and compute capability docs, with a disclaimer that per-function API docs are the authoritative source.

- **Cross-reference** from `docs/api/fp4_quantization.rst` to the new page.

### Data sources

All SM data extracted from `@supported_compute_capability` decorators in the source code, cross-verified against NVIDIA CUTLASS documentation and PTX ISA.

### Changes

| File | Change |
|------|--------|
| `docs/supported_hardware.rst` | New page (56 lines) |
| `docs/index.rst` | +1 line in "Get Started" toctree |
| `docs/api/fp4_quantization.rst` | +6 lines cross-reference |

### Testing

- `pre-commit run` passes on all changed files
- RST syntax manually verified (list-table indentation, cross-references, labels)

cc @bkryu @aleozlx @yzh119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Supported Hardware" guide outlining minimum GPU compute capability and CUDA/version notes for quantization data types.
  * Linked hardware compatibility guidance into the main documentation navigation.
  * Added cross-references from relevant pages to the hardware requirements to clarify per-data-type and backend differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->