### PR TITLE
perf: Add no-bias path for tinygemm_bf16

### DIFF
--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -177,6 +177,7 @@ benchmark_apis = {
         "mm_mxfp8",
         "mm_bf16",
         "bmm_bf16",
+        "tinygemm_bf16",
     ],
     "moe": [
         "trtllm_fp4_block_scale_moe",
@@ -396,6 +397,18 @@ routine_cc_to_supported_backends = {
         "11.0": ["cutlass"],
         "12.0": [],
         "12.1": [],
+    },
+    "tinygemm_bf16": {
+        "7.5": [],
+        "8.0": [],
+        "8.6": [],
+        "8.9": [],
+        "9.0": ["tinygemm"],
+        "10.0": ["tinygemm"],
+        "10.3": ["tinygemm"],
+        "11.0": ["tinygemm"],
+        "12.0": ["tinygemm"],
+        "12.1": ["tinygemm"],
     },
     # Note: mm_fp4, mm_bf16, and bmm_bf16 use support checkers to filter backends, so they are not listed here
     # MOE

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -49,6 +49,8 @@ def run_gemm_test(args):
         return testMmBf16(args)
     elif args.routine == "bmm_bf16":
         return testBmmBf16(args)
+    elif args.routine == "tinygemm_bf16":
+        return testTinygemmBf16(args)
     else:
         raise ValueError(f"Unsupported routine: {args.routine}")
 
@@ -149,6 +151,7 @@ def parse_gemm_args(line, parser):
             "cute-dsl",
             "b12x",
             "auto",
+            "tinygemm",
         ],
         help="Kernel backends to test. Default: cudnn",
     )
@@ -184,6 +187,22 @@ def parse_gemm_args(line, parser):
     )
 
     args = parser.parse_args(line)
+    has_backends_arg = any(
+        token == "--backends" or token.startswith("--backends=") for token in line
+    )
+    has_input_dtype_arg = any(
+        token == "--input_dtype" or token.startswith("--input_dtype=") for token in line
+    )
+    has_mat2_dtype_arg = any(
+        token == "--mat2_dtype" or token.startswith("--mat2_dtype=") for token in line
+    )
+    if args.routine == "tinygemm_bf16":
+        if not has_backends_arg:
+            args.backends = ["tinygemm"]
+        if not has_input_dtype_arg:
+            args.input_dtype = "bfloat16"
+        if not has_mat2_dtype_arg:
+            args.mat2_dtype = "bfloat16"
     if args.verbose >= 1:
         print(f"[INFO] {args = }")
     return args
@@ -1745,6 +1764,192 @@ def testMmBf16(args):
                 cur_res["k"] = k
                 cur_res["out_dtype"] = str(out_dtype)
                 cur_res["backend"] = backend_name
