### PR TITLE
[CuTe DSL] Fix FP8 MLA persistent perf regression and ProxyKind cu13 wheel breakage

### DIFF
--- a/flashinfer/cute_dsl/attention/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/mla_decode.py
@@ -188,6 +188,7 @@ class BlackwellMultiLatentAttentionForward:
         self.pt_loader_role = MLAPageTableLoaderRole(self.config)
         self.loader_role = MLALoaderRole(self.config)
         self.mma_role = MLAMmaRole(self.config, self.mainloop)
+        self.mma_role.set_dtypes(self.q_dtype, self.v_dtype)
         self.compute_role = MLAComputeRole(self.config, fusion=self.fusion)
         self.compute_role.set_dtypes(self.q_dtype)
         self.compute_role.set_barriers(self.softmax_exchange_sync_bar)

--- a/flashinfer/cute_dsl/attention/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/mla_decode_fp8.py
@@ -191,6 +191,7 @@ class BlackwellMultiLatentAttentionForwardFP8:
         self.loader_k_role = MLAFP8LoaderKRole(self.config)
         self.loader_v_role = MLAFP8LoaderVRole(self.config)
         self.mma_role = MLAMmaFP8Role(self.config, self.mainloop)
+        self.mma_role.set_dtypes(self.q_dtype, self.v_dtype)
         self.compute_role = MLAComputeRole(self.config, fusion=self.fusion)
         self.compute_role.set_dtypes(self.q_dtype)
         self.compute_role.set_barriers(self.softmax_exchange_sync_bar)

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -206,6 +206,13 @@ class BlackwellFusedMultiHeadAttentionForward:
             threads_per_warp=self.schedule.threads_per_warp,
             has_logits_transform=self.has_logits_transform,
         )
