### PR TITLE
feat: Add b12x_fused_moe / B12xMoEWrapper SM120 APIs with micro kernel and ReLU2

### DIFF
--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -737,7 +737,13 @@ def testTrtllmFp4BlockScaleMoe(args):
     median_time = np.median(times)
     std_time = np.std(times)
     tflops = calculate_moe_tflops(
-        num_tokens, hidden_size, intermediate_size, num_experts, top_k, median_time
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        top_k,
+        median_time,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
     input_format_str = {"nvfp4": "nvfp4", "mxfp4_mxfp8": "mxfp8", "mxfp4_bf16": "bf16"}[
         fp4_mode
@@ -757,6 +763,7 @@ def testTrtllmFp4BlockScaleMoe(args):
         routing_logits_dtype=routing_logits.dtype,
         active_experts=int(selected_experts.unique().numel()),
         verbose=args.verbose,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
 
     print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
@@ -1118,7 +1125,13 @@ def testCutlassFusedMoe(args):
     median_time = np.median(times)
     std_time = np.std(times)
     tflops = calculate_moe_tflops(
-        num_tokens, hidden_size, intermediate_size, num_experts, top_k, median_time
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        top_k,
+        median_time,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
     tb_per_sec = calculate_moe_kernel_bandwidth(
         num_tokens,
@@ -1134,6 +1147,7 @@ def testCutlassFusedMoe(args):
         routing_logits_dtype=router_logits.dtype,
         active_experts=int(selected_experts.unique().numel()),
         verbose=args.verbose,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
 
     print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
@@ -1512,7 +1526,13 @@ def testCuteDslFp4BlockScaleMoe(args):
     median_time = np.median(times)
     std_time = np.std(times)
     tflops = calculate_moe_tflops(
-        num_tokens, hidden_size, intermediate_size, num_experts, top_k, median_time
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        top_k,
+        median_time,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
     tb_per_sec = calculate_moe_kernel_bandwidth(
         num_tokens,
@@ -1528,6 +1548,7 @@ def testCuteDslFp4BlockScaleMoe(args):
         routing_logits_dtype=None,
         active_experts=num_active_experts,
         verbose=args.verbose,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
 
     print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
@@ -1767,7 +1788,13 @@ def testTrtllmFp8BlockScaleMoe(args):
     median_time = np.median(times)
     std_time = np.std(times)
     tflops = calculate_moe_tflops(
-        num_tokens, hidden_size, intermediate_size, num_experts, top_k, median_time
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        top_k,
+        median_time,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
     tb_per_sec = calculate_moe_kernel_bandwidth(
         num_tokens,
@@ -1996,7 +2023,13 @@ def testTrtllmFp8PerTensorScaleMoe(args):
     median_time = np.median(times)
     std_time = np.std(times)
     tflops = calculate_moe_tflops(
-        num_tokens, hidden_size, intermediate_size, num_experts, top_k, median_time
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        top_k,
+        median_time,
+        is_gated=args.activation_type in (ActivationType.Swiglu, ActivationType.Geglu),
     )
     tb_per_sec = calculate_moe_kernel_bandwidth(
         num_tokens,

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -1364,11 +1364,16 @@ def testCuteDslFp4BlockScaleMoe(args):
             f"intermediate={intermediate_size}, experts={num_experts}, top_k={top_k}"
         )
 
-    # Map ActivationType enum to string for SM120 API
+    # Map ActivationType enum to string for SM120 CuTe DSL API
     activation_type = args.activation_type
     _ACT_STR = {ActivationType.Swiglu: "silu", ActivationType.Relu2: "relu2"}
-    activation_str = _ACT_STR.get(activation_type, "silu")
-    is_gated = activation_type in (ActivationType.Swiglu, ActivationType.Geglu)
+    if activation_type not in _ACT_STR:
+        raise ValueError(
+            f"CuTe DSL MoE only supports Swiglu and Relu2 activations, "
+            f"got {activation_type.name}"
+        )
+    activation_str = _ACT_STR[activation_type]
+    is_gated = activation_type == ActivationType.Swiglu
 
     # Create CuteDSL-specific NVFP4 test data
     tensors = _create_cute_dsl_moe_test_data(

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -1394,102 +1394,181 @@ def testCuteDslFp4BlockScaleMoe(args):
 
     use_functional = getattr(args, "use_functional_api", False)
 
-    # SM120 passes bf16 as x (kernel fuses quantization); SM100 passes FP4.
     sm_major_bm = torch.cuda.get_device_capability(device)[0]
-    x_input = tensors["x_bf16"] if sm_major_bm == 12 else tensors["x"]
+    is_sm120 = sm_major_bm == 12
+    x_input = tensors["x_bf16"] if is_sm120 else tensors["x"]
 
     if use_functional:
-        from flashinfer import cute_dsl_fused_moe_nvfp4
         from functools import partial
-
-        if args.verbose >= 1:
-            print(
-                "[INFO] Using functional API (cute_dsl_fused_moe_nvfp4) with workspace cache"
-            )
 
         # Pre-allocate output buffer to avoid per-call allocation
         moe_output = torch.empty(
             num_tokens, hidden_size, dtype=torch.bfloat16, device=device
         )
 
-        runner = partial(
-            cute_dsl_fused_moe_nvfp4,
-            num_experts=num_experts,
-            top_k=top_k,
-            num_local_experts=local_num_experts,
-            local_expert_offset=local_expert_offset,
-            moe_output=moe_output,
-            activation_type=activation_str,
-        )
+        if is_sm120:
+            from flashinfer import b12x_fused_moe
+
+            if args.verbose >= 1:
+                print("[INFO] Using b12x functional API (b12x_fused_moe)")
+            runner = partial(
+                b12x_fused_moe,
+                num_experts=num_experts,
+                top_k=top_k,
+                num_local_experts=local_num_experts,
+                output=moe_output,
+                activation=activation_str,
+            )
+        else:
+            from flashinfer import cute_dsl_fused_moe_nvfp4
+
+            if args.verbose >= 1:
+                print("[INFO] Using CuTe DSL functional API (cute_dsl_fused_moe_nvfp4)")
+            runner = partial(
+                cute_dsl_fused_moe_nvfp4,
+                num_experts=num_experts,
+                top_k=top_k,
+                num_local_experts=local_num_experts,
+                local_expert_offset=local_expert_offset,
+                moe_output=moe_output,
+            )
 
         # Warmup call to populate workspace cache before timed region
-        runner(
-            x=x_input,
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            w1_weight=tensors["w1_weight"],
-            w1_weight_sf=tensors["w1_weight_sf"],
-            w1_alpha=tensors["w1_alpha"],
-            fc2_input_scale=tensors["fc2_input_scale"],
-            w2_weight=tensors["w2_weight"],
-            w2_weight_sf=tensors["w2_weight_sf"],
-            w2_alpha=tensors["w2_alpha"],
-        )
+        if is_sm120:
+            runner(
+                x=x_input,
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+            )
+        else:
+            runner(
+                x=x_input,
+                x_sf=tensors["x_sf"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+            )
     else:
-        moe = CuteDslMoEWrapper(
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            use_cuda_graph=is_cuda_graph_compatible,
-            max_num_tokens=num_tokens,
-            num_local_experts=local_num_experts,
-            local_expert_offset=local_expert_offset,
-            activation_type=activation_str,
-        )
+        if is_sm120:
+            from flashinfer import B12xMoEWrapper
+
+            moe = B12xMoEWrapper(
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                use_cuda_graph=is_cuda_graph_compatible,
+                max_num_tokens=num_tokens,
+                num_local_experts=local_num_experts,
+                activation=activation_str,
+            )
+        else:
+            moe = CuteDslMoEWrapper(
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                use_cuda_graph=is_cuda_graph_compatible,
+                max_num_tokens=num_tokens,
+                num_local_experts=local_num_experts,
+                local_expert_offset=local_expert_offset,
+            )
         runner = moe.run
 
-    def run_cute_dsl_moe(
-        x,
-        x_sf,
-        token_selected_experts,
-        token_final_scales,
-        w1_weight,
-        w1_weight_sf,
-        w1_alpha,
-        fc2_input_scale,
-        w2_weight,
-        w2_weight_sf,
-        w2_alpha,
-    ):
-        return runner(
-            x=x,
-            x_sf=x_sf,
-            token_selected_experts=token_selected_experts,
-            token_final_scales=token_final_scales,
-            w1_weight=w1_weight,
-            w1_weight_sf=w1_weight_sf,
-            w1_alpha=w1_alpha,
-            fc2_input_scale=fc2_input_scale,
-            w2_weight=w2_weight,
-            w2_weight_sf=w2_weight_sf,
-            w2_alpha=w2_alpha,
-        )
+    if is_sm120:
 
-    input_args = (
-        x_input,
-        tensors["x_sf"],
-        tensors["token_selected_experts"],
-        tensors["token_final_scales"],
-        tensors["w1_weight"],
-        tensors["w1_weight_sf"],
-        tensors["w1_alpha"],
-        tensors["fc2_input_scale"],
-        tensors["w2_weight"],
-        tensors["w2_weight_sf"],
-        tensors["w2_alpha"],
-    )
+        def run_cute_dsl_moe(
+            x,
+            w1_weight,
+            w1_weight_sf,
+            w1_alpha,
+            fc2_input_scale,
+            w2_weight,
+            w2_weight_sf,
+            w2_alpha,
+            token_selected_experts,
+            token_final_scales,
+        ):
+            return runner(
+                x=x,
+                w1_weight=w1_weight,
+                w1_weight_sf=w1_weight_sf,
+                w1_alpha=w1_alpha,
+                fc2_input_scale=fc2_input_scale,
+                w2_weight=w2_weight,
+                w2_weight_sf=w2_weight_sf,
+                w2_alpha=w2_alpha,
+                token_selected_experts=token_selected_experts,
+                token_final_scales=token_final_scales,
+            )
+
+        input_args = (
+            x_input,
+            tensors["w1_weight"],
+            tensors["w1_weight_sf"],
+            tensors["w1_alpha"],
+            tensors["fc2_input_scale"],
+            tensors["w2_weight"],
+            tensors["w2_weight_sf"],
+            tensors["w2_alpha"],
+            tensors["token_selected_experts"],
+            tensors["token_final_scales"],
+        )
+    else:
+
+        def run_cute_dsl_moe(
+            x,
+            x_sf,
+            token_selected_experts,
+            token_final_scales,
+            w1_weight,
+            w1_weight_sf,
+            w1_alpha,
+            fc2_input_scale,
+            w2_weight,
+            w2_weight_sf,
+            w2_alpha,
+        ):
+            return runner(
+                x=x,
+                x_sf=x_sf,
+                token_selected_experts=token_selected_experts,
+                token_final_scales=token_final_scales,
+                w1_weight=w1_weight,
+                w1_weight_sf=w1_weight_sf,
+                w1_alpha=w1_alpha,
+                fc2_input_scale=fc2_input_scale,
+                w2_weight=w2_weight,
+                w2_weight_sf=w2_weight_sf,
+                w2_alpha=w2_alpha,
+            )
+
+        input_args = (
+            x_input,
+            tensors["x_sf"],
+            tensors["token_selected_experts"],
+            tensors["token_final_scales"],
+            tensors["w1_weight"],
+            tensors["w1_weight_sf"],
+            tensors["w1_alpha"],
+            tensors["fc2_input_scale"],
+            tensors["w2_weight"],
+            tensors["w2_weight_sf"],
+            tensors["w2_alpha"],
+        )
 
     # Snapshot active expert count before any kernel execution, since
     # autotune tactic exploration may corrupt input tensors.

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -833,12 +833,16 @@ def testCutlassFusedMoe(args):
         return res
 
     # Create base tensors
+    activation_type = args.activation_type
+    is_gated = activation_type in (ActivationType.Swiglu, ActivationType.Geglu)
+    w1_rows = (2 if is_gated else 1) * intermediate_size
+
     torch.manual_seed(args.random_seed)
     x = torch.randn(num_tokens, hidden_size, dtype=input_dtype, device=device)
     w31_weight = (
         torch.randn(
             num_experts,
-            2 * intermediate_size,
+            w1_rows,
             hidden_size,
             dtype=input_dtype,
             device=device,
@@ -877,14 +881,17 @@ def testCutlassFusedMoe(args):
     def build_tp_shards(w31_ep_tensor: torch.Tensor, w2_ep_tensor: torch.Tensor):
         if tp_size <= 1:
             return w31_ep_tensor, w2_ep_tensor
-        # Split w31 into w3 and w1 along intermediate dim
-        w3_weight, w1_weight = torch.chunk(w31_ep_tensor, 2, dim=1)
         shard = intermediate_size // tp_size
         start = tp_rank * shard
         end = start + shard
-        w3_local = w3_weight[:, start:end, :]
-        w1_local = w1_weight[:, start:end, :]
-        w31_local = torch.cat([w3_local, w1_local], dim=1)
+        if is_gated:
+            # Split w31 into w3 and w1 along intermediate dim
+            w3_weight, w1_weight = torch.chunk(w31_ep_tensor, 2, dim=1)
+            w3_local = w3_weight[:, start:end, :]
+            w1_local = w1_weight[:, start:end, :]
+            w31_local = torch.cat([w3_local, w1_local], dim=1)
+        else:
+            w31_local = w31_ep_tensor[:, start:end, :]
         w2_local = w2_ep_tensor[:, :, start:end]
         return w31_local.contiguous(), w2_local.contiguous()
 
@@ -910,6 +917,7 @@ def testCutlassFusedMoe(args):
                 ep_rank=ep_rank,
                 quant_scales=None,
                 output=out,
+                **_activation_kwarg(cutlass_fused_moe, activation_type),
             )
 
         input_args_for_bench = (
@@ -977,6 +985,7 @@ def testCutlassFusedMoe(args):
                 ep_rank=ep_rank,
                 quant_scales=quant_scales,
                 output=out,
+                **_activation_kwarg(cutlass_fused_moe, activation_type),
             )
 
         input_args_for_bench = (
@@ -998,12 +1007,13 @@ def testCutlassFusedMoe(args):
         n = w2_local.shape[2]  # local intermediate size after TP
         k = hidden_size
         quant_blocksize = 16
+        w1_n = w31_local.shape[1]  # 2*n for gated, n for non-gated
 
         # Weight quantization buffers
-        w1_q = torch.empty((e, 2 * n, k // 2), device=device, dtype=torch.uint8)
+        w1_q = torch.empty((e, w1_n, k // 2), device=device, dtype=torch.uint8)
         w2_q = torch.empty((e, k, n // 2), device=device, dtype=torch.uint8)
         w1_blockscale = torch.empty(
-            (e, round_up(2 * n, 128), round_up(k // quant_blocksize, 4)),
+            (e, round_up(w1_n, 128), round_up(k // quant_blocksize, 4)),
             device=device,
             dtype=torch.float8_e4m3fn,
         )
@@ -1061,6 +1071,7 @@ def testCutlassFusedMoe(args):
                 quant_scales=quant_scales,
                 input_sf=input_sf,
                 output=out,
+                **_activation_kwarg(cutlass_fused_moe, activation_type),
             )
 
         input_args_for_bench = (
@@ -1180,6 +1191,7 @@ def _create_cute_dsl_moe_test_data(
     num_local_experts: int,
     top_k: int,
     device: torch.device,
+    is_gated: bool = True,
 ):
     """Create NVFP4-quantized test data for CuteDSL MoE (Blackwell kernels).
 
@@ -1208,13 +1220,14 @@ def _create_cute_dsl_moe_test_data(
     routing_weights, selected_experts = compute_routing(routing_logits, top_k)
     selected_experts = selected_experts.to(torch.int32)
 
-    # GEMM1 weights (gate + up)
-    # SM100/103: interleaved in 64-row groups for CuTe DSL SwiGLU epilogue
-    # SM120/121: non-interleaved [up_0:N, gate_0:N] for b12x fused kernel
+    # GEMM1 weights
+    # Gated (SiLU/SwiGLU): [E, 2*n, k] — gate + up fused
+    # Non-gated (ReLU2): [E, n, k] — single FC1 matrix
+    w1_rows = (2 if is_gated else 1) * intermediate_size
     w1_bf16 = (
         torch.randn(
             num_local_experts,
-            2 * intermediate_size,
+            w1_rows,
             hidden_size,
             dtype=torch.bfloat16,
             device=device,
@@ -1222,23 +1235,19 @@ def _create_cute_dsl_moe_test_data(
         / 10
     )
     sm_major = torch.cuda.get_device_capability(device)[0]
-    if sm_major == 12:
-        w1_bf16_prepared = w1_bf16  # SM120: non-interleaved
+    if sm_major == 12 or not is_gated:
+        w1_bf16_prepared = w1_bf16  # SM120 or non-gated: no interleave
     else:
         w1_bf16_prepared = _interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
     w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
-    w1_flat = w1_bf16_prepared.view(
-        num_local_experts * 2 * intermediate_size, hidden_size
-    )
+    w1_flat = w1_bf16_prepared.view(num_local_experts * w1_rows, hidden_size)
     w1_q_flat, w1_sf_flat = fp4_quantize(
         w1_flat, global_scale=w1_gs, sf_vec_size=sf_vec_size, is_sf_swizzled_layout=True
     )
-    w1_weight = w1_q_flat.view(
-        num_local_experts, 2 * intermediate_size, hidden_size // 2
-    )
+    w1_weight = w1_q_flat.view(num_local_experts, w1_rows, hidden_size // 2)
     w1_weight_sf = convert_sf_to_mma_layout(
         w1_sf_flat,
-        m=2 * intermediate_size,
+        m=w1_rows,
         k=hidden_size,
         num_groups=num_local_experts,
         sf_vec_size=sf_vec_size,
@@ -1341,6 +1350,12 @@ def testCuteDslFp4BlockScaleMoe(args):
             f"intermediate={intermediate_size}, experts={num_experts}, top_k={top_k}"
         )
 
+    # Map ActivationType enum to string for SM120 API
+    activation_type = args.activation_type
+    _ACT_STR = {ActivationType.Swiglu: "silu", ActivationType.Relu2: "relu2"}
+    activation_str = _ACT_STR.get(activation_type, "silu")
+    is_gated = activation_type in (ActivationType.Swiglu, ActivationType.Geglu)
+
     # Create CuteDSL-specific NVFP4 test data
     tensors = _create_cute_dsl_moe_test_data(
         num_tokens=num_tokens,
@@ -1350,6 +1365,7 @@ def testCuteDslFp4BlockScaleMoe(args):
         num_local_experts=local_num_experts,
         top_k=top_k,
         device=device,
+        is_gated=is_gated,
     )
 
     if args.verbose >= 2:
@@ -1384,6 +1400,7 @@ def testCuteDslFp4BlockScaleMoe(args):
             num_local_experts=local_num_experts,
             local_expert_offset=local_expert_offset,
             moe_output=moe_output,
+            activation_type=activation_str,
         )
 
         # Warmup call to populate workspace cache before timed region
@@ -1410,6 +1427,7 @@ def testCuteDslFp4BlockScaleMoe(args):
             max_num_tokens=num_tokens,
             num_local_experts=local_num_experts,
             local_expert_offset=local_expert_offset,
+            activation_type=activation_str,
         )
         runner = moe.run
 

--- a/benchmarks/routines/moe_utils.py
+++ b/benchmarks/routines/moe_utils.py
@@ -466,13 +466,15 @@ def calculate_moe_tflops(
     num_experts: int,
     top_k: int,
     time_ms: float,
+    is_gated: bool = True,
 ) -> float:
     """
     Calculate TFLOPS for MOE operation.
 
     MOE computation involves:
-    1. First GEMM: [num_tokens, hidden_size] x [num_experts, hidden_size, 2*intermediate_size]
-    2. Activation function (SwiGLU gate)
+    1. First GEMM: [num_tokens, hidden_size] x [num_experts, hidden_size, w1_cols]
+       where w1_cols = 2*intermediate_size (gated) or intermediate_size (non-gated)
+    2. Activation function (SwiGLU gate or ReLU2)
     3. Second GEMM: [num_tokens, intermediate_size] x [num_experts, intermediate_size, hidden_size]
 
     For each token, we only compute for top_k experts.
@@ -484,6 +486,7 @@ def calculate_moe_tflops(
         num_experts: Total number of experts
         top_k: Number of experts per token
         time_ms: Execution time in milliseconds
+        is_gated: Whether activation is gated (SwiGLU/GeGLU) or non-gated (ReLU2)
 
     Returns:
         TFLOPS value
@@ -491,8 +494,9 @@ def calculate_moe_tflops(
     _ = num_experts  # kept for backward compatibility
 
     # FLOPS per token per expert
+    w1_cols = (2 if is_gated else 1) * intermediate_size
     flops_per_token_per_expert = (
-        2 * hidden_size * 2 * intermediate_size  # First GEMM
+        2 * hidden_size * w1_cols  # First GEMM
         + 2 * intermediate_size * hidden_size  # Second GEMM
     )
 
@@ -515,6 +519,7 @@ def calculate_moe_kernel_bandwidth(
     routing_logits_dtype: Optional[torch.dtype] = torch.float32,
     active_experts: Optional[int] = None,
     verbose: int = 0,
+    is_gated: bool = True,
 ) -> float:
     """
     Calculate memory bandwidth for MOE kernel operation in TB/sec.
@@ -573,8 +578,9 @@ def calculate_moe_kernel_bandwidth(
     )
 
     # Weight memory
+    w1_cols = (2 if is_gated else 1) * intermediate_size
     weight_bytes_per_expert = (
-        2 * intermediate_size * hidden_size * weight_bytes_per_element  # gemm1
+        w1_cols * hidden_size * weight_bytes_per_element  # gemm1
         + hidden_size * intermediate_size * weight_bytes_per_element  # gemm2
     )
     if active_experts is not None:

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -95,6 +95,8 @@ with contextlib.suppress(ImportError):
     from .fused_moe import (
         cute_dsl_fused_moe_nvfp4 as cute_dsl_fused_moe_nvfp4,
         CuteDslMoEWrapper as CuteDslMoEWrapper,
+        b12x_fused_moe as b12x_fused_moe,
+        B12xMoEWrapper as B12xMoEWrapper,
     )
 from .gdn_prefill import chunk_gated_delta_rule as chunk_gated_delta_rule
 from .gemm import SegmentGEMMWrapper as SegmentGEMMWrapper

--- a/flashinfer/cute_dsl/fp4_common.py
+++ b/flashinfer/cute_dsl/fp4_common.py
@@ -1533,3 +1533,29 @@ def silu_mul_quantize_block_fp4(
     activated = silu_mul_16(gate, up)
     block_max = max_abs_16(activated)
     return quantize_block_fp4(activated, block_max, global_scale_val)
+
+
+# =============================================================================
+# ReLU2 Activation — ReLU(x)² for non-gated MoE (Nemotron-Super)
+# =============================================================================
+
+
+@cute.jit
+def relu2_16(x: cute.Tensor) -> cute.Tensor:
+    """Compute ReLU²(x) = max(0, x)² for 16 float32 values."""
+    out = cute.make_rmem_tensor((16,), Float32)
+    for i in cutlass.range_constexpr(16):
+        v = fmax_f32(x[i], Float32(0.0))
+        out[i] = v * v
+    return out
+
+
+@cute.jit
+def relu2_quantize_block_fp4(
+    x: cute.Tensor,
+    global_scale_val: Float32,
+) -> Tuple[Uint64, Uint8]:
+    """Fused ReLU² + FP4 quantize for 16 float32 values."""
+    activated = relu2_16(x)
+    block_max = max_abs_16(activated)
+    return quantize_block_fp4(activated, block_max, global_scale_val)

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -17,6 +17,7 @@ limitations under the License.
 import ctypes
 import functools
 import importlib.util
+import warnings
 from typing import Union, Tuple
 
 import cutlass
@@ -123,7 +124,27 @@ def get_max_active_clusters(cluster_size: int) -> int:
     Returns:
         Maximum number of active clusters supported by hardware.
     """
-    return get_hardware_info().get_max_active_clusters(cluster_size)
+    try:
+        return get_hardware_info().get_max_active_clusters(cluster_size)
+    except Exception as exc:
+        # nvidia_cutlass_dsl's hardware probe (cuKernelGetFunction) can fail
+        # in spawned subprocesses (e.g. vLLM EngineCore) when the CUDA driver
+        # API context is not current at first use, even if the PyTorch CUDA
+        # runtime is initialised. Fall back to the GPU's physical SM count,
+        # which is a safe upper bound: callers that clamp to sm_count (such
+        # as the SM120 MoE dispatch's ``min(get_max_active_clusters(1),
+        # sm_count)``) are unaffected; other callers under-parallelize
+        # slightly when per-CTA resources allow more than one cluster per
+        # SM, but never over-request (which could deadlock a resident grid).
+        warnings.warn(
+            f"cutlass.get_max_active_clusters failed "
+            f"({type(exc).__name__}: {exc}); falling back to sm_count. "
+            f"This can happen in spawned subprocesses where the CUDA driver "
+            f"API context is not current.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return get_num_sm(torch.device("cuda"))
 
 
 # WAR for CuTeDSL make_ptr implementation for flashinfer

--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -49,6 +49,8 @@ try:
     from .cute_dsl import (
         cute_dsl_fused_moe_nvfp4,
         CuteDslMoEWrapper,
+        b12x_fused_moe,
+        B12xMoEWrapper,
     )
 
     _cute_dsl_available = True
@@ -84,4 +86,6 @@ if _cute_dsl_available:
     __all__ += [
         "cute_dsl_fused_moe_nvfp4",
         "CuteDslMoEWrapper",
+        "b12x_fused_moe",
+        "B12xMoEWrapper",
     ]

--- a/flashinfer/fused_moe/cute_dsl/__init__.py
+++ b/flashinfer/fused_moe/cute_dsl/__init__.py
@@ -23,6 +23,10 @@ if is_cute_dsl_available():
         cute_dsl_fused_moe_nvfp4,
         CuteDslMoEWrapper,
     )
+    from .b12x_moe import (
+        b12x_fused_moe,
+        B12xMoEWrapper,
+    )
 
 __all__ = [
     "is_cute_dsl_available",
@@ -32,4 +36,6 @@ if is_cute_dsl_available():
     __all__ += [
         "cute_dsl_fused_moe_nvfp4",
         "CuteDslMoEWrapper",
+        "b12x_fused_moe",
+        "B12xMoEWrapper",
     ]

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -89,8 +89,9 @@ def b12x_fused_moe(
         w2_alpha: Per-expert global scale for FC2.
         fc2_input_scale: Global scale for FC2 input quantization.
         num_local_experts: Local experts for EP. Default: num_experts.
-        output: Pre-allocated output buffer [num_tokens, hidden_size].
-        output_dtype: Output data type. Default: torch.bfloat16.
+        output: Pre-allocated output buffer [num_tokens, hidden_size], bf16.
+        output_dtype: Output data type. Only torch.bfloat16 is currently
+            supported. Default: torch.bfloat16.
         activation: Activation function — "silu" (gated/SwiGLU) or
             "relu2" (non-gated/Nemotron-Super). Default: "silu".
 
@@ -103,6 +104,20 @@ def b12x_fused_moe(
         raise ValueError(
             "b12x fused MoE requires CUDA 13 or later. "
             f"Current CUDA version: {get_cuda_version()}."
+        )
+
+    # SM12x kernels hardcode BF16 for scatter_output (see Phase 0 zero-init
+    # in moe_{static,micro,dynamic}_kernel.py). Other dtypes will fail the
+    # kernel tensor binding.
+    if output_dtype != torch.bfloat16:
+        raise ValueError(
+            f"b12x fused MoE only supports output_dtype=torch.bfloat16, "
+            f"got {output_dtype}."
+        )
+    if output is not None and output.dtype != torch.bfloat16:
+        raise ValueError(
+            f"b12x fused MoE only supports bf16 output buffers, "
+            f"got output.dtype={output.dtype}."
         )
 
     if num_local_experts is None:
@@ -153,7 +168,8 @@ class B12xMoEWrapper:
         use_cuda_graph: Pre-allocate buffers for CUDA graph compatibility.
         max_num_tokens: Maximum tokens (only for use_cuda_graph=True).
         num_local_experts: Local experts for EP. Default: num_experts.
-        output_dtype: Output data type. Default: torch.bfloat16.
+        output_dtype: Output data type. Only torch.bfloat16 is currently
+            supported. Default: torch.bfloat16.
         device: Device for buffer allocation. Default: "cuda".
         activation: Activation function — "silu" or "relu2". Default: "silu".
 
@@ -184,6 +200,13 @@ class B12xMoEWrapper:
             raise ValueError(
                 "b12x fused MoE requires CUDA 13 or later. "
                 f"Current CUDA version: {get_cuda_version()}."
+            )
+
+        # SM12x kernels hardcode BF16 for scatter_output.
+        if output_dtype != torch.bfloat16:
+            raise ValueError(
+                f"b12x fused MoE only supports output_dtype=torch.bfloat16, "
+                f"got {output_dtype}."
             )
 
         self.num_experts = num_experts
@@ -218,6 +241,12 @@ class B12xMoEWrapper:
         backend = select_sm120_moe_backend(
             num_tokens=self.max_num_tokens, num_topk=self.top_k
         )
+        # Mirror the dynamic→static fallback in launch_sm120_moe: the dynamic
+        # kernel indexes row_counts/expert_write_rows with topk_ids (sized by
+        # num_local_experts). Once a dynamic workspace is passed in, runtime
+        # dispatch skips that safety check, so apply it here too.
+        if backend == "dynamic" and self.num_local_experts != self.num_experts:
+            backend = "static"
         if backend == "dynamic":
             self._workspace = allocate_sm120_dynamic_workspace(
                 state_E=self.num_local_experts,

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -1,5 +1,5 @@
 """
-B12x fused MoE API for SM120/SM121 (RTX 5090, DGX Spark).
+B12x fused MoE API for SM120/SM121.
 
 Provides high-level APIs for running Mixture of Experts (MoE)
 computations using b12x CuTe DSL kernels on Blackwell GeForce GPUs.

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -51,15 +51,16 @@ def b12x_fused_moe(
     x: torch.Tensor,
     w1_weight: torch.Tensor,
     w1_weight_sf: torch.Tensor,
-    w1_alpha: torch.Tensor,
-    fc2_input_scale: torch.Tensor,
     w2_weight: torch.Tensor,
     w2_weight_sf: torch.Tensor,
-    w2_alpha: torch.Tensor,
     token_selected_experts: torch.Tensor,
     token_final_scales: torch.Tensor,
     num_experts: int,
     top_k: int,
+    *,
+    w1_alpha: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    fc2_input_scale: torch.Tensor,
     num_local_experts: Optional[int] = None,
     output: Optional[torch.Tensor] = None,
     output_dtype: torch.dtype = torch.bfloat16,
@@ -78,15 +79,15 @@ def b12x_fused_moe(
             Gated (SiLU): [E, 2*intermediate_size, hidden_size//2].
             Non-gated (ReLU2): [E, intermediate_size, hidden_size//2].
         w1_weight_sf: Scale factors for w1_weight.
-        w1_alpha: Per-expert global scale for FC1.
-        fc2_input_scale: Global scale for FC2 input quantization.
         w2_weight: FC2 weights [E, hidden_size, intermediate_size//2], FP4.
         w2_weight_sf: Scale factors for w2_weight.
-        w2_alpha: Per-expert global scale for FC2.
         token_selected_experts: Expert assignments [num_tokens, top_k].
         token_final_scales: Routing weights [num_tokens, top_k].
         num_experts: Total number of experts.
         top_k: Number of experts per token.
+        w1_alpha: Per-expert global scale for FC1.
+        w2_alpha: Per-expert global scale for FC2.
+        fc2_input_scale: Global scale for FC2 input quantization.
         num_local_experts: Local experts for EP. Default: num_experts.
         output: Pre-allocated output buffer [num_tokens, hidden_size].
         output_dtype: Output data type. Default: torch.bfloat16.
@@ -169,6 +170,7 @@ class B12xMoEWrapper:
         top_k: int,
         hidden_size: int,
         intermediate_size: int,
+        *,
         use_cuda_graph: bool = False,
         max_num_tokens: int = 4096,
         num_local_experts: Optional[int] = None,
@@ -251,13 +253,14 @@ class B12xMoEWrapper:
         x: torch.Tensor,
         w1_weight: torch.Tensor,
         w1_weight_sf: torch.Tensor,
-        w1_alpha: torch.Tensor,
-        fc2_input_scale: torch.Tensor,
         w2_weight: torch.Tensor,
         w2_weight_sf: torch.Tensor,
-        w2_alpha: torch.Tensor,
         token_selected_experts: torch.Tensor,
         token_final_scales: torch.Tensor,
+        *,
+        w1_alpha: torch.Tensor,
+        w2_alpha: torch.Tensor,
+        fc2_input_scale: torch.Tensor,
     ) -> torch.Tensor:
         """Run MoE computation.
 
@@ -265,13 +268,13 @@ class B12xMoEWrapper:
             x: Input activations [num_tokens, hidden_size], bf16.
             w1_weight: FC1 weights, FP4 packed.
             w1_weight_sf: Scale factors for w1_weight.
-            w1_alpha: Per-expert global scale for FC1.
-            fc2_input_scale: Global scale for FC2 input quantization.
             w2_weight: FC2 weights, FP4 packed.
             w2_weight_sf: Scale factors for w2_weight.
-            w2_alpha: Per-expert global scale for FC2.
             token_selected_experts: Expert assignments [num_tokens, top_k].
             token_final_scales: Routing weights [num_tokens, top_k].
+            w1_alpha: Per-expert global scale for FC1.
+            w2_alpha: Per-expert global scale for FC2.
+            fc2_input_scale: Global scale for FC2 input quantization.
 
         Returns:
             Output tensor [num_tokens, hidden_size].

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -220,8 +220,11 @@ class B12xMoEWrapper:
         self.device = device
         self.activation = activation
 
-        # Pre-allocated objects
-        self._workspace: object = None
+        # Pre-allocated objects. Both workspace slots may be populated so
+        # run() can pick per-call; without this, the backend would be locked
+        # to whichever workspace was allocated at init time.
+        self._static_workspace: object = None
+        self._dynamic_workspace: object = None
         self._weight_views: object = None
         self._weight_key: Optional[Tuple] = None
         self._moe_output: Optional[torch.Tensor] = None
@@ -235,33 +238,47 @@ class B12xMoEWrapper:
             allocate_sm120_static_workspace,
             allocate_sm120_dynamic_workspace,
             select_sm120_moe_backend,
+            _STATIC_COMPACT_CUTOVER_PAIRS,
         )
 
         max_routed_rows = self.max_num_tokens * self.top_k
-        backend = select_sm120_moe_backend(
-            num_tokens=self.max_num_tokens, num_topk=self.top_k
+
+        # Allocate a dynamic workspace alongside the static one when
+        # max_num_tokens is large enough to cross the cutover. This lets
+        # run() adapt backend per call rather than locking at init. The
+        # dynamic kernel indexes row_counts/expert_write_rows with topk_ids
+        # (sized by num_local_experts), so it requires num_local == num_experts.
+        needs_dynamic = (
+            select_sm120_moe_backend(
+                num_tokens=self.max_num_tokens, num_topk=self.top_k
+            )
+            == "dynamic"
+            and self.num_local_experts == self.num_experts
         )
-        # Mirror the dynamic→static fallback in launch_sm120_moe: the dynamic
-        # kernel indexes row_counts/expert_write_rows with topk_ids (sized by
-        # num_local_experts). Once a dynamic workspace is passed in, runtime
-        # dispatch skips that safety check, so apply it here too.
-        if backend == "dynamic" and self.num_local_experts != self.num_experts:
-            backend = "static"
-        if backend == "dynamic":
-            self._workspace = allocate_sm120_dynamic_workspace(
+
+        # When both workspaces exist, static only serves calls with
+        # routed_rows <= cutover; size it accordingly to avoid paying for
+        # the full capacity twice.
+        static_max_rows = (
+            min(max_routed_rows, _STATIC_COMPACT_CUTOVER_PAIRS)
+            if needs_dynamic
+            else max_routed_rows
+        )
+        self._static_workspace = allocate_sm120_static_workspace(
+            state_E=self.num_local_experts,
+            weight_E=self.num_experts,
+            max_rows=max(1, static_max_rows),
+            k=self.hidden_size,
+            n=self.intermediate_size,
+            num_topk=self.top_k,
+            device=torch.device(self.device),
+        )
+
+        if needs_dynamic:
+            self._dynamic_workspace = allocate_sm120_dynamic_workspace(
                 state_E=self.num_local_experts,
                 weight_E=self.num_experts,
                 routed_rows=max_routed_rows,
-                k=self.hidden_size,
-                n=self.intermediate_size,
-                num_topk=self.top_k,
-                device=torch.device(self.device),
-            )
-        else:
-            self._workspace = allocate_sm120_static_workspace(
-                state_E=self.num_local_experts,
-                weight_E=self.num_experts,
-                max_rows=max(1, max_routed_rows),
                 k=self.hidden_size,
                 n=self.intermediate_size,
                 num_topk=self.top_k,
@@ -327,8 +344,23 @@ class B12xMoEWrapper:
 
         from .blackwell_sm12x.moe_dispatch import (
             launch_sm120_moe,
+            select_sm120_moe_backend,
             _get_weight_views as _get_sm120_weight_views,
         )
+
+        # Pick the right pre-allocated workspace for this call's token
+        # count. launch_sm120_moe otherwise infers backend from workspace
+        # type, which would lock us to whichever one was allocated at init.
+        workspace = None
+        if self.use_cuda_graph:
+            if (
+                self._dynamic_workspace is not None
+                and select_sm120_moe_backend(num_tokens=num_tokens, num_topk=self.top_k)
+                == "dynamic"
+            ):
+                workspace = self._dynamic_workspace
+            else:
+                workspace = self._static_workspace
 
         # Cache weight views; invalidate if weight pointers change.
         weight_key = (
@@ -368,6 +400,6 @@ class B12xMoEWrapper:
             num_local_experts=self.num_local_experts,
             scatter_output=moe_output,
             activation=self.activation,
-            _workspace=self._workspace,
+            _workspace=workspace,
             _weight_views=self._weight_views,
         )

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -1,0 +1,341 @@
+"""
+B12x fused MoE API for SM120/SM121 (RTX 5090, DGX Spark).
+
+Provides high-level APIs for running Mixture of Experts (MoE)
+computations using b12x CuTe DSL kernels on Blackwell GeForce GPUs.
+
+The b12x kernels take bf16 input and fuse quantization + routing +
+FC1 + activation + FC2 + scatter in a single kernel launch.
+Supports SiLU (gated, SwiGLU) and ReLU2 (non-gated, Nemotron-Super)
+activations.
+
+Two APIs are provided:
+
+1. **Functional API** (`b12x_fused_moe`):
+   Simple function call. Workspace is cached internally.
+
+2. **Wrapper API** (`B12xMoEWrapper`):
+   Class-based API with pre-allocated buffers for CUDA graph compatibility.
+
+Example (Functional API):
+    >>> from flashinfer import b12x_fused_moe
+    >>> output = b12x_fused_moe(
+    ...     x=hidden_states_bf16,
+    ...     w1_weight=w1_fp4, w1_weight_sf=w1_sf, w1_alpha=w1_alpha,
+    ...     fc2_input_scale=fc2_scale,
+    ...     w2_weight=w2_fp4, w2_weight_sf=w2_sf, w2_alpha=w2_alpha,
+    ...     token_selected_experts=topk_ids, token_final_scales=topk_weights,
+    ...     num_experts=256, top_k=8,
+    ... )
+
+Example (Wrapper API with CUDA Graph):
+    >>> from flashinfer import B12xMoEWrapper
+    >>> moe = B12xMoEWrapper(
+    ...     num_experts=256, top_k=8, hidden_size=4096,
+    ...     intermediate_size=14336, use_cuda_graph=True,
+    ... )
+    >>> output = moe.run(x=hidden_states_bf16, ...)
+"""
+
+from typing import Optional, Tuple
+
+import torch
+
+from ...api_logging import flashinfer_api
+from ...utils import supported_compute_capability
+
+
+@supported_compute_capability([120, 121])
+@flashinfer_api
+def b12x_fused_moe(
+    x: torch.Tensor,
+    w1_weight: torch.Tensor,
+    w1_weight_sf: torch.Tensor,
+    w1_alpha: torch.Tensor,
+    fc2_input_scale: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w2_weight_sf: torch.Tensor,
+    w2_alpha: torch.Tensor,
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    num_local_experts: Optional[int] = None,
+    output: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.bfloat16,
+    activation: str = "silu",
+) -> torch.Tensor:
+    """Run fused MoE on SM120/SM121 using b12x CuTe DSL kernels.
+
+    The kernel takes bf16 input and fuses quantization + routing +
+    FC1 + activation + FC2 + scatter in a single launch.
+    Automatically selects micro (decode), static, or dynamic backend
+    based on routed row count.
+
+    Args:
+        x: Input activations [num_tokens, hidden_size], bf16.
+        w1_weight: FC1 weights, FP4 packed.
+            Gated (SiLU): [E, 2*intermediate_size, hidden_size//2].
+            Non-gated (ReLU2): [E, intermediate_size, hidden_size//2].
+        w1_weight_sf: Scale factors for w1_weight.
+        w1_alpha: Per-expert global scale for FC1.
+        fc2_input_scale: Global scale for FC2 input quantization.
+        w2_weight: FC2 weights [E, hidden_size, intermediate_size//2], FP4.
+        w2_weight_sf: Scale factors for w2_weight.
+        w2_alpha: Per-expert global scale for FC2.
+        token_selected_experts: Expert assignments [num_tokens, top_k].
+        token_final_scales: Routing weights [num_tokens, top_k].
+        num_experts: Total number of experts.
+        top_k: Number of experts per token.
+        num_local_experts: Local experts for EP. Default: num_experts.
+        output: Pre-allocated output buffer [num_tokens, hidden_size].
+        output_dtype: Output data type. Default: torch.bfloat16.
+        activation: Activation function — "silu" (gated/SwiGLU) or
+            "relu2" (non-gated/Nemotron-Super). Default: "silu".
+
+    Returns:
+        Output tensor [num_tokens, hidden_size].
+    """
+    from ...jit.cpp_ext import get_cuda_version
+
+    if get_cuda_version().major < 13:
+        raise ValueError(
+            "b12x fused MoE requires CUDA 13 or later. "
+            f"Current CUDA version: {get_cuda_version()}."
+        )
+
+    if num_local_experts is None:
+        num_local_experts = num_experts
+
+    num_tokens = token_selected_experts.size(0)
+    hidden_size = x.size(1)
+
+    if output is None:
+        output = torch.empty(
+            (num_tokens, hidden_size),
+            dtype=output_dtype,
+            device=x.device,
+        )
+
+    from .blackwell_sm12x.moe_dispatch import launch_sm120_moe
+
+    return launch_sm120_moe(
+        a=x,
+        topk_ids=token_selected_experts,
+        topk_weights=token_final_scales,
+        w1_weight=w1_weight,
+        w1_weight_sf=w1_weight_sf,
+        w1_alpha=w1_alpha,
+        fc2_input_scale=fc2_input_scale,
+        w2_weight=w2_weight,
+        w2_weight_sf=w2_weight_sf,
+        w2_alpha=w2_alpha,
+        num_experts=num_experts,
+        top_k=top_k,
+        num_local_experts=num_local_experts,
+        scatter_output=output,
+        activation=activation,
+    )
+
+
+class B12xMoEWrapper:
+    """B12x fused MoE wrapper for SM120/SM121 with CUDA graph support.
+
+    Pre-allocates workspace buffers for CUDA graph compatibility.
+    Automatically selects micro/static/dynamic backend per call.
+
+    Args:
+        num_experts: Total number of experts.
+        top_k: Number of experts per token.
+        hidden_size: Hidden dimension size.
+        intermediate_size: Intermediate size.
+        use_cuda_graph: Pre-allocate buffers for CUDA graph compatibility.
+        max_num_tokens: Maximum tokens (only for use_cuda_graph=True).
+        num_local_experts: Local experts for EP. Default: num_experts.
+        output_dtype: Output data type. Default: torch.bfloat16.
+        device: Device for buffer allocation. Default: "cuda".
+        activation: Activation function — "silu" or "relu2". Default: "silu".
+
+    Example:
+        >>> moe = B12xMoEWrapper(num_experts=256, top_k=8, ...)
+        >>> output = moe.run(x=hidden_states_bf16, ...)
+    """
+
+    @supported_compute_capability([120, 121])
+    @flashinfer_api
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        use_cuda_graph: bool = False,
+        max_num_tokens: int = 4096,
+        num_local_experts: Optional[int] = None,
+        output_dtype: torch.dtype = torch.bfloat16,
+        device: str = "cuda",
+        activation: str = "silu",
+    ):
+        from ...jit.cpp_ext import get_cuda_version
+
+        if get_cuda_version().major < 13:
+            raise ValueError(
+                "b12x fused MoE requires CUDA 13 or later. "
+                f"Current CUDA version: {get_cuda_version()}."
+            )
+
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.use_cuda_graph = use_cuda_graph
+        self.max_num_tokens = max_num_tokens
+        self.num_local_experts = num_local_experts or num_experts
+        self.output_dtype = output_dtype
+        self.device = device
+        self.activation = activation
+
+        # Pre-allocated objects
+        self._workspace: object = None
+        self._weight_views: object = None
+        self._weight_key: Optional[Tuple] = None
+        self._moe_output: Optional[torch.Tensor] = None
+
+        if use_cuda_graph:
+            self._allocate_buffers()
+
+    def _allocate_buffers(self) -> None:
+        """Pre-allocate buffers for CUDA graph compatibility."""
+        from .blackwell_sm12x.moe_dispatch import (
+            allocate_sm120_static_workspace,
+            allocate_sm120_dynamic_workspace,
+            select_sm120_moe_backend,
+        )
+
+        max_routed_rows = self.max_num_tokens * self.top_k
+        backend = select_sm120_moe_backend(
+            num_tokens=self.max_num_tokens, num_topk=self.top_k
+        )
+        if backend == "dynamic":
+            self._workspace = allocate_sm120_dynamic_workspace(
+                state_E=self.num_local_experts,
+                weight_E=self.num_experts,
+                routed_rows=max_routed_rows,
+                k=self.hidden_size,
+                n=self.intermediate_size,
+                num_topk=self.top_k,
+                device=torch.device(self.device),
+            )
+        else:
+            self._workspace = allocate_sm120_static_workspace(
+                state_E=self.num_local_experts,
+                weight_E=self.num_experts,
+                max_rows=max(1, max_routed_rows),
+                k=self.hidden_size,
+                n=self.intermediate_size,
+                num_topk=self.top_k,
+                device=torch.device(self.device),
+            )
+
+        # Allocated after arch-specific buffers to preserve memory layout
+        # that the autotuner's CUDA graph profiling is sensitive to.
+        self._moe_output = torch.empty(
+            (self.max_num_tokens, self.hidden_size),
+            dtype=self.output_dtype,
+            device=self.device,
+        )
+
+    @flashinfer_api
+    def run(
+        self,
+        x: torch.Tensor,
+        w1_weight: torch.Tensor,
+        w1_weight_sf: torch.Tensor,
+        w1_alpha: torch.Tensor,
+        fc2_input_scale: torch.Tensor,
+        w2_weight: torch.Tensor,
+        w2_weight_sf: torch.Tensor,
+        w2_alpha: torch.Tensor,
+        token_selected_experts: torch.Tensor,
+        token_final_scales: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run MoE computation.
+
+        Args:
+            x: Input activations [num_tokens, hidden_size], bf16.
+            w1_weight: FC1 weights, FP4 packed.
+            w1_weight_sf: Scale factors for w1_weight.
+            w1_alpha: Per-expert global scale for FC1.
+            fc2_input_scale: Global scale for FC2 input quantization.
+            w2_weight: FC2 weights, FP4 packed.
+            w2_weight_sf: Scale factors for w2_weight.
+            w2_alpha: Per-expert global scale for FC2.
+            token_selected_experts: Expert assignments [num_tokens, top_k].
+            token_final_scales: Routing weights [num_tokens, top_k].
+
+        Returns:
+            Output tensor [num_tokens, hidden_size].
+        """
+        num_tokens = token_selected_experts.size(0)
+
+        if self.use_cuda_graph and num_tokens > self.max_num_tokens:
+            raise ValueError(
+                f"num_tokens ({num_tokens}) exceeds max_num_tokens "
+                f"({self.max_num_tokens})"
+            )
+
+        if self.use_cuda_graph:
+            moe_output = self._moe_output[:num_tokens]
+        else:
+            moe_output = torch.empty(
+                (num_tokens, self.hidden_size),
+                dtype=self.output_dtype,
+                device=x.device,
+            )
+
+        from .blackwell_sm12x.moe_dispatch import (
+            launch_sm120_moe,
+            _get_weight_views as _get_sm120_weight_views,
+        )
+
+        # Cache weight views; invalidate if weight pointers change.
+        weight_key = (
+            w1_weight.data_ptr(),
+            w1_weight_sf.data_ptr(),
+            w1_alpha.data_ptr(),
+            w2_weight.data_ptr(),
+            w2_weight_sf.data_ptr(),
+            w2_alpha.data_ptr(),
+        )
+        if self._weight_views is None or self._weight_key != weight_key:
+            self._weight_views = _get_sm120_weight_views(
+                w1_fp4=w1_weight,
+                w1_blockscale=w1_weight_sf,
+                w2_fp4=w2_weight,
+                w2_blockscale=w2_weight_sf,
+                w1_alphas=w1_alpha,
+                w2_alphas=w2_alpha,
+                n=self.intermediate_size,
+                k=self.hidden_size,
+            )
+            self._weight_key = weight_key
+
+        return launch_sm120_moe(
+            a=x,
+            topk_ids=token_selected_experts,
+            topk_weights=token_final_scales,
+            w1_weight=w1_weight,
+            w1_weight_sf=w1_weight_sf,
+            w1_alpha=w1_alpha,
+            fc2_input_scale=fc2_input_scale,
+            w2_weight=w2_weight,
+            w2_weight_sf=w2_weight_sf,
+            w2_alpha=w2_alpha,
+            num_experts=self.num_experts,
+            top_k=self.top_k,
+            num_local_experts=self.num_local_experts,
+            scatter_output=moe_output,
+            activation=self.activation,
+            _workspace=self._workspace,
+            _weight_views=self._weight_views,
+        )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/__init__.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/__init__.py
@@ -1,6 +1,7 @@
 """Blackwell SM12x (SM120/SM121) MoE kernels for CuTe DSL (ported from b12x)."""
 
 from .moe_static_kernel import MoEStaticKernel
+from .moe_micro_kernel import MoEMicroKernel
 from .moe_dynamic_kernel import MoEDynamicKernel
 from .moe_dispatch import (
     Sm120StaticMoEWorkspace,
@@ -15,6 +16,7 @@ from .moe_dispatch import (
 
 __all__ = [
     "MoEStaticKernel",
+    "MoEMicroKernel",
     "MoEDynamicKernel",
     "Sm120StaticMoEWorkspace",
     "Sm120DynamicMoEWorkspace",

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -254,7 +254,8 @@ def _get_weight_views(
     if cached is not None:
         return cached
 
-    # Permute [E, 2*n, k//2] -> [2*n, k//2, E] (view, no copy)
+    # Permute [E, w1_rows, k//2] -> [w1_rows, k//2, E] (view, no copy)
+    # w1_rows is 2*n for gated (SiLU) or n for non-gated (ReLU2)
     w13 = w1_fp4.permute(1, 2, 0)
     down = w2_fp4.permute(1, 2, 0)
 
@@ -265,9 +266,10 @@ def _get_weight_views(
     # (which would write in permuted logical order).
     # convert_sf_from_mma_layout reverses the permutation back to 2D swizzled.
     sf_dtype = cutlass.Float8E4M3FN
+    w1_rows = w1_fp4.shape[1]  # 2*n for gated, n for non-gated
     w13_sf_contiguous = convert_sf_from_mma_layout(
         w1_blockscale,
-        m=2 * n,
+        m=w1_rows,
         k=k,
         num_groups=w1_fp4.shape[0],  # num_local_experts
     ).contiguous()
@@ -322,6 +324,7 @@ def _get_static_kernel(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     mac_override: int | None = None,
+    activation: str = "silu",
 ):
     """Compile (or retrieve cached) the SM120 static MoE kernel."""
     sf_vec_size = 16
@@ -352,6 +355,7 @@ def _get_static_kernel(
         topk_ids_dtype,
         input_scales_are_reciprocal,
         fast_math,
+        activation,
     )
     cached = _STATIC_KERNEL_CACHE.get(cache_key)
     if cached is not None:
@@ -368,7 +372,11 @@ def _get_static_kernel(
         output_tile_count_n=max(1, (n + mma_tiler_mn[1] - 1) // mma_tiler_mn[1]),
         input_scales_are_reciprocal=input_scales_are_reciprocal,
         fast_math=fast_math,
+        activation=activation,
     )
+
+    is_gated = activation == "silu"
+    w1_rows = (2 if is_gated else 1) * n  # 2*n for gated, n for non-gated
 
     rows_pad_k = _align_up(max_rows, 128)
     cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
@@ -423,7 +431,7 @@ def _get_static_kernel(
     )
     b_w13_fake = cute.runtime.make_fake_compact_tensor(
         ab_dtype,
-        (2 * n, k, weight_E),
+        (w1_rows, k, weight_E),
         stride_order=(1, 0, 2),
         assumed_align=16,
     )
@@ -545,6 +553,7 @@ def _get_micro_kernel(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     mac_override: int | None = None,
+    activation: str = "silu",
 ):
     """Compile (or retrieve cached) the SM120 micro MoE kernel."""
     sf_vec_size = 16
@@ -573,6 +582,7 @@ def _get_micro_kernel(
         topk_ids_dtype,
         input_scales_are_reciprocal,
         fast_math,
+        activation,
     )
     cached = _MICRO_KERNEL_CACHE.get(cache_key)
     if cached is not None:
@@ -589,7 +599,11 @@ def _get_micro_kernel(
         output_tile_count_n=max(1, (n + mma_tiler_mn[1] - 1) // mma_tiler_mn[1]),
         input_scales_are_reciprocal=input_scales_are_reciprocal,
         fast_math=fast_math,
+        activation=activation,
     )
+
+    is_gated = activation == "silu"
+    w1_rows = (2 if is_gated else 1) * n
 
     rows_pad_k = _align_up(max_rows, 128)
     cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
@@ -644,7 +658,7 @@ def _get_micro_kernel(
     )
     b_w13_fake = cute.runtime.make_fake_compact_tensor(
         ab_dtype,
-        (2 * n, k, weight_E),
+        (w1_rows, k, weight_E),
         stride_order=(1, 0, 2),
         assumed_align=16,
     )
@@ -777,6 +791,7 @@ def launch_sm120_static_moe(
     top_k: int,
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
+    activation: str = "silu",
 ) -> torch.Tensor:
     """Launch the SM120 static or micro MoE kernel.
 
@@ -831,6 +846,7 @@ def launch_sm120_static_moe(
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
             mac_override=micro_mac,
+            activation=activation,
         )
         launch_ids = compact_ids
     else:
@@ -848,6 +864,7 @@ def launch_sm120_static_moe(
             topk_ids_dtype=torch.int32,
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
+            activation=activation,
         )
         launch_ids = flat_ids
 
@@ -1215,6 +1232,7 @@ def _get_dynamic_kernel(
     topk_ids_dtype: torch.dtype = torch.int32,
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
+    activation: str = "silu",
 ):
     """Compile (or retrieve cached) the SM120 dynamic MoE kernel."""
     sf_vec_size = 16
@@ -1231,10 +1249,14 @@ def _get_dynamic_kernel(
         topk_ids_dtype,
         input_scales_are_reciprocal,
         fast_math,
+        activation,
     )
     cached = _DYNAMIC_KERNEL_CACHE.get(cache_key)
     if cached is not None:
         return cached
+
+    is_gated = activation == "silu"
+    w1_rows = (2 if is_gated else 1) * n
 
     ab_dtype = cutlass.Float4E2M1FN
     sf_dtype = cutlass.Float8E4M3FN
@@ -1246,6 +1268,7 @@ def _get_dynamic_kernel(
         mma_tiler_mn=(_LEVEL_TILE_M, _LEVEL_TILE_N),
         input_scales_are_reciprocal=input_scales_are_reciprocal,
         fast_math=fast_math,
+        activation=activation,
     )
     launch = _DynamicMoELaunch(kernel, k=k, num_topk=num_topk)
 
@@ -1320,7 +1343,7 @@ def _get_dynamic_kernel(
 
     b_w13_fake = cute.runtime.make_fake_compact_tensor(
         ab_dtype,
-        (2 * n, k, E),
+        (w1_rows, k, E),
         stride_order=(1, 0, 2),
         assumed_align=16,
     )
@@ -1431,6 +1454,7 @@ def launch_sm120_dynamic_moe(
     top_k: int,
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
+    activation: str = "silu",
 ) -> torch.Tensor:
     """Launch the SM120 dynamic MoE kernel."""
     flat_ids = topk_ids.view(-1).to(torch.int32)
@@ -1450,6 +1474,7 @@ def launch_sm120_dynamic_moe(
         topk_ids_dtype=torch.int32,
         input_scales_are_reciprocal=input_scales_are_reciprocal,
         fast_math=fast_math,
+        activation=activation,
     )
 
     scatter_output.zero_()
@@ -1593,6 +1618,7 @@ def launch_sm120_moe(
     scatter_output: torch.Tensor,
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
+    activation: str = "silu",
     _workspace=None,
     _weight_views=None,
 ) -> torch.Tensor:
@@ -1605,7 +1631,9 @@ def launch_sm120_moe(
     """
     num_tokens = topk_ids.size(0)
     k = a.size(1)  # hidden_size
-    intermediate_size = w1_weight.size(1) // 2
+    is_gated = activation == "silu"
+    # w1_weight.size(1) is 2*n for gated or n for non-gated
+    intermediate_size = w1_weight.size(1) // 2 if is_gated else w1_weight.size(1)
     n = intermediate_size
     routed_rows = num_tokens * top_k
 
@@ -1670,6 +1698,7 @@ def launch_sm120_moe(
             top_k=top_k,
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
+            activation=activation,
         )
     else:
         return launch_sm120_static_moe(
@@ -1688,4 +1717,5 @@ def launch_sm120_moe(
             top_k=top_k,
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
+            activation=activation,
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -875,9 +875,6 @@ def launch_sm120_static_moe(
         )
         launch_ids = flat_ids
 
-    # Zero scatter output before atomic accumulation
-    scatter_output.zero_()
-
     # With TVM-FFI env stream, the stream is managed automatically.
     # max_active_clusters is still a required positional arg for TVM-FFI.
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
@@ -1483,8 +1480,6 @@ def launch_sm120_dynamic_moe(
         fast_math=fast_math,
         activation=activation,
     )
-
-    scatter_output.zero_()
 
     # Dynamic kernel: runtime-shaped args are DataPointer (pass data_ptr()),
     # fixed-shape args are Tensor (pass torch tensor directly).

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -7,6 +7,7 @@ selection.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Dict, Tuple, Union
 
@@ -90,7 +91,10 @@ def _select_moe_mma_tiler_mn(routed_rows: int, n: int) -> Tuple[int, int]:
     coarse_tiles = ((routed_rows + coarse_tile[0] - 1) // coarse_tile[0]) * (
         (n + coarse_tile[1] - 1) // coarse_tile[1]
     )
-    if routed_rows <= 128 and coarse_tiles < max(1, sm_count // 2):
+    # Single-token decode often lands exactly on the "half the machine"
+    # boundary. Keeping the coarse 128x128 tile there leaves the M dimension
+    # badly underfilled, so take the narrow 64x128 tile inclusive of equality.
+    if routed_rows <= 128 and coarse_tiles <= max(1, sm_count // 2):
         return (64, 128)
     return (128, 128)
 
@@ -552,6 +556,7 @@ def _get_micro_kernel(
     topk_ids_dtype: torch.dtype = torch.int32,
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
+    share_input_across_experts: bool = False,
     mac_override: int | None = None,
     activation: str = "silu",
 ):
@@ -582,6 +587,7 @@ def _get_micro_kernel(
         topk_ids_dtype,
         input_scales_are_reciprocal,
         fast_math,
+        share_input_across_experts,
         activation,
     )
     cached = _MICRO_KERNEL_CACHE.get(cache_key)
@@ -600,6 +606,7 @@ def _get_micro_kernel(
         input_scales_are_reciprocal=input_scales_are_reciprocal,
         fast_math=fast_math,
         activation=activation,
+        share_input_across_experts=share_input_across_experts,
     )
 
     is_gated = activation == "silu"
@@ -804,6 +811,11 @@ def launch_sm120_static_moe(
     flat_weights = topk_weights.view(-1).to(torch.float32)
     routed_rows = num_tokens * top_k
 
+    # Capture whether input_gs was a single shared scalar BEFORE expansion:
+    # the m=1 relu2 shared-input micro optimization only applies when every
+    # expert sees the same FC1-input global scale.
+    input_gs_is_shared = input_gs.numel() == 1
+
     # Broadcast scalar scales to per-expert [E] tensors
     input_gs = _expand_to_experts(input_gs, num_experts)
     down_input_scale = _expand_to_experts(down_input_scale, num_experts)
@@ -818,30 +830,54 @@ def launch_sm120_static_moe(
     base_mac = min(get_max_active_clusters(1), sm_count)
 
     if use_micro:
-        # For single-token decode, the top-k routing is already a dense set
-        # of unique expert IDs — skip the Triton compaction pre-pass entirely.
-        launch_ids = flat_ids
-        if num_tokens != 1:
+        assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
+            f"compact_topk_ids buffer too small: "
+            f"{workspace.compact_topk_ids.numel()} < {flat_ids.numel()}"
+        )
+        compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+        if num_tokens == 1:
+            # A single token's top-k is already a dense unique expert set,
+            # so we can build the compact local-id mapping on the host
+            # without launching the Triton compaction kernel. The micro
+            # kernel still reads weight_expert_ids the same way it does
+            # for m>1; it just sees a pre-filled workspace.
+            compact_ids.copy_(
+                torch.arange(
+                    flat_ids.numel(),
+                    device=flat_ids.device,
+                    dtype=torch.int32,
+                )
+            )
+            workspace.weight_expert_ids[: flat_ids.numel()].copy_(
+                flat_ids.to(torch.int32)
+            )
+            workspace.active_expert_count.fill_(flat_ids.numel())
+        else:
             from .triton_compact import compact_topk_ids as _triton_compact_topk_ids
 
-            assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
-                f"compact_topk_ids buffer too small: "
-                f"{workspace.compact_topk_ids.numel()} < {flat_ids.numel()}"
-            )
-            compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
             _triton_compact_topk_ids(
                 flat_ids,
                 compact_ids,
                 workspace.weight_expert_ids,
                 workspace.active_expert_count,
             )
-            launch_ids = compact_ids
+        launch_ids = compact_ids
         # Select micro MAC: min of tuned ladder, work tiles, and hardware limit.
         # The hardware cap (base_mac) prevents deadlocks on GPUs with fewer SMs
         # than the profiled tuning target.
         micro_work_tiles = max(1, routed_rows * max(1, (n + 128 - 1) // 128))
         tuned_mac = _lookup_mac_ladder(_MICRO_MAC_LADDER, routed_rows)
         micro_mac = min(tuned_mac or base_mac, micro_work_tiles, base_mac)
+        # For m=1 relu2 with a shared FC1-input scale, all experts see the
+        # same quantized activation — quantize once and share the packed
+        # buffer slot across all K top-k pairs. Env override lets us flip
+        # this off without a code change if a regression surfaces.
+        share_input_across_experts = (
+            activation == "relu2"
+            and num_tokens == 1
+            and input_gs_is_shared
+            and os.environ.get("FLASHINFER_B12X_MICRO_SHARE_INPUT", "1") != "0"
+        )
         compiled, mac = _get_micro_kernel(
             workspace.state_E,
             num_experts,
@@ -853,6 +889,7 @@ def launch_sm120_static_moe(
             topk_ids_dtype=torch.int32,
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
+            share_input_across_experts=share_input_across_experts,
             mac_override=micro_mac,
             activation=activation,
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -818,20 +818,24 @@ def launch_sm120_static_moe(
     base_mac = min(get_max_active_clusters(1), sm_count)
 
     if use_micro:
-        from .triton_compact import compact_topk_ids as _triton_compact_topk_ids
+        # For single-token decode, the top-k routing is already a dense set
+        # of unique expert IDs — skip the Triton compaction pre-pass entirely.
+        launch_ids = flat_ids
+        if num_tokens != 1:
+            from .triton_compact import compact_topk_ids as _triton_compact_topk_ids
 
-        # Run Triton pre-pass to compact global expert IDs to dense local indices
-        assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
-            f"compact_topk_ids buffer too small: "
-            f"{workspace.compact_topk_ids.numel()} < {flat_ids.numel()}"
-        )
-        compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
-        _triton_compact_topk_ids(
-            flat_ids,
-            compact_ids,
-            workspace.weight_expert_ids,
-            workspace.active_expert_count,
-        )
+            assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
+                f"compact_topk_ids buffer too small: "
+                f"{workspace.compact_topk_ids.numel()} < {flat_ids.numel()}"
+            )
+            compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+            _triton_compact_topk_ids(
+                flat_ids,
+                compact_ids,
+                workspace.weight_expert_ids,
+                workspace.active_expert_count,
+            )
+            launch_ids = compact_ids
         # Select micro MAC: min of tuned ladder, work tiles, and hardware limit.
         # The hardware cap (base_mac) prevents deadlocks on GPUs with fewer SMs
         # than the profiled tuning target.
@@ -852,7 +856,6 @@ def launch_sm120_static_moe(
             mac_override=micro_mac,
             activation=activation,
         )
-        launch_ids = compact_ids
     else:
         # Static path — use hardware default MAC (same as main).
         # MAC tuning for the static kernel is deferred to a follow-up

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -1,7 +1,8 @@
 """SM120/SM121 MoE dispatch layer — workspace, compilation, and launch.
 
-Ported from b12x's integration/tp_moe.py. Supports both static (decode)
-and dynamic (prefill) backends with token-count-based selection.
+Ported from b12x's integration/tp_moe.py. Supports micro (tiny decode),
+static (decode), and dynamic (prefill) backends with token-count-based
+selection.
 """
 
 from __future__ import annotations
@@ -19,8 +20,9 @@ from flashinfer.cute_dsl.utils import (
     get_num_sm,
     make_ptr,
 )
-from .moe_static_kernel import MoEStaticKernel
 from .moe_dynamic_kernel import MoEDynamicKernel
+from .moe_micro_kernel import MoEMicroKernel
+from .moe_static_kernel import MoEStaticKernel
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -29,6 +31,48 @@ _NVFP4_BLOCK_SIZE = 16
 _LEVEL_TILE_M = 128
 _LEVEL_TILE_N = 128
 SF_VEC_SIZE = 16
+
+# Micro kernel cutover thresholds (routed pairs)
+_MICRO_COMPACT_CUTOVER_PAIRS = 20
+_MICRO_COMPACT_CUTOVER_PAIRS_MULTI_TOPK = 40
+
+# MAC (max active clusters) tuning ladders from b12x decode profiling.
+# Each entry is (max_routed_rows, optimal_mac).
+_MICRO_MAC_LADDER: Tuple[Tuple[int, int], ...] = (
+    (2, 84),
+    (4, 127),
+    (8, 107),
+    (10, 84),
+    (16, 63),
+    (20, 84),
+)
+_STATIC_MAC_LADDER: Tuple[Tuple[int, int], ...] = (
+    (24, 148),
+    (32, 169),
+    (40, 132),
+    (48, 149),
+    (64, 134),
+    (80, 175),
+    (96, 171),
+    (120, 125),
+    (128, 130),
+    (160, 171),
+    (192, 166),
+    (256, 141),
+    (320, 158),
+    (512, 175),
+    (640, 188),
+)
+
+
+def _lookup_mac_ladder(
+    ladder: Tuple[Tuple[int, int], ...], routed_rows: int
+) -> int | None:
+    """Look up optimal MAC from a tuning ladder. Returns None if no match."""
+    for end_rows, mac in ladder:
+        if routed_rows <= end_rows:
+            return mac
+    return None
 
 
 def _align_up(value: int, alignment: int) -> int:
@@ -91,6 +135,7 @@ class Sm120StaticMoEWorkspace:
     active_expert_count: torch.Tensor  # [1] int32
     weight_expert_ids: torch.Tensor  # [state_E] int32
     global_to_local_expert: torch.Tensor  # [weight_E] int32
+    compact_topk_ids: torch.Tensor  # [state_E] int32, for micro kernel pre-pass
 
     # Views (set after allocation)
     packed_a_view: torch.Tensor | None = None
@@ -137,6 +182,7 @@ def allocate_sm120_static_workspace(
         active_expert_count=torch.zeros(1, dtype=torch.int32, device=device),
         weight_expert_ids=torch.arange(state_E, dtype=torch.int32, device=device),
         global_to_local_expert=torch.empty(weight_E, dtype=torch.int32, device=device),
+        compact_topk_ids=torch.empty(state_E, dtype=torch.int32, device=device),
     )
 
     # Finalize views
@@ -275,11 +321,16 @@ def _get_static_kernel(
     topk_ids_dtype: torch.dtype = torch.int32,
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
+    mac_override: int | None = None,
 ):
     """Compile (or retrieve cached) the SM120 static MoE kernel."""
     sf_vec_size = 16
     sm_count = get_num_sm(torch.device("cuda"))
-    mac = min(get_max_active_clusters(1), sm_count)
+    mac = (
+        mac_override
+        if mac_override is not None
+        else min(get_max_active_clusters(1), sm_count)
+    )
 
     # Select tile size based on actual routed rows
     routed_rows = m * num_topk
@@ -478,6 +529,227 @@ def _get_static_kernel(
     return result
 
 
+_MICRO_KERNEL_CACHE: Dict[Tuple, Tuple] = {}
+
+
+def _get_micro_kernel(
+    state_E: int,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    max_rows: int,
+    *,
+    topk_ids_dtype: torch.dtype = torch.int32,
+    input_scales_are_reciprocal: bool = False,
+    fast_math: bool = True,
+    mac_override: int | None = None,
+):
+    """Compile (or retrieve cached) the SM120 micro MoE kernel."""
+    sf_vec_size = 16
+    sm_count = get_num_sm(torch.device("cuda"))
+    mac = (
+        mac_override
+        if mac_override is not None
+        else min(get_max_active_clusters(1), sm_count)
+    )
+
+    # Micro always selects tile from routed rows (not just for multi-topk)
+    routed_rows = m * num_topk
+    mma_tiler_mn = _select_moe_mma_tiler_mn(routed_rows, n)
+
+    cache_key = (
+        "micro",
+        state_E,
+        weight_E,
+        m,
+        k,
+        n,
+        num_topk,
+        max_rows,
+        mac,
+        mma_tiler_mn,
+        topk_ids_dtype,
+        input_scales_are_reciprocal,
+        fast_math,
+    )
+    cached = _MICRO_KERNEL_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    ab_dtype = cutlass.Float4E2M1FN
+    sf_dtype = cutlass.Float8E4M3FN
+    a_dtype = cutlass.BFloat16
+    alpha_dtype = cutlass.Float32
+
+    kernel = MoEMicroKernel(
+        sf_vec_size=sf_vec_size,
+        mma_tiler_mn=mma_tiler_mn,
+        output_tile_count_n=max(1, (n + mma_tiler_mn[1] - 1) // mma_tiler_mn[1]),
+        input_scales_are_reciprocal=input_scales_are_reciprocal,
+        fast_math=fast_math,
+    )
+
+    rows_pad_k = _align_up(max_rows, 128)
+    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+
+    # Build fake tensors for compilation (identical to static kernel)
+    a_input_fake = cute.runtime.make_fake_compact_tensor(
+        a_dtype,
+        (m, k),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    topk_ids_cutlass_dtype = (
+        cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
+    )
+    topk_ids_align = 4 if topk_ids_dtype == torch.int32 else 8
+    topk_ids_fake = cute.runtime.make_fake_compact_tensor(
+        topk_ids_cutlass_dtype,
+        (m * num_topk,),
+        assumed_align=topk_ids_align,
+    )
+    topk_weights_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (m * num_topk,),
+        assumed_align=4,
+    )
+    packed_a_fake = cute.runtime.make_fake_compact_tensor(
+        ab_dtype,
+        (max_rows, k, state_E),
+        stride_order=(1, 0, 2),
+        assumed_align=16,
+    )
+    sfa_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    packed_a_storage_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Uint8,
+        (state_E * max_rows * (k // 2),),
+        assumed_align=16,
+    )
+    scale_storage_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Uint8,
+        (state_E * rows_pad_k * cols_pad_k,),
+        assumed_align=16,
+    )
+    barrier_count_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    barrier_epoch_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    b_w13_fake = cute.runtime.make_fake_compact_tensor(
+        ab_dtype,
+        (2 * n, k, weight_E),
+        stride_order=(1, 0, 2),
+        assumed_align=16,
+    )
+    sfb_w13_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    b_down_fake = cute.runtime.make_fake_compact_tensor(
+        ab_dtype,
+        (k, n, weight_E),
+        stride_order=(1, 0, 2),
+        assumed_align=16,
+    )
+    sfb_down_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    row_counts_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (state_E,),
+        assumed_align=4,
+    )
+    active_expert_count_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    weight_expert_ids_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (state_E,),
+        assumed_align=4,
+    )
+    global_to_local_expert_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (weight_E,),
+        assumed_align=4,
+    )
+    input_gs_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (weight_E,),
+        assumed_align=16,
+    )
+    alpha_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (weight_E,),
+        assumed_align=16,
+    )
+    down_alpha_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (weight_E,),
+        assumed_align=16,
+    )
+    global_scale_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (weight_E,),
+        assumed_align=16,
+    )
+    scatter_fake = cute.runtime.make_fake_compact_tensor(
+        a_dtype,
+        (m, k),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    token_map_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (state_E, max_rows),
+        stride_order=(1, 0),
+        assumed_align=4,
+    )
+    token_weights_fake = cute.runtime.make_fake_compact_tensor(
+        alpha_dtype,
+        (state_E, max_rows),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    compiled = cute.compile(
+        kernel,
+        a_input_fake,
+        topk_ids_fake,
+        topk_weights_fake,
+        packed_a_fake,
+        sfa_fake,
+        packed_a_storage_fake,
+        scale_storage_fake,
+        barrier_count_fake,
+        barrier_epoch_fake,
+        b_w13_fake,
+        sfb_w13_fake,
+        b_down_fake,
+        sfb_down_fake,
+        row_counts_fake,
+        active_expert_count_fake,
+        weight_expert_ids_fake,
+        global_to_local_expert_fake,
+        input_gs_fake,
+        alpha_fake,
+        down_alpha_fake,
+        global_scale_fake,
+        scatter_fake,
+        token_map_fake,
+        token_weights_fake,
+        mac,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--opt-level 2 --enable-tvm-ffi",
+    )
+
+    result = (compiled, mac)
+    _MICRO_KERNEL_CACHE[cache_key] = result
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Launch
 # ---------------------------------------------------------------------------
@@ -506,27 +778,78 @@ def launch_sm120_static_moe(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
 ) -> torch.Tensor:
-    """Launch the SM120 static MoE kernel."""
+    """Launch the SM120 static or micro MoE kernel.
+
+    Selects the micro kernel for tiny decode batches (routed_rows <= 20-40)
+    and the static kernel otherwise. The micro path runs a Triton pre-pass
+    to compact routing IDs before launching.
+    """
     # Flatten routing tensors
     flat_ids = topk_ids.view(-1).to(torch.int32)
     flat_weights = topk_weights.view(-1).to(torch.float32)
+    routed_rows = num_tokens * top_k
 
     # Broadcast scalar scales to per-expert [E] tensors
     input_gs = _expand_to_experts(input_gs, num_experts)
     down_input_scale = _expand_to_experts(down_input_scale, num_experts)
 
-    compiled, mac = _get_static_kernel(
-        workspace.state_E,
-        num_experts,
-        num_tokens,
-        k,
-        n,
-        top_k,
-        workspace.max_rows,
-        topk_ids_dtype=torch.int32,
-        input_scales_are_reciprocal=input_scales_are_reciprocal,
-        fast_math=fast_math,
-    )
+    # Decide micro vs static
+    micro_cutover = _MICRO_COMPACT_CUTOVER_PAIRS
+    if top_k > 1:
+        micro_cutover = _MICRO_COMPACT_CUTOVER_PAIRS_MULTI_TOPK
+    use_micro = routed_rows <= micro_cutover
+
+    sm_count = get_num_sm(torch.device("cuda"))
+    base_mac = min(get_max_active_clusters(1), sm_count)
+
+    if use_micro:
+        from .triton_compact import compact_topk_ids as _triton_compact_topk_ids
+
+        # Run Triton pre-pass to compact global expert IDs to dense local indices
+        compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+        _triton_compact_topk_ids(
+            flat_ids,
+            compact_ids,
+            workspace.weight_expert_ids,
+            workspace.active_expert_count,
+        )
+        # Select micro MAC: min of tuned ladder, work tiles, and hardware limit.
+        # The hardware cap (base_mac) prevents deadlocks on GPUs with fewer SMs
+        # than the profiled tuning target.
+        micro_work_tiles = max(1, routed_rows * max(1, (n + 128 - 1) // 128))
+        tuned_mac = _lookup_mac_ladder(_MICRO_MAC_LADDER, routed_rows)
+        micro_mac = min(tuned_mac or base_mac, micro_work_tiles, base_mac)
+        compiled, mac = _get_micro_kernel(
+            workspace.state_E,
+            num_experts,
+            num_tokens,
+            k,
+            n,
+            top_k,
+            workspace.max_rows,
+            topk_ids_dtype=torch.int32,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+            fast_math=fast_math,
+            mac_override=micro_mac,
+        )
+        launch_ids = compact_ids
+    else:
+        # Static path — use hardware default MAC (same as main).
+        # MAC tuning for the static kernel is deferred to a follow-up
+        # to avoid changing behavior for existing static workloads.
+        compiled, mac = _get_static_kernel(
+            workspace.state_E,
+            num_experts,
+            num_tokens,
+            k,
+            n,
+            top_k,
+            workspace.max_rows,
+            topk_ids_dtype=torch.int32,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+            fast_math=fast_math,
+        )
+        launch_ids = flat_ids
 
     # Zero scatter output before atomic accumulation
     scatter_output.zero_()
@@ -536,7 +859,7 @@ def launch_sm120_static_moe(
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
     compiled(
         a,
-        flat_ids,
+        launch_ids,
         flat_weights,
         workspace.packed_a_view,
         workspace.packed_input_scale.data_ptr(),

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -821,6 +821,10 @@ def launch_sm120_static_moe(
         from .triton_compact import compact_topk_ids as _triton_compact_topk_ids
 
         # Run Triton pre-pass to compact global expert IDs to dense local indices
+        assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
+            f"compact_topk_ids buffer too small: "
+            f"{workspace.compact_topk_ids.numel()} < {flat_ids.numel()}"
+        )
         compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
         _triton_compact_topk_ids(
             flat_ids,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -537,7 +537,7 @@ class MoEDynamicKernel:
             internal_type=cutlass.Int16,
         )
         # Single TMA descriptor over w13. Gated: [2*I_tp, K, E]; relu2: [I_tp, K, E].
-        # Gate tiles at N=0..I_tp/tile_N-1, up tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
+        # Up tiles at N=0..I_tp/tile_N-1, gate tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
         tma_b_w13, gB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
             b_w13,
             self.b_smem_layout_staged,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -4,9 +4,17 @@ MoEDynamicKernel — queue-driven routed NVFP4 MoE kernel for SM120/SM121.
 Ported from the b12x kernel library to FlashInfer.
 
 This is the first dynamic fused control-plane kernel derived from the current
-static implementation. It keeps the proven FC1 / SiLU / quant / FC2 / scatter
-compute body, but replaces the resident-grid route/pack -> compute barrier
-with a global ready-task queue.
+static implementation. It keeps the proven FC1 / activation / quant / FC2 /
+scatter compute body, but replaces the resident-grid route/pack -> compute
+barrier with a global ready-task queue.
+
+Supports two activation modes selected at construction time:
+  SiLU (gated, activation="silu"):
+    FC1:     A x gate^T, A x up^T     (paired FP4 block-scaled GEMMs)
+    Act:     SiLU(gate) * up           (fused SwiGLU activation)
+  ReLU2 (non-gated, activation="relu2"):
+    FC1:     A x W1^T                  (single FP4 block-scaled GEMM)
+    Act:     max(0, x)^2               (squared ReLU activation)
 
 Execution model
   Phase 0: cooperative init / clear scratch state
@@ -260,12 +268,17 @@ class MoEDynamicKernel:
         *,
         input_scales_are_reciprocal: bool = False,
         fast_math: bool = False,
+        activation: str = "silu",
     ):
+        if activation not in {"silu", "relu2"}:
+            raise ValueError(f"unsupported activation {activation!r}")
         self._dense_cls = DenseGemmKernel
         self.acc_dtype = cutlass.Float32
         self.sf_vec_size = sf_vec_size
         self.input_scales_are_reciprocal = input_scales_are_reciprocal
         self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = activation == "silu"
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.cluster_shape_mnk = (1, 1, 1)
@@ -469,8 +482,8 @@ class MoEDynamicKernel:
         task_slice_count: cute.Tensor,  # [max_tasks] int32
         task_valid_rows: cute.Tensor,  # [max_tasks] int32
         tile_write_count: cute.Tensor,  # [E * max_m_tiles] int32
-        b_w13: cute.Tensor,  # [2*I_tp, K, E] — concatenated gate+up
-        sfb_w13_ptr: cute.Pointer,  # scale factors for concatenated w13
+        b_w13: cute.Tensor,  # [2*I_tp, K, E] (gated) or [I_tp, K, E] (relu2)
+        sfb_w13_ptr: cute.Pointer,  # scale factors for w13
         b_down: cute.Tensor,  # [K, I_tp, E]
         sfb_down_ptr: cute.Pointer,
         row_counts: cute.Tensor,  # expert row histogram [E]
@@ -503,7 +516,7 @@ class MoEDynamicKernel:
         )
         sfa_tensor = cute.make_tensor(sfa_ptr, sfa_layout)
 
-        # Single SF tensor for concatenated w13 (gate+up scale factors)
+        # SF tensor for w13 (gated: gate+up concatenated; relu2: single W1)
         sfb_w13_layout = blockscaled_utils.tile_atom_to_shape_SF(
             b_w13.shape, self.sf_vec_size
         )
@@ -523,7 +536,7 @@ class MoEDynamicKernel:
             1,
             internal_type=cutlass.Int16,
         )
-        # Single TMA descriptor over concatenated w13 [2*I_tp, K, E].
+        # Single TMA descriptor over w13. Gated: [2*I_tp, K, E]; relu2: [I_tp, K, E].
         # Gate tiles at N=0..I_tp/tile_N-1, up tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
         tma_b_w13, gB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
             b_w13,
@@ -557,9 +570,9 @@ class MoEDynamicKernel:
             internal_type=cutlass.Int16,
         )
 
-        gate_tile_cnt = Int32(b_w13.shape[0]) // (
-            Int32(2) * Int32(self.tile_shape_mnk[1])
-        )
+        gate_tile_cnt = Int32(b_w13.shape[0]) // Int32(self.tile_shape_mnk[1])
+        if self.is_gated:
+            gate_tile_cnt = gate_tile_cnt // Int32(2)
         launch_params = DynamicLaunchParams(row_counts, gate_tile_cnt)
         grid = (*self.cluster_shape_mn, max_active_clusters)
         self.kernel(
@@ -710,7 +723,7 @@ class MoEDynamicKernel:
         smem = cutlass.utils.SmemAllocator()
 
         @cute.struct
-        class Storage:
+        class StorageGated:
             # ctrl layout (8 x Int32, accessed via raw shared memory PTX):
             #   [0] has_task     [4] done          [8]  expert_idx
             #   [12] m_tile_idx  [16] slice_begin   [20] slice_count
@@ -750,7 +763,39 @@ class MoEDynamicKernel:
                 self.buffer_align_bytes,
             ]
 
-        storage = smem.allocate(Storage)
+        @cute.struct
+        class StorageRelu2:
+            # ctrl layout (8 x Int32, accessed via raw shared memory PTX):
+            #   [0] has_task     [4] done          [8]  expert_idx
+            #   [12] m_tile_idx  [16] slice_begin   [20] slice_count
+            #   [24] valid_rows  [28] batch_base
+            ctrl: cute.struct.MemRange[cutlass.Int32, 8]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfa_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        storage = smem.allocate(StorageGated if self.is_gated else StorageRelu2)
 
         prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         cons_group = pipeline.CooperativeGroup(
@@ -765,13 +810,17 @@ class MoEDynamicKernel:
             barrier_storage=storage.pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
-        up_pipeline = pipeline.PipelineTmaAsync.create(
-            num_stages=self.ab_stage,
-            producer_group=prod_group,
-            consumer_group=cons_group,
-            tx_count=tma_copy_bytes,
-            barrier_storage=storage.up_pipeline_array.data_ptr(),
-            cta_layout_vmnk=cta_layout_vmnk,
+        up_pipeline = (
+            pipeline.PipelineTmaAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=prod_group,
+                consumer_group=cons_group,
+                tx_count=tma_copy_bytes,
+                barrier_storage=storage.up_pipeline_array.data_ptr(),
+                cta_layout_vmnk=cta_layout_vmnk,
+            )
+            if self.is_gated
+            else ml_pipeline
         )
         phase2_pipeline = pipeline.PipelineTmaAsync.create(
             num_stages=self.ab_stage,
@@ -786,15 +835,17 @@ class MoEDynamicKernel:
 
         sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
         sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
-        sB_up = storage.sB_up.get_tensor(
-            b_smem_staged.outer, swizzle=b_smem_staged.inner
+        sB_up = (
+            storage.sB_up.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+            if self.is_gated
+            else sB
         )
         cute.recast_tensor(sA, cutlass.Uint8)
         cute.recast_tensor(sB, cutlass.Uint8)
         cute.recast_tensor(sB_up, cutlass.Uint8)
         sSFA = storage.sSFA.get_tensor(sfa_smem_staged)
         sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
-        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
+        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged) if self.is_gated else sSFB
         cute.recast_tensor(sSFA, cutlass.Uint8)
         cute.recast_tensor(sSFB, cutlass.Uint8)
         cute.recast_tensor(sSFB_up, cutlass.Uint8)
@@ -1113,10 +1164,11 @@ class MoEDynamicKernel:
         gA = cute.local_tile(
             mA, cute.slice_(self.tile_shape_mnk, (None, 0, None)), (None, None, None)
         )
-        # Single tiled view over concatenated w13 [2*I_tp, K, E].
-        # W13 is packed as [up, gate] across the concatenated N dimension.
-        # Up tiles: N-indices 0..gate_tile_cnt-1
-        # Gate tiles: N-indices gate_tile_cnt..2*gate_tile_cnt-1
+        # Tiled view over w13.
+        # Gated: [2*I_tp, K, E] packed as [up, gate] across N.
+        #   Up tiles: N-indices 0..gate_tile_cnt-1
+        #   Gate tiles: N-indices gate_tile_cnt..2*gate_tile_cnt-1
+        # ReLU2: [I_tp, K, E] single FC1 pass, gate_tile_cnt == intermediate_tile_cnt.
         gB_w13_tiled = cute.local_tile(
             mB_w13,
             cute.slice_(self.tile_shape_mnk, (0, None, None)),
@@ -1154,7 +1206,7 @@ class MoEDynamicKernel:
         tAsSFA = cute.filter_zeros(tAsSFA)
         tAgSFA = cute.filter_zeros(tAgSFA)
 
-        # Single w13 TMA partition (gate+up concatenated)
+        # w13 TMA partition (gated: gate+up concatenated; relu2: single W1)
         tBsB_w13, tBgB_w13 = cpasync.tma_partition(
             tma_b_w13,
             b_cta_crd,
@@ -1239,13 +1291,22 @@ class MoEDynamicKernel:
         sub_shape = tCsC_for_shape.shape[:3]
         acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
         gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
-        up_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = (
+            cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+            if self.is_gated
+            else gate_acc
+        )
 
         k_tile_cnt = cute.size(gA, mode=[3])
         fc1_k_tile_cnt = k_tile_cnt
-        # w13 has 2*I_tp/tile_N N-tiles. Gate = first half, up = second half.
+        # Gated: w13 has 2*I_tp/tile_N N-tiles. Gate = second half, up = first half.
+        # ReLU2: w13 has I_tp/tile_N N-tiles. Single FC1 pass, no split.
         intermediate_tile_cnt = cute.size(gB_w13_tiled, mode=[2])
-        gate_tile_cnt = intermediate_tile_cnt // Int32(2)
+        gate_tile_cnt = (
+            intermediate_tile_cnt // Int32(2)
+            if self.is_gated
+            else intermediate_tile_cnt
+        )
         output_tile_cnt = cute.size(gB_down, mode=[2])
 
         prod_state = pipeline.make_pipeline_state(
@@ -1254,11 +1315,19 @@ class MoEDynamicKernel:
         cons_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Consumer, self.ab_stage
         )
-        up_prod_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.ab_stage
+        up_prod_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.ab_stage
+            )
+            if self.is_gated
+            else prod_state
         )
-        up_cons_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.ab_stage
+        up_cons_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            if self.is_gated
+            else cons_state
         )
         phase2_prod_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.ab_stage
@@ -1585,35 +1654,95 @@ class MoEDynamicKernel:
                                     tCrB[None, _nt, k_block_idx],
                                     gate_acc[None, _mt, _nt],
                                 )
-                    # Gate and up share the A/SFA staging buffers. Drain gate
-                    # consumers before the DMA warp starts refilling those stages
-                    # for the up pass.
+                    # Drain the FC1 gate/only pass before the DMA warp reuses
+                    # those staging buffers, either for the up pass or FC2 loads.
                     self.pass_sync_barrier.arrive_and_wait()
 
-                    # Up GEMM (inlined, same pattern)
-                    up_acc.fill(0.0)
-                    up_cons_state.reset_count()
-                    peek = up_pipeline.consumer_try_wait(up_cons_state)
-                    up_pipeline.consumer_wait(up_cons_state, peek)
-                    csA_p = csA[None, None, None, up_cons_state.index]
-                    csB_p = csB_up[None, None, None, up_cons_state.index]
-                    csSFA_p = csSFA[None, None, None, up_cons_state.index]
-                    csSFB_p = csSFB_up[None, None, None, up_cons_state.index]
-                    cute.copy(smem_copy_A, csA_p[None, None, 0], crA[None, None, 0])
-                    cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
-                    fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                    fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                    cute.copy(
-                        smem_copy_SFA,
-                        fz_csSFA_p[None, None, 0],
-                        fz_crSFA[None, None, 0],
-                    )
-                    cute.copy(
-                        smem_copy_SFB,
-                        fz_csSFB_p[None, None, 0],
-                        fz_crSFB[None, None, 0],
-                    )
-                    for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                    if cutlass.const_expr(self.is_gated):
+                        # Up GEMM (inlined, same pattern)
+                        up_acc.fill(0.0)
+                        up_cons_state.reset_count()
+                        peek = up_pipeline.consumer_try_wait(up_cons_state)
+                        up_pipeline.consumer_wait(up_cons_state, peek)
+                        csA_p = csA[None, None, None, up_cons_state.index]
+                        csB_p = csB_up[None, None, None, up_cons_state.index]
+                        csSFA_p = csSFA[None, None, None, up_cons_state.index]
+                        csSFB_p = csSFB_up[None, None, None, up_cons_state.index]
+                        cute.copy(smem_copy_A, csA_p[None, None, 0], crA[None, None, 0])
+                        cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                        fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                        fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_p[None, None, 0],
+                            fz_crSFA[None, None, 0],
+                        )
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_p[None, None, 0],
+                            fz_crSFB[None, None, 0],
+                        )
+                        for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                k_next = (
+                                    0
+                                    if k_block_idx + 1 == num_k_blocks
+                                    else k_block_idx + 1
+                                )
+                                if k_block_idx == num_k_blocks - 1:
+                                    up_pipeline.consumer_release(up_cons_state)
+                                    up_cons_state.advance()
+                                    peek = up_pipeline.consumer_try_wait(up_cons_state)
+                                    csA_p = csA[None, None, None, up_cons_state.index]
+                                    csB_p = csB_up[
+                                        None, None, None, up_cons_state.index
+                                    ]
+                                    csSFA_p = csSFA[
+                                        None, None, None, up_cons_state.index
+                                    ]
+                                    csSFB_p = csSFB_up[
+                                        None, None, None, up_cons_state.index
+                                    ]
+                                    fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                                    fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                                    up_pipeline.consumer_wait(up_cons_state, peek)
+                                for _mt in cutlass.range_constexpr(fc1_m_tiles):
+                                    for _nt in cutlass.range_constexpr(fc1_n_tiles):
+                                        mma_atom.set(
+                                            WarpField.SFA,
+                                            tCrSFA[None, _mt, k_block_idx].iterator,
+                                        )
+                                        mma_atom.set(
+                                            WarpField.SFB,
+                                            tCrSFB[None, _nt, k_block_idx].iterator,
+                                        )
+                                        cute.gemm(
+                                            mma_atom,
+                                            up_acc[None, _mt, _nt],
+                                            tCrA[None, _mt, k_block_idx],
+                                            tCrB[None, _nt, k_block_idx],
+                                            up_acc[None, _mt, _nt],
+                                        )
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFA,
+                                    fz_csSFA_p[None, None, k_next],
+                                    fz_crSFA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    fz_csSFB_p[None, None, k_next],
+                                    fz_crSFB[None, None, k_next],
+                                )
                         for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                             k_next = (
                                 0
@@ -1623,16 +1752,27 @@ class MoEDynamicKernel:
                             if k_block_idx == num_k_blocks - 1:
                                 up_pipeline.consumer_release(up_cons_state)
                                 up_cons_state.advance()
-                                peek = up_pipeline.consumer_try_wait(up_cons_state)
-                                csA_p = csA[None, None, None, up_cons_state.index]
-                                csB_p = csB_up[None, None, None, up_cons_state.index]
-                                csSFA_p = csSFA[None, None, None, up_cons_state.index]
-                                csSFB_p = csSFB_up[
-                                    None, None, None, up_cons_state.index
-                                ]
-                                fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                                fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                                up_pipeline.consumer_wait(up_cons_state, peek)
+                            if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFA,
+                                    fz_csSFA_p[None, None, k_next],
+                                    fz_crSFA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    fz_csSFB_p[None, None, k_next],
+                                    fz_crSFB[None, None, k_next],
+                                )
                             for _mt in cutlass.range_constexpr(fc1_m_tiles):
                                 for _nt in cutlass.range_constexpr(fc1_n_tiles):
                                     mma_atom.set(
@@ -1650,72 +1790,7 @@ class MoEDynamicKernel:
                                         tCrB[None, _nt, k_block_idx],
                                         up_acc[None, _mt, _nt],
                                     )
-                            cute.copy(
-                                smem_copy_A,
-                                csA_p[None, None, k_next],
-                                crA[None, None, k_next],
-                            )
-                            cute.copy(
-                                smem_copy_B,
-                                csB_p[None, None, k_next],
-                                crB[None, None, k_next],
-                            )
-                            cute.copy(
-                                smem_copy_SFA,
-                                fz_csSFA_p[None, None, k_next],
-                                fz_crSFA[None, None, k_next],
-                            )
-                            cute.copy(
-                                smem_copy_SFB,
-                                fz_csSFB_p[None, None, k_next],
-                                fz_crSFB[None, None, k_next],
-                            )
-                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                        k_next = (
-                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
-                        )
-                        if k_block_idx == num_k_blocks - 1:
-                            up_pipeline.consumer_release(up_cons_state)
-                            up_cons_state.advance()
-                        if k_next > 0 and fc1_k_tile_cnt > Int32(0):
-                            cute.copy(
-                                smem_copy_A,
-                                csA_p[None, None, k_next],
-                                crA[None, None, k_next],
-                            )
-                            cute.copy(
-                                smem_copy_B,
-                                csB_p[None, None, k_next],
-                                crB[None, None, k_next],
-                            )
-                            cute.copy(
-                                smem_copy_SFA,
-                                fz_csSFA_p[None, None, k_next],
-                                fz_crSFA[None, None, k_next],
-                            )
-                            cute.copy(
-                                smem_copy_SFB,
-                                fz_csSFB_p[None, None, k_next],
-                                fz_crSFB[None, None, k_next],
-                            )
-                        for _mt in cutlass.range_constexpr(fc1_m_tiles):
-                            for _nt in cutlass.range_constexpr(fc1_n_tiles):
-                                mma_atom.set(
-                                    WarpField.SFA,
-                                    tCrSFA[None, _mt, k_block_idx].iterator,
-                                )
-                                mma_atom.set(
-                                    WarpField.SFB,
-                                    tCrSFB[None, _nt, k_block_idx].iterator,
-                                )
-                                cute.gemm(
-                                    mma_atom,
-                                    up_acc[None, _mt, _nt],
-                                    tCrA[None, _mt, k_block_idx],
-                                    tCrB[None, _nt, k_block_idx],
-                                    up_acc[None, _mt, _nt],
-                                )
-                    # SiLU + quant into sA
+                    # Activation + quant into sA
                     sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                     packed_cols = Int32(self.tile_shape_mnk[2] // 2)
                     sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
@@ -1744,19 +1819,27 @@ class MoEDynamicKernel:
                                         (None, mma_m_in_epi, mma_n_in_epi)
                                     ]
                                     gate_slice = tRS_rGate[(None, mma_m, mma_n)]
-                                    up_slice = tRS_rUp[(None, mma_m, mma_n)]
-                                    for elem_idx in cutlass.range_constexpr(
-                                        cute.size(tRS_rD_slice)
-                                    ):
-                                        g = alpha_value * gate_slice[elem_idx]
-                                        u = alpha_value * up_slice[elem_idx]
-                                        sigmoid_g = cute.arch.rcp_approx(
-                                            cutlass.Float32(1.0)
-                                            + cute.math.exp(
-                                                -g, fastmath=self.fast_math
-                                            ),
-                                        )
-                                        tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                    if cutlass.const_expr(self.is_gated):
+                                        up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            g = alpha_value * gate_slice[elem_idx]
+                                            u = alpha_value * up_slice[elem_idx]
+                                            sigmoid_g = cute.arch.rcp_approx(
+                                                cutlass.Float32(1.0)
+                                                + cute.math.exp(
+                                                    -g, fastmath=self.fast_math
+                                                ),
+                                            )
+                                            tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                    else:
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            g = alpha_value * gate_slice[elem_idx]
+                                            relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                            tRS_rD_slice[elem_idx] = relu_g * relu_g
 
                             acc_vec = tRS_rD.load()
                             acc_vec = acc_vec.to(cutlass.BFloat16)
@@ -2059,31 +2142,27 @@ class MoEDynamicKernel:
                 while slice_idx < task_slice_count_val:
                     intermediate_slice = task_slice_begin_idx + slice_idx
 
-                    # W13 is laid out as [up, gate] across the concatenated N dimension.
+                    # FC1 producer slice. Gated activation packs [up, gate]
+                    # across N; relu2 uses a single FC1 pass.
                     tBgB_w13_up_nk = tBgB_w13[
                         (None, intermediate_slice, None, task_expert_idx)
                     ]
                     tBgSFB_w13_up_nk = tBgSFB_w13[
                         (None, intermediate_slice, None, task_expert_idx)
                     ]
+                    gate_slice_idx = (
+                        intermediate_slice + gate_tile_cnt
+                        if self.is_gated
+                        else intermediate_slice
+                    )
                     tBgB_w13_gate_nk = tBgB_w13[
-                        (
-                            None,
-                            intermediate_slice + gate_tile_cnt,
-                            None,
-                            task_expert_idx,
-                        )
+                        (None, gate_slice_idx, None, task_expert_idx)
                     ]
                     tBgSFB_w13_gate_nk = tBgSFB_w13[
-                        (
-                            None,
-                            intermediate_slice + gate_tile_cnt,
-                            None,
-                            task_expert_idx,
-                        )
+                        (None, gate_slice_idx, None, task_expert_idx)
                     ]
 
-                    # ---- FC1 gate pass ----
+                    # ---- FC1 gate/only pass ----
                     prod_state.reset_count()
                     for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
                         ml_pipeline.producer_acquire(prod_state)
@@ -2114,40 +2193,49 @@ class MoEDynamicKernel:
                         ml_pipeline.producer_commit(prod_state)
                         prod_state.advance()
 
-                    # Gate and up share the A/SFA staging buffers. Wait for MMA
-                    # warps to drain the gate pass before refilling those stages.
+                    # Wait for the MMA warps to finish the FC1 gate/only pass
+                    # before reusing the gate staging buffers.
                     self.pass_sync_barrier.arrive_and_wait()
 
-                    # ---- FC1 up pass ----
-                    up_prod_state.reset_count()
-                    for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
-                        up_pipeline.producer_acquire(up_prod_state)
-                        cute.copy(
-                            tma_a,
-                            tAgA_mk[(None, k_tile)],
-                            tAsA[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        cute.copy(
-                            tma_b_w13,
-                            tBgB_w13_up_nk[(None, k_tile)],
-                            tBsB_w13_up[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        cute.copy(
-                            tma_sfa,
-                            tAgSFA_mk[(None, k_tile)],
-                            tAsSFA[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        cute.copy(
-                            tma_sfb_w13,
-                            tBgSFB_w13_up_nk[(None, k_tile)],
-                            tBsSFB_w13_up[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        up_pipeline.producer_commit(up_prod_state)
-                        up_prod_state.advance()
+                    if cutlass.const_expr(self.is_gated):
+                        # ---- FC1 up pass ----
+                        up_prod_state.reset_count()
+                        for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                            up_pipeline.producer_acquire(up_prod_state)
+                            cute.copy(
+                                tma_a,
+                                tAgA_mk[(None, k_tile)],
+                                tAsA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_b_w13,
+                                tBgB_w13_up_nk[(None, k_tile)],
+                                tBsB_w13_up[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfa,
+                                tAgSFA_mk[(None, k_tile)],
+                                tAsSFA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfb_w13,
+                                tBgSFB_w13_up_nk[(None, k_tile)],
+                                tBsSFB_w13_up[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            up_pipeline.producer_commit(up_prod_state)
+                            up_prod_state.advance()
 
                     # ---- FC2 B_down loads: continuous pipeline ----
                     # No barrier needed: sB/sSFB are free (gate done, up uses
@@ -2199,7 +2287,8 @@ class MoEDynamicKernel:
 
         if warp_idx == self.tma_load_warp_id:
             ml_pipeline.producer_tail(prod_state)
-            up_pipeline.producer_tail(up_prod_state)
+            if cutlass.const_expr(self.is_gated):
+                up_pipeline.producer_tail(up_prod_state)
             phase2_pipeline.producer_tail(phase2_prod_state)
         return
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -1,0 +1,2284 @@
+"""
+MoEMicroKernel — micro-scheduled routed NVFP4 MoE kernel for SM120/SM121 (Blackwell).
+
+Ported from the b12x kernel library to FlashInfer.
+
+This is the micro control-plane fusion step for decode workloads: keep the
+proven FC1/FC2 compute body, but pull the route/pack frontend into the same
+resident kernel, using precompacted routing IDs from a Triton pre-pass.
+
+The result is still a two-phase algorithm, just without a host-side handoff:
+
+  Phase 0: cooperative init / set row counts (precompacted by Triton)
+  Phase 1: walk routed (token, topk_slot) pairs, append rows per expert,
+           write token_map + token_weights, and quantize each routed
+           token row directly into expert-major packed A + scale storage
+  Barrier: resident-grid barrier after all expert rows are finalized
+  Phase 2: run the FC1 -> SiLU -> quant -> FC2 -> scatter datapath
+           over the finalized expert-major packed input
+
+The compute half is intentionally the same design as the earlier two-kernel
+implementation:
+  FC1:     A x gate^T, A x up^T     (paired FP4 block-scaled GEMMs)
+  SiLU:    SiLU(gate) * up          (fused SwiGLU activation)
+  Quant:   intermediate -> FP4      (cooperative quantization into shared A)
+  FC2:     sweep all output tiles   (reuse the cached intermediate slice)
+  Scatter: bf16x2 atomic add        (directly into token-major output)
+
+What changes relative to the static kernel:
+  - topk_ids contains LOCAL expert IDs (pre-compacted by Triton pre-pass)
+  - global expert IDs looked up via weight_expert_ids[local_expert_id]
+  - all_rows_unique fast path: when num_tokens==1 and every expert has
+    exactly one row, skip atomic routing and use O(1) work assignment
+  - Phase 0 does NOT init global_to_local_expert or active_expert_count
+    (already populated by Triton pre-pass)
+  - Three values broadcast via shared ctrl (including expert_id)
+
+Work decomposition
+  Frontend:
+    One CTA leader handles one routed pair at a time. It atomically appends a
+    row to row_counts[expert], writes the source token + router weight, then
+    quantizes the source token row into that expert-major destination row.
+  Compute:
+    The compact static work loop assigns (m_tile, intermediate_slice, expert).
+    FC1 is computed once per slice, the slice is quantized into shared A, and
+    FC2 sweeps all output tiles from that cached slice. FC1 cost is therefore
+    amortized across every FC2 output tile.
+
+Layouts and dataflow
+  packed_a_storage:
+    Flat uint8 backing store for expert-major FP4 activations.
+    Logical view used by the compute path is [max_rows, K, E] fp4x2.
+  scale_storage:
+    Flat uint8 backing store for expert-major activation scale factors laid
+    out in the CUTLASS/CuTe block-scaled MMA layout expected by the compute
+    mainloop.
+  token_map / token_weights:
+    Expert-row metadata used by the FC2 scatter path to accumulate the final
+    output directly into [num_tokens, K].
+
+Why the barriers exist
+  row_counts drives the grouped scheduler shape. The compute phase cannot begin
+  until every routed pair has claimed its expert row and packed A/scales have
+  been written. The micro kernel therefore uses a resident-grid barrier between
+  route/pack and compute instead of the host-side sequencing used previously.
+
+Scale-contract note
+  This kernel supports per-expert FC1 activation scales by quantizing each
+  routed pair with input_global_scale[expert]. That is checkpoint-correct for
+  models where gate/up input scales vary across experts.
+
+Design boundary
+  The micro kernel is the compact decode backend with precompacted routing.
+  It keeps route/pack and compute in one resident launch for small routed
+  working sets, and relies on the resident-grid barrier between those phases
+  instead of overlapping them.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from cutlass.cutlass_dsl import (
+    Int32,
+    Int64,
+    Uint8,
+    Uint64,
+    T,
+    Integer,
+    dsl_user_op,
+)
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync
+
+from flashinfer.cute_dsl.utils import (
+    sm120_make_smem_layout_sfa,
+    sm120_make_smem_layout_sfb,
+)
+from flashinfer.cute_dsl.fp4_common import (
+    atomic_add_global_i32,
+    fabs_f32,
+    fmax_f32,
+    rcp_approx_ftz,
+    quantize_block_fp4,
+    quantize_block_fp4_fast,
+    get_ptr_as_int64,
+    st_global_f32,
+    st_global_i32,
+    shared_ptr_to_u32,
+    st_shared_u8,
+    st_global_u64,
+    scatter_add_bf16x2,
+)
+from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120 import (
+    Sm120BlockScaledDenseGemmKernel as DenseGemmKernel,
+)
+
+
+_SF_VEC_SIZE = 16
+_COMPACT_STATIC_TILE_M = 128
+
+
+@cute.jit
+def _compact_static_get_work_tile(
+    row_counts: cute.Tensor,
+    active_expert_count: cute.Tensor,
+    *,
+    tile_m: Int32,
+    num_tiles_n: Int32,
+    cluster_shape_mn: Tuple[Int32, Int32],
+    current_work_linear_idx: Int32,
+    current_local_expert_idx: Int32,
+    accum_tile_m: Int32,
+    cta_id_in_cluster: cute.Coord,
+) -> Tuple[Tuple[Int32, Int32, Int32], Integer, Int32, Int32]:
+    num_active_experts = active_expert_count[Int32(0)]
+    scan_local_expert_idx = current_local_expert_idx
+    tile_m_minus_one = tile_m - Int32(1)
+
+    while scan_local_expert_idx < num_active_experts:
+        batch_rows = row_counts[scan_local_expert_idx]
+        batch_m_tiles = (batch_rows + tile_m_minus_one) // tile_m
+        if (accum_tile_m + batch_m_tiles) * num_tiles_n > current_work_linear_idx:
+            current_local_expert_idx = scan_local_expert_idx
+            scan_local_expert_idx = num_active_experts
+        else:
+            accum_tile_m += batch_m_tiles
+            scan_local_expert_idx += Int32(1)
+            current_local_expert_idx = scan_local_expert_idx
+
+    is_valid = current_local_expert_idx < num_active_experts
+    if is_valid:
+        batch_rows = row_counts[current_local_expert_idx]
+        is_valid = (
+            accum_tile_m + (batch_rows + tile_m_minus_one) // tile_m
+        ) * num_tiles_n > current_work_linear_idx
+
+    cur_cluster_coord = (
+        current_work_linear_idx // num_tiles_n - accum_tile_m,
+        current_work_linear_idx % num_tiles_n,
+        current_local_expert_idx,
+    )
+    cur_tile_coord = (
+        Int32(cur_cluster_coord[0]) * cluster_shape_mn[0] + cta_id_in_cluster[0],
+        Int32(cur_cluster_coord[1]) * cluster_shape_mn[1] + cta_id_in_cluster[1],
+        Int32(cur_cluster_coord[2]),
+    )
+    return cur_tile_coord, is_valid, current_local_expert_idx, accum_tile_m
+
+
+@cute.jit
+def _compact_unique_get_work_tile(
+    *,
+    num_active_experts: Int32,
+    num_tiles_n: Int32,
+    current_work_linear_idx: Int32,
+    cta_id_in_cluster: cute.Coord,
+) -> Tuple[Tuple[Int32, Int32, Int32], Integer]:
+    """O(1) work tile assignment when every expert has exactly 1 row."""
+    local_expert_idx = current_work_linear_idx // num_tiles_n
+    cur_tile_coord = (
+        cta_id_in_cluster[0],
+        current_work_linear_idx % num_tiles_n,
+        local_expert_idx,
+    )
+    return cur_tile_coord, local_expert_idx < num_active_experts
+
+
+@dsl_user_op
+def _st_shared_i32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [Int32(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.shared.s32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _ld_shared_i32(addr, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.s32 $0, [$1];",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _st_shared_f32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.f32 [$0], $1;",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _ld_shared_f32(addr, *, loc=None, ip=None):
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.f32 $0, [$1];",
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_global_u64(addr, *, loc=None, ip=None):
+    return Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.u64 $0, [$1];",
+            "=l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_global_acquire_i32(addr, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.acquire.gpu.s32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _st_global_release_i32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.global.release.gpu.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _spin_wait_global_eq_i32(addr, expected, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(expected).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_loop:\n"
+        "  ld.global.acquire.gpu.s32 %val, [$0];\n"
+        "  setp.eq.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_loop;\n"
+        "}",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _threadfence(*, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [],
+        "membar.gl;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _atomic_cas_global_i32(addr, compare, value, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Int32(compare).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.cas.b32 $0, [$1], $2, $3;",
+            "=r,l,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+class MoEMicroKernel:
+    """Compact micro MoE kernel with precompacted routing ids for decode."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        input_scales_are_reciprocal: bool = False,
+        fast_math: bool = False,
+    ):
+        self._dense_cls = DenseGemmKernel
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.input_scales_are_reciprocal = input_scales_are_reciprocal
+        self.fast_math = fast_math
+        tile_k = sf_vec_size * 8
+        self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        self.sfa_tiles_per_block = self.sfa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.sfb_tile_shape_nk = (max(128, mma_tiler_mn[1]), tile_k)
+        self.sfb_tiles_per_block = self.sfb_tile_shape_nk[0] // mma_tiler_mn[1]
+        self.output_tile_count_n = output_tile_count_n
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cluster_shape_mn = (1, 1)
+        self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.occupancy = 1
+        self.num_mma_warps = 4
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.buffer_align_bytes = 1024
+
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.pass_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_cta,
+        )
+        self.load_register_requirement = 32
+        self.mma_register_requirement = 232
+
+    def _thrfrg_SFA(self, sfa_tensor, tiled_mma):
+        return self._dense_cls._thrfrg_SFA(self, sfa_tensor, tiled_mma)
+
+    def _thrfrg_SFB(self, sfb_tensor, tiled_mma):
+        return self._dense_cls._thrfrg_SFB(self, sfb_tensor, tiled_mma)
+
+    def _get_layoutSFA_TV(self, tiled_mma):
+        return self._dense_cls._get_layoutSFA_TV(self, tiled_mma)  # type: ignore[arg-type]
+
+    def _get_layoutSFB_TV(self, tiled_mma):
+        return self._dense_cls._get_layoutSFB_TV(self, tiled_mma)  # type: ignore[arg-type]
+
+    def _make_a_smem_layout(self, ab_stage: int):
+        import cutlass.utils.hopper_helpers as sm90_utils
+
+        a_is_k_major = self.a_layout.is_k_major_a()
+        a_major_mode_size = self.sa_tile_shape_mk[1 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                self.a_layout,
+                self.a_dtype,
+                a_major_mode_size,
+            ),
+            self.a_dtype,
+        )
+        return cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(self.sa_tile_shape_mk, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+    def _make_staged_layouts(self, ab_stage: int):
+        (
+            _,
+            b_smem_staged,
+            sfa_smem_staged,
+            sfb_smem_staged,
+            epi_smem_staged,
+        ) = self._dense_cls._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            ab_stage,
+            cutlass.BFloat16,
+            self.c_layout,
+            self.epi_stage,
+            self.sf_vec_size,
+            self.tiled_mma,
+        )
+        a_smem_staged = self._make_a_smem_layout(ab_stage)
+        return (
+            a_smem_staged,
+            b_smem_staged,
+            sfa_smem_staged,
+            sfb_smem_staged,
+            epi_smem_staged,
+        )
+
+    def _shared_storage_size_bytes(
+        self,
+        a_smem_staged,
+        b_smem_staged,
+        sfa_smem_staged,
+        sfb_smem_staged,
+        epi_smem_staged,
+    ) -> int:
+        def _align_up(value: int, align: int) -> int:
+            return ((value + align - 1) // align) * align
+
+        offset = (
+            3 * 4
+            + 3 * (self.ab_stage * 2 * 8)
+            + _COMPACT_STATIC_TILE_M * 4
+            + _COMPACT_STATIC_TILE_M * 4
+        )
+        buffers = (
+            cute.size_in_bytes(self.a_dtype, a_smem_staged),
+            cute.size_in_bytes(self.b_dtype, b_smem_staged),
+            cute.size_in_bytes(self.b_dtype, b_smem_staged),
+            cute.size_in_bytes(self.sf_dtype, sfa_smem_staged),
+            cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
+            cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
+            cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
+        )
+        offset = _align_up(offset, self.buffer_align_bytes)
+        for idx, size in enumerate(buffers):
+            offset += size
+            if idx + 1 != len(buffers):
+                offset = _align_up(offset, self.buffer_align_bytes)
+        return offset
+
+    def _setup_attributes(self, hidden_size: int):
+        import cutlass.utils.blackwell_helpers as sm120_utils
+
+        self._hidden_size = hidden_size
+
+        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+            self.a_dtype,
+            self.acc_dtype,
+            self.sf_dtype,
+        )
+        atom_layout = cute.make_layout((2, 2, 1))
+        permutation_mnk = sm120_utils.get_permutation_mnk(
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            False,
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+        self.mma_atom = cute.make_mma_atom(mma_op)
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
+        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
+        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+
+        sfa_smem = sm120_make_smem_layout_sfa(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+        sfb_smem = sm120_make_smem_layout_sfb(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        self.ab_stage, self.epi_stage = self._dense_cls._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            sfa_smem,
+            sfb_smem,
+            self.epi_tile,
+            cutlass.BFloat16,
+            self.smem_capacity,
+            self.occupancy,
+        )
+        self.ab_stage = max(1, min(self.ab_stage, 2))
+        # ab_stage must divide k_tile_cnt evenly to avoid pipeline phase mismatch.
+        # _compute_stages returns the max that fits in smem, but it may not
+        # divide k_tile_cnt. Round down to the nearest divisor.
+        k_tile_cnt = self._hidden_size // self.tile_shape_mnk[2]
+        while self.ab_stage > 1 and k_tile_cnt % self.ab_stage != 0:
+            self.ab_stage -= 1
+        self.epi_stage = 1
+        while True:
+            (
+                self.a_smem_layout_staged,
+                self.b_smem_layout_staged,
+                self.sfa_smem_layout_staged,
+                self.sfb_smem_layout_staged,
+                self.epi_smem_layout_staged,
+            ) = self._make_staged_layouts(self.ab_stage)
+            if (
+                self._shared_storage_size_bytes(
+                    self.a_smem_layout_staged,
+                    self.b_smem_layout_staged,
+                    self.sfa_smem_layout_staged,
+                    self.sfb_smem_layout_staged,
+                    self.epi_smem_layout_staged,
+                )
+                <= self.smem_capacity
+                or self.ab_stage <= 1
+            ):
+                break
+            self.ab_stage -= 1
+            while self.ab_stage > 1 and 32 % self.ab_stage != 0:
+                self.ab_stage -= 1
+
+    @cute.jit
+    def _resident_grid_barrier(
+        self,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        grid_x: Int32,
+        is_cta_leader: Int32,
+    ):
+        cute.arch.sync_threads()
+        _threadfence()
+        if is_cta_leader > Int32(0):
+            barrier_count_addr = get_ptr_as_int64(barrier_count, Int32(0))
+            barrier_epoch_addr = get_ptr_as_int64(barrier_epoch, Int32(0))
+            old_epoch = _ld_global_acquire_i32(barrier_epoch_addr)
+            arrived = atomic_add_global_i32(barrier_count_addr, Int32(1))
+            if arrived == grid_x - Int32(1):
+                st_global_i32(barrier_count_addr, Int32(0))
+                _st_global_release_i32(barrier_epoch_addr, old_epoch + Int32(1))
+            else:
+                _spin_wait_global_eq_i32(barrier_epoch_addr, old_epoch)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def __call__(
+        self,
+        a_input: cute.Tensor,  # [num_tokens, K] bf16
+        topk_ids: cute.Tensor,  # [num_tokens * topk] int32
+        topk_weights: cute.Tensor,  # [num_tokens * topk] float32
+        packed_a: cute.Tensor,  # [max_rows, K, E] fp4x2 view for compute
+        sfa_ptr: cute.Pointer,
+        packed_a_storage: cute.Tensor,  # flat uint8 backing packed_a
+        scale_storage: cute.Tensor,  # flat uint8 backing sfa_ptr
+        barrier_count: cute.Tensor,  # [1] int32 (host-zeroed)
+        barrier_epoch: cute.Tensor,  # [1] int32 (host-zeroed)
+        b_w13: cute.Tensor,  # [2*I_tp, K, E] — concatenated gate+up
+        sfb_w13_ptr: cute.Pointer,  # scale factors for concatenated w13
+        b_down: cute.Tensor,  # [K, I_tp, E]
+        sfb_down_ptr: cute.Pointer,
+        row_counts: cute.Tensor,  # [state_E] routed rows per local expert
+        active_expert_count: cute.Tensor,  # [1] active expert count
+        weight_expert_ids: cute.Tensor,  # [E] local expert id -> global weight expert id
+        global_to_local_expert: cute.Tensor,  # [weight_E] global expert id -> local expert id
+        input_global_scale: cute.Tensor,  # [E] per-expert FC1 input scale
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_output: cute.Tensor,  # [num_tokens, K]
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        self.a_dtype = packed_a.element_type
+        self.b_dtype = b_w13.element_type
+        self.sf_dtype = sfa_ptr.dtype
+        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        # Micro decode always scatters into token-major row-major output.
+        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+
+        hidden_size = a_input.shape[1]
+        self._setup_attributes(hidden_size=hidden_size)
+
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            packed_a.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa_ptr, sfa_layout)
+
+        # Single SF tensor for concatenated w13 (gate+up scale factors)
+        sfb_w13_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_w13.shape, self.sf_vec_size
+        )
+        sfb_w13_tensor = cute.make_tensor(sfb_w13_ptr, sfb_w13_layout)
+
+        # TMA descriptors
+        tma_a, gA = self._dense_cls._make_tma_atoms_and_tensors(
+            packed_a,
+            self.a_smem_layout_staged,
+            self.sa_tile_shape_mk,
+            1,
+        )
+        tma_sfa, gSFA = self._dense_cls._make_tma_atoms_and_tensors(
+            sfa_tensor,
+            self.sfa_smem_layout_staged,
+            self.sfa_tile_shape_mk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+        # Single TMA descriptor over concatenated w13 [2*I_tp, K, E].
+        # Gate tiles at N=0..I_tp/tile_N-1, up tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
+        tma_b_w13, gB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
+            b_w13,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+        )
+        tma_sfb_w13, gSFB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
+            sfb_w13_tensor,
+            self.sfb_smem_layout_staged,
+            self.sfb_tile_shape_nk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+        # B_down TMA
+        sfb_down_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_down.shape, self.sf_vec_size
+        )
+        sfb_down_tensor = cute.make_tensor(sfb_down_ptr, sfb_down_layout)
+        tma_b_down, gB_down = self._dense_cls._make_tma_atoms_and_tensors(
+            b_down,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+        )
+        tma_sfb_down, gSFB_down = self._dense_cls._make_tma_atoms_and_tensors(
+            sfb_down_tensor,
+            self.sfb_smem_layout_staged,
+            self.sfb_tile_shape_nk,
+            1,
+            internal_type=cutlass.Int16,
+        )
+
+        # Micro decode schedules over (m_tile, intermediate_slice, local_expert_idx).
+        grid = (*self.cluster_shape_mn, max_active_clusters)
+        self.kernel(
+            a_input,
+            topk_ids,
+            topk_weights,
+            packed_a_storage,
+            scale_storage,
+            barrier_count,
+            barrier_epoch,
+            tma_a,
+            gA,
+            tma_sfa,
+            gSFA,
+            tma_b_w13,
+            gB_w13,
+            tma_sfb_w13,
+            gSFB_w13,
+            tma_b_down,
+            gB_down,
+            tma_sfb_down,
+            gSFB_down,
+            self.tiled_mma,
+            self.mma_atom,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            row_counts,
+            active_expert_count,
+            weight_expert_ids,
+            global_to_local_expert,
+            input_global_scale,
+            alpha,
+            down_alpha,
+            global_scale,
+            scatter_output,
+            token_map,
+            token_weights,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        packed_a_storage: cute.Tensor,
+        scale_storage: cute.Tensor,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        tma_a: cute.CopyAtom,
+        mA: cute.Tensor,
+        tma_sfa: cute.CopyAtom,
+        mSFA: cute.Tensor,
+        tma_b_w13: cute.CopyAtom,
+        mB_w13: cute.Tensor,
+        tma_sfb_w13: cute.CopyAtom,
+        mSFB_w13: cute.Tensor,
+        tma_b_down: cute.CopyAtom,
+        mB_down: cute.Tensor,
+        tma_sfb_down: cute.CopyAtom,
+        mSFB_down: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        mma_atom: cute.MmaAtom,
+        cta_layout_mnk: cute.Layout,
+        a_smem_staged: cute.ComposedLayout,
+        b_smem_staged: cute.ComposedLayout,
+        sfa_smem_staged: cute.Layout,
+        sfb_smem_staged: cute.Layout,
+        epi_smem_staged: cute.ComposedLayout,
+        row_counts: cute.Tensor,
+        active_expert_count: cute.Tensor,
+        weight_expert_ids: cute.Tensor,
+        global_to_local_expert: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+    ):
+        """Kernel entry point."""
+        from cutlass.cute.nvgpu.warp.mma import Field as WarpField
+
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        _, _, gdim_z = cute.arch.grid_dim()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        is_cta_leader = Int32(1) if Int32(tidx) == Int32(0) else Int32(0)
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_a)
+            cpasync.prefetch_descriptor(tma_sfa)
+            cpasync.prefetch_descriptor(tma_b_w13)
+            cpasync.prefetch_descriptor(tma_sfb_w13)
+            cpasync.prefetch_descriptor(tma_b_down)
+            cpasync.prefetch_descriptor(tma_sfb_down)
+
+        cta_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cluster_coord = cta_layout_mnk.get_flat_coord(cta_rank)
+
+        a_smem_one = cute.slice_(a_smem_staged, (None, None, 0))
+        b_smem_one = cute.slice_(b_smem_staged, (None, None, 0))
+        sfa_smem_one = cute.slice_(sfa_smem_staged, (None, None, 0))
+        sfb_smem_one = cute.slice_(sfb_smem_staged, (None, None, 0))
+        tma_copy_bytes = (
+            cute.size_in_bytes(self.a_dtype, a_smem_one)
+            + cute.size_in_bytes(self.b_dtype, b_smem_one)
+            + cute.size_in_bytes(self.sf_dtype, sfa_smem_one)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        )
+        phase2_tma_copy_bytes = cute.size_in_bytes(
+            self.b_dtype, b_smem_one
+        ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 3]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB_up: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfa_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB_up: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        storage = smem.allocate(Storage)
+
+        prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        cons_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        ml_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+        up_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.up_pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+        phase2_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=phase2_tma_copy_bytes,
+            barrier_storage=storage.phase2_pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+
+        cute.arch.sync_threads()
+
+        sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+        sB_up = storage.sB_up.get_tensor(
+            b_smem_staged.outer, swizzle=b_smem_staged.inner
+        )
+        cute.recast_tensor(sA, cutlass.Uint8)
+        cute.recast_tensor(sB, cutlass.Uint8)
+        cute.recast_tensor(sB_up, cutlass.Uint8)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
+        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
+        cute.recast_tensor(sSFA, cutlass.Uint8)
+        cute.recast_tensor(sSFB, cutlass.Uint8)
+        cute.recast_tensor(sSFB_up, cutlass.Uint8)
+        sC = storage.sC.get_tensor(
+            epi_smem_staged.outer,
+            swizzle=epi_smem_staged.inner,
+        )
+        sfa_base_addr = shared_ptr_to_u32(storage.sSFA.data_ptr())
+        ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
+        scatter_tok_base_addr = shared_ptr_to_u32(storage.scatter_tok_cache.data_ptr())
+        scatter_weight_base_addr = shared_ptr_to_u32(
+            storage.scatter_weight_cache.data_ptr()
+        )
+
+        num_tokens = Int32(a_input.shape[0])
+        cols = Int32(a_input.shape[1])
+        num_experts = Int32(row_counts.shape[0])
+        sf_blocks_per_row = cols // Int32(16)
+        output_bytes_per_row = cols // Int32(2)
+        max_rows = Int32(token_map.shape[1])
+        total_pairs = Int32(topk_ids.shape[0])
+        num_topk = total_pairs // num_tokens
+        expert_scale_stride = Int32(scale_storage.shape[0]) // num_experts
+        flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
+        flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
+        num_k_tiles = (cols + Int32(63)) // Int32(64)
+
+        # Phase 0: cooperative init — set row_counts and zero scatter_output.
+        # The Triton compact pre-pass has already populated
+        # active_expert_count and weight_expert_ids.
+        num_active_experts = active_expert_count[Int32(0)]
+        all_rows_unique = Int32(0)
+        if num_tokens == Int32(1) and num_active_experts == total_pairs:
+            all_rows_unique = Int32(1)
+        i = flat_tid
+        while i < num_experts:
+            row_count = Int32(0)
+            if all_rows_unique > Int32(0) and i < num_active_experts:
+                row_count = Int32(1)
+            row_counts[i] = row_count
+            i += flat_stride
+        if flat_tid == Int32(0):
+            # Triton prepass has already populated the compact expert set.
+            pass
+        scatter_total = num_tokens * cols
+        j = flat_tid
+        while j < scatter_total:
+            scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
+            j += flat_stride
+        cute.arch.sync_threads()
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        pair_idx = Int32(bidz)
+        while pair_idx < total_pairs:
+            token_idx = Int32(0)
+            weight = cutlass.Float32(0.0)
+            if all_rows_unique == Int32(0):
+                token_idx = pair_idx // num_topk
+                weight = topk_weights[pair_idx].to(cutlass.Float32)
+
+            expert_id = Int32(0)
+            local_expert_id = Int32(0)
+            row = Int32(0)
+            if all_rows_unique > Int32(0):
+                local_expert_id = pair_idx
+                expert_id = weight_expert_ids[local_expert_id].to(Int32)
+            else:
+                if is_cta_leader > Int32(0):
+                    local_expert_id = topk_ids[pair_idx].to(Int32)
+                    expert_id = weight_expert_ids[local_expert_id].to(Int32)
+                    row = atomic_add_global_i32(
+                        get_ptr_as_int64(row_counts, local_expert_id),
+                        Int32(1),
+                    )
+                    map_idx = local_expert_id * max_rows + row
+                    st_global_i32(get_ptr_as_int64(token_map, map_idx), token_idx)
+                    st_global_f32(get_ptr_as_int64(token_weights, map_idx), weight)
+                    _st_shared_i32(ctrl_base_addr + Int32(0), local_expert_id)
+                    _st_shared_i32(ctrl_base_addr + Int32(4), row)
+                    _st_shared_i32(ctrl_base_addr + Int32(8), expert_id)
+                cute.arch.sync_threads()
+                local_expert_id = _ld_shared_i32(ctrl_base_addr + Int32(0))
+                row = _ld_shared_i32(ctrl_base_addr + Int32(4))
+                expert_id = _ld_shared_i32(ctrl_base_addr + Int32(8))
+
+            # Distribute quantization across ALL CTA threads, not just leader.
+            # Each FP4 block (16 elements) is independent — perfect parallelism.
+            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+            if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(0.0):
+                if self.fast_math:
+                    gs_value = rcp_approx_ftz(gs_value)
+                else:
+                    gs_value = cutlass.Float32(1.0) / gs_value
+            sf_idx = Int32(tidx)
+            while sf_idx < sf_blocks_per_row:
+                block_start = sf_idx * Int32(16)
+                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                block_max = cutlass.Float32(0.0)
+                for elem_idx in cutlass.range_constexpr(16):
+                    value = cutlass.Float32(
+                        a_input[token_idx, block_start + Int32(elem_idx)]
+                    )
+                    values[elem_idx] = value
+                    block_max = fmax_f32(block_max, fabs_f32(value))
+                packed64 = Uint64(0)
+                scale_byte = Uint8(0)
+                if self.fast_math:
+                    packed64, scale_byte = quantize_block_fp4_fast(
+                        values, block_max, gs_value
+                    )
+                else:
+                    packed64, scale_byte = quantize_block_fp4(
+                        values, block_max, gs_value
+                    )
+
+                output_offset = (
+                    local_expert_id * max_rows * output_bytes_per_row
+                    + row * output_bytes_per_row
+                    + sf_idx * Int32(8)
+                )
+                st_global_u64(
+                    get_ptr_as_int64(packed_a_storage, output_offset), packed64
+                )
+
+                m_tile_idx = row // Int32(32 * 4)
+                k_tile_idx = sf_idx // Int32(4)
+                outer_m_idx = row % Int32(32)
+                inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
+                inner_k_idx = sf_idx % Int32(4)
+                scale_offset = (
+                    local_expert_id * expert_scale_stride
+                    + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
+                    + k_tile_idx * Int32(32 * 4 * 4)
+                    + outer_m_idx * Int32(4 * 4)
+                    + inner_m_idx * Int32(4)
+                    + inner_k_idx
+                )
+                scale_storage[scale_offset] = scale_byte
+                sf_idx += Int32(self.threads_per_cta)
+
+            if all_rows_unique == Int32(0):
+                cute.arch.sync_threads()
+            pair_idx += Int32(gdim_z)
+
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        gA = cute.local_tile(mA, self.sa_tile_shape_mk, (None, None, None))
+        # Single tiled view over concatenated w13 [2*I_tp, K, E].
+        # W13 is packed as [up, gate] across the concatenated N dimension.
+        # Up tiles: N-indices 0..gate_tile_cnt-1
+        # Gate tiles: N-indices gate_tile_cnt..2*gate_tile_cnt-1
+        gB_w13_tiled = cute.local_tile(
+            mB_w13,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gSFA = cute.local_tile(mSFA, self.sfa_tile_shape_mk, (None, None, None))
+        gSFB_w13_tiled = cute.local_tile(
+            mSFB_w13, self.sfb_tile_shape_nk, (None, None, None)
+        )
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord[1]
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord[0]
+
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_sfa,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sSFA, 0, 2),
+            cute.group_modes(gSFA, 0, 2),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # Single w13 TMA partition (gate+up concatenated)
+        tBsB_w13, tBgB_w13 = cpasync.tma_partition(
+            tma_b_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_w13_tiled, 0, 2),
+        )
+        tBsB_w13_up, _ = cpasync.tma_partition(
+            tma_b_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB_up, 0, 2),
+            cute.group_modes(gB_w13_tiled, 0, 2),
+        )
+        tBsSFB_w13, tBgSFB_w13 = cpasync.tma_partition(
+            tma_sfb_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_w13_tiled, 0, 2),
+        )
+        tBsSFB_w13_up, _ = cpasync.tma_partition(
+            tma_sfb_w13,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB_up, 0, 2),
+            cute.group_modes(gSFB_w13_tiled, 0, 2),
+        )
+        tBsB_w13_up = cute.filter_zeros(tBsB_w13_up)
+        tBsSFB_w13 = cute.filter_zeros(tBsSFB_w13)
+        tBgSFB_w13 = cute.filter_zeros(tBgSFB_w13)
+        tBsSFB_w13_up = cute.filter_zeros(tBsSFB_w13_up)
+
+        # B_down TMA partitions
+        gB_down = cute.local_tile(
+            mB_down,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gSFB_down = cute.local_tile(
+            mSFB_down, self.sfb_tile_shape_nk, (None, None, None)
+        )
+        tBsB_down, tBgB_down = cpasync.tma_partition(
+            tma_b_down,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_down, 0, 2),
+        )
+        tBsSFB_down, tBgSFB_down = cpasync.tma_partition(
+            tma_sfb_down,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_down, 0, 2),
+        )
+        tBsSFB_down = cute.filter_zeros(tBsSFB_down)
+        tBgSFB_down = cute.filter_zeros(tBgSFB_down)
+
+        # MMA fragment partitions
+        tCsA_full = thr_mma.partition_A(sA)
+        tCrA_full = tiled_mma.make_fragment_A(tCsA_full[None, None, None, 0])
+        tCrSFA_full = self._dense_cls._partition_fragment_SFA(
+            self,  # type: ignore[arg-type]
+            sSFA[None, None, 0],
+            thr_mma,
+            tidx,
+        )
+        tCsB = thr_mma.partition_B(sB)
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCrSFB_full = self._dense_cls._partition_fragment_SFB(
+            self,  # type: ignore[arg-type]
+            sSFB[None, None, 0],
+            thr_mma,
+            tidx,
+        )
+
+        tCsC_for_shape = thr_mma.partition_C(sC[None, None, 0])
+        epi_m_scale = self.tile_shape_mnk[0] // self.epi_tile[0]
+        sub_shape = tCsC_for_shape.shape[:3]
+        acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
+        gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        k_tile_cnt = cute.size(gA, mode=[3])
+        fc1_k_tile_cnt = k_tile_cnt
+        # w13 has 2*I_tp/tile_N N-tiles. Gate = first half, up = second half.
+        intermediate_tile_cnt = cute.size(gB_w13_tiled, mode=[2])
+        gate_tile_cnt = intermediate_tile_cnt // Int32(2)
+        output_tile_cnt = cute.size(gB_down, mode=[2])
+
+        prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        up_prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        up_cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        phase2_prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        phase2_cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        # ===================================================================
+        # MMA WARP GROUP (warps 0-3)
+        # ===================================================================
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+            num_k_blocks = cute.size(tCrA_full, mode=[2])
+
+            atom_ld_A = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                self.a_dtype,
+            )
+            atom_ld_B = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                self.b_dtype,
+            )
+            smem_copy_A = cute.make_tiled_copy_A(atom_ld_A, tiled_mma)
+            smem_copy_B = cute.make_tiled_copy_B(atom_ld_B, tiled_mma)
+            atom_ld_SF = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), self.sf_dtype
+            )
+            smem_copy_SFA = cute.make_tiled_copy(
+                atom_ld_SF,
+                self._dense_cls._get_layoutSFA_TV(self, tiled_mma),  # type: ignore[arg-type]
+                (
+                    cute.size(tiled_mma.permutation_mnk[0]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            smem_copy_SFB = cute.make_tiled_copy(
+                atom_ld_SF,
+                self._dense_cls._get_layoutSFB_TV(self, tiled_mma),  # type: ignore[arg-type]
+                (
+                    cute.size(tiled_mma.permutation_mnk[1]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+
+            thr_ld_A = smem_copy_A.get_slice(tidx)
+            thr_ld_B = smem_copy_B.get_slice(tidx)
+            csA_full = thr_ld_A.partition_S(sA)
+            crA_full = thr_ld_A.retile(tCrA_full)
+            csB = thr_ld_B.partition_S(sB)
+            csB_up = thr_ld_B.partition_S(sB_up)
+            crB = thr_ld_B.retile(tCrB)
+
+            thr_ld_SFA = smem_copy_SFA.get_slice(tidx)
+            thr_ld_SFB = smem_copy_SFB.get_slice(tidx)
+            csSFA_full = thr_ld_SFA.partition_S(sSFA)
+            crSFA_full = thr_ld_SFA.retile(tCrSFA_full)
+            csSFB_full = thr_ld_SFB.partition_S(sSFB)
+            csSFB_up_full = thr_ld_SFB.partition_S(sSFB_up)
+            crSFB_full = thr_ld_SFB.retile(tCrSFB_full)
+
+            num_persistent_clusters = Int32(gdim_z)
+            cluster_shape_mn = (
+                Int32(self.cluster_shape_mn[0]),
+                Int32(self.cluster_shape_mn[1]),
+            )
+            cta_id_in_cluster = (
+                Int32(bidx % cluster_shape_mn[0]),
+                Int32(bidy % cluster_shape_mn[1]),
+                Int32(0),
+            )
+            current_work_linear_idx = Int32(bidz)
+            current_local_expert_idx = Int32(0)
+            accum_tile_m = Int32(0)
+            tile_coord = (Int32(0), Int32(0), Int32(0))
+            is_valid_tile = Int32(0) < Int32(0)
+            if all_rows_unique > Int32(0):
+                tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                    num_active_experts=num_active_experts,
+                    num_tiles_n=Int32(self.output_tile_count_n),
+                    current_work_linear_idx=current_work_linear_idx,
+                    cta_id_in_cluster=cta_id_in_cluster,
+                )
+            else:
+                tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
+                    _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                )
+
+            while is_valid_tile:
+                # tile_coord = (m_tile, intermediate_slice, local_expert_idx)
+                local_expert_idx = tile_coord[2]
+                weight_expert_idx = weight_expert_ids[local_expert_idx]
+                alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
+                valid_rows = row_counts[local_expert_idx]
+                if all_rows_unique > Int32(0):
+                    valid_rows = Int32(1)
+                tile_m_base = tile_coord[0] * Int32(self.tile_shape_mnk[0])
+                intermediate_slice = tile_coord[1]
+                sa_tile_offset = tile_coord[0] % self.sa_tiles_per_block
+                sa_row_base = sa_tile_offset * Int32(self.tile_shape_mnk[0])
+                if cutlass.const_expr(self.sa_tiles_per_block > 1):
+                    sA_tile = cute.local_tile(
+                        sA,
+                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                        (sa_tile_offset, 0, None),
+                    )
+                    csA_tile = thr_ld_A.partition_S(sA_tile)
+                    tCsA_tile = thr_mma.partition_A(sA_tile)
+                    tCrA_tile = tiled_mma.make_fragment_A(
+                        tCsA_tile[None, None, None, 0]
+                    )
+                    crA_tile = thr_ld_A.retile(tCrA_tile)
+                else:
+                    csA_tile = csA_full
+                    tCrA_tile = tCrA_full
+                    crA_tile = crA_full
+                sfa_tile_offset = tile_coord[0] % self.sfa_tiles_per_block
+                if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                    sSFA_tile = cute.local_tile(
+                        sSFA,
+                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                        (sfa_tile_offset, 0, None),
+                    )
+                    csSFA_tile = thr_ld_SFA.partition_S(sSFA_tile)
+                    tCrSFA_tile = self._dense_cls._partition_fragment_SFA(
+                        self,  # type: ignore[arg-type]
+                        sSFA_tile[None, None, 0],
+                        thr_mma,
+                        tidx,
+                    )
+                    crSFA_tile = thr_ld_SFA.retile(tCrSFA_tile)
+                else:
+                    csSFA_tile = csSFA_full
+                    tCrSFA_tile = tCrSFA_full
+                    crSFA_tile = crSFA_full
+                sfb_tile_offset = intermediate_slice % self.sfb_tiles_per_block
+                if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                    sSFB_tile = cute.local_tile(
+                        sSFB,
+                        cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                        (sfb_tile_offset, 0, None),
+                    )
+                    sSFB_up_tile = cute.local_tile(
+                        sSFB_up,
+                        cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                        (sfb_tile_offset, 0, None),
+                    )
+                    csSFB_tile = thr_ld_SFB.partition_S(sSFB_tile)
+                    csSFB_up_tile = thr_ld_SFB.partition_S(sSFB_up_tile)
+                    tCrSFB_tile = self._dense_cls._partition_fragment_SFB(
+                        self,  # type: ignore[arg-type]
+                        sSFB_tile[None, None, 0],
+                        thr_mma,
+                        tidx,
+                    )
+                    crSFB_tile = thr_ld_SFB.retile(tCrSFB_tile)
+                else:
+                    csSFB_tile = csSFB_full
+                    csSFB_up_tile = csSFB_up_full
+                    tCrSFB_tile = tCrSFB_full
+                    crSFB_tile = crSFB_full
+                valid_tile_rows = valid_rows - tile_m_base
+                if valid_tile_rows > Int32(self.tile_shape_mnk[0]):
+                    valid_tile_rows = Int32(self.tile_shape_mnk[0])
+                if valid_tile_rows < Int32(0):
+                    valid_tile_rows = Int32(0)
+
+                cache_row = Int32(tidx)
+                if all_rows_unique == Int32(0):
+                    if cache_row < Int32(_COMPACT_STATIC_TILE_M):
+                        tok = Int32(0)
+                        wv = cutlass.Float32(0.0)
+                        if cache_row < valid_tile_rows:
+                            tok = token_map[
+                                local_expert_idx, tile_m_base + cache_row
+                            ].to(Int32)
+                            wv = token_weights[
+                                local_expert_idx, tile_m_base + cache_row
+                            ].to(cutlass.Float32)
+                        _st_shared_i32(
+                            scatter_tok_base_addr + cache_row * Int32(4), tok
+                        )
+                        _st_shared_f32(
+                            scatter_weight_base_addr + cache_row * Int32(4), wv
+                        )
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                _is_m_major = self.c_layout.is_m_major_c()
+                copy_atom_r2s = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.BFloat16,
+                )
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                    cutlass.BFloat16,
+                )
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s, tiled_copy_C_Atom
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                tRS_rGate = tiled_copy_r2s.retile(gate_acc)
+                tRS_rUp = tiled_copy_r2s.retile(up_acc)
+
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+                tRS_rD_out = cute.make_rmem_tensor(
+                    tRS_rD_layout.shape, cutlass.BFloat16
+                )
+
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rGate, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rGate, mode=[2])
+                epi_buffer = Int32(0)
+
+                down_alpha_value = down_alpha[weight_expert_idx].to(cutlass.Float32)
+                down_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+                unique_tok = Int32(0)
+                unique_wv = cutlass.Float32(0.0)
+                if all_rows_unique > Int32(0):
+                    unique_tok = local_expert_idx // num_topk
+                    unique_wv = topk_weights[local_expert_idx].to(cutlass.Float32)
+
+                epi_rest_m = self.tile_shape_mnk[0] // self.epi_tile[0]
+                MmaMPerEpiM = self.epi_tile[0] // mma_tile_m
+                MmaNPerEpiN = self.epi_tile[1] // mma_tile_n
+
+                # ============================================================
+                # PHASE A: FC1 for this slice (gate + up)
+                # ============================================================
+
+                # Gate GEMM (inlined to avoid @cute.jit pass-by-value for acc)
+                fz_crSFA = cute.filter_zeros(crSFA_tile)
+                fz_crSFB = cute.filter_zeros(crSFB_tile)
+                gate_acc.fill(0.0)
+                cons_state.reset_count()
+                peek = ml_pipeline.consumer_try_wait(cons_state)
+                ml_pipeline.consumer_wait(cons_state, peek)
+                csA_p = csA_tile[None, None, None, cons_state.index]
+                csB_p = csB[None, None, None, cons_state.index]
+                csSFA_p = csSFA_tile[None, None, None, cons_state.index]
+                csSFB_p = csSFB_tile[None, None, None, cons_state.index]
+                cute.copy(smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0])
+                cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                cute.copy(
+                    smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0]
+                )
+                cute.copy(
+                    smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0]
+                )
+                for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+                        if k_block_idx == num_k_blocks - 1:
+                            ml_pipeline.consumer_release(cons_state)
+                            cons_state.advance()
+                            peek = ml_pipeline.consumer_try_wait(cons_state)
+                            csA_p = csA_tile[None, None, None, cons_state.index]
+                            csB_p = csB[None, None, None, cons_state.index]
+                            csSFA_p = csSFA_tile[None, None, None, cons_state.index]
+                            csSFB_p = csSFB_tile[None, None, None, cons_state.index]
+                            fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                            fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                            ml_pipeline.consumer_wait(cons_state, peek)
+                        for _mt in range(self.num_m_tiles):
+                            for _nt in range(self.num_n_tiles):
+                                mma_atom.set(
+                                    WarpField.SFA,
+                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                )
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                )
+                                cute.gemm(
+                                    mma_atom,
+                                    gate_acc[None, _mt, _nt],
+                                    tCrA_tile[None, _mt, k_block_idx],
+                                    tCrB[None, _nt, k_block_idx],
+                                    gate_acc[None, _mt, _nt],
+                                )
+                        cute.copy(
+                            smem_copy_A,
+                            csA_p[None, None, k_next],
+                            crA_tile[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_B,
+                            csB_p[None, None, k_next],
+                            crB[None, None, k_next],
+                        )
+                        fz_csSFA_cur = cute.filter_zeros(
+                            csSFA_tile[None, None, None, cons_state.index]
+                        )
+                        fz_csSFB_cur = cute.filter_zeros(
+                            csSFB_tile[None, None, None, cons_state.index]
+                        )
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_cur[None, None, k_next],
+                            fz_crSFA[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_cur[None, None, k_next],
+                            fz_crSFB[None, None, k_next],
+                        )
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    if k_block_idx == num_k_blocks - 1:
+                        ml_pipeline.consumer_release(cons_state)
+                        cons_state.advance()
+                    if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                        cute.copy(
+                            smem_copy_A,
+                            csA_p[None, None, k_next],
+                            crA_tile[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_B,
+                            csB_p[None, None, k_next],
+                            crB[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_p[None, None, k_next],
+                            fz_crSFA[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_p[None, None, k_next],
+                            fz_crSFB[None, None, k_next],
+                        )
+                    for _mt in range(self.num_m_tiles):
+                        for _nt in range(self.num_n_tiles):
+                            mma_atom.set(
+                                WarpField.SFA,
+                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                            )
+                            mma_atom.set(
+                                WarpField.SFB,
+                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                            )
+                            cute.gemm(
+                                mma_atom,
+                                gate_acc[None, _mt, _nt],
+                                tCrA_tile[None, _mt, k_block_idx],
+                                tCrB[None, _nt, k_block_idx],
+                                gate_acc[None, _mt, _nt],
+                            )
+                # Gate and up share the A/SFA staging buffers. Drain gate
+                # consumers before the DMA warp starts refilling those stages
+                # for the up pass.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                # Up GEMM (inlined, same pattern)
+                up_acc.fill(0.0)
+                up_cons_state.reset_count()
+                peek = up_pipeline.consumer_try_wait(up_cons_state)
+                up_pipeline.consumer_wait(up_cons_state, peek)
+                csA_p = csA_tile[None, None, None, up_cons_state.index]
+                csB_p = csB_up[None, None, None, up_cons_state.index]
+                csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
+                csSFB_p = csSFB_up_tile[None, None, None, up_cons_state.index]
+                cute.copy(smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0])
+                cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                cute.copy(
+                    smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0]
+                )
+                cute.copy(
+                    smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0]
+                )
+                for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+                        if k_block_idx == num_k_blocks - 1:
+                            up_pipeline.consumer_release(up_cons_state)
+                            up_cons_state.advance()
+                            peek = up_pipeline.consumer_try_wait(up_cons_state)
+                            csA_p = csA_tile[None, None, None, up_cons_state.index]
+                            csB_p = csB_up[None, None, None, up_cons_state.index]
+                            csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
+                            csSFB_p = csSFB_up_tile[
+                                None, None, None, up_cons_state.index
+                            ]
+                            fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                            fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                            up_pipeline.consumer_wait(up_cons_state, peek)
+                        for _mt in range(self.num_m_tiles):
+                            for _nt in range(self.num_n_tiles):
+                                mma_atom.set(
+                                    WarpField.SFA,
+                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                )
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                )
+                                cute.gemm(
+                                    mma_atom,
+                                    up_acc[None, _mt, _nt],
+                                    tCrA_tile[None, _mt, k_block_idx],
+                                    tCrB[None, _nt, k_block_idx],
+                                    up_acc[None, _mt, _nt],
+                                )
+                        cute.copy(
+                            smem_copy_A,
+                            csA_p[None, None, k_next],
+                            crA_tile[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_B,
+                            csB_p[None, None, k_next],
+                            crB[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_p[None, None, k_next],
+                            fz_crSFA[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_p[None, None, k_next],
+                            fz_crSFB[None, None, k_next],
+                        )
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    if k_block_idx == num_k_blocks - 1:
+                        up_pipeline.consumer_release(up_cons_state)
+                        up_cons_state.advance()
+                    if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                        cute.copy(
+                            smem_copy_A,
+                            csA_p[None, None, k_next],
+                            crA_tile[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_B,
+                            csB_p[None, None, k_next],
+                            crB[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFA,
+                            fz_csSFA_p[None, None, k_next],
+                            fz_crSFA[None, None, k_next],
+                        )
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_p[None, None, k_next],
+                            fz_crSFB[None, None, k_next],
+                        )
+                    for _mt in range(self.num_m_tiles):
+                        for _nt in range(self.num_n_tiles):
+                            mma_atom.set(
+                                WarpField.SFA,
+                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                            )
+                            mma_atom.set(
+                                WarpField.SFB,
+                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                            )
+                            cute.gemm(
+                                mma_atom,
+                                up_acc[None, _mt, _nt],
+                                tCrA_tile[None, _mt, k_block_idx],
+                                tCrB[None, _nt, k_block_idx],
+                                up_acc[None, _mt, _nt],
+                            )
+                # SiLU + quant into sA
+                sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
+                packed_cols = Int32(self.tile_shape_mnk[2] // 2)
+                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
+                gs_value = global_scale[weight_expert_idx].to(cutlass.Float32)
+                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                    0.0
+                ):
+                    if self.fast_math:
+                        gs_value = rcp_approx_ftz(gs_value)
+                    else:
+                        gs_value = cutlass.Float32(1.0) / gs_value
+
+                for epi_m in cutlass.range_constexpr(epi_rest_m):
+                    epi_m_valid = (
+                        valid_rows
+                        - tile_m_base
+                        - Int32(epi_m) * Int32(self.epi_tile[0])
+                    )
+                    silu_epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                    if epi_m_valid > Int32(0):
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                mma_n = mma_n_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                for elem_idx in cutlass.range_constexpr(
+                                    cute.size(tRS_rD_slice)
+                                ):
+                                    g = alpha_value * gate_slice[elem_idx]
+                                    u = alpha_value * up_slice[elem_idx]
+                                    sigmoid_g = cute.arch.rcp_approx(
+                                        cutlass.Float32(1.0)
+                                        + cute.math.exp(-g, fastmath=self.fast_math),
+                                    )
+                                    tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+
+                        acc_vec = tRS_rD.load()
+                        acc_vec = acc_vec.to(cutlass.BFloat16)
+                        tRS_rD_out.store(acc_vec)
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, silu_epi_buffer)],
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                    epi_rows = epi_m_valid
+                    if epi_rows > Int32(self.epi_tile[0]):
+                        epi_rows = Int32(self.epi_tile[0])
+                    if epi_rows < Int32(0):
+                        epi_rows = Int32(0)
+                    quant_idx = Int32(tidx)
+                    while quant_idx < epi_rows * sf_blocks_per_row:
+                        local_row = quant_idx // sf_blocks_per_row
+                        row = sa_row_base + rows_offset + local_row
+                        sf_block = quant_idx - local_row * sf_blocks_per_row
+                        block_start = sf_block * Int32(16)
+
+                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                        block_max = cutlass.Float32(0.0)
+                        for elem_idx in cutlass.range_constexpr(16):
+                            value = cutlass.Float32(
+                                sC[local_row, block_start + elem_idx, silu_epi_buffer]
+                            )
+                            values[elem_idx] = value
+                            block_max = fmax_f32(block_max, fabs_f32(value))
+
+                        packed64 = Uint64(0)
+                        scale_byte = Uint8(0)
+                        if self.fast_math:
+                            packed64, scale_byte = quantize_block_fp4_fast(
+                                values, block_max, gs_value
+                            )
+                        else:
+                            packed64, scale_byte = quantize_block_fp4(
+                                values, block_max, gs_value
+                            )
+                        packed_base = sf_block << Int32(3)
+                        dst_pcol = row & Int32(63)
+                        xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                        row_high = row >> Int32(6)
+                        for byte_idx in cutlass.range_constexpr(8):
+                            src_pcol = packed_base + Int32(byte_idx)
+                            dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                            dst_flat = dst_row * packed_cols + dst_pcol
+                            byte_val = Uint8(
+                                (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                            )
+                            sA_u8[dst_flat] = byte_val
+
+                        outer_m_idx = row % Int32(32)
+                        inner_m_idx = row // Int32(32)
+                        inner_k_idx = sf_block % Int32(4)
+                        k_tile_idx = sf_block // Int32(4)
+                        sf_raw_idx = (
+                            k_tile_idx * Int32(32 * 4 * 4)
+                            + outer_m_idx * Int32(4 * 4)
+                            + inner_m_idx * Int32(4)
+                            + inner_k_idx
+                        )
+                        st_shared_u8(sfa_base_addr + sf_raw_idx, scale_byte)
+                        quant_idx += Int32(
+                            self.num_mma_warps * self.num_threads_per_warp
+                        )
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                # epilog_sync: MMA-only barrier. DMA warp doesn't need to wait
+                # for quant — it only loads B_down into sB (separate buffer).
+                # This allows DMA to prefetch B_down tiles earlier.
+                self.epilog_sync_barrier.arrive_and_wait()
+
+                # ============================================================
+                # PHASE B: Sweep ALL FC2 output tiles using cached sA
+                # No CTA-wide barrier needed here: gate is done with sB/sSFB
+                # (barrier at line 925 ensured that), up uses sB_up/sSFB_up,
+                # and DMA's B_down loads into sB/sSFB don't conflict with
+                # MMA's SiLU+quant on sC/sA/sSFA. The phase2_pipeline
+                # handles B_down availability for FC2 GEMM.
+                # ============================================================
+                scatter_N = Int32(scatter_output.shape[1])
+                lane_id = Int32(tidx) & Int32(31)
+                warp_in_tile = Int32(tidx) >> Int32(5)
+                warp_m_base = (warp_in_tile >> Int32(1)) * Int32(64)
+                warp_n_base = (warp_in_tile & Int32(1)) * Int32(64)
+
+                csA_phase2 = csA_tile[None, None, None, 0]
+                csSFA_phase2 = csSFA_tile[None, None, None, 0]
+
+                # Consume all output tiles continuously from phase2_pipeline.
+
+                # Hoist A-side register loads: sA is constant across all
+                # FC2 output tiles (quantized intermediate). Load crA and
+                # crSFA for all k-blocks once, reuse for all 32 tiles.
+                fz_crSFA_p2 = cute.filter_zeros(crSFA_tile)
+                cute.copy(
+                    smem_copy_A, csA_phase2[None, None, 0], crA_tile[None, None, 0]
+                )
+                fz_csSFA_p2 = cute.filter_zeros(csSFA_phase2)
+                cute.copy(
+                    smem_copy_SFA,
+                    fz_csSFA_p2[None, None, 0],
+                    fz_crSFA_p2[None, None, 0],
+                )
+                for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
+                    k_pre = _kb_pre + 1
+                    cute.copy(
+                        smem_copy_A,
+                        csA_phase2[None, None, k_pre],
+                        crA_tile[None, None, k_pre],
+                    )
+                    cute.copy(
+                        smem_copy_SFA,
+                        fz_csSFA_p2[None, None, k_pre],
+                        fz_crSFA_p2[None, None, k_pre],
+                    )
+
+                phase2_cons_state.reset_count()
+                for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                        sSFB_phase2_tile = cute.local_tile(
+                            sSFB,
+                            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                            (output_tile_idx % self.sfb_tiles_per_block, 0, None),
+                        )
+                        csSFB_phase2_tile = thr_ld_SFB.partition_S(sSFB_phase2_tile)
+                        tCrSFB_phase2 = self._dense_cls._partition_fragment_SFB(
+                            self,  # type: ignore[arg-type]
+                            sSFB_phase2_tile[None, None, 0],
+                            thr_mma,
+                            tidx,
+                        )
+                        crSFB_phase2 = thr_ld_SFB.retile(tCrSFB_phase2)
+                    else:
+                        csSFB_phase2_tile = csSFB_full
+                        tCrSFB_phase2 = tCrSFB_full
+                        crSFB_phase2 = crSFB_full
+                    phase2_peek = phase2_pipeline.consumer_try_wait(phase2_cons_state)
+                    phase2_pipeline.consumer_wait(phase2_cons_state, phase2_peek)
+                    csB_phase2 = csB[None, None, None, phase2_cons_state.index]
+                    csSFB_phase2 = csSFB_phase2_tile[
+                        None, None, None, phase2_cons_state.index
+                    ]
+
+                    # Only load B-side (B_down changes per output tile; A is hoisted)
+                    cute.copy(
+                        smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
+                    )
+                    f2 = cute.filter_zeros(csSFB_phase2)
+                    f4 = cute.filter_zeros(crSFB_phase2)
+                    cute.copy(smem_copy_SFB, f2[None, None, 0], f4[None, None, 0])
+
+                    down_acc.fill(0.0)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+                        if k_block_idx == num_k_blocks - 1:
+                            phase2_pipeline.consumer_release(phase2_cons_state)
+                            phase2_cons_state.advance()
+                        if k_next > 0:
+                            # Only B-side for next k-block (A already in registers)
+                            cute.copy(
+                                smem_copy_B,
+                                csB_phase2[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+                            f2 = cute.filter_zeros(csSFB_phase2)
+                            f4 = cute.filter_zeros(crSFB_phase2)
+                            cute.copy(
+                                smem_copy_SFB,
+                                f2[None, None, k_next],
+                                f4[None, None, k_next],
+                            )
+                        for _mt in range(self.num_m_tiles):
+                            for _nt in range(self.num_n_tiles):
+                                mma_atom.set(
+                                    WarpField.SFA,
+                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                )
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_phase2[None, _nt, k_block_idx].iterator,
+                                )
+                                cute.gemm(
+                                    mma_atom,
+                                    down_acc[None, _mt, _nt],
+                                    tCrA_tile[None, _mt, k_block_idx],
+                                    tCrB[None, _nt, k_block_idx],
+                                    down_acc[None, _mt, _nt],
+                                )
+
+                    # Scatter using precomputed metadata (no redundant gmem loads)
+                    tile_n_base_cur = output_tile_idx * Int32(self.tile_shape_mnk[1])
+                    for epi_m in cutlass.range_constexpr(epi_rest_m):
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_n = mma_n_in_epi
+                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                down_epi_acc_slice = down_acc[(None, mma_m, mma_n)]
+                                for elem_idx in cutlass.range_constexpr(
+                                    cute.size(tRS_rD_slice)
+                                ):
+                                    tRS_rD_slice[elem_idx] = (
+                                        down_alpha_value * down_epi_acc_slice[elem_idx]
+                                    )
+
+                        acc_vec = tRS_rD.load()
+                        acc_vec = acc_vec.to(cutlass.BFloat16)
+                        tRS_rD_out.store(acc_vec)
+                        epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, epi_buffer)],
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        # No cross-warp barrier needed before scatter:
+                        # StMatrix is warp-local, and each warp only reads
+                        # its own 64x64 quadrant of sC below.
+
+                        rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+
+                        # Per-warp scatter: each warp scatters its own quadrant
+                        # of sC (64 M-rows x 64 N-cols). No cross-warp read
+                        # dependencies, so no pre-scatter barrier is needed.
+                        warp_epi_rows = (
+                            valid_rows - tile_m_base - rows_offset - warp_m_base
+                        )
+                        if warp_epi_rows > Int32(64):
+                            warp_epi_rows = Int32(64)
+                        if warp_epi_rows < Int32(0):
+                            warp_epi_rows = Int32(0)
+
+                        pair_idx = lane_id
+                        while pair_idx < warp_epi_rows * Int32(32):
+                            local_row = pair_idx >> Int32(5)  # / 32
+                            local_pair_col = pair_idx & Int32(31)  # % 32
+                            global_col = (
+                                tile_n_base_cur
+                                + warp_n_base
+                                + local_pair_col * Int32(2)
+                            )
+                            cached_row = rows_offset + warp_m_base + local_row
+                            tok = Int32(0)
+                            wv = cutlass.Float32(0.0)
+                            if all_rows_unique > Int32(0):
+                                tok = unique_tok
+                                wv = unique_wv
+                            else:
+                                # Only lane 0 loads tok/wv from smem; broadcast via shuffle.
+                                if lane_id == Int32(0):
+                                    tok = _ld_shared_i32(
+                                        scatter_tok_base_addr + cached_row * Int32(4)
+                                    )
+                                    wv = _ld_shared_f32(
+                                        scatter_weight_base_addr + cached_row * Int32(4)
+                                    )
+                                tok = cute.arch.shuffle_sync(tok, Int32(0))
+                                wv = cute.arch.shuffle_sync(wv, Int32(0))
+                            sc_v0 = cutlass.Float32(
+                                sC[
+                                    warp_m_base + local_row,
+                                    warp_n_base + local_pair_col * Int32(2),
+                                    epi_buffer,
+                                ]
+                            )
+                            sc_v1 = cutlass.Float32(
+                                sC[
+                                    warp_m_base + local_row,
+                                    warp_n_base + local_pair_col * Int32(2) + Int32(1),
+                                    epi_buffer,
+                                ]
+                            )
+                            scatter_add_bf16x2(
+                                get_ptr_as_int64(
+                                    scatter_output, tok * scatter_N + global_col
+                                ),
+                                wv * sc_v0,
+                                wv * sc_v1,
+                            )
+                            pair_idx += Int32(self.num_threads_per_warp)
+
+                        # Post-scatter barrier: needed to ensure all warps
+                        # finish scatter before next output tile's pipeline ops
+                        # (pipeline consumer is collective across all MMA warps).
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                # Final pass_sync: protect sA from next task's FC1 loads.
+                # DMA warp waits here too after finishing all B_down loads.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                current_work_linear_idx += num_persistent_clusters
+                if all_rows_unique > Int32(0):
+                    tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                        num_active_experts=num_active_experts,
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        current_work_linear_idx=current_work_linear_idx,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                else:
+                    (
+                        tile_coord,
+                        is_valid_tile,
+                        current_local_expert_idx,
+                        accum_tile_m,
+                    ) = _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+
+        # ===================================================================
+        # DMA WARP (warp 4)
+        # ===================================================================
+        elif warp_idx == self.tma_load_warp_id:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            num_persistent_clusters = Int32(gdim_z)
+            cluster_shape_mn = (
+                Int32(self.cluster_shape_mn[0]),
+                Int32(self.cluster_shape_mn[1]),
+            )
+            cta_id_in_cluster = (
+                Int32(bidx % cluster_shape_mn[0]),
+                Int32(bidy % cluster_shape_mn[1]),
+                Int32(0),
+            )
+            current_work_linear_idx = Int32(bidz)
+            current_local_expert_idx = Int32(0)
+            accum_tile_m = Int32(0)
+            tile_coord = (Int32(0), Int32(0), Int32(0))
+            is_valid_tile = Int32(0) < Int32(0)
+            if all_rows_unique > Int32(0):
+                tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                    num_active_experts=num_active_experts,
+                    num_tiles_n=Int32(self.output_tile_count_n),
+                    current_work_linear_idx=current_work_linear_idx,
+                    cta_id_in_cluster=cta_id_in_cluster,
+                )
+            else:
+                tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
+                    _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                )
+
+            while is_valid_tile:
+                tc = tile_coord
+                intermediate_slice = tc[1]
+                local_expert_idx = tc[2]
+                weight_expert_idx = weight_expert_ids[local_expert_idx]
+
+                sa_tile_coord_m = tc[0] // self.sa_tiles_per_block
+                tAgA_mk = tAgA[(None, sa_tile_coord_m, None, local_expert_idx)]
+                sfa_tile_coord_m = tc[0] // self.sfa_tiles_per_block
+                tAgSFA_mk = tAgSFA[(None, sfa_tile_coord_m, None, local_expert_idx)]
+
+                # W13 is laid out as [up, gate] across the concatenated N dimension.
+                tBgB_w13_up_nk = tBgB_w13[
+                    (None, intermediate_slice, None, weight_expert_idx)
+                ]
+                sfb_up_tile_coord = intermediate_slice // self.sfb_tiles_per_block
+                tBgSFB_w13_up_nk = tBgSFB_w13[
+                    (None, sfb_up_tile_coord, None, weight_expert_idx)
+                ]
+                tBgB_w13_gate_nk = tBgB_w13[
+                    (None, intermediate_slice + gate_tile_cnt, None, weight_expert_idx)
+                ]
+                sfb_gate_tile_coord = (
+                    intermediate_slice + gate_tile_cnt
+                ) // self.sfb_tiles_per_block
+                tBgSFB_w13_gate_nk = tBgSFB_w13[
+                    (None, sfb_gate_tile_coord, None, weight_expert_idx)
+                ]
+
+                # ---- FC1 gate pass ----
+                prod_state.reset_count()
+                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    ml_pipeline.producer_acquire(prod_state)
+                    cute.copy(
+                        tma_a,
+                        tAgA_mk[(None, k_tile)],
+                        tAsA[(None, prod_state.index)],
+                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                    )
+                    cute.copy(
+                        tma_b_w13,
+                        tBgB_w13_gate_nk[(None, k_tile)],
+                        tBsB_w13[(None, prod_state.index)],
+                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                    )
+                    cute.copy(
+                        tma_sfa,
+                        tAgSFA_mk[(None, k_tile)],
+                        tAsSFA[(None, prod_state.index)],
+                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                    )
+                    cute.copy(
+                        tma_sfb_w13,
+                        tBgSFB_w13_gate_nk[(None, k_tile)],
+                        tBsSFB_w13[(None, prod_state.index)],
+                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                    )
+                    ml_pipeline.producer_commit(prod_state)
+                    prod_state.advance()
+
+                # Gate and up share the A/SFA staging buffers. Wait for MMA
+                # warps to drain the gate pass before refilling those stages.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                # ---- FC1 up pass ----
+                up_prod_state.reset_count()
+                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    up_pipeline.producer_acquire(up_prod_state)
+                    cute.copy(
+                        tma_a,
+                        tAgA_mk[(None, k_tile)],
+                        tAsA[(None, up_prod_state.index)],
+                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                    )
+                    cute.copy(
+                        tma_b_w13,
+                        tBgB_w13_up_nk[(None, k_tile)],
+                        tBsB_w13_up[(None, up_prod_state.index)],
+                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                    )
+                    cute.copy(
+                        tma_sfa,
+                        tAgSFA_mk[(None, k_tile)],
+                        tAsSFA[(None, up_prod_state.index)],
+                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                    )
+                    cute.copy(
+                        tma_sfb_w13,
+                        tBgSFB_w13_up_nk[(None, k_tile)],
+                        tBsSFB_w13_up[(None, up_prod_state.index)],
+                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                    )
+                    up_pipeline.producer_commit(up_prod_state)
+                    up_prod_state.advance()
+
+                # ---- FC2 B_down loads: continuous pipeline ----
+                # No barrier needed: sB/sSFB are free (gate done, up uses
+                # sB_up/sSFB_up). phase2_pipeline handles data availability.
+                # intermediate_slice selects the K-tile of GEMM2 (FC1 output N-tile
+                # = GEMM2 K-tile since intermediate dim is the reduction dim).
+                # Load ALL FC2 tiles continuously once stage1 no longer needs
+                # the gate staging buffers.
+                phase2_prod_state.reset_count()
+                for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    phase2_pipeline.producer_acquire(phase2_prod_state)
+                    cute.copy(
+                        tma_b_down,
+                        tBgB_down[
+                            (
+                                None,
+                                output_tile_idx,
+                                intermediate_slice,
+                                weight_expert_idx,
+                            )
+                        ],
+                        tBsB_down[(None, phase2_prod_state.index)],
+                        tma_bar_ptr=phase2_pipeline.producer_get_barrier(
+                            phase2_prod_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_sfb_down,
+                        tBgSFB_down[
+                            (
+                                None,
+                                output_tile_idx // self.sfb_tiles_per_block,
+                                intermediate_slice,
+                                weight_expert_idx,
+                            )
+                        ],
+                        tBsSFB_down[(None, phase2_prod_state.index)],
+                        tma_bar_ptr=phase2_pipeline.producer_get_barrier(
+                            phase2_prod_state
+                        ),
+                    )
+                    phase2_pipeline.producer_commit(phase2_prod_state)
+                    phase2_prod_state.advance()
+
+                # Final pass_sync: match MMA warps' barrier after FC2 sweep.
+                # Ensures MMA warps finish scatter before DMA starts next task's FC1.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                current_work_linear_idx += num_persistent_clusters
+                if all_rows_unique > Int32(0):
+                    tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                        num_active_experts=num_active_experts,
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        current_work_linear_idx=current_work_linear_idx,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                else:
+                    (
+                        tile_coord,
+                        is_valid_tile,
+                        current_local_expert_idx,
+                        accum_tile_m,
+                    ) = _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+
+            ml_pipeline.producer_tail(prod_state)
+            up_pipeline.producer_tail(up_prod_state)
+            phase2_pipeline.producer_tail(phase2_prod_state)
+        return
+
+
+__all__ = ["MoEMicroKernel"]

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -366,6 +366,7 @@ class MoEMicroKernel:
         input_scales_are_reciprocal: bool = False,
         fast_math: bool = False,
         activation: str = "silu",
+        share_input_across_experts: bool = False,
     ):
         if activation not in {"silu", "relu2"}:
             raise ValueError(f"unsupported activation {activation!r}")
@@ -376,6 +377,12 @@ class MoEMicroKernel:
         self.fast_math = fast_math
         self.activation = activation
         self.is_gated = activation == "silu"
+        # For m=1 with a shared input scale, the quantized activation is
+        # identical across all K top-k experts. When set, only pair_idx==0
+        # does the quantize and all pairs read from a single shared slot
+        # in packed_input/scale_storage. Caller is responsible for the
+        # activation == "relu2" and m == 1 and shared-scale preconditions.
+        self.share_input_across_experts = share_input_across_experts
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
@@ -1000,6 +1007,11 @@ class MoEMicroKernel:
             # A single token's top-k routing is already a dense local expert set.
             all_rows_unique = Int32(1)
             num_active_experts = total_pairs
+        shared_single_input = (
+            Int32(1)
+            if cutlass.const_expr(self.share_input_across_experts)
+            else Int32(0)
+        )
         if all_rows_unique == Int32(0):
             i = flat_tid
             while i < num_experts:
@@ -1011,12 +1023,16 @@ class MoEMicroKernel:
             scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
             j += flat_stride
         cute.arch.sync_threads()
-        self._resident_grid_barrier(
-            barrier_count,
-            barrier_epoch,
-            Int32(gdim_z),
-            is_cta_leader,
-        )
+        # When the quantized input is shared across experts, only pair 0
+        # writes to packed storage; there's no expert-parallel routing to
+        # synchronize before FC1, so the grid-wide barrier is unnecessary.
+        if shared_single_input == Int32(0):
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
 
         pair_idx = Int32(bidz)
         while pair_idx < total_pairs:
@@ -1031,7 +1047,7 @@ class MoEMicroKernel:
             row = Int32(0)
             if all_rows_unique > Int32(0):
                 local_expert_id = pair_idx
-                expert_id = topk_ids[local_expert_id].to(Int32)
+                expert_id = weight_expert_ids[local_expert_id].to(Int32)
             else:
                 if is_cta_leader > Int32(0):
                     local_expert_id = topk_ids[pair_idx].to(Int32)
@@ -1053,58 +1069,71 @@ class MoEMicroKernel:
 
             # Distribute quantization across ALL CTA threads, not just leader.
             # Each FP4 block (16 elements) is independent — perfect parallelism.
-            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
-            if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(0.0):
-                if self.fast_math:
-                    gs_value = rcp_approx_ftz(gs_value)
-                else:
-                    gs_value = cutlass.Float32(1.0) / gs_value
-            sf_idx = Int32(tidx)
-            while sf_idx < sf_blocks_per_row:
-                block_start = sf_idx * Int32(16)
-                values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                block_max = cutlass.Float32(0.0)
-                for elem_idx in cutlass.range_constexpr(16):
-                    value = cutlass.Float32(
-                        a_input[token_idx, block_start + Int32(elem_idx)]
+            # When the input is shared across experts (m=1 relu2, shared
+            # a1_gscale), only pair 0 does the quantize and every pair
+            # reads from a single shared slot at (expert=0, row=0).
+            should_quantize = Int32(1)
+            packed_local_expert_id = local_expert_id
+            packed_row = row
+            if shared_single_input > Int32(0):
+                should_quantize = Int32(1) if pair_idx == Int32(0) else Int32(0)
+                packed_local_expert_id = Int32(0)
+                packed_row = Int32(0)
+            if should_quantize > Int32(0):
+                gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                    0.0
+                ):
+                    if self.fast_math:
+                        gs_value = rcp_approx_ftz(gs_value)
+                    else:
+                        gs_value = cutlass.Float32(1.0) / gs_value
+                sf_idx = Int32(tidx)
+                while sf_idx < sf_blocks_per_row:
+                    block_start = sf_idx * Int32(16)
+                    values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                    block_max = cutlass.Float32(0.0)
+                    for elem_idx in cutlass.range_constexpr(16):
+                        value = cutlass.Float32(
+                            a_input[token_idx, block_start + Int32(elem_idx)]
+                        )
+                        values[elem_idx] = value
+                        block_max = fmax_f32(block_max, fabs_f32(value))
+                    packed64 = Uint64(0)
+                    scale_byte = Uint8(0)
+                    if self.fast_math:
+                        packed64, scale_byte = quantize_block_fp4_fast(
+                            values, block_max, gs_value
+                        )
+                    else:
+                        packed64, scale_byte = quantize_block_fp4(
+                            values, block_max, gs_value
+                        )
+
+                    output_offset = (
+                        packed_local_expert_id * max_rows * output_bytes_per_row
+                        + packed_row * output_bytes_per_row
+                        + sf_idx * Int32(8)
                     )
-                    values[elem_idx] = value
-                    block_max = fmax_f32(block_max, fabs_f32(value))
-                packed64 = Uint64(0)
-                scale_byte = Uint8(0)
-                if self.fast_math:
-                    packed64, scale_byte = quantize_block_fp4_fast(
-                        values, block_max, gs_value
-                    )
-                else:
-                    packed64, scale_byte = quantize_block_fp4(
-                        values, block_max, gs_value
+                    st_global_u64(
+                        get_ptr_as_int64(packed_a_storage, output_offset), packed64
                     )
 
-                output_offset = (
-                    local_expert_id * max_rows * output_bytes_per_row
-                    + row * output_bytes_per_row
-                    + sf_idx * Int32(8)
-                )
-                st_global_u64(
-                    get_ptr_as_int64(packed_a_storage, output_offset), packed64
-                )
-
-                m_tile_idx = row // Int32(32 * 4)
-                k_tile_idx = sf_idx // Int32(4)
-                outer_m_idx = row % Int32(32)
-                inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
-                inner_k_idx = sf_idx % Int32(4)
-                scale_offset = (
-                    local_expert_id * expert_scale_stride
-                    + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
-                    + k_tile_idx * Int32(32 * 4 * 4)
-                    + outer_m_idx * Int32(4 * 4)
-                    + inner_m_idx * Int32(4)
-                    + inner_k_idx
-                )
-                scale_storage[scale_offset] = scale_byte
-                sf_idx += Int32(self.threads_per_cta)
+                    m_tile_idx = packed_row // Int32(32 * 4)
+                    k_tile_idx = sf_idx // Int32(4)
+                    outer_m_idx = packed_row % Int32(32)
+                    inner_m_idx = (packed_row % Int32(32 * 4)) // Int32(32)
+                    inner_k_idx = sf_idx % Int32(4)
+                    scale_offset = (
+                        packed_local_expert_id * expert_scale_stride
+                        + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
+                        + k_tile_idx * Int32(32 * 4 * 4)
+                        + outer_m_idx * Int32(4 * 4)
+                        + inner_m_idx * Int32(4)
+                        + inner_k_idx
+                    )
+                    scale_storage[scale_offset] = scale_byte
+                    sf_idx += Int32(self.threads_per_cta)
 
             if all_rows_unique == Int32(0):
                 cute.arch.sync_threads()
@@ -1379,7 +1408,6 @@ class MoEMicroKernel:
                 weight_expert_idx = weight_expert_ids[local_expert_idx]
                 valid_rows = row_counts[local_expert_idx]
                 if all_rows_unique > Int32(0):
-                    weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
                     valid_rows = Int32(1)
                 alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
                 tile_m_base = tile_coord[0] * Int32(self.tile_shape_mnk[0])
@@ -2202,13 +2230,19 @@ class MoEMicroKernel:
                 intermediate_slice = tc[1]
                 local_expert_idx = tc[2]
                 weight_expert_idx = weight_expert_ids[local_expert_idx]
-                if all_rows_unique > Int32(0):
-                    weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
+                # When the quantized input is shared across experts, the
+                # route/pack phase wrote a single copy at slot 0; all pairs
+                # must read it from there regardless of their expert id.
+                input_local_expert_idx = (
+                    Int32(0) if shared_single_input > Int32(0) else local_expert_idx
+                )
 
                 sa_tile_coord_m = tc[0] // self.sa_tiles_per_block
-                tAgA_mk = tAgA[(None, sa_tile_coord_m, None, local_expert_idx)]
+                tAgA_mk = tAgA[(None, sa_tile_coord_m, None, input_local_expert_idx)]
                 sfa_tile_coord_m = tc[0] // self.sfa_tiles_per_block
-                tAgSFA_mk = tAgSFA[(None, sfa_tile_coord_m, None, local_expert_idx)]
+                tAgSFA_mk = tAgSFA[
+                    (None, sfa_tile_coord_m, None, input_local_expert_idx)
+                ]
 
                 # FC1 producer slice. Gated activation packs [up, gate] along N;
                 # relu2 uses a single FC1 pass over intermediate_slice.

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -14,16 +14,21 @@ The result is still a two-phase algorithm, just without a host-side handoff:
            write token_map + token_weights, and quantize each routed
            token row directly into expert-major packed A + scale storage
   Barrier: resident-grid barrier after all expert rows are finalized
-  Phase 2: run the FC1 -> SiLU -> quant -> FC2 -> scatter datapath
+  Phase 2: run the FC1 -> activation -> quant -> FC2 -> scatter datapath
            over the finalized expert-major packed input
 
 The compute half is intentionally the same design as the earlier two-kernel
 implementation:
-  FC1:     A x gate^T, A x up^T     (paired FP4 block-scaled GEMMs)
-  SiLU:    SiLU(gate) * up          (fused SwiGLU activation)
-  Quant:   intermediate -> FP4      (cooperative quantization into shared A)
-  FC2:     sweep all output tiles   (reuse the cached intermediate slice)
-  Scatter: bf16x2 atomic add        (directly into token-major output)
+  SiLU (gated):
+    FC1:     A x gate^T, A x up^T     (paired FP4 block-scaled GEMMs)
+    Act:     SiLU(gate) * up           (fused SwiGLU activation)
+  ReLU2 (non-gated):
+    FC1:     A x W1^T                  (single FP4 block-scaled GEMM)
+    Act:     max(0, x)^2               (squared ReLU activation)
+  Common:
+    Quant:   intermediate -> FP4      (cooperative quantization into shared A)
+    FC2:     sweep all output tiles   (reuse the cached intermediate slice)
+    Scatter: bf16x2 atomic add        (directly into token-major output)
 
 What changes relative to the static kernel:
   - topk_ids contains LOCAL expert IDs (pre-compacted by Triton pre-pass)
@@ -360,12 +365,17 @@ class MoEMicroKernel:
         *,
         input_scales_are_reciprocal: bool = False,
         fast_math: bool = False,
+        activation: str = "silu",
     ):
+        if activation not in {"silu", "relu2"}:
+            raise ValueError(f"unsupported activation {activation!r}")
         self._dense_cls = DenseGemmKernel
         self.acc_dtype = cutlass.Float32
         self.sf_vec_size = sf_vec_size
         self.input_scales_are_reciprocal = input_scales_are_reciprocal
         self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = activation == "silu"
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
@@ -469,21 +479,23 @@ class MoEMicroKernel:
         def _align_up(value: int, align: int) -> int:
             return ((value + align - 1) // align) * align
 
+        pipeline_count = 3 if self.is_gated else 2
         offset = (
             3 * 4
-            + 3 * (self.ab_stage * 2 * 8)
+            + pipeline_count * (self.ab_stage * 2 * 8)
             + _COMPACT_STATIC_TILE_M * 4
             + _COMPACT_STATIC_TILE_M * 4
         )
-        buffers = (
+        buffers = [
             cute.size_in_bytes(self.a_dtype, a_smem_staged),
-            cute.size_in_bytes(self.b_dtype, b_smem_staged),
             cute.size_in_bytes(self.b_dtype, b_smem_staged),
             cute.size_in_bytes(self.sf_dtype, sfa_smem_staged),
             cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
-            cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
             cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
-        )
+        ]
+        if self.is_gated:
+            buffers.insert(2, cute.size_in_bytes(self.b_dtype, b_smem_staged))
+            buffers.insert(5, cute.size_in_bytes(self.sf_dtype, sfb_smem_staged))
         offset = _align_up(offset, self.buffer_align_bytes)
         for idx, size in enumerate(buffers):
             offset += size
@@ -825,7 +837,7 @@ class MoEMicroKernel:
         smem = cutlass.utils.SmemAllocator()
 
         @cute.struct
-        class Storage:
+        class StorageGated:
             ctrl: cute.struct.MemRange[cutlass.Int32, 3]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
@@ -867,7 +879,41 @@ class MoEMicroKernel:
                 self.buffer_align_bytes,
             ]
 
-        storage = smem.allocate(Storage)
+        @cute.struct
+        class StorageRelu2:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 3]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfa_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        storage = smem.allocate(StorageGated if self.is_gated else StorageRelu2)
 
         prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         cons_group = pipeline.CooperativeGroup(
@@ -882,13 +928,17 @@ class MoEMicroKernel:
             barrier_storage=storage.pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
-        up_pipeline = pipeline.PipelineTmaAsync.create(
-            num_stages=self.ab_stage,
-            producer_group=prod_group,
-            consumer_group=cons_group,
-            tx_count=tma_copy_bytes,
-            barrier_storage=storage.up_pipeline_array.data_ptr(),
-            cta_layout_vmnk=cta_layout_vmnk,
+        up_pipeline = (
+            pipeline.PipelineTmaAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=prod_group,
+                consumer_group=cons_group,
+                tx_count=tma_copy_bytes,
+                barrier_storage=storage.up_pipeline_array.data_ptr(),
+                cta_layout_vmnk=cta_layout_vmnk,
+            )
+            if self.is_gated
+            else ml_pipeline
         )
         phase2_pipeline = pipeline.PipelineTmaAsync.create(
             num_stages=self.ab_stage,
@@ -903,15 +953,17 @@ class MoEMicroKernel:
 
         sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
         sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
-        sB_up = storage.sB_up.get_tensor(
-            b_smem_staged.outer, swizzle=b_smem_staged.inner
+        sB_up = (
+            storage.sB_up.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+            if self.is_gated
+            else sB
         )
         cute.recast_tensor(sA, cutlass.Uint8)
         cute.recast_tensor(sB, cutlass.Uint8)
         cute.recast_tensor(sB_up, cutlass.Uint8)
         sSFA = storage.sSFA.get_tensor(sfa_smem_staged)
         sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
-        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
+        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged) if self.is_gated else sSFB
         cute.recast_tensor(sSFA, cutlass.Uint8)
         cute.recast_tensor(sSFB, cutlass.Uint8)
         cute.recast_tensor(sSFB_up, cutlass.Uint8)
@@ -1189,13 +1241,22 @@ class MoEMicroKernel:
         sub_shape = tCsC_for_shape.shape[:3]
         acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
         gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
-        up_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = (
+            cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+            if self.is_gated
+            else gate_acc
+        )
 
         k_tile_cnt = cute.size(gA, mode=[3])
         fc1_k_tile_cnt = k_tile_cnt
-        # w13 has 2*I_tp/tile_N N-tiles. Gate = first half, up = second half.
+        # Gated: w13 has 2*I_tp/tile_N N-tiles. Gate = second half, up = first half.
+        # ReLU2: w13 has I_tp/tile_N N-tiles. Single FC1 pass, no split.
         intermediate_tile_cnt = cute.size(gB_w13_tiled, mode=[2])
-        gate_tile_cnt = intermediate_tile_cnt // Int32(2)
+        gate_tile_cnt = (
+            intermediate_tile_cnt // Int32(2)
+            if self.is_gated
+            else intermediate_tile_cnt
+        )
         output_tile_cnt = cute.size(gB_down, mode=[2])
 
         prod_state = pipeline.make_pipeline_state(
@@ -1204,11 +1265,19 @@ class MoEMicroKernel:
         cons_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Consumer, self.ab_stage
         )
-        up_prod_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.ab_stage
+        up_prod_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.ab_stage
+            )
+            if self.is_gated
+            else prod_state
         )
-        up_cons_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.ab_stage
+        up_cons_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            if self.is_gated
+            else cons_state
         )
         phase2_prod_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.ab_stage
@@ -1575,31 +1644,95 @@ class MoEMicroKernel:
                                 tCrB[None, _nt, k_block_idx],
                                 gate_acc[None, _mt, _nt],
                             )
-                # Gate and up share the A/SFA staging buffers. Drain gate
-                # consumers before the DMA warp starts refilling those stages
-                # for the up pass.
+                # Drain the FC1 gate/only pass before the DMA warp reuses the
+                # gate staging buffers, either for the up pass or FC2 prefetch.
                 self.pass_sync_barrier.arrive_and_wait()
 
-                # Up GEMM (inlined, same pattern)
-                up_acc.fill(0.0)
-                up_cons_state.reset_count()
-                peek = up_pipeline.consumer_try_wait(up_cons_state)
-                up_pipeline.consumer_wait(up_cons_state, peek)
-                csA_p = csA_tile[None, None, None, up_cons_state.index]
-                csB_p = csB_up[None, None, None, up_cons_state.index]
-                csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
-                csSFB_p = csSFB_up_tile[None, None, None, up_cons_state.index]
-                cute.copy(smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0])
-                cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
-                fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                cute.copy(
-                    smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0]
-                )
-                cute.copy(
-                    smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0]
-                )
-                for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                if cutlass.const_expr(self.is_gated):
+                    # Up GEMM (inlined, same pattern)
+                    up_acc.fill(0.0)
+                    up_cons_state.reset_count()
+                    peek = up_pipeline.consumer_try_wait(up_cons_state)
+                    up_pipeline.consumer_wait(up_cons_state, peek)
+                    csA_p = csA_tile[None, None, None, up_cons_state.index]
+                    csB_p = csB_up[None, None, None, up_cons_state.index]
+                    csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
+                    csSFB_p = csSFB_up_tile[None, None, None, up_cons_state.index]
+                    cute.copy(
+                        smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0]
+                    )
+                    cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                    fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                    fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                    cute.copy(
+                        smem_copy_SFA,
+                        fz_csSFA_p[None, None, 0],
+                        fz_crSFA[None, None, 0],
+                    )
+                    cute.copy(
+                        smem_copy_SFB,
+                        fz_csSFB_p[None, None, 0],
+                        fz_crSFB[None, None, 0],
+                    )
+                    for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
+                            )
+                            if k_block_idx == num_k_blocks - 1:
+                                up_pipeline.consumer_release(up_cons_state)
+                                up_cons_state.advance()
+                                peek = up_pipeline.consumer_try_wait(up_cons_state)
+                                csA_p = csA_tile[None, None, None, up_cons_state.index]
+                                csB_p = csB_up[None, None, None, up_cons_state.index]
+                                csSFA_p = csSFA_tile[
+                                    None, None, None, up_cons_state.index
+                                ]
+                                csSFB_p = csSFB_up_tile[
+                                    None, None, None, up_cons_state.index
+                                ]
+                                fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                                fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                                up_pipeline.consumer_wait(up_cons_state, peek)
+                            for _mt in range(self.num_m_tiles):
+                                for _nt in range(self.num_n_tiles):
+                                    mma_atom.set(
+                                        WarpField.SFA,
+                                        tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                    )
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                    )
+                                    cute.gemm(
+                                        mma_atom,
+                                        up_acc[None, _mt, _nt],
+                                        tCrA_tile[None, _mt, k_block_idx],
+                                        tCrB[None, _nt, k_block_idx],
+                                        up_acc[None, _mt, _nt],
+                                    )
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, k_next],
+                                crA_tile[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_B,
+                                csB_p[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, k_next],
+                                fz_crSFA[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFB,
+                                fz_csSFB_p[None, None, k_next],
+                                fz_crSFB[None, None, k_next],
+                            )
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_next = (
                             0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
@@ -1607,16 +1740,27 @@ class MoEMicroKernel:
                         if k_block_idx == num_k_blocks - 1:
                             up_pipeline.consumer_release(up_cons_state)
                             up_cons_state.advance()
-                            peek = up_pipeline.consumer_try_wait(up_cons_state)
-                            csA_p = csA_tile[None, None, None, up_cons_state.index]
-                            csB_p = csB_up[None, None, None, up_cons_state.index]
-                            csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
-                            csSFB_p = csSFB_up_tile[
-                                None, None, None, up_cons_state.index
-                            ]
-                            fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                            fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                            up_pipeline.consumer_wait(up_cons_state, peek)
+                        if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, k_next],
+                                crA_tile[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_B,
+                                csB_p[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, k_next],
+                                fz_crSFA[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFB,
+                                fz_csSFB_p[None, None, k_next],
+                                fz_crSFB[None, None, k_next],
+                            )
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):
                                 mma_atom.set(
@@ -1634,70 +1778,8 @@ class MoEMicroKernel:
                                     tCrB[None, _nt, k_block_idx],
                                     up_acc[None, _mt, _nt],
                                 )
-                        cute.copy(
-                            smem_copy_A,
-                            csA_p[None, None, k_next],
-                            crA_tile[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_B,
-                            csB_p[None, None, k_next],
-                            crB[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_p[None, None, k_next],
-                            fz_crSFA[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFB,
-                            fz_csSFB_p[None, None, k_next],
-                            fz_crSFB[None, None, k_next],
-                        )
-                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                    k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
-                    if k_block_idx == num_k_blocks - 1:
-                        up_pipeline.consumer_release(up_cons_state)
-                        up_cons_state.advance()
-                    if k_next > 0 and fc1_k_tile_cnt > Int32(0):
-                        cute.copy(
-                            smem_copy_A,
-                            csA_p[None, None, k_next],
-                            crA_tile[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_B,
-                            csB_p[None, None, k_next],
-                            crB[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_p[None, None, k_next],
-                            fz_crSFA[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFB,
-                            fz_csSFB_p[None, None, k_next],
-                            fz_crSFB[None, None, k_next],
-                        )
-                    for _mt in range(self.num_m_tiles):
-                        for _nt in range(self.num_n_tiles):
-                            mma_atom.set(
-                                WarpField.SFA,
-                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
-                            )
-                            mma_atom.set(
-                                WarpField.SFB,
-                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
-                            )
-                            cute.gemm(
-                                mma_atom,
-                                up_acc[None, _mt, _nt],
-                                tCrA_tile[None, _mt, k_block_idx],
-                                tCrB[None, _nt, k_block_idx],
-                                up_acc[None, _mt, _nt],
-                            )
-                # SiLU + quant into sA
+
+                # Activation + quant into sA
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
                 sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
@@ -1726,17 +1808,27 @@ class MoEMicroKernel:
                                     (None, mma_m_in_epi, mma_n_in_epi)
                                 ]
                                 gate_slice = tRS_rGate[(None, mma_m, mma_n)]
-                                up_slice = tRS_rUp[(None, mma_m, mma_n)]
-                                for elem_idx in cutlass.range_constexpr(
-                                    cute.size(tRS_rD_slice)
-                                ):
-                                    g = alpha_value * gate_slice[elem_idx]
-                                    u = alpha_value * up_slice[elem_idx]
-                                    sigmoid_g = cute.arch.rcp_approx(
-                                        cutlass.Float32(1.0)
-                                        + cute.math.exp(-g, fastmath=self.fast_math),
-                                    )
-                                    tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                if cutlass.const_expr(self.is_gated):
+                                    up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        g = alpha_value * gate_slice[elem_idx]
+                                        u = alpha_value * up_slice[elem_idx]
+                                        sigmoid_g = cute.arch.rcp_approx(
+                                            cutlass.Float32(1.0)
+                                            + cute.math.exp(
+                                                -g, fastmath=self.fast_math
+                                            ),
+                                        )
+                                        tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                else:
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        g = alpha_value * gate_slice[elem_idx]
+                                        relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                        tRS_rD_slice[elem_idx] = relu_g * relu_g
 
                         acc_vec = tRS_rD.load()
                         acc_vec = acc_vec.to(cutlass.BFloat16)
@@ -2118,7 +2210,8 @@ class MoEMicroKernel:
                 sfa_tile_coord_m = tc[0] // self.sfa_tiles_per_block
                 tAgSFA_mk = tAgSFA[(None, sfa_tile_coord_m, None, local_expert_idx)]
 
-                # W13 is laid out as [up, gate] across the concatenated N dimension.
+                # FC1 producer slice. Gated activation packs [up, gate] along N;
+                # relu2 uses a single FC1 pass over intermediate_slice.
                 tBgB_w13_up_nk = tBgB_w13[
                     (None, intermediate_slice, None, weight_expert_idx)
                 ]
@@ -2126,12 +2219,13 @@ class MoEMicroKernel:
                 tBgSFB_w13_up_nk = tBgSFB_w13[
                     (None, sfb_up_tile_coord, None, weight_expert_idx)
                 ]
-                tBgB_w13_gate_nk = tBgB_w13[
-                    (None, intermediate_slice + gate_tile_cnt, None, weight_expert_idx)
-                ]
-                sfb_gate_tile_coord = (
+                gate_slice = (
                     intermediate_slice + gate_tile_cnt
-                ) // self.sfb_tiles_per_block
+                    if self.is_gated
+                    else intermediate_slice
+                )
+                tBgB_w13_gate_nk = tBgB_w13[(None, gate_slice, None, weight_expert_idx)]
+                sfb_gate_tile_coord = gate_slice // self.sfb_tiles_per_block
                 tBgSFB_w13_gate_nk = tBgSFB_w13[
                     (None, sfb_gate_tile_coord, None, weight_expert_idx)
                 ]
@@ -2167,40 +2261,41 @@ class MoEMicroKernel:
                     ml_pipeline.producer_commit(prod_state)
                     prod_state.advance()
 
-                # Gate and up share the A/SFA staging buffers. Wait for MMA
-                # warps to drain the gate pass before refilling those stages.
+                # Wait for the MMA warps to finish the FC1 gate/only pass
+                # before reusing the gate staging buffers.
                 self.pass_sync_barrier.arrive_and_wait()
 
-                # ---- FC1 up pass ----
-                up_prod_state.reset_count()
-                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
-                    up_pipeline.producer_acquire(up_prod_state)
-                    cute.copy(
-                        tma_a,
-                        tAgA_mk[(None, k_tile)],
-                        tAsA[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    cute.copy(
-                        tma_b_w13,
-                        tBgB_w13_up_nk[(None, k_tile)],
-                        tBsB_w13_up[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    cute.copy(
-                        tma_sfa,
-                        tAgSFA_mk[(None, k_tile)],
-                        tAsSFA[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    cute.copy(
-                        tma_sfb_w13,
-                        tBgSFB_w13_up_nk[(None, k_tile)],
-                        tBsSFB_w13_up[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    up_pipeline.producer_commit(up_prod_state)
-                    up_prod_state.advance()
+                if cutlass.const_expr(self.is_gated):
+                    # ---- FC1 up pass ----
+                    up_prod_state.reset_count()
+                    for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                        up_pipeline.producer_acquire(up_prod_state)
+                        cute.copy(
+                            tma_a,
+                            tAgA_mk[(None, k_tile)],
+                            tAsA[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        cute.copy(
+                            tma_b_w13,
+                            tBgB_w13_up_nk[(None, k_tile)],
+                            tBsB_w13_up[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        cute.copy(
+                            tma_sfa,
+                            tAgSFA_mk[(None, k_tile)],
+                            tAsSFA[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        cute.copy(
+                            tma_sfb_w13,
+                            tBgSFB_w13_up_nk[(None, k_tile)],
+                            tBsSFB_w13_up[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        up_pipeline.producer_commit(up_prod_state)
+                        up_prod_state.advance()
 
                 # ---- FC2 B_down loads: continuous pipeline ----
                 # No barrier needed: sB/sSFB are free (gate done, up uses
@@ -2276,7 +2371,8 @@ class MoEMicroKernel:
                     )
 
             ml_pipeline.producer_tail(prod_state)
-            up_pipeline.producer_tail(up_prod_state)
+            if cutlass.const_expr(self.is_gated):
+                up_pipeline.producer_tail(up_prod_state)
             phase2_pipeline.producer_tail(phase2_prod_state)
         return
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -996,18 +996,15 @@ class MoEMicroKernel:
         # active_expert_count and weight_expert_ids.
         num_active_experts = active_expert_count[Int32(0)]
         all_rows_unique = Int32(0)
-        if num_tokens == Int32(1) and num_active_experts == total_pairs:
+        if num_tokens == Int32(1):
+            # A single token's top-k routing is already a dense local expert set.
             all_rows_unique = Int32(1)
-        i = flat_tid
-        while i < num_experts:
-            row_count = Int32(0)
-            if all_rows_unique > Int32(0) and i < num_active_experts:
-                row_count = Int32(1)
-            row_counts[i] = row_count
-            i += flat_stride
-        if flat_tid == Int32(0):
-            # Triton prepass has already populated the compact expert set.
-            pass
+            num_active_experts = total_pairs
+        if all_rows_unique == Int32(0):
+            i = flat_tid
+            while i < num_experts:
+                row_counts[i] = Int32(0)
+                i += flat_stride
         scatter_total = num_tokens * cols
         j = flat_tid
         while j < scatter_total:
@@ -1034,7 +1031,7 @@ class MoEMicroKernel:
             row = Int32(0)
             if all_rows_unique > Int32(0):
                 local_expert_id = pair_idx
-                expert_id = weight_expert_ids[local_expert_id].to(Int32)
+                expert_id = topk_ids[local_expert_id].to(Int32)
             else:
                 if is_cta_leader > Int32(0):
                     local_expert_id = topk_ids[pair_idx].to(Int32)
@@ -1380,10 +1377,11 @@ class MoEMicroKernel:
                 # tile_coord = (m_tile, intermediate_slice, local_expert_idx)
                 local_expert_idx = tile_coord[2]
                 weight_expert_idx = weight_expert_ids[local_expert_idx]
-                alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
                 valid_rows = row_counts[local_expert_idx]
                 if all_rows_unique > Int32(0):
+                    weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
                     valid_rows = Int32(1)
+                alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
                 tile_m_base = tile_coord[0] * Int32(self.tile_shape_mnk[0])
                 intermediate_slice = tile_coord[1]
                 sa_tile_offset = tile_coord[0] % self.sa_tiles_per_block
@@ -2204,6 +2202,8 @@ class MoEMicroKernel:
                 intermediate_slice = tc[1]
                 local_expert_idx = tc[2]
                 weight_expert_idx = weight_expert_ids[local_expert_idx]
+                if all_rows_unique > Int32(0):
+                    weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
 
                 sa_tile_coord_m = tc[0] // self.sa_tiles_per_block
                 tAgA_mk = tAgA[(None, sa_tile_coord_m, None, local_expert_idx)]

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -676,7 +676,7 @@ class MoEMicroKernel:
             internal_type=cutlass.Int16,
         )
         # Single TMA descriptor over concatenated w13 [2*I_tp, K, E].
-        # Gate tiles at N=0..I_tp/tile_N-1, up tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
+        # Up tiles at N=0..I_tp/tile_N-1, gate tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
         tma_b_w13, gB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
             b_w13,
             self.b_smem_layout_staged,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -656,7 +656,7 @@ class MoEStaticKernel:
             internal_type=cutlass.Int16,
         )
         # Single TMA descriptor over concatenated w13 [2*I_tp, K, E].
-        # Gate tiles at N=0..I_tp/tile_N-1, up tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
+        # Up tiles at N=0..I_tp/tile_N-1, gate tiles at N=I_tp/tile_N..2*I_tp/tile_N-1.
         tma_b_w13, gB_w13 = self._dense_cls._make_tma_atoms_and_tensors(
             b_w13,
             self.b_smem_layout_staged,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -12,16 +12,21 @@ The result is still a two-phase algorithm, just without a host-side handoff:
            write token_map + token_weights, and quantize each routed
            token row directly into expert-major packed A + scale storage
   Barrier: resident-grid barrier after all expert rows are finalized
-  Phase 2: run the FC1 -> SiLU -> quant -> FC2 -> scatter datapath
+  Phase 2: run the FC1 -> activation -> quant -> FC2 -> scatter datapath
            over the finalized expert-major packed input
 
 The compute half is intentionally the same design as the earlier two-kernel
 implementation:
-  FC1:     A x gate^T, A x up^T     (paired FP4 block-scaled GEMMs)
-  SiLU:    SiLU(gate) * up          (fused SwiGLU activation)
-  Quant:   intermediate -> FP4      (cooperative quantization into shared A)
-  FC2:     sweep all output tiles   (reuse the cached intermediate slice)
-  Scatter: bf16x2 atomic add        (directly into token-major output)
+  SiLU (gated):
+    FC1:     A x gate^T, A x up^T     (paired FP4 block-scaled GEMMs)
+    Act:     SiLU(gate) * up           (fused SwiGLU activation)
+  ReLU2 (non-gated):
+    FC1:     A x W1^T                  (single FP4 block-scaled GEMM)
+    Act:     max(0, x)^2               (squared ReLU activation)
+  Common:
+    Quant:   intermediate -> FP4      (cooperative quantization into shared A)
+    FC2:     sweep all output tiles   (reuse the cached intermediate slice)
+    Scatter: bf16x2 atomic add        (directly into token-major output)
 
 What changes relative to the old split path:
   the compute launch used to expect the frontend to have already produced:
@@ -340,12 +345,17 @@ class MoEStaticKernel:
         *,
         input_scales_are_reciprocal: bool = False,
         fast_math: bool = False,
+        activation: str = "silu",
     ):
+        if activation not in {"silu", "relu2"}:
+            raise ValueError(f"unsupported activation {activation!r}")
         self._dense_cls = DenseGemmKernel
         self.acc_dtype = cutlass.Float32
         self.sf_vec_size = sf_vec_size
         self.input_scales_are_reciprocal = input_scales_are_reciprocal
         self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = activation == "silu"
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
@@ -449,21 +459,23 @@ class MoEStaticKernel:
         def _align_up(value: int, align: int) -> int:
             return ((value + align - 1) // align) * align
 
+        pipeline_count = 3 if self.is_gated else 2
         offset = (
             3 * 4
-            + 3 * (self.ab_stage * 2 * 8)
+            + pipeline_count * (self.ab_stage * 2 * 8)
             + _COMPACT_STATIC_TILE_M * 4
             + _COMPACT_STATIC_TILE_M * 4
         )
-        buffers = (
+        buffers = [
             cute.size_in_bytes(self.a_dtype, a_smem_staged),
-            cute.size_in_bytes(self.b_dtype, b_smem_staged),
             cute.size_in_bytes(self.b_dtype, b_smem_staged),
             cute.size_in_bytes(self.sf_dtype, sfa_smem_staged),
             cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
-            cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
             cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
-        )
+        ]
+        if self.is_gated:
+            buffers.insert(2, cute.size_in_bytes(self.b_dtype, b_smem_staged))
+            buffers.insert(5, cute.size_in_bytes(self.sf_dtype, sfb_smem_staged))
         offset = _align_up(offset, self.buffer_align_bytes)
         for idx, size in enumerate(buffers):
             offset += size
@@ -805,7 +817,7 @@ class MoEStaticKernel:
         smem = cutlass.utils.SmemAllocator()
 
         @cute.struct
-        class Storage:
+        class StorageGated:
             ctrl: cute.struct.MemRange[cutlass.Int32, 2]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
@@ -847,7 +859,41 @@ class MoEStaticKernel:
                 self.buffer_align_bytes,
             ]
 
-        storage = smem.allocate(Storage)
+        @cute.struct
+        class StorageRelu2:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfa_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        storage = smem.allocate(StorageGated if self.is_gated else StorageRelu2)
 
         prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         cons_group = pipeline.CooperativeGroup(
@@ -862,13 +908,17 @@ class MoEStaticKernel:
             barrier_storage=storage.pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
-        up_pipeline = pipeline.PipelineTmaAsync.create(
-            num_stages=self.ab_stage,
-            producer_group=prod_group,
-            consumer_group=cons_group,
-            tx_count=tma_copy_bytes,
-            barrier_storage=storage.up_pipeline_array.data_ptr(),
-            cta_layout_vmnk=cta_layout_vmnk,
+        up_pipeline = (
+            pipeline.PipelineTmaAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=prod_group,
+                consumer_group=cons_group,
+                tx_count=tma_copy_bytes,
+                barrier_storage=storage.up_pipeline_array.data_ptr(),
+                cta_layout_vmnk=cta_layout_vmnk,
+            )
+            if self.is_gated
+            else ml_pipeline
         )
         phase2_pipeline = pipeline.PipelineTmaAsync.create(
             num_stages=self.ab_stage,
@@ -883,15 +933,17 @@ class MoEStaticKernel:
 
         sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
         sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
-        sB_up = storage.sB_up.get_tensor(
-            b_smem_staged.outer, swizzle=b_smem_staged.inner
+        sB_up = (
+            storage.sB_up.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+            if self.is_gated
+            else sB
         )
         cute.recast_tensor(sA, cutlass.Uint8)
         cute.recast_tensor(sB, cutlass.Uint8)
         cute.recast_tensor(sB_up, cutlass.Uint8)
         sSFA = storage.sSFA.get_tensor(sfa_smem_staged)
         sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
-        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
+        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged) if self.is_gated else sSFB
         cute.recast_tensor(sSFA, cutlass.Uint8)
         cute.recast_tensor(sSFB, cutlass.Uint8)
         cute.recast_tensor(sSFB_up, cutlass.Uint8)
@@ -1179,13 +1231,22 @@ class MoEStaticKernel:
         sub_shape = tCsC_for_shape.shape[:3]
         acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
         gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
-        up_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = (
+            cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+            if self.is_gated
+            else gate_acc
+        )
 
         k_tile_cnt = cute.size(gA, mode=[3])
         fc1_k_tile_cnt = k_tile_cnt
-        # w13 has 2*I_tp/tile_N N-tiles. Gate = first half, up = second half.
+        # Gated: w13 has 2*I_tp/tile_N N-tiles. Gate = second half, up = first half.
+        # ReLU2: w13 has I_tp/tile_N N-tiles. Single FC1 pass, no split.
         intermediate_tile_cnt = cute.size(gB_w13_tiled, mode=[2])
-        gate_tile_cnt = intermediate_tile_cnt // Int32(2)
+        gate_tile_cnt = (
+            intermediate_tile_cnt // Int32(2)
+            if self.is_gated
+            else intermediate_tile_cnt
+        )
         output_tile_cnt = cute.size(gB_down, mode=[2])
 
         prod_state = pipeline.make_pipeline_state(
@@ -1194,11 +1255,19 @@ class MoEStaticKernel:
         cons_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Consumer, self.ab_stage
         )
-        up_prod_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.ab_stage
+        up_prod_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.ab_stage
+            )
+            if self.is_gated
+            else prod_state
         )
-        up_cons_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.ab_stage
+        up_cons_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            if self.is_gated
+            else cons_state
         )
         phase2_prod_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.ab_stage
@@ -1543,31 +1612,95 @@ class MoEStaticKernel:
                                 tCrB[None, _nt, k_block_idx],
                                 gate_acc[None, _mt, _nt],
                             )
-                # Gate and up share the A/SFA staging buffers. Drain gate
-                # consumers before the DMA warp starts refilling those stages
-                # for the up pass.
+                # Drain the FC1 gate/only pass before the DMA warp reuses the
+                # gate staging buffers, either for the up pass or FC2 prefetch.
                 self.pass_sync_barrier.arrive_and_wait()
 
-                # Up GEMM (inlined, same pattern)
-                up_acc.fill(0.0)
-                up_cons_state.reset_count()
-                peek = up_pipeline.consumer_try_wait(up_cons_state)
-                up_pipeline.consumer_wait(up_cons_state, peek)
-                csA_p = csA_tile[None, None, None, up_cons_state.index]
-                csB_p = csB_up[None, None, None, up_cons_state.index]
-                csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
-                csSFB_p = csSFB_up_tile[None, None, None, up_cons_state.index]
-                cute.copy(smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0])
-                cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
-                fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                cute.copy(
-                    smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0]
-                )
-                cute.copy(
-                    smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0]
-                )
-                for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                if cutlass.const_expr(self.is_gated):
+                    # Up GEMM (inlined, same pattern)
+                    up_acc.fill(0.0)
+                    up_cons_state.reset_count()
+                    peek = up_pipeline.consumer_try_wait(up_cons_state)
+                    up_pipeline.consumer_wait(up_cons_state, peek)
+                    csA_p = csA_tile[None, None, None, up_cons_state.index]
+                    csB_p = csB_up[None, None, None, up_cons_state.index]
+                    csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
+                    csSFB_p = csSFB_up_tile[None, None, None, up_cons_state.index]
+                    cute.copy(
+                        smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0]
+                    )
+                    cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                    fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                    fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                    cute.copy(
+                        smem_copy_SFA,
+                        fz_csSFA_p[None, None, 0],
+                        fz_crSFA[None, None, 0],
+                    )
+                    cute.copy(
+                        smem_copy_SFB,
+                        fz_csSFB_p[None, None, 0],
+                        fz_crSFB[None, None, 0],
+                    )
+                    for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
+                            )
+                            if k_block_idx == num_k_blocks - 1:
+                                up_pipeline.consumer_release(up_cons_state)
+                                up_cons_state.advance()
+                                peek = up_pipeline.consumer_try_wait(up_cons_state)
+                                csA_p = csA_tile[None, None, None, up_cons_state.index]
+                                csB_p = csB_up[None, None, None, up_cons_state.index]
+                                csSFA_p = csSFA_tile[
+                                    None, None, None, up_cons_state.index
+                                ]
+                                csSFB_p = csSFB_up_tile[
+                                    None, None, None, up_cons_state.index
+                                ]
+                                fz_csSFA_p = cute.filter_zeros(csSFA_p)
+                                fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                                up_pipeline.consumer_wait(up_cons_state, peek)
+                            for _mt in range(self.num_m_tiles):
+                                for _nt in range(self.num_n_tiles):
+                                    mma_atom.set(
+                                        WarpField.SFA,
+                                        tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                    )
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                    )
+                                    cute.gemm(
+                                        mma_atom,
+                                        up_acc[None, _mt, _nt],
+                                        tCrA_tile[None, _mt, k_block_idx],
+                                        tCrB[None, _nt, k_block_idx],
+                                        up_acc[None, _mt, _nt],
+                                    )
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, k_next],
+                                crA_tile[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_B,
+                                csB_p[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, k_next],
+                                fz_crSFA[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFB,
+                                fz_csSFB_p[None, None, k_next],
+                                fz_crSFB[None, None, k_next],
+                            )
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_next = (
                             0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
@@ -1575,16 +1708,27 @@ class MoEStaticKernel:
                         if k_block_idx == num_k_blocks - 1:
                             up_pipeline.consumer_release(up_cons_state)
                             up_cons_state.advance()
-                            peek = up_pipeline.consumer_try_wait(up_cons_state)
-                            csA_p = csA_tile[None, None, None, up_cons_state.index]
-                            csB_p = csB_up[None, None, None, up_cons_state.index]
-                            csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
-                            csSFB_p = csSFB_up_tile[
-                                None, None, None, up_cons_state.index
-                            ]
-                            fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                            fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                            up_pipeline.consumer_wait(up_cons_state, peek)
+                        if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, k_next],
+                                crA_tile[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_B,
+                                csB_p[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, k_next],
+                                fz_crSFA[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_SFB,
+                                fz_csSFB_p[None, None, k_next],
+                                fz_crSFB[None, None, k_next],
+                            )
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):
                                 mma_atom.set(
@@ -1602,70 +1746,8 @@ class MoEStaticKernel:
                                     tCrB[None, _nt, k_block_idx],
                                     up_acc[None, _mt, _nt],
                                 )
-                        cute.copy(
-                            smem_copy_A,
-                            csA_p[None, None, k_next],
-                            crA_tile[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_B,
-                            csB_p[None, None, k_next],
-                            crB[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_p[None, None, k_next],
-                            fz_crSFA[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFB,
-                            fz_csSFB_p[None, None, k_next],
-                            fz_crSFB[None, None, k_next],
-                        )
-                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                    k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
-                    if k_block_idx == num_k_blocks - 1:
-                        up_pipeline.consumer_release(up_cons_state)
-                        up_cons_state.advance()
-                    if k_next > 0 and fc1_k_tile_cnt > Int32(0):
-                        cute.copy(
-                            smem_copy_A,
-                            csA_p[None, None, k_next],
-                            crA_tile[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_B,
-                            csB_p[None, None, k_next],
-                            crB[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_p[None, None, k_next],
-                            fz_crSFA[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFB,
-                            fz_csSFB_p[None, None, k_next],
-                            fz_crSFB[None, None, k_next],
-                        )
-                    for _mt in range(self.num_m_tiles):
-                        for _nt in range(self.num_n_tiles):
-                            mma_atom.set(
-                                WarpField.SFA,
-                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
-                            )
-                            mma_atom.set(
-                                WarpField.SFB,
-                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
-                            )
-                            cute.gemm(
-                                mma_atom,
-                                up_acc[None, _mt, _nt],
-                                tCrA_tile[None, _mt, k_block_idx],
-                                tCrB[None, _nt, k_block_idx],
-                                up_acc[None, _mt, _nt],
-                            )
-                # SiLU + quant into sA
+
+                # Activation + quant into sA
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
                 sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
@@ -1694,17 +1776,27 @@ class MoEStaticKernel:
                                     (None, mma_m_in_epi, mma_n_in_epi)
                                 ]
                                 gate_slice = tRS_rGate[(None, mma_m, mma_n)]
-                                up_slice = tRS_rUp[(None, mma_m, mma_n)]
-                                for elem_idx in cutlass.range_constexpr(
-                                    cute.size(tRS_rD_slice)
-                                ):
-                                    g = alpha_value * gate_slice[elem_idx]
-                                    u = alpha_value * up_slice[elem_idx]
-                                    sigmoid_g = cute.arch.rcp_approx(
-                                        cutlass.Float32(1.0)
-                                        + cute.math.exp(-g, fastmath=self.fast_math),
-                                    )
-                                    tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                if cutlass.const_expr(self.is_gated):
+                                    up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        g = alpha_value * gate_slice[elem_idx]
+                                        u = alpha_value * up_slice[elem_idx]
+                                        sigmoid_g = cute.arch.rcp_approx(
+                                            cutlass.Float32(1.0)
+                                            + cute.math.exp(
+                                                -g, fastmath=self.fast_math
+                                            ),
+                                        )
+                                        tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                else:
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        g = alpha_value * gate_slice[elem_idx]
+                                        relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                        tRS_rD_slice[elem_idx] = relu_g * relu_g
 
                         acc_vec = tRS_rD.load()
                         acc_vec = acc_vec.to(cutlass.BFloat16)
@@ -2061,7 +2153,8 @@ class MoEStaticKernel:
                 sfa_tile_coord_m = tc[0] // self.sfa_tiles_per_block
                 tAgSFA_mk = tAgSFA[(None, sfa_tile_coord_m, None, local_expert_idx)]
 
-                # W13 is laid out as [up, gate] across the concatenated N dimension.
+                # FC1 producer slice. Gated activation packs [up, gate] along N;
+                # relu2 uses a single FC1 pass over intermediate_slice.
                 tBgB_w13_up_nk = tBgB_w13[
                     (None, intermediate_slice, None, weight_expert_idx)
                 ]
@@ -2069,12 +2162,13 @@ class MoEStaticKernel:
                 tBgSFB_w13_up_nk = tBgSFB_w13[
                     (None, sfb_up_tile_coord, None, weight_expert_idx)
                 ]
-                tBgB_w13_gate_nk = tBgB_w13[
-                    (None, intermediate_slice + gate_tile_cnt, None, weight_expert_idx)
-                ]
-                sfb_gate_tile_coord = (
+                gate_slice = (
                     intermediate_slice + gate_tile_cnt
-                ) // self.sfb_tiles_per_block
+                    if self.is_gated
+                    else intermediate_slice
+                )
+                tBgB_w13_gate_nk = tBgB_w13[(None, gate_slice, None, weight_expert_idx)]
+                sfb_gate_tile_coord = gate_slice // self.sfb_tiles_per_block
                 tBgSFB_w13_gate_nk = tBgSFB_w13[
                     (None, sfb_gate_tile_coord, None, weight_expert_idx)
                 ]
@@ -2110,40 +2204,41 @@ class MoEStaticKernel:
                     ml_pipeline.producer_commit(prod_state)
                     prod_state.advance()
 
-                # Gate and up share the A/SFA staging buffers. Wait for MMA
-                # warps to drain the gate pass before refilling those stages.
+                # Wait for the MMA warps to finish the FC1 gate/only pass
+                # before reusing the gate staging buffers.
                 self.pass_sync_barrier.arrive_and_wait()
 
-                # ---- FC1 up pass ----
-                up_prod_state.reset_count()
-                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
-                    up_pipeline.producer_acquire(up_prod_state)
-                    cute.copy(
-                        tma_a,
-                        tAgA_mk[(None, k_tile)],
-                        tAsA[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    cute.copy(
-                        tma_b_w13,
-                        tBgB_w13_up_nk[(None, k_tile)],
-                        tBsB_w13_up[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    cute.copy(
-                        tma_sfa,
-                        tAgSFA_mk[(None, k_tile)],
-                        tAsSFA[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    cute.copy(
-                        tma_sfb_w13,
-                        tBgSFB_w13_up_nk[(None, k_tile)],
-                        tBsSFB_w13_up[(None, up_prod_state.index)],
-                        tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                    )
-                    up_pipeline.producer_commit(up_prod_state)
-                    up_prod_state.advance()
+                if cutlass.const_expr(self.is_gated):
+                    # ---- FC1 up pass ----
+                    up_prod_state.reset_count()
+                    for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                        up_pipeline.producer_acquire(up_prod_state)
+                        cute.copy(
+                            tma_a,
+                            tAgA_mk[(None, k_tile)],
+                            tAsA[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        cute.copy(
+                            tma_b_w13,
+                            tBgB_w13_up_nk[(None, k_tile)],
+                            tBsB_w13_up[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        cute.copy(
+                            tma_sfa,
+                            tAgSFA_mk[(None, k_tile)],
+                            tAsSFA[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        cute.copy(
+                            tma_sfb_w13,
+                            tBgSFB_w13_up_nk[(None, k_tile)],
+                            tBsSFB_w13_up[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        up_pipeline.producer_commit(up_prod_state)
+                        up_prod_state.advance()
 
                 # ---- FC2 B_down loads: continuous pipeline ----
                 # No barrier needed: sB/sSFB are free (gate done, up uses
@@ -2208,7 +2303,8 @@ class MoEStaticKernel:
                 )
 
             ml_pipeline.producer_tail(prod_state)
-            up_pipeline.producer_tail(up_prod_state)
+            if cutlass.const_expr(self.is_gated):
+                up_pipeline.producer_tail(up_prod_state)
             phase2_pipeline.producer_tail(phase2_prod_state)
         return
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/triton_compact.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/triton_compact.py
@@ -1,0 +1,86 @@
+"""Triton kernel for compacting MoE routing IDs (ported from b12x).
+
+Remaps global expert IDs to dense local indices (0, 1, 2, ...) for the
+micro MoE kernel, which expects pre-compacted routing.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _compact_topk_ids_kernel(
+    topk_ids_ptr,
+    compact_topk_ids_ptr,
+    weight_expert_ids_ptr,
+    active_expert_count_ptr,
+    total_pairs,
+    BLOCK: tl.constexpr,
+):
+    pair_slots = tl.arange(0, BLOCK)
+    valid = pair_slots < total_pairs
+    ids = tl.load(topk_ids_ptr + pair_slots, mask=valid, other=-1).to(tl.int32)
+
+    row_slots = pair_slots[:, None]
+    col_slots = pair_slots[None, :]
+    row_valid = valid[:, None]
+    col_valid = valid[None, :]
+
+    same_id = ids[:, None] == ids[None, :]
+    prior_same = row_valid & col_valid & same_id & (col_slots < row_slots)
+
+    first_flags = valid & (tl.sum(prior_same.to(tl.int32), axis=1) == 0)
+    first_prefix = tl.cumsum(first_flags.to(tl.int32), axis=0)
+
+    prior_slots = tl.where(prior_same, col_slots, BLOCK)
+    first_match = tl.min(prior_slots, axis=1)
+    first_slot = tl.where(first_match < BLOCK, first_match, pair_slots)
+    first_slot_mask = col_slots == first_slot[:, None]
+    compact_id = tl.sum(tl.where(first_slot_mask, first_prefix[None, :], 0), axis=1) - 1
+
+    tl.store(compact_topk_ids_ptr + pair_slots, compact_id, mask=valid)
+    tl.store(weight_expert_ids_ptr + compact_id, ids, mask=valid & first_flags)
+
+    active_expert_count = tl.sum(first_flags.to(tl.int32), axis=0)
+    tl.store(active_expert_count_ptr, active_expert_count)
+
+
+def compact_topk_ids(
+    topk_ids: torch.Tensor,
+    compact_topk_ids: torch.Tensor,
+    weight_expert_ids: torch.Tensor,
+    active_expert_count: torch.Tensor,
+) -> None:
+    """Remap global expert IDs to dense contiguous local indices.
+
+    Args:
+        topk_ids: [total_pairs] int32 — flattened global expert IDs.
+        compact_topk_ids: [total_pairs] int32 — output: dense local indices.
+        weight_expert_ids: [>=total_pairs] int32 — output: local->global map.
+        active_expert_count: [1] int32 — output: number of unique experts.
+    """
+    total_pairs = topk_ids.numel()
+    if total_pairs == 0:
+        active_expert_count.zero_()
+        return
+    if compact_topk_ids.numel() < total_pairs:
+        raise ValueError("compact_topk_ids must have at least total_pairs elements")
+    if weight_expert_ids.numel() < total_pairs:
+        raise ValueError("weight_expert_ids must have at least total_pairs elements")
+    if active_expert_count.numel() != 1:
+        raise ValueError("active_expert_count must have shape [1]")
+
+    block = triton.next_power_of_2(total_pairs)
+    num_warps = 1 if block <= 16 else 2
+    _compact_topk_ids_kernel[(1,)](
+        topk_ids,
+        compact_topk_ids,
+        weight_expert_ids,
+        active_expert_count,
+        total_pairs,
+        BLOCK=block,
+        num_warps=num_warps,
+    )

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -186,9 +186,6 @@ def _moe_core_impl(
 
     # NOTE: SM120/SM121 dispatch is handled by callers (CuteDslMoEWrapper.run
     # and cute_dsl_fused_moe_nvfp4) before reaching this function.
-    # Do NOT call torch.cuda.get_device_capability() here — it would execute
-    # inside the autotuner's CUDA graph capture context, which can corrupt
-    # graph capture on CUDA 12.
 
     # Allocate output if not provided.  The caller (wrapper or functional
     # API) should pass a [:num_tokens] slice of the pre-allocated buffer
@@ -883,7 +880,6 @@ def cute_dsl_fused_moe_nvfp4(
         )
 
     # SM120/SM121: dispatch to fused kernel (bypasses autotuner).
-    # SM120/SM121: dispatch to fused kernel directly (bypasses autotuner).
     # On SM120 the caller passes bf16 activations as x; x_sf is ignored.
     major, _ = torch.cuda.get_device_capability(x.device)
     if major == 12:

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -342,7 +342,7 @@ class CuteDslMoEWrapper:
         ...     output = moe.run(x, x_sf, topk_ids, topk_weights, w1, w1_sf, ...)
     """
 
-    @supported_compute_capability([100, 103, 120, 121])
+    @supported_compute_capability([100, 103])
     @flashinfer_api
     def __init__(
         self,
@@ -359,7 +359,6 @@ class CuteDslMoEWrapper:
         output_dtype: torch.dtype = torch.bfloat16,
         device: str = "cuda",
         enable_pdl: bool = True,
-        activation_type: str = "silu",
     ):
         """Initialize the MoE wrapper.
 
@@ -391,21 +390,8 @@ class CuteDslMoEWrapper:
         self.output_dtype = output_dtype
         self.device = device
         self.enable_pdl = enable_pdl
-        self.activation_type = activation_type
 
-        # Detect SM120 for architecture-specific dispatch
-        major, minor = torch.cuda.get_device_capability(device)
-        self._is_sm120 = major == 12
-        if self._is_sm120:
-            from ...jit.cpp_ext import get_cuda_version
-
-            if get_cuda_version().major < 13:
-                raise ValueError(
-                    "SM120 CuTe DSL fused MoE requires CUDA 13 or later. "
-                    f"Current CUDA version: {get_cuda_version()}."
-                )
-
-        # Pre-allocated buffers (SM100 path)
+        # Pre-allocated buffers
         self._moe_sort_buffers: Optional[Dict[str, torch.Tensor]] = None
         self._gemm1_output: Optional[torch.Tensor] = None
         self._gemm1_output_scale: Optional[torch.Tensor] = None
@@ -414,11 +400,7 @@ class CuteDslMoEWrapper:
         self._main_event: Optional[torch.cuda.Event] = None
         self._memset_event: Optional[torch.cuda.Event] = None
 
-        # Pre-allocated objects (SM120 path)
-        self._sm120_workspace: object = None
-        self._sm120_weight_views: object = None
-
-        # Create auto-tuner runner (SM100 path only — SM120 bypasses autotuner)
+        # Create auto-tuner runner
         self._runner = CuteDslFusedMoENvfp4Runner(
             forward_impl=self._forward_with_tactic,
             num_experts=num_experts,
@@ -435,78 +417,46 @@ class CuteDslMoEWrapper:
 
     def _allocate_buffers(self) -> None:
         """Pre-allocate all buffers for CUDA graph compatibility."""
-        if self._is_sm120:
-            # SM120: pre-allocate workspace for the fused kernel.
-            from .blackwell_sm12x.moe_dispatch import (
-                allocate_sm120_static_workspace,
-                allocate_sm120_dynamic_workspace,
-                select_sm120_moe_backend,
-            )
+        max_num_permuted_tokens = get_max_num_permuted_tokens(
+            self.max_num_tokens, self.top_k, self.num_local_experts, self.tile_size
+        )
 
-            max_routed_rows = self.max_num_tokens * self.top_k
-            backend = select_sm120_moe_backend(
-                num_tokens=self.max_num_tokens, num_topk=self.top_k
-            )
-            if backend == "dynamic":
-                self._sm120_workspace = allocate_sm120_dynamic_workspace(
-                    state_E=self.num_local_experts,
-                    weight_E=self.num_experts,
-                    routed_rows=max_routed_rows,
-                    k=self.hidden_size,
-                    n=self.intermediate_size,
-                    num_topk=self.top_k,
-                    device=torch.device(self.device),
-                )
-            else:
-                self._sm120_workspace = allocate_sm120_static_workspace(
-                    state_E=self.num_local_experts,
-                    weight_E=self.num_experts,
-                    max_rows=max(1, max_routed_rows),
-                    k=self.hidden_size,
-                    n=self.intermediate_size,
-                    num_topk=self.top_k,
-                    device=torch.device(self.device),
-                )
-        else:
-            # SM100/103: pre-allocate sort and intermediate buffers.
-            max_num_permuted_tokens = get_max_num_permuted_tokens(
-                self.max_num_tokens, self.top_k, self.num_local_experts, self.tile_size
-            )
+        # moe_sort buffers
+        self._moe_sort_buffers = allocate_moe_sort_buffers(
+            num_tokens=self.max_num_tokens,
+            num_experts=self.num_experts,
+            top_k=self.top_k,
+            num_local_experts=self.num_local_experts,
+            tile_tokens_dim=self.tile_size,
+            device=self.device,
+        )
 
-            self._moe_sort_buffers = allocate_moe_sort_buffers(
-                num_tokens=self.max_num_tokens,
-                num_experts=self.num_experts,
-                top_k=self.top_k,
-                num_local_experts=self.num_local_experts,
-                tile_tokens_dim=self.tile_size,
-                device=self.device,
-            )
+        # GEMM1 output (FP4 quantized)
+        self._gemm1_output = torch.empty(
+            (max_num_permuted_tokens, self.intermediate_size // 2),
+            dtype=torch.uint8,
+            device=self.device,
+        )
 
-            self._gemm1_output = torch.empty(
-                (max_num_permuted_tokens, self.intermediate_size // 2),
-                dtype=torch.uint8,
-                device=self.device,
-            )
+        # GEMM1 output scale
+        scale_size = max_num_permuted_tokens * (
+            self.intermediate_size // self.sf_vec_size
+        )
+        self._gemm1_output_scale = torch.empty(
+            (scale_size,), dtype=torch.uint8, device=self.device
+        )
 
-            scale_size = max_num_permuted_tokens * (
-                self.intermediate_size // self.sf_vec_size
-            )
-            self._gemm1_output_scale = torch.empty(
-                (scale_size,), dtype=torch.uint8, device=self.device
-            )
-
-            self._aux_stream = torch.cuda.Stream(device=self.device)
-            self._main_event = torch.cuda.Event()
-            self._memset_event = torch.cuda.Event()
-
-        # Final output — shared by both SM100 and SM120 paths.
-        # Allocated after arch-specific buffers to preserve SM100's memory
-        # layout, which the autotuner's CUDA graph profiling is sensitive to.
+        # Final output
         self._moe_output = torch.empty(
             (self.max_num_tokens, self.hidden_size),
             dtype=self.output_dtype,
             device=self.device,
         )
+
+        # CUDA resources
+        self._aux_stream = torch.cuda.Stream(device=self.device)
+        self._main_event = torch.cuda.Event()
+        self._memset_event = torch.cuda.Event()
 
     def _forward_with_tactic(
         self,
@@ -643,66 +593,7 @@ class CuteDslMoEWrapper:
                 device=x.device,
             )
 
-        # SM120: dispatch directly to fused kernel with pre-allocated workspace.
-        # On SM120 the caller passes bf16 activations as x (the kernel fuses
-        # quantization internally); x_sf is ignored.
-        if self._is_sm120:
-            if self.local_expert_offset != 0:
-                raise ValueError(
-                    "SM120 MoE does not support expert parallelism "
-                    "(local_expert_offset != 0)."
-                )
-            from .blackwell_sm12x.moe_dispatch import (
-                launch_sm120_moe,
-                _get_weight_views as _get_sm120_weight_views,
-            )
-
-            # Cache weight views; invalidate if weight pointers change.
-            weight_key = (
-                w1_weight.data_ptr(),
-                w1_weight_sf.data_ptr(),
-                w1_alpha.data_ptr(),
-                w2_weight.data_ptr(),
-                w2_weight_sf.data_ptr(),
-                w2_alpha.data_ptr(),
-            )
-            if (
-                self._sm120_weight_views is None
-                or getattr(self, "_sm120_weight_key", None) != weight_key
-            ):
-                self._sm120_weight_views = _get_sm120_weight_views(
-                    w1_fp4=w1_weight,
-                    w1_blockscale=w1_weight_sf,
-                    w2_fp4=w2_weight,
-                    w2_blockscale=w2_weight_sf,
-                    w1_alphas=w1_alpha,
-                    w2_alphas=w2_alpha,
-                    n=self.intermediate_size,
-                    k=self.hidden_size,
-                )
-                self._sm120_weight_key = weight_key
-
-            return launch_sm120_moe(
-                a=x,
-                topk_ids=token_selected_experts,
-                topk_weights=token_final_scales,
-                w1_weight=w1_weight,
-                w1_weight_sf=w1_weight_sf,
-                w1_alpha=w1_alpha,
-                fc2_input_scale=fc2_input_scale,
-                w2_weight=w2_weight,
-                w2_weight_sf=w2_weight_sf,
-                w2_alpha=w2_alpha,
-                num_experts=self.num_experts,
-                top_k=self.top_k,
-                num_local_experts=self.num_local_experts,
-                scatter_output=moe_output,
-                activation=self.activation_type,
-                _workspace=self._sm120_workspace,
-                _weight_views=self._sm120_weight_views,
-            )
-
-        # SM100/103: use auto-tuner
+        # Use auto-tuner for tactic selection
         tuner = AutoTuner.get()
 
         inputs = [
@@ -801,7 +692,7 @@ def _cute_dsl_fused_moe_nvfp4_impl(
     )
 
 
-@supported_compute_capability([100, 103, 120, 121])
+@supported_compute_capability([100, 103])
 @flashinfer_api
 def cute_dsl_fused_moe_nvfp4(
     x: torch.Tensor,
@@ -824,11 +715,10 @@ def cute_dsl_fused_moe_nvfp4(
     moe_output: Optional[torch.Tensor] = None,
     aux_stream: Optional[torch.cuda.Stream] = None,
     enable_pdl: bool = True,
-    activation_type: str = "silu",
 ) -> torch.Tensor:
     """Run fused MoE computation using CuteDSL NVFP4 kernels.
 
-    Supported architectures: SM100, SM103, SM120, SM121.
+    Supported architectures: SM100, SM103.
 
     This is the simple functional API. For CUDA graph support, use
     `CuteDslMoEWrapper` instead.
@@ -877,42 +767,6 @@ def cute_dsl_fused_moe_nvfp4(
             (num_tokens, hidden_size),
             dtype=output_dtype,
             device=x.device,
-        )
-
-    # SM120/SM121: dispatch to fused kernel (bypasses autotuner).
-    # On SM120 the caller passes bf16 activations as x; x_sf is ignored.
-    major, _ = torch.cuda.get_device_capability(x.device)
-    if major == 12:
-        from ...jit.cpp_ext import get_cuda_version
-
-        if get_cuda_version().major < 13:
-            raise ValueError(
-                "SM120 CuTe DSL fused MoE requires CUDA 13 or later. "
-                f"Current CUDA version: {get_cuda_version()}."
-            )
-        if local_expert_offset != 0:
-            raise ValueError(
-                "SM120 MoE does not support expert parallelism "
-                "(local_expert_offset != 0)."
-            )
-        from .blackwell_sm12x.moe_dispatch import launch_sm120_moe
-
-        return launch_sm120_moe(
-            a=x,
-            topk_ids=token_selected_experts,
-            topk_weights=token_final_scales,
-            w1_weight=w1_weight,
-            w1_weight_sf=w1_weight_sf,
-            w1_alpha=w1_alpha,
-            fc2_input_scale=fc2_input_scale,
-            w2_weight=w2_weight,
-            w2_weight_sf=w2_weight_sf,
-            w2_alpha=w2_alpha,
-            num_experts=num_experts,
-            top_k=top_k,
-            num_local_experts=num_local_experts or num_experts,
-            scatter_output=moe_output,
-            activation=activation_type,
         )
 
     tuner = AutoTuner.get()

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -184,9 +184,6 @@ def _moe_core_impl(
     num_tokens = token_selected_experts.size(0)
     hidden_size = w2_weight.size(1)
 
-    # NOTE: SM120/SM121 dispatch is handled by callers (CuteDslMoEWrapper.run
-    # and cute_dsl_fused_moe_nvfp4) before reaching this function.
-
     # Allocate output if not provided.  The caller (wrapper or functional
     # API) should pass a [:num_tokens] slice of the pre-allocated buffer
     # when using CUDA graphs.  The buffer is zeroed in Step 3 below.
@@ -555,12 +552,8 @@ class CuteDslMoEWrapper:
         Supports auto-tuning via `tactic` parameter or `autotune()` context.
 
         Args:
-            x: Input tensor. On SM100/SM103: NVFP4 quantized
-                [num_tokens, hidden_size // 2]. On SM120/SM121: bf16
-                activations [num_tokens, hidden_size] (kernel fuses
-                quantization internally).
-            x_sf: Scale factors for x. Required on SM100/SM103, ignored
-                on SM120/SM121.
+            x: NVFP4-quantized input [num_tokens, hidden_size // 2].
+            x_sf: Scale factors for x.
             token_selected_experts: Expert assignments [num_tokens, top_k].
             token_final_scales: Routing weights [num_tokens, top_k].
             w1_weight: GEMM1 weights (gate + up fused).
@@ -729,12 +722,8 @@ def cute_dsl_fused_moe_nvfp4(
         ...     output = cute_dsl_fused_moe_nvfp4(...)
 
     Args:
-        x: Input tensor. On SM100/SM103: NVFP4 quantized
-            [num_tokens, hidden_size // 2]. On SM120/SM121: bf16
-            activations [num_tokens, hidden_size] (kernel fuses
-            quantization internally).
-        x_sf: Scale factors for x. Required on SM100/SM103, ignored
-            on SM120/SM121.
+        x: NVFP4-quantized input [num_tokens, hidden_size // 2].
+        x_sf: Scale factors for x.
         token_selected_experts: Expert assignments [num_tokens, top_k].
         token_final_scales: Routing weights [num_tokens, top_k].
         w1_weight: GEMM1 weights (gate + up fused).

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -184,53 +184,11 @@ def _moe_core_impl(
     num_tokens = token_selected_experts.size(0)
     hidden_size = w2_weight.size(1)
 
-    # SM120/SM121: dispatch to fused kernel (route+pack+FC1+FC2 in one launch).
-    # Selects static (decode) or dynamic (prefill) based on token count.
-    major, minor = torch.cuda.get_device_capability(x.device)
-    if major == 12:
-        from ...jit.cpp_ext import get_cuda_version
-
-        if get_cuda_version().major < 13:
-            raise ValueError(
-                "SM120 CuTe DSL fused MoE requires CUDA 13 or later. "
-                f"Current CUDA version: {get_cuda_version()}."
-            )
-        from .blackwell_sm12x.moe_dispatch import launch_sm120_moe
-
-        num_experts_local = (
-            num_local_experts if num_local_experts is not None else num_experts
-        )
-
-        if local_expert_offset != 0:
-            raise ValueError(
-                "SM120 MoE does not support expert parallelism (local_expert_offset != 0). "
-                "Use the SM100 CuTe DSL or CUTLASS backend for EP configurations."
-            )
-
-        if moe_output is None:
-            moe_output = torch.empty(
-                (num_tokens, hidden_size),
-                dtype=output_dtype,
-                device=x.device,
-            )
-
-        # On SM120 the caller passes bf16 activations as x directly.
-        return launch_sm120_moe(
-            a=x,  # bf16 [num_tokens, hidden_size]
-            topk_ids=token_selected_experts,
-            topk_weights=token_final_scales,
-            w1_weight=w1_weight,
-            w1_weight_sf=w1_weight_sf,
-            w1_alpha=w1_alpha,
-            fc2_input_scale=fc2_input_scale,
-            w2_weight=w2_weight,
-            w2_weight_sf=w2_weight_sf,
-            w2_alpha=w2_alpha,
-            num_experts=num_experts,
-            top_k=top_k,
-            num_local_experts=num_experts_local,
-            scatter_output=moe_output,
-        )
+    # NOTE: SM120/SM121 dispatch is handled by callers (CuteDslMoEWrapper.run
+    # and cute_dsl_fused_moe_nvfp4) before reaching this function.
+    # Do NOT call torch.cuda.get_device_capability() here — it would execute
+    # inside the autotuner's CUDA graph capture context, which can corrupt
+    # graph capture on CUDA 12.
 
     # Allocate output if not provided.  The caller (wrapper or functional
     # API) should pass a [:num_tokens] slice of the pre-allocated buffer
@@ -404,6 +362,7 @@ class CuteDslMoEWrapper:
         output_dtype: torch.dtype = torch.bfloat16,
         device: str = "cuda",
         enable_pdl: bool = True,
+        activation_type: str = "silu",
     ):
         """Initialize the MoE wrapper.
 
@@ -435,6 +394,7 @@ class CuteDslMoEWrapper:
         self.output_dtype = output_dtype
         self.device = device
         self.enable_pdl = enable_pdl
+        self.activation_type = activation_type
 
         # Detect SM120 for architecture-specific dispatch
         major, minor = torch.cuda.get_device_capability(device)
@@ -740,6 +700,7 @@ class CuteDslMoEWrapper:
                 top_k=self.top_k,
                 num_local_experts=self.num_local_experts,
                 scatter_output=moe_output,
+                activation=self.activation_type,
                 _workspace=self._sm120_workspace,
                 _weight_views=self._sm120_weight_views,
             )
@@ -866,6 +827,7 @@ def cute_dsl_fused_moe_nvfp4(
     moe_output: Optional[torch.Tensor] = None,
     aux_stream: Optional[torch.cuda.Stream] = None,
     enable_pdl: bool = True,
+    activation_type: str = "silu",
 ) -> torch.Tensor:
     """Run fused MoE computation using CuteDSL NVFP4 kernels.
 
@@ -921,19 +883,28 @@ def cute_dsl_fused_moe_nvfp4(
         )
 
     # SM120/SM121: dispatch to fused kernel (bypasses autotuner).
+    # SM120/SM121: dispatch to fused kernel directly (bypasses autotuner).
     # On SM120 the caller passes bf16 activations as x; x_sf is ignored.
     major, _ = torch.cuda.get_device_capability(x.device)
     if major == 12:
+        from ...jit.cpp_ext import get_cuda_version
+
+        if get_cuda_version().major < 13:
+            raise ValueError(
+                "SM120 CuTe DSL fused MoE requires CUDA 13 or later. "
+                f"Current CUDA version: {get_cuda_version()}."
+            )
         if local_expert_offset != 0:
             raise ValueError(
                 "SM120 MoE does not support expert parallelism "
                 "(local_expert_offset != 0)."
             )
-        return _moe_core_impl(
-            x=x,
-            x_sf=x_sf,
-            token_selected_experts=token_selected_experts,
-            token_final_scales=token_final_scales,
+        from .blackwell_sm12x.moe_dispatch import launch_sm120_moe
+
+        return launch_sm120_moe(
+            a=x,
+            topk_ids=token_selected_experts,
+            topk_weights=token_final_scales,
             w1_weight=w1_weight,
             w1_weight_sf=w1_weight_sf,
             w1_alpha=w1_alpha,
@@ -943,11 +914,9 @@ def cute_dsl_fused_moe_nvfp4(
             w2_alpha=w2_alpha,
             num_experts=num_experts,
             top_k=top_k,
-            num_local_experts=num_local_experts,
-            local_expert_offset=local_expert_offset,
-            moe_output=moe_output,
-            output_dtype=output_dtype,
-            enable_pdl=enable_pdl,
+            num_local_experts=num_local_experts or num_experts,
+            scatter_output=moe_output,
+            activation=activation_type,
         )
 
     tuner = AutoTuner.get()

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -65,6 +65,14 @@ def _cuda_13_or_newer():
         return False
 
 
+def _is_sm121():
+    """Check whether the current device reports compute capability SM121."""
+    if not torch.cuda.is_available():
+        return False
+    props = torch.cuda.get_device_properties(0)
+    return props.major == 12 and props.minor == 1
+
+
 # Skip decorators
 cute_dsl_available = pytest.mark.skipif(
     not is_cute_dsl_available(), reason="CuteDSL not available"
@@ -76,6 +84,10 @@ sm120_required = pytest.mark.skipif(
 cuda_13_required = pytest.mark.skipif(
     not _cuda_13_or_newer(),
     reason="b12x fused MoE requires CUDA 13 or later",
+)
+not_sm121 = pytest.mark.skipif(
+    _is_sm121(),
+    reason="b12x fused MoE is not supported on SM121",
 )
 
 
@@ -520,6 +532,7 @@ def create_relu2_moe_tensors(
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
+@not_sm121
 class TestB12xFunctional:
     """Tests for the functional API: b12x_fused_moe."""
 
@@ -600,6 +613,7 @@ class TestB12xFunctional:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
+@not_sm121
 class TestB12xWrapper:
     """Tests for the wrapper API: B12xMoEWrapper."""
 
@@ -781,6 +795,7 @@ class TestB12xWrapper:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
+@not_sm121
 class TestB12xApiConsistency:
     """Tests verifying consistency between b12x functional and wrapper APIs."""
 
@@ -859,6 +874,7 @@ class TestB12xApiConsistency:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
+@not_sm121
 class TestMicroKernel:
     """Tests for the micro kernel path (routed_rows <= 20-40).
 
@@ -1060,6 +1076,7 @@ class TestMicroKernel:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
+@not_sm121
 class TestRelu2Activation:
     """Tests for ReLU2 activation (non-gated, Nemotron-Super)."""
 

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -15,17 +15,21 @@ limitations under the License.
 """
 
 """
-Numerical accuracy tests for CuteDSL Fused MoE NVFP4 on Blackwell GPUs.
+Numerical accuracy tests for b12x Fused MoE on SM120/SM121 GPUs.
+
+These are SM120-only APIs that take bf16 input directly (no x_sf needed).
+The kernel fuses quantization + routing + FC1 + activation + FC2 + scatter.
 
 This test file covers both APIs:
-1. Functional API: `cute_dsl_fused_moe_nvfp4`
-2. Wrapper API: `CuteDslMoEWrapper`
+1. Functional API: `b12x_fused_moe`
+2. Wrapper API: `B12xMoEWrapper`
 
 Tests include:
-- Numerical accuracy against reference implementation
+- Numerical accuracy against reference implementation (SiLU and ReLU2)
 - CUDA graph capture and replay
-- Auto-tuning integration
 - API consistency between functional and wrapper APIs
+- Micro kernel path for small decode batches
+- ReLU2 (non-gated) activation for Nemotron-Super
 """
 
 import pytest
@@ -33,17 +37,6 @@ import torch
 from torch.nn import functional as F
 
 from flashinfer.cute_dsl import is_cute_dsl_available
-
-
-def is_sm100_family():
-    """Check for SM100 family (Blackwell: SM100, SM103) or SM120 family (SM120, SM121).
-
-    CuteDSL MoE NVFP4 kernels support SM10x and SM12x architectures.
-    """
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(0)
-    return props.major in (10, 12)
 
 
 def is_sm120_family():
@@ -54,34 +47,27 @@ def is_sm120_family():
     return props.major == 12
 
 
-def _has_cuda_13():
-    """Check if CUDA runtime version is 13+."""
-    return (
-        torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 13
-    )
+def _is_sm12x_supported():
+    """Check SM120/SM121 support using repo-standard utility checks."""
+    from flashinfer.utils import is_sm120a_supported, is_sm121a_supported
+
+    device = torch.device("cuda")
+    return is_sm120a_supported(device) or is_sm121a_supported(device)
 
 
 # Skip decorators
 cute_dsl_available = pytest.mark.skipif(
     not is_cute_dsl_available(), reason="CuteDSL not available"
 )
-sm100_required = pytest.mark.skipif(
-    not is_sm100_family() or is_sm120_family(),
-    reason="Requires SM100/SM103 GPU (SM120 uses b12x_fused_moe API instead)",
-)
-sm100_only = pytest.mark.skipif(
-    is_sm120_family() or not is_sm100_family(),
-    reason="Requires SM100 family GPU (SM100-specific features)",
+sm120_required = pytest.mark.skipif(
+    not _is_sm12x_supported(),
+    reason="Requires SM120/SM121 GPU with CUDA 12.8+",
 )
 
 
-def moe_input(tensors: dict) -> torch.Tensor:
-    """Return the correct x tensor for the current architecture.
-
-    SM100/103 expects pre-quantized FP4; SM120/121 expects bf16
-    (the kernel fuses quantization internally).
-    """
-    return tensors["x_bf16"] if is_sm120_family() else tensors["x"]
+# =============================================================================
+# Helper functions (shared reference logic)
+# =============================================================================
 
 
 def silu(x: torch.Tensor) -> torch.Tensor:
@@ -263,7 +249,6 @@ def create_moe_tensors(
         / 10
     )
 
-    # SM100/103: interleave gate/up for CuTe DSL SwiGLU epilogue (group_size=64)
     # SM120/121: no interleave — kernel expects [up_0:N, gate_0:N] (contiguous cat)
     if is_sm120_family():
         w1_bf16_prepared = w1_bf16  # b12x kernel: non-interleaved
@@ -357,15 +342,171 @@ def check_accuracy(
     return percent_within >= percent_threshold, percent_within, atol
 
 
+def compute_reference_moe_relu2(
+    hidden_states: torch.Tensor,
+    fc1_weights: torch.Tensor,
+    fc2_weights: torch.Tensor,
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    hidden_size: int,
+    intermediate_size: int,
+    fc2_input_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Reference ReLU2 MoE: output = relu(FC1(x))^2, then FC2."""
+    output = torch.zeros(num_tokens, hidden_size, dtype=torch.float32, device="cuda")
+
+    for token_idx in range(num_tokens):
+        token_input = hidden_states[token_idx].unsqueeze(0)
+
+        for k in range(top_k):
+            expert_idx = token_selected_experts[token_idx, k].item()
+            scale = token_final_scales[token_idx, k].item()
+
+            if expert_idx >= num_experts:
+                continue
+
+            w1 = fc1_weights[expert_idx]
+            fc1_out = token_input @ w1.T
+            activated = torch.square(torch.relu(fc1_out))
+
+            if fc2_input_scale is not None:
+                activated = quant_dequant_fp4_reference(
+                    activated, fc2_input_scale, sf_vec_size=16
+                )
+
+            w2 = fc2_weights[expert_idx]
+            fc2_out = activated @ w2.T
+
+            output[token_idx] += scale * fc2_out.squeeze(0)
+
+    return output
+
+
+def create_relu2_moe_tensors(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    num_local_experts: int,
+    top_k: int,
+    device: str = "cuda",
+    seed: int = 42,
+):
+    """Create MoE tensors for ReLU2 (non-gated: w1_rows = n, not 2*n)."""
+    from flashinfer.fp4_quantization import fp4_quantize
+    from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+
+    torch.manual_seed(seed)
+    sf_vec_size = 16
+
+    x_bf16 = (
+        torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=device) / 10
+    )
+    a1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    x_quantized, x_sf = fp4_quantize(
+        x_bf16,
+        global_scale=a1_gs,
+        sf_vec_size=sf_vec_size,
+        is_sf_swizzled_layout=False,
+    )
+    x_sf = x_sf.unsqueeze(-1)
+
+    router_logits = torch.randn(num_tokens, num_experts, device=device)
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, top_k, dim=-1)
+    routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.float()
+    selected_experts = selected_experts.to(torch.int32)
+
+    # FC1 weights — NON-GATED: [E, n, k] instead of [E, 2*n, k]
+    w1_bf16 = (
+        torch.randn(
+            num_local_experts,
+            intermediate_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 10
+    )
+    w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    w1_flat = w1_bf16.view(num_local_experts * intermediate_size, hidden_size)
+    w1_q_flat, w1_sf_flat = fp4_quantize(
+        w1_flat,
+        global_scale=w1_gs,
+        sf_vec_size=sf_vec_size,
+        is_sf_swizzled_layout=True,
+    )
+    w1_q = w1_q_flat.view(num_local_experts, intermediate_size, hidden_size // 2)
+    w1_weight_sf = convert_sf_to_mma_layout(
+        w1_sf_flat,
+        m=intermediate_size,
+        k=hidden_size,
+        num_groups=num_local_experts,
+        sf_vec_size=sf_vec_size,
+    )
+    w1_alpha = torch.ones(num_local_experts, device=device, dtype=torch.float32)
+
+    # FC2 weights — same shape as SiLU: [E, k, n]
+    w2_bf16 = (
+        torch.randn(
+            num_local_experts,
+            hidden_size,
+            intermediate_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 10
+    )
+    w2_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    w2_flat = w2_bf16.view(num_local_experts * hidden_size, intermediate_size)
+    w2_q_flat, w2_sf_flat = fp4_quantize(
+        w2_flat,
+        global_scale=w2_gs,
+        sf_vec_size=sf_vec_size,
+        is_sf_swizzled_layout=True,
+    )
+    w2_q = w2_q_flat.view(num_local_experts, hidden_size, intermediate_size // 2)
+    w2_weight_sf = convert_sf_to_mma_layout(
+        w2_sf_flat,
+        m=hidden_size,
+        k=intermediate_size,
+        num_groups=num_local_experts,
+        sf_vec_size=sf_vec_size,
+    )
+    w2_alpha = torch.ones(num_local_experts, device=device, dtype=torch.float32)
+    fc2_input_scale = torch.tensor([1.0], device=device, dtype=torch.float32)
+
+    return {
+        "x": x_quantized,
+        "x_sf": x_sf,
+        "x_bf16": x_bf16,
+        "token_selected_experts": selected_experts,
+        "token_final_scales": routing_weights,
+        "w1_weight": w1_q,
+        "w1_weight_sf": w1_weight_sf,
+        "w1_weight_bf16": w1_bf16,
+        "w1_alpha": w1_alpha,
+        "fc2_input_scale": fc2_input_scale,
+        "w2_weight": w2_q,
+        "w2_weight_sf": w2_weight_sf,
+        "w2_weight_bf16": w2_bf16,
+        "w2_alpha": w2_alpha,
+    }
+
+
 # =============================================================================
-# Test Class: Functional API (cute_dsl_fused_moe_nvfp4)
+# Test Class: Functional API (b12x_fused_moe)
 # =============================================================================
 
 
 @cute_dsl_available
-@sm100_required
-class TestCuteDslFusedMoeFunctional:
-    """Tests for the functional API: cute_dsl_fused_moe_nvfp4."""
+@sm120_required
+class TestB12xFunctional:
+    """Tests for the functional API: b12x_fused_moe."""
 
     @pytest.mark.parametrize(
         "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
@@ -381,8 +522,8 @@ class TestCuteDslFusedMoeFunctional:
         intermediate_size: int,
         num_experts: int,
     ):
-        """Accuracy test for functional API across configurations."""
-        from flashinfer import cute_dsl_fused_moe_nvfp4
+        """Accuracy test for b12x functional API across configurations."""
+        from flashinfer import b12x_fused_moe
 
         num_local_experts = num_experts
 
@@ -395,11 +536,8 @@ class TestCuteDslFusedMoeFunctional:
             top_k=top_k,
         )
 
-        result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -407,6 +545,8 @@ class TestCuteDslFusedMoeFunctional:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
             num_experts=num_experts,
             top_k=top_k,
             num_local_experts=num_local_experts,
@@ -436,60 +576,23 @@ class TestCuteDslFusedMoeFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
-    def test_with_autotune(self):
-        """Test functional API with autotune context."""
-        from flashinfer import autotune
-        from flashinfer import cute_dsl_fused_moe_nvfp4
-
-        num_tokens, hidden_size, intermediate_size = 256, 256, 512
-        num_experts, top_k = 256, 2
-
-        tensors = create_moe_tensors(
-            num_tokens=num_tokens,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_experts=num_experts,
-            num_local_experts=num_experts,
-            top_k=top_k,
-        )
-
-        with autotune(True):
-            result = cute_dsl_fused_moe_nvfp4(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
-                w1_weight=tensors["w1_weight"],
-                w1_weight_sf=tensors["w1_weight_sf"],
-                w1_alpha=tensors["w1_alpha"],
-                fc2_input_scale=tensors["fc2_input_scale"],
-                w2_weight=tensors["w2_weight"],
-                w2_weight_sf=tensors["w2_weight_sf"],
-                w2_alpha=tensors["w2_alpha"],
-                num_experts=num_experts,
-                top_k=top_k,
-            )
-
-        assert result.shape == (num_tokens, hidden_size)
-        assert not torch.isnan(result).any()
-
 
 # =============================================================================
-# Test Class: Wrapper API (CuteDslMoEWrapper)
+# Test Class: Wrapper API (B12xMoEWrapper)
 # =============================================================================
 
 
 @cute_dsl_available
-@sm100_required
-class TestCuteDslMoEWrapper:
-    """Tests for the wrapper API: CuteDslMoEWrapper."""
+@sm120_required
+class TestB12xWrapper:
+    """Tests for the wrapper API: B12xMoEWrapper."""
 
     @pytest.mark.parametrize("num_tokens", [128, 256, 512])
     @pytest.mark.parametrize("top_k", [2, 8])
     @pytest.mark.parametrize("num_experts", [256, 384])
     def test_wrapper_accuracy(self, num_tokens: int, top_k: int, num_experts: int):
-        """Accuracy test for wrapper API."""
-        from flashinfer import CuteDslMoEWrapper
+        """Accuracy test for B12xMoEWrapper."""
+        from flashinfer import B12xMoEWrapper
 
         hidden_size, intermediate_size = 256, 512
 
@@ -503,7 +606,7 @@ class TestCuteDslMoEWrapper:
         )
 
         # Create wrapper WITHOUT CUDA graph
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -512,10 +615,7 @@ class TestCuteDslMoEWrapper:
         )
 
         result = moe.run(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -523,6 +623,8 @@ class TestCuteDslMoEWrapper:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
         )
 
         assert result.shape == (num_tokens, hidden_size)
@@ -551,8 +653,8 @@ class TestCuteDslMoEWrapper:
     @pytest.mark.parametrize("num_tokens", [64, 128, 256])
     @pytest.mark.parametrize("num_experts", [256, 384])
     def test_wrapper_cuda_graph(self, num_tokens: int, num_experts: int):
-        """Test wrapper API with CUDA graph capture and replay."""
-        from flashinfer import CuteDslMoEWrapper
+        """Test B12xMoEWrapper with CUDA graph capture and replay."""
+        from flashinfer import B12xMoEWrapper
 
         hidden_size, intermediate_size = 256, 512
         top_k = 2
@@ -567,7 +669,7 @@ class TestCuteDslMoEWrapper:
         )
 
         # Create wrapper WITH CUDA graph
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -579,10 +681,7 @@ class TestCuteDslMoEWrapper:
         # Warmup
         for _ in range(3):
             moe.run(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
+                x=tensors["x_bf16"],
                 w1_weight=tensors["w1_weight"],
                 w1_weight_sf=tensors["w1_weight_sf"],
                 w1_alpha=tensors["w1_alpha"],
@@ -590,6 +689,8 @@ class TestCuteDslMoEWrapper:
                 w2_weight=tensors["w2_weight"],
                 w2_weight_sf=tensors["w2_weight_sf"],
                 w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
             )
         torch.cuda.synchronize()
 
@@ -597,10 +698,7 @@ class TestCuteDslMoEWrapper:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             output = moe.run(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
+                x=tensors["x_bf16"],
                 w1_weight=tensors["w1_weight"],
                 w1_weight_sf=tensors["w1_weight_sf"],
                 w1_alpha=tensors["w1_alpha"],
@@ -608,6 +706,8 @@ class TestCuteDslMoEWrapper:
                 w2_weight=tensors["w2_weight"],
                 w2_weight_sf=tensors["w2_weight_sf"],
                 w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
             )
         torch.cuda.synchronize()
 
@@ -656,68 +756,6 @@ class TestCuteDslMoEWrapper:
             f"CUDA graph accuracy: {percent_within * 100:.2f}% (atol={atol:.4f})"
         )
 
-    def test_wrapper_with_autotune(self):
-        """Test wrapper API with autotune context."""
-        from flashinfer import autotune
-        from flashinfer import CuteDslMoEWrapper
-
-        num_tokens, hidden_size, intermediate_size = 256, 256, 512
-        num_experts, top_k = 256, 2
-
-        tensors = create_moe_tensors(
-            num_tokens=num_tokens,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_experts=num_experts,
-            num_local_experts=num_experts,
-            top_k=top_k,
-        )
-
-        moe = CuteDslMoEWrapper(
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            use_cuda_graph=False,
-        )
-
-        with autotune(True):
-            result = moe.run(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
-                w1_weight=tensors["w1_weight"],
-                w1_weight_sf=tensors["w1_weight_sf"],
-                w1_alpha=tensors["w1_alpha"],
-                fc2_input_scale=tensors["fc2_input_scale"],
-                w2_weight=tensors["w2_weight"],
-                w2_weight_sf=tensors["w2_weight_sf"],
-                w2_alpha=tensors["w2_alpha"],
-            )
-
-        assert result.shape == (num_tokens, hidden_size)
-        assert not torch.isnan(result).any()
-
-        ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_bf16"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
-        )
-
-        passed, percent_within, atol = check_accuracy(result, ref_output)
-        assert passed, (
-            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
-        )
-
 
 # =============================================================================
 # Test Class: API Consistency
@@ -725,13 +763,13 @@ class TestCuteDslMoEWrapper:
 
 
 @cute_dsl_available
-@sm100_required
-class TestApiConsistency:
-    """Tests verifying consistency between functional and wrapper APIs."""
+@sm120_required
+class TestB12xApiConsistency:
+    """Tests verifying consistency between b12x functional and wrapper APIs."""
 
     def test_functional_vs_wrapper_output(self):
-        """Verify functional and wrapper APIs produce the same output."""
-        from flashinfer import CuteDslMoEWrapper, cute_dsl_fused_moe_nvfp4
+        """Verify b12x_fused_moe and B12xMoEWrapper produce the same output."""
+        from flashinfer import B12xMoEWrapper, b12x_fused_moe
 
         num_tokens, hidden_size, intermediate_size = 128, 256, 512
         num_experts, top_k = 256, 2
@@ -746,11 +784,8 @@ class TestApiConsistency:
         )
 
         # Functional API
-        result_functional = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+        result_functional = b12x_fused_moe(
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -758,12 +793,14 @@ class TestApiConsistency:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
             num_experts=num_experts,
             top_k=top_k,
         )
 
         # Wrapper API
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -772,10 +809,7 @@ class TestApiConsistency:
         )
 
         result_wrapper = moe.run(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -783,6 +817,8 @@ class TestApiConsistency:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
         )
 
         # Both should produce valid outputs
@@ -791,216 +827,66 @@ class TestApiConsistency:
         assert not torch.isnan(result_wrapper).any()
 
         # Outputs should be very close (may not be exactly equal due to different
-        # tuning paths, but should be within FP4 tolerance)
+        # code paths, but should be within FP4 tolerance)
         diff = (result_functional - result_wrapper).abs()
         max_diff = diff.max().item()
-        # Allow small differences from autotuner path differences
+        # Allow small differences from code path differences
         assert max_diff < 1e-3, f"Max diff between APIs: {max_diff}"
 
 
 # =============================================================================
-# Test Class: Expert Parallelism
+# Test Class: Micro Kernel (SM120-only, small decode batches)
 # =============================================================================
 
 
 @cute_dsl_available
-@sm100_only
-class TestExpertParallelism:
-    """Tests for expert parallelism (EP) configurations."""
+@sm120_required
+class TestMicroKernel:
+    """Tests for the micro kernel path (routed_rows <= 20-40).
 
-    @pytest.mark.parametrize("ep_size", [1, 8, 32])
-    @pytest.mark.parametrize("ep_rank", [0, -1])  # -1 means last rank
-    def test_wrapper_with_ep(self, ep_size: int, ep_rank: int):
-        """Test wrapper API with expert parallelism and numerical accuracy.
-
-        Tests different EP ranks to ensure local_expert_offset handling is correct.
-        ep_rank=-1 is converted to the last rank (ep_size-1) to test non-zero offsets.
-        """
-        from flashinfer import CuteDslMoEWrapper
-
-        # Convert -1 to last rank
-        if ep_rank == -1:
-            ep_rank = ep_size - 1
-
-        num_tokens, hidden_size, intermediate_size = 256, 256, 512
-        num_experts, top_k = 256, 8
-        num_local_experts = num_experts // ep_size
-        local_expert_offset = ep_rank * num_local_experts
-
-        tensors = create_moe_tensors(
-            num_tokens=num_tokens,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_experts=num_experts,
-            num_local_experts=num_local_experts,
-            top_k=top_k,
-        )
-
-        # Keep original routing - the kernel should handle filtering
-        # based on local_expert_offset and num_local_experts
-        token_selected_experts = tensors["token_selected_experts"].clone()
-
-        moe = CuteDslMoEWrapper(
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_local_experts=num_local_experts,
-            local_expert_offset=local_expert_offset,
-        )
-
-        result = moe.run(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=token_selected_experts,
-            token_final_scales=tensors["token_final_scales"],
-            w1_weight=tensors["w1_weight"],
-            w1_weight_sf=tensors["w1_weight_sf"],
-            w1_alpha=tensors["w1_alpha"],
-            fc2_input_scale=tensors["fc2_input_scale"],
-            w2_weight=tensors["w2_weight"],
-            w2_weight_sf=tensors["w2_weight_sf"],
-            w2_alpha=tensors["w2_alpha"],
-        )
-
-        assert result.shape == (num_tokens, hidden_size)
-        assert not torch.isnan(result).any()
-        assert not torch.isinf(result).any()
-
-        # Numerical accuracy verification against reference
-        ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_bf16"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            token_selected_experts=token_selected_experts,
-            token_final_scales=tensors["token_final_scales"],
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
-            num_local_experts=num_local_experts,
-            local_expert_offset=local_expert_offset,
-        )
-
-        passed, percent_within, atol = check_accuracy(result, ref_output)
-        assert passed, (
-            f"EP accuracy test failed (ep_size={ep_size}, ep_rank={ep_rank}, "
-            f"offset={local_expert_offset}): {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
-        )
-
-    @pytest.mark.parametrize("ep_size", [8])
-    def test_functional_with_ep(self, ep_size: int):
-        """Test functional API with expert parallelism and numerical accuracy."""
-        from flashinfer import cute_dsl_fused_moe_nvfp4
-
-        # Test middle rank to ensure offset handling works
-        ep_rank = ep_size // 2
-
-        num_tokens, hidden_size, intermediate_size = 256, 256, 512
-        num_experts, top_k = 256, 8
-        num_local_experts = num_experts // ep_size
-        local_expert_offset = ep_rank * num_local_experts
-
-        tensors = create_moe_tensors(
-            num_tokens=num_tokens,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_experts=num_experts,
-            num_local_experts=num_local_experts,
-            top_k=top_k,
-        )
-
-        result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            w1_weight=tensors["w1_weight"],
-            w1_weight_sf=tensors["w1_weight_sf"],
-            w1_alpha=tensors["w1_alpha"],
-            fc2_input_scale=tensors["fc2_input_scale"],
-            w2_weight=tensors["w2_weight"],
-            w2_weight_sf=tensors["w2_weight_sf"],
-            w2_alpha=tensors["w2_alpha"],
-            num_experts=num_experts,
-            top_k=top_k,
-            num_local_experts=num_local_experts,
-            local_expert_offset=local_expert_offset,
-        )
-
-        assert result.shape == (num_tokens, hidden_size)
-        assert not torch.isnan(result).any()
-        assert not torch.isinf(result).any()
-
-        # Numerical accuracy verification
-        ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_bf16"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
-            num_local_experts=num_local_experts,
-            local_expert_offset=local_expert_offset,
-        )
-
-        passed, percent_within, atol = check_accuracy(result, ref_output)
-        assert passed, (
-            f"EP functional API accuracy test failed (ep_size={ep_size}, ep_rank={ep_rank}): "
-            f"{percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
-        )
-
-
-# =============================================================================
-# Test Class: All Valid Tactics
-# =============================================================================
-
-
-@cute_dsl_available
-@sm100_only
-class TestAllValidTactics:
-    """Test that every tactic returned by get_valid_tactics produces correct output.
-
-    For each problem configuration, gets the filtered list of valid tactics via
-    can_implement checks, then runs CuteDslMoEWrapper with each tactic explicitly
-    and verifies numerical accuracy against the reference implementation.
+    The micro kernel is selected automatically when routed_rows is small.
+    These tests use num_tokens=1-4 to exercise the micro dispatch path,
+    including the all_rows_unique fast path (num_tokens=1).
     """
 
-    @pytest.mark.parametrize(
-        "num_tokens,hidden_size,intermediate_size,num_experts,top_k",
-        [
-            (128, 256, 512, 256, 2),
-            (256, 1024, 2048, 256, 8),
-        ],
-    )
-    def test_all_tactics_accuracy(
-        self,
-        num_tokens: int,
-        hidden_size: int,
-        intermediate_size: int,
-        num_experts: int,
-        top_k: int,
+    @pytest.mark.parametrize("num_tokens", [1, 2, 4])
+    @pytest.mark.parametrize("top_k", [2, 8])
+    @pytest.mark.parametrize("num_experts", [256])
+    def test_micro_functional_accuracy(
+        self, num_tokens: int, top_k: int, num_experts: int
     ):
-        """Verify every valid tactic produces correct output."""
-        from flashinfer import CuteDslMoEWrapper
+        """Accuracy test for micro kernel via b12x functional API."""
+        from flashinfer import b12x_fused_moe
 
-        num_local_experts = num_experts
+        hidden_size, intermediate_size = 256, 512
 
         tensors = create_moe_tensors(
             num_tokens=num_tokens,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             num_experts=num_experts,
-            num_local_experts=num_local_experts,
+            num_local_experts=num_experts,
             top_k=top_k,
         )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
 
         ref_output = compute_reference_moe_fp4(
             hidden_states=tensors["x_bf16"].float().cuda(),
@@ -1016,8 +902,29 @@ class TestAllValidTactics:
             fc2_input_scale=tensors["fc2_input_scale"],
         )
 
-        # Create wrapper without CUDA graph so we can freely try different tile_sizes
-        moe = CuteDslMoEWrapper(
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Micro kernel: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens}, top_k={top_k})"
+        )
+
+    def test_micro_wrapper_accuracy(self):
+        """Accuracy test for micro kernel via B12xMoEWrapper."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 2, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -1025,32 +932,330 @@ class TestAllValidTactics:
             use_cuda_graph=False,
         )
 
-        # Get the filtered list of valid tactics for this problem size
-        inputs = [
-            tensors["x"],
-            tensors["x_sf"],
-            tensors["token_selected_experts"],
-            tensors["token_final_scales"],
-            tensors["w1_weight"],
-            tensors["w1_weight_sf"],
-            tensors["w1_alpha"],
-            tensors["fc2_input_scale"],
-            tensors["w2_weight"],
-            tensors["w2_weight_sf"],
-            tensors["w2_alpha"],
-        ]
-        valid_tactics = moe._runner.get_valid_tactics(inputs, None)
-        assert len(valid_tactics) > 0, "No valid tactics found"
+        result = moe.run(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+        )
 
-        num_passed = 0
-        num_failed = 0
-        for tactic in valid_tactics:
-            tile_size = tactic[0]
-            result = moe.run(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Micro wrapper: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_micro_single_token_unique_path(self):
+        """Test the all_rows_unique fast path (num_tokens=1, top_k=8).
+
+        With 1 token and 8 experts, every expert has exactly 1 row.
+        The micro kernel detects this and uses O(1) work tile assignment.
+        """
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 1, 256, 512
+        num_experts, top_k = 256, 8
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+        )
+
+        result = moe.run(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+        )
+
+        assert result.shape == (1, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Micro unique path: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+
+# =============================================================================
+# Test Class: ReLU2 Activation (SM120-only, non-gated)
+# =============================================================================
+
+
+@cute_dsl_available
+@sm120_required
+class TestRelu2Activation:
+    """Tests for ReLU2 activation (non-gated, Nemotron-Super)."""
+
+    @pytest.mark.parametrize(
+        "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
+    )
+    @pytest.mark.parametrize("top_k", [1, 2, 8])
+    @pytest.mark.parametrize("num_tokens", [2, 128, 512])
+    @pytest.mark.parametrize("num_experts", [256])
+    def test_relu2_functional_accuracy(
+        self,
+        num_tokens: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+    ):
+        """Accuracy test for ReLU2 via b12x functional API."""
+        from flashinfer import b12x_fused_moe
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation="relu2",
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens})"
+        )
+
+    def test_relu2_wrapper_accuracy(self):
+        """Accuracy test for ReLU2 via B12xMoEWrapper."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+            activation="relu2",
+        )
+
+        result = moe.run(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2 wrapper: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_relu2_micro_accuracy(self):
+        """Accuracy test for ReLU2 with micro kernel (small decode batch)."""
+        from flashinfer import b12x_fused_moe
+
+        num_tokens, hidden_size, intermediate_size = 2, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation="relu2",
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2 micro: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_relu2_cuda_graph(self):
+        """Test ReLU2 with CUDA graph capture and replay."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=True,
+            max_num_tokens=num_tokens,
+            activation="relu2",
+        )
+
+        # Warmup
+        for _ in range(3):
+            moe.run(
+                x=tensors["x_bf16"],
                 w1_weight=tensors["w1_weight"],
                 w1_weight_sf=tensors["w1_weight_sf"],
                 w1_alpha=tensors["w1_alpha"],
@@ -1058,32 +1263,35 @@ class TestAllValidTactics:
                 w2_weight=tensors["w2_weight"],
                 w2_weight_sf=tensors["w2_weight_sf"],
                 w2_alpha=tensors["w2_alpha"],
-                tactic=tactic,
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
             )
+        torch.cuda.synchronize()
 
-            assert result.shape == (num_tokens, hidden_size)
-            assert not torch.isnan(result).any(), f"NaN in output for tactic {tactic}"
-            assert not torch.isinf(result).any(), f"Inf in output for tactic {tactic}"
+        # Capture
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            output = moe.run(
+                x=tensors["x_bf16"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+            )
+        torch.cuda.synchronize()
 
-            passed, percent_within, atol = check_accuracy(result, ref_output)
-            if passed:
-                num_passed += 1
-            else:
-                num_failed += 1
-                # Don't fail immediately; report all failures at the end
-                print(
-                    f"[FAIL] tactic tile_size={tile_size} "
-                    f"gemm1={tactic[1][0]},{tactic[1][1]} "
-                    f"gemm2={tactic[2][0]},{tactic[2][1]}: "
-                    f"{percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
-                )
+        assert output.shape == (num_tokens, hidden_size)
 
-        total = len(valid_tactics)
-        assert num_failed == 0, (
-            f"{num_failed}/{total} tactics failed accuracy check "
-            f"(tokens={num_tokens}, hidden={hidden_size}, "
-            f"intermediate={intermediate_size}, experts={num_experts}, top_k={top_k})"
-        )
+        # Replay and verify
+        g.replay()
+        torch.cuda.synchronize()
+        assert not torch.isnan(output).any(), "NaN after ReLU2 CUDA graph replay"
+        assert not (output == 0).all(), "All zeros after ReLU2 CUDA graph replay"
 
 
 if __name__ == "__main__":

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -55,6 +55,16 @@ def _is_sm12x_supported():
     return is_sm120a_supported(device) or is_sm121a_supported(device)
 
 
+def _cuda_13_or_newer():
+    """b12x fused MoE kernels require the CUDA 13 toolkit."""
+    try:
+        from flashinfer.jit.cpp_ext import get_cuda_version
+
+        return get_cuda_version().major >= 13
+    except Exception:
+        return False
+
+
 # Skip decorators
 cute_dsl_available = pytest.mark.skipif(
     not is_cute_dsl_available(), reason="CuteDSL not available"
@@ -62,6 +72,10 @@ cute_dsl_available = pytest.mark.skipif(
 sm120_required = pytest.mark.skipif(
     not _is_sm12x_supported(),
     reason="Requires SM120/SM121 GPU with CUDA 12.8+",
+)
+cuda_13_required = pytest.mark.skipif(
+    not _cuda_13_or_newer(),
+    reason="b12x fused MoE requires CUDA 13 or later",
 )
 
 
@@ -505,6 +519,7 @@ def create_relu2_moe_tensors(
 
 @cute_dsl_available
 @sm120_required
+@cuda_13_required
 class TestB12xFunctional:
     """Tests for the functional API: b12x_fused_moe."""
 
@@ -584,6 +599,7 @@ class TestB12xFunctional:
 
 @cute_dsl_available
 @sm120_required
+@cuda_13_required
 class TestB12xWrapper:
     """Tests for the wrapper API: B12xMoEWrapper."""
 
@@ -764,6 +780,7 @@ class TestB12xWrapper:
 
 @cute_dsl_available
 @sm120_required
+@cuda_13_required
 class TestB12xApiConsistency:
     """Tests verifying consistency between b12x functional and wrapper APIs."""
 
@@ -841,6 +858,7 @@ class TestB12xApiConsistency:
 
 @cute_dsl_available
 @sm120_required
+@cuda_13_required
 class TestMicroKernel:
     """Tests for the micro kernel path (routed_rows <= 20-40).
 
@@ -1041,6 +1059,7 @@ class TestMicroKernel:
 
 @cute_dsl_available
 @sm120_required
+@cuda_13_required
 class TestRelu2Activation:
     """Tests for ReLU2 activation (non-gated, Nemotron-Super)."""
 

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -1048,7 +1048,7 @@ class TestRelu2Activation:
         "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
     )
     @pytest.mark.parametrize("top_k", [1, 2, 8])
-    @pytest.mark.parametrize("num_tokens", [2, 128, 512])
+    @pytest.mark.parametrize("num_tokens", [1, 2, 128, 512])
     @pytest.mark.parametrize("num_experts", [256])
     def test_relu2_functional_accuracy(
         self,

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1294,5 +1294,426 @@ class TestMicroKernel:
         )
 
 
+# =============================================================================
+# Test Class: ReLU2 Activation (SM120-only, non-gated)
+# =============================================================================
+
+
+def compute_reference_moe_relu2(
+    hidden_states: torch.Tensor,
+    fc1_weights: torch.Tensor,
+    fc2_weights: torch.Tensor,
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    hidden_size: int,
+    intermediate_size: int,
+    fc2_input_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Reference ReLU2 MoE: output = relu(FC1(x))^2, then FC2."""
+    output = torch.zeros(num_tokens, hidden_size, dtype=torch.float32, device="cuda")
+
+    for token_idx in range(num_tokens):
+        token_input = hidden_states[token_idx].unsqueeze(0)
+
+        for k in range(top_k):
+            expert_idx = token_selected_experts[token_idx, k].item()
+            scale = token_final_scales[token_idx, k].item()
+
+            if expert_idx >= num_experts:
+                continue
+
+            w1 = fc1_weights[expert_idx]
+            fc1_out = token_input @ w1.T
+            activated = torch.square(torch.relu(fc1_out))
+
+            if fc2_input_scale is not None:
+                activated = quant_dequant_fp4_reference(
+                    activated, fc2_input_scale, sf_vec_size=16
+                )
+
+            w2 = fc2_weights[expert_idx]
+            fc2_out = activated @ w2.T
+
+            output[token_idx] += scale * fc2_out.squeeze(0)
+
+    return output
+
+
+def create_relu2_moe_tensors(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    num_local_experts: int,
+    top_k: int,
+    device: str = "cuda",
+    seed: int = 42,
+):
+    """Create MoE tensors for ReLU2 (non-gated: w1_rows = n, not 2*n)."""
+    from flashinfer.fp4_quantization import fp4_quantize
+    from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+
+    torch.manual_seed(seed)
+    sf_vec_size = 16
+
+    x_bf16 = (
+        torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=device) / 10
+    )
+    a1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    x_quantized, x_sf = fp4_quantize(
+        x_bf16,
+        global_scale=a1_gs,
+        sf_vec_size=sf_vec_size,
+        is_sf_swizzled_layout=False,
+    )
+    x_sf = x_sf.unsqueeze(-1)
+
+    router_logits = torch.randn(num_tokens, num_experts, device=device)
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, top_k, dim=-1)
+    routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.float()
+    selected_experts = selected_experts.to(torch.int32)
+
+    # FC1 weights — NON-GATED: [E, n, k] instead of [E, 2*n, k]
+    w1_bf16 = (
+        torch.randn(
+            num_local_experts,
+            intermediate_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 10
+    )
+    w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    w1_flat = w1_bf16.view(num_local_experts * intermediate_size, hidden_size)
+    w1_q_flat, w1_sf_flat = fp4_quantize(
+        w1_flat,
+        global_scale=w1_gs,
+        sf_vec_size=sf_vec_size,
+        is_sf_swizzled_layout=True,
+    )
+    w1_q = w1_q_flat.view(num_local_experts, intermediate_size, hidden_size // 2)
+    w1_weight_sf = convert_sf_to_mma_layout(
+        w1_sf_flat,
+        m=intermediate_size,
+        k=hidden_size,
+        num_groups=num_local_experts,
+        sf_vec_size=sf_vec_size,
+    )
+    w1_alpha = torch.ones(num_local_experts, device=device, dtype=torch.float32)
+
+    # FC2 weights — same shape as SiLU: [E, k, n]
+    w2_bf16 = (
+        torch.randn(
+            num_local_experts,
+            hidden_size,
+            intermediate_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 10
+    )
+    w2_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    w2_flat = w2_bf16.view(num_local_experts * hidden_size, intermediate_size)
+    w2_q_flat, w2_sf_flat = fp4_quantize(
+        w2_flat,
+        global_scale=w2_gs,
+        sf_vec_size=sf_vec_size,
+        is_sf_swizzled_layout=True,
+    )
+    w2_q = w2_q_flat.view(num_local_experts, hidden_size, intermediate_size // 2)
+    w2_weight_sf = convert_sf_to_mma_layout(
+        w2_sf_flat,
+        m=hidden_size,
+        k=intermediate_size,
+        num_groups=num_local_experts,
+        sf_vec_size=sf_vec_size,
+    )
+    w2_alpha = torch.ones(num_local_experts, device=device, dtype=torch.float32)
+    fc2_input_scale = torch.tensor([1.0], device=device, dtype=torch.float32)
+
+    return {
+        "x": x_quantized,
+        "x_sf": x_sf,
+        "x_bf16": x_bf16,
+        "token_selected_experts": selected_experts,
+        "token_final_scales": routing_weights,
+        "w1_weight": w1_q,
+        "w1_weight_sf": w1_weight_sf,
+        "w1_weight_bf16": w1_bf16,
+        "w1_alpha": w1_alpha,
+        "fc2_input_scale": fc2_input_scale,
+        "w2_weight": w2_q,
+        "w2_weight_sf": w2_weight_sf,
+        "w2_weight_bf16": w2_bf16,
+        "w2_alpha": w2_alpha,
+    }
+
+
+@cute_dsl_available
+@sm120_cuda13
+class TestRelu2Activation:
+    """Tests for ReLU2 activation (non-gated, Nemotron-Super)."""
+
+    @pytest.mark.parametrize(
+        "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
+    )
+    @pytest.mark.parametrize("top_k", [1, 2, 8])
+    @pytest.mark.parametrize("num_tokens", [2, 128, 512])
+    @pytest.mark.parametrize("num_experts", [256])
+    def test_relu2_functional_accuracy(
+        self,
+        num_tokens: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+    ):
+        """Accuracy test for ReLU2 via functional API."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        result = cute_dsl_fused_moe_nvfp4(
+            x=moe_input(tensors),
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_type="relu2",
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens})"
+        )
+
+    def test_relu2_wrapper_accuracy(self):
+        """Accuracy test for ReLU2 via wrapper API."""
+        from flashinfer import CuteDslMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+            activation_type="relu2",
+        )
+
+        result = moe.run(
+            x=moe_input(tensors),
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2 wrapper: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_relu2_micro_accuracy(self):
+        """Accuracy test for ReLU2 with micro kernel (small decode batch)."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+
+        num_tokens, hidden_size, intermediate_size = 2, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        result = cute_dsl_fused_moe_nvfp4(
+            x=moe_input(tensors),
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_type="relu2",
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2 micro: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_relu2_cuda_graph(self):
+        """Test ReLU2 with CUDA graph capture and replay."""
+        from flashinfer import CuteDslMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=True,
+            max_num_tokens=num_tokens,
+            activation_type="relu2",
+        )
+
+        # Warmup
+        for _ in range(3):
+            moe.run(
+                x=moe_input(tensors),
+                x_sf=tensors["x_sf"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+            )
+        torch.cuda.synchronize()
+
+        # Capture
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            output = moe.run(
+                x=moe_input(tensors),
+                x_sf=tensors["x_sf"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+            )
+        torch.cuda.synchronize()
+
+        assert output.shape == (num_tokens, hidden_size)
+
+        # Replay and verify
+        g.replay()
+        torch.cuda.synchronize()
+        assert not torch.isnan(output).any(), "NaN after ReLU2 CUDA graph replay"
+        assert not (output == 0).all(), "All zeros after ReLU2 CUDA graph replay"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1086,5 +1086,213 @@ class TestAllValidTactics:
         )
 
 
+# =============================================================================
+# Test Class: Micro Kernel (SM120-only, small decode batches)
+# =============================================================================
+
+sm120_cuda13 = pytest.mark.skipif(
+    not is_sm120_family() or not _has_cuda_13(),
+    reason="Requires SM120/SM121 GPU with CUDA 13+",
+)
+
+
+@cute_dsl_available
+@sm120_cuda13
+class TestMicroKernel:
+    """Tests for the micro kernel path (routed_rows <= 20-40).
+
+    The micro kernel is selected automatically when routed_rows is small.
+    These tests use num_tokens=1-4 to exercise the micro dispatch path,
+    including the all_rows_unique fast path (num_tokens=1).
+    """
+
+    @pytest.mark.parametrize("num_tokens", [1, 2, 4])
+    @pytest.mark.parametrize("top_k", [2, 8])
+    @pytest.mark.parametrize("num_experts", [256])
+    def test_micro_functional_accuracy(
+        self, num_tokens: int, top_k: int, num_experts: int
+    ):
+        """Accuracy test for micro kernel via functional API."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+
+        hidden_size, intermediate_size = 256, 512
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        result = cute_dsl_fused_moe_nvfp4(
+            x=moe_input(tensors),
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Micro kernel: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens}, top_k={top_k})"
+        )
+
+    def test_micro_wrapper_accuracy(self):
+        """Accuracy test for micro kernel via wrapper API."""
+        from flashinfer import CuteDslMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 2, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+        )
+
+        result = moe.run(
+            x=moe_input(tensors),
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Micro wrapper: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+    def test_micro_single_token_unique_path(self):
+        """Test the all_rows_unique fast path (num_tokens=1, top_k=8).
+
+        With 1 token and 8 experts, every expert has exactly 1 row.
+        The micro kernel detects this and uses O(1) work tile assignment.
+        """
+        from flashinfer import CuteDslMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 1, 256, 512
+        num_experts, top_k = 256, 8
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+        )
+
+        result = moe.run(
+            x=moe_input(tensors),
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+        )
+
+        assert result.shape == (1, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Micro unique path: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -38,8 +38,7 @@ from flashinfer.cute_dsl import is_cute_dsl_available
 def is_sm100_family():
     """Check for SM100 family (Blackwell: SM100, SM103).
 
-    CuteDSL MoE NVFP4 kernels on SM10x use cute_dsl_fused_moe_nvfp4 API.
-    SM120/121 tests are in test_b12x_fused_moe.py instead.
+    CuteDSL MoE NVFP4 kernels are optimized for SM10x architecture.
     """
     if not torch.cuda.is_available():
         return False
@@ -53,7 +52,7 @@ cute_dsl_available = pytest.mark.skipif(
 )
 sm100_required = pytest.mark.skipif(
     not is_sm100_family(),
-    reason="Requires SM100/SM103 GPU",
+    reason="Requires SM100 family GPU (Blackwell: SM100, SM103, SM110)",
 )
 
 
@@ -236,11 +235,10 @@ def create_moe_tensors(
         / 10
     )
 
-    # SM100/103: interleave gate/up for CuTe DSL SwiGLU epilogue (group_size=64)
-    w1_bf16_prepared = interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
+    w1_bf16_interleaved = interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
     w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
 
-    w1_flat = w1_bf16_prepared.view(
+    w1_flat = w1_bf16_interleaved.view(
         num_local_experts * 2 * intermediate_size, hidden_size
     )
     w1_q_flat, w1_sf_flat = fp4_quantize(

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1122,7 +1122,7 @@ class TestMicroKernel:
         self, num_tokens: int, top_k: int, num_experts: int
     ):
         """Accuracy test for micro kernel via functional API."""
-        from flashinfer import cute_dsl_fused_moe_nvfp4
+        from flashinfer import b12x_fused_moe
 
         hidden_size, intermediate_size = 256, 512
 
@@ -1135,11 +1135,8 @@ class TestMicroKernel:
             top_k=top_k,
         )
 
-        result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -1147,6 +1144,8 @@ class TestMicroKernel:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
             num_experts=num_experts,
             top_k=top_k,
         )
@@ -1177,7 +1176,7 @@ class TestMicroKernel:
 
     def test_micro_wrapper_accuracy(self):
         """Accuracy test for micro kernel via wrapper API."""
-        from flashinfer import CuteDslMoEWrapper
+        from flashinfer import B12xMoEWrapper
 
         num_tokens, hidden_size, intermediate_size = 2, 256, 512
         num_experts, top_k = 256, 2
@@ -1191,7 +1190,7 @@ class TestMicroKernel:
             top_k=top_k,
         )
 
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -1200,10 +1199,7 @@ class TestMicroKernel:
         )
 
         result = moe.run(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -1242,7 +1238,7 @@ class TestMicroKernel:
         With 1 token and 8 experts, every expert has exactly 1 row.
         The micro kernel detects this and uses O(1) work tile assignment.
         """
-        from flashinfer import CuteDslMoEWrapper
+        from flashinfer import B12xMoEWrapper
 
         num_tokens, hidden_size, intermediate_size = 1, 256, 512
         num_experts, top_k = 256, 8
@@ -1256,7 +1252,7 @@ class TestMicroKernel:
             top_k=top_k,
         )
 
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -1265,10 +1261,7 @@ class TestMicroKernel:
         )
 
         result = moe.run(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -1484,7 +1477,7 @@ class TestRelu2Activation:
         num_experts: int,
     ):
         """Accuracy test for ReLU2 via functional API."""
-        from flashinfer import cute_dsl_fused_moe_nvfp4
+        from flashinfer import b12x_fused_moe
 
         tensors = create_relu2_moe_tensors(
             num_tokens=num_tokens,
@@ -1495,11 +1488,8 @@ class TestRelu2Activation:
             top_k=top_k,
         )
 
-        result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -1507,9 +1497,11 @@ class TestRelu2Activation:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
             num_experts=num_experts,
             top_k=top_k,
-            activation_type="relu2",
+            activation="relu2",
         )
 
         assert result.shape == (num_tokens, hidden_size)
@@ -1538,7 +1530,7 @@ class TestRelu2Activation:
 
     def test_relu2_wrapper_accuracy(self):
         """Accuracy test for ReLU2 via wrapper API."""
-        from flashinfer import CuteDslMoEWrapper
+        from flashinfer import B12xMoEWrapper
 
         num_tokens, hidden_size, intermediate_size = 128, 256, 512
         num_experts, top_k = 256, 2
@@ -1552,20 +1544,17 @@ class TestRelu2Activation:
             top_k=top_k,
         )
 
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             use_cuda_graph=False,
-            activation_type="relu2",
+            activation="relu2",
         )
 
         result = moe.run(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -1600,7 +1589,7 @@ class TestRelu2Activation:
 
     def test_relu2_micro_accuracy(self):
         """Accuracy test for ReLU2 with micro kernel (small decode batch)."""
-        from flashinfer import cute_dsl_fused_moe_nvfp4
+        from flashinfer import b12x_fused_moe
 
         num_tokens, hidden_size, intermediate_size = 2, 256, 512
         num_experts, top_k = 256, 2
@@ -1614,11 +1603,8 @@ class TestRelu2Activation:
             top_k=top_k,
         )
 
-        result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
@@ -1626,9 +1612,11 @@ class TestRelu2Activation:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
             num_experts=num_experts,
             top_k=top_k,
-            activation_type="relu2",
+            activation="relu2",
         )
 
         assert result.shape == (num_tokens, hidden_size)
@@ -1656,7 +1644,7 @@ class TestRelu2Activation:
 
     def test_relu2_cuda_graph(self):
         """Test ReLU2 with CUDA graph capture and replay."""
-        from flashinfer import CuteDslMoEWrapper
+        from flashinfer import B12xMoEWrapper
 
         num_tokens, hidden_size, intermediate_size = 128, 256, 512
         num_experts, top_k = 256, 2
@@ -1670,23 +1658,20 @@ class TestRelu2Activation:
             top_k=top_k,
         )
 
-        moe = CuteDslMoEWrapper(
+        moe = B12xMoEWrapper(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             use_cuda_graph=True,
             max_num_tokens=num_tokens,
-            activation_type="relu2",
+            activation="relu2",
         )
 
         # Warmup
         for _ in range(3):
             moe.run(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
+                x=tensors["x_bf16"],
                 w1_weight=tensors["w1_weight"],
                 w1_weight_sf=tensors["w1_weight_sf"],
                 w1_alpha=tensors["w1_alpha"],
@@ -1694,6 +1679,8 @@ class TestRelu2Activation:
                 w2_weight=tensors["w2_weight"],
                 w2_weight_sf=tensors["w2_weight_sf"],
                 w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
             )
         torch.cuda.synchronize()
 
@@ -1701,10 +1688,7 @@ class TestRelu2Activation:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             output = moe.run(
-                x=moe_input(tensors),
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
+                x=tensors["x_bf16"],
                 w1_weight=tensors["w1_weight"],
                 w1_weight_sf=tensors["w1_weight_sf"],
                 w1_alpha=tensors["w1_alpha"],
@@ -1712,6 +1696,8 @@ class TestRelu2Activation:
                 w2_weight=tensors["w2_weight"],
                 w2_weight_sf=tensors["w2_weight_sf"],
                 w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
             )
         torch.cuda.synchronize()
 

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -36,29 +36,15 @@ from flashinfer.cute_dsl import is_cute_dsl_available
 
 
 def is_sm100_family():
-    """Check for SM100 family (Blackwell: SM100, SM103) or SM120 family (SM120, SM121).
+    """Check for SM100 family (Blackwell: SM100, SM103).
 
-    CuteDSL MoE NVFP4 kernels support SM10x and SM12x architectures.
+    CuteDSL MoE NVFP4 kernels on SM10x use cute_dsl_fused_moe_nvfp4 API.
+    SM120/121 tests are in test_b12x_fused_moe.py instead.
     """
     if not torch.cuda.is_available():
         return False
     props = torch.cuda.get_device_properties(0)
-    return props.major in (10, 12)
-
-
-def is_sm120_family():
-    """Check for SM120 family (SM120, SM121)."""
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(0)
-    return props.major == 12
-
-
-def _has_cuda_13():
-    """Check if CUDA runtime version is 13+."""
-    return (
-        torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 13
-    )
+    return props.major == 10
 
 
 # Skip decorators
@@ -66,22 +52,9 @@ cute_dsl_available = pytest.mark.skipif(
     not is_cute_dsl_available(), reason="CuteDSL not available"
 )
 sm100_required = pytest.mark.skipif(
-    not is_sm100_family() or is_sm120_family(),
-    reason="Requires SM100/SM103 GPU (SM120 uses b12x_fused_moe API instead)",
+    not is_sm100_family(),
+    reason="Requires SM100/SM103 GPU",
 )
-sm100_only = pytest.mark.skipif(
-    is_sm120_family() or not is_sm100_family(),
-    reason="Requires SM100 family GPU (SM100-specific features)",
-)
-
-
-def moe_input(tensors: dict) -> torch.Tensor:
-    """Return the correct x tensor for the current architecture.
-
-    SM100/103 expects pre-quantized FP4; SM120/121 expects bf16
-    (the kernel fuses quantization internally).
-    """
-    return tensors["x_bf16"] if is_sm120_family() else tensors["x"]
 
 
 def silu(x: torch.Tensor) -> torch.Tensor:
@@ -264,11 +237,7 @@ def create_moe_tensors(
     )
 
     # SM100/103: interleave gate/up for CuTe DSL SwiGLU epilogue (group_size=64)
-    # SM120/121: no interleave — kernel expects [up_0:N, gate_0:N] (contiguous cat)
-    if is_sm120_family():
-        w1_bf16_prepared = w1_bf16  # b12x kernel: non-interleaved
-    else:
-        w1_bf16_prepared = interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
+    w1_bf16_prepared = interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
     w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
 
     w1_flat = w1_bf16_prepared.view(
@@ -396,7 +365,7 @@ class TestCuteDslFusedMoeFunctional:
         )
 
         result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
+            x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
@@ -455,7 +424,7 @@ class TestCuteDslFusedMoeFunctional:
 
         with autotune(True):
             result = cute_dsl_fused_moe_nvfp4(
-                x=moe_input(tensors),
+                x=tensors["x"],
                 x_sf=tensors["x_sf"],
                 token_selected_experts=tensors["token_selected_experts"],
                 token_final_scales=tensors["token_final_scales"],
@@ -512,7 +481,7 @@ class TestCuteDslMoEWrapper:
         )
 
         result = moe.run(
-            x=moe_input(tensors),
+            x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
@@ -579,7 +548,7 @@ class TestCuteDslMoEWrapper:
         # Warmup
         for _ in range(3):
             moe.run(
-                x=moe_input(tensors),
+                x=tensors["x"],
                 x_sf=tensors["x_sf"],
                 token_selected_experts=tensors["token_selected_experts"],
                 token_final_scales=tensors["token_final_scales"],
@@ -597,7 +566,7 @@ class TestCuteDslMoEWrapper:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             output = moe.run(
-                x=moe_input(tensors),
+                x=tensors["x"],
                 x_sf=tensors["x_sf"],
                 token_selected_experts=tensors["token_selected_experts"],
                 token_final_scales=tensors["token_final_scales"],
@@ -683,7 +652,7 @@ class TestCuteDslMoEWrapper:
 
         with autotune(True):
             result = moe.run(
-                x=moe_input(tensors),
+                x=tensors["x"],
                 x_sf=tensors["x_sf"],
                 token_selected_experts=tensors["token_selected_experts"],
                 token_final_scales=tensors["token_final_scales"],
@@ -747,7 +716,7 @@ class TestApiConsistency:
 
         # Functional API
         result_functional = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
+            x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
@@ -772,7 +741,7 @@ class TestApiConsistency:
         )
 
         result_wrapper = moe.run(
-            x=moe_input(tensors),
+            x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
@@ -804,7 +773,7 @@ class TestApiConsistency:
 
 
 @cute_dsl_available
-@sm100_only
+@sm100_required
 class TestExpertParallelism:
     """Tests for expert parallelism (EP) configurations."""
 
@@ -850,7 +819,7 @@ class TestExpertParallelism:
         )
 
         result = moe.run(
-            x=moe_input(tensors),
+            x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=token_selected_experts,
             token_final_scales=tensors["token_final_scales"],
@@ -913,7 +882,7 @@ class TestExpertParallelism:
         )
 
         result = cute_dsl_fused_moe_nvfp4(
-            x=moe_input(tensors),
+            x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
@@ -964,7 +933,7 @@ class TestExpertParallelism:
 
 
 @cute_dsl_available
-@sm100_only
+@sm100_required
 class TestAllValidTactics:
     """Test that every tactic returned by get_valid_tactics produces correct output.
 
@@ -1047,7 +1016,7 @@ class TestAllValidTactics:
         for tactic in valid_tactics:
             tile_size = tactic[0]
             result = moe.run(
-                x=moe_input(tensors),
+                x=tensors["x"],
                 x_sf=tensors["x_sf"],
                 token_selected_experts=tensors["token_selected_experts"],
                 token_final_scales=tensors["token_final_scales"],

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1090,9 +1090,18 @@ class TestAllValidTactics:
 # Test Class: Micro Kernel (SM120-only, small decode batches)
 # =============================================================================
 
+
+def _is_sm12x_supported():
+    """Check SM120/SM121 support using repo-standard utility checks."""
+    from flashinfer.utils import is_sm120a_supported, is_sm121a_supported
+
+    device = torch.device("cuda")
+    return is_sm120a_supported(device) or is_sm121a_supported(device)
+
+
 sm120_cuda13 = pytest.mark.skipif(
-    not is_sm120_family() or not _has_cuda_13(),
-    reason="Requires SM120/SM121 GPU with CUDA 13+",
+    not _is_sm12x_supported(),
+    reason="Requires SM120/SM121 GPU with CUDA 12.8+",
 )
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

### Summary

 New SM120/SM121 MoE APIs (`b12x_fused_moe`, `B12xMoEWrapper`) with: 
 - **Micro kernel** for tiny decode batches (≤20-40 routed rows) on SM120/SM121, with Triton routing compaction pre-pass and MAC tuning ladder
- **ReLU2 activation** (`max(0,x)²`) for non-gated MoE (Nemotron-Super) across all three SM120 kernel backends (micro, static, dynamic)                                  
- **Benchmark ReLU2 support** for both `cutlass_fused_moe` and `cute_dsl_fp4_block_scale_moe` routines, with corrected TFLOPS/bandwidth calculations for non-gated activations
- Clean API separation: SM120 uses `b12x_fused_moe`, SM100 keeps `cute_dsl_fused_moe_nvfp4`

### API separation                                                                                                                                 
                                                                                                                                                    
| GPU | Functional API | Wrapper API |                                                  
|-----|---------------|-------------|  
| SM100/SM103 | `cute_dsl_fused_moe_nvfp4` (FP4 input) | `CuteDslMoEWrapper` |
| SM120/SM121 | `b12x_fused_moe` (bf16 input) | `B12xMoEWrapper` |                                                                                
                                                                                                                                                    
The SM100 APIs (`cute_dsl_fused_moe_nvfp4`, `CuteDslMoEWrapper`) are restored to SM100-only scope — no SM120 dispatch, no `activation_type` parameter.  

### Micro kernel

Ported from b12x. Selected automatically when `routed_rows ≤ 20` (top_k=1) or `≤ 40` (top_k>1). Key optimizations vs the static kernel:
- **Triton compact pre-pass**: remaps global expert IDs to dense local indices, eliminating CAS-based expert discovery inside the kernel
- **`all_rows_unique` fast path**: when `num_tokens=1` and every expert is unique, skips atomic row counting and uses O(1) work-tile assignment
- **MAC tuning ladder**: per-routed-row optimal cluster counts from b12x decode profiling, capped against hardware SM count to prevent deadlocks                                                                                

### ReLU2 activation                                                                                                                                 
Added `activation` parameter (`"silu"` default, `"relu2"`) to all SM120 kernel classes via `self.is_gated` compile-time branching (`cutlass.const_expr`):
- **Storage**: `StorageGated` (3 pipelines, gate+up buffers) vs `StorageRelu2` (2 pipelines, single FC1 buffer)
- **FC1**: dual GEMM (gate+up) for SiLU vs single GEMM for ReLU2
- **Activation**: `silu(gate) * up` vs `relu(x)²`
- **DMA**: up-projection TMA loads eliminated for ReLU2
                                                                                                                                                    
Exposed through `activation_type` parameter on `CuteDslMoEWrapper` and `cute_dsl_fused_moe_nvfp4` APIs.  

### API usage

#### Functional                                                                                                                                    
```python                                                                               
from flashinfer import b12x_fused_moe  

output = b12x_fused_moe(
    x=hidden_states_bf16,       # bf16 input (kernel fuses quantization)                                                                          
    w1_weight=w1_fp4, w1_weight_sf=w1_sf, w1_alpha=w1_alpha,                                                                                      
    fc2_input_scale=fc2_scale,                                                                                                                    
    w2_weight=w2_fp4, w2_weight_sf=w2_sf, w2_alpha=w2_alpha,                                                                                      
    token_selected_experts=topk_ids,                                                                                                              
    token_final_scales=topk_weights,                                                                                                              
    num_experts=512, top_k=22,                                                                                                                    
    activation="relu2",  # or "silu" (default)                                                                                                    
)                                                                                                                                                 
```                                                                                                                                               

### Wrapper (CUDA graph compatible)                                                     
```python                              
from flashinfer import B12xMoEWrapper

moe = B12xMoEWrapper(                                                                                                                             
    num_experts=512, top_k=22,
    hidden_size=1024, intermediate_size=2688,                                                                                                     
    use_cuda_graph=True, activation="relu2",                                            
)                                                                                                                                                 
output = moe.run(x=hidden_states_bf16, ...)
```                               

#### Example micro benchmarks

```
# b12x cute dsl MoE for 1-token Nemotron 3 Super Size
python benchmarks/flashinfer_benchmark.py --routine cute_dsl_fp4_block_scale_moe --activation-type Relu2 --num_tokens 1 --hidden_size 1024 --intermediate_size 2688 --num_experts 512 --top_k 22 --use_cuda_events --num_iters 50
# Equivalent cutlass_fused_moe benchmark
python benchmarks/flashinfer_benchmark.py --routine cutlass_fused_moe --cutlass_variant nvfp4 --activation-type Relu2 --num_tokens 1 --hidden_size 1024 --intermediate_size 2688 --num_experts 512 --top_k 22 --quantized_input --use_cuda_events --num_iters 50
```

## 🔍 Related Issues

<!-- Link any related issues here -->

#3013

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non‑gated ReLU2 activation and dual gated/non‑gated FC1 layouts for MoE; activation selectable at runtime.
  * New micro‑kernel backend plus routing‑ID compaction for improved single‑token/small‑batch performance.
  * SM12x (b12x) fused‑MoE functional API and CUDA‑graph‑friendly wrapper exported for SM12x workflows; runtime maps activations to kernel implementations.
  * CuTe‑DSL helpers added to support ReLU2 + FP4 quantization.

* **Tests**
  * End‑to‑end tests for ReLU2, gated vs non‑gated flows, micro‑kernel paths, CUDA graph replay, and FP4 numerical agreement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->