### PR TITLE
Fix: Extend b12x FP4 GEMM support to SM121 (GB10/DGX Spark)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4538,7 +4538,7 @@ def _cute_dsl_gemm_fp4_requirement(
     return True
 
 
-@supported_compute_capability([120])
+@supported_compute_capability([120, 121])
 def _b12x_gemm_fp4_requirement(
     a: torch.Tensor,  # unused
     b: torch.Tensor,  # unused


### PR DESCRIPTION
SM121 (GB10, used in DGX Spark and RTX Pro 6000) supports the same b12x CuTe DSL warp-level MMA FP4 GEMM kernels as SM120, but was excluded from _b12x_gemm_fp4_requirement's supported_compute_capability list. On SM121, calling mm_fp4(..., backend="b12x") raised:
  BackendSupportedError: mm_fp4 does not support backend 'b12x' with capability 121

Add 121 to the supported compute capability list so that mm_fp4(..., backend="b12x") works correctly on SM121.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended FP4 GEMM support to NVIDIA Hopper GPU architecture (SM121), in addition to Ada GPUs (SM120), enabling optimized performance on a broader range of NVIDIA GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->