### PR TITLE
perf(moe): optimize SM120 b12x MoE short decode

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -557,6 +557,8 @@ def _get_micro_kernel(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     share_input_across_experts: bool = False,
+    share_expert_scales: bool = False,
+    single_token: bool = False,
     mac_override: int | None = None,
     activation: str = "silu",
 ):
@@ -588,6 +590,8 @@ def _get_micro_kernel(
         input_scales_are_reciprocal,
         fast_math,
         share_input_across_experts,
+        share_expert_scales,
+        single_token,
         activation,
     )
     cached = _MICRO_KERNEL_CACHE.get(cache_key)
@@ -607,6 +611,8 @@ def _get_micro_kernel(
         fast_math=fast_math,
         activation=activation,
         share_input_across_experts=share_input_across_experts,
+        share_expert_scales=share_expert_scales,
+        single_token=single_token,
     )
 
     is_gated = activation == "silu"
@@ -815,6 +821,7 @@ def launch_sm120_static_moe(
     # the m=1 relu2 shared-input micro optimization only applies when every
     # expert sees the same FC1-input global scale.
     input_gs_is_shared = input_gs.numel() == 1
+    down_input_scale_is_shared = down_input_scale.numel() == 1
 
     # Broadcast scalar scales to per-expert [E] tensors
     input_gs = _expand_to_experts(input_gs, num_experts)
@@ -828,19 +835,24 @@ def launch_sm120_static_moe(
 
     sm_count = get_num_sm(torch.device("cuda"))
     base_mac = min(get_max_active_clusters(1), sm_count)
+    tuned_static_mac = _lookup_mac_ladder(_STATIC_MAC_LADDER, routed_rows)
+    static_mac = min(tuned_static_mac or base_mac, base_mac)
+    if not use_micro and routed_rows < 40:
+        static_mac = min(static_mac, 64)
 
     if use_micro:
         assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
             f"compact_topk_ids buffer too small: "
             f"{workspace.compact_topk_ids.numel()} < {flat_ids.numel()}"
         )
-        compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
-        if num_tokens == 1:
-            # A single token's top-k is already a dense unique expert set,
-            # so we can build the compact local-id mapping on the host
-            # without launching the Triton compaction kernel. The micro
-            # kernel still reads weight_expert_ids the same way it does
-            # for m>1; it just sees a pre-filled workspace.
+        # Single-token ReLU2 is non-gated, so the micro kernel can launch on
+        # the routed expert ids directly. Gated SiLU still goes through the
+        # compact id buffer so the kernel can map compact launch ids back to
+        # the physical gate/up weight experts.
+        if num_tokens == 1 and activation == "relu2":
+            launch_ids = flat_ids
+        elif num_tokens == 1:
+            compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
             compact_ids.copy_(
                 torch.arange(
                     flat_ids.numel(),
@@ -852,7 +864,9 @@ def launch_sm120_static_moe(
                 flat_ids.to(torch.int32)
             )
             workspace.active_expert_count.fill_(flat_ids.numel())
+            launch_ids = compact_ids
         else:
+            compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
             from .triton_compact import compact_topk_ids as _triton_compact_topk_ids
 
             _triton_compact_topk_ids(
@@ -861,22 +875,23 @@ def launch_sm120_static_moe(
                 workspace.weight_expert_ids,
                 workspace.active_expert_count,
             )
-        launch_ids = compact_ids
+            launch_ids = compact_ids
         # Select micro MAC: min of tuned ladder, work tiles, and hardware limit.
-        # The hardware cap (base_mac) prevents deadlocks on GPUs with fewer SMs
-        # than the profiled tuning target.
         micro_work_tiles = max(1, routed_rows * max(1, (n + 128 - 1) // 128))
         tuned_mac = _lookup_mac_ladder(_MICRO_MAC_LADDER, routed_rows)
         micro_mac = min(tuned_mac or base_mac, micro_work_tiles, base_mac)
-        # For m=1 relu2 with a shared FC1-input scale, all experts see the
-        # same quantized activation — quantize once and share the packed
-        # buffer slot across all K top-k pairs. Env override lets us flip
-        # this off without a code change if a regression surfaces.
+        # For m=1 ReLU2 with a shared FC1-input scale, all experts see the
+        # same quantized activation. Match FI main's synchronization model:
+        # one CTA writes a shared packed slot, then the resident-grid barrier
+        # below makes it visible before all CTAs read it for FC1.
         share_input_across_experts = (
             activation == "relu2"
             and num_tokens == 1
             and input_gs_is_shared
             and os.environ.get("FLASHINFER_B12X_MICRO_SHARE_INPUT", "1") != "0"
+        )
+        share_expert_scales = (
+            activation == "relu2" and input_gs_is_shared and down_input_scale_is_shared
         )
         compiled, mac = _get_micro_kernel(
             workspace.state_E,
@@ -886,17 +901,16 @@ def launch_sm120_static_moe(
             n,
             top_k,
             workspace.max_rows,
-            topk_ids_dtype=torch.int32,
+            topk_ids_dtype=launch_ids.dtype,
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
             share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=num_tokens == 1,
             mac_override=micro_mac,
             activation=activation,
         )
     else:
-        # Static path — use hardware default MAC (same as main).
-        # MAC tuning for the static kernel is deferred to a follow-up
-        # to avoid changing behavior for existing static workloads.
         compiled, mac = _get_static_kernel(
             workspace.state_E,
             num_experts,
@@ -908,6 +922,7 @@ def launch_sm120_static_moe(
             topk_ids_dtype=torch.int32,
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
+            mac_override=static_mac,
             activation=activation,
         )
         launch_ids = flat_ids

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -33,8 +33,8 @@ implementation:
 What changes relative to the static kernel:
   - topk_ids contains LOCAL expert IDs (pre-compacted by Triton pre-pass)
   - global expert IDs looked up via weight_expert_ids[local_expert_id]
-  - all_rows_unique fast path: when num_tokens==1 and every expert has
-    exactly one row, skip atomic routing and use O(1) work assignment
+  - single_token fast path: when num_tokens==1 and every expert has exactly
+    one row, skip atomic routing and use O(1) work assignment
   - Phase 0 does NOT init global_to_local_expert or active_expert_count
     (already populated by Triton pre-pass)
   - Three values broadcast via shared ctrl (including expert_id)
@@ -367,6 +367,8 @@ class MoEMicroKernel:
         fast_math: bool = False,
         activation: str = "silu",
         share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
     ):
         if activation not in {"silu", "relu2"}:
             raise ValueError(f"unsupported activation {activation!r}")
@@ -380,9 +382,10 @@ class MoEMicroKernel:
         # For m=1 with a shared input scale, the quantized activation is
         # identical across all K top-k experts. When set, only pair_idx==0
         # does the quantize and all pairs read from a single shared slot
-        # in packed_input/scale_storage. Caller is responsible for the
-        # activation == "relu2" and m == 1 and shared-scale preconditions.
+        # in packed_input/scale_storage after the resident-grid barrier.
         self.share_input_across_experts = share_input_across_experts
+        self.share_expert_scales = share_expert_scales
+        self.single_token = single_token
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
@@ -1000,19 +1003,13 @@ class MoEMicroKernel:
 
         # Phase 0: cooperative init — set row_counts and zero scatter_output.
         # The Triton compact pre-pass has already populated
-        # active_expert_count and weight_expert_ids.
-        num_active_experts = active_expert_count[Int32(0)]
-        all_rows_unique = Int32(0)
-        if num_tokens == Int32(1):
+        # active_expert_count and weight_expert_ids for non-single-token paths.
+        if cutlass.const_expr(self.single_token):
             # A single token's top-k routing is already a dense local expert set.
-            all_rows_unique = Int32(1)
             num_active_experts = total_pairs
-        shared_single_input = (
-            Int32(1)
-            if cutlass.const_expr(self.share_input_across_experts)
-            else Int32(0)
-        )
-        if all_rows_unique == Int32(0):
+        else:
+            num_active_experts = active_expert_count[Int32(0)]
+        if cutlass.const_expr(not self.single_token):
             i = flat_tid
             while i < num_experts:
                 row_counts[i] = Int32(0)
@@ -1024,9 +1021,9 @@ class MoEMicroKernel:
             j += flat_stride
         cute.arch.sync_threads()
         # When the quantized input is shared across experts, only pair 0
-        # writes to packed storage; there's no expert-parallel routing to
-        # synchronize before FC1, so the grid-wide barrier is unnecessary.
-        if shared_single_input == Int32(0):
+        # writes to packed storage; there is no expert-parallel routing to
+        # synchronize before FC1, so the pre-pack grid barrier is unnecessary.
+        if cutlass.const_expr(not self.share_input_across_experts):
             self._resident_grid_barrier(
                 barrier_count,
                 barrier_epoch,
@@ -1038,16 +1035,19 @@ class MoEMicroKernel:
         while pair_idx < total_pairs:
             token_idx = Int32(0)
             weight = cutlass.Float32(0.0)
-            if all_rows_unique == Int32(0):
+            if cutlass.const_expr(not self.single_token):
                 token_idx = pair_idx // num_topk
                 weight = topk_weights[pair_idx].to(cutlass.Float32)
 
             expert_id = Int32(0)
             local_expert_id = Int32(0)
             row = Int32(0)
-            if all_rows_unique > Int32(0):
+            if cutlass.const_expr(self.single_token):
                 local_expert_id = pair_idx
-                expert_id = weight_expert_ids[local_expert_id].to(Int32)
+                if cutlass.const_expr(self.is_gated):
+                    expert_id = weight_expert_ids[local_expert_id].to(Int32)
+                else:
+                    expert_id = topk_ids[local_expert_id].to(Int32)
             else:
                 if is_cta_leader > Int32(0):
                     local_expert_id = topk_ids[pair_idx].to(Int32)
@@ -1067,20 +1067,35 @@ class MoEMicroKernel:
                 row = _ld_shared_i32(ctrl_base_addr + Int32(4))
                 expert_id = _ld_shared_i32(ctrl_base_addr + Int32(8))
 
-            # Distribute quantization across ALL CTA threads, not just leader.
-            # Each FP4 block (16 elements) is independent — perfect parallelism.
-            # When the input is shared across experts (m=1 relu2, shared
-            # a1_gscale), only pair 0 does the quantize and every pair
-            # reads from a single shared slot at (expert=0, row=0).
+            # Distribute quantization across all CTA threads. Each FP4 block
+            # covers 16 elements and can be packed independently.
             should_quantize = Int32(1)
             packed_local_expert_id = local_expert_id
             packed_row = row
-            if shared_single_input > Int32(0):
-                should_quantize = Int32(1) if pair_idx == Int32(0) else Int32(0)
-                packed_local_expert_id = Int32(0)
-                packed_row = Int32(0)
+            quant_expert_id = expert_id
+            if cutlass.const_expr(self.share_input_across_experts):
+                if cutlass.const_expr(self.single_token):
+                    # Match FI main: pair 0 writes the shared packed input slot,
+                    # and the resident-grid barrier below makes it visible to
+                    # CTAs that did not participate in Phase 1 routing work.
+                    should_quantize = Int32(1) if pair_idx == Int32(0) else Int32(0)
+                    if cutlass.const_expr(not self.is_gated):
+                        quant_expert_id = topk_ids[Int32(0)].to(Int32)
+                    else:
+                        quant_expert_id = weight_expert_ids[Int32(0)]
+                    packed_local_expert_id = Int32(0)
+                    packed_row = Int32(0)
+                else:
+                    should_quantize = Int32(1) if pair_idx == Int32(0) else Int32(0)
+                    packed_local_expert_id = Int32(0)
+                    packed_row = Int32(0)
             if should_quantize > Int32(0):
-                gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                scale_idx = (
+                    Int32(0)
+                    if cutlass.const_expr(self.share_expert_scales)
+                    else quant_expert_id
+                )
+                gs_value = input_global_scale[scale_idx].to(cutlass.Float32)
                 if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
                     0.0
                 ):
@@ -1135,7 +1150,7 @@ class MoEMicroKernel:
                     scale_storage[scale_offset] = scale_byte
                     sf_idx += Int32(self.threads_per_cta)
 
-            if all_rows_unique == Int32(0):
+            if cutlass.const_expr(not self.single_token):
                 cute.arch.sync_threads()
             pair_idx += Int32(gdim_z)
 
@@ -1380,7 +1395,7 @@ class MoEMicroKernel:
             accum_tile_m = Int32(0)
             tile_coord = (Int32(0), Int32(0), Int32(0))
             is_valid_tile = Int32(0) < Int32(0)
-            if all_rows_unique > Int32(0):
+            if cutlass.const_expr(self.single_token):
                 tile_coord, is_valid_tile = _compact_unique_get_work_tile(
                     num_active_experts=num_active_experts,
                     num_tiles_n=Int32(self.output_tile_count_n),
@@ -1405,10 +1420,15 @@ class MoEMicroKernel:
             while is_valid_tile:
                 # tile_coord = (m_tile, intermediate_slice, local_expert_idx)
                 local_expert_idx = tile_coord[2]
-                weight_expert_idx = weight_expert_ids[local_expert_idx]
-                valid_rows = row_counts[local_expert_idx]
-                if all_rows_unique > Int32(0):
+                if cutlass.const_expr(self.single_token):
+                    if cutlass.const_expr(not self.is_gated):
+                        weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
+                    else:
+                        weight_expert_idx = weight_expert_ids[local_expert_idx]
                     valid_rows = Int32(1)
+                else:
+                    weight_expert_idx = weight_expert_ids[local_expert_idx]
+                    valid_rows = row_counts[local_expert_idx]
                 alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
                 tile_m_base = tile_coord[0] * Int32(self.tile_shape_mnk[0])
                 intermediate_slice = tile_coord[1]
@@ -1482,7 +1502,7 @@ class MoEMicroKernel:
                     valid_tile_rows = Int32(0)
 
                 cache_row = Int32(tidx)
-                if all_rows_unique == Int32(0):
+                if cutlass.const_expr(not self.single_token):
                     if cache_row < Int32(_COMPACT_STATIC_TILE_M):
                         tok = Int32(0)
                         wv = cutlass.Float32(0.0)
@@ -1535,7 +1555,7 @@ class MoEMicroKernel:
                 down_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
                 unique_tok = Int32(0)
                 unique_wv = cutlass.Float32(0.0)
-                if all_rows_unique > Int32(0):
+                if cutlass.const_expr(self.single_token):
                     unique_tok = local_expert_idx // num_topk
                     unique_wv = topk_weights[local_expert_idx].to(cutlass.Float32)
 
@@ -1809,7 +1829,12 @@ class MoEMicroKernel:
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
                 sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
-                gs_value = global_scale[weight_expert_idx].to(cutlass.Float32)
+                scale_idx = (
+                    Int32(0)
+                    if cutlass.const_expr(self.share_expert_scales)
+                    else weight_expert_idx
+                )
+                gs_value = global_scale[scale_idx].to(cutlass.Float32)
                 if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
                     0.0
                 ):
@@ -2110,7 +2135,7 @@ class MoEMicroKernel:
                             cached_row = rows_offset + warp_m_base + local_row
                             tok = Int32(0)
                             wv = cutlass.Float32(0.0)
-                            if all_rows_unique > Int32(0):
+                            if cutlass.const_expr(self.single_token):
                                 tok = unique_tok
                                 wv = unique_wv
                             else:
@@ -2157,7 +2182,7 @@ class MoEMicroKernel:
                 self.pass_sync_barrier.arrive_and_wait()
 
                 current_work_linear_idx += num_persistent_clusters
-                if all_rows_unique > Int32(0):
+                if cutlass.const_expr(self.single_token):
                     tile_coord, is_valid_tile = _compact_unique_get_work_tile(
                         num_active_experts=num_active_experts,
                         num_tiles_n=Int32(self.output_tile_count_n),
@@ -2203,7 +2228,7 @@ class MoEMicroKernel:
             accum_tile_m = Int32(0)
             tile_coord = (Int32(0), Int32(0), Int32(0))
             is_valid_tile = Int32(0) < Int32(0)
-            if all_rows_unique > Int32(0):
+            if cutlass.const_expr(self.single_token):
                 tile_coord, is_valid_tile = _compact_unique_get_work_tile(
                     num_active_experts=num_active_experts,
                     num_tiles_n=Int32(self.output_tile_count_n),
@@ -2229,12 +2254,17 @@ class MoEMicroKernel:
                 tc = tile_coord
                 intermediate_slice = tc[1]
                 local_expert_idx = tc[2]
-                weight_expert_idx = weight_expert_ids[local_expert_idx]
-                # When the quantized input is shared across experts, the
-                # route/pack phase wrote a single copy at slot 0; all pairs
-                # must read it from there regardless of their expert id.
+                if cutlass.const_expr(self.single_token):
+                    if cutlass.const_expr(not self.is_gated):
+                        weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
+                    else:
+                        weight_expert_idx = weight_expert_ids[local_expert_idx]
+                else:
+                    weight_expert_idx = weight_expert_ids[local_expert_idx]
                 input_local_expert_idx = (
-                    Int32(0) if shared_single_input > Int32(0) else local_expert_idx
+                    Int32(0)
+                    if cutlass.const_expr(self.share_input_across_experts)
+                    else local_expert_idx
                 )
 
                 sa_tile_coord_m = tc[0] // self.sa_tiles_per_block
@@ -2379,7 +2409,7 @@ class MoEMicroKernel:
                 self.pass_sync_barrier.arrive_and_wait()
 
                 current_work_linear_idx += num_persistent_clusters
-                if all_rows_unique > Int32(0):
+                if cutlass.const_expr(self.single_token):
                     tile_coord, is_valid_tile = _compact_unique_get_work_tile(
                         num_active_experts=num_active_experts,
                         num_tiles_n=Int32(self.output_tile_count_n),


### PR DESCRIPTION
Synchronize the SM120 b12x MoE implementation from the upstream b12x
kernels, including the short-decode dispatch and micro-kernel fixes.

## 📌 Description

  Synchronizes the SM120 B12x MoE implementation with the upstream b12x kernel changes.

  This PR updates the short-decode path for B12x fused MoE, including:

  - ReLU2 single-token dispatch shortcut that avoids the Triton compaction pre-pass.
  - Micro-kernel specializations for single-token decode, shared input quantization, and shared
    expert scales.
  - Tuned micro-kernel max-active-cluster selection while preserving the existing static-kernel MAC
    behavior.
  - CUDA graph workspace sizing updated to use the same static/dynamic cutover helper as dispatch.

  The goal is to bring over the upstream short-decode fixes and performance improvements without
  reintroducing the reverted post-863 micro-kernel changes.

  ## 🔍 Related Issues

  N/A

  ## 🚀 Pull Request Checklist

  Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the
  following items are complete.

  ### ✅ Pre-commit Checks

  - [x] I have installed pre-commit by running pip install pre-commit (or used your preferred
    method).
  - [x] I have installed the hooks with pre-commit install.
  - [x] I have run the hooks manually with pre-commit run --all-files and fixed any reported issues.

  ## 🧪 Tests

  - [x] Tests have been added or updated as needed.
  - [x] All tests are passing (unittest, etc.).

  Validated with:

python -m pytest -q tests/moe/test_b12x_fused_moe.py

  Result:

  90 passed, 1 warning

  Also ran a perf smoke test:

  b12x_fused_moe relu2 bs1 topk22: median 0.030 ms

  ## Reviewer Notes

  Please focus review on the SM120 MoE short-decode path, especially:

  - ReLU2 single-token routing using flat_ids.
  - Gated/SwiGLU single-token behavior preserving compacted expert mapping.
  - The intentional choice to apply the tuned MAC ladder only to the micro path, leaving static MAC
    behavior unchanged unless explicitly overridden.



