### PR TITLE
fix: fix logical bug reported in #2768

### DIFF
--- a/include/flashinfer/flat/hopper/collective/flat_collective_tma_warpspecialized_delta_rule.hpp
+++ b/include/flashinfer/flat/hopper/collective/flat_collective_tma_warpspecialized_delta_rule.hpp
@@ -325,7 +325,7 @@ struct FlatMainloopTmaWarpSpecializedDeltaRule {
       float sum = 0.0f;
       CUTE_UNROLL
       for (int iter = 1; iter < size(frag); ++iter) {
-        sum += __shfl_sync(0xFFFFFFFF, frag(iter - 1), 31);
+        sum = __shfl_sync(0xFFFFFFFF, frag(iter - 1), 31);
         frag(iter) += sum;
       }
 


### PR DESCRIPTION
Fix #2768

This is not trigger as size(frag) is 2 in the kernel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected computation logic in tensor acceleration backend to improve computational accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->