### PR TITLE
Fix routing_bias dtype handling in Python MoE wrappers

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2333,6 +2333,8 @@ def trtllm_bf16_moe(
         when do_finalize=True, returns the final MoE output.
         otherwise, returns the intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype != torch.bfloat16:
+        routing_bias = routing_bias.to(torch.bfloat16)
     result = get_trtllm_moe_sm100_module().trtllm_bf16_moe(
         routing_logits,
         routing_bias,
@@ -2533,6 +2535,8 @@ def trtllm_fp8_per_tensor_scale_moe(
         when do_finalize=True, returns the final MoE output.
         otherwise, returns the intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype not in (torch.bfloat16, torch.float32):
+        routing_bias = routing_bias.to(torch.bfloat16)
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_tensor_scale_moe(
         routing_logits,
         routing_bias,
@@ -2638,6 +2642,8 @@ def trtllm_fp8_block_scale_moe(
         when do_finalize=True, returns the final MoE output.
         otherwise, returns the intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype not in (torch.bfloat16, torch.float32):
+        routing_bias = routing_bias.to(torch.bfloat16)
     output = torch.empty(
         hidden_states.shape, dtype=torch.bfloat16, device=hidden_states.device
     )
@@ -2755,6 +2761,8 @@ def trtllm_fp8_block_scale_routed_moe(
         when do_finalize=True, returns the final MoE output.
         otherwise, returns the intermediate results (gemm2_output, undefined, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype not in (torch.bfloat16, torch.float32):
+        routing_bias = routing_bias.to(torch.bfloat16)
     result = get_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
         None,  # routing_logits
         topk_ids,
@@ -2892,6 +2900,8 @@ def trtllm_fp4_block_scale_moe(
         List[torch.Tensor]: List of output tensors. If do_finalize=True, returns the final MoE output.
             Otherwise, returns intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype not in (torch.bfloat16, torch.float32):
+        routing_bias = routing_bias.to(torch.bfloat16)
     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
         routing_logits,
         None,
@@ -3027,6 +3037,8 @@ def trtllm_fp4_block_scale_routed_moe(
         List[torch.Tensor]: List of output tensors. If do_finalize=True, returns the final MoE output.
             Otherwise, returns intermediate results (gemm2_output, undefined, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype not in (torch.bfloat16, torch.float32):
+        routing_bias = routing_bias.to(torch.bfloat16)
     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
         None,
         topk_ids,
@@ -3137,6 +3149,8 @@ def trtllm_mxint4_block_scale_moe(
         List[torch.Tensor]: List of output tensors. If do_finalize=True, returns the final MoE output.
             Otherwise, returns intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) that need further processing.
     """
+    if routing_bias is not None and routing_bias.dtype != torch.bfloat16:
+        routing_bias = routing_bias.to(torch.bfloat16)
     return get_trtllm_moe_sm100_module().trtllm_mxint4_block_scale_moe(
         routing_logits,
         routing_bias,

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -4092,6 +4092,7 @@ def test_tier_1024_experts_routing(
     [
         pytest.param(None, id="default_bias"),
         pytest.param(torch.float32, id="FP32_bias"),
+        pytest.param(torch.float16, id="FP16_bias"),
     ],
 )
 def test_routing_dtype_flexibility(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Auto-cast `routing_bias` to `torch.bfloat16` in the Python-level MoE wrapper
functions before passing to the C++ kernel. Fixes #2909.

### Problem

The TRT-LLM routing kernels assume `routing_bias` has a specific dtype. When
callers (e.g., vLLM) pass `routing_bias` in an incompatible dtype (such as
`float16`), the C++ layer either crashes or produces garbage output. This was
reported with `NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` and
`Nemotron-3-Nano-30B-A3B-FP8` served via vLLM.

While the C++ routing kernel was refactored in #2803 to correctly handle both
`bfloat16` and `float32` via type-erased `void const*` + `loadScalar()` runtime
dispatch, the Python wrapper functions had no dtype validation or auto-casting,
leaving incompatible dtypes (e.g., `float16`) to reach C++ unchecked.

### Fix

Add a dtype auto-cast guard in each public wrapper that accepts `routing_bias`:

**bf16-only paths** (`trtllm_bf16_moe`, `trtllm_mxint4_block_scale_moe`):
```python
if routing_bias is not None and routing_bias.dtype != torch.bfloat16:
    routing_bias = routing_bias.to(torch.bfloat16)
```

**bf16+fp32 paths** (fp8/fp4 variants):
```python
if routing_bias is not None and routing_bias.dtype not in (torch.bfloat16, torch.float32):
    routing_bias = routing_bias.to(torch.bfloat16)
```

This is a **defense-in-depth** complement to #2803 — it ensures correctness
even when incompatible dtypes are passed from upstream frameworks.

### Impact

- Zero-cost when `routing_bias` is already the correct dtype (`.to()` is a
  no-op on matching dtype)
- Preserves `float32` on paths that natively support it (fp4/fp8 block scale)
- Only casts unsupported dtypes (e.g., `float16`, `float64`)
- Small 1-file Python change, no C++ modifications

## 🔍 Related Issues

- Fixes #2909
- Complements #2803 (C++ routing refactor by @ChristinaZ)

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] Added `torch.float16` routing bias to `test_routing_dtype_flexibility` parametrize to exercise the auto-cast path.

### Tested

- `py_compile` + `ruff check` passed on both changed files
- Full `pytest` for MoE tests requires GPU — will be validated by CI

## Reviewer Notes

cc @ChristinaZ @aleozlx @jiahanc

This is a small Python-only change (2 files, 15 lines added). The auto-cast
preserves `float32` on paths that support it and only casts truly incompatible
dtypes to `bfloat16`. Would appreciate a quick review to confirm alignment
with the routing refactor direction in #2803.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved dtype normalization for MoE routing parameters across multiple precision formats to ensure consistent behavior and prevent compatibility issues when using different precision inputs.

## Tests
* Expanded test coverage to validate routing parameter dtype flexibility, adding support for additional input precision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->