### PR TITLE
[codex] Align CUDA CI matrix with PyTorch support

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["12.8", "12.9", "13.0"]
+        cuda: ["12.6", "13.0", "13.2"]
         arch: ['x86_64', 'aarch64']
 
     runs-on: [self-hosted, linux, "${{ matrix.arch == 'aarch64' && 'arm64' || 'x64' }}", cpu, on-demand]
@@ -153,7 +153,7 @@ jobs:
       - name: Build wheel in container
         env:
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
-          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '12.9' && '7.5 8.0 8.9 9.0a 10.0a 12.0a' || (matrix.cuda < '13.0' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f' || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f')) }}
+          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '13.0' && '7.5 8.0 8.9 9.0a' || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f') }}
           FLASHINFER_DEV_RELEASE_SUFFIX: ${{ needs.setup.outputs.dev_suffix }}
         run: |
           # Extract CUDA major and minor versions
@@ -261,7 +261,7 @@ jobs:
           # Each wheel can be several GB, so we download, upload, delete, repeat
           mkdir -p dist-jit-cache
 
-          for cuda in 128 129 130; do
+          for cuda in 126 130 132; do
             for arch in x86_64 aarch64; do
               ARTIFACT_NAME="jit-cache-cu${cuda}-${arch}"
               echo "Processing ${ARTIFACT_NAME}..."
@@ -288,7 +288,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["12.9", "13.0"]
+        cuda: ["12.6", "13.0", "13.2"]
         test-shard: [1, 2, 3, 4, 5]
     runs-on: [self-hosted, linux, x64, gpu, sm86, on-demand]
 
@@ -325,16 +325,22 @@ jobs:
           name: flashinfer-cubin-wheel
           path: dist-cubin/
 
+      - name: Derive CUDA package version
+        id: cuda-version
+        run: |
+          CUDA_NO_DOT=$(echo "${{ matrix.cuda }}" | tr -d '.')
+          echo "cuda_version=cu${CUDA_NO_DOT}" >> $GITHUB_OUTPUT
+
       - name: Download flashinfer-jit-cache artifact
         uses: actions/download-artifact@v4
         with:
-          name: jit-cache-cu${{ matrix.cuda == '12.9' && '129' || '130' }}-x86_64
+          name: jit-cache-${{ steps.cuda-version.outputs.cuda_version }}-x86_64
           path: dist-jit-cache/
 
       - name: Get Docker image tag
         id: docker-tag
         run: |
-          CUDA_VERSION="cu${{ matrix.cuda == '12.9' && '129' || '130' }}"
+          CUDA_VERSION="${{ steps.cuda-version.outputs.cuda_version }}"
           DOCKER_TAG=$(grep "flashinfer/flashinfer-ci-${CUDA_VERSION}" ci/docker-tags.yml | cut -d':' -f2 | tr -d ' ')
           echo "cuda_version=${CUDA_VERSION}" >> $GITHUB_OUTPUT
           echo "tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Get Docker Tag
         id: get-tag
         run: |
-          TAG=$(grep 'flashinfer/flashinfer-ci-cu129:' ci/docker-tags.yml | cut -d':' -f2 | tr -d ' ')
+          TAG=$(grep 'flashinfer/flashinfer-ci-cu126:' ci/docker-tags.yml | cut -d':' -f2 | tr -d ' ')
           if [ -z "$TAG" ]; then
             echo "::error::Failed to extract Docker tag from ci/docker-tags.yml"
             exit 1
@@ -201,7 +201,7 @@ jobs:
       fail-fast: true
       matrix:
         arch: [x64, arm64]
-        cuda: [cu126, cu128, cu129, cu130]
+        cuda: [cu126, cu130, cu132]
     env:
       DOCKER_IMAGE: flashinfer/flashinfer-ci-${{ matrix.cuda }}:${{ needs.setup.outputs.docker_tag }}
     steps:
@@ -273,7 +273,7 @@ jobs:
         run: |
           MATRIX='{"include":['
           for arch in x64 arm64; do
