### PR TITLE
optimize gdn decode bf16 state kernel for mtp with caching. 

### DIFF
--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -256,8 +256,11 @@ def gated_delta_rule_decode_pretranspose(
         )
         assert A_log.dtype == torch.float32, f"A_log must be float32, got {A_log.dtype}"
         scale_val = K**-0.5 if scale is None else scale
-        if T == 1 and not use_pool:
-            # T=1 kernel does not accept initial_state_indices
+        if T == 1:
+            # T=1 path handles both no-pool and pool+indices (with -1 padding).
+            # Dispatches internally to the ILP kernel for B>=16 or the MTP-T=1
+            # kernel for B<16; both accept initial_state_indices since the
+            # pool+padding refactor.
             out = _gated_delta_rule_bf16_state(
                 A_log=A_log,
                 a=a,
@@ -268,12 +271,14 @@ def gated_delta_rule_decode_pretranspose(
                 k=k,
                 v=v,
                 b=b,
-                initial_state_source=state,
+                initial_state_source=initial_state if use_pool else state,
+                initial_state_indices=initial_state_indices,
+                output_state_indices=output_state_indices,
                 use_qk_l2norm_in_kernel=use_qk_l2norm,
                 scale=scale_val,
             )
         else:
-            # MTP kernel supports T>=1 and pool+indices
+            # MTP kernel for T>1 (supports pool+indices and intermediate caching)
             out = _gated_delta_rule_bf16_state_mtp(
                 A_log=A_log,
                 a=a,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -2054,6 +2054,577 @@ def gdn_decode_bf16state_mtp_kernel(
 
 
 # ==============================================================================
+# KERNEL: MTP (ILP=4) — higher-occupancy variant for small `work_units = B*HV`
+# ==============================================================================
+# Same math as gdn_decode_bf16state_mtp_kernel, but processes 4 V-rows per
+# group iteration instead of 8. ILP=4 uses ~48 regs/thread → ~62% occupancy vs
+# ILP=8's ~37%, which better covers the T=2 inline g/beta recompute stall and
+# the small-batch latency tail. Dispatched when work_units <= 128 (B<=2 at
+# HV=64) or when seq_len == 2 and work_units <= 256.
+#
+# Keep this kernel signature minimal: single h0_indices (read == write). The
+# dispatcher in gated_delta_rule_mtp forces ILP=8 when output_state_indices is
+# not None (split-pool write), so we never need h0_out_indices here.
+
+MTP_ILP4_ROWS = 4
+
+
+@cute.kernel
+def gdn_decode_bf16state_mtp_ilp4_kernel(
+    h0_source: cute.Tensor,  # [pool_size * HV, V, K] as BF16
+    intermediate_states: cute.Tensor,  # [pool_size * T * HV, V, K] as BF16 (or dummy)
+    vec_size: cutlass.Constexpr[int],
+    num_v_tiles: cutlass.Constexpr[int],
+    tile_v: cutlass.Constexpr[int],
+    A_log: cute.Tensor,  # [HV]
+    a: cute.Tensor,  # [B, T, HV]
+    dt_bias: cute.Tensor,  # [HV]
+    q: cute.Tensor,  # [B, T, H, K]
+    k: cute.Tensor,  # [B, T, H, K]
+    v: cute.Tensor,  # [B, T, HV, V]
+    b: cute.Tensor,  # [B, T, HV]
+    o: cute.Tensor,  # [B, T, HV, V] - output
+    h0_indices: cute.Tensor,  # [B] - initial state indices (read AND write)
+    softplus_beta: cutlass.Constexpr[float],
+    softplus_threshold: cutlass.Constexpr[float],
+    scale: cutlass.Constexpr[float],
+    HV: cutlass.Constexpr[int],
+    B: cutlass.Constexpr[int],
+    T: cutlass.Constexpr[int],
+    H: cutlass.Constexpr[int],
+    K: cutlass.Constexpr[int],
+    V: cutlass.Constexpr[int],
+    use_qk_l2norm: cutlass.Constexpr[bool],
+    disable_state_update: cutlass.Constexpr[bool],
+    cache_intermediate_states: cutlass.Constexpr[bool],
+    use_packed_fma: cutlass.Constexpr[bool],
+):
+    """MTP kernel (ILP=4) for BF16 state — higher occupancy at small batch."""
+    tidx, _, _ = cute.arch.thread_idx()
+    lane_id = tidx % 32
+    warp_idx = cute.arch.warp_idx()
+    warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+    threads_per_group: cutlass.Constexpr[int] = 32  # noqa: F841
+    num_groups: cutlass.Constexpr[int] = 4
+    group_idx = warp_idx
+    lane_in_group = lane_id
+
+    batch_idx, _, _ = cute.arch.block_idx()
+
+    i_v = batch_idx % num_v_tiles
+    tmp = batch_idx // num_v_tiles
+    i_hv = tmp % HV
+    i_n = tmp // HV
+    i_h = i_hv // (HV // H)
+
+    cache_idx = h0_indices[i_n]
+
+    r_A_log = cutlass.Float32(A_log[i_hv])
+    r_dt_bias = cutlass.Float32(dt_bias[i_hv])
+
+    if cutlass.const_expr(T > 1):
+        smem = cutlass.utils.SmemAllocator()
+        sQ = smem.allocate_tensor(
+            cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
+        )
+        sK = smem.allocate_tensor(
+            cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
+        )
+        sGB = smem.allocate_tensor(
+            cutlass.Float32, cute.make_layout((T, 2), stride=(2, 1)), 16
+        )
+
+    ILP4: cutlass.Constexpr[int] = 4
+    r_q = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.Float32
+    )
+    r_k = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.Float32
+    )
+    r_h = cute.make_rmem_tensor(
+        cute.make_layout((ILP4, vec_size), stride=(vec_size, 1)),
+        cutlass.Float32,
+    )
+    r_q_bf16 = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.BFloat16
+    )
+    r_k_bf16 = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb4_0 = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb4_1 = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb4_2 = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb4_3 = cute.make_rmem_tensor(
+        cute.make_layout((vec_size,), stride=(1,)), cutlass.BFloat16
+    )
+    r_o4_bf16 = cute.make_rmem_tensor(
+        cute.make_layout((ILP4,), stride=(1,)), cutlass.BFloat16
+    )
+    r_v4_bf16 = cute.make_rmem_tensor(
+        cute.make_layout((ILP4,), stride=(1,)), cutlass.BFloat16
+    )
+
+    if cache_idx < 0:
+        cache_idx = cutlass.Int32(0)
+
+    if cache_idx >= 0:
+        k_start = lane_in_group * vec_size
+
+        if cutlass.const_expr(T > 1):
+            num_precompute_passes: cutlass.Constexpr[int] = (
+                T + num_groups - 1
+            ) // num_groups
+            for pass_idx in cutlass.range_constexpr(num_precompute_passes):
+                i_t_pre = pass_idx * num_groups + group_idx
+                if i_t_pre < T:
+                    q_tile_pre = cute.local_tile(
+                        q, (1, 1, 1, vec_size), (i_n, i_t_pre, i_h, lane_in_group)
+                    )
+                    k_tile_pre = cute.local_tile(
+                        k, (1, 1, 1, vec_size), (i_n, i_t_pre, i_h, lane_in_group)
+                    )
+                    cute.autovec_copy(q_tile_pre, r_q_bf16)
+                    cute.autovec_copy(k_tile_pre, r_k_bf16)
+
+                    for i in cutlass.range_constexpr(vec_size):
+                        r_q[i] = cutlass.Float32(r_q_bf16[i])
+                        r_k[i] = cutlass.Float32(r_k_bf16[i])
+
+                    if cutlass.const_expr(use_qk_l2norm):
+                        sum_q = 0.0
+                        sum_k = 0.0
+                        for i in cutlass.range_constexpr(vec_size):
+                            sum_q += r_q[i] * r_q[i]
+                            sum_k += r_k[i] * r_k[i]
+                        for offset in [16, 8, 4, 2, 1]:
+                            sum_q += cute.arch.shuffle_sync_bfly(
+                                sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                            )
+                            sum_k += cute.arch.shuffle_sync_bfly(
+                                sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                            )
+                        inv_norm_q_scaled = (
+                            cute.rsqrt(sum_q + 1e-6, fastmath=True) * scale
+                        )
+                        inv_norm_k = cute.rsqrt(sum_k + 1e-6, fastmath=True)
+                        for i in cutlass.range_constexpr(vec_size):
+                            r_q[i] = r_q[i] * inv_norm_q_scaled
+                            r_k[i] = r_k[i] * inv_norm_k
+                    else:
+                        for i in cutlass.range_constexpr(vec_size):
+                            r_q[i] = r_q[i] * scale
+
+                    for i in cutlass.range_constexpr(vec_size):
+                        sQ[(i_t_pre, k_start + i)] = r_q[i]
+                        sK[(i_t_pre, k_start + i)] = r_k[i]
+
+                    if cutlass.const_expr(T > 2):
+                        r_a_pre = cutlass.Float32(a[i_n, i_t_pre, i_hv])
+                        r_b_pre = cutlass.Float32(b[i_n, i_t_pre, i_hv])
+                        x_pre = r_a_pre + r_dt_bias
+                        beta_x_pre = softplus_beta * x_pre
+                        exp_beta_x_pre = cute.exp(beta_x_pre, fastmath=True)
+                        softplus_val_pre = (
+                            cutlass.Float32(1.0) / softplus_beta
+                        ) * cute.log(
+                            cutlass.Float32(1.0) + exp_beta_x_pre, fastmath=True
+                        )
+                        use_softplus_pre = (
+                            cutlass.Float32(1.0)
+                            if beta_x_pre <= softplus_threshold
+                            else cutlass.Float32(0.0)
+                        )
+                        softplus_x_pre = (
+                            use_softplus_pre * softplus_val_pre
+                            + (cutlass.Float32(1.0) - use_softplus_pre) * x_pre
+                        )
+                        r_g_value_pre = (
+                            -cute.exp(r_A_log, fastmath=True) * softplus_x_pre
+                        )
+                        r_beta_pre = cutlass.Float32(1.0) / (
+                            cutlass.Float32(1.0) + cute.exp(-r_b_pre, fastmath=True)
+                        )
+                        r_g_pre = cute.exp(r_g_value_pre, fastmath=True)
+                        if lane_in_group == 0:
+                            sGB[(i_t_pre, 0)] = r_g_pre
+                            sGB[(i_t_pre, 1)] = r_beta_pre
+
+                cute.arch.barrier()
+
+        flat_state_idx = cache_idx * HV + i_hv
+        rows_per_group: cutlass.Constexpr[int] = tile_v // num_groups
+
+        sum_q = cutlass.Float32(0.0)
+        sum_k = cutlass.Float32(0.0)
+        inv_norm_q_scaled = cutlass.Float32(1.0)
+        inv_norm_k = cutlass.Float32(1.0)
+
+        quarter_rows: cutlass.Constexpr[int] = rows_per_group // ILP4
+
+        for row_quad in cutlass.range(quarter_rows, unroll=1, unroll_full=(T <= 1)):
+            vb4 = i_v * tile_v + group_idx * rows_per_group + row_quad * ILP4
+            va = vb4
+            vb = vb4 + 1
+            vc = vb4 + 2
+            vd = vb4 + 3
+
+            hta = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_state_idx, va, lane_in_group)
+            )
+            htb = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_state_idx, vb, lane_in_group)
+            )
+            htc = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_state_idx, vc, lane_in_group)
+            )
+            htd = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_state_idx, vd, lane_in_group)
+            )
+            cute.autovec_copy(hta, r_hb4_0)
+            cute.autovec_copy(htb, r_hb4_1)
+            cute.autovec_copy(htc, r_hb4_2)
+            cute.autovec_copy(htd, r_hb4_3)
+
+            for i in cutlass.range_constexpr(vec_size):
+                r_h[0, i] = cutlass.Float32(r_hb4_0[i])
+                r_h[1, i] = cutlass.Float32(r_hb4_1[i])
+                r_h[2, i] = cutlass.Float32(r_hb4_2[i])
+                r_h[3, i] = cutlass.Float32(r_hb4_3[i])
+
+            for i_t in cutlass.range(T, unroll=1, unroll_full=(T <= 1)):
+                if cutlass.const_expr(T > 1):
+                    sQ_tile = cute.local_tile(sQ, (1, vec_size), (i_t, lane_in_group))
+                    sK_tile = cute.local_tile(sK, (1, vec_size), (i_t, lane_in_group))
+                    cute.autovec_copy(sQ_tile, r_q)
+                    cute.autovec_copy(sK_tile, r_k)
+                    if cutlass.const_expr(T > 2):
+                        r_g = sGB[(i_t, 0)]
+                        r_beta = sGB[(i_t, 1)]
+                    else:
+                        r_a_val = cutlass.Float32(a[i_n, i_t, i_hv])
+                        r_b_val = cutlass.Float32(b[i_n, i_t, i_hv])
+                        x_val = r_a_val + r_dt_bias
+                        beta_x_val = softplus_beta * x_val
+                        exp_beta_x_val = cute.exp(beta_x_val, fastmath=True)
+                        softplus_val_v = (
+                            cutlass.Float32(1.0) / softplus_beta
+                        ) * cute.log(
+                            cutlass.Float32(1.0) + exp_beta_x_val, fastmath=True
+                        )
+                        use_softplus_v = (
+                            cutlass.Float32(1.0)
+                            if beta_x_val <= softplus_threshold
+                            else cutlass.Float32(0.0)
+                        )
+                        softplus_x_v = (
+                            use_softplus_v * softplus_val_v
+                            + (cutlass.Float32(1.0) - use_softplus_v) * x_val
+                        )
+                        r_g_value_v = -cute.exp(r_A_log, fastmath=True) * softplus_x_v
+                        r_beta = cutlass.Float32(1.0) / (
+                            cutlass.Float32(1.0) + cute.exp(-r_b_val, fastmath=True)
+                        )
+                        r_g = cute.exp(r_g_value_v, fastmath=True)
+                else:
+                    q_tile_t = cute.local_tile(
+                        q, (1, 1, 1, vec_size), (i_n, i_t, i_h, lane_in_group)
+                    )
+                    k_tile_t = cute.local_tile(
+                        k, (1, 1, 1, vec_size), (i_n, i_t, i_h, lane_in_group)
+                    )
+                    cute.autovec_copy(q_tile_t, r_q_bf16)
+                    cute.autovec_copy(k_tile_t, r_k_bf16)
+                    for i in cutlass.range_constexpr(vec_size):
+                        r_q[i] = cutlass.Float32(r_q_bf16[i])
+                        r_k[i] = cutlass.Float32(r_k_bf16[i])
+                    if cutlass.const_expr(use_qk_l2norm):
+                        sum_q = cutlass.Float32(0.0)
+                        sum_k = cutlass.Float32(0.0)
+                        for i in cutlass.range_constexpr(vec_size):
+                            sum_q += r_q[i] * r_q[i]
+                            sum_k += r_k[i] * r_k[i]
+                        for offset in [16, 8, 4, 2, 1]:
+                            sum_q += cute.arch.shuffle_sync_bfly(
+                                sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                            )
+                            sum_k += cute.arch.shuffle_sync_bfly(
+                                sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                            )
+                        inv_norm_q_scaled = (
+                            cute.rsqrt(sum_q + 1e-6, fastmath=True) * scale
+                        )
+                        inv_norm_k = cute.rsqrt(sum_k + 1e-6, fastmath=True)
+                        for i in cutlass.range_constexpr(vec_size):
+                            r_q[i] = r_q[i] * inv_norm_q_scaled
+                            r_k[i] = r_k[i] * inv_norm_k
+                    else:
+                        for i in cutlass.range_constexpr(vec_size):
+                            r_q[i] = r_q[i] * scale
+                    r_a_val = cutlass.Float32(a[i_n, i_t, i_hv])
+                    r_b_val = cutlass.Float32(b[i_n, i_t, i_hv])
+                    x_val = r_a_val + r_dt_bias
+                    beta_x_val = softplus_beta * x_val
+                    exp_beta_x_val = cute.exp(beta_x_val, fastmath=True)
+                    softplus_val_v = (cutlass.Float32(1.0) / softplus_beta) * cute.log(
+                        cutlass.Float32(1.0) + exp_beta_x_val, fastmath=True
+                    )
+                    use_softplus_v = (
+                        cutlass.Float32(1.0)
+                        if beta_x_val <= softplus_threshold
+                        else cutlass.Float32(0.0)
+                    )
+                    softplus_x_v = (
+                        use_softplus_v * softplus_val_v
+                        + (cutlass.Float32(1.0) - use_softplus_v) * x_val
+                    )
+                    r_g_value_v = -cute.exp(r_A_log, fastmath=True) * softplus_x_v
+                    r_beta = cutlass.Float32(1.0) / (
+                        cutlass.Float32(1.0) + cute.exp(-r_b_val, fastmath=True)
+                    )
+                    r_g = cute.exp(r_g_value_v, fastmath=True)
+
+                sa = 0.0
+                sb = 0.0
+                sc = 0.0
+                sd = 0.0
+                sa2 = 0.0
+                sb2 = 0.0
+                sc2 = 0.0
+                sd2 = 0.0
+                for i in cutlass.range_constexpr(0, vec_size, 2):
+                    r_h[0, i] = r_h[0, i] * r_g
+                    r_h[0, i + 1] = r_h[0, i + 1] * r_g
+                    r_h[1, i] = r_h[1, i] * r_g
+                    r_h[1, i + 1] = r_h[1, i + 1] * r_g
+                    r_h[2, i] = r_h[2, i] * r_g
+                    r_h[2, i + 1] = r_h[2, i + 1] * r_g
+                    r_h[3, i] = r_h[3, i] * r_g
+                    r_h[3, i + 1] = r_h[3, i + 1] * r_g
+                    if cutlass.const_expr(use_packed_fma):
+                        sa, sa2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[0, i], r_h[0, i + 1]),
+                            src_b=(r_k[i], r_k[i + 1]),
+                            src_c=(sa, sa2),
+                        )
+                        sb, sb2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[1, i], r_h[1, i + 1]),
+                            src_b=(r_k[i], r_k[i + 1]),
+                            src_c=(sb, sb2),
+                        )
+                        sc, sc2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[2, i], r_h[2, i + 1]),
+                            src_b=(r_k[i], r_k[i + 1]),
+                            src_c=(sc, sc2),
+                        )
+                        sd, sd2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[3, i], r_h[3, i + 1]),
+                            src_b=(r_k[i], r_k[i + 1]),
+                            src_c=(sd, sd2),
+                        )
+                    else:
+                        sa, sa2 = fma_pair(
+                            r_h[0, i], r_h[0, i + 1], r_k[i], r_k[i + 1], sa, sa2
+                        )
+                        sb, sb2 = fma_pair(
+                            r_h[1, i], r_h[1, i + 1], r_k[i], r_k[i + 1], sb, sb2
+                        )
+                        sc, sc2 = fma_pair(
+                            r_h[2, i], r_h[2, i + 1], r_k[i], r_k[i + 1], sc, sc2
+                        )
+                        sd, sd2 = fma_pair(
+                            r_h[3, i], r_h[3, i + 1], r_k[i], r_k[i + 1], sd, sd2
+                        )
+                sa = sa + sa2
+                sb = sb + sb2
+                sc = sc + sc2
+                sd = sd + sd2
+
+                for offset in [16, 8, 4, 2, 1]:
+                    sa += cute.arch.shuffle_sync_bfly(
+                        sa, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sb += cute.arch.shuffle_sync_bfly(
+                        sb, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sc += cute.arch.shuffle_sync_bfly(
+                        sc, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sd += cute.arch.shuffle_sync_bfly(
+                        sd, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                vt4_slice = cute.local_tile(
+                    v, (1, 1, 1, ILP4), (i_n, i_t, i_hv, vb4 // ILP4)
+                )
+                cute.autovec_copy(vt4_slice, r_v4_bf16)
+                vna = (cutlass.Float32(r_v4_bf16[0]) - sa) * r_beta
+                vnb = (cutlass.Float32(r_v4_bf16[1]) - sb) * r_beta
+                vnc = (cutlass.Float32(r_v4_bf16[2]) - sc) * r_beta
+                vnd = (cutlass.Float32(r_v4_bf16[3]) - sd) * r_beta
+
+                oa = 0.0
+                ob = 0.0
+                oc = 0.0
+                od = 0.0
+                oa2 = 0.0
+                ob2 = 0.0
+                oc2 = 0.0
+                od2 = 0.0
+                for i in cutlass.range_constexpr(0, vec_size, 2):
+                    if cutlass.const_expr(use_packed_fma):
+                        r_h[0, i], r_h[0, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_k[i], r_k[i + 1]),
+                            src_b=(vna, vna),
+                            src_c=(r_h[0, i], r_h[0, i + 1]),
+                        )
+                        r_h[1, i], r_h[1, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_k[i], r_k[i + 1]),
+                            src_b=(vnb, vnb),
+                            src_c=(r_h[1, i], r_h[1, i + 1]),
+                        )
+                        r_h[2, i], r_h[2, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_k[i], r_k[i + 1]),
+                            src_b=(vnc, vnc),
+                            src_c=(r_h[2, i], r_h[2, i + 1]),
+                        )
+                        r_h[3, i], r_h[3, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_k[i], r_k[i + 1]),
+                            src_b=(vnd, vnd),
+                            src_c=(r_h[3, i], r_h[3, i + 1]),
+                        )
+                    else:
+                        r_h[0, i], r_h[0, i + 1] = fma_pair(
+                            r_k[i], r_k[i + 1], vna, vna, r_h[0, i], r_h[0, i + 1]
+                        )
+                        r_h[1, i], r_h[1, i + 1] = fma_pair(
+                            r_k[i], r_k[i + 1], vnb, vnb, r_h[1, i], r_h[1, i + 1]
+                        )
+                        r_h[2, i], r_h[2, i + 1] = fma_pair(
+                            r_k[i], r_k[i + 1], vnc, vnc, r_h[2, i], r_h[2, i + 1]
+                        )
+                        r_h[3, i], r_h[3, i + 1] = fma_pair(
+                            r_k[i], r_k[i + 1], vnd, vnd, r_h[3, i], r_h[3, i + 1]
+                        )
+                    if cutlass.const_expr(use_packed_fma):
+                        oa, oa2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[0, i], r_h[0, i + 1]),
+                            src_b=(r_q[i], r_q[i + 1]),
+                            src_c=(oa, oa2),
+                        )
+                        ob, ob2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[1, i], r_h[1, i + 1]),
+                            src_b=(r_q[i], r_q[i + 1]),
+                            src_c=(ob, ob2),
+                        )
+                        oc, oc2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[2, i], r_h[2, i + 1]),
+                            src_b=(r_q[i], r_q[i + 1]),
+                            src_c=(oc, oc2),
+                        )
+                        od, od2 = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[3, i], r_h[3, i + 1]),
+                            src_b=(r_q[i], r_q[i + 1]),
+                            src_c=(od, od2),
+                        )
+                    else:
+                        oa, oa2 = fma_pair(
+                            r_h[0, i], r_h[0, i + 1], r_q[i], r_q[i + 1], oa, oa2
+                        )
+                        ob, ob2 = fma_pair(
+                            r_h[1, i], r_h[1, i + 1], r_q[i], r_q[i + 1], ob, ob2
+                        )
+                        oc, oc2 = fma_pair(
+                            r_h[2, i], r_h[2, i + 1], r_q[i], r_q[i + 1], oc, oc2
+                        )
+                        od, od2 = fma_pair(
+                            r_h[3, i], r_h[3, i + 1], r_q[i], r_q[i + 1], od, od2
+                        )
+                oa = oa + oa2
+                ob = ob + ob2
+                oc = oc + oc2
+                od = od + od2
+
+                if cutlass.const_expr(cache_intermediate_states):
+                    for i in cutlass.range_constexpr(vec_size):
+                        r_hb4_0[i] = cutlass.BFloat16(r_h[0, i])
+                        r_hb4_1[i] = cutlass.BFloat16(r_h[1, i])
+                        r_hb4_2[i] = cutlass.BFloat16(r_h[2, i])
+                        r_hb4_3[i] = cutlass.BFloat16(r_h[3, i])
+
+                if cutlass.const_expr(cache_intermediate_states):
+                    flat_idx = cache_idx * T * HV + i_t * HV + i_hv
+                    ita = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec_size),
+                        (flat_idx, va, lane_in_group),
+                    )
+                    itb = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec_size),
+                        (flat_idx, vb, lane_in_group),
+                    )
+                    itc = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec_size),
+                        (flat_idx, vc, lane_in_group),
+                    )
+                    itd = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec_size),
+                        (flat_idx, vd, lane_in_group),
+                    )
+                    cute.autovec_copy(r_hb4_0, ita)
+                    cute.autovec_copy(r_hb4_1, itb)
+                    cute.autovec_copy(r_hb4_2, itc)
+                    cute.autovec_copy(r_hb4_3, itd)
+
+                for offset in [16, 8, 4, 2, 1]:
+                    oa += cute.arch.shuffle_sync_bfly(
+                        oa, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    ob += cute.arch.shuffle_sync_bfly(
+                        ob, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    oc += cute.arch.shuffle_sync_bfly(
+                        oc, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    od += cute.arch.shuffle_sync_bfly(
+                        od, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                if lane_in_group == 0:
+                    r_o4_bf16[0] = cutlass.BFloat16(oa)
+                    r_o4_bf16[1] = cutlass.BFloat16(ob)
+                    r_o4_bf16[2] = cutlass.BFloat16(oc)
+                    r_o4_bf16[3] = cutlass.BFloat16(od)
+                    ot4_slice = cute.local_tile(
+                        o,
+                        (1, 1, 1, ILP4),
+                        (i_n, i_t, i_hv, vb4 // ILP4),
+                    )
+                    cute.autovec_copy(r_o4_bf16, ot4_slice)
+
+            if cutlass.const_expr(not disable_state_update):
+                if cutlass.const_expr(not cache_intermediate_states):
+                    for i in cutlass.range_constexpr(vec_size):
+                        r_hb4_0[i] = cutlass.BFloat16(r_h[0, i])
+                        r_hb4_1[i] = cutlass.BFloat16(r_h[1, i])
+                        r_hb4_2[i] = cutlass.BFloat16(r_h[2, i])
+                        r_hb4_3[i] = cutlass.BFloat16(r_h[3, i])
+                cute.autovec_copy(r_hb4_0, hta)
+                cute.autovec_copy(r_hb4_1, htb)
+                cute.autovec_copy(r_hb4_2, htc)
+                cute.autovec_copy(r_hb4_3, htd)
+
+
+# ==============================================================================
 # LAUNCH WRAPPER (MTP version)
 # ==============================================================================
 
@@ -2126,6 +2697,92 @@ def run_gdn_decode_bf16state_mtp(
         o,
         h0_indices,
         h0_out_indices,
+        softplus_beta,
+        softplus_threshold,
+        scale,
+        HV,
+        B,
+        T,
+        H,
+        K,
+        V,
+        use_qk_l2norm,
+        disable_state_update,
+        cache_intermediate_states,
+        use_packed_fma,
+    ).launch(
+        grid=(grid_size, 1, 1),
+        block=[MTP_NUM_THREADS, 1, 1],
+        smem=smem_bytes,
+        stream=stream,
+    )
+
+
+# ==============================================================================
+# LAUNCH WRAPPER (MTP ILP=4 version)
+# ==============================================================================
+
+
+@cute.jit
+def run_gdn_decode_bf16state_mtp_ilp4(
+    h0_source: cute.Tensor,  # [pool_size * HV, V, K] BF16
+    intermediate_states: cute.Tensor,  # [pool_size * T * HV, V, K] BF16 (or dummy)
+    A_log: cute.Tensor,
+    a: cute.Tensor,
+    dt_bias: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    b: cute.Tensor,
+    o: cute.Tensor,
+    h0_indices: cute.Tensor,
+    softplus_beta: cutlass.Constexpr[float],
+    softplus_threshold: cutlass.Constexpr[float],
+    scale: cutlass.Constexpr[float],
+    HV: cutlass.Constexpr[int],
+    B: cutlass.Constexpr[int],
+    T: cutlass.Constexpr[int],
+    H: cutlass.Constexpr[int],
+    K: cutlass.Constexpr[int],
+    V: cutlass.Constexpr[int],
+    tile_v_param: cutlass.Constexpr[int],
+    use_qk_l2norm: cutlass.Constexpr[bool],
+    disable_state_update: cutlass.Constexpr[bool],
+    cache_intermediate_states: cutlass.Constexpr[bool],
+    use_packed_fma: cutlass.Constexpr[bool],
+    stream: cuda.CUstream,
+):
+    """Launch the MTP kernel (ILP=4) for BF16 state."""
+    tile_v = tile_v_param
+    vec_size = MTP_VEC_SIZE
+    _, v_dim, _k_dim = (
+        h0_source.layout.shape[0],
+        h0_source.layout.shape[1],
+        h0_source.layout.shape[2],
+    )
+
+    num_v_tiles = cute.ceil_div(v_dim, tile_v)
+    grid_size = B * HV * num_v_tiles
+
+    smem_bytes = 128
+    if T > 1:
+        smem_bytes = 4 * T * (K + 8) + 4 * T * (K + 8) + 4 * T * 2 + 128
+
+    gdn_decode_bf16state_mtp_ilp4_kernel(
+        h0_source,
+        intermediate_states,
+        vec_size,
+        num_v_tiles,
+        tile_v,
+        A_log,
+        a,
+        dt_bias,
+        q,
+        k,
+        v,
+        b,
+        o,
+        h0_indices,
         softplus_beta,
         softplus_threshold,
         scale,
@@ -2577,6 +3234,34 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
     return 32  # Minimum tile_v for maximum parallelism
 
 
+def _get_bf16_mtp_config(
+    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int
+) -> tuple:
+    """Select ``(tile_v, ilp_rows)`` for the BF16 MTP kernel.
+
+    Smaller tile_v + lower ILP gives more CTAs (better SM utilization at small
+    batch) at the cost of register pressure reduction → higher occupancy.
+
+    With ILP=8: ~76 regs/thread → ~37% occupancy
+    With ILP=4: ~48 regs/thread → ~62% occupancy
+
+    Returns ``(tile_v, ilp_rows)`` where ``ilp_rows in {4, 8}``. Callers route
+    ilp_rows == 4 to ``run_gdn_decode_bf16state_mtp_ilp4``.
+    """
+    work_units = batch_size * num_v_heads
+    # B<=2 at HV=64 (or equivalent: work_units <= 128) — tiny grid needs
+    # both smaller tile_v (more CTAs) AND ILP=4 (higher occupancy per CTA).
+    if work_units <= 128:
+        return min(16, v_dim), 4
+    # T=2 has a known inline-recompute stall (g/beta are NOT cached in sGB
+    # for T<=2; they're computed per-token per-row in the hot inner loop).
+    # At small work_units the ILP=8 pipeline cannot hide the softplus+exp+log
+    # latency; dropping to ILP=4 raises occupancy enough to cover it.
+    if seq_len == 2 and work_units <= 256:
+        return _select_tile_v_for_mtp(batch_size, num_v_heads, v_dim, seq_len), 4
+    return _select_tile_v_for_mtp(batch_size, num_v_heads, v_dim, seq_len), 8
+
+
 # Threshold above which `gated_delta_rule_mtp` dispatches to the wide_vec
 # kernel. Exposed at module scope so benchmarks can raise it to bypass the
 # dispatcher and measure the baseline path alone. See
@@ -2706,7 +3391,16 @@ def gated_delta_rule_mtp(
             output=output,
         )
 
-    tile_v = _select_tile_v_for_mtp(B, HV, V, T)
+    # Dispatch between ILP=4 and ILP=8 launchers.
+    # - The ILP=4 kernel has a minimal signature (single h0_indices for both
+    #   read and write). It does NOT support split-pool writes, so force ILP=8
+    #   whenever the caller passes a separate output_state_indices.
+    # - Otherwise pick via _get_bf16_mtp_config: ILP=4 lifts occupancy at small
+    #   work_units, most notably unsticking the T=2 inline-recompute stall.
+    if output_state_indices is None:
+        tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V)
+    else:
+        tile_v, ilp_rows = _select_tile_v_for_mtp(B, HV, V, T), 8
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
     use_packed_fma = _USE_PACKED_FMA
@@ -2721,6 +3415,7 @@ def gated_delta_rule_mtp(
         V,
         pool_size,
         tile_v,
+        ilp_rows,
         disable_state_update,
         cache_intermediate_states,
         use_qk_l2norm_in_kernel,
@@ -2753,41 +3448,79 @@ def gated_delta_rule_mtp(
             default_indices, assumed_align=32, enable_tvm_ffi=True
         )
 
-        _compiled_kernels_mtp[cache_key] = {
-            "compiled": cute.compile(
-                run_gdn_decode_bf16state_mtp,
-                h_,
-                inter_,
-                A_log_,
-                a_,
-                dt_bias_,
-                q_,
-                k_,
-                v_,
-                b_,
-                o_,
-                h0_idx_,
-                h0_out_idx_,
-                softplus_beta,
-                softplus_threshold,
-                scale,
-                HV,
-                B,
-                T,
-                H,
-                K,
-                V,
-                tile_v,
-                use_qk_l2norm_in_kernel,
-                disable_state_update,
-                cache_intermediate_states,
-                use_packed_fma,
-                stream,
-                options="--enable-tvm-ffi --generate-line-info --opt-level 3",
-            ),
-            "default_indices": default_indices,
-            "output": default_output,
-        }
+        if ilp_rows == 4:
+            _compiled_kernels_mtp[cache_key] = {
+                "compiled": cute.compile(
+                    run_gdn_decode_bf16state_mtp_ilp4,
+                    h_,
+                    inter_,
+                    A_log_,
+                    a_,
+                    dt_bias_,
+                    q_,
+                    k_,
+                    v_,
+                    b_,
+                    o_,
+                    h0_idx_,
+                    softplus_beta,
+                    softplus_threshold,
+                    scale,
+                    HV,
+                    B,
+                    T,
+                    H,
+                    K,
+                    V,
+                    tile_v,
+                    use_qk_l2norm_in_kernel,
+                    disable_state_update,
+                    cache_intermediate_states,
+                    use_packed_fma,
+                    stream,
+                    options="--enable-tvm-ffi --generate-line-info --opt-level 3",
+                ),
+                "default_indices": default_indices,
+                "output": default_output,
+                "ilp_rows": 4,
+            }
+        else:
+            _compiled_kernels_mtp[cache_key] = {
+                "compiled": cute.compile(
+                    run_gdn_decode_bf16state_mtp,
+                    h_,
+                    inter_,
+                    A_log_,
+                    a_,
+                    dt_bias_,
+                    q_,
+                    k_,
+                    v_,
+                    b_,
+                    o_,
+                    h0_idx_,
+                    h0_out_idx_,
+                    softplus_beta,
+                    softplus_threshold,
+                    scale,
+                    HV,
+                    B,
+                    T,
+                    H,
+                    K,
+                    V,
+                    tile_v,
+                    use_qk_l2norm_in_kernel,
+                    disable_state_update,
+                    cache_intermediate_states,
+                    use_packed_fma,
+                    stream,
+                    options="--enable-tvm-ffi --generate-line-info --opt-level 3",
+                ),
+                "default_indices": default_indices,
+                "output": default_output,
+                "ilp_rows": 8,
+            }
 
     cache = _compiled_kernels_mtp[cache_key]
 
@@ -2798,21 +3531,37 @@ def gated_delta_rule_mtp(
     if output is None:
         output = cache["output"]
 
-    cache["compiled"](
-        h0_source,
-        intermediate_states,
-        A_log,
-        a,
-        dt_bias,
-        q,
-        k,
-        v,
-        b,
-        output,
-        initial_state_indices,
-        output_state_indices,
-        stream,
-    )
+    if cache["ilp_rows"] == 4:
+        cache["compiled"](
+            h0_source,
+            intermediate_states,
+            A_log,
+            a,
+            dt_bias,
+            q,
+            k,
+            v,
+            b,
+            output,
+            initial_state_indices,
+            stream,
+        )
+    else:
+        cache["compiled"](
+            h0_source,
+            intermediate_states,
+            A_log,
+            a,
+            dt_bias,
+            q,
+            k,
+            v,
+            b,
+            output,
+            initial_state_indices,
+            output_state_indices,
+            stream,
+        )
 
     return output
 

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -2577,6 +2577,13 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
     return 32  # Minimum tile_v for maximum parallelism
 
 
+# Threshold above which `gated_delta_rule_mtp` dispatches to the wide_vec
+# kernel. Exposed at module scope so benchmarks can raise it to bypass the
+# dispatcher and measure the baseline path alone. See
+# results/bf16_mtp_optimization_apr18/wide_vec_design.md for derivation.
+_WIDE_VEC_WORK_UNITS_THRESHOLD = 1024
+
+
 def gated_delta_rule_mtp(
     A_log: torch.Tensor,
     a: torch.Tensor,
@@ -2660,6 +2667,44 @@ def gated_delta_rule_mtp(
         intermediate_states = h0_source[
             :1, :1, :1
         ]  # Reuse existing allocation as dummy
+
+    # Dispatch to the wide_vec kernel when the work size amortizes its lower
+    # per-CTA parallelism. Empirical sweep on B200 (see
+    # results/bf16_mtp_optimization_apr18/wide_vec_design.md) shows wide_vec
+    # wins 1.07x-1.14x for B*HV >= 1024, breaks even at 512-1023, and regresses
+    # below 512. wide_vec hardcodes TILE_V=128 so we gate on K==V==128 too.
+    # T=1 is excluded because the pytest sweep only covers T>=2.
+    # Split input/output pool indices (PR #2905) are not yet supported by
+    # wide_vec, so we fall through to the baseline path when a caller passes
+    # a non-None `output_state_indices`. The common case (None) keeps the
+    # pre-#2905 single-pool semantics, which wide_vec supports natively.
+    if (
+        B * HV >= _WIDE_VEC_WORK_UNITS_THRESHOLD
+        and K == 128
+        and V == 128
+        and T >= 2
+        and output_state_indices is None
+    ):
+        from .gdn_decode_bf16_state_wide_vec import gated_delta_rule_mtp_wide_vec
+
+        return gated_delta_rule_mtp_wide_vec(
+            A_log=A_log,
+            a=a,
+            dt_bias=dt_bias,
+            softplus_beta=softplus_beta,
+            softplus_threshold=softplus_threshold,
+            q=q,
+            k=k,
+            v=v,
+            b=b,
+            initial_state_source=initial_state_source,
+            initial_state_indices=initial_state_indices,
+            intermediate_states_buffer=intermediate_states_buffer,
+            disable_state_update=disable_state_update,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            scale=scale,
+            output=output,
+        )
 
     tile_v = _select_tile_v_for_mtp(B, HV, V, T)
 

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -385,7 +385,7 @@ def gdn_decode_bf16state_cooprow_kernel(
 
 @cute.kernel
 def gdn_decode_bf16state_ilp_kernel(
-    h0_source: cute.Tensor,  # [B*HV, V, K] as BF16 (K-last, autovec_copy compatible)
+    h0_source: cute.Tensor,  # [pool_size*HV, V, K] as BF16 (K-last, autovec_copy compatible)
     vec_size: cutlass.Constexpr[int],
     num_v_tiles: cutlass.Constexpr[int],
     tile_v: cutlass.Constexpr[int],
@@ -397,6 +397,8 @@ def gdn_decode_bf16state_ilp_kernel(
     v: cute.Tensor,  # [B, 1, HV, V]
     b: cute.Tensor,  # [B, 1, HV]
     o: cute.Tensor,  # [B, 1, HV, V] - output
+    h0_indices: cute.Tensor,  # [B] int32 - initial state pool slot to read
+    h0_out_indices: cute.Tensor,  # [B] int32 - pool slot to write updated state
     softplus_beta: cutlass.Constexpr[float],
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
@@ -410,6 +412,8 @@ def gdn_decode_bf16state_ilp_kernel(
     """
     ILP-optimized T=1 GDN decode kernel with BF16 state.
     Direct GMEM->register loads with 8-row ILP for high memory throughput.
+    Pool+padding: reads state from h0_indices[i_n]; writes to h0_out_indices[i_n].
+    Negative indices redirect to slot 0 (caller must reserve slot 0 as null buffer).
     """
     tidx, _, _ = cute.arch.thread_idx()
     lane_id = tidx % 32
@@ -547,7 +551,15 @@ def gdn_decode_bf16state_ilp_kernel(
     # ===================================================================
     # Main loop: process V rows with 8-row ILP
     # ===================================================================
-    flat_state_idx = i_n * HV + i_hv
+    # Pool+padding: read slot, write slot, redirect negatives to slot 0.
+    cache_idx = h0_indices[i_n]
+    if cache_idx < 0:
+        cache_idx = cutlass.Int32(0)
+    flat_state_idx = cache_idx * HV + i_hv
+    write_cache_idx = h0_out_indices[i_n]
+    if write_cache_idx < 0:
+        write_cache_idx = cutlass.Int32(0)
+    flat_write_idx = write_cache_idx * HV + i_hv
     rows_per_group: cutlass.Constexpr[int] = tile_v // num_groups
     eighth_rows: cutlass.Constexpr[int] = rows_per_group // ILP_ROWS
 
@@ -1056,6 +1068,7 @@ def gdn_decode_bf16state_ilp_kernel(
                 cute.autovec_copy(r_o_bf16_vec, ot_slice)
 
             # Write updated H back to GMEM: FP32 regs -> BF16 regs -> GMEM BF16 (vectorized)
+            # Writes go to flat_write_idx (separate from read; supports in/out pool split).
             for i in cutlass.range_constexpr(vec_size):
                 r_hb0[i] = cutlass.BFloat16(r_h[0, i])
                 r_hb1[i] = cutlass.BFloat16(r_h[1, i])
@@ -1065,14 +1078,38 @@ def gdn_decode_bf16state_ilp_kernel(
                 r_hb5[i] = cutlass.BFloat16(r_h[5, i])
                 r_hb6[i] = cutlass.BFloat16(r_h[6, i])
                 r_hb7[i] = cutlass.BFloat16(r_h[7, i])
-            cute.autovec_copy(r_hb0, ht0)
-            cute.autovec_copy(r_hb1, ht1)
-            cute.autovec_copy(r_hb2, ht2)
-            cute.autovec_copy(r_hb3, ht3)
-            cute.autovec_copy(r_hb4, ht4)
-            cute.autovec_copy(r_hb5, ht5)
-            cute.autovec_copy(r_hb6, ht6)
-            cute.autovec_copy(r_hb7, ht7)
+            wt0 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v0, lane_in_group)
+            )
+            wt1 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v1, lane_in_group)
+            )
+            wt2 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v2, lane_in_group)
+            )
+            wt3 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v3, lane_in_group)
+            )
+            wt4 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v4, lane_in_group)
+            )
+            wt5 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v5, lane_in_group)
+            )
+            wt6 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v6, lane_in_group)
+            )
+            wt7 = cute.local_tile(
+                h0_source, (1, 1, vec_size), (flat_write_idx, v7, lane_in_group)
+            )
+            cute.autovec_copy(r_hb0, wt0)
+            cute.autovec_copy(r_hb1, wt1)
+            cute.autovec_copy(r_hb2, wt2)
+            cute.autovec_copy(r_hb3, wt3)
+            cute.autovec_copy(r_hb4, wt4)
+            cute.autovec_copy(r_hb5, wt5)
+            cute.autovec_copy(r_hb6, wt6)
+            cute.autovec_copy(r_hb7, wt7)
 
 
 # ==============================================================================
@@ -2117,7 +2154,7 @@ def run_gdn_decode_bf16state_mtp(
 
 @cute.jit
 def run_gdn_decode_bf16state_ilp(
-    h0_source: cute.Tensor,  # [B*HV, V, K] BF16
+    h0_source: cute.Tensor,  # [pool_size*HV, V, K] BF16
     A_log: cute.Tensor,
     a: cute.Tensor,
     dt_bias: cute.Tensor,
@@ -2126,6 +2163,8 @@ def run_gdn_decode_bf16state_ilp(
     v: cute.Tensor,
     b: cute.Tensor,
     o: cute.Tensor,
+    h0_indices: cute.Tensor,
+    h0_out_indices: cute.Tensor,
     softplus_beta: cutlass.Constexpr[float],
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
@@ -2167,6 +2206,8 @@ def run_gdn_decode_bf16state_ilp(
         v,
         b,
         o,
+        h0_indices,
+        h0_out_indices,
         softplus_beta,
         softplus_threshold,
         scale,
@@ -2294,6 +2335,11 @@ ILP_BATCH_THRESHOLD = 16  # Use ILP kernel for B >= 16
 # Number of SMs on target GPU (detected dynamically)
 NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
 
+# GPU architecture detected once at import time — avoids per-call
+# torch.cuda.get_device_capability() in the hot path.
+_GPU_MAJOR, _ = torch.cuda.get_device_capability(0)
+_USE_PACKED_FMA = _GPU_MAJOR >= 10
+
 
 def _select_tile_v_for_batch(B: int, HV: int, V: int) -> int:
     """Select optimal tile_v for the ILP kernel based on batch size.
@@ -2326,6 +2372,9 @@ def gated_delta_rule(
     v: Optional[torch.Tensor] = None,
     b: Optional[torch.Tensor] = None,
     initial_state_source: Optional[torch.Tensor] = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    output_state_indices: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
     use_qk_l2norm_in_kernel: bool = True,
     scale: Optional[float] = None,
 ) -> torch.Tensor:
@@ -2340,7 +2389,13 @@ def gated_delta_rule(
         k: [B, 1, H, K] bf16
         v: [B, 1, HV, V] bf16
         b: [B, 1, HV] bf16
-        initial_state_source: [B, HV, V, K] bf16 (modified in-place)
+        initial_state_source: [B, HV, V, K] when no indices, else
+            [pool_size, HV, V, K] bf16 (modified in-place)
+        initial_state_indices: Optional [B] int32 — pool slots to read.
+            Negative entries redirect to slot 0 (null buffer).
+        output_state_indices: Optional [B] int32 — pool slots to write.
+            Defaults to initial_state_indices when None.
+        output: Optional pre-allocated [B, 1, HV, V] bf16 output
         scale: Optional, default 1/sqrt(K)
 
     Returns:
@@ -2361,7 +2416,11 @@ def gated_delta_rule(
     if scale is None:
         scale = 1.0 / math.sqrt(K)
 
-    # Small batch: route through MTP kernel (T=1 path) with identity indices.
+    use_pool = initial_state_indices is not None
+    if output_state_indices is not None and output_state_indices.dtype != torch.int32:
+        output_state_indices = output_state_indices.to(torch.int32)
+
+    # Small batch: route through MTP kernel (T=1 path).
     # The cooprow kernel has known correctness issues at small batch sizes (e.g. B=2).
     # The MTP kernel's T=1 path uses the same ILP-style computation and is well-tested.
     if B < ILP_BATCH_THRESHOLD:
@@ -2376,29 +2435,20 @@ def gated_delta_rule(
             v=v,
             b=b,
             initial_state_source=initial_state_source,
+            initial_state_indices=initial_state_indices,
+            output_state_indices=output_state_indices,
+            output=output,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
             scale=scale,
         )
 
-    output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
-
-    # Reshape state to [B*HV, V, K]
-    h0_source = initial_state_source.reshape(B * HV, V, K)
-
-    q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
-    k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
-    v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
-    a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
-    b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
-    A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
-    dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
-    h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
-    o_ = from_dlpack(output, assumed_align=32, enable_tvm_ffi=True)
+    # Reshape state: no-pool [B, HV, V, K] -> [B*HV, V, K];
+    # pool [pool_size, HV, V, K] -> [pool_size*HV, V, K].
+    pool_size = initial_state_source.shape[0] if use_pool else B
+    h0_source = initial_state_source.reshape(pool_size * HV, V, K)
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-
-    major, _ = torch.cuda.get_device_capability(q.device)
-    use_packed_fma = major >= 10
+    use_packed_fma = _USE_PACKED_FMA
 
     # B >= ILP_BATCH_THRESHOLD (small B handled by MTP path above)
     tile_v = _select_tile_v_for_batch(B, HV, V)
@@ -2409,6 +2459,7 @@ def gated_delta_rule(
         HV,
         K,
         V,
+        pool_size,
         tile_v,
         scale,
         softplus_beta,
@@ -2416,48 +2467,86 @@ def gated_delta_rule(
         use_packed_fma,
     )
     if cache_key not in _compiled_kernels_ilp:
+        # First call for this shape: allocate defaults and do dlpack
+        # conversions once for compilation. Steady-state calls reuse
+        # the cached defaults and pass torch tensors straight to the
+        # compiled callable (tvm-ffi accepts either).
+        default_output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
+        default_indices = torch.arange(B, dtype=torch.int32, device=q.device)
+
+        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
+        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
+        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
+        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
+        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
+        dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
+        h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
+        o_ = from_dlpack(default_output, assumed_align=32, enable_tvm_ffi=True)
+        h0_idx_ = from_dlpack(default_indices, assumed_align=32, enable_tvm_ffi=True)
+        h0_out_idx_ = from_dlpack(
+            default_indices, assumed_align=32, enable_tvm_ffi=True
+        )
+
         # Use maxrregcount=64 for smaller tile_v to improve occupancy
         # when grid size is small (fewer waves)
         if tile_v < 128:
             compile_opts = "--enable-tvm-ffi --generate-line-info --opt-level 3 --ptxas-options=-maxrregcount=64"
         else:
             compile_opts = "--enable-tvm-ffi --generate-line-info --opt-level 3"
-        _compiled_kernels_ilp[cache_key] = cute.compile(
-            run_gdn_decode_bf16state_ilp,
-            h_,
-            A_log_,
-            a_,
-            dt_bias_,
-            q_,
-            k_,
-            v_,
-            b_,
-            o_,
-            softplus_beta,
-            softplus_threshold,
-            scale,
-            HV,
-            B,
-            H,
-            K,
-            V,
-            use_qk_l2norm_in_kernel,
-            use_packed_fma,
-            tile_v,
-            stream,
-            options=compile_opts,
-        )
+        _compiled_kernels_ilp[cache_key] = {
+            "compiled": cute.compile(
+                run_gdn_decode_bf16state_ilp,
+                h_,
+                A_log_,
+                a_,
+                dt_bias_,
+                q_,
+                k_,
+                v_,
+                b_,
+                o_,
+                h0_idx_,
+                h0_out_idx_,
+                softplus_beta,
+                softplus_threshold,
+                scale,
+                HV,
+                B,
+                H,
+                K,
+                V,
+                use_qk_l2norm_in_kernel,
+                use_packed_fma,
+                tile_v,
+                stream,
+                options=compile_opts,
+            ),
+            "output": default_output,
+            "default_indices": default_indices,
+        }
 
-    _compiled_kernels_ilp[cache_key](
-        h_,
-        A_log_,
-        a_,
-        dt_bias_,
-        q_,
-        k_,
-        v_,
-        b_,
-        o_,
+    cache = _compiled_kernels_ilp[cache_key]
+
+    if initial_state_indices is None:
+        initial_state_indices = cache["default_indices"]
+    if output_state_indices is None:
+        output_state_indices = initial_state_indices
+    if output is None:
+        output = cache["output"]
+
+    cache["compiled"](
+        h0_source,
+        A_log,
+        a,
+        dt_bias,
+        q,
+        k,
+        v,
+        b,
+        output,
+        initial_state_indices,
+        output_state_indices,
         stream,
     )
 
@@ -2547,17 +2636,8 @@ def gated_delta_rule_mtp(
     if scale is None:
         scale = 1.0 / math.sqrt(K)
 
-    if initial_state_indices is None:
-        initial_state_indices = torch.arange(B, dtype=torch.int32, device=q.device)
-
-    # Default output indices to read indices
-    if output_state_indices is None:
-        output_state_indices = initial_state_indices
-    elif output_state_indices.dtype != torch.int32:
+    if output_state_indices is not None and output_state_indices.dtype != torch.int32:
         output_state_indices = output_state_indices.to(torch.int32)
-
-    if output is None:
-        output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
 
     # Reshape state to [pool_size * HV, V, K]
     h0_source = initial_state_source.reshape(pool_size * HV, V, K)
@@ -2583,25 +2663,8 @@ def gated_delta_rule_mtp(
 
     tile_v = _select_tile_v_for_mtp(B, HV, V, T)
 
-    h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
-    inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
-    q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
-    k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
-    v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
-    a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
-    b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
-    A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
-    dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
-    o_ = from_dlpack(output, assumed_align=32, enable_tvm_ffi=True)
-    h0_idx_ = from_dlpack(initial_state_indices, assumed_align=32, enable_tvm_ffi=True)
-    h0_out_idx_ = from_dlpack(
-        output_state_indices, assumed_align=32, enable_tvm_ffi=True
-    )
-
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-
-    major, _ = torch.cuda.get_device_capability(q.device)
-    use_packed_fma = major >= 10
+    use_packed_fma = _USE_PACKED_FMA
 
     cache_key = (
         "mtp_bf16",
@@ -2622,51 +2685,87 @@ def gated_delta_rule_mtp(
         use_packed_fma,
     )
     if cache_key not in _compiled_kernels_mtp:
-        _compiled_kernels_mtp[cache_key] = cute.compile(
-            run_gdn_decode_bf16state_mtp,
-            h_,
-            inter_,
-            A_log_,
-            a_,
-            dt_bias_,
-            q_,
-            k_,
-            v_,
-            b_,
-            o_,
-            h0_idx_,
-            h0_out_idx_,
-            softplus_beta,
-            softplus_threshold,
-            scale,
-            HV,
-            B,
-            T,
-            H,
-            K,
-            V,
-            tile_v,
-            use_qk_l2norm_in_kernel,
-            disable_state_update,
-            cache_intermediate_states,
-            use_packed_fma,
-            stream,
-            options="--enable-tvm-ffi --generate-line-info --opt-level 3",
+        # First call for this shape: allocate default indices/output and do
+        # dlpack conversions once for compilation. Steady-state calls pass
+        # torch tensors straight to the compiled callable (tvm-ffi accepts
+        # either) and reuse these cached defaults when the caller doesn't
+        # provide their own.
+        default_indices = torch.arange(B, dtype=torch.int32, device=q.device)
+        default_output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
+
+        h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
+        inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
+        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
+        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
+        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
+        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
+        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
+        dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
+        o_ = from_dlpack(default_output, assumed_align=32, enable_tvm_ffi=True)
+        h0_idx_ = from_dlpack(default_indices, assumed_align=32, enable_tvm_ffi=True)
+        h0_out_idx_ = from_dlpack(
+            default_indices, assumed_align=32, enable_tvm_ffi=True
         )
 
-    _compiled_kernels_mtp[cache_key](
-        h_,
-        inter_,
-        A_log_,
-        a_,
-        dt_bias_,
-        q_,
-        k_,
-        v_,
-        b_,
-        o_,
-        h0_idx_,
-        h0_out_idx_,
+        _compiled_kernels_mtp[cache_key] = {
+            "compiled": cute.compile(
+                run_gdn_decode_bf16state_mtp,
+                h_,
+                inter_,
+                A_log_,
+                a_,
+                dt_bias_,
+                q_,
+                k_,
+                v_,
+                b_,
+                o_,
+                h0_idx_,
+                h0_out_idx_,
+                softplus_beta,
+                softplus_threshold,
+                scale,
+                HV,
+                B,
+                T,
+                H,
+                K,
+                V,
+                tile_v,
+                use_qk_l2norm_in_kernel,
+                disable_state_update,
+                cache_intermediate_states,
+                use_packed_fma,
+                stream,
+                options="--enable-tvm-ffi --generate-line-info --opt-level 3",
+            ),
+            "default_indices": default_indices,
+            "output": default_output,
+        }
+
+    cache = _compiled_kernels_mtp[cache_key]
+
+    if initial_state_indices is None:
+        initial_state_indices = cache["default_indices"]
+    if output_state_indices is None:
+        output_state_indices = initial_state_indices
+    if output is None:
+        output = cache["output"]
+
+    cache["compiled"](
+        h0_source,
+        intermediate_states,
+        A_log,
+        a,
+        dt_bias,
+        q,
+        k,
+        v,
+        b,
+        output,
+        initial_state_indices,
+        output_state_indices,
         stream,
     )
 

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state_wide_vec.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state_wide_vec.py
@@ -1,0 +1,736 @@
+"""
+Wide-vector BF16 GDN MTP decode kernel.
+
+This kernel uses **no TMA**, **no persistent CTAs**, and **no warp specialization**
+(despite any earlier filenames that suggested otherwise). Its speed advantage over
+the production ILP=8 kernel comes entirely from widening the per-thread vector
+width from 4 BF16 (LDG.64 / STG.64) to 8 BF16 (LDG.128 / STG.128), which halves
+LSU instruction count at equal data throughput.
+
+Thread / data layout (K=V=128 fast path):
+  - 128 threads/CTA = 4 warps organised as **8 groups of 16 threads**
+    (baseline: 4 groups of 32 threads)
+  - **vec_size = 8 BF16** per thread -> LDG.128 / STG.128
+    (baseline: vec = 4 BF16 -> LDG.64 / STG.64)
+  - **ILP = 4** V-rows held in registers per thread per iter
+    (baseline: ILP = 8; register state 4 x 8 = 32 FP32 matches baseline's 8 x 4)
+  - tile_v = 128 (one V-tile per CTA); 8 groups x 4 iters = 128 V-rows per CTA
+  - 4-stage butterfly shuffle within 16-thread subgroups
+    (baseline: 5-stage within full 32-thread warps)
+  - Grid = B * HV (one CTA per (n, hv) pair; baseline grids over v-tiles too)
+
+Where this kernel wins (from an official BS x T sweep on B200):
+  - Speedup 1.07x - 1.14x when B * HV >= 1024
+    (e.g. B >= 16 at HV=64, B >= 32 at HV=32)
+  - Peaks at 77.6 % DRAM SOL at B=256 T=2 HV=64
+  - Regresses (0.5x - 1.0x) at B * HV < 1024 because the fixed-V-tile grid
+    starves SMs of parallel work
+
+Callers should prefer routing via `gated_delta_rule_mtp`, which dispatches
+automatically based on `B * HV`. This kernel is exposed as
+`gated_delta_rule_mtp_wide_vec` for advanced users who know their work size.
+
+Skip-final-write: when `intermediate_states_buffer` is provided, the last
+cached slot `[:, T-1]` already holds the final state, so the final writeback
+to `initial_state_source` is skipped to save ~67 MB / call at HV=64 K=V=128.
+"""
+
+import math
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+import cuda.bindings.driver as cuda
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+# Reuse reference impl from horiz for testing
+from .gdn_decode_bf16_state_tma_horiz import _reference_gdn_mtp  # noqa: F401
+
+
+# ===== constants =====
+LANES_PER_ROW = 16  # 16 threads cooperate on one V-row's K=128 BF16
+ELEMS_PER_LANE = 8  # 8 BF16 = LDG.128
+TILE_K = 128
+NUM_WARPS = 4
+NUM_THREADS = NUM_WARPS * 32  # 128
+NUM_GROUPS = NUM_THREADS // LANES_PER_ROW  # 8 groups of 16 threads
+ILP_ROWS = 4  # 4 V-rows held in regs per thread per iter
+TILE_V = 128  # one V-tile = 128 rows per CTA
+ROWS_PER_GROUP = TILE_V // NUM_GROUPS  # 16 V-rows per group
+ITERS_PER_GROUP = ROWS_PER_GROUP // ILP_ROWS  # 4 iters
+
+
+@cute.jit
+def fma_pair_mul(a1, a2, b1, b2):
+    return a1 * b1, a2 * b2
+
+
+@cute.jit
+def fma_pair(a1, a2, b1, b2, c1, c2):
+    return a1 * b1 + c1, a2 * b2 + c2
+
+
+@cute.kernel
+def gdn_wide_vec_kernel(
+    h0_source: cute.Tensor,
+    intermediate_states: cute.Tensor,
+    A_log: cute.Tensor,
+    a: cute.Tensor,
+    dt_bias: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    b_gate: cute.Tensor,
+    o: cute.Tensor,
+    h0_indices: cute.Tensor,
+    softplus_beta: cutlass.Constexpr[float],
+    softplus_threshold: cutlass.Constexpr[float],
+    scale: cutlass.Constexpr[float],
+    HV: cutlass.Constexpr[int],
+    B: cutlass.Constexpr[int],
+    T: cutlass.Constexpr[int],
+    H: cutlass.Constexpr[int],
+    K: cutlass.Constexpr[int],
+    V: cutlass.Constexpr[int],
+    use_qk_l2norm: cutlass.Constexpr[bool],
+    disable_state_update: cutlass.Constexpr[bool],
+    cache_intermediate_states: cutlass.Constexpr[bool],
+    use_packed_fma: cutlass.Constexpr[bool],
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    lane_in_warp = tidx % 32
+    warp_idx = cute.arch.warp_idx()
+    warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+    # 8 groups of 16 threads. Within a CTA:
+    #   group_idx in [0..8)
+    #   lane_in_group in [0..16) — owns K[lane_in_group*8 : +8]
+    group_idx = tidx // LANES_PER_ROW
+    lane_in_group = tidx % LANES_PER_ROW
+    k_start = lane_in_group * ELEMS_PER_LANE
+
+    batch_idx, _, _ = cute.arch.block_idx()
+    # Grid: one CTA per (n, hv) pair
+    i_hv = batch_idx % HV
+    i_n = batch_idx // HV
+    i_h = i_hv // (HV // H)
+
+    cache_idx = h0_indices[i_n]
+
+    r_A_log = cutlass.Float32(A_log[i_hv])
+    r_dt_bias = cutlass.Float32(dt_bias[i_hv])
+
+    # ----- SMEM -----
+    smem = cutlass.utils.SmemAllocator()
+    sQ = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
+    )
+    sK = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
+    )
+    sGB = smem.allocate_tensor(
+        cutlass.Float32, cute.make_layout((T, 3), stride=(3, 1)), 16
+    )
+
+    # ----- registers -----
+    vec: cutlass.Constexpr[int] = ELEMS_PER_LANE  # 8
+    r_h = cute.make_rmem_tensor(
+        cute.make_layout((ILP_ROWS, vec), stride=(vec, 1)), cutlass.Float32
+    )
+    r_q = cute.make_rmem_tensor(cute.make_layout((vec,), stride=(1,)), cutlass.Float32)
+    r_k = cute.make_rmem_tensor(cute.make_layout((vec,), stride=(1,)), cutlass.Float32)
+    r_q_bf16 = cute.make_rmem_tensor(
+        cute.make_layout((vec,), stride=(1,)), cutlass.BFloat16
+    )
+    r_k_bf16 = cute.make_rmem_tensor(
+        cute.make_layout((vec,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb0 = cute.make_rmem_tensor(
+        cute.make_layout((vec,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb1 = cute.make_rmem_tensor(
+        cute.make_layout((vec,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb2 = cute.make_rmem_tensor(
+        cute.make_layout((vec,), stride=(1,)), cutlass.BFloat16
+    )
+    r_hb3 = cute.make_rmem_tensor(
+        cute.make_layout((vec,), stride=(1,)), cutlass.BFloat16
+    )
+
+    if cache_idx < 0:
+        cache_idx = cutlass.Int32(0)
+
+    if cache_idx >= 0:
+        flat_state_idx = cache_idx * HV + i_hv
+
+        # ==================================================================
+        # Phase 0: precompute q/k/g/beta/kq into SMEM (all 4 warps)
+        # Each warp handles one token per pass; 4 warps -> ceil(T/4) passes.
+        # Within a warp, threads cooperate by K-lane (16 threads cover K=128).
+        # ==================================================================
+        # Use the same 16-thread-per-row layout for precompute. Only the first
+        # 16 lanes of each warp participate; the second 16 lanes sit idle for
+        # q/k loads but contribute identical work for reduction consistency.
+        # To keep it simple: all 32 threads of a warp co-load via 2 groups of 16.
+        # Here lane_in_warp < 16 loads q/k for the warp's assigned token; the
+        # upper 16 lanes redundantly load/compute (their writes land in the same
+        # SMEM slots, idempotent).
+        num_precompute_passes: cutlass.Constexpr[int] = (T + NUM_WARPS - 1) // NUM_WARPS
+        member_pre = lane_in_warp % LANES_PER_ROW
+        k_start_pre = member_pre * ELEMS_PER_LANE
+        for pass_idx in cutlass.range_constexpr(num_precompute_passes):
+            i_t_pre = pass_idx * NUM_WARPS + warp_idx
+            if i_t_pre < T:
+                q_tile_pre = cute.local_tile(
+                    q, (1, 1, 1, vec), (i_n, i_t_pre, i_h, member_pre)
+                )
+                k_tile_pre = cute.local_tile(
+                    k, (1, 1, 1, vec), (i_n, i_t_pre, i_h, member_pre)
+                )
+                cute.autovec_copy(q_tile_pre, r_q_bf16)
+                cute.autovec_copy(k_tile_pre, r_k_bf16)
+                for i in cutlass.range_constexpr(vec):
+                    r_q[i] = cutlass.Float32(r_q_bf16[i])
+                    r_k[i] = cutlass.Float32(r_k_bf16[i])
+
+                if cutlass.const_expr(use_qk_l2norm):
+                    sum_q = cutlass.Float32(0.0)
+                    sum_k = cutlass.Float32(0.0)
+                    for i in cutlass.range_constexpr(vec):
+                        sum_q += r_q[i] * r_q[i]
+                        sum_k += r_k[i] * r_k[i]
+                    # 4-stage butterfly within 16-thread subgroup
+                    for offset in [8, 4, 2, 1]:
+                        sum_q += cute.arch.shuffle_sync_bfly(
+                            sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                        sum_k += cute.arch.shuffle_sync_bfly(
+                            sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                    inv_norm_q_scaled = cute.rsqrt(sum_q + 1e-6, fastmath=True) * scale
+                    inv_norm_k = cute.rsqrt(sum_k + 1e-6, fastmath=True)
+                    for i in cutlass.range_constexpr(vec):
+                        r_q[i] = r_q[i] * inv_norm_q_scaled
+                        r_k[i] = r_k[i] * inv_norm_k
+                else:
+                    for i in cutlass.range_constexpr(vec):
+                        r_q[i] = r_q[i] * scale
+
+                # Write q, k to SMEM (both 16-thread subgroups write same data)
+                for i in cutlass.range_constexpr(vec):
+                    sQ[(i_t_pre, k_start_pre + i)] = r_q[i]
+                    sK[(i_t_pre, k_start_pre + i)] = r_k[i]
+
+                # kq partial and reduce within 16-thread subgroup
+                kq_partial = cutlass.Float32(0.0)
+                for i in cutlass.range_constexpr(vec):
+                    kq_partial += r_k[i] * r_q[i]
+                for offset in [8, 4, 2, 1]:
+                    kq_partial += cute.arch.shuffle_sync_bfly(
+                        kq_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                # g, beta, kq to sGB (lane 0 of warp writes)
+                r_a_pre = cutlass.Float32(a[i_n, i_t_pre, i_hv])
+                r_b_pre = cutlass.Float32(b_gate[i_n, i_t_pre, i_hv])
+                x_pre = r_a_pre + r_dt_bias
+                beta_x_pre = softplus_beta * x_pre
+                exp_beta_x_pre = cute.exp(beta_x_pre, fastmath=True)
+                softplus_val_pre = (cutlass.Float32(1.0) / softplus_beta) * cute.log(
+                    cutlass.Float32(1.0) + exp_beta_x_pre, fastmath=True
+                )
+                use_softplus_pre = (
+                    cutlass.Float32(1.0)
+                    if beta_x_pre <= softplus_threshold
+                    else cutlass.Float32(0.0)
+                )
+                softplus_x_pre = (
+                    use_softplus_pre * softplus_val_pre
+                    + (cutlass.Float32(1.0) - use_softplus_pre) * x_pre
+                )
+                r_g_pre = cute.exp(
+                    -cute.exp(r_A_log, fastmath=True) * softplus_x_pre, fastmath=True
+                )
+                r_beta_pre = cutlass.Float32(1.0) / (
+                    cutlass.Float32(1.0) + cute.exp(-r_b_pre, fastmath=True)
+                )
+
+                if lane_in_warp == 0:
+                    sGB[(i_t_pre, 0)] = r_g_pre
+                    sGB[(i_t_pre, 1)] = r_beta_pre
+                    sGB[(i_t_pre, 2)] = kq_partial
+
+            cute.arch.barrier()
+
+        # ==================================================================
+        # Phase 1: main compute loop
+        # Each group of 16 threads owns ROWS_PER_GROUP=16 V-rows.
+        # With ILP_ROWS=4, iterate 4 times. Each iter holds 4 V-rows in r_h.
+        # ==================================================================
+        for iter_idx in cutlass.range_constexpr(ITERS_PER_GROUP):
+            v_base = group_idx * ROWS_PER_GROUP + iter_idx * ILP_ROWS
+            v0 = v_base + 0
+            v1 = v_base + 1
+            v2 = v_base + 2
+            v3 = v_base + 3
+
+            # Load 4 V-rows of h (LDG.128 each) into r_h
+            ht0 = cute.local_tile(
+                h0_source, (1, 1, vec), (flat_state_idx, v0, lane_in_group)
+            )
+            ht1 = cute.local_tile(
+                h0_source, (1, 1, vec), (flat_state_idx, v1, lane_in_group)
+            )
+            ht2 = cute.local_tile(
+                h0_source, (1, 1, vec), (flat_state_idx, v2, lane_in_group)
+            )
+            ht3 = cute.local_tile(
+                h0_source, (1, 1, vec), (flat_state_idx, v3, lane_in_group)
+            )
+            cute.autovec_copy(ht0, r_hb0)
+            cute.autovec_copy(ht1, r_hb1)
+            cute.autovec_copy(ht2, r_hb2)
+            cute.autovec_copy(ht3, r_hb3)
+            for i in cutlass.range_constexpr(vec):
+                r_h[0, i] = cutlass.Float32(r_hb0[i])
+                r_h[1, i] = cutlass.Float32(r_hb1[i])
+                r_h[2, i] = cutlass.Float32(r_hb2[i])
+                r_h[3, i] = cutlass.Float32(r_hb3[i])
+
+            # Process each token sequentially (state is carried in registers).
+            # Non-fused form for numerical robustness: compute s = h_decayed @ k,
+            # then update h, then compute o = h_new @ q. Two reductions per token
+            # instead of one, but matches baseline's accumulation order.
+            for i_t in cutlass.range(T, unroll=1, unroll_full=(T <= 1)):
+                r_g = sGB[(i_t, 0)]
+                r_beta = sGB[(i_t, 1)]
+
+                # Decay + h @ k (in one K-loop)
+                s0 = cutlass.Float32(0.0)
+                s1 = cutlass.Float32(0.0)
+                s2 = cutlass.Float32(0.0)
+                s3 = cutlass.Float32(0.0)
+                for i in cutlass.range_constexpr(0, vec, 2):
+                    kv0 = sK[(i_t, k_start + i)]
+                    kv1 = sK[(i_t, k_start + i + 1)]
+                    if cutlass.const_expr(use_packed_fma):
+                        r_h[0, i], r_h[0, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[0, i], r_h[0, i + 1]),
+                            src_b=(r_g, r_g),
+                            src_c=(cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                        )
+                        r_h[1, i], r_h[1, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[1, i], r_h[1, i + 1]),
+                            src_b=(r_g, r_g),
+                            src_c=(cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                        )
+                        r_h[2, i], r_h[2, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[2, i], r_h[2, i + 1]),
+                            src_b=(r_g, r_g),
+                            src_c=(cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                        )
+                        r_h[3, i], r_h[3, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(r_h[3, i], r_h[3, i + 1]),
+                            src_b=(r_g, r_g),
+                            src_c=(cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                        )
+                    else:
+                        r_h[0, i], r_h[0, i + 1] = fma_pair_mul(
+                            r_h[0, i], r_h[0, i + 1], r_g, r_g
+                        )
+                        r_h[1, i], r_h[1, i + 1] = fma_pair_mul(
+                            r_h[1, i], r_h[1, i + 1], r_g, r_g
+                        )
+                        r_h[2, i], r_h[2, i + 1] = fma_pair_mul(
+                            r_h[2, i], r_h[2, i + 1], r_g, r_g
+                        )
+                        r_h[3, i], r_h[3, i + 1] = fma_pair_mul(
+                            r_h[3, i], r_h[3, i + 1], r_g, r_g
+                        )
+                    s0 = s0 + r_h[0, i] * kv0 + r_h[0, i + 1] * kv1
+                    s1 = s1 + r_h[1, i] * kv0 + r_h[1, i + 1] * kv1
+                    s2 = s2 + r_h[2, i] * kv0 + r_h[2, i + 1] * kv1
+                    s3 = s3 + r_h[3, i] * kv0 + r_h[3, i + 1] * kv1
+
+                # Butterfly reduce s across 16-thread subgroup (4 stages)
+                for offset in [8, 4, 2, 1]:
+                    s0 += cute.arch.shuffle_sync_bfly(
+                        s0, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    s1 += cute.arch.shuffle_sync_bfly(
+                        s1, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    s2 += cute.arch.shuffle_sync_bfly(
+                        s2, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    s3 += cute.arch.shuffle_sync_bfly(
+                        s3, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                # Delta rule: v_new = (v - s) * beta
+                v_val0 = cutlass.Float32(v[(i_n, i_t, i_hv, v0)])
+                v_val1 = cutlass.Float32(v[(i_n, i_t, i_hv, v1)])
+                v_val2 = cutlass.Float32(v[(i_n, i_t, i_hv, v2)])
+                v_val3 = cutlass.Float32(v[(i_n, i_t, i_hv, v3)])
+                vn0 = (v_val0 - s0) * r_beta
+                vn1 = (v_val1 - s1) * r_beta
+                vn2 = (v_val2 - s2) * r_beta
+                vn3 = (v_val3 - s3) * r_beta
+
+                # Rank-1 update + h @ q (in one K-loop)
+                o0 = cutlass.Float32(0.0)
+                o1 = cutlass.Float32(0.0)
+                o2 = cutlass.Float32(0.0)
+                o3 = cutlass.Float32(0.0)
+                for i in cutlass.range_constexpr(0, vec, 2):
+                    qv0 = sQ[(i_t, k_start + i)]
+                    qv1 = sQ[(i_t, k_start + i + 1)]
+                    kv0 = sK[(i_t, k_start + i)]
+                    kv1 = sK[(i_t, k_start + i + 1)]
+                    if cutlass.const_expr(use_packed_fma):
+                        r_h[0, i], r_h[0, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(kv0, kv1),
+                            src_b=(vn0, vn0),
+                            src_c=(r_h[0, i], r_h[0, i + 1]),
+                        )
+                        r_h[1, i], r_h[1, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(kv0, kv1),
+                            src_b=(vn1, vn1),
+                            src_c=(r_h[1, i], r_h[1, i + 1]),
+                        )
+                        r_h[2, i], r_h[2, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(kv0, kv1),
+                            src_b=(vn2, vn2),
+                            src_c=(r_h[2, i], r_h[2, i + 1]),
+                        )
+                        r_h[3, i], r_h[3, i + 1] = cute.arch.fma_packed_f32x2(
+                            src_a=(kv0, kv1),
+                            src_b=(vn3, vn3),
+                            src_c=(r_h[3, i], r_h[3, i + 1]),
+                        )
+                    else:
+                        r_h[0, i], r_h[0, i + 1] = fma_pair(
+                            kv0, kv1, vn0, vn0, r_h[0, i], r_h[0, i + 1]
+                        )
+                        r_h[1, i], r_h[1, i + 1] = fma_pair(
+                            kv0, kv1, vn1, vn1, r_h[1, i], r_h[1, i + 1]
+                        )
+                        r_h[2, i], r_h[2, i + 1] = fma_pair(
+                            kv0, kv1, vn2, vn2, r_h[2, i], r_h[2, i + 1]
+                        )
+                        r_h[3, i], r_h[3, i + 1] = fma_pair(
+                            kv0, kv1, vn3, vn3, r_h[3, i], r_h[3, i + 1]
+                        )
+                    # h_new @ q with updated r_h
+                    o0 = o0 + r_h[0, i] * qv0 + r_h[0, i + 1] * qv1
+                    o1 = o1 + r_h[1, i] * qv0 + r_h[1, i + 1] * qv1
+                    o2 = o2 + r_h[2, i] * qv0 + r_h[2, i + 1] * qv1
+                    o3 = o3 + r_h[3, i] * qv0 + r_h[3, i + 1] * qv1
+
+                # Butterfly reduce o
+                for offset in [8, 4, 2, 1]:
+                    o0 += cute.arch.shuffle_sync_bfly(
+                        o0, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    o1 += cute.arch.shuffle_sync_bfly(
+                        o1, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    o2 += cute.arch.shuffle_sync_bfly(
+                        o2, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    o3 += cute.arch.shuffle_sync_bfly(
+                        o3, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                # Output scalar write (lane_in_group==0 only)
+                if lane_in_group == 0:
+                    o[(i_n, i_t, i_hv, v0)] = cutlass.BFloat16(o0)
+                    o[(i_n, i_t, i_hv, v1)] = cutlass.BFloat16(o1)
+                    o[(i_n, i_t, i_hv, v2)] = cutlass.BFloat16(o2)
+                    o[(i_n, i_t, i_hv, v3)] = cutlass.BFloat16(o3)
+
+                # Intermediate write (for every token when caching)
+                if cutlass.const_expr(cache_intermediate_states):
+                    for i in cutlass.range_constexpr(vec):
+                        r_hb0[i] = cutlass.BFloat16(r_h[0, i])
+                        r_hb1[i] = cutlass.BFloat16(r_h[1, i])
+                        r_hb2[i] = cutlass.BFloat16(r_h[2, i])
+                        r_hb3[i] = cutlass.BFloat16(r_h[3, i])
+                    flat_idx = cache_idx * T * HV + i_t * HV + i_hv
+                    it0 = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec),
+                        (flat_idx, v0, lane_in_group),
+                    )
+                    it1 = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec),
+                        (flat_idx, v1, lane_in_group),
+                    )
+                    it2 = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec),
+                        (flat_idx, v2, lane_in_group),
+                    )
+                    it3 = cute.local_tile(
+                        intermediate_states,
+                        (1, 1, vec),
+                        (flat_idx, v3, lane_in_group),
+                    )
+                    cute.autovec_copy(r_hb0, it0)
+                    cute.autovec_copy(r_hb1, it1)
+                    cute.autovec_copy(r_hb2, it2)
+                    cute.autovec_copy(r_hb3, it3)
+
+            # Final state write-back: skip when caching (inter[T-1] already has it)
+            if cutlass.const_expr(
+                not disable_state_update and not cache_intermediate_states
+            ):
+                for i in cutlass.range_constexpr(vec):
+                    r_hb0[i] = cutlass.BFloat16(r_h[0, i])
+                    r_hb1[i] = cutlass.BFloat16(r_h[1, i])
+                    r_hb2[i] = cutlass.BFloat16(r_h[2, i])
+                    r_hb3[i] = cutlass.BFloat16(r_h[3, i])
+                cute.autovec_copy(r_hb0, ht0)
+                cute.autovec_copy(r_hb1, ht1)
+                cute.autovec_copy(r_hb2, ht2)
+                cute.autovec_copy(r_hb3, ht3)
+
+
+@cute.jit
+def _run_wide_vec(
+    h0_source: cute.Tensor,
+    intermediate_states: cute.Tensor,
+    A_log: cute.Tensor,
+    a: cute.Tensor,
+    dt_bias: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    b_gate: cute.Tensor,
+    o: cute.Tensor,
+    h0_indices: cute.Tensor,
+    softplus_beta: cutlass.Constexpr[float],
+    softplus_threshold: cutlass.Constexpr[float],
+    scale: cutlass.Constexpr[float],
+    HV: cutlass.Constexpr[int],
+    B: cutlass.Constexpr[int],
+    T: cutlass.Constexpr[int],
+    H: cutlass.Constexpr[int],
+    K: cutlass.Constexpr[int],
+    V: cutlass.Constexpr[int],
+    use_qk_l2norm: cutlass.Constexpr[bool],
+    disable_state_update: cutlass.Constexpr[bool],
+    cache_intermediate_states: cutlass.Constexpr[bool],
+    use_packed_fma: cutlass.Constexpr[bool],
+    stream: cuda.CUstream,
+):
+    grid_size = B * HV
+    smem_bytes = (
+        4 * T * (K + 8)  # sQ FP32
+        + 4 * T * (K + 8)  # sK FP32
+        + 4 * T * 3  # sGB
+        + 256
+    )
+    gdn_wide_vec_kernel(
+        h0_source,
+        intermediate_states,
+        A_log,
+        a,
+        dt_bias,
+        q,
+        k,
+        v,
+        b_gate,
+        o,
+        h0_indices,
+        softplus_beta,
+        softplus_threshold,
+        scale,
+        HV,
+        B,
+        T,
+        H,
+        K,
+        V,
+        use_qk_l2norm,
+        disable_state_update,
+        cache_intermediate_states,
+        use_packed_fma,
+    ).launch(
+        grid=(grid_size, 1, 1),
+        block=[NUM_THREADS, 1, 1],
+        smem=smem_bytes,
+        stream=stream,
+    )
+
+
+_compiled_kernels_wide_vec: dict = {}
+NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
+_GPU_MAJOR, _ = torch.cuda.get_device_capability(0)
+_USE_PACKED_FMA = _GPU_MAJOR >= 10
+
+
+def gated_delta_rule_mtp_wide_vec(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    softplus_beta: float = 1.0,
+    softplus_threshold: float = 20.0,
+    q: Optional[torch.Tensor] = None,
+    k: Optional[torch.Tensor] = None,
+    v: Optional[torch.Tensor] = None,
+    b: Optional[torch.Tensor] = None,
+    initial_state_source: Optional[torch.Tensor] = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    intermediate_states_buffer: Optional[torch.Tensor] = None,
+    disable_state_update: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    scale: Optional[float] = None,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Wide-vector BF16 GDN MTP decode.
+
+    Prefer calling via the production entry point `gated_delta_rule_mtp`,
+    which auto-dispatches to this kernel when `B * HV >= 1024`. Call this
+    symbol directly only when you know your work size hits the fast path.
+
+    When `intermediate_states_buffer is not None`, skips the final state
+    writeback; caller must read the final state from `buffer[:, T-1]`.
+    """
+    global _compiled_kernels_wide_vec
+
+    assert q is not None and k is not None and v is not None
+    assert b is not None and initial_state_source is not None
+
+    B_val, T_val, H_val, K_val = q.shape
+    HV_val = v.shape[2]
+    V_val = v.shape[3]
+    pool_size = initial_state_source.shape[0]
+    assert K_val == 128 and V_val == 128
+    assert initial_state_source.dtype == torch.bfloat16
+
+    if scale is None:
+        scale = 1.0 / math.sqrt(K_val)
+
+    h0_source = initial_state_source.reshape(pool_size * HV_val, V_val, K_val)
+
+    cache_intermediate_states = intermediate_states_buffer is not None
+    if cache_intermediate_states:
+        buffer_size = intermediate_states_buffer.shape[0]
+        cache_steps = intermediate_states_buffer.shape[1]
+        assert cache_steps >= T_val
+        assert intermediate_states_buffer.dtype == torch.bfloat16
+        intermediate_states = intermediate_states_buffer.reshape(
+            buffer_size * cache_steps * HV_val, V_val, K_val
+        )
+        if not intermediate_states.is_contiguous():
+            intermediate_states = intermediate_states.contiguous()
+        # Skip the redundant final writeback when caching is on.
+        effective_disable_final = True
+    else:
+        intermediate_states = h0_source[:1, :1, :1]
+        effective_disable_final = disable_state_update
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    use_packed_fma = _USE_PACKED_FMA
+
+    cache_key = (
+        "v3_mtp_bf16",
+        B_val,
+        T_val,
+        H_val,
+        HV_val,
+        K_val,
+        V_val,
+        pool_size,
+        effective_disable_final,
+        cache_intermediate_states,
+        use_qk_l2norm_in_kernel,
+        scale,
+        softplus_beta,
+        softplus_threshold,
+        use_packed_fma,
+    )
+    if cache_key not in _compiled_kernels_wide_vec:
+        default_indices = torch.arange(B_val, dtype=torch.int32, device=q.device)
+        default_output = torch.empty(
+            B_val, T_val, HV_val, V_val, device=q.device, dtype=q.dtype
+        )
+
+        if initial_state_indices is None:
+            initial_state_indices = default_indices
+        if output is None:
+            output = default_output
+
+        h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
+        inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
+        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
+        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
+        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
+        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
+        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
+        dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
+        o_ = from_dlpack(output, assumed_align=32, enable_tvm_ffi=True)
+        h0_idx_ = from_dlpack(
+            initial_state_indices, assumed_align=32, enable_tvm_ffi=True
+        )
+
+        _compiled_kernels_wide_vec[cache_key] = {
+            "compiled": cute.compile(
+                _run_wide_vec,
+                h_,
+                inter_,
+                A_log_,
+                a_,
+                dt_bias_,
+                q_,
+                k_,
+                v_,
+                b_,
+                o_,
+                h0_idx_,
+                softplus_beta,
+                softplus_threshold,
+                scale,
+                HV_val,
+                B_val,
+                T_val,
+                H_val,
+                K_val,
+                V_val,
+                use_qk_l2norm_in_kernel,
+                effective_disable_final,
+                cache_intermediate_states,
+                use_packed_fma,
+                stream,
+                options="--enable-tvm-ffi --generate-line-info --opt-level 3",
+            ),
+            "default_indices": default_indices,
+            "output": default_output,
+        }
+
+    cache = _compiled_kernels_wide_vec[cache_key]
+    if initial_state_indices is None:
+        initial_state_indices = cache["default_indices"]
+    if output is None:
+        output = cache["output"]
+
+    cache["compiled"](
+        h0_source,
+        intermediate_states,
+        A_log,
+        a,
+        dt_bias,
+        q,
+        k,
+        v,
+        b,
+        output,
+        initial_state_indices,
+        stream,
+    )
+    return output

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import math
 import os
+import sys
 import random
 
 import torch
@@ -1964,6 +1965,70 @@ def test_gdn_decode_bf16_state_mtp_kernel(
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     scale_val = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
+    _test_gdn_decode_bf16_state_mtp_kernel(
+        dtype,
+        batch_size,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        seq_len,
+        scale_val,
+        cache_intermediate_states,
+        seed,
+    )
+
+
+# ==============================================================================
+# BF16 state MTP: wide-vector variant (gated_delta_rule_mtp_wide_vec)
+# ==============================================================================
+# Reuses _test_gdn_decode_bf16_state_mtp_kernel by monkey-patching the module's
+# `gdn_decode_bf16_state_mtp` symbol for the scope of this test only. The
+# parametrization is wider (B up to 256, T up to 8, HV in {32, 64}) because
+# wide_vec's sweet spot is at large work-sizes; we want coverage where it
+# matters. See results/bf16_mtp_optimization_apr18/wide_vec_design.md for the design.
+
+try:
+    from flashinfer.gdn_kernels.gdn_decode_bf16_state_wide_vec import (
+        gated_delta_rule_mtp_wide_vec,
+    )
+
+    GDN_DECODE_BF16_STATE_WIDE_VEC_AVAILABLE = True
+except ImportError:
+    GDN_DECODE_BF16_STATE_WIDE_VEC_AVAILABLE = False
+
+
+@pytest.mark.parametrize("cache_intermediate_states", [True, False])
+@pytest.mark.parametrize("seq_len", [2, 3, 4, 5, 6, 7, 8])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize(
+    "num_q_heads, num_k_heads, num_v_heads",
+    [(16, 16, 32), (16, 16, 64)],
+)
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64, 128, 256])
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+def test_gdn_decode_bf16_state_wide_vec_mtp_kernel(
+    monkeypatch,
+    dtype: str,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    batch_size: int,
+    seq_len: int,
+    cache_intermediate_states: bool,
+    seed: int = int(os.environ.get("SEED", "0")),
+):
+    if not GDN_DECODE_BF16_STATE_WIDE_VEC_AVAILABLE:
+        pytest.skip("wide_vec kernel not available")
+    # Swap the module-level kernel symbol that _test_gdn_decode_bf16_state_mtp_kernel
+    # looks up at call time. monkeypatch auto-restores after the test.
+    monkeypatch.setattr(
+        sys.modules[__name__],
+        "gdn_decode_bf16_state_mtp",
+        gated_delta_rule_mtp_wide_vec,
+    )
+    scale_val = 1.0 / math.sqrt(head_size)
     _test_gdn_decode_bf16_state_mtp_kernel(
         dtype,
         batch_size,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

## GDN BF16-state MTP — dispatcher output (B200)

**Config:** HV=64, H_Q=H_K=16, K=V=128, BF16, qk_l2norm=ON. T=1 uses state-update ON (no intermediate caching); T≥2 uses intermediate caching ON with state-update OFF. Measured via `benchmarks/bench_gdn_decode.py::bench_gdn_decode_bf16_state` 


| Batch | T=1    | T=2    | T=3    | T=4    | T=5    | T=6    | T=7    | T=8    |
| ----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
|     1 |   3.49 |   5.42 |   5.79 |   6.69 |   8.80 |   9.76 |  10.59 |  11.55 |
|     2 |   4.26 |   6.43 |   7.14 |   8.24 |  10.64 |  11.90 |  12.99 |  14.14 |
|     4 |   5.79 |   9.68 |  10.48 |  12.51 |  16.05 |  18.11 |  20.22 |  22.34 |
|     8 |   9.18 |  13.70 |  17.04 |  21.12 |  26.08 |  29.95 |  34.03 |  37.86 |
|    16 |  15.01 |  21.18 |  27.23 |  33.50 |  41.30 |  48.10 |  55.30 |  61.97 |
|    32 |  26.74 |  37.89 |  50.14 |  62.64 |  78.45 |  91.31 | 103.82 | 117.71 |
|    64 |  48.22 |  70.69 |  93.87 | 118.02 | 147.38 | 171.71 | 199.01 | 223.98 |
|   128 |  89.38 | 135.20 | 180.32 | 225.92 | 279.50 | 328.64 | 379.30 | 428.86 |
|   256 | 172.18 | 262.91 | 351.06 | 440.62 | 543.81 | 641.14 | 740.19 | 838.14 |
|   512 | 337.18 | 516.48 | 691.10 | 868.46 |  ERROR |  ERROR |  ERROR |  ERROR |

### DRAM SOL % (of 8.0 TB/s B200 peak)

| Batch |  T=1  |  T=2  |  T=3  |  T=4  |  T=5  |  T=6  |  T=7  |  T=8  |
| ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
|     1 | 15.2% | 14.7% | 18.4% | 19.9% | 18.2% | 19.1% | 20.1% | 20.8% |
|     2 | 24.9% | 24.8% | 29.8% | 32.3% | 30.0% | 31.3% | 32.8% | 33.9% |
|     4 | 36.6% | 32.9% | 40.6% | 42.6% | 39.8% | 41.2% | 42.2% | 43.0% |
|     8 | 46.1% | 46.5% | 50.0% | 50.4% | 49.0% | 49.8% | 50.1% | 50.7% |
|    16 | 56.4% | 60.2% | 62.5% | 63.6% | 61.9% | 62.1% | 61.7% | 62.0% |
|    32 | 63.4% | 67.3% | 67.9% | 68.0% | 65.2% | 65.4% | 65.7% | 65.3% |
|    64 | 70.3% | 72.1% | 72.5% | 72.2% | 69.4% | 69.5% | 68.6% | 68.6% |
|   128 | 75.8% | 75.4% | 75.5% | 75.4% | 73.2% | 72.7% | 72.0% | 71.6% |
|   256 | 78.7% | 77.6% | 77.6% | 77.3% | 75.3% | 74.5% | 73.8% | 73.3% |
|   512 | 80.4% | 79.0% | 78.8% | 78.5% | ERROR | ERROR | ERROR | ERROR |

### Speedup vs `origin/main` (85593976)

| Batch |  T=1  |  T=2  |  T=3  |  T=4  |  T=5  |  T=6  |  T=7  |  T=8  |
| ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
|     1 | 2.14× | 1.06× | 1.08× | 1.06× | 1.09× | 1.07× | 1.08× | 1.06× |
|     2 | 1.95× | 1.04× | 1.04× | 1.06× | 1.05× | 1.03× | 1.05× | 1.05× |
|     4 | 1.65× | 1.15× | 1.00× | 1.00× | 1.00× | 1.00× | 1.00× | 0.99× |
|     8 | 1.42× | 1.01× | 1.00× | 1.00× | 1.00× | 1.00× | 1.00× | 1.01× |
|    16 | 1.03× | 1.10× | 1.11× | 1.13× | 1.13× | 1.13× | 1.12× | 1.12× |
|    32 | 1.04× | 1.13× | 1.08× | 1.10× | 1.09× | 1.09× | 1.10× | 1.09× |
|    64 | 1.04× | 1.11× | 1.08× | 1.09× | 1.08× | 1.09× | 1.08× | 1.09× |
|   128 | 1.02× | 1.10× | 1.07× | 1.09× | 1.09× | 1.10× | 1.10× | 1.10× |
|   256 | 1.01× | 1.10× | 1.07× | 1.09× | 1.10× | 1.10× | 1.10× | 1.11× |
|   512 | 1.00× | 1.10× | 1.07× | 1.10× | ERROR | ERROR | ERROR | ERROR |

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
