### PR TITLE
[feat] add log gate and initial state pool support in blackwell gdn prefill

### DIFF
--- a/benchmarks/bench_gdn_prefill.py
+++ b/benchmarks/bench_gdn_prefill.py
@@ -100,7 +100,18 @@ def bench_fi(endpoints, h_qk, h_v, d, warmup, iters):
     state_out = torch.zeros_like(h0)
 
     fn = lambda: chunk_gated_delta_rule(
-        q, k, v, g, beta, None, h0, True, cu_seqlens, False, None, state_out
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale=None,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=False,
+        output=None,
+        output_state=state_out,
     )
     times = bench_gpu_time(
         fn, enable_cupti=True, dry_run_iters=warmup, repeat_iters=iters

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -209,6 +209,8 @@ class GatedDeltaNetChunkedKernel:
         use_initial_state: bool,
         store_final_state: bool = True,
         enable_checkpoints: bool = False,
+        is_log_gate: bool = False,
+        is_initial_state_pool: bool = False,
         is_persistent: bool = True,
     ):
         self.io_dtype = io_dtype
@@ -224,7 +226,15 @@ class GatedDeltaNetChunkedKernel:
         self.use_initial_state = use_initial_state
         self.store_final_state = store_final_state
         self.enable_checkpoints = enable_checkpoints
+        self.is_log_gate = is_log_gate
+        self.is_initial_state_pool = is_initial_state_pool
         self.is_persistent = is_persistent
+        self.log2_e = math.log2(math.e)
+
+        if self.is_initial_state_pool:
+            assert self.use_initial_state, (
+                "is_initial_state_pool requires use_initial_state"
+            )
 
         # ------------------------------------------------------------------
         # Warp assignments  (12 warps total)
@@ -345,6 +355,8 @@ class GatedDeltaNetChunkedKernel:
         mma_tiler_qs,
         mma_tiler_qkv,
         mma_tiler_kv,
+        use_initial_state=False,
+        is_initial_state_pool=False,
     ):
         """Raise CantImplementError if this configuration is not supported."""
         if io_dtype not in [cutlass.Float16, cutlass.BFloat16]:
@@ -371,6 +383,11 @@ class GatedDeltaNetChunkedKernel:
             raise testing.CantImplementError(
                 f"mma_tiler_kv={mma_tiler_kv} not supported; only (128, 128, 64) is supported"
             )
+        if is_initial_state_pool:
+            if not use_initial_state:
+                raise testing.CantImplementError(
+                    "is_initial_state_pool requires use_initial_state"
+                )
 
     # -----------------------------------------------------------------------
     # Host entry point
@@ -387,6 +404,7 @@ class GatedDeltaNetChunkedKernel:
         o: cute.Tensor,
         cu_seqlens: cute.Tensor,
         s_in: Optional[cute.Tensor],
+        s_in_indices: Optional[cute.Tensor],
         s_out: Optional[cute.Tensor],
         s_checkpoints: Optional[cute.Tensor],
         cu_checkpoints: Optional[cute.Tensor],
@@ -395,6 +413,11 @@ class GatedDeltaNetChunkedKernel:
         tensormap_workspace: cute.Tensor,
         stream: cuda.CUstream,
     ):
+        if cutlass.const_expr(self.is_initial_state_pool):
+            assert s_in_indices is not None and s_in is not None, (
+                "s_in_indices and s_in must be provided if is_initial_state_pool is True"
+            )
+
         # chunk size
         self.b_t = 64
         h_q = q.shape[1]
@@ -810,6 +833,7 @@ class GatedDeltaNetChunkedKernel:
             tma_o,
             cu_seqlens,
             s_in,
+            s_in_indices,
             s_out,
             s_checkpoints,
             cu_checkpoints,
@@ -868,6 +892,8 @@ class GatedDeltaNetChunkedKernel:
         cu_seqlens: cute.Tensor,
         # initial state (fp32) from GMEM; None if not used
         mS_init: Optional[cute.Tensor],
+        # initial state indices (int32) from GMEM for pool mode; None otherwise
+        mS_init_indices: Optional[cute.Tensor],
         # final state output (fp32) to GMEM; None if not stored
         mS_out: Optional[cute.Tensor],
         mS_checkpoints: Optional[cute.Tensor],
@@ -1242,6 +1268,7 @@ class GatedDeltaNetChunkedKernel:
                     kv_acc_producer = self._load_initial_state(
                         tidx,
                         mS_init,
+                        mS_init_indices,
                         head_idx,
                         batch_idx,
                         tmem_ptr,
@@ -1888,15 +1915,21 @@ class GatedDeltaNetChunkedKernel:
 
         # --- Gate load ---
         if cutlass.const_expr(is_last_tile):
-            # OOB neutral: 1.0 -> log2 ~= 0.0 (no decay contribution)
-            tGrGate.fill(1.0)
+            # OOB neutral: 1.0 -> log2 ~= 0.0 (no decay contribution).
+            # When is_log_gate, gate is already in natural-log space; neutral is 0.
+            tGrGate.fill(0.0 if self.is_log_gate else 1.0)
             cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate, pred=tGpGate)
         else:
             cute.copy(tiled_copy_gate_g2r, tGgGate, tGrGate)
 
         # --- log2 + warp-wide inclusive prefix sum + SMEM store (always) ---
         for i in range(cute.size(tGrGate)):
