### PR TITLE
fix: use explicit .ptr for tmem_holding_buf scalar access (#3298)

### DIFF
--- a/flashinfer/cute_dsl/attention/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/mla_decode.py
@@ -369,7 +369,7 @@ class BlackwellMultiLatentAttentionForward:
         storage = smem.allocate(SharedStorage)
 
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.schedule.mma_warp_id,
             is_two_cta=self.config.use_2cta_instrs,

--- a/flashinfer/cute_dsl/attention/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/mla_decode_fp8.py
@@ -373,7 +373,7 @@ class BlackwellMultiLatentAttentionForwardFP8:
         storage = smem.allocate(SharedStorage)
 
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.schedule.mma_warp_id,
             is_two_cta=self.config.use_2cta_instrs,

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -179,7 +179,7 @@ class MmaRole:
     def alloc_tmem(self, storage: cute.Tensor):
         """Allocate TMEM buffer and synchronize."""
         tmem_alloc_cols = Int32(self.tmem_alloc_cols)
-        cute.arch.alloc_tmem(tmem_alloc_cols, storage.tmem_holding_buf)
+        cute.arch.alloc_tmem(tmem_alloc_cols, storage.tmem_holding_buf.ptr)
         cute.arch.barrier(
             barrier_id=self.tmem_alloc_sync_bar_id,
             number_of_threads=self.threads_per_warp,
@@ -194,7 +194,7 @@ class MmaRole:
         tmem_ptr = cute.arch.retrieve_tmem_ptr(
             Float32,
             alignment=16,
-            ptr_to_buffer_holding_addr=storage.tmem_holding_buf,
+            ptr_to_buffer_holding_addr=storage.tmem_holding_buf.ptr,
         )
         cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols)
 

--- a/flashinfer/cute_dsl/gemm_allreduce_two_shot.py
+++ b/flashinfer/cute_dsl/gemm_allreduce_two_shot.py
@@ -717,7 +717,7 @@ class PersistentDenseGemmKernel:
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
 
         # Initialize mainloop ab_pipeline (barrier) and states
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
@@ -1292,7 +1292,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
             is_two_cta=use_2cta_instrs,

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1127,7 +1127,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
             is_two_cta=use_2cta_instrs,

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -987,7 +987,7 @@ class GatedDeltaNetChunkedKernel:
 
         # TMEM allocator object - CG1 will issue the actual allocation
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             # Correction warp is the last one that accesses tmem
             allocator_warp_id=self.compute_group_1_warp_ids[0],

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
@@ -662,7 +662,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
 
         # Initialize mainloop ab_pipeline (barrier) and states
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
@@ -711,7 +711,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
             )
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
             is_two_cta=use_2cta_instrs,

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -1051,7 +1051,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
 
         # Initialize mainloop ab_pipeline (barrier) and states
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)

--- a/flashinfer/mamba/ssd_kernel.py
+++ b/flashinfer/mamba/ssd_kernel.py
@@ -937,7 +937,7 @@ class SSDKernel:
         if warp_idx == self.epilog_warp_id[0]:
             cute.arch.alloc_tmem(
                 self.num_tmem_cols_total,
-                smem_storage.tmem_holding_buf,
+                smem_storage.tmem_holding_buf.ptr,
                 is_two_cta=self.use_2cta_instrs,
             )
 
@@ -948,7 +948,7 @@ class SSDKernel:
         tmem_ptr_base = cute.arch.retrieve_tmem_ptr(
             self.acc_dtype,
             alignment=16,
-            ptr_to_buffer_holding_addr=smem_storage.tmem_holding_buf,
+            ptr_to_buffer_holding_addr=smem_storage.tmem_holding_buf.ptr,
         )
 
         # Specialized TMA load Delta/CumsumDelta/X/States warp


### PR DESCRIPTION
## Summary

Fix the deprecated implicit scalar-to-pointer conversion for `tmem_holding_buf` across all cute_dsl kernels.

`storage.tmem_holding_buf` is declared as `cutlass.Int32` (a bare scalar) in `@cute.struct SharedStorage`. When passed to APIs expecting `cute.Pointer` (`cute.arch.alloc_tmem`, `cute.arch.retrieve_tmem_ptr`, `ptr_to_buffer_holding_addr=`), the cutlass-dsl runtime implicitly uses the deprecated `_ScalarData.value` property.

In `nvidia-cutlass-dsl >= 4.4` this:
1. Emits `DeprecationWarning` on every call (will break when removed)
2. Defeats Python warning de-duplication, flooding stderr in multi-worker setups

## Fix

Use explicit `.ptr` attribute on all 13 call sites across 11 files:

| File | Change |
|------|--------|
| `cute_dsl/attention/roles/mma.py` | `alloc_tmem` + `retrieve_tmem_ptr` |
| `cute_dsl/attention/mla_decode.py` | positional arg |
| `cute_dsl/attention/mla_decode_fp8.py` | positional arg |
| `cute_dsl/gemm_allreduce_two_shot.py` | local var extraction |
| `gemm/kernels/dense_blockscaled_gemm_sm100.py` | local var extraction |
| `gemm/kernels/dense_blockscaled_gemm_sm103.py` | positional arg |
| `gemm/kernels/grouped_gemm_masked_blackwell.py` | local var extraction |
| `gdn_kernels/blackwell/gated_delta_net_chunked.py` | positional arg |
| `fused_moe/.../finalize_fusion.py` | positional arg |
| `fused_moe/.../swiglu_fusion.py` | positional arg |
| `mamba/ssd_kernel.py` | positional arg + keyword arg |

## Test Plan

- All 11 modified files pass `py_compile` ✅
- `ruff check` passes on all files ✅
- No functional change — `.ptr` is the non-deprecated equivalent of the implicit conversion

## Reproduction

The issue includes a self-contained reproduction script that demonstrates the deprecation warning. After this fix, the warnings are eliminated.

---

*AI assistance used: Claude (Anthropic) for code analysis and patch generation. All changes reviewed and verified by the author.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tensor memory buffer handling across GPU kernels for improved compatibility and correctness. This addresses how temporary memory is allocated and managed during computation on supported GPU architectures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3300)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->