### PR TITLE
cute_dsl/moe: drop redundant Python-side moe_sort buffer init

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/moe_utils.py
+++ b/flashinfer/fused_moe/cute_dsl/moe_utils.py
@@ -559,39 +559,36 @@ def moe_sort(
 
     if out_expanded_idx_to_permuted_idx is not None:
         expanded_idx_to_permuted_idx = out_expanded_idx_to_permuted_idx
-        # Reset to -1 for masked experts (kernel expects this)
-        expanded_idx_to_permuted_idx.fill_(-1)
     else:
-        expanded_idx_to_permuted_idx = torch.full(
-            (num_tokens, top_k), -1, dtype=torch.int32, device=device
+        expanded_idx_to_permuted_idx = torch.empty(
+            (num_tokens, top_k), dtype=torch.int32, device=device
         )
 
     if out_permuted_idx_to_expanded_idx is not None:
         permuted_idx_to_expanded_idx = out_permuted_idx_to_expanded_idx
-        permuted_idx_to_expanded_idx.zero_()
     else:
-        permuted_idx_to_expanded_idx = torch.zeros(
+        permuted_idx_to_expanded_idx = torch.empty(
             (max_num_permuted_tokens,), dtype=torch.int32, device=device
         )
 
     if out_total_num_padded_tokens is not None:
         total_num_padded_tokens_tensor = out_total_num_padded_tokens
-        total_num_padded_tokens_tensor.zero_()
     else:
-        total_num_padded_tokens_tensor = torch.zeros(
+        total_num_padded_tokens_tensor = torch.empty(
             (1,), dtype=torch.int32, device=device
         )
 
     if out_num_non_exiting_tiles is not None:
         num_non_exiting_tiles = out_num_non_exiting_tiles
-        num_non_exiting_tiles.zero_()
     else:
-        num_non_exiting_tiles = torch.zeros((1,), dtype=torch.int32, device=device)
+        num_non_exiting_tiles = torch.empty((1,), dtype=torch.int32, device=device)
 
-    # Allocate expert counts buffer for large token counts (>1024)
-    # Required size: 2 * num_experts
+    # Allocate expert counts buffer for large token counts (>1024).
+    # Required size: 2 * num_experts. The kernel zeros this internally via
+    # launchInitExpertCounts before reading, so no Python-side init is needed
+    # (matching trt-llm's torch::empty allocation pattern).
     if num_tokens > 1024:
-        expert_counts = torch.zeros(
+        expert_counts = torch.empty(
             (2 * num_experts,), dtype=torch.int32, device=device
         )
         expert_counts_ptr = expert_counts.data_ptr()

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1275,6 +1275,218 @@ class TestExpertParallelism:
 
 
 # =============================================================================
+# Test Class: moe_sort buffer-init invariants (poisoning)
+# =============================================================================
+
+
+@cute_dsl_available
+@sm100_required
+class TestMoeSortBufferInitPoisoned:
+    """Validate the invariant that the routing kernel writes every
+    output entry that downstream code reads, by pre-poisoning the
+    wrapper's preallocated ``moe_sort`` output buffers with a sentinel
+    value before the first call.
+
+    The ``moe_sort`` wrapper in ``moe_utils.py`` allocates its output
+    buffers via ``torch.empty(...)`` and relies on the routing kernel
+    (``runPostTopKPipeline`` in ``trtllm_fused_moe_routing_common.cu``)
+    to write every entry that any downstream kernel reads — including
+    writing ``-1`` to masked slots of ``expanded_idx_to_permuted_idx``
+    at EP > 1, and writing valid permuted indices to all unmasked
+    slots. If the kernel is ever changed to skip an entry that
+    downstream consumes, the uninitialized memory (or here, the
+    sentinel) will leak through and produce dramatic numerical
+    divergence — NaN/Inf via OOB index reads, or ``atomic-add`` into
+    wildly wrong output rows.
+
+    EP=32 specifically stresses the masked-position case for
+    ``expanded_idx_to_permuted_idx``: with ``num_experts=256``,
+    ``num_local_experts=8``, ``top_k=8`` only ~3.125% of expanded slots
+    have their expert on this rank, so ~96% of the buffer must be
+    written as ``-1`` by the kernel. If the kernel ever stops writing
+    masked slots, this test catches it.
+
+    These tests use ``use_cuda_graph=True`` so the wrapper preallocates
+    buffers (the path where stale state from prior calls / poisoning is
+    actually retained between calls). The default ``use_cuda_graph=False``
+    path allocates fresh buffers per call and doesn't exercise the
+    same scenario.
+    """
+
+    @pytest.mark.parametrize(
+        "ep_size,num_tokens",
+        [
+            (1, 256),
+            (8, 256),
+            (16, 256),
+            (32, 256),
+            # High-N case exercises the `num_tokens > 1024` branch in
+            # ``moe_sort`` where ``expert_counts`` is allocated per-call
+            # via ``torch.empty`` and the vendored kernel relies on
+            # ``launchInitExpertCounts`` to zero it before reading. No
+            # other test in this suite exercises that branch — without
+            # this case a future regression in the kernel-side init
+            # would slip past CI.
+            (8, 1280),
+        ],
+    )
+    def test_wrapper_with_poisoned_moe_sort_buffers(
+        self, ep_size: int, num_tokens: int
+    ):
+        """Pre-poison all six moe_sort output buffers with a sentinel
+        before the wrapper's first call; verify output is well-formed
+        and (at low N) matches the eager reference within tolerance.
+
+        The high-N case (``num_tokens > 1024``) skips the
+        ``compute_reference_moe_fp4`` comparison because that
+        reference is ``O(num_tokens × top_k)`` Python iterations with
+        ``.item()`` syncs and dominates CI runtime. The shape +
+        NaN/Inf + non-zero-fraction assertions still run and are
+        what the poisoning-detection logic actually relies on; the
+        reference comparison is supplementary.
+        """
+        from flashinfer import CuteDslMoEWrapper
+
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 8
+        num_local_experts = num_experts // ep_size
+        local_expert_offset = 0  # rank 0; offset > 0 covered by TestExpertParallelism
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_local_experts,
+            top_k=top_k,
+        )
+
+        # use_cuda_graph=True so the wrapper preallocates _moe_sort_buffers
+        # (the path that retains stale state between calls — exactly what
+        # we want to stress here).
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_local_experts=num_local_experts,
+            local_expert_offset=local_expert_offset,
+            use_cuda_graph=True,
+            max_num_tokens=num_tokens,
+        )
+
+        # Defensive guard: if a future refactor renames or restructures
+        # ``_moe_sort_buffers``, the poisoning loop below would silently
+        # iterate over zero items and the test would pass without
+        # actually exercising the kernel-write invariant. Fail loudly
+        # in that case so the test must be updated rather than silently
+        # rotting.
+        assert (
+            getattr(moe, "_moe_sort_buffers", None) is not None
+            and len(moe._moe_sort_buffers) > 0
+        ), (
+            "Wrapper no longer exposes a non-empty ``_moe_sort_buffers`` "
+            "dict; the poisoning loop would be a no-op. Update this "
+            "test to target the new preallocation attribute."
+        )
+
+        # Sentinel: a non-zero, non-(-1), out-of-valid-index-range int32.
+        # If the kernel writes every entry that downstream reads, none of
+        # these sentinels survive into gemm2 finalize. If any do, gemm2's
+        # atomic-add will scatter into wildly wrong output rows, producing
+        # NaN/Inf or massive numerical divergence.
+        POISON = 0x7FFFFFFE
+        for buf in moe._moe_sort_buffers.values():
+            buf.fill_(POISON)
+
+        result = moe.run(
+            x=tensors["x"],
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any(), (
+            f"ep_size={ep_size}, num_tokens={num_tokens}: NaNs in output "
+            f"after running with poisoned moe_sort buffers — strong "
+            f"indication that the routing kernel left sentinel values "
+            f"in positions that downstream gemm2 finalize reads, causing "
+            f"OOB / garbage-index atomic-adds. The invariant that the "
+            f"kernel writes every consumed entry has been violated."
+        )
+        assert not torch.isinf(result).any(), (
+            f"ep_size={ep_size}, num_tokens={num_tokens}: Infs in output "
+            f"after running with poisoned moe_sort buffers — same failure "
+            f"mode as NaN; kernel left sentinels in consumed positions."
+        )
+
+        # Sanity: verify SOMETHING non-trivial actually got computed.
+        # At EP=32 with 256 global experts and top_k=8, ~22% of tokens
+        # have at least one local expert; the rest produce all-zero
+        # output. If the kernel were silently broken and returned all
+        # zeros, this check would catch it.
+        nonzero_fraction = (result.abs() > 1e-3).float().mean().item()
+        # Lower bound proportional to local-expert coverage at this EP
+        # (probability that at least one of top_k selected experts is on
+        # this rank). EP=1 → ~100%; EP=8 → most tokens covered;
+        # EP=16 → ~40%+; EP=32 → ~20%+. Bounds set well below the real
+        # fraction to absorb FP4 quantization producing legitimately
+        # small (sub-threshold) outputs.
+        min_expected_nonzero = {1: 0.5, 8: 0.3, 16: 0.15, 32: 0.05}[ep_size]
+        assert nonzero_fraction >= min_expected_nonzero, (
+            f"ep_size={ep_size}, num_tokens={num_tokens}: only "
+            f"{nonzero_fraction * 100:.2f}% of output entries are "
+            f"non-zero (expected at least "
+            f"{min_expected_nonzero * 100:.0f}%) — kernel may not have "
+            f"executed correctly with poisoned buffers."
+        )
+
+        # Reference comparison is supplementary to the NaN/Inf +
+        # non-zero-fraction checks above. Skip at high N because
+        # ``compute_reference_moe_fp4`` is ``O(num_tokens × top_k)``
+        # Python iterations with ``.item()`` syncs, dominating CI
+        # runtime per case. The poisoning-detection signal lives in
+        # the assertions already executed.
+        if num_tokens > 1024:
+            return
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            num_local_experts=num_local_experts,
+            local_expert_offset=local_expert_offset,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ep_size={ep_size}, num_tokens={num_tokens}: poisoned-buffer "
+            f"test failed: only {percent_within * 100:.2f}% within "
+            f"tolerance (atol={atol:.4f}). The kernel left poison "
+            f"sentinels in positions that downstream reads — the "
+            f"invariant that the routing kernel writes every consumed "
+            f"entry is violated, so a Python-side ``.fill_()`` / "
+            f"``.zero_()`` init step is load-bearing at this EP."
+        )
+
+
+# =============================================================================
 # Test Class: All Valid Tactics
 # =============================================================================
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Aligns flashinfer's `moe_sort` wrapper with the trt-llm thop allocation pattern (`torch::empty(...)` with no Python-side init).

Removed from the preallocated-buffer (CUDA-graph) path:

- `expanded_idx_to_permuted_idx.fill_(-1)` (and the stale "kernel expects this" comment)
- `permuted_idx_to_expanded_idx.zero_()`
- `total_num_padded_tokens_tensor.zero_()`
- `num_non_exiting_tiles.zero_()`

Aligned the else-branch allocations (functional-API path with no preallocated buffer) from `torch.full((..., -1), ...)` and `torch.zeros(...)` to `torch.empty(...)`. The `expert_counts` buffer (used for >1024-token routing) was changed from `torch.zeros` to `torch.empty` since the vendored kernel zeros it internally via `launchInitExpertCounts` before reading.

The routing kernel `runPostTopKPipeline` (in `csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu` on the fi side) writes every entry of all four output buffers itself — including writing `-1` to masked slots of
`expanded_idx_to_permuted_idx` at EP > 1, and writing valid permuted indices to all unmasked slots. The Python-side init was redundant defensive programming; trt-llm's thop has been running this pattern in production with `torch::empty(...)` and no Python init.

4 fewer Python-launched FillFunctor kernels per `moe_sort` call when buffers are preallocated by `CuteDslMoEWrapper`.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/2811
https://github.com/flashinfer-ai/flashinfer/pull/2803

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CUDA-graph regression test to ensure MoE routing buffers are fully overwritten and outputs are numerically stable (no NaNs/Infs) across multiple configurations.

* **Improvements**
  * Optimized MoE routing memory allocation to reduce unnecessary initialization and improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->