### PR TITLE
fix(cute_dsl): avoid MoE wrapper runner reference cycle

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -51,6 +51,8 @@ Example (Wrapper API with CUDA Graph):
 
 from typing import Any, Dict, Optional, Tuple
 
+import weakref
+
 import torch
 
 from ...api_logging import flashinfer_api
@@ -408,9 +410,21 @@ class CuteDslMoEWrapper:
         self._main_event: Optional[torch.cuda.Event] = None
         self._memset_event: Optional[torch.cuda.Event] = None
 
-        # Create auto-tuner runner
+        wrapper_ref = weakref.ref(self)
+
+        def _forward_with_tactic_weak(*args, **kwargs):
+            wrapper = wrapper_ref()
+            if wrapper is None:
+                raise RuntimeError(
+                    "CuteDslMoEWrapper was destroyed before runner invocation"
+                )
+            return wrapper._forward_with_tactic(*args, **kwargs)
+
+        # Create auto-tuner runner. Use a weak trampoline instead of a bound
+        # method so the runner cannot keep CUDA graph resources alive after the
+        # wrapper drops out of scope.
         self._runner = CuteDslFusedMoENvfp4Runner(
-            forward_impl=self._forward_with_tactic,
+            forward_impl=_forward_with_tactic_weak,
             num_experts=num_experts,
             top_k=top_k,
             num_local_experts=self.num_local_experts,

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -355,10 +355,9 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 ),
             ),
             inputs_pre_hook=self._inputs_helper.inputs_pre_hook,
-            # use_cold_l2_cache intentionally unset. A latent reference
-            # cycle in CuteDslMoEWrapper retains CUDA resources across
-            # tests; cold-L2 interacts with that retained state and
-            # produces NaN during autotune.
+            # use_cold_l2_cache intentionally unset for now. The
+            # reference cycle that originally motivated this was fixed
+            # in PR #3340; re-enabling cold-L2 is tracked as a follow-up.
         )
 
     def __hash__(self):

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -28,6 +28,7 @@ Tests include:
 - API consistency between functional and wrapper APIs
 """
 
+import gc
 import weakref
 
 import pytest
@@ -1395,9 +1396,15 @@ class TestCuteDslMoEWrapper:
             assert not torch.isnan(result).any()
             return ref, finalized
 
-        wrapper_ref, finalized = warmup_and_drop_cuda_graph_wrapper()
-        assert wrapper_ref() is None
-        assert finalized
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            wrapper_ref, finalized = warmup_and_drop_cuda_graph_wrapper()
+            assert wrapper_ref() is None
+            assert finalized
+        finally:
+            if gc_was_enabled:
+                gc.enable()
 
         tensors = create_moe_tensors(
             num_tokens=target_num_tokens,

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -28,6 +28,8 @@ Tests include:
 - API consistency between functional and wrapper APIs
 """
 
+import weakref
+
 import pytest
 import torch
 from torch.nn import functional as F
