### PR TITLE
Fix [Spark unit test CI]: defer torch._dynamo.disable to avoid import-time crash in CI

### DIFF
--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -98,12 +98,20 @@ def get_num_sm(device: torch.device) -> int:
     return torch.cuda.get_device_properties(device).multi_processor_count
 
 
-@torch._dynamo.disable
-def current_cuda_stream():
+def _current_cuda_stream_impl():
     """Return the current Torch CUDA stream as a CUDA driver stream handle."""
     import cuda.bindings.driver as cuda
 
     return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+def current_cuda_stream():  # noqa: F811
+    """Lazy wrapper that applies torch._dynamo.disable on first call to avoid
+    importing torch._dynamo at module load time (which fails in containers
+    running as unmapped UIDs without /etc/passwd entries)."""
+    global current_cuda_stream
+    current_cuda_stream = torch._dynamo.disable(_current_cuda_stream_impl)
+    return current_cuda_stream()
 
 
 # Cache for HardwareInfo - it's expensive to create on every call


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- #3271 (feat(moe): add SM120 W4A16 b12x kernels) added a @torch._dynamo.disable decorator to current_cuda_stream() in cute_dsl/utils.py. This eagerly imports torch._dynamo at module load time, which triggers getpass.getuser() during cache-dir initialization. This crashes in CI containers running as unmapped UIDs (e.g. Spark runners with -u $(id -u):$(id -g) mapping to UID 996, which has no /etc/passwd entry).
- Replaces the eager decorator with a self-replacing lazy wrapper that defers torch._dynamo.disable to the first call of current_cuda_stream(), with zero overhead on subsequent calls. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved module import performance by deferring CUDA stream initialization until first use, reducing startup overhead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3290)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->