+                cur_res["bias"] = use_bias
+                cur_res["enable_pdl"] = use_pdl
+                cur_res["case_tag"] = args.case_tag
+                res.append(cur_res)
+    return res
+
+
+def testTinygemmBf16(args):
+    """
+    Test tinygemm_bf16 API.
+
+    This test:
+    1. Generates random BF16 input tensors
+    2. Runs tinygemm_bf16
+    3. Runs reference check (F.linear)
+    4. Measures performance metrics (TFLOPS, TB/sec)
+
+    Args:
+        args: Parsed command line arguments containing test configuration
+
+    Returns:
+        dict: List of dictionaries containing performance results
+    """
+    if args.verbose >= 1:
+        print("[INFO] Running testTinygemmBf16")
+        print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
+
+    device = get_device(args)
+    if args.generate_repro_command:
+        print(
+            f"[INFO] To reproduce this test case, run the following command: {args.repro_command}"
+        )
+
+    backends = list(args.backends)
+    m = args.m
+    n = args.n
+    k = args.k
+    use_bias = getattr(args, "bias", False)
+    use_pdl = getattr(args, "enable_pdl", False)
+    is_cuda_graph_compatible = not args.no_cuda_graph
+    run_refcheck = args.refcheck
+    res = []
+
+    input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
+    mat2_dtype = dtype_str_to_torch_dtype(args.mat2_dtype)
+    out_dtype = dtype_str_to_torch_dtype(args.out_dtype)
+    if input_dtype != torch.bfloat16 or mat2_dtype != torch.bfloat16:
+        raise ValueError(
+            "tinygemm_bf16 only supports bfloat16 input and weight tensors."
+        )
+    if out_dtype != torch.bfloat16:
+        raise ValueError("tinygemm_bf16 only supports bfloat16 outputs.")
+
+    backends = filter_backends_by_compute_capability(backends, args.routine, device)
+    if len(backends) == 0:
+        print("[ERROR] No backends to test. Exiting.")
+        return res
+
+    from flashinfer.gemm import tinygemm_bf16
+
+    input = torch.randn([m, k], device=device, dtype=torch.bfloat16)
+    weight = torch.randn([n, k], device=device, dtype=torch.bfloat16)
+    bias = torch.randn([n], device=device, dtype=torch.bfloat16) if use_bias else None
+    outs = {
+        backend: torch.empty([m, n], device=device, dtype=torch.bfloat16)
+        for backend in backends
+    }
+
+    if args.verbose >= 2:
+        print(f"[VVERBOSE] {input.shape = }")
+        print(f"[VVERBOSE] {input.dtype = }")
+        print(f"[VVERBOSE] {weight.shape = }")
+        print(f"[VVERBOSE] {weight.dtype = }")
+        if bias is not None:
+            print(f"[VVERBOSE] {bias.shape = }")
+            print(f"[VVERBOSE] {bias.dtype = }")
+        print(f"[VVERBOSE] {use_pdl = }")
+
+    backends_to_remove = []
+    for backend in backends:
+        if backend != "tinygemm":
+            backends_to_remove.append(backend)
+            continue
+        try:
+            tinygemm_bf16(input, weight, outs[backend], bias=bias, use_pdl=use_pdl)
+        except Exception as e:
+            print(
+                f"[INFO] {backend} backend does not support this configuration: {type(e).__name__}: {e}"
+            )
+            backends_to_remove.append(backend)
+
+    for backend in backends_to_remove:
+        backends.remove(backend)
+        outs.pop(backend, None)
+
+    if len(backends) == 0:
+        print("[ERROR] No backends passed validation. Exiting.")
+        return res
+
+    def run_backend(backend, input, weight, bias, out, use_pdl):
+        if backend != "tinygemm":
+            raise ValueError(f"Unsupported backend: {backend}")
+        tinygemm_bf16(input, weight, out, bias=bias, use_pdl=use_pdl)
+        return out
+
+    has_reference_output = False
+    if run_refcheck:
+        reference_output = F.linear(
+            input.float(),
+            weight.float(),
+            bias.float() if bias is not None else None,
+        ).bfloat16()
+        has_reference_output = True
+
+    backend_times = {backend: [] for backend in backends}
+    outputs = {}
+    for cur_backend in backends:
+        if run_refcheck:
+            outputs[cur_backend] = (
+                run_backend(
+                    cur_backend, input, weight, bias, outs[cur_backend], use_pdl
+                )
+                .detach()
+                .clone()
+            )
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=run_backend,
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            sleep_after_run=True,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+            cold_l2_cache=True,
+            input_args=(cur_backend, input, weight, bias, outs[cur_backend], use_pdl),
+        )
+
+    tested_backends = list(outputs.keys())
+    tested_outputs = list(outputs.values())
+    if len(tested_backends) > 0 and run_refcheck and has_reference_output:
+        for i in range(len(tested_backends)):
+            cos_sim = F.cosine_similarity(
+                reference_output.reshape(-1).float(),
+                tested_outputs[i].reshape(-1).float(),
+                dim=0,
+            )
+            if cos_sim < 0.99:
+                print(
+                    f"[ERROR] Output tensor mismatch from backend {tested_backends[i]} with cos_sim={cos_sim}"
+                )
+                if not args.allow_output_mismatch:
+                    raise AssertionError(
+                        f"[ERROR] Backend {tested_backends[i]} output mismatch with cos_sim={cos_sim}"
+                    )
+
+    for backend in backends:
+        if len(backend_times[backend]) > 0:
+            median_time = np.median(backend_times[backend])
+            std_time = np.std(backend_times[backend])
+            problem_flops = 2 * m * n * k
+            if use_bias:
+                problem_flops += m * n
+            problem_bytes = (
+                m * k * torch.bfloat16.itemsize
+                + n * k * torch.bfloat16.itemsize
+                + m * n * torch.bfloat16.itemsize
+            )
+            if use_bias:
+                problem_bytes += n * torch.bfloat16.itemsize
+            tflops = problem_flops / (10**9 * median_time)
+            tb_per_sec = problem_bytes / (10**9 * median_time)
+            print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
+
+            if args.output_path is not None:
+                cur_res = defaultdict(str)
+                cur_res["routine"] = args.routine
+                cur_res["median_time"] = median_time
+                cur_res["std_time"] = std_time
+                cur_res["tflops"] = tflops
+                cur_res["tb_per_sec"] = tb_per_sec
+                cur_res["m"] = m
+                cur_res["n"] = n
+                cur_res["k"] = k
+                cur_res["input_dtype"] = input_dtype
+                cur_res["mat2_dtype"] = mat2_dtype
+                cur_res["out_dtype"] = out_dtype
+                cur_res["backend"] = backend
                 cur_res["bias"] = use_bias
                 cur_res["enable_pdl"] = use_pdl
                 cur_res["case_tag"] = args.case_tag

