### PR TITLE
ci: isolate nightly package tests from source tree

### DIFF
--- a/scripts/task_test_nightly_build.sh
+++ b/scripts/task_test_nightly_build.sh
@@ -15,7 +15,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 : ${DIST_JIT_CACHE_DIR:=dist-jit-cache}
 : ${DIST_PYTHON_DIR:=dist-python}
 
-SOURCE_WORKSPACE="$(pwd)"
+SOURCE_WORKSPACE="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+cd "${SOURCE_WORKSPACE}"
 TEST_RUN_DIR="$(mktemp -d /tmp/flashinfer-nightly-tests.XXXXXX)"
 trap 'rm -rf "${TEST_RUN_DIR}"' EXIT
 

--- a/scripts/task_test_nightly_build.sh
+++ b/scripts/task_test_nightly_build.sh
@@ -15,6 +15,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 : ${DIST_JIT_CACHE_DIR:=dist-jit-cache}
 : ${DIST_PYTHON_DIR:=dist-python}
 
+SOURCE_WORKSPACE="$(pwd)"
+TEST_RUN_DIR="$(mktemp -d /tmp/flashinfer-nightly-tests.XXXXXX)"
+trap 'rm -rf "${TEST_RUN_DIR}"' EXIT
+
 # Clean Python bytecode cache to avoid stale imports (e.g., after module refactoring)
 echo "Cleaning Python bytecode cache..."
 find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
@@ -46,6 +50,11 @@ echo "Verifying installation..."
 # Run from /tmp to avoid importing local flashinfer/ source directory
 (cd /tmp && python -m flashinfer show-config)
 
+# Copy only test sources into an isolated directory so package tests exercise the
+# installed flashinfer distribution instead of shadowing it with /workspace.
+cp -a "${SOURCE_WORKSPACE}/tests" "${TEST_RUN_DIR}/"
+cp -a "${SOURCE_WORKSPACE}/pytest.ini" "${TEST_RUN_DIR}/"
+
 # Run test shard
 echo "Running test shard ${TEST_SHARD}..."
 export SKIP_INSTALL=1
@@ -55,4 +64,4 @@ if [ -n "${FLASHINFER_JIT_CACHE_REPORT_FILE}" ]; then
   export FLASHINFER_JIT_CACHE_REPORT_FILE
 fi
 
-bash scripts/task_jit_run_tests_part${TEST_SHARD}.sh
+(cd "${TEST_RUN_DIR}" && bash "${SOURCE_WORKSPACE}/scripts/task_jit_run_tests_part${TEST_SHARD}.sh")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly test runs now execute in an isolated temporary directory to ensure tests run against the installed distribution rather than local source.
  * Test artifacts (tests and test config) are copied into the temp run directory; the directory is removed on script exit to keep workspace clean.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3274)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->