### PR TITLE
Add int4 paged KV support to main paths

### DIFF
--- a/csrc/page.cu
+++ b/csrc/page.cu
@@ -90,7 +90,7 @@ void append_paged_kv_cache(TensorView append_key, TensorView append_value, Tenso
 
   ffi::CUDADeviceGuard device_guard(append_key.device().device_id);
   const cudaStream_t stream = get_stream(append_key.device());
-  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE(paged_k_cache.dtype(), c_type, [&] {
+  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_QKV(paged_k_cache.dtype(), c_type, [&] {
     paged_kv_t<c_type, int32_t> paged_kv(
         num_heads, page_size, head_dim, batch_size, kv_layout,
         static_cast<c_type*>(paged_k_cache.data_ptr()),

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -53,6 +53,7 @@ constexpr int64_t float16_code = encode_dlpack_dtype(dl_float16);
 constexpr int64_t bfloat16_code = encode_dlpack_dtype(dl_bfloat16);
 constexpr int64_t float32_code = encode_dlpack_dtype(dl_float32);
 constexpr int64_t uint8_code = encode_dlpack_dtype(dl_uint8);
+constexpr int64_t int8_code = encode_dlpack_dtype(dl_int8);
 constexpr int64_t int32_code = encode_dlpack_dtype(dl_int32);
 constexpr int64_t int64_code = encode_dlpack_dtype(dl_int64);
 constexpr int64_t float8_e4m3fn_code = encode_dlpack_dtype(dl_float8_e4m3fn);
@@ -114,6 +115,12 @@ constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
   case int32_code: {                    \
     using c_type = int32_t;             \
     return __VA_ARGS__();               \
+  }
+
+#define _DISPATCH_CASE_I8(c_type, ...) \
+  case int8_code: {                    \
+    using c_type = int8_t;             \
+    return __VA_ARGS__();              \
   }
 
 #define _DISPATCH_CASE_I64(c_type, ...) \
@@ -240,6 +247,22 @@ constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
 #define DISPATCH_DLPACK_DTYPE_TO_CTYPE(dlpack_dtype, c_type, ...)                        \
   [&]() -> bool {                                                                        \
     switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP4_E2M1(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_QKV(dlpack_dtype, c_type, ...)                    \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_I8(c_type, __VA_ARGS__)                                             \
       _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
       _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
       _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -140,6 +140,8 @@ from .prefill import (
 from .prefill import trtllm_fmha_v2_prefill as trtllm_fmha_v2_prefill
 from .quantization import packbits as packbits
 from .quantization import segment_packbits as segment_packbits
+from .quantization import int4_dequantize as int4_dequantize
+from .quantization import int4_quantize as int4_quantize
 from .rope import apply_llama31_rope as apply_llama31_rope
 from .rope import apply_llama31_rope_inplace as apply_llama31_rope_inplace
 from .rope import apply_llama31_rope_pos_ids as apply_llama31_rope_pos_ids
@@ -181,6 +183,7 @@ from .trtllm_low_latency_gemm import (
     prepare_low_latency_gemm_weights as prepare_low_latency_gemm_weights,
 )
 from .utils import next_positive_power_of_2 as next_positive_power_of_2
+from .utils import INT4Tensor as INT4Tensor
 from .xqa import xqa as xqa
 from .xqa import xqa_mla as xqa_mla
 from . import mamba as mamba

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -48,7 +48,9 @@ from .prefill import (
     get_batch_prefill_module,
     get_single_prefill_module,
 )
+from .quantization import int4_dequantize
 from .utils import (
+    INT4Tensor,
     log2e,
     FP4Tensor,
     MaskMode,
@@ -60,6 +62,7 @@ from .utils import (
     _check_pos_encoding_mode,
     check_shape_dtype_device,
     get_alibi_slopes,
+    _dequantize_int4_paged_kv_cache,
     _get_cache_alibi_slopes_buf,
     _get_range_buf,
     _unpack_paged_kv_cache,
@@ -76,6 +79,8 @@ from .utils import (
     GPUArchitectureError,
     SINGLE_KERNEL_TMP_SIZE,
     prepare_jit_additional_args,
+    is_int4_dtype,
+    is_int4_tensor,
 )
 
 
@@ -363,8 +368,8 @@ def get_batch_decode_mla_module(*args):
 @overload
 def single_decode_with_kv_cache(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    k: Union[torch.Tensor, INT4Tensor],
+    v: Union[torch.Tensor, INT4Tensor],
     kv_layout: str = "NHD",
     pos_encoding_mode: str = "NONE",
     use_tensor_cores: bool = False,
@@ -383,8 +388,8 @@ def single_decode_with_kv_cache(
 @overload
 def single_decode_with_kv_cache(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    k: Union[torch.Tensor, INT4Tensor],
+    v: Union[torch.Tensor, INT4Tensor],
     kv_layout: str = "NHD",
     pos_encoding_mode: str = "NONE",
     use_tensor_cores: bool = False,
@@ -403,8 +408,8 @@ def single_decode_with_kv_cache(
 @flashinfer_api
 def single_decode_with_kv_cache(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    k: Union[torch.Tensor, INT4Tensor],
+    v: Union[torch.Tensor, INT4Tensor],
     kv_layout: str = "NHD",
     pos_encoding_mode: str = "NONE",
     use_tensor_cores: bool = False,
@@ -498,6 +503,15 @@ def single_decode_with_kv_cache(
     """
     _check_pos_encoding_mode(pos_encoding_mode)
     _check_kv_layout(kv_layout)
+    if is_int4_tensor(k) or is_int4_tensor(v):
+        if not (is_int4_tensor(k) and is_int4_tensor(v)):
+            raise ValueError("k and v must both be INT4Tensor when using int4 KV.")
+        if k_scale is not None or v_scale is not None:
+            raise ValueError(
+                "k_scale and v_scale are not supported for INT4Tensor inputs."
+            )
+        k = int4_dequantize(k)
+        v = int4_dequantize(v)
     tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device=q.device)
     head_dim = q.shape[-1]
     if logits_soft_cap is None:
@@ -977,13 +991,31 @@ class BatchDecodeWithPagedKVCacheWrapper:
             if kv_data_type is None:
                 kv_data_type = data_type
 
+        if is_int4_dtype(q_data_type) or is_int4_dtype(o_data_type):
+            raise ValueError("q_data_type and o_data_type do not support int4.")
         q_data_type = canonicalize_torch_dtype(q_data_type)
         if kv_data_type is None:
             kv_data_type = q_data_type
-        kv_data_type = canonicalize_torch_dtype(kv_data_type)
+        self._int4_kv_enabled = is_int4_dtype(kv_data_type)
+        effective_kv_data_type = (
+            torch.float16
+            if self._int4_kv_enabled
+            else canonicalize_torch_dtype(kv_data_type)
+        )
+        if self._int4_kv_enabled:
+            if self._backend == "auto":
+                self._backend = "fa2"
+            elif self._backend != "fa2":
+                raise NotImplementedError(
+                    "INT4 paged KV cache only supports the fa2/common decode path."
+                )
         if o_data_type is None:
             o_data_type = q_data_type
         o_data_type = canonicalize_torch_dtype(o_data_type)
+        if self.is_cuda_graph_enabled and self._int4_kv_enabled:
+            raise NotImplementedError(
+                "INT4 paged KV cache is not supported with CUDA graph decode yet."
+            )
 
         if fixed_split_size is not None and not self.use_tensor_cores:
             raise ValueError(
@@ -993,7 +1025,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             fixed_split_size = -1
 
         self._cached_q_data_type = q_data_type
-        self._cached_kv_data_type = kv_data_type
+        self._cached_kv_data_type = effective_kv_data_type
+        self._external_kv_data_type = kv_data_type
         self._cached_o_data_type = o_data_type
         self._batch_size = batch_size
         self._num_qo_heads = num_qo_heads
@@ -1038,7 +1071,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     block_id += num_blocks_needed
             self._cached_module = get_trtllm_gen_decode_module(
                 q_data_type,
-                kv_data_type,
+                effective_kv_data_type,
                 o_data_type,
                 indptr.dtype,
                 head_dim,
@@ -1058,21 +1091,21 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     if {
                         torch.float8_e4m3fn,
                         torch.float8_e5m2,
-                    } & {q_data_type, kv_data_type}:
+                    } & {q_data_type, effective_kv_data_type}:
                         self._backend = determine_attention_backend(
                             self.device,
                             PosEncodingMode[pos_encoding_mode].value,
                             False,  # use_fp16_qk_reductions
                             False,  # use_custom_mask
                             q_data_type,
-                            kv_data_type,
+                            effective_kv_data_type,
                         )
                     else:
                         self._backend = "fa2"
                 self._cached_module = get_batch_prefill_module(
                     self._backend,
                     q_data_type,
-                    kv_data_type,
+                    effective_kv_data_type,
                     o_data_type,
                     indptr.dtype,
                     head_dim,  # head_dim_qk
@@ -1114,7 +1147,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             else:
                 self._cached_module = get_batch_decode_module(
                     q_data_type,
-                    kv_data_type,
+                    effective_kv_data_type,
                     o_data_type,
                     indptr.dtype,
                     head_dim,  # head_dim_qk
@@ -1138,7 +1171,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 head_dim,
                 head_dim,
                 torch.empty(0, dtype=q_data_type),
-                torch.empty(0, dtype=kv_data_type),
+                torch.empty(0, dtype=effective_kv_data_type),
             )
 
         self._pos_encoding_mode = pos_encoding_mode
@@ -1289,7 +1322,17 @@ class BatchDecodeWithPagedKVCacheWrapper:
         """
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q.device)
-        k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)
+        if self._int4_kv_enabled:
+            if k_scale is not None or v_scale is not None:
+                raise ValueError(
+                    "k_scale and v_scale are not supported for INT4 paged KV cache."
+                )
+            k_cache, v_cache = _dequantize_int4_paged_kv_cache(
+                paged_kv_cache,
+                self._kv_layout,
+            )
+        else:
+            k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)
 
         if (
             k_cache.dtype == torch.uint8 or v_cache.dtype == torch.uint8

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -156,6 +156,15 @@ def _append_paged_kv_cache_int4(
         raise ValueError(
             "The append value group count does not match the paged int4 cache."
         )
+    cache_num_heads = k_data.shape[2] if kv_layout == "NHD" else k_data.shape[1]
+    if packed_key.data.shape[1] != cache_num_heads:
+        raise ValueError(
+            "The append key head count does not match the paged int4 cache."
+        )
+    if packed_value.data.shape[1] != cache_num_heads:
+        raise ValueError(
+            "The append value head count does not match the paged int4 cache."
+        )
 
     page_size = k_data.shape[1] if kv_layout == "NHD" else k_data.shape[2]
     batch_indices = batch_indices.to(torch.int64)

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -21,10 +21,14 @@ import torch
 
 from .api_logging import flashinfer_api
 from .jit.page import gen_page_module
+from .quantization import int4_quantize
 from .utils import (
+    INT4Tensor,
     TensorLayout,
     _check_kv_layout,
+    _split_int4_paged_kv_cache_views,
     check_shape_dtype_device,
+    is_int4_paged_kv_cache,
     _unpack_paged_kv_cache,
     register_custom_op,
     register_fake_op,
@@ -118,6 +122,60 @@ def _fake_append_paged_kv_cache_kernel(
     layout: int,
 ) -> None:
     pass
+
+
+def _append_paged_kv_cache_int4(
+    append_key: torch.Tensor,
+    append_value: torch.Tensor,
+    batch_indices: torch.Tensor,
+    positions: torch.Tensor,
+    paged_kv_cache: Union[INT4Tensor, Tuple[INT4Tensor, INT4Tensor]],
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_layout: str,
+) -> None:
+    packed_key = int4_quantize(append_key)
+    packed_value = int4_quantize(append_value)
+
+    k_data, v_data, k_scale, v_scale = _split_int4_paged_kv_cache_views(
+        paged_kv_cache, kv_layout
+    )
+    if packed_key.data.shape[-1] != k_data.shape[-1]:
+        raise ValueError(
+            "The append key head dimension does not match the paged int4 cache."
+        )
+    if packed_value.data.shape[-1] != v_data.shape[-1]:
+        raise ValueError(
+            "The append value head dimension does not match the paged int4 cache."
+        )
+    if packed_key.scale.shape[-1] != k_scale.shape[-1]:
+        raise ValueError(
+            "The append key group count does not match the paged int4 cache."
+        )
+    if packed_value.scale.shape[-1] != v_scale.shape[-1]:
+        raise ValueError(
+            "The append value group count does not match the paged int4 cache."
+        )
+
+    page_size = k_data.shape[1] if kv_layout == "NHD" else k_data.shape[2]
+    batch_indices = batch_indices.to(torch.int64)
+    positions = positions.to(torch.int64)
+    kv_indices = kv_indices.to(torch.int64)
+    kv_indptr = kv_indptr.to(torch.int64)
+    page_offsets = torch.div(positions, page_size, rounding_mode="floor")
+    page_positions = torch.remainder(positions, page_size)
+    page_indices = kv_indices[kv_indptr[batch_indices] + page_offsets]
+
+    if kv_layout == "NHD":
+        k_data[page_indices, page_positions] = packed_key.data
+        v_data[page_indices, page_positions] = packed_value.data
+        k_scale[page_indices, page_positions] = packed_key.scale
+        v_scale[page_indices, page_positions] = packed_value.scale
+    else:
+        k_data[page_indices, :, page_positions, :] = packed_key.data
+        v_data[page_indices, :, page_positions, :] = packed_value.data
+        k_scale[page_indices, :, page_positions, :] = packed_key.scale
+        v_scale[page_indices, :, page_positions, :] = packed_value.scale
 
 
 @flashinfer_api
@@ -278,7 +336,12 @@ def append_paged_kv_cache(
     append_value: torch.Tensor,
     batch_indices: torch.Tensor,
     positions: torch.Tensor,
-    paged_kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+    paged_kv_cache: Union[
+        torch.Tensor,
+        INT4Tensor,
+        Tuple[torch.Tensor, torch.Tensor],
+        Tuple[INT4Tensor, INT4Tensor],
+    ],
     kv_indices: torch.Tensor,
     kv_indptr: torch.Tensor,
     kv_last_page_len: torch.Tensor,
@@ -389,6 +452,18 @@ def append_paged_kv_cache(
     get_batch_indices_positions
     """
     _check_kv_layout(kv_layout)
+    if is_int4_paged_kv_cache(paged_kv_cache):
+        _append_paged_kv_cache_int4(
+            append_key,
+            append_value,
+            batch_indices,
+            positions,
+            paged_kv_cache,
+            kv_indices,
+            kv_indptr,
+            kv_layout,
+        )
+        return
     _append_paged_kv_cache_kernel(
         append_key,
         append_value,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -18,7 +18,7 @@ import functools
 import logging
 import math
 from types import SimpleNamespace
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast, overload
 
 import torch
 
@@ -37,8 +37,9 @@ from .jit import (
 )
 from .cudnn import cudnn_batch_prefill_with_kv_cache
 from .page import get_seq_lens
-from .quantization import packbits, segment_packbits
+from .quantization import int4_dequantize, packbits, segment_packbits
 from .utils import (
+    INT4Tensor,
     log2e,
     FP4Tensor,
     MaskMode,
@@ -50,6 +51,7 @@ from .utils import (
     _check_pos_encoding_mode,
     check_shape_dtype_device,
     get_alibi_slopes,
+    _dequantize_int4_paged_kv_cache,
     _get_cache_alibi_slopes_buf,
     _get_cache_buf,
     _unpack_paged_kv_cache,
@@ -61,6 +63,8 @@ from .utils import (
     is_sm100a_supported,
     is_sm110a_supported,
     is_sm12x_supported,
+    is_int4_dtype,
+    is_int4_tensor,
     register_custom_op,
     register_fake_op,
     ceil_div,
@@ -1104,8 +1108,8 @@ def single_prefill_with_kv_cache_with_jit_module(
 @overload
 def single_prefill_with_kv_cache(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    k: Union[torch.Tensor, INT4Tensor],
+    v: Union[torch.Tensor, INT4Tensor],
     scale_q: Optional[torch.Tensor] = None,
     scale_k: Optional[torch.Tensor] = None,
     scale_v: Optional[torch.Tensor] = None,
@@ -1129,8 +1133,8 @@ def single_prefill_with_kv_cache(
 @overload
 def single_prefill_with_kv_cache(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    k: Union[torch.Tensor, INT4Tensor],
+    v: Union[torch.Tensor, INT4Tensor],
     scale_q: Optional[torch.Tensor] = None,
     scale_k: Optional[torch.Tensor] = None,
     scale_v: Optional[torch.Tensor] = None,
@@ -1154,8 +1158,8 @@ def single_prefill_with_kv_cache(
 @flashinfer_api
 def single_prefill_with_kv_cache(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    k: Union[torch.Tensor, INT4Tensor],
+    v: Union[torch.Tensor, INT4Tensor],
     scale_q: Optional[torch.Tensor] = None,
     scale_k: Optional[torch.Tensor] = None,
     scale_v: Optional[torch.Tensor] = None,
@@ -1297,6 +1301,16 @@ def single_prefill_with_kv_cache(
     """
     _check_pos_encoding_mode(pos_encoding_mode)
     _check_kv_layout(kv_layout)
+    int4_input = is_int4_tensor(k) or is_int4_tensor(v)
+    if int4_input:
+        if not (is_int4_tensor(k) and is_int4_tensor(v)):
+            raise ValueError("k and v must both be INT4Tensor when using int4 KV.")
+        if scale_k is not None or scale_v is not None:
+            raise ValueError(
+                "scale_k and scale_v are not supported for INT4Tensor inputs."
+            )
+        k = int4_dequantize(k)
+        v = int4_dequantize(v)
     tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device=q.device)
     if logits_soft_cap is None:
         logits_soft_cap = 0.0
@@ -1324,47 +1338,63 @@ def single_prefill_with_kv_cache(
     if return_lse:
         lse = torch.empty((q.size(0), q.size(1)), dtype=torch.float32, device=q.device)
 
+    k_tensor = cast(torch.Tensor, k)
+    v_tensor = cast(torch.Tensor, v)
+
     if is_float8(q):
         # FP8 quant enabled, do sanity check:
         #   1. unsupported feature
         #   2. dtype check
         assert window_left == -1
-        assert q.dtype == k.dtype == v.dtype
-        assert q.shape[-1] == k.shape[-1] == v.shape[-1]
+        assert q.dtype == k_tensor.dtype == v_tensor.dtype
+        assert q.shape[-1] == k_tensor.shape[-1] == v_tensor.shape[-1]
         if scale_q is None:
             scale_q = torch.ones(q.shape[1], dtype=torch.float32, device=q.device)
         if scale_k is None:
-            scale_k = torch.ones(k.shape[1], dtype=torch.float32, device=q.device)
+            scale_k = torch.ones(
+                k_tensor.shape[1], dtype=torch.float32, device=q.device
+            )
         if scale_v is None:
-            scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
+            scale_v = torch.ones(
+                v_tensor.shape[1], dtype=torch.float32, device=q.device
+            )
     else:
         if scale_q is not None:
             sm_scale *= _normalize_non_fp8_scalar_scale(scale_q, "scale_q")
         if scale_k is not None:
             sm_scale *= _normalize_non_fp8_scalar_scale(scale_k, "scale_k")
 
-    if backend == "auto":
+    if int4_input:
+        if backend == "auto":
+            backend = "fa2"
+        elif backend != "fa2":
+            raise NotImplementedError(
+                "INT4Tensor inputs only support the fa2 single prefill path."
+            )
+    elif backend == "auto":
         backend = determine_attention_backend(
             q.device,
             PosEncodingMode[pos_encoding_mode].value,
             use_fp16_qk_reduction,
             packed_custom_mask is not None,  # use_custom_mask
             q.dtype,
-            k.dtype,
+            k_tensor.dtype,
         )
 
     # o_dtype should be provided for FP8 attention
     if o_dtype is None:
         o_dtype = q.dtype
-    out = torch.empty(q.shape[:-1] + v.shape[-1:], dtype=o_dtype, device=q.device)
+    out = torch.empty(
+        q.shape[:-1] + v_tensor.shape[-1:], dtype=o_dtype, device=q.device
+    )
 
     module = get_single_prefill_module(
         backend,
         q.dtype,
-        k.dtype,
+        k_tensor.dtype,
         out.dtype,
         q.shape[-1],  # head_dim_qk
-        v.shape[-1],  # head_dim_vo
+        v_tensor.shape[-1],  # head_dim_vo
         PosEncodingMode[pos_encoding_mode].value,
         window_left >= 0,  # use_sliding_window
         logits_soft_cap > 0,  # use_logits_soft_cap
@@ -1373,8 +1403,8 @@ def single_prefill_with_kv_cache(
 
     module.run(
         q,
-        k,
-        v,
+        k_tensor,
+        v_tensor,
         tmp,
         out,
         lse,
@@ -1886,13 +1916,31 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
+        if is_int4_dtype(q_data_type) or is_int4_dtype(o_data_type):
+            raise ValueError("q_data_type and o_data_type do not support int4.")
         q_data_type = canonicalize_torch_dtype(q_data_type)
         if kv_data_type is None:
             kv_data_type = q_data_type
-        kv_data_type = canonicalize_torch_dtype(kv_data_type)
+        self._int4_kv_enabled = is_int4_dtype(kv_data_type)
+        effective_kv_data_type = (
+            torch.float16
+            if self._int4_kv_enabled
+            else canonicalize_torch_dtype(kv_data_type)
+        )
+        if self._int4_kv_enabled:
+            if self._backend == "auto":
+                self._backend = "fa2"
+            elif self._backend != "fa2":
+                raise NotImplementedError(
+                    "INT4 paged KV cache only supports the fa2/common prefill path."
+                )
         if o_data_type is None:
             o_data_type = q_data_type
         o_data_type = canonicalize_torch_dtype(o_data_type)
+        if self.is_cuda_graph_enabled and self._int4_kv_enabled:
+            raise NotImplementedError(
+                "INT4 paged KV cache is not supported with CUDA graph prefill yet."
+            )
 
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
@@ -2028,7 +2076,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 self._mask_indptr_buf = None
 
         self._cached_q_data_type = q_data_type
-        self._cached_kv_data_type = kv_data_type
+        self._cached_kv_data_type = effective_kv_data_type
         self._cached_o_data_type = o_data_type
 
         if self._jit_module is not None:
@@ -2041,12 +2089,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     use_fp16_qk_reduction,
                     self._custom_mask_buf is not None,  # use_custom_mask
                     q_data_type,
-                    kv_data_type,
+                    effective_kv_data_type,
                 )
             if self._backend != "cudnn":
                 get_module_args = (
                     q_data_type,
-                    kv_data_type,
+                    effective_kv_data_type,
                     o_data_type,
                     paged_kv_indptr.dtype,
                     head_dim_qk,
@@ -2274,7 +2322,17 @@ class BatchPrefillWithPagedKVCacheWrapper:
         """
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q.device)
-        k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)
+        if self._int4_kv_enabled:
+            if k_scale is not None or v_scale is not None:
+                raise ValueError(
+                    "k_scale and v_scale are not supported for INT4 paged KV cache."
+                )
+            k_cache, v_cache = _dequantize_int4_paged_kv_cache(
+                paged_kv_cache,
+                self._kv_layout,
+            )
+        else:
+            k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)
         _check_cached_qkv_data_type(
             q, k_cache, self._cached_q_data_type, self._cached_kv_data_type
         )

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1723,6 +1723,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows: Optional[int] = None
         self._backend = backend
+        self._planned_backend = backend
         self._plan_info = None
         self._cached_module = None
         self._seq_lens_kv = None
@@ -1922,15 +1923,16 @@ class BatchPrefillWithPagedKVCacheWrapper:
         if kv_data_type is None:
             kv_data_type = q_data_type
         self._int4_kv_enabled = is_int4_dtype(kv_data_type)
+        backend = self._backend
         effective_kv_data_type = (
             torch.float16
             if self._int4_kv_enabled
             else canonicalize_torch_dtype(kv_data_type)
         )
         if self._int4_kv_enabled:
-            if self._backend == "auto":
-                self._backend = "fa2"
-            elif self._backend != "fa2":
+            if backend == "auto":
+                backend = "fa2"
+            elif backend != "fa2":
                 raise NotImplementedError(
                     "INT4 paged KV cache only supports the fa2/common prefill path."
                 )
@@ -2082,8 +2084,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
-            if self._backend == "auto":
-                self._backend = determine_attention_backend(
+            if backend == "auto":
+                backend = determine_attention_backend(
                     self.device,
                     PosEncodingMode[pos_encoding_mode].value,
                     use_fp16_qk_reduction,
@@ -2091,7 +2093,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     q_data_type,
                     effective_kv_data_type,
                 )
-            if self._backend != "cudnn":
+            if backend != "cudnn":
                 get_module_args = (
                     q_data_type,
                     effective_kv_data_type,
@@ -2106,11 +2108,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 )
 
                 self._cached_module = get_batch_prefill_module(
-                    self._backend, *get_module_args
+                    backend, *get_module_args
                 )
 
         self._block_tables = block_tables
-        if self._backend == "trtllm-gen":
+        if backend == "trtllm-gen":
             if not causal:
                 raise NotImplementedError(
                     "Non-causal attention is not supported for trtllm-gen backend with paged KV cache. "
@@ -2158,7 +2160,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 causal,
                 window_left,
             ]
-            if self._backend == "fa2":
+            if backend == "fa2":
                 args.append(fixed_split_size or -1)  # fixed_split_size
                 args.append(disable_split_kv)  # disable_split_kv
                 args.append(0)  # num_colocated_ctas
@@ -2166,6 +2168,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 *args,
             )
 
+        self._planned_backend = backend
         self._causal = causal
         self._pos_encoding_mode = pos_encoding_mode
         self._use_fp16_qk_reduction = use_fp16_qk_reduction
@@ -2336,8 +2339,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
         _check_cached_qkv_data_type(
             q, k_cache, self._cached_q_data_type, self._cached_kv_data_type
         )
+        backend = self._planned_backend
         # Validate q shape matches qo_indptr (using value cached in plan() to avoid GPU sync)
-        if self._backend == "cudnn":
+        if backend == "cudnn":
             if q.numel() != self._qo_indptr_last:
                 raise ValueError(
                     f"q.numel() ({q.numel()}) does not match qo_indptr[-1] ({self._qo_indptr_last}). "
@@ -2380,7 +2384,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         else:
             page_size = k_cache.shape[2]
         window_left = self._window_left if window_left is None else window_left
-        if self._backend != "trtllm-gen":
+        if backend != "trtllm-gen":
             # NOTE(Siyuan): since window_left is appeared in the plan function, we need to make sure it is the same as the one in the plan function.
             # Remove this check if the backend supports dynamic window_left.
             assert window_left == self._window_left
@@ -2392,7 +2396,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
-        if self._backend != "cudnn":
+        if backend != "cudnn":
             if q_scale is not None:
                 sm_scale *= q_scale
             if k_scale is not None:
@@ -2427,7 +2431,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             )
 
         # Convert NHD layout to HND for trtllm-gen backend
-        if self._backend == "trtllm-gen" and self._kv_layout == "NHD":
+        if backend == "trtllm-gen" and self._kv_layout == "NHD":
             k_cache = k_cache.transpose(-3, -2)
             v_cache = v_cache.transpose(-3, -2)
             if key_block_scales is not None:
@@ -2452,7 +2456,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         if self._prefix_len_ptr is not None:
             mask_mode = MaskMode.MULTIITEMSCORING.value
 
-        if self._backend == "cudnn":
+        if backend == "cudnn":
             if self._seq_lens_q is not None and self._seq_lens_q.dim() == 1:
                 self._seq_lens_q = self._seq_lens_q.reshape(self._batch_size, 1, 1, 1)
 
@@ -2482,7 +2486,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 o_data_type=out_dtype,
             )
         else:
-            if self._backend != "trtllm-gen":
+            if backend != "trtllm-gen":
                 assert self._plan_info is not None, "plan info is not initialized"
             run_args = [
                 self._float_workspace_buffer,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1344,7 +1344,11 @@ def single_prefill_with_kv_cache(
 
     if scale_v is not None and backend != "fa3":
         # TODO(Zihao): fused into kernel
-        if out.itemsize == 1:
+        if out.dtype in (
+            torch.int8,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        ):
             out = (out.to(float) * scale_v).to(out.dtype)
         else:
             out *= scale_v

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -90,6 +90,58 @@ def _split_scale_param(scale):
         return None, float(scale)
 
 
+def _normalize_non_fp8_scalar_scale(
+    scale: Optional[Union[float, torch.Tensor]], scale_name: str
+) -> Optional[float]:
+    """Normalize scalar scales used by non-FP8 prefill paths.
+
+    Non-FA3 prefill kernels accept ``sm_scale`` as a scalar. Allow Python floats and
+    0-dim / 1-element tensors for convenience, but reject per-head tensors here.
+    """
+    if scale is None:
+        return None
+    if isinstance(scale, torch.Tensor):
+        if scale.numel() != 1:
+            raise TypeError(
+                f"{scale_name} must be a scalar for non-FP8 single prefill."
+            )
+        return float(scale.item())
+    return float(scale)
+
+
+def _apply_non_fa3_scale_v(
+    out: torch.Tensor, scale_v: Optional[Union[float, torch.Tensor]]
+) -> torch.Tensor:
+    """Apply value scaling on non-FA3 prefill outputs.
+
+    For GQA/MQA, a per-kv-head ``scale_v`` tensor must be expanded to the number of
+    query heads before broadcasting over ``out``.
+    """
+    if scale_v is None:
+        return out
+
+    scale_v_factor: Union[float, torch.Tensor]
+    if isinstance(scale_v, torch.Tensor):
+        scale_v_tensor = scale_v
+        if scale_v_tensor.ndim != 1:
+            raise ValueError("scale_v tensor must be 1D.")
+        num_qo_heads = out.shape[1]
+        num_kv_heads = scale_v_tensor.shape[0]
+        if num_qo_heads % num_kv_heads != 0:
+            raise ValueError("num_qo_heads must be a multiple of num_kv_heads.")
+        if num_qo_heads != num_kv_heads:
+            scale_v_tensor = scale_v_tensor.repeat_interleave(
+                num_qo_heads // num_kv_heads
+            )
+        scale_v_factor = scale_v_tensor.view(1, -1, 1)
+    else:
+        scale_v_factor = float(scale_v)
+
+    if out.dtype in (torch.int8, torch.float8_e4m3fn, torch.float8_e5m2):
+        return (out.to(torch.float32) * scale_v_factor).to(out.dtype)
+    return out * scale_v_factor
+
+
 def _create_scale_bmm2_d_tensor(
     scale_bmm2: float, data_dtype: torch.dtype, device: torch.device
 ) -> torch.Tensor:
@@ -1287,9 +1339,9 @@ def single_prefill_with_kv_cache(
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
     else:
         if scale_q is not None:
-            sm_scale *= scale_q
+            sm_scale *= _normalize_non_fp8_scalar_scale(scale_q, "scale_q")
         if scale_k is not None:
-            sm_scale *= scale_k
+            sm_scale *= _normalize_non_fp8_scalar_scale(scale_k, "scale_k")
 
     if backend == "auto":
         backend = determine_attention_backend(
@@ -1344,14 +1396,7 @@ def single_prefill_with_kv_cache(
 
     if scale_v is not None and backend != "fa3":
         # TODO(Zihao): fused into kernel
-        if out.dtype in (
-            torch.int8,
-            torch.float8_e4m3fn,
-            torch.float8_e5m2,
-        ):
-            out = (out.to(float) * scale_v).to(out.dtype)
-        else:
-            out *= scale_v
+        out = _apply_non_fa3_scale_v(out, scale_v)
 
     return (out, lse) if return_lse else out
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1305,6 +1305,8 @@ def single_prefill_with_kv_cache(
     if int4_input:
         if not (is_int4_tensor(k) and is_int4_tensor(v)):
             raise ValueError("k and v must both be INT4Tensor when using int4 KV.")
+        if is_float8(q):
+            raise ValueError("FP8 q is not supported with INT4 k/v.")
         if scale_k is not None or scale_v is not None:
             raise ValueError(
                 "scale_k and scale_v are not supported for INT4Tensor inputs."
@@ -1930,6 +1932,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
             else canonicalize_torch_dtype(kv_data_type)
         )
         if self._int4_kv_enabled:
+            if q_data_type in (torch.float8_e4m3fn, torch.float8_e5m2):
+                raise NotImplementedError(
+                    "INT4 paged KV cache does not support FP8 query dtypes."
+                )
             if backend == "auto":
                 backend = "fa2"
             elif backend != "fa2":

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1342,7 +1342,7 @@ def single_prefill_with_kv_cache(
         rope_theta,
     )
 
-    if scale_v is not None:
+    if scale_v is not None and backend != "fa3":
         # TODO(Zihao): fused into kernel
         if out.itemsize == 1:
             out = (out.to(float) * scale_v).to(out.dtype)

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1285,6 +1285,11 @@ def single_prefill_with_kv_cache(
             scale_k = torch.ones(k.shape[1], dtype=torch.float32, device=q.device)
         if scale_v is None:
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
+    else:
+        if scale_q is not None:
+            sm_scale *= scale_q
+        if scale_k is not None:
+            sm_scale *= scale_k
 
     if backend == "auto":
         backend = determine_attention_backend(
@@ -1336,6 +1341,13 @@ def single_prefill_with_kv_cache(
         rope_scale,
         rope_theta,
     )
+
+    if scale_v is not None:
+        # TODO(Zihao): fused into kernel
+        if out.itemsize == 1:
+            out = (out.to(float) * scale_v).to(out.dtype)
+        else:
+            out *= scale_v
 
     return (out, lse) if return_lse else out
 

--- a/flashinfer/quantization/__init__.py
+++ b/flashinfer/quantization/__init__.py
@@ -3,6 +3,7 @@ FlashInfer Quantization Module
 ==============================
 
 This module provides quantization functions for various formats:
+- INT4 (grouped packed int4)
 - FP4 (NVFP4, MXFP4)
 - FP8 (MXFP8)
 - Packbits utilities
@@ -12,7 +13,7 @@ Licensed under the Apache License, Version 2.0.
 """
 
 # Re-export packbits functions
-from .packbits import packbits, segment_packbits
+from .packbits import int4_dequantize, int4_quantize, packbits, segment_packbits
 
 # Re-export JIT module generator (used by tests and AOT compilation)
 from ..jit.quantization import gen_quantization_module
@@ -56,6 +57,8 @@ except ImportError:
 
 __all__ = [
     # Packbits
+    "int4_quantize",
+    "int4_dequantize",
     "packbits",
     "segment_packbits",
     # JIT module generator

--- a/flashinfer/quantization/packbits.py
+++ b/flashinfer/quantization/packbits.py
@@ -15,13 +15,19 @@ limitations under the License.
 """
 
 import functools
+import math
 from typing import Tuple
 
 import torch
 
 from ..api_logging import flashinfer_api
 from ..jit.quantization import gen_quantization_module
-from ..utils import register_custom_op, register_fake_op
+from ..utils import (
+    INT4Tensor,
+    INT4_GROUP_SIZE,
+    register_custom_op,
+    register_fake_op,
+)
 
 
 @functools.cache
@@ -137,3 +143,75 @@ def segment_packbits(
     y = torch.empty(output_nnzs, dtype=torch.uint8, device=device)
     get_quantization_module().segment_packbits(x, indptr, indptr_new, bitorder, y)
     return y, indptr_new
+
+
+@flashinfer_api
+def int4_quantize(
+    x: torch.Tensor,
+    group_size: int = INT4_GROUP_SIZE,
+) -> INT4Tensor:
+    r"""Quantize the input tensor into grouped packed int4 format."""
+
+    if not torch.is_tensor(x):
+        raise TypeError(f"x must be a torch.Tensor, got {type(x)}")
+    if x.ndim == 0:
+        raise ValueError("x must have at least one dimension")
+    if group_size <= 0:
+        raise ValueError(f"group_size must be positive, got {group_size}")
+    hidden_dim = x.shape[-1]
+    if hidden_dim % group_size != 0:
+        raise ValueError(
+            f"x.shape[-1] must be divisible by group_size, got {hidden_dim} and {group_size}"
+        )
+
+    x_fp32 = x.to(torch.float32)
+    num_groups = hidden_dim // group_size
+    x_grouped = x_fp32.reshape(*x.shape[:-1], num_groups, group_size)
+    amax = x_grouped.abs().amax(dim=-1, keepdim=True)
+    scale = torch.where(amax > 0, amax / 7.0, torch.ones_like(amax))
+    q = torch.round(x_grouped / scale).clamp_(-8, 7).to(torch.int8)
+    q_unsigned = (q + 8).to(torch.uint8).reshape(*x.shape[:-1], hidden_dim)
+
+    if hidden_dim % 2 != 0:
+        pad = torch.zeros(
+            (*q_unsigned.shape[:-1], 1),
+            dtype=q_unsigned.dtype,
+            device=q_unsigned.device,
+        )
+        q_unsigned = torch.cat([q_unsigned, pad], dim=-1)
+
+    packed = q_unsigned[..., 0::2] | (q_unsigned[..., 1::2] << 4)
+    return INT4Tensor(
+        packed.contiguous(),
+        scale.squeeze(-1).to(torch.float16).contiguous(),
+        group_size=group_size,
+        original_shape=tuple(x.shape),
+    )
+
+
+@flashinfer_api
+def int4_dequantize(
+    x: INT4Tensor,
+    dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+    r"""Dequantize an :class:`INT4Tensor` back to a dense tensor."""
+
+    if not isinstance(x, INT4Tensor):
+        raise TypeError(f"x must be an INT4Tensor, got {type(x)}")
+
+    hidden_dim = x.original_shape[-1]
+    unpacked_dim = math.ceil(hidden_dim / 2) * 2
+    unpacked = torch.empty(
+        (*x.data.shape[:-1], unpacked_dim),
+        dtype=torch.uint8,
+        device=x.data.device,
+    )
+    unpacked[..., 0::2] = x.data & 0x0F
+    unpacked[..., 1::2] = x.data >> 4
+    unpacked = unpacked[..., :hidden_dim]
+
+    q = unpacked.to(torch.int16) - 8
+    num_groups = math.ceil(hidden_dim / x.group_size)
+    q = q.reshape(*x.original_shape[:-1], num_groups, x.group_size).to(dtype)
+    scale = x.scale.to(dtype).unsqueeze(-1)
+    return (q * scale).reshape(x.original_shape)

--- a/flashinfer/quantization/packbits.py
+++ b/flashinfer/quantization/packbits.py
@@ -210,8 +210,20 @@ def int4_dequantize(
     unpacked[..., 1::2] = x.data >> 4
     unpacked = unpacked[..., :hidden_dim]
 
-    q = unpacked.to(torch.int16) - 8
     num_groups = math.ceil(hidden_dim / x.group_size)
+    padded_hidden_dim = num_groups * x.group_size
+    if padded_hidden_dim != hidden_dim:
+        pad = torch.full(
+            (*unpacked.shape[:-1], padded_hidden_dim - hidden_dim),
+            8,
+            dtype=torch.uint8,
+            device=x.data.device,
+        )
+        unpacked = torch.cat([unpacked, pad], dim=-1)
+
+    q = unpacked.to(torch.int16) - 8
     q = q.reshape(*x.original_shape[:-1], num_groups, x.group_size).to(dtype)
     scale = x.scale.to(dtype).unsqueeze(-1)
-    return (q * scale).reshape(x.original_shape)
+    return (q * scale).reshape(*x.original_shape[:-1], padded_hidden_dim)[
+        ..., :hidden_dim
+    ]

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -792,6 +792,147 @@ class FP4Tensor:
         self.dtype = "nvfp4"
 
 
+INT4_GROUP_SIZE = 32
+INT4_DTYPE_NAME = "int4"
+
+
+def is_int4_dtype(dtype: Union[torch.dtype, str, None]) -> bool:
+    return isinstance(dtype, str) and dtype == INT4_DTYPE_NAME
+
+
+class INT4Tensor:
+    """Wrapper class for packed int4 tensors."""
+
+    def __init__(
+        self,
+        data: torch.Tensor,
+        scale: torch.Tensor,
+        *,
+        group_size: int = INT4_GROUP_SIZE,
+        original_shape: Tuple[int, ...],
+        scheme: str = "symmetric",
+    ) -> None:
+        if data.dtype != torch.uint8:
+            raise ValueError(f"data must be uint8 tensor, got {data.dtype}")
+        if scale.dtype != torch.float16:
+            raise ValueError(f"scale must be float16 tensor, got {scale.dtype}")
+        if group_size <= 0:
+            raise ValueError(f"group_size must be positive, got {group_size}")
+        if len(original_shape) == 0:
+            raise ValueError("original_shape must have at least one dimension")
+        if data.shape[:-1] != original_shape[:-1]:
+            raise ValueError(
+                "data and original_shape must match except the last dimension: "
+                f"data.shape={data.shape}, original_shape={original_shape}"
+            )
+        expected_packed_dim = math.ceil(original_shape[-1] / 2)
+        if data.shape[-1] != expected_packed_dim:
+            raise ValueError(
+                "data last dimension must be ceil(original_shape[-1] / 2): "
+                f"data.shape[-1]={data.shape[-1]}, expected={expected_packed_dim}"
+            )
+        expected_num_groups = math.ceil(original_shape[-1] / group_size)
+        if scale.shape[:-1] != original_shape[:-1]:
+            raise ValueError(
+                "scale and original_shape must match except the last dimension: "
+                f"scale.shape={scale.shape}, original_shape={original_shape}"
+            )
+        if scale.shape[-1] != expected_num_groups:
+            raise ValueError(
+                "scale last dimension must be ceil(original_shape[-1] / group_size): "
+                f"scale.shape[-1]={scale.shape[-1]}, expected={expected_num_groups}"
+            )
+
+        self.data = data
+        self.scale = scale
+        self.group_size = group_size
+        self.original_shape = original_shape
+        self.scheme = scheme
+        self.dtype = INT4_DTYPE_NAME
+
+    def unbind(self, dim: int = 0) -> Tuple["INT4Tensor", ...]:
+        size = self.data.shape[dim]
+        original_shape = self.original_shape[:dim] + self.original_shape[dim + 1 :]
+        return tuple(
+            INT4Tensor(
+                self.data.select(dim, i),
+                self.scale.select(dim, i),
+                group_size=self.group_size,
+                original_shape=original_shape,
+                scheme=self.scheme,
+            )
+            for i in range(size)
+        )
+
+
+def is_int4_tensor(x: object) -> bool:
+    return isinstance(x, INT4Tensor)
+
+
+def is_int4_paged_kv_cache(
+    paged_kv_cache: Union[
+        torch.Tensor,
+        INT4Tensor,
+        Tuple[torch.Tensor, torch.Tensor],
+        Tuple[INT4Tensor, INT4Tensor],
+    ],
+) -> bool:
+    if isinstance(paged_kv_cache, INT4Tensor):
+        return True
+    if isinstance(paged_kv_cache, tuple) and len(paged_kv_cache) == 2:
+        return all(isinstance(x, INT4Tensor) for x in paged_kv_cache)
+    return False
+
+
+def _split_int4_paged_kv_cache_views(
+    paged_kv_cache: Union[INT4Tensor, Tuple[INT4Tensor, INT4Tensor]],
+    kv_layout: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    if isinstance(paged_kv_cache, tuple):
+        paged_k_cache, paged_v_cache = paged_kv_cache
+        return (
+            _expand_4d(paged_k_cache.data, kv_layout),
+            _expand_4d(paged_v_cache.data, kv_layout),
+            _expand_4d(paged_k_cache.scale, kv_layout),
+            _expand_4d(paged_v_cache.scale, kv_layout),
+        )
+    if isinstance(paged_kv_cache, INT4Tensor):
+        data = _expand_5d(paged_kv_cache.data, kv_layout)
+        scale = _expand_5d(paged_kv_cache.scale, kv_layout)
+        k_data, v_data = data.unbind(dim=1)
+        k_scale, v_scale = scale.unbind(dim=1)
+        return k_data, v_data, k_scale, v_scale
+    raise KeyError(
+        "Unrecognized int4 paged_kv_cache type {}, expect INT4Tensor or a tuple of INT4Tensor.".format(
+            type(paged_kv_cache)
+        )
+    )
+
+
+def _dequantize_int4_paged_kv_cache(
+    paged_kv_cache: Union[INT4Tensor, Tuple[INT4Tensor, INT4Tensor]],
+    kv_layout: str,
+    dtype: torch.dtype = torch.float16,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    from .quantization import int4_dequantize
+
+    if isinstance(paged_kv_cache, tuple):
+        paged_k_cache, paged_v_cache = paged_kv_cache
+        return (
+            _expand_4d(int4_dequantize(paged_k_cache, dtype=dtype), kv_layout),
+            _expand_4d(int4_dequantize(paged_v_cache, dtype=dtype), kv_layout),
+        )
+    if isinstance(paged_kv_cache, INT4Tensor):
+        kv_cache = _expand_5d(int4_dequantize(paged_kv_cache, dtype=dtype), kv_layout)
+        k_cache, v_cache = kv_cache.unbind(dim=1)
+        return k_cache, v_cache
+    raise KeyError(
+        "Unrecognized int4 paged_kv_cache type {}, expect INT4Tensor or a tuple of INT4Tensor.".format(
+            type(paged_kv_cache)
+        )
+    )
+
+
 # yapf: disable
 srcToDstBlk16RowMap = [
     0,  8,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -420,6 +420,10 @@ def is_fa3_backend_supported(
         torch.float8_e5m2,
     }:
         return False
+    # Int8 KV is supported by the common/fa2 path, but not by the current FA3 path.
+    # Keep Hopper functional support by falling back to fa2 in auto mode.
+    if dtype_kv == torch.int8:
+        return False
     return True
 
 

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -1887,9 +1887,7 @@ struct vec_t<int8_t, 1> {
   int8_t data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);
@@ -1924,9 +1922,7 @@ struct vec_t<int8_t, 2> {
   uint16_t data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);
@@ -1966,9 +1962,7 @@ struct vec_t<int8_t, 4> {
   uint32_t data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);
@@ -2008,9 +2002,7 @@ struct vec_t<int8_t, 8> {
   uint2 data;
 
   FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
-  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
-    return ((const int8_t*)(&data))[i];
-  }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)(&data))[i]; }
   FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
   FLASHINFER_INLINE void fill(int8_t val);
   FLASHINFER_INLINE void load(const int8_t* ptr);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -1879,6 +1879,248 @@ struct vec_t<uint8_t, vec_size> {
   }
 };
 
+/******************* vec_t<int8_t> *******************/
+
+// int8_t x 1
+template <>
+struct vec_t<int8_t, 1> {
+  int8_t data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::fill(int8_t val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::load(const int8_t* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::store(int8_t* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 1>::memcpy(int8_t* dst, const int8_t* src) { *dst = *src; }
+
+// int8_t x 2
+template <>
+struct vec_t<int8_t, 2> {
+  uint16_t data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::fill(int8_t val) {
+  uint8_t byte = static_cast<uint8_t>(val);
+  data = (uint16_t(byte) << 8) | uint16_t(byte);
+}
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::load(const int8_t* ptr) { data = *((uint16_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::store(int8_t* ptr) const { *((uint16_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 2>::memcpy(int8_t* dst, const int8_t* src) {
+  *((uint16_t*)dst) = *((uint16_t*)src);
+}
+
+// int8_t x 4
+template <>
+struct vec_t<int8_t, 4> {
+  uint32_t data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::fill(int8_t val) {
+  uint32_t byte = static_cast<uint8_t>(val);
+  data = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+}
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::load(const int8_t* ptr) { data = *((uint32_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::store(int8_t* ptr) const { *((uint32_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 4>::memcpy(int8_t* dst, const int8_t* src) {
+  *((uint32_t*)dst) = *((uint32_t*)src);
+}
+
+// int8_t x 8
+template <>
+struct vec_t<int8_t, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const {
+    return ((const int8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val);
+  FLASHINFER_INLINE void load(const int8_t* ptr);
+  FLASHINFER_INLINE void store(int8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::fill(int8_t val) {
+  uint32_t byte = static_cast<uint8_t>(val);
+  uint32_t val32 = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+  data.x = val32;
+  data.y = val32;
+}
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::load(const int8_t* ptr) { data = *((uint2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::store(int8_t* ptr) const { *((uint2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<int8_t, 8>::memcpy(int8_t* dst, const int8_t* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// int8_t x 16 or more
+template <size_t vec_size>
+struct vec_t<int8_t, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE int8_t& operator[](size_t i) { return ((int8_t*)data)[i]; }
+  FLASHINFER_INLINE const int8_t& operator[](size_t i) const { return ((const int8_t*)data)[i]; }
+  FLASHINFER_INLINE int8_t* ptr() { return reinterpret_cast<int8_t*>(&data); }
+  FLASHINFER_INLINE void fill(int8_t val) {
+    uint32_t byte = static_cast<uint8_t>(val);
+    uint32_t val32 = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i].x = val32;
+      data[i].y = val32;
+      data[i].z = val32;
+      data[i].w = val32;
+    }
+  }
+  FLASHINFER_INLINE void load(const int8_t* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(int8_t* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(int8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(int8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(int8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(int8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(int8_t* dst, const int8_t* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
 /******************* vec_t<float> *******************/
 
 // float x 1

--- a/tests/attention/test_hopper_fp8_attention.py
+++ b/tests/attention/test_hopper_fp8_attention.py
@@ -172,6 +172,59 @@ def test_single_prefill(seq_len, num_heads, causal, head_dim, dtype):
     assert mse < 1.0, f"MSE too high: {mse.item()}"
 
 
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_single_prefill_scale_v_is_not_double_applied(dtype):
+    if not is_sm90a_supported(torch.device("cuda")):
+        pytest.skip("SM90A is not supported")
+
+    seq_len = 257
+    num_heads = 8
+    head_dim = 128
+
+    q = torch.randn(seq_len, num_heads, head_dim, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, num_heads, head_dim, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, num_heads, head_dim, dtype=torch.half, device="cuda")
+
+    q_fp8, s_q = per_head_symmetric_quant(q, quant_dtype=dtype)
+    k_fp8, s_k = per_head_symmetric_quant(k, quant_dtype=dtype)
+    v_fp8, s_v = per_head_symmetric_quant(v, quant_dtype=dtype)
+
+    q_ref = (q_fp8.to(torch.float16) * s_q.view(1, -1, 1)).to(torch.float16)
+    k_ref = (k_fp8.to(torch.float16) * s_k.view(1, -1, 1)).to(torch.float16)
+    v_ref = (v_fp8.to(torch.float16) * s_v.view(1, -1, 1)).to(torch.float16)
+
+    out = flashinfer.single_prefill_with_kv_cache(
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        s_q,
+        s_k,
+        s_v,
+        causal=False,
+        backend="fa3",
+        o_dtype=torch.half,
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q_ref,
+        k_ref,
+        v_ref,
+        causal=False,
+        backend="fa3",
+    )
+    out_wrong = flashinfer.single_prefill_with_kv_cache(
+        q_ref,
+        k_ref,
+        (v_ref * s_v.view(1, -1, 1)).to(torch.float16),
+        causal=False,
+        backend="fa3",
+    )
+
+    mse_correct = torch.mean((out.float() - out_ref.float()) ** 2)
+    mse_wrong = torch.mean((out.float() - out_wrong.float()) ** 2)
+
+    assert mse_correct < mse_wrong * 0.25
+
+
 # Test block sparse attention correctness: MSE should be below threshold
 @pytest.mark.parametrize("R", [1, 4, 16])
 @pytest.mark.parametrize("C", [1, 4, 16])

--- a/tests/attention/test_int4_paged_kv.py
+++ b/tests/attention/test_int4_paged_kv.py
@@ -19,6 +19,19 @@ import torch
 
 import flashinfer
 from flashinfer import prefill as flashinfer_prefill
+from flashinfer import utils as flashinfer_utils
+
+
+def _require_sm80_or_newer() -> None:
+    major, _ = flashinfer_utils.get_compute_capability(torch.device("cuda"))
+    if major < 8:
+        pytest.skip("int4 paged-kv coverage requires sm80 or newer")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def require_sm80_or_newer():
+    _require_sm80_or_newer()
+    yield
 
 
 def _allocate_int4_tensor(shape, device="cuda:0"):
@@ -168,6 +181,41 @@ def test_append_paged_kv_cache_int4_matches_quantized_layout(
         rtol=1e-3,
         atol=1e-3,
     )
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("combined", [False, True])
+def test_append_paged_kv_cache_int4_rejects_mismatched_head_count(kv_layout, combined):
+    head_dim = 128
+    page_size = 4
+    paged_kv_cache = _make_paged_int4_cache(
+        1,
+        page_size,
+        num_kv_heads=2,
+        head_dim=head_dim,
+        kv_layout=kv_layout,
+        combined=combined,
+    )
+    k_append = torch.randn(4, 1, head_dim, dtype=torch.float16, device="cuda:0")
+    v_append = torch.randn(4, 1, head_dim, dtype=torch.float16, device="cuda:0")
+    batch_indices = torch.zeros(4, dtype=torch.int32, device="cuda:0")
+    positions = torch.arange(4, dtype=torch.int32, device="cuda:0")
+    kv_indices = torch.tensor([0], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, 1], dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor([4], dtype=torch.int32, device="cuda:0")
+
+    with pytest.raises(ValueError, match="head count does not match"):
+        flashinfer.append_paged_kv_cache(
+            k_append,
+            v_append,
+            batch_indices,
+            positions,
+            paged_kv_cache,
+            kv_indices,
+            kv_indptr,
+            kv_last_page_len,
+            kv_layout=kv_layout,
+        )
 
 
 @pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
@@ -673,7 +721,8 @@ def test_batch_wrappers_int4_auto_force_fa2():
         q_data_type=torch.float16,
         kv_data_type="int4",
     )
-    assert prefill_wrapper._backend == "fa2"
+    assert prefill_wrapper._backend == "auto"
+    assert prefill_wrapper._planned_backend == "fa2"
 
 
 def test_int4_paged_kv_cache_cuda_graph_unsupported():

--- a/tests/attention/test_int4_paged_kv.py
+++ b/tests/attention/test_int4_paged_kv.py
@@ -1,0 +1,749 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer import prefill as flashinfer_prefill
+
+
+def _allocate_int4_tensor(shape, device="cuda:0"):
+    packed_dim = (shape[-1] + 1) // 2
+    scale_dim = shape[-1] // 32
+    return flashinfer.INT4Tensor(
+        torch.zeros(*shape[:-1], packed_dim, dtype=torch.uint8, device=device),
+        torch.zeros(*shape[:-1], scale_dim, dtype=torch.float16, device=device),
+        original_shape=shape,
+    )
+
+
+def _make_paged_int4_cache(
+    num_pages: int,
+    page_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    kv_layout: str,
+    combined: bool,
+):
+    if kv_layout == "NHD":
+        kv_shape = (num_pages, 2, page_size, num_kv_heads, head_dim)
+        k_shape = (num_pages, page_size, num_kv_heads, head_dim)
+    else:
+        kv_shape = (num_pages, 2, num_kv_heads, page_size, head_dim)
+        k_shape = (num_pages, num_kv_heads, page_size, head_dim)
+    if combined:
+        return _allocate_int4_tensor(kv_shape)
+    return _allocate_int4_tensor(k_shape), _allocate_int4_tensor(k_shape)
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("combined", [False, True])
+def test_append_paged_kv_cache_int4_matches_quantized_layout(
+    kv_layout, head_dim, combined
+):
+    nnz_kv = 12
+    num_kv_heads = 2
+    page_size = 4
+    device = "cuda:0"
+
+    k_append = torch.randn(
+        nnz_kv, num_kv_heads, head_dim, dtype=torch.float16, device=device
+    )
+    v_append = torch.randn(
+        nnz_kv, num_kv_heads, head_dim, dtype=torch.float16, device=device
+    )
+
+    kv_append_length = torch.tensor([3, 5, 4], dtype=torch.int32, device=device)
+    kv_append_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(kv_append_length, dim=0),
+        ]
+    )
+    num_pages_per_req = torch.tensor([1, 2, 1], dtype=torch.int32, device=device)
+    kv_page_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(num_pages_per_req, dim=0),
+        ]
+    )
+    kv_page_indices = torch.arange(4, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.tensor([3, 1, 4], dtype=torch.int32, device=device)
+
+    batch_indices, positions = flashinfer.get_batch_indices_positions(
+        kv_append_indptr,
+        flashinfer.get_seq_lens(kv_page_indptr, kv_last_page_len, page_size),
+        nnz_kv,
+    )
+
+    paged_kv_cache = _make_paged_int4_cache(
+        8, page_size, num_kv_heads, head_dim, kv_layout, combined=combined
+    )
+    flashinfer.append_paged_kv_cache(
+        k_append,
+        v_append,
+        batch_indices,
+        positions,
+        paged_kv_cache,
+        kv_page_indices,
+        kv_page_indptr,
+        kv_last_page_len,
+        kv_layout=kv_layout,
+    )
+
+    expected_k = flashinfer.int4_quantize(k_append)
+    expected_v = flashinfer.int4_quantize(v_append)
+    if combined:
+        k_cache, v_cache = paged_kv_cache.unbind(dim=1)
+    else:
+        k_cache, v_cache = paged_kv_cache
+
+    batch_indices_i64 = batch_indices.to(torch.int64)
+    positions_i64 = positions.to(torch.int64)
+    page_offsets = torch.div(positions_i64, page_size, rounding_mode="floor")
+    page_positions = torch.remainder(positions_i64, page_size)
+    page_indices = kv_page_indices.to(torch.int64)[
+        kv_page_indptr.to(torch.int64)[batch_indices_i64] + page_offsets
+    ]
+
+    if kv_layout == "NHD":
+        torch.testing.assert_close(
+            k_cache.data[page_indices, page_positions], expected_k.data
+        )
+        torch.testing.assert_close(
+            v_cache.data[page_indices, page_positions], expected_v.data
+        )
+        torch.testing.assert_close(
+            k_cache.scale[page_indices, page_positions], expected_k.scale
+        )
+        torch.testing.assert_close(
+            v_cache.scale[page_indices, page_positions], expected_v.scale
+        )
+        gathered_k = flashinfer.int4_dequantize(k_cache)[page_indices, page_positions]
+        gathered_v = flashinfer.int4_dequantize(v_cache)[page_indices, page_positions]
+    else:
+        torch.testing.assert_close(
+            k_cache.data[page_indices, :, page_positions, :], expected_k.data
+        )
+        torch.testing.assert_close(
+            v_cache.data[page_indices, :, page_positions, :], expected_v.data
+        )
+        torch.testing.assert_close(
+            k_cache.scale[page_indices, :, page_positions, :], expected_k.scale
+        )
+        torch.testing.assert_close(
+            v_cache.scale[page_indices, :, page_positions, :], expected_v.scale
+        )
+        gathered_k = flashinfer.int4_dequantize(k_cache)[
+            page_indices, :, page_positions
+        ]
+        gathered_v = flashinfer.int4_dequantize(v_cache)[
+            page_indices, :, page_positions
+        ]
+
+    torch.testing.assert_close(
+        gathered_k,
+        flashinfer.int4_dequantize(expected_k),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+    torch.testing.assert_close(
+        gathered_v,
+        flashinfer.int4_dequantize(expected_v),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_single_decode_with_kv_cache_int4(kv_layout, head_dim, use_tensor_cores):
+    kv_len = 9
+    num_kv_heads = 2
+    num_qo_heads = 4
+    device = "cuda:0"
+
+    q = torch.randn(num_qo_heads, head_dim, dtype=torch.float16, device=device)
+    if kv_layout == "NHD":
+        k = torch.randn(
+            kv_len, num_kv_heads, head_dim, dtype=torch.float16, device=device
+        )
+        v = torch.randn(
+            kv_len, num_kv_heads, head_dim, dtype=torch.float16, device=device
+        )
+    else:
+        k = torch.randn(
+            num_kv_heads, kv_len, head_dim, dtype=torch.float16, device=device
+        )
+        v = torch.randn(
+            num_kv_heads, kv_len, head_dim, dtype=torch.float16, device=device
+        )
+
+    k_int4 = flashinfer.int4_quantize(k)
+    v_int4 = flashinfer.int4_quantize(v)
+    out = flashinfer.single_decode_with_kv_cache(
+        q,
+        k_int4,
+        v_int4,
+        kv_layout=kv_layout,
+        use_tensor_cores=use_tensor_cores,
+    )
+    out_ref = flashinfer.single_decode_with_kv_cache(
+        q,
+        flashinfer.int4_dequantize(k_int4),
+        flashinfer.int4_dequantize(v_int4),
+        kv_layout=kv_layout,
+        use_tensor_cores=use_tensor_cores,
+    )
+    torch.testing.assert_close(out, out_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_single_decode_with_kv_cache_int4_rejects_scale():
+    q = torch.randn(4, 128, dtype=torch.float16, device="cuda:0")
+    k = flashinfer.int4_quantize(
+        torch.randn(9, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+    v = flashinfer.int4_quantize(
+        torch.randn(9, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+
+    with pytest.raises(ValueError, match="k_scale and v_scale are not supported"):
+        flashinfer.single_decode_with_kv_cache(
+            q,
+            k,
+            v,
+            kv_layout="NHD",
+            k_scale=0.5,
+        )
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_single_prefill_with_kv_cache_int4(kv_layout, head_dim):
+    qo_len = 3
+    kv_len = 8
+    num_kv_heads = 2
+    num_qo_heads = 4
+    device = "cuda:0"
+
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=torch.float16, device=device)
+    if kv_layout == "NHD":
+        k = torch.randn(
+            kv_len, num_kv_heads, head_dim, dtype=torch.float16, device=device
+        )
+        v = torch.randn(
+            kv_len, num_kv_heads, head_dim, dtype=torch.float16, device=device
+        )
+    else:
+        k = torch.randn(
+            num_kv_heads, kv_len, head_dim, dtype=torch.float16, device=device
+        )
+        v = torch.randn(
+            num_kv_heads, kv_len, head_dim, dtype=torch.float16, device=device
+        )
+
+    k_int4 = flashinfer.int4_quantize(k)
+    v_int4 = flashinfer.int4_quantize(v)
+    out = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k_int4,
+        v_int4,
+        kv_layout=kv_layout,
+        causal=True,
+        backend="fa2",
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q,
+        flashinfer.int4_dequantize(k_int4),
+        flashinfer.int4_dequantize(v_int4),
+        kv_layout=kv_layout,
+        causal=True,
+        backend="fa2",
+    )
+    torch.testing.assert_close(out, out_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_single_prefill_with_kv_cache_int4_rejects_scale():
+    q = torch.randn(3, 4, 128, dtype=torch.float16, device="cuda:0")
+    k = flashinfer.int4_quantize(
+        torch.randn(8, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+    v = flashinfer.int4_quantize(
+        torch.randn(8, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+
+    with pytest.raises(ValueError, match="scale_k and scale_v are not supported"):
+        flashinfer.single_prefill_with_kv_cache(
+            q,
+            k,
+            v,
+            kv_layout="NHD",
+            scale_k=0.5,
+        )
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+@pytest.mark.parametrize("page_size", [4, 8])
+def test_batch_decode_with_paged_kv_cache_int4(
+    kv_layout, head_dim, use_tensor_cores, page_size
+):
+    batch_size = 3
+    kv_len = 9
+    num_kv_heads = 2
+    num_qo_heads = 4
+    device = "cuda:0"
+
+    q = torch.randn(
+        batch_size, num_qo_heads, head_dim, dtype=torch.float16, device=device
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    if kv_layout == "NHD":
+        kv_data = torch.randn(
+            total_num_pages,
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+    else:
+        kv_data = torch.randn(
+            total_num_pages,
+            2,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+    kv_data_int4 = flashinfer.int4_quantize(kv_data)
+    kv_data_ref = flashinfer.int4_dequantize(kv_data_int4)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout,
+        use_tensor_cores=use_tensor_cores,
+        backend="fa2",
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type="int4",
+        q_data_type=torch.float16,
+    )
+    out = wrapper.run(q, kv_data_int4)
+
+    wrapper_ref = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout,
+        use_tensor_cores=use_tensor_cores,
+        backend="fa2",
+    )
+    wrapper_ref.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    out_ref = wrapper_ref.run(q, kv_data_ref)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_batch_decode_with_paged_kv_cache_int4_rejects_scale():
+    batch_size = 2
+    kv_len = 8
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 4
+    head_dim = 128
+    device = "cuda:0"
+
+    q = torch.randn(
+        batch_size, num_qo_heads, head_dim, dtype=torch.float16, device=device
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = flashinfer.int4_quantize(
+        torch.randn(
+            total_num_pages,
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type="int4",
+        q_data_type=torch.float16,
+    )
+    with pytest.raises(ValueError, match="k_scale and v_scale are not supported"):
+        wrapper.run(q, kv_data, k_scale=0.5)
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("page_size", [4, 8])
+def test_batch_prefill_with_paged_kv_cache_int4(kv_layout, head_dim, page_size):
+    batch_size = 2
+    kv_len = 8
+    qo_len = 3
+    num_kv_heads = 2
+    num_qo_heads = 4
+    device = "cuda:0"
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, dtype=torch.float16, device=device
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * qo_len
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    if kv_layout == "NHD":
+        kv_data = torch.randn(
+            total_num_pages,
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+    else:
+        kv_data = torch.randn(
+            total_num_pages,
+            2,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+    kv_data_int4 = flashinfer.int4_quantize(kv_data)
+    kv_data_ref = flashinfer.int4_dequantize(kv_data_int4)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout,
+        backend="fa2",
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=torch.float16,
+        kv_data_type="int4",
+    )
+    out = wrapper.run(q, kv_data_int4)
+
+    wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout,
+        backend="fa2",
+    )
+    wrapper_ref.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+    )
+    out_ref = wrapper_ref.run(q, kv_data_ref)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_batch_prefill_with_paged_kv_cache_int4_rejects_scale():
+    batch_size = 2
+    kv_len = 8
+    qo_len = 3
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 4
+    head_dim = 128
+    device = "cuda:0"
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, dtype=torch.float16, device=device
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * qo_len
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = flashinfer.int4_quantize(
+        torch.randn(
+            total_num_pages,
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+        backend="auto",
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=torch.float16,
+        kv_data_type="int4",
+    )
+    with pytest.raises(ValueError, match="k_scale and v_scale are not supported"):
+        wrapper.run(q, kv_data, k_scale=0.5)
+
+
+def test_single_prefill_with_kv_cache_int4_auto_forces_fa2(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    seen = {}
+
+    def fake_get_single_prefill_module(backend, *args, **kwargs):
+        seen["backend"] = backend
+
+        class _Module:
+            def run(self, q, k, v, tmp, out, lse, *module_args):
+                out.zero_()
+
+        return _Module()
+
+    monkeypatch.setattr(
+        flashinfer_prefill,
+        "get_single_prefill_module",
+        fake_get_single_prefill_module,
+    )
+
+    q = torch.randn(3, 4, 128, dtype=torch.float16, device="cuda:0")
+    k = flashinfer.int4_quantize(
+        torch.randn(8, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+    v = flashinfer.int4_quantize(
+        torch.randn(8, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+
+    flashinfer.single_prefill_with_kv_cache(q, k, v, kv_layout="NHD", backend="auto")
+    assert seen["backend"] == "fa2"
+
+
+def test_batch_wrappers_int4_auto_force_fa2():
+    device = "cuda:0"
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    decode_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+        use_tensor_cores=True,
+        backend="auto",
+    )
+    kv_indptr = torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
+    kv_indices = torch.arange(4, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.tensor([4, 4], dtype=torch.int32, device=device)
+    decode_wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        4,
+        2,
+        128,
+        4,
+        data_type="int4",
+        q_data_type=torch.float16,
+    )
+    assert decode_wrapper._backend == "fa2"
+
+    prefill_wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+        backend="auto",
+    )
+    qo_indptr = torch.tensor([0, 3, 6], dtype=torch.int32, device=device)
+    prefill_wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        4,
+        2,
+        128,
+        4,
+        q_data_type=torch.float16,
+        kv_data_type="int4",
+    )
+    assert prefill_wrapper._backend == "fa2"
+
+
+def test_int4_paged_kv_cache_cuda_graph_unsupported():
+    batch_size = 2
+    kv_len = 8
+    qo_len = 3
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 4
+    head_dim = 128
+    device = "cuda:0"
+
+    kv_indptr = torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * (
+        (kv_len + page_size - 1) // page_size
+    )
+    kv_indices = torch.arange(kv_indptr[-1].item(), device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * qo_len
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    decode_wrapper = flashinfer.decode.CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        torch.empty(batch_size + 1, dtype=torch.int32, device=device),
+        torch.empty(kv_indices.numel(), dtype=torch.int32, device=device),
+        torch.empty(batch_size, dtype=torch.int32, device=device),
+        "NHD",
+    )
+    with pytest.raises(NotImplementedError):
+        decode_wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            data_type="int4",
+            q_data_type=torch.float16,
+        )
+
+    prefill_wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+        use_cuda_graph=True,
+        qo_indptr_buf=torch.empty(batch_size + 1, dtype=torch.int32, device=device),
+        paged_kv_indptr_buf=torch.empty(
+            batch_size + 1, dtype=torch.int32, device=device
+        ),
+        paged_kv_indices_buf=torch.empty(
+            kv_indices.numel(), dtype=torch.int32, device=device
+        ),
+        paged_kv_last_page_len_buf=torch.empty(
+            batch_size, dtype=torch.int32, device=device
+        ),
+    )
+    with pytest.raises(NotImplementedError):
+        prefill_wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            q_data_type=torch.float16,
+            kv_data_type="int4",
+        )

--- a/tests/attention/test_int4_paged_kv.py
+++ b/tests/attention/test_int4_paged_kv.py
@@ -677,6 +677,21 @@ def test_single_prefill_with_kv_cache_int4_auto_forces_fa2(
     assert seen["backend"] == "fa2"
 
 
+def test_single_prefill_with_kv_cache_int4_rejects_fp8_q():
+    q = torch.randn(3, 4, 128, dtype=torch.float16, device="cuda:0").to(
+        torch.float8_e4m3fn
+    )
+    k = flashinfer.int4_quantize(
+        torch.randn(8, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+    v = flashinfer.int4_quantize(
+        torch.randn(8, 2, 128, dtype=torch.float16, device="cuda:0")
+    )
+
+    with pytest.raises(ValueError, match="FP8 q is not supported with INT4 k/v"):
+        flashinfer.single_prefill_with_kv_cache(q, k, v, kv_layout="NHD")
+
+
 def test_batch_wrappers_int4_auto_force_fa2():
     device = "cuda:0"
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
@@ -723,6 +738,37 @@ def test_batch_wrappers_int4_auto_force_fa2():
     )
     assert prefill_wrapper._backend == "auto"
     assert prefill_wrapper._planned_backend == "fa2"
+
+
+def test_batch_prefill_with_paged_kv_cache_int4_rejects_fp8_q_dtype():
+    device = "cuda:0"
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device=device)
+    kv_indptr = torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
+    kv_indices = torch.arange(4, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.tensor([4, 4], dtype=torch.int32, device=device)
+    qo_indptr = torch.tensor([0, 3, 6], dtype=torch.int32, device=device)
+
+    prefill_wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+        backend="auto",
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="INT4 paged KV cache does not support FP8 query dtypes",
+    ):
+        prefill_wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            4,
+            2,
+            128,
+            4,
+            q_data_type=torch.float8_e4m3fn,
+            kv_data_type="int4",
+        )
 
 
 def test_int4_paged_kv_cache_cuda_graph_unsupported():

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -27,7 +27,7 @@ from tests.test_helpers.jit_utils import (
 
 
 def _require_sm80_or_newer() -> None:
-    major, _ = torch.cuda.get_device_capability(0)
+    major, _ = flashinfer_utils.get_compute_capability(torch.device("cuda"))
     if major < 8:
         pytest.skip("int8 paged-kv coverage requires sm80 or newer")
 

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -1,0 +1,408 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer import utils as flashinfer_utils
+from flashinfer.utils import PosEncodingMode, has_flashinfer_jit_cache
+from tests.test_helpers.jit_utils import (
+    gen_decode_attention_modules,
+    gen_prefill_attention_modules,
+)
+
+
+def _require_sm80_or_newer() -> None:
+    major, _ = torch.cuda.get_device_capability(0)
+    if major < 8:
+        pytest.skip("int8 paged-kv coverage requires sm80 or newer")
+
+
+@pytest.fixture(
+    autouse=not has_flashinfer_jit_cache(),
+    scope="module",
+)
+def warmup_jit():
+    _require_sm80_or_newer()
+    flashinfer.jit.build_jit_specs(
+        gen_decode_attention_modules(
+            [torch.float16],
+            [torch.int8],
+            [128],
+            [0],
+            [False],
+            [False],
+        )
+        + gen_prefill_attention_modules(
+            [torch.float16],
+            [torch.int8],
+            [128],
+            [0],
+            [False],
+            [False],
+            [False],
+        ),
+        verbose=False,
+    )
+    yield
+
+
+def test_append_paged_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    nnz_kv = 12
+    num_kv_heads = 4
+    head_dim = 128
+    page_size = 4
+
+    k_append = torch.randint(
+        -16, 16, (nnz_kv, num_kv_heads, head_dim), dtype=torch.int8, device="cuda:0"
+    )
+    v_append = torch.randint(
+        -16, 16, (nnz_kv, num_kv_heads, head_dim), dtype=torch.int8, device="cuda:0"
+    )
+
+    kv_append_length = torch.tensor([3, 5, 4], dtype=torch.int32, device="cuda:0")
+    kv_append_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device="cuda:0"),
+            torch.cumsum(kv_append_length, dim=0),
+        ]
+    )
+
+    num_pages_per_req = torch.tensor([1, 2, 1], dtype=torch.int32, device="cuda:0")
+    kv_page_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device="cuda:0"),
+            torch.cumsum(num_pages_per_req, dim=0),
+        ]
+    )
+    kv_page_indices = torch.arange(4, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor([3, 1, 4], dtype=torch.int32, device="cuda:0")
+
+    batch_indices, positions = flashinfer.get_batch_indices_positions(
+        kv_append_indptr,
+        flashinfer.get_seq_lens(kv_page_indptr, kv_last_page_len, page_size),
+        nnz_kv,
+    )
+
+    paged_kv_cache = torch.empty(
+        8, 2, page_size, num_kv_heads, head_dim, dtype=torch.int8, device="cuda:0"
+    )
+    flashinfer.append_paged_kv_cache(
+        k_append,
+        v_append,
+        batch_indices,
+        positions,
+        paged_kv_cache,
+        kv_page_indices,
+        kv_page_indptr,
+        kv_last_page_len,
+    )
+
+    batch_indices_cpu = batch_indices.cpu()
+    positions_cpu = positions.cpu()
+    kv_page_indptr_cpu = kv_page_indptr.cpu()
+    kv_page_indices_cpu = kv_page_indices.cpu()
+    for i in range(nnz_kv):
+        batch_idx = int(batch_indices_cpu[i])
+        position = int(positions_cpu[i])
+        page_slot = position // page_size
+        offset = position % page_size
+        page_idx = int(kv_page_indices_cpu[int(kv_page_indptr_cpu[batch_idx]) + page_slot])
+        torch.testing.assert_close(paged_kv_cache[page_idx, 0, offset], k_append[i])
+        torch.testing.assert_close(paged_kv_cache[page_idx, 1, offset], v_append[i])
+
+
+def test_batch_decode_with_paged_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    batch_size = 3
+    kv_len = 9
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    k_scale = 0.125
+    v_scale = 0.25
+
+    q = torch.randn(
+        batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = torch.randint(
+        -8,
+        8,
+        (total_num_pages, 2, page_size, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    kv_data_ref = kv_data.to(torch.float16)
+    kv_data_ref[:, 0].mul_(k_scale)
+    kv_data_ref[:, 1].mul_(v_scale)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device="cuda:0", dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device="cuda:0"
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type=torch.int8,
+        q_data_type=torch.float16,
+    )
+    out = wrapper.run(q, kv_data, k_scale=k_scale, v_scale=v_scale)
+
+    wrapper_ref = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper_ref.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        data_type=torch.float16,
+        q_data_type=torch.float16,
+    )
+    out_ref = wrapper_ref.run(q, kv_data_ref)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_batch_prefill_with_paged_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    batch_size = 2
+    kv_len = 8
+    qo_len = 3
+    page_size = 4
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    k_scale = 0.125
+    v_scale = 0.25
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    q_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * qo_len
+    )
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = torch.randint(
+        -8,
+        8,
+        (total_num_pages, 2, page_size, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    kv_data_ref = kv_data.to(torch.float16)
+    kv_data_ref[:, 0].mul_(k_scale)
+    kv_data_ref[:, 1].mul_(v_scale)
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device="cuda:0", dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device="cuda:0"
+    )
+
+    workspace_buffer = torch.empty(64 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        q_data_type=torch.float16,
+        kv_data_type=torch.int8,
+    )
+    out = wrapper.run(q, kv_data, k_scale=k_scale, v_scale=v_scale)
+
+    wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+    )
+    wrapper_ref.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+    )
+    out_ref = wrapper_ref.run(q, kv_data_ref)
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_single_decode_with_kv_cache_int8(use_tensor_cores: bool):
+    _require_sm80_or_newer()
+
+    kv_len = 9
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    k_scale = 0.125
+    v_scale = 0.25
+
+    q = torch.randn(num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    k = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    k_ref = k.to(torch.float16) * k_scale
+    v_ref = v.to(torch.float16) * v_scale
+
+    out = flashinfer.single_decode_with_kv_cache(
+        q,
+        k,
+        v,
+        use_tensor_cores=use_tensor_cores,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    out_ref = flashinfer.single_decode_with_kv_cache(
+        q,
+        k_ref,
+        v_ref,
+        use_tensor_cores=use_tensor_cores,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_single_prefill_with_kv_cache_int8():
+    _require_sm80_or_newer()
+
+    qo_len = 3
+    kv_len = 8
+    num_kv_heads = 2
+    num_qo_heads = 2
+    head_dim = 128
+    scale_k = 0.125
+    scale_v = 0.25
+
+    q = torch.randn(
+        qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    k_ref = k.to(torch.float16) * scale_k
+    v_ref = v.to(torch.float16) * scale_v
+
+    out = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k,
+        v,
+        causal=False,
+        scale_k=scale_k,
+        scale_v=scale_v,
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k_ref,
+        v_ref,
+        causal=False,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_determine_attention_backend_int8_falls_back_to_fa2_on_sm90(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(flashinfer_utils, "is_sm90a_supported", lambda device: True)
+
+    backend_int8 = flashinfer_utils.determine_attention_backend(
+        torch.device("cuda:0"),
+        PosEncodingMode.NONE.value,
+        False,
+        False,
+        torch.float16,
+        torch.int8,
+    )
+    backend_fp16 = flashinfer_utils.determine_attention_backend(
+        torch.device("cuda:0"),
+        PosEncodingMode.NONE.value,
+        False,
+        False,
+        torch.float16,
+        torch.float16,
+    )
+
+    assert backend_int8 == "fa2"
+    assert backend_fp16 == "fa3"

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -123,7 +123,9 @@ def test_append_paged_kv_cache_int8():
         position = int(positions_cpu[i])
         page_slot = position // page_size
         offset = position % page_size
-        page_idx = int(kv_page_indices_cpu[int(kv_page_indptr_cpu[batch_idx]) + page_slot])
+        page_idx = int(
+            kv_page_indices_cpu[int(kv_page_indptr_cpu[batch_idx]) + page_slot]
+        )
         torch.testing.assert_close(paged_kv_cache[page_idx, 0, offset], k_append[i])
         torch.testing.assert_close(paged_kv_cache[page_idx, 1, offset], v_append[i])
 
@@ -217,7 +219,11 @@ def test_batch_prefill_with_paged_kv_cache_int8():
     v_scale = 0.25
 
     q = torch.randn(
-        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+        batch_size * qo_len,
+        num_qo_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
     )
     q_indptr = (
         torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * qo_len

--- a/tests/attention/test_int8_paged_kv.py
+++ b/tests/attention/test_int8_paged_kv.py
@@ -388,6 +388,72 @@ def test_single_prefill_with_kv_cache_int8():
     torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
 
 
+def test_single_prefill_with_kv_cache_int8_scale_v_gqa_tensor():
+    _require_sm80_or_newer()
+
+    qo_len = 3
+    kv_len = 8
+    num_kv_heads = 2
+    num_qo_heads = 4
+    head_dim = 128
+    scale_v = torch.tensor([0.25, 0.5], device="cuda:0", dtype=torch.float32)
+
+    q = torch.randn(
+        qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v = torch.randint(
+        -8,
+        8,
+        (kv_len, num_kv_heads, head_dim),
+        device="cuda:0",
+        dtype=torch.int8,
+    )
+    v_ref = v.to(torch.float16) * scale_v.view(1, -1, 1)
+
+    out = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k,
+        v,
+        causal=False,
+        scale_v=scale_v,
+    )
+    out_ref = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k.to(torch.float16),
+        v_ref,
+        causal=False,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=2e-2)
+
+
+def test_single_prefill_with_kv_cache_int8_rejects_tensor_scale_k():
+    _require_sm80_or_newer()
+
+    q = torch.randn(3, 2, 128, device="cuda:0", dtype=torch.float16)
+    k = torch.randint(-8, 8, (8, 2, 128), device="cuda:0", dtype=torch.int8)
+    v = torch.randint(-8, 8, (8, 2, 128), device="cuda:0", dtype=torch.int8)
+    scale_k = torch.tensor([0.25, 0.5], device="cuda:0", dtype=torch.float32)
+
+    with pytest.raises(
+        TypeError, match="scale_k must be a scalar for non-FP8 single prefill"
+    ):
+        flashinfer.single_prefill_with_kv_cache(
+            q,
+            k,
+            v,
+            causal=False,
+            scale_k=scale_k,
+        )
+
+
 def test_determine_attention_backend_int8_falls_back_to_fa2_on_sm90(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/utils/test_quantization.py
+++ b/tests/utils/test_quantization.py
@@ -60,6 +60,38 @@ def test_segment_packbits(batch_size, bitorder):
         assert torch.equal(y_gpu[new_indptr[i] : new_indptr[i + 1]], y_segment_i_ref)
 
 
+def test_int4_dequantize_handles_partial_group_tail():
+    hidden_dim = 130
+    group_size = 32
+    x = torch.randn(3, hidden_dim, dtype=torch.float16, device="cuda:0")
+    padded_hidden_dim = ((hidden_dim + group_size - 1) // group_size) * group_size
+    x_padded = torch.cat(
+        [
+            x,
+            torch.zeros(
+                3,
+                padded_hidden_dim - hidden_dim,
+                dtype=torch.float16,
+                device="cuda:0",
+            ),
+        ],
+        dim=-1,
+    )
+    x_int4_padded = flashinfer.int4_quantize(x_padded, group_size=group_size)
+    packed_dim = (hidden_dim + 1) // 2
+    x_int4 = flashinfer.INT4Tensor(
+        x_int4_padded.data[..., :packed_dim].contiguous(),
+        x_int4_padded.scale,
+        group_size=group_size,
+        original_shape=tuple(x.shape),
+    )
+
+    dequantized = flashinfer.int4_dequantize(x_int4)
+    ref = flashinfer.int4_dequantize(x_int4_padded)[..., :hidden_dim]
+
+    torch.testing.assert_close(dequantized, ref)
+
+
 if __name__ == "__main__":
     test_packbits(999999, "big")
     test_segment_packbits(77, "little")


### PR DESCRIPTION
## 📌 Description

Builds on the int8 paged-KV work in #3100 to add int4 support.

Incremental review against the int8 branch:
https://github.com/lesj0610/flashinfer/compare/codex/int8-paged-kv-main-v068...codex/int4-paged-kv-main-v068

`torch.uint8` is already used in some paths as an FP4 container, so a plain uint8 input creates a semantic conflict. An explicit `INT4Tensor` wrapper is used to keep the contract unambiguous. Storage is packed uint8 with grouped fp16 scales (`group_size=32`).

The implementation goes through staged dequantization to fp16 before calling existing kernels. On Hopper, auto backend selection falls back to FA2 the same way as in #3100. The following are not included in this PR:

- CUDA graph: explicitly blocked, as the staging step requires temporary allocation
- Native FA3, XQA, and TRTLLM-gen int4 paths

Because the upstream PR base must stay on `main`, GitHub still shows the shared int8 commits in the main PR diff until #3100 lands. The compare link above shows the int4-only incremental delta.

Tested on Ampere (A100) and Hopper (H100):

```bash
python -m pytest tests/attention/test_int4_paged_kv.py -v
```

51 tests passed on both architectures.

## 🔍 Related Issues
<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks
- [x] I have installed pre-commit by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

### 🧪 Tests
- [x] Tests have been added or updated as needed.
- [x] All tests are passing (unittest, etc.).

Depends on #3100.

Retargeted against `main` after the `v0.6.8` release branch cut.
