### PR TITLE
fix: add trtllm_prefill_with_kv_cache_mla alias for prefill discoverability

### DIFF
--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -104,6 +104,13 @@ PageAttention for MLA
 
     trtllm_batch_decode_with_kv_cache_mla
 
+.. note::
+   ``trtllm_prefill_with_kv_cache_mla`` is an alias for
+   :func:`trtllm_batch_decode_with_kv_cache_mla`. The MLA paged attention
+   kernel supports both decode (``q_len_per_request=1``) and incremental
+   prefill (``q_len_per_request>1``). The alias is also available via
+   ``flashinfer.prefill.trtllm_prefill_with_kv_cache_mla``.
+
 .. autoclass:: BatchMLAPagedAttentionWrapper
     :members:
 

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -108,8 +108,12 @@ PageAttention for MLA
    ``trtllm_prefill_with_kv_cache_mla`` is an alias for
    :func:`trtllm_batch_decode_with_kv_cache_mla`. The MLA paged attention
    kernel supports both decode (``q_len_per_request=1``) and incremental
-   prefill (``q_len_per_request>1``). The alias is also available via
-   ``flashinfer.prefill.trtllm_prefill_with_kv_cache_mla``.
+   prefill (``q_len_per_request>1``). Caveat: the ``xqa`` backend only
+   supports ``q_len_per_request=1``, so on platforms where ``backend="auto"``
+   selects ``xqa`` you must explicitly choose a non-``xqa`` backend for
+   multi-token prefill/MTP. The alias is also available via
+   ``flashinfer.prefill.trtllm_prefill_with_kv_cache_mla`` and
+   ``flashinfer.trtllm_prefill_with_kv_cache_mla``.
 
 .. autoclass:: BatchMLAPagedAttentionWrapper
     :members:

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -137,6 +137,9 @@ from .prefill import single_prefill_with_kv_cache as single_prefill_with_kv_cach
 from .prefill import (
     single_prefill_with_kv_cache_return_lse as single_prefill_with_kv_cache_return_lse,
 )
+from .prefill import (
+    trtllm_prefill_with_kv_cache_mla as trtllm_prefill_with_kv_cache_mla,
+)
 from .prefill import trtllm_fmha_v2_prefill as trtllm_fmha_v2_prefill
 from .quantization import packbits as packbits
 from .quantization import segment_packbits as segment_packbits

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -645,6 +645,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         When set to ``auto``, the backend will be chosen based on the device architecture and kernel availability.
         For sm_100 and sm_103 (blackwell architecture), ``auto`` will choose ``trtllm-gen`` backend.
         For sm_120 (blackwell architecture), ``auto`` will choose ``xqa`` backend.
+        Caveat: ``q_len_per_request > 1`` is not supported by ``xqa``. On platforms where
+        ``auto`` selects ``xqa``, multi-token prefill/MTP requests require an explicitly
+        selected non-``xqa`` backend.
     is_var_seq : bool
         Whether the sequence length is variable.
         If True, the sequence length is variable.
