### PR TITLE
fix(gdn): allow importing gdn_decode without a CUDA device

### DIFF
--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -61,7 +61,7 @@ try:
     )
 
     _GDN_DECODE_BF16_STATE_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     _GDN_DECODE_BF16_STATE_AVAILABLE = False
     _gated_delta_rule_bf16_state = None
     _gated_delta_rule_bf16_state_mtp = None
@@ -71,7 +71,7 @@ try:
     from .gdn_kernels.gdn_decode_pretranspose import run_pretranspose_decode
 
     _PRETRANSPOSE_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     _PRETRANSPOSE_AVAILABLE = False
     run_pretranspose_decode = None
 
@@ -83,7 +83,7 @@ try:
     )
 
     _NONTRANSPOSE_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     _NONTRANSPOSE_AVAILABLE = False
     run_nontranspose_decode = None
     TILE_V_NT = 32  # fallback for assertions
@@ -98,7 +98,7 @@ try:
     )
 
     _MTP_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     _MTP_AVAILABLE = False
     run_mtp_decode = None
     get_tile_v_mtp = None

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -38,6 +38,7 @@ Both entries dispatch to one of:
   with ``tile_v < 64``). Also single-pool or split-pool.
 """
 
+import functools
 import math
 from typing import Optional
 
@@ -1385,13 +1386,17 @@ def _run_wide_vec(
 # ==============================================================================
 # PUBLIC API
 # ==============================================================================
-# Number of SMs on target GPU (detected dynamically)
-NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
 
-# GPU architecture detected once at import time — avoids per-call
-# torch.cuda.get_device_capability() in the hot path.
-_GPU_MAJOR, _ = torch.cuda.get_device_capability(0)
-_USE_PACKED_FMA = _GPU_MAJOR >= 10
+
+@functools.cache
+def _get_num_sms() -> int:
+    return torch.cuda.get_device_properties(0).multi_processor_count
+
+
+@functools.cache
+def _get_use_packed_fma() -> bool:
+    major, _ = torch.cuda.get_device_capability(0)
+    return major >= 10
 
 
 def gated_delta_rule(
@@ -1538,7 +1543,7 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
         num_v_tiles = V // tv
         grid_size = B * HV * num_v_tiles
         # Want at least 4 waves for good occupancy
-        if grid_size >= 4 * NUM_SMS:
+        if grid_size >= 4 * _get_num_sms():
             return tv
     return 32  # Minimum tile_v for maximum parallelism
 
@@ -1693,7 +1698,7 @@ def gated_delta_rule_mtp_wide_vec(
         effective_disable_final = disable_state_update
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    use_packed_fma = _get_use_packed_fma()
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -1953,7 +1958,7 @@ def gated_delta_rule_mtp(
     tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V)
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    use_packed_fma = _get_use_packed_fma()
     # Set same_pool=True when reads and writes alias (single-pool); the
     # kernel then DCEs write-side base-pointer arithmetic.
     same_pool = (

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1389,13 +1389,13 @@ def _run_wide_vec(
 
 
 @functools.cache
-def _get_num_sms() -> int:
-    return torch.cuda.get_device_properties(0).multi_processor_count
+def _get_num_sms(device: torch.device) -> int:
+    return torch.cuda.get_device_properties(device).multi_processor_count
 
 
 @functools.cache
-def _get_use_packed_fma() -> bool:
-    major, _ = torch.cuda.get_device_capability(0)
+def _get_use_packed_fma(device: torch.device) -> bool:
+    major, _ = torch.cuda.get_device_capability(device)
     return major >= 10
 
 
@@ -1531,7 +1531,9 @@ _compiled_kernels_mtp: dict = {}
 _compiled_kernels_wide_vec: dict = {}
 
 
-def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
+def _select_tile_v_for_mtp(
+    B: int, HV: int, V: int, T: int = 1, *, device: torch.device
+) -> int:
     """Select optimal tile_v for the MTP BF16 kernel based on batch size and T.
 
     tile_v must be a multiple of 4 * MTP_ILP4_ROWS (= 16) and divide V=128.
@@ -1543,13 +1545,13 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
         num_v_tiles = V // tv
         grid_size = B * HV * num_v_tiles
         # Want at least 4 waves for good occupancy