-            for cuda in cu126 cu128 cu129 cu130; do
+            for cuda in cu126 cu130 cu132; do
               MATRIX+='{"arch":"'$arch'","cuda":"'$cuda'"},'
             done
           done
@@ -355,7 +355,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5]
     env:
-      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu129:${{ needs.setup.outputs.docker_tag }}
+      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu132:${{ needs.setup.outputs.docker_tag }}
     steps:
       - name: Cleanup
         run: |
@@ -428,7 +428,7 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.analyze-gpu-a10g-failure.outputs.rerun_matrix) }}
     env:
-      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu129:${{ needs.setup.outputs.docker_tag }}
+      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu132:${{ needs.setup.outputs.docker_tag }}
     steps:
       - name: Cleanup
         run: |
@@ -471,7 +471,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gpu, sm75, spot]
     timeout-minutes: 360
     env:
-      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu129:${{ needs.setup.outputs.docker_tag }}
+      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu132:${{ needs.setup.outputs.docker_tag }}
     steps:
       - name: Cleanup
         run: |
@@ -533,7 +533,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gpu, sm75, on-demand]
     timeout-minutes: 360
     env:
-      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu129:${{ needs.setup.outputs.docker_tag }}
+      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu132:${{ needs.setup.outputs.docker_tag }}
     steps:
       - name: Cleanup
         run: |
@@ -577,7 +577,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gpu, h100]
     timeout-minutes: 360
     env:
-      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu129:${{ needs.setup.outputs.docker_tag }}
+      DOCKER_IMAGE: flashinfer/flashinfer-ci-cu132:${{ needs.setup.outputs.docker_tag }}
     steps:
       - name: Cleanup
         run: |

--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -36,7 +36,7 @@ jobs:
     needs: generate-tag
     strategy:
       matrix:
-        cuda: [cu126, cu128, cu129, cu130, cu132]
+        cuda: [cu126, cu130, cu132]
         arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
     needs: [generate-tag, build]
     strategy:
       matrix:
-        cuda: [cu126, cu128, cu129, cu130, cu132]
+        cuda: [cu126, cu130, cu132]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -108,8 +108,6 @@ jobs:
         run: |
           cat > ci/docker-tags.yml << EOF
           flashinfer/flashinfer-ci-cu126: ${DATE_SHA}
-          flashinfer/flashinfer-ci-cu128: ${DATE_SHA}
-          flashinfer/flashinfer-ci-cu129: ${DATE_SHA}
           flashinfer/flashinfer-ci-cu130: ${DATE_SHA}
           flashinfer/flashinfer-ci-cu132: ${DATE_SHA}
           EOF
@@ -125,8 +123,6 @@ jobs:
 
             Updated images:
             - flashinfer/flashinfer-ci-cu126:${{ needs.generate-tag.outputs.date_sha }}
-            - flashinfer/flashinfer-ci-cu128:${{ needs.generate-tag.outputs.date_sha }}
-            - flashinfer/flashinfer-ci-cu129:${{ needs.generate-tag.outputs.date_sha }}
             - flashinfer/flashinfer-ci-cu130:${{ needs.generate-tag.outputs.date_sha }}
             - flashinfer/flashinfer-ci-cu132:${{ needs.generate-tag.outputs.date_sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["12.8", "12.9", "13.0"]
+        cuda: ["12.6", "13.0", "13.2"]
         arch: ['x86_64', 'aarch64']
 
     runs-on: [self-hosted, linux, "${{ matrix.arch == 'aarch64' && 'arm64' || 'x64' }}", cpu, on-demand]
@@ -182,7 +182,7 @@ jobs:
       - name: Build wheel in container
         env:
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
-          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '12.9' && '7.5 8.0 8.9 9.0a 10.0a 12.0a' || (matrix.cuda < '13.0' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f' || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f')) }}
+          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '13.0' && '7.5 8.0 8.9 9.0a' || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f') }}
         run: |
           # Extract CUDA major and minor versions
           CUDA_MAJOR=$(echo "${{ matrix.cuda }}" | cut -d'.' -f1)
