### PR TITLE
fix(cute_dsl/moe): correct tile_size=256 gemm2 tactic enumeration

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -99,8 +99,10 @@ def get_gemm1_valid_tactics(tile_size: int) -> List[Tuple]:
 # Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner.get_valid_tactics
 #
 # Format: (mma_tiler_mn, cluster_shape_mn, raster_along_m)
-# - mma_tiler_mn: (128, N_tile) where N_tile is 128 or 256 (M is always 128, use_2cta_instrs=False)
-# - cluster_shape_mn: (1, cluster_n) where cluster_n is 1 or 2 (M is always 1, use_2cta_instrs=False)
+# - mma_tiler_mn: (tile_size, N_tile) where N_tile is 128 or 256.
+#   At tile_size=256 use_2cta_instrs=True, so mma_m doubles to 256.
+# - cluster_shape_mn: (tile_size // 128, cluster_n) where cluster_n is 1 or 2.
+#   At tile_size=256 cluster_m=2 (2-CTA); at tile_size=128 cluster_m=1.
 # - raster_along_m: False (fixed, theoretically more performant)
 
 
@@ -108,24 +110,25 @@ def get_gemm2_valid_tactics(tile_size: int) -> List[Tuple]:
     """Get valid tactics for GEMM2 (Finalize Fusion).
 
     Reference: TRT-LLM cute_dsl_custom_ops.py line 1165-1202
-    The finalize kernel uses use_2cta_instrs=False, so mma_tiler_mn M is
-    always 128 and cluster_shape_mn M is always 1, regardless of tile_size.
-    tile_size only affects m_aligned (padding), not the MMA tile shape.
+
+    The finalize kernel's MMA shape must match tile_size because the
+    kernel consumes the upstream gemm1 output layout. At tile_size=128
+    the kernel uses 1-CTA mma_m=128; at tile_size=256 it uses 2-CTA
+    mma_m=256 (use_2cta_instrs=True). Returning a 1-CTA gemm2 tactic
+    when tile_size=256 yields a layout mismatch and incorrect output.
 
     Args:
         tile_size: Tile size for moe_sort padding (128 or 256).
-            Does not affect MMA tiler or cluster shape for the finalize kernel.
+            Determines mma_tiler_mn[0] and cluster_shape_mn[0].
 
     Returns:
         List of (mma_tiler_mn, cluster_shape_mn, raster_along_m) tuples
     """