-            tGrGate[i] = cute.math.log2(tGrGate[i] + 1e-10, fastmath=True)
+            if cutlass.const_expr(not self.is_log_gate):
+                tGrGate[i] = cute.math.log2(tGrGate[i] + 1e-10, fastmath=True)
+            else:
+                # If gate is already in natural log, convert to log2
+                # (log2(x) = ln(x) * log2(e)).
+                tGrGate[i] = tGrGate[i] * self.log2_e
         for offset in [1, 2, 4, 8, 16]:
             for col in range(cute.size(tGrGate)):
                 n = cute.arch.shuffle_sync_up(
@@ -2935,6 +2968,7 @@ class GatedDeltaNetChunkedKernel:
         self,
         tidx,
         mS_init,
+        mS_init_indices,
         head_idx,
         batch_idx,
         tmem_ptr,
@@ -2973,8 +3007,11 @@ class GatedDeltaNetChunkedKernel:
         tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
 
+        s_in_index = (
+            mS_init_indices[batch_idx] if self.is_initial_state_pool else batch_idx
+        )
         gS_init = cute.flat_divide(
-            mS_init[None, None, head_idx, batch_idx],
+            mS_init[None, None, head_idx, s_in_index],
             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
         )[None, None, 0, 0]
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
@@ -3333,8 +3370,7 @@ class GatedDeltaNetChunkedKernel:
 
         gate_handle = load_gate_consumer.wait_and_advance()
 
-        max_coord = tTR_tCcShared[cute.size(tTR_tCcShared) - 1]
-        cumprod_total = sCumprod[max_coord[1], 0, gate_handle.index]
+        cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_handle.index]
 
         valid_state = not is_first_chunk or self.use_initial_state
         if cutlass.const_expr(valid_state):

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -3017,18 +3017,21 @@ class GatedDeltaNetChunkedKernel:
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
         kv_acc_handle = kv_acc_producer.acquire_and_advance()
         for sub in cutlass.range(tRT_tCrState.shape[2]):
-            # 1. Load S_init fp32 GMEM -> fp32 registers
-            cute.autovec_copy(
-                tGR_tCgState[None, 0, sub],
-                tGR_tCrState[None, 0, sub],
-                l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
-            )
-            if cutlass.const_expr(self.state_dtype != self.acc_dtype):
-                tRT_tCrState[None, 0, sub].store(
-                    tGR_tCrState[None, 0, sub].load().to(self.state_dtype)
-                )
+            if self.is_initial_state_pool and mS_init_indices[batch_idx] < 0:
+                tRT_tCrState[None, 0, sub].fill(0.0)
             else:
