### PR TITLE
Fix: skip git submodule update when submodules are already populated

### DIFF
--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -82,14 +82,29 @@ def _compile_jit_cache(output_dir: Path, verbose: bool = True):
     # Get the project root directory
     project_root = Path(__file__).parent.parent
 
-    # Ensure 3rdparty submodules are populated (may be empty in CI Docker images)
+    # Ensure 3rdparty submodules are populated (may be empty in CI Docker images).
+    # Skip if submodules are already present or if git metadata is incomplete
+    # (e.g., Docker builds where .git points to a parent repo not in the context).
     import subprocess
 
-    subprocess.run(
-        ["git", "submodule", "update", "--init", "--recursive"],
-        cwd=str(project_root),
-        check=True,
-    )
+    submodule_check_paths = [
+        project_root / "3rdparty" / "cutlass" / "include",
+        project_root / "3rdparty" / "spdlog" / "include",
+        project_root / "3rdparty" / "cccl" / "cub",
+    ]
+    if not all(p.exists() for p in submodule_check_paths):
+        result = subprocess.run(
+            ["git", "submodule", "update", "--init", "--recursive"],
+            cwd=str(project_root),
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            missing = [str(p) for p in submodule_check_paths if not p.exists()]
+            if missing:
+                raise RuntimeError(
+                    f"git submodule update failed and submodules are missing: {missing}\n"
+                    f"git stderr: {result.stderr.decode().strip()}"
+                )
 
     # Ensure flashinfer/data/ symlinks exist (normally created by the main
     # package's build_backend, but jit-cache builds may not install the main


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The unconditional git submodule update in jit-cache build_backend.py fails in Docker environments where .git is a submodule-style gitfile pointing to a parent repo not in the Docker context.

Check if submodule directories are already populated before attempting git submodule update. Only raise an error if git fails AND the required submodule contents are actually missing.

Fixes #3241

## 🔍 Related Issues

[<!-- Link any related issues here -->](https://github.com/flashinfer-ai/flashinfer/issues/3241)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in submodule initialization with enhanced diagnostics and clearer error messages to help troubleshoot build failures and missing dependencies.

* **Chores**
  * Optimized build backend to conditionally initialize submodules only when necessary, reducing build time and eliminating redundant operations for faster builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->