### PR TITLE
fix: Update top-k generation not to produce duplicate expert ids

### DIFF
--- a/benchmarks/bench_trtllm_gen_fused_moe_autotuner.py
+++ b/benchmarks/bench_trtllm_gen_fused_moe_autotuner.py
@@ -23,6 +23,7 @@ from flashinfer.autotuner import autotune, AutoTuner
 from flashinfer.testing.utils import bench_gpu_time
 from flashinfer.utils import device_support_pdl
 from routines.flashinfer_benchmark_utils import enum_type
+from flashinfer.fused_moe.utils import make_random_topk_ids
 
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
 FLOAT4_E2M1_MAX = 6.0
@@ -31,9 +32,7 @@ FLOAT4_E2M1_MAX = 6.0
 def _pack_topk(
     num_tokens: int, top_k: int, num_experts: int, device: torch.device
 ) -> torch.Tensor:
-    topk_ids = torch.randint(
-        0, num_experts, (num_tokens, top_k), dtype=torch.int32, device=device
-    )
+    topk_ids = make_random_topk_ids(num_experts, num_tokens, top_k, device)
     raw_w = torch.rand(num_tokens, top_k, device=device)
     weights = (raw_w / raw_w.sum(-1, keepdim=True)).to(torch.bfloat16)
     return (topk_ids << 16) | weights.view(torch.int16).to(torch.int32)

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import math
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -64,6 +65,7 @@ from ..utils import (
 from .utils import (
     get_hybrid_num_tokens_buckets,
     map_to_hybrid_bucket,
+    make_random_topk_ids,
 )
 from ..tllm_enums import (
     ActivationType,
@@ -1086,8 +1088,11 @@ def get_trtllm_moe_sm100_module():
             num_local_experts = self.num_local_experts
 
             def _init_packed_topk_ids(shapes, dtype, device):
-                expert_ids = torch.randint(
-                    0, num_local_experts, shapes, dtype=torch.int32, device=device
+                expert_ids = make_random_topk_ids(
+                    num_experts=num_local_experts,
+                    num_tokens=math.prod(shapes[:-1]),
+                    top_k=shapes[-1],
+                    device=device,
                 )
                 expert_weights = torch.ones(
                     shapes, dtype=torch.bfloat16, device=device

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1093,7 +1093,7 @@ def get_trtllm_moe_sm100_module():
                     num_tokens=math.prod(shapes[:-1]),
                     top_k=shapes[-1],
                     device=device,
-                )
+                ).view(shapes)
                 expert_weights = torch.ones(
                     shapes, dtype=torch.bfloat16, device=device
                 ).view(torch.int16)

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1102,7 +1102,7 @@ def get_trtllm_moe_sm100_module():
                     num_tokens=math.prod(shapes[:-1]),
                     top_k=shapes[-1],
                     device=device,
-                )
+                ).view(shapes)
                 expert_weights = torch.ones(
                     shapes, dtype=torch.bfloat16, device=device
                 ).view(torch.int16)

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import math
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -64,6 +65,7 @@ from ..utils import (
 from .utils import (
     get_hybrid_num_tokens_buckets,
     map_to_hybrid_bucket,
+    make_random_topk_ids,
 )
 from ..tllm_enums import (
     ActivationType,
@@ -1095,8 +1097,11 @@ def get_trtllm_moe_sm100_module():
             num_experts = self.num_experts
 
             def _init_packed_topk_ids(shapes, dtype, device):
-                expert_ids = torch.randint(
-                    0, num_experts, shapes, dtype=torch.int32, device=device
+                expert_ids = make_random_topk_ids(
+                    num_experts=num_experts,
+                    num_tokens=math.prod(shapes[:-1]),
+                    top_k=shapes[-1],
+                    device=device,
                 )
                 expert_weights = torch.ones(
                     shapes, dtype=torch.bfloat16, device=device

--- a/flashinfer/fused_moe/cute_dsl/moe_utils.py
+++ b/flashinfer/fused_moe/cute_dsl/moe_utils.py
@@ -486,10 +486,10 @@ def moe_sort(
     Example:
         >>> import torch
         >>> from flashinfer.cute_dsl_moe_utils import moe_sort
+        >>> from flashinfer.fused_moe.utils import make_random_topk_ids
         >>>
         >>> num_tokens, num_experts, top_k = 128, 8, 2
-        >>> token_selected_experts = torch.randint(0, num_experts, (num_tokens, top_k),
-        ...                                        dtype=torch.int32, device="cuda")
+        >>> token_selected_experts = make_random_topk_ids(num_experts, num_tokens, top_k, device="cuda")
         >>> token_final_scales = torch.randn(num_tokens, top_k, device="cuda")
         >>>
         >>> (tile_idx_to_expert_idx, tile_idx_to_mn_limit,

--- a/flashinfer/fused_moe/cute_dsl/moe_utils.py
+++ b/flashinfer/fused_moe/cute_dsl/moe_utils.py
@@ -494,10 +494,10 @@ def moe_sort(
     Example:
         >>> import torch
         >>> from flashinfer.cute_dsl_moe_utils import moe_sort
+        >>> from flashinfer.fused_moe.utils import make_random_topk_ids
         >>>
         >>> num_tokens, num_experts, top_k = 128, 8, 2
-        >>> token_selected_experts = torch.randint(0, num_experts, (num_tokens, top_k),
-        ...                                        dtype=torch.int32, device="cuda")
+        >>> token_selected_experts = make_random_topk_ids(num_experts, num_tokens, top_k, device="cuda")
         >>> token_final_scales = torch.randn(num_tokens, top_k, device="cuda")
         >>>
         >>> (tile_idx_to_expert_idx, tile_idx_to_mn_limit,

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -30,6 +30,7 @@ Reference: TensorRT-LLM/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
 """
 
 import itertools
+import math
 import logging
 from typing import Any, Callable, Dict, List, Tuple
 
@@ -44,6 +45,7 @@ from ...autotuner import (
 from ..utils import (
     get_hybrid_num_tokens_buckets,
     map_to_hybrid_bucket,
+    make_random_topk_ids,
 )
 
 logger = logging.getLogger(__name__)
@@ -285,13 +287,12 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                             1, 128, shapes, dtype=torch.uint8, device=device
                         ),
                         # 2: token_selected_experts — expert indices [0, num_experts)
-                        lambda shapes, dtype, device: torch.randint(
-                            0,
-                            max(num_experts, 1),
-                            shapes,
-                            dtype=torch.int32,
+                        lambda shapes, dtype, device: make_random_topk_ids(
+                            num_experts=max(num_experts, 1),
+                            num_tokens=math.prod(shapes[:-1]),
+                            top_k=shapes[-1],
                             device=device,
-                        ),
+                        ).view(shapes),
                         # 3: token_final_scales — routing weights (softmax normalized)
                         lambda shapes, dtype, device: torch.softmax(
                             torch.randn(shapes, device=device), dim=-1

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -30,6 +30,7 @@ Reference: TensorRT-LLM/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
 """
 
 import itertools
+import math
 import logging
 from typing import Any, Callable, Dict, List, Tuple
 
@@ -44,6 +45,7 @@ from ...autotuner import (
 from ..utils import (
     get_hybrid_num_tokens_buckets,
     map_to_hybrid_bucket_uncapped,
+    make_random_topk_ids,
 )
 
 logger = logging.getLogger(__name__)
@@ -294,13 +296,12 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                             1, 128, shapes, dtype=torch.uint8, device=device
                         ),
                         # 2: token_selected_experts — expert indices [0, num_experts)
-                        lambda shapes, dtype, device: torch.randint(
-                            0,
-                            max(num_experts, 1),
-                            shapes,
-                            dtype=torch.int32,
+                        lambda shapes, dtype, device: make_random_topk_ids(
+                            num_experts=max(num_experts, 1),
+                            num_tokens=math.prod(shapes[:-1]),
+                            top_k=shapes[-1],
                             device=device,
-                        ),
+                        ).view(shapes),
                         # 3: token_final_scales — routing weights (softmax normalized)
                         lambda shapes, dtype, device: torch.softmax(
                             torch.randn(shapes, device=device), dim=-1

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -434,6 +434,9 @@ def make_random_topk_ids(
     Returns a ``[num_tokens, top_k]`` int32 tensor whose rows contain unique
     values in ``[0, num_experts)``.
     """
+    if num_tokens == 0 or num_experts == 0 or top_k == 0:
+        return torch.empty(num_tokens, top_k, dtype=torch.int32, device=device)
+
     weights = torch.ones((), device=device, dtype=torch.float32).expand(
         num_tokens, num_experts
     )

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -423,3 +423,18 @@ def get_piecewise_cuda_graph_flag() -> bool:
     """Return ``True`` if piecewise CUDA graph capture is enabled."""
     global _enable_piecewise_cuda_graph
     return _enable_piecewise_cuda_graph
+
+
+def make_random_topk_ids(
+    num_experts: int, num_tokens: int, top_k: int, device: torch.device
+) -> torch.Tensor:
+    """
+    Pick ``top_k`` distinct experts (no replacement) for each of ``num_tokens`` tokens.
+
+    Returns a ``[num_tokens, top_k]`` int32 tensor whose rows contain unique
+    values in ``[0, num_experts)``.
+    """
+    weights = torch.ones((), device=device, dtype=torch.float32).expand(
+        num_tokens, num_experts
+    )
+    return torch.multinomial(weights, top_k, replacement=False).to(torch.int32)

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import threading
 from dataclasses import dataclass
 from enum import Enum
@@ -7,6 +8,8 @@ from typing import Dict, List, Sequence, Tuple
 import torch
 
 from ..utils import ceil_div, round_up
+
+logger = logging.getLogger(__name__)
 
 is_torch_compiling_flag = False
 
@@ -435,7 +438,13 @@ def make_random_topk_ids(
     values in ``[0, num_experts)``.
     """
     if num_tokens == 0 or num_experts == 0 or top_k == 0:
-        return torch.empty(num_tokens, top_k, dtype=torch.int32, device=device)
+        return torch.zeros(num_tokens, top_k, dtype=torch.int32, device=device)
+
+    if top_k > num_experts:
+        logger.debug(
+            f"top_k {top_k} is greater than num_experts {num_experts}, using top_k as num_experts"
+        )
+        num_experts = top_k
 
     weights = torch.ones((), device=device, dtype=torch.float32).expand(
         num_tokens, num_experts

--- a/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
+++ b/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
@@ -7,6 +7,7 @@ import torch
 from flashinfer import autotune, RoutingMethodType
 from flashinfer.autotuner import AutoTuner
 from flashinfer.utils import get_compute_capability
+from flashinfer.fused_moe.utils import make_random_topk_ids
 from .utils import reset_autotuner
 
 TUNE_MAX = 8192
@@ -344,12 +345,7 @@ def test_fp4_moe_autotune(
 
     with autotune(tune_mode=True):
         if routed:
-            topk_ids = torch.stack(
-                [
-                    torch.randperm(num_experts, device=device)[:top_k]
-                    for _ in range(num_tokens)
-                ]
-            )
+            topk_ids = make_random_topk_ids(num_experts, num_tokens, top_k, device)
             topk_weights = torch.ones(
                 num_tokens, top_k, dtype=torch.bfloat16, device=device
             )
@@ -452,12 +448,7 @@ def test_fp8_moe_autotune(
 
     with autotune(tune_mode=True):
         if routed:
-            topk_ids = torch.stack(
-                [
-                    torch.randperm(num_experts, device=device)[:top_k]
-                    for _ in range(num_tokens)
-                ]
-            )
+            topk_ids = make_random_topk_ids(num_experts, num_tokens, top_k, device)
             topk_weights = torch.ones(
                 num_tokens, top_k, dtype=torch.bfloat16, device=device
             )

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -334,7 +334,10 @@ def test_moe_alltoall_multi_rank_single_gpu(world_size, num_tokens, vector_dim):
     ]
 
     token_selected_experts = make_random_topk_ids(
-        world_size, num_tokens, 1, device="cuda"
+        num_experts=world_size,
+        num_tokens=world_size * num_tokens,
+        top_k=1,
+        device=torch.device("cuda"),
     )
 
     output_tensors, _, _, _ = dispatch_from_single_rank(
@@ -371,7 +374,7 @@ def test_sanitize_expert_ids(world_size, num_tokens):
     )
     token_selected_experts = make_random_topk_ids(
         num_experts=world_size,
-        num_tokens=num_tokens,
+        num_tokens=world_size * num_tokens,
         top_k=1,
         device=torch.device("cuda"),
     )

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 import pynvml
 from flashinfer.comm.mapping import Mapping
+from flashinfer.fused_moe.utils import make_random_topk_ids
 
 import flashinfer.comm.trtllm_moe_alltoall as trtllm_moe_alltoall
 
@@ -332,12 +333,8 @@ def test_moe_alltoall_multi_rank_single_gpu(world_size, num_tokens, vector_dim):
         for i, dtype in enumerate(dtypes)
     ]
 
-    token_selected_experts = torch.randint(
-        0,
-        world_size,
-        (num_tokens * world_size, 1),
-        dtype=torch.int32,
-        device=torch.device("cuda"),
+    token_selected_experts = make_random_topk_ids(
+        world_size, num_tokens, 1, device="cuda"
     )
 
     output_tensors, _, _, _ = dispatch_from_single_rank(
@@ -372,11 +369,10 @@ def test_sanitize_expert_ids(world_size, num_tokens):
     flags = torch.ones(
         num_tokens * world_size, 1, dtype=torch.bool, device=torch.device("cuda")
     )
-    token_selected_experts = torch.randint(
-        0,
-        world_size,
-        (num_tokens * world_size, 1),
-        dtype=torch.int32,
+    token_selected_experts = make_random_topk_ids(
+        num_experts=world_size,
+        num_tokens=num_tokens,
+        top_k=1,
         device=torch.device("cuda"),
     )
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Top-K ids in MOE should not have duplicate expert IDs. While this doesn't cause issues in most cases, there are a number of places that use randint() to achieve this which can lead to unexpected behaviour in downstream code that assumes there are no duplicates


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized per‑token top‑k expert selection across routing, tuning, benchmarks, docs, and tests by introducing a shared helper that generates consistent, no‑replacement top‑k samples. Updated initializers, examples, test fixtures, and benchmarks to use the unified generator; added module logging for diagnostic visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->