### PR TITLE
fix(jit): decouple FLASHINFER_JIT_VERBOSE from debug compilation flags

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -413,10 +413,15 @@ def gen_jit_spec(
     needs_device_linking: bool = False,
 ) -> JitSpec:
     check_cuda_arch()
-    # Use FLASHINFER_JIT_DEBUG if set, otherwise use FLASHINFER_JIT_VERBOSE (for backward compatibility)
+    # FLASHINFER_JIT_DEBUG controls debug compilation flags (-O0, -G, etc.)
+    # FLASHINFER_JIT_VERBOSE only controls build output verbosity, not compilation flags
     debug_env = os.environ.get("FLASHINFER_JIT_DEBUG")
-    verbose_env = os.environ.get("FLASHINFER_JIT_VERBOSE", "0")
-    debug = (debug_env if debug_env is not None else verbose_env) == "1"
+    if debug_env is None and os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1":
+        logger.warning_once(
+            "FLASHINFER_JIT_VERBOSE=1 no longer enables debug compilation flags. "
+            "Use FLASHINFER_JIT_DEBUG=1 for debug builds."
+        )
+    debug = debug_env == "1"
 
     # Only add default C++ standard if not specified in extra flags
     cflags_has_std = extra_cflags is not None and any(


### PR DESCRIPTION
## Problem

Setting `FLASHINFER_JIT_VERBOSE=1` unexpectedly triggers debug compilation flags (`-O0`, `-G`, `-g`, `-lineinfo`, `--ptxas-options=-v`, `-DCUTLASS_DEBUG_TRACE_LEVEL=2`), causing **10x-100x kernel performance degradation**.

This happens because `FLASHINFER_JIT_VERBOSE` is used as a backward-compatible fallback for `FLASHINFER_JIT_DEBUG` in `gen_jit_spec()`:

```python
# Before (broken)
debug_env = os.environ.get("FLASHINFER_JIT_DEBUG")
verbose_env = os.environ.get("FLASHINFER_JIT_VERBOSE", "0")
debug = (debug_env if debug_env is not None else verbose_env) == "1"
```

Users who set `FLASHINFER_JIT_VERBOSE=1` only expect to see build logs, not to have their kernels compiled with `-O0` and device-level debugging enabled.

## Fix

Decouple the two environment variables so each has a single responsibility:

| Env Variable | Purpose |
|---|---|
| `FLASHINFER_JIT_VERBOSE=1` | Show ninja build output (no perf impact) |
| `FLASHINFER_JIT_DEBUG=1` | Enable debug compilation flags (`-O0`, `-G`, etc.) |

```python
# After (fixed)
debug = os.environ.get("FLASHINFER_JIT_DEBUG", "0") == "1"
```

## Impact

- **No breaking change** for `FLASHINFER_JIT_DEBUG` users (behavior unchanged)
- **Fixes performance regression** for `FLASHINFER_JIT_VERBOSE` users
- Users who previously relied on `FLASHINFER_JIT_VERBOSE=1` for debug builds should switch to `FLASHINFER_JIT_DEBUG=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JIT compilation no longer treats verbosity as a trigger for debug builds—debug mode now follows the designated debug setting exclusively for predictable builds.
  * When verbosity alone previously implied debug, users now receive a one-time warning clarifying that verbosity no longer enables debug compilation flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->