### PR TITLE
Fix trace-bmm-fp8 test: B should be K-major for subword types

### DIFF
--- a/tests/trace/test_reference_correctness.py
+++ b/tests/trace/test_reference_correctness.py
@@ -2167,8 +2167,9 @@ def test_bmm_bf16_reference_correctness():
     B, M, N, K = 4, 16, 1024, 1024
     a = torch.randn(B, M, K, dtype=torch.bfloat16, device="cuda")
     b = torch.randn(B, K, N, dtype=torch.bfloat16, device="cuda")
+    b_kmaj = b.transpose(1, 2).contiguous().transpose(1, 2)
     try:
-        api = flashinfer.bmm_bf16(a, b, backend="cutlass")
+        api = flashinfer.bmm_bf16(a, b_kmaj, backend="cutlass")
     except Exception as exc:
         pytest.skip(f"bmm_bf16 unavailable: {exc}")
     ref = bmm_bf16_trace.reference(a, b)
@@ -2194,8 +2195,11 @@ def test_bmm_fp8_reference_correctness():
     b_fp8 = (b_bf / b_max).to(torch.float8_e4m3fn)
     a_scale = a_max.to(torch.float32).reshape(1)
     b_scale = b_max.to(torch.float32).reshape(1)
+    b_fp8_kmaj = b_fp8.transpose(1, 2).contiguous().transpose(1, 2)
     try:
-        api = flashinfer.bmm_fp8(a_fp8, b_fp8, a_scale, b_scale, dtype=torch.bfloat16)
+        api = flashinfer.bmm_fp8(
+            a_fp8, b_fp8_kmaj, a_scale, b_scale, dtype=torch.bfloat16
+        )
     except Exception as exc:
         pytest.skip(f"bmm_fp8 unavailable: {exc}")
     ref = bmm_fp8_trace.reference(a_fp8, b_fp8, a_scale, b_scale, dtype=torch.bfloat16)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Closes #3188 

Issue: Upstream change has introduced a failing CI test case: `tests/trace/test_reference_correctness.py::test_bmm_fp8_reference_correctness`

Cause: `flashinfer.bmm_bf16`, `flashinfer.bmm_fp8` (any sub-32 dtypes) expect K-major inputs. The `cutlass` backend checks for this but the default fp8 backend doesn't, causing wrong results.

## 🔍 Related Issues

Current CI runs

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved correctness checks for BF16 and FP8 matrix operations by normalizing inputs to match kernel layout expectations.
  * Kept original reference comparisons unchanged to ensure consistent validation.
  * Preserved behavior for skipping when kernels are unavailable and maintained existing similarity thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->