### PR TITLE
feat: fmha fwd cutlass supports fp8 output

### DIFF
--- a/csrc/fmha_cutlass_sm100.cu
+++ b/csrc/fmha_cutlass_sm100.cu
@@ -58,6 +58,13 @@ using tvm::ffi::Optional;
         using c_type_out = c_type_in;                                          \
         return __VA_ARGS__();                                                  \
       });                                                                      \
+    } else if (encode_dlpack_dtype(out_dtype) == float8_e4m3fn_code ||         \
+               encode_dlpack_dtype(out_dtype) == float8_e5m2_code) {           \
+      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(in_dtype, c_type_in, [&] {    \
+        return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(out_dtype, c_type_out, [&] { \
+          return __VA_ARGS__();                                                \
+        });                                                                    \
+      });                                                                      \
     } else {                                                                   \
       return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(in_dtype, c_type_in, [&] {     \
         using c_type_out = nv_bfloat16;                                        \

--- a/csrc/fmha_cutlass_sm100.cu
+++ b/csrc/fmha_cutlass_sm100.cu
@@ -51,27 +51,26 @@ using tvm::ffi::Optional;
     return false;                                                                  \
   }()
 
-#define DISPATCH_DTYPE_IN_OUT(in_dtype, out_dtype, c_type_in, c_type_out, ...) \
-  [&]() -> bool {                                                              \
-    if (in_dtype == out_dtype) {                                               \
-      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(in_dtype, c_type_in, [&] {    \
-        using c_type_out = c_type_in;                                          \
-        return __VA_ARGS__();                                                  \
-      });                                                                      \
-    } else if (encode_dlpack_dtype(out_dtype) == float8_e4m3fn_code ||         \
-               encode_dlpack_dtype(out_dtype) == float8_e5m2_code) {           \
-      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(in_dtype, c_type_in, [&] {    \
-        return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(out_dtype, c_type_out, [&] { \
-          return __VA_ARGS__();                                                \
-        });                                                                    \
-      });                                                                      \
-    } else {                                                                   \
-      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(in_dtype, c_type_in, [&] {     \
-        using c_type_out = nv_bfloat16;                                        \
-        return __VA_ARGS__();                                                  \
-      });                                                                      \
-    }                                                                          \
-    return false;                                                              \
+#define DISPATCH_DTYPE_IN_OUT(in_dtype, out_dtype, c_type_in, c_type_out, ...)    \
+  [&]() -> bool {                                                                 \
+    if (in_dtype == out_dtype) {                                                  \
+      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(in_dtype, c_type_in, [&] {       \
+        using c_type_out = c_type_in;                                             \
+        return __VA_ARGS__();                                                     \
+      });                                                                         \
+    } else if (encode_dlpack_dtype(out_dtype) == float8_e4m3fn_code ||            \
+               encode_dlpack_dtype(out_dtype) == float8_e5m2_code) {              \
+      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(in_dtype, c_type_in, [&] {       \
+        return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(out_dtype, c_type_out,          \
+                                                  [&] { return __VA_ARGS__(); }); \
+      });                                                                         \
+    } else {                                                                      \
+      return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(in_dtype, c_type_in, [&] {        \
+        using c_type_out = nv_bfloat16;                                           \
+        return __VA_ARGS__();                                                     \
+      });                                                                         \
+    }                                                                             \
+    return false;                                                                 \
   }()
 
 #define DISPATCH_context(DTypeIn, DTypeOut, HEAD_DIM_QK, HEAD_DIM_VO, MaskMode, ...)         \

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3081,6 +3081,31 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 use_fp16_qk_reduction,
             )
             if self._backend == "cutlass":
+                # Supported (q_data_type, o_data_type) combos on SM100 FMHA.
+                # Mirrors DISPATCH_DTYPE_IN_OUT in csrc/fmha_cutlass_sm100.cu.
+                _SUPPORTED_CUTLASS_DTYPES = {
+                    (torch.bfloat16, torch.bfloat16),
+                    (torch.float16, torch.float16),
+                    (torch.bfloat16, torch.float8_e4m3fn),
+                    (torch.float16, torch.float8_e4m3fn),
+                    (torch.bfloat16, torch.float8_e5m2),
+                    (torch.float16, torch.float8_e5m2),
+                    (torch.float8_e4m3fn, torch.bfloat16),
+                    (torch.float8_e5m2, torch.bfloat16),
+                }
+                if q_data_type != kv_data_type:
+                    raise ValueError(
+                        "cutlass prefill backend requires q_data_type == "
+                        f"kv_data_type, got q_data_type={q_data_type}, "
+                        f"kv_data_type={kv_data_type}."
+                    )
+                if (q_data_type, o_data_type) not in _SUPPORTED_CUTLASS_DTYPES:
+                    raise ValueError(
+                        "cutlass prefill backend does not support "
+                        f"(q_data_type={q_data_type}, o_data_type={o_data_type}). "
+                        f"Supported combinations: "
+                        f"{sorted(_SUPPORTED_CUTLASS_DTYPES, key=str)}."
+                    )
                 # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
                 new_get_module_args = (
                     get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3310,11 +3310,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
         if out is None:
-            # when input dtype is fp8, we need to use bf16 output
-            out_dtype = torch.bfloat16 if q.dtype.itemsize == 1 else q.dtype
             out = torch.empty(
                 q.shape[:-1] + v.shape[-1:],
-                dtype=out_dtype,
+                dtype=self._cached_o_data_type,
                 device=q.device,
             )
         else:
@@ -3601,10 +3599,14 @@ def fmha_varlen(
     workspace_buffer = _get_cache_buf(
         "fmha_varlen_cutlass_workspace", 32 * 1024 * 1024, q.device
     )
+    if out is not None:
+        out_dtype = out.dtype
+    else:
+        out_dtype = torch.bfloat16 if q.dtype.itemsize == 1 else q.dtype
     module = get_fmha_module(
         q.dtype,
         k.dtype,
-        v.dtype,
+        out_dtype,
         torch.int32,
         q.shape[2],
         v.shape[2],
@@ -3646,8 +3648,6 @@ def fmha_varlen(
     ) = plan_info
 
     if out is None:
-        # when input dtype is fp8, we need to use bf16 output
-        out_dtype = torch.bfloat16 if q.dtype.itemsize == 1 else q.dtype
         out = torch.empty(
             qo_total_len + max(max_qo_len, 128),
             num_qo_heads,

--- a/include/flashinfer/attention/blackwell/fmha_cutlass_sm100.cuh
+++ b/include/flashinfer/attention/blackwell/fmha_cutlass_sm100.cuh
@@ -119,9 +119,14 @@ struct FwdRunner {
     LayoutO layout_O = make_layout(shape_O, stride_O);
     LayoutLSE layout_LSE = make_layout(shape_LSE, stride_LSE);
 
+    // The caller's ``o_scale`` follows the dequant-scale convention (same as
+    // q_scale / k_scale / v_scale: multiply the quantized value by this scale
+    // to recover the real value). The kernel's ``inv_scale_o`` field expects
+    // the quant multiplier (1 / dequant scale), so invert here.
+    double inv_o_scale = (o_scale > 0.0) ? (1.0 / o_scale) : 1.0;
     typename Operation::Arguments arguments{
         problem_shape,
-        {q, layout_Q, k, layout_K, v, layout_V, sm_scale, q_scale, k_scale, v_scale, o_scale},
+        {q, layout_Q, k, layout_K, v, layout_V, sm_scale, q_scale, k_scale, v_scale, inv_o_scale},
         {o - max_qo_len * get<0>(stride_O), layout_O, maybe_lse, layout_LSE, max_qo_len},
         {work_indptr, qo_tile_indices, qo_head_indices, batch_indices},
         hw_info};

--- a/tests/attention/test_blackwell_fmha.py
+++ b/tests/attention/test_blackwell_fmha.py
@@ -481,6 +481,96 @@ def test_blackwell_cutlass_fmha_fp8(
     torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("batch_size", [1, 3, 17])
+@pytest.mark.parametrize("qo_len", [17, 377])
+@pytest.mark.parametrize("kv_len", [17, 977])
+@pytest.mark.parametrize("num_qo_heads", [32])
+@pytest.mark.parametrize("num_kv_heads", [8, 32])
+@pytest.mark.parametrize(
+    "head_dim_qk,head_dim_vo,sm_scale",
+    [
+        (192, 128, 1.0 / math.sqrt(192)),
+        (128, 128, 1.0 / math.sqrt(128)),
+    ],
+)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("dtype_in", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype_out", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_blackwell_cutlass_fmha_bf16_in_fp8_out(
+    batch_size,
+    qo_len,
+    kv_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim_qk,
+    head_dim_vo,
+    sm_scale,
+    causal,
+    dtype_in,
+    dtype_out,
+):
+    if qo_len > kv_len and causal:
+        pytest.skip("qo_len > kv_len and causal is not supported")
+    if not is_sm100a_supported(torch.device("cuda")) and not is_sm110a_supported(
+        torch.device("cuda")
+    ):
+        pytest.skip("only SM100A and SM110A are supported on this device")
+
+    torch.manual_seed(42)
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim_qk, dtype=dtype_in, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, head_dim_qk, dtype=dtype_in, device="cuda"
+    )
+    v = torch.randn(
+        batch_size * kv_len, num_kv_heads, head_dim_vo, dtype=dtype_in, device="cuda"
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * kv_len
+    )
+
+    wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+        kv_layout="NHD",
+        backend="cutlass",
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        causal=causal,
+        sm_scale=sm_scale,
+        q_data_type=dtype_in,
+        kv_data_type=dtype_in,
+        o_data_type=dtype_out,
+    )
+
+    # o_scale follows the dequant-scale convention: fp8_output * o_scale ~=
+    # bf16_attention. Pick o_scale so the attention fits inside FP8 range.
+    gqa_group_ratio = num_qo_heads // num_kv_heads
+    k_rep = torch.repeat_interleave(k, gqa_group_ratio, dim=1)
+    v_rep = torch.repeat_interleave(v, gqa_group_ratio, dim=1)
+    o_ref_bf16, _ = attention_ref(batch_size, q, k_rep, v_rep, causal, sm_scale)
+    max_abs = o_ref_bf16.float().abs().max().item()
+    fp8_max = torch.finfo(dtype_out).max
+    o_scale = max(max_abs, 1e-6) / (fp8_max * 0.5)  # headroom
+
+    out = wrapper.run(q, k, v, o_scale=o_scale)
+    assert out.dtype == dtype_out
+
+    # Dequantize: multiply fp8 output by the (dequant) o_scale to recover bf16.
+    out_dequant = out.float() * o_scale
+    torch.testing.assert_close(out_dequant, o_ref_bf16.float(), rtol=1e-1, atol=1e-1)
+
+
 if __name__ == "__main__":
     test_blackwell_cutlass_fmha_fp8(
         batch_size=9,


### PR DESCRIPTION
## 📌 Description
- Extends SM100 CUTLASS FMHA dispatch to cover bf16/fp16 input with fp8_e4m3fn / fp8_e5m2 output.
- Callers of `BatchPrefillWithRaggedKVCacheWrapper(backend="cutlass")` (notably vLLM's MLA prefill path) can now request fused-quantized output and skip the post-kernel BF16→FP8 quant op.

## 🔍 Related Issues
https://github.com/flashinfer-ai/flashinfer/issues/3178

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] `pytest tests/attention/test_blackwell_fmha.py` on B200

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected FP8 output scale handling so kernels receive the expected quant multiplier.
  * Improved mixed input/output dtype dispatch to handle FP8 output cases correctly.

* **New Features**
  * Enforced dtype compatibility checks to block unsupported q/kv/out combinations and surface clear errors.
  * Output allocation now respects planned/cached output dtype for variable-length paths.

* **Tests**
  * Added coverage for BF16/FP16 inputs with FP8 outputs, including ragged scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->