### PR TITLE
[CICD fix] Adjust CICD MAX_JOBS to fix OOM on H100 tests

### DIFF
--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -6,15 +6,20 @@
 : "${JUNIT_DIR:=$(realpath ./junit)}"
 
 # Cap ninja parallelism by available RAM (~12 GB per nvcc process) to avoid OOM
-# during JIT compilation.
+# during JIT compilation.  Exported because flashinfer/jit/cpp_ext.py reads it
+# from the environment (os.environ) inside the child Python process.
 if [ -z "${MAX_JOBS:-}" ]; then
-    _mem_gb=$(awk '/MemAvailable/ {printf "%d", $2/1024/1024}' /proc/meminfo 2>/dev/null || echo 0)
+    _num_cpus=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+    _mem_gb=$(awk '/MemAvailable/ {printf "%d", $2/1024/1024}' /proc/meminfo 2>/dev/null)
+    _mem_gb=${_mem_gb:-0}
     if [ "$_mem_gb" -gt 0 ]; then
         MAX_JOBS=$(( (_mem_gb - 8) / 12 ))
-        [ "$MAX_JOBS" -lt 4 ] && MAX_JOBS=4
+        [ "$MAX_JOBS" -lt 1 ] && MAX_JOBS=1
+        [ "$MAX_JOBS" -gt "$_num_cpus" ] && MAX_JOBS=$_num_cpus
     else
-        MAX_JOBS=$(nproc 2>/dev/null || echo 4)
+        MAX_JOBS=$_num_cpus
     fi
+    unset _num_cpus _mem_gb
 fi
 export MAX_JOBS
 

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -4,7 +4,20 @@
 
 # Default environment variables
 : "${JUNIT_DIR:=$(realpath ./junit)}"
-: "${MAX_JOBS:=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+
+# Cap ninja parallelism by available RAM (~12 GB per nvcc process) to avoid OOM
+# during JIT compilation.
+if [ -z "${MAX_JOBS:-}" ]; then
+    _mem_gb=$(awk '/MemAvailable/ {printf "%d", $2/1024/1024}' /proc/meminfo 2>/dev/null || echo 0)
+    if [ "$_mem_gb" -gt 0 ]; then
+        MAX_JOBS=$(( (_mem_gb - 8) / 12 ))
+        [ "$MAX_JOBS" -lt 4 ] && MAX_JOBS=4
+    else
+        MAX_JOBS=$(nproc 2>/dev/null || echo 4)
+    fi
+fi
+export MAX_JOBS
+
 # CUDA_VISIBLE_DEVICES: Not set by default - let detect_gpus() auto-detect via nvidia-smi
 : "${SAMPLE_RATE:=5}"  # Run every Nth test in sanity mode (5 = ~20% coverage)
 : "${PARALLEL_TESTS:=false}"  # Disable parallel test execution by default


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix OOM-induced JIT compilation failure for GDN prefill tests on H100 CI runners (Issue #3030).

The GDN prefill module compiles 66 CUDA source files in a single ninja build. Without MAX_JOBS set in the environment, ninja defaults to one job per CPU core. On the H100 CI runner (48 CPUs, 256GB RAM), this launches 48 concurrent nvcc processes requiring ~576GB total, exceeding available memory and triggering the OOM killer (exit code 137).

test_utils.sh previously set MAX_JOBS as a shell variable but never exported it, so the Python JIT system (flashinfer/jit/cpp_ext.py, which reads os.environ.get("MAX_JOBS")) never saw it. This change computes a memory-aware MAX_JOBS from /proc/meminfo and exports it so ninja caps parallelism to what the machine can handle.

I verified H100 passes with this change in pipeline here: https://github.com/flashinfer-ai/flashinfer/pull/3078#issuecomment-4255613151 

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3030 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
