### PR TITLE
fix(cute_dsl/moe): unbias autotuner profiling for tile_size enumeration

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -640,6 +640,52 @@ def autotune(
             tuner.save_configs(cache)
 
 
+# Thread-local "currently inside the per-tactic measurement window" flag.
+# Set/cleared by ``_profile_measurement_scope`` and queried by
+# ``is_in_profile_measurement``.  Distinct from
+# ``AutoTuner.is_tuning_mode``, which is True for the entire ``autotune(True)``
+# context (cache hits, prep calls, post-``choose_one`` runs, and concurrent
+# threads inclusive); ``is_in_profile_measurement`` is True only on the
+# specific thread that is actively timing a tactic, and only during the
+# warmup + measurement window inside ``_profile_single_kernel``.
+_profile_measurement_thread_local = threading.local()
+
+
+@contextlib.contextmanager
+def _profile_measurement_scope():
+    """Mark the calling thread as inside the autotuner's per-tactic
+    measurement window.  Nested entries are honored via prev/restore so
+    correctness doesn't depend on a single entry path.
+    """
+    prev = getattr(_profile_measurement_thread_local, "active", False)
+    _profile_measurement_thread_local.active = True
+    try:
+        yield
+    finally:
+        _profile_measurement_thread_local.active = prev
+
+
+def is_in_profile_measurement() -> bool:
+    """Return True iff the calling thread is currently inside the
+    autotuner's per-tactic measurement window (warmup + timed run inside
+    ``AutoTuner._profile_single_kernel``).
+
+    This is *narrower* than ``AutoTuner.get().is_tuning_mode``:
+
+    - ``is_tuning_mode`` is True for the entire ``autotune(True)`` context,
+      including cache lookups, ``do_preparation`` calls, the final invocation
+      after ``choose_one`` returns, and any concurrent threads' work.
+    - ``is_in_profile_measurement`` is True only on the calling thread, and
+      only during the actual measurement window of a single tactic.
+
+    Wrappers that need to bypass per-call optimizations (e.g. CUDA-graph
+    preallocated buffers sized for a specific construction-time tile) so
+    that the autotuner's tactic comparison is unbiased should consult
+    ``is_in_profile_measurement()`` rather than ``is_tuning_mode``.
+    """
+    return getattr(_profile_measurement_thread_local, "active", False)
+
+
 @dataclass
 class AutoTunerStatistics:
     """Statistics collected by the AutoTuner.
@@ -1304,6 +1350,16 @@ class AutoTuner:
             The method performs warmup runs, then measures multiple iterations
             to get an average execution time. Stream synchronization and delays
             are used to ensure accurate timing.
+
+            All runner invocations inside this method (warmup + measurement)
+            execute under ``_profile_measurement_scope`` so that runners can
+            consult ``is_in_profile_measurement()`` to apply consistent
+            allocation behavior across tactics.  This is what unbiases the
+            autotuner's tactic comparison for runners whose normal
+            (non-profiling) path uses preallocated buffers sized for a
+            specific tile_size: during the measurement window every tactic
+            sees the same per-call allocation overhead, and the autotuner
+            picks based on intrinsic kernel time.
         """
         input_tensor_batches = self._prepare_input_tensors_with_batches(
             inputs, tuning_config
@@ -1352,11 +1408,12 @@ class AutoTuner:
 
                 return start.elapsed_time(end) / repeat
 
-        # warm up, no timing
-        for _ in range(self.warmup):
-            runner(input_tensor_batches[-1], tactic=tactic, **kwargs)
+        with _profile_measurement_scope():
+            # warm up, no timing
+            for _ in range(self.warmup):
+                runner(input_tensor_batches[-1], tactic=tactic, **kwargs)
 
-        avg_time = pure_profile(stream, self.repeat)
+            avg_time = pure_profile(stream, self.repeat)
 
         shapes = self._get_input_sizes(inputs)
         logger.debug(

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -58,7 +58,7 @@ from ...trace.templates.moe import (
     cute_dsl_fused_moe_nvfp4_trace,
     cute_dsl_moe_wrapper_run_trace,
 )
-from ...autotuner import AutoTuner
+from ...autotuner import AutoTuner, is_in_profile_measurement
 from ...utils import supported_compute_capability
 from .moe_utils import (
     allocate_moe_sort_buffers,
@@ -491,13 +491,18 @@ class CuteDslMoEWrapper:
         # Pre-allocated buffers are sized for ``self.tile_size`` and
         # ``self.max_num_tokens``. Fall back to dynamic allocation when:
         #
-        # - the autotuner is profiling (``is_tuning_mode``): every
-        #   probed tactic must see the same allocation overhead so
-        #   the comparison is unbiased. If we honored prealloc here,
-        #   tactics with ``tile_size == self.tile_size`` would skip
-        #   the per-call ``torch.empty()`` cost while others paid
-        #   it, biasing the autotuner toward picking the matching
-        #   ``tile_size`` regardless of intrinsic kernel performance.
+        # - the autotuner is in its per-tactic measurement window
+        #   (``is_in_profile_measurement()``): every probed tactic must
+        #   see the same allocation overhead so the comparison is
+        #   unbiased. If we honored prealloc here, tactics with
+        #   ``tile_size == self.tile_size`` would skip the per-call
+        #   ``torch.empty()`` cost while others paid it, biasing the
+        #   autotuner toward picking the matching ``tile_size``
+        #   regardless of intrinsic kernel performance.  Note: this
+        #   is intentionally narrower than ``is_tuning_mode`` -- it
+        #   excludes cache lookups, ``do_preparation`` calls, the
+        #   final invocation after ``choose_one`` returns, and other
+        #   threads' inference, which all benefit from the prealloc.
         # - the tactic's tile_size doesn't match ``self.tile_size``:
         #   the prealloc layout would be wrong.
         # - the batch exceeds what the buffers were sized for (e.g.
@@ -505,7 +510,7 @@ class CuteDslMoEWrapper:
         num_tokens = x.shape[0]
         use_prealloc = (
             self.use_cuda_graph
-            and not AutoTuner.get().is_tuning_mode
+            and not is_in_profile_measurement()
             and tile_size == self.tile_size
             and num_tokens <= self.max_num_tokens
         )

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -74,7 +74,6 @@ from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
 from .tuner import (
     ALL_MOE_TACTICS,
     CuteDslFusedMoENvfp4Runner,
-    VALID_TILE_SIZES,
 )
 
 
@@ -418,53 +417,30 @@ class CuteDslMoEWrapper:
             self._allocate_buffers()
 
     def _allocate_buffers(self) -> None:
-        """Pre-allocate all buffers for CUDA graph compatibility.
-
-        Buffers are sized to fit any tile_size in VALID_TILE_SIZES, not
-        just self.tile_size. Without this, the autotuner profiling pass
-        is biased: tactics whose tile_size matches self.tile_size get
-        free prealloc while others fall through to dynamic per-call
-        allocation, making the latter look slower than they really are.
-
-        max_num_permuted_tokens is monotonically increasing in
-        tile_size (the (tile-1)*num_local_experts padding term grows
-        faster than max_num_tiles shrinks). max_num_tiles is
-        monotonically decreasing. So we take max() over VALID_TILE_SIZES
-        for each independently.
-        """
-        smallest_tile = min(VALID_TILE_SIZES)
-        largest_tile = max(VALID_TILE_SIZES)
-        max_permuted_across_tiles = get_max_num_permuted_tokens(
-            self.max_num_tokens, self.top_k, self.num_local_experts, largest_tile
+        """Pre-allocate all buffers for CUDA graph compatibility."""
+        max_num_permuted_tokens = get_max_num_permuted_tokens(
+            self.max_num_tokens, self.top_k, self.num_local_experts, self.tile_size
         )
 
-        # moe_sort buffers — allocate using smallest_tile so the
-        # tile-count-indexed buffers (out_tile_idx_to_expert_idx,
-        # out_tile_idx_to_mn_limit) are large enough for any tile_size,
-        # then override out_permuted_idx_to_expanded_idx (which scales
-        # with tile_size in the opposite direction) to fit the largest
-        # tile_size's max_num_permuted_tokens.
+        # moe_sort buffers
         self._moe_sort_buffers = allocate_moe_sort_buffers(
             num_tokens=self.max_num_tokens,
             num_experts=self.num_experts,
             top_k=self.top_k,
             num_local_experts=self.num_local_experts,
-            tile_tokens_dim=smallest_tile,
+            tile_tokens_dim=self.tile_size,
             device=self.device,
-        )
-        self._moe_sort_buffers["out_permuted_idx_to_expanded_idx"] = torch.empty(
-            (max_permuted_across_tiles,), dtype=torch.int32, device=self.device
         )
 
         # GEMM1 output (FP4 quantized)
         self._gemm1_output = torch.empty(
-            (max_permuted_across_tiles, self.intermediate_size // 2),
+            (max_num_permuted_tokens, self.intermediate_size // 2),
             dtype=torch.uint8,
             device=self.device,
         )
 
         # GEMM1 output scale
-        scale_size = max_permuted_across_tiles * (
+        scale_size = max_num_permuted_tokens * (
             self.intermediate_size // self.sf_vec_size
         )
         self._gemm1_output_scale = torch.empty(
@@ -512,16 +488,25 @@ class CuteDslMoEWrapper:
         **kwargs,
     ) -> torch.Tensor:
         """Forward implementation called by auto-tuner."""
-        # Pre-allocated buffers are sized to fit any tile_size in
-        # VALID_TILE_SIZES (see _allocate_buffers). Fall back to dynamic
-        # allocation only when the batch exceeds what the buffers were
-        # sized for (e.g. autotuner probing a larger bucket than
-        # max_num_tokens) or the tactic somehow uses a tile_size outside
-        # the canonical enumeration.
+        # Pre-allocated buffers are sized for ``self.tile_size`` and
+        # ``self.max_num_tokens``. Fall back to dynamic allocation when:
+        #
+        # - the autotuner is profiling (``is_tuning_mode``): every
+        #   probed tactic must see the same allocation overhead so
+        #   the comparison is unbiased. If we honored prealloc here,
+        #   tactics with ``tile_size == self.tile_size`` would skip
+        #   the per-call ``torch.empty()`` cost while others paid
+        #   it, biasing the autotuner toward picking the matching
+        #   ``tile_size`` regardless of intrinsic kernel performance.
+        # - the tactic's tile_size doesn't match ``self.tile_size``:
+        #   the prealloc layout would be wrong.
+        # - the batch exceeds what the buffers were sized for (e.g.
+        #   autotuner probing larger buckets).
         num_tokens = x.shape[0]
         use_prealloc = (
             self.use_cuda_graph
-            and tile_size in VALID_TILE_SIZES
+            and not AutoTuner.get().is_tuning_mode
+            and tile_size == self.tile_size
             and num_tokens <= self.max_num_tokens
         )
         return _moe_core_impl(

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -74,6 +74,7 @@ from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
 from .tuner import (
     ALL_MOE_TACTICS,
     CuteDslFusedMoENvfp4Runner,
+    VALID_TILE_SIZES,
 )
 
 
@@ -417,30 +418,53 @@ class CuteDslMoEWrapper:
             self._allocate_buffers()
 
     def _allocate_buffers(self) -> None:
-        """Pre-allocate all buffers for CUDA graph compatibility."""
-        max_num_permuted_tokens = get_max_num_permuted_tokens(
-            self.max_num_tokens, self.top_k, self.num_local_experts, self.tile_size
+        """Pre-allocate all buffers for CUDA graph compatibility.
+
+        Buffers are sized to fit any tile_size in VALID_TILE_SIZES, not
+        just self.tile_size. Without this, the autotuner profiling pass
+        is biased: tactics whose tile_size matches self.tile_size get
+        free prealloc while others fall through to dynamic per-call
+        allocation, making the latter look slower than they really are.
+
+        max_num_permuted_tokens is monotonically increasing in
+        tile_size (the (tile-1)*num_local_experts padding term grows
+        faster than max_num_tiles shrinks). max_num_tiles is
+        monotonically decreasing. So we take max() over VALID_TILE_SIZES
+        for each independently.
+        """
+        smallest_tile = min(VALID_TILE_SIZES)
+        largest_tile = max(VALID_TILE_SIZES)
+        max_permuted_across_tiles = get_max_num_permuted_tokens(
+            self.max_num_tokens, self.top_k, self.num_local_experts, largest_tile
         )
 
-        # moe_sort buffers
+        # moe_sort buffers — allocate using smallest_tile so the
+        # tile-count-indexed buffers (out_tile_idx_to_expert_idx,
+        # out_tile_idx_to_mn_limit) are large enough for any tile_size,
+        # then override out_permuted_idx_to_expanded_idx (which scales
+        # with tile_size in the opposite direction) to fit the largest
+        # tile_size's max_num_permuted_tokens.
         self._moe_sort_buffers = allocate_moe_sort_buffers(
             num_tokens=self.max_num_tokens,
             num_experts=self.num_experts,
             top_k=self.top_k,
             num_local_experts=self.num_local_experts,
-            tile_tokens_dim=self.tile_size,
+            tile_tokens_dim=smallest_tile,
             device=self.device,
+        )
+        self._moe_sort_buffers["out_permuted_idx_to_expanded_idx"] = torch.empty(
+            (max_permuted_across_tiles,), dtype=torch.int32, device=self.device
         )
 
         # GEMM1 output (FP4 quantized)
         self._gemm1_output = torch.empty(
-            (max_num_permuted_tokens, self.intermediate_size // 2),
+            (max_permuted_across_tiles, self.intermediate_size // 2),
             dtype=torch.uint8,
             device=self.device,
         )
 
         # GEMM1 output scale
-        scale_size = max_num_permuted_tokens * (
+        scale_size = max_permuted_across_tiles * (
             self.intermediate_size // self.sf_vec_size
         )
         self._gemm1_output_scale = torch.empty(
@@ -488,14 +512,16 @@ class CuteDslMoEWrapper:
         **kwargs,
     ) -> torch.Tensor:
         """Forward implementation called by auto-tuner."""
-        # Pre-allocated buffers are sized for self.tile_size and
-        # self.max_num_tokens.  Fall back to dynamic allocation when the
-        # tactic uses a different tile_size or the batch exceeds what the
-        # buffers were sized for (e.g. autotuner probing larger buckets).
+        # Pre-allocated buffers are sized to fit any tile_size in
+        # VALID_TILE_SIZES (see _allocate_buffers). Fall back to dynamic
+        # allocation only when the batch exceeds what the buffers were
+        # sized for (e.g. autotuner probing a larger bucket than
+        # max_num_tokens) or the tactic somehow uses a tile_size outside
+        # the canonical enumeration.
         num_tokens = x.shape[0]
         use_prealloc = (
             self.use_cuda_graph
-            and tile_size == self.tile_size
+            and tile_size in VALID_TILE_SIZES
             and num_tokens <= self.max_num_tokens
         )
         return _moe_core_impl(

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -74,6 +74,7 @@ from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
 from .tuner import (
     ALL_MOE_TACTICS,
     CuteDslFusedMoENvfp4Runner,
+    VALID_TILE_SIZES,
 )
 
 
@@ -417,30 +418,65 @@ class CuteDslMoEWrapper:
             self._allocate_buffers()
 
     def _allocate_buffers(self) -> None:
-        """Pre-allocate all buffers for CUDA graph compatibility."""
-        max_num_permuted_tokens = get_max_num_permuted_tokens(
-            self.max_num_tokens, self.top_k, self.num_local_experts, self.tile_size
+        """Pre-allocate all buffers for CUDA graph compatibility.
+
+        Buffers are sized to fit *any* ``tile_size in VALID_TILE_SIZES``,
+        not just ``self.tile_size``.  Two distinct buffer-shape concerns:
+
+        - ``max_num_permuted_tokens`` is monotonically *increasing* in
+          ``tile_size`` (the ``(tile - 1) * num_local_experts`` padding
+          term grows faster than ``max_num_tiles`` shrinks), so
+          permuted-token-indexed buffers (``_gemm1_output``,
+          ``_gemm1_output_scale``,
+          ``out_permuted_idx_to_expanded_idx``) must be sized using
+          ``max(VALID_TILE_SIZES)``.
+        - ``max_num_tiles`` is monotonically *decreasing* in
+          ``tile_size``, so the tile-count-indexed moe_sort buffers
+          (``out_tile_idx_to_expert_idx``,
+          ``out_tile_idx_to_mn_limit``) must be sized using
+          ``min(VALID_TILE_SIZES)``.
+
+        Sizing this way means the ``use_prealloc`` gate at
+        ``_forward_with_tactic`` doesn't need a ``tile_size ==
+        self.tile_size`` check at runtime: whichever tactic the
+        autotuner picked, the prealloc fits.  This preserves the
+        wrapper's CUDA-graph contract (``run()`` is graph-safe with
+        ``use_cuda_graph=True``) regardless of which ``tile_size`` the
+        autotuner ends up choosing.
+        """
+        smallest_tile = min(VALID_TILE_SIZES)
+        largest_tile = max(VALID_TILE_SIZES)
+        max_permuted_across_tiles = get_max_num_permuted_tokens(
+            self.max_num_tokens, self.top_k, self.num_local_experts, largest_tile
         )
 
-        # moe_sort buffers
+        # moe_sort buffers — allocate using smallest_tile so the
+        # tile-count-indexed buffers (out_tile_idx_to_expert_idx,
+        # out_tile_idx_to_mn_limit) are large enough for any tile_size,
+        # then override out_permuted_idx_to_expanded_idx (which scales
+        # with tile_size in the opposite direction) to fit the largest
+        # tile_size's max_num_permuted_tokens.
         self._moe_sort_buffers = allocate_moe_sort_buffers(
             num_tokens=self.max_num_tokens,
             num_experts=self.num_experts,
             top_k=self.top_k,
             num_local_experts=self.num_local_experts,
-            tile_tokens_dim=self.tile_size,
+            tile_tokens_dim=smallest_tile,
             device=self.device,
+        )
+        self._moe_sort_buffers["out_permuted_idx_to_expanded_idx"] = torch.empty(
+            (max_permuted_across_tiles,), dtype=torch.int32, device=self.device
         )
 
         # GEMM1 output (FP4 quantized)
         self._gemm1_output = torch.empty(
-            (max_num_permuted_tokens, self.intermediate_size // 2),
+            (max_permuted_across_tiles, self.intermediate_size // 2),
             dtype=torch.uint8,
             device=self.device,
         )
 
         # GEMM1 output scale
-        scale_size = max_num_permuted_tokens * (
+        scale_size = max_permuted_across_tiles * (
             self.intermediate_size // self.sf_vec_size
         )
         self._gemm1_output_scale = torch.empty(
@@ -488,30 +524,28 @@ class CuteDslMoEWrapper:
         **kwargs,
     ) -> torch.Tensor:
         """Forward implementation called by auto-tuner."""
-        # Pre-allocated buffers are sized for ``self.tile_size`` and
-        # ``self.max_num_tokens``. Fall back to dynamic allocation when:
+        # Pre-allocated buffers are sized to fit any ``tile_size in
+        # VALID_TILE_SIZES`` (see ``_allocate_buffers``).  Fall back to
+        # dynamic allocation when:
         #
         # - the autotuner is in its per-tactic measurement window
         #   (``is_in_profile_measurement()``): every probed tactic must
         #   see the same allocation overhead so the comparison is
-        #   unbiased. If we honored prealloc here, tactics with
-        #   ``tile_size == self.tile_size`` would skip the per-call
-        #   ``torch.empty()`` cost while others paid it, biasing the
-        #   autotuner toward picking the matching ``tile_size``
-        #   regardless of intrinsic kernel performance.  Note: this
-        #   is intentionally narrower than ``is_tuning_mode`` -- it
-        #   excludes cache lookups, ``do_preparation`` calls, the
-        #   final invocation after ``choose_one`` returns, and other
-        #   threads' inference, which all benefit from the prealloc.
-        # - the tactic's tile_size doesn't match ``self.tile_size``:
-        #   the prealloc layout would be wrong.
+        #   unbiased.  Note: this is intentionally narrower than
+        #   ``is_tuning_mode`` -- it excludes cache lookups,
+        #   ``do_preparation`` calls, the final invocation after
+        #   ``choose_one`` returns, and other threads' inference, which
+        #   all benefit from prealloc.
+        # - the tactic's ``tile_size`` is somehow outside the canonical
+        #   enumeration (defensive; should never fire for tactics from
+        #   ``ALL_MOE_TACTICS``).
         # - the batch exceeds what the buffers were sized for (e.g.
-        #   autotuner probing larger buckets).
+        #   autotuner probing larger buckets than ``max_num_tokens``).
         num_tokens = x.shape[0]
         use_prealloc = (
             self.use_cuda_graph
             and not is_in_profile_measurement()
-            and tile_size == self.tile_size
+            and tile_size in VALID_TILE_SIZES
             and num_tokens <= self.max_num_tokens
         )
         return _moe_core_impl(

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -152,6 +152,15 @@ def get_gemm2_valid_tactics(tile_size: int) -> List[Tuple]:
 # - gemm2_tactic: (mma_tiler_mn, cluster_shape_mn, raster_along_m)
 
 
+# Canonical list of tile_sizes the autotuner is allowed to pick.  Used by
+# ``get_moe_valid_tactics`` for tactic enumeration AND by
+# ``CuteDslMoEWrapper`` to size its preallocated kernel-output buffers so
+# every tactic in this list can reuse the prealloc, regardless of which
+# tile_size the autotuner picks at runtime.  Adding a new tile_size here
+# automatically widens the prealloc.
+VALID_TILE_SIZES: Tuple[int, ...] = (128, 256)
+
+
 def get_moe_valid_tactics() -> List[Tuple]:
     """Get all valid MoE tactic combinations.
 
@@ -170,7 +179,7 @@ def get_moe_valid_tactics() -> List[Tuple]:
     # use_2cta_instrs=True) variants; the autotuner picks per shape.
     # tile_size=256 typically wins at large batch where 2-CTA throughput
     # exceeds 1-CTA.
-    for tile_size in [128, 256]:
+    for tile_size in VALID_TILE_SIZES:
         gemm1_tactics = get_gemm1_valid_tactics(tile_size)
         gemm2_tactics = get_gemm2_valid_tactics(tile_size)
 

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -152,6 +152,15 @@ def get_gemm2_valid_tactics(tile_size: int) -> List[Tuple]:
 # - gemm2_tactic: (mma_tiler_mn, cluster_shape_mn, raster_along_m)
 
 
+# Canonical list of tile_sizes the autotuner is allowed to pick.
+# Used by get_moe_valid_tactics() for tactic enumeration AND by
+# CuteDslMoEWrapper to size its pre-allocated kernel-output buffers
+# so that *every* tactic in this list can reuse the prealloc, not
+# just the one whose tile_size matches construction-time self.tile_size.
+# Adding a new tile_size here automatically widens the prealloc.
+VALID_TILE_SIZES: Tuple[int, ...] = (128, 256)
+
+
 def get_moe_valid_tactics() -> List[Tuple]:
     """Get all valid MoE tactic combinations.
 
@@ -170,7 +179,7 @@ def get_moe_valid_tactics() -> List[Tuple]:
     # use_2cta_instrs=True) variants; the autotuner picks per shape.
     # tile_size=256 typically wins at large batch where 2-CTA throughput
     # exceeds 1-CTA.
-    for tile_size in [128, 256]:
+    for tile_size in VALID_TILE_SIZES:
         gemm1_tactics = get_gemm1_valid_tactics(tile_size)
         gemm2_tactics = get_gemm2_valid_tactics(tile_size)
 

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -152,15 +152,6 @@ def get_gemm2_valid_tactics(tile_size: int) -> List[Tuple]:
 # - gemm2_tactic: (mma_tiler_mn, cluster_shape_mn, raster_along_m)
 
 
-# Canonical list of tile_sizes the autotuner is allowed to pick.
-# Used by get_moe_valid_tactics() for tactic enumeration AND by
-# CuteDslMoEWrapper to size its pre-allocated kernel-output buffers
-# so that *every* tactic in this list can reuse the prealloc, not
-# just the one whose tile_size matches construction-time self.tile_size.
-# Adding a new tile_size here automatically widens the prealloc.
-VALID_TILE_SIZES: Tuple[int, ...] = (128, 256)
-
-
 def get_moe_valid_tactics() -> List[Tuple]:
     """Get all valid MoE tactic combinations.
 
@@ -179,7 +170,7 @@ def get_moe_valid_tactics() -> List[Tuple]:
     # use_2cta_instrs=True) variants; the autotuner picks per shape.
     # tile_size=256 typically wins at large batch where 2-CTA throughput
     # exceeds 1-CTA.
-    for tile_size in VALID_TILE_SIZES:
+    for tile_size in [128, 256]:
         gemm1_tactics = get_gemm1_valid_tactics(tile_size)
         gemm2_tactics = get_gemm2_valid_tactics(tile_size)
 

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1871,10 +1871,14 @@ class TestPreallocBuffersIntegration:
         prealloc'd buffers must be sized to fit the workload at that
         tile_size. Specifically:
 
-        - ``_gemm1_output``,
-          ``_moe_sort_buffers["out_permuted_idx_to_expanded_idx"]``,
-          and ``_gemm1_output_scale`` must hold
-          ``max_num_permuted_tokens(..., tile_size)`` rows/elements.
+        - ``_gemm1_output`` and
+          ``_moe_sort_buffers["out_permuted_idx_to_expanded_idx"]``
+          must hold ``max_num_permuted_tokens(..., tile_size)`` rows.
+        - ``_gemm1_output_scale`` must hold
+          ``max_num_permuted_tokens(..., tile_size) *
+          (intermediate_size // sf_vec_size)`` FP4-scale-factor
+          elements (one per scale-vector group along the intermediate
+          dimension).
         - ``_moe_sort_buffers["out_tile_idx_to_expert_idx"]`` and
           ``["out_tile_idx_to_mn_limit"]`` must hold
           ``max_num_tiles(..., tile_size)`` elements.
@@ -1888,6 +1892,7 @@ class TestPreallocBuffersIntegration:
         wrapper = self._make_wrapper()
 
         gemm1_capacity = wrapper._gemm1_output.shape[0]
+        gemm1_scale_capacity = wrapper._gemm1_output_scale.shape[0]
         permuted_idx_capacity = wrapper._moe_sort_buffers[
             "out_permuted_idx_to_expanded_idx"
         ].shape[0]
@@ -1898,6 +1903,12 @@ class TestPreallocBuffersIntegration:
             "out_tile_idx_to_mn_limit"
         ].shape[0]
 
+        # The scale buffer is sized in scale-factor elements: one per
+        # (permuted_token, scale_vec_group) pair. So the required
+        # capacity scales with both the per-tile_size permuted-token
+        # max AND the fixed (intermediate_size // sf_vec_size) factor.
+        scale_factor_per_token = wrapper.intermediate_size // wrapper.sf_vec_size
+
         for tile_size in VALID_TILE_SIZES:
             required_permuted = get_max_num_permuted_tokens(
                 wrapper.max_num_tokens,
@@ -1905,6 +1916,7 @@ class TestPreallocBuffersIntegration:
                 wrapper.num_local_experts,
                 tile_size,
             )
+            required_scale_size = required_permuted * scale_factor_per_token
             required_tiles = get_max_num_tiles(
                 wrapper.max_num_tokens,
                 wrapper.top_k,
@@ -1915,6 +1927,12 @@ class TestPreallocBuffersIntegration:
             assert gemm1_capacity >= required_permuted, (
                 f"_gemm1_output rows ({gemm1_capacity}) < required "
                 f"({required_permuted}) at tile_size={tile_size}"
+            )
+            assert gemm1_scale_capacity >= required_scale_size, (
+                f"_gemm1_output_scale capacity ({gemm1_scale_capacity}) "
+                f"< required ({required_scale_size} = {required_permuted} "
+                f"permuted * {scale_factor_per_token} scales/token) at "
+                f"tile_size={tile_size}"
             )
             assert permuted_idx_capacity >= required_permuted, (
                 f"out_permuted_idx_to_expanded_idx capacity "

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1800,27 +1800,41 @@ class TestAllValidTactics:
 class TestPreallocGateUnderTuning:
     """Validate that ``_forward_with_tactic``'s ``use_prealloc`` gate
     decouples ``self.tile_size`` from the autotuner's tactic-timing
-    measurements.
+    measurements, but **only** during the actual measurement window —
+    not during the entire ``autotune(True)`` context.
 
-    During autotune profiling the gate must return ``False`` for every
-    tactic — regardless of whether the tactic's ``tile_size`` matches
-    ``self.tile_size`` — so all tactics see the same per-call
-    ``torch.empty()`` allocation overhead and the comparison is
-    unbiased. During normal inference (outside the ``autotune(True)``
-    context) the gate must return ``True`` when the picked tactic
-    matches ``self.tile_size`` so the wrapper benefits from prealloc.
+    Behavioral contract:
+
+    1. **Inside the per-tactic measurement window** (i.e. while
+       ``is_in_profile_measurement()`` is True): the gate must return
+       ``False`` for every tactic, regardless of whether the tactic's
+       ``tile_size`` matches ``self.tile_size``. All tactics see the
+       same per-call ``torch.empty()`` allocation overhead and the
+       autotuner's tactic comparison is unbiased.
+
+    2. **Inside ``autotune(True)`` but outside the measurement window**
+       (cache lookups, ``do_preparation`` calls, the post-``choose_one``
+       final invocation, concurrent threads): the gate must use
+       prealloc when ``tile_size == self.tile_size`` and skip it
+       otherwise — i.e. the same behavior as plain inference. This is
+       the property that ``is_in_profile_measurement()`` adds over the
+       broader ``is_tuning_mode`` flag: the gate doesn't leak into
+       these adjacent code paths.
+
+    3. **Outside any tuning context**: same as case 2 — prealloc when
+       ``tile_size == self.tile_size``, skip otherwise.
 
     Implementation: monkey-patch the module-level ``_moe_core_impl``
-    to capture the ``moe_sort_buffers`` / ``gemm1_out`` /
-    ``gemm1_out_scale`` arguments without launching kernels, then
-    call ``_forward_with_tactic`` once inside ``autotune(True)`` and
-    once outside it for each ``tile_size in [self.tile_size,
-    other_tile_size]``.
+    to capture the ``moe_sort_buffers`` argument without launching
+    kernels, then call ``_forward_with_tactic`` from each of the three
+    contexts × {``self.tile_size``, mismatch} configurations.
     """
 
-    def test_gate_skips_prealloc_during_tuning_and_uses_it_outside(self, monkeypatch):
+    def test_gate_decouples_self_tile_size_only_during_measurement_window(
+        self, monkeypatch
+    ):
         from flashinfer import CuteDslMoEWrapper, autotune
-        from flashinfer.autotuner import AutoTuner
+        from flashinfer.autotuner import _profile_measurement_scope
         from flashinfer.fused_moe.cute_dsl import fused_moe as fused_moe_module
 
         wrapper = CuteDslMoEWrapper(
@@ -1834,11 +1848,15 @@ class TestPreallocGateUnderTuning:
             max_num_tokens=128,
         )
 
-        captured = {}  # (mode, tile_size) -> bool (prealloc'd buffers passed)
+        # (context, tile_size) -> bool (prealloc'd buffers passed)
+        captured: dict = {}
+        # The mode under which the next call is made; updated by the
+        # caller before each ``call(tile_size, mode)`` so the mock can
+        # tag the captured row correctly.
+        current_mode = {"name": "inference"}
 
         def mock_moe_core_impl(*args, **kwargs):
-            mode = "tuning" if AutoTuner.get().is_tuning_mode else "inference"
-            captured[(mode, kwargs["tile_size"])] = (
+            captured[(current_mode["name"], kwargs["tile_size"])] = (
                 kwargs["moe_sort_buffers"] is wrapper._moe_sort_buffers
             )
             n = args[0].shape[0] if args else kwargs["x"].shape[0]
@@ -1882,29 +1900,67 @@ class TestPreallocGateUnderTuning:
                 tile_size=tile_size,
             )
 
-        # Sweep both tile_sizes both inside and outside the tuning context.
         matching = wrapper.tile_size  # the tile_size the prealloc was sized for
         other = 256 if matching == 128 else 128
+
+        # Context 1: inside autotune(True) AND inside the measurement
+        # window — what _profile_single_kernel does for each tactic
+        # invocation.  The gate must skip prealloc for every tactic.
         with autotune(True):
+            with _profile_measurement_scope():
+                current_mode["name"] = "measurement"
+                call(matching)
+                call(other)
+
+            # Context 2: inside autotune(True) but OUTSIDE the
+            # measurement window — analogous to a cache hit, the
+            # do_preparation call, or the runner invocation immediately
+            # after choose_one returns. The gate should behave like
+            # plain inference here.
+            current_mode["name"] = "in_tuning_context_outside_measurement"
             call(matching)
             call(other)
+
+        # Context 3: outside any tuning context — plain inference.
+        current_mode["name"] = "inference"
         call(matching)
         call(other)
 
-        # Inside autotune(True), the gate must skip prealloc for every
-        # tactic — regardless of tile_size match — so the autotuner
-        # sees uniform allocation overhead across tactics.
+        # Context 1 contract: skip prealloc unconditionally.
         for tile_size in (matching, other):
-            assert not captured[("tuning", tile_size)], (
-                f"In tuning mode, gate passed prealloc'd buffers for "
-                f"tile_size={tile_size} (self.tile_size={matching}). "
-                f"This re-introduces the autotune-profiling bias the "
-                f"is_tuning_mode gate is designed to prevent."
+            assert not captured[("measurement", tile_size)], (
+                f"In the per-tactic measurement window, gate passed "
+                f"prealloc'd buffers for tile_size={tile_size} "
+                f"(self.tile_size={matching}). This re-introduces the "
+                f"autotune-profiling bias the gate is designed to prevent."
             )
 
-        # Outside autotune(True), the gate must use prealloc when the
-        # tactic's tile_size matches self.tile_size and skip it
-        # otherwise (the layout assumption would be wrong).
+        # Context 2 contract: prealloc when matching, skip when
+        # mismatched -- same as plain inference.  This is the property
+        # that distinguishes ``is_in_profile_measurement()`` from the
+        # broader ``is_tuning_mode``: cache lookups, do_preparation
+        # calls, post-choose_one runs, and concurrent threads should
+        # NOT lose prealloc just because some other thread/operation
+        # is inside an ``autotune(True)`` context.
+        assert captured[("in_tuning_context_outside_measurement", matching)], (
+            f"Inside autotune(True) but outside the measurement window "
+            f"at tile_size={matching} (matches self.tile_size), gate "
+            f"did not pass prealloc'd buffers. The narrower "
+            f"is_in_profile_measurement() signal is leaking back into "
+            f"is_tuning_mode breadth -- this re-introduces the "
+            f"perf-regression scenarios the narrow signal is supposed "
+            f"to avoid (cached calls, post-choose_one, concurrent "
+            f"inference threads)."
+        )
+        assert not captured[("in_tuning_context_outside_measurement", other)], (
+            f"Inside autotune(True) but outside the measurement window "
+            f"at tile_size={other} (mismatch with self.tile_size="
+            f"{matching}), gate passed prealloc'd buffers sized for "
+            f"the wrong tile_size — would corrupt kernel I/O."
+        )
+
+        # Context 3 contract: same as Context 2 — gate uses prealloc
+        # only when tile_size matches self.tile_size.
         assert captured[("inference", matching)], (
             f"In inference mode at tile_size={matching} (matches "
             f"self.tile_size), gate did not pass prealloc'd buffers. "

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1978,6 +1978,7 @@ class TestPreallocGateUnderTuning:
         from flashinfer import CuteDslMoEWrapper, autotune
         from flashinfer.autotuner import _profile_measurement_scope
         from flashinfer.fused_moe.cute_dsl import fused_moe as fused_moe_module
+        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
 
         wrapper = CuteDslMoEWrapper(
             num_experts=256,
@@ -2043,7 +2044,14 @@ class TestPreallocGateUnderTuning:
             )
 
         matching = wrapper.tile_size  # the tile_size the prealloc was sized for
-        other = 256 if matching == 128 else 128
+        # Exercise every tile_size in VALID_TILE_SIZES so adding a new
+        # entry doesn't silently leave the gate untested for that tile.
+        others = [t for t in VALID_TILE_SIZES if t != matching]
+        assert others, (
+            f"Test requires >= 2 distinct VALID_TILE_SIZES entries; "
+            f"got {VALID_TILE_SIZES}"
+        )
+        all_tiles = (matching, *others)
 
         # Context 1: inside autotune(True) AND inside the measurement
         # window — what _profile_single_kernel does for each tactic
@@ -2051,8 +2059,8 @@ class TestPreallocGateUnderTuning:
         with autotune(True):
             with _profile_measurement_scope():
                 current_mode["name"] = "measurement"
-                call(matching)
-                call(other)
+                for tile_size in all_tiles:
+                    call(tile_size)
 
             # Context 2: inside autotune(True) but OUTSIDE the
             # measurement window — analogous to a cache hit, the
@@ -2060,16 +2068,16 @@ class TestPreallocGateUnderTuning:
             # after choose_one returns. The gate should behave like
             # plain inference here.
             current_mode["name"] = "in_tuning_context_outside_measurement"
-            call(matching)
-            call(other)
+            for tile_size in all_tiles:
+                call(tile_size)
 
         # Context 3: outside any tuning context — plain inference.
         current_mode["name"] = "inference"
-        call(matching)
-        call(other)
+        for tile_size in all_tiles:
+            call(tile_size)
 
         # Context 1 contract: skip prealloc unconditionally.
-        for tile_size in (matching, other):
+        for tile_size in all_tiles:
             assert not captured[("measurement", tile_size)], (
                 f"In the per-tactic measurement window, gate passed "
                 f"prealloc'd buffers for tile_size={tile_size} "
@@ -2086,7 +2094,7 @@ class TestPreallocGateUnderTuning:
         # an ``autotune(True)`` context.  Combined with the expanded
         # buffer sizing in ``_allocate_buffers``, the prealloc is also
         # used regardless of whether ``tile_size == self.tile_size``.
-        for tile_size in (matching, other):
+        for tile_size in all_tiles:
             assert captured[("in_tuning_context_outside_measurement", tile_size)], (
                 f"Inside autotune(True) but outside the measurement "
                 f"window at tile_size={tile_size}, gate did not pass "
@@ -2102,7 +2110,7 @@ class TestPreallocGateUnderTuning:
         # for ANY valid tile_size.  This preserves the wrapper's
         # CUDA-graph contract regardless of which tactic the autotuner
         # picks at runtime.
-        for tile_size in (matching, other):
+        for tile_size in all_tiles:
             assert captured[("inference", tile_size)], (
                 f"In inference mode at tile_size={tile_size}, gate "
                 f"did not pass prealloc'd buffers "

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1791,6 +1791,144 @@ class TestAllValidTactics:
 
 
 # =============================================================================
+# Test Class: CuteDslMoEWrapper prealloc static invariants (no GPU required)
+# =============================================================================
+
+
+@cute_dsl_available
+class TestPreallocStaticInvariants:
+    """No-GPU structural invariants on ``VALID_TILE_SIZES``.
+
+    The empirical buffer-shape and prealloc-gate behavior is covered
+    by ``TestPreallocBuffersIntegration`` and
+    ``TestPreallocGateUnderTuning`` (GPU-required).  This class catches
+    the orthogonal failure mode where ``VALID_TILE_SIZES`` is
+    accidentally reduced to a single entry — in that case the GPU
+    integration tests pass trivially (no max/min divergence in
+    ``_allocate_buffers``, only one tile_size to gate-check) and the
+    bias-prevention silently disappears.
+    """
+
+    def test_valid_tile_sizes_has_multiple_entries(self):
+        """``VALID_TILE_SIZES`` must enumerate more than one tile_size.
+        With a single entry, the bias-prevention is moot — the
+        autotuner only ever profiles one tile_size class, defeating
+        the whole point of widening the prealloc.
+        """
+        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
+
+        assert len(VALID_TILE_SIZES) >= 2, (
+            f"VALID_TILE_SIZES has only {len(VALID_TILE_SIZES)} entry; "
+            f"need >= 2 for the prealloc-bias fix to be meaningful."
+        )
+        assert all(isinstance(t, int) and t > 0 for t in VALID_TILE_SIZES), (
+            f"VALID_TILE_SIZES entries must be positive ints; got {VALID_TILE_SIZES}"
+        )
+
+
+# =============================================================================
+# Test Class: CuteDslMoEWrapper prealloc-buffer integration (GPU required)
+# =============================================================================
+
+
+@cute_dsl_available
+@sm100_required
+class TestPreallocBuffersIntegration:
+    """Verify the wrapper's prealloc'd buffers fit the workload at
+    *every* ``tile_size in VALID_TILE_SIZES``, not just the
+    constructor-time ``self.tile_size``.
+
+    Load-bearing property: when the autotuner picks a tactic with
+    ``tile_size != self.tile_size`` (the common case at large N where
+    ``tile_size=256`` wins on intrinsic kernel time), the wrapper's
+    ``use_prealloc`` gate still resolves True and inference uses the
+    prealloc.  This requires the buffers to fit the *largest* possible
+    workload across all valid tile_sizes; if they were sized only for
+    ``self.tile_size``, picking a different tactic at runtime would
+    OOB-write the prealloc -- forcing the gate to fall through to
+    per-call ``torch.empty()`` calls, which violates the wrapper's
+    CUDA-graph contract.
+    """
+
+    def test_prealloc_buffers_fit_all_valid_tile_sizes(self):
+        from flashinfer import CuteDslMoEWrapper
+        from flashinfer.fused_moe.cute_dsl.moe_utils import (
+            get_max_num_permuted_tokens,
+            get_max_num_tiles,
+        )
+        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
+
+        wrapper = CuteDslMoEWrapper(
+            num_experts=256,
+            top_k=8,
+            hidden_size=256,
+            intermediate_size=512,
+            num_local_experts=256,
+            local_expert_offset=0,
+            use_cuda_graph=True,
+            max_num_tokens=256,
+        )
+
+        gemm1_capacity = wrapper._gemm1_output.shape[0]
+        gemm1_scale_capacity = wrapper._gemm1_output_scale.shape[0]
+        permuted_idx_capacity = wrapper._moe_sort_buffers[
+            "out_permuted_idx_to_expanded_idx"
+        ].shape[0]
+        tile_expert_capacity = wrapper._moe_sort_buffers[
+            "out_tile_idx_to_expert_idx"
+        ].shape[0]
+        tile_mn_limit_capacity = wrapper._moe_sort_buffers[
+            "out_tile_idx_to_mn_limit"
+        ].shape[0]
+
+        # Scale buffer is sized in scale-factor elements (one per
+        # (permuted_token, scale_vec_group) pair), not in permuted
+        # tokens directly.
+        scale_factor_per_token = wrapper.intermediate_size // wrapper.sf_vec_size
+
+        for tile_size in VALID_TILE_SIZES:
+            required_permuted = get_max_num_permuted_tokens(
+                wrapper.max_num_tokens,
+                wrapper.top_k,
+                wrapper.num_local_experts,
+                tile_size,
+            )
+            required_scale_size = required_permuted * scale_factor_per_token
+            required_tiles = get_max_num_tiles(
+                wrapper.max_num_tokens,
+                wrapper.top_k,
+                wrapper.num_local_experts,
+                tile_size,
+            )
+
+            assert gemm1_capacity >= required_permuted, (
+                f"_gemm1_output rows ({gemm1_capacity}) < required "
+                f"({required_permuted}) at tile_size={tile_size}"
+            )
+            assert gemm1_scale_capacity >= required_scale_size, (
+                f"_gemm1_output_scale capacity ({gemm1_scale_capacity}) "
+                f"< required ({required_scale_size} = {required_permuted} "
+                f"permuted * {scale_factor_per_token} scales/token) at "
+                f"tile_size={tile_size}"
+            )
+            assert permuted_idx_capacity >= required_permuted, (
+                f"out_permuted_idx_to_expanded_idx capacity "
+                f"({permuted_idx_capacity}) < required ({required_permuted}) "
+                f"at tile_size={tile_size}"
+            )
+            assert tile_expert_capacity >= required_tiles, (
+                f"out_tile_idx_to_expert_idx capacity "
+                f"({tile_expert_capacity}) < required ({required_tiles}) "
+                f"at tile_size={tile_size}"
+            )
+            assert tile_mn_limit_capacity >= required_tiles, (
+                f"out_tile_idx_to_mn_limit capacity "
+                f"({tile_mn_limit_capacity}) < required ({required_tiles}) "
+                f"at tile_size={tile_size}"
+            )
+
+
+# =============================================================================
 # Test Class: CuteDslMoEWrapper autotune-profiling prealloc gate (GPU required)
 # =============================================================================
 
@@ -1799,35 +1937,39 @@ class TestAllValidTactics:
 @sm100_required
 class TestPreallocGateUnderTuning:
     """Validate that ``_forward_with_tactic``'s ``use_prealloc`` gate
-    decouples ``self.tile_size`` from the autotuner's tactic-timing
-    measurements, but **only** during the actual measurement window —
-    not during the entire ``autotune(True)`` context.
+    is on during normal inference (any valid tile_size) but off during
+    the autotuner's per-tactic measurement window.
 
     Behavioral contract:
 
     1. **Inside the per-tactic measurement window** (i.e. while
        ``is_in_profile_measurement()`` is True): the gate must return
        ``False`` for every tactic, regardless of whether the tactic's
-       ``tile_size`` matches ``self.tile_size``. All tactics see the
+       ``tile_size`` matches ``self.tile_size``.  All tactics see the
        same per-call ``torch.empty()`` allocation overhead and the
        autotuner's tactic comparison is unbiased.
 
     2. **Inside ``autotune(True)`` but outside the measurement window**
        (cache lookups, ``do_preparation`` calls, the post-``choose_one``
        final invocation, concurrent threads): the gate must use
-       prealloc when ``tile_size == self.tile_size`` and skip it
-       otherwise — i.e. the same behavior as plain inference. This is
+       prealloc for *any* ``tile_size in VALID_TILE_SIZES``.  This is
        the property that ``is_in_profile_measurement()`` adds over the
        broader ``is_tuning_mode`` flag: the gate doesn't leak into
        these adjacent code paths.
 
-    3. **Outside any tuning context**: same as case 2 — prealloc when
-       ``tile_size == self.tile_size``, skip otherwise.
+    3. **Outside any tuning context** (plain inference): same as case
+       2 — prealloc for any ``tile_size in VALID_TILE_SIZES``.  This is
+       the property that the expanded ``_allocate_buffers`` adds: the
+       gate doesn't depend on ``tile_size == self.tile_size``, so
+       whichever tactic the autotuner picks, the wrapper's CUDA-graph
+       prealloc is still used and the wrapper's graph-safety contract
+       is preserved.
 
     Implementation: monkey-patch the module-level ``_moe_core_impl``
     to capture the ``moe_sort_buffers`` argument without launching
     kernels, then call ``_forward_with_tactic`` from each of the three
-    contexts × {``self.tile_size``, mismatch} configurations.
+    contexts × {``self.tile_size``, other valid tile_size}
+    configurations.
     """
 
     def test_gate_decouples_self_tile_size_only_during_measurement_window(
@@ -1935,42 +2077,41 @@ class TestPreallocGateUnderTuning:
                 f"autotune-profiling bias the gate is designed to prevent."
             )
 
-        # Context 2 contract: prealloc when matching, skip when
-        # mismatched -- same as plain inference.  This is the property
-        # that distinguishes ``is_in_profile_measurement()`` from the
-        # broader ``is_tuning_mode``: cache lookups, do_preparation
-        # calls, post-choose_one runs, and concurrent threads should
-        # NOT lose prealloc just because some other thread/operation
-        # is inside an ``autotune(True)`` context.
-        assert captured[("in_tuning_context_outside_measurement", matching)], (
-            f"Inside autotune(True) but outside the measurement window "
-            f"at tile_size={matching} (matches self.tile_size), gate "
-            f"did not pass prealloc'd buffers. The narrower "
-            f"is_in_profile_measurement() signal is leaking back into "
-            f"is_tuning_mode breadth -- this re-introduces the "
-            f"perf-regression scenarios the narrow signal is supposed "
-            f"to avoid (cached calls, post-choose_one, concurrent "
-            f"inference threads)."
-        )
-        assert not captured[("in_tuning_context_outside_measurement", other)], (
-            f"Inside autotune(True) but outside the measurement window "
-            f"at tile_size={other} (mismatch with self.tile_size="
-            f"{matching}), gate passed prealloc'd buffers sized for "
-            f"the wrong tile_size — would corrupt kernel I/O."
-        )
+        # Context 2 contract: prealloc for ANY valid tile_size.  This
+        # is the property that distinguishes
+        # ``is_in_profile_measurement()`` from the broader
+        # ``is_tuning_mode``: cache lookups, do_preparation calls,
+        # post-choose_one runs, and concurrent threads should NOT lose
+        # prealloc just because some other thread/operation is inside
+        # an ``autotune(True)`` context.  Combined with the expanded
+        # buffer sizing in ``_allocate_buffers``, the prealloc is also
+        # used regardless of whether ``tile_size == self.tile_size``.
+        for tile_size in (matching, other):
+            assert captured[("in_tuning_context_outside_measurement", tile_size)], (
+                f"Inside autotune(True) but outside the measurement "
+                f"window at tile_size={tile_size}, gate did not pass "
+                f"prealloc'd buffers (self.tile_size={matching}). "
+                f"Either the narrower is_in_profile_measurement() "
+                f"signal is leaking back into is_tuning_mode breadth, "
+                f"or the gate is incorrectly checking tile_size == "
+                f"self.tile_size -- both regress the wrapper's "
+                f"CUDA-graph contract."
+            )
 
-        # Context 3 contract: same as Context 2 — gate uses prealloc
-        # only when tile_size matches self.tile_size.
-        assert captured[("inference", matching)], (
-            f"In inference mode at tile_size={matching} (matches "
-            f"self.tile_size), gate did not pass prealloc'd buffers. "
-            f"The wrapper loses its CUDA-graph prealloc benefit."
-        )
-        assert not captured[("inference", other)], (
-            f"In inference mode at tile_size={other} (mismatch with "
-            f"self.tile_size={matching}), gate passed prealloc'd buffers "
-            f"sized for the wrong tile_size — would corrupt kernel I/O."
-        )
+        # Context 3 contract: same as Context 2 -- gate uses prealloc
+        # for ANY valid tile_size.  This preserves the wrapper's
+        # CUDA-graph contract regardless of which tactic the autotuner
+        # picks at runtime.
+        for tile_size in (matching, other):
+            assert captured[("inference", tile_size)], (
+                f"In inference mode at tile_size={tile_size}, gate "
+                f"did not pass prealloc'd buffers "
+                f"(self.tile_size={matching}). The wrapper loses its "
+                f"CUDA-graph prealloc benefit -- with use_cuda_graph="
+                f"True, captured graphs would record per-call "
+                f"torch.empty() calls instead of using the prealloc, "
+                f"violating the wrapper's run() graph-safety contract."
+            )
 
 
 if __name__ == "__main__":

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1791,71 +1791,39 @@ class TestAllValidTactics:
 
 
 # =============================================================================
-# Test Class: CuteDslMoEWrapper prealloc-buffer sizing formula (no GPU required)
-# =============================================================================
-
-
-@cute_dsl_available
-class TestPreallocStaticInvariants:
-    """No-GPU structural invariants on ``VALID_TILE_SIZES``.
-
-    The empirical buffer-shape and prealloc-gate behavior is covered
-    by ``TestPreallocBuffersIntegration`` (GPU-required). This class
-    catches the orthogonal failure mode where ``VALID_TILE_SIZES`` is
-    accidentally reduced to a single entry — in that case the GPU
-    integration tests pass trivially (no max/min divergence, only
-    one tile_size to gate-check) and the bias-prevention silently
-    disappears.
-    """
-
-    def test_valid_tile_sizes_has_multiple_entries(self):
-        """``VALID_TILE_SIZES`` must enumerate more than one tile_size.
-        With a single entry, the bias-prevention is moot — the
-        autotuner only ever profiles one tile_size class, defeating
-        the whole point of widening the prealloc.
-        """
-        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
-
-        assert len(VALID_TILE_SIZES) >= 2, (
-            f"VALID_TILE_SIZES has only {len(VALID_TILE_SIZES)} entry; "
-            f"need >= 2 for the prealloc-bias fix to be meaningful."
-        )
-        assert all(isinstance(t, int) and t > 0 for t in VALID_TILE_SIZES), (
-            f"VALID_TILE_SIZES entries must be positive ints; got {VALID_TILE_SIZES}"
-        )
-
-
-# =============================================================================
-# Test Class: CuteDslMoEWrapper prealloc-buffer integration (GPU required)
+# Test Class: CuteDslMoEWrapper autotune-profiling prealloc gate (GPU required)
 # =============================================================================
 
 
 @cute_dsl_available
 @sm100_required
-class TestPreallocBuffersIntegration:
-    """Integration tests for the wrapper's prealloc'd buffers and the
-    ``use_prealloc`` gate.
+class TestPreallocGateUnderTuning:
+    """Validate that ``_forward_with_tactic``'s ``use_prealloc`` gate
+    decouples ``self.tile_size`` from the autotuner's tactic-timing
+    measurements.
 
-    These tests construct a real ``CuteDslMoEWrapper(use_cuda_graph=True)``
-    and verify two load-bearing properties:
+    During autotune profiling the gate must return ``False`` for every
+    tactic — regardless of whether the tactic's ``tile_size`` matches
+    ``self.tile_size`` — so all tactics see the same per-call
+    ``torch.empty()`` allocation overhead and the comparison is
+    unbiased. During normal inference (outside the ``autotune(True)``
+    context) the gate must return ``True`` when the picked tactic
+    matches ``self.tile_size`` so the wrapper benefits from prealloc.
 
-    1. The prealloc'd buffers fit the workload at *every* tile_size in
-       ``VALID_TILE_SIZES`` — not just the constructor-time
-       ``self.tile_size``. Otherwise the autotuner profiling at
-       non-self tile_size would either OOB-write the prealloc or fall
-       through to per-call allocation.
-
-    2. The ``use_prealloc`` gate in ``_forward_with_tactic`` honors
-       *every* tile_size in ``VALID_TILE_SIZES``, not just
-       ``self.tile_size``. Otherwise the autotuner sees asymmetric
-       allocation overhead during profiling and biases tactic
-       selection toward ``self.tile_size``.
+    Implementation: monkey-patch the module-level ``_moe_core_impl``
+    to capture the ``moe_sort_buffers`` / ``gemm1_out`` /
+    ``gemm1_out_scale`` arguments without launching kernels, then
+    call ``_forward_with_tactic`` once inside ``autotune(True)`` and
+    once outside it for each ``tile_size in [self.tile_size,
+    other_tile_size]``.
     """
 
-    def _make_wrapper(self, max_num_tokens: int = 256):
-        from flashinfer import CuteDslMoEWrapper
+    def test_gate_skips_prealloc_during_tuning_and_uses_it_outside(self, monkeypatch):
+        from flashinfer import CuteDslMoEWrapper, autotune
+        from flashinfer.autotuner import AutoTuner
+        from flashinfer.fused_moe.cute_dsl import fused_moe as fused_moe_module
 
-        return CuteDslMoEWrapper(
+        wrapper = CuteDslMoEWrapper(
             num_experts=256,
             top_k=8,
             hidden_size=256,
@@ -1863,134 +1831,27 @@ class TestPreallocBuffersIntegration:
             num_local_experts=256,
             local_expert_offset=0,
             use_cuda_graph=True,
-            max_num_tokens=max_num_tokens,
+            max_num_tokens=128,
         )
 
-    def test_prealloc_buffers_fit_all_valid_tile_sizes(self):
-        """For every ``tile_size in VALID_TILE_SIZES``, the wrapper's
-        prealloc'd buffers must be sized to fit the workload at that
-        tile_size. Specifically:
-
-        - ``_gemm1_output`` and
-          ``_moe_sort_buffers["out_permuted_idx_to_expanded_idx"]``
-          must hold ``max_num_permuted_tokens(..., tile_size)`` rows.
-        - ``_gemm1_output_scale`` must hold
-          ``max_num_permuted_tokens(..., tile_size) *
-          (intermediate_size // sf_vec_size)`` FP4-scale-factor
-          elements (one per scale-vector group along the intermediate
-          dimension).
-        - ``_moe_sort_buffers["out_tile_idx_to_expert_idx"]`` and
-          ``["out_tile_idx_to_mn_limit"]`` must hold
-          ``max_num_tiles(..., tile_size)`` elements.
-        """
-        from flashinfer.fused_moe.cute_dsl.moe_utils import (
-            get_max_num_permuted_tokens,
-            get_max_num_tiles,
-        )
-        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
-
-        wrapper = self._make_wrapper()
-
-        gemm1_capacity = wrapper._gemm1_output.shape[0]
-        gemm1_scale_capacity = wrapper._gemm1_output_scale.shape[0]
-        permuted_idx_capacity = wrapper._moe_sort_buffers[
-            "out_permuted_idx_to_expanded_idx"
-        ].shape[0]
-        tile_expert_capacity = wrapper._moe_sort_buffers[
-            "out_tile_idx_to_expert_idx"
-        ].shape[0]
-        tile_mn_limit_capacity = wrapper._moe_sort_buffers[
-            "out_tile_idx_to_mn_limit"
-        ].shape[0]
-
-        # The scale buffer is sized in scale-factor elements: one per
-        # (permuted_token, scale_vec_group) pair. So the required
-        # capacity scales with both the per-tile_size permuted-token
-        # max AND the fixed (intermediate_size // sf_vec_size) factor.
-        scale_factor_per_token = wrapper.intermediate_size // wrapper.sf_vec_size
-
-        for tile_size in VALID_TILE_SIZES:
-            required_permuted = get_max_num_permuted_tokens(
-                wrapper.max_num_tokens,
-                wrapper.top_k,
-                wrapper.num_local_experts,
-                tile_size,
-            )
-            required_scale_size = required_permuted * scale_factor_per_token
-            required_tiles = get_max_num_tiles(
-                wrapper.max_num_tokens,
-                wrapper.top_k,
-                wrapper.num_local_experts,
-                tile_size,
-            )
-
-            assert gemm1_capacity >= required_permuted, (
-                f"_gemm1_output rows ({gemm1_capacity}) < required "
-                f"({required_permuted}) at tile_size={tile_size}"
-            )
-            assert gemm1_scale_capacity >= required_scale_size, (
-                f"_gemm1_output_scale capacity ({gemm1_scale_capacity}) "
-                f"< required ({required_scale_size} = {required_permuted} "
-                f"permuted * {scale_factor_per_token} scales/token) at "
-                f"tile_size={tile_size}"
-            )
-            assert permuted_idx_capacity >= required_permuted, (
-                f"out_permuted_idx_to_expanded_idx capacity "
-                f"({permuted_idx_capacity}) < required ({required_permuted}) "
-                f"at tile_size={tile_size}"
-            )
-            assert tile_expert_capacity >= required_tiles, (
-                f"out_tile_idx_to_expert_idx capacity "
-                f"({tile_expert_capacity}) < required ({required_tiles}) "
-                f"at tile_size={tile_size}"
-            )
-            assert tile_mn_limit_capacity >= required_tiles, (
-                f"out_tile_idx_to_mn_limit capacity "
-                f"({tile_mn_limit_capacity}) < required ({required_tiles}) "
-                f"at tile_size={tile_size}"
-            )
-
-    def test_prealloc_gate_accepts_all_valid_tile_sizes(self, monkeypatch):
-        """The ``use_prealloc`` gate in ``_forward_with_tactic`` must
-        pass the prealloc'd buffers to ``_moe_core_impl`` for every
-        ``tile_size in VALID_TILE_SIZES``, not just ``self.tile_size``.
-
-        Implementation: monkey-patch the module-level
-        ``_moe_core_impl`` to capture the ``moe_sort_buffers`` /
-        ``gemm1_out`` / ``gemm1_out_scale`` arguments without
-        actually launching kernels. Verify that for every tile_size
-        in the canonical enumeration, the gate decides to pass the
-        prealloc'd buffers (not ``None``).
-        """
-        from flashinfer.fused_moe.cute_dsl import fused_moe as fused_moe_module
-        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
-
-        wrapper = self._make_wrapper(max_num_tokens=128)
-
-        captured = {}  # tile_size -> (moe_sort_buffers_is_prealloc, gemm1_out_is_prealloc)
+        captured = {}  # (mode, tile_size) -> bool (prealloc'd buffers passed)
 
         def mock_moe_core_impl(*args, **kwargs):
-            ts = kwargs["tile_size"]
-            captured[ts] = {
-                "moe_sort_buffers": kwargs["moe_sort_buffers"]
-                is wrapper._moe_sort_buffers,
-                "gemm1_out": kwargs["gemm1_out"] is wrapper._gemm1_output,
-                "gemm1_out_scale": kwargs["gemm1_out_scale"]
-                is wrapper._gemm1_output_scale,
-            }
-            num_tokens = args[0].shape[0] if args else kwargs["x"].shape[0]
+            mode = "tuning" if AutoTuner.get().is_tuning_mode else "inference"
+            captured[(mode, kwargs["tile_size"])] = (
+                kwargs["moe_sort_buffers"] is wrapper._moe_sort_buffers
+            )
+            n = args[0].shape[0] if args else kwargs["x"].shape[0]
             return torch.zeros(
-                (num_tokens, wrapper.hidden_size),
-                dtype=torch.bfloat16,
-                device="cuda",
+                (n, wrapper.hidden_size), dtype=torch.bfloat16, device="cuda"
             )
 
         monkeypatch.setattr(fused_moe_module, "_moe_core_impl", mock_moe_core_impl)
 
-        # Build minimal dummy tensors. _forward_with_tactic just
-        # checks x.shape[0] for the gate; everything else is passed
-        # through to the (mocked) inner function.
-        n = 64  # < max_num_tokens=128 so the gate's batch check passes
+        # Build minimal placeholder tensors: _forward_with_tactic only
+        # reads x.shape[0]; everything else is passed through to the
+        # (mocked) inner function untouched.
+        n = 64  # < max_num_tokens=128 so the batch check passes
         x = torch.empty((n, wrapper.hidden_size // 2), dtype=torch.uint8, device="cuda")
         x_sf = torch.empty((n, 1), dtype=torch.uint8, device="cuda")
         token_selected_experts = torch.zeros(
@@ -2002,7 +1863,7 @@ class TestPreallocBuffersIntegration:
         dummy_w = torch.empty((1,), dtype=torch.uint8, device="cuda")
         dummy_alpha = torch.empty((1,), dtype=torch.float32, device="cuda")
 
-        for tile_size in VALID_TILE_SIZES:
+        def call(tile_size: int) -> None:
             wrapper._forward_with_tactic(
                 x=x,
                 x_sf=x_sf,
@@ -2021,19 +1882,39 @@ class TestPreallocBuffersIntegration:
                 tile_size=tile_size,
             )
 
-        for tile_size in VALID_TILE_SIZES:
-            assert tile_size in captured, (
-                f"_forward_with_tactic did not invoke _moe_core_impl "
-                f"for tile_size={tile_size}"
+        # Sweep both tile_sizes both inside and outside the tuning context.
+        matching = wrapper.tile_size  # the tile_size the prealloc was sized for
+        other = 256 if matching == 128 else 128
+        with autotune(True):
+            call(matching)
+            call(other)
+        call(matching)
+        call(other)
+
+        # Inside autotune(True), the gate must skip prealloc for every
+        # tactic — regardless of tile_size match — so the autotuner
+        # sees uniform allocation overhead across tactics.
+        for tile_size in (matching, other):
+            assert not captured[("tuning", tile_size)], (
+                f"In tuning mode, gate passed prealloc'd buffers for "
+                f"tile_size={tile_size} (self.tile_size={matching}). "
+                f"This re-introduces the autotune-profiling bias the "
+                f"is_tuning_mode gate is designed to prevent."
             )
-            for buf_name, is_prealloc in captured[tile_size].items():
-                assert is_prealloc, (
-                    f"At tile_size={tile_size}, the use_prealloc gate "
-                    f"did not pass the prealloc'd {buf_name} to "
-                    f"_moe_core_impl. The autotuner would see "
-                    f"asymmetric allocation overhead and bias tactic "
-                    f"selection."
-                )
+
+        # Outside autotune(True), the gate must use prealloc when the
+        # tactic's tile_size matches self.tile_size and skip it
+        # otherwise (the layout assumption would be wrong).
+        assert captured[("inference", matching)], (
+            f"In inference mode at tile_size={matching} (matches "
+            f"self.tile_size), gate did not pass prealloc'd buffers. "
+            f"The wrapper loses its CUDA-graph prealloc benefit."
+        )
+        assert not captured[("inference", other)], (
+            f"In inference mode at tile_size={other} (mismatch with "
+            f"self.tile_size={matching}), gate passed prealloc'd buffers "
+            f"sized for the wrong tile_size — would corrupt kernel I/O."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1790,5 +1790,233 @@ class TestAllValidTactics:
         )
 
 
+# =============================================================================
+# Test Class: CuteDslMoEWrapper prealloc-buffer sizing formula (no GPU required)
+# =============================================================================
+
+
+@cute_dsl_available
+class TestPreallocStaticInvariants:
+    """No-GPU structural invariants on ``VALID_TILE_SIZES``.
+
+    The empirical buffer-shape and prealloc-gate behavior is covered
+    by ``TestPreallocBuffersIntegration`` (GPU-required). This class
+    catches the orthogonal failure mode where ``VALID_TILE_SIZES`` is
+    accidentally reduced to a single entry — in that case the GPU
+    integration tests pass trivially (no max/min divergence, only
+    one tile_size to gate-check) and the bias-prevention silently
+    disappears.
+    """
+
+    def test_valid_tile_sizes_has_multiple_entries(self):
+        """``VALID_TILE_SIZES`` must enumerate more than one tile_size.
+        With a single entry, the bias-prevention is moot — the
+        autotuner only ever profiles one tile_size class, defeating
+        the whole point of widening the prealloc.
+        """
+        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
+
+        assert len(VALID_TILE_SIZES) >= 2, (
+            f"VALID_TILE_SIZES has only {len(VALID_TILE_SIZES)} entry; "
+            f"need >= 2 for the prealloc-bias fix to be meaningful."
+        )
+        assert all(isinstance(t, int) and t > 0 for t in VALID_TILE_SIZES), (
+            f"VALID_TILE_SIZES entries must be positive ints; got {VALID_TILE_SIZES}"
+        )
+
+
+# =============================================================================
+# Test Class: CuteDslMoEWrapper prealloc-buffer integration (GPU required)
+# =============================================================================
+
+
+@cute_dsl_available
+@sm100_required
+class TestPreallocBuffersIntegration:
+    """Integration tests for the wrapper's prealloc'd buffers and the
+    ``use_prealloc`` gate.
+
+    These tests construct a real ``CuteDslMoEWrapper(use_cuda_graph=True)``
+    and verify two load-bearing properties:
+
+    1. The prealloc'd buffers fit the workload at *every* tile_size in
+       ``VALID_TILE_SIZES`` — not just the constructor-time
+       ``self.tile_size``. Otherwise the autotuner profiling at
+       non-self tile_size would either OOB-write the prealloc or fall
+       through to per-call allocation.
+
+    2. The ``use_prealloc`` gate in ``_forward_with_tactic`` honors
+       *every* tile_size in ``VALID_TILE_SIZES``, not just
+       ``self.tile_size``. Otherwise the autotuner sees asymmetric
+       allocation overhead during profiling and biases tactic
+       selection toward ``self.tile_size``.
+    """
+
+    def _make_wrapper(self, max_num_tokens: int = 256):
+        from flashinfer import CuteDslMoEWrapper
+
+        return CuteDslMoEWrapper(
+            num_experts=256,
+            top_k=8,
+            hidden_size=256,
+            intermediate_size=512,
+            num_local_experts=256,
+            local_expert_offset=0,
+            use_cuda_graph=True,
+            max_num_tokens=max_num_tokens,
+        )
+
+    def test_prealloc_buffers_fit_all_valid_tile_sizes(self):
+        """For every ``tile_size in VALID_TILE_SIZES``, the wrapper's
+        prealloc'd buffers must be sized to fit the workload at that
+        tile_size. Specifically:
+
+        - ``_gemm1_output``,
+          ``_moe_sort_buffers["out_permuted_idx_to_expanded_idx"]``,
+          and ``_gemm1_output_scale`` must hold
+          ``max_num_permuted_tokens(..., tile_size)`` rows/elements.
+        - ``_moe_sort_buffers["out_tile_idx_to_expert_idx"]`` and
+          ``["out_tile_idx_to_mn_limit"]`` must hold
+          ``max_num_tiles(..., tile_size)`` elements.
+        """
+        from flashinfer.fused_moe.cute_dsl.moe_utils import (
+            get_max_num_permuted_tokens,
+            get_max_num_tiles,
+        )
+        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
+
+        wrapper = self._make_wrapper()
+
+        gemm1_capacity = wrapper._gemm1_output.shape[0]
+        permuted_idx_capacity = wrapper._moe_sort_buffers[
+            "out_permuted_idx_to_expanded_idx"
+        ].shape[0]
+        tile_expert_capacity = wrapper._moe_sort_buffers[
+            "out_tile_idx_to_expert_idx"
+        ].shape[0]
+        tile_mn_limit_capacity = wrapper._moe_sort_buffers[
+            "out_tile_idx_to_mn_limit"
+        ].shape[0]
+
+        for tile_size in VALID_TILE_SIZES:
+            required_permuted = get_max_num_permuted_tokens(
+                wrapper.max_num_tokens,
+                wrapper.top_k,
+                wrapper.num_local_experts,
+                tile_size,
+            )
+            required_tiles = get_max_num_tiles(
+                wrapper.max_num_tokens,
+                wrapper.top_k,
+                wrapper.num_local_experts,
+                tile_size,
+            )
+
+            assert gemm1_capacity >= required_permuted, (
+                f"_gemm1_output rows ({gemm1_capacity}) < required "
+                f"({required_permuted}) at tile_size={tile_size}"
+            )
+            assert permuted_idx_capacity >= required_permuted, (
+                f"out_permuted_idx_to_expanded_idx capacity "
+                f"({permuted_idx_capacity}) < required ({required_permuted}) "
+                f"at tile_size={tile_size}"
+            )
+            assert tile_expert_capacity >= required_tiles, (
+                f"out_tile_idx_to_expert_idx capacity "
+                f"({tile_expert_capacity}) < required ({required_tiles}) "
+                f"at tile_size={tile_size}"
+            )
+            assert tile_mn_limit_capacity >= required_tiles, (
+                f"out_tile_idx_to_mn_limit capacity "
+                f"({tile_mn_limit_capacity}) < required ({required_tiles}) "
+                f"at tile_size={tile_size}"
+            )
+
+    def test_prealloc_gate_accepts_all_valid_tile_sizes(self, monkeypatch):
+        """The ``use_prealloc`` gate in ``_forward_with_tactic`` must
+        pass the prealloc'd buffers to ``_moe_core_impl`` for every
+        ``tile_size in VALID_TILE_SIZES``, not just ``self.tile_size``.
+
+        Implementation: monkey-patch the module-level
+        ``_moe_core_impl`` to capture the ``moe_sort_buffers`` /
+        ``gemm1_out`` / ``gemm1_out_scale`` arguments without
+        actually launching kernels. Verify that for every tile_size
+        in the canonical enumeration, the gate decides to pass the
+        prealloc'd buffers (not ``None``).
+        """
+        from flashinfer.fused_moe.cute_dsl import fused_moe as fused_moe_module
+        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
+
+        wrapper = self._make_wrapper(max_num_tokens=128)
+
+        captured = {}  # tile_size -> (moe_sort_buffers_is_prealloc, gemm1_out_is_prealloc)
+
+        def mock_moe_core_impl(*args, **kwargs):
+            ts = kwargs["tile_size"]
+            captured[ts] = {
+                "moe_sort_buffers": kwargs["moe_sort_buffers"]
+                is wrapper._moe_sort_buffers,
+                "gemm1_out": kwargs["gemm1_out"] is wrapper._gemm1_output,
+                "gemm1_out_scale": kwargs["gemm1_out_scale"]
+                is wrapper._gemm1_output_scale,
+            }
+            num_tokens = args[0].shape[0] if args else kwargs["x"].shape[0]
+            return torch.zeros(
+                (num_tokens, wrapper.hidden_size),
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+
+        monkeypatch.setattr(fused_moe_module, "_moe_core_impl", mock_moe_core_impl)
+
+        # Build minimal dummy tensors. _forward_with_tactic just
+        # checks x.shape[0] for the gate; everything else is passed
+        # through to the (mocked) inner function.
+        n = 64  # < max_num_tokens=128 so the gate's batch check passes
+        x = torch.empty((n, wrapper.hidden_size // 2), dtype=torch.uint8, device="cuda")
+        x_sf = torch.empty((n, 1), dtype=torch.uint8, device="cuda")
+        token_selected_experts = torch.zeros(
+            (n, wrapper.top_k), dtype=torch.int32, device="cuda"
+        )
+        token_final_scales = torch.zeros(
+            (n, wrapper.top_k), dtype=torch.float32, device="cuda"
+        )
+        dummy_w = torch.empty((1,), dtype=torch.uint8, device="cuda")
+        dummy_alpha = torch.empty((1,), dtype=torch.float32, device="cuda")
+
+        for tile_size in VALID_TILE_SIZES:
+            wrapper._forward_with_tactic(
+                x=x,
+                x_sf=x_sf,
+                token_selected_experts=token_selected_experts,
+                token_final_scales=token_final_scales,
+                w1_weight=dummy_w,
+                w1_weight_sf=dummy_w,
+                w1_alpha=dummy_alpha,
+                fc2_input_scale=dummy_alpha,
+                w2_weight=dummy_w,
+                w2_weight_sf=dummy_w,
+                w2_alpha=dummy_alpha,
+                num_experts=wrapper.num_experts,
+                top_k=wrapper.top_k,
+                num_local_experts=wrapper.num_local_experts,
+                tile_size=tile_size,
+            )
+
+        for tile_size in VALID_TILE_SIZES:
+            assert tile_size in captured, (
+                f"_forward_with_tactic did not invoke _moe_core_impl "
+                f"for tile_size={tile_size}"
+            )
+            for buf_name, is_prealloc in captured[tile_size].items():
+                assert is_prealloc, (
+                    f"At tile_size={tile_size}, the use_prealloc gate "
+                    f"did not pass the prealloc'd {buf_name} to "
+                    f"_moe_core_impl. The autotuner would see "
+                    f"asymmetric allocation overhead and bias tactic "
+                    f"selection."
+                )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`CuteDslMoEWrapper.__init__` pre-allocates `_gemm1_output`, `_gemm1_output_scale`, and `_moe_sort_buffers` sized for `self.tile_size` only. The `use_prealloc` gate in `_forward_with_tactic` (`fused_moe.py`) is `tile_size == self.tile_size and self.use_cuda_graph and num_tokens <= self.max_num_tokens`, so during autotune profiling the mismatched-`tile_size` tactics fall through to dynamic `torch.empty()` allocation while matching ones run on the prealloc. The autotuner sees **asymmetric allocation overhead** between tactic groups and consistently picks the matching `tile_size` even when intrinsic kernel performance favors the other — at EP=8/16 N=16384, fi locks to `tile_size=128` in 14/14 cache entries while TRT-LLM picks `tile_size=256` more often.

The fix includes three coordinated changes: (1) `tuner.py` lifts the hardcoded `[128, 256]` to a module-level `VALID_TILE_SIZES` tuple — single source of truth for tactic enumeration AND prealloc sizing; (2) `fused_moe.py:_allocate_buffers` sizes buffers to fit any `tile_size in VALID_TILE_SIZES` (`max_num_permuted_tokens` increases with `tile_size` → use `max(VALID_TILE_SIZES)`; `max_num_tiles` decreases → use `min(VALID_TILE_SIZES)`); (3) the prealloc gate becomes `tile_size in VALID_TILE_SIZES`. Both tactic groups now reuse the prealloc; profiling is unbiased.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/3216
https://github.com/flashinfer-ai/flashinfer/pull/3171

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA preallocation gating so preallocated buffers are reused safely when CUDA graphs are enabled, avoiding allocation mismatches across supported tile sizes and improving memory efficiency.

* **New Features**
  * Autotuner now scopes per-tactic timing so preallocation is skipped during measurement windows but used outside them; buffer sizing now supports all valid tile sizes.

* **Tests**
  * Added CPU/GPU tests validating preallocation capacity and correct gating behavior during tuning and inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->