### PR TITLE
Add missing barrier/bcast methods to test CustomCommunicator

### DIFF
--- a/tests/comm/test_mnnvl_custom_comm.py
+++ b/tests/comm/test_mnnvl_custom_comm.py
@@ -45,6 +45,14 @@ class CustomCommunicator(CommBackend):
         else:
             raise TypeError(f"Unsupported type for allgather: {type(data)}")
 
+    def bcast(self, data: Any, root: int) -> Any:
+        object_list = [data]
+        dist.broadcast_object_list(object_list, src=root, group=self._group)
+        return object_list[0]
+
+    def barrier(self) -> None:
+        dist.barrier(group=self._group)
+
     def Split(self, color: int, key: int) -> "CustomCommunicator":
         return self
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

CommBackend gained barrier and bcast as abstract methods, but the test's CustomCommunicator subclass wasn't updated, so all parametrizations of test_mnnvl_custom_communicator fail at instantiation with TypeError. Implementations mirror the reference TorchDistBackend.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with additional communicator methods for distributed testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->