### PR TITLE
Tweak grouped_mm api to make backend specific argument keyword-only

### DIFF
--- a/flashinfer/grouped_mm/core.py
+++ b/flashinfer/grouped_mm/core.py
@@ -41,6 +41,7 @@ def _check_grouped_mm_bf16(
     m_indptr: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ):
@@ -84,6 +85,7 @@ def grouped_mm_bf16(
     m_indptr: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ) -> torch.Tensor:
@@ -154,6 +156,7 @@ def _check_grouped_mm_fp8(
     alpha: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ):
@@ -205,6 +208,7 @@ def grouped_mm_fp8(
     alpha: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ) -> torch.Tensor:
@@ -287,6 +291,7 @@ def _check_grouped_mm_mxfp8(
     m_indptr: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ):
@@ -346,6 +351,7 @@ def grouped_mm_mxfp8(
     m_indptr: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ) -> torch.Tensor:
@@ -425,6 +431,7 @@ def _check_grouped_mm_fp4(
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     block_size: int = 16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ):
@@ -503,6 +510,7 @@ def grouped_mm_fp4(
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     block_size: int = 16,
+    *,
     backend: str = "cudnn",
     tactic: int = -1,
 ) -> torch.Tensor:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Tweak grouped_mm api to make backend specific argument keyword-only

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core third-party dependencies to the latest versions for improved functionality and stability

* **Refactor**
  * Grouped matrix multiplication operations now require all configuration parameters to be specified as keyword-only arguments. This improves API clarity, prevents unintended parameter ordering errors, and enhances overall code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->