### PR TITLE
perf(autotuner): replace power-of-2 token buckets with hybrid spacing & fix missing routing_replay_out arg

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -51,8 +51,8 @@ from ..utils import (
     get_compute_capability,
 )
 from .utils import (
-    get_last_power_of_2_num_tokens_buckets,
-    last_positive_power_of_2,
+    get_hybrid_num_tokens_buckets,
+    map_to_hybrid_bucket,
 )
 from ..tllm_enums import (
     ActivationType,
@@ -234,8 +234,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
                 DynamicTensorSpec(
                     (0,),
                     (0,),
-                    get_last_power_of_2_num_tokens_buckets(8192),
-                    lambda x: min(last_positive_power_of_2(x), 8192),
+                    get_hybrid_num_tokens_buckets(8192),
+                    lambda x: map_to_hybrid_bucket(x, 8192),
                 ),
             )
         )
@@ -402,8 +402,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
                     DynamicTensorSpec(
                         (0,),
                         (0,),
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        get_hybrid_num_tokens_buckets(tune_max_num_tokens),
+                        lambda x: map_to_hybrid_bucket(x, tune_max_num_tokens),
                     ),
                 )
             )
@@ -1027,8 +1027,8 @@ def get_trtllm_moe_sm100_module():
                     DynamicTensorSpec(
                         input_idx,
                         dim_idx,
-                        get_last_power_of_2_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: min(last_positive_power_of_2(x), tune_max_num_tokens),
+                        get_hybrid_num_tokens_buckets(tune_max_num_tokens, 1),
+                        lambda x: map_to_hybrid_bucket(x, tune_max_num_tokens),
                         initializers,
                     ),
                 ),

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -42,8 +42,8 @@ from ...autotuner import (
     TuningConfig,
 )
 from ..utils import (
-    get_last_power_of_2_num_tokens_buckets,
-    last_positive_power_of_2,
+    get_hybrid_num_tokens_buckets,
+    map_to_hybrid_bucket,
 )
 
 logger = logging.getLogger(__name__)
