### PR TITLE
Cutlass dsl 4.5 bump

### DIFF
--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -32,7 +32,7 @@ pip3 install responses pytest scipy build cuda-python nvshmem4py-cu12
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
   pip3 install --upgrade cuda-python==13.0
   pip3 install --upgrade nvidia-cudnn-cu13
-  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]>=4.4.2"
+  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
 else
   pip3 install --upgrade cuda-python==12.*
   pip3 install --upgrade nvidia-cudnn-cu12

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -19,7 +19,7 @@
 set -e
 set -u
 
-pip3 install --upgrade "setuptools>=77,<82" "pip>=24"
+pip3 install --upgrade "setuptools>=77" "pip>=24"
 
 # Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
 CUDA_VERSION=${1:-cu128}

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -19,6 +19,8 @@
 set -e
 set -u
 
+pip3 install --upgrade "setuptools>=77" "pip>=24"
+
 # Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
 CUDA_VERSION=${1:-cu128}
 

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -19,7 +19,7 @@
 set -e
 set -u
 
-pip3 install --upgrade "setuptools>=77" "pip>=24"
+pip3 install --upgrade "setuptools>=77,<82" "pip>=24"
 
 # Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
 CUDA_VERSION=${1:-cu128}

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -913,7 +913,8 @@ def launch_sm120_static_moe(
         launch_ids = flat_ids
 
     # With TVM-FFI env stream, the stream is managed automatically.
-    # max_active_clusters is still a required positional arg for TVM-FFI.
+    # max_active_clusters (Constexpr) is baked in at cute.compile() time
+    # and must NOT be passed at runtime (cutlass-dsl >= 4.5).
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
     compiled(
         a,
@@ -940,7 +941,6 @@ def launch_sm120_static_moe(
         scatter_output,
         workspace.token_map,
         workspace.token_weights,
-        mac,
     )
 
     return scatter_output
@@ -1520,6 +1520,8 @@ def launch_sm120_dynamic_moe(
 
     # Dynamic kernel: runtime-shaped args are DataPointer (pass data_ptr()),
     # fixed-shape args are Tensor (pass torch tensor directly).
+    # max_active_clusters (Constexpr) is baked in at cute.compile() time
+    # and must NOT be passed at runtime (cutlass-dsl >= 4.5).
     compiled(
         a.data_ptr(),
         flat_ids.data_ptr(),
@@ -1561,7 +1563,6 @@ def launch_sm120_dynamic_moe(
         workspace.physical_tiles_capacity * _LEVEL_TILE_M,
         workspace.task_capacity,
         workspace.physical_tiles_capacity,
-        mac,
     )
 
     return scatter_output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ name = "flashinfer-python"
 description = "FlashInfer: Kernel Library for LLM Serving"
 requires-python = ">=3.10,<4.0"
 authors = [{ name = "FlashInfer team" }]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 readme = "README.md"
 urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
-dynamic = ["dependencies", "version"]
+license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
 cu12 = ["nvidia-cutlass-dsl>=4.5.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@
 
 [project]
 name = "flashinfer-python"
+dynamic = ["version", "dependencies"]
 description = "FlashInfer: Kernel Library for LLM Serving"
 requires-python = ">=3.10,<4.0"
 authors = [{ name = "FlashInfer team" }]
@@ -30,7 +31,7 @@ cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
 flashinfer = "flashinfer.__main__:cli"
 
 [build-system]
-requires = ["setuptools>=77,<82", "packaging>=24", "apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2"]
+requires = ["setuptools>=77", "packaging>=24", "apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2"]
 build-backend = "build_backend"
 backend-path = ["."]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,14 @@ name = "flashinfer-python"
 description = "FlashInfer: Kernel Library for LLM Serving"
 requires-python = ">=3.10,<4.0"
 authors = [{ name = "FlashInfer team" }]
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 readme = "README.md"
 urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 dynamic = ["dependencies", "version"]
-license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
-cu12 = ["nvidia-cutlass-dsl>=4.4.2"]
-cu13 = ["nvidia-cutlass-dsl[cu13]>=4.4.2"]
+cu12 = ["nvidia-cutlass-dsl>=4.5.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
 
 [project.scripts]
 flashinfer = "flashinfer.__main__:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
 flashinfer = "flashinfer.__main__:cli"
 
 [build-system]
-requires = ["setuptools>=77", "packaging>=24", "apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2"]
+requires = ["setuptools>=77,<82", "packaging>=24", "apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2"]
 build-backend = "build_backend"
 backend-path = ["."]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ einops
 ninja
 numpy
 nvidia-cudnn-frontend>=1.13.0
-nvidia-cutlass-dsl>=4.4.2
+nvidia-cutlass-dsl>=4.5.0
 nvidia-ml-py
 packaging>=24.2
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ einops
 ninja
 numpy
 nvidia-cudnn-frontend>=1.13.0
+nvidia-cutlass-dsl>=4.5.0
 nvidia-ml-py
 packaging>=24.2
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ einops
 ninja
 numpy
 nvidia-cudnn-frontend>=1.13.0
-nvidia-cutlass-dsl>=4.5.0
 nvidia-ml-py
 packaging>=24.2
 requests

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -165,6 +165,9 @@ install_and_verify() {
         # Install precompiled kernels if enabled
         install_precompiled_kernels
 
+        # Sync dependencies from the branch's requirements.txt
+        pip install -r requirements.txt
+
         # Install local python sources
         pip install -e . -v --no-deps
         echo ""

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -168,6 +168,14 @@ install_and_verify() {
         # Sync dependencies from the branch's requirements.txt
         pip install -r requirements.txt
 
+        # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
+        # version skew between libs-base and libs-cu13.
+        if [[ "${CUDA_VERSION}" == *"cu13"* ]] || [[ "${CUDA_VERSION}" == "13."* ]]; then
+            pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
+        else
+            pip install --upgrade "nvidia-cutlass-dsl>=4.5.0"
+        fi
+
         # Install local python sources
         pip install -e . -v --no-deps
         echo ""

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -170,10 +170,8 @@ install_and_verify() {
 
         # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
         # version skew between libs-base and libs-cu13.
-        if [[ "${CUDA_VERSION}" == *"cu13"* ]] || [[ "${CUDA_VERSION}" == "13."* ]]; then
+        if [[ "${CUDA_VERSION}" == *"cu13"* ]]; then
             pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
-        else
-            pip install --upgrade "nvidia-cutlass-dsl>=4.5.0"
         fi
 
         # Install local python sources

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -32,13 +32,13 @@ def _test_mm_fp4(
     if backend == "cute-dsl":
         if not use_128x4_sf_layout:
             pytest.skip("cute_dsl backend only supports 128x4 SF layout")
-        if compute_capability[0] not in [10, 12]:
-            pytest.skip("cute_dsl backend only supports SM100/SM103/SM120/SM121 GPUs.")
+        if compute_capability[0] not in [10]:
+            pytest.skip("cute_dsl backend only supports SM100/SM103 GPUs.")
     if backend == "b12x":
         if not use_128x4_sf_layout:
             pytest.skip("b12x backend only supports 128x4 SF layout")
-        if compute_capability[0] != 12 or compute_capability[1] != 0:
-            pytest.skip("b12x backend only supports SM120 GPUs.")
+        if compute_capability[0] != 12:
+            pytest.skip("b12x backend only supports SM120/SM121 GPUs.")
         if not use_nvfp4:
             pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
         if torch.version.cuda and int(torch.version.cuda.split(".")[0]) < 13:

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -32,8 +32,8 @@ def _test_mm_fp4(
     if backend == "cute-dsl":
         if not use_128x4_sf_layout:
             pytest.skip("cute_dsl backend only supports 128x4 SF layout")
-        if compute_capability[0] not in [10]:
-            pytest.skip("cute_dsl backend only supports SM100/SM103 GPUs.")
+        if compute_capability[0] not in [10, 12]:
+            pytest.skip("cute_dsl backend only supports SM100/SM103/SM120/SM121 GPUs.")
     if backend == "b12x":
         if not use_128x4_sf_layout:
             pytest.skip("b12x backend only supports 128x4 SF layout")

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -65,14 +65,6 @@ def _cuda_13_or_newer():
         return False
 
 
-def _is_sm121():
-    """Check whether the current device reports compute capability SM121."""
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(0)
-    return props.major == 12 and props.minor == 1
-
-
 # Skip decorators
 cute_dsl_available = pytest.mark.skipif(
     not is_cute_dsl_available(), reason="CuteDSL not available"
@@ -84,10 +76,6 @@ sm120_required = pytest.mark.skipif(
 cuda_13_required = pytest.mark.skipif(
     not _cuda_13_or_newer(),
     reason="b12x fused MoE requires CUDA 13 or later",
-)
-not_sm121 = pytest.mark.skipif(
-    _is_sm121(),
-    reason="b12x fused MoE is not supported on SM121",
 )
 
 
@@ -532,7 +520,6 @@ def create_relu2_moe_tensors(
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-@not_sm121
 class TestB12xFunctional:
     """Tests for the functional API: b12x_fused_moe."""
 
@@ -613,7 +600,6 @@ class TestB12xFunctional:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-@not_sm121
 class TestB12xWrapper:
     """Tests for the wrapper API: B12xMoEWrapper."""
 
@@ -795,7 +781,6 @@ class TestB12xWrapper:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-@not_sm121
 class TestB12xApiConsistency:
     """Tests verifying consistency between b12x functional and wrapper APIs."""
 
@@ -874,7 +859,6 @@ class TestB12xApiConsistency:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-@not_sm121
 class TestMicroKernel:
     """Tests for the micro kernel path (routed_rows <= 20-40).
 
@@ -1076,7 +1060,6 @@ class TestMicroKernel:
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-@not_sm121
 class TestRelu2Activation:
     """Tests for ReLU2 activation (non-gated, Nemotron-Super)."""
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Bump cutlass-dsl to 4.5 so sm121 is supported in BlockScaledMmaOp 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated packaging/install flow to upgrade Python tooling early, added preparation steps for CUDA/cu13 runtimes, and bumped cutlass dependency to >=4.5.0; minor project metadata ordering adjusted.

* **Tests**
  * Broadened GPU gating to include SM120/SM121 and added CUDA‑13+ detection for gated tests.
  * Test harness now installs branch-specific Python requirements during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->