### PR TITLE
Port TRT-LLM fused qk norm rope

### DIFF
--- a/csrc/fused_qk_norm_rope.cu
+++ b/csrc/fused_qk_norm_rope.cu
@@ -109,6 +109,16 @@ void fused_qk_norm_rope(TensorView q, TensorView k, TensorView q_weight, TensorV
         << pair_offset;
   }
 
+  // Sanity-check scalar hyperparameters before we hand them to rsqrtf / powf
+  // / YaRN interpolation. eps feeds `rsqrtf(mean_sq + eps)` (negative eps can
+  // turn into NaN on small-norm inputs); rope_theta feeds `powf(theta, ...)`
+  // with a negative exponent (non-positive base is ill-defined); yarn_factor
+  // appears as `freq / yarn_factor` (zero or negative flips / blows up the
+  // interpolation).
+  TVM_FFI_ICHECK_GE(eps, 0.0) << "eps must be >= 0, got " << eps;
+  TVM_FFI_ICHECK_GT(rope_theta, 0.0) << "rope_theta must be > 0, got " << rope_theta;
+  TVM_FFI_ICHECK_GT(yarn_factor, 0.0) << "yarn_factor must be > 0, got " << yarn_factor;
+
   if (yarn_factor == 1.0) {
     TVM_FFI_ICHECK_EQ(yarn_attention_factor, 1.0)
         << "yarn_attention_factor must be 1.0 when yarn_factor == 1.0 (YaRN disabled)";
@@ -154,6 +164,23 @@ void fused_qk_norm_rope(TensorView q, TensorView k, TensorView q_weight, TensorV
         << "FusedQKNormRopeLauncher: k.stride(1) must be a multiple of head_dim/32 = "
         << num_elems_per_thread
         << " to satisfy vectorized load alignment, got k.stride(1) = " << k_stride_h;
+  }
+
+  // Stride alignment alone isn't enough: an as_strided view with a non-zero
+  // storage offset can produce a base pointer that's only element-aligned
+  // (e.g., head_dim = 128 needs 16B, but `t[1:]` on a 2B-element tensor only
+  // shifts by 2B). Tensor allocators return ptrs aligned to at least 256B, so
+  // this only ever fires for pathological views — but when it does, a clean
+  // error here beats a misaligned-address crash inside the kernel.
+  if (num_elems_per_thread > 1) {
+    int64_t const elem_size = q.dtype().bits / 8;
+    int64_t const vec_bytes = num_elems_per_thread * elem_size;
+    TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(q.data_ptr()) % vec_bytes, 0u)
+        << "FusedQKNormRopeLauncher: q.data_ptr() must be aligned to " << vec_bytes
+        << " bytes (head_dim/32 * sizeof(dtype)) for vectorized loads";
+    TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(k.data_ptr()) % vec_bytes, 0u)
+        << "FusedQKNormRopeLauncher: k.data_ptr() must be aligned to " << vec_bytes
+        << " bytes (head_dim/32 * sizeof(dtype)) for vectorized loads";
   }
 
   ffi::CUDADeviceGuard device_guard(q.device().device_id);

--- a/csrc/fused_qk_norm_rope.cu
+++ b/csrc/fused_qk_norm_rope.cu
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <climits>
 #include <flashinfer/fused_qk_norm_rope.cuh>
 
 #include "tvm_ffi_utils.h"
