### PR TITLE
CICD bug fix: ensure data/ symlinks exist before jit-cache AOT compilation

### DIFF
--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -79,6 +79,18 @@ _create_build_metadata()
 
 def _compile_jit_cache(output_dir: Path, verbose: bool = True):
     """Compile AOT modules using flashinfer.aot functions directly."""
+    # Ensure flashinfer/data/ symlinks exist (normally created by the main
+    # package's build_backend, but jit-cache builds may not install the main
+    # package first). Use importlib to avoid name collision with this file.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "main_build_backend", Path(__file__).parent.parent / "build_backend.py"
+    )
+    main_build_backend = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(main_build_backend)
+    main_build_backend._create_data_dir(use_symlinks=True)
+
     from flashinfer import aot
 
     # Get the project root directory


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The jit-cache wheel build (`scripts/build_flashinfer_jit_cache_whl.sh`) runs `python -m build --wheel` without first installing the main flashinfer package. The AOT compilation imports flashinfer directly from the source tree, but the `flashinfer/data/` symlinks are never created because the main `build_backend._create_data_dir()` is never called.
This wasn't a problem before the CCCL submodule because CUTLASS/spdlog headers are self-contained — there's no CTK-bundled copy to shadow them. CCCL is different: the CTK also ships CCCL headers at `$cuda_home/include/`, so when the vendored `data/cccl` symlink is missing, `#include <cuda/cmath>` silently falls through to the CTK copy, which on older toolkits doesn't have `cuda::fast_mod_div`.

Call the main build_backend._create_data_dir() before importing flashinfer.aot to ensure all symlinks are in place.

Made-with: Cursor

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3159

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the JIT cache build now initializes required filesystem layout and data directories before compilation so builds succeed even when the package hasn't been previously installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->