### PR TITLE
fix: MNNVL Allreduce uses bitwise sentinel checking to avoid subnormal value issue (#3053)

### DIFF
--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -120,7 +120,7 @@ static constexpr __device__ __host__ T negZero() {
 template <typename T>
 static inline __device__ bool isNegZero(T val) {
   if constexpr (std::is_same_v<T, float>) {
-    return *reinterpret_cast<uint32_t const*>(&val) == kNEGZERO_FP32;
+    return __float_as_uint(val) == kNEGZERO_FP32;
   } else if constexpr (std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __nv_half>) {
     return Fp16BitCast<T>(val).mInt == kNEGZERO_FP16;
   } else {

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -54,6 +54,7 @@ struct AllReduceFusionParams {
 namespace utils {
 
 constexpr uint16_t kNEGZERO_FP16 = 0x8000U;
+constexpr uint32_t kNEGZERO_FP32 = 0x80000000U;
 
 template <typename T>
 union Fp16BitCast {
@@ -108,10 +109,18 @@ static constexpr __device__ __host__ T negZero() {
   return T{};  // Never reached, but needed for compilation
 }
 
+// WARNING: the Lamport sentinel is a *bit pattern* (fp32 -0.0 = 0x80000000;
+// fp16/bf16 -0.0 = 0x8000). Always compare bit-exact -- do NOT fall back to
+// `val == 0.F && signbit(val)`. nvcc emits `setp.eq.f32` with `.ftz=true`
+//  which flushes fp32 subnormal operands to +/-0.0 *before*
+// the equality while signbit() still reads bit 31, so any fp32 negative
+// subnormal pattern (e.g. 0x80010000, which appears when bf16 negative
+// subnormals 0x8001-0x807F land in the high half of a 4-byte poll load) would
+// falsely match the sentinel and deadlock the polling loop.
 template <typename T>
 static inline __device__ bool isNegZero(T val) {
   if constexpr (std::is_same_v<T, float>) {
-    return val == 0.F && signbit(val);
+    return *reinterpret_cast<uint32_t const*>(&val) == kNEGZERO_FP32;
   } else if constexpr (std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __nv_half>) {
     return Fp16BitCast<T>(val).mInt == kNEGZERO_FP16;
   } else {

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -238,7 +238,51 @@ def row_linear_residual_norm_fusion_forward_legacy(
 """Helper function to run the core MNNVL AllReduce test logic"""
 
 
-def prepare_test_data(seq_len: int, hidden_size: int, dtype: torch.dtype, fusion: bool):
+def _inject_sentinel_trigger_patterns(x_full: torch.Tensor) -> None:
+    """Overlay each rank's input slice with 16-bit patterns that exercise the
+    Lamport sentinel polling logic in the MNNVL allreduce kernels.
+
+    Three regions per rank:
+      - Region A (alternating 0x0000, 0x8001+i): a 4-byte poll load over each
+        pair reinterprets to a fp32 negative-subnormal pattern such as
+        0x80010000. A correct bit-exact sentinel compare must reject these as
+        ordinary data; a `val == 0.F && signbit(val)` check would FTZ-flush
+        them to -0.0 on SM_103+ and falsely match the sentinel 0x80000000,
+        deadlocking the poll loop.
+      - Region B (bf16/fp16 -0.0): the write-side pre-multicast sanitizer
+        must replace these with +0.0 before they reach the polled buffer.
+      - Region C (positive subnormals 0x0001..0x007F): control — must never
+        match the sentinel under any rule, on either side.
+    """
+    assert x_full.dtype in (torch.bfloat16, torch.float16)
+    world_size = x_full.shape[0]
+    flat = x_full.reshape(world_size, -1)
+    if flat.shape[1] < 3 * 256:
+        return
+
+    def _u16_to_i16(u: int) -> int:
+        return u if u < 0x8000 else u - 0x10000
+
+    region_a = []
+    for i in range(128):
+        region_a.append(_u16_to_i16(0x0000))
+        region_a.append(_u16_to_i16(0x8001 + (i % 0x7F)))
+    region_b = [_u16_to_i16(0x8000)] * 256
+    region_c = [_u16_to_i16(0x0001 + (i % 0x7F)) for i in range(256)]
+    pattern_i16 = torch.tensor(region_a + region_b + region_c, dtype=torch.int16)
+
+    for r in range(world_size):
+        view16 = flat[r].view(torch.int16)
+        view16[: pattern_i16.numel()] = pattern_i16
+
+
+def prepare_test_data(
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fusion: bool,
+    inject_sentinel_patterns: bool = False,
+):
     # Use torch.distributed for communication between ranks
     rank = dist.get_rank()
     world_size = dist.get_world_size()
@@ -247,6 +291,8 @@ def prepare_test_data(seq_len: int, hidden_size: int, dtype: torch.dtype, fusion
         x_full = torch.randn((world_size, seq_len, hidden_size), dtype=dtype)
         residual = torch.randn((seq_len, hidden_size), dtype=dtype)
         norm_weight = torch.randn((hidden_size,), dtype=dtype)
+        if inject_sentinel_patterns:
+            _inject_sentinel_trigger_patterns(x_full)
     else:
         x_full = None
         residual = None
@@ -287,6 +333,7 @@ def run_mnnvl_ar_full(
     hidden_size: int,
     legacy_explicit_workspace_bytes: Optional[int] = None,
     legacy_api: bool = False,
+    inject_sentinel_patterns: bool = False,
 ):
     """Core test logic for MNNVL AllReduce operations.
 
@@ -368,7 +415,11 @@ def run_mnnvl_ar_full(
         test_data = []
         for seq_len in seq_lens:
             (x_local, residual, norm_weight), reference_output = prepare_test_data(
-                seq_len, hidden_size, dtype, fusion
+                seq_len,
+                hidden_size,
+                dtype,
+                fusion,
+                inject_sentinel_patterns=inject_sentinel_patterns,
             )
             test_data.append(
                 (seq_len, x_local, residual, norm_weight, reference_output)
@@ -484,4 +535,34 @@ def test_mnnvl_allreduce_legacy(
         hidden_size,
         legacy_explicit_workspace_bytes=explicit_workspace_bytes,
         legacy_api=True,
+    )
+
+
+# Regression guard for the FTZ-induced Lamport-sentinel hang: the input is
+# salted with bf16/fp16 negative subnormals (0x8001-0x807F), -0.0 (0x8000), and
+# positive subnormals (0x0001-0x007F). With the bit-exact sentinel compare the
+# kernel must complete; with a `val == 0.F && signbit(val)` compare on a
+# `-ftz=true` build (the SM_103+ default) the poll loop would deadlock on the
+# fp32 negative-subnormal patterns reformed from these bytes.
+@pytest.mark.parametrize("seq_lens", [[4], [16, 64]])
+@pytest.mark.parametrize("fusion", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [2880, 8192])
+def test_mnnvl_allreduce_sentinel_patterns(
+    monkeypatch,
+    seq_lens: list[int],
+    fusion: bool,
+    dtype: torch.dtype,
+    hidden_size: int,
+):
+    """Regression test: inputs contain subnormals and -0.0 bit patterns that
+    would falsely match the Lamport sentinel under an FP-equality compare."""
+    run_mnnvl_ar_full(
+        monkeypatch,
+        seq_lens,
+        fusion,
+        dtype,
+        hidden_size,
+        legacy_api=False,
+        inject_sentinel_patterns=True,
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR fixed an inconsistency when polling communication buffer and checking for sentinel value. 

The old code does FP comparison with 0 and checks the sign bit to determine whether the polled value is -0.0; The caveat is that when the valid input contains a negative subnormal value, the FP comparison could cause FTZ behavior and flush the valid input into negative zero, which collides with the sentinel value and makes the kernel stuck at polling.

The solution is simple. This PR uses bitwise comparison to check if the incoming value is negative zero, avoiding such subnormal flushing from happening before polling.

Verified the mentioned hang issues reported in SGLang and VLLM can be solved with this fix.

## 🔍 Related Issues

#3053 

also related to the issue [vllm-project/vllm#35772](https://github.com/vllm-project/vllm/issues/35772)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened negative-zero sentinel detection for FP32 by switching to bit-exact matching and addressing GPU flush-to-zero edge cases to avoid accidental sentinel matches and potential allreduce hangs.

* **Tests**
  * Added a regression test that injects targeted sentinel patterns across data types and fusion modes to guard against deadlocks and ensure robust sentinel handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3304)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->