### PR TITLE
[Bugfix] Fix #3229 recompile after NVCC_HOME changes

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -737,7 +737,7 @@ def copy_built_kernels(
         shutil.rmtree(out_dir)
     out_dir.mkdir(parents=True, exist_ok=False)
     for jit_spec in jit_specs:
-        src = jit_env.FLASHINFER_JIT_DIR / jit_spec.name / f"{jit_spec.name}.so"
+        src = jit_spec.jit_library_path
         dst = out_dir / jit_spec.name / f"{jit_spec.name}.so"
         dst.parent.mkdir(exist_ok=False, parents=False)
         shutil.copy2(src, dst)

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -1,8 +1,10 @@
 import dataclasses
 import functools
+import hashlib
 import logging
 import os
 from contextlib import nullcontext
+from dataclasses import field
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union, Hashable
@@ -222,20 +224,46 @@ class JitSpec:
     extra_cuda_cflags: Optional[List[str]]
     extra_ldflags: Optional[List[str]]
     extra_include_dirs: Optional[List[Path]]
-    is_class: bool = False
     needs_device_linking: bool = False
+
+    _ninja_build_content_cached: Optional[str] = field(
+        default=None, repr=False, compare=False, init=False
+    )
+    _ninja_build_digest_cached: Optional[str] = field(
+        default=None, repr=False, compare=False, init=False
+    )
+
+    def _ninja_build_content(self) -> str:
+        if self._ninja_build_content_cached is None:
+            self._ninja_build_content_cached = generate_ninja_build_for_op(
+                name=self.name,
+                sources=self.sources,
+                extra_cflags=self.extra_cflags,
+                extra_cuda_cflags=self.extra_cuda_cflags,
+                extra_ldflags=self.extra_ldflags,
+                extra_include_dirs=self.extra_include_dirs,
+                needs_device_linking=self.needs_device_linking,
+            )
+        return self._ninja_build_content_cached
+
+    def _ninja_build_digest(self) -> str:
+        if self._ninja_build_digest_cached is None:
+            self._ninja_build_digest_cached = hashlib.sha256(
+                self._ninja_build_content().encode("utf-8")
+            ).hexdigest()
+        return self._ninja_build_digest_cached
 
     @property
     def ninja_path(self) -> Path:
-        return jit_env.FLASHINFER_JIT_DIR / self.name / "build.ninja"
+        return self.build_dir / "build.ninja"
 
     @property
     def build_dir(self) -> Path:
-        return jit_env.FLASHINFER_JIT_DIR / self.name
+        return jit_env.FLASHINFER_JIT_DIR / self.name / self._ninja_build_digest()
 
     @property
     def jit_library_path(self) -> Path:
-        return jit_env.FLASHINFER_JIT_DIR / self.name / f"{self.name}.so"
+        return self.build_dir / f"{self.name}.so"
 
     def get_library_path(self) -> Path:
         if self.is_aot:
@@ -266,21 +294,12 @@ class JitSpec:
 
     @property
     def lock_path(self) -> Path:
-        return get_tmpdir() / f"{self.name}.lock"
+        return get_tmpdir() / f"{self.name}_{self._ninja_build_digest()}.lock"
 
     def write_ninja(self) -> None:
         ninja_path = self.ninja_path
         self.build_dir.mkdir(parents=True, exist_ok=True)
-        content = generate_ninja_build_for_op(
-            name=self.name,
-            sources=self.sources,
-            extra_cflags=self.extra_cflags,
-            extra_cuda_cflags=self.extra_cuda_cflags,
-            extra_ldflags=self.extra_ldflags,
-            extra_include_dirs=self.extra_include_dirs,
-            needs_device_linking=self.needs_device_linking,
-        )
-        write_if_different(ninja_path, content)
+        write_if_different(ninja_path, self._ninja_build_content())
 
     @property
     def is_ninja_generated(self) -> bool:

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -316,26 +316,21 @@ def generate_ninja_build_for_op(
             ]
         )
 
