### PR TITLE
Add DeepSeek V4 sparse MLA TRTLLM-GEN kernels

### DIFF
--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -36,8 +36,7 @@ template <int32_t TileSizePerCtaQ, int32_t HeadDimPerCta, bool IsE4m3Bmm, typena
 __global__ void __launch_bounds__(NumThreadsPerCta, 2)
     fmhaReductionKernel(KernelParams const params, bool isTokenSparse, bool groupsTokensHeadsQ,
                         bool supportsVarSparseMlaTopKLens, int32_t numCtasForReduction,
-                        int32_t numCtasForAllHeads, int32_t headDimV,
-                        int32_t numHeadDimCtasV) {
+                        int32_t numCtasForAllHeads, int32_t headDimV, int32_t numHeadDimCtasV) {
   // clang-format off
   // The shape of partialO buffer: [batchSize, numHeadCtas, numCtasQ, numCtasKv, TileSizePerCtaQ, headDimPerCta].
   // The shape of final O buffer: [batchSize, numCtasQ, numHeadsQ, headDim].
@@ -285,37 +284,37 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define SELECT_FMHA_REDUCTION_KERNEL(TileSizePerCtaQ, HeadDimPerCta)                              \
-  if (kernelMeta.mDataTypeQ == DATA_TYPE_E4M3) {                                                  \
-    if (kernelMeta.mDataTypeO == DATA_TYPE_E4M3) {                                                \
-      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, __nv_fp8_e4m3, half>;   \
-    } else if (kernelMeta.mDataTypeO == DATA_TYPE_FP16) {                                         \
-      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, half, half>;            \
-    } else if (kernelMeta.mDataTypeO == DATA_TYPE_BF16) {                                         \
-      kernel =                                                                                   \
-          &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, __nv_bfloat16, __nv_bfloat16>; \
-    } else {                                                                                      \
-      FLASHINFER_CHECK(false, "Not implemented");                                                 \
-    }                                                                                             \
-  } else {                                                                                        \
-    FLASHINFER_CHECK(kernelMeta.mDataTypeQ == kernelMeta.mDataTypeO, "Not implemented");          \
-    if (kernelMeta.mDataTypeQ == DATA_TYPE_FP16) {                                                \
-      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, false, half, half>;           \
-    } else if (kernelMeta.mDataTypeQ == DATA_TYPE_BF16) {                                         \
-      kernel =                                                                                   \
-          &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, false, __nv_bfloat16, __nv_bfloat16>; \
-    } else {                                                                                      \
-      FLASHINFER_CHECK(false, "Not implemented");                                                 \
-    }                                                                                             \
+#define SELECT_FMHA_REDUCTION_KERNEL(TileSizePerCtaQ, HeadDimPerCta)                            \
+  if (kernelMeta.mDataTypeQ == DATA_TYPE_E4M3) {                                                \
+    if (kernelMeta.mDataTypeO == DATA_TYPE_E4M3) {                                              \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, __nv_fp8_e4m3, half>; \
+    } else if (kernelMeta.mDataTypeO == DATA_TYPE_FP16) {                                       \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, half, half>;          \
+    } else if (kernelMeta.mDataTypeO == DATA_TYPE_BF16) {                                       \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, __nv_bfloat16,        \
+                                    __nv_bfloat16>;                                             \
+    } else {                                                                                    \
+      FLASHINFER_CHECK(false, "Not implemented");                                               \
+    }                                                                                           \
+  } else {                                                                                      \
+    FLASHINFER_CHECK(kernelMeta.mDataTypeQ == kernelMeta.mDataTypeO, "Not implemented");        \
+    if (kernelMeta.mDataTypeQ == DATA_TYPE_FP16) {                                              \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, false, half, half>;         \
+    } else if (kernelMeta.mDataTypeQ == DATA_TYPE_BF16) {                                       \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, false, __nv_bfloat16,       \
+                                    __nv_bfloat16>;                                             \
+    } else {                                                                                    \
+      FLASHINFER_CHECK(false, "Not implemented");                                               \
+    }                                                                                           \
   }
 
-#define SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(HeadDimPerCta)                         \
-  if (kernelMeta.mTileSizeQ == 64) {                                                              \
-    SELECT_FMHA_REDUCTION_KERNEL(64, HeadDimPerCta);                                              \
-  } else if (kernelMeta.mTileSizeQ == 128) {                                                       \
-    SELECT_FMHA_REDUCTION_KERNEL(128, HeadDimPerCta);                                             \
-  } else {                                                                                         \
-    FLASHINFER_CHECK(false, "Not implemented");                                                   \
+#define SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(HeadDimPerCta) \
+  if (kernelMeta.mTileSizeQ == 64) {                                      \
+    SELECT_FMHA_REDUCTION_KERNEL(64, HeadDimPerCta);                      \
+  } else if (kernelMeta.mTileSizeQ == 128) {                              \
+    SELECT_FMHA_REDUCTION_KERNEL(128, HeadDimPerCta);                     \
+  } else {                                                                \
+    FLASHINFER_CHECK(false, "Not implemented");                           \
   }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -403,7 +402,12 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
 
   // Launch the kernel.
   bool const supportsVarSparseMlaTopKLens =
-      kernelMeta.mSparseAttn == 2 && kernelMeta.mHeadDimQk == 512 && kernelMeta.mHeadDimV == 512;
+      isDynamicTokenSparseMla(static_cast<TrtllmGenSparseMlaType>(kernelMeta.mSparseAttn)) &&
+      kernelMeta.mHeadDimQk == 512 && kernelMeta.mHeadDimV == 512;
+  if (supportsVarSparseMlaTopKLens) {
+    FLASHINFER_CHECK(params.ptrSparseMlaTopKLens != nullptr,
+                     "Dynamic sparse MLA reduction requires sparseMlaTopkLengths.");
+  }
   cudaLaunchKernelEx(&config, kernel, params, kernelMeta.mSparseAttn != 0,
                      kernelMeta.mGroupsTokensHeadsQ, supportsVarSparseMlaTopKLens,
                      numCtasForReduction, numCtasForAllHeads, kernelMeta.mHeadDimV,

--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -31,11 +31,13 @@ namespace kernels {
 
 #define NumThreadsPerCta 512
 
-template <int32_t TileSizePerCtaQ, int32_t HeadDim, int32_t HeadDimPerCta, bool IsE4m3Bmm,
-          typename DtypeO, typename DtypePartialO>
+template <int32_t TileSizePerCtaQ, int32_t HeadDimPerCta, bool IsE4m3Bmm, typename DtypeO,
+          typename DtypePartialO>
 __global__ void __launch_bounds__(NumThreadsPerCta, 2)
-    fmhaReductionKernel(KernelParams const params, bool sparseMla, int32_t numCtasForReduction,
-                        int32_t numCtasForAllHeads, int32_t numHeadDimCtasV) {
+    fmhaReductionKernel(KernelParams const params, bool isTokenSparse, bool groupsTokensHeadsQ,
+                        bool supportsVarSparseMlaTopKLens, int32_t numCtasForReduction,
+                        int32_t numCtasForAllHeads, int32_t headDimV,
+                        int32_t numHeadDimCtasV) {
   // clang-format off
   // The shape of partialO buffer: [batchSize, numHeadCtas, numCtasQ, numCtasKv, TileSizePerCtaQ, headDimPerCta].
   // The shape of final O buffer: [batchSize, numCtasQ, numHeadsQ, headDim].
@@ -57,30 +59,38 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   int32_t const ctaIdxQ{static_cast<int32_t>(blockIdx.x % params.mMaxNumCtasQ)};
   // The ctaIdx for the reduction work.
   int32_t const ctaIdxForReduction{static_cast<int32_t>(blockIdx.x / params.mMaxNumCtasQ)};
+  // The numHeadsQPerKvCta.
+  int32_t const numHeadsQPerKvCta{min(params.mNumHeadsQPerKv, TileSizePerCtaQ)};
   // The headIdxO.
-  int32_t const headIdxO{headGrpIdxO * TileSizePerCtaQ};
+  int32_t const headIdxO{headGrpIdxO * numHeadsQPerKvCta};
   // The warpGrpThreadIdx.
   int32_t const warpGrpThreadIdx{static_cast<int32_t>(threadIdx.x)};
 
-  // The number of validRows.
-  int32_t const numValidRows{TileSizePerCtaQ};
   // The seqOffsetQ.
-  int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr ? batchIdx * params.mMaxSeqLenQ
+  int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr ? batchIdx * params.mMaxNumCtasQ
                                                             : params.ptrCumSeqLensQ[batchIdx]};
   // The seqLenQ.
   int32_t const seqLenQ{params.ptrCumSeqLensQ == nullptr
                             ? params.mMaxSeqLenQ
                             : (params.ptrCumSeqLensQ[batchIdx + 1] - seqOffsetQ)};
-  // Early exit if ctaIdxQ >= seqLenQ, where each CTA processes one tokenQ.
-  if (ctaIdxQ >= seqLenQ) {
+  // The number of validTokens.
+  int32_t const numValidTokens{
+      min(seqLenQ - ctaIdxQ * params.mNumTokensPerCtaQ, params.mNumTokensPerCtaQ)};
+  // The number of validRows.
+  int32_t const numValidRows{numValidTokens * numHeadsQPerKvCta};
+  // Early exit if there are no valid tokens.
+  if (numValidTokens <= 0) {
     return;
   }
+
   // The actual number of seqLenKv.
   int32_t seqLenKv{params.ptrSeqLensKv[batchIdx]};
   // Consider the causal-mask speculative decoding.
   seqLenKv = seqLenKv - ((params.mMaxSeqLenQ - 1) - ctaIdxQ);
-  // Consider sparseMlaTopK.
-  if (sparseMla) {
+  // Consider sparseAttnTopK and variable sparse MLA topK lengths.
+  if (supportsVarSparseMlaTopKLens) {
+    seqLenKv = params.ptrSparseMlaTopKLens[seqOffsetQ + ctaIdxQ * params.mNumTokensPerCtaQ];
+  } else if (isTokenSparse) {
     seqLenKv = min(seqLenKv, params.mSparseAttnTopK);
   }
   // The actual number of CtasKv (TileSizeKv is always 128 for now).
@@ -96,10 +106,10 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   int64_t const partialOOffset{partialStatsOffset * HeadDimPerCta};
   // The offset of the softmaxStats buffer.
   int64_t const softmaxStatsOffset{
-      ((batchIdx * params.mMaxNumCtasQ + ctaIdxQ) * numCtasForAllHeads + headGrpIdxO) *
-      TileSizePerCtaQ};
+      ((seqOffsetQ + ctaIdxQ * params.mNumTokensPerCtaQ) * numCtasForAllHeads + headGrpIdxO) *
+      numHeadsQPerKvCta};
   // The offset of the O buffer.
-  int64_t const oOffset{softmaxStatsOffset * HeadDim + headDimCtaIdxV * HeadDimPerCta};
+  int64_t const oOffset{softmaxStatsOffset * headDimV + headDimCtaIdxV * HeadDimPerCta};
 
   // The partialStats pointer.
   float2* partialStatsPtr = reinterpret_cast<float2*>(params.ptrPartialStats) + partialStatsOffset;
@@ -111,7 +121,8 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   // The O pointer.
   DtypeO* oPtr = reinterpret_cast<DtypeO*>(params.ptrO) + oOffset;
   // The attentionSinks pointer.
-  float const* attentionSinksPtr = params.ptrAttentionSinks + headIdxO;
+  float const* attentionSinksPtr =
+      params.ptrAttentionSinks == nullptr ? nullptr : params.ptrAttentionSinks + headIdxO;
 
   // Whether to store the softmax stats.
   bool const storesSoftmaxStats{params.ptrSoftmaxStats != nullptr};
@@ -165,9 +176,19 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
     // The memory load offset.
     int64_t const destMemOffset{loadRowIdx * HeadDimPerCta + headDimIdx};
     // The memory store offset.
-    int64_t gmemStoreOffset{validRowIdx * HeadDim + headDimIdx};
+    int64_t gmemStoreOffset{validRowIdx * headDimV + headDimIdx};
     // The local headIdxO.
     int32_t localHeadIdxO{validRowIdx};
+    // The rowIdx of softmaxStats.
+    int32_t softmaxStatsRowIdx{validRowIdx};
+    // If grouping both tokens and headsQ, map validRowIdx into tokenIdx and headIdxInGrp.
+    if (groupsTokensHeadsQ) {
+      int32_t tokenIdx{validRowIdx / params.mNumHeadsQPerKv};
+      int32_t headIdxInGrp{validRowIdx % params.mNumHeadsQPerKv};
+      localHeadIdxO = headIdxInGrp;
+      softmaxStatsRowIdx = tokenIdx * params.mNumHeadsQ + headIdxInGrp;
+      gmemStoreOffset = int64_t(softmaxStatsRowIdx) * headDimV + headDimIdx;
+    }
 
 // Wait for the primary kernel to complete.
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -235,7 +256,7 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
       // The final max and sum values.
       float2 stats{maxVal * softmaxScale, sumVal * sumScale};
       // Store the final max and sum values to global memory.
-      reinterpret_cast<float2*>(softmaxStatsPtr)[validRowIdx] = stats;
+      reinterpret_cast<float2*>(softmaxStatsPtr)[softmaxStatsRowIdx] = stats;
     }
 
     // The final normalized scale.
@@ -264,26 +285,37 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define SELECT_FMHA_REDUCTION_KERNEL(HeadDimPerCta)                                               \
+#define SELECT_FMHA_REDUCTION_KERNEL(TileSizePerCtaQ, HeadDimPerCta)                              \
   if (kernelMeta.mDataTypeQ == DATA_TYPE_E4M3) {                                                  \
     if (kernelMeta.mDataTypeO == DATA_TYPE_E4M3) {                                                \
-      kernel = &fmhaReductionKernel<64, 512, HeadDimPerCta, true, __nv_fp8_e4m3, half>;           \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, __nv_fp8_e4m3, half>;   \
     } else if (kernelMeta.mDataTypeO == DATA_TYPE_FP16) {                                         \
-      kernel = &fmhaReductionKernel<64, 512, HeadDimPerCta, true, half, half>;                    \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, half, half>;            \
     } else if (kernelMeta.mDataTypeO == DATA_TYPE_BF16) {                                         \
-      kernel = &fmhaReductionKernel<64, 512, HeadDimPerCta, true, __nv_bfloat16, __nv_bfloat16>;  \
+      kernel =                                                                                   \
+          &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, true, __nv_bfloat16, __nv_bfloat16>; \
     } else {                                                                                      \
       FLASHINFER_CHECK(false, "Not implemented");                                                 \
     }                                                                                             \
   } else {                                                                                        \
     FLASHINFER_CHECK(kernelMeta.mDataTypeQ == kernelMeta.mDataTypeO, "Not implemented");          \
     if (kernelMeta.mDataTypeQ == DATA_TYPE_FP16) {                                                \
-      kernel = &fmhaReductionKernel<64, 512, HeadDimPerCta, false, half, half>;                   \
+      kernel = &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, false, half, half>;           \
     } else if (kernelMeta.mDataTypeQ == DATA_TYPE_BF16) {                                         \
-      kernel = &fmhaReductionKernel<64, 512, HeadDimPerCta, false, __nv_bfloat16, __nv_bfloat16>; \
+      kernel =                                                                                   \
+          &fmhaReductionKernel<TileSizePerCtaQ, HeadDimPerCta, false, __nv_bfloat16, __nv_bfloat16>; \
     } else {                                                                                      \
       FLASHINFER_CHECK(false, "Not implemented");                                                 \
     }                                                                                             \
+  }
+
+#define SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(HeadDimPerCta)                         \
+  if (kernelMeta.mTileSizeQ == 64) {                                                              \
+    SELECT_FMHA_REDUCTION_KERNEL(64, HeadDimPerCta);                                              \
+  } else if (kernelMeta.mTileSizeQ == 128) {                                                       \
+    SELECT_FMHA_REDUCTION_KERNEL(128, HeadDimPerCta);                                             \
+  } else {                                                                                         \
+    FLASHINFER_CHECK(false, "Not implemented");                                                   \
   }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -296,26 +328,32 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
     return;
   }
 
-  // This should only be enabled when the keepsMmaAbForGeneration MLA kernel (either 1-CTA or 2-CTA)
-  // is used.
+  // This should only be enabled when using keepsMmaAbForGeneration kernel.
   FLASHINFER_CHECK(
-      kernelMeta.mHeadDimQk == 576 && kernelMeta.mHeadDimV == 512 &&
-          isKeepsMmaAbForGenerationKernel(static_cast<FmhaKernelType>(kernelMeta.mKernelType)),
+      isKeepsMmaAbForGenerationKernel(static_cast<FmhaKernelType>(kernelMeta.mKernelType)),
       "Not implemented");
-  // The tileSizeQ and tileSizeKv should be 64 and 128 for those kernels.
-  FLASHINFER_CHECK(kernelMeta.mTileSizeQ == 64 && kernelMeta.mTileSizeKv == 128, "Not implemented");
+  // The tileSizeQ should be 64 or 128 and tileSizeKv should be 128 for those kernels.
+  FLASHINFER_CHECK((kernelMeta.mTileSizeQ == 64 || kernelMeta.mTileSizeQ == 128) &&
+                       kernelMeta.mTileSizeKv == 128,
+                   "Not implemented");
 
   // The headDimPerCtaV.
   int32_t const headDimPerCtaV =
       kernelMeta.m2CtaMma ? kernelMeta.mHeadDimPerCtaV * 2 : kernelMeta.mHeadDimPerCtaV;
-  FLASHINFER_CHECK(headDimPerCtaV == 128 || headDimPerCtaV == 256 || headDimPerCtaV == 512,
+  FLASHINFER_CHECK(headDimPerCtaV == 64 || headDimPerCtaV == 128 || headDimPerCtaV == 256 ||
+                       headDimPerCtaV == 512,
                    "Not implemented");
 
   // The number of slices for the reduction work.
   int32_t const numSlices = (headDimPerCtaV * /* bytesPerPartialElt */ 2 * kernelMeta.mTileSizeQ) /
                             (NumThreadsPerCta * 16);
+  // The number of heads computed by a single CTA.
+  int numHeadsPerCta{1};
+  if (kernelMeta.mGroupsHeadsQ) {
+    numHeadsPerCta = std::min(params.mNumHeadsQPerKv, kernelMeta.mTileSizeQ);
+  }
   // The number of Ctas for all heads.
-  int32_t const numCtasForAllHeads{params.mNumHeadsQ / kernelMeta.mTileSizeQ};
+  int32_t const numCtasForAllHeads{params.mNumHeadsQ / numHeadsPerCta};
   // The number of Ctas for headDim.
   int32_t const numHeadDimCtasV{kernelMeta.mHeadDimV / headDimPerCtaV};
 
@@ -351,18 +389,25 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
   config.numAttrs = 1;
 
   // Select the kernel function pointer.
-  void (*kernel)(KernelParams const, bool, int32_t, int32_t, int32_t) = nullptr;
-  if (headDimPerCtaV == 128) {
-    SELECT_FMHA_REDUCTION_KERNEL(128);
+  void (*kernel)(KernelParams const, bool, bool, bool, int32_t, int32_t, int32_t, int32_t) =
+      nullptr;
+  if (headDimPerCtaV == 64) {
+    SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(64);
+  } else if (headDimPerCtaV == 128) {
+    SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(128);
   } else if (headDimPerCtaV == 256) {
-    SELECT_FMHA_REDUCTION_KERNEL(256);
+    SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(256);
   } else if (headDimPerCtaV == 512) {
-    SELECT_FMHA_REDUCTION_KERNEL(512);
+    SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(512);
   }
 
   // Launch the kernel.
-  cudaLaunchKernelEx(&config, kernel, params, kernelMeta.mSparseAttn != 0, numCtasForReduction,
-                     numCtasForAllHeads, numHeadDimCtasV);
+  bool const supportsVarSparseMlaTopKLens =
+      kernelMeta.mSparseAttn == 2 && kernelMeta.mHeadDimQk == 512 && kernelMeta.mHeadDimV == 512;
+  cudaLaunchKernelEx(&config, kernel, params, kernelMeta.mSparseAttn != 0,
+                     kernelMeta.mGroupsTokensHeadsQ, supportsVarSparseMlaTopKLens,
+                     numCtasForReduction, numCtasForAllHeads, kernelMeta.mHeadDimV,
+                     numHeadDimCtasV);
   cudaError_t err = cudaGetLastError();
   FLASHINFER_CHECK(err == cudaSuccess, "Failed to launch kernel: ", cudaGetErrorString(err));
 }

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -187,9 +187,11 @@ void trtllm_paged_attention_launcher(
           : (sparse_mla_top_k_lens != nullptr ? TrtllmGenSparseMlaType::DynamicTokenSparse
                                               : TrtllmGenSparseMlaType::StaticTokenSparse);
   runner_params.mSparseMlaTopK = sparse_mla_top_k;
-  bool const is_mla_decode =
-      (head_dim_qk == 576 && head_dim_vo == 512) || (head_dim_qk == 320 && head_dim_vo == 256) ||
-      (head_dim_qk == 512 && head_dim_vo == 512);
+  bool const is_dsv4_sparse_mla_decode =
+      isSparseMla(runner_params.mSparseMlaType) && head_dim_qk == 512 && head_dim_vo == 512;
+  bool const is_mla_decode = (head_dim_qk == 576 && head_dim_vo == 512) ||
+                             (head_dim_qk == 320 && head_dim_vo == 256) ||
+                             is_dsv4_sparse_mla_decode;
   runner_params.sparseMlaTopKLensPtr = sparse_mla_top_k_lens;
   runner_params.mHasSlidingWindowKvPool = has_sliding_window_kv_pool;
   TVM_FFI_ICHECK(is_mla_decode || sparse_mla_top_k <= 0) << "Only decode MLA supports sparse MLA";
@@ -866,14 +868,15 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
 
   int const sparse_mla_top_k = sparse_indices.size(-1);
   TVM_FFI_ICHECK((sparse_mla_top_k % 4) == 0) << "sparse topK must be a multiple of 4";
-  int const page_size = primary_kv_cache.size(-2);
+  int const physical_page_size = primary_kv_cache.size(-2);
+  int const sparse_page_size = 1;
   int const stride_idx_factor = is_4bit(kv_data_type) ? 2 : 1;
   int const kv_stride_keys_values = primary_kv_cache.stride(-2) * stride_idx_factor;
   int const kv_stride_heads = primary_kv_cache.stride(-3) * stride_idx_factor;
-  int const kv_stride_batch = primary_kv_cache.stride(0) * stride_idx_factor;
+  int const sparse_kv_stride_batch = kv_stride_keys_values;
   int const q_stride_tokens = query.stride(0);
   int const q_stride_heads = query.stride(1);
-  int const num_pages_in_mem_pool = primary_kv_cache.size(0);
+  int const sparse_num_pages_in_mem_pool = primary_kv_cache.size(0) * physical_page_size;
 
   float* attention_sinks_ptr = nullptr;
   if (attention_sinks.has_value()) {
@@ -910,10 +913,11 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
       /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, /*lse=*/nullptr, q_data_type, kv_data_type,
       o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,
-      /*max_kv_len=*/sparse_mla_top_k, num_pages_in_mem_pool, num_qo_heads, num_kv_heads,
-      head_dim_q, head_dim_o, page_size, q_stride_tokens, q_stride_heads, kv_stride_keys_values,
-      kv_stride_heads, kv_stride_batch, /*max_num_blocks_per_seq=*/sparse_mla_top_k,
-      bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr, bmm2_scale_ptr,
+      /*max_kv_len=*/sparse_mla_top_k, sparse_num_pages_in_mem_pool, num_qo_heads, num_kv_heads,
+      head_dim_q, head_dim_o, sparse_page_size, q_stride_tokens, q_stride_heads,
+      kv_stride_keys_values, kv_stride_heads, sparse_kv_stride_batch,
+      /*max_num_blocks_per_seq=*/sparse_mla_top_k, bmm1_scale_value, bmm2_scale_value,
+      bmm1_scale_log2_ptr, bmm2_scale_ptr,
       /*o_sf_scale=*/-1.0, /*o_sf_vec_size=*/-1, /*o_sf_start_index=*/0,
       /*window_left=*/127, sum_seq_q, sparse_mla_top_k, sliding_window_kv_cache.data_ptr(),
       static_cast<int*>(sparse_mla_top_k_lens.data_ptr()), /*has_sliding_window_kv_pool=*/true,

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -182,11 +182,10 @@ void trtllm_paged_attention_launcher(
 
   // The sparse MLA parameters.
   runner_params.mSparseMlaType =
-      sparse_mla_top_k <= 0 ? TrtllmGenSparseMlaType::None
-                            : (sparse_mla_top_k_lens != nullptr
-                                   ? TrtllmGenSparseMlaType::DynamicTokenSparse
-                                   : TrtllmGenSparseMlaType::StaticTokenSparse);
-  runner_params.mSparseMla = isSparseMla(runner_params.mSparseMlaType);
+      sparse_mla_top_k <= 0
+          ? TrtllmGenSparseMlaType::None
+          : (sparse_mla_top_k_lens != nullptr ? TrtllmGenSparseMlaType::DynamicTokenSparse
+                                              : TrtllmGenSparseMlaType::StaticTokenSparse);
   runner_params.mSparseMlaTopK = sparse_mla_top_k;
   bool const is_mla_decode =
       (head_dim_qk == 576 && head_dim_vo == 512) || (head_dim_qk == 320 && head_dim_vo == 256) ||
@@ -805,8 +804,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
     TensorView sliding_window_kv_cache, TensorView workspace_buffer, TensorView sparse_indices,
     TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
     Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
-    int64_t sm_count, bool enable_pdl, int64_t workspace_size,
-    Optional<TensorView> attention_sinks, Optional<TensorView> cum_seq_lens_q) {
+    int64_t sm_count, bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
+    Optional<TensorView> cum_seq_lens_q) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(primary_kv_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
@@ -845,6 +844,10 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   if (is_varlen_q) {
     TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().ndim(), 1);
     TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().dtype(), dl_int32);
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().device().device_type, query.device().device_type)
+        << "cum_seq_lens_q must be on the same device as query";
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().device().device_id, query.device().device_id)
+        << "cum_seq_lens_q must be on the same device as query";
     TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().size(0), batch_size + 1);
   } else {
     TVM_FFI_ICHECK_EQ(sum_seq_q, batch_size * max_q_len);
@@ -853,8 +856,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   int const head_dim_q = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
   int const head_dim_k =
       is_4bit(kv_data_type) ? primary_kv_cache.size(-1) * 2 : primary_kv_cache.size(-1);
-  int const head_dim_sw = is_4bit(q_data_type) ? sliding_window_kv_cache.size(-1) * 2
-                                               : sliding_window_kv_cache.size(-1);
+  int const head_dim_sw = is_4bit(kv_data_type) ? sliding_window_kv_cache.size(-1) * 2
+                                                : sliding_window_kv_cache.size(-1);
   int const head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
   TVM_FFI_ICHECK_EQ(head_dim_q, 512);
   TVM_FFI_ICHECK_EQ(head_dim_k, 512);
@@ -904,9 +907,9 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       out.data_ptr(), /*out_scale_factor=*/nullptr, query.data_ptr(), primary_kv_cache.data_ptr(),
       primary_kv_cache.data_ptr(), workspace_buffer.data_ptr(),
       static_cast<int*>(sparse_indices.data_ptr()), /*k_block_scales_ptr=*/nullptr,
-      /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()),
-      cum_seq_lens_q_ptr, /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, q_data_type,
-      kv_data_type, o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,
+      /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
+      /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, /*lse=*/nullptr, q_data_type, kv_data_type,
+      o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,
       /*max_kv_len=*/sparse_mla_top_k, num_pages_in_mem_pool, num_qo_heads, num_kv_heads,
       head_dim_q, head_dim_o, page_size, q_stride_tokens, q_stride_heads, kv_stride_keys_values,
       kv_stride_heads, kv_stride_batch, /*max_num_blocks_per_seq=*/sparse_mla_top_k,
@@ -917,7 +920,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       /*skip_softmax_threshold_scale_factor=*/0.0f, /*skips_softmax=*/false,
       /*uses_shared_paged_kv_idx=*/true, sm_count, enable_pdl, workspace_size,
       /*k_sf_stride_heads=*/0, /*k_sf_stride_batch=*/0, /*v_sf_stride_heads=*/0,
-      /*v_sf_stride_batch=*/0, /*is_causal=*/true, stream);
+      /*v_sf_stride_batch=*/0, /*is_causal=*/true, /*lse_stride_tokens=*/0,
+      /*lse_stride_heads=*/0, stream);
 }
 
 namespace trtllm_cubin_loader {

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -105,7 +105,8 @@ void trtllm_paged_attention_launcher(
     int64_t kv_stride_batch, int64_t max_num_blocks_per_seq, double bmm1_scale, double bmm2_scale,
     const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
     int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t window_left, int64_t sum_seq_q,
-    int64_t sparse_mla_top_k, float skip_softmax_threshold_scale_factor, bool skips_softmax,
+    int64_t sparse_mla_top_k, void* sliding_window_kv_pool, int* sparse_mla_top_k_lens,
+    bool has_sliding_window_kv_pool, float skip_softmax_threshold_scale_factor, bool skips_softmax,
     bool uses_shared_paged_kv_idx, int64_t sm_count, bool enable_pdl, int64_t workspace_size,
     int64_t k_sf_stride_heads, int64_t k_sf_stride_batch, int64_t v_sf_stride_heads,
     int64_t v_sf_stride_batch, bool is_causal, int64_t lse_stride_tokens, int64_t lse_stride_heads,
@@ -126,6 +127,7 @@ void trtllm_paged_attention_launcher(
   runner_params.qPtr = query;
   runner_params.kPtr = key_cache;
   runner_params.vPtr = value_cache;
+  runner_params.slidingWindowKvPoolPtr = sliding_window_kv_pool;
   runner_params.kvPageIdxPtr = block_tables;
   runner_params.kSfBasePtr = k_block_scales_ptr;
   runner_params.vSfBasePtr = v_block_scales_ptr;
@@ -179,10 +181,18 @@ void trtllm_paged_attention_launcher(
   runner_params.enable_pdl = enable_pdl;
 
   // The sparse MLA parameters.
-  runner_params.mSparseMla = sparse_mla_top_k > 0;
+  runner_params.mSparseMlaType =
+      sparse_mla_top_k <= 0 ? TrtllmGenSparseMlaType::None
+                            : (sparse_mla_top_k_lens != nullptr
+                                   ? TrtllmGenSparseMlaType::DynamicTokenSparse
+                                   : TrtllmGenSparseMlaType::StaticTokenSparse);
+  runner_params.mSparseMla = isSparseMla(runner_params.mSparseMlaType);
   runner_params.mSparseMlaTopK = sparse_mla_top_k;
   bool const is_mla_decode =
-      (head_dim_qk == 576 && head_dim_vo == 512) || (head_dim_qk == 320 && head_dim_vo == 256);
+      (head_dim_qk == 576 && head_dim_vo == 512) || (head_dim_qk == 320 && head_dim_vo == 256) ||
+      (head_dim_qk == 512 && head_dim_vo == 512);
+  runner_params.sparseMlaTopKLensPtr = sparse_mla_top_k_lens;
+  runner_params.mHasSlidingWindowKvPool = has_sliding_window_kv_pool;
   TVM_FFI_ICHECK(is_mla_decode || sparse_mla_top_k <= 0) << "Only decode MLA supports sparse MLA";
 
   AlignedAllocator float_allocator(workspace_buffer, workspace_size);
@@ -421,10 +431,11 @@ void trtllm_paged_attention_decode(
       q_stride_tokens, q_stride_heads, kv_stride_keys_values, kv_stride_heads, kv_stride_batch,
       max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr,
       bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
-      sparse_mla_top_k, skip_softmax_threshold_scale_factor_value, skips_softmax,
-      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
-      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, /*is_causal=*/true,
-      lse_stride_tokens, lse_stride_heads, stream);
+      sparse_mla_top_k, /*sliding_window_kv_pool=*/nullptr,
+      /*sparse_mla_top_k_lens=*/nullptr, /*has_sliding_window_kv_pool=*/false,
+      skip_softmax_threshold_scale_factor_value, skips_softmax, uses_shared_paged_kv_idx_value,
+      sm_count, enable_pdl, workspace_size, k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads,
+      v_sf_stride_batch, /*is_causal=*/true, lse_stride_tokens, lse_stride_heads, stream);
 }
 
 void trtllm_paged_attention_context(
@@ -557,10 +568,11 @@ void trtllm_paged_attention_context(
       head_dim_o, page_size, q_stride_tokens, q_stride_heads, kv_stride_keys_values,
       kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value,
       bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left,
-      sum_seq_q, /*sparse_mla_top_k=*/0, skip_softmax_threshold_scale_factor_value, skips_softmax,
-      uses_shared_paged_kv_idx_value, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
-      k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, is_causal, lse_stride_tokens,
-      lse_stride_heads, stream);
+      sum_seq_q, /*sparse_mla_top_k=*/0, /*sliding_window_kv_pool=*/nullptr,
+      /*sparse_mla_top_k_lens=*/nullptr, /*has_sliding_window_kv_pool=*/false,
+      skip_softmax_threshold_scale_factor_value, skips_softmax, uses_shared_paged_kv_idx_value,
+      sm_count, enable_pdl, workspace_size, k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads,
+      v_sf_stride_batch, is_causal, lse_stride_tokens, lse_stride_heads, stream);
 }
 
 void trtllm_ragged_attention_launcher(
@@ -788,12 +800,134 @@ void trtllm_ragged_attention(
       static_cast<int>(num_elts_per_sage_attn_blk_v), lse_stride_tokens, lse_stride_heads, stream);
 }
 
+void trtllm_paged_attention_decode_sparse_mla_dsv4(
+    TensorView out, TensorView query, TensorView primary_kv_cache,
+    TensorView sliding_window_kv_cache, TensorView workspace_buffer, TensorView sparse_indices,
+    TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
+    Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
+    int64_t sm_count, bool enable_pdl, int64_t workspace_size,
+    Optional<TensorView> attention_sinks, Optional<TensorView> cum_seq_lens_q) {
+  auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
+  auto kv_data_type = dl_dtype_to_tllm_data_type(primary_kv_cache.dtype());
+  auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
+
+  TVM_FFI_ICHECK(query.ndim() == 3) << "query must have shape [B*Q, H, D]";
+  TVM_FFI_ICHECK(primary_kv_cache.ndim() == 4)
+      << "primary_kv_cache must have HND shape [pages, heads, page_size, D]";
+  TVM_FFI_ICHECK(sliding_window_kv_cache.ndim() == 4)
+      << "sliding_window_kv_cache must have HND shape [pages, heads, page_size, D]";
+  TVM_FFI_ICHECK_EQ(sparse_indices.ndim(), 2)
+      << "sparse_indices must have flattened shape [sumQ, topK]";
+  TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(sparse_mla_top_k_lens.ndim(), 1)
+      << "sparse_mla_top_k_lens must have flattened shape [sumQ]";
+  TVM_FFI_ICHECK(q_data_type == Data_type::DATA_TYPE_BF16 ||
+                 q_data_type == Data_type::DATA_TYPE_E4M3)
+      << "DeepSeek V4 sparse MLA only supports BF16 or FP8 E4M3 query";
+  TVM_FFI_ICHECK_EQ(kv_data_type, q_data_type) << "primary_kv_cache dtype must match query dtype";
+  TVM_FFI_ICHECK_EQ(dl_dtype_to_tllm_data_type(sliding_window_kv_cache.dtype()), q_data_type)
+      << "sliding_window_kv_cache dtype must match query dtype";
+  TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_BF16)
+      << "DeepSeek V4 sparse MLA output must be BF16";
+
+  int const sum_seq_q = query.size(0);
+  int const num_qo_heads = query.size(1);
+  int const num_kv_heads = primary_kv_cache.size(-3);
+  bool const is_varlen_q = cum_seq_lens_q.has_value();
+  int* cum_seq_lens_q_ptr =
+      is_varlen_q ? static_cast<int*>(cum_seq_lens_q.value().data_ptr()) : nullptr;
+  TVM_FFI_ICHECK_EQ(num_kv_heads, 1) << "DeepSeek V4 sparse MLA expects one KV head";
+  TVM_FFI_ICHECK_EQ(sliding_window_kv_cache.size(-3), 1)
+      << "sliding_window_kv_cache must have one KV head";
+  TVM_FFI_ICHECK_EQ(seq_lens.size(0), batch_size);
+  TVM_FFI_ICHECK_EQ(sparse_indices.size(0), sum_seq_q);
+  TVM_FFI_ICHECK_EQ(sparse_mla_top_k_lens.size(0), sum_seq_q);
+  if (is_varlen_q) {
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().ndim(), 1);
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().dtype(), dl_int32);
+    TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().size(0), batch_size + 1);
+  } else {
+    TVM_FFI_ICHECK_EQ(sum_seq_q, batch_size * max_q_len);
+  }
+
+  int const head_dim_q = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
+  int const head_dim_k =
+      is_4bit(kv_data_type) ? primary_kv_cache.size(-1) * 2 : primary_kv_cache.size(-1);
+  int const head_dim_sw = is_4bit(q_data_type) ? sliding_window_kv_cache.size(-1) * 2
+                                               : sliding_window_kv_cache.size(-1);
+  int const head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
+  TVM_FFI_ICHECK_EQ(head_dim_q, 512);
+  TVM_FFI_ICHECK_EQ(head_dim_k, 512);
+  TVM_FFI_ICHECK_EQ(head_dim_sw, 512);
+  TVM_FFI_ICHECK_EQ(head_dim_o, 512);
+
+  int const sparse_mla_top_k = sparse_indices.size(-1);
+  TVM_FFI_ICHECK((sparse_mla_top_k % 4) == 0) << "sparse topK must be a multiple of 4";
+  int const page_size = primary_kv_cache.size(-2);
+  int const stride_idx_factor = is_4bit(kv_data_type) ? 2 : 1;
+  int const kv_stride_keys_values = primary_kv_cache.stride(-2) * stride_idx_factor;
+  int const kv_stride_heads = primary_kv_cache.stride(-3) * stride_idx_factor;
+  int const kv_stride_batch = primary_kv_cache.stride(0) * stride_idx_factor;
+  int const q_stride_tokens = query.stride(0);
+  int const q_stride_heads = query.stride(1);
+  int const num_pages_in_mem_pool = primary_kv_cache.size(0);
+
+  float* attention_sinks_ptr = nullptr;
+  if (attention_sinks.has_value()) {
+    TVM_FFI_ICHECK_EQ(attention_sinks.value().dtype(), dl_float32)
+        << "attention_sinks must be a float tensor";
+    attention_sinks_ptr = static_cast<float*>(attention_sinks.value().data_ptr());
+  }
+
+  auto maybe_bmm1_scale_value = bmm1_scale.as<double>();
+  auto maybe_bmm2_scale_value = bmm2_scale.as<double>();
+  auto maybe_bmm1_scale_log2_tensor = bmm1_scale.as<ffi::Tensor>();
+  auto maybe_bmm2_scale_tensor = bmm2_scale.as<ffi::Tensor>();
+  TVM_FFI_CHECK(maybe_bmm1_scale_value.has_value() || maybe_bmm1_scale_log2_tensor.has_value(),
+                "bmm1_scale must be either a double or a tensor");
+  TVM_FFI_CHECK(maybe_bmm2_scale_value.has_value() || maybe_bmm2_scale_tensor.has_value(),
+                "bmm2_scale must be either a double or a tensor");
+  double bmm1_scale_value =
+      maybe_bmm1_scale_value.has_value() ? maybe_bmm1_scale_value.value() : 1.0;
+  double bmm2_scale_value =
+      maybe_bmm2_scale_value.has_value() ? maybe_bmm2_scale_value.value() : 1.0;
+  float* bmm1_scale_log2_ptr =
+      maybe_bmm1_scale_log2_tensor.has_value()
+          ? static_cast<float*>(maybe_bmm1_scale_log2_tensor.value().data_ptr())
+          : nullptr;
+  float* bmm2_scale_ptr = maybe_bmm2_scale_tensor.has_value()
+                              ? static_cast<float*>(maybe_bmm2_scale_tensor.value().data_ptr())
+                              : nullptr;
+
+  auto const stream = get_stream(query.device());
+  trtllm_paged_attention_launcher(
+      out.data_ptr(), /*out_scale_factor=*/nullptr, query.data_ptr(), primary_kv_cache.data_ptr(),
+      primary_kv_cache.data_ptr(), workspace_buffer.data_ptr(),
+      static_cast<int*>(sparse_indices.data_ptr()), /*k_block_scales_ptr=*/nullptr,
+      /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()),
+      cum_seq_lens_q_ptr, /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, q_data_type,
+      kv_data_type, o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,
+      /*max_kv_len=*/sparse_mla_top_k, num_pages_in_mem_pool, num_qo_heads, num_kv_heads,
+      head_dim_q, head_dim_o, page_size, q_stride_tokens, q_stride_heads, kv_stride_keys_values,
+      kv_stride_heads, kv_stride_batch, /*max_num_blocks_per_seq=*/sparse_mla_top_k,
+      bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr, bmm2_scale_ptr,
+      /*o_sf_scale=*/-1.0, /*o_sf_vec_size=*/-1, /*o_sf_start_index=*/0,
+      /*window_left=*/127, sum_seq_q, sparse_mla_top_k, sliding_window_kv_cache.data_ptr(),
+      static_cast<int*>(sparse_mla_top_k_lens.data_ptr()), /*has_sliding_window_kv_pool=*/true,
+      /*skip_softmax_threshold_scale_factor=*/0.0f, /*skips_softmax=*/false,
+      /*uses_shared_paged_kv_idx=*/true, sm_count, enable_pdl, workspace_size,
+      /*k_sf_stride_heads=*/0, /*k_sf_stride_batch=*/0, /*v_sf_stride_heads=*/0,
+      /*v_sf_stride_batch=*/0, /*is_causal=*/true, stream);
+}
+
 namespace trtllm_cubin_loader {
 #include <flashinfer/cubin_loader.h>
 }
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_paged_attention_decode, trtllm_paged_attention_decode);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_paged_attention_context, trtllm_paged_attention_context);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_paged_attention_decode_sparse_mla_dsv4,
+                              trtllm_paged_attention_decode_sparse_mla_dsv4);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_ragged_attention, trtllm_ragged_attention);
 
 }  // namespace flashinfer

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -31,6 +31,7 @@ from .trace.templates.attention import (
 
 ## NOTE: MLA functions have been moved to mla.py, but we keep the aliases here for backward compatibility.
 from .mla import (
+    trtllm_batch_decode_sparse_mla_dsv4 as trtllm_batch_decode_sparse_mla_dsv4,
     trtllm_batch_decode_with_kv_cache_mla as trtllm_batch_decode_with_kv_cache_mla,
     xqa_batch_decode_with_kv_cache_mla as xqa_batch_decode_with_kv_cache_mla,
 )

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -59,11 +59,17 @@ _package_root: pathlib.Path = pathlib.Path(__file__).resolve().parents[1]
 def _get_cubin_dir():
     """
     Get the cubin directory path with the following priority:
-    1. flashinfer-cubin package if installed
-    2. Environment variable FLASHINFER_CUBIN_DIR
+    1. Environment variable FLASHINFER_CUBIN_DIR
+    2. flashinfer-cubin package if installed
     3. Default cache directory
     """
-    # First check if flashinfer-cubin package is installed
+    # Check environment variable first so generated local cubins can override
+    # an installed flashinfer-cubin wheel during development and testing.
+    env_dir = os.getenv("FLASHINFER_CUBIN_DIR")
+    if env_dir:
+        return pathlib.Path(env_dir)
+
+    # Then check if flashinfer-cubin package is installed
     if has_flashinfer_cubin():
         import flashinfer_cubin
 
@@ -84,11 +90,6 @@ def _get_cubin_dir():
             )
 
         return pathlib.Path(flashinfer_cubin.get_cubin_dir())