+        self.mma_role.set_dtypes(
+            self.q_dtype,
+            self.v_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.v_major_mode,
+        )
         self.softmax_role.set_dtypes(self.q_dtype, self.o_dtype)
 
         lp = build_fmha_launch_params(
@@ -495,7 +502,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         if warp_idx == self.schedule.mma_warp_id:
             cute.arch.warpgroup_reg_dealloc(self.schedule.num_regs_other)
             self.mma_role.run(
-                qk_tiled_mma,
                 pv_tiled_mma,
                 tStS0,
                 tStS1,

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -263,10 +263,7 @@ class CorrectionRole:
             cute.copy(tiled_smem_store, tSMrO, tTMEM_LOADsO_i)
 
         # fence view async shared
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_proxy("async.shared", space="cta")
 
     @cute.jit
     def run(

--- a/flashinfer/cute_dsl/attention/roles/mla_mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma.py
@@ -19,11 +19,22 @@ prefill pattern (roles/mma.py:gemm_pv). The ACCUMULATE flag is set inside
 each helper as ``k_block != 0 or accumulate``, making it deterministic from
 the parameter and inner loop index. Callers compute the parameter from their
 own loop position — never from ``tiled_mma.get()`` after a sub-method return.
+
+Inner k-block loops use ``cutlass.range_constexpr`` (compile-time unrolled)
+for maximum tcgen05 MMA dispatch throughput.  Each GEMM helper constructs
+its own local ``TiledMma`` via ``make_trivial_tiled_mma`` so that the
+``.set(ACCUMULATE, ...)`` mutations stay inside the helper's frame and
+never leak SSA values across the persistent tile-scheduler ``while`` loop
+in ``run()``.  Same isolation pattern the compute role and the FP8 MMA
+role (mla_mma_fp8.py) already use.
 """
+
+from typing import Type
 
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 from types import SimpleNamespace
 
@@ -56,6 +67,56 @@ class MLAMmaRole:
         self.iterations_pv_n = config.iterations_pv_n
         self.enable_pdl = config.enable_pdl
         self.is_var_split_kv = config.is_var_split_kv
+        self.use_2cta_instrs = config.use_2cta_instrs
+        self.acc_dtype = config.acc_dtype
+        # self.q_dtype and self.v_dtype are populated by set_dtypes() — the
+        # operand element types are only known at __call__ time on the kernel.
+
+    def set_dtypes(
+        self,
+        q_dtype: Type[cutlass.Numeric],
+        v_dtype: Type[cutlass.Numeric],
+    ) -> None:
+        """Set tensor element types discovered at call time.
+
+        Required so the GEMM helpers can reconstruct local TiledMma
+        instances via ``make_trivial_tiled_mma``.
+        """
+        self.q_dtype: Type[cutlass.Numeric] = q_dtype
+        self.v_dtype: Type[cutlass.Numeric] = v_dtype
+
+    @cute.jit
+    def _make_local_qk_mma(self) -> cute.TiledMma:
+        """Fresh QK TiledMma — mutations on this instance never escape the
+        helper that constructs it, so the inner k-block loop can use
+        ``range_constexpr`` without leaking SSA values into the enclosing
+        persistent ``while`` loop in ``run()``."""
+        cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+        return sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            cta_group,
+            self.mma_qk_tiler[:2],
+        )
+
+    @cute.jit
+    def _make_local_pv_mma(self) -> cute.TiledMma:
+        """Fresh PV TiledMma — same isolation rationale as ``_make_local_qk_mma``."""
+        cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+        return sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.mma_pv_tiler[:2],
+        )
 
     # ------------------------------------------------------------------
     #  Tile count
@@ -97,12 +158,14 @@ class MLAMmaRole:
     #  state back via TiledMma mutations (they would be invisible to the
     #  caller due to SSA pass-by-value at the @cute.jit boundary).
     #
-    #  Inner k-block loops use ``cutlass.range()`` (dynamic scf.for),
-    #  NOT ``cutlass.range_constexpr()`` (compile-time unroll).
-    #  range_constexpr unrolls tiled_mma.set() calls into the enclosing
-    #  scope, producing SSA values that leak across dynamic while-loop
-    #  yields. range() keeps the .set() inside an scf.for scope where
-    #  SSA carry-through is handled correctly.
+    #  Inner k-block loops use ``cutlass.range_constexpr`` (compile-time
+    #  unrolled) for maximum tcgen05 MMA dispatch throughput.  To prevent
+    #  the unrolled ``tiled_mma.set(ACCUMULATE, ...)`` mutations from
+    #  leaking SSA values into the enclosing persistent ``while`` loop
+    #  in ``run()`` (which would cause SSA-dominance failures), each
+    #  helper constructs a fresh local TiledMma via
+    #  ``make_trivial_tiled_mma`` and mutates that local instance only.
+    #  The caller's TiledMma is never touched by the helper.
     # ------------------------------------------------------------------
 
     @cute.jit
@@ -116,11 +179,12 @@ class MLAMmaRole:
         accumulate: bool,
     ):
         """Compute one QK-latent stage: inner k-block GEMM loop."""
+        local_mma = self._make_local_qk_mma()
         tStS = qk_params.tStS_staged[None, None, None, s_stage_index]
-        for k_block in cutlass.range(cute.size(qk_params.tSrQ.shape[2])):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
+        for k_block in cutlass.range_constexpr(cute.size(qk_params.tSrQ.shape[2])):
+            local_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
             cute.gemm(
-                tiled_mma_qk,
+                local_mma,
                 tStS,
                 qk_params.tSrQ[None, None, k_block, q_stage],
                 qk_params.tSrKC[None, None, k_block, kv_stage_index],
@@ -138,11 +202,12 @@ class MLAMmaRole:
         accumulate: bool,
     ):
         """Compute one QK-rope stage: inner k-block GEMM loop."""
+        local_mma = self._make_local_qk_mma()
         tStS = qk_params.tStS_staged[None, None, None, s_stage_index]
-        for k_block in cutlass.range(self.rope_dim // tiled_mma_qk.shape_mnk[2]):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
+        for k_block in cutlass.range_constexpr(self.rope_dim // local_mma.shape_mnk[2]):
+            local_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
             cute.gemm(
-                tiled_mma_qk,
+                local_mma,
                 tStS,
                 qk_params.tSrQ_rope[None, None, k_block, q_stage],
                 qk_params.tSrKC[None, None, k_block, kv_stage_index],
@@ -161,11 +226,12 @@ class MLAMmaRole:
         accumulate: bool,
     ):
         """Compute one PV stage: inner k-block GEMM loop."""
+        local_mma = self._make_local_pv_mma()
         tOtO = pv_params.tOtO_staged[None, None, None, acc_stage]
-        for k_block in cutlass.range(pv_params.tOrP.shape[2]):
-            tiled_mma_pv.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
+        for k_block in cutlass.range_constexpr(pv_params.tOrP.shape[2]):
+            local_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
             cute.gemm(
-                tiled_mma_pv,
+                local_mma,
                 tOtO,
                 pv_params.tOrP[
                     None,

--- a/flashinfer/cute_dsl/attention/roles/mla_mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma.py
@@ -172,7 +172,6 @@ class MLAMmaRole:
     def _gemm_qk_latent_one_stage(
         self,
         qk_params: SimpleNamespace,
-        tiled_mma_qk: cute.TiledMma,
         s_stage_index: cutlass.Int32,
         kv_stage_index: cutlass.Int32,
         q_stage: int,
@@ -195,7 +194,6 @@ class MLAMmaRole:
     def _gemm_qk_rope_one_stage(
         self,
         qk_params: SimpleNamespace,
-        tiled_mma_qk: cute.TiledMma,
         s_stage_index: cutlass.Int32,
         kv_stage_index: cutlass.Int32,
         q_stage: int,
@@ -218,7 +216,6 @@ class MLAMmaRole:
     def _gemm_pv_one_stage(
         self,
         pv_params: SimpleNamespace,
-        tiled_mma_pv: cute.TiledMma,
         p_stage_index: cutlass.Int32,
         kv_stage_index: cutlass.Int32,
         p_stage: int,
@@ -350,7 +347,6 @@ class MLAMmaRole:
                         kv_handle = load_kv_consumer.wait_and_advance()
                         self._gemm_qk_latent_one_stage(
                             mma_qk_params,
-                            tiled_mma_qk,
                             s_handle.index,
                             kv_handle.index,
                             q_stage,
@@ -361,7 +357,6 @@ class MLAMmaRole:
                         kv_handle = load_kv_consumer.wait_and_advance()
                         self._gemm_qk_rope_one_stage(
                             mma_qk_params,
-                            tiled_mma_qk,
                             s_handle.index,
                             kv_handle.index,
                             q_stage,
@@ -379,7 +374,6 @@ class MLAMmaRole:
                             kv_handle = load_kv_consumer.wait_and_advance()
                             self._gemm_qk_latent_one_stage(
                                 mma_qk_params,
-                                tiled_mma_qk,
                                 s_handle.index,
                                 kv_handle.index,
                                 q_stage,
@@ -390,7 +384,6 @@ class MLAMmaRole:
                             kv_handle = load_kv_consumer.wait_and_advance()
                             self._gemm_qk_rope_one_stage(
                                 mma_qk_params,
-                                tiled_mma_qk,
                                 s_handle.index,
                                 kv_handle.index,
                                 q_stage,
@@ -409,7 +402,6 @@ class MLAMmaRole:
                                 kv_handle = load_kv_consumer.wait_and_advance()
                                 self._gemm_pv_one_stage(
                                     mma_pv_params,
-                                    tiled_mma_pv,
                                     p_handle.index,
                                     kv_handle.index,
                                     p_stage,
@@ -434,7 +426,6 @@ class MLAMmaRole:
                             kv_handle = load_kv_consumer.wait_and_advance()
                             self._gemm_pv_one_stage(
                                 mma_pv_params,
-                                tiled_mma_pv,
                                 p_handle.index,
                                 kv_handle.index,
                                 p_stage,

--- a/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
@@ -15,16 +15,21 @@ FP8 differs from FP16 in three structural ways:
 
 3. mma_o pipeline: 2 stages (vs 1 for FP16), with acquire/commit per acc_stage.
 
-GEMM helpers use explicit ``accumulate`` parameter and ``cutlass.range()``
-(not ``range_constexpr``) for inner k-block loops, matching the FP16 pattern
-in mla_mma.py. ``range()`` generates ``scf.for`` which keeps ``.set()`` SSA
-values properly scoped; ``range_constexpr`` unrolls at compile time and leaks
-SSA values across dynamic loop boundaries.
+Inner k-block loops use ``cutlass.range_constexpr`` (compile-time unrolled)
+for maximum tcgen05 MMA dispatch throughput.  Each GEMM helper constructs
+its own local ``TiledMma`` via ``make_trivial_tiled_mma`` so that the
+``.set(ACCUMULATE, ...)`` mutations stay inside the helper's frame and
+never leak SSA values across the persistent tile-scheduler ``while`` loop
+in ``run()``.  This is the same trick the compute role already uses to
+isolate its TiledMma from the MMA warp's mutations.
 """
+
+from typing import Type
 
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 from types import SimpleNamespace
 
@@ -57,6 +62,56 @@ class MLAMmaFP8Role:
         self.iterations_pv_n = config.iterations_pv_n
         self.enable_pdl = config.enable_pdl
         self.is_var_split_kv = config.is_var_split_kv
+        self.use_2cta_instrs = config.use_2cta_instrs
+        self.acc_dtype = config.acc_dtype
+        # self.q_dtype and self.v_dtype are populated by set_dtypes() — the
+        # operand element types are only known at __call__ time on the kernel.
+
+    def set_dtypes(
+        self,
+        q_dtype: Type[cutlass.Numeric],
+        v_dtype: Type[cutlass.Numeric],
+    ) -> None:
+        """Set tensor element types discovered at call time.
+
+        Required so the GEMM helpers can reconstruct local TiledMma
+        instances via ``make_trivial_tiled_mma``.
+        """
+        self.q_dtype: Type[cutlass.Numeric] = q_dtype
+        self.v_dtype: Type[cutlass.Numeric] = v_dtype
+
+    @cute.jit
+    def _make_local_qk_mma(self) -> cute.TiledMma:
+        """Fresh QK TiledMma — mutations on this instance never escape the
+        helper that constructs it, so the inner k-block loop can use
+        ``range_constexpr`` without leaking SSA values into the enclosing
+        persistent ``while`` loop in ``run()``."""
+        cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+        return sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            cta_group,
+            self.mma_qk_tiler[:2],
+        )
+
+    @cute.jit
+    def _make_local_pv_mma(self) -> cute.TiledMma:
+        """Fresh PV TiledMma — same isolation rationale as ``_make_local_qk_mma``."""
+        cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+        return sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.mma_pv_tiler[:2],
+        )
 
     @cute.jit
     def _get_k_tile_count(
@@ -85,12 +140,14 @@ class MLAMmaFP8Role:
     #  state back via TiledMma mutations (they would be invisible to the
     #  caller due to SSA pass-by-value at the @cute.jit boundary).
     #
-    #  Inner k-block loops use ``cutlass.range()`` (dynamic scf.for),
-    #  NOT ``cutlass.range_constexpr()`` (compile-time unroll).
-    #  range_constexpr unrolls tiled_mma.set() calls into the enclosing
-    #  scope, producing SSA values that leak across dynamic while-loop
-    #  yields. range() keeps the .set() inside an scf.for scope where
-    #  SSA carry-through is handled correctly.
+    #  Inner k-block loops use ``cutlass.range_constexpr`` (compile-time
+    #  unrolled) for maximum tcgen05 MMA dispatch throughput.  To prevent
+    #  the unrolled ``tiled_mma.set(ACCUMULATE, ...)`` mutations from
+    #  leaking SSA values into the enclosing persistent ``while`` loop
+    #  in ``run()`` (which would cause SSA-dominance failures), each
+    #  helper constructs a fresh local TiledMma via
+    #  ``make_trivial_tiled_mma`` and mutates that local instance only.
+    #  The caller's TiledMma is never touched by the helper.
     # ------------------------------------------------------------------
 
     @cute.jit
@@ -104,11 +161,12 @@ class MLAMmaFP8Role:
         accumulate: bool,
     ):
         """Compute one QK-latent stage: inner k-block GEMM loop."""
+        local_mma = self._make_local_qk_mma()
         tStS = qk_params.tStS_staged[None, None, None, s_stage_index]
-        for k_block in cutlass.range(cute.size(qk_params.tSrQ.shape[2])):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
+        for k_block in cutlass.range_constexpr(cute.size(qk_params.tSrQ.shape[2])):
+            local_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
             cute.gemm(
-                tiled_mma_qk,
+                local_mma,
                 tStS,
                 qk_params.tSrQ[None, None, k_block, (q_stage, 0)],
                 qk_params.tSrKC[None, None, k_block, (q_stage, kv_stage_index)],
@@ -126,11 +184,12 @@ class MLAMmaFP8Role:
         accumulate: bool,
     ):
         """Compute one QK-rope stage using separate tSrKC_rope fragments."""
+        local_mma = self._make_local_qk_mma()
         tStS = qk_params.tStS_staged[None, None, None, s_stage_index]
-        for k_block in cutlass.range(self.rope_dim // tiled_mma_qk.shape_mnk[2]):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
+        for k_block in cutlass.range_constexpr(self.rope_dim // local_mma.shape_mnk[2]):
+            local_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
             cute.gemm(
-                tiled_mma_qk,
+                local_mma,
                 tStS,
                 qk_params.tSrQ_rope[None, None, k_block, q_stage],
                 qk_params.tSrKC_rope[None, None, k_block, kv_stage_index],
@@ -149,11 +208,12 @@ class MLAMmaFP8Role:
         accumulate: bool,
     ):
         """Compute one PV stage: inner k-block GEMM loop."""
+        local_mma = self._make_local_pv_mma()
         tOtO = pv_params.tOtO_staged[None, None, None, acc_stage]
-        for k_block in cutlass.range(pv_params.tOrP.shape[2]):
-            tiled_mma_pv.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
+        for k_block in cutlass.range_constexpr(pv_params.tOrP.shape[2]):
+            local_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0 or accumulate)
             cute.gemm(
-                tiled_mma_pv,
+                local_mma,
                 tOtO,
                 pv_params.tOrP[
                     None,
@@ -231,13 +291,13 @@ class MLAMmaFP8Role:
         )
         work_tile = tile_sched.initial_work_tile_info()
 
-        # Track PV accumulate state as a plain bool instead of
-        # tiled_mma_pv.set/get to avoid carrying TiledMma SSA values
-        # across the dynamic while-loop yield.
-        pv_accumulated = False
-
         while work_tile.is_valid_tile:
-            pv_accumulated = False
+            # Reset PV accumulate for this work tile.  Storing the flag on
+            # tiled_mma_pv (instead of a Python bool) lets the helper read
+            # it as a compile-time-constant inside the inner k_block loop
+            # for the common p_stage==0 / acc_stage==0 case after the
+            # first PV iteration.  Same pattern as BF16 mla_mma.py.
+            tiled_mma_pv.set(tcgen05.Field.ACCUMULATE, False)
             blk_coord = work_tile.tile_idx
             k_index, k_tile_count, local_split_kv = self._get_k_tile_count(
                 split_kv, cache_seqs, block_split_kvs, blk_coord
@@ -319,6 +379,7 @@ class MLAMmaFP8Role:
                         # PV
                         p_handle = p_mma_consumer.wait_and_advance()
                         v_handle = load_v_consumer.wait_and_advance()
+                        pv_acc = tiled_mma_pv.get(tcgen05.Field.ACCUMULATE)
                         for acc_stage in range(self.iterations_pv_n):
                             o_handle = mma_o_producer.acquire_and_advance()
                             for p_stage in range(self.iterations_pv_k):
@@ -329,12 +390,12 @@ class MLAMmaFP8Role:
                                     v_handle.index,
                                     p_stage,
                                     acc_stage,
-                                    accumulate=(pv_accumulated or p_stage > 0),
+                                    accumulate=(pv_acc or p_stage > 0),
                                 )
                             o_handle.commit()
                         v_handle.release()
                         p_handle.release()
-                        pv_accumulated = True
+                        tiled_mma_pv.set(tcgen05.Field.ACCUMULATE, True)
 
                         k_tile_count -= 1
 
@@ -343,6 +404,7 @@ class MLAMmaFP8Role:
                     # === Final PV tile ===
                     p_handle = p_mma_consumer.wait_and_advance()
                     v_handle = load_v_consumer.wait_and_advance()
+                    pv_acc = tiled_mma_pv.get(tcgen05.Field.ACCUMULATE)
                     for acc_stage in range(self.iterations_pv_n):
                         o_handle = mma_o_producer.acquire_and_advance()
                         for p_stage in range(self.iterations_pv_k):
@@ -353,7 +415,7 @@ class MLAMmaFP8Role:
                                 v_handle.index,
                                 p_stage,
                                 acc_stage,
-                                accumulate=(pv_accumulated or p_stage > 0),
+                                accumulate=(pv_acc or p_stage > 0),
                             )
                         o_handle.commit()
                     v_handle.release()

--- a/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
@@ -154,7 +154,6 @@ class MLAMmaFP8Role:
     def _gemm_qk_latent_one_stage(
         self,
         qk_params: SimpleNamespace,
-        tiled_mma_qk: cute.TiledMma,
         s_stage_index: cutlass.Int32,
         kv_stage_index: cutlass.Int32,
         q_stage: int,
@@ -177,7 +176,6 @@ class MLAMmaFP8Role:
     def _gemm_qk_rope_one_stage(
         self,
         qk_params: SimpleNamespace,
-        tiled_mma_qk: cute.TiledMma,
         s_stage_index: cutlass.Int32,
         kv_stage_index: cutlass.Int32,
         q_stage: int,
@@ -200,7 +198,6 @@ class MLAMmaFP8Role:
     def _gemm_pv_one_stage(
         self,
         pv_params: SimpleNamespace,
-        tiled_mma_pv: cute.TiledMma,
         p_stage_index: cutlass.Int32,
         vc_stage_index: cutlass.Int32,
         p_stage: int,
@@ -331,7 +328,6 @@ class MLAMmaFP8Role:
                     for q_stage in range(self.iterations_qk_latent):
                         self._gemm_qk_latent_one_stage(
                             mma_qk_params,
-                            tiled_mma_qk,
                             s_handle.index,
                             kv_handle.index,
                             q_stage,
@@ -340,7 +336,6 @@ class MLAMmaFP8Role:
                     for q_stage in range(self.iterations_qk_rope):
                         self._gemm_qk_rope_one_stage(
                             mma_qk_params,
-                            tiled_mma_qk,
                             s_handle.index,
                             kv_handle.index,
                             q_stage,
@@ -358,7 +353,6 @@ class MLAMmaFP8Role:
                         for q_stage in range(self.iterations_qk_latent):
                             self._gemm_qk_latent_one_stage(
                                 mma_qk_params,
-                                tiled_mma_qk,
                                 s_handle.index,
                                 kv_handle.index,
                                 q_stage,
@@ -367,7 +361,6 @@ class MLAMmaFP8Role:
                         for q_stage in range(self.iterations_qk_rope):
                             self._gemm_qk_rope_one_stage(
                                 mma_qk_params,
-                                tiled_mma_qk,
                                 s_handle.index,
                                 kv_handle.index,
                                 q_stage,
@@ -385,7 +378,6 @@ class MLAMmaFP8Role:
                             for p_stage in range(self.iterations_pv_k):
                                 self._gemm_pv_one_stage(
                                     mma_pv_params,
-                                    tiled_mma_pv,
                                     p_handle.index,
                                     v_handle.index,
                                     p_stage,
@@ -410,7 +402,6 @@ class MLAMmaFP8Role:
                         for p_stage in range(self.iterations_pv_k):
                             self._gemm_pv_one_stage(
                                 mma_pv_params,
-                                tiled_mma_pv,
                                 p_handle.index,
                                 v_handle.index,
                                 p_stage,

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -11,11 +11,22 @@ Reusable primitives (pipeline-unaware, for composing new kernel variants):
 
 Orchestration (prefill-specific, uses raw CuTe ops for JIT compatibility):
 - run(): double-buffered interleaved QK/PV with S0/S1 and O0/O1
+
+Inner kphase loops in ``gemm_qk`` / ``gemm_pv`` use ``cutlass.range_constexpr``
+(compile-time unrolled) for maximum tcgen05 MMA dispatch throughput.  Each
+helper constructs its own local ``TiledMma`` via ``make_trivial_tiled_mma``
+so the unrolled ``.set(ACCUMULATE, ...)`` mutations stay inside the helper's
+frame and never leak SSA values across the persistent tile-scheduler
+``while`` loop in ``run()``.  Same isolation pattern the MLA decode MMA
+roles use for the same reason.
 """
+
+from typing import Type
 
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Float32
 
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
@@ -50,6 +61,67 @@ class MmaRole:
         self.tmem_alloc_sync_bar_id = tmem_alloc_sync_bar_id
         self.threads_per_warp = threads_per_warp
         self.has_logits_transform = has_logits_transform
+        # Used to (re)construct local TiledMma instances inside gemm_qk /
+        # gemm_pv so the helper's .set(ACCUMULATE, ...) mutations don't
+        # leak SSA values into the caller's persistent loop.
+        self.qk_acc_dtype = config.qk_acc_dtype
+        self.pv_acc_dtype = config.pv_acc_dtype
+        self.qk_mma_tiler = config.qk_mma_tiler
+        self.pv_mma_tiler = config.pv_mma_tiler
+        # self.q_dtype / self.v_dtype / self.q_major_mode / self.k_major_mode /
+        # self.v_major_mode are populated by set_dtypes() — they're only known
+        # at __call__ time on the kernel.
+
+    def set_dtypes(
+        self,
+        q_dtype: Type[cutlass.Numeric],
+        v_dtype: Type[cutlass.Numeric],
+        q_major_mode: tcgen05.OperandMajorMode,
+        k_major_mode: tcgen05.OperandMajorMode,
+        v_major_mode: tcgen05.OperandMajorMode,
+    ) -> None:
+        """Set tensor element types and operand major modes discovered at call time.
+
+        Required so the GEMM helpers can reconstruct local TiledMma instances
+        via ``make_trivial_tiled_mma``.
+        """
+        self.q_dtype: Type[cutlass.Numeric] = q_dtype
+        self.v_dtype: Type[cutlass.Numeric] = v_dtype
+        self.q_major_mode: tcgen05.OperandMajorMode = q_major_mode
+        self.k_major_mode: tcgen05.OperandMajorMode = k_major_mode
+        self.v_major_mode: tcgen05.OperandMajorMode = v_major_mode
+
+    @cute.jit
+    def _make_local_qk_mma(self) -> cute.TiledMma:
+        """Fresh QK TiledMma — mutations on this instance never escape the
+        helper that constructs it, so the inner kphase loop can use
+        ``range_constexpr`` without leaking SSA values into the enclosing
+        persistent ``while`` loop in ``run()``."""
+        return sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.qk_acc_dtype,
+            tcgen05.CtaGroup.ONE,
+            self.qk_mma_tiler[:2],
+        )
+
+    @cute.jit
+    def _make_local_pv_mma(self) -> cute.TiledMma:
+        """Fresh PV TiledMma — same isolation rationale as ``_make_local_qk_mma``.
+
+        P operand source is TMEM (P comes from the QK accumulator), matching
+        ``build_fmha_launch_params``.
+        """
+        return sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            tcgen05.OperandMajorMode.K,
+            self.v_major_mode,
+            self.pv_acc_dtype,
+            tcgen05.CtaGroup.ONE,
+            self.pv_mma_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
 
     # =========================================================================
     #  Reusable primitives — no pipeline awareness, for composing new kernels
@@ -63,7 +135,6 @@ class MmaRole:
     @cute.jit
     def gemm_qk(
         self,
-        tiled_mma: cute.TiledMma,
         tStS: cute.Tensor,
         tSrQ_slice: cute.Tensor,
         tSrK_slice: cute.Tensor,
@@ -71,17 +142,19 @@ class MmaRole:
         """Single QK GEMM: S += Q * K^T with kphase unrolling.
 
         Always starts a fresh accumulation (first kphase non-accumulate).
+        Constructs and mutates a fresh local TiledMma so the unrolled
+        ``.set(ACCUMULATE, ...)`` chain dies inside this helper's frame.
         """
+        local_mma = self._make_local_qk_mma()
         num_kphases = cute.size(tSrQ_slice, mode=[2])
-        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+        for kphase_idx in cutlass.range_constexpr(num_kphases):
             coord = (None, None, kphase_idx)
-            tiled_mma.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-            cute.gemm(tiled_mma, tStS, tSrQ_slice[coord], tSrK_slice[coord], tStS)
+            local_mma.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(local_mma, tStS, tSrQ_slice[coord], tSrK_slice[coord], tStS)
 
     @cute.jit
     def gemm_pv(
         self,
-        tiled_mma: cute.TiledMma,
         tOtO: cute.Tensor,
         tOrP: cute.Tensor,
         tOrV_slice: cute.Tensor,
@@ -92,12 +165,15 @@ class MmaRole:
         Args:
             accumulate: If False, first kphase starts fresh (non-accumulate),
                        rest accumulate. If True, all kphases accumulate.
+
+        Constructs a fresh local TiledMma — see ``gemm_qk`` for rationale.
         """
+        local_mma = self._make_local_pv_mma()
         num_kphases = cute.size(tOrP, mode=[2])
-        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+        for kphase_idx in cutlass.range_constexpr(num_kphases):
             coord = (None, None, kphase_idx)
-            tiled_mma.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0 or accumulate)
-            cute.gemm(tiled_mma, tOtO, tOrP[coord], tOrV_slice[coord], tOtO)
+            local_mma.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0 or accumulate)
+            cute.gemm(local_mma, tOtO, tOrP[coord], tOrV_slice[coord], tOtO)
 
     @cute.jit
     def alloc_tmem(self, storage: cute.Tensor):
@@ -129,7 +205,6 @@ class MmaRole:
     @cute.jit
     def run(
         self,
-        qk_tiled_mma: cute.TiledMma,
         pv_tiled_mma: cute.TiledMma,
         tStS0: cute.Tensor,
         tStS1: cute.Tensor,
@@ -196,14 +271,14 @@ class MmaRole:
                 k_handle_consumer = load_kv_consumer.wait_and_advance()
                 tSrK0 = tSrK[None, None, None, k_handle_consumer.index]
                 s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                self.gemm_qk(qk_tiled_mma, tStS0, tSrQ0, tSrK0)
+                self.gemm_qk(tStS0, tSrQ0, tSrK0)
                 s0_handle_producer.commit()
 
                 # GEMM_QK10 (Q1 * K0 -> S1)
                 q1_handle_consumer = load_q_consumer.wait_and_advance()
                 tSrQ1 = tSrQ[None, None, None, q1_handle_consumer.index]
                 s1_handle_producer = mma_s1_producer.acquire_and_advance()
-                self.gemm_qk(qk_tiled_mma, tStS1, tSrQ1, tSrK0)
+                self.gemm_qk(tStS1, tSrQ1, tSrK0)
                 s1_handle_producer.commit()
                 k_handle_consumer.release()
 
@@ -213,7 +288,7 @@ class MmaRole:
                 if cutlass.const_expr(not self.has_logits_transform):
                     o0_handle_producer = mma_corr_producer.acquire_and_advance()
                 s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                self.gemm_pv(pv_tiled_mma, tOtO0, tOrP0, tOrVi, False)
+                self.gemm_pv(tOtO0, tOrP0, tOrVi, False)
                 if cutlass.const_expr(not self.has_logits_transform):
                     o0_handle_producer.commit()
 
@@ -229,26 +304,36 @@ class MmaRole:
                     - 1
                 )
 
-                pv_whether_acc = False
+                # Track the PV1 "first-iter overwrite, then accumulate" state on
+                # pv_tiled_mma's ACCUMULATE field rather than a Python bool.
+                # Stored on the TiledMma type, the cute-DSL JIT propagates the
+                # value as a per-iteration compile-time constant so the
+                # `accumulate or kphase_idx > 0` expression inside gemm_pv
+                # folds statically and each tcgen05.mma issues with its
+                # ACCUMULATE bit baked into the opcode.  A Python bool would
+                # be demoted to a runtime register through the kv loop.
+                pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
                     # GEMM_QK0i
                     k_handle_consumer = load_kv_consumer.wait_and_advance()
                     tSrKi = tSrK[None, None, None, k_handle_consumer.index]
-                    self.gemm_qk(qk_tiled_mma, tStS0, tSrQ0, tSrKi)
+                    self.gemm_qk(tStS0, tSrQ0, tSrKi)
                     s0_handle_producer.commit()
 
-                    # GEMM_PV1(i-1)
+                    # GEMM_PV1(i-1) — read the constant-folded ACCUMULATE
+                    # bit just before the call so gemm_pv sees a JIT-time bool.
                     if cutlass.const_expr(not self.has_logits_transform):
                         o1_handle_producer = mma_corr_producer.acquire_and_advance()
                     s1_handle_producer = mma_s1_producer.acquire_and_advance()
-                    self.gemm_pv(pv_tiled_mma, tOtO1, tOrP1, tOrVi, pv_whether_acc)
-                    pv_whether_acc = True
+                    pv_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                    self.gemm_pv(tOtO1, tOrP1, tOrVi, pv_acc)
+                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
                     if cutlass.const_expr(not self.has_logits_transform):
                         o1_handle_producer.commit()
                     v_handle_consumer.release()
 
                     # GEMM_QK1i
-                    self.gemm_qk(qk_tiled_mma, tStS1, tSrQ1, tSrKi)
+                    self.gemm_qk(tStS1, tSrQ1, tSrKi)
                     s1_handle_producer.commit()
                     k_handle_consumer.release()
 
@@ -258,7 +343,7 @@ class MmaRole:
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer = mma_corr_producer.acquire_and_advance()
                     s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                    self.gemm_pv(pv_tiled_mma, tOtO0, tOrP0, tOrVi, True)
+                    self.gemm_pv(tOtO0, tOrP0, tOrVi, True)
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer.commit()
 
@@ -266,11 +351,12 @@ class MmaRole:
                 q0_handle_consumer.release()
                 q1_handle_consumer.release()
 
-                # GEMM_PV1(end)
+                # GEMM_PV1(end) — same pattern: read the propagated flag.
                 if cutlass.const_expr(not self.has_logits_transform):
                     o1_handle = mma_corr_producer.acquire_and_advance()
                 s1_handle_producer = mma_s1_producer.acquire_and_advance()
-                self.gemm_pv(pv_tiled_mma, tOtO1, tOrP1, tOrVi, pv_whether_acc)
+                pv_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                self.gemm_pv(tOtO1, tOrP1, tOrVi, pv_acc)
                 if cutlass.const_expr(not self.has_logits_transform):
                     o1_handle.commit()
                 v_handle_consumer.release()

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -444,10 +444,7 @@ class SoftmaxRole:
             tSMrO.store(o_vec.to(self.o_dtype))
             cute.copy(tiled_smem_store, tSMrO, tTMEM_LOADsO_i)
 
-        cute.arch.fence_proxy(
-            cute.arch.ProxyKind.async_shared,
-            space=cute.arch.SharedSpace.shared_cta,
-        )
+        cute.arch.fence_proxy("async.shared", space="cta")
 
     # For both softmax0 and softmax1 warp group
     @cute.jit


### PR DESCRIPTION
## Summary

Two functional fixes plus two defensive refactors on the modular CuTe DSL attention kernels added in #2805:

1. **`perf(cute_dsl/mla)`** — recover a ~6.4 % geomean perf regression on FP8 MLA decode persistent (`is_var_seq=False`) versus trtllm-gen on B200, by unblocking the cute-DSL JIT's constant folding around the MMA dispatch loop. Cute-DSL now beats trtllm-gen on 9/10 of the standard `seq_len=8192, num_heads=128` configs (was 0/10).
2. **`fix(cute_dsl/attention)`** — closes [#3071](https://github.com/flashinfer-ai/flashinfer/issues/3071): the `cu13` cutlass-dsl wheel doesn't re-export `cute.arch.ProxyKind` / `cute.arch.SharedSpace` (gated upstream behind `cutlass_dsl.target_version("12.9")`), causing `AttributeError` at `correction.py:267` and `softmax.py:448` on the CI's `flashinfer-ci-cu130` image. Switching to the documented string-literal API (`fence_proxy("async.shared", space="cta")`) works on both cu12.9 and cu13 wheels and silences the existing `Passing enum member directly to SharedSpace.from_str() is deprecated` warning on cu12.9.
3. **`refactor(cute_dsl/mla)`** + **`refactor(cute_dsl/fmha)`** — apply the same fresh-local-`TiledMma` + `range_constexpr` pattern that the FP8 perf fix introduced to the BF16/FP16 MLA decode and FMHA prefill MMA roles. Wall-clock perf is unchanged for these (the back-end was already collapsing the buggy form to identical SASS for these dtypes/shapes), but the IR is cleaner and the helpers' API is consistent across all three MMA roles, protecting against future cute-DSL back-end heuristic changes that could regress one variant the way FP8 did.

## Commits

| SHA | What |
|---|---|
| `ba59eb61` | `perf(cute_dsl/mla): unblock MMA-warp constant folding for FP8 MLA decode (persistent)` |
| `4e66703c` | `refactor(cute_dsl/mla): isolate MMA-warp TiledMma mutations in BF16/FP16 helpers` |
| `6e67879d` | `refactor(cute_dsl/fmha): isolate MMA-warp TiledMma mutations in prefill helpers` |
| `e15ae4ea` | `fix(cute_dsl/attention): use string literals for fence_proxy (cu13 wheel compat)` |

## Root cause analysis (FP8 perf regression)

PR #2805 introduced two patterns in the FP8 MMA role that prevented the cute-DSL JIT from emitting an unrolled MMA dispatch loop with compile-time-constant `ACCUMULATE` bits:

1. The inner k-block loops in `_gemm_qk_latent_one_stage`, `_gemm_qk_rope_one_stage`, and `_gemm_pv_one_stage` had been switched from `cutlass.range_constexpr` to `cutlass.range`. The original PR's comment explained this as a workaround for an SSA-dominance failure: when the helper's unrolled `tiled_mma.set(ACCUMULATE, ...)` chain inlined into the persistent `while` loop, the chain rooted in the caller's `TiledMma` SSA value and the loop's back-edge couldn't pick a dominating value to thread back. The runtime-loop workaround compiles but loses tcgen05 dispatch throughput. Fixed by having each helper construct its own local `TiledMma` via `sm100_utils.make_trivial_tiled_mma(...)` and mutate that local instance only — the unrolled chain now dies inside the helper frame and `range_constexpr` is safe again. Same pattern the compute role already uses.

2. PV per-tile "first-iteration overwrite, then accumulate" state was tracked in a Python `bool` (`pv_accumulated`) reassigned inside the dynamic k_tile loop. The cute-DSL JIT demoted that bool to a runtime `i1` carried through the loop, making `accumulate or p_stage > 0` a runtime OR and forcing every PV MMA to compute its `ACCUMULATE` bit at runtime. Fixed by storing the flag on `tiled_mma_pv.set(ACCUMULATE, ...)` / `.get(ACCUMULATE)` so the field becomes type-side metadata that the JIT propagates as a per-iteration compile-time constant — same pattern the BF16 `mla_mma.py` already used.

## Verification

### FP8 MLA persistent perf (Table 1 from PR #2743's reproducer, B200, median of 3 runs, CUPTI + CUDA graph + cold L2)

| Config       | trt    | cute_base | cute_fix | sp_base | sp_fix |  cute Δ% |
| :----------- | -----: | --------: | -------: | ------: | -----: | -------: |
| B=  1, q=1   | 0.0157 |    0.0158 |   0.0161 |   1.00x |  0.99x |   +1.9 % |
| B= 32, q=1   | 0.0521 |    0.0547 |   0.0522 |   0.96x |  1.00x |   −4.7 % |
| B= 64, q=1   | 0.0784 |    0.0795 |   0.0734 |   0.99x |  1.06x |   −7.7 % |
| B=128, q=1   | 0.1448 |    0.1494 |   0.1391 |   0.97x |  1.04x |   −6.9 % |
| B=256, q=1   | 0.2890 |    0.3020 |   0.2808 |   0.94x |  1.03x |   −7.0 % |
| B=  1, q=4   | 0.0190 |    0.0189 |   0.0181 |   1.00x |  1.05x |   −3.8 % |
| B= 32, q=4   | 0.1314 |    0.1447 |   0.1257 |   0.91x |  1.05x |  −13.2 % |
| B= 64, q=4   | 0.2627 |    0.2810 |   0.2540 |   0.93x |  1.03x |   −9.6 % |
| B=128, q=4   | 0.4905 |    0.5069 |   0.4753 |   0.95x |  1.03x |   −6.2 % |
| B=256, q=4   | 1.0050 |    1.0456 |   0.9869 |   0.95x |  1.02x |   −5.6 % |
| **geomean**  |        |           |          | **0.958x** | **1.029x** | **−6.4 %** |

Geomean speedup vs trtllm-gen flipped from **0.958x → 1.029x**. cute-dsl now beats trtllm-gen on 9/10 configs.

### IR / SASS evidence (FP8 MLA persistent kernel)

| Metric | Buggy | Fixed |
| :--- | ---: | ---: |
| cubin size | 156 296 B | **126 648 B (−19 %)** |
| `UTCQMMA` (FP8 MMA dispatch) | 103 | **52 (−50 %)** |
| `BSSY` / `BSYNC` (structured-sync regions) | 88 / 88 | **6 / 6 (−93 %)** |
| `VOTEU` (warp predicate votes) | 241 | **1 (−99 %)** |
| `WARPSYNC` | 67 | **2 (−97 %)** |
| `scf.while` outer carry: TiledMma type | 0 | **1** (PV TiledMma replaces the demoted `i1`) |
| `scf.while` outer carry: `i1` (Python bool) | 2 | **0** |
| `scf.while` outer carry: `i32` | 31 | **20** (intermediate state from inner runtime loops gone) |

### Other paths (defensive refactors — unchanged perf, same as predicted)

- BF16 MLA persistent: cute geomean Δ +0.12 % (single-run noise, SASS bit-identical)
- FP8 MLA var-seq: cute geomean Δ +0.52 % (noise)
- BF16 MLA var-seq: cute geomean Δ +0.79 % (noise)
- BF16 FMHA prefill (`benchmarks/bench_blackwell_attention_cutedsl.py`): cute geomean Δ −0.31 % (noise)

### ProxyKind / cu13 wheel (verified on both wheel variants)

| Wheel | `target_version("12.9")` | `cute.arch.ProxyKind` | Pre-fix code | Post-fix code |
|---|:---:|:---:|:---:|:---:|
| **cu12.9** (`libs-base==4.4.2`) | True | exists (with deprecation warning) | passes (warning) | **passes** |
| **cu13** (`libs-base + libs-cu13==4.4.2`) | False | **AttributeError** | **fails** (#3071, exact bit-identical reproduction) | **passes** |

## Test plan

- [x] `tests/attention/test_cute_dsl_mla_decode.py` — 297 passed (cu12.9), includes 24 FP8-specific cases
- [x] `tests/attention/test_modular_fmha_prefill.py` — 159 passed, 20 skipped (cu12.9)
- [x] Same test suites on cu13 wheel — 456 passed, 20 skipped (closes #3071 cleanly)
- [x] `bench_pr2743_reproduce.py` (Tables 1-4, 3 runs each for FP8 fixed-len) — see numbers above
- [x] `benchmarks/bench_blackwell_attention_cutedsl.py` — perf flat as expected
- [x] Pre-commit (mypy, ruff, etc.) — passes for all 4 commits

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Attention path now explicitly configures operand data types at runtime for more consistent numeric behavior (including FP8 paths).
  * Matrix-multiply helpers now build local compute instances, reducing external coupling and simplifying orchestration.
  * PV accumulation logic streamlined for clearer accumulate semantics.
* **Bug Fix**
  * Tightened post-shared-memory synchronization to improve stability and determinism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->