### PR TITLE
Fix bf16 cudnn override-shape test call signature

### DIFF
--- a/tests/gemm/test_cudnn_override_shape.py
+++ b/tests/gemm/test_cudnn_override_shape.py
@@ -89,6 +89,7 @@ class TestCudnnBf16OverrideShape:
             k=k,
             o_type=_torch_data_type_to_cudnn_data_type(out_dtype),
             device=device,
+            bias_is_not_none=False,
             cache_m=cache_m,
             is_a_k_major=True,
             is_b_k_major=True,
@@ -106,7 +107,7 @@ class TestCudnnBf16OverrideShape:
             ref = torch.bmm(a.float(), b.float()).to(out_dtype)
 
             execute_cudnn_gemm_bf16_graph_override_shape(
-                graph, a, b, out, workspace, tactic=0
+                graph, a, b, None, out, workspace, tactic=0
             )
             torch.cuda.synchronize()
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The build_/execute_ functions gained `bias_is_not_none` and `bias` parameters, but `test_bf16_override_shape_dynamic_m` wasn't updated — pass `False`/`None` so it exercises the no-bias path.

## 🔍 Related Issues

<!-- Link any related issues here -->

Should fix tests/gemm/test_cudnn_override_shape.py which is failing when testing with latest cuDNN (>= 9.21).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cuDNN GEMM override-shape test to properly configure bias handling during graph construction and execution, ensuring test alignment with function requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->