-
-    # Then check environment variable
-    env_dir = os.getenv("FLASHINFER_CUBIN_DIR")
-    if env_dir:
-        return pathlib.Path(env_dir)
 
     # Fall back to default cache directory
     return FLASHINFER_CACHE_DIR / "cubins"

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -59,17 +59,11 @@ _package_root: pathlib.Path = pathlib.Path(__file__).resolve().parents[1]
 def _get_cubin_dir():
     """
     Get the cubin directory path with the following priority:
-    1. Environment variable FLASHINFER_CUBIN_DIR
-    2. flashinfer-cubin package if installed
+    1. flashinfer-cubin package if installed
+    2. Environment variable FLASHINFER_CUBIN_DIR
     3. Default cache directory
     """
-    # Check environment variable first so generated local cubins can override
-    # an installed flashinfer-cubin wheel during development and testing.
-    env_dir = os.getenv("FLASHINFER_CUBIN_DIR")
-    if env_dir:
-        return pathlib.Path(env_dir)
-
-    # Then check if flashinfer-cubin package is installed
+    # First check if flashinfer-cubin package is installed
     if has_flashinfer_cubin():
         import flashinfer_cubin
 
@@ -90,6 +84,11 @@ def _get_cubin_dir():
             )
 
         return pathlib.Path(flashinfer_cubin.get_cubin_dir())
