### PR TITLE
Reject EP configurations in b12x MoE with a clear error

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -129,6 +129,13 @@ def b12x_fused_moe(
     if num_local_experts is None:
         num_local_experts = num_experts
 
+    if num_local_experts != num_experts:
+        raise NotImplementedError(
+            f"b12x_fused_moe does not yet support Expert Parallelism "
+            f"(num_local_experts={num_local_experts} != num_experts={num_experts}). "
+            f"Use a different MoE backend for EP configurations."
+        )
+
     num_tokens = token_selected_experts.size(0)
     hidden_size = x.size(1)
 
@@ -227,6 +234,14 @@ class B12xMoEWrapper:
         self.use_cuda_graph = use_cuda_graph
         self.max_num_tokens = max_num_tokens
         self.num_local_experts = num_local_experts or num_experts
+
+        if self.num_local_experts != self.num_experts:
+            raise NotImplementedError(
+                f"B12xMoEWrapper does not yet support Expert Parallelism "
+                f"(num_local_experts={self.num_local_experts} != "
+                f"num_experts={self.num_experts}). "
+                f"Use a different MoE backend for EP configurations."
+            )
         self.output_dtype = output_dtype
         self.device = device
         self.activation = activation


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The b12x fused MoE kernel does not yet support Expert Parallelism (num_local_experts != num_experts). Previously, passing EP-sliced weights would hit a confusing shape mismatch deep inside the CuTe DSL compiled kernel or cause cudaErrorIllegalAddress. Add an explicit NotImplementedError at the API boundary so users get an actionable message directing them to use a different backend.

## 🔍 Related Issues

Fixes #3294 (temporary).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject unsupported Expert Parallel configurations, preventing execution with incompatible settings and improving error clarity during initialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3302)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->