### PR TITLE
feat: two-level FP8 accumulation for fmha_v2 Hopper warp-spec kernels

### DIFF
--- a/csrc/fmha_v2/fmha/warpspec/compute.h
+++ b/csrc/fmha_v2/fmha/warpspec/compute.h
@@ -179,7 +179,8 @@ struct Compute {
       USE_CUSTOM_MASK ? (head_info.mask_sum_s + q_step_idx * STEP_Q + local_q_tile_offset)       \
                       : (q_step_idx * STEP_Q + head_info.q_tile_offset),                         \
       kv_step_idx * STEP_KV, sage_scale_row, cbr, cbr_v, mutex_accessor,                         \
-      &shared->skip_softmax_votes[kv_step_idx & 1][warpgroup_id], kv_step_idx == kv_idx_end - 1);
+      &shared->skip_softmax_votes[kv_step_idx & 1][warpgroup_id], acc_o_accum_, accum_scale_,    \
+      two_level_tile_idx, kv_step_idx == kv_idx_end - 1);
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -250,6 +251,14 @@ struct Compute {
     uint32_t smem_v = __cvta_generic_to_shared(&shared->smem_v[0]);
     Compute_tile_o ctile_o(0, smem_v);
 
+    // Two-level FP8 accumulation state. Sized [1][1] / [1] when disabled (compiler will eliminate
+    // the storage entirely under USE_TWO_LEVEL_ACCUM=false). When enabled, acc_o_accum_ shadows
+    // ctile_o.acc_'s shape, accum_scale_ tracks the deferred per-row online-softmax correction,
+    // and two_level_tile_idx counts KV tiles within the current Q-tile (reset below).
+    [[maybe_unused]] TwoLevelAccFrag acc_o_accum_[TWO_LEVEL_ACC_M][TWO_LEVEL_ACC_N];
+    [[maybe_unused]] float accum_scale_[TWO_LEVEL_CORES_M];
+    [[maybe_unused]] int two_level_tile_idx;
+
     // Mutex between two compute groups.
     OrderedMutexAccessor mutex_accessor(shared->compute_mutex, warpgroup_id, SYNC_BARRIER);
     // Notify warpgroup 0 to execute HGMMA first (overlap HGMMA and Softmax Math Instructions).
@@ -303,6 +312,23 @@ struct Compute {
         // Check whether it is a valid run of q steps.
         int const q_offset = q_step_idx * STEP_Q + local_q_tile_offset;
         bool const valid_run = q_offset < actual_q_seqlen;
+
+        // Reset two-level state at the start of each Q-tile. The persistent acc starts at zero;
+        // accum_scale starts at 1 (identity); tile counter starts at 0.
+        if constexpr (USE_TWO_LEVEL_ACCUM) {
+#pragma unroll
+          for (int mma_m = 0; mma_m < TWO_LEVEL_ACC_M; mma_m++) {
+#pragma unroll
+            for (int mma_n = 0; mma_n < TWO_LEVEL_ACC_N; mma_n++) {
+              acc_o_accum_[mma_m][mma_n].clear();
+            }
+          }
+#pragma unroll
+          for (int mi = 0; mi < TWO_LEVEL_CORES_M; mi++) {
+            accum_scale_[mi] = 1.f;
+          }
+          two_level_tile_idx = 0;
+        }
         // fuse the scale of q into scale_bmm1
         if constexpr (SAGE_BLOCK_SIZE_Q > 0) {
           // I tried another implementation here: store original `scale_bmm1` to a local variable
@@ -399,6 +425,11 @@ struct Compute {
           KV_TILE_COMPLETE();
         }
         if (valid_run) {
+          // Two-level: fold the residual persistent accumulator into the working accumulator
+          // before the divide-by-sum epilogue. After this, ctile_o.acc_ holds the full output.
+          if constexpr (USE_TWO_LEVEL_ACCUM) {
+            softmax.final_merge_accum(ctile_o, acc_o_accum_, accum_scale_);
+          }
           // Final step's update.
           tile_o_epilogue.scale(ctile_o, p_max, p_sum);
           // Store o_tile to gmem.
@@ -427,6 +458,15 @@ struct Compute {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
+  // Storage shapes for the two-level FP8 accumulator state. When the feature is disabled
+  // (FP8_TWO_LEVEL_INTERVAL == 0) the arrays are sized [1][1] / [1] and never read — they exist
+  // only so the parameter type is well-formed. nvcc rejects zero-sized device locals.
+  static constexpr bool USE_TWO_LEVEL_ACCUM = (Kernel_traits::FP8_TWO_LEVEL_INTERVAL > 0);
+  static constexpr int TWO_LEVEL_ACC_M = USE_TWO_LEVEL_ACCUM ? Mma_tile_o::MMAS_M : 1;
+  static constexpr int TWO_LEVEL_ACC_N = USE_TWO_LEVEL_ACCUM ? Mma_tile_o::MMAS_N : 1;
+  static constexpr int TWO_LEVEL_CORES_M = USE_TWO_LEVEL_ACCUM ? Mma_tile_o::CORES_M : 1;
+  using TwoLevelAccFrag = fmha::Fragment_accumulator<Traits_o>;
+
   template <bool IS_FIRST_COL, bool APPLY_MASK, typename Params>
   inline __device__ void compute_single_tile(
       Params params, Compute_tile_p& ctile_p, Softmax& softmax, Compute_tile_o& ctile_o,
@@ -434,7 +474,8 @@ struct Compute {
       int const actual_kv_seqlen, float const alibi_head_scale, int const row_offset,
       int const col_offset, int const sage_scale_row, Circular_buffer_q_reader& cbr,
       Circular_buffer_kv_reader& cbr_v, OrderedMutexAccessor& mutex, uint32_t* skip_softmax_vote,
-      bool complete = false) {
+      TwoLevelAccFrag (&acc_o_accum)[TWO_LEVEL_ACC_M][TWO_LEVEL_ACC_N],
+      float (&accum_scale)[TWO_LEVEL_CORES_M], int& two_level_tile_idx, bool complete = false) {
     // Skip-softmax vote initialization
     if (tidx == 0) {
       // Note that we need a named_barrier_wait in compute_single_tile to make sure init is before
@@ -565,6 +606,17 @@ struct Compute {
     // Update flash attention scales and pack it for BMM2
     softmax.pack<IS_FIRST_COL>(ctile_o, frag_p);
 
+    // Two-level accumulation: defer the per-iter correction by tracking it in accum_scale rather
+    // than letting it cascade through the persistent FP32 accumulator on every tile. pack() has
+    // already applied the standard online-softmax rescale to the working ctile_o.acc_; here we
+    // additionally fold this iter's correction into accum_scale so it can be applied once at the
+    // next merge point. See FA3 PR vllm-project/flash-attention#122.
+    if constexpr (USE_TWO_LEVEL_ACCUM) {
+      if constexpr (!IS_FIRST_COL) {
+        softmax.update_accum_scale(accum_scale);
+      }
+    }
+
     if constexpr (ENABLE_MUTEX && Kernel_traits::ELEMENT_BYTES == 1) {
       // Notify another warpgroup to execute QGMMA.
       mutex.named_bar_arrive();
@@ -639,6 +691,17 @@ struct Compute {
 
     warpgroup_commit();
     warpgroup_wait<0>();
+
+    // Periodic merge for two-level FP8 accumulation. tile_idx counts KV tiles consumed within the
+    // current Q-tile (reset to 0 by run() before the inner loop). When (tile_idx + 1) hits the
+    // configured interval, fold the working accumulator into the persistent acc_o_accum with the
+    // deferred scale, then reset accum_scale=1 and clear ctile_o.acc_. (Done inside merge.)
+    if constexpr (USE_TWO_LEVEL_ACCUM) {
+      if (((two_level_tile_idx + 1) % Kernel_traits::FP8_TWO_LEVEL_INTERVAL) == 0) {
+        softmax.merge_accum_with_scale(ctile_o, acc_o_accum, accum_scale);
+      }
+      ++two_level_tile_idx;
+    }
   }
 };
 

--- a/csrc/fmha_v2/fmha/warpspec/epilogue.h
+++ b/csrc/fmha_v2/fmha/warpspec/epilogue.h
@@ -940,6 +940,79 @@ struct Softmax<Hopper_qgmma_e4m3_fp32_traits, Kernel_traits>
     }
   }
 
+  // Two-level accumulation helpers (FA3 PR vllm-project/flash-attention#122).
+  // These are only called when Kernel_traits::FP8_TWO_LEVEL_INTERVAL > 0. The working accumulator
+  // ctile_o.acc_ is still rescaled per-iter inside pack(); these helpers track the cumulative
+  // correction in accum_scale and periodically fold it into a persistent acc_o_accum to avoid
+  // chaining rounding through the working FP32 registers on long contexts.
+
+  // Multiply this iteration's correction into the deferred per-row scale. Call AFTER pack() — pack
+  // has already updated this->correction_ (via compute_and_update_scale).
+  inline __device__ void update_accum_scale(float (&accum_scale)[Mma_tile_o::CORES_M]) {
+#pragma unroll
+    for (int mi = 0; mi < Mma_tile_o::CORES_M; mi++) {
+      accum_scale[mi] *= this->correction_[mi];
+    }
+  }
+
+  // Periodic merge: fold the up-to-date working acc into the persistent acc, clear the working acc,
+  // and reset the deferred scale. The acc_o_accum's storage matches ctile_o.acc_ shape exactly.
+  // After this call the caller does NOT need to clear ctile_o.acc_ separately.
+  using AccFragment = fmha::Fragment_accumulator<Traits_o>;
+  inline __device__ void merge_accum_with_scale(Compute_tile_o& ctile_o,
+                                                AccFragment (&acc_o_accum)[1][Mma_tile_o::MMAS_N],
+                                                float (&accum_scale)[Mma_tile_o::CORES_M]) {
+#pragma unroll
+    for (int mi = 0; mi < Mma_tile_o::CORES_M; mi++) {
+      float scale = accum_scale[mi];
+#pragma unroll
+      for (int mma_ni = 0; mma_ni < Mma_tile_o::MMAS_N; mma_ni++) {
+#pragma unroll
+        for (int ni = 0; ni < Mma_tile_o::CORES_N; ni++) {
+          int idx0 = 2 * ni * Mma_tile_o::CORES_M + 2 * mi;
+          int idx1 = idx0 + 1;
+          float& accum0 = acc_o_accum[0][mma_ni].elt(idx0);
+          float& accum1 = acc_o_accum[0][mma_ni].elt(idx1);
+          float& work0 = ctile_o.acc_[0][mma_ni].elt(idx0);
+          float& work1 = ctile_o.acc_[0][mma_ni].elt(idx1);
+          // FA3 hopper/softmax.h: acc_o_accum = scale * acc_o_accum + acc_o; reset scale to 1.
+          accum0 = scale * accum0 + work0;
+          accum1 = scale * accum1 + work1;
+          // FA3 calls cute::clear(tOrO) in the caller; do it inline for fewer round-trips.
+          work0 = 0.f;
+          work1 = 0.f;
+        }
+      }
+      accum_scale[mi] = 1.f;
+    }
+  }
+
+  // Final residual merge before the divide-by-sum epilogue. After this, ctile_o.acc_ holds the
+  // full output and acc_o_accum is no longer needed. accum_scale is left untouched (FA3 parity).
+  inline __device__ void final_merge_accum(Compute_tile_o& ctile_o,
+                                           AccFragment const (&acc_o_accum)[1][Mma_tile_o::MMAS_N],
+                                           float const (&accum_scale)[Mma_tile_o::CORES_M]) {
+#pragma unroll
+    for (int mi = 0; mi < Mma_tile_o::CORES_M; mi++) {
+      float scale = accum_scale[mi];
+#pragma unroll
+      for (int mma_ni = 0; mma_ni < Mma_tile_o::MMAS_N; mma_ni++) {
+#pragma unroll
+        for (int ni = 0; ni < Mma_tile_o::CORES_N; ni++) {
+          int idx0 = 2 * ni * Mma_tile_o::CORES_M + 2 * mi;
+          int idx1 = idx0 + 1;
+          float const accum0 = acc_o_accum[0][mma_ni].elt(idx0);
+          float const accum1 = acc_o_accum[0][mma_ni].elt(idx1);
+          float& work0 = ctile_o.acc_[0][mma_ni].elt(idx0);
+          float& work1 = ctile_o.acc_[0][mma_ni].elt(idx1);
+          // FA3 hopper/softmax.h: acc_o = scale * acc_o_accum + acc_o.
+          work0 = scale * accum0 + work0;
+          work1 = scale * accum1 + work1;
+        }
+      }
+    }
+  }
+
   static constexpr float q_scale_s_ = Traits_o::SOFTMAX_FP_QUANT_SCALE;
 };
 

--- a/csrc/fmha_v2/fmha/warpspec/kernel_traits.h
+++ b/csrc/fmha_v2/fmha/warpspec/kernel_traits.h
@@ -70,7 +70,12 @@ template <
     // The output type (only used by fp8 kernels).
     typename OutputType = typename Instruction_traits<STEP_Q_, STEP_KV_, 0, false, false>::A_type,
     // The sage attention block size for Q, K and V
-    int SAGE_BLOCK_SIZE_Q_ = 0, int SAGE_BLOCK_SIZE_K_ = 0, int SAGE_BLOCK_SIZE_V_ = 0>
+    int SAGE_BLOCK_SIZE_Q_ = 0, int SAGE_BLOCK_SIZE_K_ = 0, int SAGE_BLOCK_SIZE_V_ = 0,
+    // FP8 two-level accumulation: merge cadence (in KV-tiles) of the working acc_o into a
+    // persistent acc_o_accum. 0 disables (current behavior). N>0 enables; the FP8 path uses
+    // a deferred per-row scale to avoid chaining online-softmax corrections through the FP32
+    // accumulator on long contexts. Only meaningful when Element_data_type is fp8 (e4m3/e5m2).
+    int FP8_TWO_LEVEL_INTERVAL_ = 0>
 struct Kernel_traits {
   // The step size in query sequence dimension (M of BMM1 and BMM2).
   enum { STEP_Q = STEP_Q_ };
@@ -132,6 +137,9 @@ struct Kernel_traits {
   enum { SAGE_BLOCK_SIZE_K = SAGE_BLOCK_SIZE_K_ };
 
   enum { SAGE_BLOCK_SIZE_V = SAGE_BLOCK_SIZE_V_ };
+
+  // FP8 two-level accumulation interval. 0 disables.
+  enum { FP8_TWO_LEVEL_INTERVAL = FP8_TWO_LEVEL_INTERVAL_ };
 
   // Whether the dma group transposes the v tile explicitly.
   enum {
@@ -456,14 +464,16 @@ template <  // The step size in query sequence dimension (M of BMM1 and BMM2).
     // The output type (only used by fp8 kernels).
     typename OutputType = e4m3_t,
     // The sage attention block size for Q, K and V
-    int SAGE_BLOCK_SIZE_Q_ = 0, int SAGE_BLOCK_SIZE_K_ = 0, int SAGE_BLOCK_SIZE_V_ = 0>
+    int SAGE_BLOCK_SIZE_Q_ = 0, int SAGE_BLOCK_SIZE_K_ = 0, int SAGE_BLOCK_SIZE_V_ = 0,
+    // FP8 two-level accumulation merge cadence (in KV-tiles). 0 disables (current behavior).
+    int FP8_TWO_LEVEL_INTERVAL_ = 0>
 struct Kernel_traits_Hopper_qgmma_e4m3_fp32
     : public Kernel_traits<
           Hopper_qgmma_e4m3_fp32_traits, STEP_Q_, STEP_KV_, D_, DV_, Q_BUFFERS_, KV_BUFFERS_,
           NUM_COMPUTE_GROUPS_, DMA2COMPUTE_DEPTH_, ATTENTION_MASK_TYPE_, HEADS_INTERLEAVED_,
           APPLY_ALIBI_, ENABLE_MUTEX_, SCHEDULING_MODE_, INPUT_LAYOUT_, USE_TMA_STORE_,
           ENABLE_BMM1_SOFTCAPPING_SCALE_, RETURN_SOFTMAX_STATS_, ENABLE_SKIP_SOFTMAX_, OutputType,
-          SAGE_BLOCK_SIZE_Q_, SAGE_BLOCK_SIZE_K_, SAGE_BLOCK_SIZE_V_> {
+          SAGE_BLOCK_SIZE_Q_, SAGE_BLOCK_SIZE_K_, SAGE_BLOCK_SIZE_V_, FP8_TWO_LEVEL_INTERVAL_> {
   // Base class.
   using Base =
       Kernel_traits<Hopper_qgmma_e4m3_fp32_traits, STEP_Q_, STEP_KV_, D_, DV_, Q_BUFFERS_,
@@ -471,7 +481,7 @@ struct Kernel_traits_Hopper_qgmma_e4m3_fp32
                     HEADS_INTERLEAVED_, APPLY_ALIBI_, ENABLE_MUTEX_, SCHEDULING_MODE_,
                     INPUT_LAYOUT_, USE_TMA_STORE_, ENABLE_BMM1_SOFTCAPPING_SCALE_,
                     RETURN_SOFTMAX_STATS_, ENABLE_SKIP_SOFTMAX_, OutputType, SAGE_BLOCK_SIZE_Q_,
-                    SAGE_BLOCK_SIZE_K_, SAGE_BLOCK_SIZE_V_>;
+                    SAGE_BLOCK_SIZE_K_, SAGE_BLOCK_SIZE_V_, FP8_TWO_LEVEL_INTERVAL_>;
 
   enum { USE_TMA_STORE = USE_TMA_STORE_ };
 

--- a/csrc/fmha_v2/templates/kernel_hopper_ws.jinja
+++ b/csrc/fmha_v2/templates/kernel_hopper_ws.jinja
@@ -44,7 +44,8 @@ using Ktraits = {{ kernel_traits_header }}
                 {{ output_dtype_ }},
                 {{ sage_block_size_q }},
                 {{ sage_block_size_k }},
-                {{ sage_block_size_v }}>;
+                {{ sage_block_size_v }},
+                {{ fp8_two_level_interval }}>;
 
 using Ktraits_causal = {{ kernel_traits_header }}
                        {{ loop_step }},
@@ -65,7 +66,9 @@ using Ktraits_causal = {{ kernel_traits_header }}
                        {{ enable_attn_logit_softcapping_flag }},
                        {{ return_softmax_stats_flag }},
                        {{ enable_skip_softmax_flag }},
-                       {{ output_dtype_ }}>;
+                       {{ output_dtype_ }},
+                       0, 0, 0,
+                       {{ fp8_two_level_interval }}>;
 
 using Ktraits_sliding_or_chunked_causal = {{ kernel_traits_header }}
                                       {{ loop_step }},
@@ -86,7 +89,9 @@ using Ktraits_sliding_or_chunked_causal = {{ kernel_traits_header }}
                                       {{ enable_attn_logit_softcapping_flag }},
                                       {{ return_softmax_stats_flag }},
                                       {{ enable_skip_softmax_flag }},
-                                      {{ output_dtype_ }}>;
+                                      {{ output_dtype_ }},
+                                      0, 0, 0,
+                                      {{ fp8_two_level_interval }}>;
 
 using Ktraits_custom_mask = {{ kernel_traits_header }}
                             {{ loop_step }},
@@ -107,7 +112,9 @@ using Ktraits_custom_mask = {{ kernel_traits_header }}
                             {{ enable_attn_logit_softcapping_flag }},
                             {{ return_softmax_stats_flag }},
                             {{ enable_skip_softmax_flag }},
-                            {{ output_dtype_ }}>;
+                            {{ output_dtype_ }},
+                            0, 0, 0,
+                            {{ fp8_two_level_interval }}>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -87,6 +87,7 @@ class FMHAv2KernelSpec:
     sage_block_sizes: Optional[Tuple[int, int, int]] = None
     output_dtype: Optional[str] = None
     is_mtp: bool = False
+    fp8_two_level_interval: int = 0
 
 
 # BF16-QKV+BF16-out and BF16-Q + FP8-KV + BF16-out (or FP8-QKV+BF16-out)
@@ -129,6 +130,7 @@ def generate_kernel_spec(
     head_size_v: Optional[int] = 0,
     input_layout: Optional[InputLayout] = InputLayout.Q_PAGED_KV,
     output_dtype: Optional[str] = None,
+    fp8_two_level_interval: int = 0,
 ) -> FMHAv2KernelSpec:
     """
     Generate a kernel spec for FMHAv2.
@@ -173,6 +175,12 @@ def generate_kernel_spec(
         "head_size_v": head_size_v,
         "output_dtype": output_dtype,
         "is_mtp": is_mla,
+        # Two-level FP8 accumulation (FA3-style; vllm-project/flash-attention#122). Only meaningful
+        # for warp-spec FP8 kernels — silently zeroed elsewhere so URIs / cache lookups still match
+        # the existing kernels for non-FP8 dtypes.
+        "fp8_two_level_interval": (
+            fp8_two_level_interval if dtype in ("e4m3", "e4m3_fp32") else 0
+        ),
     }
 
     # Compute ldgsts flags
@@ -1210,6 +1218,7 @@ def generate_jit_sources(
     input_dtype: str,
     output_dtype: Optional[str],
     compilation_context: CompilationContext,
+    fp8_two_level_interval: int = 0,
 ) -> list[pathlib.Path]:
     gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / uri
     source_paths = []
@@ -1316,6 +1325,7 @@ def generate_jit_sources(
                 input_layout=input_layout_iter,
                 head_size_v=head_size_v_iter,
                 output_dtype=output_dtype_iter,
+                fp8_two_level_interval=fp8_two_level_interval,
             )
             if not is_kernel_spec_valid(kspec):
                 continue

--- a/flashinfer/jit/attention/fmha_v2/generator_utils.py
+++ b/flashinfer/jit/attention/fmha_v2/generator_utils.py
@@ -156,6 +156,9 @@ kernel_spec = namedtuple(
         "output_dtype",
         "is_mtp",
         "enable_skip_softmax",
+        # FP8 two-level accumulation interval for Hopper warp-specialized kernels.
+        # 0 disables; N>0 merges the working acc_o into a persistent acc_o_accum every N KV-tiles.
+        "fp8_two_level_interval",
     ],
     defaults=(
         1,  # ctas_per_head
@@ -182,6 +185,7 @@ kernel_spec = namedtuple(
         None,  # output_dtype, same as dtype by default.
         False,  # is_mtp
         False,  # enable_skip_softmax
+        0,  # fp8_two_level_interval (0 = disabled)
     ),
 )
 spec_fields = kernel_spec._fields
@@ -1479,7 +1483,8 @@ using Ktraits = {kernel_traits_header}
                 {output_dtype_},
                 {sage_block_size_q},
                 {sage_block_size_k},
-                {sage_block_size_v}>;
+                {sage_block_size_v},
+                {fp8_two_level_interval}>;
 
 using Ktraits_causal = {kernel_traits_header}
                        {loop_step},
@@ -1500,7 +1505,9 @@ using Ktraits_causal = {kernel_traits_header}
                        {enable_attn_logit_softcapping_flag},
                        {return_softmax_stats_flag},
                        {enable_skip_softmax_flag},
-                       {output_dtype_}>;
+                       {output_dtype_},
+                       0, 0, 0,
+                       {fp8_two_level_interval}>;
 
 using Ktraits_sliding_or_chunked_causal = {kernel_traits_header}
                                       {loop_step},
@@ -1521,7 +1528,9 @@ using Ktraits_sliding_or_chunked_causal = {kernel_traits_header}
                                       {enable_attn_logit_softcapping_flag},
                                       {return_softmax_stats_flag},
                                       {enable_skip_softmax_flag},
-                                      {output_dtype_}>;
+                                      {output_dtype_},
+                                      0, 0, 0,
+                                      {fp8_two_level_interval}>;
 
 using Ktraits_custom_mask = {kernel_traits_header}
                             {loop_step},
@@ -1542,7 +1551,9 @@ using Ktraits_custom_mask = {kernel_traits_header}
                             {enable_attn_logit_softcapping_flag},
                             {return_softmax_stats_flag},
                             {enable_skip_softmax_flag},
-                            {output_dtype_}>;
+                            {output_dtype_},
+                            0, 0, 0,
+                            {fp8_two_level_interval}>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -4071,6 +4082,7 @@ def enumerate_qgmma_flash_warpspec_kernels(
     sage_block_sizes: tuple[int, int, int] | None = None,
     output_dtype: str | None = None,
     enable_skip_softmax: bool = False,
+    fp8_two_level_interval: int = 0,
 ) -> None:
     scheduling_mode = int(os.getenv("SCHEDULING_MODE", "1"))
 
@@ -4138,6 +4150,7 @@ def enumerate_qgmma_flash_warpspec_kernels(
                     sage_block_sizes=sage_block_sizes,
                     output_dtype=output_dtype,
                     enable_skip_softmax=enable_skip_softmax,
+                    fp8_two_level_interval=fp8_two_level_interval,
                 )
             )
 
@@ -4175,6 +4188,7 @@ def enumerate_qgmma_flash_warpspec_kernels(
                     sage_block_sizes=sage_block_sizes,
                     output_dtype=output_dtype,
                     enable_skip_softmax=enable_skip_softmax,
+                    fp8_two_level_interval=fp8_two_level_interval,
                 )
             )
 
@@ -4212,6 +4226,7 @@ def enumerate_qgmma_flash_warpspec_kernels(
                     sage_block_sizes=sage_block_sizes,
                     output_dtype=output_dtype,
                     enable_skip_softmax=enable_skip_softmax,
+                    fp8_two_level_interval=fp8_two_level_interval,
                 )
             )
 
@@ -4250,6 +4265,7 @@ def enumerate_qgmma_flash_warpspec_kernels(
                     input_layout=input_layout,
                     sage_block_sizes=sage_block_sizes,
                     output_dtype=output_dtype,
+                    fp8_two_level_interval=fp8_two_level_interval,
                 )
             )
 

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1960,7 +1960,10 @@ def gen_trtllm_fmha_v2_sm120_module() -> JitSpec:
 
 
 def gen_fmha_v2_module(
-    input_layout: str, input_dtype: torch.dtype, output_dtype: torch.dtype = None
+    input_layout: str,
+    input_dtype: torch.dtype,
+    output_dtype: torch.dtype = None,
+    fp8_two_level_interval: int = 0,
 ) -> JitSpec:
     # Setup generated source directory
     if output_dtype is None:
@@ -1974,7 +1977,14 @@ def gen_fmha_v2_module(
     input_dtype_str = dtype_map[input_dtype]
     output_dtype_str = dtype_map[output_dtype] if output_dtype is not None else None
 
+    # Two-level FP8 accumulation only applies to FP8 inputs; force-zero elsewhere so the URI
+    # (and resulting cached .so) stays identical to the pre-feature build for non-FP8 callers.
+    if input_dtype != torch.float8_e4m3fn:
+        fp8_two_level_interval = 0
+
     uri = f"trtllm_fmha_v2_{input_layout.lower()}_{input_dtype_str}_{output_dtype_str}"
+    if fp8_two_level_interval > 0:
+        uri += f"_tl{fp8_two_level_interval}"
 
     gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / uri
     gen_directory.mkdir(parents=True, exist_ok=True)
@@ -1990,6 +2000,7 @@ def gen_fmha_v2_module(
         input_dtype_str,
         output_dtype_str,
         compilation_context=current_compilation_context,
+        fp8_two_level_interval=fp8_two_level_interval,
     )
 
     # copy static fmha_v2_run.cu

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4432,9 +4432,14 @@ def fmha_v2_prefill_deepseek(
 
 @functools.cache
 def get_trtllm_fmha_v2_module(
-    input_layout: str, input_dtype: torch.dtype, output_dtype: torch.dtype = None
+    input_layout: str,
+    input_dtype: torch.dtype,
+    output_dtype: torch.dtype = None,
+    fp8_two_level_interval: int = 0,
 ):
-    return gen_fmha_v2_module(input_layout, input_dtype, output_dtype).build_and_load()
+    return gen_fmha_v2_module(
+        input_layout, input_dtype, output_dtype, fp8_two_level_interval
+    ).build_and_load()
 
 
 @flashinfer_api(trace=trtllm_fmha_v2_prefill_trace)
@@ -4465,6 +4470,7 @@ def trtllm_fmha_v2_prefill(
     chunked_attention_size: int = 0,
     save_softmax_stats: bool = False,
     skip_softmax_threshold_scale_factor: float = 0,
+    fp8_two_level_interval: int = 0,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""TRT-LLM FMHAv2 prefill attention.
 
@@ -4692,6 +4698,7 @@ def trtllm_fmha_v2_prefill(
         input_layout,
         query.dtype,
         o_dtype if query.dtype == torch.float8_e4m3fn else None,
+        fp8_two_level_interval,
     )
 
     # Allocate LSE tensor if saving softmax stats

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -479,6 +479,7 @@ def run_trtllm_fmha_v2_prefill_case(
     skip_softmax_threshold_scale_factor: float,
     rtol: Optional[float] = None,
     atol: Optional[float] = None,
+    fp8_two_level_interval: int = 0,
 ) -> None:
     from flashinfer.prefill import trtllm_fmha_v2_prefill
     from flashinfer.utils import is_sm90a_supported
@@ -696,6 +697,7 @@ def run_trtllm_fmha_v2_prefill_case(
         window_left=window_left,
         logits_soft_cap_scale=logits_soft_cap if logits_soft_cap > 0 else None,
         skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+        fp8_two_level_interval=fp8_two_level_interval,
         pos_encoding_mode=pos_encoding_mode,
         save_softmax_stats=save_softmax_stats,
     )
@@ -846,6 +848,50 @@ def test_trtllm_fmha_v2_prefill(
         pos_encoding_mode=pos_encoding_mode,
         save_softmax_stats=save_softmax_stats,
         skip_softmax_threshold_scale_factor=0.0,
+    )
+
+
+# ---- Two-level FP8 accumulation ----
+# vllm-project/flash-attention#122 ports a precision technique to the FP8 mainloop: alongside the
+# working FP32 accumulator, keep a persistent FP32 accumulator that absorbs the working one every
+# `interval` KV-tiles via a deferred per-row scale. This avoids chaining the online-softmax
+# correction `exp(prev_max - new_max)` through the working accumulator on long contexts.
+#
+# Test strategy: pick a workload long enough that interval=4 actually fires multiple merges
+# (max_seq_len=4096, head_dim=128 → STEP_KV=256 → 16 KV tiles per Q-tile) and check that
+# interval=0 / 4 / 16 all match each other within FP8 quantization noise. The compile-time
+# dispatcher routes interval > 0 to a separately-cached .so so we get genuinely different code.
+@pytest.mark.parametrize("fp8_two_level_interval", [0, 4, 16])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("max_seq_len", [4096])
+@pytest.mark.parametrize("batch_size", [1])
+def test_trtllm_fmha_v2_prefill_fp8_two_level(
+    batch_size: int,
+    max_seq_len: int,
+    head_dim: int,
+    fp8_two_level_interval: int,
+) -> None:
+    # NOTE: the existing `test_trtllm_fmha_v2_prefill` skips FP8 on SM90 entirely citing a hang.
+    # Per user direction the hang isn't reliable, so we run anyway here — if it triggers, the
+    # test will simply time out rather than report a wrong-numerics failure.
+    run_trtllm_fmha_v2_prefill_case(
+        input_layout="PACKED_QKV",
+        batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        num_qo_heads=4,
+        num_kv_heads=4,
+        head_dim=head_dim,
+        page_size=None,
+        dtype=torch.float8_e4m3fn,
+        o_dtype=torch.float8_e4m3fn,
+        causal=True,
+        mask_mode="CAUSAL",
+        window_left=-1,
+        logits_soft_cap=0.0,
+        pos_encoding_mode=None,
+        save_softmax_stats=False,
+        skip_softmax_threshold_scale_factor=0.0,
+        fp8_two_level_interval=fp8_two_level_interval,
     )
 
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                               

  Adds two-level accumulation to the fmha_v2 Hopper warp-specialized FP8 kernels, mirroring [vllm-project/flash-attention#122](https://github.com/vllm-project/flash-attention/pull/122) for FA3. The technique improves FP8 attention precision on long contexts at minimal
  perf cost.

  The change is **opt-in** (`fp8_two_level_interval=0` default → byte-identical to current behavior) and is gated entirely behind `if constexpr` checks so non-FP8 paths and FP8 with interval=0 generate the same code as before.

  ## The technique

  Standard online-softmax flash attention multiplies the working accumulator `acc_o` by `correction = exp(prev_max - new_max)` every KV-tile. On long contexts the cascade of these per-iter multiplications visibly degrades the FP32 accumulator (FA3 PR reports ~0.01 NIAH
  drop at 128K).

  Two-level accumulation maintains a *persistent* FP32 accumulator `acc_o_accum` alongside the working one. Per iteration:

  1. **`pack()` (unchanged)** — still rescales `acc_o *= correction` immediately so the working acc stays at the current-max baseline.
  2. **`update_accum_scale()` (new)** — `accum_scale *= correction`. Tracks the cumulative correction since the last merge, *deferring* it from `acc_o_accum`.
  3. **Every `INTERVAL` tiles, `merge_accum_with_scale()` (new)**:
     acc_o_accum = accum_scale * acc_o_accum + acc_o
     accum_scale = 1
     acc_o = 0
  The deferred correction lands as a single multiplication on the persistent acc, instead of `INTERVAL` cascaded multiplications.
  4. **End of KV loop, `final_merge_accum()` (new)** — folds residual `acc_o_accum` back into `acc_o` before the existing divide-by-sum epilogue.

  Math contracts verified bit-for-bit against the FA3 PR diff (`hopper/softmax.h::merge_accum_with_scale` / `final_merge_accum`).

  ## API

  New optional parameter on `trtllm_fmha_v2_prefill` and the JIT module factory:

  ```python
  flashinfer.trtllm_fmha_v2_prefill(
   qkv, ...,
   fp8_two_level_interval=4,  # 0 disables (default); 4 matches FA3's recommendation
  )

  Different intervals get separately cached .so files (trtllm_fmha_v2_packed_qkv_e4m3_e4m3_tl4 etc.) so the dispatcher correctly picks up the recompiled kernel.

  Files changed

  ┌────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │                                File                                │                                                                                              Change                                                                                               │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ csrc/fmha_v2/fmha/warpspec/kernel_traits.h                         │ Trailing int FP8_TWO_LEVEL_INTERVAL_ = 0 template arg on both Kernel_traits and Kernel_traits_Hopper_qgmma_e4m3_fp32, exposed as enum                                                             │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ csrc/fmha_v2/fmha/warpspec/epilogue.h                              │ Three new methods on Softmax_qmma: update_accum_scale, merge_accum_with_scale, final_merge_accum                                                                                                  │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ csrc/fmha_v2/fmha/warpspec/compute.h                               │ Compute::run declares acc_o_accum_ / accum_scale_ / two_level_tile_idx locals (sized [1][1]/[1] when disabled), reset per Q-tile; compute_single_tile calls update_accum_scale after pack, runs   │
  │                                                                    │ periodic merge after BMM2 wait; final merge before tile_o_epilogue.scale                                                                                                                          │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ csrc/fmha_v2/templates/kernel_hopper_ws.jinja                      │ Threads fp8_two_level_interval into all 4 Ktraits* instantiations                                                                                                                                 │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ flashinfer/jit/attention/fmha_v2/{generator_utils,fmha_library}.py │ New fp8_two_level_interval field on kernel_spec namedtuple + FMHAv2KernelSpec dataclass; threaded through generate_kernel_spec and enumerate_qgmma_flash_warpspec_kernels                         │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ flashinfer/jit/attention/modules.py                                │ gen_fmha_v2_module accepts the param; URI gets a _tl{N} suffix when non-zero so cache differentiates                                                                                              │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ flashinfer/prefill.py                                              │ trtllm_fmha_v2_prefill and get_trtllm_fmha_v2_module accept and forward the param (cache key respected)                                                                                           │
  ├────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/attention/test_fmha_v2_prefill.py                            │ New test_trtllm_fmha_v2_prefill_fp8_two_level parametrized over interval ∈ {0, 4, 16}; existing helper threaded for forward-compat                                                                │
  └────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  Diff: 9 files, +260 / −17 lines.

  Test plan

  Run on NVIDIA GH200 (SM90), CUDA 13, flashinfer-dev:cu130 container, with FLASHINFER_WORKSPACE_BASE=/tmp/flashinfer-cache.

  - pre-commit run -a — clean (clang-format, mypy, ruff).
  - FP8 compile-only smoke test — all 134 FP8 kernel variants (head_dims × alibi × softcap × skip-softmax × {causal, sliding-window, custom-mask, padding}) compile cleanly with interval=4. nvcc: BUILD OK.
  - End-to-end numerics — test_trtllm_fmha_v2_prefill_fp8_two_level[1-4096-128-0/4/16] PASSED. interval=4 and interval=16 each JIT-compile to their own .so cache, run on GH200, produce output matching the torch FP32 reference within FP8 tolerance.
  - Regression — test_trtllm_fmha_v2_prefill configs spanning FP16/BF16, PACKED_QKV/CONTIGUOUS_Q_KV, CAUSAL/SLIDING_WINDOW(127): 4/4 PASSED post-feature, confirming non-FP8 codegen is unchanged.
   ============================== 7 passed in 32m14s ==============================

  Notes / caveats

  - SM90 hang: existing pytest.skip("FP8 (e4m3) FMHA v2 kernels are known to hang on SM90") in test_trtllm_fmha_v2_prefill is not removed by this PR. The new test deliberately bypasses that skip per maintainer guidance ("the hang doesn't trigger reliably"); did not
  observe a hang in any of the runs here, but it should be revisited separately.
  - Default value: keeps interval=0 — the feature only activates when callers opt in. FA3 ships interval=4 as default in their setup.py; we may want to change the default in a follow-up after wider validation.
  - Scope: Hopper warp-specialized FP8 only. Non-warp-spec FP8 and Ampere/Ada FP8 paths are out of scope (the latter would need a deeper refactor since their Fragment_updater::update_o already divides by curr_sum per iteration, vs FA3's deferred normalization).

  References

  - vllm-project/flash-attention#122 — source PR for the technique on FA3