### PR TITLE
Fix multi-instances using same random seed

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -807,7 +807,7 @@ class PosixFDHandleExchanger(HandleExchanger):
 
     def _init_ipc_socket(self) -> IpcSocket:
         if self.rank == 0:
-            opId = random.randint(0, 2**64 - 1)
+            opId = random.Random().randint(0, 2**64 - 1)
         else:
             opId = None
         opId = self.comm.bcast(opId, root=0)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

When running two vLLM instances on the same machine at the same time, one instance will print the following error.
```
allreduce_rms_fusion.py:779] Failed to initialize FlashInfer All Reduce workspace: [Errno 98] Address already in use. AllReduce fusion pass will be disabled.
```

The reason for this is that both instances create the same random seed, so the `IpcSocket` uses the same socket file path.



## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved inter-process communication initialization with enhanced random operation ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->