@@ -77,6 +78,14 @@ void fused_qk_norm_rope(TensorView q, TensorView k, TensorView q_weight, TensorV
   TVM_FFI_ICHECK_EQ(k_weight.size(0), head_dim) << "k_weight must have shape [head_dim]";
   TVM_FFI_ICHECK_EQ(pos_ids.size(0), nnz) << "pos_ids must have shape [nnz]";
 
+  // FusedQKNormRopeKernel indexes tokens/heads with int32 throughout (to keep
+  // register pressure low). Ensure the batch sizes fit before we cast, so we
+  // fail fast with a clear message instead of silently wrapping.
+  TVM_FFI_ICHECK_LE(nnz, static_cast<int64_t>(INT_MAX))
+      << "nnz (= q.size(0)) must fit in int32, got " << nnz;
+  TVM_FFI_ICHECK_LE(num_q_heads + num_kv_heads, static_cast<int64_t>(INT_MAX))
+      << "num_q_heads + num_kv_heads must fit in int32, got " << (num_q_heads + num_kv_heads);
+
   // head_dim must be one of the template-specialized values and a multiple of 64.
   TVM_FFI_ICHECK(head_dim == 64 || head_dim == 128 || head_dim == 256)
       << "fused_qk_norm_rope only supports head_dim in {64, 128, 256}, got " << head_dim;
@@ -113,6 +122,39 @@ void fused_qk_norm_rope(TensorView q, TensorView k, TensorView q_weight, TensorV
   size_t const q_stride_h = q.stride(1);
   size_t const k_stride_n = k.stride(0);
   size_t const k_stride_h = k.stride(1);
+
+  // FusedQKNormRopeLauncher issues per-lane vectorized loads of width
+  // `num_elems_per_thread * sizeof(DType)` bytes (uint32_t / uint2 / uint4 for
+  // head_dim = 64 / 128 / 256 respectively). The tensor base pointer is
+  // tensor-aligned and the per-lane offset (lane_id * num_elems_per_thread) is
+  // a multiple of num_elems_per_thread, so the full pointer
+  // `base + token_idx * stride_n + head_idx * stride_h + lane_id * num_elems_per_thread`
+  // is aligned iff each non-trivial stride is a multiple of num_elems_per_thread.
+  // Dimensions of size 1 (or broadcast stride 0) contribute no offset and are
+  // exempt. Validate here to fail fast with a clean diagnostic instead of
+  // hitting a misaligned-address error inside the kernel.
+  if (nnz > 1) {
+    TVM_FFI_ICHECK_EQ(q_stride_n % num_elems_per_thread, 0)
+        << "FusedQKNormRopeLauncher: q.stride(0) must be a multiple of head_dim/32 = "
+        << num_elems_per_thread
+        << " to satisfy vectorized load alignment, got q.stride(0) = " << q_stride_n;
+    TVM_FFI_ICHECK_EQ(k_stride_n % num_elems_per_thread, 0)
+        << "FusedQKNormRopeLauncher: k.stride(0) must be a multiple of head_dim/32 = "
+        << num_elems_per_thread
+        << " to satisfy vectorized load alignment, got k.stride(0) = " << k_stride_n;
+  }
+  if (num_q_heads > 1) {
+    TVM_FFI_ICHECK_EQ(q_stride_h % num_elems_per_thread, 0)
+        << "FusedQKNormRopeLauncher: q.stride(1) must be a multiple of head_dim/32 = "
+        << num_elems_per_thread
+        << " to satisfy vectorized load alignment, got q.stride(1) = " << q_stride_h;
+  }
+  if (num_kv_heads > 1) {
+    TVM_FFI_ICHECK_EQ(k_stride_h % num_elems_per_thread, 0)
+        << "FusedQKNormRopeLauncher: k.stride(1) must be a multiple of head_dim/32 = "
+        << num_elems_per_thread
+        << " to satisfy vectorized load alignment, got k.stride(1) = " << k_stride_h;
+  }
 
   ffi::CUDADeviceGuard device_guard(q.device().device_id);
   cudaStream_t const stream = get_stream(q.device());

--- a/csrc/fused_qk_norm_rope.cu
+++ b/csrc/fused_qk_norm_rope.cu
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <flashinfer/fused_qk_norm_rope.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+
+/*!
+ * \brief TVM-FFI entry point for the fused QK RMSNorm + RoPE op.
+ *
+ * Applies, in a single kernel launch and in place on ``q`` and ``k``:
+ *   1. (optional, gated by ``is_qk_norm``) per-head RMSNorm with ``q_weight`` /
+ *      ``k_weight`` along the last dimension;
+ *   2. RoPE with on-the-fly cos/sin from ``pos_ids`` and ``rope_theta``, plus
+ *      an optional YaRN frequency correction (``yarn_factor != 1``).
+ *
+ * \param q            [nnz, num_q_heads, head_dim], last dim contiguous.
+ * \param k            [nnz, num_kv_heads, head_dim], last dim contiguous.
+ * \param q_weight     [head_dim] RMSNorm weights for Q (ignored when ``is_qk_norm`` is false).
+ * \param k_weight     [head_dim] RMSNorm weights for K (ignored when ``is_qk_norm`` is false).
+ * \param pos_ids      [nnz] int32 position ids.
+ * \param rotary_dim   Number of leading dims to apply RoPE to (``<= head_dim``, even).
+ * \param interleave   If true, RoPE rotates (x[2i], x[2i+1]) (GPT-J style). If false,
+ *                     RoPE rotates (x[i], x[i + rotary_dim/2]) (Neox / Llama style).
+ * \param is_qk_norm   When false, skip RMSNorm and just apply RoPE.
+ * \param yarn_*       YaRN scaling parameters. Use ``yarn_factor = 1`` and
+ *                     ``yarn_attention_factor = 1`` to disable YaRN.
+ */
+void fused_qk_norm_rope(TensorView q, TensorView k, TensorView q_weight, TensorView k_weight,
+                        TensorView pos_ids, int64_t rotary_dim, double eps, double rope_theta,
+                        bool interleave, double yarn_factor, double yarn_low, double yarn_high,
+                        double yarn_attention_factor, bool is_qk_norm) {
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q_weight);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k_weight);
+  CHECK_INPUT(pos_ids);
+
+  CHECK_DEVICE(q, k);
+  CHECK_DEVICE(q, q_weight);
+  CHECK_DEVICE(q, k_weight);
+  CHECK_DEVICE(q, pos_ids);
+
+  CHECK_DIM(3, q);  // q: (nnz, H_Q, D)
+  CHECK_DIM(3, k);  // k: (nnz, H_K, D)
+  CHECK_DIM(1, q_weight);
+  CHECK_DIM(1, k_weight);
+  CHECK_DIM(1, pos_ids);
+
+  TVM_FFI_ICHECK_EQ(q.dtype(), k.dtype()) << "q and k must share the same dtype";
+  TVM_FFI_ICHECK_EQ(q.dtype(), q_weight.dtype()) << "q and q_weight must share the same dtype";
+  TVM_FFI_ICHECK_EQ(q.dtype(), k_weight.dtype()) << "q and k_weight must share the same dtype";
+  CHECK_INPUT_TYPE(pos_ids, dl_int32);
+
+  int64_t const nnz = q.size(0);
+  int64_t const num_q_heads = q.size(1);
+  int64_t const num_kv_heads = k.size(1);
+  int64_t const head_dim = q.size(2);
+
+  TVM_FFI_ICHECK_EQ(k.size(0), nnz) << "q and k must have matching token count";
+  TVM_FFI_ICHECK_EQ(k.size(2), head_dim) << "q and k must have matching head_dim";
+  TVM_FFI_ICHECK_EQ(q_weight.size(0), head_dim) << "q_weight must have shape [head_dim]";
+  TVM_FFI_ICHECK_EQ(k_weight.size(0), head_dim) << "k_weight must have shape [head_dim]";
+  TVM_FFI_ICHECK_EQ(pos_ids.size(0), nnz) << "pos_ids must have shape [nnz]";
+
+  // head_dim must be one of the template-specialized values and a multiple of 64.
+  TVM_FFI_ICHECK(head_dim == 64 || head_dim == 128 || head_dim == 256)
+      << "fused_qk_norm_rope only supports head_dim in {64, 128, 256}, got " << head_dim;
+
+  TVM_FFI_ICHECK_GT(rotary_dim, 0) << "rotary_dim must be positive";
+  TVM_FFI_ICHECK_LE(rotary_dim, head_dim) << "rotary_dim must be <= head_dim";
+  TVM_FFI_ICHECK_EQ(rotary_dim % 2, 0) << "rotary_dim must be even";
+
+  int64_t const num_elems_per_thread = head_dim / 32;  // = 2, 4, or 8
+
+  // For partial-rope Neox style, `pair_offset = (rotary_dim / 2) / num_elems_per_thread`
+  // drives the `__shfl_xor_sync` that swaps the two halves. The xor-shuffle only
+  // produces the desired pairing when `pair_offset` is a power of 2.
+  if (!interleave) {
+    TVM_FFI_ICHECK_EQ(rotary_dim % (2 * num_elems_per_thread), 0)
+        << "rotary_dim must be a multiple of " << (2 * num_elems_per_thread)
+        << " (2 * head_dim / 32) when interleave=False (Neox style)";
+    int64_t const pair_offset = rotary_dim / (2 * num_elems_per_thread);
+    TVM_FFI_ICHECK(pair_offset > 0 && (pair_offset & (pair_offset - 1)) == 0)
+        << "rotary_dim / (2 * head_dim / 32) must be a power of 2 when interleave=False, got "
+        << pair_offset;
+  }
+
+  if (yarn_factor == 1.0) {
+    TVM_FFI_ICHECK_EQ(yarn_attention_factor, 1.0)
+        << "yarn_attention_factor must be 1.0 when yarn_factor == 1.0 (YaRN disabled)";
+  }
+
+  if (nnz == 0) {
+    return;
+  }
+
+  size_t const q_stride_n = q.stride(0);
+  size_t const q_stride_h = q.stride(1);
+  size_t const k_stride_n = k.stride(0);
+  size_t const k_stride_h = k.stride(1);
+
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
+  cudaStream_t const stream = get_stream(q.device());
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
+    cudaError_t status = FusedQKNormRopeLauncher<c_type>(
+        static_cast<c_type*>(q.data_ptr()), static_cast<c_type*>(k.data_ptr()),
+        static_cast<c_type*>(q_weight.data_ptr()), static_cast<c_type*>(k_weight.data_ptr()),
+        static_cast<int32_t*>(pos_ids.data_ptr()), static_cast<int>(nnz),
+        static_cast<int>(num_q_heads), static_cast<int>(num_kv_heads), static_cast<int>(head_dim),
+        static_cast<int>(rotary_dim), static_cast<float>(eps), static_cast<float>(rope_theta),
+        interleave, static_cast<float>(yarn_factor), static_cast<float>(yarn_low),
+        static_cast<float>(yarn_high), static_cast<float>(yarn_attention_factor), is_qk_norm,
+        q_stride_n, q_stride_h, k_stride_n, k_stride_h, stream);
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "FusedQKNormRopeLauncher failed: " << cudaGetErrorString(status);
+    return true;
+  });
+}

--- a/csrc/fused_qk_norm_rope_jit_binding.cu
+++ b/csrc/fused_qk_norm_rope_jit_binding.cu
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Tensor;
+
+void fused_qk_norm_rope(TensorView q, TensorView k, TensorView q_weight, TensorView k_weight,
+                        TensorView pos_ids, int64_t rotary_dim, double eps, double rope_theta,
+                        bool interleave, double yarn_factor, double yarn_low, double yarn_high,
+                        double yarn_attention_factor, bool is_qk_norm);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_qk_norm_rope, fused_qk_norm_rope);

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -154,6 +154,7 @@ from .rope import apply_rope_with_cos_sin_cache as apply_rope_with_cos_sin_cache
 from .rope import (
     apply_rope_with_cos_sin_cache_inplace as apply_rope_with_cos_sin_cache_inplace,
 )
