### PR TITLE
fix: pre-convert scale to CUDA tensor in fused_add_rmsnorm_quant bechmark

### DIFF
--- a/benchmarks/routines/norm.py
+++ b/benchmarks/routines/norm.py
@@ -563,6 +563,7 @@ def testFusedAddRmsnormQuant(args):
     residual_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
     weight = torch.randn(hidden_size, dtype=input_dtype, device=device)
     out_tensor = torch.empty(input_shape, dtype=out_dtype, device=device)
+    scale = torch.tensor([scale], dtype=torch.float32, device=device)
 
     if args.verbose >= 2:
         print(f"[VVERBOSE] {input_tensor.shape = }")

--- a/benchmarks/routines/norm.py
+++ b/benchmarks/routines/norm.py
@@ -382,6 +382,7 @@ def testRmsnormQuant(args):
     input_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
     weight = torch.randn(hidden_size, dtype=input_dtype, device=device)
     out_tensor = torch.empty(input_shape, dtype=out_dtype, device=device)
+    scale_tensor = torch.tensor([scale], dtype=torch.float32, device=device)
 
     if args.verbose >= 2:
         print(f"[VVERBOSE] {input_tensor.shape = }")
@@ -396,7 +397,7 @@ def testRmsnormQuant(args):
                 out_tensor,
                 input_tensor,
                 weight,
-                scale=scale,
+                scale=scale_tensor,
                 eps=eps,
                 enable_pdl=enable_pdl,
             )
@@ -563,7 +564,7 @@ def testFusedAddRmsnormQuant(args):
     residual_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
     weight = torch.randn(hidden_size, dtype=input_dtype, device=device)
     out_tensor = torch.empty(input_shape, dtype=out_dtype, device=device)
-    scale = torch.tensor([scale], dtype=torch.float32, device=device)
+    scale_tensor = torch.tensor([scale], dtype=torch.float32, device=device)
 
     if args.verbose >= 2:
         print(f"[VVERBOSE] {input_tensor.shape = }")
@@ -580,7 +581,7 @@ def testFusedAddRmsnormQuant(args):
                 input_tensor,
                 residual_tensor,
                 weight,
-                scale=scale,
+                scale=scale_tensor,
                 eps=eps,
                 enable_pdl=enable_pdl,
             )


### PR DESCRIPTION


<!-- .github/pull_request_template.md -->

## 📌 Description

The benchmark passed `scale` as a Python float, causing `_normalize_scale_tensor` to create a CPU tensor and copy it to CUDA inside CUDA graph capture, which is forbidden unless the tensor is pinned. Pre-convert `scale` to a CUDA tensor before the closure is captured to avoid the CPU->CUDA copy entirely.

Setting type to float32 is fine here, as `_normalize_scale_tensor` explicitly casts to float32 in `norm/__init__.py`

## 🔍 Related Issues

Fixes https://github.com/flashinfer-ai/flashinfer/issues/3149

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Note: most tests are skipped due to my GPU arch, but I think this should not impact testing infrastructure

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated RMSNorm quantization benchmarks to pass the quantization scale as a GPU tensor to the backend execution path while keeping reference validation unchanged, improving fidelity of GPU-side measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->