-        if grid_size >= 4 * _get_num_sms():
+        if grid_size >= 4 * _get_num_sms(device):
             return tv
     return 32  # Minimum tile_v for maximum parallelism
 
 
 def _get_bf16_mtp_config(
-    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int
+    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int, *, device: torch.device
 ) -> tuple:
     """Select ``(tile_v, ilp_rows)`` for the BF16 MTP kernel.
 
@@ -1569,7 +1571,9 @@ def _get_bf16_mtp_config(
     if work_units <= 128:
         # Tiny grid: small tile_v gives more CTAs to fill SMs.
         return min(16, v_dim), 4
-    return _select_tile_v_for_mtp(batch_size, num_v_heads, v_dim, seq_len), 4
+    return _select_tile_v_for_mtp(
+        batch_size, num_v_heads, v_dim, seq_len, device=device
+    ), 4
 
 
 # Threshold above which `gated_delta_rule_mtp` dispatches to the wide_vec
@@ -1698,7 +1702,7 @@ def gated_delta_rule_mtp_wide_vec(
         effective_disable_final = disable_state_update
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _get_use_packed_fma()
+    use_packed_fma = _get_use_packed_fma(q.device)
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -1955,10 +1959,10 @@ def gated_delta_rule_mtp(
     # redirected here). Falls to the ILP=4 MTP path
     # (mtp_ilp4_kernel), which natively supports both single- and
     # split-pool, so the config picker is independent of pool mode.
-    tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V)
+    tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V, device=q.device)
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _get_use_packed_fma()
+    use_packed_fma = _get_use_packed_fma(q.device)
     # Set same_pool=True when reads and writes alias (single-pool); the
     # kernel then DCEs write-side base-pointer arithmetic.
     same_pool = (

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -38,7 +38,6 @@ Both entries dispatch to one of:
   with ``tile_v < 64``). Also single-pool or split-pool.
 """
 
-import functools
 import math
 from typing import Optional
 
@@ -47,6 +46,9 @@ import cutlass.cute as cute
 import cuda.bindings.driver as cuda
 import torch
 from cutlass.cute.runtime import from_dlpack
+
+from flashinfer.cute_dsl.fp4_common import get_sm_version
+from flashinfer.cute_dsl.utils import get_num_sm
 
 # ==============================================================================
 # FMA WRAPPER FUNCTIONS (SM90 Compatibility)
@@ -1388,17 +1390,6 @@ def _run_wide_vec(
 # ==============================================================================
 
 
-@functools.cache
-def _get_num_sms(device: torch.device) -> int:
-    return torch.cuda.get_device_properties(device).multi_processor_count
-
-
-@functools.cache
-def _get_use_packed_fma(device: torch.device) -> bool:
-    major, _ = torch.cuda.get_device_capability(device)
-    return major >= 10
-
-
 def gated_delta_rule(
     A_log: torch.Tensor,
     a: torch.Tensor,
@@ -1545,7 +1536,7 @@ def _select_tile_v_for_mtp(
         num_v_tiles = V // tv
         grid_size = B * HV * num_v_tiles
         # Want at least 4 waves for good occupancy
-        if grid_size >= 4 * _get_num_sms(device):
+        if grid_size >= 4 * get_num_sm(device):
             return tv
     return 32  # Minimum tile_v for maximum parallelism
 
@@ -1702,7 +1693,7 @@ def gated_delta_rule_mtp_wide_vec(
         effective_disable_final = disable_state_update
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _get_use_packed_fma(q.device)
+    use_packed_fma = get_sm_version(q.device) >= 100
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -1962,7 +1953,7 @@ def gated_delta_rule_mtp(
     tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V, device=q.device)
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _get_use_packed_fma(q.device)
+    use_packed_fma = get_sm_version(q.device) >= 100
     # Set same_pool=True when reads and writes alias (single-pool); the
     # kernel then DCEs write-side base-pointer arithmetic.
     same_pool = (


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- Defer `torch.cuda.get_device_properties()` and `torch.cuda.get_device_capability()` in `gdn_decode_bf16_state.py `from module scope to lazy `@functools.cache` helpers that derive the device from the input tensor (q.device), matching the convention used by the CuTe DSL MLA and MoE backends.
- Catch RuntimeError in addition to ImportError in all gdn_decode.py backend import blocks, matching the existing pattern in `gdn_kernels/__init__.py.`

Before this PR: 
```
CUDA_VISIBLE_DEVICES= python3 -c "import flashinfer.gdn_decode; print('Success: import worked without CUDA devices')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/workspace/flashinfer/flashinfer/gdn_decode.py", line 58, in <module>
    from .gdn_kernels.gdn_decode_bf16_state import (
  File "/workspace/flashinfer/flashinfer/gdn_kernels/gdn_decode_bf16_state.py", line 1389, in <module>
    NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py", line 614, in get_device_properties
    _lazy_init()  # will define _get_device_properties
    ^^^^^^^^^^^^
  File "/opt/conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py", line 410, in _lazy_init
    torch._C._cuda_init()
RuntimeError: No CUDA GPUs are available
```

After this PR: 
```
CUDA_VISIBLE_DEVICES= python3 -c "import flashinfer.gdn_decode; print('Success: import worked without CUDA devices')"
Success: import worked without CUDA devices
```

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3262

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Decode backends now treat runtime import failures like import errors and gracefully fall back to safe defaults.

* **Performance / Reliability**
  * GPU kernels adapt at runtime to the actual device, selecting device-aware configurations and maintaining separate compiled kernels per device for more reliable and optimized execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3293)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->