### PR TITLE
fix: guard NVFP4 KV cache on legacy decode kernel

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -72,6 +72,7 @@ from .utils import (
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
+    is_legacy_decode_supported,
     get_device_sm_count,
     is_float8,
     register_custom_op,
@@ -82,6 +83,12 @@ from .utils import (
     GPUArchitectureError,
     SINGLE_KERNEL_TMP_SIZE,
     prepare_jit_additional_args,
+)
+
+
+_NVFP4_LEGACY_DECODE_MSG = (
+    "NVFP4 KV cache (uint8 packed FP4) is not supported by the legacy decode kernel. "
+    "Use use_tensor_cores=True or backend='trtllm-gen'."
 )
 
 
@@ -701,7 +708,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         use_tensor_cores : bool
             Whether to use tensor cores for the computation. Will be faster for large group
-            size in grouped query attention. Defaults to ``False``.
+            size in grouped query attention. Required when using NVFP4 KV cache (uint8 packed FP4);
+            see :meth:`run` ``kv_cache_sf`` parameter. Defaults to ``False``.
 
         paged_kv_indptr_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
@@ -990,6 +998,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
         if o_data_type is None:
             o_data_type = q_data_type
         o_data_type = canonicalize_torch_dtype(o_data_type)
+
+        if not is_legacy_decode_supported(kv_data_type) and not self.use_tensor_cores:
+            raise NotImplementedError(_NVFP4_LEGACY_DECODE_MSG)
 
         if fixed_split_size is not None and not self.use_tensor_cores:
             raise ValueError(
@@ -1658,7 +1669,8 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper(BatchDecodeWithPagedKVCacheWra
 
         use_tensor_cores : bool
             Whether to use tensor cores for the computation. Will be faster for large group
-            size in grouped query attention. Defaults to ``False``.
+            size in grouped query attention. Required when using NVFP4 KV cache (uint8 packed FP4);
+            see :meth:`run` ``kv_cache_sf`` parameter. Defaults to ``False``.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
@@ -2879,6 +2891,12 @@ def fast_decode_plan(
 
     if kv_data_type is None:
         kv_data_type = q_data_type
+
+    if (
+        not is_legacy_decode_supported(canonicalize_torch_dtype(kv_data_type))
+        and not self.use_tensor_cores
+    ):
+        raise NotImplementedError(_NVFP4_LEGACY_DECODE_MSG)
 
     if self.use_tensor_cores:
         qo_indptr_host = _get_range_buf(batch_size + 1, "cpu")

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -432,6 +432,27 @@ def is_fa3_backend_supported(
     return True
 
 
+def is_legacy_decode_supported(dtype_kv: torch.dtype) -> bool:
+    """
+    Check if the legacy (non-tensor-cores) batch decode kernel supports the given KV dtype.
+
+    NVFP4 KV (uint8 packed) requires the tensor-cores path or the trtllm-gen backend.
+
+    Parameters
+    ----------
+    dtype_kv : torch.dtype
+        The data type of the key/value tensor.
+
+    Returns
+    -------
+    bool
+        True if the legacy decode kernel supports the given KV dtype, False otherwise.
+    """
+    if dtype_kv == torch.uint8:
+        return False
+    return True
+
+
 def is_cutlass_backend_supported(
     pos_encoding_mode: int,
     use_fp16_qk_reductions: bool,

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -23,7 +23,7 @@ from tests.test_helpers.jit_utils import (
 from tests.test_helpers.utils_fp4 import create_nvfp4_kv, nvfp4_to_float
 from functools import partial
 import flashinfer
-from flashinfer.utils import has_flashinfer_jit_cache
+from flashinfer.utils import get_compute_capability, has_flashinfer_jit_cache
 
 
 @pytest.fixture(
@@ -955,3 +955,102 @@ def test_single_decode_torch_compile_cuda_graph():
     assert result.returncode == 0 and "PASS" in result.stdout, (
         f"Test failed:\nstdout: {result.stdout[-500:]}\nstderr: {result.stderr[-500:]}"
     )
+
+
+def test_legacy_decode_rejects_nvfp4_paged():
+    """Default wrapper (use_tensor_cores=False) + uint8 KV must raise NotImplementedError."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", use_tensor_cores=False
+    )
+    indptr = torch.tensor([0, 4], dtype=torch.int32, device="cuda")
+    indices = torch.arange(4, dtype=torch.int32, device="cuda")
+    last_page_len = torch.tensor([16], dtype=torch.int32, device="cuda")
+
+    with pytest.raises(NotImplementedError, match="NVFP4 KV"):
+        wrapper.plan(
+            indptr,
+            indices,
+            last_page_len,
+            num_qo_heads=8,
+            num_kv_heads=8,
+            head_dim=128,
+            page_size=16,
+            q_data_type=torch.float16,
+            kv_data_type=torch.uint8,
+        )
+
+
+def test_legacy_decode_accepts_nvfp4_with_tensor_cores():
+    """use_tensor_cores=True + uint8 KV should not be tripped by the guard.
+
+    Numerical correctness is covered by test_batch_decode_with_paged_kv_cache_nvfp4.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    major, _ = get_compute_capability(torch.device("cuda"))
+    if major < 8:
+        pytest.skip("NVFP4 KV requires SM80+")
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", use_tensor_cores=True
+    )
+    indptr = torch.tensor([0, 4], dtype=torch.int32, device="cuda")
+    indices = torch.arange(4, dtype=torch.int32, device="cuda")
+    last_page_len = torch.tensor([16], dtype=torch.int32, device="cuda")
+
+    # Our guard should not fire. Unrelated errors (JIT compile, cubin availability,
+    # or other guards firing) propagate as test errors — acceptable, since this test
+    # only asserts the NVFP4 guard does not trigger on this legitimate path.
+    try:
+        wrapper.plan(
+            indptr,
+            indices,
+            last_page_len,
+            num_qo_heads=8,
+            num_kv_heads=8,
+            head_dim=128,
+            page_size=16,
+            q_data_type=torch.float16,
+            kv_data_type=torch.uint8,
+        )
+    except NotImplementedError as e:
+        if "NVFP4 KV" in str(e):
+            pytest.fail(f"Guard incorrectly rejected legitimate path: {e}")
+        raise
+
+
+def test_fast_decode_plan_rejects_nvfp4():
+    """fast_decode_plan + uint8 KV + use_tensor_cores=False must raise NotImplementedError.
+
+    Mirrors the BatchDecodeWithPagedKVCacheWrapper.plan() guard, since fast_decode_plan
+    is a separate entry point bound onto the same wrapper (e.g. via
+    FlashInferMultiStepDraftBackend) that routes to the legacy decode kernel under
+    use_tensor_cores=False.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", use_tensor_cores=False
+    )
+    wrapper.plan = partial(flashinfer.fast_decode_plan, wrapper)
+    indptr = torch.tensor([0, 4], dtype=torch.int32, device="cuda")
+    indices = torch.arange(4, dtype=torch.int32, device="cuda")
+    last_page_len = torch.tensor([16], dtype=torch.int32, device="cuda")
+
+    with pytest.raises(NotImplementedError, match="NVFP4 KV"):
+        wrapper.plan(
+            indptr,
+            indices,
+            last_page_len,
+            num_qo_heads=8,
+            num_kv_heads=8,
+            head_dim=128,
+            page_size=16,
+            q_data_type=torch.float16,
+            kv_data_type=torch.uint8,
+        )


### PR DESCRIPTION
## 📌 Description

When `BatchDecodeWithPagedKVCacheWrapper` is used with the default `use_tensor_cores=False`, NVFP4 KV cache (`torch.uint8` packed FP4) goes down the legacy decode path. That path has no FP4 support, and the `kv_cache_sf` information does not get threaded through the non-tensor-cores branch, so this can silently produce incorrect output instead of failing explicitly.

This PR adds guards in the legacy batch decode planning paths that raise `NotImplementedError` and point users to the supported alternatives:`use_tensor_cores=True` or `backend="trtllm-gen"`. This follows the direction suggested in #3097.

It also updates the `__init__` docstrings on `BatchDecodeWithPagedKVCacheWrapper` and `CUDAGraphBatchDecodeWithPagedKVCacheWrapper` so that the `use_tensor_cores` parameter explicitly documents the NVFP4 KV requirement. Previously, that note only appeared on `run()`.

## 🔍 Related Issues

Follow-up to #3097.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request,
please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used another preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All relevant tests are passing.

Ran on RTX PRO 6000:

- `test_legacy_decode_rejects_nvfp4_paged` — confirms that the guard raises on the default wrapper. PASSED (~74s, mostly first-time `flashinfer` import).
- `test_legacy_decode_accepts_nvfp4_with_tensor_cores` — confirms that `use_tensor_cores=True` is not rejected by the new guard. PASSED (~15s).
- `test_fast_decode_plan_rejects_nvfp4` — confirms that the same guard also covers `fast_decode_plan`. PASSED.
- `test_batch_decode_with_paged_kv_cache_nvfp4[q_dtype1-128-32-4-16-512-12]` — existing #3097 NVFP4 KV decode coverage; no regression observed. PASSED (~34s).
- `tests/attention/test_tensor_cores_decode.py -k "fast_decode_plan or fast_plan"` — all 864 selected existing tests passed, confirming that the new guard does not reject legitimate non-`uint8` KV usage. PASSED (~82s).

## Reviewer Notes

The scope here is intentionally narrow: only `BatchDecodeWithPagedKVCacheWrapper.plan()` and `fast_decode_plan` are guarded.

`single_decode_with_kv_cache` does not accept NVFP4 KV in its signature. `trtllm_batch_decode_with_kv_cache` also does not go through the legacy decode kernel — its execution paths are `trtllm-gen` and `xqa`. As a result, neither requires an additional guard in this PR.