### PR TITLE
fix(fmha_v2): enable flash_attention for Q_PAGED_KV regardless of s_kv

### DIFF
--- a/csrc/fmha_v2_run.cu
+++ b/csrc/fmha_v2_run.cu
@@ -250,9 +250,15 @@ static inline void determine_launch_params(
   launch_params.device_l2_cache_size = props.l2CacheSize;
 
   // threshold for adopting flash attention or warp_specialized kernels.
+  // For Q_PAGED_KV layouts, flash attention is required regardless of
+  // seqlen — the paged KV dispatch path only supports flash attention
+  // kernels, and `s` is the padded max_kv_len (not per-request seq_lens,
+  // which the kernel predicates on separately). Falling back to the
+  // non-flash path produces silently wrong output when max_kv_len < 16.
+  bool const is_paged_kv = input_layout == Attention_input_layout::Q_PAGED_KV;
   launch_params.flash_attention =
       (data_type == DATA_TYPE_FP16 || data_type == DATA_TYPE_BF16 || data_type == DATA_TYPE_E4M3) &&
-      (s >= 16 && d >= 16) && !force_non_flash_attention;
+      (is_paged_kv || (s >= 16 && d >= 16)) && !force_non_flash_attention;
 
   // enable warp_speialized kernels when s >= 512 on hopper
   // note that warp_speialized kernels need flash attention + tma


### PR DESCRIPTION
## Problem

`determine_launch_params()` in `csrc/fmha_v2_run.cu` disables `flash_attention` when `max_kv_len < 16` via the `s >= 16` check. For `Q_PAGED_KV` layouts this falls back to a non-flash-attention kernel that does not correctly read paged KV — producing wrong output (max_diff 4+ vs reference, or NaN) for any prefill whose total KV length is under 16 tokens.

### Reproducer

```python
import torch
from flashinfer.prefill import trtllm_fmha_v2_prefill

device = torch.device("cuda")
torch.manual_seed(42)
# Qwen2.5-0.5B-style GQA: 14 Q heads, 2 KV heads, D=64, page_size=16
# seq_len=9 (< page_size), q_len=8 (prefix-cached scenario)
seq_len, q_len, PS = 9, 8, 16
full_k = torch.randn(seq_len, 2, 64, device=device, dtype=torch.float16)
full_v = torch.randn(seq_len, 2, 64, device=device, dtype=torch.float16)
q_full = torch.randn(seq_len, 14, 64, device=device, dtype=torch.float16)

kv = torch.zeros(1, 2, PS, 2, 64, device=device, dtype=torch.float16)
kv[0, 0, :seq_len] = full_k
kv[0, 1, :seq_len] = full_v
# ... (call trtllm_fmha_v2_prefill with Q_PAGED_KV_NHD)
# Result before fix: max_diff = 2.27 vs reference attention
# Result after fix:  max_diff = 0.002
```

## Root cause

The `s >= 16` gate was added for pre-flash-attention fused kernels that required a minimum sequence length for tiling. `Q_PAGED_KV` layouts only have a flash-attention code path, so this gate incorrectly disqualifies them. Per-request bounds are already enforced via `seq_lens`; `s` is the padded `max_kv_len` used for tile scheduling, not a correctness bound.

## Fix

Exempt `Q_PAGED_KV` layouts from the `s >= 16` check:

```cpp
bool const is_paged_kv = input_layout == Attention_input_layout::Q_PAGED_KV;
launch_params.flash_attention =
    (data_type == DATA_TYPE_FP16 || data_type == DATA_TYPE_BF16 || data_type == DATA_TYPE_E4M3) &&
    (is_paged_kv || (s >= 16 && d >= 16)) && !force_non_flash_attention;
```

## Validation

Validated on SM121a (DGX Spark GB10, NVIDIA GB10):

- Reproducer (seq_len=9, page_size=16): max_diff 2.27 → 0.002 vs reference
- seq_len in {1, 5, 9, 15, 16, 17, 25, 33}: all match reference (max_diff < 0.01)
- GQA (14 Q heads, 2 KV heads): max_diff 0.002 vs reference
- vLLM end-to-end (Qwen2.5-0.5B, `trl-internal-testing/tiny-GptOssForCausalLM`) with prefix caching: deterministic output across repeated calls, no regressions on prior page-aligned cases

Contributed by Second Nature Computing (https://joinsecondnature.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash attention dispatch for paged-KV attention layouts, removing sequence length and dimension constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->