### PR TITLE
Modify release deletion command in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,7 @@ jobs:
           # Delete existing release and tag if they exist
           if gh release view "$TAG" &>/dev/null; then
             echo "Deleting existing release: $TAG"
-            gh release delete "$TAG" --yes --cleanup-tag
+            gh release delete "$TAG" --yes
           fi
 
           # Read release notes from file


### PR DESCRIPTION
Removed the cleanup-tag option from the release delete command.

<!-- .github/pull_request_template.md -->

## 📌 Description

If a prior release failed, and retagged. This step would delete the tag and retag it at the wrong place, although checkout would be done before that, following the correct tag prior to deletion. It causes some confusion about what the release contains due to the difference between the tag released worked on and the incorrect retag that will be presented on GitHub when the deletion is triggered by running the release workflow when the release page exists (likely means previous failed release, posted release page but didn't make it thru wheel building and publishing. then likely also retagged, not on main)

thanks to @dierksen root causing it

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow tag handling process during release creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->