+from .fused_qk_norm_rope import fused_qk_norm_rope as fused_qk_norm_rope
 from .sampling import chain_speculative_sampling as chain_speculative_sampling
 from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
 from .sampling import sampling_from_logits as sampling_from_logits

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -59,6 +59,7 @@ from .jit.fp4_quantization import (
 from .jit.fp4_kv_dequantization import gen_fp4_kv_dequantization_module
 from .jit.fp4_kv_quantization import gen_fp4_kv_quantization_module
 from .jit.fp8_quantization import gen_mxfp8_quantization_sm100_module
+from .jit.fused_qk_norm_rope import gen_fused_qk_norm_rope_module
 from .jit.fused_moe import (
     gen_cutlass_fused_moe_sm90_module,
     gen_cutlass_fused_moe_sm100_module,
@@ -559,6 +560,7 @@ def gen_all_modules(
     if add_misc:
         jit_specs += [
             gen_cascade_module(),
+            gen_fused_qk_norm_rope_module(),
             gen_norm_module(),
             gen_page_module(),
             gen_quantization_module(),

--- a/flashinfer/fused_qk_norm_rope.py
+++ b/flashinfer/fused_qk_norm_rope.py
@@ -1,0 +1,201 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from typing import Optional
+
+import torch
+
+from .api_logging import flashinfer_api
+from .jit.fused_qk_norm_rope import gen_fused_qk_norm_rope_module
+from .utils import register_custom_op, register_fake_op
+
+
+@functools.cache
+def get_fused_qk_norm_rope_module():
+    return gen_fused_qk_norm_rope_module().build_and_load()
+
+
+@register_custom_op("flashinfer::fused_qk_norm_rope", mutates_args=("q", "k"))
+def _fused_qk_norm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    pos_ids: torch.Tensor,
+    rotary_dim: int,
+    eps: float,
+    rope_theta: float,
+    interleave: bool,
+    yarn_factor: float,
+    yarn_low: float,
+    yarn_high: float,
+    yarn_attention_factor: float,
+    is_qk_norm: bool,
+) -> None:
+    get_fused_qk_norm_rope_module().fused_qk_norm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        pos_ids,
+        rotary_dim,
+        eps,
+        rope_theta,
+        interleave,
+        yarn_factor,
+        yarn_low,
+        yarn_high,
+        yarn_attention_factor,
+        is_qk_norm,
+    )
+
+
+@register_fake_op("flashinfer::fused_qk_norm_rope")
+def _fake_fused_qk_norm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    pos_ids: torch.Tensor,
+    rotary_dim: int,
+    eps: float,
+    rope_theta: float,
+    interleave: bool,
+    yarn_factor: float,
+    yarn_low: float,
+    yarn_high: float,
+    yarn_attention_factor: float,
+    is_qk_norm: bool,
+) -> None:
+    pass
+
+
+@flashinfer_api
+def fused_qk_norm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    pos_ids: torch.Tensor,
+    rotary_dim: Optional[int] = None,
+    eps: float = 1e-6,
+    rope_theta: float = 1e4,
+    interleave: bool = False,
+    is_qk_norm: bool = True,
+    yarn_factor: float = 1.0,
+    yarn_low: float = 0.0,
+    yarn_high: float = 0.0,
+    yarn_attention_factor: float = 1.0,
+) -> None:
+    r"""Fused per-head QK RMSNorm + Rotary Position Embedding, updated in place.
+
+    Combines (optional) per-head RMSNorm with separate ``q_weight`` / ``k_weight``
+    and RoPE (with on-the-fly cos/sin derived from ``pos_ids`` and
+    ``rope_theta``) in a single CUDA kernel launch. Optionally applies YaRN
+    frequency correction when ``yarn_factor != 1.0``. This is the flashinfer
+    port of TensorRT-LLM's ``trtllm::fused_qk_norm_rope`` torch op and is
+    intended for Qwen3-style / ExaOne4-style attention layers that place
+    QK-norm before RoPE.
+
+    Both ``q`` and ``k`` are updated **in place**.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Query tensor, shape ``(nnz, num_q_heads, head_dim)``, dtype
+        ``torch.bfloat16`` or ``torch.float16``. Last dim must be contiguous.
+        Updated in place.
+    k : torch.Tensor
+        Key tensor, shape ``(nnz, num_kv_heads, head_dim)``, same dtype as ``q``.
+        Last dim must be contiguous. Updated in place.
+    q_weight : torch.Tensor
+        Per-head RMSNorm weights for Q, shape ``(head_dim,)``, same dtype as
+        ``q``. Ignored when ``is_qk_norm=False``.
+    k_weight : torch.Tensor
+        Per-head RMSNorm weights for K, shape ``(head_dim,)``, same dtype as
+        ``q``. Ignored when ``is_qk_norm=False``.
+    pos_ids : torch.Tensor
+        Position indices, shape ``(nnz,)``, dtype ``torch.int32``.
+    rotary_dim : Optional[int]
+        Number of leading dimensions RoPE is applied to. Defaults to
+        ``head_dim`` (full rope). Must be even and ``<= head_dim``.
+    eps : float
+        RMSNorm epsilon. Default ``1e-6``.
+    rope_theta : float
+        RoPE base frequency (``base`` in TRT-LLM). Default ``1e4``.
+    interleave : bool
+        If ``True``, RoPE rotates GPT-J-style pairs
+        ``(x[..., 2i], x[..., 2i+1])``. If ``False`` (Neox / Llama style), RoPE
+        rotates ``(x[..., :rotary_dim//2], x[..., rotary_dim//2:rotary_dim])``.
+        ``interleave = not is_neox`` relative to TRT-LLM's wrapper.
+        Default ``False``.
+    is_qk_norm : bool
+        If ``False``, skip the RMSNorm stage and only apply RoPE. Default
+        ``True``.
+    yarn_factor : float
+        YaRN scaling factor. ``1.0`` disables YaRN (standard RoPE frequency).
+    yarn_low : float
+        YaRN low bound of the ramp (in half-dim units).
+    yarn_high : float
+        YaRN high bound of the ramp.
+    yarn_attention_factor : float
+        YaRN post-processing scale applied to ``cos``/``sin``. Must be ``1.0``
+        when ``yarn_factor == 1.0``.
+
+    Notes
+    -----
+    Supports ``head_dim`` in ``{64, 128, 256}``. For ``interleave=False``
+    (Neox) with partial RoPE (``rotary_dim < head_dim``), the value
+    ``rotary_dim / (2 * head_dim / 32)`` must be a positive power of 2; this
+    constraint comes from the intra-warp ``__shfl_xor_sync`` pair-swap and is
+    validated in the kernel launcher. The stricter check is adopted from
+    SGLang's port of this kernel.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import flashinfer
+    >>> nnz, H_q, H_k, D = 4, 32, 8, 128
+    >>> q = torch.randn(nnz, H_q, D, dtype=torch.bfloat16, device="cuda")
+    >>> k = torch.randn(nnz, H_k, D, dtype=torch.bfloat16, device="cuda")
+    >>> q_w = torch.ones(D, dtype=torch.bfloat16, device="cuda")
+    >>> k_w = torch.ones(D, dtype=torch.bfloat16, device="cuda")
+    >>> pos = torch.arange(nnz, dtype=torch.int32, device="cuda")
+    >>> flashinfer.fused_qk_norm_rope(q, k, q_w, k_w, pos)
+    """
+    if rotary_dim is None:
+        rotary_dim = q.size(-1)
+    if yarn_factor == 1.0 and yarn_attention_factor != 1.0:
+        raise ValueError(
+            "yarn_attention_factor must be 1.0 when yarn_factor == 1.0 (YaRN disabled)"
+        )
+    _fused_qk_norm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        pos_ids,
+        int(rotary_dim),
+        float(eps),
+        float(rope_theta),
+        bool(interleave),
+        float(yarn_factor),
+        float(yarn_low),
+        float(yarn_high),
+        float(yarn_attention_factor),
+        bool(is_qk_norm),
+    )