@@ -1341,6 +1343,84 @@ class TestCuteDslMoEWrapper:
         assert passed, (
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
+
+    def test_cuda_graph_wrapper_lifetime_before_autotune(self):
+        """Dropped CUDA graph wrappers should not wait for cyclic GC."""
+        from flashinfer import autotune
+        from flashinfer import CuteDslMoEWrapper
+
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 2
+        target_num_tokens = 256
+
+        def run_wrapper(moe, tensors):
+            return moe.run(
+                x=tensors["x"],
+                x_sf=tensors["x_sf"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+            )
+
+        def warmup_and_drop_cuda_graph_wrapper():
+            tensors = create_moe_tensors(
+                num_tokens=64,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                num_local_experts=num_experts,
+                top_k=top_k,
+            )
+            moe = CuteDslMoEWrapper(
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                use_cuda_graph=True,
+                max_num_tokens=64,
+            )
+            ref = weakref.ref(moe)
+            finalized = []
+            weakref.finalize(moe, lambda: finalized.append(True))
+
+            for _ in range(3):
+                result = run_wrapper(moe, tensors)
+            torch.cuda.synchronize()
+            assert not torch.isnan(result).any()
+            return ref, finalized
+
+        wrapper_ref, finalized = warmup_and_drop_cuda_graph_wrapper()
+        assert wrapper_ref() is None
+        assert finalized
+
+        tensors = create_moe_tensors(
+            num_tokens=target_num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+        )
+
+        with autotune(True):
+            result = run_wrapper(moe, tensors)
+        torch.cuda.synchronize()
+
+        assert result.shape == (target_num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
 
 
 # =============================================================================

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1401,7 +1401,7 @@ class TestCuteDslMoEWrapper:
         try:
             wrapper_ref, finalized = warmup_and_drop_cuda_graph_wrapper()
             assert wrapper_ref() is None
-            assert finalized
+            assert finalized == [True]
         finally:
             if gc_was_enabled:
                 gc.enable()
@@ -1428,6 +1428,83 @@ class TestCuteDslMoEWrapper:
 
         assert result.shape == (target_num_tokens, hidden_size)
         assert not torch.isnan(result).any()
+
+    def test_cuda_graph_wrapper_lifetime_after_autotune(self):
+        """Dropped CUDA graph wrappers should not wait for cyclic GC,
+        even after autotune profiling has populated the autotuner cache."""
+        from flashinfer import autotune
+        from flashinfer import CuteDslMoEWrapper
+        from flashinfer.autotuner import AutoTuner
+
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 2
+
+        def run_wrapper(moe, tensors):
+            return moe.run(
+                x=tensors["x"],
+                x_sf=tensors["x_sf"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+            )
+
+        def autotune_and_drop_cuda_graph_wrapper():
+            tensors = create_moe_tensors(
+                num_tokens=64,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                num_local_experts=num_experts,
+                top_k=top_k,
+            )
+            moe = CuteDslMoEWrapper(
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                use_cuda_graph=True,
+                max_num_tokens=64,
+            )
+            ref = weakref.ref(moe)
+            finalized = []
+            weakref.finalize(moe, lambda: finalized.append(True))
+
+            # Clear the autotuner cache so this test forces a profile pass.
+            # Otherwise a prior test in the same process may have populated
+            # a matching cache entry and `autotune(True)` would take the
+            # cache-hit path, skipping the runner-wrapper profiling
+            # interaction this test is meant to exercise.
+            autotuner = AutoTuner.get()
+            autotuner.clear_cache()
+
+            with autotune(True):
+                result = run_wrapper(moe, tensors)
+            torch.cuda.synchronize()
+            assert not torch.isnan(result).any()
+            # Confirm profiling actually ran for this custom op. Cache keys
+            # are (custom_op, runner_class, hash(runner), profile, extras)
+            # tuples; see AutoTuner._get_cache_key in flashinfer/autotuner.py.
+            assert any(
+                isinstance(k, tuple) and k[:1] == ("CuteDslMoEWrapper::run",)
+                for k in autotuner.profiling_cache
+            ), "autotune(True) did not populate a CuteDslMoEWrapper::run cache entry"
+            return ref, finalized
+
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            wrapper_ref, finalized = autotune_and_drop_cuda_graph_wrapper()
+            assert wrapper_ref() is None
+            assert finalized == [True]
+        finally:
+            if gc_was_enabled:
+                gc.enable()
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`CuteDslMoEWrapper` currently passes `self._forward_with_tactic` as a bound method into `CuteDslFusedMoENvfp4Runner`, creating a strong reference cycle: `wrapper -> runner -> bound method -> wrapper`. When the wrapper is used with `use_cuda_graph=True`, this can keep wrapper-owned CUDA graph resources alive after user code has dropped the wrapper, until Python cyclic GC eventually runs.

This PR replaces that bound-method callback with a weakref trampoline. The runner can still call into a live wrapper, but it no longer owns the wrapper lifetime. This prevents stale wrapper CUDA resources from surviving across same-process tests or later autotune runs.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/3286
https://github.com/flashinfer-ai/flashinfer/pull/3301
https://github.com/flashinfer-ai/flashinfer/pull/3252

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

Adds a focused regression test that warms a CUDA-graph wrapper, verifies it is finalized before cyclic GC, and then runs a subsequent autotuned wrapper call to ensure the output remains NaN-free.

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and cleanup of CUDA-graph wrappers to prevent resource leaks and provide a clear error when a wrapper is no longer available.

* **Tests**
  * Added lifetime tests covering CUDA-graph wrappers before and after autotune; verify stable, non-NaN outputs during autotune.

* **Documentation**
  * Updated comment about cold-L2 cache behavior and noted follow-up to re-enable it once a related issue is addressed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->