### PR TITLE
feat(moe): add SM120 W4A16 b12x kernels

### DIFF
--- a/flashinfer/cute_dsl/fp4_common.py
+++ b/flashinfer/cute_dsl/fp4_common.py
@@ -29,6 +29,7 @@ import cutlass.cute as cute
 import torch
 from cutlass import Float32, Int32, Int64, Uint8, Uint32, Uint64
 from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir import ir
 from cutlass._mlir.dialects import llvm
 
 
@@ -177,6 +178,48 @@ def ld_v4_u32(
     v3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
 
     return Uint32(v0), Uint32(v1), Uint32(v2), Uint32(v3)
+
+
+@dsl_user_op
+def ld_global_nc_u32(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    """Load 32 bits from global memory through the non-coherent cache."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.nc.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_global_nc_v4_u32(
+    base_ptr: Int64, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Load 128 bits from global memory through the non-coherent cache."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+        "ld.global.nc.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,l",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)),
+    )
 
 
 @dsl_user_op
@@ -1301,6 +1344,37 @@ def st_global_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
     )
 
 
+@dsl_user_op
+def st_global_v4_u32(
+    base_ptr: Int64,
+    v0: Uint32,
+    v1: Uint32,
+    v2: Uint32,
+    v3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Store 128 bits to global memory as four uint32 words."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(base_ptr).ir_value(loc=loc, ip=ip),
+            Uint32(v0).ir_value(loc=loc, ip=ip),
+            Uint32(v1).ir_value(loc=loc, ip=ip),
+            Uint32(v2).ir_value(loc=loc, ip=ip),
+            Uint32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.v4.u32 [$0], {$1, $2, $3, $4};",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
 # =============================================================================
 # PTX Intrinsics — Shared Memory Operations
 # =============================================================================
@@ -1310,6 +1384,80 @@ def st_global_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
 def shared_ptr_to_u32(ptr: cute.Pointer, *, loc=None, ip=None) -> Int32:
     """Convert an address-space-3 shared-memory pointer to a u32 address."""
     return Int32(llvm.ptrtoint(T.i32(), ptr.llvm_ptr, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def ld_shared_i32_relaxed(addr: Int32, *, loc=None, ip=None) -> Int32:
+    """Load int32 from shared memory when CSE/reordering is acceptable."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.s32 $0, [$1];",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_shared_i32(addr: Int32, val: Int32, *, loc=None, ip=None):
+    """Store int32 to shared memory at a 32-bit byte address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.s32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ld_shared_f32(addr: Int32, *, loc=None, ip=None) -> Float32:
+    """Load float32 from shared memory at a 32-bit byte address."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.f32 $0, [$1];",
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_shared_f32(addr: Int32, val: Float32, *, loc=None, ip=None):
+    """Store float32 to shared memory at a 32-bit byte address."""
+    llvm.inline_asm(
+        None,
+        [
+            Int32(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.f32 [$0], $1;",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
 
 
 @dsl_user_op
@@ -1353,6 +1501,109 @@ def atomic_add_global_i32(addr: Int64, val: Int32, *, loc=None, ip=None) -> Int3
     )
 
 
+@dsl_user_op
+def atomic_cas_global_i32(
+    addr: Int64, compare: Int32, value: Int32, *, loc=None, ip=None
+) -> Int32:
+    """Global memory int32 atomic compare-and-swap. Returns old value."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Int32(compare).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.cas.b32 $0, [$1], $2, $3;",
+            "=r,l,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_global_acquire_i32(addr: Int64, *, loc=None, ip=None) -> Int32:
+    """Load int32 from global memory with acquire semantics."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.acquire.gpu.s32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_global_release_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
+    """Store int32 to global memory with release semantics."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.release.gpu.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def spin_wait_global_eq_i32(addr: Int64, expected: Int32, *, loc=None, ip=None):
+    """Spin while *addr == expected, then continue with acquire semantics."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(expected).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_loop:\n"
+        "  ld.global.acquire.gpu.s32 %val, [$0];\n"
+        "  setp.eq.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_loop;\n"
+        "}",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def threadfence(*, loc=None, ip=None):
+    """Emit a global-memory fence."""
+    llvm.inline_asm(
+        None,
+        [],
+        "membar.gl;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
 # =============================================================================
 # PTX Intrinsics — Scatter Atomics (BF16)
 # =============================================================================
@@ -1379,6 +1630,39 @@ def scatter_add_bf16x2(addr: Int64, val0_f32, val1_f32, *, loc=None, ip=None):
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def scatter_add_v4_bf16x2(
+    addr: Int64, v0, v1, v2, v3, v4, v5, v6, v7, *, loc=None, ip=None
+):
+    """Vectorized BF16x2 atomic reduction of 8 f32 values."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            v0.ir_value(loc=loc, ip=ip),
+            v1.ir_value(loc=loc, ip=ip),
+            v2.ir_value(loc=loc, ip=ip),
+            v3.ir_value(loc=loc, ip=ip),
+            v4.ir_value(loc=loc, ip=ip),
+            v5.ir_value(loc=loc, ip=ip),
+            v6.ir_value(loc=loc, ip=ip),
+            v7.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b32 p0,p1,p2,p3;"
+        " cvt.rn.satfinite.bf16x2.f32 p0, $2, $1;"
+        " cvt.rn.satfinite.bf16x2.f32 p1, $4, $3;"
+        " cvt.rn.satfinite.bf16x2.f32 p2, $6, $5;"
+        " cvt.rn.satfinite.bf16x2.f32 p3, $8, $7;"
+        " red.global.add.noftz.v4.bf16x2 [$0], {p0, p1, p2, p3}; }",
+        "l,f,f,f,f,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
 
 
@@ -1422,6 +1706,433 @@ def fp8_e4m3_to_f32(fp8_val: Uint32, *, loc=None, ip=None) -> Float32:
             has_side_effects=False,
             is_align_stack=False,
             asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def nvfp4_scale_from_amax(
+    block_amax: Float32, global_scale: Float32, *, loc=None, ip=None
+) -> Float32:
+    """Compute the NVFP4 block scale from an amax and global scale."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Float32(block_amax).ir_value(loc=loc, ip=ip),
+                Float32(global_scale).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .f64 amax_d, gs_d, q_d, six_d;
+                cvt.f64.f32 amax_d, $1;
+                cvt.f64.f32 gs_d, $2;
+                mov.f64 six_d, 0d4018000000000000;
+                mul.rn.f64 q_d, amax_d, gs_d;
+                div.rn.f64 q_d, q_d, six_d;
+                cvt.rn.f32.f64 $0, q_d;
+            }
+            """,
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_e4m3x2_to_f16x2_pair(
+    packed_u32: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32]:
+    """Decode 4 packed E4M3 bytes into two f16x2 registers."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32)>"),
+        [Uint32(packed_u32).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 b16_01, b16_23;
+            .reg .b32 hi32;
+            cvt.u16.u32 b16_01, $2;
+            shr.b32 hi32, $2, 16;
+            cvt.u16.u32 b16_23, hi32;
+            cvt.rn.f16x2.e4m3x2 $0, b16_01;
+            cvt.rn.f16x2.e4m3x2 $1, b16_23;
+        }
+        """,
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def f16x2_to_f32x2(packed_h2: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    """Unpack one f16x2 register into two f32 values."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32)>"),
+        [Uint32(packed_h2).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 lo, hi;
+            mov.b32 {lo, hi}, $2;
+            cvt.f32.f16 $0, lo;
+            cvt.f32.f16 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), res, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), res, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def cvt_e4m3_to_f32_via_f16(fp8_val: Uint32, *, loc=None, ip=None) -> Float32:
+    """Convert one E4M3 byte to f32 through native E4M3-to-f16 conversion."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Uint32(fp8_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 fp8_pair;
+                .reg .b32 h2;
+                .reg .b16 lo, hi;
+                cvt.u16.u32 fp8_pair, $1;
+                cvt.rn.f16x2.e4m3x2 h2, fp8_pair;
+                mov.b32 {lo, hi}, h2;
+                cvt.f32.f16 $0, lo;
+            }
+            """,
+            "=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def fp4_decode_4bytes(
+    packed_u32: Uint32, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Decode 4 packed FP4 bytes into four f16x2 registers."""
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32, i32, i32)>"),
+        [Uint32(packed_u32).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b8 byte0, byte1, byte2, byte3;
+            mov.b32 {byte0, byte1, byte2, byte3}, $4;
+            cvt.rn.f16x2.e2m1x2 $0, byte0;
+            cvt.rn.f16x2.e2m1x2 $1, byte1;
+            cvt.rn.f16x2.e2m1x2 $2, byte2;
+            cvt.rn.f16x2.e2m1x2 $3, byte3;
+        }
+        """,
+        "=r,=r,=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [2], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), res, [3], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def fp4_decode_2(byte_val: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Decode one FP4 byte into one f16x2 register."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(byte_val).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b8 b0;
+                cvt.u8.u32 b0, $1;
+                cvt.rn.f16x2.e2m1x2 $0, b0;
+            }
+            """,
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cvt_fp32x2_to_e2m1x2(v0: Float32, v1: Float32, *, loc=None, ip=None) -> Uint32:
+    """Convert two f32 values into one packed E2M1 byte."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(v0).ir_value(loc=loc, ip=ip),
+                Float32(v1).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 b;
+                cvt.rn.satfinite.e2m1x2.f32 b, $2, $1;
+                cvt.u32.u8 $0, b;
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def quant_dequant_2(
+    v0: Float32, v1: Float32, sf_f32: Float32, eff_scale: Float32
+) -> Tuple[Float32, Float32]:
+    """Quantize/dequantize two values through FP4."""
+    inv_scale = Float32(1.0) / eff_scale
+    fp4_byte = cvt_fp32x2_to_e2m1x2(v0 * inv_scale, v1 * inv_scale)
+    h2 = fp4_decode_2(fp4_byte)
+    f0, f1 = f16x2_to_f32x2(h2)
+    return f0 * sf_f32, f1 * sf_f32
+
+
+@dsl_user_op
+def fp4_dot4_sum(
+    u_packed: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """Decode 4 FP4 bytes and dot with four f16x2 inputs."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(u_packed).ir_value(loc=loc, ip=ip),
+                Uint32(x0).ir_value(loc=loc, ip=ip),
+                Uint32(x1).ir_value(loc=loc, ip=ip),
+                Uint32(x2).ir_value(loc=loc, ip=ip),
+                Uint32(x3).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 b0, b1, b2, b3;
+                .reg .b32 h0, h1, h2, h3;
+                .reg .f16x2 acc;
+                .reg .b16 lo, hi;
+                .reg .f32 flo, fhi;
+                mov.b32 {b0, b1, b2, b3}, $1;
+                cvt.rn.f16x2.e2m1x2 h0, b0;
+                cvt.rn.f16x2.e2m1x2 h1, b1;
+                cvt.rn.f16x2.e2m1x2 h2, b2;
+                cvt.rn.f16x2.e2m1x2 h3, b3;
+                mov.b32 acc, 0;
+                fma.rn.f16x2 acc, h0, $2, acc;
+                fma.rn.f16x2 acc, h1, $3, acc;
+                fma.rn.f16x2 acc, h2, $4, acc;
+                fma.rn.f16x2 acc, h3, $5, acc;
+                mov.b32 {lo, hi}, acc;
+                cvt.f32.f16 flo, lo;
+                cvt.f32.f16 fhi, hi;
+                add.f32 $0, flo, fhi;
+            }
+            """,
+            "=f,r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def fp4_dot8_sum(
+    u_a: Uint32,
+    u_b: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    x4: Uint32,
+    x5: Uint32,
+    x6: Uint32,
+    x7: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """Decode 8 FP4 bytes and dot with eight f16x2 inputs."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Uint32(u_a).ir_value(loc=loc, ip=ip),
+                Uint32(u_b).ir_value(loc=loc, ip=ip),
+                Uint32(x0).ir_value(loc=loc, ip=ip),
+                Uint32(x1).ir_value(loc=loc, ip=ip),
+                Uint32(x2).ir_value(loc=loc, ip=ip),
+                Uint32(x3).ir_value(loc=loc, ip=ip),
+                Uint32(x4).ir_value(loc=loc, ip=ip),
+                Uint32(x5).ir_value(loc=loc, ip=ip),
+                Uint32(x6).ir_value(loc=loc, ip=ip),
+                Uint32(x7).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b8 a0, a1, a2, a3;
+                .reg .b8 b0, b1, b2, b3;
+                .reg .b32 h0, h1, h2, h3, h4, h5, h6, h7;
+                .reg .f16x2 acc;
+                .reg .b16 lo, hi;
+                .reg .f32 flo, fhi;
+                mov.b32 {a0, a1, a2, a3}, $1;
+                mov.b32 {b0, b1, b2, b3}, $2;
+                cvt.rn.f16x2.e2m1x2 h0, a0;
+                cvt.rn.f16x2.e2m1x2 h1, a1;
+                cvt.rn.f16x2.e2m1x2 h2, a2;
+                cvt.rn.f16x2.e2m1x2 h3, a3;
+                cvt.rn.f16x2.e2m1x2 h4, b0;
+                cvt.rn.f16x2.e2m1x2 h5, b1;
+                cvt.rn.f16x2.e2m1x2 h6, b2;
+                cvt.rn.f16x2.e2m1x2 h7, b3;
+                mov.b32 acc, 0;
+                fma.rn.f16x2 acc, h0, $3, acc;
+                fma.rn.f16x2 acc, h1, $4, acc;
+                fma.rn.f16x2 acc, h2, $5, acc;
+                fma.rn.f16x2 acc, h3, $6, acc;
+                fma.rn.f16x2 acc, h4, $7, acc;
+                fma.rn.f16x2 acc, h5, $8, acc;
+                fma.rn.f16x2 acc, h6, $9, acc;
+                fma.rn.f16x2 acc, h7, $10, acc;
+                mov.b32 {lo, hi}, acc;
+                cvt.f32.f16 flo, lo;
+                cvt.f32.f16 fhi, hi;
+                add.f32 $0, flo, fhi;
+            }
+            """,
+            "=f,r,r,r,r,r,r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def _f16x2_dot_sum_f32acc(a_h2: Uint32, b_h2: Uint32) -> Float32:
+    a0, a1 = f16x2_to_f32x2(a_h2)
+    b0, b1 = f16x2_to_f32x2(b_h2)
+    return a0 * b0 + a1 * b1
+
+
+@cute.jit
+def fp4_dot4_sum_f32acc(
+    u_packed: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+) -> Float32:
+    """Decode FP4 then accumulate a 4-byte dot product in f32."""
+    h0, h1, h2, h3 = fp4_decode_4bytes(u_packed)
+    return (
+        _f16x2_dot_sum_f32acc(h0, x0)
+        + _f16x2_dot_sum_f32acc(h1, x1)
+        + _f16x2_dot_sum_f32acc(h2, x2)
+        + _f16x2_dot_sum_f32acc(h3, x3)
+    )
+
+
+@cute.jit
+def fp4_dot8_sum_f32acc(
+    u_a: Uint32,
+    u_b: Uint32,
+    x0: Uint32,
+    x1: Uint32,
+    x2: Uint32,
+    x3: Uint32,
+    x4: Uint32,
+    x5: Uint32,
+    x6: Uint32,
+    x7: Uint32,
+) -> Float32:
+    """Decode FP4 then accumulate an 8-byte dot product in f32."""
+    h0, h1, h2, h3 = fp4_decode_4bytes(u_a)
+    h4, h5, h6, h7 = fp4_decode_4bytes(u_b)
+    return (
+        _f16x2_dot_sum_f32acc(h0, x0)
+        + _f16x2_dot_sum_f32acc(h1, x1)
+        + _f16x2_dot_sum_f32acc(h2, x2)
+        + _f16x2_dot_sum_f32acc(h3, x3)
+        + _f16x2_dot_sum_f32acc(h4, x4)
+        + _f16x2_dot_sum_f32acc(h5, x5)
+        + _f16x2_dot_sum_f32acc(h6, x6)
+        + _f16x2_dot_sum_f32acc(h7, x7)
+    )
+
+
+@dsl_user_op
+def pack_f32x2_to_f16x2(a: Float32, b: Float32, *, loc=None, ip=None) -> Uint32:
+    """Pack two f32 values into one f16x2 register."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 lo, hi;
+                cvt.rn.f16.f32 lo, $1;
+                cvt.rn.f16.f32 hi, $2;
+                mov.b32 $0, {lo, hi};
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
         )
     )
 

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -98,6 +98,14 @@ def get_num_sm(device: torch.device) -> int:
     return torch.cuda.get_device_properties(device).multi_processor_count
 
 
+@torch._dynamo.disable
+def current_cuda_stream():
+    """Return the current Torch CUDA stream as a CUDA driver stream handle."""
+    import cuda.bindings.driver as cuda
+
+    return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
 # Cache for HardwareInfo - it's expensive to create on every call
 _hardware_info_cache: "cutlass.utils.HardwareInfo | None" = None
 

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -61,11 +61,12 @@ def b12x_fused_moe(
     *,
     w1_alpha: torch.Tensor,
     w2_alpha: torch.Tensor,
-    fc2_input_scale: torch.Tensor,
+    fc2_input_scale: Optional[torch.Tensor] = None,
     num_local_experts: Optional[int] = None,
     output: Optional[torch.Tensor] = None,
     output_dtype: torch.dtype = torch.bfloat16,
     activation: str = "silu",
+    activation_precision: str = "fp4",
 ) -> torch.Tensor:
     """Run fused MoE on SM120/SM121 using b12x CuTe DSL kernels.
 
@@ -88,13 +89,17 @@ def b12x_fused_moe(
         top_k: Number of experts per token.
         w1_alpha: Per-expert global scale for FC1.
         w2_alpha: Per-expert global scale for FC2.
-        fc2_input_scale: Global scale for FC2 input quantization.
+        fc2_input_scale: Global scale for FC2 input quantization. Required for
+            activation_precision="fp4"; accepted but ignored for
+            activation_precision="bf16".
         num_local_experts: Local experts for EP. Default: num_experts.
         output: Pre-allocated output buffer [num_tokens, hidden_size], bf16.
         output_dtype: Output data type. Only torch.bfloat16 is currently
             supported. Default: torch.bfloat16.
         activation: Activation function — "silu" (gated/SwiGLU) or
             "relu2" (non-gated/Nemotron-Super). Default: "silu".
+        activation_precision: Intermediate activation precision: "fp4" for
+            W4A4, or "bf16" for W4A16. Default: "fp4".
 
     Returns:
         Output tensor [num_tokens, hidden_size].
@@ -152,6 +157,7 @@ def b12x_fused_moe(
         num_local_experts=num_local_experts,
         scatter_output=output,
         activation=activation,
+        activation_precision=activation_precision,
     )
 
 
@@ -173,6 +179,8 @@ class B12xMoEWrapper:
             supported. Default: torch.bfloat16.
         device: Device for buffer allocation. Default: "cuda".
         activation: Activation function — "silu" or "relu2". Default: "silu".
+        activation_precision: Intermediate activation precision, "fp4" (W4A4)
+            or "bf16" (W4A16). Default: "fp4".
 
     Example:
         >>> moe = B12xMoEWrapper(num_experts=256, top_k=8, ...)
@@ -194,8 +202,10 @@ class B12xMoEWrapper:
         output_dtype: torch.dtype = torch.bfloat16,
         device: str = "cuda",
         activation: str = "silu",
+        activation_precision: str = "fp4",
     ):
         from ...jit.cpp_ext import get_cuda_version
+        from .blackwell_sm12x.moe_dispatch import _normalize_activation_precision
 
         if get_cuda_version().major < 13:
             raise ValueError(
@@ -220,6 +230,9 @@ class B12xMoEWrapper:
         self.output_dtype = output_dtype
         self.device = device
         self.activation = activation
+        self.activation_precision = _normalize_activation_precision(
+            activation_precision
+        )
 
         # Pre-allocated objects. Both workspace slots may be populated so
         # run() can pick per-call; without this, the backend would be locked
@@ -239,7 +252,7 @@ class B12xMoEWrapper:
             allocate_sm120_static_workspace,
             allocate_sm120_dynamic_workspace,
             select_sm120_moe_backend,
-            _STATIC_COMPACT_CUTOVER_PAIRS,
+            _get_static_compact_cutover_pairs,
         )
 
         max_routed_rows = self.max_num_tokens * self.top_k
@@ -251,7 +264,9 @@ class B12xMoEWrapper:
         # (sized by num_local_experts), so it requires num_local == num_experts.
         needs_dynamic = (
             select_sm120_moe_backend(
-                num_tokens=self.max_num_tokens, num_topk=self.top_k
+                num_tokens=self.max_num_tokens,
+                num_topk=self.top_k,
+                activation_precision=self.activation_precision,
             )
             == "dynamic"
             and self.num_local_experts == self.num_experts
@@ -261,7 +276,10 @@ class B12xMoEWrapper:
         # routed_rows <= cutover; size it accordingly to avoid paying for
         # the full capacity twice.
         static_max_rows = (
-            min(max_routed_rows, _STATIC_COMPACT_CUTOVER_PAIRS)
+            min(
+                max_routed_rows,
+                _get_static_compact_cutover_pairs(self.activation_precision),
+            )
             if needs_dynamic
             else max_routed_rows
         )
@@ -273,6 +291,7 @@ class B12xMoEWrapper:
             n=self.intermediate_size,
             num_topk=self.top_k,
             device=torch.device(self.device),
+            activation_precision=self.activation_precision,
         )
 
         if needs_dynamic:
@@ -284,6 +303,7 @@ class B12xMoEWrapper:
                 n=self.intermediate_size,
                 num_topk=self.top_k,
                 device=torch.device(self.device),
+                activation_precision=self.activation_precision,
             )
 
         # Allocated after arch-specific buffers to preserve memory layout
@@ -307,7 +327,7 @@ class B12xMoEWrapper:
         *,
         w1_alpha: torch.Tensor,
         w2_alpha: torch.Tensor,
-        fc2_input_scale: torch.Tensor,
+        fc2_input_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run MoE computation.
 
@@ -321,7 +341,8 @@ class B12xMoEWrapper:
             token_final_scales: Routing weights [num_tokens, top_k].
             w1_alpha: Per-expert global scale for FC1.
             w2_alpha: Per-expert global scale for FC2.
-            fc2_input_scale: Global scale for FC2 input quantization.
+            fc2_input_scale: Global scale for FC2 input quantization. Required
+                for activation_precision="fp4"; accepted but ignored for "bf16".
 
         Returns:
             Output tensor [num_tokens, hidden_size].
@@ -356,7 +377,11 @@ class B12xMoEWrapper:
         if self.use_cuda_graph:
             if (
                 self._dynamic_workspace is not None
-                and select_sm120_moe_backend(num_tokens=num_tokens, num_topk=self.top_k)
+                and select_sm120_moe_backend(
+                    num_tokens=num_tokens,
+                    num_topk=self.top_k,
+                    activation_precision=self.activation_precision,
+                )
                 == "dynamic"
             ):
                 workspace = self._dynamic_workspace
@@ -365,6 +390,7 @@ class B12xMoEWrapper:
 
         # Cache weight views; invalidate if weight pointers change.
         weight_key = (
+            self.activation_precision,
             w1_weight.data_ptr(),
             w1_weight_sf.data_ptr(),
             w1_alpha.data_ptr(),
@@ -382,6 +408,7 @@ class B12xMoEWrapper:
                 w2_alphas=w2_alpha,
                 n=self.intermediate_size,
                 k=self.hidden_size,
+                activation_precision=self.activation_precision,
             )
             self._weight_key = weight_key
 
@@ -401,6 +428,7 @@ class B12xMoEWrapper:
             num_local_experts=self.num_local_experts,
             scatter_output=moe_output,
             activation=self.activation,
+            activation_precision=self.activation_precision,
             _workspace=workspace,
             _weight_views=self._weight_views,
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_direct_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_direct_micro_kernel.py
@@ -1,0 +1,2581 @@
+"""
+MoEDirectMicroKernel - direct routed NVFP4/W4A16 micro MoE kernel for SM120/SM121.
+
+Ported from the b12x kernel library to FlashInfer.
+
+This direct micro backend is the low-latency path for very small routed decode
+batches. Unlike the compact static/dynamic kernels, it performs the FC1 and FC2
+work with warp-level direct dot products instead of staging full MMA tiles.
+The W4A16 micro kernel subclasses this implementation with BF16 intermediate
+storage enabled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple, cast
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import BFloat16, Float32, Uint32
+
+from cutlass.cutlass_dsl import Int32, Int64
+
+from flashinfer.cute_dsl.utils import (
+    current_cuda_stream,
+    get_max_active_clusters,
+    get_num_sm,
+)
+from flashinfer.cute_dsl.fp4_common import (
+    atomic_add_global_i32,
+    cvt_e4m3_to_f32_via_f16,
+    cvt_e4m3x4_to_f32x4,
+    cvt_f32_to_e4m3,
+    fmax_f32,
+    fp4_dot4_sum,
+    fp4_dot4_sum_f32acc,
+    fp4_dot8_sum,
+    fp4_dot8_sum_f32acc,
+    get_ptr_as_int64,
+    ld_global_acquire_i32,
+    ld_global_nc_u32,
+    ld_global_nc_v4_u32,
+    nvfp4_scale_from_amax,
+    pack_f32x2_to_f16x2,
+    quant_dequant_2,
+    spin_wait_global_eq_i32,
+    st_global_i32,
+    st_global_release_i32,
+    threadfence,
+    warp_reduce,
+)
+
+
+_BLOCK_SIZE = 16
+_FP8_E4M3_MAX = 448.0
+_FC2_TILE_RECIP_GS_NUM = 6.0 * _FP8_E4M3_MAX
+_NUM_WARPS = 16
+_BLOCK_DIM = _NUM_WARPS * 32
+_K_PER_CTA = 16
+_MAX_DIRECT_K_SEGMENTS = 12
+
+
+def _direct_k_segments_supported(k_segments: int) -> bool:
+    return 1 <= int(k_segments) <= _MAX_DIRECT_K_SEGMENTS
+
+
+def _align_up(value: int, align: int) -> int:
+    return ((int(value) + int(align) - 1) // int(align)) * int(align)
+
+
+def _fc1_chunks_for_m(m: int, n: int) -> int:
+    rows_per_warp = max(1, int(m))
+    rows_per_chunk = max(_BLOCK_SIZE, _NUM_WARPS * rows_per_warp)
+    chunks = max(1, int(n) // rows_per_chunk)
+    while chunks > 1:
+        i_chunk = int(n) // chunks
+        if int(n) % chunks == 0 and i_chunk % _BLOCK_SIZE == 0:
+            return chunks
+        chunks -= 1
+    return 1
+
+
+@dataclass(frozen=True)
+class _ShapeConfig:
+    """Compile-time shape constants."""
+
+    k_dim: int
+    n: int
+    two_n: int
+    weight_E: int
+    num_topk: int
+    k_half: int
+    n_half: int
+    w1_sf_rows: int
+    w1_sf_cols: int
+    w2_sf_rows: int
+    w2_sf_cols: int
+    k_segments: int
+    fc1_chunks: int
+    fc1_chunks_per_block: int
+    i_chunk: int
+    rows_per_warp_fc1: int
+    smem_xh_stride: int
+    smem_xh_size: int
+    inter_blocks: int
+    inter_u32: int
+    fc2_n_chunks: int
+
+
+def _make_shape_config(
+    *,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    weight_E: int,
+    is_gated: bool = True,
+) -> _ShapeConfig:
+    k_half = k // 2
+    n_half = n // 2
+    two_n = 2 * n if is_gated else n
+    w1_sf_rows = _align_up(two_n, 128)
+    w1_sf_cols = _align_up(k // _BLOCK_SIZE, 4)
+    w2_sf_rows = _align_up(k, 128)
+    w2_sf_cols = _align_up(n // _BLOCK_SIZE, 4)
+    k_segments = k // (32 * _BLOCK_SIZE)
+    fc1_chunks = _fc1_chunks_for_m(m, n)
+    fc1_chunks_per_block = 16  # chunks per 128-wide swizzle block
+    i_chunk = n // fc1_chunks
+    rows_per_warp_fc1 = i_chunk // _NUM_WARPS
+    smem_xh_stride = k_segments * (_BLOCK_SIZE // 2) + 1
+    smem_xh_size = k_half + (k // (_BLOCK_SIZE * 8))
+    inter_blocks = i_chunk // _BLOCK_SIZE
+    fc2_n_chunks = (n // 2 + 127) // 128
+    inter_u32 = fc2_n_chunks * 128 * num_topk
+    return _ShapeConfig(
+        k_dim=k,
+        n=n,
+        two_n=two_n,
+        weight_E=weight_E,
+        num_topk=num_topk,
+        k_half=k_half,
+        n_half=n_half,
+        w1_sf_rows=w1_sf_rows,
+        w1_sf_cols=w1_sf_cols,
+        w2_sf_rows=w2_sf_rows,
+        w2_sf_cols=w2_sf_cols,
+        k_segments=k_segments,
+        fc1_chunks=fc1_chunks,
+        fc1_chunks_per_block=fc1_chunks_per_block,
+        i_chunk=i_chunk,
+        rows_per_warp_fc1=rows_per_warp_fc1,
+        smem_xh_stride=smem_xh_stride,
+        smem_xh_size=smem_xh_size,
+        inter_blocks=inter_blocks,
+        inter_u32=inter_u32,
+        fc2_n_chunks=fc2_n_chunks,
+    )
+
+
+def _remake_shape_config_fc1(cfg: _ShapeConfig, fc1_chunks: int) -> _ShapeConfig:
+    i_chunk = cfg.n // fc1_chunks
+    rows_per_warp_fc1 = i_chunk // _NUM_WARPS
+    smem_xh_stride = cfg.k_segments * (_BLOCK_SIZE // 2) + 1
+    smem_xh_size = cfg.k_half + (cfg.k_dim // (_BLOCK_SIZE * 8))
+    inter_blocks = i_chunk // _BLOCK_SIZE
+    fc2_n_chunks = (cfg.n // 2 + 127) // 128
+    inter_u32 = fc2_n_chunks * 128 * cfg.num_topk
+    return _ShapeConfig(
+        k_dim=cfg.k_dim,
+        n=cfg.n,
+        two_n=cfg.two_n,
+        weight_E=cfg.weight_E,
+        num_topk=cfg.num_topk,
+        k_half=cfg.k_half,
+        n_half=cfg.n_half,
+        w1_sf_rows=cfg.w1_sf_rows,
+        w1_sf_cols=cfg.w1_sf_cols,
+        w2_sf_rows=cfg.w2_sf_rows,
+        w2_sf_cols=cfg.w2_sf_cols,
+        k_segments=cfg.k_segments,
+        fc1_chunks=fc1_chunks,
+        fc1_chunks_per_block=cfg.fc1_chunks_per_block,
+        i_chunk=i_chunk,
+        rows_per_warp_fc1=rows_per_warp_fc1,
+        smem_xh_stride=smem_xh_stride,
+        smem_xh_size=smem_xh_size,
+        inter_blocks=inter_blocks,
+        inter_u32=inter_u32,
+        fc2_n_chunks=fc2_n_chunks,
+    )
+
+
+@cute.jit
+def _block_dot_hfma2(
+    u_a: Uint32,
+    u_b: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Float32:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    xh4 = Uint32(smem_xh[xh_base + Int32(4)])
+    xh5 = Uint32(smem_xh[xh_base + Int32(5)])
+    xh6 = Uint32(smem_xh[xh_base + Int32(6)])
+    xh7 = Uint32(smem_xh[xh_base + Int32(7)])
+    return fp4_dot8_sum(u_a, u_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+
+
+@cute.jit
+def _block_dot_hfma2_pair(
+    up_a: Uint32,
+    up_b: Uint32,
+    gate_a: Uint32,
+    gate_b: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Tuple[Float32, Float32]:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    xh4 = Uint32(smem_xh[xh_base + Int32(4)])
+    xh5 = Uint32(smem_xh[xh_base + Int32(5)])
+    xh6 = Uint32(smem_xh[xh_base + Int32(6)])
+    xh7 = Uint32(smem_xh[xh_base + Int32(7)])
+    up = fp4_dot8_sum(up_a, up_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+    gate = fp4_dot8_sum(gate_a, gate_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+    return up, gate
+
+
+@cute.jit
+def _block_dot_hfma2_f32acc(
+    u_a: Uint32,
+    u_b: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Float32:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    xh4 = Uint32(smem_xh[xh_base + Int32(4)])
+    xh5 = Uint32(smem_xh[xh_base + Int32(5)])
+    xh6 = Uint32(smem_xh[xh_base + Int32(6)])
+    xh7 = Uint32(smem_xh[xh_base + Int32(7)])
+    return fp4_dot8_sum_f32acc(u_a, u_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+
+
+@cute.jit
+def _block_dot_hfma2_pair_f32acc(
+    up_a: Uint32,
+    up_b: Uint32,
+    gate_a: Uint32,
+    gate_b: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Tuple[Float32, Float32]:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    xh4 = Uint32(smem_xh[xh_base + Int32(4)])
+    xh5 = Uint32(smem_xh[xh_base + Int32(5)])
+    xh6 = Uint32(smem_xh[xh_base + Int32(6)])
+    xh7 = Uint32(smem_xh[xh_base + Int32(7)])
+    up = fp4_dot8_sum_f32acc(up_a, up_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+    gate = fp4_dot8_sum_f32acc(gate_a, gate_b, xh0, xh1, xh2, xh3, xh4, xh5, xh6, xh7)
+    return up, gate
+
+
+@cute.jit
+def _block_dot4(
+    u_val: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Float32:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    return fp4_dot4_sum(u_val, xh0, xh1, xh2, xh3)
+
+
+@cute.jit
+def _block_dot4_pair(
+    up_val: Uint32,
+    gate_val: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Tuple[Float32, Float32]:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    up = fp4_dot4_sum(up_val, xh0, xh1, xh2, xh3)
+    gate = fp4_dot4_sum(gate_val, xh0, xh1, xh2, xh3)
+    return up, gate
+
+
+@cute.jit
+def _block_dot4_f32acc(
+    u_val: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Float32:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    return fp4_dot4_sum_f32acc(u_val, xh0, xh1, xh2, xh3)
+
+
+@cute.jit
+def _block_dot4_pair_f32acc(
+    up_val: Uint32,
+    gate_val: Uint32,
+    smem_xh: cute.Tensor,
+    xh_base: Int32,
+) -> Tuple[Float32, Float32]:
+    xh0 = Uint32(smem_xh[xh_base + Int32(0)])
+    xh1 = Uint32(smem_xh[xh_base + Int32(1)])
+    xh2 = Uint32(smem_xh[xh_base + Int32(2)])
+    xh3 = Uint32(smem_xh[xh_base + Int32(3)])
+    up = fp4_dot4_sum_f32acc(up_val, xh0, xh1, xh2, xh3)
+    gate = fp4_dot4_sum_f32acc(gate_val, xh0, xh1, xh2, xh3)
+    return up, gate
+
+
+@cute.jit
+def _token_publish_fc1_ready(
+    barrier_count: cute.Tensor,
+    barrier_epoch: cute.Tensor,
+    token_idx: Int32,
+    expected_epoch: Int32,
+    chunks_per_token: Int32,
+    is_cta_leader: Int32,
+):
+    if is_cta_leader > Int32(0):
+        count_addr = get_ptr_as_int64(barrier_count, token_idx)
+        epoch_addr = get_ptr_as_int64(barrier_epoch, token_idx)
+        arrived = atomic_add_global_i32(count_addr, Int32(1))
+        if arrived == chunks_per_token - Int32(1):
+            st_global_i32(count_addr, Int32(0))
+            st_global_release_i32(epoch_addr, expected_epoch + Int32(1))
+
+
+@cute.jit
+def _token_wait_fc1_ready(
+    barrier_epoch: cute.Tensor,
+    token_idx: Int32,
+    expected_epoch: Int32,
+    is_cta_leader: Int32,
+):
+    cute.arch.sync_threads()
+    if is_cta_leader > Int32(0):
+        epoch_addr = get_ptr_as_int64(barrier_epoch, token_idx)
+        spin_wait_global_eq_i32(epoch_addr, expected_epoch)
+    cute.arch.sync_threads()
+
+
+class MoEDirectMicroKernel:
+    """Decode-focused compact MoE kernel for SM120."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        fast_math: bool = False,
+        activation: str = "silu",
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
+        dynamic_down_scale: bool = False,
+        w4a16_mode: bool = False,
+    ):
+        if activation not in {"silu", "relu2"}:
+            raise ValueError(f"unsupported activation {activation!r}")
+        self.sf_vec_size = sf_vec_size
+        self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = activation == "silu"
+        self.share_input_across_experts = share_input_across_experts
+        self.share_expert_scales = share_expert_scales
+        self.single_token = single_token
+        self.dynamic_down_scale = dynamic_down_scale
+        self.w4a16_mode = w4a16_mode
+        self._cfg = cast(_ShapeConfig, None)
+        self.m_const = 0
+        self.m1_fc2_onepass = False
+        self.grid_x = 0
+
+    @cute.jit
+    def _fp4_dot4_for_math(
+        self,
+        u_packed: Uint32,
+        x0: Uint32,
+        x1: Uint32,
+        x2: Uint32,
+        x3: Uint32,
+    ) -> Float32:
+        if cutlass.const_expr(self.fast_math):
+            return fp4_dot4_sum(u_packed, x0, x1, x2, x3)
+        return fp4_dot4_sum_f32acc(u_packed, x0, x1, x2, x3)
+
+    @cute.jit
+    def _block_dot_hfma2_for_math(
+        self,
+        u_a: Uint32,
+        u_b: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Float32:
+        if cutlass.const_expr(self.fast_math):
+            return _block_dot_hfma2(u_a, u_b, smem_xh, xh_base)
+        return _block_dot_hfma2_f32acc(u_a, u_b, smem_xh, xh_base)
+
+    @cute.jit
+    def _block_dot_hfma2_pair_for_math(
+        self,
+        up_a: Uint32,
+        up_b: Uint32,
+        gate_a: Uint32,
+        gate_b: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Tuple[Float32, Float32]:
+        if cutlass.const_expr(self.fast_math):
+            return _block_dot_hfma2_pair(up_a, up_b, gate_a, gate_b, smem_xh, xh_base)
+        return _block_dot_hfma2_pair_f32acc(
+            up_a, up_b, gate_a, gate_b, smem_xh, xh_base
+        )
+
+    @cute.jit
+    def _block_dot4_for_math(
+        self,
+        u_val: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Float32:
+        if cutlass.const_expr(self.fast_math):
+            return _block_dot4(u_val, smem_xh, xh_base)
+        return _block_dot4_f32acc(u_val, smem_xh, xh_base)
+
+    @cute.jit
+    def _block_dot4_pair_for_math(
+        self,
+        up_val: Uint32,
+        gate_val: Uint32,
+        smem_xh: cute.Tensor,
+        xh_base: Int32,
+    ) -> Tuple[Float32, Float32]:
+        if cutlass.const_expr(self.fast_math):
+            return _block_dot4_pair(up_val, gate_val, smem_xh, xh_base)
+        return _block_dot4_pair_f32acc(up_val, gate_val, smem_xh, xh_base)
+
+    @classmethod
+    def is_supported(
+        cls,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+    ) -> bool:
+        if m not in (1, 2, 4, 8):
+            return False
+        if k <= 0 or k % (32 * _BLOCK_SIZE) != 0 or k % 128 != 0:
+            return False
+        if k // _BLOCK_SIZE > 32 * _MAX_DIRECT_K_SEGMENTS:
+            return False
+        if n <= 0 or n % _BLOCK_SIZE != 0:
+            return False
+        fc1_chunks = _fc1_chunks_for_m(m, n)
+        if n % fc1_chunks != 0:
+            return False
+        i_chunk = n // fc1_chunks
+        if i_chunk % _BLOCK_SIZE != 0:
+            return False
+        k_segments = k // (32 * _BLOCK_SIZE)
+        return (
+            _direct_k_segments_supported(k_segments)
+            and 0 < num_topk <= 32
+            and weight_E > 0
+        )
+
+    def configure(
+        self,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+        *,
+        max_active_ctas: int | None = None,
+        device: torch.device | None = None,
+    ):
+        cfg = _make_shape_config(
+            m=m, k=k, n=n, num_topk=num_topk, weight_E=weight_E, is_gated=self.is_gated
+        )
+        num_fc1_chunks = _fc1_chunks_for_m(m, n)
+        if self.w4a16_mode and m > 1:
+            # Keep one FC1 row per warp for W4A16 multi-token decode so the
+            # direct kernel stays within the CUTLASS 4.5 launch resource limit.
+            num_fc1_chunks = max(num_fc1_chunks, n // _BLOCK_SIZE)
+        cfg = _remake_shape_config_fc1(cfg, num_fc1_chunks)
+
+        fc1_tasks = m * cfg.num_topk * cfg.fc1_chunks
+        w4a16_rowpair_fc2 = bool(self.w4a16_mode and m > 1 and cfg.fc2_n_chunks == 1)
+        if m == 1:
+            fc2_tasks = cfg.k_dim // (_K_PER_CTA * 2)
+        elif w4a16_rowpair_fc2:
+            fc2_tasks = (m * cfg.k_dim) // (_K_PER_CTA * 2)
+        else:
+            fc2_tasks = (m * cfg.k_dim) // (_K_PER_CTA * 4)
+        if max_active_ctas is None:
+            max_active_ctas = min(get_num_sm(device), get_max_active_clusters(1))
+        if m == 1 or m == 2:
+            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+        elif num_fc1_chunks < 16:
+            grid_x = max(1, min(int(max_active_ctas), fc2_tasks))
+        else:
+            grid_x = max(1, min(int(max_active_ctas), fc1_tasks, fc2_tasks))
+        m1_fc2_onepass = bool(m == 1 and grid_x >= fc2_tasks)
+
+        self._cfg = cfg
+        self.m_const = m
+        self.m1_fc2_onepass = m1_fc2_onepass
+        self.grid_x = grid_x
+
+    @cute.jit
+    def _resident_grid_barrier(
+        self,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        grid_x: Int32,
+        is_cta_leader: Int32,
+    ):
+        cute.arch.sync_threads()
+        threadfence()
+        if is_cta_leader > Int32(0):
+            barrier_count_addr = get_ptr_as_int64(barrier_count, Int32(0))
+            barrier_epoch_addr = get_ptr_as_int64(barrier_epoch, Int32(0))
+            old_epoch = ld_global_acquire_i32(barrier_epoch_addr)
+            arrived = atomic_add_global_i32(barrier_count_addr, Int32(1))
+            if arrived == grid_x - Int32(1):
+                st_global_i32(barrier_count_addr, Int32(0))
+                st_global_release_i32(barrier_epoch_addr, old_epoch + Int32(1))
+            else:
+                spin_wait_global_eq_i32(barrier_epoch_addr, old_epoch)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _m1_fc2_rowpair_narrow(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        k_chunk_off = fc2_task * Int32(_K_PER_CTA * 2)
+        k_row0 = k_chunk_off + warp_id * Int32(2)
+        k_row1 = k_row0 + Int32(1)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        lane_cb = lane >> Int32(3)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            alpha_fc2 = w2_alphas[eid]
+            scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+
+            row_rb0 = k_row0 >> Int32(7)
+            row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+            row_mode_32_0 = k_row0 & Int32(31)
+            row_rb1 = k_row1 >> Int32(7)
+            row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+            row_mode_32_1 = k_row1 & Int32(31)
+
+            kk_off = Int32(kk) * Int32(128)
+            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+            u_packed0 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row0) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off0 = (
+                Int64(row_rb0) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_0) * Int64(16)
+                + Int64(row_mode_a0) * Int64(4)
+            )
+            sf_word0 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+            bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f0 = cvt_e4m3_to_f32_via_f16(bsf_byte0)
+            out_acc0 = (
+                out_acc0
+                + bsf_f0
+                * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed1 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row1) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off1 = (
+                Int64(row_rb1) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_1) * Int64(16)
+                + Int64(row_mode_a1) * Int64(4)
+            )
+            sf_word1 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+            bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f1 = cvt_e4m3_to_f32_via_f16(bsf_byte1)
+            out_acc1 = (
+                out_acc1
+                + bsf_f1
+                * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        if lane == Int32(0):
+            scatter_output[k_row0] = BFloat16(sum_warp0)
+            scatter_output[k_row1] = BFloat16(sum_warp1)
+
+    @cute.jit
+    def _m1_fc2_rowpair_wide(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        k_chunk_off = fc2_task * Int32(_K_PER_CTA * 2)
+        k_row0 = k_chunk_off + warp_id * Int32(2)
+        k_row1 = k_row0 + Int32(1)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            alpha_fc2 = w2_alphas[eid]
+            scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+
+            row_rb0 = k_row0 >> Int32(7)
+            row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+            row_mode_32_0 = k_row0 & Int32(31)
+            row_rb1 = k_row1 >> Int32(7)
+            row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+            row_mode_32_1 = k_row1 & Int32(31)
+
+            for nc in cutlass.range_constexpr(cfg.fc2_n_chunks):
+                chunk_base = Int32(nc) * Int32(128)
+                kk_off = Int32(kk) * n_u32_per_expert + chunk_base
+                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+                cb_idx = Int32(nc) * Int32(4) + lane_cb
+                w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                u_packed0 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row0) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_off0 = (
+                    Int64(row_rb0) * Int64(sf_cols * 128)
+                    + Int64(cb_idx) * Int64(512)
+                    + Int64(row_mode_32_0) * Int64(16)
+                    + Int64(row_mode_a0) * Int64(4)
+                )
+                sf_word0 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f0 = (
+                    cvt_e4m3_to_f32_via_f16(bsf_byte0)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+                out_acc0 = (
+                    out_acc0
+                    + bsf_f0
+                    * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed1 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row1) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_off1 = (
+                    Int64(row_rb1) * Int64(sf_cols * 128)
+                    + Int64(cb_idx) * Int64(512)
+                    + Int64(row_mode_32_1) * Int64(16)
+                    + Int64(row_mode_a1) * Int64(4)
+                )
+                sf_word1 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f1 = (
+                    cvt_e4m3_to_f32_via_f16(bsf_byte1)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+                out_acc1 = (
+                    out_acc1
+                    + bsf_f1
+                    * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        if lane == Int32(0):
+            scatter_output[k_row0] = BFloat16(sum_warp0)
+            scatter_output[k_row1] = BFloat16(sum_warp1)
+
+    @cute.jit
+    def _m2_fc2_rowpair_narrow(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        rows_per_cta = Int32(_K_PER_CTA * 2)
+        linear_row_base = fc2_task * rows_per_cta
+        t = linear_row_base // Int32(cfg.k_dim)
+        k_chunk_off = linear_row_base - t * Int32(cfg.k_dim)
+        k_row0 = k_chunk_off + warp_id * Int32(2)
+        k_row1 = k_row0 + Int32(1)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        token_inter_base = t * Int32(cfg.inter_u32)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        lane_cb = lane >> Int32(3)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+
+        row_rb0 = k_row0 >> Int32(7)
+        row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+        row_mode_32_0 = k_row0 & Int32(31)
+        row_rb1 = k_row1 >> Int32(7)
+        row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+        row_mode_32_1 = k_row1 & Int32(31)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            alpha_fc2 = w2_alphas[eid]
+            scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+
+            kk_off = token_inter_base + Int32(kk) * Int32(128)
+            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+            u_packed0 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row0) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off0 = (
+                Int64(row_rb0) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_0) * Int64(16)
+                + Int64(row_mode_a0) * Int64(4)
+            )
+            sf_word0 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+            bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f0 = cvt_e4m3_to_f32_via_f16(bsf_byte0)
+            out_acc0 = (
+                out_acc0
+                + bsf_f0
+                * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed1 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row1) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off1 = (
+                Int64(row_rb1) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_1) * Int64(16)
+                + Int64(row_mode_a1) * Int64(4)
+            )
+            sf_word1 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+            bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f1 = cvt_e4m3_to_f32_via_f16(bsf_byte1)
+            out_acc1 = (
+                out_acc1
+                + bsf_f1
+                * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        if lane == Int32(0):
+            out_base = t * Int32(cfg.k_dim)
+            scatter_output[out_base + k_row0] = BFloat16(sum_warp0)
+            scatter_output[out_base + k_row1] = BFloat16(sum_warp1)
+
+    @cute.jit
+    def _m2_fc2_rowquad_narrow(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        rows_per_cta = Int32(_K_PER_CTA * 4)
+        linear_row_base = fc2_task * rows_per_cta
+        t = linear_row_base // Int32(cfg.k_dim)
+        k_chunk_off = linear_row_base - t * Int32(cfg.k_dim)
+        k_row0 = k_chunk_off + warp_id * Int32(4)
+        k_row1 = k_row0 + Int32(1)
+        k_row2 = k_row0 + Int32(2)
+        k_row3 = k_row0 + Int32(3)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        token_inter_base = t * Int32(cfg.inter_u32)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        lane_cb = lane >> Int32(3)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        out_acc2 = Float32(0.0)
+        out_acc3 = Float32(0.0)
+
+        row_rb0 = k_row0 >> Int32(7)
+        row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+        row_mode_32_0 = k_row0 & Int32(31)
+        row_rb1 = k_row1 >> Int32(7)
+        row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+        row_mode_32_1 = k_row1 & Int32(31)
+        row_rb2 = k_row2 >> Int32(7)
+        row_mode_a2 = (k_row2 >> Int32(5)) & Int32(3)
+        row_mode_32_2 = k_row2 & Int32(31)
+        row_rb3 = k_row3 >> Int32(7)
+        row_mode_a3 = (k_row3 >> Int32(5)) & Int32(3)
+        row_mode_32_3 = k_row3 & Int32(31)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            alpha_fc2 = w2_alphas[eid]
+            scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+
+            kk_off = token_inter_base + Int32(kk) * Int32(128)
+            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+            u_packed0 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row0) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off0 = (
+                Int64(row_rb0) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_0) * Int64(16)
+                + Int64(row_mode_a0) * Int64(4)
+            )
+            sf_word0 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+            bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f0 = cvt_e4m3_to_f32_via_f16(bsf_byte0)
+            out_acc0 = (
+                out_acc0
+                + bsf_f0
+                * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed1 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row1) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off1 = (
+                Int64(row_rb1) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_1) * Int64(16)
+                + Int64(row_mode_a1) * Int64(4)
+            )
+            sf_word1 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+            bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f1 = cvt_e4m3_to_f32_via_f16(bsf_byte1)
+            out_acc1 = (
+                out_acc1
+                + bsf_f1
+                * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed2 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row2) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off2 = (
+                Int64(row_rb2) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_2) * Int64(16)
+                + Int64(row_mode_a2) * Int64(4)
+            )
+            sf_word2 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off2)
+            bsf_byte2 = (sf_word2 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f2 = cvt_e4m3_to_f32_via_f16(bsf_byte2)
+            out_acc2 = (
+                out_acc2
+                + bsf_f2
+                * self._fp4_dot4_for_math(u_packed2, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+            u_packed3 = ld_global_nc_u32(
+                w2_base_addr
+                + ebase_w
+                + Int64(k_row3) * Int64(cfg.n_half)
+                + lane_byte_off
+            )
+            bsf_off3 = (
+                Int64(row_rb3) * Int64(sf_cols * 128)
+                + Int64(lane_cb) * Int64(512)
+                + Int64(row_mode_32_3) * Int64(16)
+                + Int64(row_mode_a3) * Int64(4)
+            )
+            sf_word3 = ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off3)
+            bsf_byte3 = (sf_word3 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+            bsf_f3 = cvt_e4m3_to_f32_via_f16(bsf_byte3)
+            out_acc3 = (
+                out_acc3
+                + bsf_f3
+                * self._fp4_dot4_for_math(u_packed3, xh0, xh1, xh2, xh3)
+                * scale_lane
+            )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        sum_warp2 = cute.arch.warp_reduction_sum(out_acc2)
+        sum_warp3 = cute.arch.warp_reduction_sum(out_acc3)
+        if lane == Int32(0):
+            out_base = t * Int32(cfg.k_dim)
+            scatter_output[out_base + k_row0] = BFloat16(sum_warp0)
+            scatter_output[out_base + k_row1] = BFloat16(sum_warp1)
+            scatter_output[out_base + k_row2] = BFloat16(sum_warp2)
+            scatter_output[out_base + k_row3] = BFloat16(sum_warp3)
+
+    @cute.jit
+    def _m2_fc2_rowquad_wide(
+        self,
+        fc2_task: Int32,
+        warp_id: Int32,
+        lane: Int32,
+        w2_base_addr: Int64,
+        w2s_base_addr: Int64,
+        intermediate: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+    ):
+        cfg = self._cfg
+        rows_per_cta = Int32(_K_PER_CTA * 4)
+        linear_row_base = fc2_task * rows_per_cta
+        t = linear_row_base // Int32(cfg.k_dim)
+        k_chunk_off = linear_row_base - t * Int32(cfg.k_dim)
+        k_row0 = k_chunk_off + warp_id * Int32(4)
+        k_row1 = k_row0 + Int32(1)
+        k_row2 = k_row0 + Int32(2)
+        k_row3 = k_row0 + Int32(3)
+
+        lane_byte_off = Int64(lane) * Int64(4)
+        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+        token_inter_base = t * Int32(cfg.inter_u32)
+        sf_cols = Int32(cfg.w2_sf_cols)
+        num_cb = sf_cols >> Int32(2)
+        lane_cb = lane >> Int32(3)
+        lane_mode_c = (lane >> Int32(1)) & Int32(3)
+        bsf_byte_shift = lane_mode_c * Int32(8)
+        out_acc0 = Float32(0.0)
+        out_acc1 = Float32(0.0)
+        out_acc2 = Float32(0.0)
+        out_acc3 = Float32(0.0)
+
+        row_rb0 = k_row0 >> Int32(7)
+        row_mode_a0 = (k_row0 >> Int32(5)) & Int32(3)
+        row_mode_32_0 = k_row0 & Int32(31)
+        row_rb1 = k_row1 >> Int32(7)
+        row_mode_a1 = (k_row1 >> Int32(5)) & Int32(3)
+        row_mode_32_1 = k_row1 & Int32(31)
+        row_rb2 = k_row2 >> Int32(7)
+        row_mode_a2 = (k_row2 >> Int32(5)) & Int32(3)
+        row_mode_32_2 = k_row2 & Int32(31)
+        row_rb3 = k_row3 >> Int32(7)
+        row_mode_a3 = (k_row3 >> Int32(5)) & Int32(3)
+        row_mode_32_3 = k_row3 & Int32(31)
+
+        for kk in cutlass.range_constexpr(cfg.num_topk):
+            eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+            eid = Int32(topk_ids[eid_addr])
+            router_w = topk_weights[eid_addr]
+            alpha_fc2 = w2_alphas[eid]
+            scale_lane = alpha_fc2 * router_w
+
+            ebase_w = Int64(eid) * Int64(cfg.k_dim * cfg.n_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w2_sf_rows * cfg.w2_sf_cols)
+
+            for nc in cutlass.range_constexpr(cfg.fc2_n_chunks):
+                chunk_base = Int32(nc) * Int32(128)
+                kk_off = token_inter_base + Int32(kk) * n_u32_per_expert + chunk_base
+                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+
+                cb_idx = Int32(nc) * Int32(4) + lane_cb
+                w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                u_packed0 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row0) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_off0 = (
+                    Int64(row_rb0) * Int64(sf_cols * 128)
+                    + Int64(cb_idx) * Int64(512)
+                    + Int64(row_mode_32_0) * Int64(16)
+                    + Int64(row_mode_a0) * Int64(4)
+                )
+                sf_word0 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off0)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte0 = (sf_word0 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f0 = (
+                    cvt_e4m3_to_f32_via_f16(bsf_byte0)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+                out_acc0 = (
+                    out_acc0
+                    + bsf_f0
+                    * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed1 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row1) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_off1 = (
+                    Int64(row_rb1) * Int64(sf_cols * 128)
+                    + Int64(cb_idx) * Int64(512)
+                    + Int64(row_mode_32_1) * Int64(16)
+                    + Int64(row_mode_a1) * Int64(4)
+                )
+                sf_word1 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off1)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte1 = (sf_word1 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f1 = (
+                    cvt_e4m3_to_f32_via_f16(bsf_byte1)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+                out_acc1 = (
+                    out_acc1
+                    + bsf_f1
+                    * self._fp4_dot4_for_math(u_packed1, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed2 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row2) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_off2 = (
+                    Int64(row_rb2) * Int64(sf_cols * 128)
+                    + Int64(cb_idx) * Int64(512)
+                    + Int64(row_mode_32_2) * Int64(16)
+                    + Int64(row_mode_a2) * Int64(4)
+                )
+                sf_word2 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off2)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte2 = (sf_word2 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f2 = (
+                    cvt_e4m3_to_f32_via_f16(bsf_byte2)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+                out_acc2 = (
+                    out_acc2
+                    + bsf_f2
+                    * self._fp4_dot4_for_math(u_packed2, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+                u_packed3 = (
+                    ld_global_nc_u32(
+                        w2_base_addr
+                        + ebase_w
+                        + Int64(k_row3) * Int64(cfg.n_half)
+                        + Int64(chunk_base)
+                        + lane_byte_off
+                    )
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_off3 = (
+                    Int64(row_rb3) * Int64(sf_cols * 128)
+                    + Int64(cb_idx) * Int64(512)
+                    + Int64(row_mode_32_3) * Int64(16)
+                    + Int64(row_mode_a3) * Int64(4)
+                )
+                sf_word3 = (
+                    ld_global_nc_u32(w2s_base_addr + ebase_sf + bsf_off3)
+                    if w_valid > Int32(0)
+                    else Uint32(0)
+                )
+                bsf_byte3 = (sf_word3 >> Uint32(bsf_byte_shift)) & Uint32(0xFF)
+                bsf_f3 = (
+                    cvt_e4m3_to_f32_via_f16(bsf_byte3)
+                    if w_valid > Int32(0)
+                    else Float32(0.0)
+                )
+                out_acc3 = (
+                    out_acc3
+                    + bsf_f3
+                    * self._fp4_dot4_for_math(u_packed3, xh0, xh1, xh2, xh3)
+                    * scale_lane
+                )
+
+        sum_warp0 = cute.arch.warp_reduction_sum(out_acc0)
+        sum_warp1 = cute.arch.warp_reduction_sum(out_acc1)
+        sum_warp2 = cute.arch.warp_reduction_sum(out_acc2)
+        sum_warp3 = cute.arch.warp_reduction_sum(out_acc3)
+        if lane == Int32(0):
+            out_base = t * Int32(cfg.k_dim)
+            scatter_output[out_base + k_row0] = BFloat16(sum_warp0)
+            scatter_output[out_base + k_row1] = BFloat16(sum_warp1)
+            scatter_output[out_base + k_row2] = BFloat16(sum_warp2)
+            scatter_output[out_base + k_row3] = BFloat16(sum_warp3)
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,
+        w1_weights: cute.Tensor,
+        w1_scales: cute.Tensor,
+        w1_alphas: cute.Tensor,
+        input_gs: cute.Tensor,
+        down_input_scale: cute.Tensor,
+        intermediate: cute.Tensor,
+        w2_weights: cute.Tensor,
+        w2_scales: cute.Tensor,
+        w2_alphas: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        scatter_output: cute.Tensor,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        m_val: Int32,
+    ):
+        cfg = self._cfg
+        bidx_x, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        gdim_x, _, _ = cute.arch.grid_dim()
+        is_cta_leader = Int32(1) if Int32(tidx) == Int32(0) else Int32(0)
+        m1_epoch0 = Int32(0)
+        if cutlass.const_expr(self.m_const == 1):
+            m1_epoch0 = ld_global_acquire_i32(get_ptr_as_int64(barrier_epoch, Int32(0)))
+
+        if cutlass.const_expr(cfg.k_segments == 2):
+            smem_xh_ptr = cute.arch.alloc_smem(Uint32, 2 * cfg.smem_xh_size)
+            smem_xh = cute.make_tensor(
+                smem_xh_ptr, cute.make_layout(2 * cfg.smem_xh_size)
+            )
+        else:
+            smem_xh_ptr = cute.arch.alloc_smem(Uint32, cfg.smem_xh_size)
+            smem_xh = cute.make_tensor(smem_xh_ptr, cute.make_layout(cfg.smem_xh_size))
+        smem_int_ptr = cute.arch.alloc_smem(Float32, cfg.i_chunk)
+        smem_int = cute.make_tensor(smem_int_ptr, cute.make_layout(cfg.i_chunk))
+        reduce_scratch_ptr = cute.arch.alloc_smem(Float32, _NUM_WARPS)
+        reduce_scratch = cute.make_tensor(
+            reduce_scratch_ptr, cute.make_layout(_NUM_WARPS)
+        )
+
+        warp_id = tidx // Int32(32)
+        lane = tidx % Int32(32)
+        w1_base_addr = w1_weights.iterator.toint()
+        w1s_base_addr = w1_scales.iterator.toint()
+
+        # ===================================================================
+        # PHASE 1: FC1 over route-order tasks
+        # ===================================================================
+        fc1_task_count = Int32(self.m_const * cfg.num_topk * cfg.fc1_chunks)
+        fc1_task = Int32(bidx_x)
+        if cutlass.const_expr(cfg.k_segments == 2):
+            buf_idx = Int32(0)
+            # Pre-loop: quantize first task into buf[0]
+            if fc1_task < fc1_task_count:
+                route_idx_0 = fc1_task // Int32(cfg.fc1_chunks)
+                t0 = route_idx_0 // Int32(cfg.num_topk)
+                eid_addr_0 = t0 * Int32(cfg.num_topk) + (
+                    route_idx_0 - t0 * Int32(cfg.num_topk)
+                )
+                gs_fc1_0 = input_gs[Int32(topk_ids[eid_addr_0])]
+                in_blk = tidx
+                while in_blk < Int32(cfg.k_dim // _BLOCK_SIZE):
+                    x_base = t0 * Int32(cfg.k_dim) + in_blk * Int32(_BLOCK_SIZE)
+                    pad_off = in_blk // Int32(8)
+                    phys_base = in_blk * Int32(_BLOCK_SIZE // 2) + pad_off
+                    if cutlass.const_expr(self.w4a16_mode):
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                            v0 = Float32(a_input[x_base + Int32(i * 2)])
+                            v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                            smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(v0, v1)
+                    else:
+                        blk_peak = Float32(0.0)
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                            v = Float32(a_input[x_base + Int32(i)])
+                            abs_v = v
+                            if v < Float32(0.0):
+                                abs_v = -v
+                            if abs_v > blk_peak:
+                                blk_peak = abs_v
+                        q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc1_0)
+                        if q_scale > Float32(_FP8_E4M3_MAX):
+                            q_scale = Float32(_FP8_E4M3_MAX)
+                        sf_val = cvt_e4m3_to_f32_via_f16(cvt_f32_to_e4m3(q_scale))
+                        eff_scale = Float32(0.0)
+                        if gs_fc1_0 != Float32(0.0):
+                            eff_scale = sf_val / gs_fc1_0
+                        if eff_scale < Float32(1e-30):
+                            eff_scale = Float32(1e-30)
+                        for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                            v0 = Float32(a_input[x_base + Int32(i * 2)])
+                            v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                            f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                            smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(f0, f1)
+                    in_blk += Int32(_BLOCK_DIM)
+                cute.arch.sync_threads()
+        else:
+            prev_t = Int32(-1)
+        while fc1_task < fc1_task_count:
+            route_idx = fc1_task // Int32(cfg.fc1_chunks)
+            chunk_idx = fc1_task - route_idx * Int32(cfg.fc1_chunks)
+            t = route_idx // Int32(cfg.num_topk)
+            k_idx = route_idx - t * Int32(cfg.num_topk)
+            i_chunk_off = chunk_idx * Int32(cfg.i_chunk)
+
+            eid_addr = t * Int32(cfg.num_topk) + k_idx
+            eid = Int32(topk_ids[eid_addr])
+            alpha_fc1 = w1_alphas[eid]
+            gs_fc1 = input_gs[eid]
+            gs_fc2 = down_input_scale[eid]
+
+            # ---- Input quantization ----
+            if cutlass.const_expr(cfg.k_segments != 2):
+                need_quant = Int32(1)
+                if cutlass.const_expr(self.share_input_across_experts):
+                    need_quant = Int32(1) if t != prev_t else Int32(0)
+                if need_quant > Int32(0):
+                    in_blk = tidx
+                    while in_blk < Int32(cfg.k_dim // _BLOCK_SIZE):
+                        x_base = t * Int32(cfg.k_dim) + in_blk * Int32(_BLOCK_SIZE)
+                        pad_off = in_blk // Int32(8)
+                        phys_base = in_blk * Int32(_BLOCK_SIZE // 2) + pad_off
+                        if cutlass.const_expr(self.w4a16_mode):
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(
+                                    v0, v1
+                                )
+                        else:
+                            blk_peak = Float32(0.0)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                                v = Float32(a_input[x_base + Int32(i)])
+                                abs_v = v
+                                if v < Float32(0.0):
+                                    abs_v = -v
+                                if abs_v > blk_peak:
+                                    blk_peak = abs_v
+                            q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc1)
+                            if q_scale > Float32(_FP8_E4M3_MAX):
+                                q_scale = Float32(_FP8_E4M3_MAX)
+                            sf_val = cvt_e4m3_to_f32_via_f16(cvt_f32_to_e4m3(q_scale))
+                            eff_scale = Float32(0.0)
+                            if gs_fc1 != Float32(0.0):
+                                eff_scale = sf_val / gs_fc1
+                            if eff_scale < Float32(1e-30):
+                                eff_scale = Float32(1e-30)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                                smem_xh[phys_base + Int32(i)] = pack_f32x2_to_f16x2(
+                                    f0, f1
+                                )
+                        in_blk += Int32(_BLOCK_DIM)
+                    if cutlass.const_expr(self.share_input_across_experts):
+                        prev_t = t
+                cute.arch.sync_threads()
+
+            # ---- FC1 weight load + dot product ----
+            ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
+            ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
+            thread_byte_off = Int64(lane) * Int64(cfg.k_half // 32)
+            xh_buf_base = Int32(0)
+            if cutlass.const_expr(cfg.k_segments == 2):
+                xh_buf_base = buf_idx * Int32(cfg.smem_xh_size)
+            lane_seg_base = lane * Int32(cfg.k_segments)
+            lane_pad_base = lane_seg_base // Int32(8)
+            xh_base_t = (
+                xh_buf_base + lane_seg_base * Int32(_BLOCK_SIZE // 2) + lane_pad_base
+            )
+
+            for r_iter in cutlass.range_constexpr(cfg.rows_per_warp_fc1):
+                i_local = warp_id * Int32(cfg.rows_per_warp_fc1) + Int32(r_iter)
+                i = i_chunk_off + i_local
+
+                if cutlass.const_expr(self.is_gated):
+                    up_byte_addr = (
+                        w1_base_addr
+                        + ebase_w
+                        + Int64(i) * Int64(cfg.k_half)
+                        + thread_byte_off
+                    )
+                    row_g = Int32(cfg.n) + i
+                    rb_u = i >> Int32(7)
+                    mode_a_u = (i >> Int32(5)) & Int32(3)
+                    mode_32_u = i & Int32(31)
+                    bsf_base_u = Int64(rb_u) * Int64(cfg.w1_sf_cols * 128) + Int64(
+                        mode_32_u * Int32(16) + mode_a_u * Int32(4)
+                    )
+                    rb_g = row_g >> Int32(7)
+                    mode_a_g = (row_g >> Int32(5)) & Int32(3)
+                    mode_32_g = row_g & Int32(31)
+                    bsf_base_g = Int64(rb_g) * Int64(cfg.w1_sf_cols * 128) + Int64(
+                        mode_32_g * Int32(16) + mode_a_g * Int32(4)
+                    )
+                else:
+                    row_g = i
+                    rb_g = row_g >> Int32(7)
+                    mode_a_g = (row_g >> Int32(5)) & Int32(3)
+                    mode_32_g = row_g & Int32(31)
+                    bsf_base_g = Int64(rb_g) * Int64(cfg.w1_sf_cols * 128) + Int64(
+                        mode_32_g * Int32(16) + mode_a_g * Int32(4)
+                    )
+                gate_byte_addr = (
+                    w1_base_addr
+                    + ebase_w
+                    + Int64(row_g) * Int64(cfg.k_half)
+                    + thread_byte_off
+                )
+                col_blk_off = Int64(lane) * Int64((cfg.k_segments // 4) * 512)
+
+                if cutlass.const_expr(cfg.k_segments == 8):
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                        uw_b0, uw_b1, uw_b2, uw_b3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(16)
+                        )
+                        uw_c0, uw_c1, uw_c2, uw_c3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(32)
+                        )
+                        uw_d0, uw_d1, uw_d2, uw_d3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(48)
+                        )
+
+                        bsf_addr_u_a = (
+                            w1s_base_addr + ebase_sf + bsf_base_u + col_blk_off
+                        )
+                        bsf_addr_u_b = bsf_addr_u_a + Int64(512)
+                        sf_u0, sf_u1, sf_u2, sf_u3 = cvt_e4m3x4_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_u_a)
+                        )
+                        sf_u4, sf_u5, sf_u6, sf_u7 = cvt_e4m3x4_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_u_b)
+                        )
+
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+                    gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(16)
+                    )
+                    gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(32)
+                    )
+                    gw_d0, gw_d1, gw_d2, gw_d3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(48)
+                    )
+
+                    bsf_addr_g_a = w1s_base_addr + ebase_sf + bsf_base_g + col_blk_off
+                    bsf_addr_g_b = bsf_addr_g_a + Int64(512)
+                    sf_g0, sf_g1, sf_g2, sf_g3 = cvt_e4m3x4_to_f32x4(
+                        ld_global_nc_u32(bsf_addr_g_a)
+                    )
+                    sf_g4, sf_g5, sf_g6, sf_g7 = cvt_e4m3x4_to_f32x4(
+                        ld_global_nc_u32(bsf_addr_g_b)
+                    )
+
+                    if cutlass.const_expr(not self.is_gated):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_t + Int32(0)
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_t + Int32(8)
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_t + Int32(16)
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_t + Int32(24)
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_t + Int32(32)
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_t + Int32(40)
+                            )
+                            + sf_g6
+                            * self._block_dot_hfma2_for_math(
+                                gw_d0, gw_d1, smem_xh, xh_base_t + Int32(48)
+                            )
+                            + sf_g7
+                            * self._block_dot_hfma2_for_math(
+                                gw_d2, gw_d3, smem_xh, xh_base_t + Int32(56)
+                            )
+                        )
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0, dot_g0 = self._block_dot_hfma2_pair_for_math(
+                            uw_a0, uw_a1, gw_a0, gw_a1, smem_xh, xh_base_t + Int32(0)
+                        )
+                        dot_u1, dot_g1 = self._block_dot_hfma2_pair_for_math(
+                            uw_a2, uw_a3, gw_a2, gw_a3, smem_xh, xh_base_t + Int32(8)
+                        )
+                        dot_u2, dot_g2 = self._block_dot_hfma2_pair_for_math(
+                            uw_b0, uw_b1, gw_b0, gw_b1, smem_xh, xh_base_t + Int32(16)
+                        )
+                        dot_u3, dot_g3 = self._block_dot_hfma2_pair_for_math(
+                            uw_b2, uw_b3, gw_b2, gw_b3, smem_xh, xh_base_t + Int32(24)
+                        )
+                        dot_u4, dot_g4 = self._block_dot_hfma2_pair_for_math(
+                            uw_c0, uw_c1, gw_c0, gw_c1, smem_xh, xh_base_t + Int32(32)
+                        )
+                        dot_u5, dot_g5 = self._block_dot_hfma2_pair_for_math(
+                            uw_c2, uw_c3, gw_c2, gw_c3, smem_xh, xh_base_t + Int32(40)
+                        )
+                        dot_u6, dot_g6 = self._block_dot_hfma2_pair_for_math(
+                            uw_d0, uw_d1, gw_d0, gw_d1, smem_xh, xh_base_t + Int32(48)
+                        )
+                        dot_u7, dot_g7 = self._block_dot_hfma2_pair_for_math(
+                            uw_d2, uw_d3, gw_d2, gw_d3, smem_xh, xh_base_t + Int32(56)
+                        )
+                        partial_up = (
+                            sf_u0 * dot_u0
+                            + sf_u1 * dot_u1
+                            + sf_u2 * dot_u2
+                            + sf_u3 * dot_u3
+                            + sf_u4 * dot_u4
+                            + sf_u5 * dot_u5
+                            + sf_u6 * dot_u6
+                            + sf_u7 * dot_u7
+                        )
+                        partial_gate = (
+                            sf_g0 * dot_g0
+                            + sf_g1 * dot_g1
+                            + sf_g2 * dot_g2
+                            + sf_g3 * dot_g3
+                            + sf_g4 * dot_g4
+                            + sf_g5 * dot_g5
+                            + sf_g6 * dot_g6
+                            + sf_g7 * dot_g7
+                        )
+                elif cutlass.const_expr(cfg.k_segments == 6):
+                    xh_off0 = Int32(0)
+                    xh_off1 = Int32(8) + (
+                        (lane_seg_base + Int32(1)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off2 = Int32(16) + (
+                        (lane_seg_base + Int32(2)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off3 = Int32(24) + (
+                        (lane_seg_base + Int32(3)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off4 = Int32(32) + (
+                        (lane_seg_base + Int32(4)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off5 = Int32(40) + (
+                        (lane_seg_base + Int32(5)) // Int32(8) - lane_pad_base
+                    )
+
+                    scale_pair_off = Int64(lane_seg_base // Int32(4)) * Int64(512)
+                    scale_lane_mod = lane_seg_base % Int32(4)
+
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                        uw_b0, uw_b1, uw_b2, uw_b3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(16)
+                        )
+                        uw_c0, uw_c1, uw_c2, uw_c3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(32)
+                        )
+
+                        sf_word_u_a = ld_global_nc_u32(
+                            w1s_base_addr + ebase_sf + bsf_base_u + scale_pair_off
+                        )
+                        sf_word_u_b = ld_global_nc_u32(
+                            w1s_base_addr
+                            + ebase_sf
+                            + bsf_base_u
+                            + scale_pair_off
+                            + Int64(512)
+                        )
+                        sf_u0 = Float32(0.0)
+                        sf_u1 = Float32(0.0)
+                        sf_u2 = Float32(0.0)
+                        sf_u3 = Float32(0.0)
+                        sf_u4 = Float32(0.0)
+                        sf_u5 = Float32(0.0)
+                        if scale_lane_mod == Int32(0):
+                            sf_u0 = cvt_e4m3_to_f32_via_f16(sf_word_u_a & Uint32(0xFF))
+                            sf_u1 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_a >> Uint32(8)) & Uint32(0xFF)
+                            )
+                            sf_u2 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_a >> Uint32(16)) & Uint32(0xFF)
+                            )
+                            sf_u3 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_a >> Uint32(24)) & Uint32(0xFF)
+                            )
+                            sf_u4 = cvt_e4m3_to_f32_via_f16(sf_word_u_b & Uint32(0xFF))
+                            sf_u5 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_b >> Uint32(8)) & Uint32(0xFF)
+                            )
+                        else:
+                            sf_u0 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_a >> Uint32(16)) & Uint32(0xFF)
+                            )
+                            sf_u1 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_a >> Uint32(24)) & Uint32(0xFF)
+                            )
+                            sf_u2 = cvt_e4m3_to_f32_via_f16(sf_word_u_b & Uint32(0xFF))
+                            sf_u3 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_b >> Uint32(8)) & Uint32(0xFF)
+                            )
+                            sf_u4 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_b >> Uint32(16)) & Uint32(0xFF)
+                            )
+                            sf_u5 = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u_b >> Uint32(24)) & Uint32(0xFF)
+                            )
+
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+                    gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(16)
+                    )
+                    gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(32)
+                    )
+
+                    sf_word_g_a = ld_global_nc_u32(
+                        w1s_base_addr + ebase_sf + bsf_base_g + scale_pair_off
+                    )
+                    sf_word_g_b = ld_global_nc_u32(
+                        w1s_base_addr
+                        + ebase_sf
+                        + bsf_base_g
+                        + scale_pair_off
+                        + Int64(512)
+                    )
+                    sf_g0 = Float32(0.0)
+                    sf_g1 = Float32(0.0)
+                    sf_g2 = Float32(0.0)
+                    sf_g3 = Float32(0.0)
+                    sf_g4 = Float32(0.0)
+                    sf_g5 = Float32(0.0)
+                    if scale_lane_mod == Int32(0):
+                        sf_g0 = cvt_e4m3_to_f32_via_f16(sf_word_g_a & Uint32(0xFF))
+                        sf_g1 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_a >> Uint32(8)) & Uint32(0xFF)
+                        )
+                        sf_g2 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_a >> Uint32(16)) & Uint32(0xFF)
+                        )
+                        sf_g3 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_a >> Uint32(24)) & Uint32(0xFF)
+                        )
+                        sf_g4 = cvt_e4m3_to_f32_via_f16(sf_word_g_b & Uint32(0xFF))
+                        sf_g5 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_b >> Uint32(8)) & Uint32(0xFF)
+                        )
+                    else:
+                        sf_g0 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_a >> Uint32(16)) & Uint32(0xFF)
+                        )
+                        sf_g1 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_a >> Uint32(24)) & Uint32(0xFF)
+                        )
+                        sf_g2 = cvt_e4m3_to_f32_via_f16(sf_word_g_b & Uint32(0xFF))
+                        sf_g3 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_b >> Uint32(8)) & Uint32(0xFF)
+                        )
+                        sf_g4 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_b >> Uint32(16)) & Uint32(0xFF)
+                        )
+                        sf_g5 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g_b >> Uint32(24)) & Uint32(0xFF)
+                        )
+
+                    if cutlass.const_expr(not self.is_gated):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                            )
+                        )
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0, dot_g0 = self._block_dot_hfma2_pair_for_math(
+                            uw_a0, uw_a1, gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                        )
+                        dot_u1, dot_g1 = self._block_dot_hfma2_pair_for_math(
+                            uw_a2, uw_a3, gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                        )
+                        dot_u2, dot_g2 = self._block_dot_hfma2_pair_for_math(
+                            uw_b0, uw_b1, gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                        )
+                        dot_u3, dot_g3 = self._block_dot_hfma2_pair_for_math(
+                            uw_b2, uw_b3, gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                        )
+                        dot_u4, dot_g4 = self._block_dot_hfma2_pair_for_math(
+                            uw_c0, uw_c1, gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                        )
+                        dot_u5, dot_g5 = self._block_dot_hfma2_pair_for_math(
+                            uw_c2, uw_c3, gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                        )
+                        partial_up = (
+                            sf_u0 * dot_u0
+                            + sf_u1 * dot_u1
+                            + sf_u2 * dot_u2
+                            + sf_u3 * dot_u3
+                            + sf_u4 * dot_u4
+                            + sf_u5 * dot_u5
+                        )
+                        partial_gate = (
+                            sf_g0 * dot_g0
+                            + sf_g1 * dot_g1
+                            + sf_g2 * dot_g2
+                            + sf_g3 * dot_g3
+                            + sf_g4 * dot_g4
+                            + sf_g5 * dot_g5
+                        )
+                elif cutlass.const_expr(cfg.k_segments == 12):
+                    xh_off0 = Int32(0)
+                    xh_off1 = Int32(8) + (
+                        (lane_seg_base + Int32(1)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off2 = Int32(16) + (
+                        (lane_seg_base + Int32(2)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off3 = Int32(24) + (
+                        (lane_seg_base + Int32(3)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off4 = Int32(32) + (
+                        (lane_seg_base + Int32(4)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off5 = Int32(40) + (
+                        (lane_seg_base + Int32(5)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off6 = Int32(48) + (
+                        (lane_seg_base + Int32(6)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off7 = Int32(56) + (
+                        (lane_seg_base + Int32(7)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off8 = Int32(64) + (
+                        (lane_seg_base + Int32(8)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off9 = Int32(72) + (
+                        (lane_seg_base + Int32(9)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off10 = Int32(80) + (
+                        (lane_seg_base + Int32(10)) // Int32(8) - lane_pad_base
+                    )
+                    xh_off11 = Int32(88) + (
+                        (lane_seg_base + Int32(11)) // Int32(8) - lane_pad_base
+                    )
+
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                        uw_b0, uw_b1, uw_b2, uw_b3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(16)
+                        )
+                        uw_c0, uw_c1, uw_c2, uw_c3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(32)
+                        )
+                        uw_d0, uw_d1, uw_d2, uw_d3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(48)
+                        )
+                        uw_e0, uw_e1, uw_e2, uw_e3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(64)
+                        )
+                        uw_f0, uw_f1, uw_f2, uw_f3 = ld_global_nc_v4_u32(
+                            up_byte_addr + Int64(80)
+                        )
+
+                        bsf_addr_u_a = (
+                            w1s_base_addr + ebase_sf + bsf_base_u + col_blk_off
+                        )
+                        bsf_addr_u_b = bsf_addr_u_a + Int64(512)
+                        bsf_addr_u_c = bsf_addr_u_a + Int64(1024)
+                        sf_u0, sf_u1, sf_u2, sf_u3 = cvt_e4m3x4_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_u_a)
+                        )
+                        sf_u4, sf_u5, sf_u6, sf_u7 = cvt_e4m3x4_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_u_b)
+                        )
+                        sf_u8, sf_u9, sf_u10, sf_u11 = cvt_e4m3x4_to_f32x4(
+                            ld_global_nc_u32(bsf_addr_u_c)
+                        )
+
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+                    gw_b0, gw_b1, gw_b2, gw_b3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(16)
+                    )
+                    gw_c0, gw_c1, gw_c2, gw_c3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(32)
+                    )
+                    gw_d0, gw_d1, gw_d2, gw_d3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(48)
+                    )
+                    gw_e0, gw_e1, gw_e2, gw_e3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(64)
+                    )
+                    gw_f0, gw_f1, gw_f2, gw_f3 = ld_global_nc_v4_u32(
+                        gate_byte_addr + Int64(80)
+                    )
+
+                    bsf_addr_g_a = w1s_base_addr + ebase_sf + bsf_base_g + col_blk_off
+                    bsf_addr_g_b = bsf_addr_g_a + Int64(512)
+                    bsf_addr_g_c = bsf_addr_g_a + Int64(1024)
+                    sf_g0, sf_g1, sf_g2, sf_g3 = cvt_e4m3x4_to_f32x4(
+                        ld_global_nc_u32(bsf_addr_g_a)
+                    )
+                    sf_g4, sf_g5, sf_g6, sf_g7 = cvt_e4m3x4_to_f32x4(
+                        ld_global_nc_u32(bsf_addr_g_b)
+                    )
+                    sf_g8, sf_g9, sf_g10, sf_g11 = cvt_e4m3x4_to_f32x4(
+                        ld_global_nc_u32(bsf_addr_g_c)
+                    )
+
+                    if cutlass.const_expr(not self.is_gated):
+                        partial_gate = (
+                            sf_g0
+                            * self._block_dot_hfma2_for_math(
+                                gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                            )
+                            + sf_g1
+                            * self._block_dot_hfma2_for_math(
+                                gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                            )
+                            + sf_g2
+                            * self._block_dot_hfma2_for_math(
+                                gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                            )
+                            + sf_g3
+                            * self._block_dot_hfma2_for_math(
+                                gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                            )
+                            + sf_g4
+                            * self._block_dot_hfma2_for_math(
+                                gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                            )
+                            + sf_g5
+                            * self._block_dot_hfma2_for_math(
+                                gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                            )
+                            + sf_g6
+                            * self._block_dot_hfma2_for_math(
+                                gw_d0, gw_d1, smem_xh, xh_base_t + xh_off6
+                            )
+                            + sf_g7
+                            * self._block_dot_hfma2_for_math(
+                                gw_d2, gw_d3, smem_xh, xh_base_t + xh_off7
+                            )
+                            + sf_g8
+                            * self._block_dot_hfma2_for_math(
+                                gw_e0, gw_e1, smem_xh, xh_base_t + xh_off8
+                            )
+                            + sf_g9
+                            * self._block_dot_hfma2_for_math(
+                                gw_e2, gw_e3, smem_xh, xh_base_t + xh_off9
+                            )
+                            + sf_g10
+                            * self._block_dot_hfma2_for_math(
+                                gw_f0, gw_f1, smem_xh, xh_base_t + xh_off10
+                            )
+                            + sf_g11
+                            * self._block_dot_hfma2_for_math(
+                                gw_f2, gw_f3, smem_xh, xh_base_t + xh_off11
+                            )
+                        )
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0, dot_g0 = self._block_dot_hfma2_pair_for_math(
+                            uw_a0, uw_a1, gw_a0, gw_a1, smem_xh, xh_base_t + xh_off0
+                        )
+                        dot_u1, dot_g1 = self._block_dot_hfma2_pair_for_math(
+                            uw_a2, uw_a3, gw_a2, gw_a3, smem_xh, xh_base_t + xh_off1
+                        )
+                        dot_u2, dot_g2 = self._block_dot_hfma2_pair_for_math(
+                            uw_b0, uw_b1, gw_b0, gw_b1, smem_xh, xh_base_t + xh_off2
+                        )
+                        dot_u3, dot_g3 = self._block_dot_hfma2_pair_for_math(
+                            uw_b2, uw_b3, gw_b2, gw_b3, smem_xh, xh_base_t + xh_off3
+                        )
+                        dot_u4, dot_g4 = self._block_dot_hfma2_pair_for_math(
+                            uw_c0, uw_c1, gw_c0, gw_c1, smem_xh, xh_base_t + xh_off4
+                        )
+                        dot_u5, dot_g5 = self._block_dot_hfma2_pair_for_math(
+                            uw_c2, uw_c3, gw_c2, gw_c3, smem_xh, xh_base_t + xh_off5
+                        )
+                        dot_u6, dot_g6 = self._block_dot_hfma2_pair_for_math(
+                            uw_d0, uw_d1, gw_d0, gw_d1, smem_xh, xh_base_t + xh_off6
+                        )
+                        dot_u7, dot_g7 = self._block_dot_hfma2_pair_for_math(
+                            uw_d2, uw_d3, gw_d2, gw_d3, smem_xh, xh_base_t + xh_off7
+                        )
+                        dot_u8, dot_g8 = self._block_dot_hfma2_pair_for_math(
+                            uw_e0, uw_e1, gw_e0, gw_e1, smem_xh, xh_base_t + xh_off8
+                        )
+                        dot_u9, dot_g9 = self._block_dot_hfma2_pair_for_math(
+                            uw_e2, uw_e3, gw_e2, gw_e3, smem_xh, xh_base_t + xh_off9
+                        )
+                        dot_u10, dot_g10 = self._block_dot_hfma2_pair_for_math(
+                            uw_f0, uw_f1, gw_f0, gw_f1, smem_xh, xh_base_t + xh_off10
+                        )
+                        dot_u11, dot_g11 = self._block_dot_hfma2_pair_for_math(
+                            uw_f2, uw_f3, gw_f2, gw_f3, smem_xh, xh_base_t + xh_off11
+                        )
+                        partial_up = (
+                            sf_u0 * dot_u0
+                            + sf_u1 * dot_u1
+                            + sf_u2 * dot_u2
+                            + sf_u3 * dot_u3
+                            + sf_u4 * dot_u4
+                            + sf_u5 * dot_u5
+                            + sf_u6 * dot_u6
+                            + sf_u7 * dot_u7
+                            + sf_u8 * dot_u8
+                            + sf_u9 * dot_u9
+                            + sf_u10 * dot_u10
+                            + sf_u11 * dot_u11
+                        )
+                        partial_gate = (
+                            sf_g0 * dot_g0
+                            + sf_g1 * dot_g1
+                            + sf_g2 * dot_g2
+                            + sf_g3 * dot_g3
+                            + sf_g4 * dot_g4
+                            + sf_g5 * dot_g5
+                            + sf_g6 * dot_g6
+                            + sf_g7 * dot_g7
+                            + sf_g8 * dot_g8
+                            + sf_g9 * dot_g9
+                            + sf_g10 * dot_g10
+                            + sf_g11 * dot_g11
+                        )
+                elif cutlass.const_expr(cfg.k_segments == 2):
+                    if cutlass.const_expr(self.is_gated):
+                        uw_a0, uw_a1, uw_a2, uw_a3 = ld_global_nc_v4_u32(up_byte_addr)
+                    gw_a0, gw_a1, gw_a2, gw_a3 = ld_global_nc_v4_u32(gate_byte_addr)
+
+                    col_blk_off_2 = Int64(lane // Int32(2)) * Int64(512)
+                    sf_shift0 = Uint32((lane % Int32(2)) * Int32(16))
+                    sf_shift1 = sf_shift0 + Uint32(8)
+
+                    if cutlass.const_expr(self.is_gated):
+                        sf_word_u = ld_global_nc_u32(
+                            w1s_base_addr + ebase_sf + bsf_base_u + col_blk_off_2
+                        )
+                        sf_u0 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_u >> sf_shift0) & Uint32(0xFF)
+                        )
+                        sf_u1 = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_u >> sf_shift1) & Uint32(0xFF)
+                        )
+                    sf_word_g = ld_global_nc_u32(
+                        w1s_base_addr + ebase_sf + bsf_base_g + col_blk_off_2
+                    )
+                    sf_g0 = cvt_e4m3_to_f32_via_f16(
+                        (sf_word_g >> sf_shift0) & Uint32(0xFF)
+                    )
+                    sf_g1 = cvt_e4m3_to_f32_via_f16(
+                        (sf_word_g >> sf_shift1) & Uint32(0xFF)
+                    )
+
+                    seg_blk0 = lane * Int32(2)
+                    seg_blk1 = seg_blk0 + Int32(1)
+                    xh_base0 = xh_buf_base + seg_blk0 * Int32(8) + seg_blk0 // Int32(8)
+                    xh_base1 = xh_buf_base + seg_blk1 * Int32(8) + seg_blk1 // Int32(8)
+
+                    if cutlass.const_expr(not self.is_gated):
+                        dot_g0 = self._block_dot_hfma2_for_math(
+                            gw_a0, gw_a1, smem_xh, xh_base0
+                        )
+                        dot_g1 = self._block_dot_hfma2_for_math(
+                            gw_a2, gw_a3, smem_xh, xh_base1
+                        )
+                        partial_gate = sf_g0 * dot_g0 + sf_g1 * dot_g1
+                    elif cutlass.const_expr(self.is_gated):
+                        dot_u0a, dot_g0a = self._block_dot4_pair_for_math(
+                            uw_a0, gw_a0, smem_xh, xh_base0
+                        )
+                        dot_u0b, dot_g0b = self._block_dot4_pair_for_math(
+                            uw_a1, gw_a1, smem_xh, xh_base0 + Int32(4)
+                        )
+                        dot_u1a, dot_g1a = self._block_dot4_pair_for_math(
+                            uw_a2, gw_a2, smem_xh, xh_base1
+                        )
+                        dot_u1b, dot_g1b = self._block_dot4_pair_for_math(
+                            uw_a3, gw_a3, smem_xh, xh_base1 + Int32(4)
+                        )
+                        partial_up = sf_u0 * (dot_u0a + dot_u0b) + sf_u1 * (
+                            dot_u1a + dot_u1b
+                        )
+                        partial_gate = sf_g0 * (dot_g0a + dot_g0b) + sf_g1 * (
+                            dot_g1a + dot_g1b
+                        )
+                else:
+                    partial_up = Float32(0.0)
+                    partial_gate = Float32(0.0)
+                    for seg in cutlass.range_constexpr(cfg.k_segments):
+                        seg_byte_off = Int64(seg * (_BLOCK_SIZE // 2))
+                        scale_col = lane * Int32(cfg.k_segments) + Int32(seg)
+                        sf_group_off = Int64(scale_col // Int32(4)) * Int64(512)
+                        sf_shift = Uint32((scale_col % Int32(4)) * Int32(8))
+                        xh_base = (
+                            xh_buf_base
+                            + scale_col * Int32(_BLOCK_SIZE // 2)
+                            + scale_col // Int32(8)
+                        )
+
+                        gw0 = ld_global_nc_u32(gate_byte_addr + seg_byte_off)
+                        gw1 = ld_global_nc_u32(gate_byte_addr + seg_byte_off + Int64(4))
+                        sf_word_g = ld_global_nc_u32(
+                            w1s_base_addr + ebase_sf + bsf_base_g + sf_group_off
+                        )
+                        sf_g = cvt_e4m3_to_f32_via_f16(
+                            (sf_word_g >> sf_shift) & Uint32(0xFF)
+                        )
+
+                        if cutlass.const_expr(self.is_gated):
+                            uw0 = ld_global_nc_u32(up_byte_addr + seg_byte_off)
+                            uw1 = ld_global_nc_u32(
+                                up_byte_addr + seg_byte_off + Int64(4)
+                            )
+                            sf_word_u = ld_global_nc_u32(
+                                w1s_base_addr + ebase_sf + bsf_base_u + sf_group_off
+                            )
+                            sf_u = cvt_e4m3_to_f32_via_f16(
+                                (sf_word_u >> sf_shift) & Uint32(0xFF)
+                            )
+                            dot_u, dot_g = self._block_dot_hfma2_pair_for_math(
+                                uw0, uw1, gw0, gw1, smem_xh, xh_base
+                            )
+                            partial_up = partial_up + sf_u * dot_u
+                            partial_gate = partial_gate + sf_g * dot_g
+                        else:
+                            partial_gate = (
+                                partial_gate
+                                + sf_g
+                                * self._block_dot_hfma2_for_math(
+                                    gw0,
+                                    gw1,
+                                    smem_xh,
+                                    xh_base,
+                                )
+                            )
+                # ---- Activation + intermediate quant ----
+                gate_red = cute.arch.warp_reduction_sum(partial_gate) * alpha_fc1
+                if cutlass.const_expr(self.is_gated):
+                    up_red = cute.arch.warp_reduction_sum(partial_up) * alpha_fc1
+                if lane == Int32(0):
+                    if cutlass.const_expr(self.is_gated):
+                        sigmoid = Float32(1.0) / (
+                            Float32(1.0) + cute.math.exp(-gate_red, fastmath=False)
+                        )
+                        activated = sigmoid * gate_red * up_red
+                    else:
+                        relu_val = fmax_f32(gate_red, Float32(0.0))
+                        activated = relu_val * relu_val
+                    smem_int[i_local] = Float32(BFloat16(activated))
+
+            # Look-ahead: quantize next task into other buffer (k_segments==2 only)
+            if cutlass.const_expr(cfg.k_segments == 2):
+                next_task = fc1_task + Int32(gdim_x)
+                need_quant_next = Int32(0)
+                t_next = t
+                next_route = route_idx
+                if next_task < fc1_task_count:
+                    next_route = next_task // Int32(cfg.fc1_chunks)
+                    t_next = next_route // Int32(cfg.num_topk)
+                    need_quant_next = Int32(1)
+                    if cutlass.const_expr(self.share_input_across_experts):
+                        need_quant_next = Int32(1) if t_next != t else Int32(0)
+                if need_quant_next > Int32(0):
+                    next_eid_addr = t_next * Int32(cfg.num_topk) + (
+                        next_route - t_next * Int32(cfg.num_topk)
+                    )
+                    gs_fc1_next = input_gs[Int32(topk_ids[next_eid_addr])]
+                    next_buf_base = (Int32(1) - buf_idx) * Int32(cfg.smem_xh_size)
+                    in_blk = tidx
+                    while in_blk < Int32(cfg.k_dim // _BLOCK_SIZE):
+                        x_base = t_next * Int32(cfg.k_dim) + in_blk * Int32(_BLOCK_SIZE)
+                        pad_off = in_blk // Int32(8)
+                        phys_base = in_blk * Int32(_BLOCK_SIZE // 2) + pad_off
+                        if cutlass.const_expr(self.w4a16_mode):
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                smem_xh[next_buf_base + phys_base + Int32(i)] = (
+                                    pack_f32x2_to_f16x2(v0, v1)
+                                )
+                        else:
+                            blk_peak = Float32(0.0)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                                v = Float32(a_input[x_base + Int32(i)])
+                                abs_v = v
+                                if v < Float32(0.0):
+                                    abs_v = -v
+                                if abs_v > blk_peak:
+                                    blk_peak = abs_v
+                            q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc1_next)
+                            if q_scale > Float32(_FP8_E4M3_MAX):
+                                q_scale = Float32(_FP8_E4M3_MAX)
+                            sf_val = cvt_e4m3_to_f32_via_f16(cvt_f32_to_e4m3(q_scale))
+                            eff_scale = Float32(0.0)
+                            if gs_fc1_next != Float32(0.0):
+                                eff_scale = sf_val / gs_fc1_next
+                            if eff_scale < Float32(1e-30):
+                                eff_scale = Float32(1e-30)
+                            for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                                v0 = Float32(a_input[x_base + Int32(i * 2)])
+                                v1 = Float32(a_input[x_base + Int32(i * 2 + 1)])
+                                f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                                smem_xh[next_buf_base + phys_base + Int32(i)] = (
+                                    pack_f32x2_to_f16x2(f0, f1)
+                                )
+                        in_blk += Int32(_BLOCK_DIM)
+
+            cute.arch.sync_threads()
+
+            gs_fc2_eff = gs_fc2
+            if cutlass.const_expr(self.dynamic_down_scale):
+                local_max = Float32(0.0)
+                scan_idx = Int32(tidx)
+                while scan_idx < Int32(cfg.i_chunk):
+                    v = smem_int[scan_idx]
+                    abs_v = v
+                    if v < Float32(0.0):
+                        abs_v = -v
+                    local_max = fmax_f32(local_max, abs_v)
+                    scan_idx += Int32(_BLOCK_DIM)
+                warp_max = warp_reduce(local_max, fmax_f32)
+                if lane == Int32(0):
+                    reduce_scratch[warp_id] = warp_max
+                cute.arch.sync_threads()
+                tile_amax = Float32(0.0)
+                if warp_id == Int32(0):
+                    if lane < Int32(_NUM_WARPS):
+                        tile_amax = reduce_scratch[lane]
+                    tile_amax = warp_reduce(tile_amax, fmax_f32)
+                    if lane == Int32(0):
+                        reduce_scratch[Int32(0)] = tile_amax
+                cute.arch.sync_threads()
+                gs_fc2_eff = Float32(0.0)
+                if reduce_scratch[Int32(0)] > Float32(0.0):
+                    gs_fc2_eff = (
+                        Float32(_FC2_TILE_RECIP_GS_NUM) / reduce_scratch[Int32(0)]
+                    )
+                gs_fc2_eff = fmax_f32(gs_fc2_eff, Float32(1.0e-12))
+            fc2_rescale = Float32(1.0)
+            if cutlass.const_expr(self.dynamic_down_scale):
+                if gs_fc2_eff != Float32(0.0):
+                    fc2_rescale = gs_fc2 / gs_fc2_eff
+            if tidx < Int32(cfg.inter_blocks):
+                mid_blk = tidx
+                if cutlass.const_expr(self.w4a16_mode):
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                        v0 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2)]
+                        v1 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2 + 1)]
+                        half_base = chunk_idx * Int32(
+                            cfg.i_chunk // 2
+                        ) + mid_blk * Int32(_BLOCK_SIZE // 2)
+                        n_blk = half_base // Int32(128)
+                        h_local = half_base - n_blk * Int32(128)
+                        h_i = h_local + Int32(i)
+                        packed_idx = (
+                            t * Int32(cfg.inter_u32)
+                            + k_idx * Int32(cfg.fc2_n_chunks * 128)
+                            + n_blk * Int32(128)
+                            + (h_i % Int32(4)) * Int32(32)
+                            + (h_i // Int32(4))
+                        )
+                        intermediate[packed_idx] = pack_f32x2_to_f16x2(v0, v1)
+                else:
+                    blk_peak = Float32(0.0)
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE):
+                        v = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i)]
+                        abs_v = v
+                        if v < Float32(0.0):
+                            abs_v = -v
+                        if abs_v > blk_peak:
+                            blk_peak = abs_v
+                    q_scale = nvfp4_scale_from_amax(blk_peak, gs_fc2_eff)
+                    if q_scale > Float32(_FP8_E4M3_MAX):
+                        q_scale = Float32(_FP8_E4M3_MAX)
+                    sf_val = cvt_e4m3_to_f32_via_f16(cvt_f32_to_e4m3(q_scale))
+                    eff_scale = Float32(0.0)
+                    if gs_fc2_eff != Float32(0.0):
+                        eff_scale = sf_val / gs_fc2_eff
+                    if eff_scale < Float32(1e-30):
+                        eff_scale = Float32(1e-30)
+                    for i in cutlass.range_constexpr(_BLOCK_SIZE // 2):
+                        v0 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2)]
+                        v1 = smem_int[mid_blk * Int32(_BLOCK_SIZE) + Int32(i * 2 + 1)]
+                        f0, f1 = quant_dequant_2(v0, v1, sf_val, eff_scale)
+                        f0 = f0 * fc2_rescale
+                        f1 = f1 * fc2_rescale
+                        half_base = chunk_idx * Int32(
+                            cfg.i_chunk // 2
+                        ) + mid_blk * Int32(_BLOCK_SIZE // 2)
+                        n_blk = half_base // Int32(128)
+                        h_local = half_base - n_blk * Int32(128)
+                        h_i = h_local + Int32(i)
+                        packed_idx = (
+                            t * Int32(cfg.inter_u32)
+                            + k_idx * Int32(cfg.fc2_n_chunks * 128)
+                            + n_blk * Int32(128)
+                            + (h_i % Int32(4)) * Int32(32)
+                            + (h_i // Int32(4))
+                        )
+                        intermediate[packed_idx] = pack_f32x2_to_f16x2(f0, f1)
+
+            cute.arch.sync_threads()
+            if cutlass.const_expr(cfg.k_segments == 2):
+                if need_quant_next > Int32(0):
+                    buf_idx = Int32(1) - buf_idx
+            fc1_task += Int32(gdim_x)
+
+        if cutlass.const_expr(self.m_const == 1):
+            _token_publish_fc1_ready(
+                barrier_count,
+                barrier_epoch,
+                Int32(0),
+                m1_epoch0,
+                Int32(gdim_x),
+                is_cta_leader,
+            )
+            _token_wait_fc1_ready(barrier_epoch, Int32(0), m1_epoch0, is_cta_leader)
+        else:
+            self._resident_grid_barrier(
+                barrier_count, barrier_epoch, Int32(gdim_x), is_cta_leader
+            )
+
+        # ===================================================================
+        # PHASE 2: FC2 output
+        # ===================================================================
+        w2_base_addr = w2_weights.iterator.toint()
+        w2s_base_addr = w2_scales.iterator.toint()
+        # ---- m==1 FC2 rowpair ----
+        if cutlass.const_expr(self.m_const == 1):
+            fc2_chunks_m1 = Int32(cfg.k_dim // (_K_PER_CTA * 2))
+            if cutlass.const_expr(self.m1_fc2_onepass):
+                fc2_task = Int32(bidx_x)
+                if fc2_task < fc2_chunks_m1:
+                    if cutlass.const_expr(cfg.fc2_n_chunks > 1):
+                        self._m1_fc2_rowpair_wide(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+                    else:
+                        self._m1_fc2_rowpair_narrow(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+            else:
+                fc2_task = Int32(bidx_x)
+                while fc2_task < fc2_chunks_m1:
+                    if cutlass.const_expr(cfg.fc2_n_chunks > 1):
+                        self._m1_fc2_rowpair_wide(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+                    else:
+                        self._m1_fc2_rowpair_narrow(
+                            fc2_task,
+                            warp_id,
+                            lane,
+                            w2_base_addr,
+                            w2s_base_addr,
+                            intermediate,
+                            w2_alphas,
+                            topk_ids,
+                            topk_weights,
+                            scatter_output,
+                        )
+                    fc2_task += Int32(gdim_x)
+
+        # ---- m>=2 FC2 rowquad ----
+        else:
+            fc2_task_count = Int32((self.m_const * cfg.k_dim) // (_K_PER_CTA * 4))
+            if cutlass.const_expr(self.w4a16_mode and cfg.fc2_n_chunks == 1):
+                fc2_task_count = Int32((self.m_const * cfg.k_dim) // (_K_PER_CTA * 2))
+            fc2_task = Int32(bidx_x)
+            while fc2_task < fc2_task_count:
+                if cutlass.const_expr(self.w4a16_mode and cfg.fc2_n_chunks == 1):
+                    self._m2_fc2_rowpair_narrow(
+                        fc2_task,
+                        warp_id,
+                        lane,
+                        w2_base_addr,
+                        w2s_base_addr,
+                        intermediate,
+                        w2_alphas,
+                        topk_ids,
+                        topk_weights,
+                        scatter_output,
+                    )
+                elif cutlass.const_expr(cfg.fc2_n_chunks > 1):
+                    self._m2_fc2_rowquad_wide(
+                        fc2_task,
+                        warp_id,
+                        lane,
+                        w2_base_addr,
+                        w2s_base_addr,
+                        intermediate,
+                        w2_alphas,
+                        topk_ids,
+                        topk_weights,
+                        scatter_output,
+                    )
+                else:
+                    self._m2_fc2_rowquad_narrow(
+                        fc2_task,
+                        warp_id,
+                        lane,
+                        w2_base_addr,
+                        w2s_base_addr,
+                        intermediate,
+                        w2_alphas,
+                        topk_ids,
+                        topk_weights,
+                        scatter_output,
+                    )
+                fc2_task += Int32(gdim_x)
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        w1_ptr: cute.Pointer,
+        w1s_ptr: cute.Pointer,
+        w1a_ptr: cute.Pointer,
+        a1_ptr: cute.Pointer,
+        a2_ptr: cute.Pointer,
+        inter_ptr: cute.Pointer,
+        w2_ptr: cute.Pointer,
+        w2s_ptr: cute.Pointer,
+        w2a_ptr: cute.Pointer,
+        tid_ptr: cute.Pointer,
+        tw_ptr: cute.Pointer,
+        out_ptr: cute.Pointer,
+        barrier_count_ptr: cute.Pointer,
+        barrier_epoch_ptr: cute.Pointer,
+        m_val: Int32,
+        grid_x: Int32,
+        stream,
+    ):
+        cfg = self._cfg
+        a_input = cute.make_tensor(
+            x.iterator, cute.make_layout(Int32(m_val * cfg.k_dim))
+        )
+        w1_weights = cute.make_tensor(
+            w1_ptr, cute.make_layout(Int64(cfg.weight_E * cfg.two_n * cfg.k_half))
+        )
+        w1_scales = cute.make_tensor(
+            w1s_ptr,
+            cute.make_layout(Int64(cfg.weight_E * cfg.w1_sf_rows * cfg.w1_sf_cols)),
+        )
+        w1_alphas = cute.make_tensor(w1a_ptr, cute.make_layout(Int32(cfg.weight_E)))
+        input_gs = cute.make_tensor(a1_ptr, cute.make_layout(Int32(cfg.weight_E)))
+        down_input_scale = cute.make_tensor(
+            a2_ptr, cute.make_layout(Int32(cfg.weight_E))
+        )
+        intermediate = cute.make_tensor(
+            inter_ptr, cute.make_layout(Int32(m_val * cfg.inter_u32))
+        )
+        w2_weights = cute.make_tensor(
+            w2_ptr, cute.make_layout(Int64(cfg.weight_E * cfg.k_dim * cfg.n_half))
+        )
+        w2_scales = cute.make_tensor(
+            w2s_ptr,
+            cute.make_layout(Int64(cfg.weight_E * cfg.w2_sf_rows * cfg.w2_sf_cols)),
+        )
+        w2_alphas = cute.make_tensor(w2a_ptr, cute.make_layout(Int32(cfg.weight_E)))
+        topk_ids_tensor = cute.make_tensor(
+            tid_ptr, cute.make_layout(Int32(m_val * cfg.num_topk))
+        )
+        topk_weights_tensor = cute.make_tensor(
+            tw_ptr, cute.make_layout(Int32(m_val * cfg.num_topk))
+        )
+        scatter_output_tensor = cute.make_tensor(
+            out_ptr, cute.make_layout(Int32(m_val * cfg.k_dim))
+        )
+        barrier_slots = m_val * Int32(cfg.num_topk + 16)
+        barrier_count = cute.make_tensor(
+            barrier_count_ptr, cute.make_layout(barrier_slots)
+        )
+        barrier_epoch = cute.make_tensor(
+            barrier_epoch_ptr, cute.make_layout(barrier_slots)
+        )
+
+        self.kernel(
+            a_input,
+            w1_weights,
+            w1_scales,
+            w1_alphas,
+            input_gs,
+            down_input_scale,
+            intermediate,
+            w2_weights,
+            w2_scales,
+            w2_alphas,
+            topk_ids_tensor,
+            topk_weights_tensor,
+            scatter_output_tensor,
+            barrier_count,
+            barrier_epoch,
+            m_val,
+        ).launch(
+            grid=(grid_x, Int32(1), Int32(1)),
+            block=(_BLOCK_DIM, 1, 1),
+            smem=0,
+            stream=stream,
+        )
+
+    @staticmethod
+    def launch(
+        compiled_fn,
+        *,
+        x: torch.Tensor,
+        w1_fp4: torch.Tensor,
+        w1_blockscale: torch.Tensor,
+        w1_alphas: torch.Tensor,
+        a1_gscale: torch.Tensor,
+        a2_gscale: torch.Tensor,
+        inter_fp32: torch.Tensor,
+        w2_fp4: torch.Tensor,
+        w2_blockscale: torch.Tensor,
+        w2_alphas: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        out: torch.Tensor,
+        barrier_count: torch.Tensor,
+        barrier_epoch: torch.Tensor,
+        m: int,
+        grid_x: int,
+    ):
+        stream = current_cuda_stream()
+
+        compiled_fn(
+            x,
+            w1_fp4.data_ptr(),
+            w1_blockscale.view(torch.uint8).data_ptr(),
+            w1_alphas.data_ptr(),
+            a1_gscale.data_ptr(),
+            a2_gscale.data_ptr(),
+            inter_fp32.view(torch.uint32).data_ptr(),
+            w2_fp4.data_ptr(),
+            w2_blockscale.view(torch.uint8).data_ptr(),
+            w2_alphas.data_ptr(),
+            topk_ids.data_ptr(),
+            topk_weights.data_ptr(),
+            out.data_ptr(),
+            barrier_count.data_ptr(),
+            barrier_epoch.data_ptr(),
+            Int32(m),
+            Int32(grid_x),
+            stream,
+        )
+
+
+__all__ = ["MoEDirectMicroKernel"]

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -8,22 +8,29 @@ selection.
 from __future__ import annotations
 
 import os
+from contextlib import suppress
 from dataclasses import dataclass
-from typing import Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import cutlass
 import cutlass.cute as cute
 import torch
+from cutlass.cutlass_dsl import Int32
 
 from flashinfer.cute_dsl.utils import (
     convert_sf_from_mma_layout,
+    current_cuda_stream,
     get_max_active_clusters,
     get_num_sm,
     make_ptr,
 )
+from .moe_direct_micro_kernel import _BLOCK_DIM as _DIRECT_MICRO_BLOCK_DIM
 from .moe_dynamic_kernel import MoEDynamicKernel
 from .moe_micro_kernel import MoEMicroKernel
 from .moe_static_kernel import MoEStaticKernel
+from .moe_w4a16_dynamic_kernel import MoEDynamicKernel as MoEW4A16DynamicKernel
+from .moe_w4a16_micro_kernel import MoEMicroKernel as MoEW4A16MicroKernel
+from .moe_w4a16_static_kernel import MoEStaticKernel as MoEW4A16StaticKernel
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -31,11 +38,23 @@ from .moe_static_kernel import MoEStaticKernel
 _NVFP4_BLOCK_SIZE = 16
 _LEVEL_TILE_M = 128
 _LEVEL_TILE_N = 128
+_W4A16_LEVEL_TILE_M = 32
+_W4A16_LEVEL_TILE_N = 64
+_DYNAMIC_SLICE_CHUNK = 1
 SF_VEC_SIZE = 16
+_FORCE_MOE_W4A16_ENV = "FLASHINFER_B12X_FORCE_MOE_W4A16"
+_MICRO_SHARE_INPUT_ACROSS_EXPERTS = (
+    os.environ.get("FLASHINFER_B12X_MICRO_SHARE_INPUT", "1") != "0"
+)
 
 # Micro kernel cutover thresholds (routed pairs)
 _MICRO_COMPACT_CUTOVER_PAIRS = 20
 _MICRO_COMPACT_CUTOVER_PAIRS_MULTI_TOPK = 40
+_STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT = 640
+_W4A16_STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT = 128
+_STATIC_COMPACT_CUTOVER_PAIRS = _STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT
+_STATIC_COMPACT_CUTOVER_PAIRS_CACHE: Dict[str, int] = {}
+_W4A16_DIRECT_MICRO_TOKEN_OPTIONS = (1, 2, 4, 8, 10, 12, 16, 24, 32)
 
 # MAC (max active clusters) tuning ladders from b12x decode profiling.
 # Each entry is (max_routed_rows, optimal_mac).
@@ -78,6 +97,124 @@ def _lookup_mac_ladder(
 
 def _align_up(value: int, alignment: int) -> int:
     return ((value + alignment - 1) // alignment) * alignment
+
+
+def _first_env(*names: str) -> str | None:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+def _normalize_activation_precision(activation_precision: str) -> str:
+    """Normalize public activation-precision names to internal modes."""
+    if os.environ.get(_FORCE_MOE_W4A16_ENV, "0") == "1":
+        return "bf16"
+
+    normalized = str(activation_precision).lower()
+    aliases = {
+        "fp4": "fp4",
+        "nvfp4": "fp4",
+        "w4a4": "fp4",
+        "bf16": "bf16",
+        "w4a16": "bf16",
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        raise ValueError(
+            "activation_precision must be 'fp4' or 'bf16' "
+            f"(got {activation_precision!r})."
+        ) from exc
+
+
+def _is_w4a16(activation_precision: str) -> bool:
+    return _normalize_activation_precision(activation_precision) == "bf16"
+
+
+def _level_tile_m(activation_precision: str = "fp4") -> int:
+    return _W4A16_LEVEL_TILE_M if _is_w4a16(activation_precision) else _LEVEL_TILE_M
+
+
+def _level_tile_n(activation_precision: str = "fp4") -> int:
+    return _W4A16_LEVEL_TILE_N if _is_w4a16(activation_precision) else _LEVEL_TILE_N
+
+
+def _get_static_compact_cutover_pairs(activation_precision: str = "fp4") -> int:
+    activation_precision = _normalize_activation_precision(activation_precision)
+    cached = _STATIC_COMPACT_CUTOVER_PAIRS_CACHE.get(activation_precision)
+    if cached is not None:
+        return cached
+
+    cutover_names: tuple[str, ...] = (
+        "FLASHINFER_B12X_STATIC_COMPACT_CUTOVER_PAIRS",
+        "B12X_STATIC_COMPACT_CUTOVER_PAIRS",
+        "B12X_DYNAMIC_STATIC_CUTOVER_PAIRS",
+        "B12X_LEVEL10_STATIC_CUTOVER_PAIRS",
+    )
+    if activation_precision == "bf16":
+        cutover_names = (
+            "FLASHINFER_B12X_W4A16_STATIC_COMPACT_CUTOVER_PAIRS",
+            "B12X_W4A16_STATIC_COMPACT_CUTOVER_PAIRS",
+            *cutover_names,
+        )
+
+    cutover = _first_env(*cutover_names)
+    if cutover is None:
+        cached = (
+            _W4A16_STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT
+            if activation_precision == "bf16"
+            else _STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT
+        )
+    else:
+        cached = max(0, int(cutover))
+    _STATIC_COMPACT_CUTOVER_PAIRS_CACHE[activation_precision] = cached
+    return cached
+
+
+def _select_w4a16_static_mma_tiler_mn(routed_rows: int, n: int) -> Tuple[int, int]:
+    if n % 128 != 0:
+        return (32, 64)
+    return (32, 128) if routed_rows <= 100 or routed_rows >= 320 else (32, 64)
+
+
+def _direct_micro_intermediate_elements(
+    num_tokens: int,
+    num_topk: int,
+    k: int,
+    n: int,
+) -> int:
+    fc2_n_chunks = (n // 2 + 127) // 128
+    return (
+        int(num_tokens) * int(num_topk) * int(k)
+        + int(num_tokens) * int(num_topk) * fc2_n_chunks * 128
+    )
+
+
+def _direct_micro_barrier_slots(routed_rows: int, num_tokens: int) -> int:
+    return max(1, int(routed_rows) + int(num_tokens) * 16)
+
+
+def _w4a16_direct_micro_workspace_tokens(
+    max_rows: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    weight_E: int,
+) -> int:
+    """Return the largest direct-micro token count this workspace can hold."""
+    max_tokens = max(1, int(max_rows) // max(1, int(num_topk)))
+    for tokens in reversed(_W4A16_DIRECT_MICRO_TOKEN_OPTIONS):
+        if tokens <= max_tokens and MoEW4A16MicroKernel.is_supported(
+            m=tokens,
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            weight_E=weight_E,
+        ):
+            return tokens
+    return 0
 
 
 def _select_moe_mma_tiler_mn(routed_rows: int, n: int) -> Tuple[int, int]:
@@ -127,6 +264,7 @@ class Sm120StaticMoEWorkspace:
     n: int
     num_topk: int
     device: torch.device
+    activation_precision: str
 
     # Buffers
     row_counts: torch.Tensor  # [state_E] int32
@@ -140,6 +278,7 @@ class Sm120StaticMoEWorkspace:
     weight_expert_ids: torch.Tensor  # [state_E] int32
     global_to_local_expert: torch.Tensor  # [weight_E] int32
     compact_topk_ids: torch.Tensor  # [state_E] int32, for micro kernel pre-pass
+    micro_intermediate: torch.Tensor  # float32 scratch for W4A16 direct micro
 
     # Views (set after allocation)
     packed_a_view: torch.Tensor | None = None
@@ -157,10 +296,53 @@ def allocate_sm120_static_workspace(
     n: int,
     num_topk: int,
     device: torch.device,
+    activation_precision: str = "fp4",
 ) -> Sm120StaticMoEWorkspace:
     """Allocate workspace buffers for the SM120 static MoE kernel."""
+    activation_precision = _normalize_activation_precision(activation_precision)
+    if activation_precision == "bf16":
+        max_rows = max(max_rows, 128)
+
     rows_pad_k = _align_up(max_rows, 128)
     cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    if activation_precision == "bf16":
+        packed_input = torch.empty(
+            state_E, max_rows, k, dtype=torch.bfloat16, device=device
+        )
+    else:
+        packed_input = torch.empty(
+            state_E, max_rows, k // 2, dtype=torch.uint8, device=device
+        )
+
+    direct_micro_tokens = 0
+    if activation_precision == "bf16" and state_E == weight_E:
+        direct_micro_tokens = _w4a16_direct_micro_workspace_tokens(
+            max_rows=max_rows,
+            k=k,
+            n=n,
+            num_topk=num_topk,
+            weight_E=weight_E,
+        )
+    barrier_slots = 1
+    if direct_micro_tokens > 0:
+        barrier_slots = _direct_micro_barrier_slots(
+            direct_micro_tokens * num_topk,
+            direct_micro_tokens,
+        )
+
+    micro_intermediate_elements = 1
+    if activation_precision == "bf16":
+        micro_intermediate_elements = max(1, state_E * n)
+        if direct_micro_tokens > 0:
+            micro_intermediate_elements = max(
+                micro_intermediate_elements,
+                _direct_micro_intermediate_elements(
+                    direct_micro_tokens,
+                    num_topk,
+                    k,
+                    n,
+                ),
+            )
 
     workspace = Sm120StaticMoEWorkspace(
         state_E=state_E,
@@ -170,33 +352,41 @@ def allocate_sm120_static_workspace(
         n=n,
         num_topk=num_topk,
         device=device,
+        activation_precision=activation_precision,
         row_counts=torch.zeros(state_E, dtype=torch.int32, device=device),
         token_map=torch.zeros(state_E, max_rows, dtype=torch.int32, device=device),
         token_weights=torch.zeros(
             state_E, max_rows, dtype=torch.float32, device=device
         ),
-        packed_input=torch.empty(
-            state_E, max_rows, k // 2, dtype=torch.uint8, device=device
-        ),
+        packed_input=packed_input,
         packed_input_scale=torch.empty(
             state_E, rows_pad_k, cols_pad_k, dtype=torch.uint8, device=device
         ),
-        barrier_count=torch.zeros(1, dtype=torch.int32, device=device),
-        barrier_epoch=torch.zeros(1, dtype=torch.int32, device=device),
+        barrier_count=torch.zeros(barrier_slots, dtype=torch.int32, device=device),
+        barrier_epoch=torch.zeros(barrier_slots, dtype=torch.int32, device=device),
         active_expert_count=torch.zeros(1, dtype=torch.int32, device=device),
         weight_expert_ids=torch.arange(state_E, dtype=torch.int32, device=device),
         global_to_local_expert=torch.empty(weight_E, dtype=torch.int32, device=device),
         compact_topk_ids=torch.empty(
             max(state_E, max_rows), dtype=torch.int32, device=device
         ),
+        micro_intermediate=torch.zeros(
+            micro_intermediate_elements,
+            dtype=torch.float32,
+            device=device,
+        ),
     )
 
     # Finalize views
     sf_dtype = cutlass.Float8E4M3FN
-    workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
-        torch.float4_e2m1fn_x2
-    )
-    workspace.packed_a_flat = workspace.packed_input.view(-1)
+    if activation_precision == "bf16":
+        workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0)
+        workspace.packed_a_flat = workspace.packed_input.view(torch.uint8).view(-1)
+    else:
+        workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
+            torch.float4_e2m1fn_x2
+        )
+        workspace.packed_a_flat = workspace.packed_input.view(-1)
     workspace.scale_flat = workspace.packed_input_scale.view(-1)
     workspace.sfa_ptr = make_ptr(
         sf_dtype,
@@ -218,6 +408,10 @@ class _WeightViews:
     sfb_down_ptr: object = None
     w1_alpha: torch.Tensor | None = None
     w2_alpha: torch.Tensor | None = None
+    w1_storage: torch.Tensor | None = None
+    w1_scale_storage: torch.Tensor | None = None
+    w2_storage: torch.Tensor | None = None
+    w2_scale_storage: torch.Tensor | None = None
     _w13_sf_storage: torch.Tensor | None = None
     _down_sf_storage: torch.Tensor | None = None
 
@@ -234,21 +428,25 @@ def _get_weight_views(
     w2_alphas: torch.Tensor,
     n: int,
     k: int,
+    activation_precision: str = "fp4",
 ) -> _WeightViews:
     """Create permuted weight views for the static kernel.
 
     The kernel expects concatenated w13 data with shape [2*n, k//2, E]
     via a single TMA descriptor.
     """
+    activation_precision = _normalize_activation_precision(activation_precision)
+    tile_n = _level_tile_n(activation_precision)
     # The kernel splits w13 into gate/up halves by tile index. This only works
     # when the boundary between halves lands on a tile-aligned column.
-    if n % _LEVEL_TILE_N != 0:
+    if n % tile_n != 0:
         raise ValueError(
-            f"intermediate_size ({n}) must be a multiple of {_LEVEL_TILE_N} "
+            f"intermediate_size ({n}) must be a multiple of {tile_n} "
             f"for the SM120 MoE kernel's gate/up tile split."
         )
 
     key = (
+        activation_precision,
         w1_fp4.data_ptr(),
         w1_blockscale.data_ptr(),
         w1_alphas.data_ptr(),
@@ -303,6 +501,10 @@ def _get_weight_views(
         ),
         w1_alpha=w1_alphas.contiguous().to(torch.float32),
         w2_alpha=w2_alphas.contiguous().to(torch.float32),
+        w1_storage=w1_fp4,
+        w1_scale_storage=w13_sf_contiguous,
+        w2_storage=w2_fp4,
+        w2_scale_storage=down_sf_contiguous,
     )
     # Keep references to prevent GC of contiguous buffers
     views._w13_sf_storage = w13_sf_contiguous
@@ -331,8 +533,10 @@ def _get_static_kernel(
     fast_math: bool = True,
     mac_override: int | None = None,
     activation: str = "silu",
+    activation_precision: str = "fp4",
 ):
     """Compile (or retrieve cached) the SM120 static MoE kernel."""
+    activation_precision = _normalize_activation_precision(activation_precision)
     sf_vec_size = 16
     sm_count = get_num_sm(torch.device("cuda"))
     mac = (
@@ -343,12 +547,16 @@ def _get_static_kernel(
 
     # Select tile size based on actual routed rows
     routed_rows = m * num_topk
-    mma_tiler_mn = (128, 128)
-    if num_topk > 1:
+    if activation_precision == "bf16":
+        mma_tiler_mn = _select_w4a16_static_mma_tiler_mn(routed_rows, n)
+    else:
+        mma_tiler_mn = (128, 128)
+    if activation_precision == "fp4" and num_topk > 1:
         mma_tiler_mn = _select_moe_mma_tiler_mn(routed_rows, n)
 
     cache_key = (
         "static",
+        activation_precision,
         state_E,
         weight_E,
         m,
@@ -367,19 +575,35 @@ def _get_static_kernel(
     if cached is not None:
         return cached
 
-    ab_dtype = cutlass.Float4E2M1FN
+    ab_dtype = (
+        cutlass.BFloat16 if activation_precision == "bf16" else cutlass.Float4E2M1FN
+    )
+    weight_dtype = cutlass.Float4E2M1FN
     sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
-    kernel = MoEStaticKernel(
-        sf_vec_size=sf_vec_size,
-        mma_tiler_mn=mma_tiler_mn,
-        output_tile_count_n=max(1, (n + mma_tiler_mn[1] - 1) // mma_tiler_mn[1]),
-        input_scales_are_reciprocal=input_scales_are_reciprocal,
-        fast_math=fast_math,
-        activation=activation,
-    )
+    output_tile_count_n = max(1, (n + mma_tiler_mn[1] - 1) // mma_tiler_mn[1])
+    kernel: Any
+    if activation_precision == "bf16":
+        kernel = MoEW4A16StaticKernel(
+            sf_vec_size=sf_vec_size,
+            mma_tiler_mn=mma_tiler_mn,
+            output_tile_count_n=output_tile_count_n,
+            fast_math=fast_math,
+            activation=activation,
+            exact_mma_m_tiles=activation == "silu" and num_topk == 1,
+            single_token=m == 1,
+        )
+    else:
+        kernel = MoEStaticKernel(
+            sf_vec_size=sf_vec_size,
+            mma_tiler_mn=mma_tiler_mn,
+            output_tile_count_n=output_tile_count_n,
+            fast_math=fast_math,
+            activation=activation,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+        )
 
     is_gated = activation == "silu"
     w1_rows = (2 if is_gated else 1) * n  # 2*n for gated, n for non-gated
@@ -415,9 +639,12 @@ def _get_static_kernel(
         assumed_align=16,
     )
     sfa_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    packed_a_storage_elements = state_E * max_rows * (k // 2)
+    if activation_precision == "bf16":
+        packed_a_storage_elements = state_E * max_rows * k * 2
     packed_a_storage_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Uint8,
-        (state_E * max_rows * (k // 2),),
+        (packed_a_storage_elements,),
         assumed_align=16,
     )
     scale_storage_fake = cute.runtime.make_fake_compact_tensor(
@@ -436,14 +663,14 @@ def _get_static_kernel(
         assumed_align=4,
     )
     b_w13_fake = cute.runtime.make_fake_compact_tensor(
-        ab_dtype,
+        weight_dtype,
         (w1_rows, k, weight_E),
         stride_order=(1, 0, 2),
         assumed_align=16,
     )
     sfb_w13_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
     b_down_fake = cute.runtime.make_fake_compact_tensor(
-        ab_dtype,
+        weight_dtype,
         (k, n, weight_E),
         stride_order=(1, 0, 2),
         assumed_align=16,
@@ -534,7 +761,7 @@ def _get_static_kernel(
         token_map_fake,
         token_weights_fake,
         mac,
-        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        current_cuda_stream(),
         options="--opt-level 2 --enable-tvm-ffi",
     )
 
@@ -544,6 +771,8 @@ def _get_static_kernel(
 
 
 _MICRO_KERNEL_CACHE: Dict[Tuple, Tuple] = {}
+_MICRO_DIRECT_LAUNCH_CAP_CACHE: Dict[Tuple, bool] = {}
+_DIRECT_MICRO_SHAPE_ATTR = "_flashinfer_direct_micro_shape"
 
 
 def _get_micro_kernel(
@@ -770,13 +999,204 @@ def _get_micro_kernel(
         token_map_fake,
         token_weights_fake,
         mac,
-        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        current_cuda_stream(),
         options="--opt-level 2 --enable-tvm-ffi",
     )
 
     result = (compiled, mac)
     _MICRO_KERNEL_CACHE[cache_key] = result
     return result
+
+
+def _get_w4a16_direct_micro_kernel(
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    *,
+    topk_ids_dtype: torch.dtype,
+    fast_math: bool,
+    share_input_across_experts: bool = False,
+    share_expert_scales: bool = False,
+    single_token: bool = False,
+    mac_override: int | None = None,
+    activation: str = "silu",
+    device: torch.device | None = None,
+):
+    """Compile (or retrieve cached) the direct routed W4A16 micro kernel."""
+    device = device or torch.device("cuda")
+    sm_count = get_num_sm(device)
+    mac = (
+        mac_override
+        if mac_override is not None
+        else min(get_max_active_clusters(1), sm_count)
+    )
+    if mac_override is None and m > 8:
+        # Larger direct W4A16 decode windows are memory-bound; matching the
+        # upstream cap keeps the resident grid from over-pressuring L1/DRAM.
+        mac = min(mac, 171)
+
+    cache_key = (
+        "micro_direct",
+        "bf16",
+        m,
+        k,
+        n,
+        num_topk,
+        weight_E,
+        mac,
+        str(device),
+        topk_ids_dtype,
+        fast_math,
+        share_input_across_experts,
+        share_expert_scales,
+        single_token,
+        activation,
+    )
+    cached = _MICRO_KERNEL_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    kernel = MoEW4A16MicroKernel(
+        sf_vec_size=SF_VEC_SIZE,
+        mma_tiler_mn=(64, 128),
+        output_tile_count_n=1,
+        fast_math=fast_math,
+        activation=activation,
+        share_input_across_experts=share_input_across_experts,
+        share_expert_scales=share_expert_scales,
+        single_token=single_token,
+    )
+    kernel.configure(
+        m,
+        k,
+        n,
+        num_topk,
+        weight_E,
+        max_active_ctas=mac,
+        device=device,
+    )
+
+    def dummy(dt):
+        return make_ptr(dt, 16, cute.AddressSpace.gmem, assumed_align=16)
+
+    ids_dtype = cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
+    x_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (m, k),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    compiled = cute.compile(
+        kernel,
+        x_fake,
+        dummy(cutlass.Uint8),  # w1_ptr
+        dummy(cutlass.Uint8),  # w1s_ptr
+        dummy(cutlass.Float32),  # w1a_ptr
+        dummy(cutlass.Float32),  # a1_ptr
+        dummy(cutlass.Float32),  # a2_ptr
+        dummy(cutlass.Uint32),  # inter_ptr
+        dummy(cutlass.Uint8),  # w2_ptr
+        dummy(cutlass.Uint8),  # w2s_ptr
+        dummy(cutlass.Float32),  # w2a_ptr
+        dummy(ids_dtype),  # tid_ptr
+        dummy(cutlass.Float32),  # tw_ptr
+        dummy(cutlass.BFloat16),  # out_ptr
+        dummy(cutlass.Int32),  # barrier_count_ptr
+        dummy(cutlass.Int32),  # barrier_epoch_ptr
+        Int32(m),
+        Int32(kernel.grid_x),
+        current_cuda_stream(),
+        options="--opt-level 2 --enable-tvm-ffi",
+    )
+    with suppress(Exception):
+        setattr(
+            compiled,
+            _DIRECT_MICRO_SHAPE_ATTR,
+            ("bf16", int(m), int(k), int(n), int(num_topk), int(weight_E)),
+        )
+
+    result = (compiled, kernel.grid_x)
+    _MICRO_KERNEL_CACHE[cache_key] = result
+    return result
+
+
+def _direct_micro_shape_accepts_block_dim(compiled, block_dim: int) -> bool:
+    shape = getattr(compiled, _DIRECT_MICRO_SHAPE_ATTR, None)
+    if shape is None:
+        return True
+    mode, m, _k, n, _num_topk, _weight_E = shape
+    if mode == "bf16" and int(m) >= 4 and int(n) >= 4096:
+        return False
+    return True
+
+
+def _compiled_direct_micro_accepts_block_dim(compiled, block_dim: int) -> bool:
+    """Return whether the compiled direct micro kernel can launch block_dim threads."""
+    cache_key = (
+        id(compiled),
+        int(block_dim),
+        getattr(compiled, _DIRECT_MICRO_SHAPE_ATTR, None),
+    )
+    cached = _MICRO_DIRECT_LAUNCH_CAP_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    if not _direct_micro_shape_accepts_block_dim(compiled, block_dim):
+        _MICRO_DIRECT_LAUNCH_CAP_CACHE[cache_key] = False
+        return False
+
+    accepted = True
+    try:
+        from cuda.bindings import driver, runtime
+
+        executor = compiled.to(None)
+        kernel_info = getattr(compiled, "kernel_info", None) or {}
+        kernel_name = next(iter(kernel_info.keys()), None)
+        if kernel_name is None and hasattr(compiled, "_get_name"):
+            kernel_name = compiled._get_name()
+        if isinstance(kernel_name, str):
+            kernel_name = kernel_name.encode()
+        if kernel_name is None:
+            raise RuntimeError("compiled micro kernel did not expose a kernel name")
+
+        jit_module = getattr(executor, "jit_module", None)
+        cuda_library = getattr(jit_module, "cuda_library", None)
+        if isinstance(cuda_library, (list, tuple)):
+            cuda_library = cuda_library[0] if cuda_library else None
+        if cuda_library is None:
+            cuda_library = getattr(executor, "kernel", None)
+        if cuda_library is None and hasattr(executor, "_load_cuda_library"):
+            cuda_libraries = executor._load_cuda_library()
+            if isinstance(cuda_libraries, (list, tuple)):
+                cuda_library = cuda_libraries[0] if cuda_libraries else None
+            else:
+                cuda_library = cuda_libraries
+        if cuda_library is None:
+            raise RuntimeError("compiled micro kernel did not expose a CUDA library")
+
+        err, kernel = runtime.cudaLibraryGetKernel(cuda_library, kernel_name)
+        if err != runtime.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaLibraryGetKernel failed with {err}")
+        cu_kernel = driver.CUkernel(int(kernel))
+        err, max_threads = driver.cuKernelGetAttribute(
+            driver.CUfunction_attribute.CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+            cu_kernel,
+            0,
+        )
+        if err != driver.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"cuKernelGetAttribute failed with {err}")
+        accepted = int(max_threads) >= int(block_dim)
+    except Exception:
+        # TVM-FFI compiled functions in CUTLASS 4.5 do not always expose a CUDA
+        # library handle here. The shape predicate above carries the known
+        # unsafe W4A16 envelope, so lack of introspection should not disable
+        # the supported direct-micro path.
+        accepted = True
+
+    _MICRO_DIRECT_LAUNCH_CAP_CACHE[cache_key] = accepted
+    return accepted
 
 
 # ---------------------------------------------------------------------------
@@ -807,6 +1227,7 @@ def launch_sm120_static_moe(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     activation: str = "silu",
+    activation_precision: str = "fp4",
 ) -> torch.Tensor:
     """Launch the SM120 static or micro MoE kernel.
 
@@ -814,6 +1235,8 @@ def launch_sm120_static_moe(
     and the static kernel otherwise. The micro path runs a Triton pre-pass
     to compact routing IDs before launching.
     """
+    activation_precision = _normalize_activation_precision(activation_precision)
+
     # Flatten routing tensors
     flat_ids = topk_ids.view(-1).to(torch.int32)
     flat_weights = topk_weights.view(-1).to(torch.float32)
@@ -833,14 +1256,108 @@ def launch_sm120_static_moe(
     micro_cutover = _MICRO_COMPACT_CUTOVER_PAIRS
     if top_k > 1:
         micro_cutover = _MICRO_COMPACT_CUTOVER_PAIRS_MULTI_TOPK
-    use_micro = routed_rows <= micro_cutover
+    use_micro = activation_precision == "fp4" and routed_rows <= micro_cutover
 
     sm_count = get_num_sm(torch.device("cuda"))
     base_mac = min(get_max_active_clusters(1), sm_count)
     tuned_static_mac = _lookup_mac_ladder(_STATIC_MAC_LADDER, routed_rows)
-    static_mac = min(tuned_static_mac or base_mac, base_mac)
-    if not use_micro and routed_rows < 40:
+    if activation_precision == "bf16":
+        static_mac = base_mac
+    else:
+        static_mac = min(tuned_static_mac or base_mac, base_mac)
+    if activation_precision == "fp4" and not use_micro and routed_rows < 40:
         static_mac = min(static_mac, 64)
+
+    # Shared-scale flags are used by both compact W4A4 micro and direct W4A16
+    # micro to match the ReLU2 single-token specialization.
+    share_input_across_experts = (
+        activation == "relu2"
+        and num_tokens == 1
+        and input_gs_is_shared
+        and _MICRO_SHARE_INPUT_ACROSS_EXPERTS
+    )
+    share_expert_scales = (
+        activation == "relu2" and input_gs_is_shared and down_input_scale_is_shared
+    )
+
+    use_w4a16_direct_micro = (
+        activation_precision == "bf16"
+        and workspace.state_E == num_experts
+        and weights.w1_storage is not None
+        and weights.w2_storage is not None
+        and weights.w1_scale_storage is not None
+        and weights.w2_scale_storage is not None
+        and weights.w1_storage.is_contiguous()
+        and weights.w2_storage.is_contiguous()
+        and weights.w1_scale_storage.is_contiguous()
+        and weights.w2_scale_storage.is_contiguous()
+        and MoEW4A16MicroKernel.is_supported(
+            m=num_tokens,
+            k=k,
+            n=n,
+            num_topk=top_k,
+            weight_E=num_experts,
+        )
+    )
+    if use_w4a16_direct_micro:
+        required_intermediate = _direct_micro_intermediate_elements(
+            num_tokens,
+            top_k,
+            k,
+            n,
+        )
+        required_barriers = _direct_micro_barrier_slots(routed_rows, num_tokens)
+        use_w4a16_direct_micro = (
+            workspace.micro_intermediate.numel() >= required_intermediate
+            and workspace.barrier_count.numel() >= required_barriers
+            and workspace.barrier_epoch.numel() >= required_barriers
+        )
+
+    if use_w4a16_direct_micro:
+        if flat_ids.is_contiguous():
+            launch_ids = flat_ids
+        else:
+            launch_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+            launch_ids.copy_(flat_ids.to(torch.int32))
+        compiled, grid_x = _get_w4a16_direct_micro_kernel(
+            num_experts,
+            num_tokens,
+            k,
+            n,
+            top_k,
+            topk_ids_dtype=launch_ids.dtype,
+            fast_math=fast_math,
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=num_tokens == 1,
+            activation=activation,
+            device=a.device,
+        )
+        if _compiled_direct_micro_accepts_block_dim(
+            compiled,
+            _DIRECT_MICRO_BLOCK_DIM,
+        ):
+            MoEW4A16MicroKernel.launch(
+                compiled,
+                x=a,
+                w1_fp4=weights.w1_storage,
+                w1_blockscale=weights.w1_scale_storage,
+                w1_alphas=weights.w1_alpha,
+                a1_gscale=input_gs,
+                a2_gscale=down_input_scale,
+                inter_fp32=workspace.micro_intermediate,
+                w2_fp4=weights.w2_storage,
+                w2_blockscale=weights.w2_scale_storage,
+                w2_alphas=weights.w2_alpha,
+                topk_ids=launch_ids.view(num_tokens, top_k),
+                topk_weights=flat_weights.view(num_tokens, top_k),
+                out=scatter_output,
+                barrier_count=workspace.barrier_count,
+                barrier_epoch=workspace.barrier_epoch,
+                m=num_tokens,
+                grid_x=grid_x,
+            )
+            return scatter_output
 
     if use_micro:
         assert flat_ids.numel() <= workspace.compact_topk_ids.numel(), (
@@ -882,19 +1399,6 @@ def launch_sm120_static_moe(
         micro_work_tiles = max(1, routed_rows * max(1, (n + 128 - 1) // 128))
         tuned_mac = _lookup_mac_ladder(_MICRO_MAC_LADDER, routed_rows)
         micro_mac = min(tuned_mac or base_mac, micro_work_tiles, base_mac)
-        # For m=1 ReLU2 with a shared FC1-input scale, all experts see the
-        # same quantized activation. Match FI main's synchronization model:
-        # one CTA writes a shared packed slot, then the resident-grid barrier
-        # below makes it visible before all CTAs read it for FC1.
-        share_input_across_experts = (
-            activation == "relu2"
-            and num_tokens == 1
-            and input_gs_is_shared
-            and os.environ.get("FLASHINFER_B12X_MICRO_SHARE_INPUT", "1") != "0"
-        )
-        share_expert_scales = (
-            activation == "relu2" and input_gs_is_shared and down_input_scale_is_shared
-        )
         compiled, mac = _get_micro_kernel(
             workspace.state_E,
             num_experts,
@@ -926,14 +1430,12 @@ def launch_sm120_static_moe(
             fast_math=fast_math,
             mac_override=static_mac,
             activation=activation,
+            activation_precision=activation_precision,
         )
         launch_ids = flat_ids
 
-    # With TVM-FFI env stream, the stream is managed automatically.
-    # max_active_clusters (Constexpr) is baked in at cute.compile() time
-    # and must NOT be passed at runtime (cutlass-dsl >= 4.5).
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
-    compiled(
+    runtime_args: Tuple[Any, ...] = (
         a,
         launch_ids,
         flat_weights,
@@ -959,6 +1461,7 @@ def launch_sm120_static_moe(
         workspace.token_map,
         workspace.token_weights,
     )
+    compiled(*runtime_args, current_cuda_stream())
 
     return scatter_output
 
@@ -967,14 +1470,13 @@ def launch_sm120_static_moe(
 # Dynamic backend
 # ==========================================================================
 
-_STATIC_COMPACT_CUTOVER_PAIRS = 640
-_DYNAMIC_SLICE_CHUNK = 2
 
-
-def select_sm120_moe_backend(*, num_tokens: int, num_topk: int) -> str:
+def select_sm120_moe_backend(
+    *, num_tokens: int, num_topk: int, activation_precision: str = "fp4"
+) -> str:
     """Pick static or dynamic backend based on routed-pair count."""
     routed_rows = num_tokens * num_topk
-    if routed_rows <= _STATIC_COMPACT_CUTOVER_PAIRS:
+    if routed_rows <= _get_static_compact_cutover_pairs(activation_precision):
         return "static"
     return "dynamic"
 
@@ -993,6 +1495,7 @@ class Sm120DynamicMoEWorkspace:
     n: int
     num_topk: int
     device: torch.device
+    activation_precision: str
 
     # Core buffers
     row_counts: torch.Tensor
@@ -1029,7 +1532,14 @@ class Sm120DynamicMoEWorkspace:
     scale_flat: torch.Tensor | None = None
 
 
-def _dynamic_task_geometry(state_E: int, n: int, routed_rows: int):
+def _dynamic_task_geometry(
+    state_E: int,
+    n: int,
+    routed_rows: int,
+    *,
+    tile_m: int = _LEVEL_TILE_M,
+    tile_n: int = _LEVEL_TILE_N,
+):
     """Compute task queue dimensions from problem geometry.
 
     Each active expert can introduce at most one additional physical tile
@@ -1037,10 +1547,10 @@ def _dynamic_task_geometry(state_E: int, n: int, routed_rows: int):
     holds one entry per (m_tile, slice_group) pair — NOT multiplied by E.
     """
     routed_rows = max(1, routed_rows)
-    base_m_tiles = _align_up(routed_rows, _LEVEL_TILE_M) // _LEVEL_TILE_M
+    base_m_tiles = _align_up(routed_rows, tile_m) // tile_m
     active_expert_upper_bound = min(state_E, routed_rows)
     max_m_tiles = max(1, base_m_tiles + active_expert_upper_bound - 1)
-    gate_tile_cnt = max(1, (n + _LEVEL_TILE_N - 1) // _LEVEL_TILE_N)
+    gate_tile_cnt = max(1, (n + tile_n - 1) // tile_n)
     slice_groups = max(
         1, (gate_tile_cnt + _DYNAMIC_SLICE_CHUNK - 1) // _DYNAMIC_SLICE_CHUNK
     )
@@ -1057,11 +1567,28 @@ def allocate_sm120_dynamic_workspace(
     n: int,
     num_topk: int,
     device: torch.device,
+    activation_precision: str = "fp4",
 ) -> Sm120DynamicMoEWorkspace:
     """Allocate workspace buffers for the SM120 dynamic MoE kernel."""
-    physical_tiles, _, max_tasks = _dynamic_task_geometry(state_E, n, routed_rows)
-    rows_padded = physical_tiles * _LEVEL_TILE_M
+    activation_precision = _normalize_activation_precision(activation_precision)
+    tile_m = _level_tile_m(activation_precision)
+    physical_tiles, _, max_tasks = _dynamic_task_geometry(
+        state_E,
+        n,
+        routed_rows,
+        tile_m=tile_m,
+        tile_n=_level_tile_n(activation_precision),
+    )
+    rows_padded = physical_tiles * tile_m
     cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    if activation_precision == "bf16":
+        packed_input = torch.empty(
+            1, rows_padded, k, dtype=torch.bfloat16, device=device
+        )
+    else:
+        packed_input = torch.empty(
+            1, rows_padded, k // 2, dtype=torch.uint8, device=device
+        )
 
     workspace = Sm120DynamicMoEWorkspace(
         state_E=state_E,
@@ -1071,15 +1598,14 @@ def allocate_sm120_dynamic_workspace(
         n=n,
         num_topk=num_topk,
         device=device,
+        activation_precision=activation_precision,
         routed_rows_capacity=routed_rows,
         physical_tiles_capacity=physical_tiles,
         task_capacity=max_tasks,
         row_counts=torch.zeros(state_E, dtype=torch.int32, device=device),
         token_map=torch.zeros(rows_padded, dtype=torch.int32, device=device),
         token_weights=torch.zeros(rows_padded, dtype=torch.float32, device=device),
-        packed_input=torch.empty(
-            1, rows_padded, k // 2, dtype=torch.uint8, device=device
-        ),
+        packed_input=packed_input,
         packed_input_scale=torch.empty(
             rows_padded, cols_pad_k, dtype=torch.uint8, device=device
         ),
@@ -1103,10 +1629,14 @@ def allocate_sm120_dynamic_workspace(
 
     # Finalize views
     sf_dtype = cutlass.Float8E4M3FN
-    workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
-        torch.float4_e2m1fn_x2
-    )
-    workspace.packed_a_flat = workspace.packed_input.view(-1)
+    if activation_precision == "bf16":
+        workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0)
+        workspace.packed_a_flat = workspace.packed_input.view(torch.uint8).view(-1)
+    else:
+        workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
+            torch.float4_e2m1fn_x2
+        )
+        workspace.packed_a_flat = workspace.packed_input.view(-1)
     workspace.scale_flat = workspace.packed_input_scale.view(-1)
     workspace.sfa_ptr = make_ptr(
         sf_dtype,
@@ -1125,10 +1655,11 @@ def allocate_sm120_dynamic_workspace(
 class _DynamicMoELaunch:
     """Thin JIT wrapper that makes num_tokens and max_rows runtime Int32."""
 
-    def __init__(self, kernel, k, num_topk):
+    def __init__(self, kernel, k, num_topk, activation_precision: str = "fp4"):
+        activation_precision = _normalize_activation_precision(activation_precision)
         self._kernel = kernel
         self._k = k
-        self._half_k = k // 2
+        self._packed_storage_cols = k * 2 if activation_precision == "bf16" else k // 2
         self._num_topk = num_topk
         self._cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
 
@@ -1201,7 +1732,9 @@ class _DynamicMoELaunch:
         )
         packed_a_storage = cute.make_tensor(
             packed_a_storage_ptr,
-            layout=cute.make_layout((rows_padded * self._half_k,), stride=(1,)),
+            layout=cute.make_layout(
+                (rows_padded * self._packed_storage_cols,), stride=(1,)
+            ),
         )
         scale_storage = cute.make_tensor(
             scale_storage_ptr,
@@ -1291,23 +1824,36 @@ def _get_dynamic_kernel(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     activation: str = "silu",
+    activation_precision: str = "fp4",
+    share_input_across_experts: bool = False,
 ):
     """Compile (or retrieve cached) the SM120 dynamic MoE kernel."""
+    activation_precision = _normalize_activation_precision(activation_precision)
+    share_input_across_experts = bool(
+        share_input_across_experts and activation_precision == "fp4"
+    )
     sf_vec_size = 16
     sm_count = get_num_sm(torch.device("cuda"))
     mac = min(get_max_active_clusters(1), sm_count)
+    mma_tiler_mn = (
+        _level_tile_m(activation_precision),
+        _level_tile_n(activation_precision),
+    )
 
     cache_key = (
         "dynamic",
+        activation_precision,
         E,
         k,
         n,
         num_topk,
         mac,
+        mma_tiler_mn,
         topk_ids_dtype,
         input_scales_are_reciprocal,
         fast_math,
         activation,
+        share_input_across_experts,
     )
     cached = _DYNAMIC_KERNEL_CACHE.get(cache_key)
     if cached is not None:
@@ -1316,19 +1862,37 @@ def _get_dynamic_kernel(
     is_gated = activation == "silu"
     w1_rows = (2 if is_gated else 1) * n
 
-    ab_dtype = cutlass.Float4E2M1FN
+    scratch_dtype = (
+        cutlass.BFloat16 if activation_precision == "bf16" else cutlass.Float4E2M1FN
+    )
+    weight_dtype = cutlass.Float4E2M1FN
     sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
-    kernel = MoEDynamicKernel(
-        sf_vec_size=sf_vec_size,
-        mma_tiler_mn=(_LEVEL_TILE_M, _LEVEL_TILE_N),
-        input_scales_are_reciprocal=input_scales_are_reciprocal,
-        fast_math=fast_math,
-        activation=activation,
+    kernel: Any
+    if activation_precision == "bf16":
+        kernel = MoEW4A16DynamicKernel(
+            sf_vec_size=sf_vec_size,
+            mma_tiler_mn=mma_tiler_mn,
+            fast_math=fast_math,
+            activation=activation,
+        )
+    else:
+        kernel = MoEDynamicKernel(
+            sf_vec_size=sf_vec_size,
+            mma_tiler_mn=mma_tiler_mn,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+            fast_math=fast_math,
+            activation=activation,
+            share_input_across_experts=share_input_across_experts,
+        )
+    launch = _DynamicMoELaunch(
+        kernel,
+        k=k,
+        num_topk=num_topk,
+        activation_precision=activation_precision,
     )
-    launch = _DynamicMoELaunch(kernel, k=k, num_topk=num_topk)
 
     topk_ids_cutlass_dtype = (
         cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
@@ -1346,7 +1910,9 @@ def _get_dynamic_kernel(
     topk_weights_fake = make_ptr(
         cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4
     )
-    packed_a_fake = make_ptr(ab_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    packed_a_fake = make_ptr(
+        scratch_dtype, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
     sfa_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
     packed_a_storage_fake = make_ptr(
         cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16
@@ -1400,14 +1966,14 @@ def _get_dynamic_kernel(
     )
 
     b_w13_fake = cute.runtime.make_fake_compact_tensor(
-        ab_dtype,
+        weight_dtype,
         (w1_rows, k, E),
         stride_order=(1, 0, 2),
         assumed_align=16,
     )
     sfb_w13_fake = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
     b_down_fake = cute.runtime.make_fake_compact_tensor(
-        ab_dtype,
+        weight_dtype,
         (k, n, E),
         stride_order=(1, 0, 2),
         assumed_align=16,
@@ -1483,7 +2049,7 @@ def _get_dynamic_kernel(
         1,
         1,  # runtime Int32 placeholders
         mac,
-        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        current_cuda_stream(),
         options="--opt-level 2 --enable-tvm-ffi",
     )
 
@@ -1513,10 +2079,13 @@ def launch_sm120_dynamic_moe(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     activation: str = "silu",
+    activation_precision: str = "fp4",
 ) -> torch.Tensor:
     """Launch the SM120 dynamic MoE kernel."""
+    activation_precision = _normalize_activation_precision(activation_precision)
     flat_ids = topk_ids.view(-1).to(torch.int32)
     flat_weights = topk_weights.view(-1).to(torch.float32)
+    input_gs_is_shared = input_gs.numel() == 1
 
     # Broadcast scalar scales to per-expert [E] tensors
     input_gs = _expand_to_experts(input_gs, num_experts)
@@ -1533,13 +2102,13 @@ def launch_sm120_dynamic_moe(
         input_scales_are_reciprocal=input_scales_are_reciprocal,
         fast_math=fast_math,
         activation=activation,
+        activation_precision=activation_precision,
+        share_input_across_experts=input_gs_is_shared,
     )
 
     # Dynamic kernel: runtime-shaped args are DataPointer (pass data_ptr()),
     # fixed-shape args are Tensor (pass torch tensor directly).
-    # max_active_clusters (Constexpr) is baked in at cute.compile() time
-    # and must NOT be passed at runtime (cutlass-dsl >= 4.5).
-    compiled(
+    runtime_args: Tuple[Any, ...] = (
         a.data_ptr(),
         flat_ids.data_ptr(),
         flat_weights.data_ptr(),
@@ -1577,10 +2146,11 @@ def launch_sm120_dynamic_moe(
         workspace.token_weights.data_ptr(),
         num_tokens,
         workspace.max_rows,
-        workspace.physical_tiles_capacity * _LEVEL_TILE_M,
+        workspace.physical_tiles_capacity * _level_tile_m(activation_precision),
         workspace.task_capacity,
         workspace.physical_tiles_capacity,
     )
+    compiled(*runtime_args, current_cuda_stream())
 
     return scatter_output
 
@@ -1607,6 +2177,7 @@ def _get_cached_workspace(
     n: int,
     num_topk: int,
     device: torch.device,
+    activation_precision: str = "fp4",
 ) -> _Sm120Workspace:
     """Get or allocate a cached workspace for the given problem shape.
 
@@ -1616,7 +2187,17 @@ def _get_cached_workspace(
     geometry (physical tiles, task queue slots) depends on the original
     routed_rows, not just max_rows.
     """
-    cache_key = (state_E, weight_E, k, n, num_topk, str(device), backend)
+    activation_precision = _normalize_activation_precision(activation_precision)
+    cache_key = (
+        state_E,
+        weight_E,
+        k,
+        n,
+        num_topk,
+        str(device),
+        backend,
+        activation_precision,
+    )
     cached = _WORKSPACE_CACHE.get(cache_key)
 
     if cached is not None:
@@ -1638,6 +2219,7 @@ def _get_cached_workspace(
             n=n,
             num_topk=num_topk,
             device=device,
+            activation_precision=activation_precision,
         )
     else:
         workspace = allocate_sm120_static_workspace(
@@ -1648,6 +2230,7 @@ def _get_cached_workspace(
             n=n,
             num_topk=num_topk,
             device=device,
+            activation_precision=activation_precision,
         )
 
     _WORKSPACE_CACHE[cache_key] = workspace
@@ -1665,7 +2248,7 @@ def launch_sm120_moe(
     w1_weight: torch.Tensor,
     w1_weight_sf: torch.Tensor,
     w1_alpha: torch.Tensor,
-    fc2_input_scale: torch.Tensor,
+    fc2_input_scale: Optional[torch.Tensor] = None,
     w2_weight: torch.Tensor,
     w2_weight_sf: torch.Tensor,
     w2_alpha: torch.Tensor,
@@ -1676,6 +2259,7 @@ def launch_sm120_moe(
     input_scales_are_reciprocal: bool = False,
     fast_math: bool = True,
     activation: str = "silu",
+    activation_precision: str = "fp4",
     _workspace=None,
     _weight_views=None,
 ) -> torch.Tensor:
@@ -1686,6 +2270,20 @@ def launch_sm120_moe(
     When not provided (functional API path), a module-level workspace cache
     is used to avoid re-allocating on every call.
     """
+    activation_precision = _normalize_activation_precision(activation_precision)
+    if activation_precision == "fp4":
+        if fc2_input_scale is None:
+            raise ValueError(
+                "fc2_input_scale is required when activation_precision='fp4'."
+            )
+        down_input_scale = fc2_input_scale
+    else:
+        # W4A16 keeps the intermediate activation in BF16, so there is no FC2
+        # activation quantization scale. Accept a passed scale for call-site
+        # compatibility, but route a harmless per-expert tensor to the legacy
+        # kernel argument slot.
+        down_input_scale = w2_alpha
+
     num_tokens = topk_ids.size(0)
     k = a.size(1)  # hidden_size
     is_gated = activation == "silu"
@@ -1706,6 +2304,7 @@ def launch_sm120_moe(
             w2_alphas=w2_alpha,
             n=n,
             k=k,
+            activation_precision=activation_precision,
         )
     )
 
@@ -1715,12 +2314,30 @@ def launch_sm120_moe(
     # the caller already committed to a backend at allocation time.
     if _workspace is not None:
         workspace = _workspace
+        workspace_activation_precision = getattr(
+            workspace, "activation_precision", activation_precision
+        )
+        if workspace_activation_precision != activation_precision:
+            raise ValueError(
+                "pre-allocated workspace activation_precision does not match "
+                f"requested activation_precision={activation_precision!r}."
+            )
         if isinstance(workspace, Sm120DynamicMoEWorkspace):
+            if num_local_experts != num_experts:
+                raise ValueError(
+                    "pre-allocated dynamic SM120 MoE workspace requires "
+                    "num_local_experts == num_experts because dynamic expert "
+                    "buffers are indexed by global topk ids."
+                )
             backend = "dynamic"
         else:
             backend = "static"
     else:
-        backend = select_sm120_moe_backend(num_tokens=num_tokens, num_topk=top_k)
+        backend = select_sm120_moe_backend(
+            num_tokens=num_tokens,
+            num_topk=top_k,
+            activation_precision=activation_precision,
+        )
         # The dynamic kernel indexes row_counts/expert_write_rows directly with
         # topk_ids but those buffers are sized with num_local_experts. Unless
         # num_local_experts == num_experts, fall back to the static backend which
@@ -1736,6 +2353,7 @@ def launch_sm120_moe(
             n=n,
             num_topk=top_k,
             device=a.device,
+            activation_precision=activation_precision,
         )
 
     if backend == "dynamic":
@@ -1746,7 +2364,7 @@ def launch_sm120_moe(
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             input_gs=w1_alpha,
-            down_input_scale=fc2_input_scale,
+            down_input_scale=down_input_scale,
             scatter_output=scatter_output,
             num_experts=num_experts,
             num_tokens=num_tokens,
@@ -1756,6 +2374,7 @@ def launch_sm120_moe(
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
             activation=activation,
+            activation_precision=activation_precision,
         )
     else:
         return launch_sm120_static_moe(
@@ -1765,7 +2384,7 @@ def launch_sm120_moe(
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             input_gs=w1_alpha,
-            down_input_scale=fc2_input_scale,
+            down_input_scale=down_input_scale,
             scatter_output=scatter_output,
             num_experts=num_experts,
             num_tokens=num_tokens,
@@ -1775,4 +2394,5 @@ def launch_sm120_moe(
             input_scales_are_reciprocal=input_scales_are_reciprocal,
             fast_math=fast_math,
             activation=activation,
+            activation_precision=activation_precision,
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -61,6 +61,7 @@ from cutlass.cutlass_dsl import (
     Int32,
     Int64,
     Uint8,
+    Uint32,
     Uint64,
     T,
     dsl_user_op,
@@ -78,6 +79,8 @@ from flashinfer.cute_dsl.fp4_common import (
     atomic_add_global_i32,
     fabs_f32,
     fmax_f32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
@@ -85,9 +88,11 @@ from flashinfer.cute_dsl.fp4_common import (
     st_global_f32,
     st_global_i32,
     shared_ptr_to_u32,
+    st_shared_f32,
     st_shared_u8,
     st_global_u64,
-    scatter_add_bf16x2,
+    st_global_v4_u32,
+    scatter_add_v4_bf16x2,
 )
 from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
     Sm120B12xBlockScaledDenseGemmKernel as DenseGemmKernel,
@@ -95,7 +100,9 @@ from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
 
 
 _SF_VEC_SIZE = 16
-_TASK_SLICE_CHUNK = 2
+_TASK_SLICE_CHUNK = 1
+_PRODUCER_PAIRS_PER_WARP = 2
+_FC2_TILE_RECIP_GS_NUM = 6.0 * 448.0
 
 
 class DynamicLaunchParams:
@@ -269,6 +276,7 @@ class MoEDynamicKernel:
         input_scales_are_reciprocal: bool = False,
         fast_math: bool = False,
         activation: str = "silu",
+        share_input_across_experts: bool = False,
     ):
         if activation not in {"silu", "relu2"}:
             raise ValueError(f"unsupported activation {activation!r}")
@@ -279,6 +287,7 @@ class MoEDynamicKernel:
         self.fast_math = fast_math
         self.activation = activation
         self.is_gated = activation == "silu"
+        self.share_input_across_experts = share_input_across_experts
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.cluster_shape_mnk = (1, 1, 1)
@@ -456,6 +465,37 @@ class MoEDynamicKernel:
         while g < num_groups:
             slot = start + g
             _st_global_release_i32(get_ptr_as_int64(task_ready, slot), Int32(1))
+            g += Int32(1)
+
+    @cute.jit
+    def _publish_deferred_tasks(
+        self,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        gate_tile_cnt: Int32,
+        slice_chunk: Int32,
+        expert_idx: Int32,
+        m_tile_idx: Int32,
+        valid_rows: Int32,
+    ):
+        num_groups = (gate_tile_cnt + slice_chunk - Int32(1)) // slice_chunk
+        start = m_tile_idx * num_groups
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            slice_begin = g * slice_chunk
+            slice_count = gate_tile_cnt - slice_begin
+            if slice_count > slice_chunk:
+                slice_count = slice_chunk
+            task_expert[slot] = expert_idx
+            task_m_tile[slot] = m_tile_idx
+            task_slice_begin[slot] = slice_begin
+            task_slice_count[slot] = slice_count
+            task_valid_rows[slot] = valid_rows
             g += Int32(1)
 
     @cute.jit
@@ -729,10 +769,22 @@ class MoEDynamicKernel:
             #   [12] m_tile_idx  [16] slice_begin   [20] slice_count
             #   [24] valid_rows  [28] batch_base
             ctrl: cute.struct.MemRange[cutlass.Int32, 8]
+            route_phys_rows: cute.struct.MemRange[
+                cutlass.Int32, (self.num_mma_warps + 1) * 32
+            ]
+            route_expert_ids: cute.struct.MemRange[
+                cutlass.Int32, (self.num_mma_warps + 1) * 32
+            ]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             phase2_pipeline_array: cute.struct.MemRange[
                 cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, self.tile_shape_mnk[0]
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, self.tile_shape_mnk[0]
             ]
             sA: cute.struct.Align[
                 cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
@@ -770,9 +822,21 @@ class MoEDynamicKernel:
             #   [12] m_tile_idx  [16] slice_begin   [20] slice_count
             #   [24] valid_rows  [28] batch_base
             ctrl: cute.struct.MemRange[cutlass.Int32, 8]
+            route_phys_rows: cute.struct.MemRange[
+                cutlass.Int32, (self.num_mma_warps + 1) * 32
+            ]
+            route_expert_ids: cute.struct.MemRange[
+                cutlass.Int32, (self.num_mma_warps + 1) * 32
+            ]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             phase2_pipeline_array: cute.struct.MemRange[
                 cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, self.tile_shape_mnk[0]
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, self.tile_shape_mnk[0]
             ]
             sA: cute.struct.Align[
                 cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
@@ -855,13 +919,22 @@ class MoEDynamicKernel:
         )
         sfa_base_addr = shared_ptr_to_u32(storage.sSFA.data_ptr())
         ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
+        route_phys_rows_addr = shared_ptr_to_u32(storage.route_phys_rows.data_ptr())
+        route_expert_ids_addr = shared_ptr_to_u32(storage.route_expert_ids.data_ptr())
+        scatter_tok_base_addr = shared_ptr_to_u32(storage.scatter_tok_cache.data_ptr())
+        scatter_weight_base_addr = shared_ptr_to_u32(
+            storage.scatter_weight_cache.data_ptr()
+        )
 
         num_tokens = Int32(a_input.shape[0])
         cols = Int32(a_input.shape[1])
+        scatter_base = scatter_output.iterator.toint()
         row_counts = launch_params.row_counts
         num_experts = Int32(row_counts.shape[0])
         sf_blocks_per_row = cols // Int32(16)
         output_bytes_per_row = cols // Int32(2)
+        cols_u32 = cols // Int32(2)
+        scatter_output_u32 = cute.recast_tensor(scatter_output, cutlass.Uint32)
         total_pairs = Int32(topk_ids.shape[0])
         num_topk = total_pairs // num_tokens
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
@@ -869,9 +942,9 @@ class MoEDynamicKernel:
         num_k_tiles = (cols + Int32(63)) // Int32(64)
         route_gate_tile_cnt = launch_params.gate_tile_cnt
         task_slice_chunk = Int32(_TASK_SLICE_CHUNK)
-        full_tile_publish_enabled = total_pairs >= Int32(self.tile_shape_mnk[0])
+        full_tile_publish_enabled = Int32(0)
 
-        # Phase 0: cooperative init — zero routing state, queue state, and output
+        # Phase 0: cooperative init — zero routing state, queue state, and output.
         task_capacity = Int32(task_ready.shape[0])
         tile_write_slots = Int32(tile_write_count.shape[0])
         i = flat_tid
@@ -882,10 +955,23 @@ class MoEDynamicKernel:
         if flat_tid < num_experts + Int32(1):
             expert_tile_base[flat_tid] = Int32(0)
 
-        scatter_total = num_tokens * cols
-        j = flat_tid
-        while j < scatter_total:
-            scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
+        scatter_total_u32 = num_tokens * cols_u32
+        scatter_vecs = scatter_total_u32 // Int32(4)
+        zero_u32 = Uint32(0)
+        zv = flat_tid
+        while zv < scatter_vecs:
+            st_global_v4_u32(
+                scatter_base + Int64(zv) * Int64(16),
+                zero_u32,
+                zero_u32,
+                zero_u32,
+                zero_u32,
+            )
+            zv += flat_stride
+
+        j = scatter_vecs * Int32(4) + flat_tid
+        while j < scatter_total_u32:
+            scatter_output_u32[j // cols_u32, j % cols_u32] = Uint32(0)
             j += flat_stride
 
         k = flat_tid
@@ -955,127 +1041,370 @@ class MoEDynamicKernel:
         # Phase 2: warp-private route/pack producers into compact physical tiles.
         lane_id = Int32(tidx) & Int32(31)
         num_cta_warps = Int32(self.num_mma_warps + 1)
+        producer_batch_pairs = num_cta_warps * Int32(_PRODUCER_PAIRS_PER_WARP)
+        shared_input_gs_value = cutlass.Float32(0.0)
+        if cutlass.const_expr(self.share_input_across_experts):
+            shared_input_gs_value = input_global_scale[Int32(0)].to(cutlass.Float32)
+            if (
+                self.input_scales_are_reciprocal
+                and shared_input_gs_value != cutlass.Float32(0.0)
+            ):
+                if self.fast_math:
+                    shared_input_gs_value = rcp_approx_ftz(shared_input_gs_value)
+                else:
+                    shared_input_gs_value = cutlass.Float32(1.0) / shared_input_gs_value
+        pair_idx = Int32(0)
+        expert_id = Int32(0)
+        token_idx = Int32(0)
+        weight = cutlass.Float32(0.0)
+        row = Int32(0)
+        phys_tile = Int32(0)
+        phys_row = Int32(0)
         produce_active = Int32(1)
         while produce_active > Int32(0):
             batch_base = Int32(0)
             if is_cta_leader > Int32(0):
+                claim_count = producer_batch_pairs
+                if cutlass.const_expr(self.share_input_across_experts):
+                    claim_count = num_cta_warps
                 batch_base = atomic_add_global_i32(
                     get_ptr_as_int64(pair_head, Int32(0)),
-                    num_cta_warps,
+                    claim_count,
                 )
                 _st_shared_i32(ctrl_base_addr + Int32(28), batch_base)
             cute.arch.sync_threads()
             batch_base = _ld_shared_i32(ctrl_base_addr + Int32(28))
-            if batch_base >= total_pairs:
+            producer_limit = total_pairs
+            if cutlass.const_expr(self.share_input_across_experts):
+                producer_limit = num_tokens
+            if batch_base >= producer_limit:
                 produce_active = Int32(0)
             else:
-                pair_idx = batch_base + warp_idx
-                if pair_idx < total_pairs:
-                    expert_id = topk_ids[pair_idx].to(Int32)
-                    token_idx = pair_idx // num_topk
-                    weight = topk_weights[pair_idx].to(cutlass.Float32)
-
-                    row = Int32(0)
-                    phys_tile = Int32(0)
-                    if lane_id == Int32(0):
-                        row = atomic_add_global_i32(
-                            get_ptr_as_int64(expert_write_rows, expert_id),
-                            Int32(1),
-                        )
-                        phys_tile = expert_tile_base[expert_id] + row // Int32(
-                            self.tile_shape_mnk[0]
-                        )
-                        phys_row = phys_tile * Int32(
-                            self.tile_shape_mnk[0]
-                        ) + row % Int32(self.tile_shape_mnk[0])
-                        st_global_i32(get_ptr_as_int64(token_map, phys_row), token_idx)
-                        st_global_f32(get_ptr_as_int64(token_weights, phys_row), weight)
-
-                    row = cute.arch.shuffle_sync(row, Int32(0))
-                    phys_tile = cute.arch.shuffle_sync(phys_tile, Int32(0))
-                    expert_id = cute.arch.shuffle_sync(expert_id, Int32(0))
-                    token_idx = cute.arch.shuffle_sync(token_idx, Int32(0))
-
-                    gs_value = input_global_scale[expert_id].to(cutlass.Float32)
-                    if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
-                        0.0
-                    ):
-                        if self.fast_math:
-                            gs_value = rcp_approx_ftz(gs_value)
-                        else:
-                            gs_value = cutlass.Float32(1.0) / gs_value
-                    sf_idx = lane_id
-                    while sf_idx < sf_blocks_per_row:
-                        block_start = sf_idx * Int32(16)
-                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                        block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(16):
-                            value = cutlass.Float32(
-                                a_input[token_idx, block_start + Int32(elem_idx)]
-                            )
-                            values[elem_idx] = value
-                            block_max = fmax_f32(block_max, fabs_f32(value))
-                        packed64 = Uint64(0)
-                        scale_byte = Uint8(0)
-                        if self.fast_math:
-                            packed64, scale_byte = quantize_block_fp4_fast(
-                                values, block_max, gs_value
-                            )
-                        else:
-                            packed64, scale_byte = quantize_block_fp4(
-                                values, block_max, gs_value
-                            )
-
-                        output_offset = (
-                            phys_tile * Int32(self.tile_shape_mnk[0])
-                            + row % Int32(self.tile_shape_mnk[0])
-                        ) * output_bytes_per_row + sf_idx * Int32(8)
-                        st_global_u64(
-                            get_ptr_as_int64(packed_a_storage, output_offset), packed64
-                        )
-
-                        k_tile_idx = sf_idx // Int32(4)
-                        outer_m_idx = row % Int32(32)
-                        inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
-                        inner_k_idx = sf_idx % Int32(4)
-                        scale_offset = (
-                            phys_tile * num_k_tiles * Int32(32 * 4 * 4)
-                            + k_tile_idx * Int32(32 * 4 * 4)
-                            + outer_m_idx * Int32(4 * 4)
-                            + inner_m_idx * Int32(4)
-                            + inner_k_idx
-                        )
-                        scale_storage[scale_offset] = scale_byte
-                        sf_idx += Int32(32)
-
-                    if full_tile_publish_enabled > Int32(0):
-                        cute.arch.sync_warp()
-                        # When the whole launch has fewer than one M-tile of routed
-                        # rows, only the final partial-tile flush can publish work.
-                        # Skip the per-row fence/counter path in that common micro case.
-                        _threadfence()
-                        cute.arch.sync_warp()
-
+                if cutlass.const_expr(self.share_input_across_experts):
+                    token_idx = batch_base + warp_idx
+                    if token_idx < num_tokens:
+                        route_slot_base = warp_idx * Int32(32)
                         if lane_id == Int32(0):
-                            completed = atomic_add_global_i32(
-                                get_ptr_as_int64(tile_write_count, phys_tile),
-                                Int32(1),
-                            ) + Int32(1)
-                            if completed == Int32(self.tile_shape_mnk[0]):
-                                self._publish_ready_tasks(
-                                    task_tail,
-                                    task_ready,
-                                    task_expert,
-                                    task_m_tile,
-                                    task_slice_begin,
-                                    task_slice_count,
-                                    task_valid_rows,
-                                    route_gate_tile_cnt,
-                                    task_slice_chunk,
-                                    expert_id,
-                                    phys_tile,
-                                    Int32(self.tile_shape_mnk[0]),
+                            topk_slot = Int32(0)
+                            while topk_slot < num_topk:
+                                pair_idx = token_idx * num_topk + topk_slot
+                                expert_id = topk_ids[pair_idx].to(Int32)
+                                weight = topk_weights[pair_idx].to(cutlass.Float32)
+                                row = atomic_add_global_i32(
+                                    get_ptr_as_int64(expert_write_rows, expert_id),
+                                    Int32(1),
                                 )
+                                phys_tile = expert_tile_base[expert_id] + row // Int32(
+                                    self.tile_shape_mnk[0]
+                                )
+                                phys_row = phys_tile * Int32(
+                                    self.tile_shape_mnk[0]
+                                ) + row % Int32(self.tile_shape_mnk[0])
+                                st_global_i32(
+                                    get_ptr_as_int64(token_map, phys_row), token_idx
+                                )
+                                st_global_f32(
+                                    get_ptr_as_int64(token_weights, phys_row), weight
+                                )
+                                slot = route_slot_base + topk_slot
+                                _st_shared_i32(
+                                    route_phys_rows_addr + slot * Int32(4), phys_row
+                                )
+                                _st_shared_i32(
+                                    route_expert_ids_addr + slot * Int32(4), expert_id
+                                )
+                                topk_slot += Int32(1)
+                        cute.arch.sync_warp()
+
+                        gs_value = shared_input_gs_value
+                        if num_topk == Int32(8):
+                            route_output_base = cute.make_rmem_tensor((8,), Int32)
+                            route_scale_base = cute.make_rmem_tensor((8,), Int32)
+                            for cache_slot in cutlass.range_constexpr(8):
+                                slot = route_slot_base + Int32(cache_slot)
+                                phys_row = _ld_shared_i32(
+                                    route_phys_rows_addr + slot * Int32(4)
+                                )
+                                phys_tile = phys_row // Int32(self.tile_shape_mnk[0])
+                                tile_row = phys_row - phys_tile * Int32(
+                                    self.tile_shape_mnk[0]
+                                )
+                                route_output_base[cache_slot] = (
+                                    phys_row * output_bytes_per_row
+                                )
+                                route_scale_base[cache_slot] = (
+                                    phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                    + (tile_row % Int32(32)) * Int32(4 * 4)
+                                    + ((tile_row % Int32(32 * 4)) // Int32(32))
+                                    * Int32(4)
+                                )
+
+                            sf_idx = lane_id
+                            while sf_idx < sf_blocks_per_row:
+                                block_start = sf_idx * Int32(16)
+                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(16):
+                                    value = cutlass.Float32(
+                                        a_input[
+                                            token_idx, block_start + Int32(elem_idx)
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
+                                packed64 = Uint64(0)
+                                scale_byte = Uint8(0)
+                                if self.fast_math:
+                                    packed64, scale_byte = quantize_block_fp4_fast(
+                                        values, block_max, gs_value
+                                    )
+                                else:
+                                    packed64, scale_byte = quantize_block_fp4(
+                                        values, block_max, gs_value
+                                    )
+
+                                k_tile_idx = sf_idx // Int32(4)
+                                scale_k_base = k_tile_idx * Int32(32 * 4 * 4) + (
+                                    sf_idx % Int32(4)
+                                )
+                                for cache_slot in cutlass.range_constexpr(8):
+                                    output_offset = route_output_base[
+                                        cache_slot
+                                    ] + sf_idx * Int32(8)
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage, output_offset
+                                        ),
+                                        packed64,
+                                    )
+                                    scale_storage[
+                                        route_scale_base[cache_slot] + scale_k_base
+                                    ] = scale_byte
+                                sf_idx += Int32(32)
+                        else:
+                            sf_idx = lane_id
+                            while sf_idx < sf_blocks_per_row:
+                                block_start = sf_idx * Int32(16)
+                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(16):
+                                    value = cutlass.Float32(
+                                        a_input[
+                                            token_idx, block_start + Int32(elem_idx)
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
+                                packed64 = Uint64(0)
+                                scale_byte = Uint8(0)
+                                if self.fast_math:
+                                    packed64, scale_byte = quantize_block_fp4_fast(
+                                        values, block_max, gs_value
+                                    )
+                                else:
+                                    packed64, scale_byte = quantize_block_fp4(
+                                        values, block_max, gs_value
+                                    )
+
+                                topk_slot = Int32(0)
+                                while topk_slot < num_topk:
+                                    slot = route_slot_base + topk_slot
+                                    phys_row = _ld_shared_i32(
+                                        route_phys_rows_addr + slot * Int32(4)
+                                    )
+                                    phys_tile = phys_row // Int32(
+                                        self.tile_shape_mnk[0]
+                                    )
+                                    tile_row = phys_row - phys_tile * Int32(
+                                        self.tile_shape_mnk[0]
+                                    )
+                                    output_offset = (
+                                        phys_row * output_bytes_per_row
+                                        + sf_idx * Int32(8)
+                                    )
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage, output_offset
+                                        ),
+                                        packed64,
+                                    )
+                                    k_tile_idx = sf_idx // Int32(4)
+                                    outer_m_idx = tile_row % Int32(32)
+                                    inner_m_idx = (tile_row % Int32(32 * 4)) // Int32(
+                                        32
+                                    )
+                                    inner_k_idx = sf_idx % Int32(4)
+                                    scale_offset = (
+                                        phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                        + k_tile_idx * Int32(32 * 4 * 4)
+                                        + outer_m_idx * Int32(4 * 4)
+                                        + inner_m_idx * Int32(4)
+                                        + inner_k_idx
+                                    )
+                                    scale_storage[scale_offset] = scale_byte
+                                    topk_slot += Int32(1)
+                                sf_idx += Int32(32)
+
+                        if full_tile_publish_enabled > Int32(0):
+                            cute.arch.sync_warp()
+                            _threadfence()
+                            cute.arch.sync_warp()
+
+                            if lane_id == Int32(0):
+                                topk_slot = Int32(0)
+                                while topk_slot < num_topk:
+                                    slot = route_slot_base + topk_slot
+                                    phys_row = _ld_shared_i32(
+                                        route_phys_rows_addr + slot * Int32(4)
+                                    )
+                                    expert_id = _ld_shared_i32(
+                                        route_expert_ids_addr + slot * Int32(4)
+                                    )
+                                    phys_tile = phys_row // Int32(
+                                        self.tile_shape_mnk[0]
+                                    )
+                                    completed = atomic_add_global_i32(
+                                        get_ptr_as_int64(tile_write_count, phys_tile),
+                                        Int32(1),
+                                    ) + Int32(1)
+                                    if completed == Int32(self.tile_shape_mnk[0]):
+                                        self._publish_ready_tasks(
+                                            task_tail,
+                                            task_ready,
+                                            task_expert,
+                                            task_m_tile,
+                                            task_slice_begin,
+                                            task_slice_count,
+                                            task_valid_rows,
+                                            route_gate_tile_cnt,
+                                            task_slice_chunk,
+                                            expert_id,
+                                            phys_tile,
+                                            Int32(self.tile_shape_mnk[0]),
+                                        )
+                                    topk_slot += Int32(1)
+                else:
+                    warp_item = Int32(0)
+                    while warp_item < Int32(_PRODUCER_PAIRS_PER_WARP):
+                        pair_idx = batch_base + warp_idx + warp_item * num_cta_warps
+                        expert_id = Int32(0)
+                        token_idx = Int32(0)
+                        weight = cutlass.Float32(0.0)
+                        row = Int32(0)
+                        phys_tile = Int32(0)
+                        if pair_idx < total_pairs:
+                            expert_id = topk_ids[pair_idx].to(Int32)
+                            token_idx = pair_idx // num_topk
+                            weight = topk_weights[pair_idx].to(cutlass.Float32)
+
+                            if lane_id == Int32(0):
+                                row = atomic_add_global_i32(
+                                    get_ptr_as_int64(expert_write_rows, expert_id),
+                                    Int32(1),
+                                )
+                                phys_tile = expert_tile_base[expert_id] + row // Int32(
+                                    self.tile_shape_mnk[0]
+                                )
+                                phys_row = phys_tile * Int32(
+                                    self.tile_shape_mnk[0]
+                                ) + row % Int32(self.tile_shape_mnk[0])
+                                st_global_i32(
+                                    get_ptr_as_int64(token_map, phys_row), token_idx
+                                )
+                                st_global_f32(
+                                    get_ptr_as_int64(token_weights, phys_row), weight
+                                )
+
+                            row = cute.arch.shuffle_sync(row, Int32(0))
+                            phys_tile = cute.arch.shuffle_sync(phys_tile, Int32(0))
+                            expert_id = cute.arch.shuffle_sync(expert_id, Int32(0))
+                            token_idx = cute.arch.shuffle_sync(token_idx, Int32(0))
+
+                            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                            if (
+                                self.input_scales_are_reciprocal
+                                and gs_value != cutlass.Float32(0.0)
+                            ):
+                                if self.fast_math:
+                                    gs_value = rcp_approx_ftz(gs_value)
+                                else:
+                                    gs_value = cutlass.Float32(1.0) / gs_value
+                            sf_idx = lane_id
+                            while sf_idx < sf_blocks_per_row:
+                                block_start = sf_idx * Int32(16)
+                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(16):
+                                    value = cutlass.Float32(
+                                        a_input[
+                                            token_idx, block_start + Int32(elem_idx)
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
+                                packed64 = Uint64(0)
+                                scale_byte = Uint8(0)
+                                if self.fast_math:
+                                    packed64, scale_byte = quantize_block_fp4_fast(
+                                        values, block_max, gs_value
+                                    )
+                                else:
+                                    packed64, scale_byte = quantize_block_fp4(
+                                        values, block_max, gs_value
+                                    )
+
+                                output_offset = (
+                                    phys_tile * Int32(self.tile_shape_mnk[0])
+                                    + row % Int32(self.tile_shape_mnk[0])
+                                ) * output_bytes_per_row + sf_idx * Int32(8)
+                                st_global_u64(
+                                    get_ptr_as_int64(packed_a_storage, output_offset),
+                                    packed64,
+                                )
+
+                                k_tile_idx = sf_idx // Int32(4)
+                                outer_m_idx = row % Int32(32)
+                                inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
+                                inner_k_idx = sf_idx % Int32(4)
+                                scale_offset = (
+                                    phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                    + k_tile_idx * Int32(32 * 4 * 4)
+                                    + outer_m_idx * Int32(4 * 4)
+                                    + inner_m_idx * Int32(4)
+                                    + inner_k_idx
+                                )
+                                scale_storage[scale_offset] = scale_byte
+                                sf_idx += Int32(32)
+
+                            if full_tile_publish_enabled > Int32(0):
+                                cute.arch.sync_warp()
+                                # When the whole launch has fewer than one M-tile of routed
+                                # rows, only the final partial-tile flush can publish work.
+                                # Skip the per-row fence/counter path in that common micro case.
+                                _threadfence()
+                                cute.arch.sync_warp()
+
+                                if lane_id == Int32(0):
+                                    completed = atomic_add_global_i32(
+                                        get_ptr_as_int64(tile_write_count, phys_tile),
+                                        Int32(1),
+                                    ) + Int32(1)
+                                    if completed == Int32(self.tile_shape_mnk[0]):
+                                        self._publish_ready_tasks(
+                                            task_tail,
+                                            task_ready,
+                                            task_expert,
+                                            task_m_tile,
+                                            task_slice_begin,
+                                            task_slice_count,
+                                            task_valid_rows,
+                                            route_gate_tile_cnt,
+                                            task_slice_chunk,
+                                            expert_id,
+                                            phys_tile,
+                                            Int32(self.tile_shape_mnk[0]),
+                                        )
+                        warp_item += Int32(1)
 
         cute.arch.sync_threads()
         # Conservative publish fence before the last-producer CTA flushes any
@@ -1097,11 +1426,13 @@ class MoEDynamicKernel:
             if is_cta_leader > Int32(0):
                 expert_flush = Int32(bidz)
                 while expert_flush < num_experts:
-                    rows = row_counts[expert_flush]
-                    if rows > Int32(0):
-                        self._publish_ready_tasks(
-                            task_tail,
-                            task_ready,
+                    rows_remaining = row_counts[expert_flush]
+                    m_tile_offset = Int32(0)
+                    while rows_remaining > Int32(0):
+                        valid_rows = rows_remaining
+                        if valid_rows > Int32(self.tile_shape_mnk[0]):
+                            valid_rows = Int32(self.tile_shape_mnk[0])
+                        self._publish_deferred_tasks(
                             task_expert,
                             task_m_tile,
                             task_slice_begin,
@@ -1110,10 +1441,21 @@ class MoEDynamicKernel:
                             route_gate_tile_cnt,
                             task_slice_chunk,
                             expert_flush,
-                            expert_tile_base[expert_flush],
-                            rows,
+                            expert_tile_base[expert_flush] + m_tile_offset,
+                            valid_rows,
                         )
+                        rows_remaining -= Int32(self.tile_shape_mnk[0])
+                        m_tile_offset += Int32(1)
                     expert_flush += Int32(gdim_z)
+
+            if flat_tid == Int32(0):
+                num_groups = (
+                    route_gate_tile_cnt + task_slice_chunk - Int32(1)
+                ) // task_slice_chunk
+                st_global_i32(
+                    get_ptr_as_int64(task_tail, Int32(0)),
+                    expert_tile_base[num_experts] * num_groups,
+                )
 
             self._resident_grid_barrier(
                 barrier_count,
@@ -1462,6 +1804,24 @@ class MoEDynamicKernel:
             if has_task > Int32(0) and full_tile_publish_enabled > Int32(0):
                 claimed_slot = _ld_shared_i32(ctrl_base_addr + Int32(28))
                 _ld_global_acquire_i32(get_ptr_as_int64(task_ready, claimed_slot))
+            if has_task > Int32(0):
+                task_m_tile_idx_cache = _ld_shared_i32(ctrl_base_addr + Int32(12))
+                task_valid_rows_cache = _ld_shared_i32(ctrl_base_addr + Int32(24))
+                tile_m_base_cache = task_m_tile_idx_cache * Int32(
+                    self.tile_shape_mnk[0]
+                )
+                cache_row = Int32(tidx)
+                while cache_row < Int32(self.tile_shape_mnk[0]):
+                    tok = Int32(0)
+                    wv = cutlass.Float32(0.0)
+                    if cache_row < task_valid_rows_cache:
+                        global_row_cache = tile_m_base_cache + cache_row
+                        tok = token_map[global_row_cache].to(Int32)
+                        wv = token_weights[global_row_cache].to(cutlass.Float32)
+                    _st_shared_i32(scatter_tok_base_addr + cache_row * Int32(4), tok)
+                    st_shared_f32(scatter_weight_base_addr + cache_row * Int32(4), wv)
+                    cache_row += Int32(self.threads_per_cta)
+                cute.arch.sync_threads()
             if has_task == Int32(0):
                 if is_done > Int32(0):
                     consumer_live = Int32(0)
@@ -1474,7 +1834,6 @@ class MoEDynamicKernel:
 
                 alpha_value = alpha[task_expert_idx].to(cutlass.Float32)
                 valid_rows = task_valid_rows_val
-                tile_m_base = task_m_tile_idx * Int32(self.tile_shape_mnk[0])
 
                 _is_m_major = self.c_layout.is_m_major_c()
                 copy_atom_r2s = cute.make_copy_atom(
@@ -2061,64 +2420,103 @@ class MoEDynamicKernel:
                                 tRS_sD[(None, None, None, epi_buffer)],
                             )
                             cute.arch.fence_proxy("async.shared", space="cta")
-                            # No cross-warp barrier needed before scatter:
-                            # StMatrix is warp-local, and each warp only reads
-                            # its own 64×64 quadrant of sC below.
+                            # Vector scatter reads wider spans from sC than the
+                            # scalar path, so wait for all MMA-warps' stores.
+                            self.epilog_sync_barrier.arrive_and_wait()
                             rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
 
                             # Per-warp scatter: each warp scatters its own quadrant
-                            # of sC (64 M-rows × 64 N-cols). No cross-warp read
-                            # dependencies, so no pre-scatter barrier is needed.
+                            # of sC (64 M-rows x 64 N-cols).
                             warp_epi_rows = valid_rows - rows_offset - warp_m_base
                             if warp_epi_rows > Int32(64):
                                 warp_epi_rows = Int32(64)
                             if warp_epi_rows < Int32(0):
                                 warp_epi_rows = Int32(0)
 
-                            pair_idx = lane_id
-                            while pair_idx < warp_epi_rows * Int32(32):
-                                local_row = pair_idx >> Int32(5)  # / 32
-                                local_pair_col = pair_idx & Int32(31)  # % 32
-                                global_row = (
-                                    tile_m_base + rows_offset + warp_m_base + local_row
+                            tile_vec_cols = Int32(64) // Int32(8)
+                            vec_idx = lane_id
+                            while vec_idx < warp_epi_rows * tile_vec_cols:
+                                local_row = vec_idx // tile_vec_cols
+                                local_vec_col = vec_idx - local_row * tile_vec_cols
+                                local_col = warp_n_base + local_vec_col * Int32(8)
+                                global_col = tile_n_base_cur + local_col
+                                cached_row = rows_offset + warp_m_base + local_row
+                                tok = ld_shared_i32_relaxed(
+                                    scatter_tok_base_addr + cached_row * Int32(4)
                                 )
-                                global_col = (
-                                    tile_n_base_cur
-                                    + warp_n_base
-                                    + local_pair_col * Int32(2)
+                                wv = ld_shared_f32(
+                                    scatter_weight_base_addr + cached_row * Int32(4)
                                 )
-                                # Only lane 0 loads tok/wv from gmem; broadcast via shuffle.
-                                tok = Int32(0)
-                                wv = cutlass.Float32(0.0)
-                                if lane_id == Int32(0):
-                                    tok = token_map[global_row].to(Int32)
-                                    wv = token_weights[global_row].to(cutlass.Float32)
-                                tok = cute.arch.shuffle_sync(tok, Int32(0))
-                                wv = cute.arch.shuffle_sync(wv, Int32(0))
                                 sc_v0 = cutlass.Float32(
                                     sC[
                                         warp_m_base + local_row,
-                                        warp_n_base + local_pair_col * Int32(2),
+                                        local_col,
                                         epi_buffer,
                                     ]
                                 )
                                 sc_v1 = cutlass.Float32(
                                     sC[
                                         warp_m_base + local_row,
-                                        warp_n_base
-                                        + local_pair_col * Int32(2)
-                                        + Int32(1),
+                                        local_col + Int32(1),
                                         epi_buffer,
                                     ]
                                 )
-                                scatter_add_bf16x2(
+                                sc_v2 = cutlass.Float32(
+                                    sC[
+                                        warp_m_base + local_row,
+                                        local_col + Int32(2),
+                                        epi_buffer,
+                                    ]
+                                )
+                                sc_v3 = cutlass.Float32(
+                                    sC[
+                                        warp_m_base + local_row,
+                                        local_col + Int32(3),
+                                        epi_buffer,
+                                    ]
+                                )
+                                sc_v4 = cutlass.Float32(
+                                    sC[
+                                        warp_m_base + local_row,
+                                        local_col + Int32(4),
+                                        epi_buffer,
+                                    ]
+                                )
+                                sc_v5 = cutlass.Float32(
+                                    sC[
+                                        warp_m_base + local_row,
+                                        local_col + Int32(5),
+                                        epi_buffer,
+                                    ]
+                                )
+                                sc_v6 = cutlass.Float32(
+                                    sC[
+                                        warp_m_base + local_row,
+                                        local_col + Int32(6),
+                                        epi_buffer,
+                                    ]
+                                )
+                                sc_v7 = cutlass.Float32(
+                                    sC[
+                                        warp_m_base + local_row,
+                                        local_col + Int32(7),
+                                        epi_buffer,
+                                    ]
+                                )
+                                scatter_add_v4_bf16x2(
                                     get_ptr_as_int64(
                                         scatter_output, tok * scatter_N + global_col
                                     ),
                                     wv * sc_v0,
                                     wv * sc_v1,
+                                    wv * sc_v2,
+                                    wv * sc_v3,
+                                    wv * sc_v4,
+                                    wv * sc_v5,
+                                    wv * sc_v6,
+                                    wv * sc_v7,
                                 )
-                                pair_idx += Int32(self.num_threads_per_warp)
+                                vec_idx += Int32(self.num_threads_per_warp)
 
                             # Post-scatter barrier: needed to ensure all warps
                             # finish scatter before next output tile's pipeline ops

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_dynamic_kernel.py
@@ -1,0 +1,2068 @@
+"""
+MoEDynamicKernel - queue-driven routed W4A16 MoE kernel for SM120/SM121.
+
+Ported from the b12x kernel library to FlashInfer.
+
+This dynamic fused control-plane kernel keeps the queue-driven routing and
+task publication structure from the NVFP4 path, but its math path is W4A16:
+BF16 activations, BF16 activated intermediate, packed FP4 weights, and E4M3
+weight block scales dequantized into BF16 shared-memory B tiles before MMA.
+
+Execution model
+  Phase 0: cooperative init / clear scratch state
+  Phase 1: all CTAs start as producers
+           - claim routed (token, topk_slot) pairs from pair_head
+           - append expert rows
+           - write token_map + token_weights
+           - copy each routed BF16 token row into expert-major scratch
+           - publish one compute task per ready (expert, m_tile, slice_group)
+             as soon as a tile is fully written
+  Phase 2: CTAs that finish producing become consumers immediately
+           - CTA leader pops one ready task into shared ctrl state
+           - MMA warps run BF16 FC1 -> activation -> BF16 FC2 -> scatter
+           - DMA warp streams the corresponding FC1 / FC2 weights
+
+This is intentionally conservative:
+  - still one CTA per SM
+  - still the static per-slice microkernel, now executed sequentially for a
+    small grouped slice task
+  - still one initial resident-grid barrier after init
+
+What changes relative to the static path
+  - no global route/pack -> compute barrier
+  - no static scheduler in the compute steady state
+  - route/pack is warp-private instead of CTA-broadcast
+  - compute work is driven by a global append-only ready-task queue
+
+This file is a first implementation pass, not an optimized artifact.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+
+from cutlass.cutlass_dsl import (
+    Int32,
+    Int64,
+    Uint32,
+    T,
+    dsl_user_op,
+    extract_mlir_values,
+    new_from_mlir_values,
+)
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync
+
+from flashinfer.cute_dsl.fp4_common import (
+    atomic_add_global_i32,
+    cvt_e4m3_to_f32_via_f16,
+    f16x2_to_f32x2,
+    fmax_f32,
+    fp4_decode_4bytes,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
+    ld_global_nc_v4_u32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
+    scatter_add_v4_bf16x2,
+    shared_ptr_to_u32,
+    st_global_i32,
+    st_global_v4_u32,
+    st_shared_f32,
+)
+from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
+    Sm120B12xBlockScaledDenseGemmKernel as DenseGemmKernel,
+)
+
+
+_TASK_SLICE_CHUNK = 1
+
+
+@dsl_user_op
+def _ld_global_nc_u8(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.nc.u8 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+class DynamicLaunchParams:
+    """Minimal runtime launch state shared between host setup and kernel code."""
+
+    def __init__(
+        self,
+        row_counts: cute.Tensor,
+        gate_tile_cnt: Int32,
+        *,
+        loc=None,
+    ):
+        self.row_counts = row_counts
+        self.gate_tile_cnt = gate_tile_cnt
+        self._loc = loc
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.row_counts, self.gate_tile_cnt]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip(
+            [self.row_counts, self.gate_tile_cnt],
+            self._values_pos,
+            strict=True,
+        ):
+            obj_list.append(new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return DynamicLaunchParams(*(tuple(obj_list)), loc=self._loc)
+
+
+@dsl_user_op
+def _st_shared_i32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [Int32(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.shared.s32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _ld_shared_i32(addr, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared.s32 $0, [$1];",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_global_acquire_i32(addr, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.global.acquire.gpu.s32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _st_global_release_i32(addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int32(val).ir_value(loc=loc, ip=ip)],
+        "st.global.release.gpu.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _spin_wait_global_eq_i32(addr, expected, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(expected).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n"
+        ".reg .pred %p0;\n"
+        ".reg .s32 %val;\n"
+        "spin_loop:\n"
+        "  ld.global.acquire.gpu.s32 %val, [$0];\n"
+        "  setp.eq.s32 %p0, %val, $1;\n"
+        "  @%p0 bra spin_loop;\n"
+        "}",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _threadfence(*, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [],
+        "membar.gl;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _atomic_cas_global_i32(addr, compare, value, *, loc=None, ip=None):
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Int32(compare).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.cas.b32 $0, [$1], $2, $3;",
+            "=r,l,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+class MoEDynamicKernel:
+    """Queue-driven first-pass dynamic MoE kernel."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        *,
+        fast_math: bool = False,
+        activation: str = "silu",
+        dynamic_down_scale: bool = False,
+    ):
+        if activation not in {"silu", "relu2"}:
+            raise ValueError(f"unsupported activation {activation!r}")
+        self._dense_cls = DenseGemmKernel
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = activation == "silu"
+        self.dynamic_down_scale = dynamic_down_scale
+        # The FC1 N tile is reused as the FC2 K tile after activation. Keep the
+        # mainloop K tile equal to N so the BF16 intermediate fits the same sA
+        # tile that phase 2 consumes.
+        tile_k = mma_tiler_mn[1]
+        self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        self.sa_tile_shape_mk = (mma_tiler_mn[0], tile_k)
+        self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cluster_shape_mn = (1, 1)
+        self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.occupancy = 1
+        self.num_mma_warps = 4
+        self.num_load_warps = 4
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (
+            self.num_mma_warps + self.num_load_warps
+        ) * self.num_threads_per_warp
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.buffer_align_bytes = 1024
+
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.pass_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_cta,
+        )
+        self.fc1_stage_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=self.threads_per_cta,
+        )
+        self.load_register_requirement = 32
+        self.mma_register_requirement = 232
+
+    def _make_a_smem_layout(self, ab_stage: int):
+        a_is_k_major = self.a_layout.is_k_major_a()
+        a_major_mode_size = self.sa_tile_shape_mk[1 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                self.a_layout,
+                self.a_dtype,
+                a_major_mode_size,
+            ),
+            self.a_dtype,
+        )
+        return cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(self.sa_tile_shape_mk, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+    def _make_b_smem_layout(self, b_dtype, b_layout, ab_stage: int):
+        b_smem_shape = cute.slice_(self.tile_shape_mnk, (0, None, None))
+        b_is_k_major = b_layout.is_k_major_b()
+        b_major_mode_size = self.tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        return cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+    def _make_staged_layouts(self, ab_stage: int):
+        a_smem_staged = self._make_a_smem_layout(ab_stage)
+        b_smem_staged = self._make_b_smem_layout(self.b_dtype, self.b_layout, ab_stage)
+        epi_smem_staged = sm90_utils.make_smem_layout_epi(
+            cutlass.BFloat16,
+            self.c_layout,
+            self.epi_tile,
+            self.epi_stage,
+        )
+        return a_smem_staged, b_smem_staged, epi_smem_staged
+
+    def _shared_storage_size_bytes(
+        self,
+        a_smem_staged,
+        b_smem_staged,
+        epi_smem_staged,
+    ) -> int:
+        def _align_up(value: int, align: int) -> int:
+            return ((value + align - 1) // align) * align
+
+        offset = 8 * 4 + self.ab_stage * 2 * 8 + 2 * self.tile_shape_mnk[0] * 4
+        buffers = [
+            cute.size_in_bytes(self.a_dtype, a_smem_staged),
+            cute.size_in_bytes(self.b_dtype, b_smem_staged),
+            cute.size_in_bytes(self.b_dtype, b_smem_staged),
+            cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
+        ]
+        offset = _align_up(offset, self.buffer_align_bytes)
+        for idx, size in enumerate(buffers):
+            offset += size
+            if idx + 1 != len(buffers):
+                offset = _align_up(offset, self.buffer_align_bytes)
+        return offset
+
+    @staticmethod
+    def _compute_bf16_stages(
+        tile_shape_mnk: tuple[int, int, int],
+        a_dtype,
+        b_dtype,
+        epi_tile: tuple[int, int],
+        c_dtype,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> tuple[int, int]:
+        # The dynamic W4A16 path keeps only one epilogue stage. Using the
+        # Hopper helper default here can over-reserve epilogue smem and drive
+        # the producer/consumer stage count negative for 128x128 BF16 tiles.
+        epi_stage = 1
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_bytes = c_bytes_per_stage * epi_stage
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        mbar_helpers_bytes = 1024
+        ab_stage = (
+            (smem_capacity - occupancy * 1024) // occupancy
+            - mbar_helpers_bytes
+            - epi_bytes
+        ) // ab_bytes_per_stage
+        return max(1, ab_stage), epi_stage
+
+    @staticmethod
+    def _make_bf16_smem_layouts(
+        tile_shape_mnk: tuple[int, int, int],
+        epi_tile: tuple[int, int],
+        a_dtype,
+        a_layout: cute.Layout,
+        b_dtype,
+        b_layout: cute.Layout,
+        ab_stage: int,
+        c_dtype,
+        c_layout: cute.Layout,
+        epi_stage: int,
+    ) -> tuple[cute.ComposedLayout, cute.ComposedLayout, cute.ComposedLayout]:
+        import cutlass.utils.hopper_helpers as sm90_utils
+
+        a_smem_layout_staged = sm90_utils.make_smem_layout_a(
+            a_layout,
+            tile_shape_mnk,
+            a_dtype,
+            ab_stage,
+        )
+        b_smem_layout_staged = sm90_utils.make_smem_layout_b(
+            b_layout,
+            tile_shape_mnk,
+            b_dtype,
+            ab_stage,
+        )
+        epi_smem_layout_staged = sm90_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            epi_stage,
+        )
+        return a_smem_layout_staged, b_smem_layout_staged, epi_smem_layout_staged
+
+    def _setup_attributes(self):
+        self.mma_inst_mnk = (16, 8, 16)
+        mma_op = cute.nvgpu.warp.MmaF16BF16Op(
+            self.a_dtype,
+            self.acc_dtype,
+            self.mma_inst_mnk,
+        )
+        atom_layout = (2, 2, 1)
+        tC = cute.make_layout(atom_layout)
+        permutation_mnk = (
+            atom_layout[0] * self.mma_inst_mnk[0],
+            atom_layout[1] * self.mma_inst_mnk[1] * 2,
+            atom_layout[2] * self.mma_inst_mnk[2],
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            tC,
+            permutation_mnk=permutation_mnk,
+        )
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
+        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
+        self.num_k_blocks = self.tile_shape_mnk[2] // self.mma_inst_mnk[2]
+
+        epi_stage_max = (self.tile_shape_mnk[1] // self.epi_tile[1]) * (
+            self.tile_shape_mnk[0] // self.epi_tile[0]
+        )
+        self.epi_stage = min(epi_stage_max, 4)
+        # Keep two A/B stages when shared memory allows it so the load/dequant
+        # producer can run ahead of the MMA consumer on prefill-sized tasks.
+        self.ab_stage = 2
+        while True:
+            (
+                self.a_smem_layout_staged,
+                self.b_smem_layout_staged,
+                self.epi_smem_layout_staged,
+            ) = self._make_staged_layouts(self.ab_stage)
+            if (
+                self._shared_storage_size_bytes(
+                    self.a_smem_layout_staged,
+                    self.b_smem_layout_staged,
+                    self.epi_smem_layout_staged,
+                )
+                <= self.smem_capacity
+                or self.ab_stage <= 1
+            ):
+                break
+            self.ab_stage -= 1
+            while self.ab_stage > 1 and 32 % self.ab_stage != 0:
+                self.ab_stage -= 1
+
+    @cute.jit
+    def _load_u8_as_u32(self, base_addr: Int64, byte_offset: Int64) -> Uint32:
+        return _ld_global_nc_u8(base_addr + byte_offset)
+
+    @cute.jit
+    def _swizzled_e4m3_offset(
+        self,
+        row: Int32,
+        sf_block: Int32,
+        sf_cols: Int32,
+    ) -> Int64:
+        row_rb = row >> Int32(7)
+        mode_a = (row >> Int32(5)) & Int32(3)
+        mode_32 = row & Int32(31)
+        cb_idx = sf_block >> Int32(2)
+        mode_c = sf_block & Int32(3)
+        return (
+            Int64(row_rb) * Int64(sf_cols * Int32(128))
+            + Int64(cb_idx) * Int64(512)
+            + Int64(mode_32) * Int64(16)
+            + Int64(mode_a) * Int64(4)
+            + Int64(mode_c)
+        )
+
+    @cute.jit
+    def _stage_w13_fp4_b_tile(
+        self,
+        packed_w: cute.Tensor,
+        sfb_ptr: cute.Pointer,
+        sB: cute.Tensor,
+        stage_idx: Int32,
+        expert_idx: Int32,
+        n_tile_idx: Int32,
+        k_tile_idx: Int32,
+        weight_rows: Int32,
+        weight_cols: Int32,
+        sf_cols: Int32,
+        copy_start: Int32,
+        copy_stride: Int32,
+    ):
+        w_base = packed_w.iterator.toint()
+        sf_base = sfb_ptr.toint()
+        packed_cols = weight_cols // Int32(2)
+        tile_n = Int32(self.tile_shape_mnk[1])
+        tile_k = Int32(self.tile_shape_mnk[2])
+        blocks_per_row = tile_k // Int32(self.sf_vec_size)
+        total_blocks = tile_n * blocks_per_row
+        copy_idx = copy_start
+        while copy_idx < total_blocks:
+            local_n = copy_idx // blocks_per_row
+            local_sf_block = copy_idx - local_n * blocks_per_row
+            local_k = local_sf_block * Int32(self.sf_vec_size)
+            global_n = n_tile_idx * tile_n + local_n
+            global_k = k_tile_idx * tile_k + local_k
+            packed_offset = (
+                Int64(expert_idx) * Int64(weight_rows * packed_cols)
+                + Int64(global_n) * Int64(packed_cols)
+                + Int64(global_k // Int32(2))
+            )
+            scale_offset = Int64(expert_idx) * Int64(
+                ((weight_rows + Int32(127)) // Int32(128)) * Int32(128) * sf_cols
+            ) + self._swizzled_e4m3_offset(
+                global_n, global_k // Int32(self.sf_vec_size), sf_cols
+            )
+            scale_byte = self._load_u8_as_u32(sf_base, scale_offset)
+            scale = cvt_e4m3_to_f32_via_f16(scale_byte)
+            q_word0 = ld_global_nc_u32(w_base + packed_offset)
+            q_word1 = ld_global_nc_u32(w_base + packed_offset + Int64(4))
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word0)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k, stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(1), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(2), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(3), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(4), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(5), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(6), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(7), stage_idx] = cutlass.BFloat16(f1 * scale)
+
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word1)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k + Int32(8), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(9), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(10), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(11), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(12), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(13), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(14), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(15), stage_idx] = cutlass.BFloat16(f1 * scale)
+            copy_idx += copy_stride
+
+    @cute.jit
+    def _stage_down_fp4_b_tile(
+        self,
+        packed_w: cute.Tensor,
+        sfb_ptr: cute.Pointer,
+        sB: cute.Tensor,
+        stage_idx: Int32,
+        expert_idx: Int32,
+        output_tile_idx: Int32,
+        intermediate_tile_idx: Int32,
+        weight_rows: Int32,
+        weight_cols: Int32,
+        sf_cols: Int32,
+        copy_start: Int32,
+        copy_stride: Int32,
+    ):
+        w_base = packed_w.iterator.toint()
+        sf_base = sfb_ptr.toint()
+        packed_cols = weight_cols // Int32(2)
+        tile_n = Int32(self.tile_shape_mnk[1])
+        tile_k = Int32(self.tile_shape_mnk[2])
+        blocks_per_row = tile_k // Int32(self.sf_vec_size)
+        total_blocks = tile_n * blocks_per_row
+        copy_idx = copy_start
+        while copy_idx < total_blocks:
+            local_n = copy_idx // blocks_per_row
+            local_sf_block = copy_idx - local_n * blocks_per_row
+            local_k = local_sf_block * Int32(self.sf_vec_size)
+            global_n = output_tile_idx * tile_n + local_n
+            global_k = intermediate_tile_idx * tile_k + local_k
+            packed_offset = (
+                Int64(expert_idx) * Int64(weight_rows * packed_cols)
+                + Int64(global_n) * Int64(packed_cols)
+                + Int64(global_k // Int32(2))
+            )
+            scale_offset = Int64(expert_idx) * Int64(
+                ((weight_rows + Int32(127)) // Int32(128)) * Int32(128) * sf_cols
+            ) + self._swizzled_e4m3_offset(
+                global_n, global_k // Int32(self.sf_vec_size), sf_cols
+            )
+            scale_byte = self._load_u8_as_u32(sf_base, scale_offset)
+            scale = cvt_e4m3_to_f32_via_f16(scale_byte)
+            q_word0 = ld_global_nc_u32(w_base + packed_offset)
+            q_word1 = ld_global_nc_u32(w_base + packed_offset + Int64(4))
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word0)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k, stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(1), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(2), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(3), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(4), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(5), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(6), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(7), stage_idx] = cutlass.BFloat16(f1 * scale)
+
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word1)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k + Int32(8), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(9), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(10), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(11), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(12), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(13), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(14), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(15), stage_idx] = cutlass.BFloat16(f1 * scale)
+            copy_idx += copy_stride
+
+    @cute.jit
+    def _resident_grid_barrier(
+        self,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        grid_x: Int32,
+        is_cta_leader: Int32,
+    ):
+        cute.arch.sync_threads()
+        _threadfence()
+        if is_cta_leader > Int32(0):
+            barrier_count_addr = get_ptr_as_int64(barrier_count, Int32(0))
+            barrier_epoch_addr = get_ptr_as_int64(barrier_epoch, Int32(0))
+            old_epoch = _ld_global_acquire_i32(barrier_epoch_addr)
+            arrived = atomic_add_global_i32(barrier_count_addr, Int32(1))
+            if arrived == grid_x - Int32(1):
+                st_global_i32(barrier_count_addr, Int32(0))
+                _st_global_release_i32(barrier_epoch_addr, old_epoch + Int32(1))
+            else:
+                _spin_wait_global_eq_i32(barrier_epoch_addr, old_epoch)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _publish_ready_tasks(
+        self,
+        task_tail: cute.Tensor,
+        task_ready: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        gate_tile_cnt: Int32,
+        slice_chunk: Int32,
+        expert_idx: Int32,
+        m_tile_idx: Int32,
+        valid_rows: Int32,
+    ):
+        num_groups = (gate_tile_cnt + slice_chunk - Int32(1)) // slice_chunk
+        start = atomic_add_global_i32(get_ptr_as_int64(task_tail, Int32(0)), num_groups)
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            slice_begin = g * slice_chunk
+            slice_count = gate_tile_cnt - slice_begin
+            if slice_count > slice_chunk:
+                slice_count = slice_chunk
+            task_expert[slot] = expert_idx
+            task_m_tile[slot] = m_tile_idx
+            task_slice_begin[slot] = slice_begin
+            task_slice_count[slot] = slice_count
+            task_valid_rows[slot] = valid_rows
+            g += Int32(1)
+
+        _threadfence()
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            _st_global_release_i32(get_ptr_as_int64(task_ready, slot), Int32(1))
+            g += Int32(1)
+
+    @cute.jit
+    def _publish_deferred_tasks(
+        self,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        gate_tile_cnt: Int32,
+        slice_chunk: Int32,
+        expert_idx: Int32,
+        m_tile_idx: Int32,
+        valid_rows: Int32,
+    ):
+        num_groups = (gate_tile_cnt + slice_chunk - Int32(1)) // slice_chunk
+        start = m_tile_idx * num_groups
+
+        g = Int32(0)
+        while g < num_groups:
+            slot = start + g
+            slice_begin = g * slice_chunk
+            slice_count = gate_tile_cnt - slice_begin
+            if slice_count > slice_chunk:
+                slice_count = slice_chunk
+            task_expert[slot] = expert_idx
+            task_m_tile[slot] = m_tile_idx
+            task_slice_begin[slot] = slice_begin
+            task_slice_count[slot] = slice_count
+            task_valid_rows[slot] = valid_rows
+            g += Int32(1)
+
+    @cute.jit
+    def __call__(
+        self,
+        a_input: cute.Tensor,  # [num_tokens, K] bf16
+        topk_ids: cute.Tensor,  # [num_tokens * topk] int32
+        topk_weights: cute.Tensor,  # [num_tokens * topk] float32
+        packed_a: cute.Tensor,  # [rows_padded, K, 1] BF16 routed scratch
+        sfa_ptr: cute.Pointer,
+        packed_a_storage: cute.Tensor,  # legacy NVFP4 scratch, unused by W4A16
+        scale_storage: cute.Tensor,  # legacy activation scales, unused by W4A16
+        barrier_count: cute.Tensor,  # [1] int32 (host-zeroed)
+        barrier_epoch: cute.Tensor,  # [1] int32 (host-zeroed)
+        pair_head: cute.Tensor,  # [1] int32
+        producers_done_count: cute.Tensor,  # [1] int32
+        all_work_published: cute.Tensor,  # [1] int32
+        task_head: cute.Tensor,  # [1] int32
+        task_tail: cute.Tensor,  # [1] int32
+        task_ready: cute.Tensor,  # [max_tasks] int32
+        task_expert: cute.Tensor,  # [max_tasks] int32
+        task_m_tile: cute.Tensor,  # [max_tasks] int32
+        task_slice_begin: cute.Tensor,  # [max_tasks] int32
+        task_slice_count: cute.Tensor,  # [max_tasks] int32
+        task_valid_rows: cute.Tensor,  # [max_tasks] int32
+        tile_write_count: cute.Tensor,  # [E * max_m_tiles] int32
+        b_w13: cute.Tensor,  # [w1_n, K, E] — gated packs [up, gate], relu2 is single FC1
+        sfb_w13_ptr: cute.Pointer,  # scale factors for FC1 weights
+        b_down: cute.Tensor,  # [K, I_tp, E]
+        sfb_down_ptr: cute.Pointer,
+        row_counts: cute.Tensor,  # expert row histogram [E]
+        expert_write_rows: cute.Tensor,  # route/pack write cursors [E]
+        expert_tile_base: cute.Tensor,  # compact physical-tile prefix [E + 1]
+        input_global_scale: cute.Tensor,  # legacy activation scale, unused by W4A16
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_output: cute.Tensor,  # [num_tokens, K]
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        self.a_dtype = packed_a.element_type
+        self.b_dtype = cutlass.BFloat16
+        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        # Dynamic never materializes the intermediate C tensor. Preserve the
+        # original row-major epilogue layout without carrying a dead memref.
+        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+
+        if cutlass.const_expr(self.a_dtype != cutlass.BFloat16):
+            raise TypeError(f"expected BF16 routed A scratch, got {self.a_dtype}")
+
+        self._setup_attributes()
+
+        # TMA descriptors
+        tma_a, gA = self._dense_cls._make_tma_atoms_and_tensors(
+            packed_a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            1,
+        )
+
+        tile_n = Int32(self.tile_shape_mnk[1])
+        gate_tile_cnt = (Int32(b_w13.shape[0]) + tile_n - Int32(1)) // tile_n
+        if self.is_gated:
+            gate_tile_cnt = gate_tile_cnt // Int32(2)
+        launch_params = DynamicLaunchParams(row_counts, gate_tile_cnt)
+        grid = (*self.cluster_shape_mn, max_active_clusters)
+        self.kernel(
+            a_input,
+            topk_ids,
+            topk_weights,
+            packed_a,
+            packed_a_storage,
+            scale_storage,
+            barrier_count,
+            barrier_epoch,
+            pair_head,
+            producers_done_count,
+            all_work_published,
+            task_head,
+            task_tail,
+            task_ready,
+            task_expert,
+            task_m_tile,
+            task_slice_begin,
+            task_slice_count,
+            task_valid_rows,
+            tile_write_count,
+            tma_a,
+            gA,
+            b_w13,
+            sfb_w13_ptr,
+            b_down,
+            sfb_down_ptr,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            launch_params,
+            expert_write_rows,
+            expert_tile_base,
+            input_global_scale,
+            alpha,
+            down_alpha,
+            global_scale,
+            scatter_output,
+            token_map,
+            token_weights,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        packed_a: cute.Tensor,
+        packed_a_storage: cute.Tensor,
+        scale_storage: cute.Tensor,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        pair_head: cute.Tensor,
+        producers_done_count: cute.Tensor,
+        all_work_published: cute.Tensor,
+        task_head: cute.Tensor,
+        task_tail: cute.Tensor,
+        task_ready: cute.Tensor,
+        task_expert: cute.Tensor,
+        task_m_tile: cute.Tensor,
+        task_slice_begin: cute.Tensor,
+        task_slice_count: cute.Tensor,
+        task_valid_rows: cute.Tensor,
+        tile_write_count: cute.Tensor,
+        tma_a: cute.CopyAtom,
+        mA: cute.Tensor,
+        b_w13: cute.Tensor,
+        sfb_w13_ptr: cute.Pointer,
+        b_down: cute.Tensor,
+        sfb_down_ptr: cute.Pointer,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_staged: cute.ComposedLayout,
+        b_smem_staged: cute.ComposedLayout,
+        epi_smem_staged: cute.ComposedLayout,
+        launch_params: DynamicLaunchParams,
+        expert_write_rows: cute.Tensor,
+        expert_tile_base: cute.Tensor,
+        input_global_scale: cute.Tensor,
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+    ):
+        """Kernel entry point."""
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, bidz = cute.arch.block_idx()
+        _, _, gdim_z = cute.arch.grid_dim()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        is_cta_leader = Int32(1) if Int32(tidx) == Int32(0) else Int32(0)
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_a)
+
+        cta_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cluster_coord = cta_layout_mnk.get_flat_coord(cta_rank)
+
+        a_smem_one = cute.slice_(a_smem_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(self.a_dtype, a_smem_one)
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 8]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, self.tile_shape_mnk[0]
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, self.tile_shape_mnk[0]
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB_up: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        storage = smem.allocate(Storage)
+
+        prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        cons_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        ml_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+
+        cute.arch.sync_threads()
+
+        sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+        sB_up = storage.sB_up.get_tensor(
+            b_smem_staged.outer, swizzle=b_smem_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_staged.outer,
+            swizzle=epi_smem_staged.inner,
+        )
+        ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
+        scatter_tok_base_addr = shared_ptr_to_u32(storage.scatter_tok_cache.data_ptr())
+        scatter_weight_base_addr = shared_ptr_to_u32(
+            storage.scatter_weight_cache.data_ptr()
+        )
+
+        num_tokens = Int32(a_input.shape[0])
+        cols = Int32(a_input.shape[1])
+        a_base = a_input.iterator.toint()
+        packed_a_base = packed_a.iterator.toint()
+        scatter_base = scatter_output.iterator.toint()
+        row_counts = launch_params.row_counts
+        num_experts = Int32(row_counts.shape[0])
+        total_pairs = Int32(topk_ids.shape[0])
+        num_topk = total_pairs // num_tokens
+        cols_u32 = cols // Int32(2)
+        scatter_output_u32 = cute.recast_tensor(scatter_output, cutlass.Uint32)
+        flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
+        flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
+        route_gate_tile_cnt = launch_params.gate_tile_cnt
+        task_slice_chunk = Int32(_TASK_SLICE_CHUNK)
+        full_tile_publish_enabled = Int32(0)
+
+        # Phase 0: cooperative init — zero routing state, queue state, and output
+        task_capacity = Int32(task_ready.shape[0])
+        tile_write_slots = Int32(tile_write_count.shape[0])
+        i = flat_tid
+        while i < num_experts:
+            row_counts[i] = Int32(0)
+            expert_write_rows[i] = Int32(0)
+            i += flat_stride
+        if flat_tid < num_experts + Int32(1):
+            expert_tile_base[flat_tid] = Int32(0)
+
+        scatter_total_u32 = num_tokens * cols_u32
+        scatter_vecs = scatter_total_u32 // Int32(4)
+        zero_u32 = Uint32(0)
+        zv = flat_tid
+        while zv < scatter_vecs:
+            st_global_v4_u32(
+                scatter_base + Int64(zv) * Int64(16),
+                zero_u32,
+                zero_u32,
+                zero_u32,
+                zero_u32,
+            )
+            zv += flat_stride
+
+        j = scatter_vecs * Int32(4) + flat_tid
+        while j < scatter_total_u32:
+            scatter_output_u32[j // cols_u32, j % cols_u32] = Uint32(0)
+            j += flat_stride
+
+        k = flat_tid
+        while k < task_capacity:
+            task_ready[k] = Int32(0)
+            task_expert[k] = Int32(0)
+            task_m_tile[k] = Int32(0)
+            task_slice_begin[k] = Int32(0)
+            task_slice_count[k] = Int32(0)
+            task_valid_rows[k] = Int32(0)
+            k += flat_stride
+
+        if full_tile_publish_enabled > Int32(0):
+            tw = flat_tid
+            while tw < tile_write_slots:
+                tile_write_count[tw] = Int32(0)
+                tw += flat_stride
+
+        if flat_tid == Int32(0):
+            pair_head[Int32(0)] = Int32(0)
+            producers_done_count[Int32(0)] = Int32(0)
+            all_work_published[Int32(0)] = Int32(0)
+            task_head[Int32(0)] = Int32(0)
+            task_tail[Int32(0)] = Int32(0)
+
+        cute.arch.sync_threads()
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        # Phase 1: histogram routed rows per expert.
+        hist_idx = flat_tid
+        while hist_idx < total_pairs:
+            expert_id = topk_ids[hist_idx].to(Int32)
+            atomic_add_global_i32(get_ptr_as_int64(row_counts, expert_id), Int32(1))
+            hist_idx += flat_stride
+
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        if flat_tid == Int32(0):
+            tile_acc = Int32(0)
+            expert_idx = Int32(0)
+            while expert_idx < num_experts:
+                expert_tile_base[expert_idx] = tile_acc
+                rows = row_counts[expert_idx]
+                tile_acc += (rows + Int32(self.tile_shape_mnk[0]) - Int32(1)) // Int32(
+                    self.tile_shape_mnk[0]
+                )
+                expert_idx += Int32(1)
+            expert_tile_base[num_experts] = tile_acc
+
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        # Phase 2: warp-private route/pack producers into compact physical tiles.
+        lane_id = Int32(tidx) & Int32(31)
+        num_cta_warps = Int32(self.num_mma_warps + self.num_load_warps)
+        pair_idx = Int32(0)
+        expert_id = Int32(0)
+        token_idx = Int32(0)
+        weight = cutlass.Float32(0.0)
+        row = Int32(0)
+        phys_tile = Int32(0)
+        phys_row = Int32(0)
+        produce_active = Int32(1)
+        while produce_active > Int32(0):
+            batch_base = Int32(0)
+            if is_cta_leader > Int32(0):
+                batch_base = atomic_add_global_i32(
+                    get_ptr_as_int64(pair_head, Int32(0)),
+                    num_cta_warps,
+                )
+                _st_shared_i32(ctrl_base_addr + Int32(28), batch_base)
+            cute.arch.sync_threads()
+            batch_base = _ld_shared_i32(ctrl_base_addr + Int32(28))
+            if batch_base >= total_pairs:
+                produce_active = Int32(0)
+            else:
+                pair_idx = batch_base + warp_idx
+                expert_id = Int32(0)
+                token_idx = Int32(0)
+                weight = cutlass.Float32(0.0)
+                row = Int32(0)
+                phys_tile = Int32(0)
+                if pair_idx < total_pairs:
+                    expert_id = topk_ids[pair_idx].to(Int32)
+                    token_idx = pair_idx // num_topk
+                    weight = topk_weights[pair_idx].to(cutlass.Float32)
+
+                    if lane_id == Int32(0):
+                        row = atomic_add_global_i32(
+                            get_ptr_as_int64(expert_write_rows, expert_id),
+                            Int32(1),
+                        )
+                        phys_tile = expert_tile_base[expert_id] + row // Int32(
+                            self.tile_shape_mnk[0]
+                        )
+                        phys_row = phys_tile * Int32(
+                            self.tile_shape_mnk[0]
+                        ) + row % Int32(self.tile_shape_mnk[0])
+                        st_global_i32(get_ptr_as_int64(token_map, phys_row), token_idx)
+                        token_weights[phys_row] = weight
+
+                    row = cute.arch.shuffle_sync(row, Int32(0))
+                    phys_tile = cute.arch.shuffle_sync(phys_tile, Int32(0))
+                    expert_id = cute.arch.shuffle_sync(expert_id, Int32(0))
+                    token_idx = cute.arch.shuffle_sync(token_idx, Int32(0))
+
+                    phys_row = phys_tile * Int32(self.tile_shape_mnk[0]) + row % Int32(
+                        self.tile_shape_mnk[0]
+                    )
+                    vec_cols = cols // Int32(8)
+                    vec_idx = lane_id
+                    while vec_idx < vec_cols:
+                        vec_col = vec_idx * Int32(8)
+                        src_byte = (
+                            Int64(token_idx) * Int64(cols) + Int64(vec_col)
+                        ) * Int64(2)
+                        dst_byte = (
+                            Int64(phys_row) * Int64(cols) + Int64(vec_col)
+                        ) * Int64(2)
+                        v0, v1, v2, v3 = ld_global_nc_v4_u32(a_base + src_byte)
+                        st_global_v4_u32(packed_a_base + dst_byte, v0, v1, v2, v3)
+                        vec_idx += Int32(32)
+
+                    col = vec_cols * Int32(8) + lane_id
+                    while col < cols:
+                        packed_a[phys_row, col, Int32(0)] = a_input[token_idx, col]
+                        col += Int32(32)
+
+                    if full_tile_publish_enabled > Int32(0):
+                        cute.arch.sync_warp()
+                        # When the whole launch has fewer than one M-tile of routed
+                        # rows, only the final partial-tile flush can publish work.
+                        # Skip the per-row fence/counter path in that common micro case.
+                        _threadfence()
+                        cute.arch.sync_warp()
+
+                        if lane_id == Int32(0):
+                            completed = atomic_add_global_i32(
+                                get_ptr_as_int64(tile_write_count, phys_tile),
+                                Int32(1),
+                            ) + Int32(1)
+                            if completed == Int32(self.tile_shape_mnk[0]):
+                                self._publish_ready_tasks(
+                                    task_tail,
+                                    task_ready,
+                                    task_expert,
+                                    task_m_tile,
+                                    task_slice_begin,
+                                    task_slice_count,
+                                    task_valid_rows,
+                                    route_gate_tile_cnt,
+                                    task_slice_chunk,
+                                    expert_id,
+                                    phys_tile,
+                                    Int32(self.tile_shape_mnk[0]),
+                                )
+
+        cute.arch.sync_threads()
+        # Conservative publish fence before the last-producer CTA flushes any
+        # partial tiles. All producer threads in the CTA must have ordered
+        # their global writes before lane 0 can publish work.
+        _threadfence()
+        cute.arch.sync_threads()
+
+        if full_tile_publish_enabled == Int32(0):
+            # Flush routed work once, then consume direct task slots without
+            # per-task ready flags.
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
+
+            if is_cta_leader > Int32(0):
+                expert_flush = Int32(bidz)
+                while expert_flush < num_experts:
+                    rows_remaining = row_counts[expert_flush]
+                    m_tile_offset = Int32(0)
+                    while rows_remaining > Int32(0):
+                        valid_rows = rows_remaining
+                        if valid_rows > Int32(self.tile_shape_mnk[0]):
+                            valid_rows = Int32(self.tile_shape_mnk[0])
+                        self._publish_deferred_tasks(
+                            task_expert,
+                            task_m_tile,
+                            task_slice_begin,
+                            task_slice_count,
+                            task_valid_rows,
+                            route_gate_tile_cnt,
+                            task_slice_chunk,
+                            expert_flush,
+                            expert_tile_base[expert_flush] + m_tile_offset,
+                            valid_rows,
+                        )
+                        rows_remaining -= Int32(self.tile_shape_mnk[0])
+                        m_tile_offset += Int32(1)
+                    expert_flush += Int32(gdim_z)
+
+            if flat_tid == Int32(0):
+                num_groups = (
+                    route_gate_tile_cnt + task_slice_chunk - Int32(1)
+                ) // task_slice_chunk
+                st_global_i32(
+                    get_ptr_as_int64(task_tail, Int32(0)),
+                    expert_tile_base[num_experts] * num_groups,
+                )
+
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
+            if flat_tid == Int32(0):
+                _st_global_release_i32(
+                    get_ptr_as_int64(all_work_published, Int32(0)),
+                    Int32(1),
+                )
+        elif is_cta_leader > Int32(0):
+            prev_done = atomic_add_global_i32(
+                get_ptr_as_int64(producers_done_count, Int32(0)),
+                Int32(1),
+            )
+            if prev_done == Int32(gdim_z) - Int32(1):
+                expert_flush = Int32(0)
+                while expert_flush < num_experts:
+                    rows = row_counts[expert_flush]
+                    rem = rows % Int32(self.tile_shape_mnk[0])
+                    if rem != Int32(0):
+                        partial_m_tile = expert_tile_base[expert_flush] + rows // Int32(
+                            self.tile_shape_mnk[0]
+                        )
+                        self._publish_ready_tasks(
+                            task_tail,
+                            task_ready,
+                            task_expert,
+                            task_m_tile,
+                            task_slice_begin,
+                            task_slice_count,
+                            task_valid_rows,
+                            route_gate_tile_cnt,
+                            task_slice_chunk,
+                            expert_flush,
+                            partial_m_tile,
+                            rem,
+                        )
+                    expert_flush += Int32(1)
+                _threadfence()
+                _st_global_release_i32(
+                    get_ptr_as_int64(all_work_published, Int32(0)),
+                    Int32(1),
+                )
+
+        gA = cute.local_tile(
+            mA, cute.slice_(self.tile_shape_mnk, (None, 0, None)), (None, None, None)
+        )
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord[1]
+
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+
+        # MMA fragment partitions
+        tCsA = thr_mma.partition_A(sA)
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        tCsB = thr_mma.partition_B(sB)
+        tCsB_up = thr_mma.partition_B(sB_up)
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCrB_up = tiled_mma.make_fragment_B(tCsB_up[None, None, None, 0])
+
+        tCsC_for_shape = thr_mma.partition_C(sC[None, None, 0])
+        epi_m_scale = self.tile_shape_mnk[0] // self.epi_tile[0]
+        sub_shape = tCsC_for_shape.shape[:3]
+        acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
+        gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        k_tile_cnt = cute.size(gA, mode=[3])
+        fc1_k_tile_cnt = k_tile_cnt
+        w13_rows = Int32(b_w13.shape[0])
+        # Runtime W4A16 weight tensors are uint8 packed views, so shape[1] is
+        # K/2. Manual FP4 byte addressing needs the logical FP4 column count.
+        w13_cols = cols
+        w13_sf_cols = (
+            ((w13_cols // Int32(self.sf_vec_size)) + Int32(3)) // Int32(4) * Int32(4)
+        )
+        down_rows = Int32(b_down.shape[0])
+        down_cols = w13_rows // Int32(2) if self.is_gated else w13_rows
+        down_sf_cols = (
+            ((down_cols // Int32(self.sf_vec_size)) + Int32(3)) // Int32(4) * Int32(4)
+        )
+        tile_n = Int32(self.tile_shape_mnk[1])
+        # Gated FC1 packs [up, gate] across N; relu2 has a single FC1 pass.
+        intermediate_tile_cnt = (w13_rows + tile_n - Int32(1)) // tile_n
+        gate_tile_cnt = intermediate_tile_cnt
+        if self.is_gated:
+            gate_tile_cnt = intermediate_tile_cnt // Int32(2)
+        output_tile_cnt = (down_rows + tile_n - Int32(1)) // tile_n
+
+        prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        num_k_blocks = cute.size(tCrA, mode=[2])
+
+        atom_ld_A = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+            self.a_dtype,
+        )
+        atom_ld_B = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+            self.b_dtype,
+        )
+        smem_copy_A = cute.make_tiled_copy_A(atom_ld_A, tiled_mma)
+        smem_copy_B = cute.make_tiled_copy_B(atom_ld_B, tiled_mma)
+
+        thr_ld_A = smem_copy_A.get_slice(tidx)
+        thr_ld_B = smem_copy_B.get_slice(tidx)
+        csA = thr_ld_A.partition_S(sA)
+        crA = thr_ld_A.retile(tCrA)
+        csB = thr_ld_B.partition_S(sB)
+        csB_up = thr_ld_B.partition_S(sB_up)
+        crB = thr_ld_B.retile(tCrB)
+        crB_up = thr_ld_B.retile(tCrB_up)
+
+        # ===================================================================
+        # Per-warp setup for the consumer steady state
+        # ===================================================================
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+        elif (
+            warp_idx >= self.tma_load_warp_id
+            and warp_idx < self.tma_load_warp_id + self.num_load_warps
+        ):
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+        # ===================================================================
+        # Consumer steady state: pop one ready task per CTA, then let
+        # the MMA warps and DMA warp cooperate on that task.
+        # ===================================================================
+        consumer_live = Int32(1)
+        while consumer_live > Int32(0):
+            if is_cta_leader > Int32(0):
+                _st_shared_i32(ctrl_base_addr + Int32(0), Int32(0))  # has_task
+                _st_shared_i32(ctrl_base_addr + Int32(4), Int32(0))  # done
+                _st_shared_i32(ctrl_base_addr + Int32(28), Int32(0))  # claimed slot
+                if full_tile_publish_enabled == Int32(0):
+                    tail = _ld_global_acquire_i32(get_ptr_as_int64(task_tail, Int32(0)))
+                    slot = atomic_add_global_i32(
+                        get_ptr_as_int64(task_head, Int32(0)),
+                        Int32(1),
+                    )
+                    if slot < tail:
+                        _st_shared_i32(ctrl_base_addr + Int32(0), Int32(1))
+                        _st_shared_i32(ctrl_base_addr + Int32(28), slot)
+                        _st_shared_i32(ctrl_base_addr + Int32(8), task_expert[slot])
+                        _st_shared_i32(ctrl_base_addr + Int32(12), task_m_tile[slot])
+                        _st_shared_i32(
+                            ctrl_base_addr + Int32(16), task_slice_begin[slot]
+                        )
+                        _st_shared_i32(
+                            ctrl_base_addr + Int32(20), task_slice_count[slot]
+                        )
+                        _st_shared_i32(
+                            ctrl_base_addr + Int32(24), task_valid_rows[slot]
+                        )
+                    else:
+                        _st_shared_i32(ctrl_base_addr + Int32(4), Int32(1))
+                else:
+                    head = _ld_global_acquire_i32(get_ptr_as_int64(task_head, Int32(0)))
+                    tail = _ld_global_acquire_i32(get_ptr_as_int64(task_tail, Int32(0)))
+                    if head < tail:
+                        prev_head = _atomic_cas_global_i32(
+                            get_ptr_as_int64(task_head, Int32(0)),
+                            head,
+                            head + Int32(1),
+                        )
+                        if prev_head == head:
+                            _spin_wait_global_eq_i32(
+                                get_ptr_as_int64(task_ready, head), Int32(0)
+                            )
+                            _st_shared_i32(ctrl_base_addr + Int32(0), Int32(1))
+                            _st_shared_i32(ctrl_base_addr + Int32(28), head)
+                            _st_shared_i32(ctrl_base_addr + Int32(8), task_expert[head])
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(12), task_m_tile[head]
+                            )
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(16), task_slice_begin[head]
+                            )
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(20), task_slice_count[head]
+                            )
+                            _st_shared_i32(
+                                ctrl_base_addr + Int32(24), task_valid_rows[head]
+                            )
+                    else:
+                        if _ld_global_acquire_i32(
+                            get_ptr_as_int64(all_work_published, Int32(0))
+                        ) > Int32(0):
+                            _st_shared_i32(ctrl_base_addr + Int32(4), Int32(1))
+            cute.arch.sync_threads()
+
+            has_task = _ld_shared_i32(ctrl_base_addr + Int32(0))
+            is_done = _ld_shared_i32(ctrl_base_addr + Int32(4))
+            if has_task > Int32(0) and full_tile_publish_enabled > Int32(0):
+                claimed_slot = _ld_shared_i32(ctrl_base_addr + Int32(28))
+                _ld_global_acquire_i32(get_ptr_as_int64(task_ready, claimed_slot))
+            if has_task > Int32(0):
+                task_m_tile_idx_cache = _ld_shared_i32(ctrl_base_addr + Int32(12))
+                task_valid_rows_cache = _ld_shared_i32(ctrl_base_addr + Int32(24))
+                tile_m_base_cache = task_m_tile_idx_cache * Int32(
+                    self.tile_shape_mnk[0]
+                )
+                cache_row = Int32(tidx)
+                while cache_row < Int32(self.tile_shape_mnk[0]):
+                    tok = Int32(0)
+                    wv = cutlass.Float32(0.0)
+                    if cache_row < task_valid_rows_cache:
+                        global_row_cache = tile_m_base_cache + cache_row
+                        tok = token_map[global_row_cache].to(Int32)
+                        wv = token_weights[global_row_cache].to(cutlass.Float32)
+                    _st_shared_i32(scatter_tok_base_addr + cache_row * Int32(4), tok)
+                    st_shared_f32(scatter_weight_base_addr + cache_row * Int32(4), wv)
+                    cache_row += Int32(self.threads_per_cta)
+                cute.arch.sync_threads()
+            if has_task == Int32(0):
+                if is_done > Int32(0):
+                    consumer_live = Int32(0)
+            elif warp_idx < self.num_mma_warps:
+                task_expert_idx = _ld_shared_i32(ctrl_base_addr + Int32(8))
+                task_m_tile_idx = _ld_shared_i32(ctrl_base_addr + Int32(12))
+                task_slice_begin_idx = _ld_shared_i32(ctrl_base_addr + Int32(16))
+                task_slice_count_val = _ld_shared_i32(ctrl_base_addr + Int32(20))
+                task_valid_rows_val = _ld_shared_i32(ctrl_base_addr + Int32(24))
+
+                alpha_value = alpha[task_expert_idx].to(cutlass.Float32)
+                valid_rows = task_valid_rows_val
+                _is_m_major = self.c_layout.is_m_major_c()
+                copy_atom_r2s = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.BFloat16,
+                )
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                    cutlass.BFloat16,
+                )
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s, tiled_copy_C_Atom
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                tRS_rGate = tiled_copy_r2s.retile(gate_acc)
+                tRS_rUp = tiled_copy_r2s.retile(up_acc)
+
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+                tRS_rD_out = cute.make_rmem_tensor(
+                    tRS_rD_layout.shape, cutlass.BFloat16
+                )
+
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rGate, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rGate, mode=[2])
+                epi_buffer = Int32(0)
+
+                epi_rest_m = self.tile_shape_mnk[0] // self.epi_tile[0]
+                MmaMPerEpiM = self.epi_tile[0] // mma_tile_m
+                MmaNPerEpiN = self.epi_tile[1] // mma_tile_n
+                slice_idx = Int32(0)
+                while slice_idx < task_slice_count_val:
+                    intermediate_slice = task_slice_begin_idx + slice_idx
+                    gate_slice_idx = intermediate_slice
+                    if self.is_gated:
+                        gate_slice_idx = intermediate_slice + gate_tile_cnt
+
+                    # ============================================================
+                    # PHASE A: FC1 for this slice (gate/only pass, plus up for silu)
+                    # ============================================================
+
+                    if self.is_gated:
+                        gate_acc.fill(0.0)
+                        up_acc.fill(0.0)
+                        cons_state.reset_count()
+                        for _k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                            peek = ml_pipeline.consumer_try_wait(cons_state)
+                            ml_pipeline.consumer_wait(cons_state, peek)
+                            self._stage_w13_fp4_b_tile(
+                                b_w13,
+                                sfb_w13_ptr,
+                                sB,
+                                cons_state.index,
+                                task_expert_idx,
+                                gate_slice_idx,
+                                _k_tile,
+                                w13_rows,
+                                w13_cols,
+                                w13_sf_cols,
+                                Int32(tidx),
+                                Int32(self.num_mma_warps * self.num_threads_per_warp),
+                            )
+                            self._stage_w13_fp4_b_tile(
+                                b_w13,
+                                sfb_w13_ptr,
+                                sB_up,
+                                cons_state.index,
+                                task_expert_idx,
+                                intermediate_slice,
+                                _k_tile,
+                                w13_rows,
+                                w13_cols,
+                                w13_sf_cols,
+                                Int32(tidx),
+                                Int32(self.num_mma_warps * self.num_threads_per_warp),
+                            )
+                            cute.arch.fence_proxy("async.shared", space="cta")
+                            self.epilog_sync_barrier.arrive_and_wait()
+                            csA_p = csA[None, None, None, cons_state.index]
+                            csB_p = csB[None, None, None, cons_state.index]
+                            csB_up_p = csB_up[None, None, None, cons_state.index]
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, 0],
+                                crA[None, None, 0],
+                            )
+                            for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
+                                k_pre = _kb_pre + 1
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_pre],
+                                    crA[None, None, k_pre],
+                                )
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_block_idx],
+                                    crB[None, None, k_block_idx],
+                                )
+                                cute.gemm(
+                                    tiled_mma,
+                                    gate_acc,
+                                    tCrA[None, None, k_block_idx],
+                                    tCrB[None, None, k_block_idx],
+                                    gate_acc,
+                                )
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_up_p[None, None, k_block_idx],
+                                    crB_up[None, None, k_block_idx],
+                                )
+                                cute.gemm(
+                                    tiled_mma,
+                                    up_acc,
+                                    tCrA[None, None, k_block_idx],
+                                    tCrB_up[None, None, k_block_idx],
+                                    up_acc,
+                                )
+                            ml_pipeline.consumer_release(cons_state)
+                            cons_state.advance()
+                        self.pass_sync_barrier.arrive_and_wait()
+                    else:
+                        # Gate/only GEMM (inlined to avoid @cute.jit pass-by-value for acc)
+                        gate_acc.fill(0.0)
+                        cons_state.reset_count()
+                        peek = ml_pipeline.consumer_try_wait(cons_state)
+                        ml_pipeline.consumer_wait(cons_state, peek)
+                        self._stage_w13_fp4_b_tile(
+                            b_w13,
+                            sfb_w13_ptr,
+                            sB,
+                            cons_state.index,
+                            task_expert_idx,
+                            gate_slice_idx,
+                            Int32(0),
+                            w13_rows,
+                            w13_cols,
+                            w13_sf_cols,
+                            Int32(tidx),
+                            Int32(self.num_mma_warps * self.num_threads_per_warp),
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        csA_p = csA[None, None, None, cons_state.index]
+                        csB_p = csB[None, None, None, cons_state.index]
+                        cute.copy(smem_copy_A, csA_p[None, None, 0], crA[None, None, 0])
+                        cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                        for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
+                            for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                                k_next = (
+                                    0
+                                    if k_block_idx + 1 == num_k_blocks
+                                    else k_block_idx + 1
+                                )
+                                if k_block_idx == num_k_blocks - 1:
+                                    ml_pipeline.consumer_release(cons_state)
+                                    cons_state.advance()
+                                    peek = ml_pipeline.consumer_try_wait(cons_state)
+                                    csA_p = csA[None, None, None, cons_state.index]
+                                    csB_p = csB[None, None, None, cons_state.index]
+                                    ml_pipeline.consumer_wait(cons_state, peek)
+                                    self._stage_w13_fp4_b_tile(
+                                        b_w13,
+                                        sfb_w13_ptr,
+                                        sB,
+                                        cons_state.index,
+                                        task_expert_idx,
+                                        gate_slice_idx,
+                                        _k_tile + Int32(1),
+                                        w13_rows,
+                                        w13_cols,
+                                        w13_sf_cols,
+                                        Int32(tidx),
+                                        Int32(
+                                            self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                        ),
+                                    )
+                                    cute.arch.fence_proxy("async.shared", space="cta")
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                                cute.gemm(
+                                    tiled_mma,
+                                    gate_acc,
+                                    tCrA[None, None, k_block_idx],
+                                    tCrB[None, None, k_block_idx],
+                                    gate_acc,
+                                )
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
+                            )
+                            if k_block_idx == num_k_blocks - 1:
+                                ml_pipeline.consumer_release(cons_state)
+                                cons_state.advance()
+                            if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                            cute.gemm(
+                                tiled_mma,
+                                gate_acc,
+                                tCrA[None, None, k_block_idx],
+                                tCrB[None, None, k_block_idx],
+                                gate_acc,
+                            )
+                        self.pass_sync_barrier.arrive_and_wait()
+
+                    # Activation into BF16 sA for FC2. W4A16 has no activation
+                    # requantization and no activation scale fragment.
+                    for epi_m in cutlass.range_constexpr(epi_rest_m):
+                        epi_m_valid = valid_rows - Int32(epi_m) * Int32(
+                            self.epi_tile[0]
+                        )
+                        epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                        if epi_m_valid > Int32(0):
+                            tRS_rD.fill(0.0)
+                            for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                                for mma_m_in_epi in cutlass.range_constexpr(
+                                    MmaMPerEpiM
+                                ):
+                                    mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                    mma_n = mma_n_in_epi
+                                    tRS_rD_slice = tRS_rD[
+                                        (None, mma_m_in_epi, mma_n_in_epi)
+                                    ]
+                                    gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                    if self.is_gated:
+                                        up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            g = alpha_value * cutlass.Float32(
+                                                cutlass.BFloat16(gate_slice[elem_idx])
+                                            )
+                                            u = alpha_value * cutlass.Float32(
+                                                cutlass.BFloat16(up_slice[elem_idx])
+                                            )
+                                            sigmoid_g = cute.arch.rcp_approx(
+                                                cutlass.Float32(1.0)
+                                                + cute.math.exp(
+                                                    -g, fastmath=self.fast_math
+                                                ),
+                                            )
+                                            tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                    else:
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            g = alpha_value * cutlass.Float32(
+                                                cutlass.BFloat16(gate_slice[elem_idx])
+                                            )
+                                            relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                            tRS_rD_slice[elem_idx] = relu_g * relu_g
+
+                            acc_vec = tRS_rD.load()
+                            acc_vec = acc_vec.to(cutlass.BFloat16)
+                            tRS_rD_out.store(acc_vec)
+                            cute.copy(
+                                tiled_copy_r2s,
+                                tRS_rD_out,
+                                tRS_sD[(None, None, None, epi_buffer)],
+                            )
+                            cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                        epi_rows = epi_m_valid
+                        if epi_rows > Int32(self.epi_tile[0]):
+                            epi_rows = Int32(self.epi_tile[0])
+                        if epi_rows < Int32(0):
+                            epi_rows = Int32(0)
+                        copy_idx = Int32(tidx)
+                        epi_cols = Int32(self.epi_tile[1])
+                        while copy_idx < epi_rows * epi_cols:
+                            local_row = copy_idx // epi_cols
+                            col = copy_idx - local_row * epi_cols
+                            sA[rows_offset + local_row, col, Int32(0)] = sC[
+                                local_row, col, epi_buffer
+                            ]
+                            copy_idx += Int32(
+                                self.num_mma_warps * self.num_threads_per_warp
+                            )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    # All MMA warps must finish materializing the activated BF16
+                    # intermediate before FC2 reads sA.
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    # ============================================================
+                    # PHASE B: Sweep ALL FC2 output tiles using cached BF16 sA.
+                    # B_down is staged cooperatively by the whole CTA.
+                    # ============================================================
+                    scatter_N = Int32(scatter_output.shape[1])
+                    down_alpha_value = down_alpha[task_expert_idx].to(cutlass.Float32)
+                    down_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+                    csA_phase2 = csA[None, None, None, 0]
+
+                    # Hoist A-side register loads: sA is constant across all
+                    # FC2 output tiles (BF16 intermediate). Load crA for all
+                    # k-blocks once, reuse for all output tiles.
+                    cute.copy(
+                        smem_copy_A, csA_phase2[None, None, 0], crA[None, None, 0]
+                    )
+                    for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
+                        k_pre = _kb_pre + 1
+                        cute.copy(
+                            smem_copy_A,
+                            csA_phase2[None, None, k_pre],
+                            crA[None, None, k_pre],
+                        )
+
+                    for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                        self._stage_down_fp4_b_tile(
+                            b_down,
+                            sfb_down_ptr,
+                            sB,
+                            Int32(0),
+                            task_expert_idx,
+                            output_tile_idx,
+                            intermediate_slice,
+                            down_rows,
+                            down_cols,
+                            down_sf_cols,
+                            Int32(tidx),
+                            Int32(self.threads_per_cta),
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.fc1_stage_sync_barrier.arrive_and_wait()
+                        csB_phase2 = csB[None, None, None, 0]
+
+                        # Only load B-side (B_down changes per output tile; A is hoisted)
+                        cute.copy(
+                            smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
+                        )
+
+                        down_acc.fill(0.0)
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
+                            )
+                            if k_next > 0:
+                                # Only B-side for next k-block (A already in registers)
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_phase2[None, None, k_next],
+                                    crB[None, None, k_next],
+                                )
+                            cute.gemm(
+                                tiled_mma,
+                                down_acc,
+                                tCrA[None, None, k_block_idx],
+                                tCrB[None, None, k_block_idx],
+                                down_acc,
+                            )
+
+                        # Scatter using precomputed metadata (no redundant gmem loads)
+                        tile_n_base_cur = output_tile_idx * Int32(
+                            self.tile_shape_mnk[1]
+                        )
+                        for epi_m in cutlass.range_constexpr(epi_rest_m):
+                            for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                                for mma_m_in_epi in cutlass.range_constexpr(
+                                    MmaMPerEpiM
+                                ):
+                                    mma_n = mma_n_in_epi
+                                    mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                    tRS_rD_slice = tRS_rD[
+                                        (None, mma_m_in_epi, mma_n_in_epi)
+                                    ]
+                                    down_epi_acc_slice = down_acc[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        tRS_rD_slice[elem_idx] = (
+                                            down_alpha_value
+                                            * down_epi_acc_slice[elem_idx]
+                                        )
+
+                            acc_vec = tRS_rD.load()
+                            acc_vec = acc_vec.to(cutlass.BFloat16)
+                            tRS_rD_out.store(acc_vec)
+                            epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                            cute.copy(
+                                tiled_copy_r2s,
+                                tRS_rD_out,
+                                tRS_sD[(None, None, None, epi_buffer)],
+                            )
+                            cute.arch.fence_proxy("async.shared", space="cta")
+                            # StMatrix ownership is interleaved across MMA warps
+                            # for underfilled tiles, so wait for every warp's
+                            # store before reading sC for scatter.
+                            self.epilog_sync_barrier.arrive_and_wait()
+
+                            rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                            epi_rows = valid_rows - rows_offset
+                            if epi_rows > Int32(self.epi_tile[0]):
+                                epi_rows = Int32(self.epi_tile[0])
+                            if epi_rows < Int32(0):
+                                epi_rows = Int32(0)
+
+                            tile_vec_cols = Int32(self.tile_shape_mnk[1]) // Int32(8)
+                            vec_idx = Int32(tidx)
+                            while vec_idx < epi_rows * tile_vec_cols:
+                                local_row = vec_idx // tile_vec_cols
+                                local_vec_col = vec_idx - local_row * tile_vec_cols
+                                local_col = local_vec_col * Int32(8)
+                                global_col = tile_n_base_cur + local_col
+                                cached_row = rows_offset + local_row
+                                tok = ld_shared_i32_relaxed(
+                                    scatter_tok_base_addr + cached_row * Int32(4)
+                                )
+                                wv = ld_shared_f32(
+                                    scatter_weight_base_addr + cached_row * Int32(4)
+                                )
+                                sc_v0 = cutlass.Float32(
+                                    sC[local_row, local_col, epi_buffer]
+                                )
+                                sc_v1 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(1), epi_buffer]
+                                )
+                                sc_v2 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(2), epi_buffer]
+                                )
+                                sc_v3 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(3), epi_buffer]
+                                )
+                                sc_v4 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(4), epi_buffer]
+                                )
+                                sc_v5 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(5), epi_buffer]
+                                )
+                                sc_v6 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(6), epi_buffer]
+                                )
+                                sc_v7 = cutlass.Float32(
+                                    sC[local_row, local_col + Int32(7), epi_buffer]
+                                )
+                                scatter_add_v4_bf16x2(
+                                    get_ptr_as_int64(
+                                        scatter_output, tok * scatter_N + global_col
+                                    ),
+                                    wv * sc_v0,
+                                    wv * sc_v1,
+                                    wv * sc_v2,
+                                    wv * sc_v3,
+                                    wv * sc_v4,
+                                    wv * sc_v5,
+                                    wv * sc_v6,
+                                    wv * sc_v7,
+                                )
+                                vec_idx += Int32(
+                                    self.num_mma_warps * self.num_threads_per_warp
+                                )
+
+                            # Post-scatter barrier: needed to ensure all warps
+                            # finish scatter before next output tile's pipeline ops
+                            # (pipeline consumer is collective across all MMA warps).
+                            self.epilog_sync_barrier.arrive_and_wait()
+
+                        self.fc1_stage_sync_barrier.arrive_and_wait()
+
+                    # Final pass_sync: protect sA from next task's FC1 loads.
+                    # DMA warp waits here too after finishing all B_down loads.
+                    self.pass_sync_barrier.arrive_and_wait()
+                    slice_idx += Int32(1)
+
+            elif (
+                warp_idx >= self.tma_load_warp_id
+                and warp_idx < self.tma_load_warp_id + self.num_load_warps
+            ):
+                task_expert_idx = _ld_shared_i32(ctrl_base_addr + Int32(8))
+                task_m_tile_idx = _ld_shared_i32(ctrl_base_addr + Int32(12))
+                task_slice_begin_idx = _ld_shared_i32(ctrl_base_addr + Int32(16))
+                task_slice_count_val = _ld_shared_i32(ctrl_base_addr + Int32(20))
+                load_warp_local = warp_idx - Int32(self.tma_load_warp_id)
+
+                tAgA_mk = tAgA[(None, task_m_tile_idx, None, Int32(0))]
+                slice_idx = Int32(0)
+                while slice_idx < task_slice_count_val:
+                    intermediate_slice = task_slice_begin_idx + slice_idx
+
+                    # FC1 producer slice. Gated activation packs [up, gate]
+                    # across N; relu2 uses a single FC1 pass.
+                    gate_slice_idx = intermediate_slice
+                    if self.is_gated:
+                        gate_slice_idx = intermediate_slice + gate_tile_cnt
+
+                    # ---- FC1 gate pass ----
+                    prod_state.reset_count()
+                    if load_warp_local == Int32(0):
+                        for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                            ml_pipeline.producer_acquire(prod_state)
+                            cute.copy(
+                                tma_a,
+                                tAgA_mk[(None, k_tile)],
+                                tAsA[(None, prod_state.index)],
+                                tma_bar_ptr=ml_pipeline.producer_get_barrier(
+                                    prod_state
+                                ),
+                            )
+                            ml_pipeline.producer_commit(prod_state)
+                            prod_state.advance()
+
+                    # Wait for the MMA warps to finish FC1 before FC2 begins.
+                    self.pass_sync_barrier.arrive_and_wait()
+
+                    for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                        self._stage_down_fp4_b_tile(
+                            b_down,
+                            sfb_down_ptr,
+                            sB,
+                            Int32(0),
+                            task_expert_idx,
+                            output_tile_idx,
+                            intermediate_slice,
+                            down_rows,
+                            down_cols,
+                            down_sf_cols,
+                            Int32(tidx),
+                            Int32(self.threads_per_cta),
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.fc1_stage_sync_barrier.arrive_and_wait()
+                        self.fc1_stage_sync_barrier.arrive_and_wait()
+
+                    # Final pass_sync: match MMA warps' barrier after FC2 sweep.
+                    # Ensures MMA warps finish scatter before DMA starts next task's FC1.
+                    self.pass_sync_barrier.arrive_and_wait()
+                    slice_idx += Int32(1)
+
+        if warp_idx == self.tma_load_warp_id:
+            ml_pipeline.producer_tail(prod_state)
+        return
+
+
+__all__ = ["MoEDynamicKernel"]

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_micro_kernel.py
@@ -1,0 +1,87 @@
+"""MoEMicroKernel - direct routed W4A16 micro MoE kernel for SM120/SM121.
+
+Ported from the b12x kernel library to FlashInfer.
+
+The compact W4A16 path dequantizes whole FP4 B tiles into BF16 shared memory
+and then runs BF16 MMA.  For tiny routed batches that structure is dominated
+by CTA barriers and underfilled producer/consumer phases.  The direct micro
+kernel keeps the W4A4 scheduler, but stages 16-bit activations and activated
+intermediates directly before dotting with FP4 weights.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .moe_direct_micro_kernel import (
+    _MAX_DIRECT_K_SEGMENTS,
+    _direct_k_segments_supported,
+    MoEDirectMicroKernel,
+)
+
+
+class MoEMicroKernel(MoEDirectMicroKernel):
+    """Low-latency direct W4A16 path for micro routed batches."""
+
+    @classmethod
+    def is_supported(
+        cls,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+    ) -> bool:
+        if m not in (1, 2, 4, 8, 10, 12, 16, 24, 32):
+            return False
+        # CUTLASS 4.5 rejects the wide multi-token direct path at this envelope.
+        if m >= 4 and n >= 4096:
+            return False
+        if k <= 0 or k % (32 * 16) != 0 or k % 128 != 0:
+            return False
+        if k // 16 > 32 * _MAX_DIRECT_K_SEGMENTS:
+            return False
+        if n <= 0 or n % 16 != 0:
+            return False
+        rows_per_warp = max(1, m)
+        fc1_chunks = max(1, n // (16 * rows_per_warp))
+        if n % fc1_chunks != 0:
+            return False
+        i_chunk = n // fc1_chunks
+        if i_chunk % 16 != 0:
+            return False
+        k_segments = k // (32 * 16)
+        return (
+            _direct_k_segments_supported(k_segments)
+            and 0 < num_topk <= 32
+            and weight_E > 0
+        )
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        fast_math: bool = False,
+        activation: str = "silu",
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        single_token: bool = False,
+        dynamic_down_scale: bool = False,
+    ):
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            output_tile_count_n,
+            fast_math=fast_math,
+            activation=activation,
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=single_token,
+            dynamic_down_scale=dynamic_down_scale,
+            w4a16_mode=True,
+        )
+
+
+__all__ = ["MoEMicroKernel"]

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_static_kernel.py
@@ -1,0 +1,1729 @@
+"""
+MoEStaticKernel - static-scheduled routed W4A16 MoE kernel for SM120/SM121.
+
+Ported from the b12x kernel library to FlashInfer.
+
+This is the BF16-activation counterpart to the compact W4A4 static kernel. It
+keeps the same resident route/pack -> compute control plane, but stores routed
+activations and activated intermediates as BF16 while retaining packed FP4
+weights and E4M3 block scales.
+
+Execution model
+  Phase 0: cooperative init / clear row counts
+  Phase 1: walk routed (token, topk_slot) pairs, append rows per expert,
+           write token_map + token_weights, and copy each routed BF16 token row
+           into expert-major scratch
+  Barrier: resident-grid barrier after all expert rows are finalized
+  Phase 2: run BF16 FC1 -> activation -> BF16 FC2 -> scatter over the finalized
+           expert-major scratch
+
+Activation modes
+  SiLU (gated):
+    FC1:     A x gate^T, A x up^T
+    Act:     SiLU(gate) * up
+  ReLU2 (non-gated):
+    FC1:     A x W1^T
+    Act:     max(0, x)^2
+
+Design boundary
+  This file owns only the compact static W4A16 backend. Dispatch, workspace
+  sizing, and the W4A4/W4A16 precision switch live in moe_dispatch.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+
+from cutlass.cutlass_dsl import (
+    Int32,
+    Int64,
+    Uint32,
+    Integer,
+    T,
+    dsl_user_op,
+)
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync
+
+from flashinfer.cute_dsl.fp4_common import (
+    atomic_add_global_i32,
+    atomic_cas_global_i32,
+    cvt_e4m3_to_f32_via_f16,
+    f16x2_to_f32x2,
+    fmax_f32,
+    fp4_decode_4bytes,
+    get_ptr_as_int64,
+    ld_global_acquire_i32,
+    ld_global_nc_u32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
+    scatter_add_bf16x2,
+    shared_ptr_to_u32,
+    spin_wait_global_eq_i32,
+    st_global_f32,
+    st_global_i32,
+    st_global_release_i32,
+    st_shared_f32,
+    st_shared_i32,
+    threadfence,
+)
+from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
+    Sm120B12xBlockScaledDenseGemmKernel as DenseGemmKernel,
+)
+
+
+_SF_VEC_SIZE = 16
+_COMPACT_STATIC_TILE_M = 128
+
+
+@dsl_user_op
+def _ld_global_nc_u8(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.nc.u8 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+class _MoEStaticKernelBase:
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        exact_mma_m_tiles: bool = False,
+        fast_math: bool = False,
+        activation: str = "silu",
+        dynamic_down_scale: bool = False,
+    ):
+        if activation not in {"silu", "relu2"}:
+            raise ValueError(f"unsupported activation {activation!r}")
+        self._dense_cls = DenseGemmKernel
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.exact_mma_m_tiles = exact_mma_m_tiles
+        self.fast_math = fast_math
+        self.activation = activation
+        self.is_gated = activation == "silu"
+        self.dynamic_down_scale = dynamic_down_scale
+        # The FC1 N tile is reused as the FC2 K tile after activation. Keep the
+        # mainloop K tile equal to N so the BF16 intermediate fits the same sA
+        # tile that phase 2 consumes.
+        tile_k = mma_tiler_mn[1]
+        self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        a_tile_m = (
+            mma_tiler_mn[0] if mma_tiler_mn[1] >= 128 else max(128, mma_tiler_mn[0])
+        )
+        self.sa_tile_shape_mk = (a_tile_m, tile_k)
+        self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
+        self.output_tile_count_n = output_tile_count_n
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cluster_shape_mn = (1, 1)
+        self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.occupancy = 1
+        self.num_mma_warps = 4
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.buffer_align_bytes = 1024
+
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.pass_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_cta,
+        )
+        self.fc1_stage_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=self.threads_per_cta,
+        )
+        self.load_register_requirement = 32
+        self.mma_register_requirement = 232
+        self.a_dtype: Any = None
+        self.b_dtype: Any = None
+        self.a_layout: Any = None
+        self.b_layout: Any = None
+        self.c_layout: Any = None
+
+    def _make_a_smem_layout(self, ab_stage: int):
+        a_is_k_major = self.a_layout.is_k_major_a()
+        a_major_mode_size = self.sa_tile_shape_mk[1 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                self.a_layout,
+                self.a_dtype,
+                a_major_mode_size,
+            ),
+            self.a_dtype,
+        )
+        return cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(self.sa_tile_shape_mk, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+    def _make_b_smem_layout(self, b_dtype, b_layout, ab_stage: int):
+        b_smem_shape = cute.slice_(self.tile_shape_mnk, (0, None, None))
+        b_is_k_major = b_layout.is_k_major_b()
+        b_major_mode_size = self.tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        return cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+    def _make_staged_layouts(self, ab_stage: int):
+        a_smem_staged = self._make_a_smem_layout(ab_stage)
+        b_smem_staged = self._make_b_smem_layout(self.b_dtype, self.b_layout, ab_stage)
+        epi_smem_staged = sm90_utils.make_smem_layout_epi(
+            cutlass.BFloat16,
+            self.c_layout,
+            self.epi_tile,
+            self.epi_stage,
+        )
+        return a_smem_staged, b_smem_staged, epi_smem_staged
+
+    def _shared_storage_size_bytes(
+        self,
+        a_smem_staged,
+        b_smem_staged,
+        epi_smem_staged,
+    ) -> int:
+        def _align_up(value: int, align: int) -> int:
+            return ((value + align - 1) // align) * align
+
+        pipeline_count = 3 if self.is_gated else 2
+        offset = (
+            3 * 4
+            + pipeline_count * (self.ab_stage * 2 * 8)
+            + _COMPACT_STATIC_TILE_M * 4
+            + _COMPACT_STATIC_TILE_M * 4
+        )
+        buffers = [
+            cute.size_in_bytes(self.a_dtype, a_smem_staged),
+            cute.size_in_bytes(self.b_dtype, b_smem_staged),
+            cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
+        ]
+        if self.is_gated:
+            buffers.insert(2, cute.size_in_bytes(self.b_dtype, b_smem_staged))
+        offset = _align_up(offset, self.buffer_align_bytes)
+        for idx, size in enumerate(buffers):
+            offset += size
+            if idx + 1 != len(buffers):
+                offset = _align_up(offset, self.buffer_align_bytes)
+        return offset
+
+    def _setup_attributes(self):
+        self.mma_inst_mnk = (16, 8, 16)
+        mma_op = cute.nvgpu.warp.MmaF16BF16Op(
+            self.a_dtype,
+            self.acc_dtype,
+            self.mma_inst_mnk,
+        )
+        atom_layout = cute.make_layout((2, 2, 1))
+        permutation_mnk = (
+            2 * self.mma_inst_mnk[0],
+            2 * self.mma_inst_mnk[1] * 2,
+            self.mma_inst_mnk[2],
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+        self.num_k_blocks = self.tile_shape_mnk[2] // self.mma_inst_mnk[2]
+        epi_stage_max = (self.tile_shape_mnk[1] // self.epi_tile[1]) * (
+            self.tile_shape_mnk[0] // self.epi_tile[0]
+        )
+        self.epi_stage = min(epi_stage_max, 4)
+        # Static W4A16 is latency-bound by inline FP4 decode and TMA staging.
+        # Use two stages when shared memory permits so A-side TMA and phase-2
+        # buffer turnover can overlap the MMA/scatter tail.
+        self.ab_stage = 2
+
+        while True:
+            (
+                self.a_smem_layout_staged,
+                self.b_smem_layout_staged,
+                self.epi_smem_layout_staged,
+            ) = self._make_staged_layouts(self.ab_stage)
+            if (
+                self._shared_storage_size_bytes(
+                    self.a_smem_layout_staged,
+                    self.b_smem_layout_staged,
+                    self.epi_smem_layout_staged,
+                )
+                <= self.smem_capacity
+                or self.ab_stage <= 1
+            ):
+                break
+            self.ab_stage -= 1
+            while self.ab_stage > 1 and 32 % self.ab_stage != 0:
+                self.ab_stage -= 1
+
+
+@cute.jit
+def _compact_static_get_work_tile(
+    row_counts: cute.Tensor,
+    active_expert_count: cute.Tensor,
+    *,
+    tile_m: Int32,
+    num_tiles_n: Int32,
+    cluster_shape_mn: Tuple[Int32, Int32],
+    current_work_linear_idx: Int32,
+    current_local_expert_idx: Int32,
+    accum_tile_m: Int32,
+    cta_id_in_cluster: cute.Coord,
+) -> Tuple[Tuple[Int32, Int32, Int32], Integer, Int32, Int32]:
+    num_active_experts = active_expert_count[Int32(0)]
+    scan_local_expert_idx = current_local_expert_idx
+    tile_m_minus_one = tile_m - Int32(1)
+
+    while scan_local_expert_idx < num_active_experts:
+        batch_rows = row_counts[scan_local_expert_idx]
+        batch_m_tiles = (batch_rows + tile_m_minus_one) // tile_m
+        if (accum_tile_m + batch_m_tiles) * num_tiles_n > current_work_linear_idx:
+            current_local_expert_idx = scan_local_expert_idx
+            scan_local_expert_idx = num_active_experts
+        else:
+            accum_tile_m += batch_m_tiles
+            scan_local_expert_idx += Int32(1)
+            current_local_expert_idx = scan_local_expert_idx
+
+    is_valid = current_local_expert_idx < num_active_experts
+    if is_valid:
+        batch_rows = row_counts[current_local_expert_idx]
+        is_valid = (
+            accum_tile_m + (batch_rows + tile_m_minus_one) // tile_m
+        ) * num_tiles_n > current_work_linear_idx
+
+    cur_cluster_coord = (
+        current_work_linear_idx // num_tiles_n - accum_tile_m,
+        current_work_linear_idx % num_tiles_n,
+        current_local_expert_idx,
+    )
+    cur_tile_coord = (
+        Int32(cur_cluster_coord[0]) * cluster_shape_mn[0] + cta_id_in_cluster[0],
+        Int32(cur_cluster_coord[1]) * cluster_shape_mn[1] + cta_id_in_cluster[1],
+        Int32(cur_cluster_coord[2]),
+    )
+    return cur_tile_coord, is_valid, current_local_expert_idx, accum_tile_m
+
+
+def _compact_unique_get_work_tile(
+    *,
+    num_active_experts: Int32,
+    num_tiles_n: Int32,
+    current_work_linear_idx: Int32,
+    cta_id_in_cluster: cute.Coord,
+) -> Tuple[Tuple[Int32, Int32, Int32], Integer]:
+    local_expert_idx = current_work_linear_idx // num_tiles_n
+    cur_tile_coord = (
+        cta_id_in_cluster[0],
+        current_work_linear_idx % num_tiles_n,
+        local_expert_idx,
+    )
+    return cur_tile_coord, local_expert_idx < num_active_experts
+
+
+class MoEStaticKernel(_MoEStaticKernelBase):
+    """Compact static MoE kernel for small routed working sets."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        output_tile_count_n: int,
+        *,
+        exact_mma_m_tiles: bool = False,
+        fast_math: bool = False,
+        activation: str = "silu",
+        single_token: bool = False,
+        share_input_across_experts: bool = False,
+        share_expert_scales: bool = False,
+        dynamic_down_scale: bool = False,
+    ):
+        super().__init__(
+            sf_vec_size,
+            mma_tiler_mn,
+            output_tile_count_n,
+            exact_mma_m_tiles=exact_mma_m_tiles,
+            fast_math=fast_math,
+            activation=activation,
+            dynamic_down_scale=dynamic_down_scale,
+        )
+        self.single_token = single_token
+        self.share_input_across_experts = share_input_across_experts
+        self.share_expert_scales = share_expert_scales
+
+    @cute.jit
+    def _resident_grid_barrier(
+        self,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        grid_x: Int32,
+        is_cta_leader: Int32,
+    ):
+        cute.arch.sync_threads()
+        threadfence()
+        if is_cta_leader > Int32(0):
+            barrier_count_addr = get_ptr_as_int64(barrier_count, Int32(0))
+            barrier_epoch_addr = get_ptr_as_int64(barrier_epoch, Int32(0))
+            old_epoch = ld_global_acquire_i32(barrier_epoch_addr)
+            arrived = atomic_add_global_i32(barrier_count_addr, Int32(1))
+            if arrived == grid_x - Int32(1):
+                st_global_i32(barrier_count_addr, Int32(0))
+                st_global_release_i32(barrier_epoch_addr, old_epoch + Int32(1))
+            else:
+                spin_wait_global_eq_i32(barrier_epoch_addr, old_epoch)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def __call__(
+        self,
+        a_input: cute.Tensor,  # [num_tokens, K] bf16
+        topk_ids: cute.Tensor,  # [num_tokens * topk] int32
+        topk_weights: cute.Tensor,  # [num_tokens * topk] float32
+        packed_a: cute.Tensor,  # [max_rows, K, E] BF16 routed activation workspace
+        sfa_ptr: cute.Pointer,  # kept for API compatibility; unused for W4A16
+        packed_a_storage: cute.Tensor,  # kept for API compatibility; unused for W4A16
+        scale_storage: cute.Tensor,  # kept for API compatibility; unused for W4A16
+        barrier_count: cute.Tensor,  # [1] int32 (host-zeroed)
+        barrier_epoch: cute.Tensor,  # [1] int32 (host-zeroed)
+        b_w13: cute.Tensor,  # [w1_n, K, E] — gated packs [up, gate], relu2 is single FC1
+        sfb_w13_ptr: cute.Pointer,  # scale factors for FC1 weights
+        b_down: cute.Tensor,  # [K, I_tp, E]
+        sfb_down_ptr: cute.Pointer,
+        row_counts: cute.Tensor,  # [state_E] routed rows per local expert
+        active_expert_count: cute.Tensor,  # [1] active expert count
+        weight_expert_ids: cute.Tensor,  # [E] local expert id -> global weight expert id
+        global_to_local_expert: cute.Tensor,  # [weight_E] global expert id -> local expert id
+        input_global_scale: cute.Tensor,  # kept for API compatibility; unused for W4A16
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        global_scale: cute.Tensor,  # kept for API compatibility; unused for W4A16
+        scatter_output: cute.Tensor,  # [num_tokens, K]
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        self.a_dtype = packed_a.element_type
+        self.b_dtype = cutlass.BFloat16
+        if cutlass.const_expr(self.a_dtype != cutlass.BFloat16):
+            raise TypeError(f"expected BF16 routed A scratch, got {self.a_dtype}")
+        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        # Compact static always scatters into token-major row-major output.
+        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+
+        self._setup_attributes()
+
+        # W4A16 only TMA-loads BF16 routed activations. The packed FP4
+        # weights and E4M3 scales are decoded by the producer warp directly
+        # into BF16 shared-memory B tiles.
+        tma_a, gA = self._dense_cls._make_tma_atoms_and_tensors(
+            packed_a,
+            self.a_smem_layout_staged,
+            self.sa_tile_shape_mk,
+            1,
+        )
+
+        # Compact static schedules over (m_tile, intermediate_slice, local_expert_idx).
+        grid = (*self.cluster_shape_mn, max_active_clusters)
+        self.kernel(
+            a_input,
+            topk_ids,
+            topk_weights,
+            packed_a,
+            barrier_count,
+            barrier_epoch,
+            tma_a,
+            gA,
+            b_w13,
+            sfb_w13_ptr,
+            b_down,
+            sfb_down_ptr,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            row_counts,
+            active_expert_count,
+            weight_expert_ids,
+            global_to_local_expert,
+            alpha,
+            down_alpha,
+            scatter_output,
+            token_map,
+            token_weights,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+
+    @cute.jit
+    def _load_u8_as_u32(self, base_addr: Int64, byte_offset: Int64) -> Uint32:
+        return _ld_global_nc_u8(base_addr + byte_offset)
+
+    @cute.jit
+    def _swizzled_e4m3_offset(
+        self,
+        row: Int32,
+        sf_block: Int32,
+        sf_cols: Int32,
+    ) -> Int64:
+        row_rb = row >> Int32(7)
+        mode_a = (row >> Int32(5)) & Int32(3)
+        mode_32 = row & Int32(31)
+        cb_idx = sf_block >> Int32(2)
+        mode_c = sf_block & Int32(3)
+        return (
+            Int64(row_rb) * Int64(sf_cols * Int32(128))
+            + Int64(cb_idx) * Int64(512)
+            + Int64(mode_32) * Int64(16)
+            + Int64(mode_a) * Int64(4)
+            + Int64(mode_c)
+        )
+
+    @cute.jit
+    def _stage_w13_fp4_b_tile(
+        self,
+        packed_w: cute.Tensor,
+        sfb_ptr: cute.Pointer,
+        sB: cute.Tensor,
+        stage_idx: Int32,
+        expert_idx: Int32,
+        n_tile_idx: Int32,
+        k_tile_idx: Int32,
+        weight_rows: Int32,
+        weight_cols: Int32,
+        sf_cols: Int32,
+        copy_start: Int32,
+        copy_stride: Int32,
+    ):
+        w_base = packed_w.iterator.toint()
+        sf_base = sfb_ptr.toint()
+        packed_cols = weight_cols // Int32(2)
+        tile_n = Int32(self.tile_shape_mnk[1])
+        tile_k = Int32(self.tile_shape_mnk[2])
+        blocks_per_row = tile_k // Int32(self.sf_vec_size)
+        total_blocks = tile_n * blocks_per_row
+        copy_idx = copy_start
+        while copy_idx < total_blocks:
+            local_n = copy_idx // blocks_per_row
+            local_sf_block = copy_idx - local_n * blocks_per_row
+            local_k = local_sf_block * Int32(self.sf_vec_size)
+            global_n = n_tile_idx * tile_n + local_n
+            global_k = k_tile_idx * tile_k + local_k
+            packed_offset = (
+                Int64(expert_idx) * Int64(weight_rows * packed_cols)
+                + Int64(global_n) * Int64(packed_cols)
+                + Int64(global_k // Int32(2))
+            )
+            scale_offset = Int64(expert_idx) * Int64(
+                ((weight_rows + Int32(127)) // Int32(128)) * Int32(128) * sf_cols
+            ) + self._swizzled_e4m3_offset(
+                global_n,
+                global_k // Int32(self.sf_vec_size),
+                sf_cols,
+            )
+            scale_byte = self._load_u8_as_u32(sf_base, scale_offset)
+            scale = cvt_e4m3_to_f32_via_f16(scale_byte)
+            q_word0 = ld_global_nc_u32(w_base + packed_offset)
+            q_word1 = ld_global_nc_u32(w_base + packed_offset + Int64(4))
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word0)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k, stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(1), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(2), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(3), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(4), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(5), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(6), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(7), stage_idx] = cutlass.BFloat16(f1 * scale)
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word1)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k + Int32(8), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(9), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(10), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(11), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(12), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(13), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(14), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(15), stage_idx] = cutlass.BFloat16(f1 * scale)
+            copy_idx += copy_stride
+
+    @cute.jit
+    def _stage_down_fp4_b_tile(
+        self,
+        packed_w: cute.Tensor,
+        sfb_ptr: cute.Pointer,
+        sB: cute.Tensor,
+        stage_idx: Int32,
+        expert_idx: Int32,
+        output_tile_idx: Int32,
+        intermediate_tile_idx: Int32,
+        weight_rows: Int32,
+        weight_cols: Int32,
+        sf_cols: Int32,
+        copy_start: Int32,
+        copy_stride: Int32,
+    ):
+        w_base = packed_w.iterator.toint()
+        sf_base = sfb_ptr.toint()
+        packed_cols = weight_cols // Int32(2)
+        tile_n = Int32(self.tile_shape_mnk[1])
+        tile_k = Int32(self.tile_shape_mnk[2])
+        blocks_per_row = tile_k // Int32(self.sf_vec_size)
+        total_blocks = tile_n * blocks_per_row
+        copy_idx = copy_start
+        while copy_idx < total_blocks:
+            local_n = copy_idx // blocks_per_row
+            local_sf_block = copy_idx - local_n * blocks_per_row
+            local_k = local_sf_block * Int32(self.sf_vec_size)
+            global_n = output_tile_idx * tile_n + local_n
+            global_k = intermediate_tile_idx * tile_k + local_k
+            packed_offset = (
+                Int64(expert_idx) * Int64(weight_rows * packed_cols)
+                + Int64(global_n) * Int64(packed_cols)
+                + Int64(global_k // Int32(2))
+            )
+            scale_offset = Int64(expert_idx) * Int64(
+                ((weight_rows + Int32(127)) // Int32(128)) * Int32(128) * sf_cols
+            ) + self._swizzled_e4m3_offset(
+                global_n,
+                global_k // Int32(self.sf_vec_size),
+                sf_cols,
+            )
+            scale_byte = self._load_u8_as_u32(sf_base, scale_offset)
+            scale = cvt_e4m3_to_f32_via_f16(scale_byte)
+            q_word0 = ld_global_nc_u32(w_base + packed_offset)
+            q_word1 = ld_global_nc_u32(w_base + packed_offset + Int64(4))
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word0)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k, stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(1), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(2), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(3), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(4), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(5), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(6), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(7), stage_idx] = cutlass.BFloat16(f1 * scale)
+            d0, d1, d2, d3 = fp4_decode_4bytes(q_word1)
+            f0, f1 = f16x2_to_f32x2(d0)
+            sB[local_n, local_k + Int32(8), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(9), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d1)
+            sB[local_n, local_k + Int32(10), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(11), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d2)
+            sB[local_n, local_k + Int32(12), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(13), stage_idx] = cutlass.BFloat16(f1 * scale)
+            f0, f1 = f16x2_to_f32x2(d3)
+            sB[local_n, local_k + Int32(14), stage_idx] = cutlass.BFloat16(f0 * scale)
+            sB[local_n, local_k + Int32(15), stage_idx] = cutlass.BFloat16(f1 * scale)
+            copy_idx += copy_stride
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        routed_a: cute.Tensor,
+        barrier_count: cute.Tensor,
+        barrier_epoch: cute.Tensor,
+        tma_a: cute.CopyAtom,
+        mA: cute.Tensor,
+        b_w13: cute.Tensor,
+        sfb_w13_ptr: cute.Pointer,
+        b_down: cute.Tensor,
+        sfb_down_ptr: cute.Pointer,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_staged: cute.ComposedLayout,
+        b_smem_staged: cute.ComposedLayout,
+        epi_smem_staged: cute.ComposedLayout,
+        row_counts: cute.Tensor,
+        active_expert_count: cute.Tensor,
+        weight_expert_ids: cute.Tensor,
+        global_to_local_expert: cute.Tensor,
+        alpha: cute.Tensor,
+        down_alpha: cute.Tensor,
+        scatter_output: cute.Tensor,
+        token_map: cute.Tensor,
+        token_weights: cute.Tensor,
+    ):
+        """Kernel entry point."""
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        _, _, gdim_z = cute.arch.grid_dim()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        is_cta_leader = Int32(1) if Int32(tidx) == Int32(0) else Int32(0)
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_a)
+
+        cta_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cluster_coord = cta_layout_mnk.get_flat_coord(cta_rank)
+
+        a_smem_one = cute.slice_(a_smem_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(self.a_dtype, a_smem_one)
+
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class StorageGated:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB_up: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        @cute.struct
+        class StorageRelu2:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            scatter_tok_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M
+            ]
+            scatter_weight_cache: cute.struct.MemRange[
+                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        storage = smem.allocate(StorageGated if self.is_gated else StorageRelu2)
+
+        prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        cons_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        ml_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=prod_group,
+            consumer_group=cons_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.pipeline_array.data_ptr(),
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+        up_pipeline = (
+            pipeline.PipelineTmaAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=prod_group,
+                consumer_group=cons_group,
+                tx_count=tma_copy_bytes,
+                barrier_storage=storage.up_pipeline_array.data_ptr(),
+                cta_layout_vmnk=cta_layout_vmnk,
+            )
+            if self.is_gated
+            else ml_pipeline
+        )
+        phase2_prod_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_threads_per_warp,
+        )
+        phase2_cons_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_mma_warps * self.num_threads_per_warp,
+        )
+        _phase2_pipeline = pipeline.PipelineAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=phase2_prod_group,
+            consumer_group=phase2_cons_group,
+            barrier_storage=storage.phase2_pipeline_array.data_ptr(),
+        )
+
+        cute.arch.sync_threads()
+
+        sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+        sB_up = (
+            storage.sB_up.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
+            if self.is_gated
+            else sB
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_staged.outer,
+            swizzle=epi_smem_staged.inner,
+        )
+        ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
+        scatter_tok_base_addr = shared_ptr_to_u32(storage.scatter_tok_cache.data_ptr())
+        scatter_weight_base_addr = shared_ptr_to_u32(
+            storage.scatter_weight_cache.data_ptr()
+        )
+
+        num_tokens = Int32(a_input.shape[0])
+        cols = Int32(a_input.shape[1])
+        num_experts = Int32(row_counts.shape[0])
+        max_rows = Int32(token_map.shape[1])
+        total_pairs = Int32(topk_ids.shape[0])
+        num_topk = total_pairs // num_tokens
+        num_global_experts = Int32(global_to_local_expert.shape[0])
+        flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
+        flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
+
+        # Phase 0: cooperative init — zero row_counts and scatter_output
+        if cutlass.const_expr(not self.single_token):
+            i = flat_tid
+            while i < num_experts:
+                row_counts[i] = Int32(0)
+                i += flat_stride
+            i = flat_tid
+            while i < num_global_experts:
+                global_to_local_expert[i] = Int32(-1)
+                i += flat_stride
+            if flat_tid == Int32(0):
+                active_expert_count[Int32(0)] = Int32(0)
+        if cutlass.const_expr(self.single_token):
+            num_active_experts = total_pairs
+        else:
+            num_active_experts = active_expert_count[Int32(0)]
+        scatter_total = num_tokens * cols
+        j = flat_tid
+        while j < scatter_total:
+            scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
+            j += flat_stride
+        cute.arch.sync_threads()
+        if cutlass.const_expr(not self.share_input_across_experts):
+            self._resident_grid_barrier(
+                barrier_count,
+                barrier_epoch,
+                Int32(gdim_z),
+                is_cta_leader,
+            )
+
+        pair_idx = Int32(bidz)
+        while pair_idx < total_pairs:
+            token_idx = Int32(0)
+            weight = cutlass.Float32(0.0)
+            if cutlass.const_expr(not self.single_token):
+                expert_id = topk_ids[pair_idx].to(Int32)
+                token_idx = pair_idx // num_topk
+                weight = topk_weights[pair_idx].to(cutlass.Float32)
+
+            local_expert_id = Int32(0)
+            row = Int32(0)
+            if cutlass.const_expr(self.single_token):
+                local_expert_id = pair_idx
+                expert_id = topk_ids[local_expert_id].to(Int32)
+            else:
+                if is_cta_leader > Int32(0):
+                    prior_local_expert_id = atomic_cas_global_i32(
+                        get_ptr_as_int64(global_to_local_expert, expert_id),
+                        Int32(-1),
+                        Int32(-2),
+                    )
+                    if prior_local_expert_id == Int32(-1):
+                        local_expert_id = atomic_add_global_i32(
+                            get_ptr_as_int64(active_expert_count, Int32(0)),
+                            Int32(1),
+                        )
+                        weight_expert_ids[local_expert_id] = expert_id
+                        st_global_release_i32(
+                            get_ptr_as_int64(global_to_local_expert, expert_id),
+                            local_expert_id,
+                        )
+                    else:
+                        if prior_local_expert_id == Int32(-2):
+                            spin_wait_global_eq_i32(
+                                get_ptr_as_int64(global_to_local_expert, expert_id),
+                                Int32(-2),
+                            )
+                            prior_local_expert_id = ld_global_acquire_i32(
+                                get_ptr_as_int64(global_to_local_expert, expert_id),
+                            )
+                        local_expert_id = prior_local_expert_id
+                    row = atomic_add_global_i32(
+                        get_ptr_as_int64(row_counts, local_expert_id),
+                        Int32(1),
+                    )
+                    map_idx = local_expert_id * max_rows + row
+                    st_global_i32(get_ptr_as_int64(token_map, map_idx), token_idx)
+                    st_global_f32(get_ptr_as_int64(token_weights, map_idx), weight)
+                    st_shared_i32(ctrl_base_addr + Int32(0), local_expert_id)
+                    st_shared_i32(ctrl_base_addr + Int32(4), row)
+                cute.arch.sync_threads()
+                local_expert_id = ld_shared_i32_relaxed(ctrl_base_addr + Int32(0))
+                row = ld_shared_i32_relaxed(ctrl_base_addr + Int32(4))
+
+            should_store = Int32(1)
+            packed_local_expert_id = local_expert_id
+            packed_row = row
+            if cutlass.const_expr(self.share_input_across_experts):
+                should_store = Int32(1) if pair_idx == Int32(0) else Int32(0)
+                packed_local_expert_id = Int32(0)
+                packed_row = Int32(0)
+
+            # W4A16 keeps activations in BF16. Scatter routed rows directly
+            # into the A workspace and leave input_global_scale unused.
+            if should_store > Int32(0):
+                col_idx = Int32(tidx)
+                while col_idx < cols:
+                    routed_a[packed_row, col_idx, packed_local_expert_id] = a_input[
+                        token_idx, col_idx
+                    ]
+                    col_idx += Int32(self.threads_per_cta)
+
+            if cutlass.const_expr(not self.single_token):
+                cute.arch.sync_threads()
+            pair_idx += Int32(gdim_z)
+
+        self._resident_grid_barrier(
+            barrier_count,
+            barrier_epoch,
+            Int32(gdim_z),
+            is_cta_leader,
+        )
+
+        gA = cute.local_tile(mA, self.sa_tile_shape_mk, (None, None, None))
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord[1]
+
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+
+        # MMA fragment partitions
+        tCsA_full = thr_mma.partition_A(sA)
+        tCrA_full = tiled_mma.make_fragment_A(tCsA_full[None, None, None, 0])
+        tCsB = thr_mma.partition_B(sB)
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCsB_up = thr_mma.partition_B(sB_up)
+        tCrB_up = tiled_mma.make_fragment_B(tCsB_up[None, None, None, 0])
+
+        tCsC_for_shape = thr_mma.partition_C(sC[None, None, 0])
+        epi_m_scale = self.tile_shape_mnk[0] // self.epi_tile[0]
+        sub_shape = tCsC_for_shape.shape[:3]
+        acc_shape = (sub_shape[0], sub_shape[1] * epi_m_scale, sub_shape[2])
+        gate_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+        up_acc = (
+            cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+            if self.is_gated
+            else gate_acc
+        )
+
+        k_tile_cnt = cute.size(gA, mode=[3])
+        fc1_k_tile_cnt = k_tile_cnt
+        w13_rows = Int32(b_w13.shape[0])
+        # Runtime W4A16 weight tensors are uint8 packed views, so shape[1] is
+        # K/2. Manual FP4 byte addressing needs the logical FP4 column count.
+        w13_cols = cols
+        w13_sf_cols = (
+            ((w13_cols // Int32(self.sf_vec_size)) + Int32(3)) // Int32(4) * Int32(4)
+        )
+        down_rows = Int32(b_down.shape[0])
+        down_cols = w13_rows // Int32(2) if self.is_gated else w13_rows
+        down_sf_cols = (
+            ((down_cols // Int32(self.sf_vec_size)) + Int32(3)) // Int32(4) * Int32(4)
+        )
+        tile_n = Int32(self.tile_shape_mnk[1])
+        intermediate_tile_cnt = (w13_rows + tile_n - Int32(1)) // tile_n
+        gate_tile_cnt = (
+            intermediate_tile_cnt // Int32(2)
+            if self.is_gated
+            else intermediate_tile_cnt
+        )
+        output_tile_cnt = (down_rows + tile_n - Int32(1)) // tile_n
+
+        prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        up_prod_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.ab_stage
+            )
+            if self.is_gated
+            else prod_state
+        )
+        up_cons_state = (
+            pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            if self.is_gated
+            else cons_state
+        )
+        _phase2_prod_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        _phase2_cons_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        # ===================================================================
+        # MMA WARP GROUP (warps 0-3)
+        # ===================================================================
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+            num_k_blocks = cute.size(tCrA_full, mode=[2])
+
+            atom_ld_A = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                self.a_dtype,
+            )
+            atom_ld_B = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                self.b_dtype,
+            )
+            smem_copy_A = cute.make_tiled_copy_A(atom_ld_A, tiled_mma)
+            smem_copy_B = cute.make_tiled_copy_B(atom_ld_B, tiled_mma)
+
+            thr_ld_A = smem_copy_A.get_slice(tidx)
+            thr_ld_B = smem_copy_B.get_slice(tidx)
+            csA_full = thr_ld_A.partition_S(sA)
+            crA_full = thr_ld_A.retile(tCrA_full)
+            csB = thr_ld_B.partition_S(sB)
+            csB_up = thr_ld_B.partition_S(sB_up)
+            crB = thr_ld_B.retile(tCrB)
+            crB_up = thr_ld_B.retile(tCrB_up)
+
+            num_persistent_clusters = Int32(gdim_z)
+            cluster_shape_mn = (
+                Int32(self.cluster_shape_mn[0]),
+                Int32(self.cluster_shape_mn[1]),
+            )
+            cta_id_in_cluster = (
+                Int32(bidx % cluster_shape_mn[0]),
+                Int32(bidy % cluster_shape_mn[1]),
+                Int32(0),
+            )
+            current_work_linear_idx = Int32(bidz)
+            current_local_expert_idx = Int32(0)
+            accum_tile_m = Int32(0)
+            tile_coord = (Int32(0), Int32(0), Int32(0))
+            is_valid_tile = Int32(0) < Int32(0)
+            if cutlass.const_expr(self.single_token):
+                tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                    num_active_experts=num_active_experts,
+                    num_tiles_n=Int32(self.output_tile_count_n),
+                    current_work_linear_idx=current_work_linear_idx,
+                    cta_id_in_cluster=cta_id_in_cluster,
+                )
+            else:
+                tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
+                    _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                )
+
+            while is_valid_tile:
+                # tile_coord = (m_tile, intermediate_slice, local_expert_idx)
+                local_expert_idx = tile_coord[2]
+                if cutlass.const_expr(self.single_token):
+                    weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
+                    valid_rows = Int32(1)
+                else:
+                    weight_expert_idx = weight_expert_ids[local_expert_idx]
+                    valid_rows = row_counts[local_expert_idx]
+                alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
+                tile_m_base = tile_coord[0] * Int32(self.tile_shape_mnk[0])
+                intermediate_slice = tile_coord[1]
+                sa_tile_offset = tile_coord[0] % self.sa_tiles_per_block
+                sa_row_base = sa_tile_offset * Int32(self.tile_shape_mnk[0])
+                if cutlass.const_expr(self.sa_tiles_per_block > 1):
+                    sA_tile = cute.local_tile(
+                        sA,
+                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                        (sa_tile_offset, 0, None),
+                    )
+                    csA_tile = thr_ld_A.partition_S(sA_tile)
+                    tCsA_tile = thr_mma.partition_A(sA_tile)
+                    tCrA_tile = tiled_mma.make_fragment_A(
+                        tCsA_tile[None, None, None, 0]
+                    )
+                    crA_tile = thr_ld_A.retile(tCrA_tile)
+                else:
+                    csA_tile = csA_full
+                    tCrA_tile = tCrA_full
+                    crA_tile = crA_full
+                valid_tile_rows = valid_rows - tile_m_base
+                if valid_tile_rows > Int32(self.tile_shape_mnk[0]):
+                    valid_tile_rows = Int32(self.tile_shape_mnk[0])
+                if valid_tile_rows < Int32(0):
+                    valid_tile_rows = Int32(0)
+
+                cache_row = Int32(tidx)
+                if cutlass.const_expr(not self.single_token):
+                    if cache_row < Int32(_COMPACT_STATIC_TILE_M):
+                        tok = Int32(0)
+                        wv = cutlass.Float32(0.0)
+                        if cache_row < valid_tile_rows:
+                            tok = token_map[
+                                local_expert_idx, tile_m_base + cache_row
+                            ].to(Int32)
+                            wv = token_weights[
+                                local_expert_idx, tile_m_base + cache_row
+                            ].to(cutlass.Float32)
+                        st_shared_i32(scatter_tok_base_addr + cache_row * Int32(4), tok)
+                        st_shared_f32(
+                            scatter_weight_base_addr + cache_row * Int32(4), wv
+                        )
+                self.epilog_sync_barrier.arrive_and_wait()
+
+                _is_m_major = self.c_layout.is_m_major_c()
+                # This kernel scatters by scalar-reading sC after the warpgroup
+                # store. The BF16 dense fused path can use the TMA-store epilogue
+                # atom because it forwards sC directly to TMA; direct scatter
+                # must match the existing static scatter layout.
+                copy_atom_r2s = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    cutlass.BFloat16,
+                )
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                    cutlass.BFloat16,
+                )
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s, tiled_copy_C_Atom
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                tRS_rGate = tiled_copy_r2s.retile(gate_acc)
+                tRS_rUp = tiled_copy_r2s.retile(up_acc)
+
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+                tRS_rD_out = cute.make_rmem_tensor(
+                    tRS_rD_layout.shape, cutlass.BFloat16
+                )
+
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rGate, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rGate, mode=[2])
+                epi_buffer = Int32(0)
+
+                down_alpha_value = down_alpha[weight_expert_idx].to(cutlass.Float32)
+                down_acc = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+                unique_tok = Int32(0)
+                unique_wv = cutlass.Float32(0.0)
+                if cutlass.const_expr(self.single_token):
+                    unique_tok = local_expert_idx // num_topk
+                    unique_wv = topk_weights[local_expert_idx].to(cutlass.Float32)
+
+                epi_rest_m = self.tile_shape_mnk[0] // self.epi_tile[0]
+                MmaMPerEpiM = self.epi_tile[0] // mma_tile_m
+                MmaNPerEpiN = self.epi_tile[1] // mma_tile_n
+
+                # ============================================================
+                # PHASE A: FC1 for this slice
+                # Gated SwiGLU runs gate then up. relu2 uses only the first pass.
+                # ============================================================
+
+                # Gate GEMM (BF16 A x materialized BF16 B)
+                gate_acc.fill(0.0)
+                cons_state.reset_count()
+                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    peek = ml_pipeline.consumer_try_wait(cons_state)
+                    ml_pipeline.consumer_wait(cons_state, peek)
+                    self._stage_w13_fp4_b_tile(
+                        b_w13,
+                        sfb_w13_ptr,
+                        sB,
+                        cons_state.index,
+                        weight_expert_idx,
+                        intermediate_slice + gate_tile_cnt
+                        if self.is_gated
+                        else intermediate_slice,
+                        k_tile,
+                        w13_rows,
+                        w13_cols,
+                        w13_sf_cols,
+                        Int32(tidx),
+                        Int32(self.num_mma_warps * self.num_threads_per_warp),
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+                    csA_p = csA_tile[None, None, None, cons_state.index]
+                    csB_p = csB[None, None, None, cons_state.index]
+                    cute.copy(
+                        smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0]
+                    )
+                    cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            gate_acc,
+                            tCrA_tile[None, None, k_block_idx],
+                            tCrB[None, None, k_block_idx],
+                            gate_acc,
+                        )
+                        if k_next > 0:
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, k_next],
+                                crA_tile[None, None, k_next],
+                            )
+                            cute.copy(
+                                smem_copy_B,
+                                csB_p[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+                    ml_pipeline.consumer_release(cons_state)
+                    cons_state.advance()
+                # Drain the FC1 gate/only pass before the DMA warp reuses the
+                # gate staging buffers, either for the up pass or FC2 prefetch.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                if cutlass.const_expr(self.is_gated):
+                    up_acc.fill(0.0)
+                    up_cons_state.reset_count()
+                    for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                        peek = up_pipeline.consumer_try_wait(up_cons_state)
+                        up_pipeline.consumer_wait(up_cons_state, peek)
+                        self._stage_w13_fp4_b_tile(
+                            b_w13,
+                            sfb_w13_ptr,
+                            sB_up,
+                            up_cons_state.index,
+                            weight_expert_idx,
+                            intermediate_slice,
+                            k_tile,
+                            w13_rows,
+                            w13_cols,
+                            w13_sf_cols,
+                            Int32(tidx),
+                            Int32(self.num_mma_warps * self.num_threads_per_warp),
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        csA_p = csA_tile[None, None, None, up_cons_state.index]
+                        csB_p = csB_up[None, None, None, up_cons_state.index]
+                        cute.copy(
+                            smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0]
+                        )
+                        cute.copy(
+                            smem_copy_B, csB_p[None, None, 0], crB_up[None, None, 0]
+                        )
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
+                            )
+                            cute.gemm(
+                                tiled_mma,
+                                up_acc,
+                                tCrA_tile[None, None, k_block_idx],
+                                tCrB_up[None, None, k_block_idx],
+                                up_acc,
+                            )
+                            if k_next > 0:
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA_tile[None, None, k_next],
+                                )
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_p[None, None, k_next],
+                                    crB_up[None, None, k_next],
+                                )
+                        up_pipeline.consumer_release(up_cons_state)
+                        up_cons_state.advance()
+
+                # Activation + BF16 materialization into sA for FC2.
+                for epi_m in cutlass.range_constexpr(epi_rest_m):
+                    epi_m_valid = (
+                        valid_rows
+                        - tile_m_base
+                        - Int32(epi_m) * Int32(self.epi_tile[0])
+                    )
+                    epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                    if epi_m_valid > Int32(0):
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                mma_n = mma_n_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                if cutlass.const_expr(self.is_gated):
+                                    up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        g = alpha_value * gate_slice[elem_idx]
+                                        u = alpha_value * up_slice[elem_idx]
+                                        sigmoid_g = cute.arch.rcp_approx(
+                                            cutlass.Float32(1.0)
+                                            + cute.math.exp(
+                                                -g, fastmath=self.fast_math
+                                            ),
+                                        )
+                                        tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                else:
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        g = alpha_value * gate_slice[elem_idx]
+                                        relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                        tRS_rD_slice[elem_idx] = relu_g * relu_g
+
+                        acc_vec = tRS_rD.load()
+                        acc_vec = acc_vec.to(cutlass.BFloat16)
+                        tRS_rD_out.store(acc_vec)
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, epi_buffer)],
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                    epi_rows = epi_m_valid
+                    if epi_rows > Int32(self.epi_tile[0]):
+                        epi_rows = Int32(self.epi_tile[0])
+                    if epi_rows < Int32(0):
+                        epi_rows = Int32(0)
+                    copy_idx = Int32(tidx)
+                    copy_cols = Int32(self.tile_shape_mnk[1])
+                    while copy_idx < epi_rows * copy_cols:
+                        local_row = copy_idx // copy_cols
+                        col = copy_idx - local_row * copy_cols
+                        sA[sa_row_base + rows_offset + local_row, col, 0] = sC[
+                            local_row, col, epi_buffer
+                        ]
+                        copy_idx += Int32(
+                            self.num_mma_warps * self.num_threads_per_warp
+                        )
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                # All MMA warps must finish writing the BF16 intermediate
+                # before phase2 hoists sA into registers.
+                self.epilog_sync_barrier.arrive_and_wait()
+
+                # ============================================================
+                # PHASE B: Sweep ALL FC2 output tiles using cached sA
+                # All CTA warps stage each B_down tile cooperatively. The DMA
+                # warp is idle during FC2, so let it contribute decode lanes
+                # and hold it at an all-thread barrier until sB is reusable.
+                # ============================================================
+                scatter_N = Int32(scatter_output.shape[1])
+
+                csA_phase2 = csA_tile[None, None, None, 0]
+
+                # Hoist A-side register loads: sA is constant across all
+                # FC2 output tiles (activated BF16 intermediate). Load crA
+                # for all k-blocks once, reuse for all output tiles.
+                cute.copy(
+                    smem_copy_A, csA_phase2[None, None, 0], crA_tile[None, None, 0]
+                )
+                for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
+                    k_pre = _kb_pre + 1
+                    cute.copy(
+                        smem_copy_A,
+                        csA_phase2[None, None, k_pre],
+                        crA_tile[None, None, k_pre],
+                    )
+
+                for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    self._stage_down_fp4_b_tile(
+                        b_down,
+                        sfb_down_ptr,
+                        sB,
+                        Int32(0),
+                        weight_expert_idx,
+                        output_tile_idx,
+                        intermediate_slice,
+                        down_rows,
+                        down_cols,
+                        down_sf_cols,
+                        Int32(tidx),
+                        Int32(self.threads_per_cta),
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.fc1_stage_sync_barrier.arrive_and_wait()
+                    csB_phase2 = csB[None, None, None, 0]
+
+                    # Only load B-side (B_down changes per output tile; A is hoisted)
+                    cute.copy(
+                        smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
+                    )
+
+                    down_acc.fill(0.0)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            down_acc,
+                            tCrA_tile[None, None, k_block_idx],
+                            tCrB[None, None, k_block_idx],
+                            down_acc,
+                        )
+                        if k_next > 0:
+                            # Only B-side for next k-block (A already in registers)
+                            cute.copy(
+                                smem_copy_B,
+                                csB_phase2[None, None, k_next],
+                                crB[None, None, k_next],
+                            )
+
+                    # Scatter using precomputed metadata (no redundant gmem loads)
+                    tile_n_base_cur = output_tile_idx * Int32(self.tile_shape_mnk[1])
+                    for epi_m in cutlass.range_constexpr(epi_rest_m):
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_n = mma_n_in_epi
+                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                down_epi_acc_slice = down_acc[(None, mma_m, mma_n)]
+                                for elem_idx in cutlass.range_constexpr(
+                                    cute.size(tRS_rD_slice)
+                                ):
+                                    tRS_rD_slice[elem_idx] = (
+                                        down_alpha_value * down_epi_acc_slice[elem_idx]
+                                    )
+
+                        acc_vec = tRS_rD.load()
+                        acc_vec = acc_vec.to(cutlass.BFloat16)
+                        tRS_rD_out.store(acc_vec)
+                        epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, epi_buffer)],
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        # StMatrix ownership is interleaved across MMA warps for
+                        # both 128x128 and underfilled tiles, so the scatter path
+                        # must wait for every warp's store before reading sC.
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                        epi_rows = valid_rows - tile_m_base - rows_offset
+                        if epi_rows > Int32(self.epi_tile[0]):
+                            epi_rows = Int32(self.epi_tile[0])
+                        if epi_rows < Int32(0):
+                            epi_rows = Int32(0)
+
+                        tile_pair_cols = Int32(self.tile_shape_mnk[1]) // Int32(2)
+                        pair_idx = Int32(tidx)
+                        while pair_idx < epi_rows * tile_pair_cols:
+                            local_row = pair_idx // tile_pair_cols
+                            local_pair_col = pair_idx - local_row * tile_pair_cols
+                            global_col = tile_n_base_cur + local_pair_col * Int32(2)
+                            cached_row = rows_offset + local_row
+                            tok = Int32(0)
+                            wv = cutlass.Float32(0.0)
+                            if cutlass.const_expr(self.single_token):
+                                tok = unique_tok
+                                wv = unique_wv
+                            else:
+                                tok = ld_shared_i32_relaxed(
+                                    scatter_tok_base_addr + cached_row * Int32(4)
+                                )
+                                wv = ld_shared_f32(
+                                    scatter_weight_base_addr + cached_row * Int32(4)
+                                )
+                            sc_v0 = cutlass.Float32(
+                                sC[local_row, local_pair_col * Int32(2), epi_buffer]
+                            )
+                            sc_v1 = cutlass.Float32(
+                                sC[
+                                    local_row,
+                                    local_pair_col * Int32(2) + Int32(1),
+                                    epi_buffer,
+                                ]
+                            )
+                            scatter_add_bf16x2(
+                                get_ptr_as_int64(
+                                    scatter_output, tok * scatter_N + global_col
+                                ),
+                                wv * sc_v0,
+                                wv * sc_v1,
+                            )
+                            pair_idx += Int32(
+                                self.num_mma_warps * self.num_threads_per_warp
+                            )
+
+                        # Post-scatter barrier: needed to ensure all warps
+                        # finish scatter before next output tile's pipeline ops
+                        # (pipeline consumer is collective across all MMA warps).
+                        self.epilog_sync_barrier.arrive_and_wait()
+                    self.fc1_stage_sync_barrier.arrive_and_wait()
+
+                # Final pass_sync: protect sA from next task's FC1 loads.
+                # DMA warp waits here too after finishing all B_down loads.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                current_work_linear_idx += num_persistent_clusters
+                if cutlass.const_expr(self.single_token):
+                    tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                        num_active_experts=num_active_experts,
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        current_work_linear_idx=current_work_linear_idx,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                else:
+                    (
+                        tile_coord,
+                        is_valid_tile,
+                        current_local_expert_idx,
+                        accum_tile_m,
+                    ) = _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+
+        # ===================================================================
+        # DMA WARP (warp 4)
+        # ===================================================================
+        elif warp_idx == self.tma_load_warp_id:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            num_persistent_clusters = Int32(gdim_z)
+            cluster_shape_mn = (
+                Int32(self.cluster_shape_mn[0]),
+                Int32(self.cluster_shape_mn[1]),
+            )
+            cta_id_in_cluster = (
+                Int32(bidx % cluster_shape_mn[0]),
+                Int32(bidy % cluster_shape_mn[1]),
+                Int32(0),
+            )
+            current_work_linear_idx = Int32(bidz)
+            current_local_expert_idx = Int32(0)
+            accum_tile_m = Int32(0)
+            tile_coord = (Int32(0), Int32(0), Int32(0))
+            is_valid_tile = Int32(0) < Int32(0)
+            if cutlass.const_expr(self.single_token):
+                tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                    num_active_experts=num_active_experts,
+                    num_tiles_n=Int32(self.output_tile_count_n),
+                    current_work_linear_idx=current_work_linear_idx,
+                    cta_id_in_cluster=cta_id_in_cluster,
+                )
+            else:
+                tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
+                    _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                )
+
+            while is_valid_tile:
+                tc = tile_coord
+                intermediate_slice = tc[1]
+                local_expert_idx = tc[2]
+                if cutlass.const_expr(self.single_token):
+                    weight_expert_idx = topk_ids[local_expert_idx].to(Int32)
+                else:
+                    weight_expert_idx = weight_expert_ids[local_expert_idx]
+                input_local_expert_idx = (
+                    Int32(0)
+                    if cutlass.const_expr(self.share_input_across_experts)
+                    else local_expert_idx
+                )
+
+                sa_tile_coord_m = tc[0] // self.sa_tiles_per_block
+                tAgA_mk = tAgA[(None, sa_tile_coord_m, None, input_local_expert_idx)]
+
+                # ---- FC1 gate pass: producer only supplies BF16 A via TMA ----
+                prod_state.reset_count()
+                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    ml_pipeline.producer_acquire(prod_state)
+                    cute.copy(
+                        tma_a,
+                        tAgA_mk[(None, k_tile)],
+                        tAsA[(None, prod_state.index)],
+                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                    )
+                    ml_pipeline.producer_commit(prod_state)
+                    prod_state.advance()
+
+                # Wait for the MMA warps to finish the FC1 gate/only pass
+                # before reusing the gate staging buffers.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                if cutlass.const_expr(self.is_gated):
+                    # ---- FC1 up pass: producer only supplies BF16 A via TMA ----
+                    up_prod_state.reset_count()
+                    for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                        up_pipeline.producer_acquire(up_prod_state)
+                        cute.copy(
+                            tma_a,
+                            tAgA_mk[(None, k_tile)],
+                            tAsA[(None, up_prod_state.index)],
+                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                        )
+                        up_pipeline.producer_commit(up_prod_state)
+                        up_prod_state.advance()
+
+                # ---- FC2 B_down pass: join the MMA warps for decode staging ----
+                for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
+                    self._stage_down_fp4_b_tile(
+                        b_down,
+                        sfb_down_ptr,
+                        sB,
+                        Int32(0),
+                        weight_expert_idx,
+                        output_tile_idx,
+                        intermediate_slice,
+                        down_rows,
+                        down_cols,
+                        down_sf_cols,
+                        Int32(tidx),
+                        Int32(self.threads_per_cta),
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.fc1_stage_sync_barrier.arrive_and_wait()
+                    self.fc1_stage_sync_barrier.arrive_and_wait()
+
+                # Final pass_sync: match MMA warps' barrier after FC2 sweep.
+                # Ensures MMA warps finish scatter before DMA starts next task's FC1.
+                self.pass_sync_barrier.arrive_and_wait()
+
+                current_work_linear_idx += num_persistent_clusters
+                if cutlass.const_expr(self.single_token):
+                    tile_coord, is_valid_tile = _compact_unique_get_work_tile(
+                        num_active_experts=num_active_experts,
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        current_work_linear_idx=current_work_linear_idx,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+                else:
+                    (
+                        tile_coord,
+                        is_valid_tile,
+                        current_local_expert_idx,
+                        accum_tile_m,
+                    ) = _compact_static_get_work_tile(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32(self.output_tile_count_n),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=current_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
+                    )
+
+            ml_pipeline.producer_tail(prod_state)
+            if cutlass.const_expr(self.is_gated):
+                up_pipeline.producer_tail(up_prod_state)
+        return
+
+
+__all__ = ["MoEStaticKernel"]

--- a/flashinfer/trace/templates/moe.py
+++ b/flashinfer/trace/templates/moe.py
@@ -17,6 +17,7 @@
 import torch
 
 from ..template import Const, Scalar, Tensor, TraceTemplate, Var
+from .quantize import _fp4_quantize_reference
 
 # ---------------------------------------------------------------------------
 # Shared GEMM computation helper
@@ -2269,7 +2270,17 @@ b12x_fused_moe_trace = TraceTemplate(
         "fc2_input_scale": Tensor(
             ["one"],
             dtype="float32",
-            description="Global scale for FC2 input quantization.",
+            optional=True,
+            description=(
+                "Global scale for FC2 input quantization. Required for "
+                "activation_precision='fp4'; accepted but ignored for "
+                "activation_precision='bf16'."
+            ),
+        ),
+        "activation_precision": Scalar(
+            "string",
+            optional=True,
+            description="Intermediate activation precision: 'fp4' or 'bf16'.",
         ),
     },
     outputs={
@@ -2284,6 +2295,7 @@ b12x_fused_moe_trace = TraceTemplate(
 b12x_fused_moe_trace.axes["one"] = Var(description="Placeholder for shape [1].")
 
 _b12x_wrapper_inputs = dict(b12x_fused_moe_trace.inputs)
+_b12x_wrapper_inputs.pop("activation_precision", None)
 _b12x_wrapper_inputs["num_experts"] = Scalar(
     "int32",
     optional=True,
@@ -2339,6 +2351,84 @@ def _cute_dsl_fused_moe_nvfp4_reference(
 
 
 @torch.no_grad()
+def _b12x_activation_precision(activation_precision):
+    normalized = str(activation_precision).lower()
+    aliases = {
+        "fp4": "fp4",
+        "nvfp4": "fp4",
+        "w4a4": "fp4",
+        "bf16": "bf16",
+        "w4a16": "bf16",
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        raise ValueError(
+            "activation_precision must be 'fp4' or 'bf16' "
+            f"(got {activation_precision!r})."
+        ) from exc
+
+
+@torch.no_grad()
+def _b12x_moe_run_experts(
+    hidden_states,
+    gemm1_weights,
+    gemm2_weights,
+    weights,
+    topk_idx,
+    local_expert_offset,
+    E_global,
+    activation_precision,
+    fc2_input_scale,
+):
+    """B12x MoE expert computation with optional FP4 activation quantization."""
+    activation_precision = _b12x_activation_precision(activation_precision)
+    if activation_precision == "fp4" and fc2_input_scale is None:
+        raise ValueError("fc2_input_scale is required when activation_precision='fp4'.")
+
+    T, H = hidden_states.shape
+    E_local, gemm1_out, _ = gemm1_weights.shape
+    I = gemm1_out // 2
+    device = hidden_states.device
+    A = hidden_states.to(torch.float32)
+    W1 = gemm1_weights.to(torch.float32)
+    W2 = gemm2_weights.to(torch.float32)
+    output = torch.zeros((T, H), dtype=torch.float32, device=device)
+    local_start = int(local_expert_offset)
+    for le in range(E_local):
+        ge = local_start + le
+        if ge < 0 or ge >= E_global:
+            continue
+        sel_mask = (topk_idx == ge).any(dim=1)
+        if not sel_mask.any():
+            continue
+        token_idx = torch.nonzero(sel_mask, as_tuple=False).squeeze(1)
+        A_e = A.index_select(0, token_idx)
+        G1 = A_e.matmul(W1[le].t())
+        X1, X2 = G1[:, :I], G1[:, I:]
+        silu_X2 = X2 / (1.0 + torch.exp(-X2))
+        activated = silu_X2 * X1
+        if activation_precision == "fp4":
+            packed, scales = _fp4_quantize_reference(
+                activated,
+                global_scale=fc2_input_scale,
+                sf_vec_size=16,
+                is_sf_swizzled_layout=False,
+            )
+            activated = _dequantize_fp4_tensor(
+                packed,
+                scales,
+                is_ue8m0_scales=False,
+            )
+        O = activated.matmul(W2[le].t())
+        w_tok = weights.index_select(0, token_idx)
+        match = (topk_idx.index_select(0, token_idx) == ge).float()
+        w_e = (w_tok * match).sum(dim=1)
+        output.index_add_(0, token_idx, O * w_e.unsqueeze(1))
+    return output.to(torch.bfloat16)
+
+
+@torch.no_grad()
 def _b12x_fused_moe_reference(
     x,
     w1_weight,
@@ -2352,6 +2442,7 @@ def _b12x_fused_moe_reference(
     w1_alpha=None,
     w2_alpha=None,
     fc2_input_scale=None,
+    activation_precision="fp4",
     **_unused,
 ):
     """Reference for B12x CuTe-DSL fused MoE (bf16 input, FP4 weights)."""
@@ -2362,7 +2453,7 @@ def _b12x_fused_moe_reference(
         W1 = W1 * w1_alpha.to(torch.float32).view(E_local, 1, 1)
     if w2_alpha is not None:
         W2 = W2 * w2_alpha.to(torch.float32).view(E_local, 1, 1)
-    return _moe_bf16_run_experts(
+    return _b12x_moe_run_experts(
         x,
         W1,
         W2,
@@ -2370,6 +2461,8 @@ def _b12x_fused_moe_reference(
         token_selected_experts.to(torch.int64),
         local_expert_offset=0,
         E_global=int(num_experts),
+        activation_precision=activation_precision,
+        fc2_input_scale=fc2_input_scale,
     )
 
 

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -32,6 +32,8 @@ Tests include:
 - ReLU2 (non-gated) activation for Nemotron-Super
 """
 
+from typing import Optional
+
 import pytest
 import torch
 from torch.nn import functional as F
@@ -77,6 +79,216 @@ cuda_13_required = pytest.mark.skipif(
     not _cuda_13_or_newer(),
     reason="b12x fused MoE requires CUDA 13 or later",
 )
+
+_STATIC_CUTOVER_ENV_VARS = (
+    "FLASHINFER_B12X_W4A16_STATIC_COMPACT_CUTOVER_PAIRS",
+    "B12X_W4A16_STATIC_COMPACT_CUTOVER_PAIRS",
+    "FLASHINFER_B12X_STATIC_COMPACT_CUTOVER_PAIRS",
+    "B12X_STATIC_COMPACT_CUTOVER_PAIRS",
+)
+
+
+def _clear_static_cutover_env(monkeypatch):
+    for name in _STATIC_CUTOVER_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+# =============================================================================
+# Unit regressions for SM120 dispatch decisions
+# =============================================================================
+
+
+@cute_dsl_available
+def test_w4a16_static_tiler_uses_64_when_intermediate_not_128_aligned(monkeypatch):
+    """BF16 static tiles must not use a 128-wide tile for n=64 mod 128."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    captured = {}
+
+    class FakeKernel:
+        def __init__(self, **kwargs):
+            captured["mma_tiler_mn"] = kwargs["mma_tiler_mn"]
+
+    def fake_compile(kernel, *args, **kwargs):
+        captured["kernel"] = kernel
+        return lambda *runtime_args: None
+
+    moe_dispatch._STATIC_KERNEL_CACHE.clear()
+    monkeypatch.setattr(moe_dispatch, "get_num_sm", lambda device: 1)
+    monkeypatch.setattr(moe_dispatch, "get_max_active_clusters", lambda cluster: 1)
+    monkeypatch.setattr(moe_dispatch, "MoEW4A16StaticKernel", FakeKernel)
+    monkeypatch.setattr(moe_dispatch, "make_ptr", lambda *args, **kwargs: object())
+    monkeypatch.setattr(moe_dispatch.cute, "compile", fake_compile)
+    monkeypatch.setattr(
+        moe_dispatch.cute.runtime,
+        "make_fake_compact_tensor",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(moe_dispatch, "current_cuda_stream", lambda: object())
+
+    try:
+        moe_dispatch._get_static_kernel(
+            state_E=1,
+            weight_E=1,
+            m=32,
+            k=256,
+            n=192,
+            num_topk=2,
+            max_rows=64,
+            activation_precision="bf16",
+        )
+    finally:
+        moe_dispatch._STATIC_KERNEL_CACHE.clear()
+
+    assert captured["mma_tiler_mn"] == (32, 64)
+
+
+@cute_dsl_available
+def test_sm120_backend_cutovers_are_precision_specific(monkeypatch):
+    """W4A16 dynamic should engage much earlier than W4A4 dynamic."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    _clear_static_cutover_env(monkeypatch)
+    moe_dispatch._STATIC_COMPACT_CUTOVER_PAIRS_CACHE.clear()
+    try:
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=80,
+                num_topk=8,
+                activation_precision="fp4",
+            )
+            == "static"
+        )
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=81,
+                num_topk=8,
+                activation_precision="fp4",
+            )
+            == "dynamic"
+        )
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=16,
+                num_topk=8,
+                activation_precision="bf16",
+            )
+            == "static"
+        )
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=17,
+                num_topk=8,
+                activation_precision="bf16",
+            )
+            == "dynamic"
+        )
+    finally:
+        moe_dispatch._STATIC_COMPACT_CUTOVER_PAIRS_CACHE.clear()
+
+
+@cute_dsl_available
+def test_w4a16_static_cutover_env_override_is_precision_scoped(monkeypatch):
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    _clear_static_cutover_env(monkeypatch)
+    moe_dispatch._STATIC_COMPACT_CUTOVER_PAIRS_CACHE.clear()
+    monkeypatch.setenv("FLASHINFER_B12X_W4A16_STATIC_COMPACT_CUTOVER_PAIRS", "256")
+    try:
+        assert moe_dispatch._get_static_compact_cutover_pairs("bf16") == 256
+        assert moe_dispatch._get_static_compact_cutover_pairs("fp4") == 640
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=32,
+                num_topk=8,
+                activation_precision="bf16",
+            )
+            == "static"
+        )
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=33,
+                num_topk=8,
+                activation_precision="bf16",
+            )
+            == "dynamic"
+        )
+    finally:
+        moe_dispatch._STATIC_COMPACT_CUTOVER_PAIRS_CACHE.clear()
+
+
+@cute_dsl_available
+def test_w4a16_direct_micro_rejects_cutlass45_wide_multi_token_shape():
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_micro_kernel import (
+        MoEMicroKernel,
+    )
+
+    assert not MoEMicroKernel.is_supported(
+        m=4,
+        k=4096,
+        n=4096,
+        num_topk=8,
+        weight_E=32,
+    )
+
+
+@cute_dsl_available
+def test_w4a16_direct_micro_shape_guard_rejects_cached_wide_shape():
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    class FakeCompiled:
+        pass
+
+    compiled = FakeCompiled()
+    setattr(
+        compiled,
+        moe_dispatch._DIRECT_MICRO_SHAPE_ATTR,
+        ("bf16", 4, 4096, 4096, 8, 32),
+    )
+
+    assert not moe_dispatch._direct_micro_shape_accepts_block_dim(
+        compiled,
+        moe_dispatch._DIRECT_MICRO_BLOCK_DIM,
+    )
+
+
+@cute_dsl_available
+def test_preallocated_dynamic_workspace_rejects_remapped_experts():
+    """Dynamic workspaces index expert buffers directly with global topk ids."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    workspace = object.__new__(moe_dispatch.Sm120DynamicMoEWorkspace)
+    workspace.activation_precision = "bf16"
+
+    x = torch.empty((1, 256), dtype=torch.bfloat16)
+    topk_ids = torch.zeros((1, 1), dtype=torch.int32)
+    topk_weights = torch.ones((1, 1), dtype=torch.float32)
+    w1 = torch.empty((2, 384, 128), dtype=torch.uint8)
+    w1_sf = torch.empty((2, 384, 16), dtype=torch.float8_e4m3fn)
+    w2 = torch.empty((2, 256, 96), dtype=torch.uint8)
+    w2_sf = torch.empty((2, 256, 12), dtype=torch.float8_e4m3fn)
+    alpha = torch.ones((2,), dtype=torch.float32)
+    output = torch.empty((1, 256), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="dynamic.*num_local_experts.*num_experts"):
+        moe_dispatch.launch_sm120_moe(
+            a=x,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            w1_weight=w1,
+            w1_weight_sf=w1_sf,
+            w1_alpha=alpha,
+            w2_weight=w2,
+            w2_weight_sf=w2_sf,
+            w2_alpha=alpha,
+            num_experts=4,
+            top_k=1,
+            num_local_experts=2,
+            scatter_output=output,
+            activation_precision="bf16",
+            _workspace=workspace,
+            _weight_views=object(),
+        )
 
 
 # =============================================================================
@@ -367,7 +579,7 @@ def compute_reference_moe_relu2(
     top_k: int,
     hidden_size: int,
     intermediate_size: int,
-    fc2_input_scale: torch.Tensor,
+    fc2_input_scale: Optional[torch.Tensor],
 ) -> torch.Tensor:
     """Reference ReLU2 MoE: output = relu(FC1(x))^2, then FC2."""
     output = torch.zeros(num_tokens, hidden_size, dtype=torch.float32, device="cuda")
@@ -591,6 +803,273 @@ class TestB12xFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
+    def test_activation_precision_api_validation(self):
+        """W4A4 requires fc2_input_scale; W4A16 tolerates it."""
+        from flashinfer import b12x_fused_moe
+
+        num_tokens, hidden_size, intermediate_size = 4, 256, 512
+        num_experts, top_k = 256, 2
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+        kwargs = dict(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+        )
+
+        with pytest.raises(ValueError, match="fc2_input_scale is required"):
+            b12x_fused_moe(**kwargs)
+
+        result = b12x_fused_moe(**kwargs, activation_precision="bf16")
+        assert result.shape == (num_tokens, hidden_size)
+
+        result = b12x_fused_moe(
+            **kwargs,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            activation_precision="bf16",
+        )
+        assert result.shape == (num_tokens, hidden_size)
+
+    @pytest.mark.parametrize("num_tokens", [64, 384])
+    def test_w4a16_functional_accuracy(self, num_tokens: int):
+        """Accuracy test for the W4A16 activation path."""
+        from flashinfer import b12x_fused_moe
+
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 2
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=123,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_precision="bf16",
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"W4A16: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens})"
+        )
+
+    def test_w4a16_static_accuracy_intermediate_not_128_aligned(self):
+        """W4A16 static must handle n=64 mod 128 without crossing gate/up tiles."""
+        from flashinfer import b12x_fused_moe
+
+        num_tokens, hidden_size, intermediate_size = 32, 256, 192
+        num_experts, top_k = 256, 2
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=789,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_precision="bf16",
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"W4A16 n=192 static: {percent_within * 100:.2f}% within "
+            f"tolerance (atol={atol:.4f})"
+        )
+
+    def test_w4a16_dynamic_accuracy_with_wide_scale_tile(self, monkeypatch):
+        """Exercise dynamic W4A16 scale loads when a row spans two scale words."""
+        from flashinfer import b12x_fused_moe
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+        monkeypatch.setattr(moe_dispatch, "_W4A16_LEVEL_TILE_N", 128)
+        moe_dispatch._DYNAMIC_KERNEL_CACHE.clear()
+        moe_dispatch._WORKSPACE_CACHE.clear()
+
+        num_tokens, hidden_size, intermediate_size = 384, 256, 512
+        num_experts, top_k = 256, 2
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=123,
+        )
+
+        try:
+            result = b12x_fused_moe(
+                x=tensors["x_bf16"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                num_experts=num_experts,
+                top_k=top_k,
+                activation_precision="bf16",
+            )
+        finally:
+            moe_dispatch._DYNAMIC_KERNEL_CACHE.clear()
+            moe_dispatch._WORKSPACE_CACHE.clear()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"W4A16 wide scale tile: {percent_within * 100:.2f}% within "
+            f"tolerance (atol={atol:.4f})"
+        )
+
+    @pytest.mark.parametrize("num_tokens", [64, 384])
+    def test_w4a16_is_more_accurate_than_w4a4(self, num_tokens: int):
+        """W4A16 should be closer than W4A4 to the BF16-activation reference."""
+        from flashinfer import b12x_fused_moe
+
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 2
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=123,
+        )
+        kwargs = dict(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+        )
+
+        a4_result = b12x_fused_moe(**kwargs, activation_precision="fp4")
+        a16_result = b12x_fused_moe(**kwargs, activation_precision="bf16")
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        a4_error = (a4_result.float() - ref_output).abs()
+        a16_error = (a16_result.float() - ref_output).abs()
+        a4_mae = a4_error.mean()
+        a16_mae = a16_error.mean()
+        a4_mse = a4_error.square().mean()
+        a16_mse = a16_error.square().mean()
+
+        assert a16_mae < 0.75 * a4_mae, (
+            f"W4A16 MAE should be lower than W4A4 for tokens={num_tokens}: "
+            f"a16={a16_mae.item():.6f}, a4={a4_mae.item():.6f}"
+        )
+        assert a16_mse < 0.5 * a4_mse, (
+            f"W4A16 MSE should be lower than W4A4 for tokens={num_tokens}: "
+            f"a16={a16_mse.item():.6f}, a4={a4_mse.item():.6f}"
+        )
+
 
 # =============================================================================
 # Test Class: Wrapper API (B12xMoEWrapper)
@@ -664,6 +1143,65 @@ class TestB12xWrapper:
         passed, percent_within, atol = check_accuracy(result, ref_output)
         assert passed, (
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+
+    def test_w4a16_wrapper_accuracy(self):
+        """Accuracy test for B12xMoEWrapper with BF16 intermediates."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 64, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=321,
+        )
+
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            activation_precision="bf16",
+            use_cuda_graph=False,
+        )
+
+        result = moe.run(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"W4A16 wrapper: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f})"
         )
 
     @pytest.mark.parametrize("num_tokens", [64, 128, 256])
@@ -986,6 +1524,219 @@ class TestMicroKernel:
             f"(atol={atol:.4f})"
         )
 
+    @pytest.mark.parametrize("num_tokens", [1, 2, 4])
+    def test_w4a16_direct_micro_functional_accuracy(self, num_tokens: int):
+        """Accuracy test for the W4A16 direct micro decode path."""
+        from flashinfer import b12x_fused_moe
+
+        hidden_size, intermediate_size = 512, 256
+        num_experts, top_k = 64, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=777,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_precision="bf16",
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"W4A16 direct micro: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens})"
+        )
+
+    def test_w4a16_direct_micro_wrapper_accuracy(self):
+        """Accuracy test for W4A16 direct micro via B12xMoEWrapper."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 2, 512, 256
+        num_experts, top_k = 64, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=778,
+        )
+
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            activation_precision="bf16",
+            use_cuda_graph=False,
+        )
+
+        result = moe.run(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"W4A16 direct micro wrapper: {percent_within * 100:.2f}% "
+            f"within tolerance (atol={atol:.4f})"
+        )
+
+    def test_w4a16_direct_micro_cuda_graph(self):
+        """CUDA graph replay test for the W4A16 direct micro wrapper path."""
+        from flashinfer import B12xMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 2, 512, 256
+        num_experts, top_k = 64, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=780,
+        )
+
+        moe = B12xMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            activation_precision="bf16",
+            use_cuda_graph=True,
+            max_num_tokens=num_tokens,
+        )
+
+        for _ in range(3):
+            moe.run(
+                x=tensors["x_bf16"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+            )
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            output = moe.run(
+                x=tensors["x_bf16"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+
+        assert output.shape == (num_tokens, hidden_size)
+        assert torch.isfinite(output).all()
+        assert not (output == 0).all()
+
+    def test_w4a16_direct_micro_workspace_capacity(self):
+        """Static W4A16 workspaces reserve direct-micro scratch and barriers."""
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
+            _direct_micro_barrier_slots,
+            _direct_micro_intermediate_elements,
+            allocate_sm120_static_workspace,
+        )
+
+        num_tokens, hidden_size, intermediate_size = 2, 512, 256
+        num_experts, top_k = 64, 2
+        workspace = allocate_sm120_static_workspace(
+            state_E=num_experts,
+            weight_E=num_experts,
+            max_rows=num_tokens * top_k,
+            k=hidden_size,
+            n=intermediate_size,
+            num_topk=top_k,
+            device=torch.device("cuda"),
+            activation_precision="bf16",
+        )
+
+        assert workspace.max_rows >= 128
+        assert (
+            workspace.micro_intermediate.numel()
+            >= _direct_micro_intermediate_elements(
+                num_tokens,
+                top_k,
+                hidden_size,
+                intermediate_size,
+            )
+        )
+        assert workspace.barrier_count.numel() >= _direct_micro_barrier_slots(
+            num_tokens * top_k,
+            num_tokens,
+        )
+        assert workspace.barrier_epoch.numel() == workspace.barrier_count.numel()
+
     def test_micro_single_token_unique_path(self):
         """Test the all_rows_unique fast path (num_tokens=1, top_k=8).
 
@@ -1201,6 +1952,59 @@ class TestRelu2Activation:
             f"(atol={atol:.4f}, tokens={num_tokens})"
         )
 
+    @pytest.mark.parametrize("num_tokens", [64, 384])
+    def test_relu2_w4a16_functional_accuracy(self, num_tokens: int):
+        """Accuracy test for ReLU2 with the W4A16 activation path."""
+        from flashinfer import b12x_fused_moe
+
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 2
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=123,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation="relu2",
+            activation_precision="bf16",
+        )
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2 W4A16: {percent_within * 100:.2f}% within tolerance "
+            f"(atol={atol:.4f}, tokens={num_tokens})"
+        )
+
     def test_relu2_wrapper_accuracy(self):
         """Accuracy test for ReLU2 via B12xMoEWrapper."""
         from flashinfer import B12xMoEWrapper
@@ -1315,6 +2119,60 @@ class TestRelu2Activation:
         assert passed, (
             f"ReLU2 micro: {percent_within * 100:.2f}% within tolerance "
             f"(atol={atol:.4f})"
+        )
+
+    def test_relu2_w4a16_direct_micro_accuracy(self):
+        """Accuracy test for ReLU2 with the W4A16 direct micro path."""
+        from flashinfer import b12x_fused_moe
+
+        num_tokens, hidden_size, intermediate_size = 2, 512, 256
+        num_experts, top_k = 64, 2
+
+        tensors = create_relu2_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            seed=779,
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation="relu2",
+            activation_precision="bf16",
+        )
+
+        ref_output = compute_reference_moe_relu2(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=None,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"ReLU2 W4A16 direct micro: {percent_within * 100:.2f}% "
+            f"within tolerance (atol={atol:.4f})"
         )
 
     def test_relu2_cuda_graph(self):

--- a/tests/trace/test_b12x_moe_trace.py
+++ b/tests/trace/test_b12x_moe_trace.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+
+def _packed_ones(*shape):
+    return torch.full(shape, 0x22, dtype=torch.uint8)
+
+
+def test_b12x_wrapper_trace_does_not_expose_constructor_precision():
+    from flashinfer.trace.templates.moe import (
+        b12x_fused_moe_trace,
+        b12x_moe_wrapper_run_trace,
+    )
+
+    assert "activation_precision" in b12x_fused_moe_trace.inputs
+    assert "activation_precision" not in b12x_moe_wrapper_run_trace.inputs
+
+
+def test_b12x_reference_uses_activation_precision_and_fc2_scale():
+    from flashinfer.trace.templates.moe import b12x_fused_moe_trace
+
+    x = torch.ones((1, 2), dtype=torch.bfloat16)
+    w1_weight = _packed_ones(1, 32, 1)
+    w1_weight_sf = torch.ones((1, 32, 1), dtype=torch.float8_e4m3fn)
+    w2_weight = _packed_ones(1, 2, 8)
+    w2_weight_sf = torch.ones((1, 2, 1), dtype=torch.float8_e4m3fn)
+    token_selected_experts = torch.zeros((1, 1), dtype=torch.int32)
+    token_final_scales = torch.ones((1, 1), dtype=torch.float32)
+    alpha = torch.ones((1,), dtype=torch.float32)
+
+    common_kwargs = dict(
+        x=x,
+        w1_weight=w1_weight,
+        w1_weight_sf=w1_weight_sf,
+        w2_weight=w2_weight,
+        w2_weight_sf=w2_weight_sf,
+        token_selected_experts=token_selected_experts,
+        token_final_scales=token_final_scales,
+        num_experts=1,
+        top_k=1,
+        w1_alpha=alpha,
+        w2_alpha=alpha,
+    )
+
+    bf16 = b12x_fused_moe_trace.reference(
+        **common_kwargs,
+        activation_precision="bf16",
+    )
+
+    with pytest.raises(ValueError, match="fc2_input_scale is required"):
+        b12x_fused_moe_trace.reference(
+            **common_kwargs,
+            activation_precision="fp4",
+        )
+
+    fp4 = b12x_fused_moe_trace.reference(
+        **common_kwargs,
+        fc2_input_scale=torch.ones((1,), dtype=torch.float32),
+        activation_precision="fp4",
+    )
+
+    assert fp4.shape == bf16.shape
+    assert not torch.equal(fp4, bf16)


### PR DESCRIPTION
## 📌 Description

  Adds SM120 b12x MoE W4A16 support alongside the existing W4A4 path.

  This PR adds activation precision plumbing for W4A4/W4A16 dispatch, wires
  W4A16 static, dynamic, and direct micro   kernels, and preserves the intended scale
  semantics: fc2_input_scale is required only for activation_precision="fp4" and
  tolerated/ignored for activation_precision="bf16".

  It also ports the relevant W4A4 FlashInfer integration details to W4A16, including workspace sizing, swizzled
  scale storage, current-stream direct launches, resource gating, CUDA graph coverage, and wrapper support.

  ## 🔍 Related Issues

  N/A

  ## 🚀 Pull Request Checklist

  Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following
  items are complete.

  ### ✅ Pre-commit Checks

  - [x] I have installed pre-commit by running pip install pre-commit (or used your preferred method).
  - [x] I have installed the hooks with pre-commit install.
  - [x] I have run the hooks manually with pre-commit run --all-files and fixed any reported issues.

  > Ran via uvx pre-commit run --all-files; all hooks passed.

  ## 🧪 Tests

  - [x] Tests have been added or updated as needed.
  - [x] All tests are passing (unittest, etc.).

  Tested with:

  uvx pre-commit run --all-files
  git diff --check
  /home/luke/projects/sglang/.venv/bin/python -m compileall \
    flashinfer/cute_dsl/fp4_common.py \
    flashinfer/cute_dsl/utils.py \
    flashinfer/fused_moe/cute_dsl/b12x_moe.py \
    flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py \
    flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_direct_micro_kernel.py \
    flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_dynamic_kernel.py \
    flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_micro_kernel.py \
    flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_static_kernel.py \
    flashinfer/trace/templates/moe.py \
    tests/moe/test_b12x_fused_moe.py

  FLASHINFER_DISABLE_VERSION_CHECK=1 /home/luke/projects/sglang/.venv/bin/python \
    -m pytest tests/moe/test_b12x_fused_moe.py -k "direct_micro" -q

  FLASHINFER_DISABLE_VERSION_CHECK=1 /home/luke/projects/sglang/.venv/bin/python \
    -m pytest tests/moe/test_b12x_fused_moe.py -k "activation_precision or w4a16" -q

  ## Reviewer Notes

  The direct W4A16 micro path is intentionally limited to cases where local expert IDs match global expert IDs;
  expert-parallel remapping falls back to the compact static W4A16 path.

  The compact W4A16 micro fallback present upstream is not wired because upstream dispatch leaves it inactive;
  unsupported direct-micro cases fall back to static W4A16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable activation precision (fp4 or bf16) for fused Mixture-of-Experts with new dynamic, static, and low‑latency micro kernel variants.
  * Exposed CUDA stream helper for interoperability.

* **Improvements**
  * New GPU synchronization, atomic, non‑coherent global and relaxed shared‑memory primitives for robust kernel coordination.
  * Expanded FP4/FP8/BF16 quantize/dequantize, packing, dot‑product helpers and vectorized scatter; precision‑aware workspace/dispatch tuning and optional fc2 input‑scale semantics.

* **Tests**
  * Broadened coverage and trace schema updates to validate activation‑precision behaviors, W4A16 paths, and wrapper/trace expectations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3271)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->