--- a/flashinfer/jit/fused_qk_norm_rope.py
+++ b/flashinfer/jit/fused_qk_norm_rope.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec
+
+
+def gen_fused_qk_norm_rope_module() -> JitSpec:
+    """JIT spec for the fused QK RMSNorm + RoPE op.
+
+    The kernel uses ``__nv_bfloat16`` / ``__half`` intrinsics directly, so no
+    extra preprocessor gates are required beyond the FP16/BF16 flags already
+    added to every JIT build by :mod:`flashinfer.jit.core`.
+    """
+    return gen_jit_spec(
+        "fused_qk_norm_rope",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "fused_qk_norm_rope.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "fused_qk_norm_rope_jit_binding.cu",
+        ],
+    )

--- a/include/flashinfer/fused_qk_norm_rope.cuh
+++ b/include/flashinfer/fused_qk_norm_rope.cuh
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Fused per-head QK RMSNorm + Rotary Position Embedding.
+//
+// Adapted from NVIDIA/TensorRT-LLM:
+//   cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+// One warp processes one (token, qk_head). Elements are held in registers,
+// a warp-wide reduction computes the RMSNorm scale, and RoPE (with optional
+// YaRN frequency correction) is applied before writing the result back in
+// place. Relative to the upstream kernel, this version:
+//   - takes separate q / k pointers with runtime strides (matches flashinfer's
+//     3D ragged layout) instead of a packed 2D qkv buffer,
+//   - is templated over DType so both __nv_bfloat16 and __half are supported.
+#ifndef FLASHINFER_FUSED_QK_NORM_ROPE_CUH_
+#define FLASHINFER_FUSED_QK_NORM_ROPE_CUH_
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <type_traits>
+
+#include "utils.cuh"
+
+namespace flashinfer {
+
+namespace fused_qk_norm_rope_impl {
+
+// ------------------ Helpers ----------------------------------------
+
+// Traits to convert between a 16-bit DType and its 2-wide packed form / float.
+template <typename DType>
+struct DTypeTraits;
+
+template <>
+struct DTypeTraits<__nv_bfloat16> {
+  using pack2_t = __nv_bfloat162;
+  __device__ __forceinline__ static float2 unpack(pack2_t v) { return __bfloat1622float2(v); }
+  __device__ __forceinline__ static pack2_t pack(float2 v) { return __float22bfloat162_rn(v); }
+  __device__ __forceinline__ static float to_float(__nv_bfloat16 x) { return __bfloat162float(x); }
+};
+
+template <>
+struct DTypeTraits<__half> {
+  using pack2_t = __half2;
+  __device__ __forceinline__ static float2 unpack(pack2_t v) { return __half22float2(v); }
+  __device__ __forceinline__ static pack2_t pack(float2 v) { return __float22half2_rn(v); }
+  __device__ __forceinline__ static float to_float(__half x) { return __half2float(x); }
+};
+
+// Number of 32-bit words covered by a warp's register tile. Maps to uint,
+// uint2 or uint4 to get coalesced 32/64/128-bit global memory transactions.
+template <int kNumWords>
+struct PackedVec;
+template <>
+struct PackedVec<1> {
+  using type = uint32_t;
+};
+template <>
+struct PackedVec<2> {
+  using type = uint2;
+};
+template <>
+struct PackedVec<4> {
+  using type = uint4;
+};
+
+__device__ __forceinline__ float WarpReduceSum(float val) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    val += __shfl_xor_sync(0xffffffff, val, offset, 32);
+  }
+  return val;
+}
+
+// YaRN inverse-frequency ramp (from TRT-LLM).  When factor == 1 the YaRN
+// branch is skipped and we fall back to the standard RoPE frequency.
+__device__ __forceinline__ float ComputeFreqYarn(float base, int rotary_dim, int half_dim,
+                                                 float factor, float low, float high) {
+  float freq = powf(base, -2.0f * static_cast<float>(half_dim) / static_cast<float>(rotary_dim));
+  if (factor != 1.0f) {
+    float inv_freq_extrapolation = freq;
+    float inv_freq_interpolation = freq / factor;
+    float high_adj = high;
+    // Prevent division-by-zero when low == high (TRT-LLM does this in-place;
+    // we keep a local copy since CUDA function args are const).
+    if (fabsf(low - high_adj) <= 1e-6f) {
+      high_adj += 0.001f;
+    }
+    float linear_func = (static_cast<float>(half_dim) - low) / (high_adj - low);
+    float ramp_func = fminf(fmaxf(linear_func, 0.0f), 1.0f);
+    float inv_freq_extrapolation_factor = 1.0f - ramp_func;
+    freq = inv_freq_interpolation * (1.0f - inv_freq_extrapolation_factor) +
+           inv_freq_extrapolation * inv_freq_extrapolation_factor;
+  }
+  return freq;
+}
+
+}  // namespace fused_qk_norm_rope_impl
+
+// ------------------ Kernel ------------------------------------------
+
+/*!
+ * \brief Fused per-head QK RMSNorm + Rotary Position Embedding kernel.
+ *
+ * \tparam DType Element dtype (__nv_bfloat16 or __half).
+ * \tparam head_dim Dimension per head. Must be a multiple of 64.
+ * \tparam interleave If true, RoPE operates on even/odd pairs (GPT-J style).
+ *                    If false, RoPE operates on the first/second half (Neox / Llama style).
+ *
+ * Each warp processes one (token, qk_head) pair. The warp first loads the
+ * entire head into registers (1 element per lane iteration, numElemsPerThread
+ * iterations), performs an optional warp-level RMSNorm with the per-dim
+ * weight, then applies RoPE with on-the-fly cos/sin derived from
+ * ``position_ids`` and ``rope_theta``, and writes the result back in place.
+ */
+template <typename DType, int head_dim, bool interleave>
+__global__ void FusedQKNormRopeKernel(DType* __restrict__ q,               // [nnz, H_q, D]
+                                      DType* __restrict__ k,               // [nnz, H_k, D]
+                                      DType const* __restrict__ q_weight,  // [D]
+                                      DType const* __restrict__ k_weight,  // [D]
+                                      int const* __restrict__ pos_ids,     // [nnz]
+                                      int const num_q_heads, int const num_kv_heads,
+                                      int const rotary_dim, float const eps, float const rope_theta,
+                                      float const yarn_factor, float const yarn_low,
+                                      float const yarn_high, float const yarn_attention_factor,
+                                      int const num_tokens, bool const is_qk_norm,
+                                      size_t const q_stride_n, size_t const q_stride_h,
+                                      size_t const k_stride_n, size_t const k_stride_h) {
+  using namespace fused_qk_norm_rope_impl;
+  using Traits = DTypeTraits<DType>;
+  using pack2_t = typename Traits::pack2_t;
+
+  int const warps_per_block = blockDim.x / 32;
+  int const warp_id = threadIdx.x / 32;
+  int const lane_id = threadIdx.x % 32;
+
+  int const global_warp_idx = blockIdx.x * warps_per_block + warp_id;
+  int const total_qk_heads = num_q_heads + num_kv_heads;
+  int const token_idx = global_warp_idx / total_qk_heads;
+  int const local_head_idx = global_warp_idx % total_qk_heads;
+
+  if (token_idx >= num_tokens) return;
+
+  bool const is_q = local_head_idx < num_q_heads;
+  int const head_idx = is_q ? local_head_idx : local_head_idx - num_q_heads;
+
+  // head_dim must be divisible by 64 so each lane owns an even number of elements,
+  // which is required for the packed (pair-wise) load and for the interleaved /
+  // half-split RoPE variants to line up with the warp's 32 lanes.
+  static_assert(head_dim % 64 == 0, "head_dim must be a multiple of 64");
+  constexpr int numElemsPerThread = head_dim / 32;
+  constexpr int elemSizeBytes = numElemsPerThread * sizeof(DType);
+  static_assert(elemSizeBytes % 4 == 0,
+                "numElemsPerThread * sizeof(DType) must be a multiple of 4");
+  constexpr int vecSize = elemSizeBytes / 4;
+  using vec_T = typename PackedVec<vecSize>::type;
+
+  float elements[numElemsPerThread];
+
+  // Select the tensor (q vs k) and compute this warp's offset into it.
+  DType* head_ptr;
+  size_t offset_warp;
+  if (is_q) {
+    head_ptr = q;
+    offset_warp =
+        static_cast<size_t>(token_idx) * q_stride_n + static_cast<size_t>(head_idx) * q_stride_h;
+  } else {
+    head_ptr = k;
+    offset_warp =
+        static_cast<size_t>(token_idx) * k_stride_n + static_cast<size_t>(head_idx) * k_stride_h;
+  }
+  size_t offset_thread = offset_warp + static_cast<size_t>(lane_id) * numElemsPerThread;
+
+  // --- Load into registers and accumulate sum of squares ---
+  float sum_of_squares = 0.0f;
+  {
+    vec_T vec = *reinterpret_cast<vec_T const*>(head_ptr + offset_thread);
+#pragma unroll
+    for (int i = 0; i < vecSize; i++) {
+      pack2_t packed = *(reinterpret_cast<pack2_t*>(&vec) + i);
+      float2 vals = Traits::unpack(packed);
+      sum_of_squares += vals.x * vals.x;
+      sum_of_squares += vals.y * vals.y;
+      elements[2 * i] = vals.x;
+      elements[2 * i + 1] = vals.y;
+    }
+  }
+
+  // --- RMSNorm (optional) ---
+  if (is_qk_norm) {
+    sum_of_squares = WarpReduceSum(sum_of_squares);
+    float rms_rcp = rsqrtf(sum_of_squares / static_cast<float>(head_dim) + eps);
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      int dim = lane_id * numElemsPerThread + i;
+      float weight = is_q ? Traits::to_float(q_weight[dim]) : Traits::to_float(k_weight[dim]);
+      elements[i] *= rms_rcp * weight;
+    }
+  }
+
+  // --- RoPE ---
+  float elements2[numElemsPerThread];
+  float cos_vals[numElemsPerThread];
+  float sin_vals[numElemsPerThread];
+  float pos_id = static_cast<float>(pos_ids[token_idx]);
+
+  if constexpr (interleave) {
+    // GPT-J style: rotate even/odd pairs (elements[2i], elements[2i+1]).
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      elements2[i] = (i % 2 == 0) ? -elements[i + 1] : elements[i - 1];
+      int dim_idx = lane_id * numElemsPerThread + i;
+      int half_dim = dim_idx / 2;
+      float freq =
+          ComputeFreqYarn(rope_theta, rotary_dim, half_dim, yarn_factor, yarn_low, yarn_high);
+      float theta = pos_id * freq;
+      __sincosf(theta, &sin_vals[i], &cos_vals[i]);
+    }
+  } else {
+    // Neox / Llama style: rotate (x[i], x[i + rotary_dim/2]).
+    // Lanes in [0, pair_offset) exchange elements with lanes in
+    // [pair_offset, 2*pair_offset) via __shfl_xor_sync.
+    // pair_offset must be a power of 2 for this exchange to be correct; we
+    // enforce that in the C++ launcher / Python API.
+    __syncwarp();
+    int const pair_offset = (rotary_dim / 2) / numElemsPerThread;
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      elements2[i] = __shfl_xor_sync(0xffffffff, elements[i], pair_offset);
+      if (lane_id < pair_offset) {
+        elements2[i] = -elements2[i];
+      }
+      int dim_idx = lane_id * numElemsPerThread + i;
+      dim_idx = (dim_idx * 2) % rotary_dim;
+      int half_dim = dim_idx / 2;
+      float freq =
+          ComputeFreqYarn(rope_theta, rotary_dim, half_dim, yarn_factor, yarn_low, yarn_high);
+      float theta = pos_id * freq;
+      __sincosf(theta, &sin_vals[i], &cos_vals[i]);
+    }
+    // __shfl_xor_sync does not emit a memfence; sync before re-using `elements`.
+    __syncwarp();
+  }
+
+  bool const is_full_rope = (rotary_dim == head_dim);
+  if (is_full_rope) {
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      elements[i] =
+          (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * yarn_attention_factor;
+    }
+  } else {
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      int dim_idx = lane_id * numElemsPerThread + i;
+      if (dim_idx < rotary_dim) {
+        elements[i] =
+            (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * yarn_attention_factor;
+      }
+    }
+  }
+
+  // --- Store ---
+  {
+    vec_T vec;
+#pragma unroll
+    for (int i = 0; i < vecSize; i++) {
+      pack2_t packed = Traits::pack(make_float2(elements[2 * i], elements[2 * i + 1]));
+      *(reinterpret_cast<pack2_t*>(&vec) + i) = packed;
+    }
+    *reinterpret_cast<vec_T*>(head_ptr + offset_thread) = vec;
+  }
+}
+
+// ------------------ Host launcher -----------------------------------
+
+/*!
+ * \brief Host launcher for :c:func:`FusedQKNormRopeKernel`.
+ *
+ * Dispatches over ``head_dim`` in {64, 128, 256} and ``interleave``. Returns
+ * ``cudaErrorInvalidValue`` for unsupported ``head_dim`` so the C++ binding
+ * can surface a clean TVM-FFI error.
+ */
+template <typename DType>
+cudaError_t FusedQKNormRopeLauncher(DType* q, DType* k, DType const* q_weight,
+                                    DType const* k_weight, int const* pos_ids, int num_tokens,
+                                    int num_q_heads, int num_kv_heads, int head_dim, int rotary_dim,
+                                    float eps, float rope_theta, bool interleave, float yarn_factor,
+                                    float yarn_low, float yarn_high, float yarn_attention_factor,
+                                    bool is_qk_norm, size_t q_stride_n, size_t q_stride_h,
+                                    size_t k_stride_n, size_t k_stride_h, cudaStream_t stream) {
+  if (num_tokens == 0 || (num_q_heads + num_kv_heads) == 0) {
+    return cudaSuccess;
+  }
+
+  constexpr int block_size = 256;
+  int const warps_per_block = block_size / 32;
+  int const total_qk_heads = num_q_heads + num_kv_heads;
+  int const total_warps = num_tokens * total_qk_heads;
+  int const grid_size = (total_warps + warps_per_block - 1) / warps_per_block;
+  dim3 grid_dim(grid_size);
+  dim3 block_dim(block_size);
+
+#define LAUNCH_IMPL(HEAD_DIM_VAL)                                                                  \
+  DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {                                                    \
+    FusedQKNormRopeKernel<DType, HEAD_DIM_VAL, INTERLEAVE><<<grid_dim, block_dim, 0, stream>>>(    \
+        q, k, q_weight, k_weight, pos_ids, num_q_heads, num_kv_heads, rotary_dim, eps, rope_theta, \
+        yarn_factor, yarn_low, yarn_high, yarn_attention_factor, num_tokens, is_qk_norm,           \
+        q_stride_n, q_stride_h, k_stride_n, k_stride_h);                                           \
+  })
+
+  switch (head_dim) {
+    case 64:
+      LAUNCH_IMPL(64);
+      break;
+    case 128:
+      LAUNCH_IMPL(128);
+      break;
+    case 256:
+      LAUNCH_IMPL(256);
+      break;
+    default:
+      return cudaErrorInvalidValue;
+  }
+#undef LAUNCH_IMPL
+
+  return cudaGetLastError();
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_FUSED_QK_NORM_ROPE_CUH_

