### PR TITLE
Enable TRT-LLM Gen sparse MLA block-sparse path

### DIFF
--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -865,8 +865,7 @@ struct KernelParams {
     FLASHINFER_CHECK(!options.mSparseMla || (options.mSparseMlaTopK % 4) == 0,
                      "SparseMlaTopK must be a multiple of 4");
     params.mSparseAttnTopK = options.mSparseMlaTopK;
-    // TODO: Integrate trtllm block-sparse attention kernels when needed.
-    params.mUseBlockSparseAttention = false;
+    params.mUseBlockSparseAttention = options.mSparseMla;
     // Whether the indices for K & V pages are shared as unified index (vLLM/FlashInfer).
     params.mUsesSharedPagedKvIdx = options.mUsesSharedPagedKvIdx;
     return params;

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -901,8 +901,7 @@ struct KernelParams {
     FLASHINFER_CHECK(!options.isSparseMla() || (options.mSparseMlaTopK % 4) == 0,
                      "SparseMlaTopK must be a multiple of 4");
     params.mSparseAttnTopK = options.mSparseMlaTopK;
-    // TODO: Integrate trtllm block-sparse attention kernels when needed.
-    params.mUseBlockSparseAttention = false;
+    params.mUseBlockSparseAttention = options.isSparseMla();
     // Whether the indices for K & V pages are shared as unified index (vLLM/FlashInfer).
     params.mUsesSharedPagedKvIdx = options.mUsesSharedPagedKvIdx;
     return params;


### PR DESCRIPTION
## Summary

This wires `KernelParams::mUseBlockSparseAttention` to the existing sparse MLA selection state instead of forcing it to `false`.

Sparse MLA was already plumbed through `sparse_mla_top_k` into `runner_params.mSparseMla`, and TRT-LLM Gen already used that flag for sparse kernel selection and cubin lookup. The missing piece was passing the matching runtime flag into the generated kernel params.

Fixes #2754.

## Impact

- Enables the TRT-LLM Gen block-sparse/token-sparse runtime path when sparse MLA is selected.
- Leaves dense/non-sparse attention behavior unchanged because `options.mSparseMla` remains false for those paths.

## Validation

- `git diff --check`
- Blackwell remote validation on `cudnn-dev-zenith-22-04`:
  - `python -m pytest -s tests/attention/test_trtllm_gen_mla.py::test_trtllm_batch_decode_mla_sparse --tb=short`
  - Result: `1344 passed in 112.23s (0:01:52)`
  - Evidence log: `/home/scratch.mingyangw_gpu/work-2754-block-sparse-full-pytest.log`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Block-sparse attention now respects the sparse option and is enabled when that option is set, correcting previous unconditional disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->