### PR TITLE
fix(cute_dsl/gdn): use cutlass.range_constexpr for Blackwell GDN sub-tile loops

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -2403,7 +2403,7 @@ class GatedDeltaNetChunkedKernel:
 
         tKKrKK_out = cute.make_rmem_tensor_like(tKKrKK, self.io_dtype)
         tCrAI = tiled_ainv_r2s.retile(tKKrKK_out)
-        for sub in cutlass.range(tKKrKK.shape[2]):
+        for sub in cutlass.range_constexpr(tKKrKK.shape[2]):
             cute.copy(
                 tiled_shared_t2r,
                 tTR_tStS[None, 0, sub, kk_handle.index],
@@ -2443,7 +2443,7 @@ class GatedDeltaNetChunkedKernel:
         # Convert fp32 tQKrQK -> fp16 and store to sQk, one subtile at a time.
         tQKrQK_out = cute.make_rmem_tensor_like(tQKrQK, self.io_dtype)
         tCrQK = tiled_qk_r2s.retile(tQKrQK_out)
-        for sub in cutlass.range(tQKrQK.shape[2]):
+        for sub in cutlass.range_constexpr(tQKrQK.shape[2]):
             cute.copy(
                 tiled_shared_t2r,
                 tTR_tStS[None, 0, sub, qk_handle.index],
@@ -2979,7 +2979,7 @@ class GatedDeltaNetChunkedKernel:
         )[None, None, 0, 0]
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
         kv_acc_handle = kv_acc_producer.acquire_and_advance()
-        for sub in cutlass.range(tRT_tCrState.shape[2]):
+        for sub in cutlass.range_constexpr(tRT_tCrState.shape[2]):
             # 1. Load S_init fp32 GMEM -> fp32 registers
             cute.autovec_copy(
                 tGR_tCgState[None, 0, sub],
@@ -3063,7 +3063,7 @@ class GatedDeltaNetChunkedKernel:
         # Wait for last GEMM-7 to finish
         kv_acc_handle = kv_acc_consumer.wait_and_advance()
 
-        for sub in cutlass.range(tTR_rState.shape[2]):
+        for sub in cutlass.range_constexpr(tTR_rState.shape[2]):
             # Read state TMEM -> fp32 registers
             cute.copy(
                 tiled_state_t2r,
@@ -3344,7 +3344,7 @@ class GatedDeltaNetChunkedKernel:
             kv_handle = kv_acc_consumer.wait_and_advance()
 
             state_inp_ready_handle = state_inp_ready_producer.acquire_and_advance()
-            for sub in cutlass.range(tRT_rState_inp.shape[2]):
+            for sub in cutlass.range_constexpr(tRT_rState_inp.shape[2]):
                 cute.copy(
                     tiled_state_t2r,
                     tTR_tCtState[None, 0, sub, kv_handle.index],
@@ -3386,7 +3386,7 @@ class GatedDeltaNetChunkedKernel:
             state_inp_ready_handle.commit()
 
             # Load S_prev -> scale by Phi -> write Phi*S_prev back to same TMEM slot.
-            for sub in cutlass.range(tTR_rState.shape[2]):
+            for sub in cutlass.range_constexpr(tTR_rState.shape[2]):
                 for k in cutlass.range(sub_tile_size, vectorize=True):
                     tTR_rState[k, 0, sub] = tTR_rState[k, 0, sub] * cumprod_total
                 cute.copy(
@@ -3471,7 +3471,7 @@ class GatedDeltaNetChunkedKernel:
         # Write scaled result back to same q_state TMEM slot so GEMM 6 accumulates on top.
         if cutlass.const_expr(valid_state):
             qs_handle = q_state_acc_consumer.wait_and_advance()
-            for sub in cutlass.range(tTR_rQS.shape[1]):
+            for sub in cutlass.range_constexpr(tTR_rQS.shape[1]):
                 cute.copy(
                     tiled_qs_t2r,
                     tTR_tCtQS[None, sub, 0, qs_handle.index],
@@ -3499,7 +3499,7 @@ class GatedDeltaNetChunkedKernel:
 
         tTR_rNv = cute.make_rmem_tensor_like(tTR_tCcShared, self.acc_dtype)
         tTR_rNv_inp = cute.make_rmem_tensor_like(tTR_rNv, self.io_dtype)
-        for sub in cutlass.range(tTR_rNv.shape[1]):
+        for sub in cutlass.range_constexpr(tTR_rNv.shape[1]):
             cute.copy(
                 tiled_shared_t2r,
                 tTR_tCtShared[None, sub, 0, nv_handle.index],
@@ -3523,7 +3523,7 @@ class GatedDeltaNetChunkedKernel:
         decay_v_handle = shared_inp_ready_producer.acquire_and_advance()
         tTR_rDv = tTR_rNv
         tRT_rDv_inp = cute.make_rmem_tensor_like(tTR_rDv, self.io_dtype)
-        for sub in cutlass.range(tTR_rDv.shape[1]):
+        for sub in cutlass.range_constexpr(tTR_rDv.shape[1]):
             for k in cutlass.range(sub_tile_size, vectorize=True):
                 tTR_rDv[k, sub, 0] = tTR_rDv[k, sub, 0] * tGrDecayScale[k, sub, 0]
             tRT_rDv_inp[None, sub, 0].store(


### PR DESCRIPTION
## 📌 Description

Fixes [#3242](https://github.com/flashinfer-ai/flashinfer/issues/3242). On SM100 the Blackwell GDN chunked-prefill kernel fails to JIT-compile with:

```
error: failed to legalize unresolved materialization
       from ('!cute_nvgpu.atom.tmem_load<f32, 32 DP, 32 bit, x32>')
       to   ('!cute.tiled_copy<...>') that remained live after conversion
```

Sub-tile loops around `tcgen05.make_tmem_copy(...)` use the runtime form `cutlass.range(...)`, even though their bounds (`tKKrKK.shape[2]`, `tQKrQK.shape[2]`, `tRT_tCrState.shape[2]`, `tTR_rState.shape[2]`, `tRT_rState_inp.shape[2]`, `tTR_rQS.shape[1]`, `tTR_rNv.shape[1]`, `tTR_rDv.shape[1]`) are known at compile time. Without compile-time unroll the `tmem_load` atom cannot be consumed where the compiler expects, and the build fails. Switching those loops to `cutlass.range_constexpr(...)` forces unrolling at compile time and the kernel JITs cleanly. Behavior is unchanged — bounds are the same static integers, just unrolled.

Thanks to @sighingnow for the original [diagnosis and patch](https://github.com/vllm-project/vllm/pull/40717#issuecomment-4321012210) on the vLLM side.

## Test Result

### Functional

Hardware: 1xGB200 (SM 10.0)

**Minimal repro from #3242**:

```python
"""Minimal repro for FlashInfer Blackwell GDN prefill ICE.

One direct call into flashinfer with hand-built tensors, no benchmarking,
no vLLM imports. Smallest config from the bench (h_qk=2, h_v=8, T=2048).
If this ICEs, the bug is purely in FI/CUTLASS-DSL, not in vLLM."""

import torch
import torch.nn.functional as F
from flashinfer.gdn_prefill import chunk_gated_delta_rule as fi_gdn

device = "cuda"
dtype = torch.float16

T = 2048
h_qk = 2
h_v = 8
d = 128
num_sab = max(h_qk, h_v)

cu_seqlens = torch.tensor([0, T], dtype=torch.int64, device=device)

q = torch.randn((T, h_qk, d), dtype=dtype, device=device).contiguous()
k = (
    F.normalize(
        torch.randn(T, h_qk, d, dtype=torch.float32, device=device),
        p=2,
        dim=-1,
    )
    .to(dtype)
    .contiguous()
)
v = torch.randn((T, h_v, d), dtype=dtype, device=device).contiguous()
g = F.logsigmoid(torch.rand(T, num_sab, dtype=torch.float32, device=device))
beta = torch.rand(T, num_sab, dtype=torch.float32, device=device).sigmoid()
h0 = torch.randn((1, num_sab, d, d), dtype=torch.float32, device=device)
output = torch.empty((T, num_sab, d), dtype=dtype, device=device)
state_out = torch.empty_like(h0)

print(
    f"flashinfer={__import__('flashinfer').__version__} "
    f"torch={torch.__version__} "
    f"sm={torch.cuda.get_device_capability(0)} "
    f"shapes: T={T} h_qk={h_qk} h_v={h_v} d={d}",
    flush=True,
)
print("calling fi_gdn ...", flush=True)
fi_gdn(
    q=q,
    k=k,
    v=v,
    g=g,
    beta=beta,
    scale=None,
    initial_state=h0,
    output_final_state=True,
    cu_seqlens=cu_seqlens,
    use_qk_l2norm_in_kernel=False,
    output=output,
    output_state=state_out,
)
torch.cuda.synchronize()
print("OK", flush=True)
```

```
python repro.py
```

`repro.py` is the script attached to the issue (`T=2048`, `h_qk=2`, `h_v=8`, `d=128`, single direct call into `flashinfer.gdn_prefill.chunk_gated_delta_rule`).

| Build | Result |
| --- | --- |
| flashinfer 0.6.11.post2 | `DSLRuntimeError: 🧊 ICE 🧊` (MLIR `failed to legalize unresolved materialization`) |
| with this fix | `OK` (kernel JIT-compiles and runs to completion) |

**GDN prefill test suite**:

```
pytest tests/gdn/test_prefill_delta_rule.py -v
```

With this fix: **1547 passed, 480 skipped, 16 failed** on 1xGB200.

The 16 failures are all `test_checkpoint_correctness[*]`, hitting the same MLIR ICE at `gated_delta_net_chunked.py:3056` / `:3176` inside the `if cutlass.const_expr(self.enable_checkpoints):` blocks. They are pre-existing — without this fix, mainline ICE-s on basic prefill long before the checkpoint suite even runs (see #3242). Fixing the checkpoint path needs more than the `cutlass.range → range_constexpr` rename and is left for a follow-up.

## 🔍 Related Issues

[[Bug] Backwell GDN kernel crashes #3242](https://github.com/flashinfer-ai/flashinfer/issues/3242)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized internal GPU computation kernels for better compile-time efficiency in gated delta net operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->