### PR TITLE
Fix illegal mem access for noaux kernel

### DIFF
--- a/csrc/fused_moe/noAuxTcKernels.cu
+++ b/csrc/fused_moe/noAuxTcKernels.cu
@@ -165,9 +165,11 @@ __global__ void deepseek_v3_topk_kernel(InputT* scores, OutputT* topkValues, Idx
       reduce_topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
                               /* minValue */ invalidScoreFloat, topk);
 
-      if (laneIdx < topk) {
-        smemInterTopScores[warpIdx * MaxNumTopExperts + laneIdx] = topScores[laneIdx];
-        smemInterTopExperts[warpIdx * MaxNumTopExperts + laneIdx] = topExperts[laneIdx];
+      if (laneIdx < MaxNumTopExperts) {
+        smemInterTopScores[warpIdx * MaxNumTopExperts + laneIdx] = 
+            laneIdx < topk ? topScores[laneIdx] : invalidScoreFloat;
+        smemInterTopExperts[warpIdx * MaxNumTopExperts + laneIdx] = 
+            laneIdx < topk ? topExperts[laneIdx] : static_cast<int32_t>(numExperts - 1);
       }
     }
     __syncthreads();


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

if topk < MaxNumTopExperts=8, smemInterTopScores may exist some unintialized value, which cause select expertidx invalid. 


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed uninitialized shared memory entries in expert selection, improving stability and correctness of inference operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->