@@ -273,10 +273,8 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 DynamicTensorSpec(
                     input_idx=(0, 1, 2, 3, 11),
                     dim_idx=(0, 0, 0, 0, 0),
-                    gen_tuning_buckets=get_last_power_of_2_num_tokens_buckets(8192),
-                    map_to_tuning_buckets=lambda x: min(
-                        last_positive_power_of_2(x), 8192
-                    ),
+                    gen_tuning_buckets=get_hybrid_num_tokens_buckets(8192),
+                    map_to_tuning_buckets=lambda x: map_to_hybrid_bucket(x, 8192),
                     tensor_initializers=[
                         # 0: x — FP4 quantized input (uint8 packed)
                         lambda shapes, dtype, device: torch.randint(

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -209,29 +209,102 @@ def nearest_in_buckets(x: int, buckets: List[int]) -> int:
     return min(max(next_positive_power_of_2(x), buckets[0]), buckets[-1])
 
 
-def get_power_of_2_num_tokens_buckets(max_num_tokens) -> Tuple[int]:
-    """Return descending power-of-2 buckets from ``next_power_of_2(max_num_tokens)`` down to 1."""
-    max_num_tokens = next_positive_power_of_2(max_num_tokens)
-    num_token_buckets = []
-    m = max_num_tokens
-    while m >= 1:
-        num_token_buckets.append(m)
-        m //= 2
-
-    return tuple(num_token_buckets)
+_PHASE1_END = 256
+_PHASE2_STEP = 256
+_PHASE2_END = 2048
+_PHASE3_STEP = 512
+_PHASE3_END = 4096
 
 
-def get_last_power_of_2_num_tokens_buckets(
-    max_num_tokens, min_num_tokens=1
+def _ceil_to_step(x: int, step: int) -> int:
+    return ((x + step - 1) // step) * step
+
+
+def get_hybrid_num_tokens_buckets(
+    max_num_tokens: int, min_num_tokens: int = 1
 ) -> Tuple[int, ...]:
-    """Return descending power-of-2 buckets from ``last_power_of_2(max_num_tokens)`` down to *min_num_tokens*."""
-    max_num_tokens = last_positive_power_of_2(max_num_tokens)
-    num_token_buckets = []
-    m = max_num_tokens
-    while m >= min_num_tokens:
-        num_token_buckets.append(m)
-        m //= 2
-    return tuple(num_token_buckets)
+    """Generate tuning buckets with adaptive spacing.
+
+    Pure power-of-2 spacing creates huge gaps at large values (e.g. 1024
+    between bucket 1024 and 2048).  For MoE workloads the
+    avg_tokens_per_expert can jump across multiple tile boundaries inside a
+    single gap, forcing the autotuner to pick a kernel optimised for a very
+    different workload size.
+
+    This function uses four phases with progressively coarser spacing::
+
+        Phase 1:  [min .. 256]   — power-of-2    (step ×2)
+        Phase 2:  (256 .. 2048]  — linear step 256
+        Phase 3:  (2048 .. 4096] — linear step 512
+        Phase 4:  (4096 .. max]  — power-of-2    (step ×2)
+    """
+    buckets: List[int] = []
+
+    # Phase 1: power-of-2 up to _PHASE1_END
+    m = max(min_num_tokens, 1)
+    while m <= min(max_num_tokens, _PHASE1_END):
+        buckets.append(m)
+        m *= 2
+
+    # Phase 2: linear step 256 in (_PHASE1_END, _PHASE2_END]
+    m = _PHASE1_END + _PHASE2_STEP
+    while m <= min(max_num_tokens, _PHASE2_END):
+        buckets.append(m)
+        m += _PHASE2_STEP
+
+    # Phase 3: linear step 512 in (_PHASE2_END, _PHASE3_END]
+    m = _PHASE2_END + _PHASE3_STEP
+    while m <= min(max_num_tokens, _PHASE3_END):
+        buckets.append(m)
+        m += _PHASE3_STEP
+
+    # Phase 4: power-of-2 beyond _PHASE3_END
+    m = _PHASE3_END * 2
+    while m <= max_num_tokens:
+        buckets.append(m)
+        m *= 2
+
+    if not buckets or buckets[-1] != max_num_tokens:
+        buckets.append(max_num_tokens)
+
+    return tuple(sorted(set(buckets)))
+
+
+def map_to_hybrid_bucket(x: int, max_num_tokens: int) -> int:
+    """Map an arbitrary num_tokens to the nearest hybrid bucket (rounding up).
+
+    Mirrors the four-phase spacing of :func:`get_hybrid_num_tokens_buckets`.
+    The result is clamped to ``[1, max_num_tokens]``.
+    """
+    if x <= 0:
+        return 1
+    if x >= max_num_tokens:
+        return max_num_tokens
+    if x <= _PHASE1_END:
+        return next_positive_power_of_2(x)
+    if x <= _PHASE2_END:
+        return min(_ceil_to_step(x, _PHASE2_STEP), max_num_tokens)
+    if x <= _PHASE3_END:
+        return min(_ceil_to_step(x, _PHASE3_STEP), max_num_tokens)
+    return min(next_positive_power_of_2(x), max_num_tokens)
+
+
+def map_to_hybrid_bucket_uncapped(x: int) -> int:
+    """One-argument variant for use as a function reference in GEMM tuning.
+
+    Same rounding logic as :func:`map_to_hybrid_bucket` but without the
+    ``max_num_tokens`` clamp (the autotuner already handles upper-bound
+    clamping via the generated bucket list).
+    """
+    if x <= 0:
+        return 1
+    if x <= _PHASE1_END:
+        return next_positive_power_of_2(x)
+    if x <= _PHASE2_END:
+        return _ceil_to_step(x, _PHASE2_STEP)
+    if x <= _PHASE3_END:
+        return _ceil_to_step(x, _PHASE3_STEP)
+    return next_positive_power_of_2(x)
 
 
 def round_to_nearest_bucket(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -32,8 +32,9 @@ from ..autotuner import (
     TuningConfig,
 )
 from ..fused_moe.utils import (
-    get_last_power_of_2_num_tokens_buckets,
+    get_hybrid_num_tokens_buckets,
     last_positive_power_of_2,
+    map_to_hybrid_bucket_uncapped,
 )
 from .kernels.utils import _select_sm100_mm_fp4_cute_dsl_tactic
 from ..utils import (
@@ -815,8 +816,8 @@ _FP8_GEMM_SM100_TUNING_CONFIG = TuningConfig(
         DynamicTensorSpec(
             (0,),  # a_tensor_index
             (-2,),
-            get_last_power_of_2_num_tokens_buckets,
-            last_positive_power_of_2,
+            get_hybrid_num_tokens_buckets,
+            map_to_hybrid_bucket_uncapped,
         ),
     ),
     constraint_specs=(
@@ -871,8 +872,8 @@ _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
         DynamicTensorSpec(
             (0,),  # a_tensor_index
             (-2,),
-            get_last_power_of_2_num_tokens_buckets,
-            last_positive_power_of_2,
+            get_hybrid_num_tokens_buckets,
+            map_to_hybrid_bucket_uncapped,
         ),
     ),
     constraint_specs=(
@@ -1173,8 +1174,8 @@ def tgv_gemm_sm100(
             DynamicTensorSpec(
                 (a_tensor_index,),
                 (-2,),
-                get_last_power_of_2_num_tokens_buckets,
-                last_positive_power_of_2,
+                get_hybrid_num_tokens_buckets,
+                map_to_hybrid_bucket_uncapped,
             ),
         ),
         constraint_specs=(
@@ -5111,8 +5112,8 @@ _MM_FP4_TUNING_CONFIG_8x4 = TuningConfig(
         DynamicTensorSpec(
             (0,),  # a_tensor_index
             (0,),
-            get_last_power_of_2_num_tokens_buckets,
-            last_positive_power_of_2,
+            get_hybrid_num_tokens_buckets,
+            map_to_hybrid_bucket_uncapped,
         ),
     ),
     constraint_specs=(
@@ -5135,8 +5136,8 @@ _MM_FP4_TUNING_CONFIG_128x4 = TuningConfig(
         DynamicTensorSpec(
             (0,),  # a_tensor_index
             (0,),
-            get_last_power_of_2_num_tokens_buckets,
-            last_positive_power_of_2,
+            get_hybrid_num_tokens_buckets,
+            map_to_hybrid_bucket_uncapped,
         ),
     ),
     constraint_specs=(
@@ -5159,8 +5160,8 @@ _MM_MXFP8_TUNING_CONFIG = TuningConfig(
         DynamicTensorSpec(
             (0,),  # a_tensor_index
             (0,),
-            get_last_power_of_2_num_tokens_buckets,
-            last_positive_power_of_2,
+            get_hybrid_num_tokens_buckets,
+            map_to_hybrid_bucket_uncapped,
         ),
     ),
     constraint_specs=(

--- a/flashinfer/trtllm_low_latency_gemm.py
+++ b/flashinfer/trtllm_low_latency_gemm.py
@@ -36,8 +36,8 @@ from flashinfer.autotuner import (
     OptimizationProfile,
 )
 from flashinfer.fused_moe.utils import (
-    get_last_power_of_2_num_tokens_buckets,
-    last_positive_power_of_2,
+    get_hybrid_num_tokens_buckets,
+    map_to_hybrid_bucket_uncapped,
 )
 from flashinfer.jit import setup_cubin_loader
 from flashinfer.utils import _get_cache_buf
@@ -168,8 +168,8 @@ def trtllm_low_latency_gemm(
             DynamicTensorSpec(
                 (a_tensor_index,),
                 (-2,),
-                get_last_power_of_2_num_tokens_buckets,
-                last_positive_power_of_2,
+                get_hybrid_num_tokens_buckets,
+                map_to_hybrid_bucket_uncapped,
             ),
         ),
         constraint_specs=(


### PR DESCRIPTION
## 📌 Description

This PR includes two improvements:

1. **perf(autotuner): Replace power-of-2 token buckets with hybrid spacing** — Pure power-of-2 spacing creates huge gaps at large values (e.g. a jump from 1024 to 2048), forcing the autotuner to pick a kernel optimised for a very different workload size. The new hybrid scheme uses four phases with progressively coarser spacing:
   - Phase 1: `[min .. 256]` — power-of-2 (step ×2)
   - Phase 2: `(256 .. 2048]` — linear step 256
   - Phase 3: `(2048 .. 4096]` — linear step 512
   - Phase 4: `(4096 .. max]` — power-of-2 (step ×2)

   All callsites in MoE, GEMM, and low-latency GEMM autotuners are updated to use the new `get_hybrid_num_tokens_buckets` / `map_to_hybrid_bucket` API.

2. **fix: Pass missing `routing_replay_out` arg to `trtllm_fp8_per_tensor_scale_moe`** — Two call sites in `fused_moe/core.py` were missing the `routing_replay_out` argument, causing it to be silently dropped.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

**Changed files:**
- `flashinfer/fused_moe/utils.py` — Core implementation: new `get_hybrid_num_tokens_buckets`, `map_to_hybrid_bucket`, `map_to_hybrid_bucket_uncapped`; removed old `get_last_power_of_2_num_tokens_buckets`
- `flashinfer/fused_moe/core.py` — Updated all MoE autotuner callsites + added missing `routing_replay_out` arg
- `flashinfer/fused_moe/cute_dsl/tuner.py` — Updated CuTe DSL FP4 MoE tuner callsite
- `flashinfer/gemm/gemm_base.py` — Updated GEMM (FP8, BF16, FP4, MXFP8, TGV) autotuner configs
- `flashinfer/trtllm_low_latency_gemm.py` — Updated low-latency GEMM autotuner config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Switched autotuning to a hybrid token-bucketing scheme for more representative dynamic profiles, improving kernel selection and tuning accuracy.
  * Enhanced mapping of dynamic token counts into tuning buckets, yielding more consistent performance profiling.

* **New Features**
  * FP8 MoE execution now forwards an optional routing-replay output through the execution path for downstream routing diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->