--- a/csrc/tinygemm2.cu
+++ b/csrc/tinygemm2.cu
@@ -141,7 +141,7 @@ __device__ uint32_t elect_one_sync() {
 // ============================================================================
 
 template <int WARP_TILE_M, int TILE_M, int TILE_N, int TILE_K, int STAGES, int STAGE_UNROLL,
-          bool USE_PDL = false>
+          bool USE_PDL = false, bool HAS_BIAS = true>
 __global__ __launch_bounds__(384, 1) void tinygemm_kernel(
     __nv_bfloat16* output, __nv_bfloat16* weights, __nv_bfloat16* activations, __nv_bfloat16* bias,
     int M, int N, int K, const __grid_constant__ CUtensorMap weight_map,
@@ -280,7 +280,9 @@ __global__ __launch_bounds__(384, 1) void tinygemm_kernel(
   // Compute threads
   else {
     // Sneak the bias load into the compute warps since they're just waiting
-    if (threadIdx.x < TILE_M) sh_bias[threadIdx.x] = bias[mib + threadIdx.x];
+    if constexpr (HAS_BIAS) {
+      if (threadIdx.x < TILE_M) sh_bias[threadIdx.x] = bias[mib + threadIdx.x];
+    }
 
     int stage = warp_id;
 
@@ -380,8 +382,12 @@ __global__ __launch_bounds__(384, 1) void tinygemm_kernel(
     accum[2] = accum[2] + accum1.z + accum2.z + accum3.z;
     accum[3] = accum[3] + accum1.w + accum2.w + accum3.w;
 
-    float bias_lo = __bfloat162float(sh_bias[tm - mib]);
-    float bias_hi = __bfloat162float(sh_bias[tm + 8 - mib]);
+    float bias_lo = 0.f;
+    float bias_hi = 0.f;
+    if constexpr (HAS_BIAS) {
+      bias_lo = __bfloat162float(sh_bias[tm - mib]);
+      bias_hi = __bfloat162float(sh_bias[tm + 8 - mib]);
+    }
 
     if (tn < N && tm < M) output[tn * M + tm] = __float2bfloat16(accum[0] + bias_lo);
     if (tn + 1 < N && tm < M) output[(tn + 1) * M + tm] = __float2bfloat16(accum[1] + bias_lo);
@@ -419,7 +425,7 @@ static int get_max_dynamic_smem() {
   return cached;
 }
 
-template <int STAGES>
+template <int STAGES, bool HAS_BIAS>
 void launch_tinygemm2_impl(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC,
                            __nv_bfloat16* bias, int batch_size, int output_features,
                            int input_features, cudaStream_t stream, bool use_pdl) {
@@ -472,7 +478,7 @@ void launch_tinygemm2_impl(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* 
   if (use_pdl) {
     // PDL path: use cudaLaunchKernelEx with programmatic stream serialization.
     auto status = cudaFuncSetAttribute(
-        tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, true>,
+        tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, true, HAS_BIAS>,
         cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "cudaFuncSetAttribute failed: " << cudaGetErrorString(status);
@@ -489,19 +495,20 @@ void launch_tinygemm2_impl(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* 
     config.numAttrs = 1;
 
     status = cudaLaunchKernelEx(
-        &config, &tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, true>,
+        &config,
+        &tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, true, HAS_BIAS>,
         gC, gA, gB, bias, output_features, batch_size, input_features, weight_map, activation_map);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "cudaLaunchKernelEx failed: " << cudaGetErrorString(status);
   } else {
     // Standard path: no PDL intrinsics compiled into the kernel, plain <<<>>> launch.
     auto status = cudaFuncSetAttribute(
-        tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, false>,
+        tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, false, HAS_BIAS>,
         cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "cudaFuncSetAttribute failed: " << cudaGetErrorString(status);
 
-    tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, false>
+    tinygemm_kernel<WARP_TILE_M, TILE_M, TILE_N, TILE_K, STAGES, STAGE_UNROLL, false, HAS_BIAS>
         <<<grid, block, smem_size, stream>>>(gC, gA, gB, bias, output_features, batch_size,
                                              input_features, weight_map, activation_map);
     status = cudaGetLastError();
@@ -510,6 +517,7 @@ void launch_tinygemm2_impl(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* 
   }
 }
 
+template <bool HAS_BIAS>
 void launch_tinygemm2(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC, __nv_bfloat16* bias,
                       int batch_size, int output_features, int input_features, cudaStream_t stream,
                       bool use_pdl) {
@@ -523,12 +531,12 @@ void launch_tinygemm2(__nv_bfloat16* gA, __nv_bfloat16* gB, __nv_bfloat16* gC, _
 
   // Dispatch to the largest STAGES that fits. SM90/100f typically allows 16, SM120 allows 4.
   if (max_stages >= 16) {
-    launch_tinygemm2_impl<16>(gA, gB, gC, bias, batch_size, output_features, input_features, stream,
-                              use_pdl);
+    launch_tinygemm2_impl<16, HAS_BIAS>(gA, gB, gC, bias, batch_size, output_features,
+                                        input_features, stream, use_pdl);
   } else if (max_stages >= 4) {
     // We must keep STAGES as a multiple of 4 (one slot per compute warp).
-    launch_tinygemm2_impl<4>(gA, gB, gC, bias, batch_size, output_features, input_features, stream,
-                             use_pdl);
+    launch_tinygemm2_impl<4, HAS_BIAS>(gA, gB, gC, bias, batch_size, output_features,
+                                       input_features, stream, use_pdl);
   } else {
     TVM_FFI_ICHECK(false) << "Device has insufficient shared memory for tinygemm2 kernel ("
                           << max_smem << " bytes available, minimum " << 4 * SMEM_PER_STAGE_GROUP
@@ -544,14 +552,29 @@ void tinygemm2_op(TensorView input, TensorView weight, TensorView bias, TensorVi
   int input_features = input.shape()[1];
   int output_features = weight.shape()[0];
 
-  launch_tinygemm2(reinterpret_cast<__nv_bfloat16*>(input.data_ptr()),
-                   reinterpret_cast<__nv_bfloat16*>(weight.data_ptr()),
-                   reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
-                   reinterpret_cast<__nv_bfloat16*>(bias.data_ptr()), batch_size, output_features,
-                   input_features, stream, use_pdl);
+  launch_tinygemm2<true>(reinterpret_cast<__nv_bfloat16*>(input.data_ptr()),
+                         reinterpret_cast<__nv_bfloat16*>(weight.data_ptr()),
+                         reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
+                         reinterpret_cast<__nv_bfloat16*>(bias.data_ptr()), batch_size,
+                         output_features, input_features, stream, use_pdl);
+}
+
+void tinygemm2_nobias_op(TensorView input, TensorView weight, TensorView output, bool use_pdl) {
+  auto stream = get_stream(input.device());
+
+  int batch_size = input.shape()[0];
+  int input_features = input.shape()[1];
+  int output_features = weight.shape()[0];
+
+  launch_tinygemm2<false>(reinterpret_cast<__nv_bfloat16*>(input.data_ptr()),
+                          reinterpret_cast<__nv_bfloat16*>(weight.data_ptr()),
+                          reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
+                          static_cast<__nv_bfloat16*>(nullptr), batch_size, output_features,
+                          input_features, stream, use_pdl);
 }
 
 }  // namespace tinygemm2
 }  // namespace flashinfer
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(tinygemm2_op, flashinfer::tinygemm2::tinygemm2_op);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(tinygemm2_nobias_op, flashinfer::tinygemm2::tinygemm2_nobias_op);

--- a/csrc/tinygemm2.cu
+++ b/csrc/tinygemm2.cu
@@ -160,8 +160,7 @@ __global__ __launch_bounds__(384, 1) void tinygemm_kernel(
   __shared__ barrier bar_data_consumed[STAGES];
 
   __shared__ float4 reduction_buffer[128];
-
-  __shared__ nv_bfloat16 sh_bias[TILE_M];
+  __shared__ nv_bfloat16 sh_bias[HAS_BIAS ? TILE_M : 1];
 
   if (threadIdx.x == 0) {
     for (int i = 0; i < STAGES; i++) {
@@ -382,18 +381,21 @@ __global__ __launch_bounds__(384, 1) void tinygemm_kernel(
     accum[2] = accum[2] + accum1.z + accum2.z + accum3.z;
     accum[3] = accum[3] + accum1.w + accum2.w + accum3.w;
 
-    float bias_lo = 0.f;
-    float bias_hi = 0.f;
     if constexpr (HAS_BIAS) {
-      bias_lo = __bfloat162float(sh_bias[tm - mib]);
-      bias_hi = __bfloat162float(sh_bias[tm + 8 - mib]);
-    }
+      float bias_lo = __bfloat162float(sh_bias[tm - mib]);
+      float bias_hi = __bfloat162float(sh_bias[tm + 8 - mib]);
 
-    if (tn < N && tm < M) output[tn * M + tm] = __float2bfloat16(accum[0] + bias_lo);
-    if (tn + 1 < N && tm < M) output[(tn + 1) * M + tm] = __float2bfloat16(accum[1] + bias_lo);
-    if (tn < N && tm + 8 < M) output[tn * M + tm + 8] = __float2bfloat16(accum[2] + bias_hi);
-    if (tn + 1 < N && tm + 8 < M)
-      output[(tn + 1) * M + tm + 8] = __float2bfloat16(accum[3] + bias_hi);
+      if (tn < N && tm < M) output[tn * M + tm] = __float2bfloat16(accum[0] + bias_lo);
+      if (tn + 1 < N && tm < M) output[(tn + 1) * M + tm] = __float2bfloat16(accum[1] + bias_lo);
+      if (tn < N && tm + 8 < M) output[tn * M + tm + 8] = __float2bfloat16(accum[2] + bias_hi);
+      if (tn + 1 < N && tm + 8 < M)
+        output[(tn + 1) * M + tm + 8] = __float2bfloat16(accum[3] + bias_hi);
+    } else {
+      if (tn < N && tm < M) output[tn * M + tm] = __float2bfloat16(accum[0]);
+      if (tn + 1 < N && tm < M) output[(tn + 1) * M + tm] = __float2bfloat16(accum[1]);
+      if (tn < N && tm + 8 < M) output[tn * M + tm + 8] = __float2bfloat16(accum[2]);
+      if (tn + 1 < N && tm + 8 < M) output[(tn + 1) * M + tm + 8] = __float2bfloat16(accum[3]);
+    }
   }
 #endif  // __CUDA_ARCH__ >= 900
 }

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -305,7 +305,22 @@ def get_tinygemm2_module():
     ) -> None:
         module.tinygemm2_op(input, weight, bias, out, use_pdl)
 
-    return SimpleNamespace(tinygemm2_op=tinygemm2_op_impl)
+    @register_custom_op(
+        "flashinfer::tinygemm2_nobias_op",
+        mutates_args=["out"],
+    )
+    def tinygemm2_nobias_op_impl(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        out: torch.Tensor,
+        use_pdl: bool = False,
+    ) -> None:
+        module.tinygemm2_nobias_op(input, weight, out, use_pdl)
+
+    return SimpleNamespace(
+        tinygemm2_op=tinygemm2_op_impl,
+        tinygemm2_nobias_op=tinygemm2_nobias_op_impl,
+    )
 
 
 @backend_requirement({}, common_check=_tinygemm_bf16_shape_checks)
@@ -351,5 +366,6 @@ def tinygemm_bf16(
         This kernel requires SM90+ (Hopper or newer).
     """
     if bias is None:
-        bias = torch.zeros(weight.shape[0], dtype=torch.bfloat16, device=input.device)
-    get_tinygemm2_module().tinygemm2_op(input, weight, bias, out, use_pdl)
+        get_tinygemm2_module().tinygemm2_nobias_op(input, weight, out, use_pdl)
+    else:
+        get_tinygemm2_module().tinygemm2_op(input, weight, bias, out, use_pdl)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

This PR updates tinygemm_bf16 to use a dedicated no-bias kernel path when `bias=None`, **avoiding the previous zero-bias materialization in the Python wrapper**. It also adds shared benchmark-harness support and benchmark smoke coverage for `tinygemm_bf16`, while keeping the branch scoped to BF16-only changes.

If you want, I can also turn that into a full PR body with Summary and Test plan sections.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BF16 GEMM routine with benchmarking and optional correctness validation.
  * Added a no-bias GEMM variant to run without requiring a bias tensor.

* **Performance**
  * Reduced overhead when bias is absent by avoiding unnecessary bias allocation.

* **Compatibility**
  * BF16 routine is available only on supported GPU backends/architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->