### PR TITLE
Normalize modular attention to CUTLASS DSL APIs shipped on PyPI

### DIFF
--- a/flashinfer/cute_dsl/attention/compat.py
+++ b/flashinfer/cute_dsl/attention/compat.py
@@ -35,3 +35,28 @@ def get_max_tmem_alloc_cols(compute_capability: str) -> int:
     if compute_capability not in _TMEM_MAX_ALLOC_COLUMNS_MAP:
         raise ValueError(f"Unsupported compute capability: {compute_capability}")
     return _TMEM_MAX_ALLOC_COLUMNS_MAP[compute_capability]
+
+
+def make_register_tensor(layout_or_shape, dtype):
+    """Compat wrapper for register-memory tensor allocation."""
+    if hasattr(cute, "make_rmem_tensor"):
+        return cute.make_rmem_tensor(layout_or_shape, dtype)
+    return cute.make_fragment(layout_or_shape, dtype)
+
+
+def fence_proxy_async_shared_cta() -> None:
+    """Compat wrapper for the async.shared CTA fence_proxy call shape."""
+    if hasattr(cute.arch, "ProxyKind") and hasattr(cute.arch, "SharedSpace"):
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared,
+            space=cute.arch.SharedSpace.shared_cta,
+        )
+        return
+    cute.arch.fence_proxy("async.shared", space="cta")
+
+
+def exp2_fast(x):
+    """Compat wrapper for the fast approximate base-2 exponential."""
+    if hasattr(cute.math, "exp2"):
+        return cute.math.exp2(x, fastmath=True)
+    return cute.arch.exp2(x)

--- a/flashinfer/cute_dsl/attention/fusion/variant.py
+++ b/flashinfer/cute_dsl/attention/fusion/variant.py
@@ -119,7 +119,7 @@ Hardware Primitives
 The following hardware-mapped primitives are available for use in
 ``transform_logits`` and ``score_mod``::
 
-    cute.arch.exp2(x)       # MUFU.EX2  — base-2 exponential (approx)
+    exp2_fast(x)            # MUFU.EX2  — base-2 exponential (approx)
     cute.arch.rcp_approx(x) # MUFU.RCP  — reciprocal (approx)
     tanh_approx(x)          # MUFU.TANH — hyperbolic tangent (approx)
 
@@ -139,7 +139,7 @@ Sigmoid attention (exp2 + rcp, 2 MUFU ops/element)::
         @cute.jit
         def transform_logits(self, score):
             return cute.arch.rcp_approx(
-                1 + cute.arch.exp2(-(score * self.scale + self.bias)))
+                1 + exp2_fast(-(score * self.scale + self.bias)))
 
 Sigmoid attention via tanh (1 MUFU op/element)::
 
@@ -187,6 +187,8 @@ import cutlass.cute as cute
 from cutlass.cutlass_dsl import T, dsl_user_op
 from cutlass._mlir.dialects import llvm
 from cutlass.cute.typing import Float32
+
+from ..compat import exp2_fast
 
 
 @dsl_user_op
@@ -430,8 +432,8 @@ class AttentionWithSink(AttentionVariant):
             log2_e = math.log2(math.exp(1.0))
             sink_raw = self.params[qo_head_idx] * log2_e / scale
             m_new = sink_raw if sink_raw > m else m
-            rescale = cute.arch.exp2((m - m_new) * scale)
-            d_new = cute.arch.exp2((sink_raw - m_new) * scale) + d * rescale
+            rescale = exp2_fast((m - m_new) * scale)
+            d_new = exp2_fast((sink_raw - m_new) * scale) + d * rescale
         return m_new, d_new
 
     @cute.jit
@@ -471,18 +473,16 @@ class SigmoidAttention(AttentionVariant):
 
     @cute.jit
     def transform_logits(self, score):
