### PR TITLE
fix(jit): propagate -DNDEBUG to host-side cflags

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -452,7 +452,7 @@ def gen_jit_spec(
     else:
         # non debug mode
         cuda_cflags += ["-DNDEBUG", "-O3"]
-        cflags += ["-O3"]
+        cflags += ["-DNDEBUG", "-O3"]
 
     # useful for ncu source correlation
     if os.environ.get("FLASHINFER_JIT_LINEINFO", "0") == "1":

--- a/tests/test_jit_cpp_ext.py
+++ b/tests/test_jit_cpp_ext.py
@@ -54,6 +54,43 @@ def test_debug_jit_uses_sccache_compatible_nvcc_device_debug_flag(monkeypatch):
     assert "-G" not in spec.extra_cuda_cflags
 
 
+def test_release_jit_propagates_ndebug_to_host_cflags(monkeypatch):
+    monkeypatch.delenv("FLASHINFER_JIT_DEBUG", raising=False)
+    monkeypatch.delenv("FLASHINFER_JIT_VERBOSE", raising=False)
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(core, "get_nvcc_parallelism_flags", lambda: ["--threads=1"])
+
+    spec = core.gen_jit_spec(
+        name="test_module",
+        sources=[],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_paths=None,
+    )
+
+    assert "-DNDEBUG" in spec.extra_cflags
+    assert "-DNDEBUG" in spec.extra_cuda_cflags
+
+
+def test_debug_jit_does_not_propagate_ndebug(monkeypatch):
+    monkeypatch.setenv("FLASHINFER_JIT_DEBUG", "1")
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(core, "get_nvcc_parallelism_flags", lambda: ["--threads=1"])
+
+    spec = core.gen_jit_spec(
+        name="test_module",
+        sources=[],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_paths=None,
+    )
+
+    assert "-DNDEBUG" not in spec.extra_cflags
+    assert "-DNDEBUG" not in spec.extra_cuda_cflags
+
+
 def test_run_ninja_uses_max_jobs(monkeypatch, tmp_path):
     commands = []
 


### PR DESCRIPTION
## 📌 Description

`gen_jit_spec` adds `-DNDEBUG` only to `extra_cuda_cflags` (consumed by `nvcc` for `.cu` files), not to `extra_cflags` (consumed by `g++` for host-side `.cpp`). Several host-only translation units are part of MoE/GEMM JIT specs — most notably `csrc/nv_internal/cpp/common/logger.cpp` — and they end up compiled without `NDEBUG` while the rest of the module is a release build.

For the TensorRT-LLM logger this matters because of:

```cpp
// csrc/nv_internal/include/tensorrt_llm/common/logger.h
#ifndef NDEBUG
  Level const DEFAULT_LOG_LEVEL = DEBUG;
#else
  Level const DEFAULT_LOG_LEVEL = INFO;
#endif
```

With `NDEBUG` missing on the host side, every prebuilt `flashinfer-jit-cache` wheel ships with `Logger::level_ = DEBUG (10)`. On Hopper this turns each MoE forward pass into a stream of `[TensorRT-LLM][DEBUG] ... sm90_generic_mixed_moe_gemm_kernelLauncher ...` lines from the OSS CUTLASS kernel dispatcher. Verified by reading the data-section initializer of `Logger::Logger()` in the released `flashinfer-jit-cache==0.6.10+cu130` `fused_moe_{90,100,103,120,trtllm_sm100}.so` — all five start `Logger` with `DEFAULT_LOG_LEVEL=10` and `level_=10`, even though the same wheels carry no `.debug_*` sections (i.e. they are otherwise release-built).

The fix is one line: also append `-DNDEBUG` to the host `cflags` when not in debug mode. The `flashinfer-jit-cache` wheel build picks this up automatically and the prebuilt logger flips back to `INFO`.

## 🔍 Related Issues

Initially this bug was observed during integration of FI v0.6.10 into vLLM: [[CI/Build] Bump flashinfer to v0.6.10 #41711](https://github.com/vllm-project/vllm/pull/41711).
There is a CI job log failure due to this issue: [buildkite/ci/pr/distributed-tests-2-gpus-h100](https://buildkite.com/vllm/ci/builds/64532#019df966-e67d-4c27-af0e-76b00bc496e5).

Surfaced while debugging a downstream CI step that produced a 2.9 GB log dominated by TRT-LLM debug prints from `fused_moe_90.so`. No FlashInfer issue tracking this yet — happy to file one alongside this PR if useful.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`pytest tests/test_jit_cpp_ext.py`).

Two regression tests added in `tests/test_jit_cpp_ext.py`, mirroring the existing `test_debug_jit_uses_sccache_compatible_nvcc_device_debug_flag` style:

```
pytest tests/test_jit_cpp_ext.py -v
```

```
test_release_jit_propagates_ndebug_to_host_cflags PASSED
test_debug_jit_does_not_propagate_ndebug          PASSED
```

The first asserts that a release build (`FLASHINFER_JIT_DEBUG`/`FLASHINFER_JIT_VERBOSE` unset) puts `-DNDEBUG` in **both** `spec.extra_cflags` and `spec.extra_cuda_cflags`. The second locks in symmetry: with `FLASHINFER_JIT_DEBUG=1` neither list contains `-DNDEBUG`. Without the fix, the first test fails on `assert "-DNDEBUG" in spec.extra_cflags`.

## Reviewer Notes

Single-line behavior change in `flashinfer/jit/core.py`. No effect on debug builds. Prebuilt wheels rebuilt from this commit will pick up the change automatically — no schema/version bump needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JIT-compiled code now includes optimized compilation flags in release mode for improved performance.

* **Tests**
  * Added test coverage for proper compilation flag handling between debug and release build modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->