### PR TITLE
feat(testing): expose fp8 quantization helpers via flashinfer.testing.fp8 submodule

### DIFF
--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -49,3 +49,24 @@ GPU Benchmarking
     bench_gpu_time_with_cuda_event
     bench_gpu_time_with_cudagraph
     bench_gpu_time_with_cupti
+
+FP8 Quantization Helpers
+------------------------
+
+Reference quantize/dequantize helpers used by FP8 tests and benchmarks. Import
+from the ``flashinfer.testing.fp8`` submodule:
+
+.. code-block:: python
+
+    from flashinfer.testing.fp8 import quantize_fp8, dequantize_fp8
+    from flashinfer.testing.fp8 import per_token_cast_to_fp8, per_block_cast_to_fp8
+
+.. currentmodule:: flashinfer.testing.fp8
+
+.. autosummary::
+    :toctree: ../generated
+
+    per_token_cast_to_fp8
+    per_block_cast_to_fp8
+    quantize_fp8
+    dequantize_fp8

--- a/flashinfer/testing/__init__.py
+++ b/flashinfer/testing/__init__.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from . import fp8
 from .utils import (
     attention_flops,
     attention_flops_with_actual_seq_lens,

--- a/flashinfer/testing/fp8.py
+++ b/flashinfer/testing/fp8.py
@@ -1,0 +1,229 @@
+"""
+Copyright (c) 2023 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""FP8 quantization helpers used by FlashInfer tests and benchmarks.
+
+These helpers were previously defined inside ``flashinfer.testing.utils`` and
+imported by the test suite and benchmark scripts via the semi-private path
+``from flashinfer.testing.utils import ...``.  They are collected here so
+downstream FP8-related contributions have a stable submodule path
+(``flashinfer.testing.fp8``) without expanding the top-level
+``flashinfer.testing`` namespace.
+
+The original names remain re-exported from ``flashinfer.testing.utils`` for
+backward compatibility.
+"""
+
+from typing import Tuple
+
+import torch
+from einops import rearrange, reduce, repeat
+
+from flashinfer.utils import round_up
+
+
+__all__ = [
+    "per_token_cast_to_fp8",
+    "per_block_cast_to_fp8",
+    "quantize_fp8",
+    "dequantize_fp8",
+]
+
+
+def _ceil_to_ue8m0(x: torch.Tensor):
+    """imported from DeepGEMM"""
+    assert x.view(-1).amax().item() > 0
+    return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
+
+
+def per_token_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """imported from DeepGEMM"""
+    assert x.dim() == 2 and x.size(1) % 128 == 0
+    m, n = x.shape
+    x_view = x.view(m, -1, 128)
+    x_amax = x_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
+    sf = _ceil_to_ue8m0(x_amax / 448.0)
+    return (x_view * (1.0 / sf.unsqueeze(2))).to(torch.float8_e4m3fn).view(m, n), sf
+
+
+def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """imported from DeepGEMM"""
+    assert x.dim() == 2
+    m, n = x.shape
+    x_padded = torch.zeros(
+        (round_up(m, 128), round_up(n, 128)), dtype=x.dtype, device=x.device
+    )
+    x_padded[:m, :n] = x
+    x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
+    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
+    sf = _ceil_to_ue8m0(x_amax / 448.0)
+    x_scaled = (x_view * (1.0 / sf)).to(torch.float8_e4m3fn)
+    return x_scaled.view_as(x_padded)[:m, :n].contiguous(), sf.view(
+        x_view.size(0), x_view.size(2)
+    )
+
+
+def quantize_fp8(x, scale_shape, tile_shape, scale_major_mode):
+    """
+    Quantizes a 2D or 3D tensor to FP8.
+
+    Args:
+        x (torch.Tensor): The 2D or 3D input tensor.
+        scale_shape (tuple): The shape of the scale tensor.
+        tile_shape (tuple): The shape of the tiles.
+        scale_major_mode (str): The tiling order, "K" for row-major like,
+                                or another value for column-major like.
+
+    Returns:
+        tuple: A tuple containing the quantized FP8 tensor and the
+               calculated float32 scales.
+    """
+    # 1. Assertions and Initial Setup
+    ndim = x.ndim
+    assert ndim in [2, 3], f"x.ndim must be 2 or 3, but got {ndim}"
+    assert ndim == len(scale_shape) == len(tile_shape)
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    fp8_amax = torch.tensor(fp8_info.max, device=x.device, dtype=torch.float32)
+
+    # 2. Tiling and Scale Calculation
+    if ndim == 2:
+        s0, s1 = scale_shape
+        t0, t1 = tile_shape
+        if scale_major_mode == "K":
+            # Tile x and find the max absolute value in each tile
+            x_tiled = rearrange(x, "(s0 t0) (s1 t1) -> s0 s1 t0 t1", s0=s0, s1=s1)
+            abs_max = reduce(x_tiled.abs(), "s0 s1 t0 t1 -> s0 s1", "max").clamp(1e-4)
+            x_scale = abs_max / fp8_amax
+            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
+
+            # Broadcast scales back to the original tensor shape
+            scales_repeated = repeat(x_scale, "s0 s1 -> (s0 t0) (s1 t1)", t0=t0, t1=t1)
+        else:
+            # Handle column-major tiling
+            x_tiled = rearrange(x, "(s1 t0) (s0 t1) -> s0 s1 t0 t1", s0=s0, s1=s1)
+            abs_max = reduce(x_tiled.abs(), "s0 s1 t0 t1 -> s0 s1", "max").clamp(1e-4)
+            x_scale = abs_max / fp8_amax
+            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
+
+            # Permute scale axes before repeating to match layout
+            scales_permuted = rearrange(x_scale, "s0 s1 -> s1 s0")
+            scales_repeated = repeat(
+                scales_permuted, "s1 s0 -> (s1 t0) (s0 t1)", t0=t0, t1=t1
+            )
+
+    elif ndim == 3:
+        s0, s1, s2 = scale_shape
+        t0, t1, t2 = tile_shape
+        if scale_major_mode == "K":
+            # Tile x and find the max absolute value in each tile
+            x_tiled = rearrange(
+                x, "(s0 t0) (s1 t1) (s2 t2) -> s0 s1 s2 t0 t1 t2", s0=s0, s1=s1, s2=s2
+            )
+            abs_max = reduce(
+                x_tiled.abs(), "s0 s1 s2 t0 t1 t2 -> s0 s1 s2", "max"
+            ).clamp(1e-4)
+            x_scale = abs_max / fp8_amax
+            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
+
+            # Broadcast scales back to the original tensor shape
+            scales_repeated = repeat(
+                x_scale, "s0 s1 s2 -> (s0 t0) (s1 t1) (s2 t2)", t0=t0, t1=t1, t2=t2
+            )
+        else:
+            # Handle layout where the last two axes are swapped
+            x_tiled = rearrange(
+                x, "(s0 t0) (s2 t1) (s1 t2) -> s0 s1 s2 t0 t1 t2", s0=s0, s1=s1, s2=s2
+            )
+            abs_max = reduce(
+                x_tiled.abs(), "s0 s1 s2 t0 t1 t2 -> s0 s1 s2", "max"
+            ).clamp(1e-4)
+            x_scale = abs_max / fp8_amax
+            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
+
+            # Permute scale axes before repeating to match layout
+            scales_permuted = rearrange(x_scale, "s0 s1 s2 -> s0 s2 s1")
+            scales_repeated = repeat(
+                scales_permuted,
+                "s0 s2 s1 -> (s0 t0) (s2 t1) (s1 t2)",
+                t0=t0,
+                t1=t1,
+                t2=t2,
+            )
+
+    # 3. Final Quantization
+    # Divide the original tensor by the broadcasted scales
+    x_fp32 = x / (scales_repeated + 1e-8)
+
+    # Convert the result to the target FP8 format
+    x_fp8 = x_fp32.to(torch.float8_e4m3fn)
+
+    return x_fp8, x_scale
+
+
+def dequantize_fp8(x, x_scale, scale_major_mode):
+    """
+    Dequantizes a 2D or 3D FP8 tensor back to float32 using per-tile scales.
+
+    Args:
+        x (torch.Tensor): The 2D or 3D FP8 input tensor.
+        x_scale (torch.Tensor): The float32 per-tile scales produced by
+            :func:`quantize_fp8`.
+        scale_major_mode (str): The tiling order, "K" for row-major like,
+                                or another value for column-major like.
+
+    Returns:
+        torch.Tensor: The dequantized float32 tensor with the same shape as
+        ``x``.
+    """
+    # 1. Assertions and Initial Setup
+    ndim = x.ndim
+    assert ndim in [2, 3], f"x.ndim must be 2 or 3, but got {ndim}"
+    assert ndim == len(x_scale.shape)
+
+    # 2. Tiling and Scale Calculation
+    if ndim == 2:
+        if scale_major_mode == "K":
+            s0, s1 = x_scale.shape
+        else:
+            s1, s0 = x_scale.shape
+        x = rearrange(
+            x.to(torch.float32), "(s0 t0) (s1 t1) -> s0 s1 t0 t1", s0=s0, s1=s1
+        )
+        if scale_major_mode == "K":
+            x_scale = rearrange(x_scale, "s0 s1 -> s0 s1 1 1")
+        else:
+            x_scale = rearrange(x_scale, "s0 s1 -> s1 s0 1 1")
+        out = rearrange(x * x_scale, "s0 s1 t0 t1 -> (s0 t0) (s1 t1)")
+
+    elif ndim == 3:
+        if scale_major_mode == "K":
+            s0, s1, s2 = x_scale.shape
+        else:
+            s0, s2, s1 = x_scale.shape
+        x = rearrange(
+            x.to(torch.float32),
+            "(s0 t0) (s1 t1) (s2 t2)-> s0 s1 s2 t0 t1 t2",
+            s0=s0,
+            s1=s1,
+            s2=s2,
+        )
+        if scale_major_mode == "K":
+            x_scale = rearrange(x_scale, "s0 s1 s2 -> s0 s1 s2 1 1 1")
+        else:
+            x_scale = rearrange(x_scale, "s0 s1 s2 -> s0 s2 s1 1 1 1")
+        out = rearrange(x * x_scale, "s0 s1 s2 t0 t1 t2 -> (s0 t0) (s1 t1) (s2 t2)")
+    return out

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -25,9 +25,6 @@ import warnings
 
 import numpy as np
 import torch
-from einops import rearrange, reduce, repeat
-
-from flashinfer.utils import round_up
 
 
 # =============================================================================
@@ -230,190 +227,17 @@ def _infer_device_from_tensors(input_args, input_kwargs, default="cuda"):
     return default
 
 
-def _ceil_to_ue8m0(x: torch.Tensor):
-    """imported from DeepGEMM"""
-    assert x.view(-1).amax().item() > 0
-    return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
-
-
-def per_token_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """imported from DeepGEMM"""
-    assert x.dim() == 2 and x.size(1) % 128 == 0
-    m, n = x.shape
-    x_view = x.view(m, -1, 128)
-    x_amax = x_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
-    sf = _ceil_to_ue8m0(x_amax / 448.0)
-    return (x_view * (1.0 / sf.unsqueeze(2))).to(torch.float8_e4m3fn).view(m, n), sf
-
-
-def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """imported from DeepGEMM"""
-    assert x.dim() == 2
-    m, n = x.shape
-    x_padded = torch.zeros(
-        (round_up(m, 128), round_up(n, 128)), dtype=x.dtype, device=x.device
-    )
-    x_padded[:m, :n] = x
-    x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
-    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
-    sf = _ceil_to_ue8m0(x_amax / 448.0)
-    x_scaled = (x_view * (1.0 / sf)).to(torch.float8_e4m3fn)
-    return x_scaled.view_as(x_padded)[:m, :n].contiguous(), sf.view(
-        x_view.size(0), x_view.size(2)
-    )
-
-
-def quantize_fp8(x, scale_shape, tile_shape, scale_major_mode):
-    """
-    Quantizes a 2D or 3D tensor to FP8.
-
-    Args:
-        x (torch.Tensor): The 2D or 3D input tensor.
-        scale_shape (tuple): The shape of the scale tensor.
-        tile_shape (tuple): The shape of the tiles.
-        scale_major_mode (str): The tiling order, "K" for row-major like,
-                                or another value for column-major like.
-
-    Returns:
-        tuple: A tuple containing the quantized FP8 tensor and the
-               calculated float32 scales.
-    """
-    # 1. Assertions and Initial Setup
-    ndim = x.ndim
-    assert ndim in [2, 3], f"x.ndim must be 2 or 3, but got {ndim}"
-    assert ndim == len(scale_shape) == len(tile_shape)
-
-    fp8_info = torch.finfo(torch.float8_e4m3fn)
-    fp8_amax = torch.tensor(fp8_info.max, device=x.device, dtype=torch.float32)
-
-    # 2. Tiling and Scale Calculation
-    if ndim == 2:
-        s0, s1 = scale_shape
-        t0, t1 = tile_shape
-        if scale_major_mode == "K":
-            # Tile x and find the max absolute value in each tile
-            x_tiled = rearrange(x, "(s0 t0) (s1 t1) -> s0 s1 t0 t1", s0=s0, s1=s1)
-            abs_max = reduce(x_tiled.abs(), "s0 s1 t0 t1 -> s0 s1", "max").clamp(1e-4)
-            x_scale = abs_max / fp8_amax
-            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
-
-            # Broadcast scales back to the original tensor shape
-            scales_repeated = repeat(x_scale, "s0 s1 -> (s0 t0) (s1 t1)", t0=t0, t1=t1)
-        else:
-            # Handle column-major tiling
-            x_tiled = rearrange(x, "(s1 t0) (s0 t1) -> s0 s1 t0 t1", s0=s0, s1=s1)
-            abs_max = reduce(x_tiled.abs(), "s0 s1 t0 t1 -> s0 s1", "max").clamp(1e-4)
-            x_scale = abs_max / fp8_amax
-            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
-
-            # Permute scale axes before repeating to match layout
-            scales_permuted = rearrange(x_scale, "s0 s1 -> s1 s0")
-            scales_repeated = repeat(
-                scales_permuted, "s1 s0 -> (s1 t0) (s0 t1)", t0=t0, t1=t1
-            )
-
-    elif ndim == 3:
-        s0, s1, s2 = scale_shape
-        t0, t1, t2 = tile_shape
-        if scale_major_mode == "K":
-            # Tile x and find the max absolute value in each tile
-            x_tiled = rearrange(
-                x, "(s0 t0) (s1 t1) (s2 t2) -> s0 s1 s2 t0 t1 t2", s0=s0, s1=s1, s2=s2
-            )
-            abs_max = reduce(
-                x_tiled.abs(), "s0 s1 s2 t0 t1 t2 -> s0 s1 s2", "max"
-            ).clamp(1e-4)
-            x_scale = abs_max / fp8_amax
-            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
-
-            # Broadcast scales back to the original tensor shape
-            scales_repeated = repeat(
-                x_scale, "s0 s1 s2 -> (s0 t0) (s1 t1) (s2 t2)", t0=t0, t1=t1, t2=t2
-            )
-        else:
-            # Handle layout where the last two axes are swapped
-            x_tiled = rearrange(
-                x, "(s0 t0) (s2 t1) (s1 t2) -> s0 s1 s2 t0 t1 t2", s0=s0, s1=s1, s2=s2
-            )
-            abs_max = reduce(
-                x_tiled.abs(), "s0 s1 s2 t0 t1 t2 -> s0 s1 s2", "max"
-            ).clamp(1e-4)
-            x_scale = abs_max / fp8_amax
-            x_scale = torch.pow(2.0, torch.ceil(torch.log2(x_scale.abs())))
-
-            # Permute scale axes before repeating to match layout
-            scales_permuted = rearrange(x_scale, "s0 s1 s2 -> s0 s2 s1")
-            scales_repeated = repeat(
-                scales_permuted,
-                "s0 s2 s1 -> (s0 t0) (s2 t1) (s1 t2)",
-                t0=t0,
-                t1=t1,
-                t2=t2,
-            )
-
-    # 3. Final Quantization
-    # Divide the original tensor by the broadcasted scales
-    x_fp32 = x / (scales_repeated + 1e-8)
-
-    # Convert the result to the target FP8 format
-    x_fp8 = x_fp32.to(torch.float8_e4m3fn)
-
-    return x_fp8, x_scale
-
-
-def dequantize_fp8(x, x_scale, scale_major_mode):
-    """
-    Quantizes a 2D or 3D tensor to FP8.
-
-    Args:
-        x (torch.Tensor): The 2D or 3D input tensor.
-        scale_shape (tuple): The shape of the scale tensor.
-        tile_shape (tuple): The shape of the tiles.
-        scale_major_mode (str): The tiling order, "K" for row-major like,
-                                or another value for column-major like.
-
-    Returns:
-        tuple: A tuple containing the quantized FP8 tensor and the
-               calculated float32 scales.
-    """
-    # 1. Assertions and Initial Setup
-    ndim = x.ndim
-    assert ndim in [2, 3], f"x.ndim must be 2 or 3, but got {ndim}"
-    assert ndim == len(x_scale.shape)
-
-    # 2. Tiling and Scale Calculation
-    if ndim == 2:
-        if scale_major_mode == "K":
-            s0, s1 = x_scale.shape
-        else:
-            s1, s0 = x_scale.shape
-        x = rearrange(
-            x.to(torch.float32), "(s0 t0) (s1 t1) -> s0 s1 t0 t1", s0=s0, s1=s1
-        )
-        if scale_major_mode == "K":
-            x_scale = rearrange(x_scale, "s0 s1 -> s0 s1 1 1")
-        else:
-            x_scale = rearrange(x_scale, "s0 s1 -> s1 s0 1 1")
-        out = rearrange(x * x_scale, "s0 s1 t0 t1 -> (s0 t0) (s1 t1)")
-
-    elif ndim == 3:
-        if scale_major_mode == "K":
-            s0, s1, s2 = x_scale.shape
-        else:
-            s0, s2, s1 = x_scale.shape
-        x = rearrange(
-            x.to(torch.float32),
-            "(s0 t0) (s1 t1) (s2 t2)-> s0 s1 s2 t0 t1 t2",
-            s0=s0,
-            s1=s1,
-            s2=s2,
-        )
-        if scale_major_mode == "K":
-            x_scale = rearrange(x_scale, "s0 s1 s2 -> s0 s1 s2 1 1 1")
-        else:
-            x_scale = rearrange(x_scale, "s0 s1 s2 -> s0 s2 s1 1 1 1")
-        out = rearrange(x * x_scale, "s0 s1 s2 t0 t1 t2 -> (s0 t0) (s1 t1) (s2 t2)")
-    return out
+# FP8 quantization helpers live in `flashinfer.testing.fp8`. They are
+# re-exported here so existing internal call sites that use
+# `from flashinfer.testing.utils import quantize_fp8` keep working without
+# expanding the top-level `flashinfer.testing` namespace.
+from flashinfer.testing.fp8 import (
+    _ceil_to_ue8m0,
+    dequantize_fp8,
+    per_block_cast_to_fp8,
+    per_token_cast_to_fp8,
+    quantize_fp8,
+)
 
 
 def set_seed(random_seed):

--- a/flashinfer/testing/utils.py
+++ b/flashinfer/testing/utils.py
@@ -231,13 +231,11 @@ def _infer_device_from_tensors(input_args, input_kwargs, default="cuda"):
 # re-exported here so existing internal call sites that use
 # `from flashinfer.testing.utils import quantize_fp8` keep working without
 # expanding the top-level `flashinfer.testing` namespace.
-from flashinfer.testing.fp8 import (
-    _ceil_to_ue8m0,
-    dequantize_fp8,
-    per_block_cast_to_fp8,
-    per_token_cast_to_fp8,
-    quantize_fp8,
-)
+from flashinfer.testing.fp8 import _ceil_to_ue8m0 as _ceil_to_ue8m0
+from flashinfer.testing.fp8 import dequantize_fp8 as dequantize_fp8
+from flashinfer.testing.fp8 import per_block_cast_to_fp8 as per_block_cast_to_fp8
+from flashinfer.testing.fp8 import per_token_cast_to_fp8 as per_token_cast_to_fp8
+from flashinfer.testing.fp8 import quantize_fp8 as quantize_fp8
 
 
 def set_seed(random_seed):


### PR DESCRIPTION
## 📌 Description

Move the four FP8 quantization helpers currently defined in
`flashinfer/testing/utils.py` —

- `per_token_cast_to_fp8`
- `per_block_cast_to_fp8`
- `quantize_fp8`
- `dequantize_fp8`

— plus the internal `_ceil_to_ue8m0` helper, into a new
`flashinfer/testing/fp8` submodule, and document them under
`docs/api/testing.rst`.

## 🔍 Related Issues

None — this is preventative housekeeping for the public testing surface.

## 🚀 Motivation

Eight in-tree call sites currently import these helpers via the
semi-private path `from flashinfer.testing.utils import …` (e.g.
`benchmarks/bench_deepgemm_blackwell.py`, `benchmarks/routines/moe.py`,
`benchmarks/routines/moe_comm.py`, `tests/gemm/test_fp8_blockscale_gemm.py`).
The names are already de-facto public — tests and benchmarks pin them by
name — but there is no documented public path, so downstream FP8
contributors either reach into `.utils` or copy-paste the helpers into
their own test files (e.g. `tests/moe/test_trtllm_cutlass_fused_moe.py`
currently redefines its own `per_block_cast_to_fp8`).

This PR gives them a stable, documented submodule path:

```python
from flashinfer.testing.fp8 import quantize_fp8, dequantize_fp8
from flashinfer.testing.fp8 import per_token_cast_to_fp8, per_block_cast_to_fp8
```

## 🎯 Why a submodule rather than top-level `flashinfer.testing.*`?

These helpers are thin reference implementations (DeepGEMM-derived
per-token/per-block casts plus a general tiled `quantize_fp8`); they are
not the autotuned FP8 GEMM kernels in `flashinfer.gemm`. Promoting them
to the top-level `flashinfer.testing` namespace alongside
`bench_gpu_time`, `attention_flops`, etc. would conflate
benchmark/measurement helpers with quantization utilities, and a future
contributor doing `from flashinfer.testing import *` would see four
names that look like they're the canonical FP8 quantization API.

Scoping them under `flashinfer.testing.fp8` keeps the top-level
`flashinfer.testing` surface stable while still giving FP8 contributors
a clear, importable home. This follows the same pattern as the existing
`flashinfer.fp8_quantization` → `flashinfer.quantization.fp8_quantization`
compatibility-stub structure.

## 🔄 Backward compatibility

- `from flashinfer.testing.utils import quantize_fp8` (and the other
  three names) continues to work via re-export at the top of
  `flashinfer/testing/utils.py`. No call sites in `tests/`,
  `benchmarks/`, or `flashinfer/` need to change for this PR to land.
- `flashinfer/testing/__init__.py` deliberately does **not** add the
  helpers as top-level `flashinfer.testing` names. Only the submodule
  (`flashinfer.testing.fp8`) is exposed.
- No behavior change: the function bodies are moved verbatim, not
  rewritten.

## ✅ Verification

- `python -c "from flashinfer.testing.fp8 import quantize_fp8, dequantize_fp8, per_token_cast_to_fp8, per_block_cast_to_fp8"` — succeeds.
- `python -c "from flashinfer.testing.utils import quantize_fp8, dequantize_fp8, per_token_cast_to_fp8, per_block_cast_to_fp8"` — still succeeds (backward compat).
- `python -c "from flashinfer.testing import fp8; print(fp8.__all__)"` — succeeds.
- Round-trip smoke test on `per_token_cast_to_fp8` / `per_block_cast_to_fp8` / `quantize_fp8` / `dequantize_fp8` returns the expected shapes and `torch.float8_e4m3fn` dtype.
- `pre-commit run --files flashinfer/testing/fp8.py flashinfer/testing/utils.py flashinfer/testing/__init__.py` — all hooks pass (ruff check, ruff format, mypy, end-of-file, trailing whitespace, line-ending).

## 🧐 Reviewer notes / open question

@yzh119 @kahyunnam — happy to either (a) leave the helpers also
re-exported from `flashinfer.testing.utils` indefinitely as I've done
here, or (b) follow up with a second PR that migrates the eight
in-tree call sites to `from flashinfer.testing.fp8 import …` and
removes the back-compat aliases (separated to keep this PR a pure
structural move). Preference welcome.

## 📊 Diff size

| File | Insertions | Deletions |
|------|-----------:|----------:|
| `flashinfer/testing/fp8.py` (new) | 229 | 0 |
| `flashinfer/testing/utils.py` | 9 | 187 |
| `flashinfer/testing/__init__.py` | 1 | 0 |
| `docs/api/testing.rst` | 21 | 0 |
| **Total** | **260** | **187** |

Most of the deletions are the function bodies physically moving to the
new file; net new logic is zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FP8 quantization helpers now available as a dedicated `flashinfer.testing.fp8` submodule, including per-token and per-block casting utilities, plus quantization and dequantization functions.

* **Documentation**
  * Updated testing API documentation to include new FP8 quantization helpers section with usage examples.

* **Refactor**
  * Reorganized FP8 quantization utilities into a dedicated module for improved code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3331)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->