### PR TITLE
Use cudnn 9.23 new API to query workspace with override shape

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2102,6 +2102,12 @@ def is_cudnn_override_shape_available() -> bool:
         return False
 
 
+def _get_cudnn_workspace_size(graph, tactic: int) -> int:
+    if tactic < 0:
+        return graph.get_workspace_size()
+    return graph.get_workspace_size_plan_at_index(tactic)
+
+
 def _get_cudnn_override_shape_workspace_size(
     graph,
     tactic: int,
@@ -2111,10 +2117,17 @@ def _get_cudnn_override_shape_workspace_size(
     override_strides,
 ) -> int:
     if cudnn.backend_version() >= 92300:
+        if tactic < 0:
+            return graph.get_workspace_size(
+                cudnn_handle, override_uids, override_shapes, override_strides
+            )
         return graph.get_workspace_size_plan_at_index(
             tactic, cudnn_handle, override_uids, override_shapes, override_strides
         )
-    return graph.get_workspace_size_plan_at_index(tactic)
+    else:
+        if tactic < 0:
+            return graph.get_workspace_size()
+        return graph.get_workspace_size_plan_at_index(tactic)
 
 
 def clear_cudnn_graph_cache() -> None:
@@ -2356,10 +2369,9 @@ def execute_cudnn_gemm_fp4_graph(
     if alpha is not None:
         variant_pack[UIDs.ALPHA_UID.value] = alpha.view(torch.float)
 
-    if workspace_buffer.numel() < graph.get_workspace_size():
-        workspace_buffer = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
+    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    if workspace_buffer.numel() < workspace_size:
+        workspace_buffer.resize_(workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
 
@@ -2595,7 +2607,7 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
         graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
     )
     if workspace.numel() < workspace_size:
-        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
+        workspace.resize_(workspace_size)
 
     graph.execute_plan_at_index(
         variant_pack,
@@ -2626,12 +2638,10 @@ def execute_cudnn_gemm_mxfp8_graph(
         UIDs.O_UID.value: c_final,
     }
 
-    workspace_size = graph.get_workspace_size()
+    workspace_size = _get_cudnn_workspace_size(graph, tactic)
 
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer = torch.empty(
-            workspace_size, device=a.device, dtype=torch.uint8
-        )
+        workspace_buffer.resize_(workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
 
@@ -2811,7 +2821,7 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
     )
     if workspace.numel() < workspace_size:
-        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
+        workspace.resize_(workspace_size)
 
     graph.execute_plan_at_index(
         variant_pack,
@@ -2938,10 +2948,9 @@ def execute_cudnn_gemm_fp8_graph(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if workspace.numel() < graph.get_workspace_size():
-        workspace = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
+    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    if workspace.numel() < workspace_size:
+        workspace.resize_(workspace_size)
 
     if tactic == -1:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
@@ -3070,7 +3079,7 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
         graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
     )
     if workspace.numel() < workspace_size:
-        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
+        workspace.resize_(workspace_size)
 
     graph.execute_plan_at_index(
         variant_pack,
@@ -3344,10 +3353,9 @@ def execute_cudnn_gemm_bf16_graph(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if workspace.numel() < graph.get_workspace_size():
-        workspace = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
+    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    if workspace.numel() < workspace_size:
+        workspace.resize_(workspace_size)
 
     if tactic == -1:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
@@ -3520,7 +3528,7 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
         graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
     )
     if workspace.numel() < workspace_size:
-        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
+        workspace.resize_(workspace_size)
 
     graph.execute_plan_at_index(
         variant_pack,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1226,14 +1226,6 @@ def bf16_gemm_sm100(
     use_sm_100f = is_sm100f_supported(a.device)
 
     tuner = AutoTuner.get()
-    # Effective bucket mapper, accounting for any active
-    # ``with autotune(tuning_buckets=..., round_up=...)`` overrides.
-    # The cuDNN runner uses this for its override-shape ``cache_m`` so the
-    # graph it builds at runtime is the SAME graph the autotuner profiled
-    # tactics on.
-    effective_m_bucket_mapper = tuner.get_effective_map_to_tuning_buckets(
-        _BF16_GEMM_SM100_TUNING_CONFIG, spec_idx=0
-    )
     # Capture the real tensors' stride layout so the cuDNN graph built
     # for autotune profiling (where ``a`` is a torch.rand-synthesized
     # contiguous tensor) matches the graph used at runtime.
@@ -1244,7 +1236,6 @@ def bf16_gemm_sm100(
     if "cudnn" in runner_names:
         runners.append(
             _cudnn_gemm_bf16_runner(
-                effective_m_bucket_mapper,
                 is_a_k_major=is_a_k_major,
                 is_b_k_major=is_b_k_major,
             )
@@ -1282,9 +1273,6 @@ def fp8_gemm_sm100(
     runner_names: List[str],
 ) -> None:
     tuner = AutoTuner.get()
-    effective_m_bucket_mapper = tuner.get_effective_map_to_tuning_buckets(
-        _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
-    )
 
     runners = []
     if "cutlass_sm10x" in runner_names:
@@ -1294,11 +1282,7 @@ def fp8_gemm_sm100(
     if "cublas" in runner_names:
         runners.append(get_gemm_module().cublas_fp8_gemm_runner())
     if "cudnn" in runner_names:
-        runners.append(
-            _cudnn_gemm_fp8_runner(
-                effective_m_bucket_mapper,
-            )
-        )
+        runners.append(_cudnn_gemm_fp8_runner())
     assert runners, "No suitable runners found"
 
     inputs = [a, b, scale_a, scale_b, out, workspace_buffer]
@@ -2088,15 +2072,17 @@ def _check_cudnn_override_shape_availability():
     try:
         version_str = cudnn.__version__
         major, minor = map(int, version_str.split(".")[:2])
-        if (major, minor) < (1, 20):
+        required_frontend_version = (1, 24) if backend_version >= 92300 else (1, 20)
+        if (major, minor) < required_frontend_version:
             raise RuntimeError(
-                f"cuDNN override-shape GEMM requires cudnn-frontend version >= 1.20, found {version_str}. "
+                f"cuDNN override-shape GEMM requires cudnn-frontend version >= "
+                f"{required_frontend_version[0]}.{required_frontend_version[1]}, found {version_str}. "
                 f"Please upgrade: pip install --upgrade nvidia-cudnn-frontend"
             )
     except (AttributeError, ValueError, IndexError) as e:
         raise RuntimeError(
             "Unable to determine cudnn-frontend version. "
-            "Override-shape GEMM requires cudnn-frontend >= 1.20"
+            "Override-shape GEMM requires cudnn-frontend >= 1.20, or >= 1.24 with cuDNN backend >= 9.23.0"
         ) from e
 
 
@@ -2105,13 +2091,30 @@ def is_cudnn_override_shape_available() -> bool:
     if not CUDNN_AVAILABLE:
         return False
     try:
-        if cudnn.backend_version() < 92100:
+        backend_version = cudnn.backend_version()
+        if backend_version < 92100:
             return False
         version_str = cudnn.__version__
         major, minor = map(int, version_str.split(".")[:2])
-        return (major, minor) >= (1, 20)
+        required_frontend_version = (1, 24) if backend_version >= 92300 else (1, 20)
+        return (major, minor) >= required_frontend_version
     except Exception:
         return False
+
+
+def _get_cudnn_override_shape_workspace_size(
+    graph,
+    tactic: int,
+    cudnn_handle,
+    override_uids,
+    override_shapes,
+    override_strides,
+) -> int:
+    if cudnn.backend_version() >= 92300:
+        return graph.get_workspace_size_plan_at_index(
+            tactic, cudnn_handle, override_uids, override_shapes, override_strides
+        )
+    return graph.get_workspace_size_plan_at_index(tactic)
 
 
 def clear_cudnn_graph_cache() -> None:
@@ -2529,7 +2532,7 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
     b_descale,
     alpha,
     c_final,
-    workspace_buffer,
+    workspace,
     tactic: int = 0,
 ):
     """Execute FP4 GEMM cuDNN graph with dynamic-shape overrides."""
@@ -2585,18 +2588,20 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
         c_stride,
     ]
 
-    if workspace_buffer.numel() < graph.get_workspace_size():
-        workspace_buffer = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
-
     stream = torch.cuda.current_stream(a.device)
+    cudnn_handle = _get_cudnn_handle(a.device, stream)
+
+    workspace_size = _get_cudnn_override_shape_workspace_size(
+        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+    )
+    if workspace.numel() < workspace_size:
+        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
 
     graph.execute_plan_at_index(
         variant_pack,
-        workspace_buffer,
+        workspace,
         tactic,
-        handle=_get_cudnn_handle(a.device, stream),
+        handle=cudnn_handle,
         override_uids=override_uids,
         override_shapes=override_shapes,
         override_strides=override_strides,
@@ -2765,7 +2770,7 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
     a_descale,
     b_descale,
     c_final,
-    workspace_buffer,
+    workspace,
     tactic: int = 0,
 ):
     """Execute MXFP8 GEMM cuDNN graph with dynamic-shape overrides."""
@@ -2799,18 +2804,20 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         list(c_final.stride()),
     ]
 
-    if workspace_buffer.numel() < graph.get_workspace_size():
-        workspace_buffer = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
-
     stream = torch.cuda.current_stream(a.device)
+    cudnn_handle = _get_cudnn_handle(a.device, stream)
+
+    workspace_size = _get_cudnn_override_shape_workspace_size(
+        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+    )
+    if workspace.numel() < workspace_size:
+        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
 
     graph.execute_plan_at_index(
         variant_pack,
-        workspace_buffer,
+        workspace,
         tactic,
-        handle=_get_cudnn_handle(a.device, stream),
+        handle=cudnn_handle,
         override_uids=override_uids,
         override_shapes=override_shapes,
         override_strides=override_strides,
@@ -3059,10 +3066,11 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if workspace.numel() < graph.get_workspace_size():
-        workspace = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
+    workspace_size = _get_cudnn_override_shape_workspace_size(
+        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+    )
+    if workspace.numel() < workspace_size:
+        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
 
     graph.execute_plan_at_index(
         variant_pack,
@@ -3132,17 +3140,15 @@ def _cudnn_gemm_fp8(
     return out
 
 
-def _cudnn_gemm_fp8_runner(
-    m_bucket_mapper=None,
-):
+def _cudnn_gemm_fp8_runner():
+    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
+        _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
+    )
+
     class CudnnFp8GemmRunner(TunableRunner):
-        def __init__(self, m_bucket_mapper):
+        def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = (
-                m_bucket_mapper
-                if m_bucket_mapper is not None
-                else map_to_hybrid_bucket_uncapped
-            )
+            self._m_bucket_mapper = m_bucket_mapper
             self._use_override_shape = is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
@@ -3224,7 +3230,7 @@ def _cudnn_gemm_fp8_runner(
                 )
             return out
 
-    return CudnnFp8GemmRunner(m_bucket_mapper)
+    return CudnnFp8GemmRunner()
 
 
 def _get_3d_shape_stride_from_vector(vector: torch.Tensor, dim: int = 0):
@@ -3510,10 +3516,11 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if workspace.numel() < graph.get_workspace_size():
-        workspace = torch.empty(
-            graph.get_workspace_size(), device=a.device, dtype=torch.uint8
-        )
+    workspace_size = _get_cudnn_override_shape_workspace_size(
+        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+    )
+    if workspace.numel() < workspace_size:
+        workspace = torch.empty(workspace_size, device=a.device, dtype=torch.uint8)
 
     graph.execute_plan_at_index(
         variant_pack,
@@ -3569,18 +3576,16 @@ def _cudnn_gemm_bf16(
 
 
 def _cudnn_gemm_bf16_runner(
-    m_bucket_mapper=None,
     is_a_k_major: Optional[bool] = None,
     is_b_k_major: Optional[bool] = None,
 ):
     """Build a CudnnBf16GemmRunner.
 
     See :func:`_cudnn_gemm_fp4_runner` for the ``m_bucket_mapper``
-    rationale; this is the BF16 GEMM analog using the same alignment
-    scheme.  When ``m_bucket_mapper`` is ``None``, defaults to
-    ``map_to_hybrid_bucket_uncapped`` -- the same mapper
-    ``_BF16_GEMM_SM100_TUNING_CONFIG`` uses as
-    ``map_to_tuning_buckets``.
+    rationale; this is the BF16 GEMM analog using the effective mapper
+    from ``AutoTuner.get_effective_map_to_tuning_buckets`` so active
+    ``with autotune(tuning_buckets=..., round_up=...)`` overrides are
+    reflected in the override-shape ``cache_m``.
 
     ``is_a_k_major`` / ``is_b_k_major`` describe the stride layout of
     the real ``a`` and ``b`` tensors at the call site.  These are baked
@@ -3594,24 +3599,22 @@ def _cudnn_gemm_bf16_runner(
     construction (using the real tensors from the caller) keeps the
     flag identical across profile and runtime paths.
 
-    Callers (``bf16_gemm_sm100``) typically pass the effective mapper
-    from ``AutoTuner.get_effective_map_to_tuning_buckets`` and the
-    real ``a.stride()[-1] == 1`` / ``b.stride()[-2] == 1``.
+    Callers (``bf16_gemm_sm100``) pass the real
+    ``a.stride()[-1] == 1`` / ``b.stride()[-2] == 1``.
     """
+
+    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
+        _BF16_GEMM_SM100_TUNING_CONFIG, spec_idx=0
+    )
 
     class CudnnBf16GemmRunner(TunableRunner):
         def __init__(
             self,
-            m_bucket_mapper,
             is_a_k_major: Optional[bool],
             is_b_k_major: Optional[bool],
         ):
             super().__init__()
-            self._m_bucket_mapper = (
-                m_bucket_mapper
-                if m_bucket_mapper is not None
-                else map_to_hybrid_bucket_uncapped
-            )
+            self._m_bucket_mapper = m_bucket_mapper
             # Default to k-major (the convention torch.rand-synthesized
             # profile tensors use) when caller didn't specify.
             self._is_a_k_major = True if is_a_k_major is None else is_a_k_major
@@ -3720,7 +3723,7 @@ def _cudnn_gemm_bf16_runner(
 
             return out
 
-    return CudnnBf16GemmRunner(m_bucket_mapper, is_a_k_major, is_b_k_major)
+    return CudnnBf16GemmRunner(is_a_k_major, is_b_k_major)
 
 
 def _get_real_fp4_shape_from_packed_uint8(packed_fp4_tensor):
@@ -4832,17 +4835,12 @@ def _cudnn_gemm_fp4(
     return out
 
 
-def _cudnn_gemm_fp4_runner(m_bucket_mapper=None):
+def _cudnn_gemm_fp4_runner(tuning_config):
     """Build a CudnnFp4GemmRunner.
 
     Args:
-        m_bucket_mapper: A callable ``int -> int`` mapping the runtime M
-            (i.e. ``actual_m``) to the build-time ``cache_m`` for the cuDNN
-            override-shape graph.  When ``None``, defaults to
-            ``map_to_hybrid_bucket_uncapped`` -- the same mapper the
-            ``_MM_FP4_TUNING_CONFIG_*`` configs use as
-            ``map_to_tuning_buckets``.  Callers (``mm_fp4``) typically
-            override this with the *currently active* mapper from
+        tuning_config: The FP4 tuning config currently used by ``mm_fp4``.
+            The runner derives the effective mapper from
             ``AutoTuner.get_effective_map_to_tuning_buckets`` so any
             ``with autotune(tuning_buckets=..., round_up=...)`` overrides
             propagate into the cuDNN graph.
@@ -4865,14 +4863,14 @@ def _cudnn_gemm_fp4_runner(m_bucket_mapper=None):
         runtime-time produce the same ``cache_m`` for the same input.
     """
 
+    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
+        tuning_config, spec_idx=0
+    )
+
     class CudnnFp4GemmRunner(TunableRunner):
-        def __init__(self, m_bucket_mapper):
+        def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = (
-                m_bucket_mapper
-                if m_bucket_mapper is not None
-                else map_to_hybrid_bucket_uncapped
-            )
+            self._m_bucket_mapper = m_bucket_mapper
             self._use_override_shape = is_cudnn_override_shape_available()
 
         def _get_override_graph(self, a, b, alpha, out_dtype, block_size, use_nvfp4):
@@ -4886,9 +4884,9 @@ def _cudnn_gemm_fp4_runner(m_bucket_mapper=None):
 
             # cache_m must match the AutoTuner cache key so the runtime
             # graph is the SAME graph the autotuner profiled tactics on.
-            # ``self._m_bucket_mapper`` is set by the caller (``mm_fp4``)
-            # to the *currently effective* ``map_to_tuning_buckets`` (with
-            # any ``autotune(tuning_buckets=..., round_up=...)`` override
+            # ``self._m_bucket_mapper`` is the *currently effective*
+            # ``map_to_tuning_buckets`` (with any
+            # ``autotune(tuning_buckets=..., round_up=...)`` override
             # applied).  Sharing the mapper keeps cache_m and the tactic
             # cache key in lockstep -- otherwise a tactic profiled on
             # graph ``cache_m=A`` is silently applied to graph ``cache_m=B``
@@ -5023,7 +5021,7 @@ def _cudnn_gemm_fp4_runner(m_bucket_mapper=None):
 
             return out
 
-    return CudnnFp4GemmRunner(m_bucket_mapper)
+    return CudnnFp4GemmRunner()
 
 
 def _check_mm_fp4_problem_size(
@@ -5968,18 +5966,8 @@ def mm_fp4(
         _MM_FP4_TUNING_CONFIG_8x4 if use_8x4_sf_layout else _MM_FP4_TUNING_CONFIG_128x4
     )
 
-    # Effective bucket mapper, accounting for any active
-    # ``with autotune(tuning_buckets=..., round_up=...)`` overrides.
-    # The cuDNN runner uses this for its override-shape ``cache_m`` so the
-    # graph it builds at runtime is the SAME graph the autotuner profiled
-    # tactics on.  Without this, custom-bucket overrides cause silent
-    # cache_m / autotune-key drift (wrong plan, possible NaN).
-    effective_m_bucket_mapper = tuner.get_effective_map_to_tuning_buckets(
-        tuning_config, spec_idx=0
-    )
-
     backend_to_runner_factory = {
-        "cudnn": lambda: _cudnn_gemm_fp4_runner(effective_m_bucket_mapper),
+        "cudnn": lambda: _cudnn_gemm_fp4_runner(tuning_config),
         "trtllm": lambda: get_trtllm_gemm_module().trtllm_fp4_gemm_runner(
             use_8x4_sf_layout
         ),
@@ -8100,17 +8088,15 @@ def _cudnn_gemm_mxfp8(
     )
 
 
-def _cudnn_gemm_mxfp8_runner(
-    m_bucket_mapper=None,
-):
+def _cudnn_gemm_mxfp8_runner():
+    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
+        _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
+    )
+
     class CudnnMxfp8GemmRunner(TunableRunner):
-        def __init__(self, m_bucket_mapper):
+        def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = (
-                m_bucket_mapper
-                if m_bucket_mapper is not None
-                else map_to_hybrid_bucket_uncapped
-            )
+            self._m_bucket_mapper = m_bucket_mapper
             self._use_override_shape = is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
@@ -8178,7 +8164,7 @@ def _cudnn_gemm_mxfp8_runner(
                     a_descale=scale_a,
                     b_descale=scale_b,
                     c_final=out,
-                    workspace_buffer=workspace_buffer,
+                    workspace=workspace_buffer,
                     tactic=max(tactic, 0),
                 )
             else:
@@ -8194,7 +8180,7 @@ def _cudnn_gemm_mxfp8_runner(
                 )
             return out
 
-    return CudnnMxfp8GemmRunner(m_bucket_mapper)
+    return CudnnMxfp8GemmRunner()
 
 
 def mxfp8_gemm_sm100(
@@ -8207,13 +8193,10 @@ def mxfp8_gemm_sm100(
     runner_names: List[str],
 ) -> None:
     tuner = AutoTuner.get()
-    effective_m_bucket_mapper = tuner.get_effective_map_to_tuning_buckets(
-        _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
-    )
 
     runners = []
     if "cudnn" in runner_names:
-        runners.append(_cudnn_gemm_mxfp8_runner(effective_m_bucket_mapper))
+        runners.append(_cudnn_gemm_mxfp8_runner())
     assert runners, "No suitable runners found"
 
     inputs = [a, b, scale_a, scale_b, out, workspace_buffer]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

## Description

This MR makes two cuDNN GEMM backend cleanups/improvements:

1. Move effective M-bucket mapper lookup into the cuDNN runners

   The effective `map_to_tuning_buckets` lookup is now owned by the cuDNN GEMM runners instead of the higher-level GEMM dispatch functions. This keeps the bucket-to-`cache_m` logic local to the backend that uses it, while still respecting active autotune overrides such as custom `tuning_buckets` / `round_up`.

2. Query override-shape workspace size dynamically on cuDNN 9.23+

   For cuDNN override-shape GEMM execution, cuDNN 9.23+ can query the workspace requirement for the actual runtime problem shape via `get_workspace_size_plan_at_index(...)` with override shapes and strides. The code now uses this API when available, so workspace allocation matches the executed dynamic problem size. Older cuDNN versions continue to query workspace by execution plan index without override-shape metadata.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better cuDNN version compatibility checks for more reliable GPU support across driver versions.
  * More robust and efficient workspace sizing and allocation for matrix-multiply workloads, improving performance and memory use.
  * Autotuning and runner initialization simplified so tuning behavior is computed automatically, improving reliability across BF16/FP8/FP4/MXFP8 workloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3291)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->