### PR TITLE
fix(gdn): address remaining CodeRabbit feedback from #3001

### DIFF
--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -269,23 +269,8 @@ def chunk_gated_delta_rule(
             device=q.device,
         )
 
-    # Allocate output_state if needed
-    if output_final_state and output_state is None:
-        output_state = torch.empty(
-            (num_seqs, num_sab_heads, head_size, head_size),
-            dtype=torch.float32,
-            device=q.device,
-        )
-    elif not output_final_state and output_state is None:
-        # Still need to allocate since kernel always writes state
-        output_state = torch.empty(
-            (num_seqs, num_sab_heads, head_size, head_size),
-            dtype=torch.float32,
-            device=q.device,
-        )
-
     device = q.device
-    _scale = scale if scale is not None else 1.0 / math.sqrt(head_size)
+    _scale = scale if scale is not None and scale != 0.0 else 1.0 / math.sqrt(head_size)
 
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
     if _has_blackwell_prefill and is_sm100a_supported(device) and _cuda_major >= 13:
@@ -293,6 +278,16 @@ def chunk_gated_delta_rule(
         assert head_size == 128, (
             f"Blackwell GDN prefill requires head_size=128, got {head_size}"
         )
+
+        # Allocate output_state only when needed
+        if not output_final_state:
+            output_state = None
+        elif output_state is None:
+            output_state = torch.empty(
+                (num_seqs, num_sab_heads, head_size, head_size),
+                dtype=torch.float32,
+                device=device,
+            )
 
         _g = (
             g
@@ -323,7 +318,7 @@ def chunk_gated_delta_rule(
             output,
             cu_seqlens.to(torch.int32),
             initial_state,
-            output_state if output_final_state else None,
+            output_state,
             _scale,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             cu_checkpoints=_cu_checkpoints,
@@ -331,6 +326,13 @@ def chunk_gated_delta_rule(
         )
     else:
         # SM90 Hopper path (C++ JIT kernel)
+        if output_state is None:
+            output_state = torch.empty(
+                (num_seqs, num_sab_heads, head_size, head_size),
+                dtype=torch.float32,
+                device=device,
+            )
+
         workspace_size = get_device_sm_count(device) * 128
         workspace_buffer = _get_cache_buf(
             "gdn_prefill_workspace", workspace_size, device
@@ -346,7 +348,7 @@ def chunk_gated_delta_rule(
             initial_state,
             g,
             beta,
-            scale if scale is not None else 0.0,
+            _scale,
             workspace_buffer,
             state_checkpoints,
             checkpoint_cu_starts.to(torch.int64)


### PR DESCRIPTION
## 📌 Description

Addresses the two remaining CodeRabbit findings on [#3001](https://github.com/flashinfer-ai/flashinfer/pull/3001) that weren't applied before merge:

* **Normalize `scale=0.0` to the default `1/sqrt(d_k)`** before backend dispatch so the same call gives matching numerics on SM90 and SM100. The SM90 C++ kernel treats `0.0` as a sentinel for "use default", but the SM100 CuTe-DSL kernel forwarded the literal `0.0` → zeroed QK → broken attention.

* **Don't eagerly allocate `output_state`** on the SM100 path when `output_final_state=False`. The CuTe-DSL kernel drops the buffer anyway, so the old code wasted a full `[num_seqs, H, 128, 128]` float32 scratch per call. SM90 still allocates unconditionally because its C++ kernel always writes into `output_state`.

Dispatcher callsites now pass `output_state` directly on both branches (no inline `output_state if output_final_state else None`), so SM90 and SM100 read identically.


## 🔍 Related Issues

* [[feat] Add blackwell GDN prefill kernel](https://github.com/flashinfer-ai/flashinfer/pull/3001)
* [fix(gdn): use physical SM count for SM100 persistent prefill kernel#3155](https://github.com/flashinfer-ai/flashinfer/pull/3155)
* [[fix] fix blackwell gdn accuracy issue#3156](https://github.com/flashinfer-ai/flashinfer/pull/3156)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scale parameter handling to correctly interpret explicit values and apply default scaling behavior.
  * Improved memory efficiency by avoiding unnecessary state allocations in certain configurations.

* **Improvements**
  * Enhanced consistency in kernel invocation logic across different hardware architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->