### PR TITLE
autotuner: check cache before synthesizing profile input tensors

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -365,6 +365,12 @@ class TunableRunner(ABC):
         Override this method to differentiate cache entries that share the same
         input shapes but differ in other properties (e.g. output dtype).
         The returned tuple must be hashable.
+
+        Returned values must be synthesis-invariant: the same tuple must
+        be produced for the caller's real inputs and for tensors the
+        autotuner would synthesize for the same profile (i.e., depend only
+        on dtype, is-None flags, or scalar-argument values -- not on
+        per-tensor content).
         """
         return ()
 
@@ -619,6 +625,16 @@ class AutoTuner:
         Returns:
             A tuple containing:
             [is_cache_hit, runner_id, tactic, stored_profile]
+
+        Note:
+            input_shapes and inputs feed orthogonal paths inside
+            this method: input_shapes flows only into
+            _find_nearest_profile (bucket matching) and inputs
+            flows only into r.get_cache_key_extras(inputs).  Callers
+            may therefore pass them describing different tensor sets
+            (e.g. a profile's opt_shapes alongside the caller's real
+            inputs) so long as get_cache_key_extras is
+            synthesis-invariant; see: TunableRunner.get_cache_key_extras.
         """
         with self._lock:
             for r in runners:

--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -745,15 +745,34 @@ class AutoTuner:
             pbar = None
             for _step, p in enumerate(profiles):
                 try:
-                    tensors = self._prepare_input_tensors(p, inputs)
+                    # Check the cache before synthesizing profile inputs.
+                    # `_prepare_input_tensors` launches a GPU kernel per
+                    # `DynamicTensorSpec`; on a cache hit the synthesized
+                    # tensors are immediately discarded.  Skipping them
+                    # matters for callers that invoke `choose_one`
+                    # repeatedly inside `autotune(True)` -- otherwise every
+                    # warm-cache forward still fires those kernels, which
+                    # CUPTI / nsys will attribute to the measured region
+                    # and inflate per-forward timings (asymmetrically
+                    # across runners, since their `dynamic_tensor_specs`
+                    # differ -- enough to invert measured rankings).
+                    #
+                    # Passing `inputs=inputs` is safe: `_get_cache_key`
+                    # uses `p.get_opt_shapes()` plus
+                    # `get_cache_key_extras`, whose contract is to return
+                    # dtype-like properties preserved by the synthesis
+                    # initializers.  Matches the non-tuning branch above
+                    # and the post-loop `search_cache` call below.
                     is_cache_hit, runner_id, tactic, _ = self.search_cache(
                         custom_op,
                         runners,
                         p.get_opt_shapes(),
                         tuning_config,
-                        inputs=tensors,
+                        inputs=inputs,
                     )
                     if not is_cache_hit:
+                        # Synthesize inputs only on the profiling path.
+                        tensors = self._prepare_input_tensors(p, inputs)
                         if pbar is None:
                             pbar = tqdm.tqdm(
                                 total=len(profiles),


### PR DESCRIPTION
## 📌 Description

  AutoTuner.choose_one's tuning-mode loop calls _prepare_input_tensors(p, inputs) before checking the cache. On a cache hit the synthesized tensors are thrown away, but their torch.rand / torch.randint kernel launches already happened on the
  device. For any caller that runs choose_one repeatedly inside autotune(True) (e.g. a benchmark sharing its tuning and measurement call-sites), those kernels recur on every warm-cache call and get attributed to the measured region by CUPTI /
  nsys.

Move search_cache above _prepare_input_tensors in the tuning-mode loop. Skip synthesis on cache hit; synthesize as before on cache miss. The lookup passes the caller's inputs (rather than synthesized tensors), which aligns it with the
  non-tuning branch and the post-loop search_cache. Safe under the existing get_cache_key_extras contract (dtype-like properties preserved by synthesis).
  
## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/2398

https://github.com/flashinfer-ai/flashinfer/pull/2886/

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced runtime overhead during tuning by checking the cache before preparing/synthesized inputs, avoiding unnecessary expensive tensor synthesis on cache hits.
* **Documentation**
  * Clarified cache behavior and requirements: cache-key extras must be synthesis-invariant, and input shapes vs. actual inputs influence separate matching steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->