+
+    # Then check environment variable
+    env_dir = os.getenv("FLASHINFER_CUBIN_DIR")
+    if env_dir:
+        return pathlib.Path(env_dir)
 
     # Fall back to default cache directory
     return FLASHINFER_CACHE_DIR / "cubins"

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -198,6 +198,408 @@ def _check_trtllm_gen_mla_shape(
     return kv_cache
 
 
+def _normalize_dsv4_sparse_mla_kv_cache(
+    kv_cache: torch.Tensor,
+    kv_layout: Literal["HND", "NHD"],
+    name: str,
+) -> torch.Tensor:
+    if kv_cache.ndim == 3:
+        if kv_layout == "NHD":
+            raise ValueError(
+                f"{name} with ndim == 3 is only valid for kv_layout='HND'; "
+                f"got kv_layout={kv_layout}"
+            )
+        kv_cache = kv_cache.unsqueeze(1)
+    elif kv_cache.ndim != 4:
+        raise ValueError(f"Expected {name}.ndim == 3 or 4, got {kv_cache.ndim}")
+
+    if kv_layout == "HND":
+        # [num_pages, num_kv_heads, page_size, head_dim]
+        if kv_cache.size(1) != 1:
+            raise ValueError(f"Expected {name}.shape[1] == 1, got {kv_cache.size(1)}")
+        return kv_cache
+    if kv_layout == "NHD":
+        # [num_pages, page_size, num_kv_heads, head_dim] -> HND strides.
+        if kv_cache.size(2) != 1:
+            raise ValueError(f"Expected {name}.shape[2] == 1, got {kv_cache.size(2)}")
+        return kv_cache.transpose(-3, -2)
+
+    raise ValueError(f"kv_layout must be either 'HND' or 'NHD', got {kv_layout}")
+
+
+def _normalize_dsv4_topk_lens(
+    topk_lens: torch.Tensor,
+    batch_size: int,
+    q_len_per_request: int,
+    sum_seq_q: int,
+    name: str,
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if topk_lens.dtype != torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32, got {topk_lens.dtype}")
+    if topk_lens.ndim != 1:
+        raise ValueError(f"Expected flattened {name}.ndim == 1, got {topk_lens.ndim}")
+    if topk_lens.size(0) != sum_seq_q:
+        raise ValueError(
+            f"Expected flattened {name}.shape == ({sum_seq_q},), "
+            f"got {tuple(topk_lens.shape)}"
+        )
+    if cum_seq_lens_q is not None:
+        check_shape_dtype_device(
+            cum_seq_lens_q,
+            (batch_size + 1,),
+            torch.int32,
+            cum_seq_lens_q.device,
+            "cum_seq_lens_q",
+        )
+    return topk_lens
+
+
+def _check_dsv4_sparse_mla_inputs(
+    query: torch.Tensor,
+    swa_kv_cache: torch.Tensor,
+    sparse_indices: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    sparse_topk_lens: torch.Tensor,
+    out: Optional[torch.Tensor],
+    sinks: Optional[torch.Tensor],
+    kv_layout: Literal["HND", "NHD"],
+    cum_seq_lens_q: Optional[torch.Tensor],
+    max_q_len: Optional[int],
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    int,
+    int,
+    torch.Tensor,
+    Tuple[int, ...],
+    Optional[torch.Tensor],
+]:
+    is_varlen_q = cum_seq_lens_q is not None
+    if is_varlen_q:
+        if query.ndim != 3:
+            raise ValueError(
+                "Expected query.ndim == 3 when cum_seq_lens_q is provided, "
+                f"got {query.ndim}"
+            )
+        assert cum_seq_lens_q is not None
+        if cum_seq_lens_q.dtype != torch.int32:
+            raise ValueError(
+                f"cum_seq_lens_q must have dtype torch.int32, got {cum_seq_lens_q.dtype}"
+            )
+        if cum_seq_lens_q.ndim != 1:
+            raise ValueError(
+                f"Expected cum_seq_lens_q.ndim == 1, got {cum_seq_lens_q.ndim}"
+            )
+        batch_size = cum_seq_lens_q.numel() - 1
+        if batch_size <= 0:
+            raise ValueError(
+                f"Expected cum_seq_lens_q.numel() >= 2, got {cum_seq_lens_q.numel()}"
+            )
+        sum_seq_q, num_heads, head_dim = query.shape
+        if max_q_len is None:
+            max_q_len = int((cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]).max().item())
+        if max_q_len <= 0:
+            raise ValueError(f"Expected max_q_len > 0, got {max_q_len}")
+        q_len_per_request = max_q_len
+        query_flat = query
+        out_shape = (sum_seq_q, num_heads, 512)
+        sparse_indices_prefix_shape = (sum_seq_q,)
+    else:
+        if query.ndim != 4:
+            raise ValueError(f"Expected query.ndim == 4, got {query.ndim}")
+        batch_size, q_len_per_request, num_heads, head_dim = query.shape
+        sum_seq_q = batch_size * q_len_per_request
+        if max_q_len is not None and max_q_len != q_len_per_request:
+            raise ValueError(
+                f"Expected max_q_len == {q_len_per_request} for dense query input, "
+                f"got {max_q_len}"
+            )
+        max_q_len = q_len_per_request
+        query_flat = query.flatten(0, 1)
+        out_shape = (batch_size, q_len_per_request, num_heads, 512)
+        sparse_indices_prefix_shape = (sum_seq_q,)
+
+    if query.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise ValueError(
+            "DeepSeek V4 sparse MLA only supports BF16 or FP8 E4M3 query, "
+            f"got {query.dtype}"
+        )
+    if head_dim != 512:
+        raise ValueError(f"Expected query head dim 512, got {head_dim}")
+    if num_heads not in (64, 128):
+        raise ValueError(f"Expected 64 or 128 query heads, got {num_heads}")
+
+    if sparse_indices is None or compressed_kv_cache is None or sparse_topk_lens is None:
+        raise ValueError(
+            "sparse_indices, compressed_kv_cache, and sparse_topk_lens are required"
+        )
+    if sparse_indices.dtype != torch.int32:
+        raise ValueError(
+            f"sparse_indices must have dtype torch.int32, got {sparse_indices.dtype}"
+        )
+    if sparse_indices.device != query.device:
+        raise ValueError(
+            f"sparse_indices must be on query device {query.device}, "
+            f"got {sparse_indices.device}"
+        )
+    if sparse_indices.ndim != 2:
+        raise ValueError(
+            "Expected flattened sparse_indices.ndim == 2, got "
+            f"{sparse_indices.ndim}"
+        )
+    if sparse_indices.shape[:-1] != sparse_indices_prefix_shape:
+        raise ValueError(
+            "Expected sparse_indices.shape[:-1] == "
+            f"{sparse_indices_prefix_shape}, got {sparse_indices.shape[:-1]}"
+        )
+    if sparse_indices.size(-1) < 128:
+        raise ValueError(
+            "sparse_indices must include the fixed 128 SWA entries, got "
+            f"{sparse_indices.size(-1)}"
+        )
+    if sparse_indices.size(-1) % 4 != 0:
+        raise ValueError(
+            "sparse_indices last dimension must be a multiple of 4, got "
+            f"{sparse_indices.size(-1)}"
+        )
+
+    swa_kv_cache = _normalize_dsv4_sparse_mla_kv_cache(
+        swa_kv_cache, kv_layout, "swa_kv_cache"
+    )
+    if swa_kv_cache.dtype != query.dtype:
+        raise ValueError(
+            f"swa_kv_cache dtype must match query dtype, got {swa_kv_cache.dtype} "
+            f"and {query.dtype}"
+        )
+    if swa_kv_cache.size(-1) != 512:
+        raise ValueError(
+            f"Expected swa_kv_cache head dim 512, got {swa_kv_cache.size(-1)}"
+        )
+
+    compressed_kv_cache = _normalize_dsv4_sparse_mla_kv_cache(
+        compressed_kv_cache, kv_layout, "compressed_kv_cache"
+    )
+    if compressed_kv_cache.dtype != query.dtype:
+        raise ValueError(
+            "compressed_kv_cache dtype must match query dtype, got "
+            f"{compressed_kv_cache.dtype} and {query.dtype}"
+        )
+    if compressed_kv_cache.size(-1) != 512:
+        raise ValueError(
+            f"Expected compressed_kv_cache head dim 512, got {compressed_kv_cache.size(-1)}"
+        )
+    normalized_sparse_lens = _normalize_dsv4_topk_lens(
+        sparse_topk_lens,
+        batch_size,
+        q_len_per_request,
+        sum_seq_q,
+        "sparse_topk_lens",
+        cum_seq_lens_q,
+    ).to(query.device)
+    if normalized_sparse_lens.numel() > 0:
+        min_sparse_len = int(normalized_sparse_lens.min().item())
+        max_sparse_len = int(normalized_sparse_lens.max().item())
+        if min_sparse_len < 128:
+            raise ValueError(
+                "sparse_topk_lens values must include the fixed 128 SWA entries, "
+                f"got minimum {min_sparse_len}"
+            )
+        if max_sparse_len > sparse_indices.size(-1):
+            raise ValueError(
+                "sparse_topk_lens values cannot exceed sparse_indices capacity, "
+                f"got max {max_sparse_len} and capacity {sparse_indices.size(-1)}"
+            )
+
+    if out is not None:
+        check_shape_dtype_device(out, out_shape, torch.bfloat16, query.device, "out")
+    if sinks is not None:
+        check_shape_dtype_device(
+            sinks, (num_heads,), torch.float32, query.device, "sinks"
+        )
+
+    if cum_seq_lens_q is not None:
+        cum_seq_lens_q = cum_seq_lens_q.to(query.device)
+
+    return (
+        swa_kv_cache,
+        compressed_kv_cache,
+        normalized_sparse_lens,
+        batch_size,
+        q_len_per_request,
+        query_flat,
+        out_shape,
+        cum_seq_lens_q,
+    )
+
+
+def trtllm_batch_decode_sparse_mla_dsv4(
+    query: torch.Tensor,
+    swa_kv_cache: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    sparse_indices: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    sparse_topk_lens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    bmm1_scale: Union[float, torch.Tensor] = 1.0,
+    bmm2_scale: Union[float, torch.Tensor] = 1.0,
+    sinks: Optional[torch.Tensor] = None,
+    kv_layout: Literal["HND", "NHD"] = "HND",
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+    max_q_len: Optional[int] = None,
+    enable_pdl: bool | None = None,
+) -> torch.Tensor:
+    r"""Decode DeepSeek V4 sparse MLA with separate SWA and compressed KV pools.
+
+    This API is for the TRTLLM-GEN DeepSeek V4 sparse MLA kernels where
+    ``headDimQk == headDimV == 512``. It supports BF16 and per-tensor FP8 E4M3
+    inputs with BF16 output. The SWA side is fixed to 128 indices per query.
+    Callers must provide a primary/compressed KV pool, the concatenated sparse
+    index matrix, and total sparse MLA top-k lengths for every query token.
+
+    Parameters
+    ----------
+    query : torch.Tensor
+        Dense query input ``[batch_size, q_len_per_request, num_heads, 512]``
+        or varlen query input ``[sum_q, num_heads, 512]`` when
+        ``cum_seq_lens_q`` is provided. BF16 or FP8 E4M3.
+    swa_kv_cache : torch.Tensor
+        SWA KV cache. HND layout is ``[num_pages, 1, page_size, 512]`` and NHD
+        layout is ``[num_pages, page_size, 1, 512]``. A 3D HND shorthand
+        ``[num_pages, page_size, 512]`` is also accepted.
+    workspace_buffer : torch.Tensor
+        TRTLLM-GEN workspace buffer. Must be zero-initialized for first use.
+    sparse_indices : torch.Tensor
+        Flattened concatenated sparse MLA physical token indices in query-token
+        order with shape ``[sum_q, sparse_topk_capacity]``. The first 128
+        columns are SWA indices into ``swa_kv_cache``; the remaining columns are
+        compressed/top-k indices into ``compressed_kv_cache``. For SWA-only
+        calls, callers may provide padded invalid compressed columns, while
+        ``sparse_topk_lens`` controls the active length.
+    compressed_kv_cache : torch.Tensor
+        Primary/compressed KV cache in the same layout and dtype as
+        ``swa_kv_cache``. For SWA-only calls, provide any valid primary pool.
+    sparse_topk_lens : torch.Tensor
+        Flattened total sparse MLA top-k lengths in query-token order, shape
+        ``[sum_q]``. Values must already include the fixed 128 SWA entries,
+        matching TRTLLM-GEN ``sparseMlaTopkLengths``, and must not exceed
+        ``sparse_indices.shape[-1]``.
+    seq_lens : torch.Tensor
+        Original KV sequence lengths for the SWA side, shape ``[batch_size]``
+        INT32. This is required even though ``sparse_topk_lens`` already
+        includes the fixed SWA 128 entries. TRTLLM-GEN uses ``seq_lens`` and the
+        per-request query length to compute the valid length of tile 0, the
+        SWA-128 tile, as ``min(seq_lens[b] - q_lens[b] + q_idx + 1, 128)``.
+        ``sparse_topk_lens`` controls the total sparse MLA length; it does not
+        replace the SWA tile validity signal.
+    bmm1_scale : Union[float, torch.Tensor]
+        Fused per-tensor scale for QK and softmax. Tensor form must be FP32.
+    bmm2_scale : Union[float, torch.Tensor]
+        Fused per-tensor scale for VO. Tensor form must be FP32.
+    sinks : Optional[torch.Tensor]
+        Optional attention sink logits, shape ``[num_heads]`` FP32.
+    kv_layout : Literal["HND", "NHD"]
+        Layout of both KV pools.
+    cum_seq_lens_q : Optional[torch.Tensor]
+        Cumulative query lengths for varlen query input, shape ``[batch_size + 1]``
+        INT32. When provided, dynamic top-k lengths are consumed in flattened
+        query-token order.
+    max_q_len : Optional[int]
+        Maximum query length in the varlen batch. If omitted with
+        ``cum_seq_lens_q``, it is computed from ``cum_seq_lens_q``.
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.
+    """
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(query.device)
+    if isinstance(bmm1_scale, torch.Tensor):
+        assert bmm1_scale.dtype == torch.float32
+        bmm1_scale = bmm1_scale * log2e
+    if isinstance(bmm2_scale, torch.Tensor):
+        assert bmm2_scale.dtype == torch.float32
+
+    (
+        swa_kv_cache,
+        compressed_kv_cache,
+        sparse_topk_lens,
+        batch_size,
+        q_len_per_request,
+        query_flat,
+        expected_out_shape,
+        cum_seq_lens_q,
+    ) = (
+        _check_dsv4_sparse_mla_inputs(
+            query,
+            swa_kv_cache,
+            sparse_indices,
+            compressed_kv_cache,
+            sparse_topk_lens,
+            out,
+            sinks,
+            kv_layout,
+            cum_seq_lens_q,
+            max_q_len,
+        )
+    )
+
+    if out is None:
+        out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
+
+    if seq_lens is None:
+        raise ValueError(
+            "seq_lens is required for DeepSeek V4 sparse MLA because TRTLLM-GEN "
+            "uses it to mask the fixed SWA-128 tile"
+        )
+    check_shape_dtype_device(
+        seq_lens, (batch_size,), torch.int32, query.device, "seq_lens"
+    )
+    if cum_seq_lens_q is None:
+        q_lens = seq_lens.new_full((batch_size,), q_len_per_request)
+    else:
+        q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
+    if torch.any(seq_lens < q_lens).item():
+        raise ValueError(
+            "seq_lens must be greater than or equal to the per-request query "
+            "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
+        )
+
+    primary_kv_cache = compressed_kv_cache
+    sparse_indices = sparse_indices.reshape(query_flat.size(0), -1).contiguous()
+    sparse_topk_lens = sparse_topk_lens.contiguous()
+
+    op = get_trtllm_gen_fmha_module()
+    run_func = getattr(op, "trtllm_paged_attention_decode_sparse_mla_dsv4", None)
+    if run_func is None:
+        raise RuntimeError(
+            "trtllm_paged_attention_decode_sparse_mla_dsv4 is not available. "
+            "Rebuild FlashInfer with the DeepSeek V4 sparse MLA TRTLLM-GEN launcher."
+        )
+
+    sm_count = get_device_sm_count(query.device)
+    run_func(
+        out,
+        query_flat,
+        primary_kv_cache,
+        swa_kv_cache,
+        workspace_buffer,
+        sparse_indices,
+        seq_lens.contiguous(),
+        sparse_topk_lens,
+        bmm1_scale,
+        bmm2_scale,
+        batch_size,
+        q_len_per_request,
+        sm_count,
+        enable_pdl,
+        workspace_buffer.numel() * workspace_buffer.element_size(),
+        sinks,
+        cum_seq_lens_q.contiguous() if cum_seq_lens_q is not None else None,
+    )
+    return out
+
+
 @functools.cache
 def get_trtllm_gen_fmha_module():
     mod = gen_trtllm_gen_fmha_module()

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -17,6 +17,7 @@ limitations under the License.
 from dataclasses import dataclass
 import functools
 import math
+import os
 from typing import List, Literal, Optional, Tuple, Union, overload
 
 import torch
@@ -233,10 +234,13 @@ def _normalize_dsv4_topk_lens(
     q_len_per_request: int,
     sum_seq_q: int,
     name: str,
+    device: torch.device,
     cum_seq_lens_q: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if topk_lens.dtype != torch.int32:
         raise ValueError(f"{name} must have dtype torch.int32, got {topk_lens.dtype}")
+    if topk_lens.device != device:
+        raise ValueError(f"{name} must be on device {device}, got {topk_lens.device}")
     if topk_lens.ndim != 1:
         raise ValueError(f"Expected flattened {name}.ndim == 1, got {topk_lens.ndim}")
     if topk_lens.size(0) != sum_seq_q:
@@ -249,10 +253,14 @@ def _normalize_dsv4_topk_lens(
             cum_seq_lens_q,
             (batch_size + 1,),
             torch.int32,
-            cum_seq_lens_q.device,
+            device,
             "cum_seq_lens_q",
         )
     return topk_lens
+
+
+def _validate_dsv4_sync_checks() -> bool:
+    return os.environ.get("FLASHINFER_VALIDATE_INPUTS", "0") not in ("0", "")
 
 
 def _check_dsv4_sparse_mla_inputs(
@@ -277,13 +285,16 @@ def _check_dsv4_sparse_mla_inputs(
     Optional[torch.Tensor],
 ]:
     is_varlen_q = cum_seq_lens_q is not None
+    out_shape: Tuple[int, ...]
+    sparse_indices_prefix_shape: Tuple[int, ...]
     if is_varlen_q:
         if query.ndim != 3:
             raise ValueError(
                 "Expected query.ndim == 3 when cum_seq_lens_q is provided, "
                 f"got {query.ndim}"
             )
-        assert cum_seq_lens_q is not None
+        if cum_seq_lens_q is None:
+            raise ValueError("cum_seq_lens_q is required for varlen query input")
         if cum_seq_lens_q.dtype != torch.int32:
             raise ValueError(
                 f"cum_seq_lens_q must have dtype torch.int32, got {cum_seq_lens_q.dtype}"
@@ -297,9 +308,17 @@ def _check_dsv4_sparse_mla_inputs(
             raise ValueError(
                 f"Expected cum_seq_lens_q.numel() >= 2, got {cum_seq_lens_q.numel()}"
             )
+        if cum_seq_lens_q.device != query.device:
+            raise ValueError(
+                f"cum_seq_lens_q must be on query device {query.device}, "
+                f"got {cum_seq_lens_q.device}"
+            )
         sum_seq_q, num_heads, head_dim = query.shape
         if max_q_len is None:
-            max_q_len = int((cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]).max().item())
+            raise ValueError(
+                "max_q_len is required when cum_seq_lens_q is provided to avoid "
+                "an implicit device-to-host synchronization"
+            )
         if max_q_len <= 0:
             raise ValueError(f"Expected max_q_len > 0, got {max_q_len}")
         q_len_per_request = max_q_len
@@ -331,7 +350,11 @@ def _check_dsv4_sparse_mla_inputs(
     if num_heads not in (64, 128):
         raise ValueError(f"Expected 64 or 128 query heads, got {num_heads}")
 
-    if sparse_indices is None or compressed_kv_cache is None or sparse_topk_lens is None:
+    if (
+        sparse_indices is None
+        or compressed_kv_cache is None
+        or sparse_topk_lens is None
+    ):
         raise ValueError(
             "sparse_indices, compressed_kv_cache, and sparse_topk_lens are required"
         )
@@ -346,8 +369,7 @@ def _check_dsv4_sparse_mla_inputs(
         )
     if sparse_indices.ndim != 2:
         raise ValueError(
-            "Expected flattened sparse_indices.ndim == 2, got "
-            f"{sparse_indices.ndim}"
+            f"Expected flattened sparse_indices.ndim == 2, got {sparse_indices.ndim}"
         )
     if sparse_indices.shape[:-1] != sparse_indices_prefix_shape:
         raise ValueError(
@@ -396,20 +418,26 @@ def _check_dsv4_sparse_mla_inputs(
         q_len_per_request,
         sum_seq_q,
         "sparse_topk_lens",
+        query.device,
         cum_seq_lens_q,
-    ).to(query.device)
-    if normalized_sparse_lens.numel() > 0:
-        min_sparse_len = int(normalized_sparse_lens.min().item())
-        max_sparse_len = int(normalized_sparse_lens.max().item())
-        if min_sparse_len < 128:
-            raise ValueError(
-                "sparse_topk_lens values must include the fixed 128 SWA entries, "
-                f"got minimum {min_sparse_len}"
-            )
-        if max_sparse_len > sparse_indices.size(-1):
+    )
+    if _validate_dsv4_sync_checks() and normalized_sparse_lens.numel() > 0:
+        sparse_topk_capacity = sparse_indices.size(-1)
+        invalid_sparse_lens = torch.logical_or(
+            normalized_sparse_lens < 128,
+            normalized_sparse_lens > sparse_topk_capacity,
+        )
+        if invalid_sparse_lens.any().item():
+            min_sparse_len = int(normalized_sparse_lens.min().item())
+            max_sparse_len = int(normalized_sparse_lens.max().item())
+            if min_sparse_len < 128:
+                raise ValueError(
+                    "sparse_topk_lens values must include the fixed 128 SWA entries, "
+                    f"got minimum {min_sparse_len}"
+                )
             raise ValueError(
                 "sparse_topk_lens values cannot exceed sparse_indices capacity, "
-                f"got max {max_sparse_len} and capacity {sparse_indices.size(-1)}"
+                f"got max {max_sparse_len} and capacity {sparse_topk_capacity}"
             )
 
     if out is not None:
@@ -418,9 +446,6 @@ def _check_dsv4_sparse_mla_inputs(
         check_shape_dtype_device(
             sinks, (num_heads,), torch.float32, query.device, "sinks"
         )
-
-    if cum_seq_lens_q is not None:
-        cum_seq_lens_q = cum_seq_lens_q.to(query.device)
 
     return (
         swa_kv_cache,
@@ -507,18 +532,21 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         INT32. When provided, dynamic top-k lengths are consumed in flattened
         query-token order.
     max_q_len : Optional[int]
-        Maximum query length in the varlen batch. If omitted with
-        ``cum_seq_lens_q``, it is computed from ``cum_seq_lens_q``.
+        Maximum query length in the varlen batch. Required when
+        ``cum_seq_lens_q`` is provided so the wrapper does not need a
+        device-to-host synchronization to infer it.
     enable_pdl : Optional[bool]
         Whether to enable Programmatic Dependent Launch.
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(query.device)
     if isinstance(bmm1_scale, torch.Tensor):
-        assert bmm1_scale.dtype == torch.float32
+        if bmm1_scale.dtype != torch.float32:
+            raise TypeError("bmm1_scale tensor must have dtype torch.float32")
         bmm1_scale = bmm1_scale * log2e
     if isinstance(bmm2_scale, torch.Tensor):
-        assert bmm2_scale.dtype == torch.float32
+        if bmm2_scale.dtype != torch.float32:
+            raise TypeError("bmm2_scale tensor must have dtype torch.float32")
 
     (
         swa_kv_cache,
@@ -529,29 +557,22 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         query_flat,
         expected_out_shape,
         cum_seq_lens_q,
-    ) = (
-        _check_dsv4_sparse_mla_inputs(
-            query,
-            swa_kv_cache,
-            sparse_indices,
-            compressed_kv_cache,
-            sparse_topk_lens,
-            out,
-            sinks,
-            kv_layout,
-            cum_seq_lens_q,
-            max_q_len,
-        )
+    ) = _check_dsv4_sparse_mla_inputs(
+        query,
+        swa_kv_cache,
+        sparse_indices,
+        compressed_kv_cache,
+        sparse_topk_lens,
+        out,
+        sinks,
+        kv_layout,
+        cum_seq_lens_q,
+        max_q_len,
     )
 
     if out is None:
         out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
 
-    if seq_lens is None:
-        raise ValueError(
-            "seq_lens is required for DeepSeek V4 sparse MLA because TRTLLM-GEN "
-            "uses it to mask the fixed SWA-128 tile"
-        )
     check_shape_dtype_device(
         seq_lens, (batch_size,), torch.int32, query.device, "seq_lens"
     )
@@ -559,7 +580,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         q_lens = seq_lens.new_full((batch_size,), q_len_per_request)
     else:
         q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-    if torch.any(seq_lens < q_lens).item():
+    if _validate_dsv4_sync_checks() and torch.any(seq_lens < q_lens).item():
         raise ValueError(
             "seq_lens must be greater than or equal to the per-request query "
             "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
@@ -1131,10 +1152,12 @@ def trtllm_batch_decode_with_kv_cache_mla(
             "trtllm-gen" if get_compute_capability(query.device)[0] == 10 else "xqa"
         )
     if isinstance(bmm1_scale, torch.Tensor):
-        assert bmm1_scale.dtype == torch.float32
+        if bmm1_scale.dtype != torch.float32:
+            raise TypeError("bmm1_scale tensor must have dtype torch.float32")
         bmm1_scale = bmm1_scale * log2e
     if isinstance(bmm2_scale, torch.Tensor):
-        assert bmm2_scale.dtype == torch.float32
+        if bmm2_scale.dtype != torch.float32:
+            raise TypeError("bmm2_scale tensor must have dtype torch.float32")
     if backend == "xqa":
         if not is_sm12x_supported(query.device):
             raise ValueError(

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -157,7 +157,7 @@ class TllmGenFmhaKernel {
   inline uint64_t hashID(int qkvLayout, int maskType, int kernelType, int scheduler,
                          int multiCtasKvMode, int headDimPerCtaV, int headDimQk, int headDimV,
                          int tileSizeQ, int tileSizeKv, int numTokensPerPage, bool reuseSmemKForV,
-                         bool uses2CtaMma, bool sparseMla, bool skipsSoftmax) const {
+                         bool uses2CtaMma, int sparseMlaType, bool skipsSoftmax) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -171,6 +171,8 @@ class TllmGenFmhaKernel {
     FLASHINFER_CHECK((tileSizeQ & (tileSizeQ - 1)) == 0 && (tileSizeKv & (tileSizeKv - 1)) == 0,
                      "The tileSizeQ and tileSizeKv must be power of 2.");
     FLASHINFER_CHECK(tileSizeKv == 64 || tileSizeKv == 128, "The tileSizeKv must be 64 or 128.");
+    FLASHINFER_CHECK(sparseMlaType >= 0 && sparseMlaType <= 3,
+                     "The sparse MLA type must fit in 2 bits.");
     // Format of the hash key:
     // Bit 0  - 3 : qkvLayout.
     // Bit 4  - 7 : maskType.
@@ -185,8 +187,8 @@ class TllmGenFmhaKernel {
     // Bit 49 - 52: (log2(tileSizeQ)).
     // Bit 53 - 53: reuseSmemKForV.
     // Bit 54 - 54: uses2CtaMma.
-    // Bit 55 - 55: sparseMla.
-    // Bit 56 - 56: skipsSoftmax.
+    // Bit 55 - 56: sparseMlaType (0=none, 1=static token sparse, 2=dynamic token sparse).
+    // Bit 57 - 57: skipsSoftmax.
     uint64_t const numTokensPerPageLog2 =
         numTokensPerPage == 0 ? 0 : static_cast<uint64_t>(log2(numTokensPerPage));
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 4) |
@@ -198,8 +200,9 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(tileSizeKv >> 6) << 42) | (numTokensPerPageLog2 << 44) |
            (static_cast<uint64_t>(log2(tileSizeQ)) << 49) |
            (static_cast<uint64_t>(reuseSmemKForV) << 53) |
-           (static_cast<uint64_t>(uses2CtaMma) << 54) | (static_cast<uint64_t>(sparseMla) << 55) |
-           (static_cast<uint64_t>(skipsSoftmax) << 56);
+           (static_cast<uint64_t>(uses2CtaMma) << 54) |
+           (static_cast<uint64_t>(sparseMlaType) << 55) |
+           (static_cast<uint64_t>(skipsSoftmax) << 57);
   }
 
   uint64_t hashID(KernelMeta const& kernelMeta) const {
@@ -207,7 +210,7 @@ class TllmGenFmhaKernel {
                   kernelMeta.mTileScheduler, kernelMeta.mMultiCtasKvMode,
                   kernelMeta.mHeadDimPerCtaV, kernelMeta.mHeadDimQk, kernelMeta.mHeadDimV,
                   kernelMeta.mTileSizeQ, kernelMeta.mTileSizeKv, kernelMeta.mNumTokensPerPage,
-                  kernelMeta.mReuseSmemKForV, kernelMeta.m2CtaMma, kernelMeta.mSparseAttn != 0,
+                  kernelMeta.mReuseSmemKForV, kernelMeta.m2CtaMma, kernelMeta.mSparseAttn,
                   kernelMeta.mSkipsSoftmaxWhenPossible);
   }
 
@@ -367,19 +370,21 @@ class TllmGenFmhaKernel {
   // Is it MLA generation kernel ?
   inline bool isMlaGenKernel(RunnerParams const& params) const {
     return (params.mHeadDimQk == 576 && params.mHeadDimV == 512) ||
-           (params.mHeadDimQk == 320 && params.mHeadDimV == 256);
+           (params.mHeadDimQk == 320 && params.mHeadDimV == 256) ||
+           (isSparseMla(params.mSparseMlaType) && params.mHeadDimQk == 512 &&
+            params.mHeadDimV == 512);
   }
 
   inline bool useDynamicNumTokensPerPage(RunnerParams const& params) const {
-    return isPagedKv(params.mQkvLayout) && !params.mSparseMla && params.mNumHeadsQPerKv > 1 &&
-           params.mHeadDimQk == params.mHeadDimV &&
+    return isPagedKv(params.mQkvLayout) && !isSparseMla(params.mSparseMlaType) &&
+           params.mNumHeadsQPerKv > 1 && params.mHeadDimQk == params.mHeadDimV &&
            params.mNumTokensPerPage >= kDynamicNumTokensPerPageThreshold;
   }
 
   void selectNumTokensPerPage(RunnerParams const& params,
                               SelectKernelParams& selectKernelParams) const {
     selectKernelParams.mDynamicNumTokensPerPage = false;
-    if (params.mSparseMla) {
+    if (isSparseMla(params.mSparseMlaType)) {
       // SparseMla kernels use a fixed numTokensPerPage = 1.
       selectKernelParams.mNumTokensPerPage = 1;
     } else if (!isPagedKv(params.mQkvLayout)) {
@@ -456,7 +461,7 @@ class TllmGenFmhaKernel {
       // The maximum attention window (the maximum number of tokensKv that will be attended to).
       int maxAttentionWindow{params.mMaxSeqLenKv};
       // The sparseMla only selects topK tokensKv.
-      if (params.mSparseMla) {
+      if (isSparseMla(params.mSparseMlaType)) {
         maxAttentionWindow = std::min(params.mMaxSeqLenKv, params.mSparseMlaTopK);
       }
       // Some of the tilesKv will be skipped if the sliding window attention or chunked attention is
@@ -493,7 +498,7 @@ class TllmGenFmhaKernel {
         // Need to select a different kernel.
         selectKernelParams.mSelectNewKernel = true;
       } else if (totalNumCtas < params.mMultiProcessorCount && isMlaGenKernel(params) &&
-                 !params.mSparseMla && selectKernelParams.mTileSizeKv == 128 &&
+                 !isSparseMla(params.mSparseMlaType) && selectKernelParams.mTileSizeKv == 128 &&
                  getEnvUseTileSizeKv64ForTrtllmGen()) {
         // Use smaller tileSizeKv to fully utilize the SMs.
         selectKernelParams.mTileSizeKv = 64;
@@ -643,12 +648,18 @@ class TllmGenFmhaKernel {
       // For numHeadsQ=128, use 2CTA when there are enough CTAs to amortize 2CTA overhead.
       // numCtasPerToken = numHeadsQPerKv / tileSizeQ (number of CTAs per token per batch item).
       // Benchmarks (fp16/e4m3, sparseMlaTopK=2048):
-      //   batch=1  : 1CTA wins by ~20%;  batch=8  : 1CTA wins by 3-8%
-      //   batch=16 : 2CTA wins by 8-16%; batch=32+: 2CTA wins by 12-20%
+      //   decode, s_q=1:
+      //     batch=1  : 1CTA wins by ~20%;  batch=8  : 1CTA wins by 3-8%
+      //     batch=16 : 2CTA wins by 8-16%; batch=32+: 2CTA wins by 12-20%
+      //   prefill/spec, s_q>1, DS MLA generation:
+      //     2CTA wins by ~20-50% because it avoids the 1CTA h128 path's duplicated head-dim work.
       // Threshold: batchSize * numCtasPerToken * 8 > MP -> crossover at batch ~ MP/16 ~ 9.
       int const numCtasPerToken = params.mNumHeadsQPerKv / 64;
+      bool const use2CtaForMultiTokenMla = params.mMaxSeqLenQ > 1;
       bool const use2Cta = params.mNumHeadsQPerKv == 128 &&
-                           params.mBatchSize * numCtasPerToken * 8 > params.mMultiProcessorCount;
+                           (use2CtaForMultiTokenMla ||
+                            params.mBatchSize * numCtasPerToken * 8 >
+                                params.mMultiProcessorCount);
       if (use2Cta) {
         selectKernelParams.mUses2CtaMma = true;
         selectKernelParams.mHeadDimPerCtaV = 256;
@@ -664,7 +675,7 @@ class TllmGenFmhaKernel {
     // The tile size for Q.
     int& tileSizeQ = selectKernelParams.mTileSizeQ;
 
-    if (params.mSparseMla) {
+    if (isSparseMla(params.mSparseMlaType)) {
       selectSparseMlaGenerationKernel(params, selectKernelParams);
     } else {
       // Non-sparse MLA: use SwapsMmaAb when numHeadsQPerKv <= 32 or seqLenPerCtaKv is small.
@@ -875,7 +886,8 @@ class TllmGenFmhaKernel {
     // Enable sliding window or chunked causal if the max kv sequence length exceeds attention
     // window size or chunked attention size. This is supported by causal-mask context kernels and
     // generation-phase kernels.
-    if ((selectKernelParams.mMaskType == TrtllmGenAttentionMaskType::Causal ||
+    if (!isSparseMla(params.mSparseMlaType) &&
+        (selectKernelParams.mMaskType == TrtllmGenAttentionMaskType::Causal ||
          !isContextKernel(params.mKernelType)) &&
         (params.mMaxSeqLenKv > params.mAttentionWindowSize ||
          params.mChunkedAttentionSize != INT_MAX)) {
@@ -906,7 +918,7 @@ class TllmGenFmhaKernel {
         ", dynamicNumTokensPerPage=" + std::to_string(selectKernelParams.mDynamicNumTokensPerPage) +
         ", reuseSmemKForV=" + std::to_string(selectKernelParams.mReuseSmemKForV) +
         ", uses2CtaMma=" + std::to_string(selectKernelParams.mUses2CtaMma) +
-        ", sparseMla=" + std::to_string(params.mSparseMla) +
+        ", sparseMlaType=" + std::to_string(static_cast<int>(params.mSparseMlaType)) +
         ", skipsSoftmax=" + std::to_string(selectKernelParams.mSkipsSoftmaxWhenPossible);
     IKL_LOG_DEBUG(
         "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
@@ -921,7 +933,7 @@ class TllmGenFmhaKernel {
                selectKernelParams.mHeadDimPerCtaV, params.mHeadDimQk, params.mHeadDimV,
                selectKernelParams.mTileSizeQ, selectKernelParams.mTileSizeKv,
                selectKernelParams.mNumTokensPerPage, selectKernelParams.mReuseSmemKForV,
-               selectKernelParams.mUses2CtaMma, params.mSparseMla,
+               selectKernelParams.mUses2CtaMma, static_cast<int>(params.mSparseMlaType),
                selectKernelParams.mSkipsSoftmaxWhenPossible),
         info);
   }

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -20,6 +20,7 @@
 
 #include <cfloat>
 #include <cstdint>
+#include <cstring>
 #include <cuda/std/cfloat>
 #include <iterator>
 #include <memory>
@@ -156,8 +157,9 @@ class TllmGenFmhaKernel {
 
   inline uint64_t hashID(int qkvLayout, int maskType, int kernelType, int scheduler,
                          int multiCtasKvMode, int headDimPerCtaV, int headDimQk, int headDimV,
-                         int tileSizeQ, int tileSizeKv, int numTokensPerPage, bool reuseSmemKForV,
-                         bool uses2CtaMma, int sparseMlaType, bool skipsSoftmax) const {
+                         int tileSizeQ, int tileSizeKv, int numTokensPerPage,
+                         bool dynamicNumTokensPerPage, bool reuseSmemKForV, bool uses2CtaMma,
+                         int sparseMlaType, bool skipsSoftmax) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -189,6 +191,7 @@ class TllmGenFmhaKernel {
     // Bit 54 - 54: uses2CtaMma.
     // Bit 55 - 56: sparseMlaType (0=none, 1=static token sparse, 2=dynamic token sparse).
     // Bit 57 - 57: skipsSoftmax.
+    // Bit 58 - 58: dynamicNumTokensPerPage.
     uint64_t const numTokensPerPageLog2 =
         numTokensPerPage == 0 ? 0 : static_cast<uint64_t>(log2(numTokensPerPage));
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 4) |
@@ -202,7 +205,13 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(reuseSmemKForV) << 53) |
            (static_cast<uint64_t>(uses2CtaMma) << 54) |
            (static_cast<uint64_t>(sparseMlaType) << 55) |
-           (static_cast<uint64_t>(skipsSoftmax) << 57);
+           (static_cast<uint64_t>(skipsSoftmax) << 57) |
+           (static_cast<uint64_t>(dynamicNumTokensPerPage) << 58);
+  }
+
+  inline bool isDynamicNumTokensPerPageKernel(KernelMeta const& kernelMeta) const {
+    return kernelMeta.mNumTokensPerPage == kDynamicNumTokensPerPageKernelKey &&
+           std::strstr(kernelMeta.mFuncName, "P128") == nullptr;
   }
 
   uint64_t hashID(KernelMeta const& kernelMeta) const {
@@ -210,7 +219,8 @@ class TllmGenFmhaKernel {
                   kernelMeta.mTileScheduler, kernelMeta.mMultiCtasKvMode,
                   kernelMeta.mHeadDimPerCtaV, kernelMeta.mHeadDimQk, kernelMeta.mHeadDimV,
                   kernelMeta.mTileSizeQ, kernelMeta.mTileSizeKv, kernelMeta.mNumTokensPerPage,
-                  kernelMeta.mReuseSmemKForV, kernelMeta.m2CtaMma, kernelMeta.mSparseAttn,
+                  isDynamicNumTokensPerPageKernel(kernelMeta), kernelMeta.mReuseSmemKForV,
+                  kernelMeta.m2CtaMma, kernelMeta.mSparseAttn,
                   kernelMeta.mSkipsSoftmaxWhenPossible);
   }
 
@@ -658,8 +668,7 @@ class TllmGenFmhaKernel {
       bool const use2CtaForMultiTokenMla = params.mMaxSeqLenQ > 1;
       bool const use2Cta = params.mNumHeadsQPerKv == 128 &&
                            (use2CtaForMultiTokenMla ||
-                            params.mBatchSize * numCtasPerToken * 8 >
-                                params.mMultiProcessorCount);
+                            params.mBatchSize * numCtasPerToken * 8 > params.mMultiProcessorCount);
       if (use2Cta) {
         selectKernelParams.mUses2CtaMma = true;
         selectKernelParams.mHeadDimPerCtaV = 256;
@@ -867,10 +876,12 @@ class TllmGenFmhaKernel {
       // CTA processes a bounded query tile, so the runtime sequence lengths/indices provide the
       // effective masking.
       selectKernelParams.mMaskType = TrtllmGenAttentionMaskType::Dense;
-      FLASHINFER_CHECK(
-          params.mMaxSeqLenKv <= params.mAttentionWindowSize &&
-              params.mChunkedAttentionSize == INT_MAX,
-          "TRTLLM-GEN MLA generation does not support sliding-window or chunked attention.");
+      if (!isSparseMla(params.mSparseMlaType)) {
+        FLASHINFER_CHECK(
+            params.mMaxSeqLenKv <= params.mAttentionWindowSize &&
+                params.mChunkedAttentionSize == INT_MAX,
+            "TRTLLM-GEN MLA generation does not support sliding-window or chunked attention.");
+      }
     } else if (isGenerationKernel(params.mKernelType)) {
       selectGqGenerationKernel(params, selectKernelParams);
     }
@@ -932,8 +943,9 @@ class TllmGenFmhaKernel {
                static_cast<int>(selectKernelParams.mMultiCtasKvMode),
                selectKernelParams.mHeadDimPerCtaV, params.mHeadDimQk, params.mHeadDimV,
                selectKernelParams.mTileSizeQ, selectKernelParams.mTileSizeKv,
-               selectKernelParams.mNumTokensPerPage, selectKernelParams.mReuseSmemKForV,
-               selectKernelParams.mUses2CtaMma, static_cast<int>(params.mSparseMlaType),
+               selectKernelParams.mNumTokensPerPage, selectKernelParams.mDynamicNumTokensPerPage,
+               selectKernelParams.mReuseSmemKForV, selectKernelParams.mUses2CtaMma,
+               static_cast<int>(params.mSparseMlaType),
                selectKernelParams.mSkipsSoftmaxWhenPossible),
         info);
   }

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -336,8 +336,6 @@ struct TllmGenFmhaRunnerParams {
   float mSkipSoftmaxThresholdScaleFactor;
   // Sparse MLA type. DeepSeek V4 uses DynamicTokenSparse with per-query-token top-k lengths.
   TrtllmGenSparseMlaType mSparseMlaType;
-  // Whether to use sparse MLA. Kept as a cached predicate for existing call sites.
-  bool mSparseMla;
   // The top k value for sparse MLA.
   int mSparseMlaTopK;
   // Whether DSv4 sparse MLA should read tile 0 from slidingWindowKvPoolPtr.
@@ -349,6 +347,8 @@ struct TllmGenFmhaRunnerParams {
   cudaStream_t stream;
   // Whether to enable PDL (Programmatic Dependent Launch).
   bool enable_pdl;
+
+  bool isSparseMla() const { return ::isSparseMla(mSparseMlaType); }
 
   // set the attention mask type
   TllmGenFmhaRunnerParams& setAttentionMaskType(std::int8_t maskType) {

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -146,6 +146,21 @@ enum class MultiCtasKvMode {
   CgaSmemReduction
 };
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+enum class TrtllmGenSparseMlaType {
+  None = 0,
+  StaticTokenSparse = 1,
+  DynamicTokenSparse = 2,
+};
+
+inline bool isSparseMla(TrtllmGenSparseMlaType sparseMlaType) {
+  return sparseMlaType != TrtllmGenSparseMlaType::None;
+}
+
+inline bool isDynamicTokenSparseMla(TrtllmGenSparseMlaType sparseMlaType) {
+  return sparseMlaType == TrtllmGenSparseMlaType::DynamicTokenSparse;
+}
+
 // Helper function to check if the multiCtasKv is enabled.
 inline bool isMultiCtasKvEnabled(MultiCtasKvMode multiCtasKvMode) {
   return multiCtasKvMode != MultiCtasKvMode::Disabled;
@@ -182,6 +197,9 @@ struct TllmGenFmhaRunnerParams {
   void const* qPtr;
   void const* kPtr;
   void const* vPtr;
+  // Optional DSv4 sparse MLA sliding-window KV pool. Dynamic sparse MLA kernels
+  // read the first KV tile from this pool and the remaining tiles from kPtr/vPtr.
+  void const* slidingWindowKvPoolPtr;
   // Packed KV buffer
   void const* kvPtr;
   // Packed QKV buffer
@@ -196,6 +214,8 @@ struct TllmGenFmhaRunnerParams {
   int64_t const* customMaskOffsetsPtr;
   // The first sparseMask offsets in the Kv sequence dimension.
   int32_t const* firstSparseMaskOffsetsKvPtr;
+  // Runtime sparse MLA top-k lengths, one value per query token.
+  int32_t const* sparseMlaTopKLensPtr;
   // The counter for the multiCtasKv mode.
   int32_t* multiCtasKvCounterPtr;
   // The sequence length buffer for K/V.
@@ -314,10 +334,14 @@ struct TllmGenFmhaRunnerParams {
   bool mSkipsSoftmaxWhenPossible;
   // Skip softmax threshold scale factor.
   float mSkipSoftmaxThresholdScaleFactor;
-  // Whether to use sparse MLA.
+  // Sparse MLA type. DeepSeek V4 uses DynamicTokenSparse with per-query-token top-k lengths.
+  TrtllmGenSparseMlaType mSparseMlaType;
+  // Whether to use sparse MLA. Kept as a cached predicate for existing call sites.
   bool mSparseMla;
   // The top k value for sparse MLA.
   int mSparseMlaTopK;
+  // Whether DSv4 sparse MLA should read tile 0 from slidingWindowKvPoolPtr.
+  bool mHasSlidingWindowKvPool;
   // Whether the indices for K & V pages are shared as unified index.
   // true -> vLLM/FlashInfer; false -> TRT-LLM.
   bool mUsesSharedPagedKvIdx;

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -737,7 +737,7 @@ struct KernelParams {
 
     // If sparse MLA is enabled, the shape and stride for K need to be updated for 2D layout
     // (numTokensKvInPagedKv, headDimQk).
-    if (options.mSparseMla) {
+    if (options.isSparseMla()) {
       shapeK = std::vector<uint64_t>{static_cast<uint64_t>(options.mHeadDimQk),
                                      static_cast<uint64_t>(INT_MAX)};
       strideK = std::vector<uint64_t>{1, static_cast<uint64_t>(options.mHeadDimQk)};
@@ -759,7 +759,7 @@ struct KernelParams {
         options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK, const_cast<void*>(kPtr),
         /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
 
-    if (options.mHasSlidingWindowKvPool && options.mSparseMla &&
+    if (options.mHasSlidingWindowKvPool && options.isSparseMla() &&
         options.slidingWindowKvPoolPtr != nullptr) {
       params.tmaKSlidingWindowKvPool_ =
           buildNdTmaDescriptor(options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK,
@@ -894,7 +894,7 @@ struct KernelParams {
     params.ptrSoftmaxStats = options.softmaxStatsPtr;
     // The sparseMlaTopK needs to be a multiple of 4 as we use 16B cpAsync instructions for the
     // indices.
-    FLASHINFER_CHECK(!options.mSparseMla || (options.mSparseMlaTopK % 4) == 0,
+    FLASHINFER_CHECK(!options.isSparseMla() || (options.mSparseMlaTopK % 4) == 0,
                      "SparseMlaTopK must be a multiple of 4");
     params.mSparseAttnTopK = options.mSparseMlaTopK;
     // TODO: Integrate trtllm block-sparse attention kernels when needed.

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <cuda/cmath>
 #include <cute/tensor.hpp>
 
@@ -44,12 +45,14 @@ struct KernelParams {
   CUtensorMap tmaQ_;
   // TMA descriptor for K.
   CUtensorMap tmaK_;
-  // The descriptor for O.
-  CUtensorMap tmaO_;
+  // TMA descriptor for DSv4 sparse MLA sliding-window KV pool. Same format as tmaK_.
+  CUtensorMap tmaKSlidingWindowKvPool_;
   // TMA descriptor for V.
   CUtensorMap tmaV_;
-  // TMA descriptor for output scaling factor.
-  CUtensorMap tmaOSf_;
+  // The descriptor for O.
+  CUtensorMap tmaO_;
+
+  // For FP4 KV cache, additional scaling factors are needed.
   // TMA descriptor for K scaling factor.
   CUtensorMap tmaKSf_;
   // TMA descriptor for V scaling factor.
@@ -117,11 +120,10 @@ struct KernelParams {
 
   // The softmax stats buffer.
   float2* ptrSoftmaxStats;
-  // The variable sparse MLA top-k lengths, one value per query token.
+
+  // The variable sparseMla topK lengths with shape of [numTokensQ].
   int32_t const* ptrSparseMlaTopKLens;
 
-  // Reserved scalar ABI state expected by newer trtllm-gen cubins.
-  int32_t mReservedAttentionWindowState[2]{};
   // The attention window size for sliding window attention.
   int32_t mAttentionWindowSize;
   // The batch size
@@ -759,8 +761,10 @@ struct KernelParams {
         options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK, const_cast<void*>(kPtr),
         /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
 
-    if (options.mHasSlidingWindowKvPool && options.isSparseMla() &&
-        options.slidingWindowKvPoolPtr != nullptr) {
+    bool const useSparseMlaSlidingWindowKvPool = options.mHasSlidingWindowKvPool &&
+                                                 options.isSparseMla() &&
+                                                 options.slidingWindowKvPoolPtr != nullptr;
+    if (useSparseMlaSlidingWindowKvPool) {
       params.tmaKSlidingWindowKvPool_ =
           buildNdTmaDescriptor(options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK,
                                const_cast<void*>(options.slidingWindowKvPoolPtr),

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -117,6 +117,8 @@ struct KernelParams {
 
   // The softmax stats buffer.
   float2* ptrSoftmaxStats;
+  // The variable sparse MLA top-k lengths, one value per query token.
+  int32_t const* ptrSparseMlaTopKLens;
 
   // Reserved scalar ABI state expected by newer trtllm-gen cubins.
   int32_t mReservedAttentionWindowState[2]{};
@@ -756,6 +758,15 @@ struct KernelParams {
     params.tmaK_ = buildNdTmaDescriptor(
         options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK, const_cast<void*>(kPtr),
         /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
+
+    if (options.mHasSlidingWindowKvPool && options.mSparseMla &&
+        options.slidingWindowKvPoolPtr != nullptr) {
+      params.tmaKSlidingWindowKvPool_ =
+          buildNdTmaDescriptor(options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK,
+                               const_cast<void*>(options.slidingWindowKvPoolPtr),
+                               /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
+    }
+
     params.tmaV_ = buildNdTmaDescriptor(
         options, kernelMeta.mDataTypeV, shapeV, strideV, tileShapeV, const_cast<void*>(vPtr),
         /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
@@ -820,6 +831,7 @@ struct KernelParams {
 
     // The sequence lengths for Kv.
     params.ptrSeqLensKv = options.seqLensKvPtr;
+    params.ptrSparseMlaTopKLens = options.sparseMlaTopKLensPtr;
 
     // Attention sink
     params.ptrAttentionSinks = options.ptrAttentionSinks;

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -1448,8 +1448,9 @@ def _test_trtllm_batch_decode(
             # Reference is computed on ref_q (with possibly different token count when padded);
             # compare on overlapping token slice.
             n = min(lse_out.shape[0], lse_ref.shape[0])
+            lse_atol = 1e-2 if kv_dtype == "fp8" else 3e-3
             torch.testing.assert_close(
-                lse_out[:n], lse_ref[:n].float(), rtol=1e-3, atol=1e-3
+                lse_out[:n], lse_ref[:n].float(), rtol=1e-3, atol=lse_atol
             )
         softmax_end = trtllm_gen_workspace_softmax_end_bytes_decode(
             num_qo_heads, batch_size, max_q_len_val

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -1448,7 +1448,7 @@ def _test_trtllm_batch_decode(
             # Reference is computed on ref_q (with possibly different token count when padded);
             # compare on overlapping token slice.
             n = min(lse_out.shape[0], lse_ref.shape[0])
-            lse_atol = 1e-2 if kv_dtype == "fp8" else 3e-3
+            lse_atol = 1.2e-2 if kv_dtype == "fp8" else 3e-3
             torch.testing.assert_close(
                 lse_out[:n], lse_ref[:n].float(), rtol=1e-3, atol=lse_atol
             )

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -637,7 +637,7 @@ def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Te
         ).contiguous()
     else:
         compressed_kv_cache = testcase.kv_scope.get_kvcache_for_flashinfer(t.kv_layout)
-        compressed_indices = swa_indices.new_full((swa_indices.size(0), 4), -1)
+        compressed_indices = swa_indices.new_empty((swa_indices.size(0), 0))
         sparse_topk_lens = swa_indices.new_full((swa_indices.size(0),), DSV4_SWA_TOPK)
     sparse_indices = torch.cat((swa_indices, compressed_indices), dim=-1).contiguous()
     if t.decode.is_varlen:

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -80,8 +80,9 @@ class TestParam:
     def id(self) -> str:
         assert self.decode is not None
         dtype_name = "bf16" if self.dtype == torch.bfloat16 else "fp8"
+        q_mode = "varq" if self.decode.is_varlen else "denseq"
         return (
-            f"{self.sparse_case}-b{self.decode.b}-h{self.h_q}-q{self.s_q}-"
+            f"{self.sparse_case}-{q_mode}-b{self.decode.b}-h{self.h_q}-q{self.s_q}-"
             f"kv{self.s_kv}-{dtype_name}-{self.kv_layout}"
         )
 
@@ -271,6 +272,23 @@ def gen_testcase() -> tuple[RawTestParamForDecode, ...]:
         kv_layout="HND",
         sparse_case="swa128",
     )
+    add_case(
+        b=2,
+        h_q=64,
+        s_q=DECODE_Q_LEN,
+        h_kv=1,
+        s_kv=DECODE_SEQ_LEN_CASES[0][0],
+        is_varlen=False,
+        topk=DSV4_SWA_TOPK,
+        extra_s_k=DECODE_SEQ_LEN_CASES[0][1],
+        extra_topk=_c4_topk(64),
+        block_size=SWA_PAGE_SIZE,
+        extra_block_size=C4_PAGE_SIZE,
+        have_extra_topk_length=True,
+        dtype=torch.bfloat16,
+        kv_layout="HND",
+        sparse_case="swa128+topk4x",
+    )
 
     # The DSv4 decode kernels are also used for prefill-style varlen Q. These
     # mirror the FlashMLA MODEL1 production rows, with larger Q and 16K KV.
@@ -332,9 +350,9 @@ def _make_block_table(cache_seqlens: torch.Tensor, block_size: int) -> torch.Ten
     block_table = torch.arange(
         batch_size * max_pages, dtype=torch.int32, device="cuda:0"
     ).view(batch_size, max_pages)
-    return block_table.view(-1)[torch.randperm(block_table.numel(), device="cuda:0")].view(
-        batch_size, max_pages
-    )
+    return block_table.view(-1)[
+        torch.randperm(block_table.numel(), device="cuda:0")
+    ].view(batch_size, max_pages)
 
 
 def _abs_indices2indices_in_kvcache(
@@ -437,9 +455,8 @@ def _make_cache_seqlens(
 ) -> torch.Tensor:
     assert t.decode is not None
     base_len = max(s_k, topk, int(q_lens.max().item()))
-    cache_seqlens = (
-        base_len
-        + block_size * torch.arange(t.decode.b, dtype=torch.int32, device="cuda:0")
+    cache_seqlens = base_len + block_size * torch.arange(
+        t.decode.b, dtype=torch.int32, device="cuda:0"
     )
     if t.decode.have_zero_seqlen_k:
         cache_seqlens[::2] = 0
@@ -623,10 +640,18 @@ def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Te
         compressed_indices = swa_indices.new_full((swa_indices.size(0), 4), -1)
         sparse_topk_lens = swa_indices.new_full((swa_indices.size(0),), DSV4_SWA_TOPK)
     sparse_indices = torch.cat((swa_indices, compressed_indices), dim=-1).contiguous()
+    if t.decode.is_varlen:
+        query = testcase.q[testcase.valid_q].contiguous()
+        cum_seq_lens_q = _make_cum_seq_lens(testcase.q_lens)
+        max_q_len = t.s_q
+    else:
+        query = testcase.q.contiguous()
+        cum_seq_lens_q = None
+        max_q_len = None
 
     try:
         return trtllm_batch_decode_sparse_mla_dsv4(
-            query=testcase.q[testcase.valid_q].contiguous(),
+            query=query,
             swa_kv_cache=testcase.kv_scope.get_kvcache_for_flashinfer(t.kv_layout),
             workspace_buffer=testcase.workspace_buffer,
             sparse_indices=sparse_indices,
@@ -637,8 +662,8 @@ def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Te
             bmm2_scale=_scale_for_flashinfer(t, 1.0),
             sinks=testcase.attn_sink,
             kv_layout=t.kv_layout,
-            cum_seq_lens_q=_make_cum_seq_lens(testcase.q_lens),
-            max_q_len=t.s_q,
+            cum_seq_lens_q=cum_seq_lens_q,
+            max_q_len=max_q_len,
             enable_pdl=False,
         )
     except RuntimeError as err:
@@ -675,9 +700,9 @@ def ref_sparse_attn_decode(
         invalid_mask = kv_scope.indices_in_kvcache == -1
         if kv_scope.topk_length is not None:
             lens = _topk_length_for_ref(kv_scope.topk_length, batch_size, p.s_q)
-            invalid_mask |= torch.arange(0, topk, device=t.q.device).view(
-                1, 1, topk
-            ) >= lens
+            invalid_mask |= (
+                torch.arange(0, topk, device=t.q.device).view(1, 1, topk) >= lens
+            )
         return gathered_kv, invalid_mask
 
     gathered_kv, invalid_mask = process_kv_scope(t.kv_scope)
@@ -727,8 +752,12 @@ def _assert_close(out: torch.Tensor, ref: torch.Tensor, dtype: torch.dtype) -> N
 def _skip_unless_sm100_or_sm103() -> None:
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for TRTLLM-GEN sparse MLA tests")
-    if get_compute_capability(torch.device("cuda"))[0] != 10:
-        pytest.skip("TRTLLM-GEN DeepSeek V4 sparse MLA requires SM100/SM103")
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability not in ((10, 0), (10, 3)):
+        pytest.skip(
+            "TRTLLM-GEN DeepSeek V4 sparse MLA requires SM100/SM103, "
+            f"got SM{compute_capability[0]}{compute_capability[1]}"
+        )
 
 
 @pytest.mark.parametrize("p", TESTCASES, ids=lambda p: p.id)
@@ -738,4 +767,6 @@ def test_trtllm_gen_sparse_mla_dsv4(p: TestParam) -> None:
     testcase = generate_testcase_for_decode(p)
     out_ans = run_flashinfer_decode(p, testcase)
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
-    _assert_close(out_ans, out_ref[testcase.valid_q], p.dtype)
+    if p.decode is not None and p.decode.is_varlen:
+        out_ref = out_ref[testcase.valid_q]
+    _assert_close(out_ans, out_ref, p.dtype)

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -1,0 +1,741 @@
+import dataclasses
+import random
+from typing import Literal
+
+import pytest
+import torch
+
+from flashinfer.mla import trtllm_batch_decode_sparse_mla_dsv4
+from flashinfer.utils import get_compute_capability
+
+
+WORKSPACE_SIZE = 128 * 1024 * 1024
+DSV4_HEAD_DIM = 512
+DSV4_SWA_TOPK = 128
+TEST_SEED_BASE = 2026
+
+DECODE_BATCH_SIZE = 3
+DECODE_Q_LEN = 5
+DECODE_SEQ_LEN_CASES = (
+    (512, 1024, 128),
+    (1024, 2048, 256),
+)
+
+PREFILL_BATCH_SIZE = 2
+PREFILL_Q_LEN = 257
+PREFILL_SEQ_LENS = (4096, 16 * 1024)
+
+SWA_PAGE_SIZE = 256
+C4_PAGE_SIZE = 64
+C128_PAGE_SIZE = 2
+
+QUERY_RANDOM_SCALE = 0.05
+KV_RANDOM_SCALE = 0.05
+SINK_RANDOM_SCALE = 0.05
+SWA_KV_OFFSET = -0.20
+COMPRESSED_KV_OFFSET = 0.25
+TOPK_BATCH_VARIATION_DIVISOR = 16
+TOPK_PER_QUERY_DECAY = 1
+
+KVLayout = Literal["HND", "NHD"]
+SparseCase = Literal["swa128", "swa128+topk4x", "swa128+topk128x"]
+TopkLengthMode = Literal["none", "profile", "seqlen"]
+
+
+@dataclasses.dataclass
+class ExtraTestParamForDecode:
+    b: int
+    is_varlen: bool
+    have_zero_seqlen_k: bool
+    extra_s_k: int | None = None
+    extra_topk: int | None = None
+    block_size: int = SWA_PAGE_SIZE
+    extra_block_size: int | None = None
+    have_extra_topk_length: bool = False
+
+
+@dataclasses.dataclass
+class TestParam:
+    __test__ = False
+
+    s_q: int
+    s_kv: int
+    topk: int
+    h_q: int = 128
+    h_kv: int = 1
+    d_qk: int = DSV4_HEAD_DIM
+    d_v: int = DSV4_HEAD_DIM
+    seed: int = -1
+    check_correctness: bool = True
+    is_all_indices_invalid: bool = False
+    num_runs: int = 0
+    have_attn_sink: bool = True
+    have_topk_length: bool = False
+    decode: ExtraTestParamForDecode | None = None
+    dtype: torch.dtype = torch.bfloat16
+    kv_layout: KVLayout = "HND"
+    sparse_case: SparseCase = "swa128"
+
+    @property
+    def id(self) -> str:
+        assert self.decode is not None
+        dtype_name = "bf16" if self.dtype == torch.bfloat16 else "fp8"
+        return (
+            f"{self.sparse_case}-b{self.decode.b}-h{self.h_q}-q{self.s_q}-"
+            f"kv{self.s_kv}-{dtype_name}-{self.kv_layout}"
+        )
+
+
+@dataclasses.dataclass
+class RawTestParamForDecode:
+    """FlashMLA-style flattened decode testcase parameters.
+
+    The dtype and kv_layout fields are FlashInfer-only extensions. DSv4
+    FlashInfer sparse MLA supports BF16 and per-tensor FP8 E4M3, so these tests
+    intentionally do not use FlashMLA's block-wise FP8 cache recipe.
+    """
+
+    b: int
+    h_q: int
+    s_q: int
+    h_kv: int
+    s_kv: int
+    is_varlen: bool
+    topk: int
+    is_all_indices_invalid: bool = False
+    have_zero_seqlen_k: bool = False
+    have_topk_length: bool = False
+    enable_attn_sink: bool = True
+    extra_s_k: int | None = None
+    extra_topk: int | None = None
+    block_size: int = SWA_PAGE_SIZE
+    extra_block_size: int | None = None
+    have_extra_topk_length: bool = False
+    d_qk: int = DSV4_HEAD_DIM
+    d_v: int = DSV4_HEAD_DIM
+    check_correctness: bool = True
+    num_runs: int = 0
+    seed: int = -1
+    dtype: torch.dtype = torch.bfloat16
+    kv_layout: KVLayout = "HND"
+    sparse_case: SparseCase = "swa128"
+
+    def to_test_param(self) -> TestParam:
+        return TestParam(
+            self.s_q,
+            self.s_kv,
+            self.topk,
+            self.h_q,
+            self.h_kv,
+            self.d_qk,
+            self.d_v,
+            self.seed,
+            self.check_correctness,
+            self.is_all_indices_invalid,
+            self.num_runs,
+            self.enable_attn_sink,
+            self.have_topk_length,
+            decode=ExtraTestParamForDecode(
+                self.b,
+                self.is_varlen,
+                self.have_zero_seqlen_k,
+                self.extra_s_k,
+                self.extra_topk,
+                self.block_size,
+                self.extra_block_size,
+                self.have_extra_topk_length,
+            ),
+            dtype=self.dtype,
+            kv_layout=self.kv_layout,
+            sparse_case=self.sparse_case,
+        )
+
+
+@dataclasses.dataclass
+class KVScope:
+    t: TestParam
+    cache_seqlens: torch.Tensor
+    block_table: torch.Tensor
+    blocked_k: torch.Tensor
+    abs_indices: torch.Tensor
+    indices_in_kvcache: torch.Tensor
+    topk_length: torch.Tensor | None
+
+    def get_kvcache_for_flashinfer(self, kv_layout: KVLayout) -> torch.Tensor:
+        if kv_layout == "HND":
+            return self.blocked_k.transpose(1, 2).contiguous()
+        return self.blocked_k.contiguous()
+
+
+@dataclasses.dataclass
+class TestcaseForDecode:
+    __test__ = False
+
+    p: TestParam
+    q: torch.Tensor
+    attn_sink: torch.Tensor | None
+    sm_scale: float
+    kv_scope: KVScope
+    extra_kv_scope: KVScope | None
+    q_lens: torch.Tensor
+    valid_q: torch.Tensor
+    workspace_buffer: torch.Tensor
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return ((x + multiple - 1) // multiple) * multiple
+
+
+def _c4_topk(h_q: int) -> int:
+    return 512 if h_q == 64 else 1024
+
+
+def gen_testcase() -> tuple[RawTestParamForDecode, ...]:
+    cases: list[RawTestParamForDecode] = []
+    seed = TEST_SEED_BASE
+
+    def add_case(**kwargs) -> None:
+        nonlocal seed
+        cases.append(RawTestParamForDecode(seed=seed, **kwargs))
+        seed += 1
+
+    for h_q in (64, 128):
+        c4_topk = _c4_topk(h_q)
+        for swa_seq_len, c4_seq_len, c128_seq_len in DECODE_SEQ_LEN_CASES:
+            c128_topk = _round_up(
+                c128_seq_len + (DECODE_BATCH_SIZE - 1) * C128_PAGE_SIZE, 4
+            )
+            for dtype in (torch.bfloat16, torch.float8_e4m3fn):
+                for kv_layout in ("HND", "NHD"):
+                    add_case(
+                        b=DECODE_BATCH_SIZE,
+                        h_q=h_q,
+                        s_q=DECODE_Q_LEN,
+                        h_kv=1,
+                        s_kv=swa_seq_len,
+                        is_varlen=True,
+                        topk=DSV4_SWA_TOPK,
+                        block_size=SWA_PAGE_SIZE,
+                        dtype=dtype,
+                        kv_layout=kv_layout,
+                        sparse_case="swa128",
+                    )
+                    add_case(
+                        b=DECODE_BATCH_SIZE,
+                        h_q=h_q,
+                        s_q=DECODE_Q_LEN,
+                        h_kv=1,
+                        s_kv=swa_seq_len,
+                        is_varlen=True,
+                        topk=DSV4_SWA_TOPK,
+                        extra_s_k=c4_seq_len,
+                        extra_topk=c4_topk,
+                        block_size=SWA_PAGE_SIZE,
+                        extra_block_size=C4_PAGE_SIZE,
+                        have_extra_topk_length=True,
+                        dtype=dtype,
+                        kv_layout=kv_layout,
+                        sparse_case="swa128+topk4x",
+                    )
+                    add_case(
+                        b=DECODE_BATCH_SIZE,
+                        h_q=h_q,
+                        s_q=DECODE_Q_LEN,
+                        h_kv=1,
+                        s_kv=swa_seq_len,
+                        is_varlen=True,
+                        topk=DSV4_SWA_TOPK,
+                        extra_s_k=c128_seq_len,
+                        extra_topk=c128_topk,
+                        block_size=SWA_PAGE_SIZE,
+                        extra_block_size=C128_PAGE_SIZE,
+                        have_extra_topk_length=True,
+                        dtype=dtype,
+                        kv_layout=kv_layout,
+                        sparse_case="swa128+topk128x",
+                    )
+
+    # Guard seq_lens-driven SWA masking. With q_len == kv_len == 128, early
+    # query tokens have fewer than 128 valid SWA entries, so the kernel must use
+    # real seq_lens instead of treating every SWA tile as full.
+    add_case(
+        b=1,
+        h_q=64,
+        s_q=DSV4_SWA_TOPK,
+        h_kv=1,
+        s_kv=DSV4_SWA_TOPK,
+        is_varlen=True,
+        topk=DSV4_SWA_TOPK,
+        block_size=SWA_PAGE_SIZE,
+        dtype=torch.bfloat16,
+        kv_layout="HND",
+        sparse_case="swa128",
+    )
+
+    # The DSv4 decode kernels are also used for prefill-style varlen Q. These
+    # mirror the FlashMLA MODEL1 production rows, with larger Q and 16K KV.
+    for prefill_seq_len in PREFILL_SEQ_LENS:
+        for h_q in (64, 128):
+            for dtype in (torch.bfloat16, torch.float8_e4m3fn):
+                add_case(
+                    b=PREFILL_BATCH_SIZE,
+                    h_q=h_q,
+                    s_q=PREFILL_Q_LEN,
+                    h_kv=1,
+                    s_kv=prefill_seq_len,
+                    is_varlen=True,
+                    topk=DSV4_SWA_TOPK,
+                    extra_s_k=prefill_seq_len,
+                    extra_topk=_c4_topk(h_q),
+                    block_size=SWA_PAGE_SIZE,
+                    extra_block_size=C4_PAGE_SIZE,
+                    have_extra_topk_length=True,
+                    dtype=dtype,
+                    kv_layout="HND",
+                    sparse_case="swa128+topk4x",
+                )
+
+    return tuple(cases)
+
+
+TESTCASES = tuple(t.to_test_param() for t in gen_testcase())
+
+
+def _make_cum_seq_lens(lengths: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (
+            torch.zeros(1, dtype=torch.int32, device=lengths.device),
+            lengths.cumsum(0, dtype=torch.int32),
+        )
+    )
+
+
+def _make_q_lens(t: TestParam) -> torch.Tensor:
+    assert t.decode is not None
+    if not t.decode.is_varlen:
+        return torch.full((t.decode.b,), t.s_q, dtype=torch.int32, device="cuda:0")
+    min_len = max(1, (t.s_q + 1) // 2)
+    return (
+        torch.linspace(min_len, t.s_q, t.decode.b, dtype=torch.float32, device="cuda:0")
+        .round()
+        .to(torch.int32)
+    )
+
+
+def _num_pages(seq_lens: torch.Tensor, page_size: int) -> torch.Tensor:
+    return torch.div(seq_lens + page_size - 1, page_size, rounding_mode="floor")
+
+
+def _make_block_table(cache_seqlens: torch.Tensor, block_size: int) -> torch.Tensor:
+    batch_size = cache_seqlens.numel()
+    max_pages = int(_num_pages(cache_seqlens, block_size).max().item())
+    block_table = torch.arange(
+        batch_size * max_pages, dtype=torch.int32, device="cuda:0"
+    ).view(batch_size, max_pages)
+    return block_table.view(-1)[torch.randperm(block_table.numel(), device="cuda:0")].view(
+        batch_size, max_pages
+    )
+
+
+def _abs_indices2indices_in_kvcache(
+    abs_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    indices = abs_indices.clone()
+    valid = indices >= 0
+    safe = indices.clamp_min(0)
+    block_idx = torch.div(safe, block_size, rounding_mode="floor")
+    block_offset = safe % block_size
+    batch_ids = torch.arange(indices.shape[0], device=indices.device).view(-1, 1, 1)
+    physical_blocks = block_table[batch_ids, block_idx]
+    indices = physical_blocks * block_size + block_offset
+    indices[~valid] = -1
+    return indices.to(torch.int32)
+
+
+def _make_kv_cache(
+    num_blocks: int,
+    block_size: int,
+    h_kv: int,
+    dtype: torch.dtype,
+    value_offset: float,
+) -> torch.Tensor:
+    cache = torch.randn(
+        (num_blocks, block_size, h_kv, DSV4_HEAD_DIM),
+        dtype=torch.float32,
+        device="cuda:0",
+    )
+    return cache.mul_(KV_RANDOM_SCALE).add_(value_offset).clamp_(-1.0, 1.0).to(dtype)
+
+
+def _make_causal_abs_indices(
+    cache_seqlens: torch.Tensor,
+    q_lens: torch.Tensor,
+    topk: int,
+    max_q_len: int,
+) -> torch.Tensor:
+    indices = torch.empty(
+        (cache_seqlens.numel(), max_q_len, topk),
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+    for batch_idx in range(cache_seqlens.numel()):
+        seq_len = int(cache_seqlens[batch_idx].item())
+        q_len = int(q_lens[batch_idx].item())
+        for q_idx in range(max_q_len):
+            token_idx = seq_len - q_len + min(q_idx, q_len - 1)
+            num_valid = min(topk, token_idx + 1)
+            start = token_idx - num_valid + 1
+            logical = torch.arange(
+                start, start + num_valid, dtype=torch.int32, device="cuda:0"
+            )
+            indices[batch_idx, q_idx].fill_(-1)
+            indices[batch_idx, q_idx, :num_valid] = logical
+    return indices
+
+
+def _randperm_batch(
+    perm_range: torch.Tensor,
+    perm_size: int,
+    padding: int,
+) -> torch.Tensor:
+    batch_size = perm_range.numel()
+    perm_range_max = max(int(perm_range.max().item()), perm_size)
+    rand = torch.rand(
+        batch_size,
+        perm_range_max,
+        dtype=torch.float32,
+        device=perm_range.device,
+    )
+    rand[
+        torch.arange(perm_range_max, device=perm_range.device).view(1, -1)
+        >= perm_range.view(batch_size, 1)
+    ] = float("-inf")
+    res = rand.topk(perm_size, dim=-1, sorted=True).indices.to(torch.int32)
+    res[res >= perm_range.view(batch_size, 1)] = padding
+    return res
+
+
+def _make_random_abs_indices(
+    cache_seqlens: torch.Tensor,
+    topk: int,
+    max_q_len: int,
+) -> torch.Tensor:
+    perm_range = cache_seqlens.repeat_interleave(max_q_len)
+    return _randperm_batch(perm_range, topk, -1).view(
+        cache_seqlens.numel(), max_q_len, topk
+    )
+
+
+def _make_cache_seqlens(
+    t: TestParam,
+    s_k: int,
+    block_size: int,
+    q_lens: torch.Tensor,
+    topk: int,
+) -> torch.Tensor:
+    assert t.decode is not None
+    base_len = max(s_k, topk, int(q_lens.max().item()))
+    cache_seqlens = (
+        base_len
+        + block_size * torch.arange(t.decode.b, dtype=torch.int32, device="cuda:0")
+    )
+    if t.decode.have_zero_seqlen_k:
+        cache_seqlens[::2] = 0
+    return cache_seqlens.contiguous()
+
+
+def _make_topk_length(
+    cache_seqlens: torch.Tensor,
+    topk: int,
+    max_q_len: int,
+    mode: TopkLengthMode,
+) -> torch.Tensor | None:
+    if mode == "none":
+        return None
+    if mode == "seqlen":
+        return cache_seqlens.view(-1, 1).expand(-1, max_q_len).clamp(max=topk)
+
+    batch_delta = max(1, topk // TOPK_BATCH_VARIATION_DIVISOR)
+    base_topk = topk - batch_delta * torch.arange(
+        cache_seqlens.numel(), dtype=torch.int32, device="cuda:0"
+    )
+    q_positions = torch.arange(max_q_len, dtype=torch.int32, device="cuda:0")
+    lens = base_topk.view(-1, 1) - TOPK_PER_QUERY_DECAY * q_positions.view(1, -1)
+    return lens.clamp(min=1, max=topk).contiguous()
+
+
+def _topk_length_for_flashinfer(
+    topk_length: torch.Tensor,
+    valid_q: torch.Tensor,
+) -> torch.Tensor:
+    if topk_length.ndim == 1:
+        topk_length = topk_length.view(-1, 1).expand_as(valid_q)
+    return topk_length[valid_q].contiguous()
+
+
+def _topk_length_for_ref(
+    topk_length: torch.Tensor,
+    batch_size: int,
+    max_q_len: int,
+) -> torch.Tensor:
+    if topk_length.ndim == 1:
+        return topk_length.view(batch_size, 1, 1)
+    return topk_length.view(batch_size, max_q_len, 1)
+
+
+def generate_one_k_scope(
+    t: TestParam,
+    q_lens: torch.Tensor,
+    s_k: int,
+    block_size: int,
+    topk: int,
+    value_offset: float,
+    topk_length_mode: TopkLengthMode,
+    random_indices: bool,
+) -> KVScope:
+    assert t.decode is not None
+    cache_seqlens = _make_cache_seqlens(t, s_k, block_size, q_lens, topk)
+    block_table = _make_block_table(cache_seqlens, block_size)
+    blocked_k = _make_kv_cache(
+        block_table.numel(), block_size, t.h_kv, t.dtype, value_offset
+    )
+    if random_indices:
+        abs_indices = _make_random_abs_indices(cache_seqlens, topk, t.s_q)
+    else:
+        abs_indices = _make_causal_abs_indices(cache_seqlens, q_lens, topk, t.s_q)
+    if t.is_all_indices_invalid:
+        abs_indices.fill_(-1)
+    indices_in_kvcache = _abs_indices2indices_in_kvcache(
+        abs_indices, block_table, block_size
+    )
+    topk_length = _make_topk_length(cache_seqlens, topk, t.s_q, topk_length_mode)
+    return KVScope(
+        t,
+        cache_seqlens,
+        block_table,
+        blocked_k,
+        abs_indices,
+        indices_in_kvcache,
+        topk_length,
+    )
+
+
+def generate_testcase_for_decode(t: TestParam) -> TestcaseForDecode:
+    random.seed(t.seed)
+    torch.manual_seed(t.seed)
+    torch.cuda.manual_seed_all(t.seed)
+
+    assert t.h_q % t.h_kv == 0
+    assert t.h_kv == 1
+    assert t.decode is not None
+    assert t.d_qk == DSV4_HEAD_DIM and t.d_v == DSV4_HEAD_DIM
+    assert t.topk == DSV4_SWA_TOPK
+    assert t.dtype in (torch.bfloat16, torch.float8_e4m3fn)
+
+    q = torch.randn(
+        (t.decode.b, t.s_q, t.h_q, t.d_qk),
+        dtype=torch.float32,
+        device="cuda:0",
+    )
+    q = q.mul_(QUERY_RANDOM_SCALE).clamp_(min=-1.0, max=1.0).to(t.dtype)
+
+    q_lens = _make_q_lens(t)
+    valid_q = torch.arange(t.s_q, device="cuda:0").view(1, t.s_q) < q_lens.view(
+        t.decode.b, 1
+    )
+
+    attn_sink = None
+    if t.have_attn_sink:
+        attn_sink = (
+            torch.randn((t.h_q,), dtype=torch.float32, device="cuda:0")
+            * SINK_RANDOM_SCALE
+        )
+
+    kv_scope0 = generate_one_k_scope(
+        t,
+        q_lens,
+        t.s_kv,
+        t.decode.block_size,
+        t.topk,
+        SWA_KV_OFFSET,
+        "none",
+        False,
+    )
+
+    kv_scope1 = None
+    if t.decode.extra_topk is not None:
+        assert t.decode.extra_s_k is not None
+        assert t.decode.extra_block_size is not None
+        topk_length_mode: TopkLengthMode = (
+            "seqlen" if t.decode.extra_block_size == C128_PAGE_SIZE else "profile"
+        )
+        kv_scope1 = generate_one_k_scope(
+            t,
+            q_lens,
+            t.decode.extra_s_k,
+            t.decode.extra_block_size,
+            t.decode.extra_topk,
+            COMPRESSED_KV_OFFSET,
+            topk_length_mode,
+            True,
+        )
+
+    return TestcaseForDecode(
+        t,
+        q,
+        attn_sink,
+        t.d_qk**-0.55,
+        kv_scope0,
+        kv_scope1,
+        q_lens,
+        valid_q,
+        torch.zeros(WORKSPACE_SIZE, dtype=torch.int8, device="cuda:0"),
+    )
+
+
+def _scale_for_flashinfer(t: TestParam, value: float) -> float | torch.Tensor:
+    if t.dtype == torch.float8_e4m3fn:
+        return torch.tensor([value], dtype=torch.float32, device="cuda:0")
+    return value
+
+
+def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Tensor:
+    assert t.decode is not None
+    swa_indices = testcase.kv_scope.indices_in_kvcache[testcase.valid_q].contiguous()
+    if testcase.extra_kv_scope is not None:
+        assert testcase.extra_kv_scope.topk_length is not None
+        compressed_kv_cache = testcase.extra_kv_scope.get_kvcache_for_flashinfer(
+            t.kv_layout
+        )
+        compressed_indices = testcase.extra_kv_scope.indices_in_kvcache[
+            testcase.valid_q
+        ].contiguous()
+        sparse_topk_lens = (
+            _topk_length_for_flashinfer(
+                testcase.extra_kv_scope.topk_length, testcase.valid_q
+            )
+            + DSV4_SWA_TOPK
+        ).contiguous()
+    else:
+        compressed_kv_cache = testcase.kv_scope.get_kvcache_for_flashinfer(t.kv_layout)
+        compressed_indices = swa_indices.new_full((swa_indices.size(0), 4), -1)
+        sparse_topk_lens = swa_indices.new_full((swa_indices.size(0),), DSV4_SWA_TOPK)
+    sparse_indices = torch.cat((swa_indices, compressed_indices), dim=-1).contiguous()
+
+    try:
+        return trtllm_batch_decode_sparse_mla_dsv4(
+            query=testcase.q[testcase.valid_q].contiguous(),
+            swa_kv_cache=testcase.kv_scope.get_kvcache_for_flashinfer(t.kv_layout),
+            workspace_buffer=testcase.workspace_buffer,
+            sparse_indices=sparse_indices,
+            compressed_kv_cache=compressed_kv_cache,
+            sparse_topk_lens=sparse_topk_lens,
+            seq_lens=testcase.kv_scope.cache_seqlens,
+            bmm1_scale=_scale_for_flashinfer(t, testcase.sm_scale),
+            bmm2_scale=_scale_for_flashinfer(t, 1.0),
+            sinks=testcase.attn_sink,
+            kv_layout=t.kv_layout,
+            cum_seq_lens_q=_make_cum_seq_lens(testcase.q_lens),
+            max_q_len=t.s_q,
+            enable_pdl=False,
+        )
+    except RuntimeError as err:
+        err_msg = str(err)
+        if (
+            "trtllm_paged_attention_decode_sparse_mla_dsv4 is not available" in err_msg
+            or "Missing TRTLLM-GEN kernel (decode)" in err_msg
+        ):
+            pytest.skip("DeepSeek V4 sparse MLA TRTLLM-GEN cubins are not available")
+        if (
+            "Ninja build failed" in err_msg
+            and "trtllm_fmha_kernel_launcher.cu" in err_msg
+            and "missing and no known rule" in err_msg
+        ):
+            pytest.skip("TRTLLM-GEN JIT launcher sources are not available")
+        raise
+
+
+def ref_sparse_attn_decode(
+    p: TestParam,
+    t: TestcaseForDecode,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert p.h_kv == 1
+    assert p.decode is not None
+    batch_size = p.decode.b
+
+    def process_kv_scope(kv_scope: KVScope) -> tuple[torch.Tensor, torch.Tensor]:
+        topk = kv_scope.indices_in_kvcache.size(-1)
+        indices_fixed = kv_scope.indices_in_kvcache.clamp_min(0)
+        flat_kv = kv_scope.blocked_k.view(-1, p.d_qk).float()
+        gathered_kv = flat_kv.index_select(0, indices_fixed.view(-1).long()).view(
+            batch_size, p.s_q, topk, p.d_qk
+        )
+        invalid_mask = kv_scope.indices_in_kvcache == -1
+        if kv_scope.topk_length is not None:
+            lens = _topk_length_for_ref(kv_scope.topk_length, batch_size, p.s_q)
+            invalid_mask |= torch.arange(0, topk, device=t.q.device).view(
+                1, 1, topk
+            ) >= lens
+        return gathered_kv, invalid_mask
+
+    gathered_kv, invalid_mask = process_kv_scope(t.kv_scope)
+    if t.extra_kv_scope is not None:
+        gathered_kv1, invalid_mask1 = process_kv_scope(t.extra_kv_scope)
+        gathered_kv = torch.cat([gathered_kv, gathered_kv1], dim=2)
+        invalid_mask = torch.cat([invalid_mask, invalid_mask1], dim=2)
+
+    gathered_kv = gathered_kv.view(batch_size * p.s_q, -1, p.d_qk).float()
+    q = t.q.float().view(batch_size * p.s_q, p.h_q, p.d_qk)
+    attn_weight = q @ gathered_kv.transpose(-1, -2)
+    attn_weight *= t.sm_scale
+    attn_weight[
+        invalid_mask.view(batch_size * p.s_q, 1, -1).broadcast_to(
+            batch_size * p.s_q, p.h_q, invalid_mask.size(-1)
+        )
+    ] = float("-inf")
+    lse = attn_weight.logsumexp(dim=-1)
+    attn_weight = torch.exp(attn_weight - lse.unsqueeze(-1))
+    output = attn_weight @ gathered_kv[..., : p.d_v]
+    output = output.view(batch_size, p.s_q, p.h_q, p.d_v)
+    lse = lse.view(batch_size, p.s_q, p.h_q)
+
+    if t.attn_sink is not None:
+        sink_scale = 1.0 / (1.0 + torch.exp(t.attn_sink.view(1, 1, p.h_q) - lse))
+        sink_scale = torch.where(
+            torch.isfinite(sink_scale), sink_scale, torch.zeros_like(sink_scale)
+        )
+        output *= sink_scale.unsqueeze(-1)
+
+    lonely_q_mask = lse == float("-inf")
+    output[lonely_q_mask.unsqueeze(-1).broadcast_to(output.shape)] = 0.0
+    lse[lonely_q_mask] = float("+inf")
+    return output.to(torch.bfloat16), lse.transpose(1, 2)
+
+
+def _assert_close(out: torch.Tensor, ref: torch.Tensor, dtype: torch.dtype) -> None:
+    assert out.shape == ref.shape
+    assert out.dtype == torch.bfloat16
+    assert not torch.isnan(out).any()
+    if dtype == torch.float8_e4m3fn:
+        torch.testing.assert_close(out.float(), ref.float(), rtol=1e-1, atol=1e-1)
+    else:
+        torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=8e-4)
+
+
+def _skip_unless_sm100_or_sm103() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for TRTLLM-GEN sparse MLA tests")
+    if get_compute_capability(torch.device("cuda"))[0] != 10:
+        pytest.skip("TRTLLM-GEN DeepSeek V4 sparse MLA requires SM100/SM103")
+
+
+@pytest.mark.parametrize("p", TESTCASES, ids=lambda p: p.id)
+@torch.inference_mode()
+def test_trtllm_gen_sparse_mla_dsv4(p: TestParam) -> None:
+    _skip_unless_sm100_or_sm103()
+    testcase = generate_testcase_for_decode(p)
+    out_ans = run_flashinfer_decode(p, testcase)
+    out_ref, _ = ref_sparse_attn_decode(p, testcase)
+    _assert_close(out_ans, out_ref[testcase.valid_q], p.dtype)


### PR DESCRIPTION
## Summary
- Add DeepSeek V4 sparse MLA TRTLLM-GEN decode support for BF16 and per-tensor FP8 paths.
- Plumb SWA and compressed KV pools, concatenated sparse indices, and per-query sparse top-k lengths through FlashInfer.
- Add DeepSeek V4 sparse MLA tests covering SWA-only and compressed top-k cases with variable Q/KV lengths.

## Tests
- `python -m pytest -q --tb=short -k 'not xqa and not cute and not trtllm-native' tests/attention/test_trtllm_gen_sparse_mla_dsv4.py`: 57 passed
- `python -m pytest -q --tb=short -k 'not xqa and not cute and not trtllm-native' tests/attention/test_attention_sink_blackwell.py`: 144 passed
- `python -m pytest -q --tb=short -k 'not xqa and not cute and not trtllm-native' tests/attention/test_trtllm_gen_mla.py`: 7686 passed, 12672 deselected
- `python -m pytest -q --tb=short -n 8 -k 'not xqa and not cute and not trtllm-native' tests/attention/test_trtllm_gen_attention.py`: 75736 passed, 30800 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V4 sparse MLA decode support with variable top-k behavior and sliding-window KV cache integration.
  * Enhanced kernel selection with dynamic token-per-page support for improved performance flexibility.

* **Tests**
  * Added comprehensive test suite for DeepSeek V4 sparse MLA decode across multiple configurations.

* **Chores**
  * Updated environment variable priority for CUBIN directory selection.
  * Added backward-compatibility alias for MLA decode function.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3269)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->