### PR TITLE
Add CUDA version detection to build backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ pip install flashinfer-python flashinfer-cubin
 pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
 ```
 
-**For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
+**For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels when installing the prebuilt PyPI wheel:
 
 ```bash
 pip install flashinfer-python[cu13]
 ```
+
+When building FlashInfer from source, the build backend auto-selects the CUTLASS DSL dependency from your CUDA version. Set `FLASHINFER_CUDA_VERSION=13.0` to force CUDA 13 dependency metadata in CI or Docker builds.
 
 ### Verify Installation
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ pip install flashinfer-python flashinfer-cubin
 pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
 ```
 
-**For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels when installing the prebuilt PyPI wheel:
+**For Blackwell (SM 10.0+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels when installing the prebuilt PyPI wheel:
 
 ```bash
 pip install flashinfer-python[cu13]

--- a/build_backend.py
+++ b/build_backend.py
@@ -270,9 +270,7 @@ def _patch_wheel_metadata(wheel_path: Path) -> None:
         infos = wheel.infolist()
         contents = {info.filename: wheel.read(info.filename) for info in infos}
 
-    metadata_files = [
-        name for name in contents if name.endswith(".dist-info/METADATA")
-    ]
+    metadata_files = [name for name in contents if name.endswith(".dist-info/METADATA")]
     if len(metadata_files) != 1:
         return
 

--- a/build_backend.py
+++ b/build_backend.py
@@ -26,7 +26,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 from setuptools import build_meta as orig
@@ -193,22 +193,26 @@ def _is_unmarked_cutlass_dsl_requirement(requirement: str) -> bool:
     return (
         canonicalize_name(parsed_requirement.name)
         == canonicalize_name(_CUTLASS_DSL_PACKAGE)
+        and not parsed_requirement.extras
         and parsed_requirement.marker is None
     )
 
 
 def _patch_metadata_content(content: str) -> str:
-    selected_requirement = _selected_cutlass_dsl_requirement()
+    selected_requirement = None
     patched_lines = []
     for line in content.splitlines(keepends=True):
         prefix = "Requires-Dist: "
         if line.startswith(prefix):
-            requirement = line[len(prefix) :].strip()
+            line_without_newline = line.rstrip("\r\n")
+            line_ending = line[len(line_without_newline) :]
+            requirement = line_without_newline[len(prefix) :].strip()
             try:
                 if _is_unmarked_cutlass_dsl_requirement(requirement):
-                    newline = "\n" if line.endswith("\n") else ""
-                    line = f"{prefix}{selected_requirement}{newline}"
-            except Exception:
+                    if selected_requirement is None:
+                        selected_requirement = _selected_cutlass_dsl_requirement()
+                    line = f"{prefix}{selected_requirement}{line_ending}"
+            except InvalidRequirement:
                 pass
         patched_lines.append(line)
     return "".join(patched_lines)
@@ -266,40 +270,59 @@ def _rewrite_record(
 
 
 def _patch_wheel_metadata(wheel_path: Path) -> None:
-    with zipfile.ZipFile(wheel_path, "r") as wheel:
-        infos = wheel.infolist()
-        contents = {info.filename: wheel.read(info.filename) for info in infos}
-
-    metadata_files = [name for name in contents if name.endswith(".dist-info/METADATA")]
-    if len(metadata_files) != 1:
-        return
-
-    metadata_name = metadata_files[0]
-    metadata = contents[metadata_name]
-    patched_metadata = _patch_metadata_content(metadata.decode("utf-8")).encode("utf-8")
-    if patched_metadata == metadata:
-        return
-
-    dist_info_dir = metadata_name.rsplit("/", 1)[0]
-    record_name = f"{dist_info_dir}/RECORD"
-    contents[metadata_name] = patched_metadata
-    if record_name in contents:
-        contents[record_name] = _rewrite_record(
-            contents[record_name], metadata_name, patched_metadata, record_name
-        )
-
-    fd, temp_path = tempfile.mkstemp(
-        prefix=f"{wheel_path.stem}.", suffix=".whl", dir=wheel_path.parent
-    )
-    os.close(fd)
-    temp_wheel_path = Path(temp_path)
+    temp_wheel_path = None
     try:
-        with zipfile.ZipFile(temp_wheel_path, "w") as patched_wheel:
-            for info in infos:
-                patched_wheel.writestr(info, contents[info.filename])
+        with zipfile.ZipFile(wheel_path, "r") as wheel:
+            infos = wheel.infolist()
+            metadata_files = [
+                info.filename
+                for info in infos
+                if info.filename.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_files) != 1:
+                return
+
+            metadata_name = metadata_files[0]
+            metadata = wheel.read(metadata_name)
+            patched_metadata = _patch_metadata_content(metadata.decode("utf-8")).encode(
+                "utf-8"
+            )
+            if patched_metadata == metadata:
+                return
+
+            dist_info_dir = metadata_name.rsplit("/", 1)[0]
+            record_name = f"{dist_info_dir}/RECORD"
+            record_names = {info.filename for info in infos}
+            patched_record = None
+            if record_name in record_names:
+                patched_record = _rewrite_record(
+                    wheel.read(record_name),
+                    metadata_name,
+                    patched_metadata,
+                    record_name,
+                )
+
+            fd, temp_path = tempfile.mkstemp(
+                prefix=f"{wheel_path.stem}.", suffix=".whl", dir=wheel_path.parent
+            )
+            os.close(fd)
+            temp_wheel_path = Path(temp_path)
+            with zipfile.ZipFile(temp_wheel_path, "w") as patched_wheel:
+                for info in infos:
+                    if info.filename == metadata_name:
+                        patched_wheel.writestr(info, patched_metadata)
+                    elif info.filename == record_name and patched_record is not None:
+                        patched_wheel.writestr(info, patched_record)
+                    else:
+                        with (
+                            wheel.open(info, "r") as source,
+                            patched_wheel.open(info, "w") as target,
+                        ):
+                            shutil.copyfileobj(source, target)
+
         temp_wheel_path.replace(wheel_path)
     finally:
-        if temp_wheel_path.exists():
+        if temp_wheel_path is not None and temp_wheel_path.exists():
             temp_wheel_path.unlink()
 
 

--- a/build_backend.py
+++ b/build_backend.py
@@ -14,15 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import base64
+import csv
+import hashlib
+import io
 import os
+import re
 import shutil
+import subprocess
+import tempfile
+import zipfile
 from pathlib import Path
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
 from setuptools import build_meta as orig
 from build_utils import get_git_version
 
 _root = Path(__file__).parent.resolve()
 _data_dir = _root / "flashinfer" / "data"
+_CUTLASS_DSL_PACKAGE = "nvidia-cutlass-dsl"
+_CUTLASS_DSL_MIN_VERSION = ">=4.5.0"
+_CUTLASS_DSL_BASE_REQUIREMENT = f"{_CUTLASS_DSL_PACKAGE}{_CUTLASS_DSL_MIN_VERSION}"
+_CUTLASS_DSL_CU13_REQUIREMENT = (
+    f"{_CUTLASS_DSL_PACKAGE}[cu13]{_CUTLASS_DSL_MIN_VERSION}"
+)
 
 
 def _create_build_metadata():
@@ -80,6 +97,212 @@ def write_if_different(path: Path, content: str) -> None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
+
+
+def _parse_cuda_version(raw_version: str) -> Version:
+    value = raw_version.strip().lower()
+    if value.startswith("cuda"):
+        value = value.removeprefix("cuda").strip("-_ ")
+    if value.startswith("cu"):
+        cuda_digits = value.removeprefix("cu")
+        if not cuda_digits.isdigit():
+            raise InvalidVersion(raw_version)
+        if len(cuda_digits) <= 2:
+            value = cuda_digits
+        else:
+            value = f"{cuda_digits[:-1]}.{cuda_digits[-1]}"
+    return Version(value)
+
+
+def _detect_cuda_version_from_env() -> Version | None:
+    for env_name in ("FLASHINFER_CUDA_VERSION", "CUDA_VERSION"):
+        raw_version = os.environ.get(env_name)
+        if not raw_version:
+            continue
+        try:
+            return _parse_cuda_version(raw_version)
+        except InvalidVersion as exc:
+            raise RuntimeError(
+                f"{env_name}={raw_version!r} is not a valid CUDA version. "
+                "Expected values like '13.0', 'cu130', or 'cu13'."
+            ) from exc
+    return None
+
+
+def _detect_cuda_version_from_nvcc() -> Version | None:
+    candidate_paths: list[Path] = []
+    for env_name in ("CUDA_HOME", "CUDA_PATH"):
+        cuda_home = os.environ.get(env_name)
+        if cuda_home:
+            candidate_paths.append(Path(cuda_home) / "bin" / "nvcc")
+
+    nvcc_path = shutil.which("nvcc")
+    if nvcc_path:
+        candidate_paths.append(Path(nvcc_path))
+
+    for candidate in candidate_paths:
+        if not candidate.exists():
+            continue
+        try:
+            output = subprocess.check_output(
+                [str(candidate), "--version"],
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        match = re.search(r"release\s+(\d+\.\d+)", output)
+        if match:
+            return _parse_cuda_version(match.group(1))
+
+    return None
+
+
+def _detect_cuda_version_from_torch() -> Version | None:
+    try:
+        import torch
+    except Exception:
+        return None
+
+    torch_cuda_version = getattr(getattr(torch, "version", None), "cuda", None)
+    if not torch_cuda_version:
+        return None
+    try:
+        return _parse_cuda_version(torch_cuda_version)
+    except InvalidVersion:
+        return None
+
+
+def _detect_cuda_version() -> Version | None:
+    return (
+        _detect_cuda_version_from_env()
+        or _detect_cuda_version_from_nvcc()
+        or _detect_cuda_version_from_torch()
+    )
+
+
+def _selected_cutlass_dsl_requirement() -> str:
+    cuda_version = _detect_cuda_version()
+    if cuda_version is not None and cuda_version.major >= 13:
+        return _CUTLASS_DSL_CU13_REQUIREMENT
+    return _CUTLASS_DSL_BASE_REQUIREMENT
+
+
+def _is_unmarked_cutlass_dsl_requirement(requirement: str) -> bool:
+    parsed_requirement = Requirement(requirement)
+    return (
+        canonicalize_name(parsed_requirement.name)
+        == canonicalize_name(_CUTLASS_DSL_PACKAGE)
+        and parsed_requirement.marker is None
+    )
+
+
+def _patch_metadata_content(content: str) -> str:
+    selected_requirement = _selected_cutlass_dsl_requirement()
+    patched_lines = []
+    for line in content.splitlines(keepends=True):
+        prefix = "Requires-Dist: "
+        if line.startswith(prefix):
+            requirement = line[len(prefix) :].strip()
+            try:
+                if _is_unmarked_cutlass_dsl_requirement(requirement):
+                    newline = "\n" if line.endswith("\n") else ""
+                    line = f"{prefix}{selected_requirement}{newline}"
+            except Exception:
+                pass
+        patched_lines.append(line)
+    return "".join(patched_lines)
+
+
+def _patch_metadata_file(metadata_file: Path) -> None:
+    content = metadata_file.read_text()
+    patched_content = _patch_metadata_content(content)
+    write_if_different(metadata_file, patched_content)
+
+
+def _patch_dist_info_metadata(metadata_directory: str, dist_info: str) -> None:
+    metadata_file = Path(metadata_directory) / dist_info / "METADATA"
+    if metadata_file.exists():
+        _patch_metadata_file(metadata_file)
+
+
+def _record_hash(data: bytes) -> tuple[str, str]:
+    digest = hashlib.sha256(data).digest()
+    encoded_digest = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded_digest}", str(len(data))
+
+
+def _rewrite_record(
+    record: bytes,
+    metadata_name: str,
+    metadata: bytes,
+    record_name: str,
+) -> bytes:
+    rows = list(csv.reader(io.StringIO(record.decode("utf-8"))))
+    metadata_hash, metadata_size = _record_hash(metadata)
+    found_metadata = False
+    found_record = False
+
+    for row in rows:
+        if not row:
+            continue
+        if row[0] == metadata_name:
+            row[1] = metadata_hash
+            row[2] = metadata_size
+            found_metadata = True
+        elif row[0] == record_name:
+            row[1] = ""
+            row[2] = ""
+            found_record = True
+
+    if not found_metadata:
+        rows.append([metadata_name, metadata_hash, metadata_size])
+    if not found_record:
+        rows.append([record_name, "", ""])
+
+    output = io.StringIO()
+    csv.writer(output, lineterminator="\n").writerows(rows)
+    return output.getvalue().encode("utf-8")
+
+
+def _patch_wheel_metadata(wheel_path: Path) -> None:
+    with zipfile.ZipFile(wheel_path, "r") as wheel:
+        infos = wheel.infolist()
+        contents = {info.filename: wheel.read(info.filename) for info in infos}
+
+    metadata_files = [
+        name for name in contents if name.endswith(".dist-info/METADATA")
+    ]
+    if len(metadata_files) != 1:
+        return
+
+    metadata_name = metadata_files[0]
+    metadata = contents[metadata_name]
+    patched_metadata = _patch_metadata_content(metadata.decode("utf-8")).encode("utf-8")
+    if patched_metadata == metadata:
+        return
+
+    dist_info_dir = metadata_name.rsplit("/", 1)[0]
+    record_name = f"{dist_info_dir}/RECORD"
+    contents[metadata_name] = patched_metadata
+    if record_name in contents:
+        contents[record_name] = _rewrite_record(
+            contents[record_name], metadata_name, patched_metadata, record_name
+        )
+
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f"{wheel_path.stem}.", suffix=".whl", dir=wheel_path.parent
+    )
+    os.close(fd)
+    temp_wheel_path = Path(temp_path)
+    try:
+        with zipfile.ZipFile(temp_wheel_path, "w") as patched_wheel:
+            for info in infos:
+                patched_wheel.writestr(info, contents[info.filename])
+        temp_wheel_path.replace(wheel_path)
+    finally:
+        if temp_wheel_path.exists():
+            temp_wheel_path.unlink()
 
 
 def _create_data_dir(use_symlinks=True):
@@ -157,17 +380,29 @@ def get_requires_for_build_editable(config_settings=None):
 
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     _prepare_for_wheel()
-    return orig.prepare_metadata_for_build_wheel(metadata_directory, config_settings)
+    dist_info = orig.prepare_metadata_for_build_wheel(
+        metadata_directory, config_settings
+    )
+    _patch_dist_info_metadata(metadata_directory, dist_info)
+    return dist_info
 
 
 def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
     _prepare_for_editable()
-    return orig.prepare_metadata_for_build_editable(metadata_directory, config_settings)
+    dist_info = orig.prepare_metadata_for_build_editable(
+        metadata_directory, config_settings
+    )
+    _patch_dist_info_metadata(metadata_directory, dist_info)
+    return dist_info
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
     _prepare_for_editable()
-    return orig.build_editable(wheel_directory, config_settings, metadata_directory)
+    wheel_name = orig.build_editable(
+        wheel_directory, config_settings, metadata_directory
+    )
+    _patch_wheel_metadata(Path(wheel_directory) / wheel_name)
+    return wheel_name
 
 
 def build_sdist(sdist_directory, config_settings=None):
@@ -177,4 +412,6 @@ def build_sdist(sdist_directory, config_settings=None):
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     _prepare_for_wheel()
-    return orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+    wheel_name = orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+    _patch_wheel_metadata(Path(wheel_directory) / wheel_name)
+    return wheel_name

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ FlashInfer provides three packages:
 
 This eliminates compilation and downloading overhead at runtime.
 
-**For Blackwell (SM100+) CuTe DSL kernels**, install the CUDA 13 extra when using the prebuilt PyPI wheel:
+**For Blackwell (SM 10.0+) CuTe DSL kernels**, install the CUDA 13 extra when using the prebuilt PyPI wheel:
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,6 +48,14 @@ FlashInfer provides three packages:
 
 This eliminates compilation and downloading overhead at runtime.
 
+**For Blackwell (SM100+) CuTe DSL kernels**, install the CUDA 13 extra when using the prebuilt PyPI wheel:
+
+.. code-block:: bash
+
+    pip install flashinfer-python[cu13]
+
+When building FlashInfer from source, the build backend auto-selects the CUTLASS DSL dependency from your CUDA version. Set ``FLASHINFER_CUDA_VERSION=13.0`` to force CUDA 13 dependency metadata in CI or Docker builds.
+
 
 .. _install-from-source:
 

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -36,26 +36,30 @@ class BuildBackendTest(unittest.TestCase):
     def test_selected_cutlass_dsl_requirement_defaults_to_base_when_cuda_unknown(
         self,
     ):
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch.object(
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
                 build_backend, "_detect_cuda_version_from_nvcc", return_value=None
-            ):
-                with mock.patch.object(
-                    build_backend, "_detect_cuda_version_from_torch", return_value=None
-                ):
-                    self.assertEqual(
-                        build_backend._selected_cutlass_dsl_requirement(),
-                        "nvidia-cutlass-dsl>=4.5.0",
-                    )
+            ),
+            mock.patch.object(
+                build_backend, "_detect_cuda_version_from_torch", return_value=None
+            ),
+        ):
+            self.assertEqual(
+                build_backend._selected_cutlass_dsl_requirement(),
+                "nvidia-cutlass-dsl>=4.5.0",
+            )
 
     def test_invalid_flashinfer_cuda_version_fails_clearly(self):
-        with mock.patch.dict(
-            os.environ,
-            {"FLASHINFER_CUDA_VERSION": "not-cuda"},
-            clear=False,
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"FLASHINFER_CUDA_VERSION": "not-cuda"},
+                clear=False,
+            ),
+            self.assertRaisesRegex(RuntimeError, "FLASHINFER_CUDA_VERSION"),
         ):
-            with self.assertRaisesRegex(RuntimeError, "FLASHINFER_CUDA_VERSION"):
-                build_backend._selected_cutlass_dsl_requirement()
+            build_backend._selected_cutlass_dsl_requirement()
 
     def test_patch_metadata_content_replaces_only_unmarked_cutlass_dependency(self):
         with mock.patch.dict(
@@ -77,9 +81,7 @@ class BuildBackendTest(unittest.TestCase):
 
             patched = build_backend._patch_metadata_content(metadata)
 
-        self.assertIn(
-            "Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0\n", patched
-        )
+        self.assertIn("Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0\n", patched)
         self.assertIn(
             'Requires-Dist: nvidia-cutlass-dsl>=4.5.0; extra == "cu12"',
             patched,
@@ -90,45 +92,45 @@ class BuildBackendTest(unittest.TestCase):
         )
 
     def test_patch_wheel_metadata_updates_record(self):
-        with mock.patch.dict(
-            os.environ,
-            {"FLASHINFER_CUDA_VERSION": "13.0"},
-            clear=False,
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"FLASHINFER_CUDA_VERSION": "13.0"},
+                clear=False,
+            ),
+            tempfile.TemporaryDirectory() as tmp_dir,
         ):
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                wheel_path = Path(tmp_dir) / (
-                    "flashinfer_python-0.0.0-py3-none-any.whl"
-                )
-                dist_info = "flashinfer_python-0.0.0.dist-info"
-                metadata_name = f"{dist_info}/METADATA"
-                record_name = f"{dist_info}/RECORD"
-                metadata = "\n".join(
-                    [
-                        "Metadata-Version: 2.4",
-                        "Name: flashinfer-python",
-                        "Requires-Dist: nvidia-cutlass-dsl>=4.5.0",
-                        "",
-                    ]
-                ).encode()
-                record = "\n".join(
-                    [
-                        "flashinfer/__init__.py,,",
-                        f"{metadata_name},sha256=old,1",
-                        f"{record_name},,",
-                        "",
-                    ]
-                ).encode()
+            wheel_path = Path(tmp_dir) / "flashinfer_python-0.0.0-py3-none-any.whl"
+            dist_info = "flashinfer_python-0.0.0.dist-info"
+            metadata_name = f"{dist_info}/METADATA"
+            record_name = f"{dist_info}/RECORD"
+            metadata = "\n".join(
+                [
+                    "Metadata-Version: 2.4",
+                    "Name: flashinfer-python",
+                    "Requires-Dist: nvidia-cutlass-dsl>=4.5.0",
+                    "",
+                ]
+            ).encode()
+            record = "\n".join(
+                [
+                    "flashinfer/__init__.py,,",
+                    f"{metadata_name},sha256=old,1",
+                    f"{record_name},,",
+                    "",
+                ]
+            ).encode()
 
-                with zipfile.ZipFile(wheel_path, "w") as wheel:
-                    wheel.writestr("flashinfer/__init__.py", b"")
-                    wheel.writestr(metadata_name, metadata)
-                    wheel.writestr(record_name, record)
+            with zipfile.ZipFile(wheel_path, "w") as wheel:
+                wheel.writestr("flashinfer/__init__.py", b"")
+                wheel.writestr(metadata_name, metadata)
+                wheel.writestr(record_name, record)
 
-                build_backend._patch_wheel_metadata(wheel_path)
+            build_backend._patch_wheel_metadata(wheel_path)
 
-                with zipfile.ZipFile(wheel_path, "r") as wheel:
-                    patched_metadata = wheel.read(metadata_name)
-                    patched_record = wheel.read(record_name)
+            with zipfile.ZipFile(wheel_path, "r") as wheel:
+                patched_metadata = wheel.read(metadata_name)
+                patched_record = wheel.read(record_name)
 
         self.assertIn(
             b"Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0",

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -73,6 +73,7 @@ class BuildBackendTest(unittest.TestCase):
                     "Name: flashinfer-python",
                     "Requires-Dist: numpy",
                     "Requires-Dist: nvidia-cutlass-dsl>=4.5.0",
+                    "Requires-Dist: nvidia-cutlass-dsl[dev]>=4.5.0",
                     'Requires-Dist: nvidia-cutlass-dsl>=4.5.0; extra == "cu12"',
                     'Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0; extra == "cu13"',
                     "",
@@ -82,6 +83,7 @@ class BuildBackendTest(unittest.TestCase):
             patched = build_backend._patch_metadata_content(metadata)
 
         self.assertIn("Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0\n", patched)
+        self.assertIn("Requires-Dist: nvidia-cutlass-dsl[dev]>=4.5.0", patched)
         self.assertIn(
             'Requires-Dist: nvidia-cutlass-dsl>=4.5.0; extra == "cu12"',
             patched,
@@ -90,6 +92,27 @@ class BuildBackendTest(unittest.TestCase):
             'Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0; extra == "cu13"',
             patched,
         )
+
+    def test_patch_metadata_content_preserves_crlf_and_invalid_requirements(self):
+        with mock.patch.dict(
+            os.environ,
+            {"FLASHINFER_CUDA_VERSION": "cu130"},
+            clear=False,
+        ):
+            metadata = "\r\n".join(
+                [
+                    "Metadata-Version: 2.4",
+                    "Name: flashinfer-python",
+                    "Requires-Dist: ???",
+                    "Requires-Dist: nvidia-cutlass-dsl>=4.5.0",
+                    "",
+                ]
+            )
+
+            patched = build_backend._patch_metadata_content(metadata)
+
+        self.assertIn("Requires-Dist: ???\r\n", patched)
+        self.assertIn("Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0\r\n", patched)
 
     def test_patch_wheel_metadata_updates_record(self):
         with (
@@ -104,6 +127,8 @@ class BuildBackendTest(unittest.TestCase):
             dist_info = "flashinfer_python-0.0.0.dist-info"
             metadata_name = f"{dist_info}/METADATA"
             record_name = f"{dist_info}/RECORD"
+            large_name = "flashinfer/data/large.bin"
+            large_content = b"x" * 1024
             metadata = "\n".join(
                 [
                     "Metadata-Version: 2.4",
@@ -115,6 +140,7 @@ class BuildBackendTest(unittest.TestCase):
             record = "\n".join(
                 [
                     "flashinfer/__init__.py,,",
+                    f"{large_name},,",
                     f"{metadata_name},sha256=old,1",
                     f"{record_name},,",
                     "",
@@ -123,19 +149,31 @@ class BuildBackendTest(unittest.TestCase):
 
             with zipfile.ZipFile(wheel_path, "w") as wheel:
                 wheel.writestr("flashinfer/__init__.py", b"")
+                wheel.writestr(large_name, large_content)
                 wheel.writestr(metadata_name, metadata)
                 wheel.writestr(record_name, record)
 
-            build_backend._patch_wheel_metadata(wheel_path)
+            original_read = zipfile.ZipFile.read
+
+            def guarded_read(self, name, pwd=None):
+                filename = name.filename if isinstance(name, zipfile.ZipInfo) else name
+                if filename == large_name:
+                    raise AssertionError("large wheel entries should be streamed")
+                return original_read(self, name, pwd)
+
+            with mock.patch.object(zipfile.ZipFile, "read", guarded_read):
+                build_backend._patch_wheel_metadata(wheel_path)
 
             with zipfile.ZipFile(wheel_path, "r") as wheel:
                 patched_metadata = wheel.read(metadata_name)
                 patched_record = wheel.read(record_name)
+                patched_large_content = wheel.read(large_name)
 
         self.assertIn(
             b"Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0",
             patched_metadata,
         )
+        self.assertEqual(patched_large_content, large_content)
 
         rows = list(csv.reader(io.StringIO(patched_record.decode())))
         metadata_rows = [row for row in rows if row and row[0] == metadata_name]

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -1,0 +1,146 @@
+import csv
+import io
+import os
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+import build_backend
+
+
+class BuildBackendTest(unittest.TestCase):
+    def test_selected_cutlass_dsl_requirement_uses_cuda_13_override(self):
+        with mock.patch.dict(
+            os.environ,
+            {"FLASHINFER_CUDA_VERSION": "13.0"},
+            clear=False,
+        ):
+            self.assertEqual(
+                build_backend._selected_cutlass_dsl_requirement(),
+                "nvidia-cutlass-dsl[cu13]>=4.5.0",
+            )
+
+    def test_selected_cutlass_dsl_requirement_uses_cuda_version_env(self):
+        with mock.patch.dict(
+            os.environ,
+            {"CUDA_VERSION": "cu130"},
+            clear=True,
+        ):
+            self.assertEqual(
+                build_backend._selected_cutlass_dsl_requirement(),
+                "nvidia-cutlass-dsl[cu13]>=4.5.0",
+            )
+
+    def test_selected_cutlass_dsl_requirement_defaults_to_base_when_cuda_unknown(
+        self,
+    ):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch.object(
+                build_backend, "_detect_cuda_version_from_nvcc", return_value=None
+            ):
+                with mock.patch.object(
+                    build_backend, "_detect_cuda_version_from_torch", return_value=None
+                ):
+                    self.assertEqual(
+                        build_backend._selected_cutlass_dsl_requirement(),
+                        "nvidia-cutlass-dsl>=4.5.0",
+                    )
+
+    def test_invalid_flashinfer_cuda_version_fails_clearly(self):
+        with mock.patch.dict(
+            os.environ,
+            {"FLASHINFER_CUDA_VERSION": "not-cuda"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "FLASHINFER_CUDA_VERSION"):
+                build_backend._selected_cutlass_dsl_requirement()
+
+    def test_patch_metadata_content_replaces_only_unmarked_cutlass_dependency(self):
+        with mock.patch.dict(
+            os.environ,
+            {"FLASHINFER_CUDA_VERSION": "cu130"},
+            clear=False,
+        ):
+            metadata = "\n".join(
+                [
+                    "Metadata-Version: 2.4",
+                    "Name: flashinfer-python",
+                    "Requires-Dist: numpy",
+                    "Requires-Dist: nvidia-cutlass-dsl>=4.5.0",
+                    'Requires-Dist: nvidia-cutlass-dsl>=4.5.0; extra == "cu12"',
+                    'Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0; extra == "cu13"',
+                    "",
+                ]
+            )
+
+            patched = build_backend._patch_metadata_content(metadata)
+
+        self.assertIn(
+            "Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0\n", patched
+        )
+        self.assertIn(
+            'Requires-Dist: nvidia-cutlass-dsl>=4.5.0; extra == "cu12"',
+            patched,
+        )
+        self.assertIn(
+            'Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0; extra == "cu13"',
+            patched,
+        )
+
+    def test_patch_wheel_metadata_updates_record(self):
+        with mock.patch.dict(
+            os.environ,
+            {"FLASHINFER_CUDA_VERSION": "13.0"},
+            clear=False,
+        ):
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                wheel_path = Path(tmp_dir) / (
+                    "flashinfer_python-0.0.0-py3-none-any.whl"
+                )
+                dist_info = "flashinfer_python-0.0.0.dist-info"
+                metadata_name = f"{dist_info}/METADATA"
+                record_name = f"{dist_info}/RECORD"
+                metadata = "\n".join(
+                    [
+                        "Metadata-Version: 2.4",
+                        "Name: flashinfer-python",
+                        "Requires-Dist: nvidia-cutlass-dsl>=4.5.0",
+                        "",
+                    ]
+                ).encode()
+                record = "\n".join(
+                    [
+                        "flashinfer/__init__.py,,",
+                        f"{metadata_name},sha256=old,1",
+                        f"{record_name},,",
+                        "",
+                    ]
+                ).encode()
+
+                with zipfile.ZipFile(wheel_path, "w") as wheel:
+                    wheel.writestr("flashinfer/__init__.py", b"")
+                    wheel.writestr(metadata_name, metadata)
+                    wheel.writestr(record_name, record)
+
+                build_backend._patch_wheel_metadata(wheel_path)
+
+                with zipfile.ZipFile(wheel_path, "r") as wheel:
+                    patched_metadata = wheel.read(metadata_name)
+                    patched_record = wheel.read(record_name)
+
+        self.assertIn(
+            b"Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.5.0",
+            patched_metadata,
+        )
+
+        rows = list(csv.reader(io.StringIO(patched_record.decode())))
+        metadata_rows = [row for row in rows if row and row[0] == metadata_name]
+        self.assertEqual(len(metadata_rows), 1)
+        self.assertNotEqual(metadata_rows[0][1], "sha256=old")
+        self.assertEqual(metadata_rows[0][2], str(len(patched_metadata)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR updates the FlashInfer build backend so source builds publish the CUTLASS DSL runtime dependency that matches the CUDA version used for the build.

The build backend now:

- detects CUDA from `FLASHINFER_CUDA_VERSION`, `CUDA_VERSION`, `nvcc`, or `torch.version.cuda`
- keeps the default `nvidia-cutlass-dsl>=4.5.0` dependency for CUDA 12 or unknown CUDA versions
- rewrites generated wheel/editable metadata to use `nvidia-cutlass-dsl[cu13]>=4.5.0` for CUDA 13+
- refreshes the wheel `RECORD` hash and size after metadata changes

The docs now distinguish prebuilt PyPI wheel usage (`flashinfer-python[cu13]`) from source builds, where dependency metadata is selected automatically and can be forced with `FLASHINFER_CUDA_VERSION=13.0`.

## Related Issues

None linked.

## Validation

- Added focused unit coverage for CUDA version overrides, default dependency selection, metadata patching, wheel `RECORD` updates, CRLF metadata preservation, malformed requirement handling, and streaming wheel copy behavior.
- `uv run --no-project --with pre-commit pre-commit run --all-files`
- `tests/test_build_backend.py` passes in an isolated temp copy of the changed backend/test files with `uv run --no-project --with packaging --with setuptools python -m unittest tests.test_build_backend -v`.

## Reviewer Notes

The approach intentionally patches generated package metadata rather than changing `requirements.txt`, so CUDA 12 and unknown-CUDA source builds keep the existing default dependency while CUDA 13 source builds get the `cu13` CUTLASS DSL extra.

Review feedback addressed in the latest update:

- wheel patching no longer reads the whole wheel into memory; it streams unchanged entries and only buffers `METADATA`/`RECORD`
- malformed `Requires-Dist` lines now catch `InvalidRequirement` specifically instead of a broad `Exception`
- metadata line endings are preserved when rewriting `Requires-Dist`
- existing unmarked `nvidia-cutlass-dsl[...]` extras are left untouched
- Blackwell SM notation now matches the existing `SM 10.0+` style in docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build process now auto-selects the appropriate CuTe DSL CUDA variant based on detected CUDA, with an option to force CUDA 13 metadata via FLASHINFER_CUDA_VERSION.

* **Documentation**
  * Expanded installation notes for Blackwell (SM 10.0+) CuTe DSL: guidance for the prebuilt wheel extra (cu13) and for forcing CUDA version when building from source (CI/Docker).

* **Tests**
  * Added tests covering CUDA-version selection and wheel metadata patching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3316)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
