### PR TITLE
Yanqinz/fix cudnn sm120 nan

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -1051,18 +1051,35 @@ class AutoTuner:
 
                     # If the user has loaded an autotune cache (via
                     # ``autotune(cache=...)``) or warmed up profiling
-                    # results in the current process but this particular
-                    # input shape still falls back, that almost always
-                    # means the runtime input is *outside the tuned
-                    # range* (e.g. ``max_num_tokens`` was 2048 during
-                    # tuning, runtime sees 4000).  This is a silent
-                    # perf regression: the fallback tactic is correct
-                    # but not optimised for this shape.  Warn once per
+                    # results *for this specific custom_op* in the
+                    # current process but this particular input shape
+                    # still falls back, that almost always means the
+                    # runtime input is *outside the tuned range* (e.g.
+                    # ``max_num_tokens`` was 2048 during tuning,
+                    # runtime sees 4000).  This is a silent perf
+                    # regression: the fallback tactic is correct but
+                    # not optimised for this shape.  Warn once per
                     # unique (op, profile-signature) pair so the user
                     # can extend ``tuning_buckets`` / re-tune.
-                    has_tune_data = bool(self._file_configs) or bool(
-                        self.profiling_cache
+                    #
+                    # The has-tune-data check is intentionally scoped
+                    # to ``custom_op`` -- unrelated ops with their own
+                    # cache entries should not trigger a "tuned range
+                    # exceeded" warning for an op that was never tuned
+                    # in the first place.  ``profiling_cache`` keys are
+                    # tuples ``(custom_op, ..., extras)`` and
+                    # ``_file_configs`` keys are
+                    # ``str((custom_op, runner_class_name, profile))``,
+                    # so we filter by ``custom_op`` on each.
+                    op_has_profiling = any(
+                        isinstance(k, tuple) and len(k) > 0 and k[0] == custom_op
+                        for k in self.profiling_cache
                     )
+                    file_key_op_prefix = f"({repr(custom_op)}, "
+                    op_has_file = any(
+                        k.startswith(file_key_op_prefix) for k in self._file_configs
+                    )
+                    has_tune_data = op_has_profiling or op_has_file
                     if has_tune_data:
                         try:
                             signature = self._find_nearest_profile(

--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -148,7 +148,28 @@ def _get_cublas_version() -> str:
 
 
 def _collect_metadata() -> Dict[str, str]:
-    """Collect environment metadata that can affect tactic-to-kernel mappings."""
+    """Collect environment metadata that can affect tactic-to-kernel mappings.
+
+    Tactics in flashinfer's autotune cache are stored as plan indices into
+    cuDNN's ``policy=ALL`` plan list (or backend-internal kernel ids for
+    other backends).  Anything that can shuffle that ordering must be
+    captured here so ``load_configs`` rejects a cache that no longer
+    matches the runtime environment.
+
+    Specifically tracked:
+
+        * ``flashinfer_version``  -- our own bucketing / ordering changes
+        * ``cuda_version``        -- CUDA driver/runtime ABI
+        * ``cublas_version``      -- cuBLAS plan availability inside cuDNN
+        * ``cudnn_version``       -- cuDNN **backend** version
+        * ``cudnn_frontend_version`` -- cuDNN-frontend Python wrapper
+                                        version (independent of backend);
+                                        plan_index ordering can change
+                                        when only the frontend is updated
+                                        but the backend is not
+        * ``gpu``                 -- device name (different SM may have
+                                     different available engines)
+    """
     meta: Dict[str, str] = {}
     meta["flashinfer_version"] = _flashinfer_version
     meta["cuda_version"] = getattr(torch.version, "cuda", None) or "unknown"
@@ -157,6 +178,17 @@ def _collect_metadata() -> Dict[str, str]:
         meta["cudnn_version"] = str(torch.backends.cudnn.version())
     except Exception:
         meta["cudnn_version"] = "unknown"
+    try:
+        # cudnn-frontend is an optional dependency; failing to import is
+        # not fatal -- we just record "unknown" and let the metadata
+        # check fall back to the backend-version field.
+        import cudnn as _cudnn_frontend
+
+        meta["cudnn_frontend_version"] = getattr(
+            _cudnn_frontend, "__version__", "unknown"
+        )
+    except Exception:
+        meta["cudnn_frontend_version"] = "unknown"
     try:
         meta["gpu"] = torch.cuda.get_device_name(torch.cuda.current_device())
     except Exception:
@@ -715,6 +747,10 @@ class AutoTuner:
         self._file_configs: Dict[str, Tuple] = {}
         # Track which file config keys have been logged (to avoid per-call spam)
         self._logged_file_hits: Set[Tuple[str, str]] = set()
+        # Track which (custom_op, profile-shape signature) pairs have already
+        # produced an out-of-range cache-miss warning, so we warn at most
+        # once per unique missing shape.
+        self._logged_cache_miss_oor: Set[Tuple[str, Tuple]] = set()
         # Set when new profiling results are added; cleared on save.
         self._dirty = False
         self._dirty_seq = 0
@@ -763,6 +799,42 @@ class AutoTuner:
                 if cls._instance is None:
                     cls._instance = AutoTuner()
         return cls._instance
+
+    def get_effective_map_to_tuning_buckets(
+        self,
+        tuning_config: "TuningConfig",
+        spec_idx: int = 0,
+    ) -> Callable[[int], int]:
+        """Return the currently effective ``map_to_tuning_buckets`` callable.
+
+        Reflects any active ``autotune(tuning_buckets=..., round_up=...)``
+        overrides on the current thread.  When no override is active,
+        returns
+        ``tuning_config.dynamic_tensor_specs[spec_idx].map_to_tuning_buckets``
+        unchanged.
+
+        Runners that have their own internal bucketing (e.g. cuDNN's
+        override-shape ``cache_m``) should call this so their bucket
+        function matches what the autotuner uses for cache lookup;
+        otherwise a tactic profiled under one bucket scheme can be
+        applied at runtime under a different one, with subtly wrong
+        results.
+
+        Args:
+            tuning_config: The default ``TuningConfig`` the runner would
+                pass to ``choose_one``.
+            spec_idx: Index into ``tuning_config.dynamic_tensor_specs``
+                whose mapper to return.  Defaults to 0 (single dynamic
+                dimension, the common case).
+
+        Returns:
+            A callable ``int -> int`` mapping a runtime size to the
+            currently effective bucket value.
+        """
+        with self._lock:
+            if self._override_tuning_buckets is not None or self._override_round_up:
+                tuning_config = self._apply_tuning_overrides(tuning_config)
+        return tuning_config.dynamic_tensor_specs[spec_idx].map_to_tuning_buckets
 
     def search_cache(
         self,
@@ -976,6 +1048,40 @@ class AutoTuner:
                     logger.debug(
                         f"[AutoTuner]: Generated key{AutoTuner._get_cache_key(custom_op, runners[0], input_shapes, tuning_config, runners[0].get_cache_key_extras(inputs))}"
                     )
+
+                    # If the user has loaded an autotune cache (via
+                    # ``autotune(cache=...)``) or warmed up profiling
+                    # results in the current process but this particular
+                    # input shape still falls back, that almost always
+                    # means the runtime input is *outside the tuned
+                    # range* (e.g. ``max_num_tokens`` was 2048 during
+                    # tuning, runtime sees 4000).  This is a silent
+                    # perf regression: the fallback tactic is correct
+                    # but not optimised for this shape.  Warn once per
+                    # unique (op, profile-signature) pair so the user
+                    # can extend ``tuning_buckets`` / re-tune.
+                    has_tune_data = bool(self._file_configs) or bool(
+                        self.profiling_cache
+                    )
+                    if has_tune_data:
+                        try:
+                            signature = self._find_nearest_profile(
+                                input_shapes, tuning_config
+                            )
+                        except Exception:
+                            signature = tuple(tuple(s) for s in input_shapes)
+                        warn_key = (custom_op, signature)
+                        if warn_key not in self._logged_cache_miss_oor:
+                            self._logged_cache_miss_oor.add(warn_key)
+                            logger.warning(
+                                f"[AutoTuner]: No tuned config covers "
+                                f"{custom_op} input_shapes={input_shapes}; "
+                                f"falling back to runner={runners[0].__class__.__name__} "
+                                f"tactic=-1.  This shape is outside the tuning "
+                                f"bucket range -- expand tuning_buckets / "
+                                f"max_num_tokens during the next tuning "
+                                f"pass to avoid this perf cliff."
+                            )
                 return runner, tactic
 
             assert len(runners) > 0, "At least one runner is required"
@@ -1559,8 +1665,22 @@ class AutoTuner:
         can return pre-tuned results without re-running autotuning.
 
         If the file contains ``_metadata`` that does not match the current
-        environment (different FlashInfer version, GPU, cuBLAS, etc.), the
-        entire cache is **skipped** to avoid silently using invalid tactics.
+        environment, the entire cache is **skipped** to avoid silently
+        using invalid tactics.  Specifically the following metadata fields
+        must all match (or be the wildcard ``"*"``):
+
+            * ``flashinfer_version`` (writer bucketing/ordering changes)
+            * ``cuda_version``
+            * ``cublas_version``
+            * ``cudnn_version`` (backend)
+            * ``cudnn_frontend_version`` (Python wrapper -- can shuffle
+              ``policy=ALL`` plan_index ordering independent of backend)
+            * ``gpu`` (different SM may expose different engines)
+
+        Caches saved by older flashinfer versions that predate the
+        ``cudnn_frontend_version`` metadata field will fail this check
+        (since saved metadata does not contain the field) and need to
+        be regenerated.  See :func:`_collect_metadata` for the exact list.
 
         Note:
             This is called automatically on entry to
@@ -1668,6 +1788,7 @@ class AutoTuner:
             self.profiling_cache.clear()
             self._file_configs.clear()
             self._logged_file_hits.clear()
+            self._logged_cache_miss_oor.clear()
             self._dirty = False
             self._dirty_seq = 0
 

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -21,6 +21,7 @@ from .gemm_base import group_gemm_fp8_nt_groupwise as group_gemm_fp8_nt_groupwis
 from .gemm_base import fp8_blockscale_gemm_sm90 as fp8_blockscale_gemm_sm90
 from .gemm_base import (
     is_cudnn_override_shape_available as is_cudnn_override_shape_available,
+    clear_cudnn_graph_cache as clear_cudnn_graph_cache,
     build_cudnn_gemm_bf16_graph_override_shape as build_cudnn_gemm_bf16_graph_override_shape,
     execute_cudnn_gemm_bf16_graph_override_shape as execute_cudnn_gemm_bf16_graph_override_shape,
     build_cudnn_gemm_fp4_graph_override_shape as build_cudnn_gemm_fp4_graph_override_shape,
@@ -91,6 +92,7 @@ __all__ = [
     "mm_M1_16_K7168_N256",
     "tinygemm_bf16",
     "is_cudnn_override_shape_available",
+    "clear_cudnn_graph_cache",
     "build_cudnn_gemm_bf16_graph_override_shape",
     "execute_cudnn_gemm_bf16_graph_override_shape",
     "build_cudnn_gemm_fp4_graph_override_shape",

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -21,7 +21,6 @@ from .gemm_base import group_gemm_fp8_nt_groupwise as group_gemm_fp8_nt_groupwis
 from .gemm_base import fp8_blockscale_gemm_sm90 as fp8_blockscale_gemm_sm90
 from .gemm_base import (
     is_cudnn_override_shape_available as is_cudnn_override_shape_available,
-    clear_cudnn_graph_cache as clear_cudnn_graph_cache,
     build_cudnn_gemm_bf16_graph_override_shape as build_cudnn_gemm_bf16_graph_override_shape,
     execute_cudnn_gemm_bf16_graph_override_shape as execute_cudnn_gemm_bf16_graph_override_shape,
     build_cudnn_gemm_fp4_graph_override_shape as build_cudnn_gemm_fp4_graph_override_shape,
@@ -92,7 +91,6 @@ __all__ = [
     "mm_M1_16_K7168_N256",
     "tinygemm_bf16",
     "is_cudnn_override_shape_available",
-    "clear_cudnn_graph_cache",
     "build_cudnn_gemm_bf16_graph_override_shape",
     "execute_cudnn_gemm_bf16_graph_override_shape",
     "build_cudnn_gemm_fp4_graph_override_shape",

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2015,30 +2015,51 @@ def is_cudnn_override_shape_available() -> bool:
 
 
 def clear_cudnn_graph_cache() -> None:
-    """Clear all process-local cuDNN GEMM graph caches.
+    """Invalidate all process-local cuDNN GEMM graph caches **and** the
+    AutoTuner profiling cache.
 
-    Each ``build_cudnn_gemm_*`` helper in this module is wrapped with
-    ``functools.lru_cache(maxsize=1024)``.  In production this is
-    self-managing: the 1024-entry LRU caps memory growth (cold shapes
-    are evicted) while keeping hot shapes resident.  But LRU cannot
-    handle a few cases that this function does:
+    .. note::
+        **Internal / debug-only helper** -- not part of FlashInfer's
+        public API.  Production callers should never need this:
+        every ``build_cudnn_gemm_*`` helper is wrapped with
+        ``functools.lru_cache(maxsize=1024)``, which auto-evicts cold
+        shapes and keeps hot shapes resident, capping GPU memory
+        growth on its own.
 
-        * Hot-patching a ``build_*`` helper during development -- LRU
-          will not evict the now-stale graph because the dev workload
-          rarely reaches 1024 distinct shapes.
-        * Deliberately switching between two cuDNN library versions in
-          the same Python process -- all cached graphs become invalid
-          regardless of access recency.
-        * Freeing GPU memory at a controlled time (e.g. before loading
-          a large model) without waiting for natural LRU eviction.
-        * Test setup that wants a clean slate per testcase.
+        This function exists for the few cases LRU cannot handle.  In
+        every one of them, **the AutoTuner cache must also be cleared**
+        because tactic indices (``execute_plan_at_index(..., N)``) are
+        offsets into the cuDNN ``policy=ALL`` plan list of a *specific
+        graph* -- if we throw the graph away and let it rebuild, the
+        rebuilt plan list may enumerate engines differently and the
+        stored ``N`` would silently point to a different kernel.  We
+        therefore clear both stores atomically so plan indices and the
+        graphs they were profiled against stay in lockstep:
+
+            * **Hot-patching during development** -- after editing a
+              ``build_*`` helper in-place, LRU will not evict the
+              now-stale graph because the dev workload rarely reaches
+              1024 distinct shapes; reach for this to invalidate
+              without restarting Python.
+            * **Deliberate cuDNN library version swap** in the same
+              process -- the rebuilt graphs may expose different
+              engines, so old tactic indices are no longer valid.
+            * **Test fixtures** that want a clean slate per testcase.
+            * **Manual GPU memory release** -- safe even if the build
+              code is unchanged (the next call will simply re-tune
+              from cold and pick equivalent tactics again).
+
+        The function is intentionally *not* re-exported from
+        :mod:`flashinfer.gemm` (i.e. not in its ``__all__``) and has
+        no API stability guarantee.  Import it directly from this
+        module if you really need it::
+
+            from flashinfer.gemm.gemm_base import clear_cudnn_graph_cache
 
     This does **not** clear:
 
         * cuDNN handles (``_cudnn_handles``) -- those are cheap to
           re-set the stream on and expensive to recreate.
-        * ``AutoTuner.profiling_cache`` -- use
-          ``AutoTuner.get().clear_cache()`` for that.
         * The autotuner's ``_find_nearest_profile`` LRU cache -- it is
           shape-keyed, not graph-keyed, and stays correct across
           rebuilds.
@@ -2056,6 +2077,13 @@ def clear_cudnn_graph_cache() -> None:
     for fn in cached_builders:
         if hasattr(fn, "cache_clear"):
             fn.cache_clear()
+
+    # Plan indices stored in AutoTuner.profiling_cache are offsets into
+    # the cuDNN plan list of the graph that was profiled.  Once we
+    # discard the graph LRU, those indices may no longer refer to the
+    # same engine after the rebuilt graph re-enumerates plans, so we
+    # clear the autotuner cache too.  See the docstring for details.
+    AutoTuner.get().clear_cache()
 
 
 # One cudnn handle per each GPU

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -3461,8 +3461,8 @@ def _cudnn_gemm_bf16_runner(
             self._is_b_k_major = True if is_b_k_major is None else is_b_k_major
 
         def _get_override_graph(self, a, b, bias, out):
-            a_shape, _a_stride = _get_bf16_3d_shape_stride(a)
-            b_shape, _b_stride = _get_bf16_3d_shape_stride(b)
+            a_shape, _ = _get_bf16_3d_shape_stride(a)
+            b_shape, _ = _get_bf16_3d_shape_stride(b)
 
             batch = a_shape[0]
             actual_m = a_shape[-2]

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -318,7 +318,7 @@ def _cublaslt_mm_bf16_requirement(
     return True
 
 
-@supported_compute_capability([80, 86, 89, 90, 100, 103])
+@supported_compute_capability([80, 86, 87, 89, 90, 100, 103, 110, 120, 121])
 def _cudnn_mm_bf16_requirement(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -46,7 +46,6 @@ from ..autotuner import (
 )
 from ..fused_moe.utils import (
     get_hybrid_num_tokens_buckets,
-    last_positive_power_of_2,
     map_to_hybrid_bucket_uncapped,
 )
 from .kernels.utils import _select_sm100_mm_fp4_cute_dsl_tactic
@@ -1134,10 +1133,32 @@ def bf16_gemm_sm100(
     workspace_buffer: torch.Tensor,
     runner_names: List[str],
 ) -> None:
-    runners = []
     use_sm_100f = is_sm100f_supported(a.device)
+
+    tuner = AutoTuner.get()
+    # Effective bucket mapper, accounting for any active
+    # ``with autotune(tuning_buckets=..., round_up=...)`` overrides.
+    # The cuDNN runner uses this for its override-shape ``cache_m`` so the
+    # graph it builds at runtime is the SAME graph the autotuner profiled
+    # tactics on.
+    effective_m_bucket_mapper = tuner.get_effective_map_to_tuning_buckets(
+        _BF16_GEMM_SM100_TUNING_CONFIG, spec_idx=0
+    )
+    # Capture the real tensors' stride layout so the cuDNN graph built
+    # for autotune profiling (where ``a`` is a torch.rand-synthesized
+    # contiguous tensor) matches the graph used at runtime.
+    is_a_k_major = a.stride(-1) == 1
+    is_b_k_major = b.stride(-2) == 1
+
+    runners = []
     if "cudnn" in runner_names:
-        runners.append(_cudnn_gemm_bf16_runner())
+        runners.append(
+            _cudnn_gemm_bf16_runner(
+                effective_m_bucket_mapper,
+                is_a_k_major=is_a_k_major,
+                is_b_k_major=is_b_k_major,
+            )
+        )
     if "cublaslt" in runner_names:
         runners.append(get_mm_bf16_cublaslt_module().cublaslt_bf16_gemm_runner())
     if "cutlass" in runner_names:
@@ -1147,7 +1168,6 @@ def bf16_gemm_sm100(
             get_tgv_gemm_sm10x_module(a.dtype, use_sm_100f).tgv_gemm_runner()
         )
     assert runners, "No suitable runners found"
-    tuner = AutoTuner.get()
 
     inputs = [a, b, bias, pdl, out, workspace_buffer]
     runner, tactic = tuner.choose_one(
@@ -1994,6 +2014,50 @@ def is_cudnn_override_shape_available() -> bool:
         return False
 
 
+def clear_cudnn_graph_cache() -> None:
+    """Clear all process-local cuDNN GEMM graph caches.
+
+    Each ``build_cudnn_gemm_*`` helper in this module is wrapped with
+    ``functools.lru_cache(maxsize=1024)``.  In production this is
+    self-managing: the 1024-entry LRU caps memory growth (cold shapes
+    are evicted) while keeping hot shapes resident.  But LRU cannot
+    handle a few cases that this function does:
+
+        * Hot-patching a ``build_*`` helper during development -- LRU
+          will not evict the now-stale graph because the dev workload
+          rarely reaches 1024 distinct shapes.
+        * Deliberately switching between two cuDNN library versions in
+          the same Python process -- all cached graphs become invalid
+          regardless of access recency.
+        * Freeing GPU memory at a controlled time (e.g. before loading
+          a large model) without waiting for natural LRU eviction.
+        * Test setup that wants a clean slate per testcase.
+
+    This does **not** clear:
+
+        * cuDNN handles (``_cudnn_handles``) -- those are cheap to
+          re-set the stream on and expensive to recreate.
+        * ``AutoTuner.profiling_cache`` -- use
+          ``AutoTuner.get().clear_cache()`` for that.
+        * The autotuner's ``_find_nearest_profile`` LRU cache -- it is
+          shape-keyed, not graph-keyed, and stays correct across
+          rebuilds.
+    """
+    cached_builders = (
+        build_cudnn_gemm_fp4_graph,
+        build_cudnn_gemm_fp4_graph_override_shape,
+        build_cudnn_gemm_mxfp8_graph_override_shape,
+        build_cudnn_gemm_with_per_tensor_q_graph,
+        build_cudnn_gemm_with_per_tensor_q_graph_override_shape,
+        build_cudnn_gemm_bf16_graph,
+        build_cudnn_gemm_bf16_graph_override_shape,
+        create_cudnn_execution_plans_mxfp8_gemm,
+    )
+    for fn in cached_builders:
+        if hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+
 # One cudnn handle per each GPU
 _cudnn_handles: dict[int, int] = {}
 
@@ -2030,7 +2094,7 @@ def _validate_bf16_output_dtype(dtype: torch.dtype):
         )
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_fp4_graph(
     a_shape,
     a_stride,
@@ -2191,7 +2255,7 @@ def execute_cudnn_gemm_fp4_graph(
 _OVERRIDE_SHAPE_CACHE_M = 8192
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_fp4_graph_override_shape(
     batch,
     n,
@@ -2451,7 +2515,7 @@ def execute_cudnn_gemm_mxfp8_graph(
         )
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_mxfp8_graph_override_shape(
     batch,
     n,
@@ -2757,7 +2821,7 @@ def execute_cudnn_gemm_with_per_tensor_q_graph(
 # ---------------------------------------------------------------------------
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_with_per_tensor_q_graph_override_shape(
     batch, n, k, a_type, b_type, o_type, device, cache_m: int = _OVERRIDE_SHAPE_CACHE_M
 ):
@@ -3005,7 +3069,7 @@ def _get_bf16_3d_shape_stride(tensor: torch.Tensor):
     return (tuple(shape), tuple(stride))
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_bf16_graph(
     a_shape,
     a_stride,
@@ -3107,7 +3171,7 @@ def execute_cudnn_gemm_bf16_graph(
 # ---------------------------------------------------------------------------
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_bf16_graph_override_shape(
     batch,
     n,
@@ -3319,12 +3383,58 @@ def _cudnn_gemm_bf16(
     return out
 
 
-def _cudnn_gemm_bf16_runner():
+def _cudnn_gemm_bf16_runner(
+    m_bucket_mapper=None,
+    is_a_k_major: Optional[bool] = None,
+    is_b_k_major: Optional[bool] = None,
+):
+    """Build a CudnnBf16GemmRunner.
+
+    See :func:`_cudnn_gemm_fp4_runner` for the ``m_bucket_mapper``
+    rationale; this is the BF16 GEMM analog using the same alignment
+    scheme.  When ``m_bucket_mapper`` is ``None``, defaults to
+    ``map_to_hybrid_bucket_uncapped`` -- the same mapper
+    ``_BF16_GEMM_SM100_TUNING_CONFIG`` uses as
+    ``map_to_tuning_buckets``.
+
+    ``is_a_k_major`` / ``is_b_k_major`` describe the stride layout of
+    the real ``a`` and ``b`` tensors at the call site.  These are baked
+    into the cuDNN graph at build time (see
+    :func:`build_cudnn_gemm_bf16_graph_override_shape`), so they are
+    part of the graph cache key.  The autotuner's profile path
+    synthesizes ``a`` via ``torch.rand`` which is always contiguous
+    (k-major); if the real tensor is *not* k-major we would otherwise
+    profile under one stride flag and execute under another, picking
+    a tactic from the wrong graph.  Capturing the flags here at runner
+    construction (using the real tensors from the caller) keeps the
+    flag identical across profile and runtime paths.
+
+    Callers (``bf16_gemm_sm100``) typically pass the effective mapper
+    from ``AutoTuner.get_effective_map_to_tuning_buckets`` and the
+    real ``a.stride()[-1] == 1`` / ``b.stride()[-2] == 1``.
+    """
+
     class CudnnBf16GemmRunner(TunableRunner):
-        @staticmethod
-        def _get_override_graph(a, b, bias, out):
-            a_shape, a_stride = _get_bf16_3d_shape_stride(a)
-            b_shape, b_stride = _get_bf16_3d_shape_stride(b)
+        def __init__(
+            self,
+            m_bucket_mapper,
+            is_a_k_major: Optional[bool],
+            is_b_k_major: Optional[bool],
+        ):
+            super().__init__()
+            self._m_bucket_mapper = (
+                m_bucket_mapper
+                if m_bucket_mapper is not None
+                else map_to_hybrid_bucket_uncapped
+            )
+            # Default to k-major (the convention torch.rand-synthesized
+            # profile tensors use) when caller didn't specify.
+            self._is_a_k_major = True if is_a_k_major is None else is_a_k_major
+            self._is_b_k_major = True if is_b_k_major is None else is_b_k_major
+
+        def _get_override_graph(self, a, b, bias, out):
+            a_shape, _a_stride = _get_bf16_3d_shape_stride(a)
+            b_shape, _b_stride = _get_bf16_3d_shape_stride(b)
 
             batch = a_shape[0]
             actual_m = a_shape[-2]
@@ -3332,11 +3442,17 @@ def _cudnn_gemm_bf16_runner():
             n = b_shape[-1]
             o_type = _torch_data_type_to_cudnn_data_type(out.dtype)
 
-            # Ceiling power-of-2 ensures cache_m >= actual_M.
-            cache_m = last_positive_power_of_2(actual_m)
-
-            is_a_k_major = a_stride[-1] == 1
-            is_b_k_major = b_stride[-2] == 1
+            # See _cudnn_gemm_fp4_runner._get_override_graph for full
+            # rationale: cache_m must match the AutoTuner cache key so
+            # the runtime graph is the SAME graph the autotuner profiled
+            # tactics on.  is_a_k_major / is_b_k_major are taken from
+            # ``self`` (captured from the real input tensors at runner
+            # construction) instead of from the local ``a``/``b`` here:
+            # in autotuner.profile mode ``a`` is a torch.rand-synthesized
+            # contiguous tensor regardless of the real layout, so reading
+            # its stride would build a different graph than the runtime
+            # call, breaking tactic-index alignment.
+            cache_m = self._m_bucket_mapper(actual_m)
 
             graph = build_cudnn_gemm_bf16_graph_override_shape(
                 batch=batch,
@@ -3346,8 +3462,8 @@ def _cudnn_gemm_bf16_runner():
                 device=a.device,
                 bias_is_not_none=bias is not None,
                 cache_m=cache_m,
-                is_a_k_major=is_a_k_major,
-                is_b_k_major=is_b_k_major,
+                is_a_k_major=self._is_a_k_major,
+                is_b_k_major=self._is_b_k_major,
                 policy=cudnn.build_plan_policy.ALL,
             )
             return graph
@@ -3418,7 +3534,7 @@ def _cudnn_gemm_bf16_runner():
 
             return out
 
-    return CudnnBf16GemmRunner()
+    return CudnnBf16GemmRunner(m_bucket_mapper, is_a_k_major, is_b_k_major)
 
 
 def _get_real_fp4_shape_from_packed_uint8(packed_fp4_tensor):
@@ -4503,7 +4619,7 @@ def _cudnn_gemm_fp4(
         policy = cudnn.build_plan_policy.ALL
 
     # build the fp4 cudnn graph
-    # Constructed graph is cached, via @functools.cache decorator.
+    # Constructed graph is cached, via @functools.lru_cache decorator.
     graph = build_cudnn_gemm_fp4_graph(
         real_a_shape,
         real_a_stride,
@@ -4530,10 +4646,49 @@ def _cudnn_gemm_fp4(
     return out
 
 
-def _cudnn_gemm_fp4_runner():
+def _cudnn_gemm_fp4_runner(m_bucket_mapper=None):
+    """Build a CudnnFp4GemmRunner.
+
+    Args:
+        m_bucket_mapper: A callable ``int -> int`` mapping the runtime M
+            (i.e. ``actual_m``) to the build-time ``cache_m`` for the cuDNN
+            override-shape graph.  When ``None``, defaults to
+            ``map_to_hybrid_bucket_uncapped`` -- the same mapper the
+            ``_MM_FP4_TUNING_CONFIG_*`` configs use as
+            ``map_to_tuning_buckets``.  Callers (``mm_fp4``) typically
+            override this with the *currently active* mapper from
+            ``AutoTuner.get_effective_map_to_tuning_buckets`` so any
+            ``with autotune(tuning_buckets=..., round_up=...)`` overrides
+            propagate into the cuDNN graph.
+
+    Why this matters:
+        cuDNN's override-shape feature builds one graph keyed by
+        ``cache_m`` and reuses it for any runtime M (the real shape is
+        passed through ``override_shapes`` at execute time).  The
+        AutoTuner stores per-bucket tactics keyed by
+        ``map_to_tuning_buckets(M)``.  If the runner's ``cache_m``
+        function and the autotuner's ``map_to_tuning_buckets`` disagree,
+        a tactic profiled on graph ``cache_m=A`` is silently applied
+        to graph ``cache_m=B`` at runtime -- the plan index has
+        different meaning in the two graphs.  Sharing the mapper keeps
+        both keyed by the exact same value.
+
+        The mapper need NOT satisfy ``mapper(M) >= M`` -- cuDNN
+        override-shape accepts arbitrary ``cache_m`` and ``actual_m``
+        in any order.  We only require that profile-time and
+        runtime-time produce the same ``cache_m`` for the same input.
+    """
+
     class CudnnFp4GemmRunner(TunableRunner):
-        @staticmethod
-        def _get_override_graph(a, b, alpha, out_dtype, block_size, use_nvfp4):
+        def __init__(self, m_bucket_mapper):
+            super().__init__()
+            self._m_bucket_mapper = (
+                m_bucket_mapper
+                if m_bucket_mapper is not None
+                else map_to_hybrid_bucket_uncapped
+            )
+
+        def _get_override_graph(self, a, b, alpha, out_dtype, block_size, use_nvfp4):
             real_a_shape, _ = _get_real_fp4_shape_from_packed_uint8(a)
             real_b_shape, _ = _get_real_fp4_shape_from_packed_uint8(b)
 
@@ -4542,8 +4697,16 @@ def _cudnn_gemm_fp4_runner():
             k = real_a_shape[2]
             n = real_b_shape[2]
 
-            # Ceiling power-of-2 ensures cache_m >= actual_m.
-            cache_m = last_positive_power_of_2(actual_m)
+            # cache_m must match the AutoTuner cache key so the runtime
+            # graph is the SAME graph the autotuner profiled tactics on.
+            # ``self._m_bucket_mapper`` is set by the caller (``mm_fp4``)
+            # to the *currently effective* ``map_to_tuning_buckets`` (with
+            # any ``autotune(tuning_buckets=..., round_up=...)`` override
+            # applied).  Sharing the mapper keeps cache_m and the tactic
+            # cache key in lockstep -- otherwise a tactic profiled on
+            # graph ``cache_m=A`` is silently applied to graph ``cache_m=B``
+            # at runtime, which has a different plan-index meaning.
+            cache_m = self._m_bucket_mapper(actual_m)
 
             graph = build_cudnn_gemm_fp4_graph_override_shape(
                 batch=batch,
@@ -4680,7 +4843,7 @@ def _cudnn_gemm_fp4_runner():
 
             return out
 
-    return CudnnFp4GemmRunner()
+    return CudnnFp4GemmRunner(m_bucket_mapper)
 
 
 def _check_mm_fp4_problem_size(
@@ -5620,8 +5783,23 @@ def mm_fp4(
     # Lazy initialization of runners to avoid overhead of creating a new runner that will not be used
     major, minor = get_compute_capability(a.device)
 
+    tuner = AutoTuner.get()
+    tuning_config = (
+        _MM_FP4_TUNING_CONFIG_8x4 if use_8x4_sf_layout else _MM_FP4_TUNING_CONFIG_128x4
+    )
+
+    # Effective bucket mapper, accounting for any active
+    # ``with autotune(tuning_buckets=..., round_up=...)`` overrides.
+    # The cuDNN runner uses this for its override-shape ``cache_m`` so the
+    # graph it builds at runtime is the SAME graph the autotuner profiled
+    # tactics on.  Without this, custom-bucket overrides cause silent
+    # cache_m / autotune-key drift (wrong plan, possible NaN).
+    effective_m_bucket_mapper = tuner.get_effective_map_to_tuning_buckets(
+        tuning_config, spec_idx=0
+    )
+
     backend_to_runner_factory = {
-        "cudnn": lambda: _cudnn_gemm_fp4_runner(),
+        "cudnn": lambda: _cudnn_gemm_fp4_runner(effective_m_bucket_mapper),
         "trtllm": lambda: get_trtllm_gemm_module().trtllm_fp4_gemm_runner(
             use_8x4_sf_layout
         ),
@@ -5636,13 +5814,6 @@ def mm_fp4(
         ),
     }
     runners = [backend_to_runner_factory[cur_backend]() for cur_backend in backends]
-
-    # Now we have a list of runners for desired & supported backends.
-    tuner = AutoTuner.get()
-
-    tuning_config = (
-        _MM_FP4_TUNING_CONFIG_8x4 if use_8x4_sf_layout else _MM_FP4_TUNING_CONFIG_128x4
-    )
 
     inputs = [
         a,

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -43,10 +43,7 @@ def test_mm_bf16(
 
     if backend == "auto" and (enable_bias or pdl):
         pytest.skip("mm_bf16 with auto backend does not support bias or pdl arguments.")
-    if backend == "cudnn" and (enable_bias or pdl):
-        pytest.skip(
-            "mm_bf16 with cuDNN backend does not support bias or pdl arguments."
-        )
+
     if backend == "cutlass" and (enable_bias or pdl):
         pytest.skip(
             "mm_bf16 with CUTLASS backend does not support bias or pdl arguments."


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Aligns the cuDNN GEMM runners with the AutoTuner's bucket bookkeeping, fixes a rare NaN/Inf in FP4 GEMM caused by mismatched tactic indices, and adds a few production-quality plumbing improvements.

1. Root-cause fix for FP4 GEMM NaN/Inf
Symptom: flashinfer.mm_fp4(..., backend="cudnn") produced sparse NaN/Inf (typically a few values out of millions) at specific shapes (e.g. M=2001, K=2688, N=10304) under sglang prefill workloads.

Root cause: CudnnFp4GemmRunner._get_override_graph (and the BF16 analog) computed the cuDNN override-shape cache_m using last_positive_power_of_2(actual_m) (a floor-to-power-of-2 function), while a comment claimed the call was a ceiling. The function flashinfer was actually calling is largest 2^k <= x, so for a non-power-of-2 actual_m (e.g. 2001) it produced cache_m=1024, smaller than the runtime M.

The cuDNN graph cache is keyed on cache_m. The AutoTuner's plan-index lookup is keyed on the bucket the runtime size maps to (map_to_tuning_buckets). When those two bucket functions disagreed — which they did, in subtle ways — a tactic that was profiled on graph A could be silently applied to graph B at runtime, where the same plan index points to a different cuDNN engine. This produced rare NaN/Inf at the shapes where the two functions diverged.

Fix: Make the cuDNN runner share the AutoTuner's bucket function.

flashinfer/autotuner.py: new public method AutoTuner.get_effective_map_to_tuning_buckets(tuning_config, spec_idx=0) that returns the currently effective map_to_tuning_buckets for a given TuningConfig, applying any active with autotune(tuning_buckets=..., round_up=...) overrides.
flashinfer/gemm/gemm_base.py:
_cudnn_gemm_fp4_runner and _cudnn_gemm_bf16_runner now take a m_bucket_mapper argument; the inner _get_override_graph is converted from @staticmethod to an instance method and computes cache_m = self._m_bucket_mapper(actual_m).
mm_fp4 and bf16_gemm_sm100 query the active mapper via tuner.get_effective_map_to_tuning_buckets(...) and inject it into the runner factory.
After the fix, the cuDNN graph used at runtime is always the same graph the AutoTuner profiled tactics against, regardless of whether the user is in default mode, autotune(round_up=True), autotune(tuning_buckets=...), or any nested combination.

2. Stride-flag profile/runtime alignment for BF16 GEMM
build_cudnn_gemm_bf16_graph_override_shape bakes is_a_k_major / is_b_k_major into the graph cache key (the build-time stride layout differs between row- and column-major). The AutoTuner profile path uses torch.rand-synthesized tensors which are always contiguous (k-major), but the runtime tensor a may be column-major in real workloads. That made profile time and runtime build different cuDNN graphs from the cache's perspective and apply tactic indices across them.

Fix: Capture is_a_k_major / is_b_k_major from the real input tensors at runner construction time (in bf16_gemm_sm100) and store them on the runner instance. _get_override_graph now reads self._is_*_k_major instead of the local tensor's stride, so profile and runtime always build the same graph.

3. cuDNN graph cache is now bounded + manually clearable
The 8 build_cudnn_gemm_*_graph_* helpers were a mix of @functools.cache (unbounded, 6 uses) and @functools.lru_cache(maxsize=1024) (2 uses). On a long-running serving process with diverse shapes (different batch sizes, model layers, sequence lengths), the unbounded cache grows monotonically.

Fix:

All 8 helpers now use @functools.lru_cache(maxsize=1024). Cold shapes are evicted automatically; hot shapes stay resident. GPU memory usage is bounded.
New public function flashinfer.gemm.clear_cudnn_graph_cache() for the cases LRU cannot handle: development hot-patching, deliberate cuDNN library version switching, controlled GPU memory release, and unit-test cleanup. Calls .cache_clear() on every cuDNN graph builder.
The other @functools.cache decorators (JIT module loaders) are unchanged — those have a small bounded number of unique entries (~tens, by hardware × dtype combinations) and don't need eviction.

4. Out-of-range autotune cache miss warning
When a user ran with autotune(False, cache="cfg.json") for inference but the runtime input shape was outside the tuning bucket range used during profiling, the lookup silently fell back to tactic=-1 and the user had no way to notice they were missing the tuned tactic.

Fix (flashinfer/autotuner.py): in the non-tuning branch of choose_one, when search_cache returns a fallback and the user has loaded autotune data (file configs or in-memory profiling cache), emit a logger.warning once per (custom_op, profile-shape signature) pair pointing the user at expanding tuning_buckets / max_num_tokens. New _logged_cache_miss_oor: Set tracks dedup; clear_cache() clears it so a re-tune resets the deduplication.

5. Cache file metadata: include cudnn-frontend version
AutoTuner.save_configs writes a _metadata block to JSON; load_configs rejects (and refuses to overwrite) caches whose metadata doesn't match the current environment. Previously the check covered flashinfer_version, cuda_version, cublas_version, cudnn_version (backend), and gpu — but not cudnn-frontend (the Python wrapper) version.

policy=ALL plan_index ordering can shuffle when only the frontend is upgraded but the backend is the same. A cache saved under one frontend can have stale indices under another with no warning.

Fix (_collect_metadata): also record cudnn_frontend_version (from cudnn.__version__, falls back to "unknown" if cudnn is not importable). Caches saved by older flashinfer versions that predate this metadata field will be rejected on load and need to be regenerated — which is the correct behavior: those caches were never validated against frontend version and may already be stale.

load_configs docstring updated to enumerate the metadata fields and call out the migration cost.

## 🔍 Related Issues

Recently, sglang reported a silent nan encountered during running NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 on sm120/sm121

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose effective tuning-bucket mapping from the autotuner.
  * Ability to clear cuDNN graph-builder and tuning caches (also resets out-of-range warning state).
  * Broader BF16 backend eligibility on newer GPU architectures.

* **Bug Fixes**
  * Improved fallback warnings for operations outside tuned ranges (deduplicated).
  * Override-shape execution now respects runtime layout and active bucket mapping to avoid stale plan mismatches.

* **Tests**
  * GEMM tests now exercise additional cuDNN configurations.

* **Chores**
  * Bounded internal caches to limit growth and reduce resource use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->