-        return cute.arch.rcp_approx(
-            1 + cute.arch.exp2(-(score * self.scale + self.bias))
-        )
+        return cute.arch.rcp_approx(1 + exp2_fast(-(score * self.scale + self.bias)))
 
     @cute.jit
     def transform_logits_vec(self, scores):
         for i in cutlass.range_constexpr(0, cute.size(scores), 2):
             scores[i] = cute.arch.rcp_approx(
-                1 + cute.arch.exp2(-(scores[i] * self.scale + self.bias))
+                1 + exp2_fast(-(scores[i] * self.scale + self.bias))
             )
             scores[i + 1] = cute.arch.rcp_approx(
-                1 + cute.arch.exp2(-(scores[i + 1] * self.scale + self.bias))
+                1 + exp2_fast(-(scores[i + 1] * self.scale + self.bias))
             )
 
 

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -13,6 +13,10 @@ from .config import AttentionConfig, AttentionFusion
 from .warp_schedule import WarpSchedule, PREFILL_SCHEDULE, PREFILL_TRANSFORM_SCHEDULE
 from .mainloop_spec import make_prefill_mainloop_spec
 from .collective_builder import build_fmha_launch_params
+from .compat import (
+    setmaxregister_decrease as _setmaxregister_decrease,
+    setmaxregister_increase as _setmaxregister_increase,
+)
 from .scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -463,13 +467,13 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  EMPTY
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.schedule.empty_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_empty)
+            _setmaxregister_decrease(self.schedule.num_regs_empty)
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  LOAD
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.schedule.load_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_other)
+            _setmaxregister_decrease(self.schedule.num_regs_other)
             self.loader_role.run(
                 qk_thr_mma,
                 pv_thr_mma,
@@ -493,7 +497,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  MMA
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.schedule.mma_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_other)
+            _setmaxregister_decrease(self.schedule.num_regs_other)
             self.mma_role.run(
                 qk_tiled_mma,
                 pv_tiled_mma,
@@ -524,7 +528,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  Epilogue
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.schedule.epilogue_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_other)
+            _setmaxregister_decrease(self.schedule.num_regs_other)
             self.epilogue_role.run(
                 tma_atom_o,
                 mO_qdl,
@@ -541,7 +545,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx < self.schedule.softmax1_warp_ids[0]:
             # increase register after decreasing
-            cute.arch.warpgroup_reg_alloc(self.schedule.num_regs_softmax)
+            _setmaxregister_increase(self.schedule.num_regs_softmax)
 
             self.softmax_role.run(
                 stage=0,
@@ -575,7 +579,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             and warp_idx < self.schedule.softmax1_upper_warp_id
         ):
             # increase register after decreasing
-            cute.arch.warpgroup_reg_alloc(self.schedule.num_regs_softmax)
+            _setmaxregister_increase(self.schedule.num_regs_softmax)
 
             self.softmax_role.run(
                 stage=1,
@@ -609,7 +613,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 warp_idx >= self.schedule.softmax1_upper_warp_id
                 and warp_idx < self.schedule.mma_warp_id
             ):
-                cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_correction)
+                _setmaxregister_decrease(self.schedule.num_regs_correction)
                 self.correction_role.run(
                     qk_thr_mma,
                     pv_thr_mma,

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -22,6 +22,7 @@ from cutlass.cute.typing import Int32, Float32
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig, AttentionFusion
+from ..compat import exp2_fast, fence_proxy_async_shared_cta, make_register_tensor
 from ..tmem_layout import TmemLayout
 from ..fusion.mask import get_trip_count
 from ..scheduler.persistent import (
@@ -132,7 +133,7 @@ class CorrectionRole:
 
         tTMEM_STOREtO = thr_tmem_store.partition_D(tOtO_i)
 
-        tTMrO = cute.make_fragment(
+        tTMrO = make_register_tensor(
             (tTMEM_LOADcO.shape, 128 // corr_tile_size), self.pv_acc_dtype
         )
         for i in range(self.cta_tiler[2] // corr_tile_size):
@@ -234,7 +235,7 @@ class CorrectionRole:
         for i in range(self.cta_tiler[2] // corr_tile_size):
             tTMEM_LOADtO_i = tTMEM_LOADtO[None, 0, 0, i]
             tTMEM_LOADsO_i = tTMEM_LOADsO[None, 0, 0, i]
-            tTMrO = cute.make_fragment(
+            tTMrO = make_register_tensor(
                 tTMEM_LOADoO[None, 0, 0, i].shape, self.pv_acc_dtype
             )
             cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
@@ -257,16 +258,13 @@ class CorrectionRole:
                         rcp_d,
                         scale,
                     )
-            tSMrO = cute.make_fragment(tTMrO.shape, self.o_dtype)
+            tSMrO = make_register_tensor(tTMrO.shape, self.o_dtype)
             o_vec = tTMrO.load()
             tSMrO.store(o_vec.to(self.o_dtype))
             cute.copy(tiled_smem_store, tSMrO, tTMEM_LOADsO_i)
 
         # fence view async shared
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        fence_proxy_async_shared_cta()
 
     @cute.jit
     def run(
@@ -375,14 +373,14 @@ class CorrectionRole:
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
                     # wait for vec0 (row_wise current max & previous max)
                     vec0_handle = s0_corr_consumer.wait_and_advance()
-                    tTMEM_LOAD_VECrS = cute.make_fragment(
+                    tTMEM_LOAD_VECrS = make_register_tensor(
                         tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype
                     )
                     cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtS0, tTMEM_LOAD_VECrS)
                     scale_ = scale_softmax_log2 * (
                         tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1]
                     )
-                    scale = cute.arch.exp2(scale_)
+                    scale = exp2_fast(scale_)
 
                     # wait for o0
                     o0_handle_consumer = mma_corr_consumer.wait_and_advance()
@@ -399,7 +397,7 @@ class CorrectionRole:
                     scale_ = scale_softmax_log2 * (
                         tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1]
                     )
-                    scale = cute.arch.exp2(scale_)
+                    scale = exp2_fast(scale_)
 
                     o1_handle_consumer = mma_corr_consumer.wait_and_advance()
                     if cutlass.const_expr(not self.has_logits_transform):
@@ -412,7 +410,7 @@ class CorrectionRole:
 
                 # wait for vec0 (row_wise global sum)
                 vec0_handle = s0_corr_consumer.wait_and_advance()
-                tTMEM_LOAD_VECrS = cute.make_fragment(
+                tTMEM_LOAD_VECrS = make_register_tensor(
                     tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype
                 )
                 cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtS0, tTMEM_LOAD_VECrS)

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -24,6 +24,7 @@ from cutlass.cute.typing import Int32, Float32
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from .softmax_math import exp2_scale
+from ..compat import exp2_fast, fence_proxy_async_shared_cta, make_register_tensor
 from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
 from ..fusion.mask import (
@@ -192,7 +193,7 @@ class SoftmaxRole:
 
         # Wait for Si
         si_handle = mma_si_consumer.wait_and_advance()
-        tTMEM_LOADrS = cute.make_fragment(tTMEM_LOADcS.shape, self.qk_acc_dtype)
+        tTMEM_LOADrS = make_register_tensor(tTMEM_LOADcS.shape, self.qk_acc_dtype)
         cute.copy(tiled_tmem_load, tTMEM_LOADtS, tTMEM_LOADrS)
         if need_apply_mask:
             apply_mask(
@@ -243,7 +244,7 @@ class SoftmaxRole:
 
             if row_max == -cutlass.Float32.inf:
                 row_max_safe = 0.0
-            tTMEM_STORE_VECrS = cute.make_fragment(
+            tTMEM_STORE_VECrS = make_register_tensor(
                 tTMEM_STORE_VECcS.shape, self.qk_acc_dtype
             )
 
@@ -253,7 +254,7 @@ class SoftmaxRole:
             cute.arch.fence_view_async_tmem_store()
             vec_i_handle.commit()
 
-        tTMEM_STORErS_x4 = cute.make_fragment(tTMEM_STOREcS.shape, self.qk_acc_dtype)
+        tTMEM_STORErS_x4 = make_register_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
         tTMEM_STORErS_x4_e = cute.make_tensor(
             cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.q_dtype),
             tTMEM_LOADrS.layout,
@@ -310,7 +311,7 @@ class SoftmaxRole:
             ### di = di-1 * (e^(mi-1 - mi) * scale) + sum e^(xi*scale - mi*scale)
             acc_scale_ = scale * (old_row_max - row_max_safe)
             # * 0.5 compensates for initializing both packed elements with row_sum below
-            acc_scale = cute.arch.exp2(acc_scale_) * 0.5
+            acc_scale = exp2_fast(acc_scale_) * 0.5
             row_sum *= acc_scale
             # 4-way unrolled reduction for ILP: 4 independent accumulator chains
             # run in parallel, then tree-reduce. local_row_sum_0 is seeded with
@@ -430,7 +431,7 @@ class SoftmaxRole:
         for i in range(self.cta_tiler[2] // corr_tile_size):
             tTMEM_LOADtO_i = tTMEM_LOADtO[None, 0, 0, i]
             tTMEM_LOADsO_i = tTMEM_LOADsO[None, 0, 0, i]
-            tTMrO = cute.make_fragment(
+            tTMrO = make_register_tensor(
                 tTMEM_LOADoO[None, 0, 0, i].shape, self.pv_acc_dtype
             )
             cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
@@ -439,15 +440,12 @@ class SoftmaxRole:
                     (tTMrO[j], tTMrO[j + 1]),
                     (scale, scale),
                 )
-            tSMrO = cute.make_fragment(tTMrO.shape, self.o_dtype)
+            tSMrO = make_register_tensor(tTMrO.shape, self.o_dtype)
             o_vec = tTMrO.load()
             tSMrO.store(o_vec.to(self.o_dtype))
             cute.copy(tiled_smem_store, tSMrO, tTMEM_LOADsO_i)
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        fence_proxy_async_shared_cta()
 
     # For both softmax0 and softmax1 warp group
     @cute.jit
@@ -694,7 +692,7 @@ class SoftmaxRole:
                     )
                 si_handle = mma_si_consumer.wait_and_advance()
                 if cutlass.const_expr(not self.has_logits_transform):
-                    tTMEM_STORE_VECrS = cute.make_fragment(
+                    tTMEM_STORE_VECrS = make_register_tensor(
                         tTMEM_STORE_VECcS.shape, self.qk_acc_dtype
                     )
                     tTMEM_STORE_VECrS[0] = row_sum

--- a/flashinfer/cute_dsl/attention/roles/softmax_math.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax_math.py
@@ -10,6 +10,8 @@ duplicating the core exp2-scale and packed row-sum reduction logic.
 import cutlass
 import cutlass.cute as cute
 
+from ..compat import exp2_fast
+
 
 @cute.jit
 def exp2_scale(scores, scale_log2, row_max):
@@ -21,8 +23,8 @@ def exp2_scale(scores, scale_log2, row_max):
             (scale_log2, scale_log2),
             (minus_max_scale, minus_max_scale),
         )
-        scores[i] = cute.arch.exp2(scores[i])
-        scores[i + 1] = cute.arch.exp2(scores[i + 1])
+        scores[i] = exp2_fast(scores[i])
+        scores[i + 1] = exp2_fast(scores[i + 1])
 
 
 @cute.jit


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Updated modular attention call sites to prefer the current CUTLASS DSL APIs while preserving backward-compatible fallbacks in the compat layer. Use the existing `setmaxregister_*` compatibility path in `flashinfer/cute_dsl/attention/compat.py', and add compatibility layer for `fence_proxy_async_shared_cta`, `exp2_fast`, and `make_rmem_tensor.`

Fixes the modular FMHA prefill failure reported in #3071: `AttributeError: module 'cutlass.cute.arch' has no attribute 'ProxyKind'`.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3071

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced compatibility wrappers for low-level GPU primitives to standardize exponentiation, tensor/register creation, and synchronization across environments.
  * Updated attention kernels to use these wrappers, improving consistency of math and memory/register handling.
  * Improved register budgeting and synchronization behavior in the kernel execution pipeline for more reliable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->