### PR TITLE
(moe) b12x cutedsl moe avoid redundant tma copy at single stage

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -719,6 +719,14 @@ class MoEDynamicKernel:
         phase2_tma_copy_bytes = cute.size_in_bytes(
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        up_tma_copy_bytes = (
+            (
+                cute.size_in_bytes(self.b_dtype, b_smem_one)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+            )
+            if self.ab_stage == 1
+            else tma_copy_bytes
+        )
 
         smem = cutlass.utils.SmemAllocator()
 
@@ -815,7 +823,7 @@ class MoEDynamicKernel:
                 num_stages=self.ab_stage,
                 producer_group=prod_group,
                 consumer_group=cons_group,
-                tx_count=tma_copy_bytes,
+                tx_count=up_tma_copy_bytes,
                 barrier_storage=storage.up_pipeline_array.data_ptr(),
                 cta_layout_vmnk=cta_layout_vmnk,
             )
@@ -2202,26 +2210,27 @@ class MoEDynamicKernel:
                         up_prod_state.reset_count()
                         for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
                             up_pipeline.producer_acquire(up_prod_state)
-                            cute.copy(
-                                tma_a,
-                                tAgA_mk[(None, k_tile)],
-                                tAsA[(None, up_prod_state.index)],
-                                tma_bar_ptr=up_pipeline.producer_get_barrier(
-                                    up_prod_state
-                                ),
-                            )
+                            if self.ab_stage > 1:
+                                cute.copy(
+                                    tma_a,
+                                    tAgA_mk[(None, k_tile)],
+                                    tAsA[(None, up_prod_state.index)],
+                                    tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                        up_prod_state
+                                    ),
+                                )
+                                cute.copy(
+                                    tma_sfa,
+                                    tAgSFA_mk[(None, k_tile)],
+                                    tAsSFA[(None, up_prod_state.index)],
+                                    tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                        up_prod_state
+                                    ),
+                                )
                             cute.copy(
                                 tma_b_w13,
                                 tBgB_w13_up_nk[(None, k_tile)],
                                 tBsB_w13_up[(None, up_prod_state.index)],
-                                tma_bar_ptr=up_pipeline.producer_get_barrier(
-                                    up_prod_state
-                                ),
-                            )
-                            cute.copy(
-                                tma_sfa,
-                                tAgSFA_mk[(None, k_tile)],
-                                tAsSFA[(None, up_prod_state.index)],
                                 tma_bar_ptr=up_pipeline.producer_get_barrier(
                                     up_prod_state
                                 ),

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -842,9 +842,13 @@ class MoEMicroKernel:
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
         # up pass only needs B_up and SFB_up; A and SFA are reused from gate pass.
         up_tma_copy_bytes = (
-            cute.size_in_bytes(self.b_dtype, b_smem_one)
-            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
-        ) if self.ab_stage == 1 else tma_copy_bytes
+            (
+                cute.size_in_bytes(self.b_dtype, b_smem_one)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+            )
+            if self.ab_stage == 1
+            else tma_copy_bytes
+        )
 
         smem = cutlass.utils.SmemAllocator()
 
@@ -2314,13 +2318,17 @@ class MoEMicroKernel:
                                 tma_a,
                                 tAgA_mk[(None, k_tile)],
                                 tAsA[(None, up_prod_state.index)],
