### PR TITLE
[feat] Add gemma RMS AR fusion

### DIFF
--- a/benchmarks/bench_gemma_ar_fusion.py
+++ b/benchmarks/bench_gemma_ar_fusion.py
@@ -1,0 +1,205 @@
+"""Benchmark: AllReduce + Gemma RMSNorm — fused vs unfused.
+
+Compares the perf of two equivalent paths for Qwen3.5 / Gemma tensor-parallel
+RMSNorm:
+
+  Fused:    flashinfer.comm.allreduce_fusion(pattern=kARResidualRMSNorm,
+                                             weight_bias=1.0)
+  Unfused:  torch.distributed.all_reduce(input) + residual add
+            + flashinfer.norm.gemma_fused_add_rmsnorm
+
+Launch with mpirun for the rank count you care about, e.g.:
+
+  mpirun -np 2 python benchmarks/bench_gemma_ar_fusion.py \\
+      --hidden-sizes 2048 4096 8192 --num-tokens 16 128 1024
+
+(OpenMPI as root: add `--allow-run-as-root`. The flag is rejected by MPICH.)
+"""
+
+import argparse
+import os
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from mpi4py import MPI
+
+import flashinfer.comm as comm
+from flashinfer.comm.mnnvl import TorchDistBackend
+from flashinfer.norm import gemma_fused_add_rmsnorm
+from flashinfer.testing.utils import bench_gpu_time
+
+
+def _init_distributed() -> tuple[int, int, int]:
+    """Stand up a TorchDist NCCL group via mpi4py (works for OpenMPI + MPICH)."""
+    mpi_comm = MPI.COMM_WORLD
+    rank = mpi_comm.Get_rank()
+    world_size = mpi_comm.Get_size()
+    local_rank = mpi_comm.Split_type(MPI.COMM_TYPE_SHARED).Get_rank()
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29501")
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(
+        backend="nccl", init_method="env://", rank=rank, world_size=world_size
+    )
+    return rank, world_size, local_rank
+
+
+def _bench_fused(workspace, x, residual, rms_gamma, rms_eps, num_iters, dry_run_iters):
+    norm_out = torch.empty_like(x)
+    residual_out = torch.empty_like(x)
+
+    def _run(inp):
+        comm.allreduce_fusion(
+            input=inp,
+            workspace=workspace,
+            pattern=comm.AllReduceFusionPattern.kARResidualRMSNorm,
+            launch_with_pdl=True,
+            residual_in=residual,
+            residual_out=residual_out,
+            norm_out=norm_out,
+            rms_gamma=rms_gamma,
+            rms_eps=rms_eps,
+            weight_bias=1.0,
+        )
+        return norm_out
+
+    return bench_gpu_time(
+        fn=_run,
+        input_args=(x,),
+        dry_run_iters=dry_run_iters,
+        repeat_iters=num_iters,
+        sleep_after_run=False,
+        use_cuda_graph=True,
+        cold_l2_cache=True,
+    )
+
+
+def _bench_unfused(x, residual, rms_gamma, rms_eps, group, num_iters, dry_run_iters):
+    # Pre-allocate scratch so we don't time allocation. The standalone Gemma
+    # kernel mutates input and residual in place; allocate fresh copies each
+    # call (matches how an inference loop would feed it).
+    scratch_x = torch.empty_like(x)
+    scratch_r = torch.empty_like(residual)
+
+    def _run(inp):
+        scratch_x.copy_(inp)
+        scratch_r.copy_(residual)
+        dist.all_reduce(scratch_x, group=group)
+        gemma_fused_add_rmsnorm(scratch_x, scratch_r, rms_gamma, eps=rms_eps)
+        return scratch_x
+
+    return bench_gpu_time(
+        fn=_run,
+        input_args=(x,),
+        dry_run_iters=dry_run_iters,
+        repeat_iters=num_iters,
+        sleep_after_run=False,
+        use_cuda_graph=True,
+        cold_l2_cache=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--hidden-sizes", nargs="+", type=int, default=[2048, 4096, 8192]
+    )
+    parser.add_argument("--num-tokens", nargs="+", type=int, default=[16, 128, 1024])
+    parser.add_argument("--dtype", choices=["bfloat16", "float16"], default="bfloat16")
+    parser.add_argument("--num-iters", type=int, default=50)
+    parser.add_argument("--dry-run-iters", type=int, default=10)
+    parser.add_argument("--max-token-num", type=int, default=2048)
+    args = parser.parse_args()
+
+    rank, world_size, _ = _init_distributed()
+    dtype = getattr(torch, args.dtype)
+    device = torch.device("cuda")
+    rms_eps = 1e-6
+
+    # Build one workspace sized for the largest config we'll exercise.
+    max_hidden = max(args.hidden_sizes)
+    workspace = comm.create_allreduce_fusion_workspace(
+        backend="trtllm",
+        world_size=world_size,
+        rank=rank,
+        max_token_num=args.max_token_num,
+        hidden_dim=max_hidden,
+        dtype=dtype,
+        comm_backend=TorchDistBackend(),
+    )
+
+    if rank == 0:
+        print(
+            f"\n=== Gemma AR-Fusion Benchmark (TP={world_size}, dtype={args.dtype}) ===\n"
+        )
+        print(
+            f"{'tokens':>8} {'hidden':>8} {'fused_us':>12} {'unfused_us':>12} "
+            f"{'speedup':>10}"
+        )
+        print("-" * 56)
+
+    try:
+        for tok in args.num_tokens:
+            for hidden in args.hidden_sizes:
+                if hidden > max_hidden:
+                    continue
+
+                torch.manual_seed(42)
+                rms_gamma = torch.randn(hidden, dtype=dtype, device=device)
+                torch.manual_seed(42 + rank)
+                x = torch.randn(tok, hidden, dtype=dtype, device=device)
+                residual = torch.randn(tok, hidden, dtype=dtype, device=device)
+
+                # Synchronize across ranks for fair timing.
+                dist.barrier()
+                torch.cuda.synchronize()
+
+                fused_times = _bench_fused(
+                    workspace,
+                    x,
+                    residual,
+                    rms_gamma,
+                    rms_eps,
+                    args.num_iters,
+                    args.dry_run_iters,
+                )
+                dist.barrier()
+
+                unfused_times = _bench_unfused(
+                    x,
+                    residual,
+                    rms_gamma,
+                    rms_eps,
+                    dist.group.WORLD,
+                    args.num_iters,
+                    args.dry_run_iters,
+                )
+                dist.barrier()
+
+                # Use max across ranks (sync collectives) → median across iters.
+                # bench_gpu_time returns per-iter time in milliseconds.
+                fused_local_ms = np.median(fused_times)
+                unfused_local_ms = np.median(unfused_times)
+                # Reduce-max across ranks
+                fused_t = torch.tensor([fused_local_ms], device=device)
+                unfused_t = torch.tensor([unfused_local_ms], device=device)
+                dist.all_reduce(fused_t, op=dist.ReduceOp.MAX)
+                dist.all_reduce(unfused_t, op=dist.ReduceOp.MAX)
+                fused_us = fused_t.item() * 1e3  # ms -> us
+                unfused_us = unfused_t.item() * 1e3
+
+                if rank == 0:
+                    speedup = unfused_us / fused_us if fused_us > 0 else float("nan")
+                    print(
+                        f"{tok:>8d} {hidden:>8d} "
+                        f"{fused_us:>12.2f} {unfused_us:>12.2f} "
+                        f"{speedup:>9.2f}x"
+                    )
+    finally:
+        workspace.destroy()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/trtllm_allreduce_fusion.cu
+++ b/csrc/trtllm_allreduce_fusion.cu
@@ -37,7 +37,8 @@ void trtllm_allreduce_fusion(TensorView allreduce_in, int64_t world_size, int64_
                              Optional<TensorView> quant_out, Optional<TensorView> scale_out,
                              Optional<TensorView> rms_gamma, Optional<double> rms_eps,
                              Optional<TensorView> scale_factor, Optional<int64_t> layout_code,
-                             Optional<int64_t> block_quant_group_size) {
+                             Optional<int64_t> block_quant_group_size,
+                             Optional<double> weight_bias) {
   ffi::CUDADeviceGuard device_guard(allreduce_in.device().device_id);
   // todo(Yingyi): add dispatch for float and bfloat16
 
@@ -69,6 +70,7 @@ void trtllm_allreduce_fusion(TensorView allreduce_in, int64_t world_size, int64_
     params.rms_gamma =
         rms_gamma.has_value() ? reinterpret_cast<void*>(rms_gamma.value().data_ptr()) : nullptr;
     params.rms_eps = rms_eps.has_value() ? static_cast<float>(rms_eps.value()) : 0.0f;
+    params.weight_bias = weight_bias.has_value() ? static_cast<float>(weight_bias.value()) : 0.0f;
     params.scale_factor = scale_factor.has_value()
                               ? reinterpret_cast<float*>(scale_factor.value().data_ptr())
                               : nullptr;

--- a/csrc/trtllm_mnnvl_allreduce.cu
+++ b/csrc/trtllm_mnnvl_allreduce.cu
@@ -32,7 +32,7 @@ void trtllm_mnnvl_allreduce_fusion(TensorView input, int64_t multicast_buffer_pt
                                    bool rmsnorm_fusion, bool launch_with_pdl, bool use_oneshot,
                                    TensorView output, Optional<TensorView> residual_out,
                                    Optional<TensorView> residual_in, Optional<TensorView> gamma,
-                                   Optional<double> epsilon) {
+                                   Optional<double> epsilon, Optional<double> weight_bias) {
   ffi::CUDADeviceGuard device_guard(input.device().device_id);
   auto stream = get_stream(input.device());
 
@@ -94,6 +94,7 @@ void trtllm_mnnvl_allreduce_fusion(TensorView input, int64_t multicast_buffer_pt
         residual_in.has_value() ? const_cast<void const*>(residual_in.value().data_ptr()) : nullptr;
     params.gamma = gamma.has_value() ? const_cast<void const*>(gamma.value().data_ptr()) : nullptr;
     params.epsilon = epsilon.has_value() ? epsilon.value() : 1e-5;
+    params.weightBias = weight_bias.has_value() ? static_cast<float>(weight_bias.value()) : 0.0f;
 
     // output data
     params.output = const_cast<void*>(output.data_ptr());

--- a/csrc/trtllm_moe_allreduce_fusion.cu
+++ b/csrc/trtllm_moe_allreduce_fusion.cu
@@ -31,7 +31,8 @@ void trtllm_moe_allreduce_fusion(
     TensorView moe_reduction_scale_input, TensorView moe_reduction_active_experts_token_input,
     TensorView moe_reduction_token_input, Optional<int64_t> layout_code,
     Optional<TensorView> moe_allreduce_out, Optional<TensorView> residual_out,
-    Optional<TensorView> norm_out, Optional<TensorView> quant_out, Optional<TensorView> scale_out) {
+    Optional<TensorView> norm_out, Optional<TensorView> quant_out, Optional<TensorView> scale_out,
+    Optional<double> weight_bias) {
   ffi::CUDADeviceGuard device_guard(moe_reduction_active_experts_token_input.device().device_id);
   auto stream = get_stream(moe_reduction_active_experts_token_input.device());
 
@@ -60,6 +61,8 @@ void trtllm_moe_allreduce_fusion(
             scale_out.has_value() ? reinterpret_cast<void*>(scale_out.value().data_ptr()) : nullptr;
         params.rms_gamma = reinterpret_cast<void*>(rms_gamma.data_ptr());
         params.rms_eps = static_cast<float>(rms_eps);
+        params.weight_bias =
+            weight_bias.has_value() ? static_cast<float>(weight_bias.value()) : 0.0f;
         params.scale_factor = static_cast<float>(scale_factor);
         params.layout = layout_code.has_value()
                             ? static_cast<QuantizationSFLayout>(layout_code.value())
@@ -88,7 +91,7 @@ void trtllm_moe_finalize_allreduce_fusion(
     Optional<TensorView> scale_out, bool launch_with_pdl, TensorView workspace,
     int64_t const world_rank, int64_t const world_size, double const eps,
     Optional<TensorView> shared_expert_output, Optional<TensorView> expert_scale_factor,
-    Optional<float> routed_scaling_factor) {
+    Optional<float> routed_scaling_factor, Optional<double> weight_bias) {
   DISPATCH_FLOATING_TYPES_FOR_ALLREDUCE(residual_in.dtype(), c_type, [&] {
     MoeFinalizeAllReduceFusionParams<c_type> params;
 
@@ -105,6 +108,7 @@ void trtllm_moe_finalize_allreduce_fusion(
     params.workspace = reinterpret_cast<void**>(workspace.data_ptr());
     params.rms_gamma = norm_weight.data_ptr();
     params.rms_eps = static_cast<float>(eps);
+    params.weight_bias = weight_bias.has_value() ? static_cast<float>(weight_bias.value()) : 0.0f;
     params.residual_in = residual_in.data_ptr();
     params.stream = get_stream(norm_weight.device());
 

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -138,6 +138,8 @@ TensorRT-LLM MNNVL AllReduce
     :toctree: ../generated
 
     trtllm_mnnvl_all_reduce
+    trtllm_mnnvl_allreduce
+    trtllm_mnnvl_fused_allreduce_add_rmsnorm
     trtllm_mnnvl_fused_allreduce_rmsnorm
     mpi_barrier
 

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -489,6 +489,8 @@ def allreduce_fusion(
     shared_expert_output: Optional[torch.Tensor] = None,
     # ===== Group quant parameters =====
     block_quant_group_size: Optional[int] = None,
+    # ===== RMSNorm variant =====
+    weight_bias: float = 0.0,
 ) -> torch.Tensor:
     """
     AllReduce + RMSNorm fusion operation.
@@ -538,6 +540,12 @@ def allreduce_fusion(
         residual_in: Residual tensor to ADD [token_num, hidden_dim]
         rms_gamma: RMSNorm weight [hidden_dim]
         rms_eps: RMSNorm epsilon for numerical stability
+        weight_bias: [trtllm only] Bias added to rms_gamma before scaling.
+                     0.0 (default) -> standard RMSNorm (out = gamma * x * rsqrt(...)).
+                     1.0           -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).
+                     Supported for kARResidualRMSNorm, the quant variants, and the
+                     MoE Reduction / Finalize variants. Ignored for kAllReduce.
+                     MNNVL backend supports only weight_bias=0.0.
         scale_factor: Input scale factor for quantization [trtllm only]
         layout_code: Scale factor layout (QuantizationSFLayout) [trtllm only]
 
@@ -688,6 +696,7 @@ def allreduce_fusion(
                 norm_out=norm_out,
                 quant_out=quant_out,
                 scale_out=scale_out,
+                weight_bias=weight_bias,
             )
 
             if norm_out is not None:
@@ -738,6 +747,7 @@ def allreduce_fusion(
                 shared_expert_output=shared_expert_output,
                 expert_scale_factor=expert_scale_factor,
                 routed_scaling_factor=None,
+                weight_bias=weight_bias,
             )
 
             return norm_out
@@ -839,6 +849,7 @@ def allreduce_fusion(
             scale_out=scale_out,  # scale_out is not reshaped
             rms_gamma=rms_gamma,  # 1D tensor, no reshape needed
             rms_eps=rms_eps,
+            weight_bias=weight_bias,
             scale_factor=scale_factor,
             layout_code=layout_code,  # type: ignore[arg-type]
             metadata=workspace.metadata,
@@ -883,6 +894,11 @@ def allreduce_fusion(
         elif pattern == AllReduceFusionPattern.kARResidualRMSNorm:
             # AllReduce + Residual + RMSNorm fusion
             # Validate required parameters
+            if weight_bias != 0.0:
+                raise NotImplementedError(
+                    "MNNVL backend does not yet support weight_bias != 0.0 "
+                    "(Gemma / Qwen3.5 RMSNorm). Use the TRTLLM backend instead."
+                )
             if residual_in is None:
                 raise ValueError("MNNVL AllReduce+RMS fusion requires residual_in")
             if rms_gamma is None:

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -540,12 +540,12 @@ def allreduce_fusion(
         residual_in: Residual tensor to ADD [token_num, hidden_dim]
         rms_gamma: RMSNorm weight [hidden_dim]
         rms_eps: RMSNorm epsilon for numerical stability
-        weight_bias: [trtllm only] Bias added to rms_gamma before scaling.
+        weight_bias: Bias added to rms_gamma before scaling.
                      0.0 (default) -> standard RMSNorm (out = gamma * x * rsqrt(...)).
                      1.0           -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).
-                     Supported for kARResidualRMSNorm, the quant variants, and the
-                     MoE Reduction / Finalize variants. Ignored for kAllReduce.
-                     MNNVL backend supports only weight_bias=0.0.
+                     Supported by both TRTLLM and MNNVL backends for kARResidualRMSNorm
+                     plus all TRTLLM RMSNorm variants (quant + MoE Reduction/Finalize).
+                     Ignored for kAllReduce (no normalization).
         scale_factor: Input scale factor for quantization [trtllm only]
         layout_code: Scale factor layout (QuantizationSFLayout) [trtllm only]
 
@@ -894,11 +894,6 @@ def allreduce_fusion(
         elif pattern == AllReduceFusionPattern.kARResidualRMSNorm:
             # AllReduce + Residual + RMSNorm fusion
             # Validate required parameters
-            if weight_bias != 0.0:
-                raise NotImplementedError(
-                    "MNNVL backend does not yet support weight_bias != 0.0 "
-                    "(Gemma / Qwen3.5 RMSNorm). Use the TRTLLM backend instead."
-                )
             if residual_in is None:
                 raise ValueError("MNNVL AllReduce+RMS fusion requires residual_in")
             if rms_gamma is None:
@@ -920,6 +915,7 @@ def allreduce_fusion(
                 output=norm_out,
                 residual_out=residual_out,
                 launch_with_pdl=launch_with_pdl,
+                weight_bias=weight_bias,
             )
             return norm_result
 

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -242,6 +242,7 @@ def get_trtllm_comm_module():
             "scale_factor",
             "layout_code",
             "block_quant_group_size",
+            "weight_bias",
         ],
     )
     def trtllm_allreduce_fusion(
@@ -267,6 +268,7 @@ def get_trtllm_comm_module():
         scale_factor: Optional[Union[torch.Tensor, float]],
         layout_code: Optional[QuantizationSFLayout],
         block_quant_group_size: Optional[int] = None,
+        weight_bias: Optional[float] = None,
     ) -> None:
         module.trtllm_allreduce_fusion(
             allreduce_in,
@@ -291,6 +293,7 @@ def get_trtllm_comm_module():
             scale_factor,
             layout_code,
             block_quant_group_size,
+            weight_bias,
         )
 
     @register_custom_op(
@@ -317,6 +320,7 @@ def get_trtllm_comm_module():
             "norm_out",
             "quant_out",
             "scale_out",
+            "weight_bias",
         ],
     )
     def trtllm_moe_allreduce_fusion(
@@ -340,6 +344,7 @@ def get_trtllm_comm_module():
         norm_out: Optional[torch.Tensor],
         quant_out: Optional[torch.Tensor],
         scale_out: Optional[torch.Tensor],
+        weight_bias: Optional[float] = None,
     ) -> None:
         module.trtllm_moe_allreduce_fusion(
             world_size,
@@ -362,11 +367,18 @@ def get_trtllm_comm_module():
             norm_out,
             quant_out,
             scale_out,
+            weight_bias,
         )
 
     @register_custom_op(
         "flashinfer::trtllm_moe_finalize_allreduce_fusion",
-        mutates_args=["residual_out", "norm_out", "quant_out", "scale_out"],
+        mutates_args=[
+            "residual_out",
+            "norm_out",
+            "quant_out",
+            "scale_out",
+            "weight_bias",
+        ],
     )
     def trtllm_moe_finalize_allreduce_fusion(
         allreduce_in: torch.Tensor,
@@ -385,6 +397,7 @@ def get_trtllm_comm_module():
         shared_expert_output: Optional[torch.Tensor],
         expert_scale_factor: Optional[torch.Tensor],
         routed_scaling_factor: Optional[float],
+        weight_bias: Optional[float] = None,
     ) -> None:
         module.trtllm_moe_finalize_allreduce_fusion(
             allreduce_in,
@@ -403,6 +416,7 @@ def get_trtllm_comm_module():
             shared_expert_output,
             expert_scale_factor,
             routed_scaling_factor,
+            weight_bias,
         )
 
     return SimpleNamespace(
@@ -972,6 +986,7 @@ def trtllm_allreduce_fusion(
     layout_code: Optional[QuantizationSFLayout],
     metadata: Optional[dict] = None,
     block_quant_group_size: Optional[int] = None,
+    weight_bias: Optional[float] = None,
 ) -> None:
     """
     Parameters:
@@ -999,6 +1014,10 @@ def trtllm_allreduce_fusion(
     - metadata: optional workspace metadata dict from create_ipc_workspace_for_all_reduce_fusion.
                 If provided, validates that token_num <= max_token_num, world_size == tp_size,
                 and hidden_dim == workspace hidden_dim. Raises ValueError if validation fails.
+    - weight_bias: bias added to rms_gamma before scaling.
+                   None or 0.0 -> standard RMSNorm (out = gamma * x * rsqrt(...)).
+                   1.0          -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).
+                   Ignored for kAllReduce and quant-only patterns that don't apply RMSNorm.
     """
 
     # Validate against workspace metadata if provided
@@ -1053,6 +1072,7 @@ def trtllm_allreduce_fusion(
         scale_out=scale_out,
         rms_gamma=rms_gamma,
         rms_eps=rms_eps,
+        weight_bias=weight_bias,
         scale_factor=scale_factor,
         layout_code=layout_code,
         block_quant_group_size=block_quant_group_size,
@@ -1080,6 +1100,7 @@ def trtllm_moe_allreduce_fusion(
     norm_out: Optional[torch.Tensor],
     quant_out: Optional[torch.Tensor],
     scale_out: Optional[torch.Tensor],
+    weight_bias: Optional[float] = None,
 ) -> None:
     """
     Parameters:
@@ -1103,6 +1124,9 @@ def trtllm_moe_allreduce_fusion(
     - norm_out: the norm output tensor. [token_num, hidden_dim]
     - quant_out: the quant output tensor. [token_num // 4, hidden_dim], fp16/bf16 -> fp4
     - scale_out: the scale output tensor. Initialization referece: tests/comm/test_trtllm_moe_allreduce_fusion.py
+    - weight_bias: bias added to rms_gamma before scaling.
+                   None or 0.0 -> standard RMSNorm (out = gamma * x * rsqrt(...)).
+                   1.0          -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).
     """
 
     required_lamport_comm_size = moe_reduction_token_input.numel() * 2 * world_size
@@ -1134,6 +1158,7 @@ def trtllm_moe_allreduce_fusion(
         norm_out=norm_out,
         quant_out=quant_out,
         scale_out=scale_out,
+        weight_bias=weight_bias,
     )
 
 
@@ -1154,6 +1179,7 @@ def trtllm_moe_finalize_allreduce_fusion(
     shared_expert_output: Optional[torch.Tensor],
     expert_scale_factor: Optional[torch.Tensor],
     routed_scaling_factor: Optional[float],
+    weight_bias: Optional[float] = None,
 ) -> None:
     """
     Parameters:
@@ -1173,6 +1199,9 @@ def trtllm_moe_finalize_allreduce_fusion(
     - shared_expert_output: the shared expert output tensor. [token_num, hidden_dim]
     - expert_scale_factor: the expert scale factor tensor. [token_num, top_k]
     - routed_scaling_factor: the routed scaling factor.
+    - weight_bias: bias added to rms_gamma before scaling.
+                   None or 0.0 -> standard RMSNorm (out = gamma * x * rsqrt(...)).
+                   1.0          -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).
     """
 
     required_lamport_comm_size = allreduce_in.numel() * 2 * world_size
@@ -1200,4 +1229,5 @@ def trtllm_moe_finalize_allreduce_fusion(
         shared_expert_output=shared_expert_output,
         expert_scale_factor=expert_scale_factor,
         routed_scaling_factor=routed_scaling_factor,
+        weight_bias=weight_bias,
     )

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -242,7 +242,6 @@ def get_trtllm_comm_module():
             "scale_factor",
             "layout_code",
             "block_quant_group_size",
-            "weight_bias",
         ],
     )
     def trtllm_allreduce_fusion(
@@ -320,7 +319,6 @@ def get_trtllm_comm_module():
             "norm_out",
             "quant_out",
             "scale_out",
-            "weight_bias",
         ],
     )
     def trtllm_moe_allreduce_fusion(
@@ -372,13 +370,7 @@ def get_trtllm_comm_module():
 
     @register_custom_op(
         "flashinfer::trtllm_moe_finalize_allreduce_fusion",
-        mutates_args=[
-            "residual_out",
-            "norm_out",
-            "quant_out",
-            "scale_out",
-            "weight_bias",
-        ],
+        mutates_args=["residual_out", "norm_out", "quant_out", "scale_out"],
     )
     def trtllm_moe_finalize_allreduce_fusion(
         allreduce_in: torch.Tensor,

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -280,6 +280,7 @@ def get_trtllm_mnnvl_comm_module():
             "residual_in",
             "gamma",
             "epsilon",
+            "weight_bias",
         ],
     )
     def trtllm_mnnvl_allreduce_fusion(
@@ -298,6 +299,7 @@ def get_trtllm_mnnvl_comm_module():
         residual_in: Optional[torch.Tensor],
         gamma: Optional[torch.Tensor],
         epsilon: Optional[float],
+        weight_bias: Optional[float] = None,
     ) -> None:
         """
         Perform a multi-node NVLink all-reduce operation with fusion.
@@ -333,6 +335,7 @@ def get_trtllm_mnnvl_comm_module():
             residual_in,
             gamma,
             epsilon,
+            weight_bias,
         )
 
     return SimpleNamespace(
@@ -428,6 +431,7 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm(
     residual_out: Optional[torch.Tensor] = None,
     launch_with_pdl: bool = False,
     strategy: MNNVLAllreduceFusionStrategy = MNNVLAllreduceFusionStrategy.AUTO,
+    weight_bias: float = 0.0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Performs MNNVL Allreduce + Residual + RMSNorm.
 
@@ -445,6 +449,9 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm(
         residual_out: Residual output tensor [num_tokens, hidden_dim], empty tensor will be created if not provided.
         launch_with_pdl: Whether to launch with PDL
         strategy: MNNVLAllreduceFusionStrategy. Internal heuristics will be used if not provided.
+        weight_bias: Bias added to gamma before scaling. 0.0 (default) for standard
+            RMSNorm (gamma * x * rsqrt(...)); 1.0 for Gemma / Qwen3.5 RMSNorm
+            ((1 + gamma) * x * rsqrt(...)).
 
     Returns:
         output: Add-residual and normalized tensor [num_tokens, hidden_dim]
@@ -508,6 +515,7 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm(
         residual_in,
         gamma,
         epsilon,
+        weight_bias,
     )
     return output, residual_out
 

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -280,7 +280,6 @@ def get_trtllm_mnnvl_comm_module():
             "residual_in",
             "gamma",
             "epsilon",
-            "weight_bias",
         ],
     )
     def trtllm_mnnvl_allreduce_fusion(

--- a/flashinfer/trace/templates/comm.py
+++ b/flashinfer/trace/templates/comm.py
@@ -34,6 +34,7 @@ def _allreduce_fusion_reference(
     residual_in=None,
     rms_gamma=None,
     rms_eps: float = 1e-6,
+    weight_bias: float = 0.0,
     **_unused,
 ):
     """Single-rank reference for allreduce_fusion.
@@ -45,7 +46,9 @@ def _allreduce_fusion_reference(
 
     - pattern 0 (kAllReduce): passthrough input.
     - pattern 1 (kARResidualRMSNorm): ``residual_out = input + residual_in``;
-      ``norm_out = rmsnorm(residual_out, rms_gamma, rms_eps)``.
+      ``norm_out = rmsnorm(residual_out, weight_bias + rms_gamma, rms_eps)``.
+      ``weight_bias=0`` is standard RMSNorm; ``weight_bias=1`` is Gemma /
+      Qwen3.5 style (``(1 + gamma) * x * rsqrt(...)``).
 
     Quantized / MoE patterns (>= 2) are outside the single-rank scope —
     this reference raises ``NotImplementedError`` for them and callers
@@ -63,7 +66,7 @@ def _allreduce_fusion_reference(
             )
         pre = input.to(torch.float32) + residual_in.to(torch.float32)
         inv_rms = torch.rsqrt(pre.pow(2).mean(dim=-1, keepdim=True) + float(rms_eps))
-        normed = (pre * inv_rms) * rms_gamma.to(torch.float32)
+        normed = (pre * inv_rms) * (float(weight_bias) + rms_gamma.to(torch.float32))
         pre_dtype = pre.to(input.dtype)
         normed_dtype = normed.to(input.dtype)
         if residual_out is not None:
@@ -151,6 +154,15 @@ allreduce_fusion_trace = TraceTemplate(
             description="RMSNorm weight (patterns 1..5).",
         ),
         "rms_eps": Scalar("float32", optional=True),
+        "weight_bias": Scalar(
+            "float32",
+            optional=True,
+            description=(
+                "Bias added to rms_gamma before scaling. 0.0 (default) is "
+                "standard RMSNorm; 1.0 selects Gemma / Qwen3.5 RMSNorm "
+                "((1 + gamma) * x * rsqrt(...))."
+            ),
+        ),
     },
     outputs={
         "output": Tensor(

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -802,6 +802,9 @@ struct AllReduceFusionParams {
   void* scale_out;
   void* rms_gamma;
   float rms_eps;
+  // 0 for standard RMSNorm (out = gamma * x * rsqrt(...)),
+  // 1 for Gemma / Qwen3.5 (out = (1 + gamma) * x * rsqrt(...)).
+  float weight_bias = 0.f;
   float* scale_factor;
   bool use_oneshot;
   QuantizationSFLayout layout = QuantizationSFLayout::SWIZZLED_128x4;
@@ -1179,9 +1182,9 @@ class FusedOp {
     __syncthreads();
 #pragma unroll
     for (int i = 0; i < VEC_SIZE; ++i) {
-      reinterpret_cast<T*>(&norm_out)[i] =
-          static_cast<T>(static_cast<float>(reinterpret_cast<T const*>(&residual)[i]) * s_val *
-                         static_cast<float>(reinterpret_cast<T const*>(&gamma)[i]));
+      reinterpret_cast<T*>(&norm_out)[i] = static_cast<T>(
+          static_cast<float>(reinterpret_cast<T const*>(&residual)[i]) * s_val *
+          (m_params.weight_bias + static_cast<float>(reinterpret_cast<T const*>(&gamma)[i])));
     }
     return norm_out;
   }

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -45,6 +45,9 @@ struct AllReduceFusionParams {
   void const* residualIn;
   void const* gamma;
   double epsilon;
+  // 0 for standard RMSNorm (out = gamma * x * rsqrt(...)),
+  // 1 for Gemma / Qwen3.5 (out = (1 + gamma) * x * rsqrt(...)).
+  float weightBias = 0.f;
 
   void* residualOut;
   void* output;
@@ -516,7 +519,8 @@ __global__ void __launch_bounds__(1024)
     oneshotAllreduceFusionKernel(T* outputPtr, T* prenormedPtr, T const* shardPtr,
                                  T const* residualInPtr, T const* gammaPtr, T** inputPtrs,
                                  T* mcastPtr, int const numTokens, int const tokenDim,
-                                 float epsilon, int const rank, uint32_t* bufferFlags) {
+                                 float epsilon, float weightBias, int const rank,
+                                 uint32_t* bufferFlags) {
   constexpr int kELTS_PER_THREAD = sizeof(PackedType) / sizeof(T);
   constexpr int kLAMPORT_ELTS_PER_PACKED = sizeof(PackedType) / sizeof(float);
   constexpr uint32_t kELT_SIZE = sizeof(T);
@@ -647,7 +651,7 @@ __global__ void __launch_bounds__(1024)
 #pragma unroll
     for (int i = 0; i < kELTS_PER_THREAD; i++) {
       packedAccum.elements[i] = fromFloat<T>(toFloat<T>(packedAccum.elements[i]) * rcpRms *
-                                             toFloat<T>(gamma.elements[i]));
+                                             (weightBias + toFloat<T>(gamma.elements[i])));
     }
   }
   reinterpret_cast<PackedType*>(&outputPtr[threadOffset])[0] = packedAccum.packed;
@@ -702,7 +706,7 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(                                                        \
       &config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM>, output, residualOut, input, \
       residualIn, gamma, ucPtrs, mcPtr, numTokens, tokenDim, static_cast<float>(params.epsilon),  \
-      params.rank, params.bufferFlags));
+      params.weightBias, params.rank, params.bufferFlags));
 #define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE)   \
   if (params.rmsNormFusion) {                   \
     LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true);  \
@@ -893,9 +897,10 @@ using utils::copyF4;
 template <typename T_IN, typename T_OUT, int LoadsPerThread = 1>
 __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OUT* outputNorm,
                                                        T_IN* bufferInput, T_IN const* gamma,
-                                                       float epsilon, T_IN const* residual,
-                                                       uint32_t numTokens, uint32_t dim,
-                                                       uint32_t worldSize, uint32_t* bufferFlags) {
+                                                       float epsilon, float weightBias,
+                                                       T_IN const* residual, uint32_t numTokens,
+                                                       uint32_t dim, uint32_t worldSize,
+                                                       uint32_t* bufferFlags) {
   static_assert(std::is_same_v<T_IN, T_OUT>, "T_IN and T_OUT must be the same type");
   static int const kELTS_PER_LOAD = sizeof(float4) / sizeof(T_IN);
 
@@ -1040,7 +1045,7 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
 
 #pragma unroll
       for (uint32_t j = 0; j < kELTS_PER_LOAD; j++) {
-        r_out.elements[j] = fromFloat<T_OUT>(toFloat<T_IN>(gamma.elements[j]) *
+        r_out.elements[j] = fromFloat<T_OUT>((weightBias + toFloat<T_IN>(gamma.elements[j])) *
                                              rInput[i * kELTS_PER_LOAD + j] * rcpRms);
       }
 
@@ -1159,15 +1164,15 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
         numTokens, rnClusterSize, rnBlockSize, rnClusterSize, rnLoadsPerThread,
         ceil_div(tokenDim, numEltsPerThread));
 
-#define RUN_RMSNORM_KERNEL(LOADS_PER_THREAD)                                                      \
-  FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(&rmsNormLamport<T, T, LOADS_PER_THREAD>,              \
-                                            cudaFuncAttributeMaxDynamicSharedMemorySize,          \
-                                            smemSize));                                           \
-  rnConfig.dynamicSmemBytes = smemSize;                                                           \
-  FLASHINFER_CUDA_CALL(                                                                           \
-      cudaLaunchKernelEx(&rnConfig, &rmsNormLamport<T, T, LOADS_PER_THREAD>, residualOut, output, \
-                         bufferInput, gamma, static_cast<float>(params.epsilon), residualIn,      \
-                         numTokens, tokenDim, params.nRanks, params.bufferFlags));
+#define RUN_RMSNORM_KERNEL(LOADS_PER_THREAD)                                                       \
+  FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(&rmsNormLamport<T, T, LOADS_PER_THREAD>,               \
+                                            cudaFuncAttributeMaxDynamicSharedMemorySize,           \
+                                            smemSize));                                            \
+  rnConfig.dynamicSmemBytes = smemSize;                                                            \
+  FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(                                                         \
+      &rnConfig, &rmsNormLamport<T, T, LOADS_PER_THREAD>, residualOut, output, bufferInput, gamma, \
+      static_cast<float>(params.epsilon), params.weightBias, residualIn, numTokens, tokenDim,      \
+      params.nRanks, params.bufferFlags));
 
     T* residualOut = reinterpret_cast<T*>(params.residualOut);
     T* output = reinterpret_cast<T*>(params.output);

--- a/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh
@@ -671,6 +671,9 @@ struct AllReduceFusionParams {
   void* scale_out;
   void* rms_gamma;
   float rms_eps;
+  // 0 for standard RMSNorm (out = gamma * x * rsqrt(...)),
+  // 1 for Gemma / Qwen3.5 (out = (1 + gamma) * x * rsqrt(...)).
+  float weight_bias = 0.f;
   // todo(review): why float* scale_factor in trt-llm?
   float scale_factor;
   QuantizationSFLayout layout = QuantizationSFLayout::SWIZZLED_128x4;
@@ -766,7 +769,8 @@ __device__ __forceinline__ vec_t<T, VEC_SIZE> vec_add(const vec_t<T, VEC_SIZE>& 
 template <typename T, uint32_t VEC_SIZE>
 __device__ __forceinline__ vec_t<T, VEC_SIZE> rms_norm(vec_t<T, VEC_SIZE> const& residual,
                                                        vec_t<T, VEC_SIZE> const& gamma,
-                                                       float const eps, int hidden_dim) {
+                                                       float const eps, int hidden_dim,
+                                                       float weight_bias = 0.f) {
   __shared__ float s_val;
   vec_t<T, VEC_SIZE> norm_out;
   namespace cg = cooperative_groups;
@@ -797,7 +801,8 @@ __device__ __forceinline__ vec_t<T, VEC_SIZE> rms_norm(vec_t<T, VEC_SIZE> const&
   __syncthreads();
 #pragma unroll
   for (int i = 0; i < VEC_SIZE; ++i) {
-    norm_out[i] = static_cast<float>(residual[i]) * s_val * static_cast<float>(gamma[i]);
+    norm_out[i] =
+        static_cast<float>(residual[i]) * s_val * (weight_bias + static_cast<float>(gamma[i]));
   }
   return norm_out;
 }
@@ -819,7 +824,8 @@ __device__ __forceinline__ void fused_op(vec_t<T, VEC_SIZE> const& val, int acce
     residual_val.store(reinterpret_cast<T*>(params.residual_out) + access_id * VEC_SIZE);
   }
   vec_t<T, VEC_SIZE> norm_val;
-  norm_val = rms_norm<T, VEC_SIZE>(residual_val, gamma_val, params.rms_eps, params.hidden_dim);
+  norm_val = rms_norm<T, VEC_SIZE>(residual_val, gamma_val, params.rms_eps, params.hidden_dim,
+                                   params.weight_bias);
   if constexpr (NormOut) {
     norm_val.store(reinterpret_cast<T*>(params.norm_out) + access_id * VEC_SIZE);
   }

--- a/tests/comm/test_allreduce_fusion_moe_unified_api.py
+++ b/tests/comm/test_allreduce_fusion_moe_unified_api.py
@@ -29,10 +29,16 @@ MAX_TOKEN_NUM = 2048
 HIDDEN_SIZE = 7168
 
 
-def _rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6):
+def _rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+    weight_bias: float = 0.0,
+):
+    # weight_bias=0 -> standard RMSNorm; weight_bias=1 -> Gemma / Qwen3.5.
     y = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
     if weight is not None:
-        y = y * weight
+        y = y * (weight_bias + weight)
     return y
 
 
@@ -80,6 +86,7 @@ def _run_moe_finalize_unified_worker(
     scale,
     expanded_idx_to_permuted_idx,
     residual,
+    weight_bias=0.0,
 ):
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
@@ -134,6 +141,7 @@ def _run_moe_finalize_unified_worker(
                     expanded_idx_to_permuted_idx=idx_d,
                     expert_scale_factor=scale_d,
                     shared_expert_output=shared_d,
+                    weight_bias=weight_bias,
                 )
                 torch.cuda.synchronize()
 
@@ -151,7 +159,10 @@ def _run_moe_finalize_unified_worker(
                 torch_before_residual = torch_before_residual * world_size
                 torch_residual = torch_before_residual + residual.float()
                 torch_norm = _rms_norm(
-                    torch_residual, norm_weight.cpu().float(), eps
+                    torch_residual,
+                    norm_weight.cpu().float(),
+                    eps,
+                    weight_bias=weight_bias,
                 ).to(dtype)
 
                 # Validate
@@ -188,6 +199,7 @@ def _run_moe_finalize_unified_worker(
                         expanded_idx_to_permuted_idx=idx_d,
                         expert_scale_factor=scale_d,
                         shared_expert_output=shared_d,
+                        weight_bias=weight_bias,
                     )
             torch.cuda.current_stream().wait_stream(s)
 
@@ -207,6 +219,7 @@ def _run_moe_finalize_unified_worker(
                         expanded_idx_to_permuted_idx=idx_d,
                         expert_scale_factor=scale_d,
                         shared_expert_output=shared_d,
+                        weight_bias=weight_bias,
                     )
             g.replay()
             torch.cuda.synchronize()
@@ -250,9 +263,11 @@ def _run_moe_finalize_unified_worker(
         (128, 4, True),  # larger batch, different top_k
     ],
 )
+@pytest.mark.parametrize("weight_bias", [0.0, 1.0])
 def test_moe_finalize_allreduce_unified_api(
-    world_size, dtype, seq_len, top_k, use_shared_expert
+    world_size, dtype, seq_len, top_k, use_shared_expert, weight_bias
 ):
+    # weight_bias=0 -> standard RMSNorm; weight_bias=1 -> Gemma / Qwen3.5 RMSNorm.
     """Test kMoEFinalizeARResidualRMSNorm pattern via allreduce_fusion()."""
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
@@ -284,6 +299,7 @@ def test_moe_finalize_allreduce_unified_api(
             scale,
             expanded_idx_to_permuted_idx,
             residual,
+            weight_bias,
         ),
     )
 
@@ -303,6 +319,7 @@ def _run_moe_reduction_unified_worker(
     moe_scale_input,
     residual,
     num_experts,
+    weight_bias=0.0,
 ):
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
@@ -355,6 +372,7 @@ def _run_moe_reduction_unified_worker(
                     moe_reduction_scale_input=scale_d,
                     moe_reduction_active_experts_token_input=active_d,
                     moe_reduction_token_input=token_d,
+                    weight_bias=weight_bias,
                 )
                 torch.cuda.synchronize()
 
@@ -382,8 +400,15 @@ def _run_moe_reduction_unified_worker(
 
 @pytest.mark.parametrize("world_size", [2])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_moe_reduction_allreduce_unified_api(world_size, dtype):
-    """Test kMoEReductionARResidualRMSNorm pattern via allreduce_fusion()."""
+@pytest.mark.parametrize("weight_bias", [0.0, 1.0])
+def test_moe_reduction_allreduce_unified_api(world_size, dtype, weight_bias):
+    """Test kMoEReductionARResidualRMSNorm pattern via allreduce_fusion().
+
+    weight_bias parametrize covers the Gemma / Qwen3.5 RMSNorm path
+    ((1 + gamma) * x * rsqrt(...)). Reduction shares its rms_norm() with
+    Finalize (proved numerically in test_moe_finalize_allreduce_unified_api),
+    so here we only check dispatch + finite outputs to keep this test cheap.
+    """
     available_gpus = torch.cuda.device_count()
     if world_size > available_gpus:
         pytest.skip(f"world_size {world_size} > available_gpus {available_gpus}")
@@ -415,6 +440,7 @@ def test_moe_reduction_allreduce_unified_api(world_size, dtype):
             moe_scale_input,
             residual,
             num_experts,
+            weight_bias,
         ),
     )
 

--- a/tests/comm/test_allreduce_negative.py
+++ b/tests/comm/test_allreduce_negative.py
@@ -173,23 +173,6 @@ class TestMNNVLMissingRequiredParameters:
                 # rms_gamma is missing
             )
 
-    def test_rmsnorm_rejects_weight_bias(self):
-        """MNNVL backend does not yet support weight_bias != 0 (Gemma RMSNorm)."""
-        input_tensor = torch.randn(16, 2880, dtype=torch.float16, device="cuda")
-        residual = torch.randn(16, 2880, dtype=torch.float16, device="cuda")
-        rms_gamma = torch.randn(2880, dtype=torch.float16, device="cuda")
-
-        with pytest.raises(NotImplementedError, match="weight_bias"):
-            allreduce_fusion(
-                input=input_tensor,
-                workspace=self.workspace,
-                pattern=AllReduceFusionPattern.kARResidualRMSNorm,
-                launch_with_pdl=True,
-                residual_in=residual,
-                rms_gamma=rms_gamma,
-                weight_bias=1.0,
-            )
-
 
 @pytest.mark.parametrize("backend", ["mnnvl", "trtllm"])
 class TestBufferSizeSufficient:

--- a/tests/comm/test_allreduce_negative.py
+++ b/tests/comm/test_allreduce_negative.py
@@ -173,6 +173,23 @@ class TestMNNVLMissingRequiredParameters:
                 # rms_gamma is missing
             )
 
+    def test_rmsnorm_rejects_weight_bias(self):
+        """MNNVL backend does not yet support weight_bias != 0 (Gemma RMSNorm)."""
+        input_tensor = torch.randn(16, 2880, dtype=torch.float16, device="cuda")
+        residual = torch.randn(16, 2880, dtype=torch.float16, device="cuda")
+        rms_gamma = torch.randn(2880, dtype=torch.float16, device="cuda")
+
+        with pytest.raises(NotImplementedError, match="weight_bias"):
+            allreduce_fusion(
+                input=input_tensor,
+                workspace=self.workspace,
+                pattern=AllReduceFusionPattern.kARResidualRMSNorm,
+                launch_with_pdl=True,
+                residual_in=residual,
+                rms_gamma=rms_gamma,
+                weight_bias=1.0,
+            )
+
 
 @pytest.mark.parametrize("backend", ["mnnvl", "trtllm"])
 class TestBufferSizeSufficient:

--- a/tests/comm/test_gemma_ar_fusion.py
+++ b/tests/comm/test_gemma_ar_fusion.py
@@ -108,8 +108,6 @@ def _run_gemma_worker(world_size, rank, distributed_init_port):
         )
 
         # ---- Asserts --------------------------------------------------------
-        # bf16 tolerance: tight enough to catch a `(1+w)` -> `w` regression
-        # (diff would be ~1.0 magnitude). Loose enough for bf16 cumulative err.
         atol = 2e-2
         rtol = 1e-2
 

--- a/tests/comm/test_gemma_ar_fusion.py
+++ b/tests/comm/test_gemma_ar_fusion.py
@@ -1,0 +1,190 @@
+"""Focused multi-rank test for Gemma / Qwen3.5 RMSNorm in AllReduce fusion.
+
+The big parametrized test in test_trtllm_allreduce_fusion.py uses a 1728-
+config inner loop and a loose bf16 tolerance (8e-1). This test runs a single
+focused config with two reference paths:
+
+  1. Hand-rolled torch FP32 reference (`(1 + gamma) * x * rsqrt(...)`).
+  2. flashinfer.norm.gemma_fused_add_rmsnorm applied to the post-AllReduce
+     tensor — bit-equivalent to the fused kernel modulo the residual-add
+     dtype (standalone is fp32 add; fusion is bf16 add).
+
+Tolerance is tighter than the big test (atol=2e-2 bf16) so a Gemma-specific
+regression that the loose 8e-1 check would miss still trips this one.
+"""
+
+import multiprocessing as mp
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import flashinfer.comm as comm
+from flashinfer.comm.mnnvl import TorchDistBackend
+from flashinfer.norm import gemma_fused_add_rmsnorm
+
+
+def _run_gemma_worker(world_size, rank, distributed_init_port):
+    """One rank of the Gemma-fusion correctness probe."""
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://localhost:{distributed_init_port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    group = dist.group.WORLD
+
+    try:
+        torch.manual_seed(42 + rank)
+        dtype = torch.bfloat16
+        token_num = 8
+        hidden_dim = 2048
+        rms_eps = 1e-6
+        weight_bias = 1.0
+
+        workspace = comm.create_allreduce_fusion_workspace(
+            backend="trtllm",
+            world_size=world_size,
+            rank=rank,
+            max_token_num=128,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            comm_backend=TorchDistBackend(),
+        )
+
+        # Same data across ranks for the rms_gamma; per-rank shards for input.
+        torch.manual_seed(42)
+        rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
+        torch.manual_seed(42 + rank)
+        input_shard = torch.randn(token_num, hidden_dim, dtype=dtype, device=device)
+        residual_in = torch.randn(token_num, hidden_dim, dtype=dtype, device=device)
+
+        # ---- Fused path: AR + residual add + Gemma RMSNorm ------------------
+        fused_in = input_shard.clone()
+        fused_resid_out = torch.empty_like(residual_in)
+        fused_norm_out = torch.empty_like(residual_in)
+        comm.allreduce_fusion(
+            input=fused_in,
+            workspace=workspace,
+            pattern=comm.AllReduceFusionPattern.kARResidualRMSNorm,
+            launch_with_pdl=False,
+            residual_in=residual_in,
+            residual_out=fused_resid_out,
+            norm_out=fused_norm_out,
+            rms_gamma=rms_gamma,
+            rms_eps=rms_eps,
+            weight_bias=weight_bias,
+            use_oneshot=True,
+        )
+        torch.cuda.synchronize()
+
+        # ---- Reference A: hand-rolled FP32 RMSNorm --------------------------
+        ar_clone = input_shard.clone()
+        dist.all_reduce(ar_clone, group=group)
+        pre_fp32 = ar_clone.to(torch.float32) + residual_in.to(torch.float32)
+        var = pre_fp32.pow(2).mean(dim=-1, keepdim=True)
+        normed_fp32 = pre_fp32 * torch.rsqrt(var + rms_eps)
+        normed_fp32 = normed_fp32 * (weight_bias + rms_gamma.to(torch.float32))
+        ref_resid = pre_fp32.to(dtype)
+        ref_norm = normed_fp32.to(dtype)
+
+        # ---- Reference B: gemma_fused_add_rmsnorm on post-AR tensor ---------
+        # AR done manually then handed to the standalone Gemma kernel:
+        #   step 1: residual += input              (in fp32 inside the kernel)
+        #   step 2: input = (residual/RMS) * (1+w)
+        # `standalone_norm` ends up holding the norm result; `standalone_resid`
+        # ends up holding the post-add residual.
+        # Note: the standalone path uses fp32 residual-add (norm.cuh:418-425),
+        # while the fused kernel does the add in bf16 — so residuals may differ
+        # by ~1 bf16 ulp. Norm outputs should still agree within bf16 tol.
+        standalone_norm = input_shard.clone()
+        dist.all_reduce(standalone_norm, group=group)
+        standalone_resid = residual_in.clone()
+        gemma_fused_add_rmsnorm(
+            standalone_norm, standalone_resid, rms_gamma, eps=rms_eps
+        )
+
+        # ---- Asserts --------------------------------------------------------
+        # bf16 tolerance: tight enough to catch a `(1+w)` -> `w` regression
+        # (diff would be ~1.0 magnitude). Loose enough for bf16 cumulative err.
+        atol = 2e-2
+        rtol = 1e-2
+
+        torch.testing.assert_close(
+            fused_resid_out.to(torch.float32),
+            ref_resid.to(torch.float32),
+            atol=atol,
+            rtol=rtol,
+            msg="fused residual_out mismatches torch FP32 reference",
+        )
+        torch.testing.assert_close(
+            fused_norm_out.to(torch.float32),
+            ref_norm.to(torch.float32),
+            atol=atol,
+            rtol=rtol,
+            msg="fused norm_out mismatches torch FP32 reference",
+        )
+        torch.testing.assert_close(
+            fused_norm_out.to(torch.float32),
+            standalone_norm.to(torch.float32),
+            atol=atol,
+            rtol=rtol,
+            msg=(
+                "fused norm_out diverges from standalone gemma_fused_add_rmsnorm; "
+                "both kernels should compute the same Gemma RMSNorm output."
+            ),
+        )
+
+        workspace.destroy()
+        if rank == 0:
+            print(
+                f"[rank {rank}] Gemma AR fusion: torch ref + cross-kernel "
+                f"agreement OK (tol={atol})"
+            )
+    finally:
+        dist.barrier(group=group)
+        dist.destroy_process_group(group=group)
+
+
+def _get_open_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+    except OSError:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return s.getsockname()[1]
+
+
+@pytest.mark.parametrize("world_size", [2])
+def test_gemma_rmsnorm_ar_fusion(world_size):
+    """End-to-end Gemma RMSNorm correctness for fused AllReduce path."""
+    available_gpus = torch.cuda.device_count()
+    if world_size > available_gpus:
+        pytest.skip(f"world_size {world_size} > available GPUs {available_gpus}")
+
+    mp.set_start_method("spawn", force=True)
+    port = _get_open_port()
+    procs = []
+    for rank in range(world_size):
+        p = mp.Process(
+            target=_run_gemma_worker,
+            args=(world_size, rank, port),
+            name=f"gemma-ar-rank-{rank}",
+        )
+        p.start()
+        procs.append(p)
+
+    for i, p in enumerate(procs):
+        p.join()
+        assert p.exitcode == 0, (
+            f"Gemma AR-fusion worker rank {i} failed (exitcode={p.exitcode})"
+        )
+
+
+if __name__ == "__main__":
+    test_gemma_rmsnorm_ar_fusion(2)

--- a/tests/comm/test_trtllm_allreduce_fusion.py
+++ b/tests/comm/test_trtllm_allreduce_fusion.py
@@ -31,6 +31,7 @@ def _run_correctness_worker(
     hidden_dim,
     distributed_init_port,
     legacy_api=True,
+    weight_bias=0.0,
     gpu_offset=0,
 ):
     device = torch.device(f"cuda:{rank + gpu_offset}")
@@ -208,6 +209,7 @@ def _run_correctness_worker(
                                                     scale_out=scale_out,
                                                     rms_gamma=rms_gamma,
                                                     rms_eps=rms_eps,
+                                                    weight_bias=weight_bias,
                                                     scale_factor=scale_factor,
                                                     layout_code=swizzled_layout_code,
                                                     metadata=workspace_metadata,
@@ -238,6 +240,7 @@ def _run_correctness_worker(
                                                     scale_out=scale_out,
                                                     rms_gamma=rms_gamma,
                                                     rms_eps=rms_eps,
+                                                    weight_bias=weight_bias,
                                                     scale_factor=scale_factor,
                                                     layout_code=swizzled_layout_code,
                                                     pattern=pattern_code,
@@ -272,6 +275,7 @@ def _run_correctness_worker(
                                                     scale_out=scale_out,
                                                     rms_gamma=rms_gamma,
                                                     rms_eps=rms_eps,
+                                                    weight_bias=weight_bias,
                                                     scale_factor=scale_factor,
                                                     layout_code=swizzled_layout_code,
                                                     metadata=workspace_metadata,
@@ -302,6 +306,7 @@ def _run_correctness_worker(
                                                     scale_out=scale_out,
                                                     rms_gamma=rms_gamma,
                                                     rms_eps=rms_eps,
+                                                    weight_bias=weight_bias,
                                                     scale_factor=scale_factor,
                                                     layout_code=swizzled_layout_code,
                                                     pattern=pattern_code,
@@ -349,8 +354,8 @@ def _run_correctness_worker(
                                         variance + rms_eps
                                     )
                                     ref_norm_out = (
-                                        rms_gamma.to(torch.float32) * hidden_states
-                                    )
+                                        weight_bias + rms_gamma.to(torch.float32)
+                                    ) * hidden_states
 
                                     # check correctness
                                     tolerance = 8e-2 if dtype == torch.float16 else 8e-1
@@ -461,7 +466,11 @@ def multi_process_parallel(
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("hidden_dim", [1024, 2048, 4096, 7168, 8192])
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_trtllm_allreduce_fusion(world_size, dtype, hidden_dim, legacy_api):
+@pytest.mark.parametrize("weight_bias", [0.0, 1.0])
+def test_trtllm_allreduce_fusion(
+    world_size, dtype, hidden_dim, legacy_api, weight_bias
+):
+    # weight_bias=0.0 -> standard RMSNorm; weight_bias=1.0 -> Gemma / Qwen3.5 RMSNorm.
     np.random.seed(42)
     torch.manual_seed(42)
     torch.cuda.manual_seed_all(42)
@@ -471,16 +480,22 @@ def test_trtllm_allreduce_fusion(world_size, dtype, hidden_dim, legacy_api):
             f"world_size {world_size} is greater than available_gpus {available_gpus}"
         )
     api_str = "legacy" if legacy_api else "unified"
-    print(f"Running test for world_size={world_size} with {api_str} API")
+    print(
+        f"Running test for world_size={world_size} with {api_str} API, "
+        f"weight_bias={weight_bias}"
+    )
 
     multi_process_parallel(
         world_size,
         dtype,
         hidden_dim,
         _run_correctness_worker,
-        target_args=(legacy_api,),
+        target_args=(legacy_api, weight_bias),
     )
-    print(f"allreduce fusion tp = {world_size} ({api_str} API): OK")
+    print(
+        f"allreduce fusion tp = {world_size} ({api_str} API, "
+        f"weight_bias={weight_bias}): OK"
+    )
 
 
 @pytest.mark.parametrize("world_size", [2, 4])
@@ -514,15 +529,22 @@ def test_trtllm_allreduce_fusion_gpu_offset(world_size, dtype, legacy_api):
         dtype,
         1024,
         _run_correctness_worker,
-        target_args=(legacy_api,),
+        # weight_bias must be passed positionally so gpu_offset (appended after
+        # target_args) reaches the worker correctly.
+        target_args=(legacy_api, 0.0),
         gpu_offset=gpu_offset,
     )
     print(f"gpu_offset allreduce fusion tp={world_size} ({api_str} API): OK")
 
 
 if __name__ == "__main__":
-    # Test both legacy and unified APIs
-    print("Testing legacy API...")
-    test_trtllm_allreduce_fusion(2, torch.float16, 1024, legacy_api=True)
-    print("\nTesting unified API...")
-    test_trtllm_allreduce_fusion(2, torch.float16, 1024, legacy_api=False)
+    # Test both legacy and unified APIs, both standard and Gemma RMSNorm.
+    for wb in (0.0, 1.0):
+        print(f"Testing legacy API (weight_bias={wb})...")
+        test_trtllm_allreduce_fusion(
+            2, torch.float16, 1024, legacy_api=True, weight_bias=wb
+        )
+        print(f"\nTesting unified API (weight_bias={wb})...")
+        test_trtllm_allreduce_fusion(
+            2, torch.float16, 1024, legacy_api=False, weight_bias=wb
+        )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Verified from framework side. See perf at https://github.com/vllm-project/vllm/pull/42646

Add weight bias to RMS norm AR fusion to support gemma and qwen3.5 RMS

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GPU benchmark to compare fused vs unfused AllReduce+RMSNorm performance.
  * Introduced an optional weight_bias parameter to AllReduce-fusion APIs to support alternate RMSNorm scaling.

* **Tests**
  * Added a distributed correctness test for Gemma/Qwen3.5-style RMSNorm AllReduce fusion.
  * Extended AllReduce fusion tests to validate weight_bias variants (e.g., 0.0 and 1.0).

* **Documentation**
  * Updated reference traces and docstrings to describe weight_bias behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->