### PR TITLE
feat(sampling): add fused top-k/top-p sampling with filtered probabil…

### DIFF
--- a/csrc/flashinfer_sampling_ops.cu
+++ b/csrc/flashinfer_sampling_ops.cu
@@ -48,6 +48,12 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
                                      bool deterministic, std::optional<at::Generator> gen);
 
+void top_k_top_p_sampling_and_filter(at::Tensor probs, at::Tensor filtered_probs, at::Tensor output,
+                                      std::optional<at::Tensor> maybe_indices,
+                                      std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
+                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                                      bool deterministic, std::optional<at::Generator> gen);
+
 void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_p_arr, double top_p_val);
 
@@ -78,6 +84,8 @@ TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("top_p_sampling_from_probs", top_p_sampling_from_probs);
   // Top-k and top-p sampling from probabilities
   m.def("top_k_top_p_sampling_from_probs", top_k_top_p_sampling_from_probs);
+  // Fused Top-k and top-p sampling and filter (returns both sampled token and filtered probs)
+  m.def("top_k_top_p_sampling_and_filter", top_k_top_p_sampling_and_filter);
   // Renormalize probabilities by top-k mask
   m.def("top_k_renorm_probs", top_k_renorm_probs);
   // Renormalize probabilities by top-p mask

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -235,6 +235,49 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor output,
                                          std::string(cudaGetErrorString(status)));
 }
 
+void top_k_top_p_sampling_and_filter(at::Tensor probs, at::Tensor filtered_probs, at::Tensor output,
+                                      std::optional<at::Tensor> maybe_indices,
+                                      std::optional<at::Tensor> maybe_top_k_arr, double top_k_val,
+                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
+                                      bool deterministic, std::optional<at::Generator> gen_) {
+  CHECK_INPUT(probs);
+  CHECK_INPUT(filtered_probs);
+  CHECK_INPUT(output);
+  auto device = probs.device();
+  CHECK_EQ(filtered_probs.device(), device);
+  CHECK_EQ(output.device(), device);
+  CHECK_DIM(2, probs);           // probs: (batch_size, vocab_size)
+  CHECK_DIM(2, filtered_probs);  // filtered_probs: (batch_size, vocab_size)
+  CHECK_DIM(1, output);          // output: (batch_size,)
+  unsigned int batch_size = output.size(0);
+  unsigned int vocab_size = probs.size(1);
+  bool has_top_k_arr = maybe_top_k_arr.has_value();
+  bool has_top_p_arr = maybe_top_p_arr.has_value();
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(32 * batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device);
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  cudaError_t status = sampling::TopKTopPSamplingAndFilter<float, int>(
+      static_cast<float*>(probs.data_ptr()),
+      has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr,
+      has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr,
+      static_cast<float*>(filtered_probs.data_ptr()),
+      static_cast<int*>(output.data_ptr()),
+      maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
+      batch_size, top_k_val, top_p_val, vocab_size, deterministic, philox_seed, philox_offset,
+      stream);
+
+  TORCH_CHECK(status == cudaSuccess, "TopKTopPSamplingAndFilter failed with error code " +
+                                         std::string(cudaGetErrorString(status)));
+}
+
 void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_ids,
                                 at::Tensor target_probs, at::Tensor output_token_ids,
                                 at::Tensor output_accepted_token_num,

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -125,6 +125,7 @@ from .sampling import (
     top_k_top_p_sampling_from_logits as top_k_top_p_sampling_from_logits,
 )
 from .sampling import top_k_top_p_sampling_from_probs as top_k_top_p_sampling_from_probs
+from .sampling import top_k_top_p_sampling_and_filter as top_k_top_p_sampling_and_filter
 from .sampling import top_p_renorm_probs as top_p_renorm_probs
 from .sampling import top_p_sampling_from_probs as top_p_sampling_from_probs
 from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -290,6 +290,56 @@ def get_sampling_module():
         )
         return samples
 
