### PR TITLE
Issue #3047: Handle empty KV in MLA chunked-prefill

### DIFF
--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -912,6 +912,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
                     params.num_heads);
 
     if (kv_end <= kv_start) {
+      cp_async::commit_group();
+      cp_async::wait_group<0>();
       __syncthreads();
       write_empty_o<KTraits>(
           final_o + q_indptr * o_stride_n, final_lse ? final_lse + q_indptr * num_heads : nullptr,

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -18,6 +18,7 @@
 #include <cooperative_groups.h>
 
 #include <cstdint>
+#include <cuda/std/limits>
 #include <sstream>
 
 #include "../profiler.cuh"
@@ -670,6 +671,54 @@ __device__ void DevicePersistentMergeStates(
 }
 
 template <typename KTraits>
+__device__ __forceinline__ void write_empty_o(typename KTraits::DTypeO* final_o, float* final_lse,
+                                              typename KTraits::DTypeO* partial_o,
+                                              float* partial_lse, const uint32_t o_stride_n,
+                                              const uint32_t o_stride_h, const uint32_t q_len,
+                                              const uint32_t packed_offset,
+                                              const uint_fastdiv& num_heads) {
+  const uint32_t thread_id = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x;
+  const uint32_t total_packed = q_len * static_cast<uint32_t>(num_heads);
+  const uint32_t remaining_packed =
+      (packed_offset < total_packed) ? total_packed - packed_offset : 0;
+  const uint32_t num_valid_packed = remaining_packed < static_cast<uint32_t>(KTraits::CTA_TILE_Q)
+                                        ? remaining_packed
+                                        : static_cast<uint32_t>(KTraits::CTA_TILE_Q);
+  const uint32_t num_elems = num_valid_packed * KTraits::HEAD_DIM_CKV;
+
+  if (partial_o != nullptr) {
+    const uint32_t partial_packed_offset = blockIdx.x * KTraits::CTA_TILE_Q;
+    for (uint32_t elem_idx = thread_id; elem_idx < num_elems; elem_idx += KTraits::NUM_THREADS) {
+      const uint32_t packed_idx = elem_idx / KTraits::HEAD_DIM_CKV;
+      const uint32_t dim_idx = elem_idx - packed_idx * KTraits::HEAD_DIM_CKV;
+      partial_o[(partial_packed_offset + packed_idx) * KTraits::HEAD_DIM_CKV + dim_idx] =
+          typename KTraits::DTypeO(0.f);
+    }
+    for (uint32_t packed_idx = thread_id; packed_idx < num_valid_packed;
+         packed_idx += KTraits::NUM_THREADS) {
+      partial_lse[partial_packed_offset + packed_idx] =
+          -cuda::std::numeric_limits<float>::infinity();
+    }
+  } else {
+    for (uint32_t elem_idx = thread_id; elem_idx < num_elems; elem_idx += KTraits::NUM_THREADS) {
+      const uint32_t packed_idx = elem_idx / KTraits::HEAD_DIM_CKV;
+      const uint32_t dim_idx = elem_idx - packed_idx * KTraits::HEAD_DIM_CKV;
+      uint32_t q, r;
+      num_heads.divmod(packed_offset + packed_idx, q, r);
+      final_o[q * o_stride_n + r * o_stride_h + dim_idx] = typename KTraits::DTypeO(0.f);
+    }
+    if (final_lse) {
+      for (uint32_t packed_idx = thread_id; packed_idx < num_valid_packed;
+           packed_idx += KTraits::NUM_THREADS) {
+        uint32_t q, r;
+        num_heads.divmod(packed_offset + packed_idx, q, r);
+        final_lse[q * num_heads + r] = -cuda::std::numeric_limits<float>::infinity();
+      }
+    }
+  }
+}
+
+template <typename KTraits>
 __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_storage,
                                         typename KTraits::DTypeO* final_o, float* final_lse,
                                         typename KTraits::DTypeO* partial_o, float* partial_lse,
@@ -711,8 +760,10 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
     for (uint32_t j = 0; j < 2; ++j) {
       uint32_t q_idx = (packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4) / num_heads;
       if (lane_idx % 4 == 0 && q_idx < q_len) {
-        partial_lse[(blockIdx.x * 4 + warp_idx_in_wg) * 16 + 8 * j + lane_idx / 4] =
-            math::ptx_log2(d[j]) + float(m[j]);
+        float lse = (m[j] == typename KTraits::DTypeQKAccum(-math::inf))
+                        ? -cuda::std::numeric_limits<float>::infinity()
+                        : math::ptx_log2(d[j]) + float(m[j]);
+        partial_lse[(blockIdx.x * 4 + warp_idx_in_wg) * 16 + 8 * j + lane_idx / 4] = lse;
       }
     }
 
@@ -747,7 +798,9 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
         uint32_t q, r;
         num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4, q, r);
         if (lane_idx % 4 == 0 && q < q_len) {
-          final_lse[q * num_heads + r] = math::ptx_log2(d[j]) + float(m[j]);
+          final_lse[q * num_heads + r] = (m[j] == typename KTraits::DTypeQKAccum(-math::inf))
+                                             ? -cuda::std::numeric_limits<float>::infinity()
+                                             : math::ptx_log2(d[j]) + float(m[j]);
           if (return_lse_base_on_e) {
             final_lse[q * num_heads + r] *= math::loge2;
           }
@@ -857,6 +910,16 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
                     q_pe + q_indptr * q_pe_stride_n, q_nope_stride_n, q_nope_stride_h,
                     q_pe_stride_n, q_pe_stride_h, qo_upperbound, qo_packed_idx_base,
                     params.num_heads);
+
+    if (kv_end <= kv_start) {
+      __syncthreads();
+      write_empty_o<KTraits>(
+          final_o + q_indptr * o_stride_n, final_lse ? final_lse + q_indptr * num_heads : nullptr,
+          (partial_indptr == -1) ? nullptr : partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
+          (partial_indptr == -1) ? nullptr : partial_lse + partial_indptr, o_stride_n, o_stride_h,
+          qo_upperbound, qo_packed_idx_base, num_heads);
+      continue;
+    }
 
     int kv_tile_idx =
         ceil_div(

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -18,6 +18,7 @@
 #include <cooperative_groups.h>
 
 #include <cstdint>
+#include <cuda/std/limits>
 #include <sstream>
 
 #include "hopper.cuh"
@@ -507,8 +508,9 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
       for (uint32_t j = 0; j < 2; ++j) {
         uint32_t q_idx = (packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4) / num_heads;
         if (lane_idx % 4 == 0 && q_idx < q_len) {
-          partial_lse[(blockIdx.x * 4 + warp_idx_in_wg) * 16 + 8 * j + lane_idx / 4] =
-              math::ptx_log2(d[j]) + float(m[j]);
+          float lse = (m[j] == -math::inf) ? -cuda::std::numeric_limits<float>::infinity()
+                                           : math::ptx_log2(d[j]) + float(m[j]);
+          partial_lse[(blockIdx.x * 4 + warp_idx_in_wg) * 16 + 8 * j + lane_idx / 4] = lse;
         }
       }
     }
@@ -543,7 +545,9 @@ __device__ __forceinline__ void write_o(typename KTraits::SharedStorage* smem_st
           uint32_t q, r;
           num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4, q, r);
           if (lane_idx % 4 == 0 && q < q_len) {
-            final_lse[q * num_heads + r] = math::ptx_log2(d[j]) + float(m[j]);
+            final_lse[q * num_heads + r] = (m[j] == -math::inf)
+                                               ? -cuda::std::numeric_limits<float>::infinity()
+                                               : math::ptx_log2(d[j]) + float(m[j]);
             if (return_lse_base_on_e) {
               final_lse[q * num_heads + r] *= math::loge2;
             }
@@ -711,10 +715,10 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
 
       const uint32_t block_iter_base = kv_indptr * block_size + kv_start;
 
-      prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
-                               ckv_stride_page, ckv_stride_n, kpe_stride_page, kpe_stride_n,
-                               block_size, kv_indices, ckv_offset, kpe_offset);
       if (has_kv) {
+        prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
+                                 ckv_stride_page, ckv_stride_n, kpe_stride_page, kpe_stride_n,
+                                 block_size, kv_indices, ckv_offset, kpe_offset);
         pipeline_kv.producer_acquire(smem_pipe_write_kv);
         PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadKV);
         load_kv<true, KTraits>(&smem_storage, ckv, kpe, packed_kv_bound,
@@ -724,9 +728,11 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
         pipeline_kv.producer_commit(smem_pipe_write_kv, cutlass::arch::cpasync_barrier_arrive);
         kv_tile_idx -= 1;
         ++smem_pipe_write_kv;
-        prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
-                                 ckv_stride_page, ckv_stride_n, kpe_stride_page, kpe_stride_n,
-                                 block_size, kv_indices, ckv_offset, kpe_offset);
+        if (kv_tile_idx >= 0) {
+          prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
+                                   ckv_stride_page, ckv_stride_n, kpe_stride_page, kpe_stride_n,
+                                   block_size, kv_indices, ckv_offset, kpe_offset);
+        }
       }
 
       pipeline_q.producer_acquire(smem_pipe_write_q);

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -408,9 +408,9 @@ def test_batch_mla_varlen_page_attention(
         o_ref, lse_ref = attention_ref(batch_size, q, k, v, causal, sm_scale)
         lse_ref = lse_ref.flatten(0, 1)
         o_i = o[q_rows_arr[i]]
+        lse_i = lse[q_rows_arr[i]]
         torch.testing.assert_close(o_i, o_ref, rtol=1e-3, atol=1e-3)
-        # if kv_lens[i] != 0:
-        #     torch.testing.assert_close(lse_i, lse_ref, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(lse_i, lse_ref, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5, 6, 7, 157])


### PR DESCRIPTION
## 📌 Description

Moves empty-KV handling for MLA chunked-prefill into the kernels.

The generic MLA path now short-circuits zero-KV tiles before invalid negative tile access and writes the empty-attention identity directly (`out = 0`, `lse = -inf`). The empty writer also handles partial outputs with the same per-CTA tile offset as the normal partial-output path.

The Hopper path now guards KV prefetch for empty tiles and exports true IEEE `-inf` LSE for empty online-softmax states.

## 🔍 Related Issues

Fixes #3047

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation run:

- `pre-commit run --files include/flashinfer/attention/mla.cuh include/flashinfer/attention/mla_hopper.cuh tests/attention/test_deepseek_mla.py`
- Blackwell FA2 targeted DeepSeek MLA varlen paged-attention test: `4320 passed, 9504 skipped`
- Hopper FA3 targeted DeepSeek MLA varlen paged-attention test on H100: `4320 passed, 2592 skipped, 6912 deselected`

## Reviewer Notes

The empty-output helper deliberately supports both final and partial output buffers. The partial path includes `blockIdx.x * KTraits::CTA_TILE_Q` so split-K partial storage stays aligned with the normal writer layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty key/value ranges in MLA attention to skip computation and produce consistent zeroed outputs and -∞ LSEs for affected positions
  * Corrected LSE write logic to preserve -∞ when an invalid/max state is detected, improving numerical correctness and stability

* **Tests**
  * Strengthened validation to assert LSE outputs per query row in variable-length attention tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->