-                tRT_tCrState = tGR_tCrState
+                # 1. Load S_init fp32 GMEM -> fp32 registers
+                cute.autovec_copy(
+                    tGR_tCgState[None, 0, sub],
+                    tGR_tCrState[None, 0, sub],
+                    l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                )
+                if cutlass.const_expr(self.state_dtype != self.acc_dtype):
+                    tRT_tCrState[None, 0, sub].store(
+                        tGR_tCrState[None, 0, sub].load().to(self.state_dtype)
+                    )
+                else:
+                    tRT_tCrState = tGR_tCrState
 
             # 2. fp32 registers -> state TMEM; signal kv_acc (GEMM 7 accumulates dS on top)
             cute.copy(

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -56,6 +56,8 @@ def _get_compiled_cache(
     use_initial_state: bool,
     store_final_state: bool,
     enable_checkpoints: bool,
+    is_log_gate: bool,
+    is_initial_state_pool: bool,
 ):
     """Return a mutable dict that lazily stores the compiled kernel."""
     return {}
@@ -97,11 +99,13 @@ def chunk_gated_delta_rule_sm100(
     output: torch.Tensor,
     cu_seqlens: torch.Tensor,
     initial_state: Optional[torch.Tensor],
+    initial_state_indices: Optional[torch.Tensor],
     output_state: Optional[torch.Tensor],
     scale: float,
     checkpoint_every_n_tokens: int = 0,
     cu_checkpoints: Optional[torch.Tensor] = None,
     output_checkpoints: Optional[torch.Tensor] = None,
+    is_log_gate: bool = False,
 ) -> None:
     """Execute the Blackwell chunked GDN prefill kernel.
 
@@ -115,18 +119,30 @@ def chunk_gated_delta_rule_sm100(
         beta: ``(total_tokens, HO)`` float32, update gate
         output: ``(total_tokens, HO, DK)`` float16/bfloat16, pre-allocated
         cu_seqlens: ``(num_seqs + 1,)`` int32
-        initial_state: ``(num_seqs, HO, DK, DK)`` float32/bfloat16, or None
+        initial_state: ``(pool_size, HO, DK, DK)`` float32/bfloat16, or None.
+            When ``initial_state_indices`` is None, ``pool_size == num_seqs``
+            and the i-th sequence reads its initial state from row i. When
+            ``initial_state_indices`` is not None (pool mode), each sequence
+            reads its initial state from ``initial_state[initial_state_indices[i]]``.
+        initial_state_indices: ``(num_seqs,)`` int32, or None.
+            Pool indices selecting which row of ``initial_state`` each sequence
+            uses. Requires ``initial_state`` to be provided.
         output_state: ``(num_seqs, HO, DK, DK)`` float32/bfloat16, or None
         scale: attention scale factor (must not be 0)
         checkpoint_every_n_tokens: store intermediate state every N tokens (0 = disabled)
         cu_checkpoints: ``(num_seqs + 1,)`` int32, cumulative checkpoint counts
         output_checkpoints: ``(total_checkpoints, HO, DK, DK)`` float32/bfloat16, or None
+        is_log_gate: if True, ``gate`` is already in natural-log space
+            (i.e. caller provides ``log(gate)``). Default False.
     """
     HQ = q.size(1)
     HV = v.size(1)
     DK = q.size(2)
     is_GQA = HQ >= HV
     use_initial_state = initial_state is not None
+    is_initial_state_pool = initial_state_indices is not None
+    if is_initial_state_pool and not use_initial_state:
+        raise ValueError("initial_state_indices requires initial_state to be provided")
     store_final_state = output_state is not None
     enable_checkpoints = checkpoint_every_n_tokens > 0
     io_dtype = _cutlass_io_dtype(q.dtype)
@@ -153,6 +169,8 @@ def chunk_gated_delta_rule_sm100(
         use_initial_state,
         store_final_state,
         enable_checkpoints,
+        is_log_gate,
+        is_initial_state_pool,
     )
 
     if "compiled" not in cache:
@@ -175,6 +193,8 @@ def chunk_gated_delta_rule_sm100(
             use_initial_state=use_initial_state,
             store_final_state=store_final_state,
             enable_checkpoints=enable_checkpoints,
+            is_log_gate=is_log_gate,
+            is_initial_state_pool=is_initial_state_pool,
             is_persistent=True,
         )
 
@@ -214,6 +234,12 @@ def chunk_gated_delta_rule_sm100(
                 mode=3, stride_order=(0, 1, 2, 3), divisibility=DK
             )
 
+        s_in_indices_cute = None
+        if is_initial_state_pool:
+            s_in_indices_cute = from_dlpack(
+                initial_state_indices, assumed_align=4
+            ).mark_layout_dynamic()
+
         s_out_cute = None
         if store_final_state:
             s_out_cute = from_dlpack(_output_state, assumed_align=16)
@@ -250,6 +276,7 @@ def chunk_gated_delta_rule_sm100(
             o_cute,
             cu_seqlens_cute,
             s_in_cute,
+            s_in_indices_cute,
             s_out_cute,
             s_checkpoints_cute,
             cu_checkpoints_cute,
@@ -285,6 +312,7 @@ def chunk_gated_delta_rule_sm100(
         output,
         cu_seqlens,
         _initial_state,
+        initial_state_indices if is_initial_state_pool else None,
         _output_state,
         output_checkpoints,
         cu_checkpoints,

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -104,6 +104,7 @@ def chunk_gated_delta_rule(
     beta: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     initial_state: Optional[torch.Tensor] = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
     use_qk_l2norm_in_kernel: bool = False,
@@ -112,6 +113,7 @@ def chunk_gated_delta_rule(
     state_checkpoints: Optional[torch.Tensor] = None,
     checkpoint_cu_starts: Optional[torch.Tensor] = None,
     checkpoint_every_n_tokens: int = 0,
+    is_log_gate: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated Delta Rule (GDN) attention for prefill.
 
@@ -140,8 +142,17 @@ def chunk_gated_delta_rule(
             Scale factor for the attention scores.
             If not provided, defaults to ``1 / sqrt(head_size)``. Default: ``None``.
         initial_state (Optional[torch.Tensor]):
-            Initial KV state of shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
-            Must be float32. If None, starts from zero state. Default: ``None``.
+            Initial KV state of shape ``[pool_size, num_sab_heads, head_size, head_size]``.
+            Must be float32 or bfloat16. If None, starts from zero state.
+            ``pool_size`` equals ``num_seqs`` unless ``initial_state_indices`` is
+            provided, in which case ``pool_size`` can be anything and each
+            sequence ``i`` reads its initial state from row
+            ``initial_state_indices[i]``. Default: ``None``.
+        initial_state_indices (Optional[torch.Tensor]):
+            Optional int32 pool indices of shape ``[num_seqs]``. When provided,
+            the i-th sequence reads its initial state from
+            ``initial_state[initial_state_indices[i]]``. Requires
+            ``initial_state`` to be provided. SM100-only. Default: ``None``.
         output_final_state (bool):
             Whether to output the final state. Default: ``False``.
         cu_seqlens (torch.Tensor):
@@ -171,6 +182,12 @@ def chunk_gated_delta_rule(
         checkpoint_every_n_tokens (int):
             Store intermediate state every N tokens. Must be a multiple of
             the chunk size (64). 0 means disabled (default).
+        is_log_gate (bool):
+            If ``True``, the ``g`` tensor is interpreted as already being in
+            natural-log space (i.e. the caller has applied ``torch.log(alpha)``).
+            If ``False`` (default), ``g`` is taken to be in the standard
+            multiplicative space and the kernel applies ``log2`` internally.
+            SM100-only.
 
     Returns:
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -211,6 +228,9 @@ def chunk_gated_delta_rule(
             "state_checkpoints and checkpoint_cu_starts must be None "
             "when checkpoint_every_n_tokens == 0"
         )
+
+    if initial_state_indices is not None and initial_state is None:
+        raise ValueError("initial_state_indices requires initial_state to be provided")
 
     assert cu_seqlens is not None, "cu_seqlens is required for varlen mode"
 
@@ -314,6 +334,12 @@ def chunk_gated_delta_rule(
         if checkpoint_every_n_tokens > 0 and checkpoint_cu_starts is not None:
             _cu_checkpoints = checkpoint_cu_starts.to(torch.int32)
 
+        _initial_state_indices = (
+            initial_state_indices.to(torch.int32)
+            if initial_state_indices is not None
+            else None
+        )
+
         chunk_gated_delta_rule_sm100(
             q,
             k,
@@ -323,14 +349,24 @@ def chunk_gated_delta_rule(
             output,
             cu_seqlens.to(torch.int32),
             initial_state,
+            _initial_state_indices,
             output_state if output_final_state else None,
             _scale,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             cu_checkpoints=_cu_checkpoints,
             output_checkpoints=state_checkpoints,
+            is_log_gate=is_log_gate,
         )
     else:
         # SM90 Hopper path (C++ JIT kernel)
+        if is_log_gate:
+            raise NotImplementedError(
+                "is_log_gate=True is only supported on SM100 (Blackwell)"
+            )
+        if initial_state_indices is not None:
+            raise NotImplementedError(
+                "initial_state_indices is only supported on SM100 (Blackwell)"
+            )
         workspace_size = get_device_sm_count(device) * 128
         workspace_buffer = _get_cache_buf(
             "gdn_prefill_workspace", workspace_size, device

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -405,10 +405,17 @@ def blockwise_delta_rule(
         blk_offset = seq_start
         if initial_state is not None:
             if initial_state_indices is not None:
-                pool_idx = int(initial_state_indices[seq_idx].item())
+                if initial_state_indices[seq_idx] >= 0:
+                    pool_idx = initial_state_indices[seq_idx]
+                    state_HKV = initial_state[pool_idx].to(state_dtype).to(q.device)
+                else:
+                    state_HKV = torch.zeros(
+                        (num_sab_heads, head_size, head_size),
+                        dtype=state_dtype,
+                        device=q.device,
+                    )
             else:
-                pool_idx = seq_idx
-            state_HKV = initial_state[pool_idx].to(state_dtype).to(q.device)
+                state_HKV = initial_state[seq_idx].to(state_dtype).to(q.device)
         else:
             state_HKV = torch.zeros(
                 (num_sab_heads, head_size, head_size),

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -363,6 +363,8 @@ def blockwise_delta_rule(
     block_size: int = 32,
     scale_factor=1.0,
     state_dtype: torch.dtype = torch.float32,
+    initial_state: torch.Tensor | None = None,  # [pool_size, H, head_size, head_size]
+    initial_state_indices: torch.Tensor | None = None,  # [num_seqs] int32 pool indices
     # intermediate_outputs = None,  # debug output
 ) -> torch.Tensor:
     total_seqlen = q.size(0)
@@ -401,9 +403,18 @@ def blockwise_delta_rule(
     for seq_idx, seq_start in enumerate(seq_offset[:-1]):
         seq_end = seq_offset[seq_idx + 1]
         blk_offset = seq_start
-        state_HKV = torch.zeros(
-            (num_sab_heads, head_size, head_size), dtype=state_dtype, device=q.device
-        )
+        if initial_state is not None:
+            if initial_state_indices is not None:
+                pool_idx = int(initial_state_indices[seq_idx].item())
+            else:
+                pool_idx = seq_idx
+            state_HKV = initial_state[pool_idx].to(state_dtype).to(q.device)
+        else:
+            state_HKV = torch.zeros(
+                (num_sab_heads, head_size, head_size),
+                dtype=state_dtype,
+                device=q.device,
+            )
         while blk_offset < seq_end:
             is_full_block = seq_end - blk_offset >= block_size
             valid_len = block_size if is_full_block else seq_end - blk_offset

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -422,7 +422,7 @@ def _test_prefill_kernel_initial_state_pool(
         atol_kv = 5e-3
         rtol_kv = 1e-3
     else:
-        atol_o = 2e-3
+        atol_o = 1e-3
         rtol_o = 1e-3
         atol_kv = 1e-3
         rtol_kv = 1e-4

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -350,7 +350,7 @@ def _test_prefill_kernel_initial_state_pool(
 
         # Build a state pool of `pool_size` entries, then a random int32
         # indices tensor that selects one entry per sequence.
-        state_pool = torch.randn(
+        state_pool = torch.rand(
             (pool_size, num_sab_heads, head_size, head_size),
             dtype=torch.float32,
             device=device,

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -65,6 +65,7 @@ def _test_prefill_kernel(
     alpha: bool,
     beta: bool,
     seed: int | None = None,
+    is_log_gate: bool = False,
 ):
     _skip_if_unsupported()
     if not alpha and not beta:
@@ -94,6 +95,14 @@ def _test_prefill_kernel(
         alpha = torch.rand(total_seqlen, num_sab_heads) if alpha else None
         beta = torch.rand(total_seqlen, num_sab_heads) if beta else None
 
+    # If is_log_gate, the kernel expects the gate to be in natural-log space.
+    # Apply a small epsilon before log to avoid -inf.
+    alpha_kernel = (
+        (alpha + 1e-10).log() if (alpha is not None and is_log_gate) else alpha
+    )
+    # The reference always takes alpha in multiplicative space.
+    alpha_ref = alpha
+
     our_o = torch.empty(
         [total_seqlen, num_o_heads, head_size], dtype=q.dtype, device=q.device
     )
@@ -109,15 +118,16 @@ def _test_prefill_kernel(
         q,
         k,
         v,
-        alpha,
+        alpha_kernel,
         beta,
-        scale,
-        None,
-        True,
-        cu_seq_lens,
-        True,
+        scale=scale,
+        initial_state=None,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens,
+        use_qk_l2norm_in_kernel=True,
         output=our_o,
         output_state=our_state,
+        is_log_gate=is_log_gate,
     )
 
     torch.cuda.synchronize()
@@ -131,7 +141,7 @@ def _test_prefill_kernel(
         v.float(),
         seq_lens,
         scale_factor=scale,
-        alpha=alpha,
+        alpha=alpha_ref,
         beta=beta,
         state_dtype=torch.float32,
     )
@@ -145,7 +155,7 @@ def _test_prefill_kernel(
         atol_kv = 5e-3
         rtol_kv = 1e-3
     else:
-        atol_o = 2e-3
+        atol_o = 1e-3
         rtol_o = 1e-3
         atol_kv = 1e-3
         rtol_kv = 1e-4
@@ -259,6 +269,220 @@ def test_prefill_kernel_nonfull(
     )
 
 
+@pytest.mark.parametrize("beta", [True])
+@pytest.mark.parametrize("scale", [1.0, "auto"])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize(
+    "num_q_heads, num_k_heads, num_v_heads",
+    [(4, 1, 1), (2, 2, 4), (16, 16, 32)],
+)
+@pytest.mark.parametrize("seq_lens", [[128], [256], [64, 128, 512]])
+@pytest.mark.parametrize("block_size", [64])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_prefill_kernel_log_gate(
+    qkv_factory,
+    dtype: str,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    block_size: int,
+    seq_lens: list[int],
+    scale: float | str,
+    beta: bool,
+    seed: int = int(os.environ.get("SEED", "0")),
+):
+    """Verify is_log_gate=True path against multiplicative-gate reference."""
+    _skip_if_not_sm100()
+    scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
+    _test_prefill_kernel(
+        qkv_factory,
+        dtype,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        block_size,
+        seq_lens,
+        scale,
+        alpha=True,
+        beta=beta,
+        seed=seed,
+        is_log_gate=True,
+    )
+
+
+def _test_prefill_kernel_initial_state_pool(
+    qkv_factory,
+    dtype: str,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    seq_lens: list[int],
+    scale: float,
+    pool_size: int,
+    is_log_gate: bool = False,
+    seed: int | None = None,
+):
+    """Verify initial_state_indices (pool mode) vs. non-pool reference."""
+    _skip_if_not_sm100()
+
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_seqs = len(seq_lens)
+    total_seqlen = sum(seq_lens)
+    num_o_heads = max(num_q_heads, num_v_heads)
+    num_sab_heads = num_o_heads
+
+    dtype = getattr(torch, dtype)
+    device = torch.device("cuda")
+    with device:
+        q, k, v = qkv_factory(
+            seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype
+        )
+        k = torch.nn.functional.normalize(k, p=2.0, dim=-1)
+        cu_seq_lens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int64)
+        alpha = torch.rand(total_seqlen, num_sab_heads)
+        beta = torch.rand(total_seqlen, num_sab_heads)
+
+        # Build a state pool of `pool_size` entries, then a random int32
+        # indices tensor that selects one entry per sequence.
+        state_pool = torch.randn(
+            (pool_size, num_sab_heads, head_size, head_size),
+            dtype=torch.float32,
+            device=device,
+        )
+        pool_indices = torch.randint(
+            0, pool_size, (num_seqs,), dtype=torch.int32, device=device
+        )
+
+    alpha_kernel = (alpha + 1e-10).log() if is_log_gate else alpha
+
+    our_o = torch.empty(
+        [total_seqlen, num_o_heads, head_size], dtype=dtype, device=device
+    )
+    our_state = torch.empty(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+    our_o.fill_(float("nan"))
+    our_state.fill_(float("nan"))
+
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha_kernel,
+        beta,
+        scale=scale,
+        initial_state=state_pool,
+        initial_state_indices=pool_indices,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens,
+        use_qk_l2norm_in_kernel=True,
+        output=our_o,
+        output_state=our_state,
+        is_log_gate=is_log_gate,
+    )
+    torch.cuda.synchronize()
+
+    # Reference: reshape pool into per-seq initial state via gather, then call
+    # non-pool reference.
+    our_state_t = our_state.transpose(-1, -2)
+
+    # blockwise_delta_rule uses state layout [N, H, K, V]; the kernel's output
+    # layout is [N, H, V, K] which we transpose above. We pass the pool in
+    # [pool_size, H, K, V] order with the same convention used elsewhere in
+    # this file (transposed outside).
+    # Since the kernel reads initial_state as [pool_size, H, V, K] (same layout
+    # as output_state), we pass state_pool transposed(-1, -2) to the reference.
+    state_pool_ref = state_pool.transpose(-1, -2).float()
+
+    ref_o, ref_state = blockwise_delta_rule(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        scale_factor=scale,
+        alpha=alpha,
+        beta=beta,
+        state_dtype=torch.float32,
+        initial_state=state_pool_ref,
+        initial_state_indices=pool_indices,
+    )
+    ref_o = ref_o.to(dtype)
+
+    if dtype == torch.bfloat16:
+        atol_o = 1e-2
+        rtol_o = 1e-2
+        atol_kv = 5e-3
+        rtol_kv = 1e-3
+    else:
+        atol_o = 2e-3
+        rtol_o = 1e-3
+        atol_kv = 1e-3
+        rtol_kv = 1e-4
+
+    torch.testing.assert_close(our_o, ref_o, atol=atol_o, rtol=rtol_o)
+    torch.testing.assert_close(our_state_t, ref_state, atol=atol_kv, rtol=rtol_kv)
+
+
+@pytest.mark.parametrize("is_log_gate", [False, True])
+@pytest.mark.parametrize("pool_size", [1, 4])
+@pytest.mark.parametrize("scale", [1.0])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize(
+    "num_q_heads, num_k_heads, num_v_heads",
+    [(4, 1, 1), (16, 16, 32)],
+)
+@pytest.mark.parametrize("seq_lens", [[128], [64, 128, 512]])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_prefill_kernel_initial_state_pool(
+    qkv_factory,
+    dtype: str,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int,
+    seq_lens: list[int],
+    scale: float | str,
+    pool_size: int,
+    is_log_gate: bool,
+    seed: int = int(os.environ.get("SEED", "0")),
+):
+    scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
+    _test_prefill_kernel_initial_state_pool(
+        qkv_factory,
+        dtype,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        seq_lens,
+        scale,
+        pool_size,
+        is_log_gate=is_log_gate,
+        seed=seed,
+    )
+
+
+def test_initial_state_indices_without_state_error():
+    """initial_state_indices without initial_state should raise ValueError."""
+    device = torch.device("cuda")
+    with pytest.raises(ValueError, match="initial_state_indices requires"):
+        chunk_gated_delta_rule(
+            torch.empty(1, 1, 128, device=device),
+            torch.empty(1, 1, 128, device=device),
+            torch.empty(1, 1, 128, device=device),
+            cu_seqlens=torch.tensor([0, 1], dtype=torch.int64, device=device),
+            initial_state_indices=torch.zeros(1, dtype=torch.int32, device=device),
+        )
+
+
 def _test_chunked_prefill(
     qkv_factory,
     dtype: str,
@@ -338,11 +562,11 @@ def _test_chunked_prefill(
         v1,
         alpha1,
         beta1,
-        scale,
-        None,
-        True,
-        cu_seq_lens1,
-        True,
+        scale=scale,
+        initial_state=None,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens1,
+        use_qk_l2norm_in_kernel=True,
         output=our_o1,
         output_state=our_state1,
     )
@@ -352,11 +576,11 @@ def _test_chunked_prefill(
         v2,
         alpha2,
         beta2,
-        scale,
-        our_state1,
-        True,
-        cu_seq_lens2,
-        True,
+        scale=scale,
+        initial_state=our_state1,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens2,
+        use_qk_l2norm_in_kernel=True,
         output=our_o2,
         output_state=our_state2,
     )
@@ -541,11 +765,11 @@ def _test_checkpoint(
         v,
         alpha,
         beta,
-        scale,
-        None,
-        True,
-        cu_seq_lens,
-        True,
+        scale=scale,
+        initial_state=None,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens,
+        use_qk_l2norm_in_kernel=True,
         output=our_o,
         output_state=our_state,
         state_checkpoints=state_checkpoints,
@@ -587,11 +811,11 @@ def _test_checkpoint(
                 prefix_v,
                 prefix_alpha,
                 prefix_beta,
-                scale,
-                None,
-                True,
-                prefix_cu,
-                True,
+                scale=scale,
+                initial_state=None,
+                output_final_state=True,
+                cu_seqlens=prefix_cu,
+                use_qk_l2norm_in_kernel=True,
                 output=prefix_o,
                 output_state=prefix_state,
             )
@@ -687,11 +911,11 @@ def test_checkpoint_noop(qkv_factory):
         v,
         alpha,
         beta,
-        scale,
-        None,
-        True,
-        cu_seq_lens,
-        True,
+        scale=scale,
+        initial_state=None,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens,
+        use_qk_l2norm_in_kernel=True,
         output=o1,
         output_state=s1,
     )
@@ -705,11 +929,11 @@ def test_checkpoint_noop(qkv_factory):
         v,
         alpha,
         beta,
-        scale,
-        None,
-        True,
-        cu_seq_lens,
-        True,
+        scale=scale,
+        initial_state=None,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens,
+        use_qk_l2norm_in_kernel=True,
         output=o2,
         output_state=s2,
         checkpoint_every_n_tokens=0,
@@ -863,11 +1087,11 @@ def _test_prefill_kernel_bf16_state(
         v,
         alpha,
         beta,
-        scale,
-        None,
-        True,
-        cu_seq_lens,
-        True,
+        scale=scale,
+        initial_state=None,
+        output_final_state=True,
+        cu_seqlens=cu_seq_lens,
+        use_qk_l2norm_in_kernel=True,
         output=our_o,
         output_state=our_state,
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add optional log gate and initial state pool support. The demands are from sglang team.

No perf regression after the new feature addition.

```
GPU: NVIDIA B200 [Blackwell (SM100)]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v    FI Blackwell (SM100)   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x8192               2    8                  0.330ms    13.0      0.388ms     1.17x +
397B/122B TP8    1x4096               2    8                  0.174ms    12.3      0.275ms     1.58x +
397B/122B TP8    1x2048               2    8                  0.096ms    11.1      0.225ms     2.33x +
397B/122B TP8    6144+2048            2    8                  0.252ms    17.0      0.334ms     1.32x +
397B/122B TP8    4096+4096            2    8                  0.175ms    24.6      0.291ms     1.66x +
397B/122B TP8    2048+6144            2    8                  0.253ms    17.0      0.335ms     1.32x +
397B/122B TP8    1024+7168            2    8                  0.292ms    14.7      0.358ms     1.23x +
397B/122B TP8    2048x4               2    8                  0.098ms    44.0      0.243ms     2.49x +
397B/122B TP8    1024x8               2    8                  0.060ms    71.6      0.247ms     4.12x +

397B/122B TP4    1x8192               4   16                  0.331ms    26.0      0.426ms     1.29x +
397B/122B TP4    1x4096               4   16                  0.175ms    24.5      0.291ms     1.67x +
397B/122B TP4    1x2048               4   16                  0.097ms    22.1      0.285ms     2.94x +
397B/122B TP4    6144+2048            4   16                  0.252ms    34.0      0.375ms     1.48x +
397B/122B TP4    4096+4096            4   16                  0.176ms    48.9      0.329ms     1.87x +
397B/122B TP4    2048+6144            4   16                  0.254ms    33.8      0.374ms     1.47x +
397B/122B TP4    1024+7168            4   16                  0.293ms    29.3      0.396ms     1.35x +
397B/122B TP4    2048x4               4   16                  0.099ms    86.7      0.335ms     3.38x +
397B/122B TP4    1024x8               4   16                  0.064ms   134.9      0.342ms     5.37x +

397B/122B TP2    1x8192               8   32                  0.333ms    51.6      0.588ms     1.77x +
397B/122B TP2    1x4096               8   32                  0.176ms    48.9      0.334ms     1.90x +
397B/122B TP2    1x2048               8   32                  0.098ms    43.9      0.247ms     2.52x +
397B/122B TP2    6144+2048            8   32                  0.255ms    67.5      0.586ms     2.30x +
397B/122B TP2    4096+4096            8   32                  0.178ms    96.7      0.588ms     3.31x +
397B/122B TP2    2048+6144            8   32                  0.256ms    67.1      0.589ms     2.30x +
397B/122B TP2    1024+7168            8   32                  0.295ms    58.2      0.590ms     2.00x +
397B/122B TP2    2048x4               8   32                  0.104ms   165.4      0.595ms     5.73x +
397B/122B TP2    1024x8               8   32                  0.120ms   143.0      0.590ms     4.91x +

397B/122B TP1    1x8192              16   64                  0.335ms   102.4      1.004ms     2.99x +
397B/122B TP1    1x4096              16   64                  0.178ms    96.7      0.528ms     2.97x +
397B/122B TP1    1x2048              16   64                  0.099ms    87.0      0.305ms     3.09x +
397B/122B TP1    6144+2048           16   64                  0.260ms   132.3      0.999ms     3.85x +
397B/122B TP1    4096+4096           16   64                  0.184ms   187.0      1.003ms     5.46x +
397B/122B TP1    2048+6144           16   64                  0.262ms   131.3      1.005ms     3.84x +
397B/122B TP1    1024+7168           16   64                  0.300ms   114.4      1.005ms     3.35x +
397B/122B TP1    2048x4              16   64                  0.200ms   172.0      1.017ms     5.09x +
397B/122B TP1    1024x8              16   64                  0.232ms   148.2      1.009ms     4.35x +

35B/9B/4B TP1    1x8192              16   32                  0.334ms    51.5      0.586ms     1.75x +
35B/9B/4B TP1    1x4096              16   32                  0.177ms    48.6      0.333ms     1.88x +
35B/9B/4B TP1    1x2048              16   32                  0.098ms    43.7      0.241ms     2.45x +
35B/9B/4B TP1    6144+2048           16   32                  0.255ms    67.3      0.586ms     2.30x +
35B/9B/4B TP1    4096+4096           16   32                  0.179ms    96.0      0.588ms     3.29x +
35B/9B/4B TP1    2048+6144           16   32                  0.258ms    66.5      0.588ms     2.28x +
35B/9B/4B TP1    1024+7168           16   32                  0.298ms    57.7      0.589ms     1.98x +
35B/9B/4B TP1    2048x4              16   32                  0.104ms   165.4      0.595ms     5.73x +
35B/9B/4B TP1    1024x8              16   32                  0.121ms   142.2      0.589ms     4.88x +

27B TP1          1x8192              16   48                  0.332ms    77.7      0.834ms     2.51x +
27B TP1          1x4096              16   48                  0.176ms    73.2      0.454ms     2.58x +
27B TP1          1x2048              16   48                  0.099ms    65.4      0.283ms     2.87x +
27B TP1          6144+2048           16   48                  0.256ms   100.7      0.771ms     3.01x +
27B TP1          4096+4096           16   48                  0.179ms   143.6      0.828ms     4.62x +
27B TP1          2048+6144           16   48                  0.258ms   100.0      0.830ms     3.22x +
27B TP1          1024+7168           16   48                  0.297ms    86.8      0.830ms     2.80x +
27B TP1          2048x4              16   48                  0.196ms   131.2      0.783ms     3.98x +
27B TP1          1024x8              16   48                  0.178ms   144.9      0.793ms     4.46x +

2B/0.8B TP1      1x8192              16   16                  0.330ms    26.1      0.423ms     1.28x +
2B/0.8B TP1      1x4096              16   16                  0.175ms    24.6      0.288ms     1.65x +
2B/0.8B TP1      1x2048              16   16                  0.097ms    22.1      0.229ms     2.35x +
2B/0.8B TP1      6144+2048           16   16                  0.252ms    34.1      0.375ms     1.49x +
2B/0.8B TP1      4096+4096           16   16                  0.176ms    48.9      0.331ms     1.88x +
2B/0.8B TP1      2048+6144           16   16                  0.253ms    34.0      0.375ms     1.49x +
2B/0.8B TP1      1024+7168           16   16                  0.292ms    29.4      0.399ms     1.37x +
2B/0.8B TP1      2048x4              16   16                  0.099ms    86.7      0.335ms     3.38x +
2B/0.8B TP1      1024x8              16   16                  0.064ms   134.9      0.344ms     5.41x +

Sym h32          1x8192              32   32                  0.332ms    51.7      0.586ms     1.76x +
Sym h32          1x4096              32   32                  0.176ms    48.8      0.331ms     1.88x +
Sym h32          1x2048              32   32                  0.098ms    43.7      0.245ms     2.50x +
Sym h32          6144+2048           32   32                  0.255ms    67.3      0.586ms     2.30x +
Sym h32          4096+4096           32   32                  0.178ms    96.6      0.588ms     3.31x +
Sym h32          2048+6144           32   32                  0.255ms    67.3      0.589ms     2.31x +
Sym h32          1024+7168           32   32                  0.295ms    58.3      0.589ms     2.00x +
Sym h32          2048x4              32   32                  0.104ms   165.0      0.595ms     5.72x +
Sym h32          1024x8              32   32                  0.121ms   141.9      0.590ms     4.88x +

```

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pooled initial-state support via per-sequence initial-state indices.
  * Log-space gate mode to interpret gate inputs as natural logs.

* **Improvements**
  * Call sites and kernels updated to accept pooled states and log-gate mode; call sites now use explicit keyword arguments.
  * Tighter numerical tolerances in reference checks.

* **Bug Fixes**
  * Validation to prevent using indices without provided initial states.

* **Tests**
  * Expanded tests for pooled states, log-gate paths, SM100 cases, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->