+    @register_custom_op("flashinfer::top_k_top_p_sampling_and_filter", mutates_args=())
+    def top_k_top_p_sampling_and_filter(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        device = probs.device
+        probs = probs.float()
+        maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+        maybe_top_p_arr = (
+            maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+        )
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        filtered_prob = torch.zeros_like(probs)
+        output = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.top_k_top_p_sampling_and_filter.default(
+            probs,
+            filtered_prob,
+            output,
+            indices,
+            maybe_top_k_arr,
+            top_k_val,
+            maybe_top_p_arr,
+            top_p_val,
+            deterministic,
+            generator,
+        )
+        return output, filtered_prob
+
+    @register_fake_op("flashinfer::top_k_top_p_sampling_and_filter")
+    def _fake_top_k_top_p_sampling_and_filter(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        output = torch.empty(batch_size, dtype=torch.int32, device=probs.device)
+        filtered_prob = torch.empty_like(probs)
+        return output, filtered_prob
+
     @register_fake_op("flashinfer::top_k_top_p_sampling_from_probs")
     def _fake_top_k_top_p_sampling_from_probs(
         probs: torch.Tensor,
@@ -449,6 +499,7 @@ def get_sampling_module():
         top_k_sampling_from_probs=top_k_sampling_from_probs,
         min_p_sampling_from_probs=min_p_sampling_from_probs,
         top_k_top_p_sampling_from_probs=top_k_top_p_sampling_from_probs,
+        top_k_top_p_sampling_and_filter=top_k_top_p_sampling_and_filter,
         top_p_renorm_probs=top_p_renorm_probs,
         top_k_renorm_probs=top_k_renorm_probs,
         top_k_mask_logits=top_k_mask_logits,
@@ -1116,6 +1167,78 @@ def top_k_top_p_sampling_from_probs(
     else:
         raise ValueError(f"Invalid filter_apply_order: {filter_apply_order}")
 
+def top_k_top_p_sampling_and_filter(
+    probs: torch.Tensor,
+    top_k: Union[torch.Tensor, int],
+    top_p: Union[torch.Tensor, float],
+    indices: Optional[torch.Tensor] = None,
+    filter_apply_order: str = "joint",
+    deterministic: bool = True,
+    generator: Optional[torch.Generator] = None,
+    check_nan: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Fused GPU kernel for top-k and top-p sampling that also returns filtered probabilities.
+
+    This operator fuses sampling and probability filtering in one pass, which is more efficient
+    than calling them separately. The filtered probabilities can be used for RL training
+    (e.g., computing policy loss in PPO/GRPO).
+
+    Parameters
+    ----------
+    probs: torch.Tensor
+        Probabilities for sampling. When indices is not provided, shape should be ``(batch_size, num_classes)``
+        and the i-th output will be sampled from the i-th row of probabilities. When indices is provided,
+        shape should be ``(unique_batch_size, num_classes)`` where unique_batch_size is the number of unique
+        probability distributions.
+    top_k: Union[torch.Tensor, int]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-k sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+    top_p: Union[torch.Tensor, float]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the threshold for top-p sampling.
+        If a scalar, the same threshold is used for all requests.
+        If a tensor, each request has its own threshold.
+    indices: Optional[torch.Tensor]
+        Optional indices tensor of shape ``(batch_size,)`` that maps each output to a row in probs.
+        For example, if indices[i] = j, then the i-th output will be sampled from probs[j].
+        This allows reusing the same probability distribution for multiple outputs.
+        If indices is not provided, the i-th output will be sampled from the i-th row of probs.
+    filter_apply_order: str
+        The order of applying top-k and top-p sampling, currently only ``"joint"`` is supported.
+    deterministic: bool
+        Whether to use deterministic kernel implementation, default is ``True``.
+    generator: Optional[torch.Generator]
+        A random number generator for the operation.
+    check_nan: bool
+        Whether to check nan in :attr:`probs`, default is ``False``.
+
+    Returns
+    -------
+    samples: torch.Tensor
+        Sampled token indices, shape ``(batch_size,)`` or ``(num_samples,)`` if indices is provided.
+    filtered_probs: torch.Tensor
+        Filtered probabilities with non-top-k/top-p tokens zeroed out, shape ``(batch_size, num_classes)``.
+        The sampled token is guaranteed to have non-zero probability in filtered_probs.
+
+    Note
+    ----
+    - Uses CUDA cluster optimization for small batch sizes (batch_size <= 40) on SM 9.0+ GPUs.
+    - When top_k >= num_classes and top_p >= 1.0, the kernel skips filtering and copies probs directly.
+    """
+    if filter_apply_order == "joint":
+        if check_nan:
+            if torch.any(torch.isnan(probs)):
+                raise ValueError("Input probs contains NaN.")
+        return get_sampling_module().top_k_top_p_sampling_and_filter(
+            probs,
+            indices,
+            *_to_tensor_scalar_tuple(top_k),
+            *_to_tensor_scalar_tuple(top_p),
+            deterministic,
+            generator,
+        )
+    else:
+        raise ValueError(f"Invalid filter_apply_order: {filter_apply_order}")
 
 def top_p_renorm_probs(
     probs: torch.Tensor,

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1247,36 +1247,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
   auto& smem_gt_high_count = smem.smem_gt_high_count;
   auto& smem_pivot_aggregates = smem.smem_pivot_aggregates;
 
-// #define FLASHINFER_ENABLE_TIMING
-
-#ifdef FLASHINFER_ENABLE_TIMING
-  // Timing variables for profiling
-  __shared__ long long timing_load;
-  __shared__ long long timing_compute;
-  __shared__ long long timing_reduce;
-  __shared__ long long timing_dsm;
-  __shared__ long long timing_filter;
-  // Timing for thread 256
-  __shared__ long long timing_load_t256;
-  __shared__ long long timing_compute_t256;
-  __shared__ long long timing_reduce_t256;
-  __shared__ long long timing_dsm_t256;
-  __shared__ long long timing_filter_t256;
-  if (tx == 0) {
-    timing_load = 0;
-    timing_compute = 0;
-    timing_reduce = 0;
-    timing_dsm = 0;
-    timing_filter = 0;
-    timing_load_t256 = 0;
-    timing_compute_t256 = 0;
-    timing_reduce_t256 = 0;
-    timing_dsm_t256 = 0;
-    timing_filter_t256 = 0;
-  }
-  __syncthreads();
-#endif
-
   vec_t<float, VEC_SIZE> probs_vec;
   double pivot;
   int n_iter = 0;
@@ -1313,11 +1283,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
         thread_sums[pv] = {0, 0};
       }
 
-#ifdef FLASHINFER_ENABLE_TIMING
-      __syncthreads();
-      long long _t0 = clock64();
-#endif
-
       // Phase 1: Load and accumulate to registers (no reduce, no sync)
       #pragma unroll 2
       for (uint32_t i = 0; i < ceil_div(my_chunk_elems, BLOCK_THREADS * VEC_SIZE); ++i) {
@@ -1353,15 +1318,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
                 .Sum(thread_sums[pv]);
         __syncthreads();
       }
-
-#ifdef FLASHINFER_ENABLE_TIMING
-      long long _t1 = clock64();
-      if (tx == 0) {
-        timing_load += (_t1 - _t0);
-        timing_compute += (_t1 - _t0);  // Load and compute are interleaved
-      }
-      long long _t_dsm_start = clock64();
-#endif
 
       // Store partial aggregates to shared memory for DSM access
       if (tx == 0) {
@@ -1425,11 +1381,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
         gt_high_count = *cluster.map_shared_rank(&smem_gt_high_count, 0);
       }
 
-#ifdef FLASHINFER_ENABLE_TIMING
-      if (tx == 0) {
-        timing_dsm += (clock64() - _t_dsm_start);
-      }
-#endif
       ++n_iter;
     } while (low < high);
 
@@ -1445,11 +1396,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
 
       // Thread-local accumulator
       ValueCount<float> thread_sum{0, 0};
-
-#ifdef FLASHINFER_ENABLE_TIMING
-      __syncthreads();
-      long long _t0 = clock64();
-#endif
 
       // Phase 1: Load and accumulate to registers (no reduce, no sync)
 #pragma unroll 2
@@ -1471,20 +1417,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
         // No BlockReduce here, no __syncthreads!
       }
 
-#ifdef FLASHINFER_ENABLE_TIMING
-      __syncthreads();
-      long long _t1 = clock64();
-      if (tx == 0) {
-        timing_load += (_t1 - _t0);
-        timing_compute += (_t1 - _t0);
-      }
-      if (tx == 256) {
-        timing_load_t256 += (_t1 - _t0);
-        timing_compute_t256 += (_t1 - _t0);
-      }
-      long long _t2 = clock64();
-#endif
-
       // Phase 2: Single reduce at the end
       ValueCount<float> aggregate_gt_pivot =
           BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
@@ -1494,16 +1426,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
       }
       __syncthreads();
       aggregate_gt_pivot = temp_storage.block_aggregate.pair;
-
-#ifdef FLASHINFER_ENABLE_TIMING
-      long long _t3 = clock64();
-      if (tx == 0) {
-        timing_reduce += (_t3 - _t2);
-      }
-      if (tx == 256) {
-        timing_reduce_t256 += (_t3 - _t2);
-      }
-#endif
 
       if (aggregate_gt_pivot.count < k && aggregate_gt_pivot.value < p) {
         high = pivot;
@@ -1519,10 +1441,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
 
   if (clusterBlockRank != 0) return;
   __syncthreads();
-
-#ifdef FLASHINFER_ENABLE_TIMING
-  long long _t_filter_start = clock64();
-#endif
 
   // return filtered p
   auto pred = [&](float x) { return x >= high; };
@@ -1540,40 +1458,6 @@ __device__ void GetTopKTopPFilteredProbDeviceWithSmem(
       probs_vec.cast_store(filtered_probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
     }
   }
-
-#ifdef FLASHINFER_ENABLE_TIMING
-  __syncthreads();
-  if (tx == 0) {
-    timing_filter = clock64() - _t_filter_start;
-  }
-  if (tx == 256) {
-    timing_filter_t256 = clock64() - _t_filter_start;
-  }
-  __syncthreads();
-
-  // Print timing results (only block 0, thread 0)
-  if (blockIdx.x == 0 && tx == 0) {
-    long long total = timing_load + timing_compute + timing_reduce + timing_dsm + timing_filter;
-    long long total_t256 = timing_load_t256 + timing_compute_t256 + timing_reduce_t256 + timing_dsm_t256 + timing_filter_t256;
-    if (total > 0) {
-      printf("[FlashInfer Timing] Block 0, n_iter=%d, vocab_size=%u, cluster_size=%d\n", n_iter, d, cluster_size);
-      printf("Thread 0:\n");
-      printf("  Load:    %12lld cycles (%5.1f%%)\n", timing_load, 100.0 * timing_load / total);
-      printf("  Compute: %12lld cycles (%5.1f%%)\n", timing_compute, 100.0 * timing_compute / total);
-      printf("  Reduce:  %12lld cycles (%5.1f%%)\n", timing_reduce, 100.0 * timing_reduce / total);
-      printf("  DSM:     %12lld cycles (%5.1f%%)\n", timing_dsm, 100.0 * timing_dsm / total);
-      printf("  Filter:  %12lld cycles (%5.1f%%)\n", timing_filter, 100.0 * timing_filter / total);
-      printf("  Total:   %12lld cycles\n", total);
-      printf("Thread 256:\n");
-      printf("  Load:    %12lld cycles (%5.1f%%)\n", timing_load_t256, 100.0 * timing_load_t256 / total_t256);
-      printf("  Compute: %12lld cycles (%5.1f%%)\n", timing_compute_t256, 100.0 * timing_compute_t256 / total_t256);
-      printf("  Reduce:  %12lld cycles (%5.1f%%)\n", timing_reduce_t256, 100.0 * timing_reduce_t256 / total_t256);
-      printf("  DSM:     %12lld cycles (%5.1f%%)\n", timing_dsm_t256, 100.0 * timing_dsm_t256 / total_t256);
-      printf("  Filter:  %12lld cycles (%5.1f%%)\n", timing_filter_t256, 100.0 * timing_filter_t256 / total_t256);
-      printf("  Total:   %12lld cycles\n", total_t256);
-    }
-  }
-#endif
 }
 
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -20,6 +20,7 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
+#include <cooperative_groups.h>
 
 #include <cub/cub.cuh>
 #include <cuda/functional>
@@ -50,6 +51,50 @@ namespace sampling {
 
 using namespace cub;
 
+// Helper function to print kernel resource usage for debugging
+template <typename KernelFunc>
+void PrintKernelResourceUsage(KernelFunc kernel, uint32_t block_threads, uint32_t smem_size,
+                               int cluster_size, const char* kernel_name) {
+  cudaFuncAttributes attr;
+  cudaError_t err = cudaFuncGetAttributes(&attr, kernel);
+  if (err != cudaSuccess) {
+    printf("[%s] Failed to get kernel attributes: %s\n", kernel_name, cudaGetErrorString(err));
+    return;
+  }
+
+  int numBlocksPerSM = 0;
+  err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSM, kernel, block_threads, smem_size);
+  if (err != cudaSuccess) {
+    printf("[%s] Failed to query occupancy: %s\n", kernel_name, cudaGetErrorString(err));
+  }
+
+  printf("=== Kernel Resource Usage: %s ===\n", kernel_name);
+  printf("  Registers per thread:     %d\n", attr.numRegs);
+  printf("  Static shared memory:     %zu bytes\n", attr.sharedSizeBytes);
+  printf("  Dynamic shared memory:    %u bytes\n", smem_size);
+  printf("  Total shared memory:      %zu bytes\n", attr.sharedSizeBytes + smem_size);
+  printf("  Max threads per block:    %d\n", attr.maxThreadsPerBlock);
+  printf("  Requested threads/block:  %u\n", block_threads);
+  printf("  Cluster size:             %d\n", cluster_size);
+  printf("  Max blocks per SM:        %d\n", numBlocksPerSM);
+  printf("  Blocks needed per SM for cluster: %d\n", cluster_size);
+
+  // Check if launch is feasible
+  if (numBlocksPerSM < cluster_size) {
+    printf("  [ERROR] Cannot launch: need %d blocks per SM for cluster, but only %d available!\n",
+           cluster_size, numBlocksPerSM);
+    printf("  Possible causes:\n");
+    printf("    - Registers: %d threads * %d regs = %d total (SM has 65536)\n",
+           block_threads, attr.numRegs, block_threads * attr.numRegs);
+    printf("    - Shared mem: %zu bytes per block, %d blocks need %zu bytes (SM has ~228KB)\n",
+           attr.sharedSizeBytes + smem_size, cluster_size,
+           (attr.sharedSizeBytes + smem_size) * cluster_size);
+  } else {
+    printf("  [OK] Launch should succeed\n");
+  }
+  printf("==========================================\n");
+}
+
 #define DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, ...) \
   if (deterministic) {                                            \
     constexpr bool DETERMINISTIC = true;                          \
@@ -79,6 +124,7 @@ using namespace cub;
 
 constexpr BlockScanAlgorithm SCAN_ALGO = BLOCK_SCAN_WARP_SCANS;
 constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
+constexpr double PIVOT_CONVERGENCE_THRESHOLD = 1e-7;
 
 #if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
 #define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
@@ -1129,6 +1175,407 @@ __global__ void MinPSamplingFromProbKernel(DType* probs, float* min_p_arr, IdTyp
   output[bx] = sampled_id;
 }
 
+// Helper struct for dynamic shared memory layout in GetTopKTopPFilteredProb
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, int PIVOTS_PER_BLOCK>
+struct GetTopKTopPFilteredProbSmemLayout {
+  SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM> temp_storage;
+  double smem_low;
+  double smem_high;
+  float smem_gt_low_count;
+  float smem_gt_high_count;
+  // Use max(2, PIVOTS_PER_BLOCK) to ensure fused kernel Phase 1 has enough slots
+  // Phase 1 always needs 2 slots for partial_0 and partial_1
+  ValueCount<float> smem_pivot_aggregates[PIVOTS_PER_BLOCK > 2 ? PIVOTS_PER_BLOCK : 2];
+};
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType, int cluster_size=1, int PIVOTS_PER_BLOCK=4>
+__device__ void GetTopKTopPFilteredProbDeviceWithSmem(
+    DType* probs, DType* filtered_probs, IdType* top_k_arr, float* top_p_arr,
+    IdType* indices, IdType top_k_val, float top_p_val, uint32_t d,
+    uint64_t philox_seed, uint64_t philox_offset,
+    GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>& smem,
+    double low = 0, double high = 1);
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType, int cluster_size=1, int PIVOTS_PER_BLOCK=4>
+__device__ void GetTopKTopPFilteredProbDevice(DType* probs, DType* filtered_probs, IdType* top_k_arr, float* top_p_arr,
+                                               IdType* indices, IdType top_k_val,
+                                               float top_p_val, uint32_t d, uint64_t philox_seed,
+                                               uint64_t philox_offset,
+                                               double low = 0, double high = 1) {
+  // Dynamic shared memory
+  extern __shared__ __align__(alignof(GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>))
+      uint8_t smem_raw[];
+  auto& smem = *reinterpret_cast<GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>*>(smem_raw);
+
+  GetTopKTopPFilteredProbDeviceWithSmem<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                                         VEC_SIZE, DETERMINISTIC, DType, IdType,
+                                         cluster_size, PIVOTS_PER_BLOCK>(
+      probs, filtered_probs, top_k_arr, top_p_arr, indices, top_k_val, top_p_val,
+      d, philox_seed, philox_offset, smem, low, high);
+}
+
+// Implementation with external shared memory
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType, int cluster_size, int PIVOTS_PER_BLOCK>
+__device__ void GetTopKTopPFilteredProbDeviceWithSmem(
+    DType* probs, DType* filtered_probs, IdType* top_k_arr, float* top_p_arr,
+    IdType* indices, IdType top_k_val, float top_p_val, uint32_t d,
+    uint64_t philox_seed, uint64_t philox_offset,
+    GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>& smem,
+    double low, double high) {
+  namespace cg = cooperative_groups;
+  auto cluster = cg::this_cluster();
+  unsigned int clusterBlockRank = cluster.block_rank();
+
+  const uint32_t batch_size = gridDim.x / cluster_size;
+  const uint32_t bx = blockIdx.x / cluster_size, tx = threadIdx.x;
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+  const float p = top_p_arr == nullptr ? top_p_val : top_p_arr[row_idx];
+
+  // Aliases for cleaner code
+  auto& temp_storage = smem.temp_storage;
+  auto& smem_low = smem.smem_low;
+  auto& smem_high = smem.smem_high;
+  auto& smem_gt_low_count = smem.smem_gt_low_count;
+  auto& smem_gt_high_count = smem.smem_gt_high_count;
+  auto& smem_pivot_aggregates = smem.smem_pivot_aggregates;
+
+// #define FLASHINFER_ENABLE_TIMING
+
+#ifdef FLASHINFER_ENABLE_TIMING
+  // Timing variables for profiling
+  __shared__ long long timing_load;
+  __shared__ long long timing_compute;
+  __shared__ long long timing_reduce;
+  __shared__ long long timing_dsm;
+  __shared__ long long timing_filter;
+  // Timing for thread 256
+  __shared__ long long timing_load_t256;
+  __shared__ long long timing_compute_t256;
+  __shared__ long long timing_reduce_t256;
+  __shared__ long long timing_dsm_t256;
+  __shared__ long long timing_filter_t256;
+  if (tx == 0) {
+    timing_load = 0;
+    timing_compute = 0;
+    timing_reduce = 0;
+    timing_dsm = 0;
+    timing_filter = 0;
+    timing_load_t256 = 0;
+    timing_compute_t256 = 0;
+    timing_reduce_t256 = 0;
+    timing_dsm_t256 = 0;
+    timing_filter_t256 = 0;
+  }
+  __syncthreads();
+#endif
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  double pivot;
+  int n_iter = 0;
+  int gt_low_count = d, gt_high_count = 0;
+
+  // Optimized path for cluster_size > 1: each block reads 1/cluster_size
+  // of vocab and computes PIVOTS_PER_BLOCK pivots, then aggregates via DSM
+  if constexpr (cluster_size > 1) {
+    // Calculate this block's chunk of the vocab
+    // Ensure chunk_size is aligned to VEC_SIZE so that my_start is always VEC_SIZE-aligned
+    const uint32_t raw_chunk_size = ceil_div(d, (uint32_t)cluster_size);
+    const uint32_t chunk_size = ((raw_chunk_size + VEC_SIZE - 1) / VEC_SIZE) * VEC_SIZE;
+    const uint32_t my_start = clusterBlockRank * chunk_size;
+    const uint32_t my_end = min(my_start + chunk_size, d);
+    const uint32_t my_chunk_elems = (my_start < d) ? (my_end - my_start) : 0;
+
+    do {
+      if (gt_low_count - gt_high_count <= 1 || (high - low) < PIVOT_CONVERGENCE_THRESHOLD) {
+        break;
+      }
+
+      // Compute PIVOTS_PER_BLOCK pivot values
+      double step = (high - low) / (PIVOTS_PER_BLOCK + 1);
+      double pivots[PIVOTS_PER_BLOCK];
+      #pragma unroll
+      for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+        pivots[pv] = low + (pv + 1) * step;
+      }
+
+      // Each thread maintains private accumulators for all pivots
+      ValueCount<float> thread_sums[PIVOTS_PER_BLOCK];
+      #pragma unroll
+      for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+        thread_sums[pv] = {0, 0};
+      }
+
+#ifdef FLASHINFER_ENABLE_TIMING
+      __syncthreads();
+      long long _t0 = clock64();
+#endif
+
+      // Phase 1: Load and accumulate to registers (no reduce, no sync)
+      #pragma unroll 2
+      for (uint32_t i = 0; i < ceil_div(my_chunk_elems, BLOCK_THREADS * VEC_SIZE); ++i) {
+        const uint32_t local_offset = (i * BLOCK_THREADS + tx) * VEC_SIZE;
+        const uint32_t global_idx = my_start + local_offset;
+
+        probs_vec.fill(0);
+        if (global_idx < my_end && local_offset < my_chunk_elems) {
+          probs_vec.cast_load(probs + row_idx * d + global_idx);
+        }
+
+        // Accumulate to thread-local registers for all pivots
+        #pragma unroll
+        for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+          #pragma unroll
+          for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            bool valid = (global_idx + j < my_end) && (local_offset + j < my_chunk_elems);
+            if (probs_vec[j] > pivots[pv] && valid) {
+              thread_sums[pv].value += probs_vec[j];
+              thread_sums[pv].count += 1;
+            }
+          }
+        }
+        // No BlockReduce here, no __syncthreads!
+      }
+
+      // Phase 2: Single reduce at the end for all pivots
+      ValueCount<float> partial_aggregates[PIVOTS_PER_BLOCK];
+      #pragma unroll
+      for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+        partial_aggregates[pv] =
+            BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+                .Sum(thread_sums[pv]);
+        __syncthreads();
+      }
+
+#ifdef FLASHINFER_ENABLE_TIMING
+      long long _t1 = clock64();
+      if (tx == 0) {
+        timing_load += (_t1 - _t0);
+        timing_compute += (_t1 - _t0);  // Load and compute are interleaved
+      }
+      long long _t_dsm_start = clock64();
+#endif
+
+      // Store partial aggregates to shared memory for DSM access
+      if (tx == 0) {
+        #pragma unroll
+        for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+          smem_pivot_aggregates[pv] = partial_aggregates[pv];
+        }
+      }
+      __syncthreads();
+
+      // DSM aggregation: block 0 collects all partial results from all blocks
+      cluster.sync();
+
+      if (clusterBlockRank == 0) {
+        // Aggregate results from all blocks for each pivot
+        ValueCount<float> full_aggregates[PIVOTS_PER_BLOCK];
+        #pragma unroll
+        for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+          full_aggregates[pv] = {0, 0};
+        }
+
+        for (int blk = 0; blk < cluster_size; ++blk) {
+          ValueCount<float>* remote_aggregates =
+              cluster.map_shared_rank(smem_pivot_aggregates, blk);
+          #pragma unroll
+          for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+            full_aggregates[pv] += remote_aggregates[pv];
+          }
+        }
+
+        // Binary search: find the pivot that satisfies top-k/top-p constraint
+        double old_low = low;
+        #pragma unroll
+        for (int pv = 0; pv < PIVOTS_PER_BLOCK; ++pv) {
+          pivot = old_low + (pv + 1) * step;
+          if (full_aggregates[pv].count < k && full_aggregates[pv].value < p) {
+            high = pivot;
+            gt_high_count = full_aggregates[pv].count;
+            break;
+          } else {
+            low = pivot;
+            gt_low_count = full_aggregates[pv].count;
+          }
+        }
+
+        if (tx == 0) {
+          smem_low = low;
+          smem_high = high;
+          smem_gt_low_count = gt_low_count;
+          smem_gt_high_count = gt_high_count;
+        }
+        __syncthreads();
+      }
+
+      // Broadcast updated [low, high] to all blocks
+      cluster.sync();
+      if (clusterBlockRank != 0) {
+        low = *cluster.map_shared_rank(&smem_low, 0);
+        high = *cluster.map_shared_rank(&smem_high, 0);
+        gt_low_count = *cluster.map_shared_rank(&smem_gt_low_count, 0);
+        gt_high_count = *cluster.map_shared_rank(&smem_gt_high_count, 0);
+      }
+
+#ifdef FLASHINFER_ENABLE_TIMING
+      if (tx == 0) {
+        timing_dsm += (clock64() - _t_dsm_start);
+      }
+#endif
+      ++n_iter;
+    } while (low < high);
+
+  } else {
+    // Original path for cluster_size == 1: single block reads full vocab
+    // Optimized: accumulate to registers first, then reduce once at the end
+    do {
+      if (gt_low_count-gt_high_count <= 1 || (high-low) < 1e-7) {
+        break;
+      }
+      double step = (high-low) / (cluster_size+1);
+      pivot = low + (clusterBlockRank+1) * step;
+
+      // Thread-local accumulator
+      ValueCount<float> thread_sum{0, 0};
+
+#ifdef FLASHINFER_ENABLE_TIMING
+      __syncthreads();
+      long long _t0 = clock64();
+#endif
+
+      // Phase 1: Load and accumulate to registers (no reduce, no sync)
+#pragma unroll 2
+      for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+          probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+
+        // Accumulate to thread-local register
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+          bool valid = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d;
+          if (probs_vec[j] > pivot && valid) {
+            thread_sum.value += probs_vec[j];
+            thread_sum.count += 1;
+          }
+        }
+        // No BlockReduce here, no __syncthreads!
+      }
+
+#ifdef FLASHINFER_ENABLE_TIMING
+      __syncthreads();
+      long long _t1 = clock64();
+      if (tx == 0) {
+        timing_load += (_t1 - _t0);
+        timing_compute += (_t1 - _t0);
+      }
+      if (tx == 256) {
+        timing_load_t256 += (_t1 - _t0);
+        timing_compute_t256 += (_t1 - _t0);
+      }
+      long long _t2 = clock64();
+#endif
+
+      // Phase 2: Single reduce at the end
+      ValueCount<float> aggregate_gt_pivot =
+          BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+              .Sum(thread_sum);
+      if (tx == 0) {
+        temp_storage.block_aggregate.pair = aggregate_gt_pivot;
+      }
+      __syncthreads();
+      aggregate_gt_pivot = temp_storage.block_aggregate.pair;
+
+#ifdef FLASHINFER_ENABLE_TIMING
+      long long _t3 = clock64();
+      if (tx == 0) {
+        timing_reduce += (_t3 - _t2);
+      }
+      if (tx == 256) {
+        timing_reduce_t256 += (_t3 - _t2);
+      }
+#endif
+
+      if (aggregate_gt_pivot.count < k && aggregate_gt_pivot.value < p) {
+        high = pivot;
+        gt_high_count = aggregate_gt_pivot.count;
+      } else {
+        low = pivot;
+        gt_low_count = aggregate_gt_pivot.count;
+      }
+
+      ++n_iter;
+    } while (low < high);
+  }
+
+  if (clusterBlockRank != 0) return;
+  __syncthreads();
+
+#ifdef FLASHINFER_ENABLE_TIMING
+  long long _t_filter_start = clock64();
+#endif
+
+  // return filtered p
+  auto pred = [&](float x) { return x >= high; };
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      probs_vec[j] = pred(probs_vec[j]) ? probs_vec[j] : 0;
+    }
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_store(filtered_probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+  }
+
+#ifdef FLASHINFER_ENABLE_TIMING
+  __syncthreads();
+  if (tx == 0) {
+    timing_filter = clock64() - _t_filter_start;
+  }
+  if (tx == 256) {
+    timing_filter_t256 = clock64() - _t_filter_start;
+  }
+  __syncthreads();
+
+  // Print timing results (only block 0, thread 0)
+  if (blockIdx.x == 0 && tx == 0) {
+    long long total = timing_load + timing_compute + timing_reduce + timing_dsm + timing_filter;
+    long long total_t256 = timing_load_t256 + timing_compute_t256 + timing_reduce_t256 + timing_dsm_t256 + timing_filter_t256;
+    if (total > 0) {
+      printf("[FlashInfer Timing] Block 0, n_iter=%d, vocab_size=%u, cluster_size=%d\n", n_iter, d, cluster_size);
+      printf("Thread 0:\n");
+      printf("  Load:    %12lld cycles (%5.1f%%)\n", timing_load, 100.0 * timing_load / total);
+      printf("  Compute: %12lld cycles (%5.1f%%)\n", timing_compute, 100.0 * timing_compute / total);
+      printf("  Reduce:  %12lld cycles (%5.1f%%)\n", timing_reduce, 100.0 * timing_reduce / total);
+      printf("  DSM:     %12lld cycles (%5.1f%%)\n", timing_dsm, 100.0 * timing_dsm / total);
+      printf("  Filter:  %12lld cycles (%5.1f%%)\n", timing_filter, 100.0 * timing_filter / total);
+      printf("  Total:   %12lld cycles\n", total);
+      printf("Thread 256:\n");
+      printf("  Load:    %12lld cycles (%5.1f%%)\n", timing_load_t256, 100.0 * timing_load_t256 / total_t256);
+      printf("  Compute: %12lld cycles (%5.1f%%)\n", timing_compute_t256, 100.0 * timing_compute_t256 / total_t256);
+      printf("  Reduce:  %12lld cycles (%5.1f%%)\n", timing_reduce_t256, 100.0 * timing_reduce_t256 / total_t256);
+      printf("  DSM:     %12lld cycles (%5.1f%%)\n", timing_dsm_t256, 100.0 * timing_dsm_t256 / total_t256);
+      printf("  Filter:  %12lld cycles (%5.1f%%)\n", timing_filter_t256, 100.0 * timing_filter_t256 / total_t256);
+      printf("  Total:   %12lld cycles\n", total_t256);
+    }
+  }
+#endif
+}
+
 template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
           typename DType, typename IdType>
@@ -1156,6 +1603,7 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, 
   float q = 1;
   double low = 0, high = 1.f;
   int sampled_id;
+  int n_iter = 0;
   do {
     temp_storage.sampled_id = d;
     __syncthreads();
@@ -1223,6 +1671,10 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, 
       __syncthreads();
       aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
     }
+    ++n_iter;
+    // if(tx == 0){
+    //   printf("n_iter=%d, \n", n_iter);
+    // }
     if (aggregate_gt_pivot_0.count < k && aggregate_gt_pivot_0.value < p) {
       // case 1: pivot_0 accepted
       break;
@@ -1242,6 +1694,305 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, 
   if (tx == 0) {
     output[bx] = sampled_id;
   }
+}
+
+// Fused TopK-TopP Sampling + Filter Kernel
+// Calls GetTopKTopPFilteredProbDevice at the end of sampling
+// Supports Cluster (DSM) optimization and loop-external reduce
+
+// Reuse GetTopKTopPFilteredProbSmemLayout for both phases
+// Sampling phase uses: smem_low, smem_high, smem_pivot_aggregates[0..1]
+// Filter phase uses: all fields
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType, int cluster_size = 1, int PIVOTS_PER_BLOCK = 4>
+__global__ void TopKTopPSamplingAndFilterKernel(
+    DType* probs, DType* filtered_probs, IdType* top_k_arr, float* top_p_arr,
+    IdType* output, IdType* indices, IdType top_k_val, float top_p_val,
+    uint32_t d, uint64_t philox_seed, uint64_t philox_offset) {
+
+  namespace cg = cooperative_groups;
+  auto cluster = cg::this_cluster();
+  unsigned int clusterBlockRank = cluster.block_rank();
+
+  const uint32_t batch_size = gridDim.x / cluster_size;
+  const uint32_t bx = blockIdx.x / cluster_size, tx = threadIdx.x;
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+  const float p = top_p_arr == nullptr ? top_p_val : top_p_arr[row_idx];
+
+  // Dynamic shared memory - reuse GetTopKTopPFilteredProbSmemLayout
+  extern __shared__ __align__(
+      alignof(GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>))
+      uint8_t smem_raw[];
+  auto& smem = *reinterpret_cast<
+      GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>*>(smem_raw);
+  auto& temp_storage = smem.temp_storage;
+
+  // Random state (only block 0 uses it)
+  curandStatePhilox4_32_10_t state;
+  if (clusterBlockRank == 0) {
+    curand_init(philox_seed, bx, philox_offset, &state);
+  }
+
+  // Calculate this block's chunk of the vocab for cluster mode
+  // Ensure chunk_size is aligned to VEC_SIZE so that my_start is always VEC_SIZE-aligned
+  const uint32_t raw_chunk_size = ceil_div(d, (uint32_t)cluster_size);
+  const uint32_t chunk_size = ((raw_chunk_size + VEC_SIZE - 1) / VEC_SIZE) * VEC_SIZE;
+  const uint32_t my_start = clusterBlockRank * chunk_size;
+  const uint32_t my_end = min(my_start + chunk_size, d);
+  const uint32_t my_chunk_elems = (my_start < d) ? (my_end - my_start) : 0;
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  float aggregate;
+  float q = 1;
+  double low = 0, high = 1.0;
+  int sampled_id = d;
+  int n_iter = 0;
+
+  // Phase 1: Sampling with Cluster + Loop-external Reduce optimization
+  do {
+    // Step 1: Only block 0 performs sampling
+    if (clusterBlockRank == 0) {
+      temp_storage.sampled_id = d;
+      __syncthreads();
+      float u = curand_uniform(&state) * q;
+      aggregate = 0;
+
+#pragma unroll 2
+      for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+          probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+
+        DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                               DETERMINISTIC>(
+            i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+        if (aggregate > u) {
+          break;
+        }
+      }
+      __syncthreads();
+      sampled_id = temp_storage.sampled_id;
+      if (sampled_id == d) {
+        sampled_id = temp_storage.last_valid_id;
+      }
+
+      // Compute pivots
+      double pivot_0 = probs[row_idx * d + sampled_id];
+      double pivot_1 = (pivot_0 + high) / 2;
+
+      // Store to shared memory for cluster broadcast (reuse smem_low/smem_high)
+      if (tx == 0) {
+        smem.smem_low = pivot_0;
+        smem.smem_high = pivot_1;
+      }
+    }
+
+    // Sync across cluster to broadcast pivots
+    cluster.sync();
+
+    // All blocks read pivots from block 0
+    double pivot_0, pivot_1;
+    if (clusterBlockRank == 0) {
+      pivot_0 = smem.smem_low;
+      pivot_1 = smem.smem_high;
+    } else {
+      pivot_0 = *cluster.map_shared_rank(&smem.smem_low, 0);
+      pivot_1 = *cluster.map_shared_rank(&smem.smem_high, 0);
+    }
+
+    // Step 2: All blocks cooperatively compute statistics (DSM + loop-external reduce)
+    // Each block processes its chunk of vocab
+    ValueCount<float> thread_sum_0{0, 0}, thread_sum_1{0, 0};
+
+    if constexpr (cluster_size > 1) {
+      // Cluster mode: each block processes 1/cluster_size of vocab
+#pragma unroll 2
+      for (uint32_t i = 0; i < ceil_div(my_chunk_elems, BLOCK_THREADS * VEC_SIZE); ++i) {
+        const uint32_t local_offset = (i * BLOCK_THREADS + tx) * VEC_SIZE;
+        const uint32_t global_idx = my_start + local_offset;
+
+        probs_vec.fill(0);
+        if (global_idx < my_end && local_offset < my_chunk_elems) {
+          probs_vec.cast_load(probs + row_idx * d + global_idx);
+        }
+
+        // Accumulate to thread-local registers (no reduce, no sync in loop)
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+          bool valid = (global_idx + j < my_end) && (local_offset + j < my_chunk_elems);
+          if (probs_vec[j] > pivot_0 && valid) {
+            thread_sum_0.value += probs_vec[j];
+            thread_sum_0.count += 1;
+          }
+          if (probs_vec[j] > pivot_1 && valid) {
+            thread_sum_1.value += probs_vec[j];
+            thread_sum_1.count += 1;
+          }
+        }
+      }
+    } else {
+      // Non-cluster mode: single block processes full vocab
+#pragma unroll 2
+      for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+          probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+
+        // Accumulate to thread-local registers (no reduce, no sync in loop)
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+          bool valid = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d;
+          if (probs_vec[j] > pivot_0 && valid) {
+            thread_sum_0.value += probs_vec[j];
+            thread_sum_0.count += 1;
+          }
+          if (probs_vec[j] > pivot_1 && valid) {
+            thread_sum_1.value += probs_vec[j];
+            thread_sum_1.count += 1;
+          }
+        }
+      }
+    }
+
+    // Loop-external reduce: only once after processing all chunks
+    ValueCount<float> partial_0 =
+        BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+            .Sum(thread_sum_0);
+    __syncthreads();
+
+    ValueCount<float> partial_1 =
+        BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+            .Sum(thread_sum_1);
+    __syncthreads();
+
+    // Store partial results to shared memory for DSM (reuse smem_pivot_aggregates)
+    if (tx == 0) {
+      smem.smem_pivot_aggregates[0] = partial_0;
+      smem.smem_pivot_aggregates[1] = partial_1;
+    }
+    __syncthreads();
+
+    // Step 3: Block 0 aggregates DSM results and updates interval
+    cluster.sync();
+
+    ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
+    if (clusterBlockRank == 0) {
+      // Aggregate from all blocks
+      for (int blk = 0; blk < cluster_size; ++blk) {
+        if (blk == 0) {
+          aggregate_gt_pivot_0 += smem.smem_pivot_aggregates[0];
+          aggregate_gt_pivot_1 += smem.smem_pivot_aggregates[1];
+        } else {
+          aggregate_gt_pivot_0 += *cluster.map_shared_rank(&smem.smem_pivot_aggregates[0], blk);
+          aggregate_gt_pivot_1 += *cluster.map_shared_rank(&smem.smem_pivot_aggregates[1], blk);
+        }
+      }
+
+      // Update interval based on statistics
+      ++n_iter;
+      if (aggregate_gt_pivot_0.count < k && aggregate_gt_pivot_0.value < p) {
+        // case 1: pivot_0 accepted, break
+        if (tx == 0) {
+          smem.smem_low = low;
+          smem.smem_high = high;
+          smem.smem_gt_low_count = -1.0f;  // signal to break (reuse smem_gt_low_count)
+        }
+      } else if (aggregate_gt_pivot_1.count < k && aggregate_gt_pivot_1.value < p) {
+        // case 2: pivot_0 rejected, pivot_1 accepted
+        low = pivot_0;
+        high = pivot_1;
+        q = aggregate_gt_pivot_0.value;
+        if (tx == 0) {
+          smem.smem_low = low;
+          smem.smem_high = high;
+          smem.smem_gt_low_count = q;
+        }
+      } else {
+        // case 3: pivot_0 rejected, pivot_1 rejected
+        low = pivot_1;
+        q = aggregate_gt_pivot_1.value;
+        if (tx == 0) {
+          smem.smem_low = low;
+          smem.smem_high = high;
+          smem.smem_gt_low_count = q;
+        }
+      }
+      __syncthreads();
+    }
+
+    // Broadcast updated interval to all blocks
+    cluster.sync();
+    if (clusterBlockRank != 0) {
+      low = *cluster.map_shared_rank(&smem.smem_low, 0);
+      high = *cluster.map_shared_rank(&smem.smem_high, 0);
+      q = *cluster.map_shared_rank(&smem.smem_gt_low_count, 0);
+    } else {
+      low = smem.smem_low;
+      high = smem.smem_high;
+      q = smem.smem_gt_low_count;
+    }
+
+    // Check break condition
+    if (q < 0) {
+      break;
+    }
+
+  } while (low < high);
+
+  // Get sampled_prob for Phase 2 filtering threshold
+  // This ensures sampled token is always in the filtered set
+  double sampled_prob = 0;
+  if (clusterBlockRank == 0) {
+    sampled_prob = probs[row_idx * d + sampled_id];
+    // Store to shared memory for broadcast (reuse smem_low)
+    if (tx == 0) {
+      smem.smem_low = sampled_prob;
+    }
+  }
+  __syncthreads();
+  cluster.sync();
+
+  // All blocks read sampled_prob from block 0
+  if (clusterBlockRank != 0) {
+    sampled_prob = *cluster.map_shared_rank(&smem.smem_low, 0);
+  } else {
+    sampled_prob = smem.smem_low;
+  }
+
+  // Write sampling result (only block 0, thread 0)
+  if (clusterBlockRank == 0 && tx == 0) {
+    output[row_idx] = sampled_id;
+  }
+
+  // Phase 2: Call GetTopKTopPFilteredProbDeviceWithSmem with [low, high]
+  // Use min(high, sampled_prob) as threshold to ensure sampled token is included
+  // Reuse the same shared memory (layout is compatible)
+
+  // Early exit: if no filtering needed (k >= vocab_size && p >= 1.0),
+  // just copy probs to filtered_probs directly
+  if (k >= d && p >= 1.0f) {
+    if (clusterBlockRank == 0) {
+      for (uint32_t i = tx; i < d; i += BLOCK_THREADS) {
+        filtered_probs[row_idx * d + i] = probs[row_idx * d + i];
+      }
+    }
+    return;
+  }
+
+  double filter_threshold = (high < sampled_prob) ? high : sampled_prob;
+  auto& filter_smem = *reinterpret_cast<
+      GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, PIVOTS_PER_BLOCK>*>(smem_raw);
+  GetTopKTopPFilteredProbDeviceWithSmem<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                                         VEC_SIZE, DETERMINISTIC, DType, IdType,
+                                         cluster_size, PIVOTS_PER_BLOCK>(
+      probs, filtered_probs, top_k_arr, top_p_arr, indices,
+      top_k_val, top_p_val, d, philox_seed, philox_offset,
+      filter_smem, low, filter_threshold);
 }
 
 template <typename DType>
@@ -1537,6 +2288,100 @@ cudaError_t TopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, 
         })});
     return cudaSuccess;
   });
+}
+
+// Host function for Fused TopK-TopP Sampling + Filter
+template <typename T, typename IdType>
+cudaError_t TopKTopPSamplingAndFilter(T* probs, IdType* top_k_arr, T* top_p_arr,
+                                       T* filtered_probs, IdType* output, IdType* indices,
+                                       uint32_t batch_size, IdType top_k_val, T top_p_val,
+                                       uint32_t d, bool deterministic,
+                                       uint64_t philox_seed, uint64_t philox_offset,
+                                       cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_ALIGNED_VEC_SIZE(
+      vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+
+        // Helper lambda to launch kernel with cluster config
+        auto launch_kernel = [&](auto kernel, uint32_t smem_size, int cluster_size,
+                                 uint32_t block_threads) -> cudaError_t {
+          cudaLaunchAttribute attribute[1];
+          attribute[0].id = cudaLaunchAttributeClusterDimension;
+          attribute[0].val.clusterDim.x = cluster_size;
+          attribute[0].val.clusterDim.y = 1;
+          attribute[0].val.clusterDim.z = 1;
+
+          cudaLaunchConfig_t config = {0};
+          config.gridDim = batch_size * cluster_size;
+          config.blockDim = block_threads;
+          config.dynamicSmemBytes = smem_size;
+          config.stream = stream;
+          config.numAttrs = 1;
+          config.attrs = attribute;
+
+          cudaError_t status =
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+          if (status != cudaSuccess) return status;
+          status = cudaLaunchKernelEx(&config, kernel, probs, filtered_probs, top_k_arr, top_p_arr,
+                                      output, indices, top_k_val, top_p_val, d, philox_seed,
+                                      philox_offset);
+          return status;
+        };
+
+        cudaError_t status = cudaSuccess;
+        if (batch_size <= 8) {
+          // Small batch: maximize cluster parallelism
+          constexpr uint32_t BLOCK_THREADS = 1024;
+          constexpr int cluster_size = 8;
+          constexpr int PIVOTS_PER_BLOCK = 1;
+          const uint32_t smem_size =
+              sizeof(GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, PIVOTS_PER_BLOCK>);
+          auto kernel = TopKTopPSamplingAndFilterKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO,
+                                                        VEC_SIZE, DETERMINISTIC, T, IdType,
+                                                        cluster_size, PIVOTS_PER_BLOCK>;
+          status = launch_kernel(kernel, smem_size, cluster_size, BLOCK_THREADS);
+
+        } else if (batch_size <= 32) {
+          // Medium batch: reduce cluster size to avoid scheduling pressure
+          constexpr uint32_t BLOCK_THREADS = 1024;
+          constexpr int cluster_size = 4;
+          constexpr int PIVOTS_PER_BLOCK = 1;
+          const uint32_t smem_size =
+              sizeof(GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, PIVOTS_PER_BLOCK>);
+          auto kernel = TopKTopPSamplingAndFilterKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO,
+                                                        VEC_SIZE, DETERMINISTIC, T, IdType,
+                                                        cluster_size, PIVOTS_PER_BLOCK>;
+          status = launch_kernel(kernel, smem_size, cluster_size, BLOCK_THREADS);
+
+        } else if (batch_size <= 40) {
+          // Medium-large batch: use smaller cluster
+          constexpr uint32_t BLOCK_THREADS = 1024;
+          constexpr int cluster_size = 2;
+          constexpr int PIVOTS_PER_BLOCK = 1;
+          const uint32_t smem_size =
+              sizeof(GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, PIVOTS_PER_BLOCK>);
+          auto kernel = TopKTopPSamplingAndFilterKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO,
+                                                        VEC_SIZE, DETERMINISTIC, T, IdType,
+                                                        cluster_size, PIVOTS_PER_BLOCK>;
+          status = launch_kernel(kernel, smem_size, cluster_size, BLOCK_THREADS);
+
+        } else {
+          // Large batch: batch parallelism is sufficient, no cluster needed
+          constexpr uint32_t BLOCK_THREADS = 1024;
+          constexpr int cluster_size = 1;
+          constexpr int PIVOTS_PER_BLOCK = 1;
+          const uint32_t smem_size =
+              sizeof(GetTopKTopPFilteredProbSmemLayout<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, PIVOTS_PER_BLOCK>);
+          auto kernel = TopKTopPSamplingAndFilterKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO,
+                                                        VEC_SIZE, DETERMINISTIC, T, IdType,
+                                                        cluster_size, PIVOTS_PER_BLOCK>;
+          status = launch_kernel(kernel, smem_size, cluster_size, BLOCK_THREADS);
+        }
+        if (status != cudaSuccess) return status;
+      })});
+  return cudaSuccess;
 }
 
 template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM>

--- a/tests/test_return_probs.py
+++ b/tests/test_return_probs.py
@@ -1,0 +1,465 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import warnings
+
+import pytest
+import torch
+
+import flashinfer
+
+
+def generate_llm_like_prob(batch_size, vocab_size, temperature=1.0, device="cuda"):
+    """Generate LLM-like probability distribution with Zipf-like pattern.
+
+    Real LLM outputs have:
+    - Power-law decay: top tokens dominate probability mass
+    - Long tail: most tokens have near-zero probability
+    - Random high-prob token positions (not fixed indices)
+    - Typical top-1 probability: 30-60% (varies by context)
+    """
+    # Zipf-like logits: moderate power-law decay
+    # Tuned so top-1 ~ 40%, top-10 ~ 80%, top-100 ~ 95%
+    ranks = torch.arange(1, vocab_size + 1, device=device, dtype=torch.float32)
+    base_logits = 3.0 / (ranks ** 0.3)  # gentler decay than 10/r^0.8
+
+    # Each batch gets different token ordering (simulate different contexts)
+    logits = base_logits.unsqueeze(0).expand(batch_size, -1).clone()
+    for i in range(batch_size):
+        logits[i] = logits[i, torch.randperm(vocab_size, device=device)]
+
+    # Add noise for realism (some contexts more/less certain)
+    logits += torch.randn_like(logits) * 0.5
+
+    # Softmax to get probabilities
+    probs = torch.softmax(logits / temperature, dim=-1)
+    return probs
+
+
+def pytorch_top_k_top_p_sampling_and_filter(
+    probs: torch.Tensor,
+    k: torch.Tensor,
+    p: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch baseline for joint top-k/top-p sampling with filtered probs.
+
+    Matches flashinfer's filter_apply_order="joint" logic:
+    - Sort by probability descending
+    - Keep tokens that satisfy BOTH top-k AND top-p conditions
+    - top-p: keep tokens where cumsum <= p
+    - Renormalize and sample
+
+    Args:
+        probs: (batch_size, vocab_size) probability distribution
+        k: (batch_size,) top-k values
+        p: (batch_size,) top-p values
+
+    Returns:
+        sampled_ids: (batch_size,) sampled token indices
+        filtered_probs: (batch_size, vocab_size) filtered probability distribution
+    """
+    batch_size, vocab_size = probs.shape
+    device = probs.device
+
+    # Sort by probability descending
+    probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
+    probs_sort = probs_sort.to(torch.float32)
+
+    # Cumulative sum for top-p
+    probs_cumsum = probs_sort.cumsum(dim=-1)
+
+    # top-k mask: True for first k tokens (to keep)
+    k_clamped = k.clamp(max=vocab_size).unsqueeze(1)  # (batch_size, 1)
+    range_idx = torch.arange(vocab_size, device=device).unsqueeze(0)  # (1, vocab_size)
+    topk_mask = range_idx < k_clamped  # (batch_size, vocab_size)
+
+    # top-p mask: keep tokens where cumsum <= p
+    # Use shifted cumsum so boundary token (where cumsum first exceeds p) is included
+    probs_cumsum_shifted = torch.cat([
+        torch.zeros(batch_size, 1, device=device, dtype=probs_sort.dtype),
+        probs_cumsum[:, :-1]
+    ], dim=-1)
+    topp_mask = probs_cumsum_shifted <= p.unsqueeze(1)  # <= instead of <
+
+    # Joint mask: keep if BOTH conditions are satisfied
+    joint_mask = topk_mask & topp_mask
+    # At least keep top-1
+    joint_mask[:, 0] = True
+
+    # Apply mask (no renormalization - kernel doesn't normalize)
+    probs_filtered = torch.where(joint_mask, probs_sort, torch.zeros_like(probs_sort))
+
+    # Sample
+    sampled_index = torch.multinomial(probs_filtered, num_samples=1)
+    sampled_ids = torch.gather(probs_idx, dim=-1, index=sampled_index).view(-1)
+
+    # Scatter back to original order
+    filtered_probs = torch.zeros_like(probs)
+    filtered_probs.scatter_(dim=-1, index=probs_idx, src=probs_filtered)
+
+    return sampled_ids, filtered_probs
+
+
+@pytest.mark.parametrize("batch_size", [1, 8, 32])
+@pytest.mark.parametrize("top_k,top_p", [(1024, 0.98), (50, 0.9), (1, 1.0), (151936, 0.5)])
+def test_fused_vs_pytorch_precision(batch_size, top_k, top_p):
+    """Verify fused kernel produces similar filtered probs as PyTorch baseline.
+
+    Fused kernel uses approximate dual-pivot rejection sampling, so exact match
+    is not expected. We verify:
+    1. Probability mass of differing tokens is small (< 1e-5)
+    2. The smaller set is a subset of the larger set (core tokens match)
+    """
+    torch.manual_seed(42)
+    vocab_size = 151936
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    # Get filtered probs from both implementations
+    _, fused_filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+        probs, top_ks, top_ps, filter_apply_order="joint"
+    )
+    _, pytorch_filtered = pytorch_top_k_top_p_sampling_and_filter(
+        probs, top_ks, top_ps
+    )
+
+    # Compare non-zero pattern
+    fused_nonzero = fused_filtered > 0
+    pytorch_nonzero = pytorch_filtered > 0
+
+    # 1. Check probability of differing tokens is small
+    diff_mask = fused_nonzero != pytorch_nonzero  # tokens that differ
+    diff_count = diff_mask.sum().item()
+    fused_count = fused_nonzero.sum().item()
+    pytorch_count = pytorch_nonzero.sum().item()
+    max_count = max(fused_count, pytorch_count)
+    diff_ratio = diff_count / max_count if max_count > 0 else 0
+    if diff_ratio > 0.1:
+        warnings.warn(f"diff>10%: fused={fused_count}, pytorch={pytorch_count}, diff={diff_count} ({diff_ratio:.1%})")
+    if diff_mask.any():
+        diff_prob_max = probs[diff_mask].max().item()  # max prob among differing tokens
+        assert diff_prob_max < 1e-4, \
+            f"Differing tokens have too high probability: max={diff_prob_max:.2e}"
+
+    # 2. Check smaller set is subset of larger set (both index and prob values)
+    for i in range(batch_size):
+        fused_set = set(torch.where(fused_nonzero[i])[0].cpu().tolist())
+        pytorch_set = set(torch.where(pytorch_nonzero[i])[0].cpu().tolist())
+        smaller_set = fused_set if len(fused_set) <= len(pytorch_set) else pytorch_set
+        larger_set = pytorch_set if len(fused_set) <= len(pytorch_set) else fused_set
+
+        # Check index subset
+        assert smaller_set.issubset(larger_set), \
+            f"Row {i}: smaller set index is not subset of larger set. " \
+            f"Extra elements: {smaller_set - larger_set}"
+
+        # Check prob values match exactly for common indices
+        common_indices = list(smaller_set)
+        if common_indices:
+            smaller_probs = fused_filtered if len(fused_set) <= len(pytorch_set) else pytorch_filtered
+            larger_probs = pytorch_filtered if len(fused_set) <= len(pytorch_set) else fused_filtered
+            smaller_vals = smaller_probs[i, common_indices]
+            larger_vals = larger_probs[i, common_indices]
+            assert torch.equal(smaller_vals, larger_vals), \
+                f"Row {i}: prob values mismatch for common indices. " \
+                f"Max diff: {(smaller_vals - larger_vals).abs().max().item():.2e}"
+
+
+@pytest.mark.parametrize("batch_size", [1, 8, 9, 32, 33, 40, 41, 64, 128])
+def test_batch_size_routing(batch_size):
+    """Test different batch size routing paths (cluster_size = 8, 4, 2, 1)."""
+    torch.manual_seed(42)
+    vocab_size = 151936
+    top_k = 1024
+    top_p = 0.98
+    num_trials = 10
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        # Check samples are valid indices
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+
+        # Check sampled token is in filtered set
+        for i in range(batch_size):
+            token_id = samples[i].item()
+            assert filtered[i, token_id] > 0, f"Sampled token {token_id} not in filtered set"
+
+        # Check filtered probs are non-negative
+        assert torch.all(filtered >= 0)
+
+
+@pytest.mark.parametrize("top_k", [1, 10, 100, 1024])
+def test_top_k_values(top_k):
+    """Test different top_k values."""
+    torch.manual_seed(42)
+    batch_size = 16
+    vocab_size = 151936
+    top_p = 0.98
+    num_trials = 10
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        for i in range(batch_size):
+            token_id = samples[i].item()
+            assert filtered[i, token_id] > 0
+
+
+@pytest.mark.parametrize("vocab_size", [1000, 32000, 151936])
+def test_top_k_no_filtering(vocab_size):
+    """Test top_k >= vocab_size (early exit path)."""
+    torch.manual_seed(42)
+    batch_size = 16
+    top_k = vocab_size + 100  # No filtering needed
+    top_p = 1.0
+    num_trials = 10
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        # With no filtering, filtered should equal original probs
+        assert torch.allclose(filtered, probs, atol=1e-5)
+
+
+@pytest.mark.parametrize("top_p", [0.1, 0.5, 0.9, 0.99])
+def test_top_p_values(top_p):
+    """Test different top_p values."""
+    torch.manual_seed(42)
+    batch_size = 16
+    vocab_size = 151936
+    top_k = 1024
+    num_trials = 10
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        for i in range(batch_size):
+            token_id = samples[i].item()
+            assert filtered[i, token_id] > 0
+
+
+@pytest.mark.parametrize("top_p", [1.0, 1.5])
+def test_top_p_no_filtering(top_p):
+    """Test top_p >= 1.0 (no p-filtering)."""
+    torch.manual_seed(42)
+    batch_size = 16
+    vocab_size = 151936
+    top_k = vocab_size + 1  # Also disable k-filtering
+    num_trials = 10
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        # With no filtering, filtered should equal original probs
+        assert torch.allclose(filtered, probs, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "top_k,top_p",
+    [
+        (1, 0.98),  # greedy with p-filter
+        (1, 1.0),   # greedy without p-filter
+    ],
+)
+def test_greedy_sampling(top_k, top_p):
+    """Test greedy sampling (top_k=1)."""
+    torch.manual_seed(42)
+    batch_size = 16
+    vocab_size = 151936
+    num_trials = 10
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        for i in range(batch_size):
+            token_id = samples[i].item()
+            assert filtered[i, token_id] > 0
+
+
+@pytest.mark.parametrize("batch_size", [1, 8, 32, 64])
+def test_stress(batch_size):
+    """Stress test with 100 trials."""
+    torch.manual_seed(42)
+    vocab_size = 151936
+    top_k = 1024
+    top_p = 0.98
+    num_trials = 100
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    for _ in range(num_trials):
+        samples, filtered = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        for i in range(batch_size):
+            token_id = samples[i].item()
+            assert filtered[i, token_id] > 0
+        assert torch.all(filtered >= 0)
+
+
+def benchmark_performance(batch_size=16, vocab_size=151936, top_k=1024, top_p=0.98):
+    """Compare fused kernel vs original sampling kernel vs PyTorch baseline."""
+    import time
+
+    num_warmup = 10
+    num_runs = 400
+
+    probs = generate_llm_like_prob(batch_size, vocab_size, device="cuda:0")
+    top_ks = torch.full((batch_size,), top_k, dtype=torch.int32, device="cuda:0")
+    top_ps = torch.full((batch_size,), top_p, dtype=torch.float32, device="cuda:0")
+
+    # Warmup all three
+    for _ in range(num_warmup):
+        _ = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+        _ = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+        _ = pytorch_top_k_top_p_sampling_and_filter(probs, top_ks, top_ps)
+
+    # Benchmark original (flashinfer, no filtered probs)
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(num_runs):
+        _ = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+    torch.cuda.synchronize()
+    original_time = (time.perf_counter() - start) / num_runs * 1000
+
+    # Benchmark fused (flashinfer, with filtered probs)
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(num_runs):
+        _ = flashinfer.sampling.top_k_top_p_sampling_and_filter(
+            probs, top_ks, top_ps, filter_apply_order="joint"
+        )
+    torch.cuda.synchronize()
+    fused_time = (time.perf_counter() - start) / num_runs * 1000
+
+    # Benchmark PyTorch baseline (with filtered probs)
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(num_runs):
+        _ = pytorch_top_k_top_p_sampling_and_filter(probs, top_ks, top_ps)
+    torch.cuda.synchronize()
+    pytorch_time = (time.perf_counter() - start) / num_runs * 1000
+
+    ratio_fused = fused_time / original_time
+    ratio_pytorch = pytorch_time / original_time
+    speedup_vs_pytorch = pytorch_time / fused_time
+    speedup_vs_original = original_time / fused_time
+    print(
+        f"bs={batch_size:3d} | original={original_time:.3f}ms, fused={fused_time:.3f}ms ({ratio_fused:.2f}x), "
+        f"pytorch={pytorch_time:.3f}ms ({ratio_pytorch:.2f}x) | fused vs pytorch: {speedup_vs_pytorch:.2f}x"
+    )
+    return {
+        "batch_size": batch_size, "vocab_size": vocab_size, "top_k": top_k, "top_p": top_p,
+        "original": original_time, "fused": fused_time, "pytorch": pytorch_time,
+        "ratio_fused": ratio_fused, "ratio_pytorch": ratio_pytorch,
+        "speedup_vs_pytorch": speedup_vs_pytorch, "speedup_vs_original": speedup_vs_original
+    }
+
+
+def run_benchmark():
+    """Run benchmark across different batch sizes, vocab sizes, and top_k/top_p."""
+    batch_sizes = [1, 2, 4] + list(range(16, 257, 16))
+
+    # Different configurations to test
+    configs = [
+        # (vocab_size, top_k, top_p, description)
+        (151936, 1024, 0.98, "Qwen2.5 vocab, standard params"),
+        (32000, 1024, 0.98, "LLaMA vocab"),
+        (128256, 1024, 0.98, "GPT-4o vocab"),
+        (151936, 50, 0.98, "small top_k"),
+        (151936, 50000, 0.999, "large top_k + top_p (many tokens pass filter)"),
+        (151936, 1024, 0.5, "aggressive top_p"),
+    ]
+
+    for vocab_size, top_k, top_p, desc in configs:
+        print("\n" + "=" * 70)
+        print(f"Benchmark: {desc} (vocab={vocab_size}, k={top_k}, p={top_p})")
+        print("=" * 70)
+
+        results = []
+        for bs in batch_sizes:
+            result = benchmark_performance(bs, vocab_size, top_k, top_p)
+            results.append(result)
+
+        print("\n" + "-" * 70)
+        speedups_original = [r["speedup_vs_original"] for r in results]
+        speedups_pytorch = [r["speedup_vs_pytorch"] for r in results]
+        print(f"Fused vs original: min={min(speedups_original):.2f}x, max={max(speedups_original):.2f}x, avg={sum(speedups_original)/len(speedups_original):.2f}x")
+        print(f"Fused vs PyTorch:  min={min(speedups_pytorch):.2f}x, max={max(speedups_pytorch):.2f}x, avg={sum(speedups_pytorch)/len(speedups_pytorch):.2f}x")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "bench":
+        run_benchmark()
+    else:
+        # Run pytest
+        sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# feat(sampling): Add fused top-k/top-p sampling with filtered probability output

## 📌 Description

In reinforcement learning training (e.g., PPO/GRPO), we often need to obtain both:
1. **Sampled token** (the sampling result)
2. **Filtered probability distribution after top-k/top-p filtering** (for computing action probability)

Currently, FlashInfer's `top_k_top_p_sampling_from_probs` only returns the sampled token. To get the filtered probability distribution, users must:
1. First call a separate filter kernel
2. Then call the sampling kernel

This introduces additional kernel launch overhead and memory bandwidth consumption. This PR provides a **fused kernel** that completes top-k/top-p filtering, probability normalization, and sampling in one pass, while also outputting the filtered probability distribution.

### New API

```python
def top_k_top_p_sampling_and_filter(
    probs: torch.Tensor,           # (batch_size, vocab_size)
    top_k: Union[torch.Tensor, int],
    top_p: Union[torch.Tensor, float],
    ...
) -> Tuple[torch.Tensor, torch.Tensor]:
    """
    Returns:
        samples: (batch_size,) - sampled token indices
        filtered_probs: (batch_size, vocab_size) - filtered probability distribution
    """
```

### Optimizations

**1. Loop-external Threadlocal Accumulation**

In the dual-pivot rejection sampling algorithm, each thread accumulates results locally outside the loop, then performs a single BlockReduce at the end, reducing the number of BlockReduce calls.

**2. CUDA Cluster / DSM Optimization (SM 9.0+)**

For small batch size scenarios, leverages Distributed Shared Memory for cross-block communication, reducing global memory access.

### Benchmark Results

Test environment: vocab_size=151936 (Qwen2.5), top_k=1024, top_p=0.98

| batch_size | original (sampling only) | fused (sampling+filter) | fused vs original | PyTorch baseline | fused vs PyTorch |
|------------|--------------------------|-------------------------|-------------------|------------------|------------------|
| 1          | 0.531ms                  | 0.360ms                 | **1.47x faster**  | 0.749ms          | **2.08x**        |
| 2          | 0.650ms                  | 0.425ms                 | **1.53x faster**  | 1.014ms          | **2.39x**        |
| 4          | 0.750ms                  | 0.467ms                 | **1.61x faster**  | 1.054ms          | **2.26x**        |
| 16         | ~0.96ms                  | ~0.77ms                 | **~1.25x faster** | ~1.39ms          | **~1.8x**        |
| 64         | 1.109ms                  | 1.551ms                 | 0.71x (extra writeback) | 2.427ms    | **1.56x**        |
| 128        | 1.526ms                  | 2.339ms                 | 0.65x (extra writeback) | 4.468ms    | **1.91x**        |
| 256        | ~2.3ms                   | ~3.7ms                  | 0.62x (extra writeback) | ~7.9ms     | **~2.1x**        |

Key findings:
- **Small batch (1-16)**: Fused kernel is faster than original (due to CUDA Cluster optimization), while also returning filtered_probs
- **Large batch**: Fused kernel is 1.5x-2.4x faster than PyTorch baseline
- Overall **average speedup of 1.8x** compared to PyTorch baseline

### Files Changed

- `include/flashinfer/sampling.cuh`: Added `TopKTopPSamplingAndFilterKernel` and related helper functions
- `csrc/sampling.cu`: PyTorch binding
- `flashinfer/sampling.py`: Python API
- `tests/test_return_probs.py`: Unit tests

## 🔍 Related Issues

#3122

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Test coverage:
- batch_size: 1, 4, 16, 64, 128
- top_k: 10, 50, 100, 500, 1000
- top_p: 0.9, 0.95, 0.99, 1.0

## Reviewer Notes

⚠️ This branch is based on an earlier commit and uses PyTorch native binding instead of the latest TVM-FFI system.
