### PR TITLE
[codex] decouple nightly index update from tests

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -392,7 +392,7 @@ jobs:
           fi
 
   update-wheel-index:
-    needs: [setup, create-release, test-nightly-build]
+    needs: [setup, create-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout flashinfer repo


### PR DESCRIPTION
## Summary

Decouple the nightly wheel-index update from the full nightly test matrix. The index job still waits for `create-release`, so it only publishes wheels after build artifacts have been uploaded to the GitHub Release.

## Why

Recent nightly package test failures are preventing the wheel index from updating even when the wheels have built and release upload has completed. This lets nightly wheels remain available while test failures continue to report through the existing test and summary jobs.

## Validation

- `git diff --check`
- `uvx --from pyyaml python - <<PY ... yaml.safe_load(...) ... PY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the nightly release workflow to streamline the package index update process, reducing overall build pipeline execution time.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3288)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->