### PR TITLE
[chore] Add guard to blackwell GDN prefill

### DIFF
--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -274,7 +274,10 @@ def chunk_gated_delta_rule(
     _scale = scale if scale is not None and scale != 0.0 else 1.0 / math.sqrt(head_size)
 
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
-    if _has_blackwell_prefill and is_sm100a_supported(device) and _cuda_major >= 13:
+    _is_blackwell = is_sm100a_supported(device)
+    if _is_blackwell and _cuda_major < 13:
+        raise NotImplementedError("Blackwell GDN prefill is only supported on CUDA 13+")
+    elif _has_blackwell_prefill and _is_blackwell and _cuda_major >= 13:
         # Blackwell SM100 and SM103 path (CuTe DSL kernel)
         assert head_size == 128, (
             f"Blackwell GDN prefill requires head_size=128, got {head_size}"

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -27,7 +27,7 @@ from .utils import (
     register_custom_op,
     register_fake_op,
     get_device_sm_count,
-    is_sm100a_supported,
+    get_compute_capability,
     _get_cache_buf,
 )
 from .gdn_kernels import chunk_gated_delta_rule_sm100, _has_blackwell_prefill
@@ -274,10 +274,15 @@ def chunk_gated_delta_rule(
     _scale = scale if scale is not None and scale != 0.0 else 1.0 / math.sqrt(head_size)
 
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
-    _is_blackwell = is_sm100a_supported(device)
-    if _is_blackwell and _cuda_major < 13:
-        raise NotImplementedError("Blackwell GDN prefill is only supported on CUDA 13+")
-    elif _has_blackwell_prefill and _is_blackwell and _cuda_major >= 13:
+    _is_sm100a = get_compute_capability(device)[0] == 10
+    if _is_sm100a:
+        if _cuda_major < 13:
+            raise NotImplementedError(
+                "Blackwell GDN prefill is only supported on CUDA 13+"
+            )
+        if not _has_blackwell_prefill:
+            raise NotImplementedError("Blackwell GDN prefill kernel is unavailable")
+
         # Blackwell SM100 and SM103 path (CuTe DSL kernel)
         assert head_size == 128, (
             f"Blackwell GDN prefill requires head_size=128, got {head_size}"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Raise not implemented error when trying to use blackwell GDN prefill kernel but cuda version earlier than 13

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Blackwell GPU compatibility with clearer validation for CUDA major version.
  * Now surfaces explicit, user-friendly errors when running on unsupported CUDA versions (requires CUDA 13+).
  * Provides distinct error feedback when required Blackwell prefill support is unavailable, reducing ambiguous failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->