### PR TITLE
Add git submodule update to build_backend.py

### DIFF
--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -79,22 +79,31 @@ _create_build_metadata()
 
 def _compile_jit_cache(output_dir: Path, verbose: bool = True):
     """Compile AOT modules using flashinfer.aot functions directly."""
+    # Get the project root directory
+    project_root = Path(__file__).parent.parent
+
+    # Ensure 3rdparty submodules are populated (may be empty in CI Docker images)
+    import subprocess
+
+    subprocess.run(
+        ["git", "submodule", "update", "--init", "--recursive"],
+        cwd=str(project_root),
+        check=True,
+    )
+
     # Ensure flashinfer/data/ symlinks exist (normally created by the main
     # package's build_backend, but jit-cache builds may not install the main
     # package first). Use importlib to avoid name collision with this file.
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
-        "main_build_backend", Path(__file__).parent.parent / "build_backend.py"
+        "main_build_backend", project_root / "build_backend.py"
     )
     main_build_backend = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(main_build_backend)
     main_build_backend._create_data_dir(use_symlinks=True)
 
     from flashinfer import aot
-
-    # Get the project root directory
-    project_root = Path(__file__).parent.parent
 
     # Set up build directory
     build_dir = project_root / "build" / "aot"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Follow up to https://github.com/flashinfer-ai/flashinfer/pull/3158. This adds git submodule update --init --recursive in the jit-cache build_backend.py before AOT compilation begins, ensuring all submodules are populated.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3159 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Git submodule handling in the build system to enhance reliability during JIT cache compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->