### PR TITLE
fix: remove over-strict K%4 assert in get_shuffle_matrix_sf_a_row_indices

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -877,12 +877,7 @@ def get_shuffle_matrix_sf_a_row_indices(
     # M, K from the input
     M, K = input_tensor.shape
     assert M % 128 == 0
-    # K % 4 alignment is not required here: this function only computes row
-    # permutation indices over the M dimension and never uses K. The downstream
-    # block_scale_interleave kernel pads K to a multiple of 4 internally via
-    # _compute_swizzled_layout_sf_size. Allows non-aligned K (e.g. K=90 in
-    # GPT-OSS-120B MXFP4 weights).
-
+    # K % 4 alignment is not required here, downstream block_scale_interleave kernel pads K to a multiple of 4 internally
     row_indices = get_shuffle_matrix_a_row_indices(input_tensor, epilogue_tile_m)
 
     return row_indices

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -877,7 +877,11 @@ def get_shuffle_matrix_sf_a_row_indices(
     # M, K from the input
     M, K = input_tensor.shape
     assert M % 128 == 0
-    assert K % 4 == 0
+    # K % 4 alignment is not required here: this function only computes row
+    # permutation indices over the M dimension and never uses K. The downstream
+    # block_scale_interleave kernel pads K to a multiple of 4 internally via
+    # _compute_swizzled_layout_sf_size. Allows non-aligned K (e.g. K=90 in
+    # GPT-OSS-120B MXFP4 weights).
 
     row_indices = get_shuffle_matrix_a_row_indices(input_tensor, epilogue_tile_m)
 

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -880,7 +880,11 @@ def get_shuffle_matrix_sf_a_row_indices(
     # M, K from the input
     M, K = input_tensor.shape
     assert M % 128 == 0
-    assert K % 4 == 0
+    # K % 4 alignment is not required here: this function only computes row
+    # permutation indices over the M dimension and never uses K. The downstream
+    # block_scale_interleave kernel pads K to a multiple of 4 internally via
+    # _compute_swizzled_layout_sf_size. Allows non-aligned K (e.g. K=90 in
+    # GPT-OSS-120B MXFP4 weights).
 
     row_indices = get_shuffle_matrix_a_row_indices(input_tensor, epilogue_tile_m)
 

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -880,12 +880,7 @@ def get_shuffle_matrix_sf_a_row_indices(
     # M, K from the input
     M, K = input_tensor.shape
     assert M % 128 == 0
-    # K % 4 alignment is not required here: this function only computes row
-    # permutation indices over the M dimension and never uses K. The downstream
-    # block_scale_interleave kernel pads K to a multiple of 4 internally via
-    # _compute_swizzled_layout_sf_size. Allows non-aligned K (e.g. K=90 in
-    # GPT-OSS-120B MXFP4 weights).
-
+    # K % 4 alignment is not required here, downstream block_scale_interleave kernel pads K to a multiple of 4 internally
     row_indices = get_shuffle_matrix_a_row_indices(input_tensor, epilogue_tile_m)
 
     return row_indices


### PR DESCRIPTION
## Summary

Removes the `assert K % 4 == 0` guard from `get_shuffle_matrix_sf_a_row_indices` in `flashinfer/utils.py`. The assertion rejects valid inputs (e.g. `K=90` for GPT-OSS-120B MXFP4 weights), even though the downstream kernel handles them correctly.

**Why it's safe to remove:**
- `get_shuffle_matrix_sf_a_row_indices` only computes row permutation indices over the **M dimension**. K is unpacked from the shape but never used.
- K is padded up to a multiple of 4 in the downstream path:
  - **C++ launcher** (`csrc/nv_internal/tensorrt_llm/thop/fp4Op.cpp:197`): `cols_padded = PadUpFn(cols, 4)` and passes `n_padded` to the kernel.
  - **CUDA kernel** (`csrc/nv_internal/cpp/kernels/quantization.cu:400-418`): loops up to `numColsPadded`, writes `0` for padded slots (`T sf = 0; if (colIdx < numCols) sf = SFIn[...];`).
  - **Python** (`flashinfer/quantization/fp4_quantization.py:51-54, 297-304`): `_compute_swizzled_layout_sf_size` uses `round_up(total_column, 4)` to size the output buffer to match.

Fixes #2122.

## Test plan

- [ ] Verify `get_shuffle_matrix_sf_a_row_indices` succeeds for `K=90` (the GPT-OSS-120B case that triggered the original assertion).
- [ ] Verify `K=1`, `K=4`, `K=88` (previously valid) still return correct row indices.
- [ ] Verify the full `shuffle_matrix_sf_a` pipeline (row shuffle → `block_scale_interleave`) produces correctly-sized outputs for non-aligned K.
- [ ] Run the GPT-OSS-120B MXFP4 MoE repro from #2122 and confirm it no longer asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Relaxed a strict precondition on matrix dimensions: the system now accepts sizes previously rejected and relies on internal padding/alignment handled downstream, improving compatibility and reducing manual configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3163)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->