### PR TITLE
Refactor Part 3- Add block-per-token feature in the customized routing method

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -806,8 +806,20 @@ void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Block dimension for routingIndicesBlockScoresKernel.  Chosen so that:
+//   - __launch_bounds__ can reserve the per-thread register budget
+//     (each SM then fits 2 blocks at 64 regs/thread, the measured sweet spot).
+//   - SoftmaxPreprocess::applyToSmem<kBlockDim> can size its cub::BlockReduce
+//     temp storage at compile time.
+// The value is kept as a compile-time constant (rather than a runtime
+// parameter) so the kernel and its launcher share a single source of truth;
+// the internal Softmax path would not function correctly if the actual
+// blockDim.x disagreed with this value.
+constexpr int kBlockScoresKernelBlockDim = 256;
+
 template <typename KernelParams>
-__global__ void __launch_bounds__(256) routingIndicesBlockScoresKernel(KernelParams params) {
+__global__ void __launch_bounds__(kBlockScoresKernelBlockDim)
+    routingIndicesBlockScoresKernel(KernelParams params) {
   using OutputT = typename KernelParams::OutputT;
   using InputT = typename KernelParams::InputT;
   using ExpertSelect = typename KernelParams::ExpertSelectPolicy;
@@ -861,7 +873,10 @@ __global__ void __launch_bounds__(256) routingIndicesBlockScoresKernel(KernelPar
     auto block = cg::this_thread_block();
     auto warp = cg::tiled_partition<WarpSize>(block);
     int32_t const laneIdx = cutlass::arch::LaneId();
-    int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
+    // blockDim.x is always kBlockScoresKernelBlockDim (a multiple of WarpSize),
+    // so `threadIdx.x / WarpSize` is already uniform within a warp — no
+    // `__shfl_sync` broadcast needed.
+    int32_t const warpIdx = threadIdx.x / WarpSize;
     int32_t const tokenIdx = blockIdx.x;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -888,9 +903,11 @@ __global__ void __launch_bounds__(256) routingIndicesBlockScoresKernel(KernelPar
     if constexpr (std::is_same_v<PreProc, SoftmaxPreprocess>) {
       // Softmax needs block-level reductions; pass the block size as a template
       // parameter so it can construct cub::BlockReduce with the right size.
-      PreProc::template applyToSmem<256>(block, params.mPtrScores + scoreBase, params.mNumExperts,
-                                         smemBiased, auxPtr,
-                                         params.mExpertSelectParams.mPreprocessParams);
+      // We rely on kBlockScoresKernelBlockDim matching the actual launch
+      // blockDim.x — enforced by the launcher below.
+      PreProc::template applyToSmem<kBlockScoresKernelBlockDim>(
+          block, params.mPtrScores + scoreBase, params.mNumExperts, smemBiased, auxPtr,
+          params.mExpertSelectParams.mPreprocessParams);
     } else {
       PreProc::applyToSmem(block, params.mPtrScores + scoreBase, params.mNumExperts, smemBiased,
                            auxPtr, params.mExpertSelectParams.mPreprocessParams);
@@ -940,12 +957,14 @@ __global__ void __launch_bounds__(256) routingIndicesBlockScoresKernel(KernelPar
   }  // end `if constexpr (kSupported)` else branch
 }
 
-void launchBlockScoresKernel(Data const& data, uint32_t blockDimX, void* stream) {
+void launchBlockScoresKernel(Data const& data, void* stream) {
   // Custom dispatch that does NOT clamp blockDim to the dispatched tier's
-  // expert count (unlike `LAUNCH_ROUTING_CUSTOM`).  This kernel's layout (256
-  // threads with a grid-stride loop over experts) is decoupled from
-  // MaxNumExperts — oversizing blockDim would waste registers and shrink
-  // occupancy.
+  // expert count (unlike `LAUNCH_ROUTING_CUSTOM`).  The kernel's layout —
+  // kBlockScoresKernelBlockDim threads with a grid-stride loop over experts —
+  // is decoupled from MaxNumExperts; oversizing blockDim would waste
+  // registers and shrink occupancy.  The blockDim is intentionally fixed to
+  // the kernel-side constant so host and device agree (SoftmaxPreprocess
+  // sizes its cub::BlockReduce with the same value at compile time).
   dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* policyName_) {
     using PreProc_ = decltype(preProc_);
     using PostProc_ = decltype(postProc_);
@@ -954,7 +973,7 @@ void launchBlockScoresKernel(Data const& data, uint32_t blockDimX, void* stream)
         dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {
           LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/false, routingIndicesBlockScoresKernel,
                                        /*gridDim=*/data.mNumTokens,
-                                       /*blockDim=*/blockDimX,
+                                       /*blockDim=*/kBlockScoresKernelBlockDim,
                                        /*smemSize=*/0, stream, PreProc_, PostProc_,
                                        decltype(eTag_)::value, decltype(kTag_)::value);
         });
@@ -1189,6 +1208,16 @@ void run(Data const& data, void* stream) {
         << "When #tokens is large, `mPtrTopKPacked` is a required input.";
     TVM_FFI_ICHECK(data.mPtrExpertCounts != nullptr)
         << "When #tokens is large, `mPtrExpertCounts` is a required input.";
+  } else if (useSplitTopKPath) {
+    // BlockScoresKernel unconditionally writes topK results to mPtrTopKPacked
+    // (the downstream runPostTopKPipeline then reads it as pre-computed topK).
+    // Unlike the large-BS path above, this branch is gated on useSingleCluster,
+    // so we need a separate check here.  mPtrExpertCounts has its own
+    // `nullptr` guard inside the kernel (histogram reset), so it remains
+    // optional and doesn't need a check.
+    TVM_FFI_ICHECK(data.mPtrTopKPacked != nullptr)
+        << "The block-per-token split path requires `mPtrTopKPacked` to be non-null "
+           "(BlockScoresKernel writes the topK result into it).";
   }
 
   uint32_t const numThreadsHist =
@@ -1200,23 +1229,23 @@ void run(Data const& data, void* stream) {
   if (useSplitTopKPath) {
     // Step 1: scores → mPtrTopKPacked via a block-per-token kernel that
     // mirrors TRT-LLM's deepseek_v3_topk_kernel (no-groups path) layout:
-    //   - One block per token, 256 threads per block.
+    //   - One block per token, kBlockScoresKernelBlockDim threads per block.
     //   - Block-parallel preprocess (via PreprocessPolicy::applyToSmem).
     //   - Warp 0 alone does the sort-based reduceTopK<K, N=ceil(E/32)> plus
     //     the postprocess (via PostprocessPolicy::applyWithAux).
     //   - Only warp 0 holds the K-sized register arrays, so per-block
     //     register pressure stays low and occupancy high.
     //
-    // Why 256 threads: larger blocks (e.g. 512) would reserve the ~99-register
-    // budget across more threads and limit occupancy to 1 block/SM.  256
-    // threads gives 2 blocks/SM with the same per-warp workload, doubling
-    // arithmetic throughput during the preprocess phase.  For E=512 the
-    // grid-stride loop iterates 2× per thread; for E<=256 it iterates once.
+    // Why 256 threads (kBlockScoresKernelBlockDim): larger blocks (e.g. 512)
+    // would reserve the ~99-register budget across more threads and limit
+    // occupancy to 1 block/SM.  256 threads gives 2 blocks/SM with the same
+    // per-warp workload, doubling arithmetic throughput during the preprocess
+    // phase.  For E=512 the grid-stride loop iterates 2× per thread; for
+    // E<=256 it iterates once.
     //
     // The kernel is generic in (PreprocessPolicy, PostprocessPolicy) — any
     // registered policy pair in RoutingCustomPolicy.cuh works here.
-    constexpr uint32_t kBlockScoresThreads = 256;
-    launchBlockScoresKernel(mutableData, kBlockScoresThreads, stream);
+    launchBlockScoresKernel(mutableData, stream);
 
     // Step 2: delegate the permutation pipeline to runPostTopKPipeline, which
     //   will pick the cluster kernel (LoadExpertIdxFromGlobal=true branch) for
@@ -1279,8 +1308,7 @@ void run(Data const& data, void* stream) {
       useBlockScoresForTopK = false;
     }
     if (useBlockScoresForTopK) {
-      constexpr uint32_t kBlockScoresThreads = 256;
-      launchBlockScoresKernel(mutableData, kBlockScoresThreads, stream);
+      launchBlockScoresKernel(mutableData, stream);
     } else {
       launchHistogramScoresKernel(mutableData, maxNumBlocks, numThreadsHist, stream);
     }

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -1188,12 +1188,12 @@ void run(Data const& data, void* stream) {
   // interface?  Queried via PolicyPairSupportsBlockPerToken — policies that
   // don't opt in (no applyToSmem / applyWithAux specialisation) will force
   // this branch to false and fall back to the fused single-cluster kernel.
-  bool policySupportsBlockPerToken = false;
-  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* /*policyName*/) {
-    using PreProc_ = decltype(preProc_);
-    using PostProc_ = decltype(postProc_);
-    policySupportsBlockPerToken = PolicyPairSupportsBlockPerToken<PreProc_, PostProc_>::value;
-  });
+  bool const policySupportsBlockPerToken = queryPolicySupportsBlockPerToken(data);
+  if (forceMode == ForceMode::kOn && !policySupportsBlockPerToken) {
+    FLASHINFER_WARN(
+        "FLASHINFER_ROUTING_FORCE_BLOCK_PER_TOKEN is set but the active routing policy does not "
+        "support block-per-token; the request is ignored.");
+  }
 
   bool useSplitTopKPath = useSingleCluster && !useSingleBlock && policySupportsBlockPerToken &&
                           (data.mNumExperts >= NumExperts160Experts);

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -26,6 +26,9 @@
 //   6. routingIndicesHistogramKernel  — histogram from packed TopK (defined in RoutingKernel.cuh)
 //   7. routingIndicesOffsetsKernel    — prefix-scan + permutation (defined in RoutingKernel.cuh)
 
+#include <cstdlib>
+#include <string>
+
 #include "flashinfer/trtllm/common/cudaUtils.h"
 #include "flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh"
 #include "tvm_ffi_utils.h"
@@ -774,6 +777,198 @@ void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
+// 3b. BlockScores kernel — one block per token, block-parallel preprocess + warp-0 sort-based topK.
+//
+// Motivation: for small numTokens with high topK (e.g. Nemotron Super V3:
+// BS<=256, E=512, K=22), the per-warp-per-token `routingIndicesHistogramScoresKernel`
+// suffers from (a) high register pressure — *every* warp in a block carries
+// the K-sized topK arrays (~99 regs/thread → 25% occupancy), and (b) low
+// arithmetic intensity per warp during preprocess (each lane redundantly
+// processes VecSize=MaxNumExperts/32 experts into registers).
+//
+// This kernel instead mirrors the design used by the no-groups path of
+// TRT-LLM's `deepseek_v3_topk_kernel`:
+//   Phase 1: parallelise the preprocess across all threads via a grid-stride
+//            loop (PreprocessPolicy::applyToSmem), writing per-expert topK
+//            key (and optional aux data) into smem.
+//   Phase 2: warp 0 alone does the topK via a sort-based reduceTopK with
+//            N = ceil(MaxNumExperts / WarpSize) elements per lane.
+//   Phase 3: warp 0 applies the postprocess (PostprocessPolicy::applyWithAux),
+//            in-place modifying topScores.
+// Only warp 0 carries the K-sized register arrays, so per-block register
+// pressure stays low (~64 regs/thread) and occupancy rises to 2 blocks/SM.
+//
+// The kernel is generic in (PreprocessPolicy, PostprocessPolicy).  The
+// auxiliary smem array is only allocated when the policy pair requires it
+// (today: only ScaledSumNormalizePostprocess — see PolicyPairNeedsAux trait
+// in RoutingCustomPolicy.cuh).  Otherwise, the "aux" pointer aliases the
+// "biased" pointer and no extra smem is reserved.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void __launch_bounds__(256) routingIndicesBlockScoresKernel(KernelParams params) {
+  using OutputT = typename KernelParams::OutputT;
+  using InputT = typename KernelParams::InputT;
+  using ExpertSelect = typename KernelParams::ExpertSelectPolicy;
+  using PreProc = typename ExpertSelect::PreprocessPolicy;
+  using PostProc = typename ExpertSelect::PostprocessPolicy;
+  using BaseType = typename ExpertSelect::template BaseType<InputT>;
+
+  static constexpr int MaxNumExperts = KernelParams::MaxNumExperts;
+  static constexpr int MaxNumTopExperts = KernelParams::MaxNumTopExperts;
+  // One chunk per warp lane — each lane of warp 0 holds NumChunks experts.
+  // For E=512 this is 16; for E=1024 it's 32; for E=2048 it's 64 — which hits
+  // Sort<N>'s 64-element cap (the static_assert inside topk::reduceTopK).
+  static constexpr int NumChunks = (MaxNumExperts + WarpSize - 1) / WarpSize;
+
+  // Compile-time opt-out: the macro dispatch instantiates this kernel across
+  // every (PreProc, PostProc, tier) combination, but we only emit a real
+  // kernel body for policy pairs that implement the block-per-token interface
+  // (PolicyPairSupportsBlockPerToken<PreProc, PostProc>::value).  For the
+  // other instantiations we emit an empty kernel body.  These instantiations
+  // are never reached at runtime because `run()` gates the host-side launch
+  // on the same trait check, but compiling them as no-ops keeps this kernel
+  // generic across the whole policy matrix.
+  //
+  // The expert count is bounded by Sort<N>'s N ≤ 64 cap, i.e. MaxNumExperts
+  // ≤ 64 * WarpSize = 2048.  This matches `MaxSupportedExperts` in
+  // RoutingCustomPolicy.cuh, so every tier declared in `PolicyTraits` fits
+  // and no extra guard is needed here.
+  static constexpr bool kSupported = PolicyPairSupportsBlockPerToken<PreProc, PostProc>::value;
+  static_assert(NumChunks <= 64,
+                "routingIndicesBlockScoresKernel: MaxNumExperts must be <= 64 * WarpSize = 2048 "
+                "(Sort<N>'s upper bound inside topk::reduceTopK)");
+  if constexpr (!kSupported) {
+    return;
+  } else {
+    // Allocate smemAux only when the postprocess actually reads it.  For every
+    // other (pre, post) combination we save MaxNumExperts × 4 B of smem by
+    // letting `auxPtr` alias `smemBiased`.
+    static constexpr bool kNeedsAux = PolicyPairNeedsAux<PreProc, PostProc>::value;
+    static constexpr int kAuxSize = kNeedsAux ? MaxNumExperts : 1;
+
+    static constexpr float invalidScoreFloat = -INFINITY;
+
+    // Per-expert smem arrays:
+    //   smemBiased[e] = topK selection key for expert e
+    //   smemAux[e]    = auxiliary data for expert e (only used / written when
+    //                   PolicyPairNeedsAux<PreProc, PostProc>::value is true)
+    __shared__ BaseType __attribute((aligned(128))) smemBiased[MaxNumExperts];
+    __shared__ BaseType __attribute((aligned(128))) smemAuxStorage[kAuxSize];
+    BaseType* auxPtr = kNeedsAux ? smemAuxStorage : smemBiased;
+
+    auto block = cg::this_thread_block();
+    auto warp = cg::tiled_partition<WarpSize>(block);
+    int32_t const laneIdx = cutlass::arch::LaneId();
+    int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
+    int32_t const tokenIdx = blockIdx.x;
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    if (params.mUsePdl) {
+      cudaGridDependencySynchronize();
+    }
+#endif
+
+    // Reset `mPtrExpertCounts` (histogram needed by the downstream coop /
+    // multi-kernel permutation paths).  Block 0 does this across its threads;
+    // other blocks skip to avoid redundant writes.  Size is 2*numExperts (the
+    // array is used both for the final histogram and the tile-offset histogram).
+    if (blockIdx.x == 0 && params.mPtrExpertCounts != nullptr) {
+      int32_t const expertCountsNum = 2 * params.mNumExperts;
+      for (int i = threadIdx.x; i < expertCountsNum; i += blockDim.x) {
+        params.mPtrExpertCounts[i] = 0;
+      }
+    }
+
+    // Phase 1: block-parallel preprocess.  Dispatches on PreProc so the kernel
+    // works for all registered preprocess policies (single-pass NoOp / Sigmoid /
+    // SigmoidBias, two-pass Softmax).
+    int64_t const scoreBase = int64_t{tokenIdx} * int64_t{params.mNumExperts};
+    if constexpr (std::is_same_v<PreProc, SoftmaxPreprocess>) {
+      // Softmax needs block-level reductions; pass the block size as a template
+      // parameter so it can construct cub::BlockReduce with the right size.
+      PreProc::template applyToSmem<256>(block, params.mPtrScores + scoreBase, params.mNumExperts,
+                                         smemBiased, auxPtr,
+                                         params.mExpertSelectParams.mPreprocessParams);
+    } else {
+      PreProc::applyToSmem(block, params.mPtrScores + scoreBase, params.mNumExperts, smemBiased,
+                           auxPtr, params.mExpertSelectParams.mPreprocessParams);
+    }
+
+    __syncthreads();
+
+    // Phase 2: warp-0 sort-based topK over NumChunks elements per lane.
+    // Warps 1..N-1 are done and can exit; only warp 0 carries the K-sized
+    // register arrays from here on.
+    if (warpIdx != 0) {
+      return;
+    }
+
+    BaseType localScores[NumChunks];
+    int32_t localIdx[NumChunks];
+#pragma unroll
+    for (int ii = 0; ii < NumChunks; ++ii) {
+      int const eIdx = ii * WarpSize + laneIdx;
+      localIdx[ii] = eIdx;
+      localScores[ii] = eIdx < params.mNumExperts ? smemBiased[eIdx] : BaseType{invalidScoreFloat};
+    }
+
+    BaseType topScores[MaxNumTopExperts];
+    int32_t topExperts[MaxNumTopExperts];
+    topk::reduceTopK(warp, topScores, topExperts, localScores, localIdx,
+                     /*minValue=*/BaseType{invalidScoreFloat}, params.mTopK);
+
+    // Phase 3: postprocess.  Reads the per-expert aux data (if the policy needs
+    // it) and in-place modifies topScores.
+    PostProc::applyWithAux(warp, topScores, topExperts, laneIdx, params.mTopK, auxPtr,
+                           params.mExpertSelectParams.mPostprocessParams);
+
+    // Phase 4: write packed (score, expertIdx) for the downstream permutation stage.
+    if (laneIdx < params.mTopK) {
+      int32_t const expertIdx = topExperts[laneIdx];
+      PackedScoreIdx<OutputT> packedScore{static_cast<OutputT>(topScores[laneIdx]),
+                                          static_cast<int16_t>(expertIdx)};
+      params.mPtrTopKPacked[int64_t{tokenIdx} * int64_t{params.mTopK} + laneIdx] = packedScore;
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    if (params.mUsePdl) {
+      cudaTriggerProgrammaticLaunchCompletion();
+    }
+#endif
+  }  // end `if constexpr (kSupported)` else branch
+}
+
+void launchBlockScoresKernel(Data const& data, uint32_t blockDimX, void* stream) {
+  // Custom dispatch that does NOT clamp blockDim to the dispatched tier's
+  // expert count (unlike `LAUNCH_ROUTING_CUSTOM`).  This kernel's layout (256
+  // threads with a grid-stride loop over experts) is decoupled from
+  // MaxNumExperts — oversizing blockDim would waste registers and shrink
+  // occupancy.
+  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* policyName_) {
+    using PreProc_ = decltype(preProc_);
+    using PostProc_ = decltype(postProc_);
+    using Pairs_ = typename PolicyTraits<PreProc_, PostProc_>::Pairs;
+    bool dispatched_ =
+        dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {
+          LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/false, routingIndicesBlockScoresKernel,
+                                       /*gridDim=*/data.mNumTokens,
+                                       /*blockDim=*/blockDimX,
+                                       /*smemSize=*/0, stream, PreProc_, PostProc_,
+                                       decltype(eTag_)::value, decltype(kTag_)::value);
+        });
+    if (!dispatched_) {
+      FLASHINFER_WARN(
+          "No compiled tier covers numExperts=%d topK=%d for policy %s in "
+          "launchBlockScoresKernel.",
+          data.mNumExperts, data.mTopK, policyName_);
+    }
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
 // 4. Coop kernel — cooperative histogram + offsets via grid-sync.
 //
 // The coop kernel only performs the post-topK permutation pipeline (histogram, prefix-scan,
@@ -892,8 +1087,6 @@ void run(Data const& data, void* stream) {
   TVM_FFI_ICHECK_LE(data.mNumExperts, static_cast<int32_t>(MaxSupportedExperts))
       << "Routing kernel expects #experts " << data.mNumExperts << " to be no more than "
       << MaxSupportedExperts << ".";
-  TVM_FFI_ICHECK_EQ(data.mNumExperts % 4, 0)
-      << "Routing kernel expects #experts " << data.mNumExperts << " to be a multiple of 4.";
 
   static int const smMajor = tensorrt_llm::common::getSMVersion() / 10;
   bool const useStaticBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
@@ -911,6 +1104,86 @@ void run(Data const& data, void* stream) {
   bool const useSingleCluster =
       (smMajor >= 9) && (data.mNumTokens <= MaxNumTokensSingleClusterScores);
 
+  // Split-topK path: block-per-token scores kernel + permutation-only cluster
+  // kernel, the two overlapping via PDL.  This replaces the fused single-
+  // cluster kernel for configs where it underperforms:
+  //
+  //   - Register pressure / spills: the fused kernel has every cluster warp
+  //     carry K-sized per-thread arrays across the cluster barrier.  For
+  //     Nemotron Super V3 (K=22) on B200 this yields 1088 spill slots and
+  //     caps occupancy to 1 block/SM.
+  //   - Idle-warp barrier stalls: at BS < cluster capacity the cluster
+  //     still launches 256 warps, but only ~BS of them carry a token; the
+  //     rest wait at __cluster_barrier_wait, dominating the profile (~75%
+  //     of stalls at BS=64 on Nemotron).
+  //   - No PDL overlap: everything happens in one kernel.
+  //
+  // Split-path structure:
+  //   * routingIndicesBlockScoresKernel writes mPtrTopKPacked
+  //     (1 block / token, 256 threads, only warp 0 carries K-sized regs).
+  //   * runPostTopKPipeline selects the cluster kernel with
+  //     LoadExpertIdxFromGlobal=true → permutation only.
+  // The two kernels overlap via cudaTriggerProgrammaticLaunchCompletion()
+  // and cudaGridDependencySynchronize().
+  //
+  // Dispatch rule (derived from a policy × (E, K) × BS sweep, see
+  // `bench_routing_sweep.py` + `bench_routing_analyze.py`):
+  //
+  //   useSplit = useSingleCluster && !useSingleBlock && numExperts >= 160
+  //
+  // Why this rule (measured on B200 across {Default, Renormalize,
+  // DeepSeekV3_nGrp1, MiniMax2} policies, BS ∈ [17, 256]):
+  //   - At `numExperts >= 160` split wins on average for every policy:
+  //     1.17× (Renormalize 160/8) up to 3.62× (DeepSeekV3 1024/32).
+  //   - At `numExperts = 128`, split's two-kernel overhead (launch + PDL
+  //     handoff) approximately cancels the single-cluster savings.  Default
+  //     128/8 is ~1.0×; DeepSeekV3 / MiniMax2 128/8 show ~1.11× but
+  //     Renormalize 128/8 is ~1.06× — not worth the complexity.
+  //   - At numTokens < 17 the block/dynblock kernels already handle small
+  //     BS optimally; this branch only fires when the cluster path would.
+  //
+  // Env-var override for benchmarking, applies to *both* the single-cluster
+  // split path and the large-BS topK kernel choice:
+  //   `FLASHINFER_ROUTING_FORCE_BLOCK_PER_TOKEN`
+  //     unset / "auto" / "" → use the heuristic above (default)
+  //     "1" / "on"          → force the block-per-token topK kernel wherever
+  //                           applicable (ignores the numExperts guard, but
+  //                           still requires the policy to opt in via
+  //                           PolicyPairSupportsBlockPerToken)
+  //     "0" / "off"         → force the fused single-cluster kernel for small
+  //                           BS, and HistogramScoresKernel (warp-per-token)
+  //                           for large BS
+  //   Read once per process via a static local; invalid values silently fall
+  //   back to "auto".
+  enum class ForceMode { kAuto, kOn, kOff };
+  static ForceMode const forceMode = [] {
+    char const* raw = std::getenv("FLASHINFER_ROUTING_FORCE_BLOCK_PER_TOKEN");
+    if (raw == nullptr) return ForceMode::kAuto;
+    std::string v = raw;
+    if (v == "1" || v == "on" || v == "ON") return ForceMode::kOn;
+    if (v == "0" || v == "off" || v == "OFF") return ForceMode::kOff;
+    return ForceMode::kAuto;
+  }();
+
+  // Does the currently-active policy pair implement the block-per-token
+  // interface?  Queried via PolicyPairSupportsBlockPerToken — policies that
+  // don't opt in (no applyToSmem / applyWithAux specialisation) will force
+  // this branch to false and fall back to the fused single-cluster kernel.
+  bool policySupportsBlockPerToken = false;
+  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* /*policyName*/) {
+    using PreProc_ = decltype(preProc_);
+    using PostProc_ = decltype(postProc_);
+    policySupportsBlockPerToken = PolicyPairSupportsBlockPerToken<PreProc_, PostProc_>::value;
+  });
+
+  bool useSplitTopKPath = useSingleCluster && !useSingleBlock && policySupportsBlockPerToken &&
+                          (data.mNumExperts >= NumExperts160Experts);
+  if (forceMode == ForceMode::kOn && useSingleCluster && !useSingleBlock &&
+      policySupportsBlockPerToken) {
+    useSplitTopKPath = true;
+  } else if (forceMode == ForceMode::kOff) {
+    useSplitTopKPath = false;
+  }
   if (!useSingleCluster && !useSingleBlock) {
     TVM_FFI_ICHECK(data.mPtrTopKPacked != nullptr)
         << "When #tokens is large, `mPtrTopKPacked` is a required input.";
@@ -924,6 +1197,40 @@ void run(Data const& data, void* stream) {
   // We need a mutable copy since `data` is const.
   Data mutableData = data;
 
+  if (useSplitTopKPath) {
+    // Step 1: scores → mPtrTopKPacked via a block-per-token kernel that
+    // mirrors TRT-LLM's deepseek_v3_topk_kernel (no-groups path) layout:
+    //   - One block per token, 256 threads per block.
+    //   - Block-parallel preprocess (via PreprocessPolicy::applyToSmem).
+    //   - Warp 0 alone does the sort-based reduceTopK<K, N=ceil(E/32)> plus
+    //     the postprocess (via PostprocessPolicy::applyWithAux).
+    //   - Only warp 0 holds the K-sized register arrays, so per-block
+    //     register pressure stays low and occupancy high.
+    //
+    // Why 256 threads: larger blocks (e.g. 512) would reserve the ~99-register
+    // budget across more threads and limit occupancy to 1 block/SM.  256
+    // threads gives 2 blocks/SM with the same per-warp workload, doubling
+    // arithmetic throughput during the preprocess phase.  For E=512 the
+    // grid-stride loop iterates 2× per thread; for E<=256 it iterates once.
+    //
+    // The kernel is generic in (PreprocessPolicy, PostprocessPolicy) — any
+    // registered policy pair in RoutingCustomPolicy.cuh works here.
+    constexpr uint32_t kBlockScoresThreads = 256;
+    launchBlockScoresKernel(mutableData, kBlockScoresThreads, stream);
+
+    // Step 2: delegate the permutation pipeline to runPostTopKPipeline, which
+    //   will pick the cluster kernel (LoadExpertIdxFromGlobal=true branch) for
+    //   small numTokens.  The cluster kernel in that branch reads topK from
+    //   mPtrTopKPacked instead of doing topK itself, so it does not carry the
+    //   K-sized register arrays or suffer from idle-warp barrier waits.
+    //
+    //   Clear mPtrScores so runPostTopKPipeline takes the pre-computed-topK
+    //   path (we've already written mPtrTopKPacked above).
+    mutableData.mPtrScores = nullptr;
+    runPostTopKPipeline(mutableData, stream);
+    return;
+  }
+
   if (useDynBlock) {
     launchDynBlockKernel(mutableData, numThreadsHist, stream);
   } else if (useStaticBlock) {
@@ -933,7 +1240,50 @@ void run(Data const& data, void* stream) {
   } else {
     uint32_t const maxNumBlocks = 1024;
 
-    launchHistogramScoresKernel(mutableData, maxNumBlocks, numThreadsHist, stream);
+    // TopK kernel selection for the large-BS path.
+    //
+    // The default is `routingIndicesHistogramScoresKernel` (warp-per-token,
+    // grid-stride over numTokens): well-suited to the large-BS regime where
+    // there's naturally one warp's worth of work per token.
+    //
+    // For policies that support the block-per-token interface and have E >= 256,
+    // `routingIndicesBlockScoresKernel` (1 block/token, warp-0 sort-based topK)
+    // can be faster because:
+    //   - Only warp 0 carries the K-sized topK register arrays (saves ~40
+    //     regs/thread for K=22, avoids spills even at large E).
+    //   - The bitonic-sort reduceTopK over N=ceil(E/32) elements per lane
+    //     beats the K sequential warp reductions a warp-per-token layout
+    //     does for high-K configs like Nemotron.
+    //
+    // The trade-off is one block per token — at BS = 4096 that's 4096 blocks
+    // vs ~128 blocks for warp-per-token.  Above BS ≈ 1024 block-per-token
+    // starts oversubscribing SMs and loses to the warp-per-token layout.
+    //
+    // Dispatch rule (derived from the same sweep as the cluster path):
+    //
+    //   useBlockScores = (E >= NumExperts1024Experts)
+    //                 || (E >= NumExperts256Experts && BS <= 1024)
+    //
+    // The E=1024/K=32 tier is a special corner: block-per-token wins at
+    // every BS (1.95×–5.17×) because fused warp-per-token topK explodes on
+    // register pressure when K=32.  For E ∈ [256, 576], speedups are
+    // 1.01×–1.75× at BS <= 1024 but collapse to 0.77×–1.03× at BS >= 2048,
+    // hence the BS cap.
+    bool useBlockScoresForTopK =
+        policySupportsBlockPerToken &&
+        ((data.mNumExperts >= NumExperts1024Experts) ||
+         (data.mNumExperts >= NumExperts256Experts && data.mNumTokens <= 1024));
+    if (forceMode == ForceMode::kOn && policySupportsBlockPerToken) {
+      useBlockScoresForTopK = true;
+    } else if (forceMode == ForceMode::kOff) {
+      useBlockScoresForTopK = false;
+    }
+    if (useBlockScoresForTopK) {
+      constexpr uint32_t kBlockScoresThreads = 256;
+      launchBlockScoresKernel(mutableData, kBlockScoresThreads, stream);
+    } else {
+      launchHistogramScoresKernel(mutableData, maxNumBlocks, numThreadsHist, stream);
+    }
 
     bool const canUseCoop =
         (smMajor >= 9) && (data.mNumExperts <= 1024) && (data.mPtrPermutedIdxSize != nullptr);

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
@@ -524,8 +524,6 @@ void run(Data& data, void* stream) {
     FLASHINFER_CHECK(data.mNumExpertGroups >= data.mNumLimitedGroups,
                      "Routing kernel expects top groups %d to be limited by #expert groups %d",
                      data.mNumLimitedGroups, data.mNumExpertGroups);
-    FLASHINFER_CHECK(data.mNumExperts % 4 == 0,
-                     "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
   }
 
   int const numBlocks = data.mNumTokens;

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
@@ -514,8 +514,6 @@ void run(Data const& data, void* stream) {
   FLASHINFER_CHECK(data.mNumExperts <= MaxSupportedExperts,
                    "Routing kernel expects #experts %d to be no more than %d", data.mNumExperts,
                    MaxSupportedExperts);
-  FLASHINFER_CHECK(data.mNumExperts % 4 == 0,
-                   "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
 
   // After this point, mPtrTopKIds is guaranteed to be nullptr.
   // Input is either mPtrScores (raw logits) or mPtrTopKPacked (topK already computed, needs

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -105,13 +105,16 @@ struct SoftmaxPreprocess {
     calcSoftmax(warp, score);
   }
 
-  /// Block-per-token interface: two-pass softmax over all experts.
-  ///   Pass 1: find block-wide max
-  ///   Pass 2: compute exp(score - max), sum them, divide
+  /// Block-per-token interface: three-pass softmax over all experts.
+  ///   Pass 1: find block-wide max and stash raw scores in smemBiased.
+  ///   Pass 2: compute exp(score - max) into smemBiased and reduce block sum.
+  ///   Pass 3: normalize by the reduced sum.
   /// smemAux aliases smemBiased (postprocess doesn't need pre-softmax scores).
-  /// The caller is responsible for guaranteeing that the block has at least
-  /// one thread per expert slot (i.e. blockDim.x >= 32), and that
-  /// kBlockDim matches the actual blockDim.x.
+  /// Preconditions:
+  ///   - kBlockDim must match the kernel's blockDim.x so BlockReduce uses the
+  ///     correct temp storage layout.
+  ///   - The caller must launch enough threads to cover expert slots; work is
+  ///     striped across experts via e += block.size().
   template <int kBlockDim, typename SmemT, typename InputT, typename ParamsT>
   __forceinline__ __device__ static void applyToSmem(cg::thread_block const& block,
                                                      InputT const* ptrScores, int32_t numExperts,
@@ -848,8 +851,8 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
 
 // Single source of truth for runtime → compile-time policy dispatch.
 // Maps (mPreprocessType, mPostprocessType) to compile-time (PreProc, PostProc) policy types.
-// Both LAUNCH_ROUTING_CUSTOM and queryDispatchedMaxExperts use this function,
-// so they are always in sync.
+// LAUNCH_ROUTING_CUSTOM, queryDispatchedMaxExperts, and queryPolicySupportsBlockPerToken use this
+// function, so they are always in sync.
 // The callback receives (PreProc{}, PostProc{}, policyName) where policyName is a human-readable
 // string for diagnostics.
 template <typename Fn>
@@ -879,6 +882,18 @@ inline int32_t queryDispatchedMaxExperts(Data const& data) {
                       [&](auto eTag, auto /*kTag*/) { result = decltype(eTag)::value; });
   });
   return result;
+}
+
+// Whether the dispatched (pre, post) policy pair implements the block-per-token kernel interface
+// (both policies opt in; see PolicyPairSupportsBlockPerToken).
+inline bool queryPolicySupportsBlockPerToken(Data const& data) {
+  bool supports = false;
+  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* /*policyName*/) {
+    using PreProc_ = decltype(preProc_);
+    using PostProc_ = decltype(postProc_);
+    supports = PolicyPairSupportsBlockPerToken<PreProc_, PostProc_>::value;
+  });
+  return supports;
 }
 
 // Top-level dispatch: maps runtime preprocess/postprocess enums to compile-time policy types,

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -30,11 +30,29 @@ namespace moe::dev::routing {
 //       Empty for policies that don't need extra data (zero register cost).
 //   - template <typename DataType, int VecSize, typename ParamsT>
 //     static void apply(warp, score[VecSize], idx[VecSize], numExperts, params)
-//       Transforms scores in-place before topK selection.
+//       Warp-per-token interface.  Transforms per-lane register scores in-place
+//       before topK selection.  Used by the fused cluster / coop / dyn-block
+//       kernels, where 32 lanes collectively process one token's experts.
+//
+// A policy MAY additionally provide the block-per-token interface used by
+// routingIndicesBlockScoresKernel.  Opting in requires:
+//   - static constexpr bool kSupportsBlockPerToken = true;
+//   - template <typename SmemT, typename InputT, typename ParamsT>
+//     static void applyToSmem(block, ptrScores, numExperts, smemBiased, smemAux, params)
+//       Reads a token's raw scores from global memory, writes the per-expert
+//       "biased" (topK key) and "aux" (postprocess input) values into smem.
+//       `smemBiased` and `smemAux` may alias — callers that don't need aux
+//       data pass the same pointer for both.
+// The block-per-token kernel is enabled only for (pre, post) pairs where
+// *both* policies set kSupportsBlockPerToken = true; see
+// PolicyPairSupportsBlockPerToken below.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// No-op: scores are passed through unchanged.
 struct NoOpPreprocess {
+  /// Opts into the block-per-token kernel (provides applyToSmem below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   /// BaseType: when no preprocess is applied, use the input type directly.
   template <typename InputT>
   using BaseType = InputT;
@@ -49,10 +67,25 @@ struct NoOpPreprocess {
                                                DataType (& /*score*/)[VecSize],
                                                int32_t const (& /*idx*/)[VecSize],
                                                int32_t /*numExperts*/, ParamsT const& /*params*/) {}
+
+  /// Block-per-token interface: copy raw scores into smem.  smemAux aliases
+  /// smemBiased because no postprocess needs separate aux data.
+  template <typename SmemT, typename InputT, typename ParamsT>
+  __forceinline__ __device__ static void applyToSmem(cg::thread_block const& block,
+                                                     InputT const* ptrScores, int32_t numExperts,
+                                                     SmemT* smemBiased, SmemT* /*smemAux*/,
+                                                     ParamsT const& /*params*/) {
+    for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
+      smemBiased[e] = static_cast<SmemT>(ptrScores[e]);
+    }
+  }
 };
 
 /// Softmax: applies softmax over all expert scores before topK selection.
 struct SoftmaxPreprocess {
+  /// Opts into the block-per-token kernel (provides applyToSmem below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   /// BaseType: softmax is always computed in float for numerical stability.
   template <typename InputT>
   using BaseType = float;
@@ -69,10 +102,65 @@ struct SoftmaxPreprocess {
                                                int32_t /*numExperts*/, ParamsT const& /*params*/) {
     calcSoftmax(warp, score);
   }
+
+  /// Block-per-token interface: two-pass softmax over all experts.
+  ///   Pass 1: find block-wide max
+  ///   Pass 2: compute exp(score - max), sum them, divide
+  /// smemAux aliases smemBiased (postprocess doesn't need pre-softmax scores).
+  /// The caller is responsible for guaranteeing that the block has at least
+  /// one thread per expert slot (i.e. blockDim.x >= 32), and that
+  /// kBlockDim matches the actual blockDim.x.
+  template <int kBlockDim, typename SmemT, typename InputT, typename ParamsT>
+  __forceinline__ __device__ static void applyToSmem(cg::thread_block const& block,
+                                                     InputT const* ptrScores, int32_t numExperts,
+                                                     SmemT* smemBiased, SmemT* /*smemAux*/,
+                                                     ParamsT const& /*params*/) {
+    using BlockReduce = cub::BlockReduce<float, kBlockDim>;
+    __shared__ typename BlockReduce::TempStorage reduceStorage;
+    __shared__ float smemBlockMax;
+    __shared__ float smemBlockSum;
+
+    // Pass 1: block-wide max.  We define a tiny functor rather than relying on
+    // cub::Max (removed in newer CUB) or cuda::maximum (libcu++) so the kernel
+    // stays portable across CUDA versions.
+    struct MaxOp {
+      __device__ __forceinline__ float operator()(float a, float b) const { return a > b ? a : b; }
+    };
+    float localMax = -INFINITY;
+    for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
+      float s = static_cast<float>(ptrScores[e]);
+      smemBiased[e] = static_cast<SmemT>(s);  // stash raw score for pass 2
+      localMax = s > localMax ? s : localMax;
+    }
+    float blockMax = BlockReduce(reduceStorage).Reduce(localMax, MaxOp{});
+    if (block.thread_rank() == 0) smemBlockMax = blockMax;
+    __syncthreads();
+    float const mx = smemBlockMax;
+
+    // Pass 2: compute exp(score - max) into smemBiased, accumulate sum.
+    float localSum = 0.f;
+    for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
+      float v = expf(static_cast<float>(smemBiased[e]) - mx);
+      smemBiased[e] = static_cast<SmemT>(v);
+      localSum += v;
+    }
+    float blockSum = BlockReduce(reduceStorage).Sum(localSum);
+    if (block.thread_rank() == 0) smemBlockSum = blockSum;
+    __syncthreads();
+    float const invSum = 1.f / smemBlockSum;
+
+    // Pass 3: normalize.
+    for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
+      smemBiased[e] = static_cast<SmemT>(static_cast<float>(smemBiased[e]) * invSum);
+    }
+  }
 };
 
 /// Sigmoid: applies sigmoid(score) for topK selection (no bias).
 struct SigmoidPreprocess {
+  /// Opts into the block-per-token kernel (provides applyToSmem below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   /// BaseType: sigmoid is computed in float for numerical stability.
   template <typename InputT>
   using BaseType = float;
@@ -93,11 +181,28 @@ struct SigmoidPreprocess {
       score[i] = idx[i] < numExperts ? static_cast<DataType>(s) : DataType{-INFINITY};
     }
   }
+
+  /// Block-per-token interface: compute sigmoid per expert and write to smem.
+  /// smemAux aliases smemBiased (SumNormalize postprocess only uses the
+  /// biased top-K values, so no separate aux data is needed).
+  template <typename SmemT, typename InputT, typename ParamsT>
+  __forceinline__ __device__ static void applyToSmem(cg::thread_block const& block,
+                                                     InputT const* ptrScores, int32_t numExperts,
+                                                     SmemT* smemBiased, SmemT* /*smemAux*/,
+                                                     ParamsT const& /*params*/) {
+    for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
+      float s = sigmoid_accurate(static_cast<float>(ptrScores[e]));
+      smemBiased[e] = static_cast<SmemT>(s);
+    }
+  }
 };
 
 /// SigmoidBias: applies sigmoid(score) + bias[expertIdx] for topK selection.
 /// Used by DeepSeek-style routing where expert selection is based on biased sigmoid scores.
 struct SigmoidBiasPreprocess {
+  /// Opts into the block-per-token kernel (provides applyToSmem below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   /// BaseType: sigmoid is computed in float for numerical stability.
   template <typename InputT>
   using BaseType = float;
@@ -127,6 +232,23 @@ struct SigmoidBiasPreprocess {
       score[i] = static_cast<DataType>(s + bias);
     }
   }
+
+  /// Block-per-token interface: compute (sigmoid, sigmoid+bias) per expert.
+  /// `smemAux[e] = sigmoid(score[e])`         — read by ScaledSumNormalizePostprocess
+  /// `smemBiased[e] = sigmoid(score[e]) + bias[e]` — used as the topK selection key
+  /// The two arrays must be distinct (cannot alias).
+  template <typename SmemT, typename InputT, typename ParamsT>
+  __forceinline__ __device__ static void applyToSmem(cg::thread_block const& block,
+                                                     InputT const* ptrScores, int32_t numExperts,
+                                                     SmemT* smemBiased, SmemT* smemAux,
+                                                     ParamsT const& params) {
+    for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
+      float s = sigmoid_accurate(static_cast<float>(ptrScores[e]));
+      float bias = loadScalar(params.ptrRoutingBias, e, params.dtypeBias);
+      smemAux[e] = static_cast<SmemT>(s);
+      smemBiased[e] = static_cast<SmemT>(s + bias);
+    }
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -137,11 +259,32 @@ struct SigmoidBiasPreprocess {
 //       Policy-specific runtime data. Empty when not needed.
 //   - template <typename DataType, int K, typename ParamsT>
 //     static void apply(warp, warpTopKScore[K], warpTopKExpertIdx[K], laneIdx, topK, params)
-//       Transforms top-K scores in-place after topK selection.
+//       Transforms top-K scores in-place after topK selection.  Used by the
+//       warp-per-token kernels.
+//
+// A policy MAY additionally provide the block-per-token interface used by
+// routingIndicesBlockScoresKernel.  Opting in requires:
+//   - static constexpr bool kSupportsBlockPerToken = true;
+//   - template <typename DataType, int K, typename SmemT, typename ParamsT>
+//     static void applyWithAux(warp, warpTopKScore[K], warpTopKExpertIdx[K], laneIdx, topK,
+//                               smemAux, params)
+//       Same as `apply` but additionally receives `smemAux` — the per-expert
+//       auxiliary data written by the preprocess policy.  Policies that do
+//       not need aux data can default-forward to `apply(...)`; policies that
+//       do (e.g. ScaledSumNormalize needs un-biased sigmoid) read from
+//       smemAux[warpTopKExpertIdx[laneIdx]].
+// Postprocess policies that read per-expert aux data must additionally set
+//   - static constexpr bool kNeedsAux = true;
+// so the block-per-token kernel allocates a separate smemAux array instead
+// of aliasing it to smemBiased.  Default: false (smemAux aliases smemBiased,
+// saving MaxNumExperts × 4B of smem).
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// No-op: top-K scores are left unchanged.
 struct NoOpPostprocess {
+  /// Opts into the block-per-token kernel (provides applyWithAux below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   template <typename OutputT>
   struct Params {
     void set(routingCustom::Data const& /*data*/) {}
@@ -153,10 +296,23 @@ struct NoOpPostprocess {
                                                int32_t const (& /*warpTopKExpertIdx*/)[K],
                                                int32_t /*laneIdx*/, int32_t /*topK*/,
                                                ParamsT const& /*params*/) {}
+
+  template <typename DataType, int K, typename SmemT, typename ParamsT>
+  __forceinline__ __device__ static void applyWithAux(cg::thread_block_tile<WarpSize> const& warp,
+                                                      DataType (&warpTopKScore)[K],
+                                                      int32_t const (&warpTopKExpertIdx)[K],
+                                                      int32_t laneIdx, int32_t topK,
+                                                      SmemT const* /*smemAux*/,
+                                                      ParamsT const& params) {
+    apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK, params);
+  }
 };
 
 /// Softmax: applies softmax over the top-K scores.
 struct SoftmaxPostprocess {
+  /// Opts into the block-per-token kernel (provides applyWithAux below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   template <typename OutputT>
   struct Params {
     void set(routingCustom::Data const& /*data*/) {}
@@ -175,11 +331,24 @@ struct SoftmaxPostprocess {
       warpTopKScore[laneIdx] = softmaxScore;
     }
   }
+
+  template <typename DataType, int K, typename SmemT, typename ParamsT>
+  __forceinline__ __device__ static void applyWithAux(cg::thread_block_tile<WarpSize> const& warp,
+                                                      DataType (&warpTopKScore)[K],
+                                                      int32_t const (&warpTopKExpertIdx)[K],
+                                                      int32_t laneIdx, int32_t topK,
+                                                      SmemT const* /*smemAux*/,
+                                                      ParamsT const& params) {
+    apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK, params);
+  }
 };
 
 /// SumNormalize: divides each top-K score by the sum of all top-K scores.
 /// Used when softmax has already been applied before topK selection.
 struct SumNormalizePostprocess {
+  /// Opts into the block-per-token kernel (provides applyWithAux below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
   template <typename OutputT>
   struct Params {
     bool normTopkProb = true;
@@ -203,6 +372,16 @@ struct SumNormalizePostprocess {
       warpTopKScore[laneIdx] = warpTopKScore[laneIdx] / denom;
     }
   }
+
+  template <typename DataType, int K, typename SmemT, typename ParamsT>
+  __forceinline__ __device__ static void applyWithAux(cg::thread_block_tile<WarpSize> const& warp,
+                                                      DataType (&warpTopKScore)[K],
+                                                      int32_t const (&warpTopKExpertIdx)[K],
+                                                      int32_t laneIdx, int32_t topK,
+                                                      SmemT const* /*smemAux*/,
+                                                      ParamsT const& params) {
+    apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK, params);
+  }
 };
 
 /// ScaledSumNormalize: recovers un-biased sigmoid scores by subtracting per-expert bias from the
@@ -210,6 +389,15 @@ struct SumNormalizePostprocess {
 /// Used by DeepSeek-style routing: final_weight = sigmoid(raw) * routeScale / (sum + epsilon).
 /// DeepSeek uses epsilon=0 (no guard); MiniMax2 uses epsilon=1e-20 to prevent division by zero.
 struct ScaledSumNormalizePostprocess {
+  /// Opts into the block-per-token kernel (provides applyWithAux below).
+  static constexpr bool kSupportsBlockPerToken = true;
+
+  /// Needs per-expert aux data (un-biased sigmoid) in the block-per-token
+  /// kernel — paired with SigmoidBiasPreprocess, which writes the un-biased
+  /// sigmoid to smemAux[e].  The kernel allocates a distinct smemAux array
+  /// instead of aliasing it to smemBiased.
+  static constexpr bool kNeedsAux = true;
+
   template <typename OutputT>
   struct Params {
     // Store as void const* to support any bias dtype (float, bfloat16, etc.) without conversion.
@@ -244,6 +432,24 @@ struct ScaledSumNormalizePostprocess {
           static_cast<DataType>(sigmoidScore * params.routeScale / (sum + params.sumEpsilon));
     }
   }
+
+  /// Block-per-token variant: read un-biased sigmoid directly from smemAux
+  /// (written by SigmoidBiasPreprocess::applyToSmem) instead of reloading bias
+  /// and subtracting.  Saves one global memory read + one FMA per top-K lane.
+  template <typename DataType, int K, typename SmemT, typename ParamsT>
+  __forceinline__ __device__ static void applyWithAux(cg::thread_block_tile<WarpSize> const& warp,
+                                                      DataType (&warpTopKScore)[K],
+                                                      int32_t const (&warpTopKExpertIdx)[K],
+                                                      int32_t laneIdx, int32_t topK,
+                                                      SmemT const* smemAux, ParamsT const& params) {
+    float sigmoidScore =
+        laneIdx < topK ? static_cast<float>(smemAux[warpTopKExpertIdx[laneIdx]]) : 0.f;
+    float sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
+    if (laneIdx < topK) {
+      warpTopKScore[laneIdx] =
+          static_cast<DataType>(sigmoidScore * params.routeScale / (sum + params.sumEpsilon));
+    }
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -265,10 +471,55 @@ struct ScaledSumNormalizePostprocess {
 // pattern (e.g., lookup-table-based expert selection).
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Trait: does a (pre, post) policy pair need a separate `smemAux` array in
+/// the block-per-token kernel?  This is purely a postprocess-side property:
+/// true iff the postprocess policy reads per-expert auxiliary data that
+/// differs from the topK selection key (via its `kNeedsAux` member).  Today
+/// only `ScaledSumNormalize` sets `kNeedsAux = true`.  For every other
+/// postprocess, `smemAux` aliases `smemBiased` and no extra smem is
+/// allocated.  Postprocess policies that don't declare `kNeedsAux` are
+/// treated as not needing it (safe default).
+template <typename PostprocessPolicy_, typename = void>
+struct PostprocessNeedsAux : std::false_type {};
+
+template <typename PostprocessPolicy_>
+struct PostprocessNeedsAux<PostprocessPolicy_, std::void_t<decltype(PostprocessPolicy_::kNeedsAux)>>
+    : std::bool_constant<PostprocessPolicy_::kNeedsAux> {};
+
+template <typename PreprocessPolicy_, typename PostprocessPolicy_>
+struct PolicyPairNeedsAux : PostprocessNeedsAux<PostprocessPolicy_> {};
+
+/// Trait: does a (pre, post) policy pair implement the block-per-token
+/// interface (`PreProc::applyToSmem` + `PostProc::applyWithAux`) and
+/// therefore opt in to `routingIndicesBlockScoresKernel`?  A pair opts in
+/// iff *both* policies declare `kSupportsBlockPerToken = true`.
+///
+/// To opt a new policy in:
+///   1. Implement the block-per-token method on the policy itself
+///      (`applyToSmem` for preprocess, `applyWithAux` for postprocess) —
+///      see the "Policy Interfaces" doc at the top of this file.
+///   2. Add `static constexpr bool kSupportsBlockPerToken = true;` to the
+///      policy struct.
+/// Once both members of a pair opt in, every (this_policy, other_policy)
+/// combination works with the block-per-token kernel automatically — no
+/// per-pair trait specialisation needed.  Every preprocess / postprocess
+/// policy defined above must declare `kSupportsBlockPerToken` (true or
+/// false); missing it is a compile error, which intentionally forces new
+/// policies to make an explicit choice.
+template <typename PreprocessPolicy_, typename PostprocessPolicy_>
+struct PolicyPairSupportsBlockPerToken
+    : std::bool_constant<PreprocessPolicy_::kSupportsBlockPerToken &&
+                         PostprocessPolicy_::kSupportsBlockPerToken> {};
+
 /// Default ExpertSelectPolicy: preprocess + topK reduction + postprocess.
 /// Wraps existing PreprocessPolicy and PostprocessPolicy as internal composition.
 template <typename PreprocessPolicy_, typename PostprocessPolicy_>
 struct TopKExpertSelect {
+  /// Expose component policies so the block-per-token kernel can dispatch
+  /// directly on preprocess / postprocess without going through `apply()`.
+  using PreprocessPolicy = PreprocessPolicy_;
+  using PostprocessPolicy = PostprocessPolicy_;
+
   /// BaseType: delegated to the preprocess policy.
   template <typename InputT>
   using BaseType = typename PreprocessPolicy_::template BaseType<InputT>;

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <cuda/functional>  // cuda::maximum<> used by SoftmaxPreprocess::applyToSmem
+
 #include "RoutingKernel.cuh"
 
 namespace moe::dev::routing {
@@ -120,19 +122,16 @@ struct SoftmaxPreprocess {
     __shared__ float smemBlockMax;
     __shared__ float smemBlockSum;
 
-    // Pass 1: block-wide max.  We define a tiny functor rather than relying on
-    // cub::Max (removed in newer CUB) or cuda::maximum (libcu++) so the kernel
-    // stays portable across CUDA versions.
-    struct MaxOp {
-      __device__ __forceinline__ float operator()(float a, float b) const { return a > b ? a : b; }
-    };
+    // Pass 1: block-wide max.  `fmaxf` / `cuda::maximum<>` map to hardware
+    // `MAX.F32` and follow IEEE 754 NaN handling — both are used elsewhere in
+    // trtllm_backend (e.g. trtllm_fused_moe_dev_kernel.cu).
     float localMax = -INFINITY;
     for (int e = block.thread_rank(); e < numExperts; e += block.size()) {
       float s = static_cast<float>(ptrScores[e]);
       smemBiased[e] = static_cast<SmemT>(s);  // stash raw score for pass 2
-      localMax = s > localMax ? s : localMax;
+      localMax = fmaxf(s, localMax);
     }
-    float blockMax = BlockReduce(reduceStorage).Reduce(localMax, MaxOp{});
+    float blockMax = BlockReduce(reduceStorage).Reduce(localMax, cuda::maximum<>{});
     if (block.thread_rank() == 0) smemBlockMax = blockMax;
     __syncthreads();
     float const mx = smemBlockMax;

--- a/scripts/task_test_jit_cache_package_build_import.sh
+++ b/scripts/task_test_jit_cache_package_build_import.sh
@@ -10,10 +10,10 @@ echo "========================================"
 echo "Starting flashinfer-jit-cache test script"
 echo "========================================"
 
-# MAX_JOBS = min(nproc, max(1, MemAvailable_GB/(8 on aarch64, 4 otherwise)))
+# MAX_JOBS = min(nproc, max(1, MemAvailable_GB/(8 on aarch64, 16 otherwise)))
 MEM_AVAILABLE_GB=$(free -g | awk '/^Mem:/ {print $7}')
 NPROC=$(nproc)
-MAX_JOBS=$(( MEM_AVAILABLE_GB / $([ "$(uname -m)" = "aarch64" ] && echo 8 || echo 4) ))
+MAX_JOBS=$(( MEM_AVAILABLE_GB / $([ "$(uname -m)" = "aarch64" ] && echo 8 || echo 16) ))
 if (( MAX_JOBS < 1 )); then
   MAX_JOBS=1
 elif (( NPROC < MAX_JOBS )); then

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -3987,6 +3987,12 @@ def test_tier_1024_experts_routing(
             FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_DEEPSEEK),
             id="FP8_Block_DeepSeek",
         ),
+        pytest.param(BF16Moe(), id="BF16xBF16"),
+        pytest.param(FP8PerTensorMoe(), id="FP8_PerTensor"),
+        pytest.param(
+            FP4Moe(quant_mode=QuantMode.FP4_NVFP4_NVFP4),
+            id="NvFP4xNvFP4",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -4005,7 +4011,12 @@ def test_tier_1024_experts_routing(
                 "routed_scaling": 2.5,
                 "has_routing_bias": True,
                 "routing_method_type": RoutingMethodType.DeepSeekV3,
-                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_moe_impls": [
+                    FP8BlockScaleMoe,
+                    BF16Moe,
+                    FP8PerTensorMoe,
+                    FP4Moe,
+                ],
                 "compatible_intermediate_size": [512],
                 "enable_autotune": False,
             },
@@ -4022,7 +4033,12 @@ def test_tier_1024_experts_routing(
                 "routed_scaling": 2.5,
                 "has_routing_bias": True,
                 "routing_method_type": RoutingMethodType.DeepSeekV3,
-                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_moe_impls": [
+                    FP8BlockScaleMoe,
+                    BF16Moe,
+                    FP8PerTensorMoe,
+                    FP4Moe,
+                ],
                 "compatible_intermediate_size": [512],
                 "enable_autotune": False,
             },
@@ -4041,9 +4057,35 @@ def test_tier_1024_experts_routing(
             },
             id="NoShuffle_MajorK",
         ),
+        pytest.param(
+            {
+                "use_shuffled_weight": True,
+                "layout": WeightLayout.MajorK,
+                "compatible_moe_impls": [FP4Moe, FP8PerTensorMoe, FP8BlockScaleMoe],
+            },
+            id="Shuffled_MajorK",
+        ),
+        pytest.param(
+            {
+                "use_shuffled_weight": True,
+                "layout": WeightLayout.BlockMajorK,
+                "compatible_moe_impls": [
+                    FP8BlockScaleMoe,
+                    MxInt4BlockScaleMoe,
+                    BF16Moe,
+                ],
+            },
+            id="Shuffled_BlockMajorK",
+        ),
     ],
 )
-@pytest.mark.parametrize("activation_type", [ActivationType.Swiglu])
+@pytest.mark.parametrize(
+    "activation_type",
+    [
+        pytest.param(ActivationType.Swiglu, id="Swiglu"),
+        pytest.param(ActivationType.Relu2, id="Relu2"),
+    ],
+)
 def test_deepseek_ngroup1_block_per_token_routing(
     num_tokens,
     hidden_size,
@@ -4052,14 +4094,16 @@ def test_deepseek_ngroup1_block_per_token_routing(
     routing_config,
     weight_processing,
     activation_type,
+    cache_permute_indices,
 ):
     """Exercise the block-per-token BlockScores kernel in routingCustom.
 
     DeepSeekV3 with n_group == 1 dispatches to routingCustom with the
-    (SigmoidBiasPreprocess, ScaledSumNormalizePostprocess) policy pair, which
-    opts into PolicyPairSupportsBlockPerToken. For num_experts >= 160 and
+    (SigmoidBiasPreprocess, ScaledSumNormalizePostprocess) policy pair, which opts
+    into PolicyPairSupportsBlockPerToken. For num_experts >= 160 and
     17 <= num_tokens <= 256, routingIndicesBlockScoresKernel replaces the
-    fused single-cluster kernel.
+    fused single-cluster kernel. We intentionally use independent
+    parametrization here; incompatible combinations are filtered by skip_checks.
 
     Covered tiers:
       - Tier<384, 8>  via num_experts=384, top_k=6
@@ -4073,7 +4117,7 @@ def test_deepseek_ngroup1_block_per_token_routing(
         routing_config,
         weight_processing,
         activation_type,
-        cache_permute_indices=False,
+        cache_permute_indices=cache_permute_indices,
     )
 
 

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -3969,6 +3969,114 @@ def test_tier_1024_experts_routing(
     )
 
 
+# num_tokens is chosen to straddle the dispatch thresholds in routingCustom::run
+# (see trtllm_fused_moe_routing_custom.cu):
+#   - tokens == 8  : dyn-block kernel path (tokens <= DynBlockKernelMaxNumTokens=16,
+#                    numExperts <= DynBlockKernelMaxNumExperts=512)
+#   - tokens == 32 : block-per-token "split" path on the single-cluster kernel
+#                    (17 <= tokens <= 256, numExperts >= 160, policy pair opts into
+#                    PolicyPairSupportsBlockPerToken) — exercises the
+#                    routingIndicesBlockScoresKernel path added for this feature.
+@pytest.mark.parametrize("num_tokens", [8, 32])
+@pytest.mark.parametrize("hidden_size", [512])
+@pytest.mark.parametrize("intermediate_size", [512])
+@pytest.mark.parametrize(
+    "moe_impl",
+    [
+        pytest.param(
+            FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_DEEPSEEK),
+            id="FP8_Block_DeepSeek",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "routing_config",
+    [
+        # DeepSeekV3 + nGroup == 1 routes through routingCustom with
+        # (SigmoidBiasPreprocess, ScaledSumNormalizePostprocess) — the policy pair
+        # that opts into the block-per-token BlockScores kernel.
+        pytest.param(
+            {
+                "num_experts": 384,
+                "top_k": 6,
+                "padding": 8,
+                "n_groups": 1,
+                "top_k_groups": 1,
+                "routed_scaling": 2.5,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.DeepSeekV3,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="DeepSeekV3_ngroup1_384e_top6",
+        ),
+        pytest.param(
+            {
+                # top_k=22 requires num_experts > NumKimiK2Experts (384).
+                "num_experts": 512,
+                "top_k": 22,
+                "padding": 8,
+                "n_groups": 1,
+                "top_k_groups": 1,
+                "routed_scaling": 2.5,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.DeepSeekV3,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+                "compatible_intermediate_size": [512],
+                "enable_autotune": False,
+            },
+            id="DeepSeekV3_ngroup1_512e_top22",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "weight_processing",
+    [
+        pytest.param(
+            {
+                "use_shuffled_weight": False,
+                "layout": WeightLayout.MajorK,
+                "compatible_moe_impls": [FP8BlockScaleMoe],
+            },
+            id="NoShuffle_MajorK",
+        ),
+    ],
+)
+@pytest.mark.parametrize("activation_type", [ActivationType.Swiglu])
+def test_deepseek_ngroup1_block_per_token_routing(
+    num_tokens,
+    hidden_size,
+    intermediate_size,
+    moe_impl,
+    routing_config,
+    weight_processing,
+    activation_type,
+):
+    """Exercise the block-per-token BlockScores kernel in routingCustom.
+
+    DeepSeekV3 with n_group == 1 dispatches to routingCustom with the
+    (SigmoidBiasPreprocess, ScaledSumNormalizePostprocess) policy pair, which
+    opts into PolicyPairSupportsBlockPerToken. For num_experts >= 160 and
+    17 <= num_tokens <= 256, routingIndicesBlockScoresKernel replaces the
+    fused single-cluster kernel.
+
+    Covered tiers:
+      - Tier<384, 8>  via num_experts=384, top_k=6
+      - Tier<512, 22> via num_experts=512, top_k=22
+    """
+    run_moe_test(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        moe_impl,
+        routing_config,
+        weight_processing,
+        activation_type,
+        cache_permute_indices=False,
+    )
+
+
 @pytest.mark.parametrize("num_tokens", [8])
 @pytest.mark.parametrize("hidden_size", [512])
 @pytest.mark.parametrize("intermediate_size", [512])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Adds `routingIndicesBlockScoresKernel` — a block-per-token top-K kernel modeled on TRT-LLM's `deepseek_v3_topk_kernel` (no-groups path) — to `routingCustom`, and wires it into the dispatcher alongside the fused
cluster / warp-per-token paths.  Also removes a stale `num_experts % 4 == 0` precondition that no kernel actually depends on.
### Motivation
The fused single-cluster and warp-per-token top-K kernels have every cluster warp carry K-sized per-thread arrays.  For high-K / high-E configs (e.g. Nemotron Super V3 E=512/K=22 on B200), this produces large spill slots and caps occupancy at 1 block/SM.  Small-BS configs also suffer from idle-warp barrier stalls on the cluster path.
### Design
- **One block per token, 256 threads.**
- **Phase 1:** block-parallel preprocess via `PreprocessPolicy::applyToSmem` — all threads cooperatively write
  per-expert topK-key (and optional aux) values into smem.
- **Phase 2:** warp 0 alone runs a sort-based `reduceTopK` over `NumChunks = ceil(MaxNumExperts / 32)` elements per lane.
- **Phase 3:** warp 0 applies `PostprocessPolicy::applyWithAux`.
Only warp 0 holds K-sized register arrays, so per-block register pressure stays low (~64 regs/thread) and occupancy rises to 2 blocks/SM.
### Policy opt-in
Each preprocess / postprocess policy declares `static constexpr bool kSupportsBlockPerToken = true/false;`.
`PolicyPairSupportsBlockPerToken<Pre, Post>` is simply the AND of the two flags — no per-pair trait specialisation needed.  Policies that also need a separate `smemAux` array declare `static constexpr bool kNeedsAux = true;` (today only `ScaledSumNormalizePostprocess`).  

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

> pytest tests/moe/test_trtllm_gen_fused_moe.py::test_deepseek_ngroup1_block_per_token_routing -v


## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added a block-per-token TopK scoring path and a runtime heuristic (env override) to choose the fastest kernel per workload.

* **New Features**
  * Block-per-token routing pathway with opt-in preprocess/postprocess policies and optional auxiliary support.
  * Split-pipeline mode to precompute block scores and defer permutation handling.

* **Improvements**
  * Removed expert-count divisibility restriction for more flexible configurations.

* **Tests**
  * Added routing tests targeting the new block-per-token path.

* **Chores**
  * Adjusted build script parallelism for non-aarch64 systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->