### PR TITLE
fix(gemm): exclude cublas from bmm_fp8 heuristic on sm_120 (RTX 5090)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6036,7 +6036,13 @@ def _heuristic_func_bmm_fp8(
         elif is_sm120_supported:
             # supports all K values through padding
             heuristic_backends.append("cutlass_sm12x")
-    if "cublas" in suitable_backends:
+    if "cublas" in suitable_backends and not is_sm120_supported:
+        # cuBLASLt bmm_fp8 returns CUBLAS_STATUS_NOT_SUPPORTED on sm_120 (RTX 5090 /
+        # GeForce Blackwell) for real model tensor shapes.  The autotuner profiles on
+        # small synthetic shapes where cuBLASLt heuristics succeed and incorrectly
+        # selects cublas; at inference time the same kernel fails.
+        # cutlass_sm12x is the correct backend for sm_120 — it handles all K values
+        # via padding and is already added above.
         heuristic_backends.append("cublas")
     if CUDNN_AVAILABLE and "cudnn" in suitable_backends:
         heuristic_backends.append("cudnn")

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5972,7 +5972,7 @@ def _cudnn_bmm_fp8_requirement(
     return True
 
 
-@supported_compute_capability([89, 90, 100, 103, 110, 120, 121])
+@supported_compute_capability([89, 90, 100, 103, 110])
 def _cublas_bmm_fp8_requirement(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -5982,6 +5982,10 @@ def _cublas_bmm_fp8_requirement(
     out: Optional[torch.Tensor] = None,
     backend: Literal["cudnn", "cublas", "cutlass", "auto"] = "cublas",
 ):
+    # sm_120/121 (RTX 5090 / GeForce Blackwell) excluded: cuBLASLt bmm_fp8 returns
+    # CUBLAS_STATUS_NOT_SUPPORTED for real model tensor shapes on sm_120, even though
+    # the autotuner succeeds on the small synthetic shapes used during profiling.
+    # cutlass_sm12x is the correct backend for sm_120 (handles all K values via padding).
     return True
 
 
@@ -6036,13 +6040,10 @@ def _heuristic_func_bmm_fp8(
         elif is_sm120_supported:
             # supports all K values through padding
             heuristic_backends.append("cutlass_sm12x")
+    # cuBLASLt bmm_fp8 is excluded on sm_120/121 (RTX 5090 / GeForce Blackwell):
+    # CUBLAS_STATUS_NOT_SUPPORTED for real model tensor shapes even when the autotuner
+    # succeeds on small synthetic shapes. cutlass_sm12x handles all shapes on sm_120.
     if "cublas" in suitable_backends and not is_sm120_supported:
-        # cuBLASLt bmm_fp8 returns CUBLAS_STATUS_NOT_SUPPORTED on sm_120 (RTX 5090 /
-        # GeForce Blackwell) for real model tensor shapes.  The autotuner profiles on
-        # small synthetic shapes where cuBLASLt heuristics succeed and incorrectly
-        # selects cublas; at inference time the same kernel fails.
-        # cutlass_sm12x is the correct backend for sm_120 — it handles all K values
-        # via padding and is already added above.
         heuristic_backends.append("cublas")
     if CUDNN_AVAILABLE and "cudnn" in suitable_backends:
         heuristic_backends.append("cudnn")


### PR DESCRIPTION
Fixes #3255.

## Problem

`_heuristic_func_bmm_fp8` in `flashinfer/gemm/gemm_base.py` adds `cublas` to the heuristic
candidate list unconditionally — even on sm_120 (RTX 5090 / GeForce Blackwell) where
`cutlass_sm12x` was already selected. The variable `is_sm120_supported` is computed two
lines above the guard but never used to exclude `cublas`.

The autotuner benchmarks on small synthetic shapes where cuBLASLt's heuristic lookup
returns N>0 results, so `cublas` wins the profile. At inference time, on real model tensor
shapes, `bmm_fp8_internal_cublaslt` returns `CUBLAS_STATUS_NOT_SUPPORTED` and crashes:

```
RuntimeError: bmm_fp8_internal_cublaslt failed: CUBLAS_STATUS_NOT_SUPPORTED
  File ".../flashinfer/data/csrc/bmm_fp8.cu", line 57
```

## Fix

```diff
-    if "cublas" in suitable_backends:
+    if "cublas" in suitable_backends and not is_sm120_supported:
         heuristic_backends.append("cublas")
```

`cutlass_sm12x` handles all K values on sm_120 via padding (the existing comment already
documents this). The cublas exclusion lets the autotuner use `cutlass_sm12x` consistently
on sm_120.

## Testing

Tested on RTX 5090 hardware (driver 580.126.09 / CUDA 13.0, flashinfer 0.6.8.post1,
vLLM 0.20.1, model speakleash/Bielik-11B-v2.3-Instruct-FP8, 2× RTX 5090 tensor-parallel):

- **Before**: autotuner selects `cublas`, crashes with `CUBLAS_STATUS_NOT_SUPPORTED`
- **After**: autotuner selects `cutlass_sm12x`, 924-record inference run completes cleanly

Note: this fix targets the heuristic logic only. The pre-built sm_120 AOT kernels are
absent from the cu130/torch2.11 wheel (separate issue #3085); users on CUDA < 12.9 still
need nvcc ≥ 12.9 for JIT compilation. This fix is independent of that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected backend selection for FP8 batched matrix operations on recent SM12x GPUs so the most compatible implementation is chosen, preventing runtime failures and improving stability during matrix workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->