-                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
                             )
                             cute.copy(
                                 tma_sfa,
                                 tAgSFA_mk[(None, k_tile)],
                                 tAsSFA[(None, up_prod_state.index)],
-                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
                             )
                         cute.copy(
                             tma_b_w13,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -840,6 +840,11 @@ class MoEMicroKernel:
         phase2_tma_copy_bytes = cute.size_in_bytes(
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        # up pass only needs B_up and SFB_up; A and SFA are reused from gate pass.
+        up_tma_copy_bytes = (
+            cute.size_in_bytes(self.b_dtype, b_smem_one)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        ) if self.ab_stage == 1 else tma_copy_bytes
 
         smem = cutlass.utils.SmemAllocator()
 
@@ -940,7 +945,7 @@ class MoEMicroKernel:
                 num_stages=self.ab_stage,
                 producer_group=prod_group,
                 consumer_group=cons_group,
-                tx_count=tma_copy_bytes,
+                tx_count=up_tma_copy_bytes,
                 barrier_storage=storage.up_pipeline_array.data_ptr(),
                 cta_layout_vmnk=cta_layout_vmnk,
             )
@@ -2304,22 +2309,23 @@ class MoEMicroKernel:
                     up_prod_state.reset_count()
                     for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
                         up_pipeline.producer_acquire(up_prod_state)
-                        cute.copy(
-                            tma_a,
-                            tAgA_mk[(None, k_tile)],
-                            tAsA[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
+                        if self.ab_stage > 1:
+                            cute.copy(
+                                tma_a,
+                                tAgA_mk[(None, k_tile)],
+                                tAsA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                            )
+                            cute.copy(
+                                tma_sfa,
+                                tAgSFA_mk[(None, k_tile)],
+                                tAsSFA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                            )
                         cute.copy(
                             tma_b_w13,
                             tBgB_w13_up_nk[(None, k_tile)],
                             tBsB_w13_up[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        cute.copy(
-                            tma_sfa,
-                            tAgSFA_mk[(None, k_tile)],
-                            tAsSFA[(None, up_prod_state.index)],
                             tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
                         )
                         cute.copy(

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -814,9 +814,13 @@ class MoEStaticKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
         up_tma_copy_bytes = (
-            cute.size_in_bytes(self.b_dtype, b_smem_one)
-            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
-        ) if self.ab_stage == 1 else tma_copy_bytes
+            (
+                cute.size_in_bytes(self.b_dtype, b_smem_one)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+            )
+            if self.ab_stage == 1
+            else tma_copy_bytes
+        )
 
         smem = cutlass.utils.SmemAllocator()
 
@@ -2222,13 +2226,17 @@ class MoEStaticKernel:
                                 tma_a,
                                 tAgA_mk[(None, k_tile)],
                                 tAsA[(None, up_prod_state.index)],
-                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
                             )
                             cute.copy(
                                 tma_sfa,
                                 tAgSFA_mk[(None, k_tile)],
                                 tAsSFA[(None, up_prod_state.index)],
-                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
                             )
                         cute.copy(
                             tma_b_w13,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -813,6 +813,10 @@ class MoEStaticKernel:
         phase2_tma_copy_bytes = cute.size_in_bytes(
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        up_tma_copy_bytes = (
+            cute.size_in_bytes(self.b_dtype, b_smem_one)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        ) if self.ab_stage == 1 else tma_copy_bytes
 
         smem = cutlass.utils.SmemAllocator()
 
@@ -913,7 +917,7 @@ class MoEStaticKernel:
                 num_stages=self.ab_stage,
                 producer_group=prod_group,
                 consumer_group=cons_group,
-                tx_count=tma_copy_bytes,
+                tx_count=up_tma_copy_bytes,
                 barrier_storage=storage.up_pipeline_array.data_ptr(),
                 cta_layout_vmnk=cta_layout_vmnk,
             )
@@ -2213,22 +2217,23 @@ class MoEStaticKernel:
                     up_prod_state.reset_count()
                     for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
                         up_pipeline.producer_acquire(up_prod_state)
-                        cute.copy(
-                            tma_a,
-                            tAgA_mk[(None, k_tile)],
-                            tAsA[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
+                        if self.ab_stage > 1:
+                            cute.copy(
+                                tma_a,
+                                tAgA_mk[(None, k_tile)],
+                                tAsA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                            )
+                            cute.copy(
+                                tma_sfa,
+                                tAgSFA_mk[(None, k_tile)],
+                                tAsSFA[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                            )
                         cute.copy(
                             tma_b_w13,
                             tBgB_w13_up_nk[(None, k_tile)],
                             tBsB_w13_up[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        cute.copy(
-                            tma_sfa,
-                            tAgSFA_mk[(None, k_tile)],
-                            tAsSFA[(None, up_prod_state.index)],
                             tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
                         )
                         cute.copy(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

When ab_stage is 1, the `A` and `SFA` in up stage can be reused from the gate stage, no need for redundant copy.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

74 passed, 16 skipped due to OOM (on a single RTX5090 card)

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized memory transfer efficiency across Mixture of Experts kernels.
  * Enhanced pipeline configuration with stage-dependent behavior to reduce unnecessary data transfers.
  * Improved TMA transaction handling in kernel variants with more efficient conditional data copy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->