@@ -323,7 +323,7 @@ jobs:
           # Each wheel can be several GB, so we download, upload, delete, repeat
           mkdir -p dist-jit-cache
 
-          for cuda in 128 129 130; do
+          for cuda in 126 130 132; do
             for arch in x86_64 aarch64; do
               ARTIFACT_NAME="jit-cache-cu${cuda}-${arch}"
               echo "Processing ${ARTIFACT_NAME}..."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,19 +76,19 @@ Internal CI runs an extended test matrix across NVIDIA GPU architectures. It is 
 
 | Test | GPU | CUDA | Notes |
 |------|-----|------|-------|
-| `unit_test_h100` | H100 | cu129, cu130 | |
-| `unit_test_b200` | B200 | cu129, cu130 | |
-| `unit_test_b300` | B300 | cu129, cu130 | |
-| `unit_test_gb200` | GB200 | cu129, cu130 | |
-| `unit_test_gb300` | GB300 | cu129, cu130 | |
-| `unit_test_5090` | RTX 5090 | cu129, cu130 | |
-| `unit_test_rtx_pro_6000` | RTX PRO 6000 Blackwell | cu129, cu130 | |
-| `unit_test_spark` | Spark | cu129, cu130 | manual-trigger only |
-| `unit_test_thor` | Thor | cu130 | manual-trigger only |
-| `multi_gpu_test_b300` | B300 (multi-GPU) | cu129, cu130 | |
-| `multi_node_test_b300` | B300 (multi-node) | cu129, cu130 | |
-| `multi_node_test_gb200` | GB200 (multi-node) | cu129, cu130 | |
-| `multi_node_test_gb300` | GB300 (multi-node) | cu129, cu130 | |
+| `unit_test_h100` | H100 | cu126, cu130, cu132 | |
+| `unit_test_b200` | B200 | cu126, cu130, cu132 | |
+| `unit_test_b300` | B300 | cu126, cu130, cu132 | |
+| `unit_test_gb200` | GB200 | cu126, cu130, cu132 | |
+| `unit_test_gb300` | GB300 | cu126, cu130, cu132 | |
+| `unit_test_5090` | RTX 5090 | cu126, cu130, cu132 | |
+| `unit_test_rtx_pro_6000` | RTX PRO 6000 Blackwell | cu126, cu130, cu132 | |
+| `unit_test_spark` | Spark | cu126, cu130, cu132 | manual-trigger only |
+| `unit_test_thor` | Thor | cu130, cu132 | manual-trigger only |
+| `multi_gpu_test_b300` | B300 (multi-GPU) | cu126, cu130, cu132 | |
+| `multi_node_test_b300` | B300 (multi-node) | cu126, cu130, cu132 | |
+| `multi_node_test_gb200` | GB200 (multi-node) | cu126, cu130, cu132 | |
+| `multi_node_test_gb300` | GB300 (multi-node) | cu126, cu130, cu132 | |
 
 # Claiming Issues
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -323,24 +323,6 @@ stage('Unittest') {
       run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu126',
         { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu126') })
     },
-    // CUDA 12.8 AOT Tests
-    'AOT-Build-Import-x86-64-cu128': {
-      run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu128',
-        { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu128') })
-    },
-    'AOT-Build-Import-aarch64-cu128': {
-      run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu128',
-        { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu128') })
-    },
-    // CUDA 12.9 AOT Tests
-    'AOT-Build-Import-x86-64-cu129': {
-      run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu129',
-        { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu129') })
-    },
-    'AOT-Build-Import-aarch64-cu129': {
-      run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu129',
-        { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu129') })
-    },
     // CUDA 13.0 AOT Tests
     'AOT-Build-Import-x86-64-cu130': {
       run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu130',
@@ -350,32 +332,41 @@ stage('Unittest') {
       run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu130',
         { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu130') })
     },
-    // JIT unittest only for cu129
-    'JIT-Unittest-1-cu129': {
-      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-1-cu129',
-        { node_type -> shard_run_unittest_GPU(node_type, 1, 'cu129') })
+    // CUDA 13.2 AOT Tests
+    'AOT-Build-Import-x86-64-cu132': {
+      run_with_spot_retry('CPU-LARGE-SPOT', 'CPU-LARGE', 'AOT-Build-Import-x86-64-cu132',
+        { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu132') })
     },
-    'JIT-Unittest-2-cu129': {
-      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-2-cu129',
-        { node_type -> shard_run_unittest_GPU(node_type, 2, 'cu129') })
+    'AOT-Build-Import-aarch64-cu132': {
+      run_with_spot_retry('ARM-LARGE-SPOT', 'ARM-LARGE', 'AOT-Build-Import-aarch64-cu132',
+        { node_type -> run_unittest_CPU_JIT_CACHE_PACKAGE_BUILD_IMPORT(node_type, 'cu132') })
     },
-    'JIT-Unittest-3-cu129': {
-      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-3-cu129',
-        { node_type -> shard_run_unittest_GPU(node_type, 3, 'cu129') })
+    // JIT unittest only for cu132
+    'JIT-Unittest-1-cu132': {
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-1-cu132',
+        { node_type -> shard_run_unittest_GPU(node_type, 1, 'cu132') })
     },
-    'JIT-Unittest-4-cu129': {
-      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-4-cu129',
-        { node_type -> shard_run_unittest_GPU(node_type, 4, 'cu129') })
+    'JIT-Unittest-2-cu132': {
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-2-cu132',
+        { node_type -> shard_run_unittest_GPU(node_type, 2, 'cu132') })
     },
-    'JIT-Unittest-5-cu129': {
-      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-5-cu129',
-        { node_type -> shard_run_unittest_GPU(node_type, 5, 'cu129') })
+    'JIT-Unittest-3-cu132': {
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-3-cu132',
+        { node_type -> shard_run_unittest_GPU(node_type, 3, 'cu132') })
     },
-    // JIT unit test for CUDA 12.9 with SM75 (AWS G4)
+    'JIT-Unittest-4-cu132': {
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-4-cu132',
+        { node_type -> shard_run_unittest_GPU(node_type, 4, 'cu132') })
+    },
+    'JIT-Unittest-5-cu132': {
+      run_with_spot_retry('GPU-G5-SPOT', 'GPU-G5', 'JIT-Unittest-5-cu132',
+        { node_type -> shard_run_unittest_GPU(node_type, 5, 'cu132') })
+    },
+    // JIT unit test for CUDA 13.2 with SM75 (AWS G4)
     // For now, we only enable sampling test for SM75
-    'JIT-Unittest-G4-cu129': {
-      run_with_spot_retry('GPU-G4-SPOT', 'GPU-G4', 'JIT-Unittest-G4-cu129',
-        { node_type -> shard_run_unittest_GPU(node_type, 3, 'cu129') })
+    'JIT-Unittest-G4-cu132': {
+      run_with_spot_retry('GPU-G4-SPOT', 'GPU-G4', 'JIT-Unittest-G4-cu132',
+        { node_type -> shard_run_unittest_GPU(node_type, 3, 'cu132') })
     },
   )
 }

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ pip install flashinfer-python
 
 ```bash
 pip install flashinfer-python flashinfer-cubin
-# JIT cache (replace cu129 with your CUDA version)
-pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
+# JIT cache (replace cu132 with your CUDA version: cu126, cu130, or cu132)
+pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu132
 ```
 
-**For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
+**For Blackwell (SM 10.0+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
 
 ```bash
 pip install flashinfer-python[cu13]
@@ -140,6 +140,13 @@ See [documentation](https://docs.flashinfer.ai/) for comprehensive API reference
 git clone https://github.com/flashinfer-ai/flashinfer.git --recursive
 cd flashinfer
 python -m pip install -v .
+```
+
+For CUDA 13 source or development environments, install dependencies with the CUDA 13 requirements overlay before installing the local package:
+
+```bash
+python -m pip install -r requirements-cu13.txt
+python -m pip install --no-deps -v .
 ```
 
 **For development**, install in editable mode:
@@ -176,10 +183,11 @@ For more details, see the [Install from Source documentation](https://docs.flash
 
 ```bash
 pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps
-pip install flashinfer-python  # Install dependencies from PyPI
+# Install dependencies from PyPI (use flashinfer-python[cu13] for CUDA 13)
+pip install flashinfer-python
 pip install -U --pre flashinfer-cubin --index-url https://flashinfer.ai/whl/nightly/
-# JIT cache (replace cu129 with your CUDA version)
-pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu129
+# JIT cache (replace cu132 with your CUDA version: cu126, cu130, or cu132)
+pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu132
 ```
 
 ### CLI Tools
@@ -224,9 +232,9 @@ Users can customize their own attention variants with additional parameters. For
 
 ## CUDA Support
 
-**Supported CUDA Versions:** 12.6, 12.8, 13.0, 13.1
+**Supported CUDA Versions:** 12.6, 13.0, 13.2
 
-> **Note:** FlashInfer strives to follow PyTorch's supported CUDA versions plus the latest CUDA release.
+> **Note:** FlashInfer strives to follow PyTorch's supported CUDA versions.
 
 ## Adoption
 

--- a/ci/docker-tags.yml
+++ b/ci/docker-tags.yml
@@ -1,5 +1,3 @@
 flashinfer/flashinfer-ci-cu126: 20260408-4cce866
-flashinfer/flashinfer-ci-cu128: 20260408-4cce866
-flashinfer/flashinfer-ci-cu129: 20260408-4cce866
 flashinfer/flashinfer-ci-cu130: 20260408-4cce866
 flashinfer/flashinfer-ci-cu132: 20260408-4cce866

--- a/docker/Dockerfile.cu126
+++ b/docker/Dockerfile.cu126
@@ -23,7 +23,7 @@ ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/cublas/lib/:$LD_LIBRARY_PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu126
 

--- a/docker/Dockerfile.cu126.dev
+++ b/docker/Dockerfile.cu126.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu126 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu128
+++ b/docker/Dockerfile.cu128
@@ -23,7 +23,7 @@ ENV PATH="/opt/conda/envs/py312/bin:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/cublas/lib/:$LD_LIBRARY_PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu128
 

--- a/docker/Dockerfile.cu128.dev
+++ b/docker/Dockerfile.cu128.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu128 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu129
+++ b/docker/Dockerfile.cu129
@@ -26,7 +26,7 @@ ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/c
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu129
 

--- a/docker/Dockerfile.cu129.dev
+++ b/docker/Dockerfile.cu129.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu129 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu130
+++ b/docker/Dockerfile.cu130
@@ -26,7 +26,7 @@ ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/c
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130
 

--- a/docker/Dockerfile.cu130.dev
+++ b/docker/Dockerfile.cu130.dev
@@ -45,7 +45,7 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu131
+++ b/docker/Dockerfile.cu131
@@ -27,7 +27,7 @@ ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
 # TODO: update cu130 -> cu131 when PyTorch starts publishing cu131 wheels
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130
 

--- a/docker/Dockerfile.cu131.dev
+++ b/docker/Dockerfile.cu131.dev
@@ -46,7 +46,7 @@ ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
 # TODO: update cu130 -> cu131 when PyTorch starts publishing cu131 wheels
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh cu130 && pip3 install pre-commit
 

--- a/docker/Dockerfile.cu132
+++ b/docker/Dockerfile.cu132
@@ -26,10 +26,9 @@ ENV LD_LIBRARY_PATH="/opt/conda/envs/py312/lib/python3.12/site-packages/nvidia/c
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 
 # Install torch and other python packages
-# use nightly/cu132 temporarily and change to cu132 when torch releases stable version
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh nightly/cu132
+RUN bash /install/install_python_packages.sh cu132
 
 # Install tilelang and cuda-tile
 RUN pip install tilelang cuda-tile

--- a/docker/Dockerfile.cu132.dev
+++ b/docker/Dockerfile.cu132.dev
@@ -45,10 +45,9 @@ ENV PATH="/home/$USERNAME/conda/bin:$PATH"
 ENV PATH="/home/$USERNAME/conda/envs/py312/bin:$PATH"
 
 # Install torch and other python packages
-# use nightly/cu132 temporarily and change to cu132 when torch releases stable version
-COPY requirements.txt /install/requirements.txt
+COPY requirements*.txt /install/
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
-RUN bash /install/install_python_packages.sh nightly/cu132 && pip3 install pre-commit
+RUN bash /install/install_python_packages.sh cu132 && pip3 install pre-commit
 
 # Install tilelang and cuda-tile
 RUN pip install tilelang cuda-tile

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -21,20 +21,44 @@ set -u
 
 pip3 install --upgrade "setuptools>=77" "pip>=24"
 
-# Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
-CUDA_VERSION=${1:-cu128}
+# Accept CUDA version as parameter (e.g., cu126, cu130, cu132).
+CUDA_VERSION=${1:-cu126}
+
+is_cuda13() {
+  local cuda_version="${1#nightly/}"
+  [[ "${cuda_version}" == cu13* || "${cuda_version}" == 13.* ]]
+}
+
+torch_index_cuda_version() {
+  local cuda_version="${1}"
+  local cuda_version_no_stream="${cuda_version#nightly/}"
+  if [[ "${cuda_version_no_stream}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+    cuda_version_no_stream="cu${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+    if [[ "${cuda_version}" == nightly/* ]]; then
+      echo "nightly/${cuda_version_no_stream}"
+    else
+      echo "${cuda_version_no_stream}"
+    fi
+    return
+  fi
+  echo "${cuda_version}"
+}
 
 # Install torch with specific CUDA version first, followed by others in requirements.txt, and then others.
 # This is to ensure that the torch version is compatible with the CUDA version.
-pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
-pip3 install -r /install/requirements.txt
+TORCH_CUDA_VERSION=$(torch_index_cuda_version "${CUDA_VERSION}")
+pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/${TORCH_CUDA_VERSION}
+if is_cuda13 "${CUDA_VERSION}"; then
+  pip3 install -r /install/requirements-cu13.txt
+else
+  pip3 install -r /install/requirements.txt
+fi
 pip3 install responses pytest scipy build cuda-python nvshmem4py-cu12
 
 # Install cudnn package based on CUDA version
-if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
+if is_cuda13 "${CUDA_VERSION}"; then
   pip3 install --upgrade cuda-python==13.0
   pip3 install --upgrade nvidia-cudnn-cu13
-  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
 else
   pip3 install --upgrade cuda-python==12.*
   pip3 install --upgrade nvidia-cudnn-cu12

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,10 +15,10 @@ Prerequisites
 
 - Python: 3.10, 3.11, 3.12, 3.13, 3.14
 
-- CUDA: 12.6, 12.8, 13.0, 13.1
+- CUDA: 12.6, 13.0, 13.2
 
 .. note::
-   FlashInfer strives to follow PyTorch's supported CUDA versions plus the latest CUDA release.
+   FlashInfer strives to follow PyTorch's supported CUDA versions.
 
 Quick Start
 ^^^^^^^^^^^
@@ -43,10 +43,16 @@ FlashInfer provides three packages:
 .. code-block:: bash
 
     pip install flashinfer-python flashinfer-cubin
-    # JIT cache package (replace cu129 with your CUDA version: cu128, cu129, or cu130)
-    pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
+    # JIT cache package (replace cu132 with your CUDA version: cu126, cu130, or cu132)
+    pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu132
 
 This eliminates compilation and downloading overhead at runtime.
+
+**For Blackwell (SM 10.0+) CuTe DSL kernels**, install the CUDA 13 extra when using the prebuilt PyPI wheel:
+
+.. code-block:: bash
+
+    pip install flashinfer-python[cu13]
 
 
 .. _install-from-source:
@@ -76,6 +82,13 @@ You can follow the steps below to install FlashInfer from source code:
 
        cd flashinfer
        python -m pip install -v .
+
+   For CUDA 13 source or development environments, install dependencies with the CUDA 13 requirements overlay before installing the local package:
+
+   .. code-block:: bash
+
+       python -m pip install -r requirements-cu13.txt
+       python -m pip install --no-deps -v .
 
    **For development**, install in editable mode:
 
@@ -122,10 +135,10 @@ Nightly builds are available for testing the latest features:
 
     # Core and cubin packages
     pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps # Install the nightly package from custom index, without installing dependencies
-    pip install flashinfer-python  # Install flashinfer-python's dependencies from PyPI
+    pip install flashinfer-python  # Install dependencies from PyPI; use flashinfer-python[cu13] for CUDA 13
     pip install -U --pre flashinfer-cubin --index-url https://flashinfer.ai/whl/nightly/
-    # JIT cache package (replace cu129 with your CUDA version: cu128, cu129, or cu130)
-    pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu129
+    # JIT cache package (replace cu132 with your CUDA version: cu126, cu130, or cu132)
+    pip install -U --pre flashinfer-jit-cache --index-url https://flashinfer.ai/whl/nightly/cu132
 
 Verify Installation
 ^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
+# CUDA 13 consumers should request flashinfer-python[cu13]; plain
+# flashinfer-python keeps the CUDA 12-compatible CUTLASS DSL dependency.
 cu12 = ["nvidia-cutlass-dsl>=4.5.0"]
 cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
 

--- a/requirements-cu13.txt
+++ b/requirements-cu13.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+nvidia-cutlass-dsl[cu13]>=4.5.0

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -9,6 +9,21 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+detect_cuda_major() {
+  local cuda_version="${CUDA_VERSION:-}"
+  cuda_version="${cuda_version#nightly/}"
+  if [[ "${cuda_version}" == cu* ]]; then
+    cuda_version="${cuda_version#cu}"
+    echo "${cuda_version:0:2}"
+    return
+  fi
+  if [[ "${cuda_version}" =~ ^([0-9]+)\. ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return
+  fi
+  python -c "import torch; print(torch.version.cuda.split('.')[0])" 2>/dev/null || echo "12"
+}
+
 # Source the environment override file if it exists
 if [ -f "${REPO_ROOT}/ci/setup_python.env" ]; then
   source "${REPO_ROOT}/ci/setup_python.env"
@@ -27,7 +42,7 @@ fi
 # Override nvidia-cutlass-dsl if specified
 if [ -n "${CUTLASS_DSL_VERSION:-}" ]; then
   # Detect CUDA major version: only CUDA 13+ needs [cu13] extra
-  CUDA_MAJOR=$(python -c "import torch; print(torch.version.cuda.split('.')[0])" 2>/dev/null || echo "12")
+  CUDA_MAJOR=$(detect_cuda_major)
   if [ "$CUDA_MAJOR" = "13" ]; then
     CUTLASS_DSL_PKG="nvidia-cutlass-dsl[cu13]==${CUTLASS_DSL_VERSION}"
   else

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -49,6 +49,24 @@ SAMPLED_TEST_CASES=0
 # shellcheck disable=SC2034  # EXIT_CODE is used by calling scripts
 EXIT_CODE=0
 
+is_cuda13() {
+    local cuda_version="${1#nightly/}"
+    [[ "${cuda_version}" == cu13* || "${cuda_version}" == 13.* ]]
+}
+
+cuda_stream_from_version() {
+    local cuda_version="${1#nightly/}"
+    if [[ "${cuda_version}" == cu* ]]; then
+        echo "${cuda_version}"
+        return
+    fi
+    if [[ "${cuda_version}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+        echo "cu${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+        return
+    fi
+    echo "cu130"
+}
+
 # Parse command line arguments
 # Set DISABLE_SANITY_TEST=true before sourcing to disable sanity testing
 : "${DISABLE_SANITY_TEST:=false}"
@@ -99,13 +117,7 @@ install_precompiled_kernels() {
 
     JIT_ARCH_EFFECTIVE=""
     # Map CUDA_VERSION to CUDA_STREAM for artifact lookup
-    if [[ "${CUDA_VERSION}" == cu* ]]; then
-        CUDA_STREAM="${CUDA_VERSION}"
-    elif [ "${CUDA_VERSION}" = "12.9.0" ]; then
-        CUDA_STREAM="cu129"
-    else
-        CUDA_STREAM="cu130"
-    fi
+    CUDA_STREAM=$(cuda_stream_from_version "${CUDA_VERSION}")
     echo "Using CUDA stream: ${CUDA_STREAM}"
     echo ""
 
@@ -165,13 +177,13 @@ install_and_verify() {
         # Install precompiled kernels if enabled
         install_precompiled_kernels
 
-        # Sync dependencies from the branch's requirements.txt
-        pip install -r requirements.txt
-
-        # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
-        # version skew between libs-base and libs-cu13.
-        if [[ "${CUDA_VERSION}" == *"cu13"* ]]; then
-            pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
+        # Sync dependencies from the branch's requirements files. CUDA 13 uses
+        # the CUTLASS DSL cu13 extra to avoid version skew between libs-base
+        # and libs-cu13.
+        if is_cuda13 "${CUDA_VERSION}"; then
+            pip install -r requirements-cu13.txt
+        else
+            pip install -r requirements.txt
         fi
 
         # Install local python sources

--- a/scripts/update_whl_index.py
+++ b/scripts/update_whl_index.py
@@ -4,7 +4,7 @@ Update wheel index for flashinfer packages.
 This script generates PEP 503 compatible simple repository index pages for:
 - flashinfer-python (no CUDA suffix in version)
 - flashinfer-cubin (no CUDA suffix in version)
-- flashinfer-jit-cache (has CUDA suffix like +cu130)
+- flashinfer-jit-cache (has CUDA suffix like +cu132)
 
 The index is organized by CUDA version for jit-cache, and flat for others.
 """
@@ -19,7 +19,7 @@ from typing import Optional
 
 def get_cuda_version(wheel_name: str) -> Optional[str]:
     """Extract CUDA version from wheel filename."""
-    # Match patterns like +cu128, +cu129, +cu130
+    # Match patterns like +cu126, +cu130, +cu132
     match = re.search(r"\+cu(\d+)", wheel_name)
     if match:
         return match.group(1)
@@ -170,7 +170,7 @@ def update_index(
             base_output = base_output / "nightly"
 
         if cuda:
-            # CUDA-specific index for jit-cache: whl/nightly/cu130/flashinfer-jit-cache/
+            # CUDA-specific index for jit-cache: whl/nightly/cu132/flashinfer-jit-cache/
             index_dir = base_output / f"cu{cuda}" / package
         else:
             # No CUDA version for python/cubin: whl/nightly/flashinfer-python/


### PR DESCRIPTION
## Summary

- Reduce active CUDA CI/build coverage to `cu126`, `cu130`, and `cu132` to match PyTorch-supported CUDA versions.
- Add `cu132` coverage to PR, release, nightly, Docker image, and Jenkins matrices while removing active `cu128`/`cu129` jobs.
- Include the CUDA 13 CUTLASS DSL dependency overlay from #3319 and route CUDA 13 Docker/test install paths through `requirements-cu13.txt`.
- Update docs, Docker tags, and wheel index examples for the supported CUDA set.

## Notes

- This PR is intended to subsume #3319.
- Existing `cu128`, `cu129`, and `cu131` Dockerfiles remain available for manual use but are no longer part of active CI/image publishing.
- `cu132` Dockerfiles now use PyTorch stable `cu132` wheels instead of the temporary nightly index.

## Validation

- `bash -n docker/install/install_python_packages.sh scripts/test_utils.sh scripts/setup_test_env.sh scripts/task_test_jit_cache_package_build_import.sh scripts/task_test_nightly_build.sh`
- `git diff --check`
- `uv run --no-project --with pyyaml python` workflow parse check for release-ci-docker, pr-test, release, and nightly-release workflows
- CUDA helper smoke checks for `cu126`, `cu130`, `cu132`, `12.6`, `13.0`, `13.2`, and `nightly/cu132`
