### PR TITLE
fix: pass skip_softmax_threshold_scale_factor to prefill wrapper in test

### DIFF
--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -849,6 +849,7 @@ def _test_trtllm_batch_prefill(
             v_scale=v_scale / o_scale,
             enable_pdl=enable_pdl,
             sinks=(sink if enable_sink else None),
+            skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
         )
         # v_scale, o_scale in wrapper is emulated by multiplying output by v_scale instead of fused into kernel.
         if v_scale == o_scale == 1.0:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The wrapper consistency check in _test_trtllm_batch_prefill was calling wrapper_trtllm_gen.run() without skip_softmax_threshold_scale_factor, causing it to default to None (standard attention kernel) while the raw API used 1e-30 (skipsSoftmax kernel variant). Different cubin kernels produce bit-different results, failing the exact-equality assert.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3029

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test to verify that prefill execution respects the softmax-skip threshold configuration, ensuring backend and reference execution paths align.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Re-opening of #3075 which was closed by accident. The decode counterpart was already fixed in main via #2959; this PR applies the equivalent fix to the prefill wrapper consistency check.