-    # Use absolute paths for outputs so ninja files work with any workdir
-    # This enables isolated workdirs for runtime JIT (avoiding .ninja_log races)
-    # while still supporting subninja for parallel AOT builds
-    output_dir = jit_env.FLASHINFER_JIT_DIR / name
-
+    # Object and .so paths are relative to the directory that contains this
+    # build.ninja file (each JitSpec uses an isolated build_dir, see JitSpec.build_dir).
     objects = []
     for source in sources:
         is_cuda = source.suffix == ".cu"
         object_suffix = ".cuda.o" if is_cuda else ".o"
         cmd = "cuda_compile" if is_cuda else "compile"
         obj_name = f"{source.parent.name}_{source.stem}{object_suffix}"
-        obj = str((output_dir / obj_name).resolve())
-        objects.append(obj)
-        lines.append(f"build {obj}: {cmd} {source.resolve()}")
+        objects.append(obj_name)
+        lines.append(f"build {obj_name}: {cmd} {source}")
 
     lines.append("")
     link_rule = "nvcc_link" if needs_device_linking else "link"
-    output_so = str((output_dir / f"{name}.so").resolve())
-    lines.append(f"build {output_so}: {link_rule} " + " ".join(objects))
-    lines.append(f"default {output_so}")
+    lines.append(f"build $name.so: {link_rule} " + " ".join(objects))
+    lines.append("default $name.so")
     lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_jit_spec.py
+++ b/tests/test_jit_spec.py
@@ -1,0 +1,31 @@
+from flashinfer.jit.core import gen_jit_spec
+from flashinfer.jit.cpp_ext import get_cuda_path
+
+
+def test_issue_3229(monkeypatch, tmp_path):
+    """
+    Generate two JitSpec objects with different settings.
+    Assert that their `jit_library_path`s are different.
+
+    https://github.com/flashinfer-ai/flashinfer/issues/3229
+    """
+    monkeypatch.setattr(
+        "flashinfer.jit.core.check_cuda_arch", lambda: None, raising=True
+    )
+
+    cu = tmp_path / "k.cu"
+    cu.write_text("// test\n", encoding="utf-8")
+
+    monkeypatch.setenv("CUDA_HOME", "dummy1")
+    get_cuda_path.cache_clear()
+    jit_spec1 = gen_jit_spec("test_issue_3229", [cu])
+    build_dir1 = jit_spec1.build_dir
+
+    monkeypatch.setenv("CUDA_HOME", "dummy2")
+    get_cuda_path.cache_clear()
+    jit_spec2 = gen_jit_spec("test_issue_3229", [cu])
+    build_dir2 = jit_spec2.build_dir
+
+    assert build_dir1 != build_dir2
+
+    get_cuda_path.cache_clear()


### PR DESCRIPTION
## 📌 Description

This patch adds hash of build.ninja to the path of JIT build dir.  Thus, when NVCC_HOME or other environment variables change, the cached JIT objects produced by previous JIT build will be no longer reused.

AOT related paths are left unchanged.

This patch also reverts part of commit 63a834d45, which introduced absolute path of output dir to build.ninja.  This patch changes it back to relative dir, because it would be impossible to determine the absolute path of output dir, where hash of build.ninja is included, **before** build.ninja is actually generated.  I think this harmless, as the call- site of `run_ninja` always set correct `work_dir`.

## 🔍 Related Issues

[[Bug] Nothing recompiled after NVCC_HOME changes #3229 ](https://github.com/flashinfer-ai/flashinfer/issues/3229)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Memoized build descriptions and cached digests for faster, more consistent JIT builds.
  * Build outputs and locks are now scoped by build-content digest for stronger isolation.
  * Build rules now use relative paths for generated objects to improve portability.

* **Bug Fixes**
  * Copying of compiled kernels now uses each kernel’s recorded library path to avoid mismatches.

* **Tests**
  * Added regression test ensuring distinct build directories when CUDA configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3231)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->