### PR TITLE
feat: add first-class trace apply support

### DIFF
--- a/docs/apply.rst
+++ b/docs/apply.rst
@@ -1,0 +1,240 @@
+.. _apply:
+
+Apply - Runtime Kernel Substitution
+===================================
+
+``flashinfer.apply`` lets you replace selected FlashInfer API calls with a
+user-provided Python solution at runtime.  It is keyed by the same definition
+names produced by :ref:`fi_trace <fi_trace>`, so a replacement is selected by
+the concrete operation schema, not by the Python function name alone.
+
+This is useful when you want to test or deploy a custom kernel implementation
+for a specific FlashInfer operation shape while preserving the original
+FlashInfer API surface.
+
+Quick Start
+-----------
+
+Enable solutions with ``flashinfer.enable_apply()``.  The registration key is
+the ``fi_trace`` definition name, for example ``"rmsnorm_h4096"``.
+
+.. code-block:: python
+
+    import torch
+    import flashinfer
+
+    hidden_states = torch.randn(32, 4096, device="cuda", dtype=torch.float16)
+    weight = torch.randn(4096, device="cuda", dtype=torch.float16)
+
+    def rmsnorm_solution(hidden_states, weight):
+        # Replace this body with your custom implementation.
+        return hidden_states * weight
+
+    flashinfer.enable_apply({"rmsnorm_h4096": rmsnorm_solution})
+    out = flashinfer.rmsnorm(hidden_states, weight)
+    flashinfer.disable_apply()
+
+When the installed apply wrapper has no matching solution, or when the solution
+fails, FlashInfer falls back to the original API implementation and emits a
+warning for the failure case.
+
+Finding the Definition Name
+---------------------------
+
+Every traced API exposes ``.fi_trace()``.  Call it with representative inputs to
+inspect the definition name that should be used as the apply key.
+
+.. code-block:: python
+
+    definition = flashinfer.rmsnorm.fi_trace(hidden_states, weight)
+    print(definition["name"])  # rmsnorm_h4096
+
+``fi_trace`` only uses tensor metadata such as shape and dtype.  It does not
+dump tensor values.
+
+Public API
+----------
+
+FlashInfer exposes top-level enable/disable APIs:
+
+.. code-block:: python
+
+    flashinfer.enable_apply({"rmsnorm_h4096": rmsnorm_solution})
+    flashinfer.enable_apply(apply_config)
+    flashinfer.disable_apply()
+
+``enable_apply(config)``
+    Installs apply wrappers for imported FlashInfer APIs.  ``config`` can be an
+    ``ApplyConfig`` or a mapping from definition name to Python callable or
+    ``flashinfer.trace.Solution`` object.
+
+``disable_apply()``
+    Restores patched APIs and disables apply.
+
+Calling ``enable_apply()`` again replaces the active apply routing.  A later
+``disable_apply()`` restores all patched APIs to their original implementations.
+
+Callable Solutions
+------------------
+
+Callable solutions are invoked with positional arguments only.  The argument
+order follows the corresponding ``TraceTemplate.inputs`` order.
+
+For ``rmsnorm``, the solution receives ``hidden_states`` and ``weight``:
+
+.. code-block:: python
+
+    def rmsnorm_solution(hidden_states, weight):
+        return hidden_states * weight
+
+    flashinfer.enable_apply({"rmsnorm_h4096": rmsnorm_solution})
+    out = flashinfer.rmsnorm(hidden_states, weight)
+    flashinfer.disable_apply()
+
+If the original FlashInfer call provides an ``out=`` buffer, the returned tensor
+is copied into that buffer and the original API return convention is preserved.
+
+flashinfer-bench Solution Objects
+---------------------------------
+
+``enable_apply`` can also consume a minimal Python Solution object compatible
+with `flashinfer-bench <https://github.com/flashinfer-ai/flashinfer-bench>`_.
+The current installer supports the simple no-build subset:
+
+* ``spec.language == "python"``
+* ``spec.entry_point == "<file.py>::<function>"``
+* ``sources`` contains the Python source for that entry file
+* calls are positional only
+
+.. code-block:: python
+
+    from flashinfer.trace import BuildSpec, Solution, SourceFile
+
+    solution = Solution(
+        name="rmsnorm_h4096_python",
+        definition="rmsnorm_h4096",
+        author="example",
+        spec=BuildSpec(
+            language="python",
+            target_hardware=["CUDA"],
+            entry_point="main.py::run",
+            destination_passing_style=False,
+        ),
+        sources=[
+            SourceFile(
+                path="main.py",
+                content=(
+                    "def run(hidden_states, weight):\n"
+                    "    return hidden_states * weight\n"
+                ),
+            )
+        ],
+    )
+
+    flashinfer.enable_apply({"rmsnorm_h4096": solution})
+    out = flashinfer.rmsnorm(hidden_states, weight)
+    flashinfer.disable_apply()
+
+Solution source is executed in-process and should be treated as trusted code.
+
+Serializable Apply Config
+-------------------------
+
+Use ``ApplyConfig`` when you want a serializable definition-to-solution routing
+table.  The config only specifies which solution to use for each definition; it
+does not contain benchmark-selection policies or file I/O.
+
+.. code-block:: python
+
+    config = flashinfer.ApplyConfig.from_dict(config_dict)
+    flashinfer.enable_apply(config)
+    out = flashinfer.rmsnorm(hidden_states, weight)
+    flashinfer.disable_apply()
+
+Example config dictionary:
+
+.. code-block:: json
+
+    {
+      "solutions": {
+        "rmsnorm_h4096": {
+          "name": "rmsnorm_h4096_python",
+          "definition": "rmsnorm_h4096",
+          "author": "example",
+          "spec": {
+            "language": "python",
+            "target_hardware": ["CUDA"],
+            "entry_point": "main.py::run",
+            "destination_passing_style": false
+          },
+          "sources": [
+            {
+              "path": "main.py",
+              "content": "def run(hidden_states, weight):\n    return hidden_states * weight\n"
+            }
+          ]
+        }
+      }
+    }
+
+The ``definition`` field inside each solution is required and must match the
+surrounding ``solutions`` key.
+
+Environment Variables
+---------------------
+
+Set ``FLASHINFER_APPLY=1`` to enable apply automatically when ``flashinfer`` is
+imported.  ``FLASHINFER_APPLY_CONFIG`` must point to a config JSON file.
+
+.. code-block:: bash
+
+    export FLASHINFER_APPLY=1
+    export FLASHINFER_APPLY_CONFIG=/path/to/apply.json
+    python run_engine.py
+
+Invalid or missing env config emits a warning and leaves apply disabled.
+
+Destination-Passing Style
+-------------------------
+
+For solutions that mutate output buffers directly, set
+``destination_passing_style`` to ``True``.  FlashInfer appends output buffers
+after the input arguments in ``TraceTemplate.outputs`` order.
+
+.. code-block:: python
+
+    solution = Solution(
+        name="rmsnorm_h4096_dps",
+        definition="rmsnorm_h4096",
+        author="example",
+        spec=BuildSpec(
+            language="python",
+            target_hardware=["CUDA"],
+            entry_point="main.py::run",
+            destination_passing_style=True,
+        ),
+        sources=[
+            SourceFile(
+                path="main.py",
+                content=(
+                    "def run(hidden_states, weight, output):\n"
+                    "    output.copy_(hidden_states * weight)\n"
+                ),
+            )
+        ],
+    )
+
+    out = torch.empty_like(hidden_states)
+    flashinfer.enable_apply({"rmsnorm_h4096": solution})
+    result = flashinfer.rmsnorm(hidden_states, weight, out=out)
+    flashinfer.disable_apply()
+
+    assert result is out
+
+Limitations
+-----------
+
+The first apply implementation intentionally supports directly replaceable
+kernel functions only.  Stateful wrapper replacement, automatic solution
+selection from benchmark results, external build systems, and environment-file
+configuration are out of scope for this runtime path.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    cli
    logging
    fi_trace
+   apply
    autotuning
 
 .. toctree::

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -192,3 +192,9 @@ from .xqa import xqa as xqa
 from .xqa import xqa_mla as xqa_mla
 from . import mamba as mamba
 from .fi_trace import fi_trace as fi_trace
