### PR TITLE
Fix OOB crash in intermediate_states indexing for GDN decode MTP kernel

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1095,7 +1095,7 @@ MTP_ILP_ROWS = 8  # Process 8 V-rows simultaneously per group iteration
 @cute.kernel
 def gdn_decode_bf16state_mtp_kernel(
     h0_source: cute.Tensor,  # [pool_size * HV, V, K] as BF16
-    intermediate_states: cute.Tensor,  # [pool_size * T * HV, V, K] as BF16 (or dummy)
+    intermediate_states: cute.Tensor,  # [B * T * HV, V, K] as BF16 (or dummy)
     vec_size: cutlass.Constexpr[int],
     num_v_tiles: cutlass.Constexpr[int],
     tile_v: cutlass.Constexpr[int],
@@ -2024,7 +2024,7 @@ def gdn_decode_bf16state_mtp_kernel(
 @cute.jit
 def run_gdn_decode_bf16state_mtp(
     h0_source: cute.Tensor,  # [pool_size * HV, V, K] BF16
-    intermediate_states: cute.Tensor,  # [pool_size * T * HV, V, K] BF16 (or dummy)
+    intermediate_states: cute.Tensor,  # [B * T * HV, V, K] BF16 (or dummy)
     A_log: cute.Tensor,
     a: cute.Tensor,
     dt_bias: cute.Tensor,
@@ -2524,7 +2524,7 @@ def gated_delta_rule_mtp(
         initial_state_indices: [B] int32 - indices into state pool (read)
         output_state_indices: Optional [B] int32 - indices for writing updated state.
             Defaults to initial_state_indices when None.
-        intermediate_states_buffer: Optional [pool_size, T, HV, V, K] bf16
+        intermediate_states_buffer: Optional [B, T, HV, V, K] bf16
         disable_state_update: bool - if True, don't update initial state
         scale: Optional, default 1/sqrt(K)
         output: Optional pre-allocated output tensor [B, T, HV, V] bf16

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1877,7 +1877,7 @@ def gdn_decode_bf16state_mtp_kernel(
 
                 # Write intermediate state BEFORE output shuffles (issue stores early to overlap with shuffles)
                 if cutlass.const_expr(cache_intermediate_states):
-                    flat_idx = cache_idx * T * HV + i_t * HV + i_hv
+                    flat_idx = i_n * T * HV + i_t * HV + i_hv
                     it0 = cute.local_tile(
                         intermediate_states,
                         (1, 1, vec_size),

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1813,7 +1813,7 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
     dtype_torch = getattr(torch, dtype)
     device = torch.device("cuda")
     pool_size = batch_size * pool_size_multiplier
-    
+
     with device:
         q = torch.randn(batch_size, seq_len, num_q_heads, head_size, dtype=dtype_torch)
         k = torch.randn(batch_size, seq_len, num_k_heads, head_size, dtype=dtype_torch)
@@ -1841,7 +1841,7 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
         slot_offset = pool_size - batch_size
         initial_state_indices = (
             torch.arange(batch_size, dtype=torch.int32, device=device) + slot_offset
-         )
+        )
 
     if cache_intermediate_states:
         intermediate_states_buffer = torch.zeros(
@@ -1930,7 +1930,9 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
     # Buffer is [B, T, HV, V, K]; ref is [B, T, HV, K, V] -> transpose to [B, T, HV, V, K].
     if cache_intermediate_states and intermediate_states_buffer is not None:
         ref_inter = torch.stack(ref_intermediate_states, dim=1)  # [B, T, HV, K, V]
-        ref_inter_transposed = ref_inter.transpose(-2, -1).contiguous()  # [B, T, HV, V, K]
+        ref_inter_transposed = ref_inter.transpose(
+            -2, -1
+        ).contiguous()  # [B, T, HV, V, K]
 
         atol_s = 0.02
         rtol_s = 0.01

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1787,12 +1787,18 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
     seq_len: int,
     scale: float,
     cache_intermediate_states: bool,
+    pool_size_multiplier: int = 1,
     seed: int | None = None,
 ):
     """Test MTP BF16 state kernel for T>=2.
 
     Both kernel and reference use bf16 h state.
     Tests cache_intermediate_states and disable_state_update=True.
+
+    pool_size_multiplier > 1 tests the case where pool_size > B: initial_state_indices
+    point to the upper range of the pool, and intermediate_states_buffer is sized by
+    batch_size (not pool_size). This catches the bug where the kernel indexes
+    intermediate_states by cache_idx (pool slot) instead of i_n (batch index).
     """
     _skip_if_not_sm90_or_later()
 
@@ -1806,13 +1812,13 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
     num_sab_heads = num_v_heads
     dtype_torch = getattr(torch, dtype)
     device = torch.device("cuda")
-
+    pool_size = batch_size * pool_size_multiplier
+    
     with device:
         q = torch.randn(batch_size, seq_len, num_q_heads, head_size, dtype=dtype_torch)
         k = torch.randn(batch_size, seq_len, num_k_heads, head_size, dtype=dtype_torch)
         v = torch.randn(batch_size, seq_len, num_v_heads, head_size, dtype=dtype_torch)
 
-        pool_size = batch_size
         input_state_kernel = torch.randn(
             pool_size, num_sab_heads, head_size, head_size, dtype=torch.bfloat16
         )
@@ -1829,13 +1835,17 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
         b_tensor = torch.randn(
             batch_size, seq_len, num_sab_heads, dtype=dtype_torch, device=device
         )
-        initial_state_indices = torch.arange(
-            batch_size, dtype=torch.int32, device=device
-        )
+        # When pool_size > batch_size, assign each batch entry to an upper pool slot so
+        # that cache_idx >= batch_size. An intermediate_states_buffer sized by batch_size
+        # (not pool_size) will then OOB if the kernel incorrectly uses cache_idx.
+        slot_offset = pool_size - batch_size
+        initial_state_indices = (
+            torch.arange(batch_size, dtype=torch.int32, device=device) + slot_offset
+         )
 
     if cache_intermediate_states:
         intermediate_states_buffer = torch.zeros(
-            pool_size,
+            batch_size,
             seq_len,
             num_sab_heads,
             head_size,
@@ -1868,8 +1878,9 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
 
     torch.cuda.synchronize()
 
-    # Reference: step through tokens with bf16 state
-    ref_state = input_state_ref_bf16.clone()
+    # Reference: step through tokens with bf16 state.
+    # Select only the batch entries' initial states from the pool.
+    ref_state = input_state_ref_bf16[initial_state_indices.cpu()].clone()
     ref_outputs = []
     ref_intermediate_states = []
 
@@ -1903,7 +1914,7 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
         ref_o.float(),
         atol=atol_o,
         rtol=rtol_o,
-        msg=f"Output mismatch for MTP BF16 state kernel (B={batch_size}, T={seq_len})",
+        msg=f"Output mismatch for MTP BF16 state kernel (B={batch_size}, T={seq_len}, pool_multiplier={pool_size_multiplier})",
     )
 
     # With disable_state_update=True, initial state should be unchanged
@@ -1915,15 +1926,11 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
         msg=f"State should be unchanged with disable_state_update=True (B={batch_size}, T={seq_len})",
     )
 
-    # Check intermediate states buffer contents against reference
+    # Check intermediate states buffer contents against reference.
+    # Buffer is [B, T, HV, V, K]; ref is [B, T, HV, K, V] -> transpose to [B, T, HV, V, K].
     if cache_intermediate_states and intermediate_states_buffer is not None:
-        # intermediate_states_buffer: [pool_size, T, HV, V, K] (K-last layout, bf16)
-        # ref intermediate states: [B, HV, K, V] per step (K-major layout, bf16)
-        # Stack ref: [B, T, HV, K, V], transpose to [B, T, HV, V, K] for comparison
         ref_inter = torch.stack(ref_intermediate_states, dim=1)  # [B, T, HV, K, V]
-        ref_inter_transposed = ref_inter.transpose(
-            -2, -1
-        ).contiguous()  # [B, T, HV, V, K]
+        ref_inter_transposed = ref_inter.transpose(-2, -1).contiguous()  # [B, T, HV, V, K]
 
         atol_s = 0.02
         rtol_s = 0.01
@@ -1932,15 +1939,16 @@ def _test_gdn_decode_bf16_state_mtp_kernel(
             ref_inter_transposed.float(),
             atol=atol_s,
             rtol=rtol_s,
-            msg=f"Intermediate states mismatch for MTP BF16 state kernel (B={batch_size}, T={seq_len})",
+            msg=f"Intermediate states mismatch for MTP BF16 state kernel (B={batch_size}, T={seq_len}, pool_multiplier={pool_size_multiplier})",
         )
 
     print(
         f"  BF16 state MTP PASS (batch={batch_size}, T={seq_len}, "
-        f"cache_intermediate={cache_intermediate_states})"
+        f"pool_multiplier={pool_size_multiplier}, cache_intermediate={cache_intermediate_states})"
     )
 
 
+@pytest.mark.parametrize("pool_size_multiplier", [1, 4])
 @pytest.mark.parametrize("cache_intermediate_states", [True, False])
 @pytest.mark.parametrize("seq_len", [2, 4, 8])
 @pytest.mark.parametrize("scale", ["auto"])
@@ -1961,6 +1969,7 @@ def test_gdn_decode_bf16_state_mtp_kernel(
     seq_len: int,
     scale: float | str,
     cache_intermediate_states: bool,
+    pool_size_multiplier: int,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     scale_val = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
@@ -1974,6 +1983,7 @@ def test_gdn_decode_bf16_state_mtp_kernel(
         seq_len,
         scale_val,
         cache_intermediate_states,
+        pool_size_multiplier,
         seed,
     )
 


### PR DESCRIPTION
co-authored by @YAMY1234 
## Problem

  `gdn_decode_bf16state_mtp_kernel` crashes with an out-of-bounds GPU memory write when
  `intermediate_states_buffer` is provided and `pool_size > B` with `initial_state_indices`
  pointing to upper pool slots (the normal serving scenario).

  **Affected path:** `flashinfer/gdn_kernels/gdn_decode_bf16_state.py:1873`

  \```python
   Before (wrong)
  flat_idx = cache_idx * T * HV + i_t * HV + i_hv

   After (correct)
  flat_idx = i_n * T * HV + i_t * HV + i_hv
  \```

  ## Root Cause

  When `intermediate_states` support was added to the BF16 state kernel, the author reused
  the `cache_idx`-based addressing pattern from the persistent state pool access:

  \```python
  flat_state_idx = cache_idx * HV + i_hv   # correct: h0_source is pool-scoped
  \```

  ...and extended it by analogy to add a `T` dimension for `intermediate_states`. This is
  wrong because the two buffers have different ownership semantics:

  - **`h0_source`** (the state pool) is pool-scoped — persists across decode steps, one slot
    per concurrent request in the system → correctly indexed by `cache_idx` (pool slot)
  - **`intermediate_states`** is batch-scoped — a per-forward-pass output capturing states at
    each of the T steps → should be indexed by `i_n` (batch position)

  The float32 counterpart `gdn_decode_mtp.py` has always used `i_n` correctly. The BF16
  kernel diverged when it was written.

  The bug was invisible in existing tests because they always set `pool_size = batch_size`
  with `initial_state_indices = arange(B)`, making `cache_idx == i_n` identically. The
  buggy and correct indexing produce the same result in that configuration. The docstring
  describing the buffer shape as `[pool_size, T, HV, V, K]` further reinforced the incorrect
  mental model.

  The crash only manifests in the realistic serving scenario where `pool_size >> B` and
  `initial_state_indices` contains values ≥ `B`, causing `cache_idx`-based writes to go
  beyond the end of a batch-sized buffer.

  ## Fix

  Change `cache_idx` to `i_n` at the `intermediate_states` indexing site, and update the
  docstring to reflect the correct buffer shape `[B, T, HV, V, K]` instead of
  `[pool_size, T, HV, V, K]`.

  ## Test Changes

  The existing `test_gdn_decode_bf16_state_mtp_kernel` always used `pool_size = batch_size`,
  which masked the bug entirely. Two changes are made:

  1. **`pool_size_multiplier` parameter** added to the helper
     `_test_gdn_decode_bf16_state_mtp_kernel`. When `> 1`, it sets
     `pool_size = batch_size * pool_size_multiplier` and assigns each batch entry to an upper
     pool slot (`initial_state_indices = arange(B) + pool_size - B`), so `cache_idx >= B`
     for every entry. The `intermediate_states_buffer` is allocated with `batch_size` as its
     first dimension — the semantically correct size — which is smaller than `pool_size`.
     With the buggy `cache_idx` indexing the kernel writes out of bounds and crashes; after
     the fix it produces results matching the reference.

  2. **`@pytest.mark.parametrize("pool_size_multiplier", [1, 4])`** added to the public
     test, doubling the existing matrix with a realistic pool-vs-batch configuration. The
     `pool_size_multiplier=4, cache_intermediate_states=True` cases are the ones that
     directly catch this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermediate-state indexing so cached states are written and read per batch slice consistently.

* **Tests**
  * Expanded tests to cover pool sizes larger than the batch (parameterized), including remapped indices and updated assertions for those scenarios.

* **Documentation**
  * Updated API/docs and launcher expectations to reflect the new intermediate-states buffer shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->