### PR TITLE
[codex] Add CUDA 13 CUTLASS DSL dependency overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ pip install flashinfer-python flashinfer-cubin
 pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
 ```
 
-**For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
+**For Blackwell (SM 10.0+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
 
 ```bash
 pip install flashinfer-python[cu13]
@@ -140,6 +140,13 @@ See [documentation](https://docs.flashinfer.ai/) for comprehensive API reference
 git clone https://github.com/flashinfer-ai/flashinfer.git --recursive
 cd flashinfer
 python -m pip install -v .
+```
+
+For CUDA 13 source or development environments, install dependencies with the CUDA 13 requirements overlay before installing the local package:
+
+```bash
+python -m pip install -r requirements-cu13.txt
+python -m pip install --no-deps -v .
 ```
 
 **For development**, install in editable mode:
@@ -176,7 +183,8 @@ For more details, see the [Install from Source documentation](https://docs.flash
 
 ```bash
 pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps
-pip install flashinfer-python  # Install dependencies from PyPI
+# Install dependencies from PyPI (use flashinfer-python[cu13] for CUDA 13)
+pip install flashinfer-python
 pip install -U --pre flashinfer-cubin --index-url https://flashinfer.ai/whl/nightly/
 # JIT cache (replace cu129 with your CUDA version)
 pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu129

--- a/docker/Dockerfile.cu126
+++ b/docker/Dockerfile.cu126
@@ -23,7 +23,7 @@ ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/cublas/lib/:$LD_LIBRARY_PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu126
 

--- a/docker/Dockerfile.cu126.dev
+++ b/docker/Dockerfile.cu126.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu126 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu128
+++ b/docker/Dockerfile.cu128
@@ -23,7 +23,7 @@ ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/cublas/lib/:$LD_LIBRARY_PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu128
 

--- a/docker/Dockerfile.cu128.dev
+++ b/docker/Dockerfile.cu128.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu128 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu129
+++ b/docker/Dockerfile.cu129
@@ -26,7 +26,7 @@ ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/c
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu129
 

--- a/docker/Dockerfile.cu129.dev
+++ b/docker/Dockerfile.cu129.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu129 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu130
+++ b/docker/Dockerfile.cu130
@@ -26,7 +26,7 @@ ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/c
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130
 

--- a/docker/Dockerfile.cu130.dev
+++ b/docker/Dockerfile.cu130.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu131
+++ b/docker/Dockerfile.cu131
@@ -27,7 +27,7 @@ ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
 # TODO: update cu130 -> cu131 when PyTorch starts publishing cu131 wheels
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130
 

--- a/docker/Dockerfile.cu131.dev
+++ b/docker/Dockerfile.cu131.dev
@@ -46,7 +46,7 @@ ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
 # TODO: update cu130 -> cu131 when PyTorch starts publishing cu131 wheels
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu132
+++ b/docker/Dockerfile.cu132
@@ -27,7 +27,7 @@ ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
 # use nightly/cu132 temporarily and change to cu132 when torch releases stable version
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh nightly/cu132
 

--- a/docker/Dockerfile.cu132.dev
+++ b/docker/Dockerfile.cu132.dev
@@ -46,7 +46,7 @@ ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
 # use nightly/cu132 temporarily and change to cu132 when torch releases stable version
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh nightly/cu132 && pip3 install pre-commit
 

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -21,20 +21,28 @@ set -u
 
 pip3 install --upgrade "setuptools>=77" "pip>=24"
 
-# Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
+# Accept CUDA version as parameter (e.g., cu126, cu128, cu129, cu130).
 CUDA_VERSION=${1:-cu128}
+
+is_cuda13() {
+  local cuda_version="${1#nightly/}"
+  [[ "${cuda_version}" == cu13* || "${cuda_version}" == 13.* ]]
+}
 
 # Install torch with specific CUDA version first, followed by others in requirements.txt, and then others.
 # This is to ensure that the torch version is compatible with the CUDA version.
 pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
-pip3 install -r /install/requirements.txt
+if is_cuda13 "${CUDA_VERSION}"; then
+  pip3 install -r /install/requirements-cu13.txt
+else
+  pip3 install -r /install/requirements.txt
+fi
 pip3 install responses pytest scipy build cuda-python nvshmem4py-cu12
 
 # Install cudnn package based on CUDA version
-if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
+if is_cuda13 "${CUDA_VERSION}"; then
   pip3 install --upgrade cuda-python==13.0
   pip3 install --upgrade nvidia-cudnn-cu13
-  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
 else
   pip3 install --upgrade cuda-python==12.*
   pip3 install --upgrade nvidia-cudnn-cu12

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,6 +48,12 @@ FlashInfer provides three packages:
 
 This eliminates compilation and downloading overhead at runtime.
 
+**For Blackwell (SM 10.0+) CuTe DSL kernels**, install the CUDA 13 extra when using the prebuilt PyPI wheel:
+
+.. code-block:: bash
+
+    pip install flashinfer-python[cu13]
+
 
 .. _install-from-source:
 
@@ -76,6 +82,13 @@ You can follow the steps below to install FlashInfer from source code:
 
        cd flashinfer
        python -m pip install -v .
+
+   For CUDA 13 source or development environments, install dependencies with the CUDA 13 requirements overlay before installing the local package:
+
+   .. code-block:: bash
+
+       python -m pip install -r requirements-cu13.txt
+       python -m pip install --no-deps -v .
 
    **For development**, install in editable mode:
 
@@ -122,7 +135,7 @@ Nightly builds are available for testing the latest features:
 
     # Core and cubin packages
     pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps # Install the nightly package from custom index, without installing dependencies
-    pip install flashinfer-python  # Install flashinfer-python's dependencies from PyPI
+    pip install flashinfer-python  # Install dependencies from PyPI; use flashinfer-python[cu13] for CUDA 13
     pip install -U --pre flashinfer-cubin --index-url https://flashinfer.ai/whl/nightly/
     # JIT cache package (replace cu129 with your CUDA version: cu128, cu129, or cu130)
     pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu129

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
+# CUDA 13 consumers should request flashinfer-python[cu13]; plain
+# flashinfer-python keeps the CUDA 12-compatible CUTLASS DSL dependency.
 cu12 = ["nvidia-cutlass-dsl>=4.5.0"]
 cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
 

--- a/requirements-cu13.txt
+++ b/requirements-cu13.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+nvidia-cutlass-dsl[cu13]>=4.5.0

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -9,6 +9,21 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+detect_cuda_major() {
+  local cuda_version="${CUDA_VERSION:-}"
+  cuda_version="${cuda_version#nightly/}"
+  if [[ "${cuda_version}" == cu* ]]; then
+    cuda_version="${cuda_version#cu}"
+    echo "${cuda_version:0:2}"
+    return
+  fi
+  if [[ "${cuda_version}" =~ ^([0-9]+)\. ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return
+  fi
+  python -c "import torch; print(torch.version.cuda.split('.')[0])" 2>/dev/null || echo "12"
+}
+
 # Source the environment override file if it exists
 if [ -f "${REPO_ROOT}/ci/setup_python.env" ]; then
   source "${REPO_ROOT}/ci/setup_python.env"
@@ -27,7 +42,7 @@ fi
 # Override nvidia-cutlass-dsl if specified
 if [ -n "${CUTLASS_DSL_VERSION:-}" ]; then
   # Detect CUDA major version: only CUDA 13+ needs [cu13] extra
-  CUDA_MAJOR=$(python -c "import torch; print(torch.version.cuda.split('.')[0])" 2>/dev/null || echo "12")
+  CUDA_MAJOR=$(detect_cuda_major)
   if [ "$CUDA_MAJOR" = "13" ]; then
     CUTLASS_DSL_PKG="nvidia-cutlass-dsl[cu13]==${CUTLASS_DSL_VERSION}"
   else

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -49,6 +49,11 @@ SAMPLED_TEST_CASES=0
 # shellcheck disable=SC2034  # EXIT_CODE is used by calling scripts
 EXIT_CODE=0
 
+is_cuda13() {
+    local cuda_version="${1#nightly/}"
+    [[ "${cuda_version}" == cu13* || "${cuda_version}" == 13.* ]]
+}
+
 # Parse command line arguments
 # Set DISABLE_SANITY_TEST=true before sourcing to disable sanity testing
 : "${DISABLE_SANITY_TEST:=false}"
@@ -165,13 +170,13 @@ install_and_verify() {
         # Install precompiled kernels if enabled
         install_precompiled_kernels
 
-        # Sync dependencies from the branch's requirements.txt
-        pip install -r requirements.txt
-
-        # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
-        # version skew between libs-base and libs-cu13.
-        if [[ "${CUDA_VERSION}" == *"cu13"* ]]; then
-            pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
+        # Sync dependencies from the branch's requirements files. CUDA 13 uses
+        # the CUTLASS DSL cu13 extra to avoid version skew between libs-base
+        # and libs-cu13.
+        if is_cuda13 "${CUDA_VERSION}"; then
+            pip install -r requirements-cu13.txt
+        else
+            pip install -r requirements.txt
         fi
 
         # Install local python sources


### PR DESCRIPTION
## Summary

- Add `requirements-cu13.txt` as a CUDA 13 overlay that requests `nvidia-cutlass-dsl[cu13]>=4.5.0` on top of the base requirements.
- Update Docker and test install paths to choose the CUDA 13 overlay for `cu13*`, `nightly/cu13*`, and `13.x` CUDA versions while preserving the existing CUDA 12 default path.
- Document the CUDA 13 extra for PyPI installs and source/development environments that need Blackwell CuTe DSL kernels.

## Why

Plain `nvidia-cutlass-dsl` installs the base CUTLASS DSL libs only. The CUDA 13 libraries are behind the package extra, so CUDA 13 environments need to request `nvidia-cutlass-dsl[cu13]` explicitly. This keeps the default CUDA 12-compatible dependency path unchanged while making CUDA 13 container, CI, source, and user install paths explicit.

## Validation

- `git diff --check`
- `bash -n docker/install/install_python_packages.sh scripts/test_utils.sh scripts/setup_test_env.sh`
- `detect_cuda_major` smoke checks for `cu130`, `nightly/cu132`, `13.0`, and `12.9.0`
- `is_cuda13` smoke checks for `cu130`, `nightly/cu132`, `13.0`, and `cu129`
- `uv run --no-project --with pre-commit pre-commit run --all-files`