-    # From TRT-LLM line 1176-1177:
-    # mma_tiler_mn_candidates = [(128, 128), (128, 256)]
-    # cluster_shape_mn_candidates = [(1, 1), (1, 2)]
-    # The finalize kernel always uses use_2cta_instrs=False.
-
-    mma_tiler_mn_candidates = [(128, 128), (128, 256)]
-    cluster_shape_mn_candidates = [(1, 1), (1, 2)]
+    mma_tiler_mn_candidates = [(tile_size, 128), (tile_size, 256)]
+    cluster_shape_mn_candidates = [
+        (tile_size // 128, 1),
+        (tile_size // 128, 2),
+    ]
     raster_along_m_candidates = [False]
 
     tactics = []
@@ -163,10 +166,11 @@ def get_moe_valid_tactics() -> List[Tuple]:
     """
     tactics = []
 
-    # Only tile_size=128 is enabled. tile_size=256 (use_2cta_instrs=True)
-    # produces incorrect results in the GEMM1 gather+SwiGLU kernel and is
-    # disabled until the kernel bug is fixed.
-    for tile_size in [128]:
+    # Enable both 1-CTA (tile_size=128) and 2-CTA (tile_size=256,
+    # use_2cta_instrs=True) variants; the autotuner picks per shape.
+    # tile_size=256 typically wins at large batch where 2-CTA throughput
+    # exceeds 1-CTA.
+    for tile_size in [128, 256]:
         gemm1_tactics = get_gemm1_valid_tactics(tile_size)
         gemm2_tactics = get_gemm2_valid_tactics(tile_size)
 
@@ -180,7 +184,8 @@ def get_moe_valid_tactics() -> List[Tuple]:
 
 # Pre-generate all valid tactics
 # tile_size=128: 2 GEMM1 tactics × 4 GEMM2 tactics = 8
-# Total: 8 tactics
+# tile_size=256: 2 GEMM1 tactics × 4 GEMM2 tactics = 8
+# Total: 16 tactics
 ALL_MOE_TACTICS = get_moe_valid_tactics()
 
 # Default tactic (tile_size=128, smallest MMA tiles, cluster_n=1)

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -325,6 +325,99 @@ def check_accuracy(
 
 
 # =============================================================================
+# Test Class: Tactic-enumeration structural invariants (no GPU required)
+# =============================================================================
+
+
+@cute_dsl_available
+class TestTacticEnumeration:
+    """Structural invariants for the tactic-enumeration helpers in
+    flashinfer.fused_moe.cute_dsl.tuner.
+
+    These tests run without a GPU. They exercise the enumeration
+    functions directly to enforce invariants that the end-to-end
+    accuracy tests can fail to detect when a tile size is gated out of
+    ALL_MOE_TACTICS as a workaround.
+
+    The MoE pipeline runs gemm1 (gather + SwiGLU) followed by gemm2
+    (finalize fusion) back-to-back on the same padded token sequence.
+    For the layouts to match, gemm1 and gemm2 must share the same
+    mma_tiler M dimension and the same cluster_shape M dimension.
+    """
+
+    @pytest.mark.parametrize("tile_size", [128, 256])
+    def test_gemm1_tactics_match_tile_size(self, tile_size):
+        """Every gemm1 tactic must have mma_tiler[0] == tile_size and
+        cluster_shape[0] == tile_size // 128 (1-CTA at tile=128, 2-CTA
+        at tile=256)."""
+        from flashinfer.fused_moe.cute_dsl.tuner import get_gemm1_valid_tactics
+
+        tactics = get_gemm1_valid_tactics(tile_size)
+        assert len(tactics) > 0, f"no gemm1 tactics returned at tile_size={tile_size}"
+        expected_cluster_m = tile_size // 128
+        for mma_tiler_mn, cluster_shape_mn, _ in tactics:
+            assert mma_tiler_mn[0] == tile_size, (
+                f"gemm1 mma_tiler[0]={mma_tiler_mn[0]} does not match "
+                f"tile_size={tile_size}; tactic={(mma_tiler_mn, cluster_shape_mn)}"
+            )
+            assert cluster_shape_mn[0] == expected_cluster_m, (
+                f"gemm1 cluster_shape[0]={cluster_shape_mn[0]} does not "
+                f"match tile_size//128={expected_cluster_m}; "
+                f"tactic={(mma_tiler_mn, cluster_shape_mn)}"
+            )
+
+    @pytest.mark.parametrize("tile_size", [128, 256])
+    def test_gemm2_tactics_match_tile_size(self, tile_size):
+        """Every gemm2 tactic must have mma_tiler[0] == tile_size and
+        cluster_shape[0] == tile_size // 128. The finalize kernel
+        consumes the upstream gemm1 output layout — a 1-CTA gemm2
+        tactic at tile_size=256 cannot consume a 2-CTA gemm1 output
+        and produces incorrect results (regression for #3067)."""
+        from flashinfer.fused_moe.cute_dsl.tuner import get_gemm2_valid_tactics
+
+        tactics = get_gemm2_valid_tactics(tile_size)
+        assert len(tactics) > 0, f"no gemm2 tactics returned at tile_size={tile_size}"
+        expected_cluster_m = tile_size // 128
+        for mma_tiler_mn, cluster_shape_mn, _ in tactics:
+            assert mma_tiler_mn[0] == tile_size, (
+                f"gemm2 mma_tiler[0]={mma_tiler_mn[0]} does not match "
+                f"tile_size={tile_size}; tactic={(mma_tiler_mn, cluster_shape_mn)}"
+            )
+            assert cluster_shape_mn[0] == expected_cluster_m, (
+                f"gemm2 cluster_shape[0]={cluster_shape_mn[0]} does not "
+                f"match tile_size//128={expected_cluster_m}; "
+                f"tactic={(mma_tiler_mn, cluster_shape_mn)}"
+            )
+
+    def test_all_moe_tactics_pair_gemm1_and_gemm2_consistently(self):
+        """Every (tile_size, gemm1_tactic, gemm2_tactic) tuple in
+        ALL_MOE_TACTICS must have gemm1 and gemm2 share both
+        mma_tiler[0] and cluster_shape[0] (the M dimensions). This
+        catches a class of bug where the product loop in
+        get_moe_valid_tactics accidentally pairs incompatible
+        gemm1/gemm2 tactics, even if each individual enumeration is
+        internally consistent."""
+        from flashinfer.fused_moe.cute_dsl.tuner import ALL_MOE_TACTICS
+
+        assert len(ALL_MOE_TACTICS) > 0
+        for tile_size, gemm1_tactic, gemm2_tactic in ALL_MOE_TACTICS:
+            gemm1_mma_m = gemm1_tactic[0][0]
+            gemm1_cluster_m = gemm1_tactic[1][0]
+            gemm2_mma_m = gemm2_tactic[0][0]
+            gemm2_cluster_m = gemm2_tactic[1][0]
+            assert gemm1_mma_m == gemm2_mma_m == tile_size, (
+                f"gemm1/gemm2 mma_m mismatch in ALL_MOE_TACTICS at "
+                f"tile_size={tile_size}: gemm1_mma_m={gemm1_mma_m}, "
+                f"gemm2_mma_m={gemm2_mma_m}"
+            )
+            assert gemm1_cluster_m == gemm2_cluster_m == tile_size // 128, (
+                f"gemm1/gemm2 cluster_m mismatch in ALL_MOE_TACTICS at "
+                f"tile_size={tile_size}: gemm1_cluster_m={gemm1_cluster_m}, "
+                f"gemm2_cluster_m={gemm2_cluster_m}"
+            )
+
+
+# =============================================================================
 # Test Class: Functional API (cute_dsl_fused_moe_nvfp4)
 # =============================================================================
 


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

`get_gemm2_valid_tactics(tile_size)` in `flashinfer/fused_moe/cute_dsl/tuner.py` ignored its `tile_size` argument and unconditionally returned 1-CTA tactics (`mma_m=128, cluster=(1, X)`). At `tile_size=256` the upstream gemm1 kernel emits a 2-CTA `mma_m=256` layout that the 1-CTA gemm2 cannot consume — every `(gemm1, gemm2)` tactic pair at `tile_size=256` was structurally broken. This was the underlying cause of #3067 and the workaround that disabled `tile_size=256` in the  autotuner.

This PR parameterizes `get_gemm2_valid_tactics` on `tile_size` (mirroring the existing `get_gemm1_valid_tactics` pattern) and lifts the `[128]` gate to `[128, 256]`. At `tile_size=128` the returned tactics are unchanged (backward-compatible); at `tile_size=256` it returns the corresponding 4 2-CTA entries.

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * MOE tuner now derives GEMM tactic shapes from tile configuration, expanding candidate tactics (8 → 16) and enabling multi-CTA behavior for larger tile sizes.
* **Tests**
  * New unit tests ensure generated tactic lists follow requested tile-size parameters and that paired upstream/downstream tactics remain layout-compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->