### PR TITLE
fix: guard MXFP8 fc1 weight shape check for non-gated activations

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -890,18 +890,19 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       CHECK_DIM(1, fc1_global);
       CHECK_DIM(3, fc2_weight_block);
       CHECK_DIM(1, fc2_global);
+      int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  2 &&
+                  fc1_n_mult &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // 4 "
-             "// block_scale_vector_size)";
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size"
+          << (fc1_n_mult == 2 ? " * 2" : "") << ", hidden_size // 4 // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
       TVM_FFI_ICHECK(
@@ -997,18 +998,19 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       CHECK_DIM(3, fc2_weight_block);
       CHECK_DIM(1, fc2_global);
       // Check shapes
+      int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  2 &&
+                  fc1_n_mult &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // 4 "
-             "// block_scale_vector_size)";
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size"
+          << (fc1_n_mult == 2 ? " * 2" : "") << ", hidden_size // 4 // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
       TVM_FFI_ICHECK(fc2_act_global.ndim() == 0 || fc2_act_global.size(0) == num_experts_on_rank)
@@ -1056,18 +1058,19 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       CHECK_DIM(1, fc1_global);
       CHECK_DIM(3, fc2_weight_block);
       CHECK_DIM(1, fc2_global);
+      int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
           fc1_weight_block.size(1) ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX) *
-                  2 &&
+                  fc1_n_mult &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX))
-          << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // 4 "
-             "// block_scale_vector_size)";
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size"
+          << (fc1_n_mult == 2 ? " * 2" : "") << ", hidden_size // 4 // block_scale_vector_size)";
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";
       TVM_FFI_ICHECK(


### PR DESCRIPTION
Fixes #2731.

## What's broken?

When using the CUTLASS fused MoE backend with **non-gated activations** (e.g., Relu2, Gelu, Silu) and MXFP8 quantization, the fc1 weight shape validation unconditionally rejects the input — even when the shape is correct.

## Who is affected?

Anyone using the **CUTLASS fused MoE** path with:
- **Quantization**: `WMxfp8AMxfp8`, `WMxfp4AFp8`, or `WMxfp4AMxfp8`
- **Activation**: any non-gated type (Relu2, Gelu, Silu, etc.)

Not affected: gated activations (Swiglu, Geglu, SwigluBias), or other quant modes (NVFP4 already handles this correctly).

## Where is the bug?

`csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu`, inside `getQuantParams()` — the fc1 weight block N-dimension check hardcodes `* 2` at three MXFP8 branches (~L898, ~L1004, ~L1063).

## Why does it happen?

PR #2581 introduced MXFP8 support when only gated activations (Swiglu) existed, so `inter_size * 2` was correct. Later, non-gated activation support was added to the trtllm-gen backend (PR #2707), but the CUTLASS backend's validation was never updated. The NVFP4 path in the same file (line ~1131) already handles this correctly with an `if (isGatedActivation(...))` guard.

## How did we fix it?

For each of the 3 MXFP8 quant branches:
1. Extract `int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;`
2. Replace the hardcoded `* 2` with `* fc1_n_mult`
3. Update error messages: gated shows `"inter_size * 2"`, non-gated shows `"inter_size"`

**Before:**
```cpp
fc1_weight_block.size(1) == alignToSfDim(inter_size, ...) * 2
```

**After:**
```cpp
int const fc1_n_mult = isGatedActivation(base_activation_type) ? 2 : 1;
fc1_weight_block.size(1) == alignToSfDim(inter_size, ...) * fc1_n_mult
```

## How do we know it works?

- `pre-commit run` passes (clang-format, lint, etc.)
- Gated activations (default Swiglu): `fc1_n_mult = 2` — identical to old behavior, no regression
- Non-gated activations: `fc1_n_mult = 1` — shape check now accepts correct `inter_size` dimension
- Full GPU test suite requires CI (`@flashinfer-bot run`)

## Related

- Builds on the approach identified in #2753 (stale ~27 days, CI unresolved).
- Addresses the Gemini review feedback from #2753 by extracting the multiplier to a local variable before the validation checks.

cc @aleozlx @nv-yunzheq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weight block size validation for Mixture of Experts (MOE) to correctly handle both gated and non-gated activation types, ensuring proper support across different activation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->