+from .trace_apply import ApplyConfig as ApplyConfig
+from .trace_apply import enable_apply_from_env as _enable_apply_from_env
+from .trace_apply import disable_apply as disable_apply
+from .trace_apply import enable_apply as enable_apply
+
+_enable_apply_from_env()

--- a/flashinfer/api_logging.py
+++ b/flashinfer/api_logging.py
@@ -1431,6 +1431,10 @@ def _log_function_outputs(func_name: str, result: Any, level: int) -> None:
 # all registered templates without requiring manual maintenance.
 _TRACE_REGISTRY: List[Tuple[Callable, Any, str]] = []
 
+# Runtime apply uses the same trace metadata, but keeps dispatch outside this
+# logging decorator.
+_TRACE_APPLY_REGISTRY: List[Dict[str, Any]] = []
+
 
 def _attach_fi_trace(
     wrapped: Callable,
@@ -1469,6 +1473,13 @@ def _attach_fi_trace(
             module = getattr(original, "__module__", "") or ""
             qualname = getattr(original, "__qualname__", "") or ""
             fi_api = f"{module}.{qualname}" if module else qualname
+            _TRACE_APPLY_REGISTRY.append(
+                {
+                    "original": original,
+                    "fi_api": fi_api,
+                    "trace": trace_template,
+                }
+            )
 
             if isinstance(trace_template, TraceTemplate):
                 # Static template: pre-build the fi_trace callable once.

--- a/flashinfer/apply.py
+++ b/flashinfer/apply.py
@@ -12,27 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-flashinfer.trace — TraceTemplate system for fi_trace.
+"""Compatibility re-export for trace apply runtime."""
 
-Usage::
-
-    from flashinfer.trace import TraceTemplate, Var, Const, Tensor, Scalar, Solution
-"""
-
-from .solution import BuildSpec, Solution, SourceFile, SupportedBindings, SupportedLanguages
-from .template import Const, Scalar, Tensor, TraceTemplate, Var, _TRACE_DUMP_DIR
+from .trace_apply.apply import (
+    ApplyError,
+    disable_apply,
+    enable_apply,
+)
+from .trace_apply.config import ApplyConfig
 
 __all__ = [
-    "TraceTemplate",
-    "Var",
-    "Const",
-    "Tensor",
-    "Scalar",
-    "Solution",
-    "BuildSpec",
-    "SourceFile",
-    "SupportedLanguages",
-    "SupportedBindings",
-    "_TRACE_DUMP_DIR",
+    "ApplyError",
+    "ApplyConfig",
+    "enable_apply",
+    "disable_apply",
 ]

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -22,6 +22,7 @@ from typing import Any, List, Literal, Optional, Tuple, Union, overload
 import torch
 
 from .api_logging import flashinfer_api
+from .trace_apply import register_plan_run
 from .trace.templates.attention import (
     gqa_paged_decode_trace,
     single_decode_with_kv_cache_trace,
@@ -1600,6 +1601,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
     def end_forward(self) -> None:
         r"""Warning: this function is deprecated and has no effect."""
         pass
+
+
+register_plan_run(
+    plan_fi_api="flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper.plan",
+    run_fi_api="flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper.run",
+)
 
 
 class CUDAGraphBatchDecodeWithPagedKVCacheWrapper(BatchDecodeWithPagedKVCacheWrapper):

--- a/flashinfer/trace/solution.py
+++ b/flashinfer/trace/solution.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Strong-typed data definitions for solution implementations.
+
+The schema mirrors flashinfer-bench Solution objects, but is implemented with
+standard-library dataclasses to avoid adding a runtime dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+
+class SupportedLanguages(str, Enum):
+    """Supported programming languages for solution implementations."""
+
+    PYTHON = "python"
+    TRITON = "triton"
+    CPP = "cpp"
+    CUDA = "cuda"
+    TILELANG = "tilelang"
+
+
+class SupportedBindings(str, Enum):
+    """Supported bindings for C++/CUDA solution implementations."""
+
+    TVM_FFI = "tvm-ffi"
+    TORCH = "torch"
+
+
+@dataclass(frozen=True)
+class SourceFile:
+    """A single source code file in a solution implementation."""
+
+    path: str
+    """The relative path of the file, including its name and extension."""
+    content: str
+    """The complete text content of the source file."""
+
+    def __post_init__(self) -> None:
+        src_path = Path(self.path)
+        if src_path.is_absolute():
+            raise ValueError(f"Invalid source path (absolute path not allowed): {self.path}")
+        if ".." in src_path.parts:
+            raise ValueError(
+                f"Invalid source path (parent directory traversal not allowed): {self.path}"
+            )
+
+@dataclass(frozen=True)
+class BuildSpec:
+    """Build specification for a solution implementation."""
+
+    language: SupportedLanguages
+    """The primary programming language."""
+    target_hardware: Sequence[str]
+    """List of hardware this solution is compatible with."""
+    entry_point: str
+    """The exact path to the function to be called: ``<file_path>::<function>``."""
+    dependencies: Sequence[str] = field(default_factory=list)
+    """Optional list of required libraries or packages."""
+    destination_passing_style: bool = True
+    """Whether the solution accepts output tensors as the last arguments."""
+    binding: Optional[SupportedBindings] = None
+    """The binding type to use for C++/CUDA solutions."""
+
+    def __post_init__(self) -> None:
+        try:
+            language = SupportedLanguages(self.language)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported solution language: {self.language!r}") from exc
+
+        if self.entry_point.count("::") != 1:
+            raise ValueError(
+                f"Invalid entry point format: {self.entry_point}. Expected "
+                '"<file_path>::<function_name>".'
+            )
+
+        if not self.target_hardware:
+            raise ValueError("BuildSpec.target_hardware must be non-empty")
+        target_hardware = tuple(self.target_hardware)
+        dependencies = tuple(self.dependencies)
+
+        binding = None
+        if self.binding is not None:
+            try:
+                binding = SupportedBindings(self.binding)
+            except ValueError as exc:
+                raise ValueError(f"Unsupported solution binding: {self.binding!r}") from exc
+
+        object.__setattr__(self, "language", language)
+        object.__setattr__(self, "target_hardware", target_hardware)
+        object.__setattr__(self, "entry_point", self.entry_point)
+        object.__setattr__(self, "dependencies", dependencies)
+        object.__setattr__(self, "destination_passing_style", bool(self.destination_passing_style))
+        object.__setattr__(self, "binding", binding)
+
+@dataclass(frozen=True, eq=False)
+class Solution:
+    """A concrete implementation for a given fi_trace Definition."""
+
+    name: str
+    """A unique, human-readable name for this specific solution."""
+    definition: str
+    """The name of the Definition this implementation solves."""
+    author: str
+    """The name of the author or agent system that created this solution."""
+    spec: BuildSpec
+    """Technical specifications for building and executing this solution."""
+    sources: Sequence[SourceFile]
+    """Array of source code files representing the complete implementation."""
+    description: Optional[str] = None
+    """Optional human-readable description of the solution's technique."""
+    _hash_cache: str = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.spec, BuildSpec):
+            raise TypeError("Solution.spec must be a BuildSpec")
+        if not self.sources:
+            raise ValueError("Solution.sources must be non-empty")
+
+        sources = tuple(self.sources)
+        seen_paths: set[str] = set()
+        for source in sources:
+            if not isinstance(source, SourceFile):
+                raise TypeError("Solution.sources entries must be SourceFile")
+            if source.path in seen_paths:
+                raise ValueError(f"Duplicate source path '{source.path}'")
+            seen_paths.add(source.path)
+
+        entry_file = self.spec.entry_point.split("::")[0]
+        if entry_file not in seen_paths:
+            raise ValueError(f"Entry source file '{entry_file}' not found in sources")
+
+        object.__setattr__(self, "sources", sources)
+        object.__setattr__(self, "_hash_cache", self._compute_hash())
+
+    def get_entry_symbol(self) -> str:
+        """Extract the function/symbol name from the entry point specification."""
+
+        return self.spec.entry_point.split("::")[-1]
+
+    def get_entry_source(self) -> Optional[SourceFile]:
+        """Get the entry source file specified in the build spec."""
+
+        entry_path = self.spec.entry_point.split("::")[0]
+        for source in self.sources:
+            if source.path == entry_path:
+                return source
+        return None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Solution":
+        """Build a Solution from a JSON-compatible dictionary."""
+
+        solution_definition = data.get("definition")
+        if solution_definition is None:
+            raise ValueError("Solution dictionary requires a definition")
+
+        spec_data = data.get("spec")
+        if not isinstance(spec_data, Mapping):
+            raise TypeError(f"Solution '{solution_definition}' requires a spec object")
+
+        sources_data = data.get("sources")
+        if not isinstance(sources_data, list):
+            raise TypeError(f"Solution '{solution_definition}' requires a sources list")
+
+        return cls(
+            name=data["name"],
+            definition=solution_definition,
+            author=data["author"],
+            spec=BuildSpec(
+                language=spec_data["language"],
+                target_hardware=spec_data["target_hardware"],
+                entry_point=spec_data["entry_point"],
+                dependencies=spec_data.get("dependencies", ()),
+                destination_passing_style=spec_data.get(
+                    "destination_passing_style", True
+                ),
+                binding=spec_data.get("binding"),
+            ),
+            sources=[
+                SourceFile(path=source["path"], content=source["content"])
+                for source in sources_data
+            ],
+            description=data.get("description"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible dictionary."""
+
+        spec = self.spec
+        out = {
+            "name": self.name,
+            "definition": self.definition,
+            "author": self.author,
+            "spec": {
+                "language": spec.language.value,
+                "target_hardware": list(spec.target_hardware),
+                "entry_point": spec.entry_point,
+                "dependencies": list(spec.dependencies),
+                "destination_passing_style": spec.destination_passing_style,
+            },
+            "sources": [
+                {"path": source.path, "content": source.content}
+                for source in self.sources
+            ],
+        }
+        if spec.binding is not None:
+            out["spec"]["binding"] = spec.binding.value
+        if self.description is not None:
+            out["description"] = self.description
+        return out
+
+    def _compute_hash(self) -> str:
+        """Compute a deterministic hash of the solution content."""
+
+        h = hashlib.sha1()
+        for part in (
+            self.definition,
+            self.spec.language.value,
+            self.spec.entry_point,
+            self.spec.binding.value if self.spec.binding else "",
+            *self.spec.dependencies,
+            *(item for source in self.sources for item in (source.path, source.content)),
+        ):
+            h.update(part.encode())
+        return h.hexdigest()
+
+    def hash(self) -> str:
+        """Return the memoized deterministic hash of the solution content."""
+
+        return self._hash_cache
+
+    def __hash__(self) -> int:
+        return hash(self._hash_cache)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Solution):
+            return NotImplemented
+        return self._hash_cache == other._hash_cache

--- a/flashinfer/trace/template.py
+++ b/flashinfer/trace/template.py
@@ -364,6 +364,7 @@ class TraceTemplate:
         def fi_trace(
             save_dir: Optional[Union[str, Path]] = None,
             name: Optional[str] = None,
+            _write: bool = True,
             **kwargs: Any,
         ) -> Dict[str, Any]:
             # ── 1. Extract axis values ─────────────────────────────────────
@@ -496,7 +497,7 @@ class TraceTemplate:
             # Explicit save_dir= calls always write (no dedup).
             effective_dir = save_dir if save_dir is not None else _get_trace_dump_dir()
             _is_auto_dump = save_dir is None
-            if effective_dir is not None and (
+            if _write and effective_dir is not None and (
                 not _is_auto_dump or name not in _DUMPED_NAMES
             ):
                 out_dir = Path(effective_dir)

--- a/flashinfer/trace_apply/__init__.py
+++ b/flashinfer/trace_apply/__init__.py
@@ -12,27 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-flashinfer.trace — TraceTemplate system for fi_trace.
+"""Runtime apply support for fi_trace definitions."""
 
-Usage::
-
-    from flashinfer.trace import TraceTemplate, Var, Const, Tensor, Scalar, Solution
-"""
-
-from .solution import BuildSpec, Solution, SourceFile, SupportedBindings, SupportedLanguages
-from .template import Const, Scalar, Tensor, TraceTemplate, Var, _TRACE_DUMP_DIR
+from .apply import (
+    ApplyError,
+    disable_apply,
+    enable_apply,
+    enable_apply_from_env,
+    register_plan_run,
+)
+from .config import ApplyConfig
 
 __all__ = [
-    "TraceTemplate",
-    "Var",
-    "Const",
-    "Tensor",
-    "Scalar",
-    "Solution",
-    "BuildSpec",
-    "SourceFile",
-    "SupportedLanguages",
-    "SupportedBindings",
-    "_TRACE_DUMP_DIR",
+    "ApplyError",
+    "ApplyConfig",
+    "enable_apply",
+    "enable_apply_from_env",
+    "disable_apply",
+    "register_plan_run",
 ]

--- a/flashinfer/trace_apply/apply.py
+++ b/flashinfer/trace_apply/apply.py
@@ -1,0 +1,695 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""First-class runtime kernel substitution for FlashInfer APIs.
+
+This module provides a small, explicit apply runtime keyed by fi_trace
+definition names.  It intentionally does not select kernels from benchmark
+results; callers register the solution they want for each definition.
+
+The design is derived from flashinfer-bench
+(https://github.com/flashinfer-ai/flashinfer-bench) apply system.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import inspect
+import json
+import os
+import sys
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Optional, Union
+
+import torch
+
+from ..trace.solution import Solution
+from ..trace.template import Scalar, Tensor, TraceTemplate
+from .config import ApplyConfig
+from .solution_builder.python import load_solution_object
+
+
+class ApplyError(RuntimeError):
+    """Raised when an apply solution fails during execution."""
+
+
+@dataclass
+class _ApplySolution:
+    """Callable solution registered for one fi_trace definition."""
+
+    fn: Callable[..., Any]
+    definition: Optional[str] = None
+    destination_passing_style: bool = False
+
+    def __post_init__(self) -> None:
+        if not callable(self.fn):
+            raise TypeError("ApplySolution callable must be callable")
+
+    def __call__(self, *args: Any) -> Any:
+        return self.fn(*args)
+
+
+def _resolve_param(json_key: str, descriptor: Union[Tensor, Scalar]) -> str:
+    return descriptor.param if descriptor.param is not None else json_key
+
+
+def _extract_argument(
+    bound_kwargs: Mapping[str, Any],
+    json_key: str,
+    descriptor: Union[Tensor, Scalar],
+) -> tuple[bool, Any]:
+    """Return ``(found, value)`` for a template input descriptor."""
+
+    param = _resolve_param(json_key, descriptor)
+    if param not in bound_kwargs or bound_kwargs[param] is None:
+        return False, None
+
+    value = bound_kwargs[param]
+    if isinstance(descriptor, Tensor) and descriptor.tuple_idx is not None:
+        if not isinstance(value, (tuple, list)) or len(value) <= descriptor.tuple_idx:
+            return False, None
+        value = value[descriptor.tuple_idx]
+
+    return True, value
+
+
+def build_solution_args(
+    template: TraceTemplate,
+    bound_kwargs: Mapping[str, Any],
+) -> list[Any]:
+    """Build positional solution args from ``TraceTemplate.inputs``.
+
+    ``Tensor(param=...)`` and tuple inputs are resolved against ``bound_kwargs``.
+    """
+
+    args: list[Any] = []
+    missing: list[str] = []
+    for json_key, descriptor in template.inputs.items():
+        found, value = _extract_argument(bound_kwargs, json_key, descriptor)
+        if found:
+            args.append(value)
+        elif not descriptor.optional:
+            missing.append(json_key)
+
+    if missing:
+        raise ApplyError(
+            "Cannot build apply solution inputs; missing required input(s): "
+            + ", ".join(missing)
+        )
+    return args
+
+
+def _resolve_output_buffer(
+    template: TraceTemplate,
+    bound_kwargs: Mapping[str, Any],
+    output_name: str,
+) -> Any:
+    if output_name in bound_kwargs and bound_kwargs[output_name] is not None:
+        return bound_kwargs[output_name]
+
+    # Common value-returning APIs use an optional Python parameter named
+    # ``out`` while the trace output is named semantically (for example
+    # ``"output"``). Allow DPS solutions to use that caller-provided buffer.
+    if len(template.outputs) == 1 and isinstance(bound_kwargs.get("out"), torch.Tensor):
+        return bound_kwargs["out"]
+
+    descriptor = template.outputs.get(output_name)
+    if (
+        isinstance(descriptor, Tensor)
+        and descriptor.param is not None
+        and descriptor.param in bound_kwargs
+        and bound_kwargs[descriptor.param] is not None
+    ):
+        return bound_kwargs[descriptor.param]
+
+    raise ApplyError(
+        f"Cannot call DPS apply solution; missing output buffer '{output_name}'"
+    )
+
+
+def _build_positional_output_args(
+    template: TraceTemplate,
+    bound_kwargs: Mapping[str, Any],
+) -> list[Any]:
+    return [
+        _resolve_output_buffer(template, bound_kwargs, output_name)
+        for output_name in template.outputs
+    ]
+
+
+def _adapt_dps_outputs(
+    template: TraceTemplate,
+    output_args: list[Any],
+    bound_kwargs: Mapping[str, Any],
+) -> Any:
+    if len(output_args) == 1:
+        output_name = next(iter(template.outputs))
+        if output_name == "out":
+            return None
+        if output_args[0] is bound_kwargs.get("out"):
+            return bound_kwargs["out"]
+        return output_args[0]
+    return tuple(output_args)
+
+
+def _copy_tensor(dst: Any, src: Any, *, name: str) -> None:
+    if not isinstance(dst, torch.Tensor) or not isinstance(src, torch.Tensor):
+        raise ApplyError(
+            f"Cannot copy apply output '{name}': expected tensor destination and source"
+        )
+    if tuple(dst.shape) != tuple(src.shape):
+        raise ApplyError(
+            f"Cannot copy apply output '{name}': shape mismatch "
+            f"dst={tuple(dst.shape)} src={tuple(src.shape)}"
+        )
+    dst.copy_(src)
+
+
+def _flatten_outputs(template: TraceTemplate, result: Any) -> Dict[str, Any]:
+    output_names = list(template.outputs)
+    if isinstance(result, dict):
+        return result
+    if len(output_names) == 1:
+        return {output_names[0]: result}
+    if isinstance(result, (tuple, list)):
+        if len(result) != len(output_names):
+            raise ApplyError(
+                f"Apply solution returned {len(result)} outputs, expected {len(output_names)}"
+            )
+        return dict(zip(output_names, result, strict=True))
+    raise ApplyError(
+        f"Apply solution returned a single value for {len(output_names)} outputs"
+    )
+
+
+def _adapt_solution_result(
+    result: Any,
+    template: TraceTemplate,
+    bound_kwargs: Mapping[str, Any],
+) -> Any:
+    """Copy destination-style outputs back when the original call provides buffers."""
+
+    if result is None:
+        return None
+
+    output_values = _flatten_outputs(template, result)
+    copied_output_names: set[str] = set()
+
+    for output_name, output_value in output_values.items():
+        if output_name in bound_kwargs and bound_kwargs[output_name] is not None:
+            _copy_tensor(bound_kwargs[output_name], output_value, name=output_name)
+            copied_output_names.add(output_name)
+            continue
+
+        descriptor = template.outputs.get(output_name)
+        if (
+            isinstance(descriptor, Tensor)
+            and descriptor.param is not None
+            and descriptor.param in bound_kwargs
+            and bound_kwargs[descriptor.param] is not None
+        ):
+            _copy_tensor(bound_kwargs[descriptor.param], output_value, name=output_name)
+            copied_output_names.add(output_name)
+
+    # Many value-returning FlashInfer APIs accept an optional ``out`` buffer
+    # even though the trace output is named semantically (for example
+    # ``"output"``). Preserve the API contract by copying the single solution
+    # output into that buffer and returning the buffer.
+    explicit_out = bound_kwargs.get("out")
+    if (
+        isinstance(explicit_out, torch.Tensor)
+        and "out" not in template.outputs
+        and len(output_values) == 1
+    ):
+        output_name, output_value = next(iter(output_values.items()))
+        if output_name not in copied_output_names:
+            _copy_tensor(explicit_out, output_value, name="out")
+        return explicit_out
+
+    # Common destination-passing FlashInfer APIs use an output named "out" and
+    # return None after mutating the caller-provided buffer.
+    if len(output_values) == 1 and "out" in copied_output_names:
+        return None
+
+    return result
+
+
+@dataclass
+class _Patch:
+    owner: Any
+    attr: str
+    original: Callable[..., Any]
+
+
+def _warn_once(
+    warned: set[tuple[str, str]],
+    definition_name: str,
+    exc: BaseException,
+) -> None:
+    key = (definition_name, type(exc).__name__)
+    if key in warned:
+        return
+    warned.add(key)
+    warnings.warn(
+        f"[flashinfer] apply failed for '{definition_name}': "
+        f"{type(exc).__name__}: {exc}. Falling back to the original API.",
+        stacklevel=3,
+    )
+
+
+def _build_solution_map(
+    config: Union[ApplyConfig, Mapping[str, Union[Callable[..., Any], Solution]]],
+) -> Dict[str, _ApplySolution]:
+    solution_map: Dict[str, _ApplySolution] = {}
+    if isinstance(config, ApplyConfig):
+        for definition_name, solution in config.solutions.items():
+            solution_map[definition_name] = _build_apply_solution(solution)
+        return solution_map
+
+    if isinstance(config, Mapping):
+        for definition_name, solution in config.items():
+            solution_map[definition_name] = _build_apply_solution(solution)
+        return solution_map
+
+    raise TypeError("enable_apply expects an ApplyConfig or definition-to-solution mapping")
+
+
+def _build_apply_solution(
+    solution: Union[Callable[..., Any], Solution],
+) -> _ApplySolution:
+    if isinstance(solution, Solution):
+        built_solution = load_solution_object(solution)
+        return _ApplySolution(
+            built_solution.fn,
+            definition=built_solution.definition,
+            destination_passing_style=built_solution.destination_passing_style,
+        )
+    elif callable(solution):
+        return _ApplySolution(solution)
+    raise TypeError("apply solutions must be callables or Solution objects")
+
+
+def _resolve_target(dotted: str) -> tuple[Any, str] | None:
+    parts = dotted.split(".")
+    if len(parts) < 2:
+        return None
+
+    module = None
+    module_end = 0
+    for i in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:i])
+        try:
+            module = importlib.import_module(candidate)
+            module_end = i
+            break
+        except ImportError:
+            continue
+    if module is None:
+        return None
+
+    owner: Any = module
+    for part in parts[module_end : len(parts) - 1]:
+        owner = getattr(owner, part, None)
+        if owner is None:
+            return None
+
+    attr = parts[-1]
+    if not hasattr(owner, attr):
+        return None
+    return owner, attr
+
+
+def _resolve_patch_targets(dotted: str) -> list[tuple[Any, str]]:
+    resolved = _resolve_target(dotted)
+    if resolved is None:
+        return []
+
+    targets = [resolved]
+    owner, attr = resolved
+    original = getattr(owner, attr)
+
+    flashinfer_module = sys.modules.get("flashinfer")
+    if flashinfer_module is not None:
+        for alias, value in vars(flashinfer_module).items():
+            if value is original:
+                target = (flashinfer_module, alias)
+                if target not in targets:
+                    targets.append(target)
+
+    return targets
+
+
+def _resolve_template(trace_spec: Any, bound_kwargs: Mapping[str, Any]) -> TraceTemplate | None:
+    if isinstance(trace_spec, TraceTemplate):
+        return trace_spec
+    template = trace_spec(**bound_kwargs)
+    if template is None:
+        return None
+    if not isinstance(template, TraceTemplate):
+        raise ApplyError("trace dispatch callable did not return a TraceTemplate")
+    return template
+
+
+def _bind_call(
+    signature: inspect.Signature,
+    args: tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    bound = signature.bind(*args, **kwargs)
+    bound.apply_defaults()
+    return dict(bound.arguments)
+
+
+def _build_definition(
+    *,
+    fi_api: str,
+    trace_spec: Any,
+    definition_fns: dict[int, Callable[..., dict]],
+    bound_kwargs: Mapping[str, Any],
+) -> tuple[TraceTemplate | None, dict | None]:
+    template = _resolve_template(trace_spec, bound_kwargs)
+    if template is None:
+        return None, None
+    template_id = id(template)
+    definition_fn = definition_fns.get(template_id)
+    if definition_fn is None:
+        definition_fn = template.build_fi_trace_fn(fi_api)
+        definition_fns[template_id] = definition_fn
+    return template, definition_fn(_write=False, **bound_kwargs)
+
+
+def _resolve_solution(
+    *,
+    solutions: Mapping[str, _ApplySolution],
+    warned: set[tuple[str, str]],
+    definition: dict,
+) -> _ApplySolution | None:
+    definition_name = definition.get("name")
+    if not isinstance(definition_name, str) or not definition_name:
+        return None
+
+    solution = solutions.get(definition_name)
+    if solution is None:
+        return None
+
+    if solution.definition is not None and solution.definition != definition_name:
+        _warn_once(
+            warned,
+            definition_name,
+            ApplyError(
+                f"Apply solution declares definition '{solution.definition}', "
+                f"but runtime definition is '{definition_name}'"
+            ),
+        )
+        return None
+    return solution
+
+
+def _dispatch_solution(
+    *,
+    solutions: Mapping[str, _ApplySolution],
+    warned: set[tuple[str, str]],
+    definition: dict,
+    template: TraceTemplate,
+    bound_kwargs: Mapping[str, Any],
+    fallback: Callable[[], Any],
+) -> Any:
+    solution = _resolve_solution(
+        solutions=solutions,
+        warned=warned,
+        definition=definition,
+    )
+    if solution is None:
+        return fallback()
+
+    try:
+        input_args = build_solution_args(template, bound_kwargs)
+        if solution.destination_passing_style:
+            output_args = _build_positional_output_args(template, bound_kwargs)
+            solution(*input_args, *output_args)
+            return _adapt_dps_outputs(template, output_args, bound_kwargs)
+        result = solution(*input_args)
+        return _adapt_solution_result(result, template, bound_kwargs)
+    except Exception as exc:
+        definition_name = definition.get("name")
+        if not isinstance(definition_name, str):
+            definition_name = "<unknown>"
+        _warn_once(warned, definition_name, exc)
+        return fallback()
+
+
+def _make_wrapper(
+    *,
+    registration: Mapping[str, Any],
+    original: Callable[..., Any],
+    solutions: Mapping[str, _ApplySolution],
+    warned: set[tuple[str, str]],
+) -> Callable[..., Any]:
+    fi_api = registration["fi_api"]
+    plan_fi_api = _PLAN_RUN_PAIRS.get(fi_api)
+    if plan_fi_api is not None:
+        _patch_plan(plan_fi_api, warned)
+        return _patch_run(
+            registration=registration,
+            original=original,
+            solutions=solutions,
+            warned=warned,
+        )
+
+    trace_spec = registration["trace"]
+    signature = inspect.signature(registration["original"])
+    definition_fns: dict[int, Callable[..., dict]] = {}
+
+    @functools.wraps(original)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            bound_kwargs = _bind_call(signature, args, kwargs)
+            template, definition = _build_definition(
+                fi_api=fi_api,
+                trace_spec=trace_spec,
+                definition_fns=definition_fns,
+                bound_kwargs=bound_kwargs,
+            )
+            if template is None or definition is None:
+                return original(*args, **kwargs)
+            return _dispatch_solution(
+                solutions=solutions,
+                warned=warned,
+                definition=definition,
+                template=template,
+                bound_kwargs=bound_kwargs,
+                fallback=lambda: original(*args, **kwargs),
+            )
+        except Exception as exc:
+            _warn_once(warned, fi_api, exc)
+            return original(*args, **kwargs)
+
+    return wrapper
+
+
+def _patch_plan(plan_fi_api: str, warned: set[tuple[str, str]]) -> None:
+    def make_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
+        signature = inspect.signature(original)
+
+        @functools.wraps(original)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                bound_kwargs = _bind_call(signature, args, kwargs)
+            except Exception as exc:
+                _warn_once(warned, plan_fi_api, exc)
+                return original(*args, **kwargs)
+
+            result = original(*args, **kwargs)
+            instance = bound_kwargs.get("self")
+            if instance is not None:
+                plan_kwargs = dict(bound_kwargs)
+                plan_kwargs.pop("self", None)
+                setattr(instance, _PLAN_RUN_CACHE_ATTR, plan_kwargs)
+            return result
+
+        return wrapper
+
+    for owner, attr in _resolve_patch_targets(plan_fi_api):
+        patch = _find_patch(owner, attr)
+        if patch is None:
+            original = getattr(owner, attr)
+            _patches[(id(owner), attr)] = _Patch(
+                owner=owner, attr=attr, original=original
+            )
+        else:
+            original = patch.original
+
+        setattr(owner, attr, make_wrapper(original))
+
+
+def _patch_run(
+    *,
+    registration: Mapping[str, Any],
+    original: Callable[..., Any],
+    solutions: Mapping[str, _ApplySolution],
+    warned: set[tuple[str, str]],
+) -> Callable[..., Any]:
+    fi_api = registration["fi_api"]
+    trace_spec = registration["trace"]
+    signature = inspect.signature(registration["original"])
+    definition_fns: dict[int, Callable[..., dict]] = {}
+
+    @functools.wraps(original)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            run_kwargs = _bind_call(signature, args, kwargs)
+            instance = run_kwargs.get("self")
+            plan_kwargs = getattr(instance, _PLAN_RUN_CACHE_ATTR, None)
+            if not isinstance(plan_kwargs, dict):
+                return original(*args, **kwargs)
+
+            bound_kwargs = {**plan_kwargs, **run_kwargs}
+            bound_kwargs.pop("self", None)
+            template, definition = _build_definition(
+                fi_api=fi_api,
+                trace_spec=trace_spec,
+                definition_fns=definition_fns,
+                bound_kwargs=bound_kwargs,
+            )
+            if template is None or definition is None:
+                return original(*args, **kwargs)
+            solution = _resolve_solution(
+                solutions=solutions,
+                warned=warned,
+                definition=definition,
+            )
+            if solution is None:
+                return original(*args, **kwargs)
+
+            result = solution.fn(**bound_kwargs)
+            return _adapt_solution_result(result, template, bound_kwargs)
+        except Exception as exc:
+            _warn_once(warned, fi_api, exc)
+            return original(*args, **kwargs)
+
+    return wrapper
+
+
+_patches: dict[tuple[int, str], _Patch] = {}
+_PLAN_RUN_PAIRS: dict[str, str] = {}
+_PLAN_RUN_CACHE_ATTR = "_flashinfer_apply_plan_kwargs"
+_APPLY_ENV = "FLASHINFER_APPLY"
+_APPLY_CONFIG_ENV = "FLASHINFER_APPLY_CONFIG"
+
+
+def _find_patch(owner: Any, attr: str) -> _Patch | None:
+    return _patches.get((id(owner), attr))
+
+
+def register_plan_run(
+    *,
+    plan_fi_api: str,
+    run_fi_api: str,
+) -> None:
+    """Register a plan/run method pair for trace apply."""
+
+    _PLAN_RUN_PAIRS[run_fi_api] = plan_fi_api
+
+
+def enable_apply(
+    config: Union[ApplyConfig, Mapping[str, Union[Callable[..., Any], Solution]]],
+) -> None:
+    """Enable apply wrappers for imported FlashInfer APIs.
+
+    The wrappers are installed independently of ``@flashinfer_api`` logging:
+    trace decorators only register metadata, while this function performs the
+    runtime monkey-patching.
+    """
+
+    solution_map = _build_solution_map(config)
+    if not solution_map:
+        return
+
+    from flashinfer.api_logging import _TRACE_APPLY_REGISTRY  # noqa: PLC0415
+
+    warned: set[tuple[str, str]] = set()
+    seen_targets: set[str] = set()
+    for registration in _TRACE_APPLY_REGISTRY:
+        fi_api = registration.get("fi_api")
+        if not isinstance(fi_api, str) or fi_api in seen_targets:
+            continue
+        seen_targets.add(fi_api)
+        targets = _resolve_patch_targets(fi_api)
+        if not targets:
+            continue
+        for owner, attr in targets:
+            patch = _find_patch(owner, attr)
+            if patch is None:
+                original = getattr(owner, attr)
+                _patches[(id(owner), attr)] = _Patch(
+                    owner=owner, attr=attr, original=original
+                )
+            else:
+                original = patch.original
+            wrapper = _make_wrapper(
+                registration=registration,
+                original=original,
+                solutions=solution_map,
+                warned=warned,
+            )
+            setattr(owner, attr, wrapper)
+
+
+def disable_apply() -> None:
+    """Disable trace apply and restore patched APIs."""
+
+    while _patches:
+        _, patch = _patches.popitem()
+        setattr(patch.owner, patch.attr, patch.original)
+
+
+def enable_apply_from_env() -> None:
+    enabled = os.environ.get(_APPLY_ENV, "0")
+    if enabled in ("", "0"):
+        return
+    if enabled != "1":
+        warnings.warn(
+            f"{_APPLY_ENV} must be '0' or '1', got {enabled!r}; trace apply is disabled.",
+            stacklevel=2,
+        )
+        return
+
+    config_path = os.environ.get(_APPLY_CONFIG_ENV)
+    if not config_path:
+        warnings.warn(
+            f"{_APPLY_ENV}=1 but {_APPLY_CONFIG_ENV} is not set; trace apply is disabled.",
+            stacklevel=2,
+        )
+        return
+
+    try:
+        enable_apply(_load_apply_config_path(config_path))
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to enable trace apply from {_APPLY_CONFIG_ENV}={config_path!r}: "
+            f"{type(exc).__name__}: {exc}",
+            stacklevel=2,
+        )
+
+
+def _load_apply_config_path(path: str) -> ApplyConfig:
+    config_path = Path(path).expanduser()
+    with config_path.open() as f:
+        data = json.load(f)
+    if not isinstance(data, Mapping):
+        raise TypeError(f"{config_path} must contain a JSON object")
+    return ApplyConfig.from_dict(data)

--- a/flashinfer/trace_apply/config.py
+++ b/flashinfer/trace_apply/config.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serializable configuration for trace apply solution routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from ..trace.solution import Solution
+
+
+@dataclass(frozen=True)
+class ApplyConfig:
+    """Serializable mapping from fi_trace definition names to solutions."""
+
+    solutions: Mapping[str, Solution] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ApplyConfig":
+        """Build an ApplyConfig from a JSON-compatible dictionary."""
+
+        raw_solutions = data.get("solutions", {})
+        if not isinstance(raw_solutions, Mapping):
+            raise TypeError("ApplyConfig.solutions must be a mapping")
+
+        solutions: dict[str, Solution] = {}
+        for definition_name, raw_solution in raw_solutions.items():
+            if not isinstance(definition_name, str) or not definition_name:
+                raise ValueError("ApplyConfig solution keys must be non-empty strings")
+            if isinstance(raw_solution, Solution):
+                solution = raw_solution
+            elif isinstance(raw_solution, Mapping):
+                solution = Solution.from_dict(raw_solution)
+            else:
+                raise TypeError(
+                    "ApplyConfig solutions must be Solution objects or dictionaries"
+                )
+            if solution.definition != definition_name:
+                raise ValueError(
+                    f"Solution key '{definition_name}' does not match "
+                    f"solution.definition '{solution.definition}'"
+                )
+            solutions[definition_name] = solution
+        return cls(solutions=solutions)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible dictionary."""
+
+        return {
+            "solutions": {
+                definition_name: solution.to_dict()
+                for definition_name, solution in self.solutions.items()
+            }
+        }
+
+
+__all__ = ["ApplyConfig"]

--- a/flashinfer/trace_apply/solution_builder/python.py
+++ b/flashinfer/trace_apply/solution_builder/python.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build in-process Python callables from Solution objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+
+from ...trace.solution import Solution, SupportedLanguages
+
+
+_SUPPORTED_LANGUAGES = {
+    SupportedLanguages.PYTHON,
+    SupportedLanguages.TRITON,
+    SupportedLanguages.CUDA,
+    SupportedLanguages.TILELANG,
+}
+
+
+@dataclass(frozen=True)
+class BuiltSolution:
+    """Callable extracted from a Solution object."""
+
+    fn: Callable[..., Any]
+    definition: str
+    destination_passing_style: bool
+
+
+def load_solution_object(solution: Solution) -> BuiltSolution:
+    """Load a minimal flashinfer-bench Solution object.
+
+    Only the smallest no-build subset is supported:
+
+    - ``spec.language`` is any supported language except ``"cpp"``
+    - ``spec.entry_point == "<file_path>::<function_name>"``
+    - ``sources`` contains one file object with that path and source content
+    """
+
+    if solution.spec.language not in _SUPPORTED_LANGUAGES:
+        raise ValueError(
+            f"Unsupported apply solution language: {solution.spec.language.value!r}"
+        )
+
+    entry_point = solution.spec.entry_point
+    entry_name = solution.get_entry_symbol()
+    source = solution.get_entry_source()
+    if source is None:
+        entry_path = solution.spec.entry_point.split("::", 1)[0]
+        raise ValueError(f"Python apply solution missing source file {entry_path}")
+
+    namespace: dict[str, Any] = {"torch": torch}
+    exec(source.content, namespace)  # noqa: S102 - trusted user-provided solution code
+    fn: Any = namespace
+    for part in entry_name.split("."):
+        fn = fn[part] if isinstance(fn, dict) else getattr(fn, part)
+    if not callable(fn):
+        raise TypeError(f"Entry point '{entry_point}' does not resolve to a callable")
+
+    return BuiltSolution(
+        fn=fn,
+        definition=solution.definition,
+        destination_passing_style=solution.spec.destination_passing_style,
+    )

--- a/tests/apply/test_apply.py
+++ b/tests/apply/test_apply.py
@@ -421,5 +421,79 @@ def test_plan_run_apply_uses_cached_plan_inputs():
     assert calls == [(3, 2.0, 5.0)]
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_batch_decode_plan_run_apply_end_to_end():
+    device = torch.device("cuda")
+    dtype = torch.float16
+    batch_size = 2
+    num_qo_heads = 2
+    num_kv_heads = 1
+    head_dim = 16
+    page_size = 1
+    num_pages = 2
+
+    workspace = torch.zeros(32 * 1024 * 1024, dtype=torch.uint8, device=device)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        kv_layout="NHD",
+    )
+
+    indptr = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    indices = torch.arange(num_pages, dtype=torch.int32, device=device)
+    last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+    q = torch.randn(
+        batch_size,
+        num_qo_heads,
+        head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    k_cache = torch.randn(
+        num_pages,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    v_cache = torch.randn_like(k_cache)
+    calls = []
+
+    def solution(**kwargs):
+        calls.append(kwargs)
+        q = kwargs["q"]
+        lse = torch.zeros(
+            q.shape[0],
+            q.shape[1],
+            dtype=torch.float32,
+            device=q.device,
+        )
+        return q + 1, lse
+
+    flashinfer.enable_apply({"gqa_paged_decode_h2_kv1_d16_ps1": solution})
+
+    wrapper.plan(
+        indptr,
+        indices,
+        last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    out, lse = wrapper.run(q, (k_cache, v_cache), return_lse=True)
+
+    torch.testing.assert_close(out, q + 1)
+    torch.testing.assert_close(lse, torch.zeros_like(lse))
+    assert len(calls) == 1
+    assert calls[0]["indptr"] is indptr
+    assert calls[0]["indices"] is indices
+    assert calls[0]["last_page_len"] is last_page_len
+    assert calls[0]["q"] is q
+    assert calls[0]["paged_kv_cache"] == (k_cache, v_cache)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/apply/test_apply.py
+++ b/tests/apply/test_apply.py
@@ -1,0 +1,425 @@
+import json
+import sys
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.api_logging import flashinfer_api
+from flashinfer.trace_apply import enable_apply_from_env, register_plan_run
+from flashinfer.trace import (
+    BuildSpec,
+    Const,
+    Scalar,
+    Solution,
+    SourceFile,
+    Tensor,
+    TraceTemplate,
+    Var,
+)
+from flashinfer.trace.templates.norm import rmsnorm_trace
+
+_test_apply_trace = TraceTemplate(
+    op_type="apply_test",
+    name_prefix="apply_test",
+    axes={
+        "batch_size": Var(),
+        "hidden_size": Const(abbrev="h"),
+    },
+    inputs={
+        "x": Tensor(["batch_size", "hidden_size"]),
+    },
+    outputs={
+        "output": Tensor(["batch_size", "hidden_size"], dtype_from="x"),
+    },
+)
+
+
+_plan_run_trace = TraceTemplate(
+    op_type="plan_run_test",
+    name_prefix="plan_run",
+    axes={
+        "batch_size": Var(),
+        "hidden_size": Const(abbrev="h"),
+        "factor": Const(abbrev="f"),
+    },
+    inputs={
+        "x": Tensor(["batch_size", "hidden_size"]),
+        "factor": Scalar("int32", optional=True),
+        "scale": Scalar("float32", optional=True),
+        "bias": Scalar("float32", optional=True),
+    },
+    outputs={
+        "output": Tensor(["batch_size", "hidden_size"], dtype_from="x"),
+    },
+)
+
+
+@flashinfer_api(trace=_test_apply_trace)
+def _apply_test_api(x):
+    return x - 1
+
+
+class _PlanRunApplyTest:
+    @flashinfer_api
+    def plan(self, factor: int, scale: float = 1.0):
+        self.factor = factor
+        self.scale = scale
+
+    @flashinfer_api(trace=_plan_run_trace)
+    def run(self, x, bias: float = 0.0):
+        return x * self.factor * self.scale + bias
+
+
+@pytest.fixture(autouse=True)
+def _reset_trace_apply():
+    flashinfer.disable_apply()
+    yield
+    flashinfer.disable_apply()
+
+
+def _python_solution(definition, content, *, dps=False, language="python"):
+    return Solution(
+        name=f"{definition}_python",
+        definition=definition,
+        author="test",
+        spec=BuildSpec(
+            language=language,
+            target_hardware=["CPU"],
+            entry_point="main.py::run",
+            destination_passing_style=dps,
+        ),
+        sources=[SourceFile(path="main.py", content=content)],
+    )
+
+
+def _apply_config_dict(definition, expression):
+    return {
+        "solutions": {
+            definition: {
+                "name": f"{definition}_python",
+                "definition": definition,
+                "author": "test",
+                "spec": {
+                    "language": "python",
+                    "target_hardware": ["CPU"],
+                    "entry_point": "main.py::run",
+                    "destination_passing_style": False,
+                },
+                "sources": [
+                    {
+                        "path": "main.py",
+                        "content": f"def run(x):\n    return {expression}\n",
+                    }
+                ],
+            }
+        }
+    }
+
+
+def test_rmsnorm():
+    x = torch.randn(3, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    calls = []
+
+    def solution(hidden_states, weight):
+        calls.append((hidden_states, weight))
+        return hidden_states + weight
+
+    flashinfer.enable_apply({"rmsnorm_h4": solution})
+    out = flashinfer.rmsnorm(x, weight)
+
+    torch.testing.assert_close(out, x + weight)
+    assert calls == [(x, weight)]
+
+
+def test_rmsnorm_positional_and_kwargs():
+    x_positional = torch.randn(3, 4, dtype=torch.float32)
+    x_kwargs = torch.randn(3, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    calls = []
+
+    def solution(hidden_states, weight):
+        calls.append((hidden_states, weight))
+        return hidden_states + weight
+
+    flashinfer.enable_apply({"rmsnorm_h4": solution})
+    out_positional = flashinfer.rmsnorm(x_positional, weight)
+    out_kwargs = flashinfer.rmsnorm(input=x_kwargs, weight=weight)
+
+    torch.testing.assert_close(out_positional, x_positional + weight)
+    torch.testing.assert_close(out_kwargs, x_kwargs + weight)
+    assert calls == [(x_positional, weight), (x_kwargs, weight)]
+
+
+def test_rmsnorm_out():
+    x = torch.randn(3, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    def solution(hidden_states, weight):
+        return hidden_states + weight
+
+    flashinfer.enable_apply({"rmsnorm_h4": solution})
+    result = flashinfer.rmsnorm(x, weight, out=out)
+
+    assert result is out
+    torch.testing.assert_close(out, x + weight)
+
+
+def test_solution_object():
+    x = torch.randn(3, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    solution = _python_solution(
+        "rmsnorm_h4",
+        "def run(hidden_states, weight):\n    return hidden_states + weight\n",
+    )
+
+    flashinfer.enable_apply({"rmsnorm_h4": solution})
+    out = flashinfer.rmsnorm(x, weight)
+
+    torch.testing.assert_close(out, x + weight)
+
+
+def test_apply_config_from_dict():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    config = flashinfer.ApplyConfig.from_dict(
+        {
+            "solutions": {
+                "apply_test_h4": {
+                    "name": "apply_test_h4_python",
+                    "definition": "apply_test_h4",
+                    "author": "test",
+                    "spec": {
+                        "language": "python",
+                        "target_hardware": ["CPU"],
+                        "entry_point": "main.py::run",
+                        "destination_passing_style": False,
+                    },
+                    "sources": [
+                        {
+                            "path": "main.py",
+                            "content": "def run(x):\n    return x + 1\n",
+                        }
+                    ],
+                }
+            }
+        }
+    )
+
+    flashinfer.enable_apply(config)
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x + 1)
+
+
+def test_solution_dict_roundtrip():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    config_solution = _python_solution(
+        "apply_test_h4",
+        "def run(x):\n    return x + 1\n",
+    )
+    config = flashinfer.ApplyConfig(solutions={"apply_test_h4": config_solution})
+
+    loaded_config = flashinfer.ApplyConfig.from_dict(config.to_dict())
+    flashinfer.enable_apply(loaded_config)
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x + 1)
+
+
+def test_enable_apply_from_env_file(tmp_path, monkeypatch):
+    x = torch.randn(2, 4, dtype=torch.float32)
+    path = tmp_path / "apply.json"
+    path.write_text(json.dumps(_apply_config_dict("apply_test_h4", "x + 1")))
+    monkeypatch.setenv("FLASHINFER_APPLY", "1")
+    monkeypatch.setenv("FLASHINFER_APPLY_CONFIG", str(path))
+
+    enable_apply_from_env()
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x + 1)
+
+
+def test_solution_language_allowlist():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    solution = _python_solution(
+        "apply_test_h4",
+        "def run(x):\n    return x + 1\n",
+        language="triton",
+    )
+
+    flashinfer.enable_apply({"apply_test_h4": solution})
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x + 1)
+
+
+def test_cpp_solution_rejected():
+    solution = _python_solution(
+        "apply_test_h4",
+        "def run(x):\n    return x + 1\n",
+        language="cpp",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported apply solution language"):
+        flashinfer.enable_apply({"apply_test_h4": solution})
+
+
+def test_fallback_on_miss():
+    x = torch.randn(2, 4, dtype=torch.float32)
+
+    def solution(x):
+        return x + 1
+
+    flashinfer.enable_apply({"apply_test_h8": solution})
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x - 1)
+
+
+def test_enable_overrides_previous_apply_until_disable():
+    x = torch.randn(2, 4, dtype=torch.float32)
+
+    def solution_one(x):
+        return x + 1
+
+    def solution_two(x):
+        return x + 2
+
+    flashinfer.enable_apply({"apply_test_h4": solution_one})
+    flashinfer.enable_apply({"apply_test_h4": solution_two})
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x + 2)
+
+    flashinfer.disable_apply()
+    out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x - 1)
+
+
+def test_fallback_on_error():
+    x = torch.randn(2, 4, dtype=torch.float32)
+
+    def solution(x):
+        raise RuntimeError("boom")
+
+    flashinfer.enable_apply({"apply_test_h4": solution})
+    with pytest.warns(UserWarning, match="apply failed"):
+        out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x - 1)
+
+
+def test_fallback_on_definition_mismatch():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    solution = _python_solution("wrong", "def run(x):\n    return x + 1\n")
+
+    flashinfer.enable_apply({"apply_test_h4": solution})
+    with pytest.warns(UserWarning, match="declares definition"):
+        out = _apply_test_api(x)
+
+    torch.testing.assert_close(out, x - 1)
+
+
+def test_rmsnorm_quant_out():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    scale = torch.tensor([1.0], dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    def solution(hidden_states, weight, scale):
+        return hidden_states + weight + scale.reshape(())
+
+    flashinfer.enable_apply({"rmsnorm_quant_h4": solution})
+    result = flashinfer.rmsnorm_quant(out, x, weight, scale)
+
+    assert result is None
+    torch.testing.assert_close(out, x + weight + 1.0)
+
+
+def test_solution_object_dps():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    scale = torch.tensor([2.0], dtype=torch.float32)
+    out = torch.empty_like(x)
+    solution = _python_solution(
+        "rmsnorm_quant_h4",
+        (
+            "def run(hidden_states, weight, scale, out):\n"
+            "    out.copy_(hidden_states + weight + scale.reshape(()))\n"
+        ),
+        dps=True,
+    )
+
+    flashinfer.enable_apply({"rmsnorm_quant_h4": solution})
+    result = flashinfer.rmsnorm_quant(out, x, weight, scale)
+
+    assert result is None
+    torch.testing.assert_close(out, x + weight + 2.0)
+
+
+def test_fused_add_rmsnorm_mutation():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    residual = torch.randn(2, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+    expected_x = x + 1
+    expected_residual = residual + 2
+
+    def solution(hidden_states, residual, weight):
+        del weight
+        hidden_states.copy_(hidden_states + 1)
+        residual.copy_(residual + 2)
+        return None
+
+    flashinfer.enable_apply({"fused_add_rmsnorm_h4": solution})
+    result = flashinfer.fused_add_rmsnorm(x, residual, weight)
+
+    assert result is None
+    torch.testing.assert_close(x, expected_x)
+    torch.testing.assert_close(residual, expected_residual)
+
+
+def test_build_definition():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    weight = torch.randn(4, dtype=torch.float32)
+
+    definition = rmsnorm_trace.build_fi_trace_fn("flashinfer.norm.rmsnorm")(
+        _write=False, input=x, weight=weight
+    )
+    traced = flashinfer.rmsnorm.fi_trace(input=x, weight=weight)
+
+    assert definition == traced
+
+
+def test_plan_run_apply_uses_cached_plan_inputs():
+    x = torch.randn(2, 4, dtype=torch.float32)
+    op = _PlanRunApplyTest()
+    op.factor = 10
+    op.scale = 1.0
+    calls = []
+
+    def solution(x, factor, scale=1.0, bias=0.0):
+        calls.append((factor, scale, bias))
+        return x * factor * scale + bias + 1
+
+    register_plan_run(
+        plan_fi_api=f"{__name__}._PlanRunApplyTest.plan",
+        run_fi_api=f"{__name__}._PlanRunApplyTest.run",
+    )
+    flashinfer.enable_apply({"plan_run_h4_f3": solution})
+
+    fallback = op.run(x, bias=1.0)
+    torch.testing.assert_close(fallback, x * 10 + 1.0)
+    assert calls == []
+
+    op.plan(3, scale=2.0)
+    out = op.run(x, bias=5.0)
+
+    torch.testing.assert_close(out, x * 3 * 2.0 + 6.0)
+    assert calls == [(3, 2.0, 5.0)]
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
## Summary

Used as implementation reference to #3240.

This PR adds a first-class trace apply system for FlashInfer. Users can deterministically substitute selected FlashInfer APIs with custom solutions based on fi_trace definition names.

Unlike benchmark-driven apply systems, this implementation does not do workload filtering, autotuning, speed ranking, or policy selection. The user provides an explicit routing table from definition name to solution, and FlashInfer applies that mapping directly when the matching API is called.

## Features

1. Deterministic apply: directly applies a solution to a trace definition without workload filtering, autotuning, speed ranking, or policy selection.
2. `ApplyConfig` class: provides a serializable config object for the apply routing table.
3. Plan/run registration and substitution: supports two-stage APIs where `plan()` records metadata inputs and `run()` dispatches the registered solution with both plan-time and run-time arguments.
4. DPS format support: supports destination-passing solutions that write into caller-provided output tensors, in addition to value-returning solutions.
5. Combined positional args and kwargs support: wrappers bind both positional arguments and keyword arguments through the original API signature before constructing trace definitions and invoking solutions.

## API Spec

```python
from collections.abc import Callable, Mapping
from typing import Any, Union

from flashinfer.trace import Solution
from flashinfer.trace_apply import ApplyConfig

def enable_apply(
    config: Union[ApplyConfig, Mapping[str, Union[Callable[..., Any], Solution]]],
) -> None: ...

def disable_apply() -> None: ...
```

`enable_apply(...)` requires an explicit routing table. Calling it multiple times is allowed: each call replaces the active routing table while preserving the original functions. `disable_apply()` restores the original FlashInfer APIs.

## Basic Usage

For in-process Python callables, pass a direct routing table:

```python
import flashinfer

flashinfer.enable_apply({
    "definition_name": solution_callable,
})

# FlashInfer calls matching the definition are substituted.

flashinfer.disable_apply()
```

## Serializable Config Usage

For config-driven use cases, build an `ApplyConfig` with `Solution` objects:

```python
from flashinfer.trace import BuildSpec, Solution, SourceFile, SupportedLanguages
from flashinfer.trace_apply import ApplyConfig

config = ApplyConfig(
    solutions={
        "definition_name": Solution(
            name="my_solution",
            definition="definition_name",
            author="me",
            spec=BuildSpec(
                language=SupportedLanguages.PYTHON,
                target_hardware=["cuda"],
                entry_point="solution.py::solution",
                destination_passing_style=False,
            ),
            sources=[
                SourceFile(
                    path="solution.py",
                    content="def solution(x):\n    return x\n",
                )
            ],
        )
    }
)

flashinfer.enable_apply(config)
```

`ApplyConfig.to_dict()` and `ApplyConfig.from_dict(...)` provide JSON-compatible serialization. `Solution.to_dict()` and `Solution.from_dict(...)` do the same for individual solutions.

## Environment Enablement

The apply system can be enabled at import time with environment variables:

```bash
export FLASHINFER_APPLY=1
export FLASHINFER_APPLY_CONFIG=/path/to/apply_config.json
```

`FLASHINFER_APPLY_CONFIG` points to a single JSON config file containing an `ApplyConfig` dictionary. Import-time failures are warning-only, so a bad apply config does not make `import flashinfer` fail.

## Solution Styles

Value-returning solutions return output tensors directly:

```python
def solution(x, weight):
    return custom_kernel(x, weight)
```

DPS solutions receive output buffers from the original call and write into them:

```python
def solution(x, weight, out):
    custom_kernel_out(x, weight, out)
```

The wrapper adapts either style to the original FlashInfer API return convention.

## Plan/Run Substitution

For registered two-stage APIs, `plan()` still executes normally and caches its bound arguments on the wrapper instance. Later, `run()` combines the cached plan arguments with its own bound arguments, builds the trace definition, and dispatches the matching solution when present. If no matching solution exists, the original `run()` executes.

This PR includes built-in registration for `BatchDecodeWithPagedKVCacheWrapper.plan/run`.

## Implementation Notes

The apply dispatcher is installed by `enable_apply(...)`, not by the logging path. `@flashinfer_api(trace=...)` only exposes metadata needed for tracing/apply discovery; it does not load solutions or perform apply dispatch itself.