### PR TITLE
Add int8 paged KV support to main paths

### DIFF
--- a/csrc/page.cu
+++ b/csrc/page.cu
@@ -90,7 +90,7 @@ void append_paged_kv_cache(TensorView append_key, TensorView append_value, Tenso
 
   ffi::CUDADeviceGuard device_guard(append_key.device().device_id);
   const cudaStream_t stream = get_stream(append_key.device());
-  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE(paged_k_cache.dtype(), c_type, [&] {
+  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_QKV(paged_k_cache.dtype(), c_type, [&] {
     paged_kv_t<c_type, int32_t> paged_kv(
         num_heads, page_size, head_dim, batch_size, kv_layout,
         static_cast<c_type*>(paged_k_cache.data_ptr()),

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -53,6 +53,7 @@ constexpr int64_t float16_code = encode_dlpack_dtype(dl_float16);
 constexpr int64_t bfloat16_code = encode_dlpack_dtype(dl_bfloat16);
 constexpr int64_t float32_code = encode_dlpack_dtype(dl_float32);
 constexpr int64_t uint8_code = encode_dlpack_dtype(dl_uint8);
+constexpr int64_t int8_code = encode_dlpack_dtype(dl_int8);
 constexpr int64_t int32_code = encode_dlpack_dtype(dl_int32);
 constexpr int64_t int64_code = encode_dlpack_dtype(dl_int64);
 constexpr int64_t float8_e4m3fn_code = encode_dlpack_dtype(dl_float8_e4m3fn);
@@ -114,6 +115,12 @@ constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
   case int32_code: {                    \
     using c_type = int32_t;             \
     return __VA_ARGS__();               \
+  }
+
+#define _DISPATCH_CASE_I8(c_type, ...) \
+  case int8_code: {                    \
+    using c_type = int8_t;             \
+    return __VA_ARGS__();              \
   }
 
 #define _DISPATCH_CASE_I64(c_type, ...) \
@@ -240,6 +247,22 @@ constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
 #define DISPATCH_DLPACK_DTYPE_TO_CTYPE(dlpack_dtype, c_type, ...)                        \
   [&]() -> bool {                                                                        \
     switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP4_E2M1(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_QKV(dlpack_dtype, c_type, ...)                    \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_I8(c_type, __VA_ARGS__)                                             \
       _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
       _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
       _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1344,7 +1344,11 @@ def single_prefill_with_kv_cache(
 
     if scale_v is not None and backend != "fa3":
         # TODO(Zihao): fused into kernel
-        if out.itemsize == 1:
+        if out.dtype in (
+            torch.int8,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        ):
             out = (out.to(float) * scale_v).to(out.dtype)
         else:
             out *= scale_v

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -90,6 +90,58 @@ def _split_scale_param(scale):
         return None, float(scale)
 
 
+def _normalize_non_fp8_scalar_scale(
+    scale: Optional[Union[float, torch.Tensor]], scale_name: str
+) -> Optional[float]:
+    """Normalize scalar scales used by non-FP8 prefill paths.
+
+    Non-FA3 prefill kernels accept ``sm_scale`` as a scalar. Allow Python floats and
+    0-dim / 1-element tensors for convenience, but reject per-head tensors here.
+    """
+    if scale is None:
+        return None
+    if isinstance(scale, torch.Tensor):
+        if scale.numel() != 1:
+            raise TypeError(
+                f"{scale_name} must be a scalar for non-FP8 single prefill."
+            )
+        return float(scale.item())
+    return float(scale)
+
+
+def _apply_non_fa3_scale_v(
+    out: torch.Tensor, scale_v: Optional[Union[float, torch.Tensor]]
+) -> torch.Tensor:
+    """Apply value scaling on non-FA3 prefill outputs.
+
+    For GQA/MQA, a per-kv-head ``scale_v`` tensor must be expanded to the number of
+    query heads before broadcasting over ``out``.
+    """
+    if scale_v is None:
+        return out
+
+    scale_v_factor: Union[float, torch.Tensor]
+    if isinstance(scale_v, torch.Tensor):
+        scale_v_tensor = scale_v
+        if scale_v_tensor.ndim != 1:
+            raise ValueError("scale_v tensor must be 1D.")
+        num_qo_heads = out.shape[1]
+        num_kv_heads = scale_v_tensor.shape[0]
+        if num_qo_heads % num_kv_heads != 0:
+            raise ValueError("num_qo_heads must be a multiple of num_kv_heads.")
+        if num_qo_heads != num_kv_heads:
+            scale_v_tensor = scale_v_tensor.repeat_interleave(
+                num_qo_heads // num_kv_heads
+            )
+        scale_v_factor = scale_v_tensor.view(1, -1, 1)
+    else:
+        scale_v_factor = float(scale_v)
+
+    if out.dtype in (torch.int8, torch.float8_e4m3fn, torch.float8_e5m2):
+        return (out.to(torch.float32) * scale_v_factor).to(out.dtype)
+    return out * scale_v_factor
+
+
 def _create_scale_bmm2_d_tensor(
     scale_bmm2: float, data_dtype: torch.dtype, device: torch.device
 ) -> torch.Tensor:
@@ -1287,9 +1339,9 @@ def single_prefill_with_kv_cache(
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
     else:
         if scale_q is not None:
-            sm_scale *= scale_q
+            sm_scale *= _normalize_non_fp8_scalar_scale(scale_q, "scale_q")
         if scale_k is not None:
-            sm_scale *= scale_k
+            sm_scale *= _normalize_non_fp8_scalar_scale(scale_k, "scale_k")
 
     if backend == "auto":
         backend = determine_attention_backend(
@@ -1344,14 +1396,7 @@ def single_prefill_with_kv_cache(
 
     if scale_v is not None and backend != "fa3":
         # TODO(Zihao): fused into kernel
-        if out.dtype in (
-            torch.int8,
-            torch.float8_e4m3fn,
-            torch.float8_e5m2,
-        ):
-            out = (out.to(float) * scale_v).to(out.dtype)
-        else:
-            out *= scale_v
+        out = _apply_non_fa3_scale_v(out, scale_v)
 
     return (out, lse) if return_lse else out
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1342,7 +1342,7 @@ def single_prefill_with_kv_cache(
         rope_theta,
     )
 
-    if scale_v is not None:
+    if scale_v is not None and backend != "fa3":
         # TODO(Zihao): fused into kernel
         if out.itemsize == 1:
             out = (out.to(float) * scale_v).to(out.dtype)

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1285,6 +1285,11 @@ def single_prefill_with_kv_cache(
             scale_k = torch.ones(k.shape[1], dtype=torch.float32, device=q.device)
         if scale_v is None:
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
+    else:
+        if scale_q is not None:
+            sm_scale *= scale_q
+        if scale_k is not None:
+            sm_scale *= scale_k
 
     if backend == "auto":
         backend = determine_attention_backend(
@@ -1336,6 +1341,13 @@ def single_prefill_with_kv_cache(
         rope_scale,
         rope_theta,
     )
+
+    if scale_v is not None:
+        # TODO(Zihao): fused into kernel
+        if out.itemsize == 1:
+            out = (out.to(float) * scale_v).to(out.dtype)
+        else:
+            out *= scale_v
 
     return (out, lse) if return_lse else out
 

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -420,6 +420,10 @@ def is_fa3_backend_supported(
         torch.float8_e5m2,
     }:
         return False
+    # Int8 KV is supported by the common/fa2 path, but not by the current FA3 path.
+    # Keep Hopper functional support by falling back to fa2 in auto mode.
+    if dtype_kv == torch.int8:
+        return False
     return True
 
 

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -1887,9 +1887,7 @@ struct vec_t<int8_t, 1> {
   int8_t data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);
@@ -1924,9 +1922,7 @@ struct vec_t<int8_t, 2> {
   uint16_t data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);
@@ -1966,9 +1962,7 @@ struct vec_t<int8_t, 4> {
   uint32_t data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);
@@ -2008,9 +2002,7 @@ struct vec_t<int8_t, 8> {
   uint2 data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -1879,6 +1879,248 @@ struct vec_t<uint8_t, vec_size> {
   }
 };
 
+/******************* vec_t<int8_t> *******************/
+
+// int8_t x 1
+template <>
+struct vec_t<int8_t, 1> {
+  int8_t data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::fill(int8_t val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::load(const int8_t* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::store(int8_t* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::memcpy(int8_t* dst, const int8_t* src) { *dst = *src; }
+
+// int8_t x 2
+template <>
+struct vec_t<int8_t, 2> {
+  uint16_t data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::fill(int8_t val) {
+  uint8_t byte = static_cast<uint8_t>(val);
+  data = (uint16_t(byte) << 8) | uint16_t(byte);
+}
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::load(const int8_t* ptr) { data = *((uint16_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::store(int8_t* ptr) const { *((uint16_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::memcpy(int8_t* dst, const int8_t* src) {
+  *((uint16_t*)dst) = *((uint16_t*)src);
+}
+
+// int8_t x 4
+template <>
+struct vec_t<int8_t, 4> {
+  uint32_t data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::fill(int8_t val) {
+  uint32_t byte = static_cast<uint8_t>(val);
+  data = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+}
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::load(const int8_t* ptr) { data = *((uint32_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::store(int8_t* ptr) const { *((uint32_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::memcpy(int8_t* dst, const int8_t* src) {
+  *((uint32_t*)dst) = *((uint32_t*)src);
+}
+
+// int8_t x 8
+template <>
+struct vec_t<int8_t, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::fill(int8_t val) {
+  uint32_t byte = static_cast<uint8_t>(val);
+  uint32_t val32 = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+  data.x = val32;
+  data.y = val32;
+}
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::load(const int8_t* ptr) { data = *((uint2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::store(int8_t* ptr) const { *((uint2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::memcpy(int8_t* dst, const int8_t* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// int8_t x 16 or more
+template <size_t vec_size>
+struct vec_t<int8_t, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)data)[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)data)[i]; }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val) {
+    uint32_t byte = static_cast<uint8_t>(val);
+    uint32_t val32 = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i].x = val32;
+      data[i].y = val32;
+      data[i].z = val32;
+      data[i].w = val32;
+    }
+  }
+  FLASHINFER_INLINE void load(const int8_t* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(int8_t* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(int8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(int8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(int8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(int8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
 /******************* vec_t<float> *******************/
 
 // float x 1

--- a/tests/attention/test_hopper_fp8_attention.py
+++ b/tests/attention/test_hopper_fp8_attention.py
@@ -172,6 +172,59 @@ def test_single_prefill(seq_len, num_heads, causal, head_dim, dtype):
     assert mse < 1.0, f"MSE too high: {mse.item()}"
 
 
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_single_prefill_scale_v_is_not_double_applied(dtype):
+    if not is_sm90a_supported(torch.device("cuda")):
+        pytest.skip("SM90A is not supported")
+
+    seq_len = 257
+    num_heads = 8
+    head_dim = 128
+
+    q = torch.randn(seq_len, num_heads, head_dim, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, num_heads, head_dim, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, num_heads, head_dim, dtype=torch.half, device="cuda")
+
+    q_fp8, s_q = per_head_symmetric_quant(q, quant_dtype=dtype)
+    k_fp8, s_k = per_head_symmetric_quant(k, quant_dtype=dtype)
+    v_fp8, s_v = per_head_symmetric_quant(v, quant_dtype=dtype)
+
+    q_ref = (q_fp8.to(torch.float16) * s_q.view(1, -1, 1)).to(torch.float16)
+    k_ref = (k_fp8.to(torch.float16) * s_k.view(1, -1, 1)).to(torch.float16)
+    v_ref = (v_fp8.to(torch.float16) * s_v.view(1, -1, 1)).to(torch.float16)
+
+    out = flashinfer.single_prefill_with_kv_cache(
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        s_q,
+        s_k,
+        s_v,
+        causal=False,
+        backend="fa3",
+        o_dtype=torch.half,
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q_ref,
+        k_ref,
+        v_ref,
+        causal=False,
+        backend="fa3",
+    )
+    out_wrong = flashinfer.single_prefill_with_kv_cache(
+        q_ref,
+        k_ref,
+        (v_ref * s_v.view(1, -1, 1)).to(torch.float16),
+        causal=False,
+        backend="fa3",
+    )
+
+    mse_correct = torch.mean((out.float() - out_ref.float()) ** 2)
+    mse_wrong = torch.mean((out.float() - out_wrong.float()) ** 2)
+
+    assert mse_correct < mse_wrong * 0.25
+
+
 # Test block sparse attention correctness: MSE should be below threshold
 @pytest.mark.parametrize("R", [1, 4, 16])
 @pytest.mark.parametrize("C", [1, 4, 16])

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -27,7 +27,7 @@ from tests.test_helpers.jit_utils import (
 
 
 def _require_sm80_or_newer() -> None:
-    major, _ = torch.cuda.get_device_capability(0)
+    major, _ = flashinfer_utils.get_compute_capability(torch.device("cuda"))
     if major < 8:
         pytest.skip("int8 paged-kv coverage requires sm80 or newer")
 

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -1,0 +1,408 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer import utils as flashinfer_utils
+from flashinfer.utils import PosEncodingMode, has_flashinfer_jit_cache
+from tests.test_helpers.jit_utils import (
+    gen_decode_attention_modules,
+    gen_prefill_attention_modules,
+)
+
+
+def _require_sm80_or_newer() -> None:
+    major, _ = torch.cuda.get_device_capability(0)
+    if major < 8:
+        pytest.skip("int8 paged-kv coverage requires sm80 or newer")
+
+
+@pytest.fixture(
+    autouse=not has_flashinfer_jit_cache(),
+    scope="module",
+)
+def warmup_jit():
+    _require_sm80_or_newer()
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],
+            [torch.int8],
+            [128],
+            [0],
+            [False],
+            [False],
+        )
+        + gen_prefill_attention_modules(
+            [torch.float16],
+            [torch.int8],
+            [128],
+            [0],
+            [False],
+            [False],
+            [False],
+        ),
+        verbose=False,
+    )
+    yield
+
+
+def test_append_paged_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    nnz_kv = 12
+    num_kv_heads = 4
+    head_dim = 128
+    page_size = 4
+
+    k_append = torch.randint(
+        -16, 16, (nnz_kv, num_kv_heads, head_dim), dtype=torch.int8, device="cuda:0"
+    )
+    v_append = torch.randint(
+        -16, 16, (nnz_kv, num_kv_heads, head_dim), dtype=torch.int8, device="cuda:0"
+    )
+
+    kv_append_length = torch.tensor([3, 5, 4], dtype=torch.int32, device="cuda:0")
+    kv_append_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device="cuda:0"),
+            torch.cumsum(kv_append_length, dim=0),
+        ]
+    )
+
+    num_pages_per_req = torch.tensor([1, 2, 1], dtype=torch.int32, device="cuda:0")
+    kv_page_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device="cuda:0"),
+            torch.cumsum(num_pages_per_req, dim=0),
+        ]
+    )
+    kv_page_indices = torch.arange(4, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor([3, 1, 4], dtype=torch.int32, device="cuda:0")
+
+    batch_indices, positions = flashinfer.get_batch_indices_positions(
+        kv_append_indptr,
+        flashinfer.get_seq_lens(kv_page_indptr, kv_last_page_len, page_size),
+        nnz_kv,
+    )
+
+    paged_kv_cache = torch.empty(
+        8, 2, page_size, num_kv_heads, head_dim, dtype=torch.int8, device="cuda:0"
+    )
+    flashinfer.append_paged_kv_cache(
+        k_append,
+        v_append,
+        batch_indices,
+        positions,
+        paged_kv_cache,
+        kv_page_indices,
+        kv_page_indptr,
+        kv_last_page_len,
+    )
+
+    batch_indices_cpu = batch_indices.cpu()
+    positions_cpu = positions.cpu()
+    kv_page_indptr_cpu = kv_page_indptr.cpu()
+    kv_page_indices_cpu = kv_page_indices.cpu()
+    for i in range(nnz_kv):
+        batch_idx = int(batch_indices_cpu[i])
+        position = int(positions_cpu[i])
+        page_slot = position // page_size
+        offset = position % page_size
+        page_idx = int(kv_page_indices_cpu[int(kv_page_indptr_cpu[batch_idx]) + page_slot])
+        torch.testing.assert_close(paged_kv_cache[page_idx, 0, offset], k_append[i])
+        torch.testing.assert_close(paged_kv_cache[page_idx, 1, offset], v_append[i])
+
+
+def test_batch_decode_with_paged_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    batch_size = 3
+    kv_len = 9
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    k_scale = 0.125
+    v_scale = 0.25
+
+    q = torch.randn(
+        batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = torch.randint(
+        -8,
+        8,
+        (total_num_pages, 2, page_size, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    kv_data_ref = kv_data.to(torch.float16)
+    kv_data_ref[:, 0].mul_(k_scale)
+    kv_data_ref[:, 1].mul_(v_scale)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device="cuda:0", dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device="cuda:0"
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type=torch.int8,
+        q_data_type=torch.float16,
+    )
+    out = wrapper.run(q, kv_data, k_scale=k_scale, v_scale=v_scale)
+
+    wrapper_ref = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper_ref.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    out_ref = wrapper_ref.run(q, kv_data_ref)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_batch_prefill_with_paged_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    batch_size = 2
+    kv_len = 8
+    qo_len = 3
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    k_scale = 0.125
+    v_scale = 0.25
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    q_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * qo_len
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = torch.randint(
+        -8,
+        8,
+        (total_num_pages, 2, page_size, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    kv_data_ref = kv_data.to(torch.float16)
+    kv_data_ref[:, 0].mul_(k_scale)
+    kv_data_ref[:, 1].mul_(v_scale)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device="cuda:0", dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device="cuda:0"
+    )
+
+    workspace_buffer = torch.empty(64 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        q_data_type=torch.float16,
+        kv_data_type=torch.int8,
+    )
+    out = wrapper.run(q, kv_data, k_scale=k_scale, v_scale=v_scale)
+
+    wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper_ref.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+    )
+    out_ref = wrapper_ref.run(q, kv_data_ref)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_single_decode_with_kv_cache_int8(use_tensor_cores: bool):
+    _require_sm80_or_newer()
+
+    kv_len = 9
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    k_scale = 0.125
+    v_scale = 0.25
+
+    q = torch.randn(num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    k = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    k_ref = k.to(torch.float16) * k_scale
+    v_ref = v.to(torch.float16) * v_scale
+
+    out = flashinfer.single_decode_with_kv_cache(
+        q,
+        k,
+        v,
+        use_tensor_cores=use_tensor_cores,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    out_ref = flashinfer.single_decode_with_kv_cache(
+        q,
+        k_ref,
+        v_ref,
+        use_tensor_cores=use_tensor_cores,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_single_prefill_with_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    qo_len = 3
+    kv_len = 8
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    scale_k = 0.125
+    scale_v = 0.25
+
+    q = torch.randn(
+        qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    k_ref = k.to(torch.float16) * scale_k
+    v_ref = v.to(torch.float16) * scale_v
+
+    out = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k,
+        v,
+        causal=False,
+        scale_k=scale_k,
+        scale_v=scale_v,
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k_ref,
+        v_ref,
+        causal=False,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_determine_attention_backend_int8_falls_back_to_fa2_on_sm90(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(flashinfer_utils, "is_sm90a_supported", lambda device: True)
+
+    backend_int8 = flashinfer_utils.determine_attention_backend(
+        torch.device("cuda:0"),
+        PosEncodingMode.NONE.value,
+        False,
+        False,
+        torch.float16,
+        torch.int8,
+    )
+    backend_fp16 = flashinfer_utils.determine_attention_backend(
+        torch.device("cuda:0"),
+        PosEncodingMode.NONE.value,
+        False,
+        False,
+        torch.float16,
+        torch.float16,
+    )
+
+    assert backend_int8 == "fa2"
+    assert backend_fp16 == "fa3"

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -123,7 +123,9 @@ def test_append_paged_kv_cache_int8():
         position = int(positions_cpu[i])
         page_slot = position // page_size
         offset = position % page_size
-        page_idx = int(kv_page_indices_cpu[int(kv_page_indptr_cpu[batch_idx]) + page_slot])
+        page_idx = int(
+            kv_page_indices_cpu[int(kv_page_indptr_cpu[batch_idx]) + page_slot]
+        )
         torch.testing.assert_close(paged_kv_cache[page_idx, 0, offset], k_append[i])
         torch.testing.assert_close(paged_kv_cache[page_idx, 1, offset], v_append[i])
 
@@ -217,7 +219,11 @@ def test_batch_prefill_with_paged_kv_cache_int8():
     v_scale = 0.25
 
     q = torch.randn(
-        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+        batch_size * qo_len,
+        num_qo_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
     )
     q_indptr = (
         torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * qo_len

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -388,6 +388,72 @@ def test_single_prefill_with_kv_cache_int8():
     torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
 
 
+def test_single_prefill_with_kv_cache_int8_scale_v_gqa_tensor():
+    _require_sm80_or_newer()
+
+    qo_len = 3
+    kv_len = 8
+    num_kv_heads = 2
+    num_qo_heads = 4
+    head_dim = 128
+    scale_v = torch.tensor([0.25, 0.5], device="cuda:0", dtype=torch.float32)
+
+    q = torch.randn(
+        qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v_ref = v.to(torch.float16) * scale_v.view(1, -1, 1)
+
+    out = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k,
+        v,
+        causal=False,
+        scale_v=scale_v,
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k.to(torch.float16),
+        v_ref,
+        causal=False,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_single_prefill_with_kv_cache_int8_rejects_tensor_scale_k():
+    _require_sm80_or_newer()
+
+    q = torch.randn(3, 2, 128, device="cuda:0", dtype=torch.float16)
+    k = torch.randint(-8, 8, (8, 2, 128), device="cuda:0", dtype=torch.int8)
+    v = torch.randint(-8, 8, (8, 2, 128), device="cuda:0", dtype=torch.int8)
+    scale_k = torch.tensor([0.25, 0.5], device="cuda:0", dtype=torch.float32)
+
+    with pytest.raises(
+        TypeError, match="scale_k must be a scalar for non-FP8 single prefill"
+    ):
+        flashinfer.single_prefill_with_kv_cache(
+            q,
+            k,
+            v,
+            causal=False,
+            scale_k=scale_k,
+        )
+
+
 def test_determine_attention_backend_int8_falls_back_to_fa2_on_sm90(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## 📌 Description

The main paged-KV path had no int8 support. This PR extends the following to accept int8 KV cache:

- append
- single decode, single prefill
- batch decode, batch prefill

On Hopper, auto backend selection routes to FA2 when FA3 int8 KV is unavailable, so no combination falls through to an unsupported path.

Tested on Ampere (A100) and Hopper (H100):

```bash
python -m pytest tests/attention/test_int8_paged_kv.py -v
```

7 tests passed on both architectures. The int4 part is in a separate follow-up PR.

## 🔍 Related Issues
<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks
- [x] I have installed pre-commit by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

### 🧪 Tests
- [x] Tests have been added or updated as needed.
- [x] All tests are passing (unittest, etc.).

Retargeted against `main` after the `v0.6.8` release branch cut.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Int8 quantized key/value cache support for paged and single-step attention; improved Int8 vector handling for efficient kernels

* **Bug Fixes**
  * Fixed prefill scaling to avoid double-applying V scales; added validated scalar/tensor scale handling
  * FA3 backend explicitly disabled for Int8 KV paths

* **Tests**
  * Added extensive tests validating Int8 paged KV behavior, FA3 gating, and FP8 scale correctness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->