### PR TITLE
feat: Enable FP8 (E4M3/E5M2) in concat_mla_k for optimize long-context prefill performance and refactor type dispatch for BF16/FP16

### DIFF
--- a/csrc/concat_mla.cu
+++ b/csrc/concat_mla.cu
@@ -19,20 +19,6 @@
 
 using namespace flashinfer;
 
-#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8(dlpack_dtype, c_type, ...)               \
-  [&]() -> bool {                                                                        \
-    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
-      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
-      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
-      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
-      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
-      default:                                                                           \
-        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
-                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
-        return false;                                                                    \
-    }                                                                                    \
-  }()
-
 /*!
  * \brief Concatenate k_nope and k_rope tensors for MLA attention
  *

--- a/csrc/concat_mla.cu
+++ b/csrc/concat_mla.cu
@@ -19,6 +19,20 @@
 
 using namespace flashinfer;
 
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8(dlpack_dtype, c_type, ...)               \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
 /*!
  * \brief Concatenate k_nope and k_rope tensors for MLA attention
  *
@@ -84,7 +98,7 @@ void concat_mla_k(TensorView k, TensorView k_nope, TensorView k_rope) {
   ffi::CUDADeviceGuard device_guard(k.device().device_id);
   const cudaStream_t stream = get_stream(k.device());
 
-  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(k.dtype(), c_type, [&] {
+  bool success = DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8(k.dtype(), c_type, [&] {
     cudaError_t status = ConcatMLAK<c_type>(
         static_cast<c_type*>(k.data_ptr()), static_cast<c_type*>(k_nope.data_ptr()),
         static_cast<c_type*>(k_rope.data_ptr()), num_tokens, k_stride_0, k_stride_1,

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -166,6 +166,20 @@ constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
     }                                                                                    \
   }()
 
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8(dlpack_dtype, c_type, ...)               \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
 #ifdef FLASHINFER_ENABLE_F32
 #define _DISPATCH_CASE_F32(c_type, ...) \
   case float32_code: {                  \

--- a/flashinfer/concat_ops.py
+++ b/flashinfer/concat_ops.py
@@ -42,9 +42,12 @@ def concat_mla_k(
       - k_nope: per-head nope values
       - k_rope: shared rope values (broadcast to all heads)
 
+    Supported dtypes: ``torch.bfloat16``, ``torch.float16``,
+      ``torch.float8_e4m3fn``, ``torch.float8_e5m2``.
+
     Key optimizations:
       - Warp-based processing with software pipelining
-      - Vectorized memory access (int2 for nope, int for rope)
+      - Vectorized memory access (compile-time dispatch per dtype)
       - L2 prefetching for next row while processing current
       - Register reuse for rope values across all heads in a chunk
 
@@ -67,6 +70,7 @@ def concat_mla_k(
     >>> num_heads = 128
     >>> nope_dim = 128
     >>> rope_dim = 64
+    >>> # BF16 example
     >>> k = torch.empty(num_tokens, num_heads, nope_dim + rope_dim, dtype=torch.bfloat16, device="cuda")
     >>> k_nope = torch.randn(num_tokens, num_heads, nope_dim, dtype=torch.bfloat16, device="cuda")
     >>> k_rope = torch.randn(num_tokens, 1, rope_dim, dtype=torch.bfloat16, device="cuda")

--- a/include/flashinfer/concat_mla.cuh
+++ b/include/flashinfer/concat_mla.cuh
@@ -18,6 +18,7 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
 #include "utils.cuh"
@@ -33,6 +34,91 @@ constexpr int MLA_K_HEAD_DIM = MLA_QK_NOPE_HEAD_DIM + MLA_QK_ROPE_HEAD_DIM;
 constexpr int MLA_HEAD_CHUNK_SIZE = 16;
 constexpr int MLA_NUM_HEAD_CHUNKS = MLA_NUM_LOCAL_HEADS / MLA_HEAD_CHUNK_SIZE;
 
+// ======================= Vec Traits for DType dispatch =======================
+// BF16/FP16: int2 (8B) for nope, int (4B) for rope  → ld/st_v2 / ld/st_v1
+// FP8:       int  (4B) for nope, short (2B) for rope → ld/st_v1 / ld/st_s16
+// Elements-per-vec is always 4 (nope) and 2 (rope), so stride arithmetic is
+// identical across all DTypes; only the vector width and PTX instructions differ.
+
+template <typename DType>
+struct ConcatMLAVecTraits;
+
+template <>
+struct ConcatMLAVecTraits<nv_half> {
+  using NopeVec = int2;
+  using RopeVec = int;
+
+  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+    return ld_na_global_v2(reinterpret_cast<const int2*>(ptr));
+  }
+  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+    return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
+  }
+  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+    st_na_global_v2(reinterpret_cast<int2*>(ptr), val);
+  }
+  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+    st_na_global_v1(reinterpret_cast<int*>(ptr), val);
+  }
+};
+
+template <>
+struct ConcatMLAVecTraits<nv_bfloat16> {
+  using NopeVec = int2;
+  using RopeVec = int;
+
+  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+    return ld_na_global_v2(reinterpret_cast<const int2*>(ptr));
+  }
+  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+    return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
+  }
+  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+    st_na_global_v2(reinterpret_cast<int2*>(ptr), val);
+  }
+  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+    st_na_global_v1(reinterpret_cast<int*>(ptr), val);
+  }
+};
+
+template <>
+struct ConcatMLAVecTraits<__nv_fp8_e4m3> {
+  using NopeVec = int;
+  using RopeVec = short;
+
+  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+    return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
+  }
+  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+    return ld_na_global_s16(reinterpret_cast<const short*>(ptr));
+  }
+  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+    st_na_global_v1(reinterpret_cast<int*>(ptr), val);
+  }
+  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+    st_na_global_s16(reinterpret_cast<short*>(ptr), val);
+  }
+};
+
+template <>
+struct ConcatMLAVecTraits<__nv_fp8_e5m2> {
+  using NopeVec = int;
+  using RopeVec = short;
+
+  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+    return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
+  }
+  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+    return ld_na_global_s16(reinterpret_cast<const short*>(ptr));
+  }
+  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+    st_na_global_v1(reinterpret_cast<int*>(ptr), val);
+  }
+  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+    st_na_global_s16(reinterpret_cast<short*>(ptr), val);
+  }
+};
+
 // ======================= Optimized Kernel =======================
 /*!
  * \brief Optimized CUDA kernel for concatenating k_nope and k_rope for MLA
@@ -45,11 +131,11 @@ constexpr int MLA_NUM_HEAD_CHUNKS = MLA_NUM_LOCAL_HEADS / MLA_HEAD_CHUNK_SIZE;
  *
  * Key optimizations:
  * - Warp-based processing: each warp handles one (token, head_chunk) pair
- * - Vectorized memory access: int2 (8B) for nope, int (4B) for rope
+ * - Vectorized memory access via ConcatMLAVecTraits (compile-time dispatch)
  * - L2 prefetching: prefetch next row while processing current
  * - Register reuse: rope is loaded once and written to all heads in chunk
  *
- * \tparam DType Data type (nv_bfloat16 or nv_half)
+ * \tparam DType Data type (nv_bfloat16, nv_half, __nv_fp8_e4m3, __nv_fp8_e5m2)
  */
 template <typename DType>
 __global__ void ConcatMLAKKernel(DType* __restrict__ k, const DType* __restrict__ k_nope,
@@ -70,59 +156,53 @@ __global__ void ConcatMLAKKernel(DType* __restrict__ k, const DType* __restrict_
 
   if (token_id >= num_tokens) return;
 
-  // Vector types for efficient memory access
-  // NopeVec: 8B/thread, 32 threads = 256B/row (covers nope_dim bf16 elements)
-  // RopeVec: 4B/thread, 32 threads = 128B/row (covers rope_dim bf16 elements)
-  using NopeVec = int2;
-  using RopeVec = int;
+  using Traits = ConcatMLAVecTraits<DType>;
+  using NopeVec = typename Traits::NopeVec;
+  using RopeVec = typename Traits::RopeVec;
   static_assert(sizeof(NopeVec) * 32 == QK_NOPE_HEAD_DIM * sizeof(DType), "nope vec mismatch");
   static_assert(sizeof(RopeVec) * 32 == QK_ROPE_HEAD_DIM * sizeof(DType), "rope vec mismatch");
 
   const int head_row0 = head_chunk_id * HEAD_CHUNK_SIZE;
 
-  // Source pointer for k_nope (indexed by token and head)
-  const int2* __restrict__ nope_src =
-      reinterpret_cast<const int2*>(k_nope + token_id * k_nope_stride_0 +
-                                    head_row0 * k_nope_stride_1) +
+  const NopeVec* __restrict__ nope_src =
+      reinterpret_cast<const NopeVec*>(k_nope + token_id * k_nope_stride_0 +
+                                       head_row0 * k_nope_stride_1) +
       lane_id;
 
-  // Destination pointers for output k (nope part and rope part)
-  int2* __restrict__ nope_dst =
-      reinterpret_cast<int2*>(k + token_id * k_stride_0 + head_row0 * k_stride_1) + lane_id;
+  NopeVec* __restrict__ nope_dst =
+      reinterpret_cast<NopeVec*>(k + token_id * k_stride_0 + head_row0 * k_stride_1) + lane_id;
 
-  int* __restrict__ rope_dst = reinterpret_cast<int*>(k + token_id * k_stride_0 +
-                                                      head_row0 * k_stride_1 + QK_NOPE_HEAD_DIM) +
-                               lane_id;
+  RopeVec* __restrict__ rope_dst =
+      reinterpret_cast<RopeVec*>(k + token_id * k_stride_0 + head_row0 * k_stride_1 +
+                                 QK_NOPE_HEAD_DIM) +
+      lane_id;
 
-  // Stride calculations for vector types
-  const int nope_src_stride_v = (k_nope_stride_1 >> 2);  // int2 covers 4 bf16
+  const int nope_src_stride_v = (k_nope_stride_1 >> 2);  // 4 elements per vec for all DTypes
   const int nope_dst_stride_v = (k_stride_1 >> 2);
-  const int rope_dst_stride_v = (k_stride_1 >> 1);  // int covers 2 bf16
+  const int rope_dst_stride_v = (k_stride_1 >> 1);  // 2 elements per vec for all DTypes
 
-  // Load rope value once - it's shared across all heads
-  const int* rope_base = reinterpret_cast<const int*>(k_rope + token_id * k_rope_stride_0);
-  const RopeVec rope_val = ld_na_global_v1(rope_base + lane_id);
+  // Load rope value once - shared across all heads
+  const RopeVec* rope_ptr =
+      reinterpret_cast<const RopeVec*>(k_rope + token_id * k_rope_stride_0) + lane_id;
+  RopeVec rope_val = Traits::load_rope(rope_ptr);
 
   // Prefetch first nope row and load it
   prefetch_L2(nope_src);
-  NopeVec cur = ld_na_global_v2(nope_src);
+  NopeVec cur = Traits::load_nope(nope_src);
 
 // Process all heads in this chunk with software pipelining
 #pragma unroll
   for (int i = 0; i < HEAD_CHUNK_SIZE; ++i) {
     NopeVec next;
     if (i + 1 < HEAD_CHUNK_SIZE) {
-      // Prefetch and load next row while processing current
-      const int2* next_src = nope_src + nope_src_stride_v;
+      const NopeVec* next_src = nope_src + nope_src_stride_v;
       prefetch_L2(next_src);
-      next = ld_na_global_v2(next_src);
+      next = Traits::load_nope(next_src);
     }
 
-    // Write current nope and rope values
-    st_na_global_v2(nope_dst, cur);
-    st_na_global_v1(rope_dst, rope_val);
+    Traits::store_nope(nope_dst, cur);
+    Traits::store_rope(rope_dst, rope_val);
 
-    // Advance pointers
     nope_src += nope_src_stride_v;
     nope_dst += nope_dst_stride_v;
     rope_dst += rope_dst_stride_v;

--- a/include/flashinfer/concat_mla.cuh
+++ b/include/flashinfer/concat_mla.cuh
@@ -48,16 +48,16 @@ struct ConcatMLAVecTraits<nv_half> {
   using NopeVec = int2;
   using RopeVec = int;
 
-  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+  static __forceinline__ __device__ NopeVec load_nope(const NopeVec* ptr) {
     return ld_na_global_v2(reinterpret_cast<const int2*>(ptr));
   }
-  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+  static __forceinline__ __device__ RopeVec load_rope(const RopeVec* ptr) {
     return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
   }
-  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+  static __forceinline__ __device__ void store_nope(NopeVec* ptr, NopeVec val) {
     st_na_global_v2(reinterpret_cast<int2*>(ptr), val);
   }
-  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+  static __forceinline__ __device__ void store_rope(RopeVec* ptr, RopeVec val) {
     st_na_global_v1(reinterpret_cast<int*>(ptr), val);
   }
 };
@@ -67,16 +67,16 @@ struct ConcatMLAVecTraits<nv_bfloat16> {
   using NopeVec = int2;
   using RopeVec = int;
 
-  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+  static __forceinline__ __device__ NopeVec load_nope(const NopeVec* ptr) {
     return ld_na_global_v2(reinterpret_cast<const int2*>(ptr));
   }
-  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+  static __forceinline__ __device__ RopeVec load_rope(const RopeVec* ptr) {
     return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
   }
-  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+  static __forceinline__ __device__ void store_nope(NopeVec* ptr, NopeVec val) {
     st_na_global_v2(reinterpret_cast<int2*>(ptr), val);
   }
-  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+  static __forceinline__ __device__ void store_rope(RopeVec* ptr, RopeVec val) {
     st_na_global_v1(reinterpret_cast<int*>(ptr), val);
   }
 };
@@ -86,16 +86,16 @@ struct ConcatMLAVecTraits<__nv_fp8_e4m3> {
   using NopeVec = int;
   using RopeVec = short;
 
-  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+  static __forceinline__ __device__ NopeVec load_nope(const NopeVec* ptr) {
     return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
   }
-  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+  static __forceinline__ __device__ RopeVec load_rope(const RopeVec* ptr) {
     return ld_na_global_s16(reinterpret_cast<const short*>(ptr));
   }
-  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+  static __forceinline__ __device__ void store_nope(NopeVec* ptr, NopeVec val) {
     st_na_global_v1(reinterpret_cast<int*>(ptr), val);
   }
-  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+  static __forceinline__ __device__ void store_rope(RopeVec* ptr, RopeVec val) {
     st_na_global_s16(reinterpret_cast<short*>(ptr), val);
   }
 };
@@ -105,16 +105,16 @@ struct ConcatMLAVecTraits<__nv_fp8_e5m2> {
   using NopeVec = int;
   using RopeVec = short;
 
-  __forceinline__ __device__ static NopeVec load_nope(const NopeVec* ptr) {
+  static __forceinline__ __device__ NopeVec load_nope(const NopeVec* ptr) {
     return ld_na_global_v1(reinterpret_cast<const int*>(ptr));
   }
-  __forceinline__ __device__ static RopeVec load_rope(const RopeVec* ptr) {
+  static __forceinline__ __device__ RopeVec load_rope(const RopeVec* ptr) {
     return ld_na_global_s16(reinterpret_cast<const short*>(ptr));
   }
-  __forceinline__ __device__ static void store_nope(NopeVec* ptr, NopeVec val) {
+  static __forceinline__ __device__ void store_nope(NopeVec* ptr, NopeVec val) {
     st_na_global_v1(reinterpret_cast<int*>(ptr), val);
   }
-  __forceinline__ __device__ static void store_rope(RopeVec* ptr, RopeVec val) {
+  static __forceinline__ __device__ void store_rope(RopeVec* ptr, RopeVec val) {
     st_na_global_s16(reinterpret_cast<short*>(ptr), val);
   }
 };

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -447,6 +447,22 @@ __forceinline__ __device__ int get_lane_id() {
 }
 
 /*!
+ * \brief Non-atomic global load for short (2 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ short ld_na_global_s16(const short* addr) {
+  short val;
+  asm volatile("ld.global.cs.b16 %0, [%1];" : "=h"(val) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global store for short (2 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_s16(short* addr, short val) {
+  asm volatile("st.global.cs.b16 [%0], %1;" ::"l"(addr), "h"(val));
+}
+
+/*!
  * \brief Non-atomic global load for int (4 bytes) with cache streaming hint
  */
 __forceinline__ __device__ int ld_na_global_v1(const int* addr) {

--- a/tests/utils/test_concat_mla.py
+++ b/tests/utils/test_concat_mla.py
@@ -1,0 +1,191 @@
+"""
+Tests for concat_mla_k kernel — verifies correctness across BF16, FP16, and FP8 dtypes.
+
+concat_mla_k is a pure memory movement operation (copy + broadcast), so the output
+must be **bit-exact** compared to the PyTorch slice-assign reference.
+"""
+
+import pytest
+import torch
+
+from flashinfer.concat_ops import concat_mla_k
+from flashinfer.utils import get_compute_capability
+
+NUM_LOCAL_HEADS = 128
+QK_NOPE_HEAD_DIM = 128
+QK_ROPE_HEAD_DIM = 64
+K_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM
+
+
+def _reference_concat(k_nope: torch.Tensor, k_rope: torch.Tensor) -> torch.Tensor:
+    """PyTorch reference: slice-assign with broadcast."""
+    k = torch.empty(
+        (*k_nope.shape[:-1], K_HEAD_DIM),
+        dtype=k_nope.dtype,
+        device=k_nope.device,
+    )
+    k[..., :QK_NOPE_HEAD_DIM] = k_nope
+    k[..., QK_NOPE_HEAD_DIM:] = k_rope
+    return k
+
+
+def _make_tensors(num_tokens: int, dtype: torch.dtype, device: str = "cuda"):
+    """Create contiguous k_nope, k_rope, and pre-allocated output k."""
+    # Generate in BF16 then cast — FP8 doesn't support randn directly
+    k_nope = (
+        torch.randn(
+            num_tokens,
+            NUM_LOCAL_HEADS,
+            QK_NOPE_HEAD_DIM,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        .to(dtype)
+        .contiguous()
+    )
+    k_rope = (
+        torch.randn(
+            num_tokens, 1, QK_ROPE_HEAD_DIM, device=device, dtype=torch.bfloat16
+        )
+        .to(dtype)
+        .contiguous()
+    )
+    k = torch.empty(num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM, dtype=dtype, device=device)
+    return k, k_nope, k_rope
+
+
+# ────────────────────────── Core correctness tests ──────────────────────────
+
+
+@pytest.mark.parametrize("num_tokens", [1, 32, 1024, 8192])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bfloat16,
+        torch.float16,
+        pytest.param(torch.float8_e4m3fn, id="fp8_e4m3"),
+        pytest.param(torch.float8_e5m2, id="fp8_e5m2"),
+    ],
+)
+def test_concat_mla_k_correctness(num_tokens, dtype):
+    """Bit-exact correctness: flashinfer output == PyTorch reference."""
+    if dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        major, minor = get_compute_capability(torch.device("cuda"))
+        if (major, minor) < (8, 9):
+            pytest.skip("FP8 requires SM >= 89 (Ada/Hopper)")
+
+    k, k_nope, k_rope = _make_tensors(num_tokens, dtype)
+    concat_mla_k(k, k_nope, k_rope)
+
+    ref = _reference_concat(k_nope, k_rope)
+
+    # Pure copy — must be bit-exact
+    if dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        assert torch.equal(k.view(torch.uint8), ref.view(torch.uint8)), (
+            f"Mismatch for dtype={dtype}, num_tokens={num_tokens}."
+        )
+    else:
+        assert torch.equal(k, ref), (
+            f"Mismatch for dtype={dtype}, num_tokens={num_tokens}. "
+            f"max abs diff = {(k.to(torch.float32) - ref.to(torch.float32)).abs().max().item()}"
+        )
+
+
+# ────────────────────────── Zero-token edge case ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float16, torch.float8_e4m3fn],
+)
+def test_concat_mla_k_zero_tokens(dtype):
+    """num_tokens=0 should return immediately without error."""
+    if dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        major, minor = get_compute_capability(torch.device("cuda"))
+        if (major, minor) < (8, 9):
+            pytest.skip("FP8 requires SM >= 89")
+
+    k, k_nope, k_rope = _make_tensors(0, dtype)
+    concat_mla_k(k, k_nope, k_rope)  # should not crash
+
+
+# ────────────────────────── Strided (non-contiguous last dim) inputs ──────
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bfloat16,
+        pytest.param(torch.float8_e4m3fn, id="fp8_e4m3"),
+    ],
+)
+def test_concat_mla_k_strided_inputs(dtype):
+    """Verify correctness when k_nope is a slice of a larger contiguous tensor."""
+    if dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        major, minor = get_compute_capability(torch.device("cuda"))
+        if (major, minor) < (8, 9):
+            pytest.skip("FP8 requires SM >= 89")
+
+    num_tokens = 2048
+
+    # k_nope is a slice — last-dim contiguous but has a stride gap on dim-1
+    nope_container = torch.randn(
+        num_tokens,
+        NUM_LOCAL_HEADS,
+        QK_NOPE_HEAD_DIM + 128,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ).to(dtype)
+    k_nope = nope_container[:, :, :QK_NOPE_HEAD_DIM]
+
+    k_rope = (
+        torch.randn(
+            num_tokens, 1, QK_ROPE_HEAD_DIM, device="cuda", dtype=torch.bfloat16
+        )
+        .to(dtype)
+        .contiguous()
+    )
+
+    k = torch.empty(num_tokens, NUM_LOCAL_HEADS, K_HEAD_DIM, dtype=dtype, device="cuda")
+    concat_mla_k(k, k_nope, k_rope)
+
+    ref = _reference_concat(k_nope, k_rope)
+    if dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        assert torch.equal(k.view(torch.uint8), ref.view(torch.uint8))
+    else:
+        assert torch.equal(k, ref)
+
+
+# ────────────────────────── Cross-dtype guard ──────────────────────────
+
+
+def test_concat_mla_k_dtype_mismatch_raises():
+    """Passing mismatched dtypes should raise an error from the C++ side."""
+    num_tokens = 64
+    k_nope = torch.randn(
+        num_tokens,
+        NUM_LOCAL_HEADS,
+        QK_NOPE_HEAD_DIM,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    k_rope = torch.randn(
+        num_tokens,
+        1,
+        QK_ROPE_HEAD_DIM,
+        device="cuda",
+        dtype=torch.float16,  # intentional mismatch
+    )
+    k = torch.empty(
+        num_tokens,
+        NUM_LOCAL_HEADS,
+        K_HEAD_DIM,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    with pytest.raises(RuntimeError):
+        concat_mla_k(k, k_nope, k_rope)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Enable FP8 (E4M3/E5M2) support in `concat_mla_k`, fixing a crash that blocks FP8 chunked prefill for all MLA models (DeepSeek-V2/V3/R1) on long-context workloads.

## Motivation

For long-context inference (ISL >= 4K) in vLLM, chunked prefill + FP8 quantization (`use_prefill_query_quantization: true`) is critical for reducing TTFT and improve throughput. The FP8 FMHA kernel is ~1.35x faster than BF16 at 128K context, but this path was complete unusable because `concat_mla_k` rejected FP8 inputs.

In vLLM's `_compute_prefill_context` (the chunked prefill path for MLA), K/V tensors are cast to FP8 before being passed to `flashinfer_concat_mla_k`:

```python
if use_fp8_prefill:
    kv_nope = kv_nope.to(prefill_metadata.q_data_type)  # BF16 to FP8
    k_pe = k_pe.to(prefill_metadata.q_data_type)
k_nope, v = kv_nope.split(...)
k = self._concat_k_nope_k_pe(k_nope, k_pe)  # ← crash: FP8 not supported
```

The kernel uses `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16` which only dispatches BF16/FP16, causing RuntimeError

A vLLM-side workaround (my [PR #39841](https://github.com/vllm-project/vllm/pull/39841) reordering cast after concat) works, but it introduces an extra BF16 to FP8 round-trip and does not address the root cause. The proper fix is enabling FP8 at the kernel level. We keep it for temporal workaround.

## Changes

| File | Change |
|---|---|
| `include/flashinfer/utils.cuh` | Add `ld_na_global_s16` / `st_na_global_s16` for 2-byte vectorized load and store (FP8 rope = 64 elements × 1B = 2B/thread) |
| `include/flashinfer/concat_mla.cuh` | Add `ConcatMLAVecTraits<DType>` template for compile time vector type selection (BF16/FP16 to int2/int, FP8 → int or short) with `if constexpr` dispatch |
| `csrc/concat_mla.cu` | Add `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16_FP8` macro extending dispatch to FP8 E4M3/E5M2 |
| `flashinfer/concat_ops.py` | Update docstring to list supported FP8 dtypes |
| `tests/utils/test_concat_mla.py` | Add full pytest covering BF16, FP16, FP8-E4M3, FP8-E5M2 with bit exact correctness checks |

## Design

The key insight is that `concat_mla_k` is pure memory movement, so FP8 support we adjust vectorized load and store widths:

- **BF16/FP16 (2B/elem)**: nope 128 elem × 2B = 256B to `int2` (8B/thread × 32 threads), rope 64 elem × 2B = 128B to `int` (4B/thread × 32 threads)
- **FP8 (1B/elem)**: nope 128 elem × 1B = 128B to `int` (4B/thread × 32 threads), rope 64 elem × 1B = 64B to `short` (2B/thread × 32 threads)

`if constexpr` ensures that we do not addition runtime overhead.

## Benchmark Results

End-to-end on GB300 (DeepSeek-R1-0528-FP4, DP=4, chunked prefill, ISL=128K, 16 requests):

| Metric | BF16 (baseline) | FP8 (this fix) | Delta |
|---|---|---|---|
| Median TTFT | 42.0 s | 30.1 s | **-28.3%** |
| Mean TTFT | 41.7 s | 30.5 s | **-27.0%** |
| P99 TTFT | 43.8s | 33.5s | **-23.5%** |
| Token throughput | 12,069 tok/s | 16,524 tok/s | **+37.0%** |



## Test Plan

- [x] Unit test: `pytest tests/utils/test_concat_mla.py`, bit exact correctness for all 4 dtypes
- [x] E2E crash check: ISL=128K with `use_prefill_query_quantization=true`, all succeed
- [x] Performance: FP8 prefill -27% Median TTFT vs BF16 at long context
- [x] No regression: BF16 baseline all succeed with identical perf to stock flashinfer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two FP8 formats alongside FP16 and BF16 in the concat operation.
* **Documentation**
  * Updated docs to list supported dtypes and clarify compile-time dtype dispatch semantics.
* **Refactor**
  * Generalized vector and memory access handling to uniformly support additional low-precision dtypes.
* **Tests**
  * Added comprehensive tests for BF16/FP16/FP8 correctness, edge cases, strided inputs, and dtype-mismatch checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->