### PR TITLE
fix: align is_sm120f_supported with SM12x family semantics

### DIFF
--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -572,8 +572,8 @@ def is_sm120a_supported(device: torch.device) -> bool:
 
 
 def is_sm120f_supported(device: torch.device) -> bool:
-    major, minor = get_compute_capability(device)
-    return major == 12 and minor == 0 and version_at_least(torch.version.cuda, "12.9")
+    major, _ = get_compute_capability(device)
+    return major == 12 and version_at_least(torch.version.cuda, "12.9")
 
 
 def is_sm121a_supported(device: torch.device) -> bool:


### PR DESCRIPTION
 ## 📌 Description

`is_sm120f_supported` requires `minor == 0`, so it returns False on sm_121 even though the `120f` gencode target covers both sm_120 and sm_121. Drop the `minor == 0` check.

  No callers in `flashinfer/` or `tests/`. Only `CLAUDE.md` mentions it. Could delete the function instead if that's cleaner.

  ## 🔍 Related Issues

  Refs #3170 (Action Item 5 / A1).

  ## 🚀 Pull Request Checklist

  ### ✅ Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` (or
  used your preferred method).
  - [x] I have installed the hooks with `pre-commit install`.
  - [ ] I have run the hooks manually with `pre-commit run --all-files` and
  fixed any reported issues.

  Ran `pre-commit run --files flashinfer/utils.py`; passed.

  ## 🧪 Tests

  - [ ] Tests have been added or updated as needed.
  - [ ] All tests are passing (`unittest`, etc.).

  No new tests; the function is currently uncalled.

  ## Reviewer Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded SM120f GPU support compatibility to include additional GPU variants within the compute capability 12 family while maintaining CUDA version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->