@@ -858,7 +861,55 @@ def trtllm_batch_decode_with_kv_cache_mla(
 
 # Alias: the MLA kernel handles both decode and incremental prefill
 # (with q_len_per_request > 1), see issue #2877.
-trtllm_prefill_with_kv_cache_mla = trtllm_batch_decode_with_kv_cache_mla
+@flashinfer_api
+def trtllm_prefill_with_kv_cache_mla(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    qk_nope_head_dim: int,  # TODO: remove in 1.0?
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_seq_len: int,
+    sparse_mla_top_k: int = 0,
+    out: Optional[torch.Tensor] = None,
+    bmm1_scale: Union[float, torch.Tensor] = 1.0,
+    bmm2_scale: Union[float, torch.Tensor] = 1.0,
+    sinks: Optional[List[torch.Tensor]] = None,
+    skip_softmax_threshold_scale_factor: Optional[float] = None,
+    enable_pdl: bool | None = None,
+    backend: str = "auto",
+    is_var_seq: bool = True,
+    uses_shared_paged_kv_idx: bool = True,
+) -> torch.Tensor:
+    """Alias for :func:`trtllm_batch_decode_with_kv_cache_mla`.
+
+    Caveat: ``q_len_per_request > 1`` is not supported by the ``xqa`` backend, so callers
+    using ``backend="auto"`` on platforms that select ``xqa`` must explicitly request a
+    non-``xqa`` backend for multi-token prefill/MTP.
+    """
+    return trtllm_batch_decode_with_kv_cache_mla.__wrapped__(  # type: ignore[attr-defined]
+        query,
+        kv_cache,
+        workspace_buffer,
+        qk_nope_head_dim,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        block_tables,
+        seq_lens,
+        max_seq_len,
+        sparse_mla_top_k=sparse_mla_top_k,
+        out=out,
+        bmm1_scale=bmm1_scale,
+        bmm2_scale=bmm2_scale,
+        sinks=sinks,
+        skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+        enable_pdl=enable_pdl,
+        backend=backend,
+        is_var_seq=is_var_seq,
+        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
 
 
 @flashinfer_api

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -613,7 +613,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
     """
     Parameters
     ----------
-    query: [batch_size, q_len_per_request, num_heads, head_dim_qk], head_dim_qk = qk_nope_head_dim (kv_lora_rank) + qk_rope_head_dim, should be concated q_nope + q_rope; q_len_per_request is the MTP query length.
+    query: [batch_size, q_len_per_request, num_heads, head_dim_qk], head_dim_qk = qk_nope_head_dim (kv_lora_rank) + qk_rope_head_dim, should be concated q_nope + q_rope; q_len_per_request is the query length per request (1 for decode, >1 for prefill/MTP).
     kv_cache: [num_pages, page_size, head_dim_ckv + head_dim_kpe] or [num_pages, 1, page_size, head_dim_ckv + head_dim_kpe], should be concated ckv_cache + kpe_cache. Both 3D and 4D formats are supported for backward compatibility.
     workspace_buffer: [num_semaphores, 4], used for multi_block mode. Must be initialized to 0 for its first use.
     qk_nope_head_dim: qk_nope_head_dim, must be 128 or 64
@@ -854,6 +854,11 @@ def trtllm_batch_decode_with_kv_cache_mla(
         )
     else:
         raise ValueError(f"Backend {backend} not supported")
+
+
+# Alias: the MLA kernel handles both decode and incremental prefill
+# (with q_len_per_request > 1), see issue #2877.
+trtllm_prefill_with_kv_cache_mla = trtllm_batch_decode_with_kv_cache_mla
 
 
 @flashinfer_api

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -23,6 +23,11 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
 import torch
 
 from .api_logging import flashinfer_api
+
+## NOTE: MLA prefill alias — see issue #2877.
+from .mla import (
+    trtllm_prefill_with_kv_cache_mla as trtllm_prefill_with_kv_cache_mla,
+)
 from .jit import (
     gen_batch_prefill_module,
     gen_customize_batch_prefill_module,

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -984,19 +984,19 @@ def test_trtllm_batch_decode_mla_preallocated_out(
 
 
 def test_trtllm_prefill_mla_alias():
-    """Verify trtllm_prefill_with_kv_cache_mla is an alias for
-    trtllm_batch_decode_with_kv_cache_mla (issue #2877)."""
+    """Verify trtllm_prefill_with_kv_cache_mla is exported on all expected paths."""
+    import flashinfer
     from flashinfer.prefill import trtllm_prefill_with_kv_cache_mla
     from flashinfer.mla import (
-        trtllm_batch_decode_with_kv_cache_mla,
         trtllm_prefill_with_kv_cache_mla as mla_prefill,
     )
 
-    # Both paths must resolve to the exact same function object
-    assert trtllm_prefill_with_kv_cache_mla is trtllm_batch_decode_with_kv_cache_mla
-    assert mla_prefill is trtllm_batch_decode_with_kv_cache_mla
+    # All alias export paths must resolve to the same callable
+    assert trtllm_prefill_with_kv_cache_mla is mla_prefill
+    assert flashinfer.trtllm_prefill_with_kv_cache_mla is mla_prefill
+    assert trtllm_prefill_with_kv_cache_mla.__name__ == "trtllm_prefill_with_kv_cache_mla"
 
-    # Also accessible via top-level decode module (backward compat)
+    # Canonical decode export remains available for backward compat
     from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla as decode_fn
 
-    assert decode_fn is trtllm_batch_decode_with_kv_cache_mla
+    assert decode_fn.__name__ == "trtllm_batch_decode_with_kv_cache_mla"

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -981,3 +981,22 @@ def test_trtllm_batch_decode_mla_preallocated_out(
     )
     assert result_pre.shape == expected_shape
     torch.testing.assert_close(result_none, result_pre, rtol=1e-3, atol=1e-3)
+
+
+def test_trtllm_prefill_mla_alias():
+    """Verify trtllm_prefill_with_kv_cache_mla is an alias for
+    trtllm_batch_decode_with_kv_cache_mla (issue #2877)."""
+    from flashinfer.prefill import trtllm_prefill_with_kv_cache_mla
+    from flashinfer.mla import (
+        trtllm_batch_decode_with_kv_cache_mla,
+        trtllm_prefill_with_kv_cache_mla as mla_prefill,
+    )
+
+    # Both paths must resolve to the exact same function object
+    assert trtllm_prefill_with_kv_cache_mla is trtllm_batch_decode_with_kv_cache_mla
+    assert mla_prefill is trtllm_batch_decode_with_kv_cache_mla
+
+    # Also accessible via top-level decode module (backward compat)
+    from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla as decode_fn
+
+    assert decode_fn is trtllm_batch_decode_with_kv_cache_mla

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -119,6 +119,26 @@ class TestAPILogging:
         finally:
             Path(log_file).unlink(missing_ok=True)
 
+    def test_level_1_alias_wrapper_uses_alias_name(self, tmp_path):
+        """Test that wrapper aliases log the alias name rather than the impl name."""
+        log_file = tmp_path / "alias-log.txt"
+        decorator = self.setup_logging(level=1, dest=str(log_file))
+
+        @decorator
+        def canonical_function(x):
+            return x + 1
+
+        @decorator
+        def alias_function(x):
+            return canonical_function.__wrapped__(x)
+
+        result = alias_function(10)
+        assert result == 11
+
+        log_contents = log_file.read_text()
+        assert "FlashInfer API Call: alias_function" in log_contents
+        assert "canonical_function" not in log_contents
+
     def test_level_3_inputs_outputs(self):
         """Test that level 3 logs inputs and outputs with metadata."""
         with tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".txt") as f:

--- a/tests/utils/test_logging_replay.py
+++ b/tests/utils/test_logging_replay.py
@@ -28,6 +28,7 @@ with all decorated FlashInfer APIs. For each API, we:
 
 import os
 import sys
+import json
 
 import pytest
 import torch
@@ -121,6 +122,65 @@ def verify_and_replay_dump(
     # Verify execution result matches original (in-memory check)
     execution_result = result["execution_result"]
     assert torch.allclose(original_output, execution_result, atol=1e-5, rtol=1e-3)
+
+
+def test_level10_alias_wrapper_records_alias_name(tmp_path):
+    """Test that level 10 dump metadata records the alias wrapper name."""
+    original_env = {
+        "FLASHINFER_LOGLEVEL": os.environ.get("FLASHINFER_LOGLEVEL"),
+        "FLASHINFER_LOGDEST": os.environ.get("FLASHINFER_LOGDEST"),
+        "FLASHINFER_DUMP_DIR": os.environ.get("FLASHINFER_DUMP_DIR"),
+        "FLASHINFER_DUMP_INCLUDE": os.environ.get("FLASHINFER_DUMP_INCLUDE"),
+        "FLASHINFER_DUMP_EXCLUDE": os.environ.get("FLASHINFER_DUMP_EXCLUDE"),
+        "FLASHINFER_DUMP_SAFETENSORS": os.environ.get("FLASHINFER_DUMP_SAFETENSORS"),
+    }
+
+    try:
+        dump_dir = tmp_path / "alias_dumps"
+        os.environ["FLASHINFER_LOGLEVEL"] = "10"
+        os.environ["FLASHINFER_LOGDEST"] = "stdout"
+        os.environ["FLASHINFER_DUMP_DIR"] = str(dump_dir)
+        for key in [
+            "FLASHINFER_DUMP_INCLUDE",
+            "FLASHINFER_DUMP_EXCLUDE",
+            "FLASHINFER_DUMP_SAFETENSORS",
+        ]:
+            if key in os.environ:
+                del os.environ[key]
+
+        _clean_flashinfer_modules()
+
+        from flashinfer.api_logging import flashinfer_api
+
+        @flashinfer_api
+        def canonical_function(x):
+            return x + 1
+
+        @flashinfer_api
+        def alias_function(x):
+            return canonical_function.__wrapped__(x)
+
+        assert alias_function(10) == 11
+
+        session_jsonl_path = dump_dir / "session.jsonl"
+        assert session_jsonl_path.exists(), "session.jsonl was not created"
+
+        with open(session_jsonl_path, "r") as f:
+            records = [json.loads(line) for line in f if line.strip()]
+
+        alias_records = [r for r in records if r["function_name"] == "alias_function"]
+        assert len(alias_records) == 2
+        assert {r["execution_status"] for r in alias_records} == {
+            "inputs_saved",
+            "completed",
+        }
+    finally:
+        for key, value in original_env.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
+        _clean_flashinfer_modules()
 
 
 def test_replay_sequence(level10_environment):


### PR DESCRIPTION
## 📌 Description

The MLA paged attention kernel `trtllm_batch_decode_with_kv_cache_mla` handles both **decode** (`q_len_per_request=1`) and **incremental prefill** (`q_len_per_request>1`), but its name only says "decode". Users looking for a prefill kernel in `flashinfer.prefill` cannot find it.

This PR adds a `trtllm_prefill_with_kv_cache_mla` alias to improve discoverability:

1. **`flashinfer/mla/_core.py`**: Bare alias `trtllm_prefill_with_kv_cache_mla = trtllm_batch_decode_with_kv_cache_mla` (following project convention, e.g. `gated_delta_rule_bf16state_cooprow = gated_delta_rule`). Updated docstring to clarify `q_len_per_request` supports both decode and prefill/MTP.

2. **`flashinfer/prefill.py`**: Re-exported the alias via `from .mla import trtllm_prefill_with_kv_cache_mla as trtllm_prefill_with_kv_cache_mla`.

3. **`docs/api/attention.rst`**: Added a `.. note::` documenting the alias in the MLA section (used manual note instead of `autosummary` entry to avoid Sphinx rendering the original function name for the alias object).

4. **`tests/attention/test_trtllm_gen_mla.py`**: Added `test_trtllm_prefill_mla_alias()` verifying all import paths (`flashinfer.prefill`, `flashinfer.mla`, `flashinfer.decode`) resolve to the same function object.

No breaking changes — the existing `trtllm_batch_decode_with_kv_cache_mla` name is preserved.

cc @yzh119 @qsang-nv @saltyminty @nvjullin

## 🔍 Related Issues

Fixes #2877

## 🚀 Pull Request Checklist

- [x] I have installed `pre-commit` by running `pip install pre-commit && pre-commit install`
- [x] I have run `pre-commit run` to check the formatting
- [x] I have added tests for my changes (identity test for alias)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a package-level prefill API alias for MLA prefill workflows, exposed for backward-compatible use.

* **Documentation**
  * Clarified MLA paged-attention behavior for decode vs incremental prefill and noted a backend caveat when auto-selecting a backend that doesn't support multi-token prefill.

* **Tests**
  * Added tests to verify the alias is exposed, identity-preserving, and that logging/dump records use the alias name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->