--- a/include/flashinfer/fused_qk_norm_rope.cuh
+++ b/include/flashinfer/fused_qk_norm_rope.cuh
@@ -31,6 +31,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <climits>
 #include <cstdint>
 #include <type_traits>
 
@@ -237,7 +238,12 @@ __global__ void FusedQKNormRopeKernel(DType* __restrict__ q,               // [n
     // [pair_offset, 2*pair_offset) via __shfl_xor_sync.
     // pair_offset must be a power of 2 for this exchange to be correct; we
     // enforce that in the C++ launcher / Python API.
-    __syncwarp();
+    //
+    // __shfl_xor_sync with a full mask (0xffffffff) is itself a warp-wide
+    // barrier, and this kernel only touches registers (no shared/global
+    // memory) between the prior writes and the shuffle, so no explicit
+    // __syncwarp() is needed -- see `QKRMSNormKernel` in flashinfer/norm.cuh
+    // for the same convention.
     int const pair_offset = (rotary_dim / 2) / numElemsPerThread;
 #pragma unroll
     for (int i = 0; i < numElemsPerThread; i++) {
@@ -253,8 +259,6 @@ __global__ void FusedQKNormRopeKernel(DType* __restrict__ q,               // [n
       float theta = pos_id * freq;
       __sincosf(theta, &sin_vals[i], &cos_vals[i]);
     }
-    // __shfl_xor_sync does not emit a memfence; sync before re-using `elements`.
-    __syncwarp();
   }
 
   bool const is_full_rope = (rotary_dim == head_dim);
@@ -311,8 +315,17 @@ cudaError_t FusedQKNormRopeLauncher(DType* q, DType* k, DType const* q_weight,
   constexpr int block_size = 256;
   int const warps_per_block = block_size / 32;
   int const total_qk_heads = num_q_heads + num_kv_heads;
-  int const total_warps = num_tokens * total_qk_heads;
-  int const grid_size = (total_warps + warps_per_block - 1) / warps_per_block;
+  // Use int64_t for the intermediate so num_tokens * total_qk_heads cannot
+  // silently overflow int32 (e.g., ~54M tokens with H_q+H_k = 40 already
+  // approaches INT_MAX). CUDA's x-grid limit is still INT_MAX, so the
+  // resulting grid_size must fit in int.
+  int64_t const total_warps =
+      static_cast<int64_t>(num_tokens) * static_cast<int64_t>(total_qk_heads);
+  int64_t const grid_size_i64 = (total_warps + warps_per_block - 1) / warps_per_block;
+  if (grid_size_i64 > static_cast<int64_t>(INT_MAX)) {
+    return cudaErrorInvalidConfiguration;
+  }
+  int const grid_size = static_cast<int>(grid_size_i64);
   dim3 grid_dim(grid_size);
   dim3 block_dim(block_size);
 

--- a/include/flashinfer/fused_qk_norm_rope.cuh
+++ b/include/flashinfer/fused_qk_norm_rope.cuh
@@ -187,7 +187,10 @@ __global__ void FusedQKNormRopeKernel(DType* __restrict__ q,               // [n
   }
   size_t offset_thread = offset_warp + static_cast<size_t>(lane_id) * numElemsPerThread;
 
-  // --- Load into registers and accumulate sum of squares ---
+  // --- Load into registers and (if RMSNorm is enabled) accumulate sum of squares ---
+  // is_qk_norm is a runtime arg, but it's uniform across the warp and loop-
+  // invariant inside this unrolled block, so the branch hoists out and the
+  // no-norm path drops the FMAs entirely.
   float sum_of_squares = 0.0f;
   {
     vec_T vec = *reinterpret_cast<vec_T const*>(head_ptr + offset_thread);
@@ -195,8 +198,10 @@ __global__ void FusedQKNormRopeKernel(DType* __restrict__ q,               // [n
     for (int i = 0; i < vecSize; i++) {
       pack2_t packed = *(reinterpret_cast<pack2_t*>(&vec) + i);
       float2 vals = Traits::unpack(packed);
-      sum_of_squares += vals.x * vals.x;
-      sum_of_squares += vals.y * vals.y;
+      if (is_qk_norm) {
+        sum_of_squares += vals.x * vals.x;
+        sum_of_squares += vals.y * vals.y;
+      }
       elements[2 * i] = vals.x;
       elements[2 * i + 1] = vals.y;
     }

--- a/tests/attention/test_fused_qk_norm_rope.py
+++ b/tests/attention/test_fused_qk_norm_rope.py
@@ -225,6 +225,19 @@ def test_fused_qk_norm_rope_correctness(
     torch.testing.assert_close(k, k_ref_out, rtol=rtol, atol=atol)
 
 
+def _yarn_tolerances(dtype: torch.dtype):
+    # YaRN uses rope_theta=5e5 with pos_ids up to 32768, so the kernel's
+    # __sincosf drifts a bit further from torch's IEEE sin/cos than it does
+    # at rope_theta=1e4. Combined with fp16 rounding plus the
+    # yarn_attention_factor scaling, a handful of elements land just past
+    # the tight per-dtype tolerance used elsewhere.
+    if dtype == torch.bfloat16:
+        return 2e-2, 2e-2
+    if dtype == torch.float16:
+        return 1e-2, 1e-2
+    raise ValueError(f"Unsupported dtype {dtype}")
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("head_dim", [64, 128])
 @pytest.mark.parametrize("interleave", [True, False])
@@ -283,7 +296,7 @@ def test_fused_qk_norm_rope_yarn(dtype, head_dim, interleave):
         yarn_attention_factor=yarn_attention_factor,
     )
 
-    rtol, atol = _tolerances(dtype)
+    rtol, atol = _yarn_tolerances(dtype)
     torch.testing.assert_close(q, q_ref_out, rtol=rtol, atol=atol)
     torch.testing.assert_close(k, k_ref_out, rtol=rtol, atol=atol)
 

--- a/tests/attention/test_fused_qk_norm_rope.py
+++ b/tests/attention/test_fused_qk_norm_rope.py
@@ -417,3 +417,33 @@ def test_fused_qk_norm_rope_interleave_accepts_partial():
         rotary_dim=24,
         interleave=True,
     )
+
+
+def test_fused_qk_norm_rope_misaligned_stride():
+    """Stride along a non-trivial dimension must be a multiple of
+    ``num_elems_per_thread = head_dim / 32`` so per-lane vectorized loads stay
+    aligned. Construct an ``as_strided`` view with an odd outer stride and
+    check we get a clear validation error rather than a misaligned-address
+    crash inside the kernel."""
+    _skip_if_unsupported()
+    device = "cuda:0"
+    dtype = torch.bfloat16
+    nnz, head_dim = 2, 128  # num_elems_per_thread = 4
+    num_q_heads, num_kv_heads = 4, 2
+
+    bad_stride_n = num_q_heads * head_dim + 1  # not a multiple of 4
+    storage_q = torch.randn(nnz * bad_stride_n, dtype=dtype, device=device)
+    q = torch.as_strided(
+        storage_q,
+        size=(nnz, num_q_heads, head_dim),
+        stride=(bad_stride_n, head_dim, 1),
+    )
+    assert q.stride(-1) == 1 and q.stride(0) % 4 != 0
+
+    k = torch.randn(nnz, num_kv_heads, head_dim, dtype=dtype, device=device)
+    q_weight = torch.ones(head_dim, dtype=dtype, device=device)
+    k_weight = torch.ones(head_dim, dtype=dtype, device=device)
+    pos_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+
+    with pytest.raises(_KERNEL_VALIDATION_EXC):
+        flashinfer.fused_qk_norm_rope(q, k, q_weight, k_weight, pos_ids)

--- a/tests/attention/test_fused_qk_norm_rope.py
+++ b/tests/attention/test_fused_qk_norm_rope.py
@@ -1,0 +1,419 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Tests for :func:`flashinfer.fused_qk_norm_rope`, the flashinfer port of
+TensorRT-LLM's ``trtllm::fused_qk_norm_rope`` torch op.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.utils import get_compute_capability
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation
+# ---------------------------------------------------------------------------
+
+
+def _yarn_inv_freq(
+    rotary_dim: int,
+    rope_theta: float,
+    yarn_factor: float,
+    yarn_low: float,
+    yarn_high: float,
+    device,
+) -> torch.Tensor:
+    """Torch reference for the YaRN ramp used inside the kernel.
+
+    Mirrors ``compute_freq_yarn`` in ``include/flashinfer/fused_qk_norm_rope.cuh``
+    but vectorized over ``half_dim``.
+    """
+    half_dim = torch.arange(rotary_dim // 2, dtype=torch.float32, device=device)
+    freq = rope_theta ** (-2.0 * half_dim / rotary_dim)
+    if yarn_factor != 1.0:
+        inv_freq_extrapolation = freq
+        inv_freq_interpolation = freq / yarn_factor
+        # Match the kernel's guard against low == high.
+        if abs(yarn_low - yarn_high) <= 1e-6:
+            high_adj = yarn_high + 0.001
+        else:
+            high_adj = yarn_high
+        linear = (half_dim - yarn_low) / (high_adj - yarn_low)
+        ramp = torch.clamp(linear, 0.0, 1.0)
+        inv_freq_extrapolation_factor = 1.0 - ramp
+        freq = (
+            inv_freq_interpolation * (1.0 - inv_freq_extrapolation_factor)
+            + inv_freq_extrapolation * inv_freq_extrapolation_factor
+        )
+    return freq
+
+
+def ref_fused_qk_norm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    pos_ids: torch.Tensor,
+    rotary_dim: int,
+    eps: float,
+    rope_theta: float,
+    interleave: bool,
+    is_qk_norm: bool,
+    yarn_factor: float,
+    yarn_low: float,
+    yarn_high: float,
+    yarn_attention_factor: float,
+):
+    """Reference implementation for the fused RMSNorm + RoPE op.
+
+    All math runs in float32 to keep the reference tight; we downcast the final
+    result back to ``q.dtype``. Only the RoPE region is multiplied by
+    ``yarn_attention_factor`` — the kernel leaves the pass-through tail
+    unchanged, and so do we.
+    """
+    orig_dtype = q.dtype
+    q = q.to(torch.float32)
+    k = k.to(torch.float32)
+
+    if is_qk_norm:
+        rms_q = torch.rsqrt(q.pow(2).mean(dim=-1, keepdim=True) + eps)
+        q = q * rms_q * q_weight.to(torch.float32)
+        rms_k = torch.rsqrt(k.pow(2).mean(dim=-1, keepdim=True) + eps)
+        k = k * rms_k * k_weight.to(torch.float32)
+
+    inv_freq = _yarn_inv_freq(
+        rotary_dim, rope_theta, yarn_factor, yarn_low, yarn_high, pos_ids.device
+    )
+    theta = pos_ids.to(torch.float32).unsqueeze(-1) * inv_freq.unsqueeze(0)
+    cos = theta.cos()  # [nnz, rotary_dim/2]
+    sin = theta.sin()
+
+    def _rotate(x: torch.Tensor) -> torch.Tensor:
+        x_rot = x[..., :rotary_dim]
+        x_pass = x[..., rotary_dim:]
+        cos_b = cos.unsqueeze(1)  # [nnz, 1, rotary_dim/2]
+        sin_b = sin.unsqueeze(1)
+        if interleave:
+            x_even = x_rot[..., 0::2]
+            x_odd = x_rot[..., 1::2]
+            new_even = x_even * cos_b - x_odd * sin_b
+            new_odd = x_even * sin_b + x_odd * cos_b
+            x_rot_new = torch.stack([new_even, new_odd], dim=-1).flatten(-2)
+        else:
+            x1 = x_rot[..., : rotary_dim // 2]
+            x2 = x_rot[..., rotary_dim // 2 :]
+            new1 = x1 * cos_b - x2 * sin_b
+            new2 = x1 * sin_b + x2 * cos_b
+            x_rot_new = torch.cat([new1, new2], dim=-1)
+        x_rot_new = x_rot_new * yarn_attention_factor
+        return torch.cat([x_rot_new, x_pass], dim=-1)
+
+    q_out = _rotate(q).to(orig_dtype)
+    k_out = _rotate(k).to(orig_dtype)
+    return q_out, k_out
+
+
+# ---------------------------------------------------------------------------
+# Correctness tests
+# ---------------------------------------------------------------------------
+
+
+def _skip_if_unsupported():
+    """BF16 native arithmetic, warp shuffles, and tensor-core-sized loads are
+    all available on SM80+, which is what the kernel targets."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    device = torch.device("cuda:0")
+    cc = get_compute_capability(device)
+    if cc[0] < 8:
+        pytest.skip(f"fused_qk_norm_rope requires SM80+ (got SM{cc[0]}{cc[1]})")
+
+
+def _tolerances(dtype: torch.dtype):
+    if dtype == torch.bfloat16:
+        return 2e-2, 2e-2
+    if dtype == torch.float16:
+        return 5e-3, 5e-3
+    raise ValueError(f"Unsupported dtype {dtype}")
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize(
+    "num_q_heads, num_kv_heads", [(8, 8), (32, 8), (16, 4), (4, 4)]
+)
+@pytest.mark.parametrize("nnz", [1, 17, 1024])
+@pytest.mark.parametrize("partial_rotary_factor", [1.0, 0.5])
+@pytest.mark.parametrize("interleave", [True, False])
+@pytest.mark.parametrize("is_qk_norm", [True, False])
+def test_fused_qk_norm_rope_correctness(
+    dtype,
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    nnz,
+    partial_rotary_factor,
+    interleave,
+    is_qk_norm,
+):
+    _skip_if_unsupported()
+
+    torch.manual_seed(0)
+    device = "cuda:0"
+    rotary_dim = int(head_dim * partial_rotary_factor)
+    if rotary_dim % 2 != 0:
+        pytest.skip("rotary_dim must be even")
+
+    # Neox partial-rope requires `(rotary_dim / 2) / num_elems_per_thread` to be a
+    # power of 2. For the head_dims we dispatch over, partial_rotary_factor=0.5
+    # always yields pair_offset = 8, 16, 32 which is fine.
+
+    q = torch.randn(nnz, num_q_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(nnz, num_kv_heads, head_dim, dtype=dtype, device=device)
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.1 + 1.0
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.1 + 1.0
+    pos_ids = torch.randint(0, 4096, (nnz,), dtype=torch.int32, device=device)
+    eps = 1e-6
+    rope_theta = 1e4
+
+    q_ref_out, k_ref_out = ref_fused_qk_norm_rope(
+        q.clone(),
+        k.clone(),
+        q_weight,
+        k_weight,
+        pos_ids,
+        rotary_dim,
+        eps,
+        rope_theta,
+        interleave,
+        is_qk_norm,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+    )
+
+    flashinfer.fused_qk_norm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        pos_ids,
+        rotary_dim=rotary_dim,
+        eps=eps,
+        rope_theta=rope_theta,
+        interleave=interleave,
+        is_qk_norm=is_qk_norm,
+    )
+
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(q, q_ref_out, rtol=rtol, atol=atol)
+    torch.testing.assert_close(k, k_ref_out, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("interleave", [True, False])
+def test_fused_qk_norm_rope_yarn(dtype, head_dim, interleave):
+    """Correctness with YaRN scaling enabled (factor != 1.0)."""
+    _skip_if_unsupported()
+
+    torch.manual_seed(1)
+    device = "cuda:0"
+    nnz = 37
+    num_q_heads, num_kv_heads = 8, 4
+    rotary_dim = head_dim  # full rope
+
+    q = torch.randn(nnz, num_q_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(nnz, num_kv_heads, head_dim, dtype=dtype, device=device)
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.1 + 1.0
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.1 + 1.0
+    pos_ids = torch.randint(0, 32768, (nnz,), dtype=torch.int32, device=device)
+
+    yarn_factor = 4.0
+    yarn_low = float(head_dim // 8)
+    yarn_high = float(head_dim // 4)
+    yarn_attention_factor = 0.9
+
+    q_ref_out, k_ref_out = ref_fused_qk_norm_rope(
+        q.clone(),
+        k.clone(),
+        q_weight,
+        k_weight,
+        pos_ids,
+        rotary_dim,
+        1e-6,
+        5e5,  # larger base for long-context models
+        interleave,
+        True,
+        yarn_factor,
+        yarn_low,
+        yarn_high,
+        yarn_attention_factor,
+    )
+
+    flashinfer.fused_qk_norm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        pos_ids,
+        rotary_dim=rotary_dim,
+        eps=1e-6,
+        rope_theta=5e5,
+        interleave=interleave,
+        is_qk_norm=True,
+        yarn_factor=yarn_factor,
+        yarn_low=yarn_low,
+        yarn_high=yarn_high,
+        yarn_attention_factor=yarn_attention_factor,
+    )
+
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(q, q_ref_out, rtol=rtol, atol=atol)
+    torch.testing.assert_close(k, k_ref_out, rtol=rtol, atol=atol)
+
+
+def test_fused_qk_norm_rope_noncontiguous():
+    """Last dim contiguous but outer strides non-standard (e.g., q and k
+    slices from a packed qkv buffer)."""
+    _skip_if_unsupported()
+
+    torch.manual_seed(2)
+    device = "cuda:0"
+    dtype = torch.bfloat16
+    nnz, head_dim = 23, 128
+    num_q_heads, num_kv_heads, num_v_heads = 8, 2, 2
+
+    total_heads = num_q_heads + num_kv_heads + num_v_heads
+    qkv = torch.randn(nnz, total_heads, head_dim, dtype=dtype, device=device)
+    q = qkv[:, :num_q_heads, :]
+    k = qkv[:, num_q_heads : num_q_heads + num_kv_heads, :]
+
+    # These are views, not contiguous, but have contiguous last dim.
+    assert not q.is_contiguous()
+    assert not k.is_contiguous()
+    assert q.stride(-1) == 1 and k.stride(-1) == 1
+
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.1 + 1.0
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.1 + 1.0
+    pos_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+
+    # Reference on a contiguous clone.
+    q_ref, k_ref = q.contiguous(), k.contiguous()
+    q_ref_out, k_ref_out = ref_fused_qk_norm_rope(
+        q_ref,
+        k_ref,
+        q_weight,
+        k_weight,
+        pos_ids,
+        head_dim,
+        1e-6,
+        1e4,
+        False,
+        True,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+    )
+
+    flashinfer.fused_qk_norm_rope(q, k, q_weight, k_weight, pos_ids)
+
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(q.contiguous(), q_ref_out, rtol=rtol, atol=atol)
+    torch.testing.assert_close(k.contiguous(), k_ref_out, rtol=rtol, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# Negative tests
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs(head_dim: int = 128, dtype: torch.dtype = torch.bfloat16):
+    device = "cuda:0"
+    nnz = 4
+    q = torch.randn(nnz, 4, head_dim, dtype=dtype, device=device)
+    k = torch.randn(nnz, 2, head_dim, dtype=dtype, device=device)
+    q_weight = torch.ones(head_dim, dtype=dtype, device=device)
+    k_weight = torch.ones(head_dim, dtype=dtype, device=device)
+    pos_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+    return q, k, q_weight, k_weight, pos_ids
+
+
+# ``TVM_FFI_ICHECK`` raises ``InternalError`` which surfaces as Python
+# ``RuntimeError`` via ``tvm_ffi.core.ERROR_NAME_TO_TYPE`` (the fallback for
+# unregistered kinds).
+_KERNEL_VALIDATION_EXC = RuntimeError
+
+
+def test_fused_qk_norm_rope_invalid_head_dim():
+    _skip_if_unsupported()
+    q, k, q_weight, k_weight, pos_ids = _make_inputs(head_dim=96)
+    with pytest.raises(_KERNEL_VALIDATION_EXC):
+        flashinfer.fused_qk_norm_rope(q, k, q_weight, k_weight, pos_ids)
+
+
+def test_fused_qk_norm_rope_pos_ids_wrong_dtype():
+    _skip_if_unsupported()
+    q, k, q_weight, k_weight, pos_ids = _make_inputs()
+    pos_ids = pos_ids.to(torch.int64)
+    with pytest.raises(_KERNEL_VALIDATION_EXC):
+        flashinfer.fused_qk_norm_rope(q, k, q_weight, k_weight, pos_ids)
+
+
+def test_fused_qk_norm_rope_dtype_mismatch():
+    _skip_if_unsupported()
+    q, k, q_weight, k_weight, pos_ids = _make_inputs(dtype=torch.bfloat16)
+    k_weight = k_weight.to(torch.float16)  # intentionally mismatched
+    with pytest.raises(_KERNEL_VALIDATION_EXC):
+        flashinfer.fused_qk_norm_rope(q, k, q_weight, k_weight, pos_ids)
+
+
+def test_fused_qk_norm_rope_neox_non_power_of_2_partial():
+    """Neox (interleave=False) with partial rope where pair_offset is not a
+    power of 2 should be rejected. For head_dim=128 / numElemsPerThread=4,
+    rotary_dim=24 gives pair_offset=3 which is not a power of 2."""
+    _skip_if_unsupported()
+    q, k, q_weight, k_weight, pos_ids = _make_inputs(head_dim=128)
+    with pytest.raises(_KERNEL_VALIDATION_EXC):
+        flashinfer.fused_qk_norm_rope(
+            q,
+            k,
+            q_weight,
+            k_weight,
+            pos_ids,
+            rotary_dim=24,
+            interleave=False,
+        )
+
+
+def test_fused_qk_norm_rope_interleave_accepts_partial():
+    """Interleave=True has no power-of-2 constraint on partial rope; any even
+    rotary_dim <= head_dim should work."""
+    _skip_if_unsupported()
+    q, k, q_weight, k_weight, pos_ids = _make_inputs(head_dim=128)
+    # rotary_dim = 24 would fail in neox mode, but is allowed in interleave mode.
+    flashinfer.fused_qk_norm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        pos_ids,
+        rotary_dim=24,
+        interleave=True,
+    )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

port the TRT-LLM version of this operator to flashinfer (https://github.com/NVIDIA/TensorRT-LLM/blob/f4cb0f81345caeea90efa6ce926aa2801dd0d4f9/cpp/tensorrt_llm/thop/fusedQKNormRopeOp.cpp#L31)

This is useful for GLM 4.x series models, as well as Qwen3 series.

A few minor changes from the original implementation:

* we adapt the flashinfer-style 3d separated q/k layout
* support fp16 (in addition to existing bf16)
* use `interleave` convention in lieu of `is_neox`
* fix an upstream issue with partial-rope validation on non-power-of-2 `pair_offset` values

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fused in-place Q/K operation combining optional per-head RMSNorm + RoPE with YaRN support, BF16/FP16 paths, and sensible runtime validation and defaults.

* **API**
  * Exposed a high-level Python API and registered custom op; kernel is lazily compiled/loaded via the JIT/AOT generation path.

* **Tests**
  * Added comprehensive GPU tests covering datatypes, head sizes, layouts, YaRN behavior, edge cases, and negative validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->