### PR TITLE
feat: integrate cute-dsl Blackwell GQA decode into BatchDecodeWithPagedKVCacheWrapper

### DIFF
--- a/benchmarks/bench_cute_dsl_decode.py
+++ b/benchmarks/bench_cute_dsl_decode.py
@@ -32,11 +32,11 @@ if not is_cute_dsl_available():
     sys.exit(0)
 
 
-def _build_inputs(batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype):
+def _build_inputs(batch_size, prediction, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype):
     pages_per_seq = (seq_len + page_size - 1) // page_size
     total_pages = pages_per_seq * batch_size
     q = torch.randn(
-        batch_size, num_qo_heads, head_dim, device="cuda", dtype=dtype
+        batch_size * prediction, num_qo_heads, head_dim, device="cuda", dtype=dtype
     )
     kv = torch.randn(
         total_pages,
@@ -57,27 +57,45 @@ def _build_inputs(batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, he
     return q, kv, kv_indptr, kv_indices, last_page_len
 
 
-def _bench(wrapper, q, kv):
-    return np.median(
+def _bench(wrapper, q, kv, o):
+    return np.mean(
         bench_gpu_time(
-            lambda: wrapper.run(q, kv),
-            dry_run_time_ms=50,
-            repeat_time_ms=200,
-            enable_cupti=True,
+            lambda q, kv, o: wrapper.run(q, kv, out=o, enable_pdl=True),
+            dry_run_iters=10,
+            repeat_iters=50,
+            enable_cupti=False,
+            use_cuda_graph=True,
+            input_args=(q, kv, o),
+            cold_l2_cache=True,
         )
     )
 
 
 def bench_one(
-    batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+    batch_size, prediction, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
 ):
-    q, kv, kv_indptr, kv_indices, last_page_len = _build_inputs(
-        batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+    print(
+        f"b={batch_size:2d} mtp={prediction - 1} s={seq_len:5d} pg={page_size:2d} "
+        f"h_q={num_qo_heads} h_kv={num_kv_heads} d={head_dim} dtype={dtype}"
     )
 
-    results = {}
-    for backend in ("fa2", "cute-dsl"):
-        workspace = torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    q, kv, kv_indptr, kv_indices, last_page_len = _build_inputs(
+        batch_size, prediction, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+    )
+    io_bytes = q.nbytes * 2 + kv.nbytes
+
+    for backend in ("fa2", "trtllm-gen", "cute-dsl"):
+        if backend == "fa2" and prediction > 1:
+            continue # fa2 IMAs in this case
+
+        # trtllm-gen backend expects workspace to be zero-init for semaphores
+        workspace_alloc = torch.zeros if backend == "trtllm-gen" else torch.empty
+        workspace = workspace_alloc(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+        # cute-dsl backend expects out to be zero-init if provided
+        out_alloc = torch.zeros_like if backend == "cute-dsl" else torch.empty_like
+        out = out_alloc(q)
+
         wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
             workspace, kv_layout="NHD", backend=backend
         )
@@ -91,36 +109,31 @@ def bench_one(
             page_size,
             q_data_type=dtype,
             kv_data_type=dtype,
+            q_len_per_req=prediction,
         )
-        # warmup compile (cute-dsl), then time
-        wrapper.run(q, kv)
-        results[backend] = _bench(wrapper, q, kv)
 
-    io_bytes = q.numel() * q.element_size() + kv.numel() * kv.element_size()
-    print(
-        f"b={batch_size:4d} s={seq_len:6d} p={page_size:3d} "
-        f"h_q={num_qo_heads} h_kv={num_kv_heads} d={head_dim} dtype={dtype}"
-    )
-    for backend, ms in results.items():
+        ms = _bench(wrapper, q, kv, out)
         bw = io_bytes / ms / 1e9
-        print(f"  {backend:>9s}: {ms * 1000:8.3f} us  {bw:7.1f} GB/s")
+        print(f"  {backend:>11s}: {ms * 1000:8.3f} us  {bw:7.1f} GB/s")
 
 
 if __name__ == "__main__":
-    num_qo_heads = 32
-    num_kv_heads = 4
-    head_dim = 128
+    num_qo_heads = 64
+    num_kv_heads = 8
     page_size = 16
 
     for dtype in (torch.bfloat16,):
-        for batch_size in (1, 4, 16, 64):
-            for seq_len in (1024, 4096, 16384):
-                bench_one(
-                    batch_size,
-                    seq_len,
-                    page_size,
-                    num_qo_heads,
-                    num_kv_heads,
-                    head_dim,
-                    dtype,
-                )
+        for head_dim in (128,):
+            for prediction in (1, 4):
+                for batch_size in (1, 8, 64):
+                    for seq_len in (1024, 4096, 16384):
+                        bench_one(
+                            batch_size,
+                            prediction,
+                            seq_len,
+                            page_size,
+                            num_qo_heads,
+                            num_kv_heads,
+                            head_dim,
+                            dtype,
+                        )

--- a/benchmarks/bench_cute_dsl_decode.py
+++ b/benchmarks/bench_cute_dsl_decode.py
@@ -14,68 +14,68 @@ Example::
 B200 Results::
 
 b= 1 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:   12.243 us      0.3 GB/s
-   trtllm-gen:    6.301 us      0.7 GB/s
-     cute-dsl:    4.862 us      0.9 GB/s
+          fa2:   12.243 us      0.3 TB/s
+   trtllm-gen:    6.301 us      0.7 TB/s
+     cute-dsl:    4.862 us      0.9 TB/s
 b= 1 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:   18.184 us      0.9 GB/s
-   trtllm-gen:    8.128 us      2.1 GB/s
-     cute-dsl:   11.002 us      1.5 GB/s
+          fa2:   18.184 us      0.9 TB/s
+   trtllm-gen:    8.128 us      2.1 TB/s
+     cute-dsl:   11.002 us      1.5 TB/s
 b= 1 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:   44.368 us      1.5 GB/s
-   trtllm-gen:   17.782 us      3.8 GB/s
-     cute-dsl:   18.137 us      3.7 GB/s
+          fa2:   44.368 us      1.5 TB/s
+   trtllm-gen:   17.782 us      3.8 TB/s
+     cute-dsl:   18.137 us      3.7 TB/s
 b= 8 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:   28.691 us      1.2 GB/s
-   trtllm-gen:   10.577 us      3.2 GB/s
-     cute-dsl:    8.952 us      3.8 GB/s
+          fa2:   28.691 us      1.2 TB/s
+   trtllm-gen:   10.577 us      3.2 TB/s
+     cute-dsl:    8.952 us      3.8 TB/s
 b= 8 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:   85.133 us      1.6 GB/s
-   trtllm-gen:   24.139 us      5.6 GB/s
-     cute-dsl:   22.920 us      5.9 GB/s
+          fa2:   85.133 us      1.6 TB/s
+   trtllm-gen:   24.139 us      5.6 TB/s
+     cute-dsl:   22.920 us      5.9 TB/s
 b= 8 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:  300.016 us      1.8 GB/s
-   trtllm-gen:   78.230 us      6.9 GB/s
-     cute-dsl:   77.682 us      6.9 GB/s
+          fa2:  300.016 us      1.8 TB/s
+   trtllm-gen:   78.230 us      6.9 TB/s
+     cute-dsl:   77.682 us      6.9 TB/s
 b=64 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:  159.955 us      1.7 GB/s
-   trtllm-gen:   43.420 us      6.2 GB/s
-     cute-dsl:   45.634 us      5.9 GB/s
+          fa2:  159.955 us      1.7 TB/s
+   trtllm-gen:   43.420 us      6.2 TB/s
+     cute-dsl:   45.634 us      5.9 TB/s
 b=64 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2:  589.830 us      1.8 GB/s
-   trtllm-gen:  156.094 us      6.9 GB/s
-     cute-dsl:  152.400 us      7.1 GB/s
+          fa2:  589.830 us      1.8 TB/s
+   trtllm-gen:  156.094 us      6.9 TB/s
+     cute-dsl:  152.400 us      7.1 TB/s
 b=64 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-          fa2: 2314.402 us      1.9 GB/s
-   trtllm-gen:  606.548 us      7.1 GB/s
-     cute-dsl:  598.255 us      7.2 GB/s
+          fa2: 2314.402 us      1.9 TB/s
+   trtllm-gen:  606.548 us      7.1 TB/s
+     cute-dsl:  598.255 us      7.2 TB/s
 b= 1 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:    6.703 us      0.6 GB/s
-     cute-dsl:    6.693 us      0.6 GB/s
+   trtllm-gen:    6.703 us      0.6 TB/s
+     cute-dsl:    6.693 us      0.6 TB/s
 b= 1 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:   10.593 us      1.6 GB/s
-     cute-dsl:   11.871 us      1.4 GB/s
+   trtllm-gen:   10.593 us      1.6 TB/s
+     cute-dsl:   11.871 us      1.4 TB/s
 b= 1 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:   19.029 us      3.5 GB/s
-     cute-dsl:   21.917 us      3.1 GB/s
+   trtllm-gen:   19.029 us      3.5 TB/s
+     cute-dsl:   21.917 us      3.1 TB/s
 b= 8 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:   11.857 us      2.9 GB/s
-     cute-dsl:   11.616 us      3.0 GB/s
+   trtllm-gen:   11.857 us      2.9 TB/s
+     cute-dsl:   11.616 us      3.0 TB/s
 b= 8 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:   25.721 us      5.3 GB/s
-     cute-dsl:   29.520 us      4.6 GB/s
+   trtllm-gen:   25.721 us      5.3 TB/s
+     cute-dsl:   29.520 us      4.6 TB/s
 b= 8 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:   80.154 us      6.7 GB/s
-     cute-dsl:   90.475 us      5.9 GB/s
+   trtllm-gen:   80.154 us      6.7 TB/s
+     cute-dsl:   90.475 us      5.9 TB/s
 b=64 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:   49.531 us      5.6 GB/s
-     cute-dsl:   63.087 us      4.4 GB/s
+   trtllm-gen:   49.531 us      5.6 TB/s
+     cute-dsl:   63.087 us      4.4 TB/s
 b=64 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:  162.000 us      6.7 GB/s
-     cute-dsl:  180.057 us      6.0 GB/s
+   trtllm-gen:  162.000 us      6.7 TB/s
+     cute-dsl:  180.057 us      6.0 TB/s
 b=64 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
-   trtllm-gen:  621.074 us      6.9 GB/s
-     cute-dsl:  690.734 us      6.2 GB/s
+   trtllm-gen:  621.074 us      6.9 TB/s
+     cute-dsl:  690.734 us      6.2 TB/s
 """
 
 import sys
@@ -202,7 +202,7 @@ def bench_one(
 
         ms = _bench(wrapper, q, kv, out)
         bw = io_bytes / ms / 1e9
-        print(f"  {backend:>11s}: {ms * 1000:8.3f} us  {bw:7.1f} GB/s")
+        print(f"  {backend:>11s}: {ms * 1000:8.3f} us  {bw:7.1f} TB/s")
 
 
 if __name__ == "__main__":

--- a/benchmarks/bench_cute_dsl_decode.py
+++ b/benchmarks/bench_cute_dsl_decode.py
@@ -98,7 +98,16 @@ if not is_cute_dsl_available():
     sys.exit(0)
 
 
-def _build_inputs(batch_size, prediction, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype):
+def _build_inputs(
+    batch_size,
+    prediction,
+    seq_len,
+    page_size,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+):
     pages_per_seq = (seq_len + page_size - 1) // page_size
     total_pages = pages_per_seq * batch_size
     q = torch.randn(
@@ -138,7 +147,14 @@ def _bench(wrapper, q, kv, o):
 
 
 def bench_one(
-    batch_size, prediction, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+    batch_size,
+    prediction,
+    seq_len,
+    page_size,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
 ):
     print(
         f"b={batch_size:2d} mtp={prediction - 1} s={seq_len:5d} pg={page_size:2d} "
@@ -146,13 +162,20 @@ def bench_one(
     )
 
     q, kv, kv_indptr, kv_indices, last_page_len = _build_inputs(
-        batch_size, prediction, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+        batch_size,
+        prediction,
+        seq_len,
+        page_size,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        dtype,
     )
     io_bytes = q.nbytes * 2 + kv.nbytes
 
     for backend in ("fa2", "trtllm-gen", "cute-dsl"):
         if backend == "fa2" and prediction > 1:
-            continue # fa2 IMAs in this case
+            continue  # fa2 IMAs in this case
 
         # trtllm-gen backend expects workspace to be zero-init for semaphores
         workspace_alloc = torch.zeros if backend == "trtllm-gen" else torch.empty

--- a/benchmarks/bench_cute_dsl_decode.py
+++ b/benchmarks/bench_cute_dsl_decode.py
@@ -10,6 +10,72 @@ they can be compared side-by-side.
 Example::
 
     python benchmarks/bench_cute_dsl_decode.py
+
+B200 Results::
+
+b= 1 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:   12.243 us      0.3 GB/s
+   trtllm-gen:    6.301 us      0.7 GB/s
+     cute-dsl:    4.862 us      0.9 GB/s
+b= 1 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:   18.184 us      0.9 GB/s
+   trtllm-gen:    8.128 us      2.1 GB/s
+     cute-dsl:   11.002 us      1.5 GB/s
+b= 1 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:   44.368 us      1.5 GB/s
+   trtllm-gen:   17.782 us      3.8 GB/s
+     cute-dsl:   18.137 us      3.7 GB/s
+b= 8 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:   28.691 us      1.2 GB/s
+   trtllm-gen:   10.577 us      3.2 GB/s
+     cute-dsl:    8.952 us      3.8 GB/s
+b= 8 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:   85.133 us      1.6 GB/s
+   trtllm-gen:   24.139 us      5.6 GB/s
+     cute-dsl:   22.920 us      5.9 GB/s
+b= 8 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:  300.016 us      1.8 GB/s
+   trtllm-gen:   78.230 us      6.9 GB/s
+     cute-dsl:   77.682 us      6.9 GB/s
+b=64 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:  159.955 us      1.7 GB/s
+   trtllm-gen:   43.420 us      6.2 GB/s
+     cute-dsl:   45.634 us      5.9 GB/s
+b=64 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2:  589.830 us      1.8 GB/s
+   trtllm-gen:  156.094 us      6.9 GB/s
+     cute-dsl:  152.400 us      7.1 GB/s
+b=64 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+          fa2: 2314.402 us      1.9 GB/s
+   trtllm-gen:  606.548 us      7.1 GB/s
+     cute-dsl:  598.255 us      7.2 GB/s
+b= 1 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:    6.703 us      0.6 GB/s
+     cute-dsl:    6.693 us      0.6 GB/s
+b= 1 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:   10.593 us      1.6 GB/s
+     cute-dsl:   11.871 us      1.4 GB/s
+b= 1 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:   19.029 us      3.5 GB/s
+     cute-dsl:   21.917 us      3.1 GB/s
+b= 8 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:   11.857 us      2.9 GB/s
+     cute-dsl:   11.616 us      3.0 GB/s
+b= 8 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:   25.721 us      5.3 GB/s
+     cute-dsl:   29.520 us      4.6 GB/s
+b= 8 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:   80.154 us      6.7 GB/s
+     cute-dsl:   90.475 us      5.9 GB/s
+b=64 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:   49.531 us      5.6 GB/s
+     cute-dsl:   63.087 us      4.4 GB/s
+b=64 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:  162.000 us      6.7 GB/s
+     cute-dsl:  180.057 us      6.0 GB/s
+b=64 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
+   trtllm-gen:  621.074 us      6.9 GB/s
+     cute-dsl:  690.734 us      6.2 GB/s
 """
 
 import sys

--- a/benchmarks/bench_cute_dsl_decode.py
+++ b/benchmarks/bench_cute_dsl_decode.py
@@ -85,7 +85,7 @@ import torch
 
 import flashinfer
 from flashinfer.cute_dsl.utils import is_cute_dsl_available
-from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.testing import bench_gpu_time
 from flashinfer.utils import is_sm100a_supported
 
 
@@ -138,7 +138,6 @@ def _bench(wrapper, q, kv, o):
             lambda q, kv, o: wrapper.run(q, kv, out=o, enable_pdl=True),
             dry_run_iters=10,
             repeat_iters=50,
-            enable_cupti=False,
             use_cuda_graph=True,
             input_args=(q, kv, o),
             cold_l2_cache=True,

--- a/benchmarks/bench_cute_dsl_decode.py
+++ b/benchmarks/bench_cute_dsl_decode.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the cute-dsl GQA decode backend against fa2/trtllm-gen.
+
+Runs paged batch decode through ``flashinfer.BatchDecodeWithPagedKVCacheWrapper``
+with backend="cute-dsl" alongside the same workload through backend="fa2" so
+they can be compared side-by-side.
+
+Example::
+
+    python benchmarks/bench_cute_dsl_decode.py
+"""
+
+import sys
+
+import numpy as np
+import torch
+
+import flashinfer
+from flashinfer.cute_dsl.utils import is_cute_dsl_available
+from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.utils import is_sm100a_supported
+
+
+if not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")):
+    print("Skipping: cute-dsl GQA decode requires Blackwell (SM100a)")
+    sys.exit(0)
+
+if not is_cute_dsl_available():
+    print("Skipping: nvidia-cutlass-dsl not installed")
+    sys.exit(0)
+
+
+def _build_inputs(batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype):
+    pages_per_seq = (seq_len + page_size - 1) // page_size
+    total_pages = pages_per_seq * batch_size
+    q = torch.randn(
+        batch_size, num_qo_heads, head_dim, device="cuda", dtype=dtype
+    )
+    kv = torch.randn(
+        total_pages,
+        2,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        device="cuda",
+        dtype=dtype,
+    )
+    kv_indptr = (
+        torch.arange(batch_size + 1, device="cuda", dtype=torch.int32) * pages_per_seq
+    )
+    kv_indices = torch.arange(total_pages, device="cuda", dtype=torch.int32)
+    last_page_len = torch.full(
+        (batch_size,), (seq_len - 1) % page_size + 1, device="cuda", dtype=torch.int32
+    )
+    return q, kv, kv_indptr, kv_indices, last_page_len
+
+
+def _bench(wrapper, q, kv):
+    return np.median(
+        bench_gpu_time(
+            lambda: wrapper.run(q, kv),
+            dry_run_time_ms=50,
+            repeat_time_ms=200,
+            enable_cupti=True,
+        )
+    )
+
+
+def bench_one(
+    batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+):
+    q, kv, kv_indptr, kv_indices, last_page_len = _build_inputs(
+        batch_size, seq_len, page_size, num_qo_heads, num_kv_heads, head_dim, dtype
+    )
+
+    results = {}
+    for backend in ("fa2", "cute-dsl"):
+        workspace = torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace, kv_layout="NHD", backend=backend
+        )
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+        )
+        # warmup compile (cute-dsl), then time
+        wrapper.run(q, kv)
+        results[backend] = _bench(wrapper, q, kv)
+
+    io_bytes = q.numel() * q.element_size() + kv.numel() * kv.element_size()
+    print(
+        f"b={batch_size:4d} s={seq_len:6d} p={page_size:3d} "
+        f"h_q={num_qo_heads} h_kv={num_kv_heads} d={head_dim} dtype={dtype}"
+    )
+    for backend, ms in results.items():
+        bw = io_bytes / ms / 1e9
+        print(f"  {backend:>9s}: {ms * 1000:8.3f} us  {bw:7.1f} GB/s")
+
+
+if __name__ == "__main__":
+    num_qo_heads = 32
+    num_kv_heads = 4
+    head_dim = 128
+    page_size = 16
+
+    for dtype in (torch.bfloat16,):
+        for batch_size in (1, 4, 16, 64):
+            for seq_len in (1024, 4096, 16384):
+                bench_one(
+                    batch_size,
+                    seq_len,
+                    page_size,
+                    num_qo_heads,
+                    num_kv_heads,
+                    head_dim,
+                    dtype,
+                )

--- a/flashinfer/cute_dsl/attention/__init__.py
+++ b/flashinfer/cute_dsl/attention/__init__.py
@@ -77,3 +77,7 @@ from .wrappers.batch_mla import (
     BatchMLADecodeCuteDSLWrapper,
     cute_dsl_mla_decode,
 )
+from .wrappers.batch_decode import (
+    BatchDecodeCuteDSLWrapper,
+    BatchDecodePagedCuteDSLWrapper,
+)

--- a/flashinfer/cute_dsl/attention/collective_builder.py
+++ b/flashinfer/cute_dsl/attention/collective_builder.py
@@ -20,7 +20,7 @@ import cutlass.cute.nvgpu.tcgen05 as tcgen05
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int64
 
-from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
+from cutlass.cute.nvgpu import OperandMajorMode
 import cutlass.cute.nvgpu.cpasync as cpasync
 
 from .mainloop_spec import MainloopSpec, MLAMainloopSpec
@@ -62,7 +62,7 @@ def build_fmha_launch_params(
     config = mainloop.config
 
     cta_group = tcgen05.CtaGroup.ONE
-    p_major_mode = tcgen05.OperandMajorMode.K
+    p_major_mode = cute.nvgpu.OperandMajorMode.K
     p_source = tcgen05.OperandSource.TMEM
 
     qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
@@ -328,10 +328,10 @@ def build_mla_launch_params(
     config = mainloop.config
 
     cta_group = tcgen05.CtaGroup.TWO
-    q_major_mode = tcgen05.OperandMajorMode.K
-    k_major_mode = tcgen05.OperandMajorMode.K
-    v_major_mode = tcgen05.OperandMajorMode.MN
-    p_major_mode = tcgen05.OperandMajorMode.K
+    q_major_mode = cute.nvgpu.OperandMajorMode.K
+    k_major_mode = cute.nvgpu.OperandMajorMode.K
+    v_major_mode = cute.nvgpu.OperandMajorMode.MN
+    p_major_mode = cute.nvgpu.OperandMajorMode.K
 
     qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
         q_dtype,

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math
-from typing import Type, Tuple
+from typing import Literal, Type, Tuple, cast
 from functools import partial
 
 import cuda.bindings.driver as cuda
@@ -20,9 +20,12 @@ from cutlass.pipeline import (
 
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import (
-    Float32, BFloat16, Float16,
-    Int32, Int64,
-    Optional, Literal,
+    Float32,
+    BFloat16,
+    Float16,
+    Int32,
+    Int64,
+    Optional,
 )
 
 # Kernel invariants
@@ -40,6 +43,7 @@ warp_fmax = partial(cute.arch.warp_redux_sync, kind="fmax", nan=True)
 smem_fmax = partial(cute.arch.atomic_fmax, sem="relaxed", scope="cta")
 gmem_fmax = partial(cute.arch.atomic_fmax, sem="relaxed", scope="gpu")
 
+
 class GroupedQueryAttentionDecode:
     def __init__(
         self,
@@ -47,10 +51,10 @@ class GroupedQueryAttentionDecode:
         grouped_head_tile,  # Grouped heads per threadblock (GQA packing factor)
         prediction_tile=1,  # Predicted tokens per threadblock
         sequence_tile=256,  # KV tokens per threadblock per loop iteration
-        reduction_mode : Literal[  # split-K reduction algorithm
-            "kernel", # Deterministic kernel reduction with partial result workspace
-            "atomic", # Cluster reduction with atomic adds, no workspace
-            "none", # no split-K, flash decoding disabled
+        reduction_mode: Literal[  # split-K reduction algorithm
+            "kernel",  # Deterministic kernel reduction with partial result workspace
+            "atomic",  # Cluster reduction with atomic adds, no workspace
+            "none",  # no split-K, flash decoding disabled
         ] = "kernel",
         *,
         # No causal masking, oob scores are masked to 0 instead of -inf
@@ -77,7 +81,9 @@ class GroupedQueryAttentionDecode:
     # Launch helpers
     ##############################
     # Runtime implementable check
-    def can_implement(self, kv_splits, qo_shape_bshd, kv_shape_bshd, qkv_dtype, o_dtype):
+    def can_implement(
+        self, kv_splits, qo_shape_bshd, kv_shape_bshd, qkv_dtype, o_dtype
+    ):
         b_k, s_q, h_q, d_q = qo_shape_bshd
         b_q, s_k, h_k, d_k = kv_shape_bshd
 
@@ -85,21 +91,29 @@ class GroupedQueryAttentionDecode:
             raise TypeError("use Float8E4M3FN instead of Float8E4M3")
 
         if not (d_q == d_k == self.headdim):
-            raise ValueError(f"headdim_q({d_q}), headdim_k({d_k}) must be {self.headdim}")
+            raise ValueError(
+                f"headdim_q({d_q}), headdim_k({d_k}) must be {self.headdim}"
+            )
 
         if h_q % h_k != 0:
             raise ValueError(f"heads_q({h_q}) must be a multiple of heads_k({h_k})")
-        
+
         if 0 < s_k < s_q:
-            raise ValueError(f"non-zero seqlen({s_k}) must be at least prediction({s_q})")
+            raise ValueError(
+                f"non-zero seqlen({s_k}) must be at least prediction({s_q})"
+            )
 
         # Only causal mask up to two tiles
         if not self.tma_mask and s_q > self.sequence_tile:
-            raise ValueError(f"prediction({s_q}) with causal mask can be at most {self.sequence_tile}")
+            raise ValueError(
+                f"prediction({s_q}) with causal mask can be at most {self.sequence_tile}"
+            )
 
         if self.tma_mask and 0 < s_k < 8:
-            raise ValueError(f"non-zero seqlen({s_k}) with TMA masking must be at least 8")
-        
+            raise ValueError(
+                f"non-zero seqlen({s_k}) with TMA masking must be at least 8"
+            )
+
         if b_k != b_q:
             raise ValueError(f"batches_k({b_k}) and batches_q({b_q}) mismatch")
 
@@ -113,13 +127,13 @@ class GroupedQueryAttentionDecode:
                 raise TypeError(
                     f"atomic reduction requires (Float32, BFloat16, Float16) o_dtype, got {o_dtype}"
                 )
-            
+
         if self.do_none_red and kv_splits != 1:
             raise ValueError("KV splits must be 1 if flash decoding is disabled")
 
     # Pack grouped heads with predicted tokens (s_q)
     @staticmethod
-    def gqa_pack(t_bshd: cute.Tensor, h_k : int):
+    def gqa_pack(t_bshd: cute.Tensor, h_k: int):
         d, h_q, s_q, b = tuple(reversed(t_bshd.shape))[:4]
         stride_d, stride_h, stride_s, stride_b = tuple(reversed(t_bshd.stride))[:4]
         # Batch + partial stride must be coalescible
@@ -134,7 +148,7 @@ class GroupedQueryAttentionDecode:
 
     # Reorder and group modes for GEMM
     @staticmethod
-    def gemm_view(t_bshd: cute.Tensor, s_first : bool):
+    def gemm_view(t_bshd: cute.Tensor, s_first: bool):
         sdhb = (1, 3, 2, 0)  # GEMM1 MKL
         dshb = (3, 1, 2, 0)  # GEMM2 MKL
         reorder = sdhb if s_first else dshb
@@ -144,7 +158,7 @@ class GroupedQueryAttentionDecode:
 
     # Pack, reorder, and group modes for GEMM workspace
     @staticmethod
-    def gemm_view_bsh(t_bsh: cute.Tensor, h_k : int):
+    def gemm_view_bsh(t_bsh: cute.Tensor, h_k: int):
         h_q, s_q, b = tuple(reversed(t_bsh.shape))[:3]
         stride_h, stride_s, stride_b = tuple(reversed(t_bsh.stride))[:3]
         h_g = h_q // h_k
@@ -168,10 +182,18 @@ class GroupedQueryAttentionDecode:
         v_bshd: cute.Tensor,
         o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
         l_bsh: Optional[cute.Tensor],  # log-sum-exp output (Float32), log2 base
-        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized (kernel-red workspace)
-        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split (kernel-red workspace)
-        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split (kernel-red workspace)
-        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split (kernel-red workspace)
+        m_bsh: Optional[
+            cute.Tensor
+        ],  # colmax_s, must be -inf initialized (kernel-red workspace)
+        o_partial_bshd: Optional[
+            cute.Tensor
+        ],  # partial O per kv split (kernel-red workspace)
+        l_partial_bsh: Optional[
+            cute.Tensor
+        ],  # partial colsum_p per kv split (kernel-red workspace)
+        m_partial_bsh: Optional[
+            cute.Tensor
+        ],  # partial colmax_s per kv split (kernel-red workspace)
         scale_s: Float32,
         scale_o: Float32,
         stream: cuda.CUstream,
@@ -245,7 +267,7 @@ class GroupedQueryAttentionDecode:
         self.s_stages = s_stages = min(max_s_stages, p_stages)
 
         tmem_alloc_cols += tmem_s_stage_cols * s_stages  # S
-        tmem_alloc_cols = 2 ** math.ceil(math.log2(tmem_alloc_cols)) # po2
+        tmem_alloc_cols = 2 ** math.ceil(math.log2(tmem_alloc_cols))  # po2
         self.tmem_alloc_cols = tmem_alloc_cols
         assert tmem_alloc_cols <= tmem_capacity_cols
 
@@ -343,7 +365,10 @@ class GroupedQueryAttentionDecode:
             tiled_mma_vp,
         )
         tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
-            tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
+            tma_store_op,
+            mO_mnl,
+            cute.select(smem_layout_o, mode=[0, 1]),
+            tma_tile_mnk[:2],
         )
 
         # GEMM view for LSE output
@@ -354,9 +379,13 @@ class GroupedQueryAttentionDecode:
         # GEMM views for workspace tensors
         mM_nl = mM_partial_nl = mL_partial_nl = None
         if cutlass.const_expr(self.do_kernel_red):
-            assert (m_bsh.dtype == m_partial_bsh.dtype
-                    == l_partial_bsh.dtype == o_partial_bshd.dtype
-                    == acc_dtype)
+            assert (
+                m_bsh.dtype
+                == m_partial_bsh.dtype
+                == l_partial_bsh.dtype
+                == o_partial_bshd.dtype
+                == acc_dtype
+            )
 
             # ((h_g, s_q), (h_k, b), kv_splits)
             mM_nl = self.gemm_view_bsh(m_bsh, h_k)
@@ -476,7 +505,7 @@ class GroupedQueryAttentionDecode:
         mcast_layout = cute.make_layout((1, 1, 1, 1))  # vmnk
 
         # Alias types
-        q_dtype = k_dtype = v_dtype = mma_dtype
+        q_dtype = k_dtype = mma_dtype
         o_dtype = out_dtype
         acc_dtype = Float32
 
@@ -527,14 +556,10 @@ class GroupedQueryAttentionDecode:
         softmax_regs = 120
         correction_regs = min(
             max_sw_regs_per_wg_thread,
-            max_hw_regs_per_wg_thread
-            - mma_tma_regs
-            - softmax_regs * 2
+            max_hw_regs_per_wg_thread - mma_tma_regs - softmax_regs * 2,
         )
         assert (
-            mma_tma_regs
-            + softmax_regs * 2
-            + correction_regs
+            mma_tma_regs + softmax_regs * 2 + correction_regs
         ) <= max_hw_regs_per_wg_thread
 
         # Read thread indices
@@ -563,7 +588,7 @@ class GroupedQueryAttentionDecode:
         # Runtime control flow
         tiles_s = cute.ceil_div(seqlen, blk_tile_s)
         iters_s = cute.ceil_div(tiles_s - kv_split_idx, kv_splits)
-        prefetch_iters = min(2, self.s_stages - 1) # MMA KQ iters to hide first softmax
+        prefetch_iters = min(2, self.s_stages - 1)  # MMA KQ iters to hide first softmax
         exit_early = kv_split_idx >= tiles_s
         lane_store_max = blk_tile_n == warp_threads or lane_idx < blk_tile_n
 
@@ -605,6 +630,7 @@ class GroupedQueryAttentionDecode:
         sL_final_nbar = nbar(10, correction_threads + reduction_threads)
         sO_final_nbar = nbar(11, correction_threads + tma_threads)
         sM_mutex_nbar = nbar(12, softmax_threads * softmax_warpgroups)
+
         # named barrier stage helper
         def with_phase(nbar_, phase):
             return nbar(nbar_.barrier_id + phase, nbar_.num_threads)
@@ -735,9 +761,7 @@ class GroupedQueryAttentionDecode:
 
         # O
         # Reuse KV smem for O TMA store
-        sO_iterator = cute.recast_ptr(
-            tAsK.iterator, smem_layout_o.inner, dtype=o_dtype
-        )
+        sO_iterator = cute.recast_ptr(tAsK.iterator, smem_layout_o.inner, dtype=o_dtype)
         # (MMA_TILE_M, MMA_TILE_N, #TILE_DM)
         sO_mma = cute.make_tensor(sO_iterator, smem_layout_o.outer)
         # (MMA, #MMA_M, #MMA_N, #TILE_DM, o_stages)
@@ -763,9 +787,7 @@ class GroupedQueryAttentionDecode:
 
         # per-thread colsum
         # (MMA_MN, #MMA_M=1, #MMA_N=1, o_stages)
-        tCtL_shape = tiled_mma_kq.partition_shape_C(
-            (mma_tile_m, mma_tile_n, o_stages)
-        )
+        tCtL_shape = tiled_mma_kq.partition_shape_C((mma_tile_m, mma_tile_n, o_stages))
         tCtL = thrblk_mma_kq.make_fragment_C(tCtL_shape)
 
         # R - cluster reduction buffers for colmax + colsum
@@ -943,21 +965,25 @@ class GroupedQueryAttentionDecode:
             cute.arch.griddepcontrol_wait()
 
             # Load Q
-            cute.copy(tma_atom_q, tBgQ_tma, tBsQ_tma, tma_bar_ptr=q_load_mbar,)
+            cute.copy(
+                tma_atom_q,
+                tBgQ_tma,
+                tBsQ_tma,
+                tma_bar_ptr=q_load_mbar,
+            )
 
             # Slice and partition O
             # (TILE_D, TILE_H)
-            coord_b_partial = (kv_split_idx * batches + coord_b
-                               if do_kernel_red else coord_b)
+            coord_b_partial = (
+                kv_split_idx * batches + coord_b if do_kernel_red else coord_b
+            )
             gO = cute.local_tile(
                 mO,
                 tiler=(blk_tile_d, blk_tile_hp),
                 coord=(0, coord_hp, (coord_hk, coord_b_partial)),
             )
             # (MMA_TILE_M, MMA_TILE_N, #TILE_DM, #TILE_HN=1)
-            gO_mma = cute.flat_divide(
-                gO, (mma_tile_m, mma_tile_n)
-            )
+            gO_mma = cute.flat_divide(gO, (mma_tile_m, mma_tile_n))
             gO_mma = gO_mma[None, None, None, 0]
             # (TMA, #TILE_DM)
             sO_tma, gO_tma = cute.nvgpu.cpasync.tma_partition(
@@ -1024,7 +1050,7 @@ class GroupedQueryAttentionDecode:
                 s_handle.commit()
 
             # Tail loop
-            for s in cutlass.range_constexpr(prefetch_iters):
+            for _s in cutlass.range_constexpr(prefetch_iters):
                 mma_order_vp_nbar.arrive_and_wait()
                 mma_order_kq_nbar.arrive()
 
@@ -1173,7 +1199,9 @@ class GroupedQueryAttentionDecode:
                     elif (is_last_split or is_prev_split) and is_last_phase:
                         masked_start_s = 0
                         masked_iters_s = 1
-                        masked_coord_s = (tiles_s - 1) if is_last_split else (tiles_s - 2)
+                        masked_coord_s = (
+                            (tiles_s - 1) if is_last_split else (tiles_s - 2)
+                        )
                         # if last split only has 1 tile then some cols will never
                         # see inbounds values, so P = exp(-inf + inf) -> nan
                         check_safe_max = is_last_split and iters_s == 1
@@ -1225,11 +1253,13 @@ class GroupedQueryAttentionDecode:
 
                     # Reduce colmax in thread RF
                     rM = cute.make_rmem_tensor_like(sM)
-                    rM.store(scores.reduce(
-                        cute.ReductionOp.MAX,
-                        init_val=-Float32.inf,
-                        reduction_profile=(None, 0)
-                    ))
+                    rM.store(
+                        scores.reduce(
+                            cute.ReductionOp.MAX,
+                            init_val=-Float32.inf,
+                            reduction_profile=(None, 0),
+                        )
+                    )
 
                     # Reduce colmax in warp RF
                     rM_lane = Float32(0)
@@ -1287,7 +1317,7 @@ class GroupedQueryAttentionDecode:
                     cute.arch.fence_view_async_tmem_store()
                     tL_producer_nbar.arrive()
 
-                    # Advance again for dual warpgroups 
+                    # Advance again for dual warpgroups
                     s_consumer.advance()
                     p_producer.advance()
 
@@ -1323,12 +1353,12 @@ class GroupedQueryAttentionDecode:
             # colsum load helper
             def colsum_load(
                 phase,
-                blk_tile_n = blk_tile_n,
-                tOtL = tOtL,
-                tOrO_shape = tOsO.shape[:1],
-                tmem_load_atom_o = tmem_load_atom_o,
-                tL_producer_nbar = tL_producer_nbar,
-                tL_consumer_nbar = tL_consumer_nbar,
+                blk_tile_n=blk_tile_n,
+                tOtL=tOtL,
+                tOrO_shape=tOsO.shape[:1],
+                tmem_load_atom_o=tmem_load_atom_o,
+                tL_producer_nbar=tL_producer_nbar,
+                tL_consumer_nbar=tL_consumer_nbar,
             ):
                 with_phase(tL_producer_nbar, phase).arrive_and_wait()
                 tOtL_s = tOtL[None, phase]
@@ -1541,14 +1571,14 @@ class GroupedQueryAttentionDecode:
     @staticmethod
     @cute.jit
     def reduction_none(
-        lane_store_max : bool,
-        lane_idx : Int32,
-        sM_final_nbar : nbar,
-        sL_final_nbar : nbar,
-        sM : cute.Tensor,
-        sL : cute.Tensor,
-        gL : Optional[cute.Tensor],
-        scale_o : Float32,
+        lane_store_max: bool,
+        lane_idx: Int32,
+        sM_final_nbar: nbar,
+        sL_final_nbar: nbar,
+        sM: cute.Tensor,
+        sL: cute.Tensor,
+        gL: Optional[cute.Tensor],
+        scale_o: Float32,
     ):
         store_lse = gL is not None
         colmax = Float32(0)
@@ -1571,18 +1601,18 @@ class GroupedQueryAttentionDecode:
     @staticmethod
     @cute.jit
     def reduction_epilogue(
-        blk_tile_hp : Tuple[int, int],
+        blk_tile_hp: Tuple[int, int],
         coord_hp: Tuple[Int32, Int32],
         coord_hb: Tuple[Int32, Int32],
-        kv_split_idx : Int32,
-        lane_idx : Int32,
-        sM_final_nbar : nbar,
-        sL_final_nbar : nbar,
-        sM : cute.Tensor,
-        sL : cute.Tensor,
-        mM : cute.Tensor,
-        mM_partial : cute.Tensor,
-        mL_partial : cute.Tensor,
+        kv_split_idx: Int32,
+        lane_idx: Int32,
+        sM_final_nbar: nbar,
+        sL_final_nbar: nbar,
+        sM: cute.Tensor,
+        sL: cute.Tensor,
+        mM: cute.Tensor,
+        mM_partial: cute.Tensor,
+        mL_partial: cute.Tensor,
     ):
         # get gmem colmax + colsum to store to
         coord_h = (coord_hp, coord_hb, kv_split_idx)
@@ -1615,27 +1645,24 @@ class GroupedQueryAttentionDecode:
         sL_final_nbar.arrive_and_wait()
         if lane_store_max:
             sL_lane_wg = sL[lane_idx, None]
-            sL_lane = (
-                sL_lane_wg[0] + sL_lane_wg[1] + sL_lane_wg[2] + sL_lane_wg[3]
-            )
+            sL_lane = sL_lane_wg[0] + sL_lane_wg[1] + sL_lane_wg[2] + sL_lane_wg[3]
             gL_partial[lane_idx] = sL_lane
-
 
     @staticmethod
     @cute.jit
     def reduction_cluster(
-        blk_tile_n : int,
-        kv_splits : Int32,
-        kv_split_idx : Int32,
-        lane_idx : Int32,
-        sM_final_nbar : nbar,
-        sL_final_nbar : nbar,
-        reduction_mbars_ptr : cute.Pointer,
-        sM : cute.Tensor,
-        sL : cute.Tensor,
-        sR : cute.Tensor,
-        gL : Optional[cute.Tensor],
-        scale_o : Float32,
+        blk_tile_n: int,
+        kv_splits: Int32,
+        kv_split_idx: Int32,
+        lane_idx: Int32,
+        sM_final_nbar: nbar,
+        sL_final_nbar: nbar,
+        reduction_mbars_ptr: cute.Pointer,
+        sM: cute.Tensor,
+        sL: cute.Tensor,
+        sR: cute.Tensor,
+        gL: Optional[cute.Tensor],
+        scale_o: Float32,
     ):
         acc_dtype = sM.dtype
         colmax_bits = blk_tile_n * acc_dtype.width
@@ -1767,10 +1794,11 @@ class GroupedQueryAttentionDecode:
         splits, b, s_q, h_q, d = o_partial_bshd.shape
 
         # Tile in headdim first
-        def reverse(t : cute.Tensor):
+        def reverse(t: cute.Tensor):
             modes = tuple(reversed(range(cute.rank(t))))
             layout = cute.select(t.layout, modes)
             return cute.make_tensor(t.iterator, layout)
+
         o_dhsb = reverse(o_bshd)
         l_hsb = reverse(l_bsh) if l_bsh is not None else None
         m_hsb = reverse(m_bsh)
@@ -1785,8 +1813,12 @@ class GroupedQueryAttentionDecode:
 
         GroupedQueryAttentionDecode.reduction_kernel(
             (thr_per_blk, d_per_thr, d_per_blk),
-            o_dhsb, l_hsb, m_hsb,
-            o_partial_dhsb, l_partial_hsb, m_partial_hsb,
+            o_dhsb,
+            l_hsb,
+            m_hsb,
+            o_partial_dhsb,
+            l_partial_hsb,
+            m_partial_hsb,
             scale_o,
         ).launch(
             grid=[d_blks, h_q * s_q, b],
@@ -1841,8 +1873,7 @@ class GroupedQueryAttentionDecode:
         sM = cute.make_tensor(smem_ptr + splits * 2, sM_layout)
 
         cpasync_atom = cute.make_copy_atom(
-            cute.nvgpu.cpasync.CopyG2SOp(), Float32,
-            num_bits_per_copy=32
+            cute.nvgpu.cpasync.CopyG2SOp(), Float32, num_bits_per_copy=32
         )
 
         copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), Float32)
@@ -1934,7 +1965,7 @@ def run(
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
 
-    npo2 = lambda x : 2 ** math.ceil(math.log2(x))
+    npo2 = lambda x: 2 ** math.ceil(math.log2(x))
 
     grouped_heads = heads_q // heads_k
     grouped_head_tile = npo2(grouped_heads)
@@ -1979,15 +2010,16 @@ def run(
     do_atomic_red = reduction == "atomic"
     do_kernel_red = reduction == "kernel"
 
-    print(f"Command: python {__file__.split("/")[-1]}"
+    print(
+        f"Command: python {__file__.split('/')[-1]}"
         f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
         f" --b {batches} --p {prediction} --s {seqlen}"
         f" --kv_splits {kv_splits} --reduction {reduction}"
         f" --mma_dtype {qkv_dtype} --out_dtype {o_dtype}"
-        f" --atol {tolerance}{" --skip_ref_check" if skip_ref_check else ""}"
+        f" --atol {tolerance}{' --skip_ref_check' if skip_ref_check else ''}"
         f" --scale {scale_s}"
-        f" --iterations {iterations} --warmups {warmup_iterations}{" --use_warm_l2" if use_warm_l2 else ""}"
-        f"{" --quiet" if quiet else ""}"
+        f" --iterations {iterations} --warmups {warmup_iterations}{' --use_warm_l2' if use_warm_l2 else ''}"
+        f"{' --quiet' if quiet else ''}"
     )
 
     if not quiet:
@@ -1997,18 +2029,18 @@ def run(
             f"\tbatches: {batches}\tprediction: {prediction}\tseqlen: {seqlen}\n"
             f"\tkv_splits: {kv_splits}\treduction: {reduction}\n"
             f"\tqkv: {qkv_dtype}\to: {o_dtype}\t\n"
-            f"\tatol: {tolerance if not skip_ref_check else "skip"}"
-            f"\tscale_s: {f"1 / sqrt({headdim})" if scale_s == 0 else scale_s}\n"
+            f"\tatol: {tolerance if not skip_ref_check else 'skip'}"
+            f"\tscale_s: {f'1 / sqrt({headdim})' if scale_s == 0 else scale_s}\n"
             f"\titerations: {iterations}\twarmups: {warmup_iterations}\tL2 warm: {use_warm_l2}"
         )
 
     # Automatic scale
     if scale_s == 0:
-        scale_s = headdim ** -0.5
+        scale_s = headdim**-0.5
 
     sequence_tile = 256
     if prediction_tile > 1 and blk_tile_n > 8:
-        sequence_tile = 128 # Prevent spills
+        sequence_tile = 128  # Prevent spills
 
     #
     # Config Kernel
@@ -2018,7 +2050,7 @@ def run(
         grouped_head_tile,
         prediction_tile=prediction_tile,
         sequence_tile=sequence_tile,
-        reduction_mode=reduction,
+        reduction_mode=cast(Literal["kernel", "atomic", "none"], reduction),
         tma_mask=(prediction == 1),
     )
 
@@ -2038,10 +2070,10 @@ def run(
     def create_tensor(shape, dtype, init=None):
         init_type = cutlass.torch.TensorInitType.SKIP
         init_config = None
-        if isinstance(init, int) or isinstance(init, float):
+        if isinstance(init, (int, float)):
             init_type = cutlass.torch.TensorInitType.SCALAR
             init_config = cutlass.torch.ScalarInitConfig(value=init)
-        elif isinstance(init, tuple) or isinstance(init, list):
+        elif isinstance(init, (tuple, list)):
             if len(init) == 2:
                 init_type = cutlass.torch.TensorInitType.RANDOM
                 init_config = cutlass.torch.RandomInitConfig(
@@ -2122,19 +2154,19 @@ def run(
             [SDPBackend.FLASH_ATTENTION, SDPBackend.MATH], set_priority=True
         ):
             # bottom right causal
-            decode_mask = torch.ones(
-                prediction, seqlen, dtype=torch.bool
-            ).tril(diagonal=(seqlen - prediction))
+            decode_mask = torch.ones(prediction, seqlen, dtype=torch.bool).tril(
+                diagonal=(seqlen - prediction)
+            )
             o_bshd = scaled_dot_product_attention(
-                q_bshd.transpose(1,2),
-                k_bshd.transpose(1,2),
-                v_bshd.transpose(1,2),
+                q_bshd.transpose(1, 2),
+                k_bshd.transpose(1, 2),
+                v_bshd.transpose(1, 2),
                 attn_mask=decode_mask,
                 dropout_p=0.0,
                 scale=scale_s,
                 is_causal=False,  # built-in is upper left causal
                 enable_gqa=(heads_q != heads_k),
-            ).transpose(1,2)
+            ).transpose(1, 2)
             return o_bshd
 
     if not skip_ref_check:
@@ -2179,7 +2211,9 @@ def run(
         _, q_cute, _ = create_tensor(qo_shape[1:], qkv_dtype, init=[-8, 7])
         _, k_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
         _, v_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
-        _, o_cute, _ = create_tensor(qo_shape[1:], o_dtype, init=(0 if do_atomic_red else None))
+        _, o_cute, _ = create_tensor(
+            qo_shape[1:], o_dtype, init=(0 if do_atomic_red else None)
+        )
         _, l_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype)
         m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
         if do_kernel_red:
@@ -2244,6 +2278,7 @@ def run(
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(
         description="Example of MHA/GQA decode on Blackwell."
     )

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -275,8 +275,6 @@ class GroupedQueryAttentionDecode:
         kv_stages = remaining_bits // mk_stage_bits
         kv_stages -= 1 if kv_stages * pipe_stage_bits > alignment_bits else 0
 
-        print(f"\ts stages: {s_stages}\tkv stages: {kv_stages}")
-
         ##############################
         # TMA creation
         ##############################

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -1,15 +1,9 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import argparse
 import math
 from typing import Type, Tuple
 from functools import partial
-from enum import Enum
-
-import torch
-from torch.nn.functional import scaled_dot_product_attention
-from torch.nn.attention import SDPBackend, sdpa_kernel
 
 import cuda.bindings.driver as cuda
 
@@ -24,14 +18,16 @@ from cutlass.pipeline import (
     NamedBarrier as nbar,
 )
 
-import cutlass.torch as cutlass_torch
 import cutlass.utils.blackwell_helpers as sm100_utils
-import cutlass.cute.testing as testing
 from cutlass.cute.typing import (
     Float32, BFloat16, Float16,
     Int32, Int64,
     Optional, Literal,
 )
+
+# Example-only imports (torch SDPA, cutlass.torch, cutlass.cute.testing,
+# argparse) are deferred into run() and __main__ so library users
+# importing GroupedQueryAttentionDecode don't pay for them.
 
 # Kernel invariants
 mma_modes = (0, 1, 2)
@@ -1877,6 +1873,14 @@ def run(
     quiet: bool = False,
     **kwargs,
 ):
+    # Example-only imports deferred here so importing the kernel module
+    # doesn't pull in torch SDPA, cutlass.torch, or cutlass.cute.testing.
+    import torch
+    from torch.nn.functional import scaled_dot_product_attention
+    from torch.nn.attention import SDPBackend, sdpa_kernel
+    import cutlass.torch as cutlass_torch
+    import cutlass.cute.testing as testing
+
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
 
@@ -2178,6 +2182,7 @@ def run(
 
 
 if __name__ == "__main__":
+    import argparse
     parser = argparse.ArgumentParser(
         description="Example of MHA/GQA decode on Blackwell."
     )

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -1450,7 +1450,8 @@ class GroupedQueryAttentionDecode:
                     # Store partial colsum in smem and notify
                     if lane_store_max:
                         sL[lane_idx, warpgroup_widx] = rL_lane
-                    sL_final_nbar.arrive()
+                    # Wait to ensure reduction warp has reset sM_final_nbar
+                    sL_final_nbar.arrive_and_wait()
 
             # Load O of s-1, s
             tOrO_tail = cute.make_rmem_tensor((*tOsO.shape, o_stages), acc_dtype)

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -174,6 +174,7 @@ class GroupedQueryAttentionDecode:
         scale_s: Float32,
         scale_o: Float32,
         stream: cuda.CUstream,
+        enable_pdl: bool = True,
     ):
         ##############################
         # TiledMma creation
@@ -413,7 +414,7 @@ class GroupedQueryAttentionDecode:
             cluster=[cluster_x, 1, 1],
             stream=stream,
             min_blocks_per_mp=1,
-            use_pdl=True,
+            use_pdl=enable_pdl,
         )
 
         if cutlass.const_expr(self.do_kernel_red):
@@ -427,6 +428,7 @@ class GroupedQueryAttentionDecode:
                 m_partial_bsh,
                 scale_o,
                 stream,
+                enable_pdl,
             )
 
     @cute.kernel
@@ -1713,6 +1715,7 @@ class GroupedQueryAttentionDecode:
         m_partial_bsh: cute.Tensor,  # partial colmax_s per kv split
         scale_o: Float32,
         stream: cuda.CUstream,
+        enable_pdl: bool = True,
     ):
         splits, b, s_q, h_q, d = o_partial_bshd.shape
 
@@ -1745,7 +1748,7 @@ class GroupedQueryAttentionDecode:
             stream=stream,
             smem=smem_bytes,
             min_blocks_per_mp=1,
-            use_pdl=True,
+            use_pdl=enable_pdl,
         )
 
     @staticmethod

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -25,10 +25,6 @@ from cutlass.cute.typing import (
     Optional, Literal,
 )
 
-# Example-only imports (torch SDPA, cutlass.torch, cutlass.cute.testing,
-# argparse) are deferred into run() and __main__ so library users
-# importing GroupedQueryAttentionDecode don't pay for them.
-
 # Kernel invariants
 mma_modes = (0, 1, 2)
 mma_dice = (None, None, None)  # (MMA, #MMA_M, #MMA_K)
@@ -54,6 +50,7 @@ class GroupedQueryAttentionDecode:
         reduction_mode : Literal[  # split-K reduction algorithm
             "kernel", # Deterministic kernel reduction with partial result workspace
             "atomic", # Cluster reduction with atomic adds, no workspace
+            "none", # no split-K, flash decoding disabled
         ] = "kernel",
         *,
         # No causal masking, oob scores are masked to 0 instead of -inf
@@ -67,13 +64,14 @@ class GroupedQueryAttentionDecode:
         self.sequence_tile = sequence_tile
         self.do_kernel_red = reduction_mode == "kernel"
         self.do_atomic_red = reduction_mode == "atomic"
+        self.do_none_red = reduction_mode == "none" or reduction_mode is None
         self.tma_mask = tma_mask
         self.threads_per_cta = 4 * warpgroup_threads
 
         assert headdim > 0 and headdim % 64 == 0
         assert grouped_head_tile * prediction_tile in (1, 2, 4, 8, 16, 32)
         assert sequence_tile > 0 and sequence_tile % 128 == 0
-        assert self.do_kernel_red ^ self.do_atomic_red
+        assert self.do_kernel_red ^ self.do_atomic_red ^ self.do_none_red
 
     ##############################
     # Launch helpers
@@ -115,6 +113,9 @@ class GroupedQueryAttentionDecode:
                 raise TypeError(
                     f"atomic reduction requires (Float32, BFloat16, Float16) o_dtype, got {o_dtype}"
                 )
+            
+        if self.do_none_red and kv_splits != 1:
+            raise ValueError("KV splits must be 1 if flash decoding is disabled")
 
     # Pack grouped heads with predicted tokens (s_q)
     @staticmethod
@@ -279,7 +280,7 @@ class GroupedQueryAttentionDecode:
         # TMA creation
         ##############################
         h_k = k_bshd.shape[2]
-        o_bshd_ = o_bshd if self.do_atomic_red else o_partial_bshd
+        o_bshd_ = o_partial_bshd if self.do_kernel_red else o_bshd
 
         # ((h_g, s_q), d, (h_k, b))
         mQ_nkl = self.gemm_view(self.gqa_pack(q_bshd, h_k), True)
@@ -345,12 +346,10 @@ class GroupedQueryAttentionDecode:
             tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
         )
 
-        # GEMM view for LSE output (atomic-reduction path; kernel-reduction
-        # path writes LSE directly from reduction_kernel using the raw bsh).
-        mL_nl = None
-        if cutlass.const_expr(l_bsh is not None and self.do_atomic_red):
-            assert l_bsh.dtype == acc_dtype
-            mL_nl = self.gemm_view_bsh(l_bsh, h_k)  # ((h_g, s_q), (h_k, b))
+        # GEMM view for LSE output
+        # ((h_g, s_q), (h_k, b))
+        mL_nl = None if l_bsh is None else self.gemm_view_bsh(l_bsh, h_k)
+        assert l_bsh is None or l_bsh.dtype == acc_dtype
 
         # GEMM views for workspace tensors
         mM_nl = mM_partial_nl = mL_partial_nl = None
@@ -370,9 +369,10 @@ class GroupedQueryAttentionDecode:
         scale_s_log2_e = scale_s * log2_e
 
         n_tiles = cute.ceil_div(mQ_nkl.shape[0], (blk_tile_h, blk_tile_p))
-        n_tiles = cute.size(n_tiles)
-        l_tiles = cute.size(mQ_nkl.shape[2])
-        grid = (kv_splits, n_tiles, l_tiles)
+        grid_y = cute.size(n_tiles)
+        grid_z = cute.size(mQ_nkl.shape[2])  # l tiles
+        grid_x = 1 if self.do_none_red else kv_splits
+        grid = (grid_x, grid_y, grid_z)
         cluster_x = kv_splits if self.do_atomic_red else 1
 
         self.decode(
@@ -493,6 +493,8 @@ class GroupedQueryAttentionDecode:
         # Static control flow
         do_kernel_red = self.do_kernel_red
         do_atomic_red = self.do_atomic_red
+        do_none_red = self.do_none_red
+        store_lse = mL is not None
         tma_mask = self.tma_mask
 
         ##############################
@@ -538,6 +540,8 @@ class GroupedQueryAttentionDecode:
         # Read thread indices
         kv_splits, tiles_hp, tiles_hb = cute.arch.grid_dim()
         kv_split_idx, coord_hp, coord_hb = cute.arch.block_idx()
+        if cutlass.const_expr(do_none_red):
+            kv_splits, kv_split_idx = (1, 0)
         tidx, _, _ = cute.arch.thread_idx()
         lane_idx = cute.arch.lane_idx()
         warp_idx = cute.arch.make_warp_uniform(tidx // warp_threads)
@@ -943,8 +947,8 @@ class GroupedQueryAttentionDecode:
 
             # Slice and partition O
             # (TILE_D, TILE_H)
-            coord_b_partial = (coord_b if do_atomic_red
-                               else kv_split_idx * batches + coord_b)
+            coord_b_partial = (kv_split_idx * batches + coord_b
+                               if do_kernel_red else coord_b)
             gO = cute.local_tile(
                 mO,
                 tiler=(blk_tile_d, blk_tile_hp),
@@ -1466,12 +1470,12 @@ class GroupedQueryAttentionDecode:
             output_final = tOrO_final.reshape((blk_tile_n, tiles_dm))
             output_final += correction * output_prev
 
-            # Apply final correction
-            if cutlass.const_expr(do_atomic_red):
-                # final correction stored in sM
+            # Apply final normalization
+            if cutlass.const_expr(do_atomic_red or do_none_red):
+                # final normalization stored in sM
                 sM_final_nbar.arrive_and_wait()
-                correction = sM.load()
-                output_final *= correction
+                normalization = sM.load()
+                output_final *= normalization
 
             # Store O to smem and notify
             tOsO.store(output_final.to(o_dtype).reshape(tOsO.shape))
@@ -1497,9 +1501,9 @@ class GroupedQueryAttentionDecode:
                     mM_partial,
                     mL_partial,
                 )
-            else:
+            elif cutlass.const_expr(do_atomic_red):
                 gL = None
-                if cutlass.const_expr(mL is not None):
+                if cutlass.const_expr(store_lse):
                     gL = cute.local_tile(mL, (blk_tile_hp,), (coord_hp, coord_hb))
                 self.reduction_cluster(
                     blk_tile_n,
@@ -1515,9 +1519,53 @@ class GroupedQueryAttentionDecode:
                     gL,
                     scale_o,
                 )
+            elif cutlass.const_expr(do_none_red):
+                gL = None
+                if cutlass.const_expr(store_lse):
+                    gL = cute.local_tile(mL, (blk_tile_hp,), (coord_hp, coord_hb))
+                self.reduction_none(
+                    lane_store_max,
+                    lane_idx,
+                    sM_final_nbar,
+                    sL_final_nbar,
+                    sM,
+                    sL,
+                    gL,
+                    scale_o,
+                )
             cute.arch.griddepcontrol_launch_dependents()
 
         return
+
+    @staticmethod
+    @cute.jit
+    def reduction_none(
+        lane_store_max : bool,
+        lane_idx : Int32,
+        sM_final_nbar : nbar,
+        sL_final_nbar : nbar,
+        sM : cute.Tensor,
+        sL : cute.Tensor,
+        gL : Optional[cute.Tensor],
+        scale_o : Float32,
+    ):
+        store_lse = gL is not None
+        colmax = Float32(0)
+        colsum = Float32(0)
+        sM_final_nbar.arrive_and_wait()
+        if cutlass.const_expr(store_lse):
+            if lane_store_max:
+                colmax = sM[lane_idx]
+        sL_final_nbar.arrive_and_wait()
+        if lane_store_max:
+            sL_lane = sL[lane_idx, None]
+            colsum = sL_lane[0] + sL_lane[1] + sL_lane[2] + sL_lane[3]
+            normalization = cute.arch.rcp_approx(colsum) * scale_o
+            sM[lane_idx] = normalization
+        sM_final_nbar.arrive()
+        if cutlass.const_expr(store_lse):
+            if lane_store_max:
+                gL[lane_idx] = colmax + cute.math.log2(colsum)
 
     @staticmethod
     @cute.jit
@@ -1911,18 +1959,23 @@ def run(
             kv_splits = 9  # 2 waves
         # At least 256 tokens per split
         kv_splits = min(kv_splits, math.ceil(seqlen / 256))
-        # Cluster reduction requires po2 splits
-        if reduction == "atomic":
+        if reduction == "none":
+            kv_splits = 1
+        elif reduction == "atomic":
+            # Cluster reduction requires po2 splits
             if kv_splits not in (1, 2, 4):
                 kv_splits = 8  # generally performs well
 
     # Automatic reduction mode
     if reduction == "auto":
-        if o_dtype in (Float32, Float16, BFloat16) and kv_splits in (1, 2, 4, 8):
+        if kv_splits == 1:
+            reduction = "none"
+        elif o_dtype in (Float32, Float16, BFloat16) and kv_splits in (2, 4, 8):
             reduction = "atomic"
         else:
             reduction = "kernel"
-    atomic = reduction == "atomic"
+    do_atomic_red = reduction == "atomic"
+    do_kernel_red = reduction == "kernel"
 
     print(f"Command: python {__file__.split("/")[-1]}"
         f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
@@ -2018,7 +2071,7 @@ def run(
     k_ref, k_cute, k_torch = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
     v_ref, v_cute, v_torch = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
     _, o_cute, o_torch = create_tensor(
-        qo_shape[1:], o_dtype, init=(0 if atomic else None)
+        qo_shape[1:], o_dtype, init=(0 if do_atomic_red else None)
     )
     # LSE output (log2 base). Allocated unconditionally for both reduction
     # modes; the kernel only writes here, we don't refcheck — exists solely
@@ -2026,7 +2079,7 @@ def run(
     _, l_cute, l_torch = create_tensor(qo_shape[1:-1], acc_dtype)
     # Workspace tensors
     m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
-    if not atomic:
+    if do_kernel_red:
         _, m_cute, m_torch = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
         _, o_partial_cute, o_partial_torch = create_tensor(qo_shape, acc_dtype)
         _, m_partial_cute, m_partial_torch = create_tensor(qo_shape[:-1], acc_dtype)
@@ -2119,10 +2172,10 @@ def run(
         _, q_cute, _ = create_tensor(qo_shape[1:], qkv_dtype, init=[-8, 7])
         _, k_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
         _, v_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
-        _, o_cute, _ = create_tensor(qo_shape[1:], o_dtype, init=(0 if atomic else None))
+        _, o_cute, _ = create_tensor(qo_shape[1:], o_dtype, init=(0 if do_atomic_red else None))
         _, l_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype)
         m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
-        if not atomic:
+        if do_kernel_red:
             _, m_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
             _, o_partial_cute, _ = create_tensor(qo_shape, acc_dtype)
             _, m_partial_cute, _ = create_tensor(qo_shape[:-1], acc_dtype)
@@ -2147,7 +2200,7 @@ def run(
     qkvo_bytes = q_torch.nbytes + k_torch.nbytes + v_torch.nbytes + o_torch.nbytes
     if not use_warm_l2:
         one_workspace_bytes = qkvo_bytes
-        if not atomic:
+        if do_kernel_red:
             one_workspace_bytes += (
                 m_torch.nbytes
                 + o_partial_torch.nbytes
@@ -2250,7 +2303,7 @@ if __name__ == "__main__":
         "--reduction",
         type=str,
         default="auto",
-        help="split KV reduction mode, can be kernel, atomic, or auto",
+        help="split KV reduction mode, can be kernel, atomic, none, auto",
     )
 
     parser.add_argument(

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -2009,6 +2009,15 @@ def run(
     do_atomic_red = reduction == "atomic"
     do_kernel_red = reduction == "kernel"
 
+    # Absolute output tolerance for integer-valued inputs
+    if tolerance < 0:
+        if o_dtype.width == 8:
+            tolerance = 0.4
+        elif qkv_dtype.width == 8:
+            tolerance = 0.2
+        else:
+            tolerance = 0.1
+
     print(
         f"Command: python {__file__.split('/')[-1]}"
         f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
@@ -2098,6 +2107,9 @@ def run(
             is_dynamic_layout=True,
             assumed_align=16,
         )
+
+        # handle if we casted to int8/uint8 for dlpack
+        torch_tensor = torch_tensor.view(cutlass_torch.dtype(dtype))
 
         return (
             ref_torch_tensor,
@@ -2368,7 +2380,7 @@ if __name__ == "__main__":
         "--tolerance",
         "--atol",
         type=float,
-        default=1e-01,
+        default=-1,
         help="Absolute tolerance for validation",
     )
 

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -176,6 +176,7 @@ class GroupedQueryAttentionDecode:
         m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
         l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
         scale_s: Float32,
+        scale_o: Float32,
         stream: cuda.CUstream,
     ):
         ##############################
@@ -401,6 +402,7 @@ class GroupedQueryAttentionDecode:
             mM_partial_nl,
             mL_partial_nl,
             scale_s_log2_e,
+            scale_o,
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -418,6 +420,7 @@ class GroupedQueryAttentionDecode:
                 o_partial_bshd,
                 m_partial_bsh,
                 l_partial_bsh,
+                scale_o,
                 stream,
             )
 
@@ -452,6 +455,7 @@ class GroupedQueryAttentionDecode:
         mM_partial: Optional[cute.Tensor],
         mL_partial: Optional[cute.Tensor],
         scale_s_log2_e: Float32,
+        scale_o: Float32,
     ):
         ##############################
         # Static variables
@@ -1499,6 +1503,7 @@ class GroupedQueryAttentionDecode:
                     sM,
                     sL,
                     sR,
+                    scale_o,
                 )
             cute.arch.griddepcontrol_launch_dependents()
 
@@ -1570,6 +1575,7 @@ class GroupedQueryAttentionDecode:
         sM : cute.Tensor,
         sL : cute.Tensor,
         sR : cute.Tensor,
+        scale_o : Float32,
     ):
         acc_dtype = sM.dtype
         colmax_bits = blk_tile_n * acc_dtype.width
@@ -1664,7 +1670,7 @@ class GroupedQueryAttentionDecode:
             rcp_colsum = cute.make_rmem_tensor(colsum.shape, acc_dtype)
             for i in cutlass.range(cute.size(colsum.shape)):
                 rcp_colsum[i] = cute.arch.rcp_approx(colsum[i])
-            tRsM.store(correction * rcp_colsum.load())
+            tRsM.store(correction * rcp_colsum.load() * scale_o)
 
         # Notify for final correction
         sM_final_nbar.arrive()
@@ -1682,6 +1688,7 @@ class GroupedQueryAttentionDecode:
         o_partial_bshd: cute.Tensor,  # partial O per kv split
         m_partial_bsh: cute.Tensor,  # partial colmax_s per kv split
         l_partial_bsh: cute.Tensor,  # partial colsum_p per kv split
+        scale_o: Float32,
         stream: cuda.CUstream,
     ):
         splits, b, s_q, h_q, d = o_partial_bshd.shape
@@ -1704,7 +1711,8 @@ class GroupedQueryAttentionDecode:
 
         GroupedQueryAttentionDecode.reduction_kernel(
             (thr_per_blk, d_per_thr, d_per_blk),
-            o_dhsb, m_hsb, o_partial_dhsb, m_partial_hsb, l_partial_hsb
+            o_dhsb, m_hsb, o_partial_dhsb, m_partial_hsb, l_partial_hsb,
+            scale_o,
         ).launch(
             grid=[d_blks, h_q * s_q, b],
             block=[thr_per_blk, 1, 1],
@@ -1724,6 +1732,7 @@ class GroupedQueryAttentionDecode:
         o_partial_dhsb: cute.Tensor,
         m_partial_hsb: cute.Tensor,
         l_partial_hsb: cute.Tensor,
+        scale_o: Float32,
     ):
         thr_per_blk, d_per_thr, d_per_blk = tile_d
         d, h_q, s_q, b, splits = o_partial_dhsb.shape
@@ -1803,7 +1812,7 @@ class GroupedQueryAttentionDecode:
                     correction = exp2(max_partial - max_final)
                     sum_final += correction * sL_partial[0, split_idx]
                     tCrO_final += correction * tCgO_partial[None, split_idx].load()
-            tCrO_final *= cute.arch.rcp_approx(sum_final)
+            tCrO_final *= cute.arch.rcp_approx(sum_final) * scale_o
 
         cute.arch.griddepcontrol_launch_dependents()
 
@@ -1996,6 +2005,7 @@ def run(
         m_partial_cute,
         l_partial_cute,
         scale_s,
+        1.0,  # scale_o
         current_stream,
     )
     print("Finished Compiling")
@@ -2037,6 +2047,7 @@ def run(
             m_partial_cute,
             l_partial_cute,
             scale_s,
+            1.0,  # scale_o
             current_stream,
         )
         print("Verifying results...")
@@ -2081,6 +2092,7 @@ def run(
             m_partial_cute,
             l_partial_cute,
             scale_s,
+            1.0,  # scale_o
             profile_stream,
         )
 

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -48,20 +48,35 @@ class GroupedQueryAttentionDecode:
     def __init__(
         self,
         headdim,
-        grouped_head_tile,  # Grouped heads per threadblock (GQA packing factor)
-        prediction_tile=1,  # Predicted tokens per threadblock
-        sequence_tile=256,  # KV tokens per threadblock per loop iteration
-        reduction_mode: Literal[  # split-K reduction algorithm
-            "kernel",  # Deterministic kernel reduction with partial result workspace
-            "atomic",  # Cluster reduction with atomic adds, no workspace
-            "none",  # no split-K, flash decoding disabled
-        ] = "kernel",
+        grouped_head_tile,
+        prediction_tile=1,
+        sequence_tile=256,
+        reduction_mode: Literal["kernel", "atomic", "none"] = "kernel",
         *,
-        # No causal masking, oob scores are masked to 0 instead of -inf
-        # Results in mathematically equivalent softmax, but may produce
-        # subnormal exponentiations if non-oob scores are all negative (max goes to 0)
         tma_mask=False,
     ):
+        """
+        Parameters
+        ----------
+        headdim
+            Head dimension.
+        grouped_head_tile
+            Grouped heads per threadblock (GQA packing factor).
+        prediction_tile
+            Predicted tokens per threadblock.
+        sequence_tile
+            KV tokens per threadblock per loop iteration.
+        reduction_mode
+            Split-K reduction algorithm:
+              - ``"kernel"``: deterministic kernel reduction with partial result workspace.
+              - ``"atomic"``: cluster reduction with atomic adds, no workspace.
+              - ``"none"``: no split-K, flash decoding disabled.
+        tma_mask
+            Disable causal masking — out-of-bounds scores are masked to 0
+            instead of -inf. Mathematically equivalent softmax, but may
+            produce subnormal exponentiations if non-oob scores are all
+            negative (max goes to 0).
+        """
         self.headdim = headdim
         self.grouped_head_tile = grouped_head_tile
         self.prediction_tile = prediction_tile
@@ -176,29 +191,51 @@ class GroupedQueryAttentionDecode:
     @cute.jit
     def __call__(
         self,
-        kv_splits: Int32,  # threadblocks per sequence (flash decoding)
+        kv_splits: Int32,
         q_bshd: cute.Tensor,
         k_bshd: cute.Tensor,
         v_bshd: cute.Tensor,
-        o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
-        l_bsh: Optional[cute.Tensor],  # log-sum-exp output (Float32), log2 base
-        m_bsh: Optional[
-            cute.Tensor
-        ],  # colmax_s, must be -inf initialized (kernel-red workspace)
-        o_partial_bshd: Optional[
-            cute.Tensor
-        ],  # partial O per kv split (kernel-red workspace)
-        l_partial_bsh: Optional[
-            cute.Tensor
-        ],  # partial colsum_p per kv split (kernel-red workspace)
-        m_partial_bsh: Optional[
-            cute.Tensor
-        ],  # partial colmax_s per kv split (kernel-red workspace)
+        o_bshd: cute.Tensor,
+        l_bsh: Optional[cute.Tensor],
+        m_bsh: Optional[cute.Tensor],
+        o_partial_bshd: Optional[cute.Tensor],
+        l_partial_bsh: Optional[cute.Tensor],
+        m_partial_bsh: Optional[cute.Tensor],
         scale_s: Float32,
         scale_o: Float32,
         stream: cuda.CUstream,
         enable_pdl: bool = True,
     ):
+        """
+        Parameters
+        ----------
+        kv_splits
+            Threadblocks per sequence (flash decoding).
+        q_bshd, k_bshd, v_bshd
+            Q/K/V tensors in BSHD logical view. Strides can be BHSD.
+        o_bshd
+            Output tensor. Must be zero initialized for atomic reduction.
+        l_bsh
+            Log-sum-exp output (Float32, log2 base). May be None.
+        m_bsh
+            ``colmax_s`` running accumulator. Must be -inf initialized
+            (kernel-red workspace).
+        o_partial_bshd
+            Partial O per kv split (kernel-red workspace).
+        l_partial_bsh
+            Partial ``colsum_p`` per kv split (kernel-red workspace).
+        m_partial_bsh
+            Partial ``colmax_s`` per kv split (kernel-red workspace).
+        scale_s
+            Softmax scale.
+        scale_o
+            Output scale, applied in the reduction epilogue.
+        stream
+            CUDA stream to launch on.
+        enable_pdl
+            Programmatic Dependent Launch. Runtime-dynamic — no recompile on
+            toggle.
+        """
         ##############################
         # TiledMma creation
         ##############################

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -1944,7 +1944,6 @@ def run(
     reduction: str,
     qkv_dtype: Type[cutlass.Numeric],
     o_dtype: Type[cutlass.Numeric],
-    acc_dtype: Type[cutlass.Numeric],
     tolerance: float,
     scale_s: float,
     warmup_iterations: int = 0,
@@ -2115,6 +2114,7 @@ def run(
     # LSE output (log2 base). Allocated unconditionally for both reduction
     # modes; the kernel only writes here, we don't refcheck — exists solely
     # to exercise the LSE-on compile path.
+    acc_dtype = Float32
     _, l_cute, l_torch = create_tensor(qo_shape[1:-1], acc_dtype)
     # Workspace tensors
     m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
@@ -2362,13 +2362,6 @@ if __name__ == "__main__":
         type=cutlass.dtype,
         default=BFloat16,
         help="output data type",
-    )
-
-    parser.add_argument(
-        "--acc_dtype",
-        type=cutlass.dtype,
-        default=Float32,
-        help="accumulator/reduction data type",
     )
 
     parser.add_argument(

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -170,11 +170,11 @@ class GroupedQueryAttentionDecode:
         k_bshd: cute.Tensor,
         v_bshd: cute.Tensor,
         o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
-        # Workspace tensors for kernel reduction
-        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized
-        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split
-        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
-        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
+        l_bsh: Optional[cute.Tensor],  # log-sum-exp output (Float32), log2 base
+        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized (kernel-red workspace)
+        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split (kernel-red workspace)
+        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split (kernel-red workspace)
+        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split (kernel-red workspace)
         scale_s: Float32,
         scale_o: Float32,
         stream: cuda.CUstream,
@@ -350,6 +350,13 @@ class GroupedQueryAttentionDecode:
             tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
         )
 
+        # GEMM view for LSE output (atomic-reduction path; kernel-reduction
+        # path writes LSE directly from reduction_kernel using the raw bsh).
+        mL_nl = None
+        if cutlass.const_expr(l_bsh is not None and self.do_atomic_red):
+            assert l_bsh.dtype == acc_dtype
+            mL_nl = self.gemm_view_bsh(l_bsh, h_k)  # ((h_g, s_q), (h_k, b))
+
         # GEMM views for workspace tensors
         mM_nl = mM_partial_nl = mL_partial_nl = None
         if cutlass.const_expr(self.do_kernel_red):
@@ -398,9 +405,10 @@ class GroupedQueryAttentionDecode:
             tma_atom_o,
             tma_tensor_o,
             # Rest
+            mL_nl,
             mM_nl,
-            mM_partial_nl,
             mL_partial_nl,
+            mM_partial_nl,
             scale_s_log2_e,
             scale_o,
         ).launch(
@@ -416,10 +424,11 @@ class GroupedQueryAttentionDecode:
             self.launch_reduction(
                 self.headdim,
                 o_bshd,
+                l_bsh,
                 m_bsh,
                 o_partial_bshd,
-                m_partial_bsh,
                 l_partial_bsh,
+                m_partial_bsh,
                 scale_o,
                 stream,
             )
@@ -451,9 +460,10 @@ class GroupedQueryAttentionDecode:
         tma_atom_o: cute.CopyAtom,
         mO: cute.Tensor,
         # Rest
+        mL: Optional[cute.Tensor],  # LSE output (Float32, log2 base)
         mM: Optional[cute.Tensor],
-        mM_partial: Optional[cute.Tensor],
         mL_partial: Optional[cute.Tensor],
+        mM_partial: Optional[cute.Tensor],
         scale_s_log2_e: Float32,
         scale_o: Float32,
     ):
@@ -1492,6 +1502,9 @@ class GroupedQueryAttentionDecode:
                     mL_partial,
                 )
             else:
+                gL = None
+                if cutlass.const_expr(mL is not None):
+                    gL = cute.local_tile(mL, (blk_tile_hp,), (coord_hp, coord_hb))
                 self.reduction_cluster(
                     blk_tile_n,
                     kv_splits,
@@ -1503,6 +1516,7 @@ class GroupedQueryAttentionDecode:
                     sM,
                     sL,
                     sR,
+                    gL,
                     scale_o,
                 )
             cute.arch.griddepcontrol_launch_dependents()
@@ -1575,6 +1589,7 @@ class GroupedQueryAttentionDecode:
         sM : cute.Tensor,
         sL : cute.Tensor,
         sR : cute.Tensor,
+        gL : Optional[cute.Tensor],
         scale_o : Float32,
     ):
         acc_dtype = sM.dtype
@@ -1602,6 +1617,7 @@ class GroupedQueryAttentionDecode:
         tRrM_shape = thr_store_r.partition_D(sM).shape
         tRrM_final = cute.make_rmem_tensor(tRrM_shape, acc_dtype)
         tRrM_prev = cute.make_rmem_tensor(tRrM_shape, acc_dtype)
+        tRrL_final = cute.make_rmem_tensor(tRrM_shape, acc_dtype)
 
         # Wait for last colmax
         cute.arch.fence_acq_rel_cta()  # Don't reorder partitioning after barrier
@@ -1672,9 +1688,19 @@ class GroupedQueryAttentionDecode:
                 rcp_colsum[i] = cute.arch.rcp_approx(colsum[i])
             tRsM.store(correction * rcp_colsum.load() * scale_o)
 
+            # Save final colsum for LSE
+            if cutlass.const_expr(gL is not None):
+                tRrL_final.store(colsum)
+
         # Notify for final correction
         sM_final_nbar.arrive()
 
+        # Compute and store LSE
+        if cutlass.const_expr(gL is not None):
+            tRgL = thr_store_r.partition_D(gL)  # (CPY, #CPY=1)
+            if kv_split_idx == 0 and is_reduction_lane:
+                lse = tRrM_final.load() + cute.math.log2(tRrL_final.load())
+                tRgL.store(lse)
 
     ##############################
     # Reduction Kernel launch
@@ -1684,10 +1710,11 @@ class GroupedQueryAttentionDecode:
     def launch_reduction(
         d_per_blk: int,
         o_bshd: cute.Tensor,
+        l_bsh: Optional[cute.Tensor],  # LSE output (log2 base) or None
         m_bsh: cute.Tensor,  # colmax_s, already computed
         o_partial_bshd: cute.Tensor,  # partial O per kv split
-        m_partial_bsh: cute.Tensor,  # partial colmax_s per kv split
         l_partial_bsh: cute.Tensor,  # partial colsum_p per kv split
+        m_partial_bsh: cute.Tensor,  # partial colmax_s per kv split
         scale_o: Float32,
         stream: cuda.CUstream,
     ):
@@ -1699,10 +1726,11 @@ class GroupedQueryAttentionDecode:
             layout = cute.select(t.layout, modes)
             return cute.make_tensor(t.iterator, layout)
         o_dhsb = reverse(o_bshd)
+        l_hsb = reverse(l_bsh) if l_bsh is not None else None
         m_hsb = reverse(m_bsh)
         o_partial_dhsb = reverse(o_partial_bshd)
-        m_partial_hsb = reverse(m_partial_bsh)
         l_partial_hsb = reverse(l_partial_bsh)
+        m_partial_hsb = reverse(m_partial_bsh)
 
         d_per_thr = 32 // o_bshd.dtype.width
         thr_per_blk = d_per_blk // d_per_thr
@@ -1711,7 +1739,8 @@ class GroupedQueryAttentionDecode:
 
         GroupedQueryAttentionDecode.reduction_kernel(
             (thr_per_blk, d_per_thr, d_per_blk),
-            o_dhsb, m_hsb, o_partial_dhsb, m_partial_hsb, l_partial_hsb,
+            o_dhsb, l_hsb, m_hsb,
+            o_partial_dhsb, l_partial_hsb, m_partial_hsb,
             scale_o,
         ).launch(
             grid=[d_blks, h_q * s_q, b],
@@ -1728,10 +1757,11 @@ class GroupedQueryAttentionDecode:
     def reduction_kernel(
         tile_d: cute.Tile,
         o_dhsb: cute.Tensor,
+        l_hsb: Optional[cute.Tensor],
         m_hsb: cute.Tensor,
         o_partial_dhsb: cute.Tensor,
-        m_partial_hsb: cute.Tensor,
         l_partial_hsb: cute.Tensor,
+        m_partial_hsb: cute.Tensor,
         scale_o: Float32,
     ):
         thr_per_blk, d_per_thr, d_per_blk = tile_d
@@ -1818,6 +1848,10 @@ class GroupedQueryAttentionDecode:
 
         if not_oob_d:
             tCgO.store(tCrO_final.to(o_dhsb.dtype))
+
+        if cutlass.const_expr(l_hsb is not None):
+            if d_blk_idx == 0 and tidx == 0:
+                l_hsb[coord_h, coord_s, coord_b] = max_final + cute.math.log2(sum_final)
 
         return
 
@@ -1981,6 +2015,10 @@ def run(
     _, o_cute, o_torch = create_tensor(
         qo_shape[1:], o_dtype, init=(0 if atomic else None)
     )
+    # LSE output (log2 base). Allocated unconditionally for both reduction
+    # modes; the kernel only writes here, we don't refcheck — exists solely
+    # to exercise the LSE-on compile path.
+    _, l_cute, l_torch = create_tensor(qo_shape[1:-1], acc_dtype)
     # Workspace tensors
     m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
     if not atomic:
@@ -2000,10 +2038,11 @@ def run(
         k_cute,
         v_cute,
         o_cute,
+        l_cute,  # LSE output (compile-path exercise; not refchecked)
         m_cute,
         o_partial_cute,
-        m_partial_cute,
         l_partial_cute,
+        m_partial_cute,
         scale_s,
         1.0,  # scale_o
         current_stream,
@@ -2042,10 +2081,11 @@ def run(
             k_cute,
             v_cute,
             o_cute,
+            l_cute,
             m_cute,
             o_partial_cute,
-            m_partial_cute,
             l_partial_cute,
+            m_partial_cute,
             scale_s,
             1.0,  # scale_o
             current_stream,
@@ -2075,6 +2115,7 @@ def run(
         _, k_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
         _, v_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
         _, o_cute, _ = create_tensor(qo_shape[1:], o_dtype, init=(0 if atomic else None))
+        _, l_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype)
         m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
         if not atomic:
             _, m_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
@@ -2087,10 +2128,11 @@ def run(
             k_cute,
             v_cute,
             o_cute,
+            l_cute,
             m_cute,
             o_partial_cute,
-            m_partial_cute,
             l_partial_cute,
+            m_partial_cute,
             scale_s,
             1.0,  # scale_o
             profile_stream,

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -1945,7 +1945,8 @@ def run(
     prediction_tile = min(32 // grouped_head_tile, prediction_tile)
     prediction_tiles = math.ceil(prediction / prediction_tile)
 
-    if grouped_head_tile == prediction_tile == 1 and qkv_dtype.width == 8:
+    blk_tile_n = grouped_head_tile * prediction_tile
+    if blk_tile_n == 1 and qkv_dtype.width == 8:
         grouped_head_tile = 2
 
     # Automatic KV splits
@@ -2005,6 +2006,10 @@ def run(
     if scale_s == 0:
         scale_s = headdim ** -0.5
 
+    sequence_tile = 256
+    if prediction_tile > 1 and blk_tile_n > 8:
+        sequence_tile = 128 # Prevent spills
+
     #
     # Config Kernel
     #
@@ -2012,6 +2017,7 @@ def run(
         headdim,
         grouped_head_tile,
         prediction_tile=prediction_tile,
+        sequence_tile=sequence_tile,
         reduction_mode=reduction,
         tma_mask=(prediction == 1),
     )

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -1,0 +1,2270 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import argparse
+import math
+from typing import Type, Tuple
+from functools import partial
+from enum import Enum
+
+import torch
+from torch.nn.functional import scaled_dot_product_attention
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import tcgen05, OperandMajorMode
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import (
+    Agent,
+    CooperativeGroup,
+    NamedBarrier as nbar,
+)
+
+import cutlass.torch as cutlass_torch
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.cute.testing as testing
+from cutlass.cute.typing import (
+    Float32, BFloat16, Float16,
+    Int32, Int64,
+    Optional, Literal,
+)
+
+# Kernel invariants
+mma_modes = (0, 1, 2)
+mma_dice = (None, None, None)  # (MMA, #MMA_M, #MMA_K)
+warp_threads = 32
+warpgroup_warps = 4
+warpgroup_threads = 128
+max_reduction_iters = 4  # log2(16)
+
+# Math helpers
+log2_e = math.log2(math.e)  # change exponential base
+exp2 = partial(cute.math.exp2, fastmath=True)
+warp_fmax = partial(cute.arch.warp_redux_sync, kind="fmax", nan=True)
+smem_fmax = partial(cute.arch.atomic_fmax, sem="relaxed", scope="cta")
+gmem_fmax = partial(cute.arch.atomic_fmax, sem="relaxed", scope="gpu")
+
+class GroupedQueryAttentionDecode:
+    def __init__(
+        self,
+        headdim,
+        grouped_head_tile,  # Grouped heads per threadblock (GQA packing factor)
+        prediction_tile=1,  # Predicted tokens per threadblock
+        sequence_tile=256,  # KV tokens per threadblock per loop iteration
+        reduction_mode : Literal[  # split-K reduction algorithm
+            "kernel", # Deterministic kernel reduction with partial result workspace
+            "atomic", # Cluster reduction with atomic adds, no workspace
+        ] = "kernel",
+        *,
+        # No causal masking, oob scores are masked to 0 instead of -inf
+        # Results in mathematically equivalent softmax, but may produce
+        # subnormal exponentiations if non-oob scores are all negative (max goes to 0)
+        tma_mask=False,
+    ):
+        self.headdim = headdim
+        self.grouped_head_tile = grouped_head_tile
+        self.prediction_tile = prediction_tile
+        self.sequence_tile = sequence_tile
+        self.do_kernel_red = reduction_mode == "kernel"
+        self.do_atomic_red = reduction_mode == "atomic"
+        self.tma_mask = tma_mask
+        self.threads_per_cta = 4 * warpgroup_threads
+
+        assert headdim > 0 and headdim % 64 == 0
+        assert grouped_head_tile * prediction_tile in (1, 2, 4, 8, 16, 32)
+        assert sequence_tile > 0 and sequence_tile % 128 == 0
+        assert self.do_kernel_red ^ self.do_atomic_red
+
+    ##############################
+    # Launch helpers
+    ##############################
+    # Runtime implementable check
+    def can_implement(self, kv_splits, qo_shape_bshd, kv_shape_bshd, qkv_dtype, o_dtype):
+        b_k, s_q, h_q, d_q = qo_shape_bshd
+        b_q, s_k, h_k, d_k = kv_shape_bshd
+
+        if qkv_dtype is cutlass.Float8E4M3:
+            raise TypeError("use Float8E4M3FN instead of Float8E4M3")
+
+        if not (d_q == d_k == self.headdim):
+            raise ValueError(f"headdim_q({d_q}), headdim_k({d_k}) must be {self.headdim}")
+
+        if h_q % h_k != 0:
+            raise ValueError(f"heads_q({h_q}) must be a multiple of heads_k({h_k})")
+        
+        if 0 < s_k < s_q:
+            raise ValueError(f"non-zero seqlen({s_k}) must be at least prediction({s_q})")
+
+        # Only causal mask up to two tiles
+        if not self.tma_mask and s_q > self.sequence_tile:
+            raise ValueError(f"prediction({s_q}) with causal mask can be at most {self.sequence_tile}")
+
+        if self.tma_mask and 0 < s_k < 8:
+            raise ValueError(f"non-zero seqlen({s_k}) with TMA masking must be at least 8")
+        
+        if b_k != b_q:
+            raise ValueError(f"batches_k({b_k}) and batches_q({b_q}) mismatch")
+
+        if self.do_atomic_red:
+            if kv_splits not in (1, 2, 4, 8, 16):
+                raise ValueError(
+                    f"atomic reduction requires kv_splits po2 <= 16, got {kv_splits}"
+                )
+
+            if o_dtype not in (Float32, BFloat16, Float16):
+                raise TypeError(
+                    f"atomic reduction requires (Float32, BFloat16, Float16) o_dtype, got {o_dtype}"
+                )
+
+    # Pack grouped heads with predicted tokens (s_q)
+    @staticmethod
+    def gqa_pack(t_bshd: cute.Tensor, h_k : int):
+        d, h_q, s_q, b = tuple(reversed(t_bshd.shape))[:4]
+        stride_d, stride_h, stride_s, stride_b = tuple(reversed(t_bshd.stride))[:4]
+        # Batch + partial stride must be coalescible
+        # to get 5 independent TMA modes (TMA limitation)
+        has_partial = cute.rank(t_bshd) == 5
+        b_partial = b * t_bshd.shape[0] if has_partial else b
+        h_g = h_q // h_k  # grouped heads
+        gqa_shape = (b_partial, (h_g, s_q), h_k, d)
+        gqa_stride = (stride_b, (stride_h, stride_s), stride_h * h_g, stride_d)
+        gqa_layout = cute.make_layout(gqa_shape, stride=gqa_stride)
+        return cute.make_tensor(t_bshd.iterator, gqa_layout)
+
+    # Reorder and group modes for GEMM
+    @staticmethod
+    def gemm_view(t_bshd: cute.Tensor, s_first : bool):
+        sdhb = (1, 3, 2, 0)  # GEMM1 MKL
+        dshb = (3, 1, 2, 0)  # GEMM2 MKL
+        reorder = sdhb if s_first else dshb
+        mT_layout = cute.select(t_bshd.layout, reorder)
+        mT_layout = cute.group_modes(mT_layout, 2, 4)
+        return cute.make_tensor(t_bshd.iterator, mT_layout)
+
+    # Pack, reorder, and group modes for GEMM workspace
+    @staticmethod
+    def gemm_view_bsh(t_bsh: cute.Tensor, h_k : int):
+        h_q, s_q, b = tuple(reversed(t_bsh.shape))[:3]
+        stride_h, stride_s, stride_b = tuple(reversed(t_bsh.stride))[:3]
+        h_g = h_q // h_k
+        mT_shape = ((h_g, s_q), (h_k, b))
+        mT_stride = ((stride_h, stride_s), (stride_h * h_g, stride_b))
+        has_partial = cute.rank(t_bsh) == 4
+        mT_shape += (t_bsh.shape[0],) if has_partial else ()
+        mT_stride += (t_bsh.stride[0],) if has_partial else ()
+        mT_layout = cute.make_layout(mT_shape, stride=mT_stride)
+        return cute.make_tensor(t_bsh.iterator, mT_layout)
+
+    ##############################
+    # Decode Kernel launch
+    ##############################
+    @cute.jit
+    def __call__(
+        self,
+        kv_splits: Int32,  # threadblocks per sequence (flash decoding)
+        q_bshd: cute.Tensor,
+        k_bshd: cute.Tensor,
+        v_bshd: cute.Tensor,
+        o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
+        # Workspace tensors for kernel reduction
+        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized
+        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split
+        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
+        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
+        scale_s: Float32,
+        stream: cuda.CUstream,
+    ):
+        ##############################
+        # TiledMma creation
+        ##############################
+        mma_dtype = q_bshd.dtype
+        acc_dtype = Float32
+        assert k_bshd.dtype == v_bshd.dtype == mma_dtype
+
+        # Block tile sets the granularity at which threadblocks consume work (BMM1/BMM2)
+        blk_tile_s = self.sequence_tile
+        blk_tile_h = self.grouped_head_tile
+        blk_tile_p = self.prediction_tile
+        blk_tile_d = self.headdim
+        blk_tile_shpd = (blk_tile_s, blk_tile_h, blk_tile_p, blk_tile_d)
+
+        # MMA tile sets the granularity at which TMAs + MMAs are staged in smem
+        mma_tile_m = 128
+        mma_tile_k = 128 * 8 // mma_dtype.width
+        # N-major 8b B in smem requires N multiple of 16
+        min_mma_tile_n = 16 if mma_dtype.width == 8 else 8
+        blk_tile_n = blk_tile_h * blk_tile_p  # linearized tiler
+        mma_tile_n = max(min_mma_tile_n, blk_tile_n)
+        mma_tile_mnk = (mma_tile_m, mma_tile_n, mma_tile_k)
+
+        # MMA tiles per block tile
+        tiles_sm = blk_tile_s // mma_tile_m
+        tiles_dm = math.ceil(blk_tile_d / mma_tile_m)
+        tiles_dk = math.ceil(blk_tile_d / mma_tile_k)
+        assert blk_tile_s % mma_tile_m == 0
+        assert mma_tile_n % blk_tile_n == 0
+
+        # GEMM1: (S_K, (H_R, S_Q), D, (H_K, B))
+        tiled_mma_kq = sm100_utils.make_trivial_tiled_mma(
+            mma_dtype,
+            mma_dtype,
+            OperandMajorMode.K,  # K
+            OperandMajorMode.K,  # Q
+            acc_dtype,
+            tcgen05.CtaGroup.ONE,
+            mma_tile_mnk[:2],
+        )
+
+        # GEMM2: (D, (H_R, S_Q), S_K, (H_K, B))
+        tiled_mma_vp = sm100_utils.make_trivial_tiled_mma(
+            mma_dtype,
+            mma_dtype,
+            OperandMajorMode.MN,  # V
+            OperandMajorMode.MN,  # P
+            acc_dtype,
+            tcgen05.CtaGroup.ONE,
+            mma_tile_mnk[:2],
+        )
+
+        ##############################
+        # Calculate stage counts
+        ##############################
+        # Fixed stage counts
+        self.p_stages = p_stages = 4  # smem P (BMM2 B)
+        self.o_stages = o_stages = 2  # tmem O (BMM2 C)
+
+        # Calculate tmem alloc
+        tmem_capacity_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
+        tmem_s_stage_cols = tiles_sm * mma_tile_n
+        tmem_alloc_cols = mma_tile_n * o_stages  # per-thread colsum
+        tmem_alloc_cols += tiles_dm * mma_tile_n * o_stages  # O
+        max_s_stages = (tmem_capacity_cols - tmem_alloc_cols) // tmem_s_stage_cols
+        self.s_stages = s_stages = min(max_s_stages, p_stages)
+
+        tmem_alloc_cols += tmem_s_stage_cols * s_stages  # S
+        tmem_alloc_cols = 2 ** math.ceil(math.log2(tmem_alloc_cols)) # po2
+        self.tmem_alloc_cols = tmem_alloc_cols
+        assert tmem_alloc_cols <= tmem_capacity_cols
+
+        # Calculate smem alloc
+        smem_alloc_bits = 0
+        mbarrier_bits = Int64.width
+        pipe_stage_bits = mbarrier_bits * 2  # producer + consumer
+        mk_stage_bits = mma_tile_m * mma_tile_k * mma_dtype.width
+        nk_stage_bits = mma_tile_n * mma_tile_k * mma_dtype.width
+        mn_stage_bits = mma_tile_m * mma_tile_n * mma_dtype.width
+        # tmem ptr
+        smem_alloc_bits += Int32.width
+        # colmax + colsum
+        smem_alloc_bits += blk_tile_n * acc_dtype.width
+        smem_alloc_bits += blk_tile_n * warpgroup_warps * acc_dtype.width
+        if cutlass.const_expr(self.do_atomic_red):
+            smem_alloc_bits += max_reduction_iters * blk_tile_n * acc_dtype.width * 2
+            smem_alloc_bits += max_reduction_iters * mbarrier_bits * 2
+        # Q, S, P, O
+        smem_alloc_bits += tiles_dk * nk_stage_bits + mbarrier_bits  # 1 mbar for Q
+        smem_alloc_bits += s_stages * pipe_stage_bits  # s in tmem
+        smem_alloc_bits += p_stages * (tiles_sm * mn_stage_bits + pipe_stage_bits)
+        smem_alloc_bits += o_stages * pipe_stage_bits  # o in tmem
+        alignment_bits = 1024 - (smem_alloc_bits % 1024)
+        # K, V
+        smem_capacity_bits = utils.get_smem_capacity_in_bytes("sm_100") * 8
+        remaining_bits = smem_capacity_bits - smem_alloc_bits - alignment_bits
+        kv_stages = remaining_bits // mk_stage_bits
+        kv_stages -= 1 if kv_stages * pipe_stage_bits > alignment_bits else 0
+
+        print(f"\ts stages: {s_stages}\tkv stages: {kv_stages}")
+
+        ##############################
+        # TMA creation
+        ##############################
+        h_k = k_bshd.shape[2]
+        o_bshd_ = o_bshd if self.do_atomic_red else o_partial_bshd
+
+        # ((h_g, s_q), d, (h_k, b))
+        mQ_nkl = self.gemm_view(self.gqa_pack(q_bshd, h_k), True)
+        mK_mkl = self.gemm_view(k_bshd, True)  # (s_k, d, (h_k, b))
+        mV_mkl = self.gemm_view(v_bshd, False)  # (d, s_k, (h_k, b))
+        # (d, (h_g, s_q), (h_k, b_partial))
+        mO_mnl = self.gemm_view(self.gqa_pack(o_bshd_, h_k), False)
+
+        # (MMA, MMA_M/N, MMA_K, stages)
+        smem_layout_q = sm100_utils.make_smem_layout_b(
+            tiled_mma_kq, mma_tile_mnk, mma_dtype, tiles_dk
+        )
+        smem_layout_k = sm100_utils.make_smem_layout_a(
+            tiled_mma_kq, mma_tile_mnk, mma_dtype, kv_stages
+        )
+        smem_layout_v = sm100_utils.make_smem_layout_a(
+            tiled_mma_vp, mma_tile_mnk, mma_dtype, kv_stages
+        )
+
+        o_smem_dtype = mO_mnl.dtype
+        smem_layout_atom_o = tcgen05.make_smem_layout_atom(
+            tcgen05.mma.SmemLayoutAtomKind.MN_SW128, o_smem_dtype
+        )
+        smem_layout_o = cute.tile_to_shape(
+            smem_layout_atom_o, (max(blk_tile_d, mma_tile_m), mma_tile_n), order=(1, 0)
+        )
+        smem_layout_o = cute.flat_divide(smem_layout_o, (mma_tile_m, mma_tile_n))
+        # (MMA_TILE_M, MMA_TILE_N, #TILE_DM)
+        smem_layout_o = cute.select(smem_layout_o, (0, 1, 2))
+
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+        tma_store_op = (
+            cute.nvgpu.cpasync.CopyReduceBulkTensorTileS2GOp()
+            if self.do_atomic_red
+            else cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+        )
+
+        # Construct multimode gmem tiler
+        tma_tile_n = (blk_tile_h, mma_tile_n // blk_tile_h)
+        tma_tile_mnk = (mma_tile_m, tma_tile_n, mma_tile_k)
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            mQ_nkl,
+            cute.select(smem_layout_q, mma_modes),
+            tma_tile_mnk,
+            tiled_mma_kq,
+        )
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            mK_mkl,
+            cute.select(smem_layout_k, mma_modes),
+            tma_tile_mnk,
+            tiled_mma_kq,
+        )
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            mV_mkl,
+            cute.select(smem_layout_v, mma_modes),
+            tma_tile_mnk,
+            tiled_mma_vp,
+        )
+        tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
+        )
+
+        # GEMM views for workspace tensors
+        mM_nl = mM_partial_nl = mL_partial_nl = None
+        if cutlass.const_expr(self.do_kernel_red):
+            assert (m_bsh.dtype == m_partial_bsh.dtype
+                    == l_partial_bsh.dtype == o_partial_bshd.dtype
+                    == acc_dtype)
+
+            # ((h_g, s_q), (h_k, b), kv_splits)
+            mM_nl = self.gemm_view_bsh(m_bsh, h_k)
+            mM_partial_nl = self.gemm_view_bsh(m_partial_bsh, h_k)
+            mL_partial_nl = self.gemm_view_bsh(l_partial_bsh, h_k)
+
+        ##############################
+        # Launch kernel(s)
+        ##############################
+        scale_s_log2_e = scale_s * log2_e
+
+        n_tiles = cute.ceil_div(mQ_nkl.shape[0], (blk_tile_h, blk_tile_p))
+        n_tiles = cute.size(n_tiles)
+        l_tiles = cute.size(mQ_nkl.shape[2])
+        grid = (kv_splits, n_tiles, l_tiles)
+        cluster_x = kv_splits if self.do_atomic_red else 1
+
+        self.decode(
+            # MMA
+            blk_tile_shpd,
+            mma_tile_mnk,
+            tiled_mma_kq,
+            tiled_mma_vp,
+            mma_dtype,
+            o_smem_dtype,
+            # Q
+            smem_layout_q,
+            tma_atom_q,
+            tma_tensor_q,
+            # K
+            smem_layout_k,
+            tma_atom_k,
+            tma_tensor_k,
+            # V
+            smem_layout_v,
+            tma_atom_v,
+            tma_tensor_v,
+            # O
+            smem_layout_o,
+            tma_atom_o,
+            tma_tensor_o,
+            # Rest
+            mM_nl,
+            mM_partial_nl,
+            mL_partial_nl,
+            scale_s_log2_e,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[cluster_x, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=True,
+        )
+
+        if cutlass.const_expr(self.do_kernel_red):
+            self.launch_reduction(
+                self.headdim,
+                o_bshd,
+                m_bsh,
+                o_partial_bshd,
+                m_partial_bsh,
+                l_partial_bsh,
+                stream,
+            )
+
+    @cute.kernel
+    def decode(
+        self,
+        # MMA
+        blk_tile_shpd: cute.Tile,
+        mma_tile_mnk: cute.Tile,
+        tiled_mma_kq: cute.TiledMma,
+        tiled_mma_vp: cute.TiledMma,
+        mma_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        # Q
+        smem_layout_q: cute.ComposedLayout,
+        tma_atom_q: cute.CopyAtom,
+        mQ: cute.Tensor,
+        # K
+        smem_layout_k: cute.ComposedLayout,
+        tma_atom_k: cute.CopyAtom,
+        mK: cute.Tensor,
+        # V
+        smem_layout_v: cute.ComposedLayout,
+        tma_atom_v: cute.CopyAtom,
+        mV: cute.Tensor,
+        # O
+        smem_layout_o: cute.ComposedLayout,
+        tma_atom_o: cute.CopyAtom,
+        mO: cute.Tensor,
+        # Rest
+        mM: Optional[cute.Tensor],
+        mM_partial: Optional[cute.Tensor],
+        mL_partial: Optional[cute.Tensor],
+        scale_s_log2_e: Float32,
+    ):
+        ##############################
+        # Static variables
+        ##############################
+        # Smem alloc helper
+        svector_align = 16
+        stensor_align = 128
+        smem = utils.SmemAllocator()
+
+        # No multicast
+        mcast_coord = 0
+        mcast_layout = cute.make_layout((1, 1, 1, 1))  # vmnk
+
+        # Alias types
+        q_dtype = k_dtype = v_dtype = mma_dtype
+        o_dtype = out_dtype
+        acc_dtype = Float32
+
+        # Shapes for MMA tile indexing (Read TMA partition for example)
+        blk_tile_s, blk_tile_h, blk_tile_p, blk_tile_d = blk_tile_shpd
+        blk_tile_hp = (blk_tile_h, blk_tile_p)  # multimode tiler
+        blk_tile_n = blk_tile_h * blk_tile_p  # linearized tiler
+        mma_tile_m, mma_tile_n, mma_tile_k = mma_tile_mnk
+        tiles_sm = blk_tile_s // mma_tile_m
+        tiles_sk = blk_tile_s // mma_tile_k
+        tiles_dm = cute.ceil_div(blk_tile_d, mma_tile_m)
+        tiles_dk = cute.ceil_div(blk_tile_d, mma_tile_k)
+
+        # Static control flow
+        do_kernel_red = self.do_kernel_red
+        do_atomic_red = self.do_atomic_red
+        tma_mask = self.tma_mask
+
+        ##############################
+        # Warp specialization
+        ##############################
+        # Warp assignments
+        warpgroup_id = 0
+        mma_kq_warp_id = warpgroup_id * warpgroup_warps + 0
+        mma_vp_warp_id = warpgroup_id * warpgroup_warps + 1
+        tma_kv_warp_id = warpgroup_id * warpgroup_warps + 2
+        tma_qo_warp_id = warpgroup_id * warpgroup_warps + 3
+        reduction_warp_id = tma_kv_warp_id
+        warpgroup_id += 1
+
+        softmax_warpgroups = 2
+        softmax_warpgroup_ids = tuple(
+            range(warpgroup_id, warpgroup_id + softmax_warpgroups)
+        )
+        warpgroup_id += softmax_warpgroups
+
+        correction_warpgroup_id = warpgroup_id
+        warpgroup_id += 1
+        assert self.threads_per_cta == warpgroup_id * warpgroup_threads
+
+        # Register allocations
+        use_reg_reconfig = blk_tile_n > 16
+        max_sw_regs_per_wg_thread = 256  # CUDA limitation
+        max_hw_regs_per_wg_thread = 64 * 1024 // warpgroup_threads  # 64K regs per SM
+        mma_tma_regs = 64
+        softmax_regs = 120
+        correction_regs = min(
+            max_sw_regs_per_wg_thread,
+            max_hw_regs_per_wg_thread
+            - mma_tma_regs
+            - softmax_regs * 2
+        )
+        assert (
+            mma_tma_regs
+            + softmax_regs * 2
+            + correction_regs
+        ) <= max_hw_regs_per_wg_thread
+
+        # Read thread indices
+        kv_splits, tiles_hp, tiles_hb = cute.arch.grid_dim()
+        kv_split_idx, coord_hp, coord_hb = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_idx = cute.arch.lane_idx()
+        warp_idx = cute.arch.make_warp_uniform(tidx // warp_threads)
+        warpgroup_idx = cute.arch.make_warp_uniform(tidx // warpgroup_threads)
+        warpgroup_tidx = tidx % warpgroup_threads
+        warpgroup_widx = warp_idx % warpgroup_warps
+        init_warp = 1  # warp 0 does all mbarrier inits for now
+
+        # Unpack multimodes
+        seqlen = mK.shape[0]
+        grouped_heads, prediction = mQ.shape[0]
+        heads_k, batches = tiles_hb = mQ.shape[2]
+        tiles_hp = cute.ceil_div(mQ.shape[0], blk_tile_hp)
+        coord_hb = cute.idx2crd(coord_hb, tiles_hb)
+        coord_hp = cute.idx2crd(coord_hp, tiles_hp)
+        coord_hg, coord_p = coord_hp
+        coord_hk, coord_b = coord_hb
+
+        # Runtime control flow
+        tiles_s = cute.ceil_div(seqlen, blk_tile_s)
+        iters_s = cute.ceil_div(tiles_s - kv_split_idx, kv_splits)
+        prefetch_iters = min(2, self.s_stages - 1) # MMA KQ iters to hide first softmax
+        exit_early = kv_split_idx >= tiles_s
+        lane_store_max = blk_tile_n == warp_threads or lane_idx < blk_tile_n
+
+        ##############################
+        # Prefetch TMA descriptor
+        ##############################
+        if warp_idx == init_warp and not exit_early:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
+        init_warp += 1
+
+        ##############################
+        # Tmem Allocation
+        ##############################
+        tmem_alloc_cols = self.tmem_alloc_cols
+        tmem_ptr_smem_ptr = smem.allocate_array(Int32)
+        if warp_idx == init_warp and not exit_early:
+            cute.arch.alloc_tmem(tmem_alloc_cols, tmem_ptr_smem_ptr)
+        init_warp += 1
+
+        ##############################
+        # Pipeline Allocation + Init
+        ##############################
+        # Initialize named barriers
+        softmax_threads = warpgroup_threads
+        correction_threads = warpgroup_threads
+        reduction_threads = warp_threads
+        tma_threads = warp_threads
+        # Shared KV pipeline requires ordering MMA
+        mma_order_kq_nbar = nbar(1, tma_threads + tma_threads)
+        mma_order_vp_nbar = nbar(2, tma_threads + tma_threads)
+        sM_producer_nbar = nbar(3, softmax_threads + correction_threads)
+        sM_consumer_nbar = nbar(4, softmax_threads + correction_threads)
+        tL_producer_nbar = nbar(5, softmax_threads + correction_threads)
+        tL_consumer_nbar = nbar(7, softmax_threads + correction_threads)
+        sM_final_nbar = nbar(9, correction_threads + reduction_threads)
+        sL_final_nbar = nbar(10, correction_threads + reduction_threads)
+        sO_final_nbar = nbar(11, correction_threads + tma_threads)
+        sM_mutex_nbar = nbar(12, softmax_threads * softmax_warpgroups)
+        # named barrier stage helper
+        def with_phase(nbar_, phase):
+            return nbar(nbar_.barrier_id + phase, nbar_.num_threads)
+
+        # Alias thread cooperatives
+        thr_cg = lambda t: CooperativeGroup(Agent.Thread, t)
+        elect_one_cooperative = thr_cg(1)
+        warpgroup_cooperative = thr_cg(warpgroup_threads)
+        mma_group = elect_one_cooperative
+        tma_group = elect_one_cooperative
+        softmax_group = warpgroup_cooperative
+        correction_group = warpgroup_cooperative
+
+        # Initialize cluster colmax + colsum mbar (even if this split exits early)
+        if cutlass.const_expr(do_atomic_red):
+            reduction_mbars_ptr = smem.allocate_array(Int64, max_reduction_iters * 2)
+            if warp_idx == init_warp:
+                if lane_idx < max_reduction_iters * 2:
+                    mbar_ptr = reduction_mbars_ptr + lane_idx
+                    arrive_count = 1
+                    expect_tx_bytes = blk_tile_n * acc_dtype.width // 8
+                    cute.arch.mbarrier_init(mbar_ptr, arrive_count)
+                    cute.arch.mbarrier_init_fence()
+                    cute.arch.mbarrier_arrive_and_expect_tx(mbar_ptr, expect_tx_bytes)
+            init_warp += 1
+            cute.arch.cluster_arrive_relaxed()
+
+        # Initialize Q load mbarrier
+        q_load_mbar = smem.allocate_array(Int64, 1)
+        if warp_idx == init_warp:
+            expect_tx_bytes = cute.size_in_bytes(q_dtype, smem_layout_q)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_init(q_load_mbar, 1)
+                cute.arch.mbarrier_init_fence()
+                cute.arch.mbarrier_arrive_and_expect_tx(q_load_mbar, expect_tx_bytes)
+        init_warp += 1
+
+        # Initialize pipelines
+        kv_stages = smem_layout_k.shape[-1]
+        kv_stage_bytes = mma_tile_m * mma_tile_k * k_dtype.width // 8
+        kv_pipeline_ptr = smem.allocate_array(Int64, kv_stages * 2)
+        kv_producer, kv_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=kv_stages,
+            producer_group=tma_group,
+            consumer_group=mma_group,
+            tx_count=kv_stage_bytes,
+            barrier_storage=kv_pipeline_ptr,
+            cta_layout_vmnk=mcast_layout,
+            defer_sync=True,
+        ).make_participants()
+
+        s_stages = self.s_stages
+        s_pipeline_ptr = smem.allocate_array(Int64, s_stages * 2)
+        s_producer, s_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=s_stages,
+            producer_group=mma_group,
+            consumer_group=softmax_group,
+            barrier_storage=s_pipeline_ptr,
+            defer_sync=True,
+        ).make_participants()
+
+        p_stages = self.p_stages
+        p_pipeline_ptr = smem.allocate_array(Int64, p_stages * 2)
+        p_producer, p_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=p_stages,
+            producer_group=softmax_group,
+            consumer_group=mma_group,
+            barrier_storage=p_pipeline_ptr,
+            defer_sync=True,
+        ).make_participants()
+
+        o_stages = self.o_stages
+        o_pipeline_ptr = smem.allocate_array(Int64, o_stages * 2)
+        o_producer, o_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=o_stages,
+            producer_group=mma_group,
+            consumer_group=correction_group,
+            barrier_storage=o_pipeline_ptr,
+            defer_sync=True,
+        ).make_participants()
+
+        ##############################
+        # Smem Tensor Allocation
+        ##############################
+        # Threadblock slice
+        thrblk_mma_kq = tiled_mma_kq.get_slice(0)
+        thrblk_mma_vp = tiled_mma_vp.get_slice(0)
+
+        # Q, K, V
+        tAsK = smem.allocate_tensor(
+            k_dtype, smem_layout_k.outer, stensor_align, smem_layout_k.inner
+        )  # (MMA, #MMA_M, #MMA_K, kv_stages)
+        tAsV = cute.make_tensor(
+            tAsK.iterator, smem_layout_v.outer
+        )  # (MMA, #MMA_M, #MMA_K, kv_stages)
+        tBsQ = smem.allocate_tensor(
+            q_dtype, smem_layout_q.outer, stensor_align, smem_layout_q.inner
+        )  # (MMA, #MMA_N, #MMA_K, q_stages)
+
+        # S
+        # (MMA_MN, #MMA_M=1, #MMA_N=1, #TILE_SM, s_stages)
+        tCtS_shape = tiled_mma_kq.partition_shape_C(
+            (mma_tile_m, mma_tile_n, tiles_sm, s_stages)
+        )
+        tCtS = thrblk_mma_kq.make_fragment_C(tCtS_shape)
+
+        # P - Treat MN C tile of BMM0 as NM B tile of BMM1
+        # (MMA_NK, #MMA_N=1, #MMA_K=TILE_S/MMA_K, p_stages)
+        blk_tile_nm = (None, mma_tile_n, mma_tile_m * tiles_sm)
+        tBsP_nm_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma_vp, blk_tile_nm, mma_dtype, p_stages
+        )
+        tBsP_nm = smem.allocate_tensor(
+            mma_dtype, tBsP_nm_layout.outer, stensor_align, tBsP_nm_layout.inner
+        )
+
+        # Tile for NK B tile iteration
+        tBsP_nk_tile = thrblk_mma_vp.partition_shape_B(
+            (mma_tile_n, mma_tile_k)
+        )  # (MMA_NK, #MMA_N=1, #MMA_K=MMA_TILE_K/MMA_K, #TILE_SK=TILE_S/MMA_TILE_K, p_stages)
+        tBsP_nk = cute.local_tile(tBsP_nm, tBsP_nk_tile, (0, 0, None, None))
+
+        # Reshape NM B tile of BMM1 to become MN C tile of BMM0
+        # (MMA_NK, #MMA_N, #MMA_K=TILE_S/MMA_K, p_stages) ->
+        # (MMA_MN, #MMA_M, #MMA_N, #TILE_SM, p_stages)
+        tCsP_tile = cute.make_ordered_layout(tCtS_shape, order=((2, 0), 3, 1, 4, 5))
+        tCsP = cute.composition(tBsP_nm, tCsP_tile)
+
+        # O
+        # Reuse KV smem for O TMA store
+        sO_iterator = cute.recast_ptr(
+            tAsK.iterator, smem_layout_o.inner, dtype=o_dtype
+        )
+        # (MMA_TILE_M, MMA_TILE_N, #TILE_DM)
+        sO_mma = cute.make_tensor(sO_iterator, smem_layout_o.outer)
+        # (MMA, #MMA_M, #MMA_N, #TILE_DM, o_stages)
+        tCsO = thrblk_mma_vp.partition_C(sO_mma)
+        tCtO = thrblk_mma_vp.make_fragment_C((*tCsO.shape, o_stages))
+
+        # M - colmax
+        sM_layout = cute.make_layout(blk_tile_n)
+        sM = smem.allocate_tensor(acc_dtype, sM_layout, svector_align)
+        if warp_idx == init_warp:
+            if lane_store_max:
+                sM[lane_idx] = -Float32.inf
+        init_warp += 1
+
+        # L - colsum
+        sL_layout = cute.make_layout((blk_tile_n, warpgroup_warps))
+        sL = smem.allocate_tensor(acc_dtype, sL_layout, svector_align)
+        if warp_idx == init_warp:
+            for i in cutlass.range_constexpr(0, cute.size(sL), warp_threads):
+                if i + lane_idx < cute.size(sL):
+                    sL[i + lane_idx] = Float32(0)
+        init_warp += 1
+
+        # per-thread colsum
+        # (MMA_MN, #MMA_M=1, #MMA_N=1, o_stages)
+        tCtL_shape = tiled_mma_kq.partition_shape_C(
+            (mma_tile_m, mma_tile_n, o_stages)
+        )
+        tCtL = thrblk_mma_kq.make_fragment_C(tCtL_shape)
+
+        # R - cluster reduction buffers for colmax + colsum
+        if cutlass.const_expr(do_atomic_red):
+            sR_layout = cute.make_layout((blk_tile_n, max_reduction_iters, 2))
+            sR = smem.allocate_tensor(acc_dtype, sR_layout, svector_align)
+
+        ##############################
+        # Sync
+        ##############################
+        # Ensure visibility of cluster mbarriers
+        if cutlass.const_expr(do_atomic_red):
+            cute.arch.cluster_wait()
+
+        # Ensure visibility of local mbarrier inits and tmem alloc
+        cute.arch.sync_threads()
+        assert init_warp < (self.threads_per_cta // warp_threads), (
+            f"used {init_warp + 1} init warps, {self.threads_per_cta // warp_threads} warps available"
+        )
+
+        ##############################
+        # Tmem tensor allocation
+        ##############################
+        tmem_ptr = cute.arch.retrieve_tmem_ptr(Int32, 16, tmem_ptr_smem_ptr)
+        tmem_offset = 0
+
+        tCtS = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + tmem_offset, dtype=acc_dtype), tCtS.layout
+        )
+        tmem_offset += tcgen05.find_tmem_tensor_col_offset(tCtS)
+
+        tCtL = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + tmem_offset, dtype=acc_dtype), tCtL.layout
+        )
+        tmem_offset += tcgen05.find_tmem_tensor_col_offset(tCtL)
+
+        tCtO = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + tmem_offset, dtype=acc_dtype), tCtO.layout
+        )
+        tmem_offset += tcgen05.find_tmem_tensor_col_offset(tCtO)
+
+        assert tmem_offset <= tmem_alloc_cols, (
+            f"\t{tmem_offset} tmem cols used, {tmem_alloc_cols} tmem cols allocated"
+        )
+
+        ##############################
+        # Exit early
+        ##############################
+        if exit_early:
+            if warpgroup_idx == correction_warpgroup_id:
+                sM_final_nbar.arrive()
+                sL_final_nbar.arrive()
+
+        ##############################
+        # TMA KV Dispatch
+        ##############################
+        elif warp_idx == tma_kv_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Apply block tiler and slice
+            gK = cute.local_tile(
+                mK, tiler=(blk_tile_s, blk_tile_d), coord=(None, 0, coord_hb)
+            )  # (TILE_S, TILE_D, #TILE_S)
+            gV = cute.local_tile(
+                mV, tiler=(blk_tile_d, blk_tile_s), coord=(0, None, coord_hb)
+            )  # (TILE_D, TILE_S, #TILE_S)
+
+            # Apply MMA tiler and MMA partition
+            gK_mma = cute.flat_divide(
+                gK, (mma_tile_m, mma_tile_k)
+            )  # (MMA_TILE_M, MMA_TILE_K, #TILE_SM, #TILE_DK, #TILE_S)
+            gV_mma = cute.flat_divide(
+                gV, (mma_tile_m, mma_tile_k)
+            )  # (MMA_TILE_M, MMA_TILE_K, #TILE_DM, #TILE_SK, #TILE_S)
+            tAgK = thrblk_mma_kq.partition_A(
+                gK_mma
+            )  # (MMA, #MMA_M, #MMA_K, #TILE_SM, #TILE_DK, #TILE_S)
+            tAgV = thrblk_mma_vp.partition_A(
+                gV_mma
+            )  # (MMA, #MMA_M, #MMA_K, #TILE_DM, #TILE_SK, #TILE_S)
+
+            # #TILE_SM=TILE_S/MMA_TILE_M, #TILE_HN=TILE_H/MMA_TILE_N, #TILE_DK=TILE_D/MMA_TILE_K
+            # #TILE_DM=TILE_D/MMA_TILE_M, #TILE_HN=TILE_H/MMA_TILE_N, #TILE_SK=TILE_S/MMA_TILE_K
+            #
+            # Example with TILE_S=MMA_TILE_M=128, TILE_H=MMA_TILE_N=8, MMA_TILE_K=64, TILE_D=512
+            # BMM1: MMA=128x8x16, #MMA_M=1, #MMA_N=1, #MMA_K=4,
+            #       TILE_SM=1, #TILE_HN=1, #TILE_DK=8, #TILE_S=S/128
+            # BMM2: MMA=128x8x16, #MMA_M=1, #MMA_N=1, #MMA_K=4,
+            #       #TILE_DM=4, #TILE_HN=1, #TILE_SK=2, #TILE_S=S/128
+
+            # TMA partition
+            # (MMA, #MMA_M, #MMA_K, Rest...) -> (TMA, Rest...)
+            tGSsK, tGSgK = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_k,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=cute.group_modes(tAsK, 0, 3),
+                gmem_tensor=cute.group_modes(tAgK, 0, 3),
+            )
+
+            tGSsV, tGSgV = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_v,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=cute.group_modes(tAsV, 0, 3),
+                gmem_tensor=cute.group_modes(tAgV, 0, 3),
+            )
+
+            cute.arch.griddepcontrol_wait()
+
+            # Sequence loop
+            prefetch_tiles = prefetch_iters * kv_splits
+            kv_token = True  # Producer always acquires first
+            for s in cutlass.range(kv_split_idx, prefetch_tiles + tiles_s, kv_splits):
+                # Load K
+                if s < tiles_s:
+                    tGSgK_s = tGSgK[None, None, None, s]
+                    for sm in cutlass.range_constexpr(tiles_sm):
+                        for dk in cutlass.range_constexpr(tiles_dk):
+                            kv_handle = kv_producer.acquire_and_advance(kv_token)
+                            kv_token = kv_producer.try_acquire()
+                            cute.copy(
+                                tma_atom_k,
+                                tGSgK_s[None, sm, dk],
+                                tGSsK[None, kv_handle.index],
+                                tma_bar_ptr=kv_handle.barrier,
+                            )
+
+                # Load V
+                if s >= prefetch_tiles:
+                    tGSgV_s = tGSgV[None, None, None, s - prefetch_tiles]
+                    for sk in cutlass.range_constexpr(tiles_sk):
+                        for dm in cutlass.range_constexpr(tiles_dm):
+                            kv_handle = kv_producer.acquire_and_advance(kv_token)
+                            kv_token = kv_producer.try_acquire()
+                            cute.copy(
+                                tma_atom_v,
+                                tGSgV_s[None, dm, sk],
+                                tGSsV[None, kv_handle.index],
+                                tma_bar_ptr=kv_handle.barrier,
+                            )
+
+        ##############################
+        # TMA QO Dispatch
+        ##############################
+        elif warp_idx == tma_qo_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Slice and partition Q
+            # (TILE_H, TILE_D)
+            gQ = cute.local_tile(
+                mQ,
+                tiler=(blk_tile_hp, blk_tile_d),
+                coord=(coord_hp, 0, coord_hb),
+            )
+            # Apply MMA tiler and MMA partition
+            # (MMA_TILE_N, MMA_TILE_K, #TILE_HN=1, #TILE_DK)
+            gQ_mma = cute.flat_divide(gQ, (mma_tile_n, mma_tile_k))
+            gQ_mma = gQ_mma[None, None, 0, None]
+            # (MMA, #MMA_N, #MMA_K, #TILE_DK)
+            tBgQ = thrblk_mma_kq.partition_B(gQ_mma)
+            # (TMA, #TILE_DK)
+            tBsQ_tma, tBgQ_tma = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_q,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=cute.group_modes(tBsQ, 0, 3),
+                gmem_tensor=cute.group_modes(tBgQ, 0, 3),
+            )
+
+            cute.arch.griddepcontrol_wait()
+
+            # Load Q
+            cute.copy(tma_atom_q, tBgQ_tma, tBsQ_tma, tma_bar_ptr=q_load_mbar,)
+
+            # Slice and partition O
+            # (TILE_D, TILE_H)
+            coord_b_partial = (coord_b if do_atomic_red
+                               else kv_split_idx * batches + coord_b)
+            gO = cute.local_tile(
+                mO,
+                tiler=(blk_tile_d, blk_tile_hp),
+                coord=(0, coord_hp, (coord_hk, coord_b_partial)),
+            )
+            # (MMA_TILE_M, MMA_TILE_N, #TILE_DM, #TILE_HN=1)
+            gO_mma = cute.flat_divide(
+                gO, (mma_tile_m, mma_tile_n)
+            )
+            gO_mma = gO_mma[None, None, None, 0]
+            # (TMA, #TILE_DM)
+            sO_tma, gO_tma = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_o,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=cute.group_modes(sO_mma, 0, 2),
+                gmem_tensor=cute.group_modes(gO_mma, 0, 2),
+            )
+
+            # Store O to gmem
+            sO_final_nbar.arrive_and_wait()
+            cute.copy(tma_atom_o, sO_tma, gO_tma)
+
+        ##############################
+        # MMA KQ (BMM1) Dispatch
+        ##############################
+        elif warp_idx == mma_kq_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Setup mma descriptors
+            tAsK_desc = thrblk_mma_kq.make_fragment_A(tAsK)
+            tBsQ_desc = thrblk_mma_kq.make_fragment_B(tBsQ)
+
+            # Wait for Q
+            cute.arch.mbarrier_wait(q_load_mbar, phase=0)
+
+            # Sequence loop
+            for s in cutlass.range(iters_s):
+                s_token = s_producer.try_acquire()
+
+                # Advance for MMA VP
+                if s >= prefetch_iters + 1:
+                    for _ in cutlass.range_constexpr(tiles_dm * tiles_sk):
+                        kv_consumer.advance()
+                mma_order_vp_nbar.arrive_and_wait()
+                k_token = kv_consumer.try_wait()
+
+                s_handle = s_producer.acquire_and_advance(s_token)
+                for sm in cutlass.range_constexpr(tiles_sm):
+                    tiled_mma_kq.set(tcgen05.Field.ACCUMULATE, False)
+                    for dk in cutlass.range_constexpr(tiles_dk):
+                        k_handle = kv_consumer.wait_and_advance(k_token)
+                        is_last_iter = sm == tiles_sm - 1 and dk == tiles_dk - 1
+                        if is_last_iter:
+                            mma_order_kq_nbar.arrive()
+                        else:
+                            k_token = kv_consumer.try_wait()
+
+                        mmas_k = cute.size(tAsK.shape[2])
+                        for mma_k in cutlass.range_constexpr(mmas_k):
+                            cute.gemm(
+                                tiled_mma_kq,
+                                tCtS[mma_dice + (sm, s_handle.index)],
+                                tAsK_desc[None, None, mma_k, k_handle.index],
+                                tBsQ_desc[None, None, mma_k, dk],
+                                tCtS[mma_dice + (sm, s_handle.index)],
+                            )
+                            if dk == 0 and mma_k == 0:
+                                tiled_mma_kq.set(tcgen05.Field.ACCUMULATE, True)
+                        k_handle.release()
+                s_handle.commit()
+
+            # Tail loop
+            for s in cutlass.range_constexpr(prefetch_iters):
+                mma_order_vp_nbar.arrive_and_wait()
+                mma_order_kq_nbar.arrive()
+
+        ##############################
+        # MMA VP (BMM2) Dispatch
+        ##############################
+        elif warp_idx == mma_vp_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Setup mma descriptors
+            tiled_mma_vp.set(tcgen05.Field.ACCUMULATE, True)
+            tAsV_desc = thrblk_mma_vp.make_fragment_A(tAsV)
+            tBsP_desc = thrblk_mma_vp.make_fragment_B(tBsP_nk)
+
+            # Prefetch loop
+            mma_order_vp_nbar.arrive()
+            for s in cutlass.range_constexpr(prefetch_iters):
+                if s < iters_s:
+                    for _ in cutlass.range_constexpr(tiles_sm * tiles_dk):
+                        kv_consumer.advance()
+                mma_order_kq_nbar.arrive_and_wait()
+                mma_order_vp_nbar.arrive()
+
+            # Sequence loop
+            for s in cutlass.range(iters_s):
+                p_token = p_consumer.try_wait()
+                o_token = o_producer.try_acquire()
+
+                # Advance for MMA KQ
+                if s < iters_s - prefetch_iters:
+                    for _ in cutlass.range_constexpr(tiles_sm * tiles_dk):
+                        kv_consumer.advance()
+                mma_order_kq_nbar.arrive_and_wait()
+                v_token = kv_consumer.try_wait()
+
+                p_handle = p_consumer.wait_and_advance(p_token)
+                o_handle = o_producer.acquire_and_advance(o_token)
+                for sk in cutlass.range_constexpr(tiles_sk):
+                    for dm in cutlass.range_constexpr(tiles_dm):
+                        v_handle = kv_consumer.wait_and_advance(v_token)
+                        is_last_iter = sk == tiles_sk - 1 and dm == tiles_dm - 1
+                        if is_last_iter:
+                            mma_order_vp_nbar.arrive()
+                        else:
+                            v_token = kv_consumer.try_wait()
+
+                        mmas_k = cute.size(tAsV.shape[2])
+                        for mma_k in cutlass.range_constexpr(mmas_k):
+                            cute.gemm(
+                                tiled_mma_vp,
+                                tCtO[mma_dice + (dm, o_handle.index)],
+                                tAsV_desc[None, None, mma_k, v_handle.index],
+                                tBsP_desc[None, None, mma_k, sk, p_handle.index],
+                                tCtO[mma_dice + (dm, o_handle.index)],
+                            )
+                        v_handle.release()
+                p_handle.release()
+                o_handle.commit()
+
+            # Wait for signal to dealloc tmem, then dealloc
+            if iters_s == 1:
+                # Epilogue still reads the empty buffer
+                o_producer.commit()
+                o_producer.advance()
+            o_producer.tail()
+            cute.arch.relinquish_tmem_alloc_permit()
+            cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols)
+
+        ##############################
+        # Softmax Dispatch
+        ##############################
+        elif warpgroup_idx in softmax_warpgroup_ids:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(softmax_regs)
+
+            # Initialize for dual warpgroups
+            softmax_phase = (warpgroup_idx - 1) % softmax_warpgroups
+            tL_producer_nbar = with_phase(tL_producer_nbar, softmax_phase)
+            tL_consumer_nbar = with_phase(tL_consumer_nbar, softmax_phase)
+            sM_acquire_nbar = with_phase(sM_mutex_nbar, softmax_phase)
+            sM_release_nbar = with_phase(sM_mutex_nbar, softmax_phase ^ 1)
+            if softmax_phase == 1:
+                s_consumer.advance()
+                p_producer.advance()
+                sM_release_nbar.arrive()
+                if iters_s == 1:
+                    tL_producer_nbar.arrive()
+
+            # Construct copy atom for S
+            tmem_repeat_op_s = blk_tile_n
+            if cutlass.const_expr(mma_tile_n == blk_tile_n and tiles_sm in (2, 4)):
+                tmem_repeat_op_s *= tiles_sm
+            tmem_repeat_op_s = tcgen05.Repetition(tmem_repeat_op_s)
+            tmem_load_op_s = tcgen05.Ld32x32bOp(tmem_repeat_op_s)
+            tmem_load_atom_s = cute.make_copy_atom(tmem_load_op_s, acc_dtype)
+            # Tile atom and slice
+            tCtS_stage = tCtS[mma_dice + (None, 0)]
+            tmem_load_s = tcgen05.make_tmem_copy(tmem_load_atom_s, tCtS_stage)
+            thr_load_s = tmem_load_s.get_slice(warpgroup_tidx)
+            # Partition S and P
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, #CPY_SM, stages)
+            tStS = thr_load_s.partition_S(tCtS)
+            tSsP = thr_load_s.partition_D(tCsP)
+            # Slice unused modes
+            tStS = tStS[None, 0, 0, 0, None, None]  # (CPY, #CPY_SM, s_stages)
+            tSsP = tSsP[None, 0, 0, 0, None, None]  # (CPY, #CPY_SM, p_stages)
+
+            # Construct copy atom for L
+            tmem_repeat_op_l = tcgen05.Repetition(blk_tile_n)
+            tmem_load_op_l = tcgen05.Ld32x32bOp(tmem_repeat_op_l)
+            tmem_store_op_l = tcgen05.St32x32bOp(tmem_repeat_op_l)
+            tmem_load_atom_l = cute.make_copy_atom(tmem_load_op_l, acc_dtype)
+            tmem_store_atom_l = cute.make_copy_atom(tmem_store_op_l, acc_dtype)
+            # Tile atom and slice
+            tCtL_phase = tCtL[mma_dice + (softmax_phase,)]
+            tmem_load_l = tcgen05.make_tmem_copy(tmem_load_atom_l, tCtL_phase)
+            thr_load_l = tmem_load_l.get_slice(warpgroup_tidx)
+            # Partition L
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N)
+            tStL = thr_load_l.partition_S(tCtL_phase)
+            tSrL_shape = thr_load_l.partition_D(tCtL_phase).shape
+            # Slice unused modes
+            # (CPY,)
+            tStL = tStL[None, 0, 0, 0]
+            tSrL_shape = tSrL_shape[:1]
+
+            # Causal masking for spec decode verification
+            masked_iters_s = masked_start_s = masked_coord_s = 0
+            check_safe_max = False
+            if cutlass.const_expr(not tma_mask):
+                is_last_split = kv_split_idx == (tiles_s - 1) % kv_splits
+                is_prev_split = kv_split_idx == (tiles_s - 2) % kv_splits
+                is_last_phase = softmax_phase == (iters_s - 1) % softmax_warpgroups
+                is_prev_phase = softmax_phase == (iters_s - 2) % softmax_warpgroups
+                # 2 masked tiles
+                if 0 < seqlen % blk_tile_s < prediction:
+                    # 1 split masks 2 tiles
+                    if kv_splits == 1:
+                        masked_start_s = 0 if is_prev_phase else 1
+                        masked_iters_s = 2
+                        masked_coord_s = tiles_s - 2
+                    # 2 splits mask 1 tile each
+                    elif (is_last_split or is_prev_split) and is_last_phase:
+                        masked_start_s = 0
+                        masked_iters_s = 1
+                        masked_coord_s = (tiles_s - 1) if is_last_split else (tiles_s - 2)
+                        # if last split only has 1 tile then some cols will never
+                        # see inbounds values, so P = exp(-inf + inf) -> nan
+                        check_safe_max = is_last_split and iters_s == 1
+                # 1 masked tile
+                elif prediction > 1 or seqlen % blk_tile_s != 0:
+                    # 1 split masks 1 tile
+                    if is_last_split and is_last_phase:
+                        masked_start_s = 0
+                        masked_iters_s = 1
+                        masked_coord_s = tiles_s - 1
+
+            # Sequence loop
+            num_loops = 2 if not tma_mask else 1
+            for loop in cutlass.range_constexpr(num_loops):
+                is_masked_loop = loop == 1
+                for s in cutlass.range(
+                    masked_start_s if is_masked_loop else softmax_phase,
+                    masked_iters_s if is_masked_loop else (iters_s - masked_iters_s),
+                    softmax_warpgroups,
+                ):
+                    s_token = s_consumer.try_wait()
+                    p_token = p_producer.try_acquire()
+
+                    # Load S from tmem and notify BMM1
+                    s_handle = s_consumer.wait_and_advance(s_token)
+                    tStS_s = tStS[None, None, s_handle.index]
+                    tSrS_s = cute.make_rmem_tensor(tSsP.shape[:-1], acc_dtype)
+                    cute.copy(tmem_load_atom_s, tStS_s, tSrS_s)
+                    cute.arch.fence_view_async_tmem_load()
+                    s_handle.release()
+
+                    # Apply causal mask
+                    if cutlass.const_expr(is_masked_loop):
+                        masked = cute.make_rmem_tensor(
+                            (blk_tile_h, blk_tile_p, tiles_sm), acc_dtype
+                        )
+                        masked.store(tSrS_s.load().reshape(masked.shape))
+                        offset_s = (masked_coord_s + s) * blk_tile_s + warpgroup_tidx
+                        offset_p = seqlen - prediction + coord_p * blk_tile_p
+                        for sm in cutlass.range_constexpr(tiles_sm):
+                            for p in cutlass.range_constexpr(blk_tile_p):
+                                masked_p = masked[None, p, sm]
+                                is_oob = offset_s + sm * mma_tile_m > offset_p + p
+                                mask = -Float32.inf if is_oob else Float32(0)
+                                masked_p.store(masked_p.load() + mask)
+                        scores = masked.load().reshape((blk_tile_n, tiles_sm))
+                    else:
+                        scores = tSrS_s.load().reshape((blk_tile_n, tiles_sm))
+
+                    # Reduce colmax in thread RF
+                    rM = cute.make_rmem_tensor_like(sM)
+                    rM.store(scores.reduce(
+                        cute.ReductionOp.MAX,
+                        init_val=-Float32.inf,
+                        reduction_profile=(None, 0)
+                    ))
+
+                    # Reduce colmax in warp RF
+                    rM_lane = Float32(0)
+                    for n in cutlass.range_constexpr(blk_tile_n):
+                        rM[n] = warp_fmax(rM[n])  # warp reduction
+                        # Avoid dynamic register indexing (creates spills)
+                        if n == lane_idx:
+                            rM_lane = rM[n]
+                    rM_lane *= scale_s_log2_e  # apply scale
+
+                    # Reduce colmax in smem
+                    sM_acquire_nbar.arrive_and_wait()
+                    sM_consumer_nbar.arrive_and_wait()
+                    if lane_store_max:
+                        smem_fmax(sM.iterator + sM.layout(lane_idx), rM_lane)
+
+                    # Wait for colmax and load
+                    sM_producer_nbar.arrive_and_wait()
+                    colmax = sM.load()
+                    sM_release_nbar.arrive()
+
+                    # Handle if we never saw any in-bounds values
+                    if cutlass.const_expr(is_masked_loop and do_atomic_red):
+                        if check_safe_max:
+                            rM = cute.make_rmem_tensor_like(colmax)
+                            rM.store(colmax)
+                            for n in cutlass.range_constexpr(blk_tile_n):
+                                if rM[n] == -Float32.inf:
+                                    rM[n] = Float32(0)
+                            colmax = rM.load()
+
+                    # Wait for empty P buffer
+                    # Here so we can interleave ex2 with convert ops
+                    p_handle = p_producer.acquire_and_advance(p_token)
+                    tSsP_s = tSsP[None, None, p_handle.index]
+
+                    # Compute online softmax
+                    probs = exp2(scale_s_log2_e * scores - colmax)
+
+                    # Store P to smem and notify BMM2
+                    tSsP_s.store(probs.to(mma_dtype).reshape(tSsP_s.shape))
+                    cute.arch.fence_view_async_shared()
+                    p_handle.commit()
+
+                    # Accumulate per-thread colsum
+                    colsum = probs[None, 0]
+                    for sm in cutlass.range_constexpr(1, tiles_sm, 1):
+                        colsum += probs[None, sm]
+                    tSrL = cute.make_rmem_tensor(tSrL_shape, acc_dtype)
+                    tSrL.store(colsum.reshape(tSrL.shape))
+
+                    # Store per-thread colsum to tmem
+                    tL_consumer_nbar.arrive_and_wait()
+                    cute.copy(tmem_store_atom_l, tSrL, tStL)
+                    cute.arch.fence_view_async_tmem_store()
+                    tL_producer_nbar.arrive()
+
+                    # Advance again for dual warpgroups 
+                    s_consumer.advance()
+                    p_producer.advance()
+
+        ##############################
+        # Correction Dispatch
+        ##############################
+        elif warpgroup_idx == correction_warpgroup_id:
+            # Alloc registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_increase(correction_regs)
+
+            # Select copy atoms for O and L
+            tmem_repeat_op_o = tcgen05.Repetition(blk_tile_n)
+            tmem_load_op_o = tcgen05.Ld32x32bOp(tmem_repeat_op_o)
+            tmem_store_op_o = tcgen05.St32x32bOp(tmem_repeat_op_o)
+            tmem_load_atom_o = cute.make_copy_atom(tmem_load_op_o, acc_dtype)
+            tmem_store_atom_o = cute.make_copy_atom(tmem_store_op_o, acc_dtype)
+            # Tile atoms and slice
+            tCtO_dm = tCtO[mma_dice + (0, 0)]
+            tmem_load_o = tcgen05.make_tmem_copy(tmem_load_atom_o, tCtO_dm)
+            thr_load_o = tmem_load_o.get_slice(warpgroup_tidx)
+            # Partition O and L
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, #TILE_DM, o_stages)
+            tOtO = thr_load_o.partition_S(tCtO)
+            tOsO = thr_load_o.partition_D(tCsO)
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, o_stages)
+            tOtL = thr_load_o.partition_S(tCtL)
+            # Slice unused modes
+            tOtO = tOtO[None, 0, 0, 0, None, None]  # (CPY, #TILE_DM, o_stages)
+            tOsO = tOsO[None, 0, 0, 0, None]  # (CPY, #TILE_DM)
+            tOtL = tOtL[None, 0, 0, 0, None]  # (CPY, o_stages)
+
+            # colsum load helper
+            def colsum_load(
+                phase,
+                blk_tile_n = blk_tile_n,
+                tOtL = tOtL,
+                tOrO_shape = tOsO.shape[:1],
+                tmem_load_atom_o = tmem_load_atom_o,
+                tL_producer_nbar = tL_producer_nbar,
+                tL_consumer_nbar = tL_consumer_nbar,
+            ):
+                with_phase(tL_producer_nbar, phase).arrive_and_wait()
+                tOtL_s = tOtL[None, phase]
+                tOrL_s = cute.make_rmem_tensor(tOrO_shape, Float32)
+                cute.copy(tmem_load_atom_o, tOtL_s, tOrL_s)
+                cute.arch.fence_view_async_tmem_load()
+                with_phase(tL_consumer_nbar, phase).arrive()
+                return tOrL_s.load().reshape(blk_tile_n)
+
+            # Initialize O and colsum
+            tOrO = cute.make_rmem_tensor(tOsO.shape, acc_dtype)
+            tOrO.fill(Float32(0))
+            for phase in cutlass.range_constexpr(o_stages):
+                cute.copy(tmem_store_atom_o, tOrO, tOtO[None, None, phase])
+            cute.copy(tmem_store_atom_o, tOrO[None, 0], tOtL[None, 1])
+            cute.arch.fence_view_async_tmem_store()
+
+            # Initialize consumer barriers
+            sM_consumer_nbar.arrive()
+            for phase in cutlass.range_constexpr(o_stages):
+                with_phase(tL_consumer_nbar, phase).arrive()
+
+            # Initialize colsum in RF
+            colsum_p = cute.make_rmem_tensor((blk_tile_n, o_stages), Float32)
+            colsum_0, colsum_1 = colsum_p[None, 0], colsum_p[None, 1]
+            colsum_p.fill(Float32(0))
+
+            # Load colmax of s-2, s-1
+            sM_lane_prev_prev = sM_lane_prev = -Float32.inf
+            for s in cutlass.range_constexpr(o_stages):
+                sM_lane_prev_prev = sM_lane_prev
+                if not (s == 1 and iters_s == 1):
+                    sM_producer_nbar.arrive_and_wait()
+                    if lane_store_max:
+                        sM_lane_prev = sM[lane_idx]
+                    sM_consumer_nbar.arrive()
+
+            # Sequence loop
+            phase = 0
+            for s in cutlass.range(iters_s - o_stages, unroll=o_stages):
+                # Load colsum of s-2
+                colsum_s = colsum_load(phase)
+
+                # Load colmax of s
+                sM_producer_nbar.arrive_and_wait()
+                if s == iters_s - o_stages - 1:  # Notify for final colmax
+                    sM_final_nbar.arrive()
+                sM_lane = Float32(0)
+                if lane_store_max:
+                    sM_lane = sM[lane_idx]
+                sM_consumer_nbar.arrive()
+
+                # Wait for O of s-2
+                # Here so we can interleave shuffle_sync with correction muls
+                o_token = o_consumer.try_wait()
+                o_handle = o_consumer.wait_and_advance(o_token)
+
+                # Compute correction of s-2
+                correction_lane = exp2(sM_lane_prev_prev - sM_lane)
+                correction = cute.make_rmem_tensor_like(sM)
+                for n in cutlass.range_constexpr(blk_tile_n):
+                    correction[n] = cute.arch.shuffle_sync(correction_lane, n)
+                correction = correction.load()
+
+                # Correct O of s-2 and notify MMA VP
+                correction_o = correction.reshape(tOsO.shape[:1])
+                for dm in cutlass.range_constexpr(tiles_dm):
+                    tOtO_dm = tOtO[None, dm, phase]
+                    tOrO_dm = cute.make_rmem_tensor(tOsO.shape[:1], acc_dtype)
+                    cute.copy(tmem_load_atom_o, tOtO_dm, tOrO_dm)
+                    tOrO_dm.store(correction_o * tOrO_dm.load())
+                    cute.copy(tmem_store_atom_o, tOrO_dm, tOtO_dm)
+                cute.arch.fence_view_async_tmem_store()
+                o_handle.release()
+
+                # Correct and accumulate colsum of s-2
+                colsum_s *= correction
+                if phase == 0:
+                    colsum_0.store(correction * colsum_0.load() + colsum_s)
+                elif phase == 1:
+                    colsum_1.store(correction * colsum_1.load() + colsum_s)
+
+                # Advance loop
+                sM_lane_prev_prev, sM_lane_prev = sM_lane_prev, sM_lane
+                phase ^= 1
+
+            # Notify for final colmax if we didn't enter loop
+            if iters_s <= o_stages:
+                sM_final_nbar.arrive()
+
+            # Handle if we never saw any in-bounds values
+            if cutlass.const_expr(not tma_mask and do_atomic_red):
+                if sM_lane_prev == -Float32.inf:
+                    sM_lane_prev = Float32(0)
+
+            # Compute correction of s-1
+            correction_lane = exp2(sM_lane_prev_prev - sM_lane_prev)
+            correction = cute.make_rmem_tensor_like(sM)
+            for n in cutlass.range_constexpr(blk_tile_n):
+                correction[n] = cute.arch.shuffle_sync(correction_lane, n)
+            correction = correction.load()
+
+            # Correct and accumulate final colsum
+            tail_phase = iters_s % o_stages
+            for phase in cutlass.range_constexpr(o_stages):
+                if tail_phase == phase:
+                    # Accumulate in thread RF
+                    colsum_prev = colsum_load(phase)
+                    colsum_final = colsum_load(phase ^ 1)
+                    colsum_prev += colsum_p[None, phase].load()
+                    colsum_final += colsum_p[None, phase ^ 1].load()
+                    colsum_final += correction * colsum_prev
+                    # Reduce colsum in warp RF
+                    rL_lane = Float32(0.0)
+                    for n in cutlass.range_constexpr(blk_tile_n):
+                        rL_n = cute.arch.warp_reduction_sum(colsum_final[n])
+                        if n == lane_idx:
+                            rL_lane = rL_n
+                    # Store partial colsum in smem and notify
+                    if lane_store_max:
+                        sL[lane_idx, warpgroup_widx] = rL_lane
+                    sL_final_nbar.arrive()
+
+            # Load O of s-1, s
+            tOrO_tail = cute.make_rmem_tensor((*tOsO.shape, o_stages), acc_dtype)
+            for s in cutlass.range_constexpr(o_stages):
+                phase_s = tail_phase ^ s
+                tOtO_phase = tOtO[None, None, phase_s]
+                tOrO_tail_s = tOrO_tail[None, None, s]
+                o_handle = o_consumer.wait_and_advance()
+                cute.copy(tmem_load_atom_o, tOtO_phase, tOrO_tail_s)
+                cute.arch.fence_view_async_tmem_load()
+                o_handle.release()  # Final release signals tmem dealloc
+            tOrO_prev = tOrO_tail[None, None, 0].load()
+            tOrO_final = tOrO_tail[None, None, 1].load()
+
+            # Correct and accumulate output
+            output_prev = tOrO_prev.reshape((blk_tile_n, tiles_dm))
+            output_final = tOrO_final.reshape((blk_tile_n, tiles_dm))
+            output_final += correction * output_prev
+
+            # Apply final correction
+            if cutlass.const_expr(do_atomic_red):
+                # final correction stored in sM
+                sM_final_nbar.arrive_and_wait()
+                correction = sM.load()
+                output_final *= correction
+
+            # Store O to smem and notify
+            tOsO.store(output_final.to(o_dtype).reshape(tOsO.shape))
+            cute.arch.fence_view_async_shared()
+            sO_final_nbar.arrive()
+
+        ##############################
+        # Reduction Dispatch
+        ##############################
+        if warp_idx == reduction_warp_id:
+            if cutlass.const_expr(do_kernel_red):
+                self.reduction_epilogue(
+                    blk_tile_hp,
+                    coord_hp,
+                    coord_hb,
+                    kv_split_idx,
+                    lane_idx,
+                    sM_final_nbar,
+                    sL_final_nbar,
+                    sM,
+                    sL,
+                    mM,
+                    mM_partial,
+                    mL_partial,
+                )
+            else:
+                self.reduction_cluster(
+                    blk_tile_n,
+                    kv_splits,
+                    kv_split_idx,
+                    lane_idx,
+                    sM_final_nbar,
+                    sL_final_nbar,
+                    reduction_mbars_ptr,
+                    sM,
+                    sL,
+                    sR,
+                )
+            cute.arch.griddepcontrol_launch_dependents()
+
+        return
+
+    @staticmethod
+    @cute.jit
+    def reduction_epilogue(
+        blk_tile_hp : Tuple[int, int],
+        coord_hp: Tuple[Int32, Int32],
+        coord_hb: Tuple[Int32, Int32],
+        kv_split_idx : Int32,
+        lane_idx : Int32,
+        sM_final_nbar : nbar,
+        sL_final_nbar : nbar,
+        sM : cute.Tensor,
+        sL : cute.Tensor,
+        mM : cute.Tensor,
+        mM_partial : cute.Tensor,
+        mL_partial : cute.Tensor,
+    ):
+        # get gmem colmax + colsum to store to
+        coord_h = (coord_hp, coord_hb, kv_split_idx)
+        gM = cute.local_tile(mM, (blk_tile_hp,), coord_h[:-1])
+        gM_partial = cute.local_tile(mM_partial, (blk_tile_hp,), coord_h)
+        gL_partial = cute.local_tile(mL_partial, (blk_tile_hp,), coord_h)
+
+        # tile predication
+        blk_tile_h, blk_tile_p = blk_tile_hp
+        blk_tile_n = blk_tile_h * blk_tile_p
+        lane_store_max = blk_tile_n == warp_threads or lane_idx < blk_tile_n
+
+        # gmem predication
+        grouped_heads, prediction = mM.shape[0]
+        cM = cute.make_identity_tensor(mM.shape[0])
+        cM = cute.local_tile(cM, blk_tile_hp, coord_hp)
+        idx_hg, idx_p = cM[lane_idx]
+        lane_store_max &= idx_hg < grouped_heads
+        lane_store_max &= idx_p < prediction
+
+        # Load partial colmax and reduce
+        cute.arch.fence_acq_rel_cta()  # Don't reorder partitioning after barrier
+        sM_final_nbar.arrive_and_wait()
+        if lane_store_max:
+            sM_lane = sM[lane_idx]
+            gM_partial[lane_idx] = sM_lane
+            gmem_fmax(gM.iterator + gM.layout(lane_idx), sM_lane)
+
+        # Load partial colsum and reduce
+        sL_final_nbar.arrive_and_wait()
+        if lane_store_max:
+            sL_lane_wg = sL[lane_idx, None]
+            sL_lane = (
+                sL_lane_wg[0] + sL_lane_wg[1] + sL_lane_wg[2] + sL_lane_wg[3]
+            )
+            gL_partial[lane_idx] = sL_lane
+
+
+    @staticmethod
+    @cute.jit
+    def reduction_cluster(
+        blk_tile_n : int,
+        kv_splits : Int32,
+        kv_split_idx : Int32,
+        lane_idx : Int32,
+        sM_final_nbar : nbar,
+        sL_final_nbar : nbar,
+        reduction_mbars_ptr : cute.Pointer,
+        sM : cute.Tensor,
+        sL : cute.Tensor,
+        sR : cute.Tensor,
+    ):
+        acc_dtype = sM.dtype
+        colmax_bits = blk_tile_n * acc_dtype.width
+        copy_vec_bits = min(colmax_bits, 128)
+        dsmem_store_threads = colmax_bits // copy_vec_bits
+        dsmem_store_values = copy_vec_bits // acc_dtype.width
+        dsmem_store_atom_r = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyDsmemStoreOp(),
+            acc_dtype,
+            num_bits_per_copy=copy_vec_bits,
+        )
+        dsmem_store_r = cute.make_tiled_copy(
+            dsmem_store_atom_r,
+            cute.make_ordered_layout(
+                (dsmem_store_threads, dsmem_store_values), order=(1, 0)
+            ),
+            (blk_tile_n,),
+        )
+        thr_store_r = dsmem_store_r.get_slice(lane_idx)
+        tRsM = thr_store_r.partition_S(sM)  # (CPY, #CPY)
+        tRsL = thr_store_r.partition_S(sL)  # (CPY, #CPY, warpgroup_warps)
+        tRsR = thr_store_r.partition_S(sR)  # (CPY, #CPY, max_red_iters, 2)
+
+        tRrM_shape = thr_store_r.partition_D(sM).shape
+        tRrM_final = cute.make_rmem_tensor(tRrM_shape, acc_dtype)
+        tRrM_prev = cute.make_rmem_tensor(tRrM_shape, acc_dtype)
+
+        # Wait for last colmax
+        cute.arch.fence_acq_rel_cta()  # Don't reorder partitioning after barrier
+        sM_final_nbar.arrive_and_wait()
+        is_reduction_lane = lane_idx < dsmem_store_threads
+        if is_reduction_lane:
+            tRrM_prev.store(tRsM.load())
+            tRrM_final.store(tRrM_prev.load())
+
+            # Cluster butterfly reduction
+            for i in cutlass.range_constexpr(max_reduction_iters):
+                xor_mask = 0x01 << i
+                if xor_mask < kv_splits:
+                    peer_idx = kv_split_idx ^ xor_mask
+                    tRsR_local = tRsR[None, None, i, 0]
+                    tRsR_peer = cute.make_tensor(
+                        cute.arch.map_dsmem_ptr(tRsR_local.iterator, peer_idx),
+                        tRsR_local.layout,
+                    )
+                    local_mbar = reduction_mbars_ptr + i
+                    peer_mbar = cute.arch.map_dsmem_ptr(local_mbar, peer_idx)
+                    cute.copy(
+                        dsmem_store_atom_r, tRrM_final, tRsR_peer, mbar_ptr=peer_mbar
+                    )
+                    cute.arch.fence_acq_rel_cta()  # dont reorder dsmem store after wait
+                    cute.arch.mbarrier_wait(local_mbar, phase=0)
+                    tRrR = tRsR_local.load()
+                    for j in cutlass.range_constexpr(cute.size(tRrM_final)):
+                        tRrM_final[j] = cute.arch.fmax(tRrM_final[j], tRrR[j])
+
+        # Wait for last colsum
+        sL_final_nbar.arrive_and_wait()
+        if is_reduction_lane:
+            # Warpgroup reduction
+            colsum = tRsL[None, None, 0].load()
+            for i in cutlass.range_constexpr(1, warpgroup_warps, 1):
+                colsum += tRsL[None, None, i].load()
+
+            # Compute final correction and correct local colsum
+            correction = exp2(tRrM_prev.load() - tRrM_final.load())
+            correction = correction.reshape(colsum.shape)
+            colsum *= correction
+
+            # Cluster butterfly reduction
+            for i in cutlass.range_constexpr(max_reduction_iters):
+                xor_mask = 0x01 << i
+                if xor_mask < kv_splits:
+                    peer_idx = kv_split_idx ^ xor_mask
+                    tRrL_local = cute.make_rmem_tensor(tRrM_shape, acc_dtype)
+                    tRrL_local.store(colsum)
+                    tRsR_local = tRsR[None, None, i, 1]
+                    tRsR_peer = cute.make_tensor(
+                        cute.arch.map_dsmem_ptr(tRsR_local.iterator, peer_idx),
+                        tRsR_local.layout,
+                    )
+                    local_mbar = reduction_mbars_ptr + max_reduction_iters + i
+                    peer_mbar = cute.arch.map_dsmem_ptr(local_mbar, peer_idx)
+                    cute.copy(
+                        dsmem_store_atom_r, tRrL_local, tRsR_peer, mbar_ptr=peer_mbar
+                    )
+                    cute.arch.fence_acq_rel_cta()  # dont reorder dsmem store after wait
+                    cute.arch.mbarrier_wait(local_mbar, phase=0)
+                    colsum += tRsR_local.load()
+
+            # Divide by final colsum and store
+            rcp_colsum = cute.make_rmem_tensor(colsum.shape, acc_dtype)
+            for i in cutlass.range(cute.size(colsum.shape)):
+                rcp_colsum[i] = cute.arch.rcp_approx(colsum[i])
+            tRsM.store(correction * rcp_colsum.load())
+
+        # Notify for final correction
+        sM_final_nbar.arrive()
+
+
+    ##############################
+    # Reduction Kernel launch
+    ##############################
+    @staticmethod
+    @cute.jit
+    def launch_reduction(
+        d_per_blk: int,
+        o_bshd: cute.Tensor,
+        m_bsh: cute.Tensor,  # colmax_s, already computed
+        o_partial_bshd: cute.Tensor,  # partial O per kv split
+        m_partial_bsh: cute.Tensor,  # partial colmax_s per kv split
+        l_partial_bsh: cute.Tensor,  # partial colsum_p per kv split
+        stream: cuda.CUstream,
+    ):
+        splits, b, s_q, h_q, d = o_partial_bshd.shape
+
+        # Tile in headdim first
+        def reverse(t : cute.Tensor):
+            modes = tuple(reversed(range(cute.rank(t))))
+            layout = cute.select(t.layout, modes)
+            return cute.make_tensor(t.iterator, layout)
+        o_dhsb = reverse(o_bshd)
+        m_hsb = reverse(m_bsh)
+        o_partial_dhsb = reverse(o_partial_bshd)
+        m_partial_hsb = reverse(m_partial_bsh)
+        l_partial_hsb = reverse(l_partial_bsh)
+
+        d_per_thr = 32 // o_bshd.dtype.width
+        thr_per_blk = d_per_blk // d_per_thr
+        d_blks = cute.ceil_div(d, d_per_blk)
+        smem_bytes = (splits * 2 + 1) * Float32.width // 8
+
+        GroupedQueryAttentionDecode.reduction_kernel(
+            (thr_per_blk, d_per_thr, d_per_blk),
+            o_dhsb, m_hsb, o_partial_dhsb, m_partial_hsb, l_partial_hsb
+        ).launch(
+            grid=[d_blks, h_q * s_q, b],
+            block=[thr_per_blk, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+            smem=smem_bytes,
+            min_blocks_per_mp=1,
+            use_pdl=True,
+        )
+
+    @staticmethod
+    @cute.kernel
+    def reduction_kernel(
+        tile_d: cute.Tile,
+        o_dhsb: cute.Tensor,
+        m_hsb: cute.Tensor,
+        o_partial_dhsb: cute.Tensor,
+        m_partial_hsb: cute.Tensor,
+        l_partial_hsb: cute.Tensor,
+    ):
+        thr_per_blk, d_per_thr, d_per_blk = tile_d
+        d, h_q, s_q, b, splits = o_partial_dhsb.shape
+        d_blk_idx, coord_hs, coord_b = cute.arch.block_idx()
+        coord_h, coord_s = cute.idx2crd(coord_hs, (h_q, s_q))
+        tidx, _, _ = cute.arch.thread_idx()
+
+        not_oob_d = True
+        if d % d_per_blk != 0:
+            not_oob_d = d_blk_idx * d_per_blk + tidx * d_per_thr < d
+
+        coord_o = (d_blk_idx, coord_h, coord_s, coord_b, None)
+        gO = cute.local_tile(o_dhsb, (d_per_blk,), coord_o[:-1])
+        gO_partial = cute.local_tile(o_partial_dhsb, (d_per_blk,), coord_o)
+
+        gM = cute.local_tile(m_hsb, (1,), coord_o[1:-1])
+        gM_partial = cute.local_tile(m_partial_hsb, (1,), coord_o[1:])
+        gL_partial = cute.local_tile(l_partial_hsb, (1,), coord_o[1:])
+        gM_partial_0 = gM_partial[None, tidx]
+        gL_partial_0 = gL_partial[None, tidx]
+
+        smem_ptr = cute.arch.get_dyn_smem(Float32)
+        partial_layout = cute.make_layout((1, splits))
+        sM_partial = cute.make_tensor(smem_ptr, partial_layout)
+        sL_partial = cute.make_tensor(smem_ptr + splits, partial_layout)
+        sL_partial_0 = sL_partial[None, tidx]
+        sM_partial_0 = sM_partial[None, tidx]
+
+        sM_layout = cute.make_layout(1)
+        sM = cute.make_tensor(smem_ptr + splits * 2, sM_layout)
+
+        cpasync_atom = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(), Float32,
+            num_bits_per_copy=32
+        )
+
+        copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), Float32)
+        tv_layout = cute.make_ordered_layout((thr_per_blk, d_per_thr), order=(1, 0))
+        tiled_copy = cute.make_tiled_copy(copy_atom, tv_layout, (d_per_blk,))
+        thr_copy = tiled_copy.get_slice(tidx)
+
+        tCgO_partial = thr_copy.partition_S(gO_partial)  # (CPY, #CPY=1, splits)
+        tCgO_partial = tCgO_partial[None, 0, None]  # (CPY, splits)
+        tCgO = thr_copy.partition_D(gO)  # (CPY, #CPY=1)
+        tCgO = tCgO[None, 0]  # (CPY)
+        tCrO_final = cute.zeros_like(tCgO, Float32)
+
+        cute.arch.fence_acq_rel_cta()  # Don't reorder partitioning after PDL wait
+        cute.arch.griddepcontrol_wait()
+
+        if tidx == 0:
+            cute.copy(cpasync_atom, gM, sM)
+
+        if tidx < splits:
+            cute.copy(cpasync_atom, gL_partial_0, sL_partial_0)
+            cute.copy(cpasync_atom, gM_partial_0, sM_partial_0)
+
+        for split_idx in cutlass.range(thr_per_blk + tidx, splits, thr_per_blk):
+            gL_partial_n = gL_partial[None, split_idx]
+            sL_partial_n = sL_partial[None, split_idx]
+            cute.copy(cpasync_atom, gL_partial_n, sL_partial_n)
+
+            gM_partial_n = gM_partial[None, split_idx]
+            sM_partial_n = sM_partial[None, split_idx]
+            cute.copy(cpasync_atom, gM_partial_n, sM_partial_n)
+
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        max_final = sM[0]
+        sum_final = Float32(0)
+        if max_final > -Float32.inf and not_oob_d:
+            for split_idx in cutlass.range(splits, unroll=8):
+                max_partial = sM_partial[0, split_idx]
+                if max_partial > -Float32.inf:
+                    correction = exp2(max_partial - max_final)
+                    sum_final += correction * sL_partial[0, split_idx]
+                    tCrO_final += correction * tCgO_partial[None, split_idx].load()
+            tCrO_final *= cute.arch.rcp_approx(sum_final)
+
+        cute.arch.griddepcontrol_launch_dependents()
+
+        if not_oob_d:
+            tCgO.store(tCrO_final.to(o_dhsb.dtype))
+
+        return
+
+
+def run(
+    batches: int,
+    prediction: int,
+    seqlen: int,
+    heads_q: int,
+    heads_k: int,
+    headdim: int,
+    kv_splits: int,
+    reduction: str,
+    qkv_dtype: Type[cutlass.Numeric],
+    o_dtype: Type[cutlass.Numeric],
+    acc_dtype: Type[cutlass.Numeric],
+    tolerance: float,
+    scale_s: float,
+    warmup_iterations: int = 0,
+    iterations: int = 0,
+    skip_ref_check: bool = False,
+    use_warm_l2: bool = False,
+    quiet: bool = False,
+    **kwargs,
+):
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    npo2 = lambda x : 2 ** math.ceil(math.log2(x))
+
+    grouped_heads = heads_q // heads_k
+    grouped_head_tile = npo2(grouped_heads)
+    grouped_head_tile = min(32, grouped_head_tile)
+    grouped_head_tiles = math.ceil(grouped_heads / grouped_head_tile)
+
+    prediction_tile = npo2(prediction)
+    prediction_tile = min(32 // grouped_head_tile, prediction_tile)
+    prediction_tiles = math.ceil(prediction / prediction_tile)
+
+    if grouped_head_tile == prediction_tile == 1 and qkv_dtype.width == 8:
+        grouped_head_tile = 2
+
+    # Automatic KV splits
+    if kv_splits == 0:
+        hardware_info = cutlass.utils.HardwareInfo()
+        sm_count = hardware_info.get_device_multiprocessor_count()
+        sm_count = 148 if sm_count <= 0 else sm_count
+        grid_yz = batches * heads_k * grouped_head_tiles * prediction_tiles
+        kv_splits = sm_count // grid_yz  # 1 wave
+        kv_splits = max(1, kv_splits)
+        if sm_count == 148 and grid_yz == 32:
+            kv_splits = 9  # 2 waves
+        # At least 256 tokens per split
+        kv_splits = min(kv_splits, math.ceil(seqlen / 256))
+        # Cluster reduction requires po2 splits
+        if reduction == "atomic":
+            if kv_splits not in (1, 2, 4):
+                kv_splits = 8  # generally performs well
+
+    # Automatic reduction mode
+    if reduction == "auto":
+        if o_dtype in (Float32, Float16, BFloat16) and kv_splits in (1, 2, 4, 8):
+            reduction = "atomic"
+        else:
+            reduction = "kernel"
+    atomic = reduction == "atomic"
+
+    print(f"Command: python {__file__.split("/")[-1]}"
+        f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
+        f" --b {batches} --p {prediction} --s {seqlen}"
+        f" --kv_splits {kv_splits} --reduction {reduction}"
+        f" --mma_dtype {qkv_dtype} --out_dtype {o_dtype}"
+        f" --atol {tolerance}{" --skip_ref_check" if skip_ref_check else ""}"
+        f" --scale {scale_s}"
+        f" --iterations {iterations} --warmups {warmup_iterations}{" --use_warm_l2" if use_warm_l2 else ""}"
+        f"{" --quiet" if quiet else ""}"
+    )
+
+    if not quiet:
+        print(
+            "Running Blackwell SM100 GQA Decode test with:\n"
+            f"\theaddim: {headdim}\theads_q: {heads_q}\theads_k: {heads_k}\n"
+            f"\tbatches: {batches}\tprediction: {prediction}\tseqlen: {seqlen}\n"
+            f"\tkv_splits: {kv_splits}\treduction: {reduction}\n"
+            f"\tqkv: {qkv_dtype}\to: {o_dtype}\t\n"
+            f"\tatol: {tolerance if not skip_ref_check else "skip"}"
+            f"\tscale_s: {f"1 / sqrt({headdim})" if scale_s == 0 else scale_s}\n"
+            f"\titerations: {iterations}\twarmups: {warmup_iterations}\tL2 warm: {use_warm_l2}"
+        )
+
+    # Automatic scale
+    if scale_s == 0:
+        scale_s = headdim ** -0.5
+
+    #
+    # Config Kernel
+    #
+    fmha = GroupedQueryAttentionDecode(
+        headdim,
+        grouped_head_tile,
+        prediction_tile=prediction_tile,
+        reduction_mode=reduction,
+        tma_mask=(prediction == 1),
+    )
+
+    seqlen_q = prediction
+    seqlen_k = seqlen
+    qo_shape = (kv_splits, batches, seqlen_q, heads_q, headdim)
+    kv_shape = (batches, seqlen_k, heads_k, headdim)
+
+    fmha.can_implement(qo_shape[0], qo_shape[1:], kv_shape, qkv_dtype, o_dtype)
+
+    #
+    # Allocate Tensors
+    #
+    torch_ref_dtype = torch.float16
+    torch.manual_seed(1111)
+
+    def create_tensor(shape, dtype, init=None):
+        init_type = cutlass.torch.TensorInitType.SKIP
+        init_config = None
+        if isinstance(init, int) or isinstance(init, float):
+            init_type = cutlass.torch.TensorInitType.SCALAR
+            init_config = cutlass.torch.ScalarInitConfig(value=init)
+        elif isinstance(init, tuple) or isinstance(init, list):
+            if len(init) == 2:
+                init_type = cutlass.torch.TensorInitType.RANDOM
+                init_config = cutlass.torch.RandomInitConfig(
+                    min_val=init[0], max_val=init[1]
+                )
+            if len(init) == 3:
+                init_type = cutlass.torch.TensorInitType.GAUSSIAN
+                init_config = cutlass.torch.RandomInitConfig(
+                    mean=init[0], std=init[1], scale=init[2]
+                )
+
+        ref_torch_tensor = cutlass_torch.create_and_permute_torch_tensor(
+            shape,
+            torch_ref_dtype,
+            permute_order=None,
+            init_type=init_type,
+            init_config=init_config,
+        )
+
+        cute_tensor, torch_tensor = cutlass_torch.cute_tensor_like(
+            ref_torch_tensor,
+            dtype,
+            is_dynamic_layout=True,
+            assumed_align=16,
+        )
+
+        return (
+            ref_torch_tensor,
+            cute_tensor,
+            torch_tensor,
+        )
+
+    q_ref, q_cute, q_torch = create_tensor(qo_shape[1:], qkv_dtype, init=[-8, 7])
+    k_ref, k_cute, k_torch = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
+    v_ref, v_cute, v_torch = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
+    _, o_cute, o_torch = create_tensor(
+        qo_shape[1:], o_dtype, init=(0 if atomic else None)
+    )
+    # Workspace tensors
+    m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
+    if not atomic:
+        _, m_cute, m_torch = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
+        _, o_partial_cute, o_partial_torch = create_tensor(qo_shape, acc_dtype)
+        _, m_partial_cute, m_partial_torch = create_tensor(qo_shape[:-1], acc_dtype)
+        _, l_partial_cute, l_partial_torch = create_tensor(qo_shape[:-1], acc_dtype)
+
+    #
+    # Compile
+    #
+    current_stream = cutlass_torch.default_stream()
+    compiled_fmha = cute.compile(
+        fmha,
+        kv_splits,
+        q_cute,
+        k_cute,
+        v_cute,
+        o_cute,
+        m_cute,
+        o_partial_cute,
+        m_partial_cute,
+        l_partial_cute,
+        scale_s,
+        current_stream,
+    )
+    print("Finished Compiling")
+
+    #
+    # Refcheck
+    #
+    def run_torch_fmha(q_bshd, k_bshd, v_bshd, scale_s):
+        with sdpa_kernel(
+            [SDPBackend.FLASH_ATTENTION, SDPBackend.MATH], set_priority=True
+        ):
+            # bottom right causal
+            decode_mask = torch.ones(
+                prediction, seqlen, dtype=torch.bool
+            ).tril(diagonal=(seqlen - prediction))
+            o_bshd = scaled_dot_product_attention(
+                q_bshd.transpose(1,2),
+                k_bshd.transpose(1,2),
+                v_bshd.transpose(1,2),
+                attn_mask=decode_mask,
+                dropout_p=0.0,
+                scale=scale_s,
+                is_causal=False,  # built-in is upper left causal
+                enable_gqa=(heads_q != heads_k),
+            ).transpose(1,2)
+            return o_bshd
+
+    if not skip_ref_check:
+        # Execute kernel once for reference checking
+        print("Running...")
+        compiled_fmha(
+            kv_splits,
+            q_cute,
+            k_cute,
+            v_cute,
+            o_cute,
+            m_cute,
+            o_partial_cute,
+            m_partial_cute,
+            l_partial_cute,
+            scale_s,
+            current_stream,
+        )
+        print("Verifying results...")
+        o_ref = run_torch_fmha(q_ref, k_ref, v_ref, scale_s).cuda()
+        torch.testing.assert_close(
+            o_ref, o_torch.to(torch_ref_dtype), atol=tolerance, rtol=1e-05
+        )
+        print("PASS")
+
+    else:
+        print("SKIP")
+
+    #
+    # Profile
+    #
+    if iterations <= 0:
+        return 0.0
+
+    # Create non-default stream for CUDA graph profiling
+    torch_stream = torch.cuda.Stream()
+    profile_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    def workspace_generator():
+        _, q_cute, _ = create_tensor(qo_shape[1:], qkv_dtype, init=[-8, 7])
+        _, k_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
+        _, v_cute, _ = create_tensor(kv_shape, qkv_dtype, init=[-8, 7])
+        _, o_cute, _ = create_tensor(qo_shape[1:], o_dtype, init=(0 if atomic else None))
+        m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
+        if not atomic:
+            _, m_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
+            _, o_partial_cute, _ = create_tensor(qo_shape, acc_dtype)
+            _, m_partial_cute, _ = create_tensor(qo_shape[:-1], acc_dtype)
+            _, l_partial_cute, _ = create_tensor(qo_shape[:-1], acc_dtype)
+        return testing.JitArguments(
+            kv_splits,
+            q_cute,
+            k_cute,
+            v_cute,
+            o_cute,
+            m_cute,
+            o_partial_cute,
+            m_partial_cute,
+            l_partial_cute,
+            scale_s,
+            profile_stream,
+        )
+
+    workspace_count = 1
+    qkvo_bytes = q_torch.nbytes + k_torch.nbytes + v_torch.nbytes + o_torch.nbytes
+    if not use_warm_l2:
+        one_workspace_bytes = qkvo_bytes
+        if not atomic:
+            one_workspace_bytes += (
+                m_torch.nbytes
+                + o_partial_torch.nbytes
+                + m_partial_torch.nbytes
+                + l_partial_torch.nbytes
+            )
+        workspace_count = testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    runtime_us = testing.benchmark(
+        compiled_fmha,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        stream=profile_stream,
+        workspace_generator=workspace_generator,
+        workspace_count=workspace_count,
+        use_cuda_graphs=True,
+    )
+
+    # Print throughputs
+    terabytes_per_s = qkvo_bytes / runtime_us * 1.0e-6
+    flops = batches * heads_q * seqlen_q * seqlen_k * headdim * 2 * 2
+    teraflops_per_s = flops / runtime_us * 1.0e-6
+
+    print(
+        f"{runtime_us:.3f} us\n"
+        f"{terabytes_per_s:.3f} TB/s\n"
+        f"{teraflops_per_s:.3f} TFLOPS/s"
+    )
+
+    return (runtime_us, teraflops_per_s, terabytes_per_s)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Example of MHA/GQA decode on Blackwell."
+    )
+
+    parser.add_argument(
+        "--batches",
+        "--batch",
+        "--b",
+        type=int,
+        default=1,
+        help="batch size",
+    )
+
+    parser.add_argument(
+        "--prediction",
+        "--p",
+        type=int,
+        default=1,
+        help="number of predicted tokens",
+    )
+
+    parser.add_argument(
+        "--seqlen",
+        "--seq",
+        "--s",
+        type=int,
+        default=1024,
+        help="key/value sequence length",
+    )
+
+    parser.add_argument(
+        "--heads_q",
+        "--h_q",
+        type=int,
+        default=64,
+        help="query heads",
+    )
+
+    parser.add_argument(
+        "--heads_k",
+        "--h_k",
+        type=int,
+        default=8,
+        help="key/value heads",
+    )
+
+    parser.add_argument(
+        "--headdim",
+        "--d",
+        type=int,
+        default=128,
+        help="head dimension",
+    )
+
+    parser.add_argument(
+        "--kv_splits",
+        "--splits",
+        type=int,
+        default=0,
+        help="threadblocks per sequence",
+    )
+
+    parser.add_argument(
+        "--reduction",
+        type=str,
+        default="auto",
+        help="split KV reduction mode, can be kernel, atomic, or auto",
+    )
+
+    parser.add_argument(
+        "--qkv_dtype",
+        "--mma_dtype",
+        type=cutlass.dtype,
+        default=BFloat16,
+        help="query/key/value data type",
+    )
+
+    parser.add_argument(
+        "--o_dtype",
+        "--out_dtype",
+        type=cutlass.dtype,
+        default=BFloat16,
+        help="output data type",
+    )
+
+    parser.add_argument(
+        "--acc_dtype",
+        type=cutlass.dtype,
+        default=Float32,
+        help="accumulator/reduction data type",
+    )
+
+    parser.add_argument(
+        "--tolerance",
+        "--atol",
+        type=float,
+        default=1e-01,
+        help="Absolute tolerance for validation",
+    )
+
+    parser.add_argument(
+        "--scale_s",
+        "--scale",
+        type=float,
+        default=0,
+        help="score (Q*K) scale factor; if zero, defaults to 1/sqrt(D)",
+    )
+
+    parser.add_argument(
+        "--warmup_iterations",
+        "--warmups",
+        type=int,
+        default=10,
+        help="Number of iterations for warmup",
+    )
+
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=10,
+        help="Number of iterations after warmup",
+    )
+
+    parser.add_argument(
+        "--skip_ref_check",
+        action="store_true",
+        help="Skip reference check",
+    )
+
+    parser.add_argument(
+        "--use_warm_l2",
+        action="store_true",
+        help="dont rotate profiling workspace and dont flush L2 before profiling",
+    )
+
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Less verbose prints",
+    )
+
+    kwargs = vars(parser.parse_args())
+
+    run(**kwargs)

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -240,8 +240,6 @@ class GroupedQueryAttentionDecodePaged:
         kv_stages = remaining_bits // mk_stage_bits
         kv_stages -= 1 if kv_stages * pipe_stage_bits > alignment_bits else 0
 
-        print(f"\ts stages: {s_stages}\tkv stages: {kv_stages}")
-
         ##############################
         # TMA creation
         ##############################

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -25,7 +25,7 @@ from cutlass.cute.typing import (
     Optional, Literal, Union,
 )
 
-from flashinfer.cute_dsl.attention.gqa_decode import (
+from .gqa_decode import (
     # Kernel invariants
     mma_modes,
     mma_dice,
@@ -1694,7 +1694,8 @@ class GroupedQueryAttentionDecodePaged:
                     # Store partial colsum in smem and notify
                     if lane_store_max:
                         sL[lane_idx, warpgroup_widx] = rL_lane
-                    sL_final_nbar.arrive()
+                    # Wait to ensure reduction warp has reset sM_final_nbar
+                    sL_final_nbar.arrive_and_wait()
 
             # Load O of s-1, s
             tOrO_tail = cute.make_rmem_tensor((*tOsO.shape, o_stages), acc_dtype)

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -1820,7 +1820,6 @@ def run(
     reduction: str,
     qkv_dtype: Type[cutlass.Numeric],
     o_dtype: Type[cutlass.Numeric],
-    acc_dtype: Type[cutlass.Numeric],
     tolerance: float,
     scale_s: float,
     threshold_scale_factor: float,
@@ -2040,6 +2039,7 @@ def run(
     # LSE output (log2 base). Allocated unconditionally for both reduction
     # modes; the kernel only writes here, we don't refcheck — exists solely
     # to exercise the LSE-on compile path.
+    acc_dtype = Float32
     _, l_cute, l_torch = create_tensor(qo_shape[1:-1], acc_dtype)
     # Workspace tensors
     m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
@@ -2434,13 +2434,6 @@ if __name__ == "__main__":
         type=cutlass.dtype,
         default=BFloat16,
         help="output data type",
-    )
-
-    parser.add_argument(
-        "--acc_dtype",
-        type=cutlass.dtype,
-        default=Float32,
-        help="accumulator/reduction data type",
     )
 
     parser.add_argument(

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -123,11 +123,11 @@ class GroupedQueryAttentionDecodePaged:
         v_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
         q_bshd: cute.Tensor,
         o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
-        # Workspace tensors for kernel reduction
-        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized
-        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split
-        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
-        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
+        l_bsh: Optional[cute.Tensor],  # log-sum-exp output (Float32), log2 base
+        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized (kernel-red workspace)
+        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split (kernel-red workspace)
+        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split (kernel-red workspace)
+        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split (kernel-red workspace)
         scale_s: Float32,
         scale_o: Float32,
         threshold_scale_factor: Optional[Float32],
@@ -335,6 +335,13 @@ class GroupedQueryAttentionDecodePaged:
             tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
         )
 
+        # GEMM view for LSE output (atomic-reduction path; kernel-reduction
+        # path writes LSE directly from reduction_kernel using the raw bsh).
+        mL_nl = None
+        if cutlass.const_expr(l_bsh is not None and self.do_atomic_red):
+            assert l_bsh.dtype == acc_dtype
+            mL_nl = GqaDecode.gemm_view_bsh(l_bsh, h_k)  # ((h_g, s_q), (h_k, b))
+
         # GEMM views for workspace tensors
         mM_nl = mM_partial_nl = mL_partial_nl = None
         if cutlass.const_expr(self.do_kernel_red):
@@ -397,9 +404,10 @@ class GroupedQueryAttentionDecodePaged:
             tma_atom_o,
             tma_tensor_o,
             # Rest
+            mL_nl,
             mM_nl,
-            mM_partial_nl,
             mL_partial_nl,
+            mM_partial_nl,
             scale_s_log2_e,
             scale_o,
             log2_threshold_scale_factor,
@@ -416,10 +424,11 @@ class GroupedQueryAttentionDecodePaged:
             GqaDecode.launch_reduction(
                 self.headdim,
                 o_bshd,
+                l_bsh,
                 m_bsh,
                 o_partial_bshd,
-                m_partial_bsh,
                 l_partial_bsh,
+                m_partial_bsh,
                 scale_o,
                 stream,
             )
@@ -457,9 +466,10 @@ class GroupedQueryAttentionDecodePaged:
         tma_atom_o: cute.CopyAtom,
         mO: cute.Tensor,
         # Rest
+        mL: Optional[cute.Tensor],  # LSE output (Float32, log2 base)
         mM: Optional[cute.Tensor],
-        mM_partial: Optional[cute.Tensor],
         mL_partial: Optional[cute.Tensor],
+        mM_partial: Optional[cute.Tensor],
         scale_s_log2_e: Float32,
         scale_o: Float32,
         log2_threshold_scale_factor: Optional[Float32],
@@ -1749,6 +1759,9 @@ class GroupedQueryAttentionDecodePaged:
                     mL_partial,
                 )
             else:
+                gL = None
+                if cutlass.const_expr(mL is not None):
+                    gL = cute.local_tile(mL, blk_tile_hp, (coord_hp, coord_hb))
                 GqaDecode.reduction_cluster(
                     blk_tile_n,
                     kv_splits,
@@ -1760,6 +1773,7 @@ class GroupedQueryAttentionDecodePaged:
                     sM,
                     sL,
                     sR,
+                    gL,
                     scale_o,
                 )
             cute.arch.griddepcontrol_launch_dependents()
@@ -1968,6 +1982,10 @@ def run(
     _, o_cute, o_torch = create_tensor(
         qo_shape[1:], o_dtype, init=(0 if atomic else None)
     )
+    # LSE output (log2 base). Allocated unconditionally for both reduction
+    # modes; the kernel only writes here, we don't refcheck — exists solely
+    # to exercise the LSE-on compile path.
+    _, l_cute, l_torch = create_tensor(qo_shape[1:-1], acc_dtype)
     # Workspace tensors
     m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
     if not atomic:
@@ -2080,10 +2098,11 @@ def run(
         v_paged_cute,
         q_cute,
         o_cute,
+        l_cute,  # LSE output (compile-path exercise; not refchecked)
         m_cute,
         o_partial_cute,
-        m_partial_cute,
         l_partial_cute,
+        m_partial_cute,
         scale_s,
         1.0,  # scale_o
         threshold_scale_factor,
@@ -2134,10 +2153,11 @@ def run(
             v_paged_cute,
             q_cute,
             o_cute,
+            l_cute,
             m_cute,
             o_partial_cute,
-            m_partial_cute,
             l_partial_cute,
+            m_partial_cute,
             scale_s,
             1.0,  # scale_o
             threshold_scale_factor,
@@ -2190,6 +2210,7 @@ def run(
 
         q_cute, _ = cute_tensor_like(q_torch, qkv_dtype)
         o_cute, _ = cute_tensor_like(o_torch, o_dtype)
+        _, l_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype)
 
         m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
         if not atomic:
@@ -2207,10 +2228,11 @@ def run(
             v_paged_cute,
             q_cute,
             o_cute,
+            l_cute,
             m_cute,
             o_partial_cute,
-            m_partial_cute,
             l_partial_cute,
+            m_partial_cute,
             scale_s,
             1.0,  # scale_o
             threshold_scale_factor,

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -58,23 +58,42 @@ gmem_add = partial(cute.arch.atomic_add, sem="relaxed", scope="gpu")  # count sk
 class GroupedQueryAttentionDecodePaged:
     def __init__(
         self,
-        page_size,  # tokens per page
+        page_size,
         headdim,
-        grouped_head_tile,  # Grouped heads per threadblock (GQA packing factor)
-        prediction_tile=1,  # Predicted tokens per threadblock
-        sequence_tile=256,  # KV tokens per threadblock per loop iteration
-        reduction_mode: Literal[  # split-K reduction algorithm
-            "kernel",  # Deterministic kernel reduction with partial result workspace
-            "atomic",  # Cluster reduction with atomic adds, no workspace
-            "none",  # no split-K, flash decoding disabled
-        ] = "kernel",
+        grouped_head_tile,
+        prediction_tile=1,
+        sequence_tile=256,
+        reduction_mode: Literal["kernel", "atomic", "none"] = "kernel",
         softmax_warpgroups=1,
         *,
-        # No causal masking, oob scores are masked to 0 instead of -inf
-        # Results in mathematically equivalent softmax, but may produce
-        # subnormal exponentiations if non-oob scores are all negative (max goes to 0)
         tma_mask=False,
     ):
+        """
+        Parameters
+        ----------
+        page_size
+            Tokens per page.
+        headdim
+            Head dimension.
+        grouped_head_tile
+            Grouped heads per threadblock (GQA packing factor).
+        prediction_tile
+            Predicted tokens per threadblock.
+        sequence_tile
+            KV tokens per threadblock per loop iteration.
+        reduction_mode
+            Split-K reduction algorithm:
+              - ``"kernel"``: deterministic kernel reduction with partial result workspace.
+              - ``"atomic"``: cluster reduction with atomic adds, no workspace.
+              - ``"none"``: no split-K, flash decoding disabled.
+        softmax_warpgroups
+            Number of softmax warpgroups (1 or 2).
+        tma_mask
+            Disable causal masking — out-of-bounds scores are masked to 0
+            instead of -inf. Mathematically equivalent softmax, but may
+            produce subnormal exponentiations if non-oob scores are all
+            negative (max goes to 0).
+        """
         self.headdim = headdim
         self.grouped_head_tile = grouped_head_tile
         self.page_size = page_size
@@ -111,35 +130,67 @@ class GroupedQueryAttentionDecodePaged:
     @cute.jit
     def __call__(
         self,
-        kv_splits: Int32,  # threadblocks per sequence
-        seqlens: Union[cute.Tensor, Int32],  # sequence lengths for each batch
-        table_offsets: Optional[
-            cute.Tensor
-        ],  # starting offset into page table for each batch
-        page_table: cute.Tensor,  # logical to virtual page index mappings
-        k_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
-        v_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
+        kv_splits: Int32,
+        seqlens: Union[cute.Tensor, Int32],
+        table_offsets: Optional[cute.Tensor],
+        page_table: cute.Tensor,
+        k_bshd: cute.Tensor,
+        v_bshd: cute.Tensor,
         q_bshd: cute.Tensor,
-        o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
-        l_bsh: Optional[cute.Tensor],  # log-sum-exp output (Float32), log2 base
-        m_bsh: Optional[
-            cute.Tensor
-        ],  # colmax_s, must be -inf initialized (kernel-red workspace)
-        o_partial_bshd: Optional[
-            cute.Tensor
-        ],  # partial O per kv split (kernel-red workspace)
-        l_partial_bsh: Optional[
-            cute.Tensor
-        ],  # partial colsum_p per kv split (kernel-red workspace)
-        m_partial_bsh: Optional[
-            cute.Tensor
-        ],  # partial colmax_s per kv split (kernel-red workspace)
+        o_bshd: cute.Tensor,
+        l_bsh: Optional[cute.Tensor],
+        m_bsh: Optional[cute.Tensor],
+        o_partial_bshd: Optional[cute.Tensor],
+        l_partial_bsh: Optional[cute.Tensor],
+        m_partial_bsh: Optional[cute.Tensor],
         scale_s: Float32,
         scale_o: Float32,
         threshold_scale_factor: Optional[Float32],
         stream: cuda.CUstream,
         enable_pdl: bool = True,
     ):
+        """
+        Parameters
+        ----------
+        kv_splits
+            Threadblocks per sequence (flash decoding).
+        seqlens
+            Per-batch sequence lengths.
+        table_offsets
+            Starting offset into ``page_table`` for each batch.
+        page_table
+            Logical → virtual page index mapping.
+        k_bshd, v_bshd
+            Paged K/V tensors of shape ``(page_count, page_size, h_k, d)``.
+        q_bshd
+            Q tensor in BSHD logical view (strides can be BHSD)
+        o_bshd
+            Output tensor. Must be zero initialized for atomic reduction.
+        l_bsh
+            Log-sum-exp output (Float32, log2 base). May be None.
+        m_bsh
+            ``colmax_s`` running accumulator. Must be -inf initialized
+            (kernel-red workspace).
+        o_partial_bshd
+            Partial O per kv split (kernel-red workspace).
+        l_partial_bsh
+            Partial ``colsum_p`` per kv split (kernel-red workspace).
+        m_partial_bsh
+            Partial ``colmax_s`` per kv split (kernel-red workspace).
+        scale_s
+            Softmax scale.
+        scale_o
+            Output scale, applied in the reduction epilogue.
+        threshold_scale_factor
+            BLASST per-batch skip-softmax threshold scale factor. The kernel
+            divides this by each batch's KV seqlen to obtain the effective
+            per-request threshold. ``None`` disables BLASST.
+        stream
+            CUDA stream to launch on.
+        enable_pdl
+            Programmatic Dependent Launch. Runtime-dynamic — no recompile on
+            toggle.
+        """
         ##############################
         # TiledMma creation
         ##############################

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -128,6 +128,7 @@ class GroupedQueryAttentionDecodePaged:
         scale_o: Float32,
         threshold_scale_factor: Optional[Float32],
         stream: cuda.CUstream,
+        enable_pdl: bool = True,
     ):
         ##############################
         # TiledMma creation
@@ -413,7 +414,7 @@ class GroupedQueryAttentionDecodePaged:
             cluster=[cluster_x, 1, 1],
             stream=stream,
             min_blocks_per_mp=1,
-            use_pdl=True,
+            use_pdl=enable_pdl,
         )
 
         if cutlass.const_expr(self.do_kernel_red):
@@ -427,6 +428,7 @@ class GroupedQueryAttentionDecodePaged:
                 m_partial_bsh,
                 scale_o,
                 stream,
+                enable_pdl,
             )
 
     @cute.kernel

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -126,6 +126,7 @@ class GroupedQueryAttentionDecodePaged:
         m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
         l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
         scale_s: Float32,
+        scale_o: Float32,
         threshold_p: Optional[Float32],
         stream: cuda.CUstream,
     ):
@@ -394,6 +395,7 @@ class GroupedQueryAttentionDecodePaged:
             mM_partial_nl,
             mL_partial_nl,
             scale_s_log2_e,
+            scale_o,
             log2_threshold_p,
         ).launch(
             grid=grid,
@@ -412,6 +414,7 @@ class GroupedQueryAttentionDecodePaged:
                 o_partial_bshd,
                 m_partial_bsh,
                 l_partial_bsh,
+                scale_o,
                 stream,
             )
 
@@ -452,6 +455,7 @@ class GroupedQueryAttentionDecodePaged:
         mM_partial: Optional[cute.Tensor],
         mL_partial: Optional[cute.Tensor],
         scale_s_log2_e: Float32,
+        scale_o: Float32,
         log2_threshold_p: Optional[Float32],
     ):
         ##############################
@@ -1745,6 +1749,7 @@ class GroupedQueryAttentionDecodePaged:
                     sM,
                     sL,
                     sR,
+                    scale_o,
                 )
             cute.arch.griddepcontrol_launch_dependents()
 
@@ -2068,6 +2073,7 @@ def run(
         m_partial_cute,
         l_partial_cute,
         scale_s,
+        1.0,  # scale_o
         threshold_p,
         current_stream,
     )
@@ -2121,6 +2127,7 @@ def run(
             m_partial_cute,
             l_partial_cute,
             scale_s,
+            1.0,  # scale_o
             threshold_p,
             current_stream,
         )
@@ -2193,6 +2200,7 @@ def run(
             m_partial_cute,
             l_partial_cute,
             scale_s,
+            1.0,  # scale_o
             threshold_p,
             profile_stream,
         )

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -1922,6 +1922,12 @@ def run(
         threshold_scale_factor = Float32(threshold_scale_factor)
     enable_blasst = threshold_scale_factor is not None
 
+    sequence_tile = 256
+    if enable_blasst:
+        sequence_tile = 128 # Promote skipping
+    elif prediction_tile > 1 and blk_tile_n > 8:
+        sequence_tile = 128 # Prevent spills
+
     #
     # Config Kernel
     #
@@ -1930,7 +1936,7 @@ def run(
         headdim,
         grouped_head_tile,
         prediction_tile=prediction_tile,
-        sequence_tile=128 if enable_blasst else 256,
+        sequence_tile=sequence_tile,
         reduction_mode=reduction,
         softmax_warpgroups=(
             2 if not enable_blasst

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -1759,7 +1759,7 @@ class GroupedQueryAttentionDecodePaged:
             else:
                 gL = None
                 if cutlass.const_expr(mL is not None):
-                    gL = cute.local_tile(mL, blk_tile_hp, (coord_hp, coord_hb))
+                    gL = cute.local_tile(mL, (blk_tile_hp,), (coord_hp, coord_hb))
                 GqaDecode.reduction_cluster(
                     blk_tile_n,
                     kv_splits,

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -97,14 +97,17 @@ class GroupedQueryAttentionDecodePaged:
         assert self.do_kernel_red ^ self.do_atomic_red
 
     def can_implement(
-        self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype, threshold_p
+        self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype, threshold_scale_factor
     ):
         GqaDecode.can_implement(
             self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype
         )
 
-        if threshold_p is not None and not (0 < threshold_p <= 1):
-            raise ValueError(f"threshold_p must be None or in (0,1], got {threshold_p}")
+        if threshold_scale_factor is not None and not threshold_scale_factor > 0:
+            raise ValueError(
+                f"threshold_scale_factor must be None or > 0, "
+                f"got {threshold_scale_factor}"
+            )
 
     ##############################
     # Decode Kernel launch
@@ -127,7 +130,7 @@ class GroupedQueryAttentionDecodePaged:
         l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
         scale_s: Float32,
         scale_o: Float32,
-        threshold_p: Optional[Float32],
+        threshold_scale_factor: Optional[Float32],
         stream: cuda.CUstream,
     ):
         ##############################
@@ -220,7 +223,7 @@ class GroupedQueryAttentionDecodePaged:
         # page table
         smem_alloc_bits += pt_stages * pages_s * Int32.width
         # skip predicates
-        if cutlass.const_expr(threshold_p is not None):
+        if cutlass.const_expr(threshold_scale_factor is not None):
             smem_alloc_bits += sp_stages * (Int32.width + pipe_stage_bits)
         # colmax + colsum
         smem_alloc_bits += blk_tile_n * acc_dtype.width
@@ -349,9 +352,12 @@ class GroupedQueryAttentionDecodePaged:
         ##############################
         scale_s_log2_e = scale_s * log2_e
 
-        enable_blasst = threshold_p is not None
-        log2_threshold_p = (
-            Float32(cute.math.log2(threshold_p)) if enable_blasst else None
+        # BLASST threshold is normalized per-CTA inside `decode` using the
+        # CTA's batch seqlen. Precompute log2 of the host-side scale factor
+        # here so the kernel just subtracts log2(seqlen) per CTA.
+        enable_blasst = threshold_scale_factor is not None
+        log2_threshold_scale_factor = (
+            Float32(cute.math.log2(threshold_scale_factor)) if enable_blasst else None
         )
 
         n_tiles = cute.ceil_div(mQ_nkl.shape[0], (blk_tile_h, blk_tile_p))
@@ -396,7 +402,7 @@ class GroupedQueryAttentionDecodePaged:
             mL_partial_nl,
             scale_s_log2_e,
             scale_o,
-            log2_threshold_p,
+            log2_threshold_scale_factor,
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -456,7 +462,7 @@ class GroupedQueryAttentionDecodePaged:
         mL_partial: Optional[cute.Tensor],
         scale_s_log2_e: Float32,
         scale_o: Float32,
-        log2_threshold_p: Optional[Float32],
+        log2_threshold_scale_factor: Optional[Float32],
     ):
         ##############################
         # Static variables
@@ -494,7 +500,7 @@ class GroupedQueryAttentionDecodePaged:
         do_atomic_red = self.do_atomic_red
         tma_mask = self.tma_mask
         is_varlen = isinstance(seqlens_iter, cute.Pointer)
-        enable_blasst = log2_threshold_p is not None
+        enable_blasst = log2_threshold_scale_factor is not None
 
         ##############################
         # Warp specialization
@@ -1369,9 +1375,14 @@ class GroupedQueryAttentionDecodePaged:
                         masked_iters_s = 1
                         masked_coord_s = tiles_s - 1
 
-            # Tile skip tracking
             if cutlass.const_expr(enable_blasst):
+                # Tile skip tracking
                 sM_lane_prev = -Float32.inf
+                # Per-batch BLASST threshold, matching trtllm:
+                # effective threshold_p = scale_factor / seqlen
+                log2_threshold_p = (
+                    log2_threshold_scale_factor - cute.math.log2(Float32(seqlen))
+                )
 
             # Sequence loop
             num_loops = 2 if not tma_mask else 1
@@ -1771,7 +1782,7 @@ def run(
     acc_dtype: Type[cutlass.Numeric],
     tolerance: float,
     scale_s: float,
-    threshold_p: float,
+    threshold_scale_factor: float,
     warmup_iterations: int = 0,
     iterations: int = 0,
     skip_ref_check: bool = False,
@@ -1838,7 +1849,7 @@ def run(
         f" --kv_splits {kv_splits} --reduction {reduction}"
         f" --mma_dtype {qkv_dtype} --out_dtype {o_dtype}"
         f" --atol {tolerance}{" --skip_ref_check" if skip_ref_check else ""}"
-        f" --scale {scale_s} --threshold {threshold_p}"
+        f" --scale {scale_s} --threshold {threshold_scale_factor}"
         f" --iterations {iterations} --warmups {warmup_iterations}{" --use_warm_l2" if use_warm_l2 else ""}"
         f"{" --quiet" if quiet else ""}"
     )
@@ -1857,18 +1868,18 @@ def run(
             f"\tqkv: {qkv_dtype}\to: {o_dtype}\t\n"
             f"\tatol: {tolerance if not skip_ref_check else "skip"}"
             f"\tscale_s: {f"1 / sqrt({headdim})" if scale_s == 0 else scale_s}"
-            f"\tthreshold_p: {threshold_p}\n"
+            f"\tthreshold_scale_factor: {threshold_scale_factor}\n"
             f"\titerations: {iterations}\twarmups: {warmup_iterations}\twarm L2: {use_warm_l2}"
         )
 
     # Automatic scale + threshold
     if scale_s == 0:
         scale_s = headdim ** -0.5
-    if threshold_p == 0:
-        threshold_p = None  # disable
+    if threshold_scale_factor == 0:
+        threshold_scale_factor = None  # disable
     else:
-        threshold_p = Float32(threshold_p)
-    enable_blasst = threshold_p is not None
+        threshold_scale_factor = Float32(threshold_scale_factor)
+    enable_blasst = threshold_scale_factor is not None
 
     #
     # Config Kernel
@@ -1895,7 +1906,8 @@ def run(
     kv_shape = (batches, min_seqlen, heads_k, headdim)
 
     fmha.can_implement(
-        qo_shape[0], qo_shape[1:], kv_shape, qkv_dtype, o_dtype, threshold_p
+        qo_shape[0], qo_shape[1:], kv_shape, qkv_dtype, o_dtype,
+        threshold_scale_factor,
     )
 
     #
@@ -2074,7 +2086,7 @@ def run(
         l_partial_cute,
         scale_s,
         1.0,  # scale_o
-        threshold_p,
+        threshold_scale_factor,
         current_stream,
     )
     print("Finished Compiling")
@@ -2128,7 +2140,7 @@ def run(
             l_partial_cute,
             scale_s,
             1.0,  # scale_o
-            threshold_p,
+            threshold_scale_factor,
             current_stream,
         )
         if debug_blasst:
@@ -2201,7 +2213,7 @@ def run(
             l_partial_cute,
             scale_s,
             1.0,  # scale_o
-            threshold_p,
+            threshold_scale_factor,
             profile_stream,
         )
 
@@ -2373,11 +2385,14 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--threshold_p",
+        "--threshold_scale_factor",
         "--threshold",
         type=float,
         default=0,
-        help="skips block_pv if exp(block_qk - running_max) < threshold_p",
+        help=(
+            "BLASST skip threshold scale factor (per-batch effective threshold "
+            "is scale_factor / seqlen; 0 disables the optimization)."
+        ),
     )
 
     if debug_blasst:

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -1,0 +1,2427 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import argparse
+import math
+import random
+from typing import Type, Tuple
+from itertools import accumulate
+from functools import partial
+
+import torch
+from torch.nn.functional import scaled_dot_product_attention
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import tcgen05, OperandMajorMode
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import (
+    Agent,
+    CooperativeGroup,
+    NamedBarrier as nbar,
+)
+
+import cutlass.torch as cutlass_torch
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.cute.testing as testing
+from cutlass.cute.typing import (
+    Float32, Float16, BFloat16,
+    Int8, Int32, Int64,
+    Optional, Literal, Union,
+)
+
+from flashinfer.cute_dsl.attention.gqa_decode import (
+    # Kernel invariants
+    mma_modes,
+    mma_dice,
+    warp_threads,
+    warpgroup_warps,
+    warpgroup_threads,
+    max_reduction_iters,
+    # Math helpers
+    log2_e,
+    exp2,
+    warp_fmax,
+    smem_fmax,
+    # Kernel code
+    GroupedQueryAttentionDecode as GqaDecode,
+)
+
+# Math helpers
+warp_or = partial(cute.arch.warp_redux_sync, kind="or")  # skip predicate reduction
+
+# Debug helpers
+debug_blasst = False
+gmem_add = partial(cute.arch.atomic_add, sem="relaxed", scope="gpu")  # count skips
+
+
+class GroupedQueryAttentionDecodePaged:
+    def __init__(
+        self,
+        page_size,  # tokens per page
+        headdim,
+        grouped_head_tile,  # Grouped heads per threadblock (GQA packing factor)
+        prediction_tile=1,  # Predicted tokens per threadblock
+        sequence_tile=256,  # KV tokens per threadblock per loop iteration
+        reduction_mode : Literal[  # split-K reduction algorithm
+            "kernel", # Deterministic kernel reduction with partial result workspace
+            "atomic", # Cluster reduction with atomic adds, no workspace
+        ] = "kernel",
+        softmax_warpgroups=1,
+        *,
+        # No causal masking, oob scores are masked to 0 instead of -inf
+        # Results in mathematically equivalent softmax, but may produce
+        # subnormal exponentiations if non-oob scores are all negative (max goes to 0)
+        tma_mask=False,
+    ):
+        self.headdim = headdim
+        self.grouped_head_tile = grouped_head_tile
+        self.page_size = page_size
+        self.prediction_tile = prediction_tile
+        self.sequence_tile = sequence_tile
+        self.do_kernel_red = reduction_mode == "kernel"
+        self.do_atomic_red = reduction_mode == "atomic"
+        self.tma_mask = tma_mask
+        self.softmax_warpgroups = softmax_warpgroups
+        self.threads_per_cta = (2 + softmax_warpgroups) * warpgroup_threads
+
+        assert headdim > 0 and headdim % 64 == 0
+        assert grouped_head_tile * prediction_tile in (1, 2, 4, 8, 16, 32)
+        assert sequence_tile > 0 and sequence_tile % 128 == 0
+        assert page_size in (8, 16, 32, 64)
+        assert self.softmax_warpgroups in (1, 2)
+        assert self.do_kernel_red ^ self.do_atomic_red
+
+    def can_implement(
+        self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype, threshold_p
+    ):
+        GqaDecode.can_implement(
+            self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype
+        )
+
+        if threshold_p is not None and not (0 < threshold_p <= 1):
+            raise ValueError(f"threshold_p must be None or in (0,1], got {threshold_p}")
+
+    ##############################
+    # Decode Kernel launch
+    ##############################
+    @cute.jit
+    def __call__(
+        self,
+        kv_splits: Int32,  # threadblocks per sequence
+        seqlens: Union[cute.Tensor, Int32],  # sequence lengths for each batch
+        table_offsets: Optional[cute.Tensor],  # starting offset into page table for each batch
+        page_table: cute.Tensor,  # logical to virtual page index mappings
+        k_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
+        v_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
+        q_bshd: cute.Tensor,
+        o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
+        # Workspace tensors for kernel reduction
+        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized
+        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split
+        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
+        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
+        scale_s: Float32,
+        threshold_p: Optional[Float32],
+        stream: cuda.CUstream,
+    ):
+        ##############################
+        # TiledMma creation
+        ##############################
+        mma_dtype = q_bshd.dtype
+        acc_dtype = Float32
+        assert k_bshd.dtype == v_bshd.dtype == mma_dtype
+
+        # Block tile sets the granularity at which threadblocks consume work
+        blk_tile_s = self.sequence_tile
+        blk_tile_h = self.grouped_head_tile
+        blk_tile_p = self.prediction_tile
+        blk_tile_d = self.headdim
+        blk_tile_shpd = (blk_tile_s, blk_tile_h, blk_tile_p, blk_tile_d)
+
+        # MMA tile sets the granularity at which TMAs + MMAs are staged
+        mma_tile_m = 128
+        mma_tile_k = 128 * 8 // mma_dtype.width
+        # N-major 8b B in smem requires N multiple of 16
+        min_mma_tile_n = 16 if mma_dtype.width == 8 else 8
+        blk_tile_n = blk_tile_h * blk_tile_p  # linearized tiler
+        mma_tile_n = max(min_mma_tile_n, blk_tile_n)
+        mma_tile_mnk = (mma_tile_m, mma_tile_n, mma_tile_k)
+
+        # MMA tiles per block tile
+        tiles_sm = blk_tile_s // mma_tile_m
+        tiles_dm = math.ceil(blk_tile_d / mma_tile_m)
+        tiles_dk = math.ceil(blk_tile_d / mma_tile_k)
+        pages_s = blk_tile_s // self.page_size
+        assert blk_tile_s % mma_tile_m == 0
+        assert mma_tile_n % blk_tile_n == 0
+
+        # GEMM1: (S_K, H_R, D, (H_K, B))
+        tiled_mma_kq = sm100_utils.make_trivial_tiled_mma(
+            mma_dtype,
+            mma_dtype,
+            OperandMajorMode.K,  # K
+            OperandMajorMode.K,  # Q
+            acc_dtype,
+            tcgen05.CtaGroup.ONE,
+            mma_tile_mnk[:2],
+        )
+
+        # GEMM2: (D, H_R, S_K, (H_K, B))
+        tiled_mma_vp = sm100_utils.make_trivial_tiled_mma(
+            mma_dtype,
+            mma_dtype,
+            OperandMajorMode.MN,  # V
+            OperandMajorMode.MN,  # P
+            acc_dtype,
+            tcgen05.CtaGroup.ONE,
+            mma_tile_mnk[:2],
+        )
+
+        ##############################
+        # Calculate stage counts
+        ##############################
+        # Fixed stage counts
+        self.pt_stages = pt_stages = 4  # smem page table buffer
+        self.sp_stages = sp_stages = 4  # smem skip predicates
+        self.p_stages = p_stages = 4  # smem P (BMM2 B)
+        self.o_stages = o_stages = 2  # tmem O (BMM2 C)
+
+        # Calculate tmem alloc
+        tmem_capacity_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
+        tmem_s_stage_cols = tiles_sm * mma_tile_n
+        tmem_alloc_cols = mma_tile_n * o_stages  # per-thread colsum
+        tmem_alloc_cols += tiles_dm * mma_tile_n * o_stages  # O
+        max_s_stages = (tmem_capacity_cols - tmem_alloc_cols) // tmem_s_stage_cols
+        self.s_stages = s_stages = min(max_s_stages, p_stages)
+
+        tmem_alloc_cols += tmem_s_stage_cols * s_stages  # S
+        tmem_alloc_cols = 2 ** math.ceil(math.log2(tmem_alloc_cols)) # po2
+        self.tmem_alloc_cols = tmem_alloc_cols
+        assert tmem_alloc_cols <= tmem_capacity_cols
+
+        # Calculate smem alloc
+        smem_alloc_bits = 0
+        mbarrier_bits = Int64.width
+        pipe_stage_bits = mbarrier_bits * 2  # producer + consumer
+        mk_stage_bits = mma_tile_m * mma_tile_k * mma_dtype.width
+        nk_stage_bits = mma_tile_n * mma_tile_k * mma_dtype.width
+        mn_stage_bits = mma_tile_m * mma_tile_n * mma_dtype.width
+        # tmem ptr
+        smem_alloc_bits += Int32.width
+        # seqlen, table offset
+        is_varlen = isinstance(seqlens, cute.Tensor)
+        smem_alloc_bits += (Int32.width * 2) if is_varlen else 0
+        # page table
+        smem_alloc_bits += pt_stages * pages_s * Int32.width
+        # skip predicates
+        if cutlass.const_expr(threshold_p is not None):
+            smem_alloc_bits += sp_stages * (Int32.width + pipe_stage_bits)
+        # colmax + colsum
+        smem_alloc_bits += blk_tile_n * acc_dtype.width
+        smem_alloc_bits += blk_tile_n * warpgroup_warps * acc_dtype.width
+        if cutlass.const_expr(self.do_atomic_red):
+            smem_alloc_bits += max_reduction_iters * blk_tile_n * acc_dtype.width * 2
+            smem_alloc_bits += max_reduction_iters * mbarrier_bits * 2
+        # Q, S, P, O
+        smem_alloc_bits += tiles_dk * nk_stage_bits + mbarrier_bits  # 1 mbar for Q
+        smem_alloc_bits += s_stages * pipe_stage_bits  # s in tmem
+        smem_alloc_bits += p_stages * (tiles_sm * mn_stage_bits + pipe_stage_bits)
+        smem_alloc_bits += o_stages * pipe_stage_bits  # o in tmem
+        alignment_bits = 1024 - (smem_alloc_bits % 1024)
+        # K, V
+        smem_capacity_bits = utils.get_smem_capacity_in_bytes("sm_100") * 8
+        remaining_bits = smem_capacity_bits - smem_alloc_bits - alignment_bits
+        kv_stages = remaining_bits // mk_stage_bits
+        kv_stages -= 1 if kv_stages * pipe_stage_bits > alignment_bits else 0
+
+        print(f"\ts stages: {s_stages}\tkv stages: {kv_stages}")
+
+        ##############################
+        # TMA creation
+        ##############################
+        h_k = k_bshd.shape[2]
+        o_bshd_ = o_bshd if self.do_atomic_red else o_partial_bshd
+
+        # Reorder and group modes for GEMM
+        # ((h_g, s_q), d, (h_k, b))
+        mQ_nkl = GqaDecode.gemm_view(GqaDecode.gqa_pack(q_bshd, h_k), True)
+        mK_mkl = GqaDecode.gemm_view(k_bshd, True)  # (page_size, d, (h_k, page_count))
+        mV_mkl = GqaDecode.gemm_view(v_bshd, False)  # (d, page_size, (h_k, page_count))
+        # (d, (h_g, s_q), (h_k, b_partial))
+        mO_mnl = GqaDecode.gemm_view(GqaDecode.gqa_pack(o_bshd_, h_k), False)
+
+        # ((MMA_N, MMA_K), #MMA_N, #MMA_K, q_stages)
+        smem_layout_q = sm100_utils.make_smem_layout_b(
+            tiled_mma_kq, mma_tile_mnk, mma_dtype, tiles_dk
+        )
+
+        # ((MMA_M, MMA_K), #MMA_M, #MMA_K, kv_stages)
+        smem_layout_k_mma = sm100_utils.make_smem_layout_a(
+            tiled_mma_kq, mma_tile_mnk, mma_dtype, kv_stages
+        )
+        smem_layout_v_mma = sm100_utils.make_smem_layout_a(
+            tiled_mma_vp, mma_tile_mnk, mma_dtype, kv_stages
+        )
+
+        # (MMA_TILE_M, MMA_TILE_K, kv_stages)
+        smem_layout_k_mk = cute.composition(
+            smem_layout_k_mma,
+            cute.make_layout((mma_tile_m, mma_tile_k, kv_stages)),
+        )
+        smem_layout_v_mk = cute.composition(
+            smem_layout_v_mma,
+            cute.make_layout((mma_tile_m, mma_tile_k, kv_stages)),
+        )
+
+        # ((PAGE, MMA_TILE_K), #PAGE_M, 1, kv_stages)
+        smem_layout_k_tma = cute.tiled_divide(
+            smem_layout_k_mk, (self.page_size, mma_tile_k)
+        )
+        # (TMA, #PAGE_M, kv_stages)
+        smem_layout_k_tma = cute.select(
+            smem_layout_k_tma, [0, 1, 3]
+        )
+        # ((MMA_TILE_M, PAGE), 1, #PAGE_K, kv_stages)
+        smem_layout_v_tma = cute.tiled_divide(
+            smem_layout_v_mk, (mma_tile_m, self.page_size)
+        )
+        # (TMA, #PAGE_K, kv_stages)
+        smem_layout_v_tma = cute.select(
+            smem_layout_v_tma, [0, 2, 3]
+        )
+
+        o_smem_dtype = mO_mnl.dtype
+        smem_layout_atom_o = tcgen05.make_smem_layout_atom(
+            tcgen05.mma.SmemLayoutAtomKind.MN_SW128, o_smem_dtype
+        )
+        smem_layout_o = cute.tile_to_shape(
+            smem_layout_atom_o, (max(blk_tile_d, mma_tile_m), mma_tile_n), order=(1, 0)
+        )
+        smem_layout_o = cute.flat_divide(smem_layout_o, (mma_tile_m, mma_tile_n))
+
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+        tma_store_op = (
+            cute.nvgpu.cpasync.CopyReduceBulkTensorTileS2GOp()
+            if self.do_atomic_red
+            else cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+        )
+
+        # Construct multimode gmem tiler
+        tma_tile_n = (blk_tile_h, mma_tile_n // blk_tile_h)
+        tma_tile_mnk = (mma_tile_m, tma_tile_n, mma_tile_k)
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            mQ_nkl,
+            cute.select(smem_layout_q, mma_modes),
+            tma_tile_mnk,
+            tiled_mma_kq,
+        )
+        tma_atom_k, tma_tensor_k = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_load_op, mK_mkl, smem_layout_k_tma[0], (self.page_size, mma_tile_k)
+        )
+        tma_atom_v, tma_tensor_v = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_load_op, mV_mkl, smem_layout_v_tma[0], (mma_tile_m, self.page_size)
+        )
+        tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
+        )
+
+        # GEMM views for workspace tensors
+        mM_nl = mM_partial_nl = mL_partial_nl = None
+        if cutlass.const_expr(self.do_kernel_red):
+            assert (m_bsh.dtype == m_partial_bsh.dtype
+                    == l_partial_bsh.dtype == o_partial_bshd.dtype
+                    == acc_dtype)
+
+            # ((h_g, s_q), (h_k, b), kv_splits)
+            mM_nl = GqaDecode.gemm_view_bsh(m_bsh, h_k)
+            mM_partial_nl = GqaDecode.gemm_view_bsh(m_partial_bsh, h_k)
+            mL_partial_nl = GqaDecode.gemm_view_bsh(l_partial_bsh, h_k)
+
+        ##############################
+        # Launch kernel(s)
+        ##############################
+        scale_s_log2_e = scale_s * log2_e
+
+        enable_blasst = threshold_p is not None
+        log2_threshold_p = (
+            Float32(cute.math.log2(threshold_p)) if enable_blasst else None
+        )
+
+        n_tiles = cute.ceil_div(mQ_nkl.shape[0], (blk_tile_h, blk_tile_p))
+        n_tiles = cute.size(n_tiles)
+        l_tiles = cute.size(mQ_nkl.shape[2])
+        grid = (kv_splits, n_tiles, l_tiles)
+        cluster_x = kv_splits if self.do_atomic_red else 1
+
+        self.decode(
+            # MMA
+            blk_tile_shpd,
+            mma_tile_mnk,
+            tiled_mma_kq,
+            tiled_mma_vp,
+            mma_dtype,
+            o_smem_dtype,
+            # Page Table
+            seqlens.iterator if is_varlen else seqlens,
+            table_offsets.iterator if is_varlen else None,
+            page_table.iterator,
+            # K
+            smem_layout_k_mma,
+            smem_layout_k_tma,
+            tma_atom_k,
+            tma_tensor_k,
+            # V
+            smem_layout_v_mma,
+            smem_layout_v_tma,
+            tma_atom_v,
+            tma_tensor_v,
+            # Q
+            smem_layout_q,
+            tma_atom_q,
+            tma_tensor_q,
+            # O
+            smem_layout_o,
+            tma_atom_o,
+            tma_tensor_o,
+            # Rest
+            mM_nl,
+            mM_partial_nl,
+            mL_partial_nl,
+            scale_s_log2_e,
+            log2_threshold_p,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[cluster_x, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=True,
+        )
+
+        if cutlass.const_expr(self.do_kernel_red):
+            GqaDecode.launch_reduction(
+                self.headdim,
+                o_bshd,
+                m_bsh,
+                o_partial_bshd,
+                m_partial_bsh,
+                l_partial_bsh,
+                stream,
+            )
+
+    @cute.kernel
+    def decode(
+        self,
+        # MMA
+        blk_tile_shpd: cute.Tile,
+        mma_tile_mnk: cute.Tile,
+        tiled_mma_kq: cute.TiledMma,
+        tiled_mma_vp: cute.TiledMma,
+        mma_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        # Page Table
+        seqlens_iter: Union[cute.Pointer, Int32],
+        table_offsets_iter: Optional[cute.Pointer],
+        page_table_iter: cute.Pointer,
+        # K
+        smem_layout_k_mma: cute.ComposedLayout,
+        smem_layout_k_tma: cute.ComposedLayout,
+        tma_atom_k: cute.CopyAtom,
+        mK: cute.Tensor,
+        # V
+        smem_layout_v_mma: cute.ComposedLayout,
+        smem_layout_v_tma: cute.ComposedLayout,
+        tma_atom_v: cute.CopyAtom,
+        mV: cute.Tensor,
+        # Q
+        smem_layout_q: cute.ComposedLayout,
+        tma_atom_q: cute.CopyAtom,
+        mQ: cute.Tensor,
+        # O
+        smem_layout_o: cute.ComposedLayout,
+        tma_atom_o: cute.CopyAtom,
+        mO: cute.Tensor,
+        # Rest
+        mM: Optional[cute.Tensor],
+        mM_partial: Optional[cute.Tensor],
+        mL_partial: Optional[cute.Tensor],
+        scale_s_log2_e: Float32,
+        log2_threshold_p: Optional[Float32],
+    ):
+        ##############################
+        # Static variables
+        ##############################
+        # Smem alloc helper
+        svector_align = 16
+        stensor_align = 128
+        smem = utils.SmemAllocator()
+
+        # No multicast
+        mcast_coord = 0
+        mcast_layout = cute.make_layout((1, 1, 1, 1))  # vmnk
+
+        # Alias types
+        q_dtype = k_dtype = v_dtype = mma_dtype
+        o_dtype = out_dtype
+        acc_dtype = Float32
+
+        # Shapes for MMA tile indexing
+        blk_tile_s, blk_tile_h, blk_tile_p, blk_tile_d = blk_tile_shpd
+        blk_tile_hp = (blk_tile_h, blk_tile_p)  # multimode tiler
+        blk_tile_n = blk_tile_h * blk_tile_p  # linearized tiler
+        mma_tile_m, mma_tile_n, mma_tile_k = mma_tile_mnk
+        tiles_sm = blk_tile_s // mma_tile_m
+        tiles_sk = blk_tile_s // mma_tile_k
+        tiles_dm = cute.ceil_div(blk_tile_d, mma_tile_m)
+        tiles_dk = cute.ceil_div(blk_tile_d, mma_tile_k)
+        page_size = self.page_size
+        pages_s = blk_tile_s // page_size
+        pages_m = mma_tile_m // page_size
+        pages_k = mma_tile_k // page_size
+
+        # Static control flow
+        do_kernel_red = self.do_kernel_red
+        do_atomic_red = self.do_atomic_red
+        tma_mask = self.tma_mask
+        is_varlen = isinstance(seqlens_iter, cute.Pointer)
+        enable_blasst = log2_threshold_p is not None
+
+        ##############################
+        # Warp specialization
+        ##############################
+        # Warp assignments
+        warpgroup_id = 0
+        mma_kq_warp_id = warpgroup_id * warpgroup_warps + 0
+        mma_vp_warp_id = warpgroup_id * warpgroup_warps + 1
+        tma_qk_warp_id = warpgroup_id * warpgroup_warps + 2
+        tma_vo_warp_id = warpgroup_id * warpgroup_warps + 3
+        reduction_warp_id = mma_kq_warp_id
+        warpgroup_id += 1
+
+        softmax_warpgroups = self.softmax_warpgroups
+        softmax_warpgroup_ids = tuple(
+            range(warpgroup_id, warpgroup_id + softmax_warpgroups)
+        )
+        warpgroup_id += softmax_warpgroups
+        assert softmax_warpgroups in (1, 2)
+
+        correction_warpgroup_id = warpgroup_id
+        warpgroup_id += 1
+        assert self.threads_per_cta == warpgroup_id * warpgroup_threads
+
+        # Register allocations
+        use_reg_reconfig = blk_tile_h > 16
+        max_sw_regs_per_wg_thread = 256  # CUDA limitation
+        max_hw_regs_per_wg_thread = 64 * 1024 // warpgroup_threads  # 64K regs per SM
+        mma_tma_regs = 64
+        softmax_regs = 120
+        correction_regs = min(
+            max_sw_regs_per_wg_thread,
+            max_hw_regs_per_wg_thread
+            - mma_tma_regs
+            - softmax_regs * softmax_warpgroups
+        )
+        assert (
+            mma_tma_regs
+            + softmax_regs * softmax_warpgroups
+            + correction_regs
+        ) <= max_hw_regs_per_wg_thread
+
+        # Read thread indices
+        kv_splits, tiles_hp, tiles_hb = cute.arch.grid_dim()
+        kv_split_idx, coord_hp, coord_hb = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_idx = cute.arch.lane_idx()
+        warp_idx = cute.arch.make_warp_uniform(tidx // warp_threads)
+        warpgroup_idx = cute.arch.make_warp_uniform(tidx // warpgroup_threads)
+        warpgroup_tidx = tidx % warpgroup_threads
+        warpgroup_widx = warp_idx % warpgroup_warps
+        init_warp = 1  # warp 0 does all pipeline inits for now
+
+        # Unpack multimodes
+        grouped_heads, prediction = mQ.shape[0]
+        heads_k, batches = tiles_hb = mQ.shape[2]
+        tiles_hp = cute.ceil_div(mQ.shape[0], blk_tile_hp)
+        coord_hb = cute.idx2crd(coord_hb, tiles_hb)
+        coord_hp = cute.idx2crd(coord_hp, tiles_hp)
+        coord_hg, coord_p = coord_hp
+        coord_hk, coord_b = coord_hb
+
+        ##############################
+        # Prefetch Seqlen
+        ##############################
+        cpasync_atom = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(), Int32, num_bits_per_copy=32
+        )
+        if cutlass.const_expr(is_varlen):
+            scalar_layout = cute.make_layout(1)
+            seqlen_smem = smem.allocate_tensor(Int32, scalar_layout)
+            table_offset_smem = smem.allocate_tensor(Int32, scalar_layout)
+            if warp_idx == init_warp:
+                seqlen_gmem = cute.make_tensor(
+                    seqlens_iter + coord_b, scalar_layout
+                )
+                table_offset_gmem = cute.make_tensor(
+                    table_offsets_iter + coord_b, scalar_layout
+                )
+                cute.arch.griddepcontrol_wait()
+                with cute.arch.elect_one():
+                    cute.copy(cpasync_atom, seqlen_gmem, seqlen_smem)
+                    cute.copy(cpasync_atom, table_offset_gmem, table_offset_smem)
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+            init_warp += 1
+
+
+        ##############################
+        # Prefetch TMA descriptor
+        ##############################
+        if warp_idx == init_warp:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
+        init_warp += 1
+
+        ##############################
+        # Tmem Allocation
+        ##############################
+        tmem_alloc_cols = self.tmem_alloc_cols
+        tmem_ptr_smem_ptr = smem.allocate_array(Int32)
+        if warp_idx == init_warp:
+            cute.arch.alloc_tmem(tmem_alloc_cols, tmem_ptr_smem_ptr)
+        init_warp += 1
+
+        ##############################
+        # Pipeline Allocation + Init
+        ##############################
+        # Initialize named barriers
+        softmax_threads = warpgroup_threads
+        correction_threads = warpgroup_threads
+        reduction_threads = warp_threads
+        mma_threads = warp_threads
+        tma_threads = warp_threads
+        # Shared KV pipeline requires ordering MMA + TMA
+        # Prefer to keep MMA/TMA in separate warps even if we order their execution
+        # Compiler optimization is easier with less warp uniform register pressure
+        # Small pages increase pressure on TMA warps (More TMAs per unrolled block tile)
+        # Large headdim increases pressure on MMA warps (More MMAs per unrolled block tile)
+        tma_order_k_nbar = nbar(1, tma_threads + tma_threads)
+        tma_order_v_nbar = nbar(2, tma_threads + tma_threads)
+        mma_order_kq_nbar = nbar(3, mma_threads + mma_threads)
+        mma_order_vp_nbar = nbar(4, mma_threads + mma_threads)
+        sM_producer_nbar = nbar(5, softmax_threads + correction_threads)
+        sM_consumer_nbar = nbar(6, softmax_threads + correction_threads)
+        tL_producer_nbar = nbar(7, softmax_threads + correction_threads)
+        tL_consumer_nbar = nbar(9, softmax_threads + correction_threads)
+        sM_final_nbar = nbar(11, correction_threads + reduction_threads)
+        sL_final_nbar = nbar(12, correction_threads + reduction_threads)
+        sO_final_nbar = nbar(13, correction_threads + tma_threads)
+        # dual softmax and blasst are mutually exclusive
+        sSP_producer_nbar = nbar(14, softmax_threads)
+        sM_mutex_nbar = nbar(14, softmax_threads * softmax_warpgroups)
+        # named barrier stage helper
+        def with_phase(nbar_, phase):
+            return nbar(nbar_.barrier_id + phase, nbar_.num_threads)
+
+        # Alias thread cooperatives
+        thr_cg = lambda t: CooperativeGroup(Agent.Thread, t)
+        elect_one_cooperative = thr_cg(1)
+        warpgroup_cooperative = thr_cg(warpgroup_threads)
+        mma_group = elect_one_cooperative
+        tma_group = elect_one_cooperative
+        softmax_group = warpgroup_cooperative
+        correction_group = warpgroup_cooperative
+
+        # Initialize cluster colmax + colsum mbar (even if this split exits early)
+        if cutlass.const_expr(do_atomic_red):
+            reduction_mbars_ptr = smem.allocate_array(Int64, max_reduction_iters * 2)
+            if warp_idx == init_warp:
+                if lane_idx < max_reduction_iters * 2:
+                    mbar_ptr = reduction_mbars_ptr + lane_idx
+                    arrive_count = 1
+                    expect_tx_bytes = blk_tile_n * acc_dtype.width // 8
+                    cute.arch.mbarrier_init(mbar_ptr, arrive_count)
+                    cute.arch.mbarrier_init_fence()
+                    cute.arch.mbarrier_arrive_and_expect_tx(mbar_ptr, expect_tx_bytes)
+            init_warp += 1
+            cute.arch.cluster_arrive_relaxed()
+
+        # Initialize Q load mbarrier
+        q_load_mbar = smem.allocate_array(Int64, 1)
+        if warp_idx == init_warp:
+            expect_tx_bytes = cute.size_in_bytes(q_dtype, smem_layout_q)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_init(q_load_mbar, 1)
+                cute.arch.mbarrier_init_fence()
+                cute.arch.mbarrier_arrive_and_expect_tx(q_load_mbar, expect_tx_bytes)
+        init_warp += 1
+
+        # Initialize pipelines
+        kv_stages = smem_layout_k_tma.shape[-1]
+        kv_stage_bytes = mma_tile_m * mma_tile_k * k_dtype.width // 8
+        kv_pipeline_ptr = smem.allocate_array(Int64, kv_stages * 2)
+        kv_producer, kv_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=kv_stages,
+            producer_group=tma_group,
+            consumer_group=mma_group,
+            tx_count=kv_stage_bytes,
+            barrier_storage=kv_pipeline_ptr,
+            cta_layout_vmnk=mcast_layout,
+            defer_sync=True,
+        ).make_participants()
+
+        s_stages = self.s_stages
+        s_pipeline_ptr = smem.allocate_array(Int64, s_stages * 2)
+        s_producer, s_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.s_stages,
+            producer_group=mma_group,
+            consumer_group=softmax_group,
+            barrier_storage=s_pipeline_ptr,
+            defer_sync=True,
+        ).make_participants()
+
+        p_stages = self.p_stages
+        p_pipeline_ptr = smem.allocate_array(Int64, p_stages * 2)
+        p_producer, p_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.p_stages,
+            producer_group=softmax_group,
+            consumer_group=mma_group,
+            barrier_storage=p_pipeline_ptr,
+            defer_sync=True,
+        ).make_participants()
+
+        o_stages = self.o_stages
+        o_pipeline_ptr = smem.allocate_array(Int64, o_stages * 2)
+        o_producer, o_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=o_stages,
+            producer_group=mma_group,
+            consumer_group=correction_group,
+            barrier_storage=o_pipeline_ptr,
+            defer_sync=True,
+        ).make_participants()
+
+        if cutlass.const_expr(enable_blasst):
+            skip_group = thr_cg(correction_threads + (mma_threads + tma_threads) * 2)
+
+            sp_stages = self.sp_stages
+            sp_pipeline_ptr = smem.allocate_array(Int64, sp_stages * 2)
+            sp_producer, sp_consumer = pipeline.PipelineAsync.create(
+                num_stages=sp_stages,
+                producer_group=softmax_group,
+                consumer_group=skip_group,
+                barrier_storage=sp_pipeline_ptr,
+                defer_sync=True,
+            ).make_participants()
+
+            # SP - skip predicates
+            sSP_i32 = smem.allocate_tensor(Int32, cute.make_layout(sp_stages))
+            sSP_i8 = cute.make_tensor(
+                cute.recast_ptr(sSP_i32.iterator, dtype=Int8),
+                cute.make_layout((warpgroup_warps, sp_stages)),
+            )
+
+        ##############################
+        # Smem Tensor Allocation
+        ##############################
+        # Threadblock slice
+        thrblk_mma_kq = tiled_mma_kq.get_slice(0)
+        thrblk_mma_vp = tiled_mma_vp.get_slice(0)
+
+        # Q, K, V
+        tAsK = smem.allocate_tensor(
+            k_dtype, smem_layout_k_mma.outer, stensor_align, smem_layout_k_mma.inner
+        )  # (MMA, #MMA_M, #MMA_K, kv_stages)
+        tAsV = cute.make_tensor(
+            tAsK.iterator, smem_layout_v_mma.outer
+        )  # (MMA, #MMA_M, #MMA_K, kv_stages)
+        tBsQ = smem.allocate_tensor(
+            q_dtype, smem_layout_q.outer, stensor_align, smem_layout_q.inner
+        )  # (MMA, #MMA_N, #MMA_K, q_stages)
+
+        # S
+        # (MMA_MN, #MMA_M=1, #MMA_N=1, #TILE_SM, s_stages)
+        tCtS_shape = tiled_mma_kq.partition_shape_C(
+            (mma_tile_m, mma_tile_n, tiles_sm, s_stages)
+        )
+        tCtS = thrblk_mma_kq.make_fragment_C(tCtS_shape)
+
+        # P - Treat MN C tile of BMM0 as NM B tile of BMM1
+        # (MMA_NK, #MMA_N=1, #MMA_K=TILE_S/MMA_K, p_stages)
+        blk_tile_nm = (None, mma_tile_n, mma_tile_m * tiles_sm)
+        tBsP_nm_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma_vp, blk_tile_nm, mma_dtype, p_stages
+        )
+        tBsP_nm = smem.allocate_tensor(
+            mma_dtype, tBsP_nm_layout.outer, stensor_align, tBsP_nm_layout.inner
+        )
+
+        # Tile for NK B tile iteration
+        tBsP_nk_tile = thrblk_mma_vp.partition_shape_B(
+            (mma_tile_n, mma_tile_k)
+        )  # (MMA_NK, #MMA_N=1, #MMA_K=MMA_TILE_K/MMA_K, #TILE_SK=TILE_S/MMA_TILE_K, p_stages)
+        tBsP_nk = cute.local_tile(tBsP_nm, tBsP_nk_tile, (0, 0, None, None))
+
+        # Reshape NM B tile of BMM1 to become MN C tile of BMM0
+        # (MMA_NK, #MMA_N, #MMA_K=TILE_S/MMA_K, p_stages) ->
+        # (MMA_MN, #MMA_M, #MMA_N, #TILE_SM, p_stages)
+        tCsP_tile = cute.make_ordered_layout(tCtS_shape, order=((2, 0), 3, 1, 4, 5))
+        tCsP = cute.composition(tBsP_nm, tCsP_tile)
+
+        # O
+        # Reuse KV smem for O TMA store
+        sO_iterator = cute.recast_ptr(
+            tAsK.iterator, smem_layout_o.inner, dtype=o_dtype
+        )
+        # (MMA_TILE_M, MMA_TILE_N, #TILE_DM, #TILE_HN)
+        sO_mma = cute.make_tensor(sO_iterator, smem_layout_o.outer)
+        # (MMA, #MMA_M, #MMA_N, #TILE_DM, #TILE_HN=1)
+        tCsO = thrblk_mma_vp.partition_C(sO_mma)
+        tCsO = tCsO[mma_dice + (None, 0)]
+        # (MMA, #MMA_M, #MMA_N, #TILE_DM, o_stages)
+        tCtO = thrblk_mma_vp.make_fragment_C((*tCsO.shape, o_stages))
+
+        # PT - Page Table lookup buffer
+        pt_stages = self.pt_stages
+        sPT_layout = cute.make_layout((pages_s, pt_stages))
+        sPT = smem.allocate_tensor(Int32, sPT_layout, svector_align)
+
+        # M - colmax
+        sM_layout = cute.make_layout(blk_tile_n)
+        sM = smem.allocate_tensor(acc_dtype, sM_layout, svector_align)
+        lane_store_max = blk_tile_n == warp_threads or lane_idx < blk_tile_n
+        if warp_idx == init_warp:
+            if lane_store_max:
+                sM[lane_idx] = -Float32.inf
+        init_warp += 1
+
+        # L - colsum
+        sL_layout = cute.make_layout((blk_tile_n, warpgroup_warps))
+        sL = smem.allocate_tensor(acc_dtype, sL_layout, svector_align)
+        if warp_idx == init_warp:
+            for i in cutlass.range_constexpr(0, cute.size(sL), warp_threads):
+                if i + lane_idx < cute.size(sL):
+                    sL[i + lane_idx] = Float32(0)
+        init_warp += 1
+
+        # per-thread colsum
+        # (MMA_MN, #MMA_M=1, #MMA_N=1, o_stages)
+        tCtL_shape = tiled_mma_kq.partition_shape_C(
+            (mma_tile_m, mma_tile_n, o_stages)
+        )
+        tCtL = thrblk_mma_kq.make_fragment_C(tCtL_shape)
+
+        # R - cluster reduction buffers for colmax + colsum
+        if cutlass.const_expr(do_atomic_red):
+            sR_layout = cute.make_layout((blk_tile_n, max_reduction_iters, 2))
+            sR = smem.allocate_tensor(acc_dtype, sR_layout, svector_align)
+
+        ##############################
+        # Sync
+        ##############################
+        # Ensure visibility of cluster mbarriers
+        if cutlass.const_expr(do_atomic_red):
+            cute.arch.cluster_wait()
+
+        # Ensure visibility of local mbarrier inits, table offset async load, tmem alloc
+        cute.arch.sync_threads()
+        assert init_warp <= (self.threads_per_cta // warp_threads), (
+            f"used {init_warp} init warps, {self.threads_per_cta // warp_threads} warps available"
+        )
+
+        # Runtime control flow
+        if cutlass.const_expr(is_varlen):
+            seqlen = seqlen_smem[0]
+            page_count = cute.ceil_div(seqlen, page_size)
+            table_offset = table_offset_smem[0]
+        else:
+            seqlen = seqlens_iter
+            page_count = cute.ceil_div(seqlen, page_size)
+            table_offset = coord_b * page_count
+        tiles_s = cute.ceil_div(seqlen, blk_tile_s)
+        iters_s = cute.ceil_div(tiles_s - kv_split_idx, kv_splits)
+        exit_early = kv_split_idx >= tiles_s
+        prefetch_iters = min(2, s_stages - 1) # MMA KQ iters to hide first softmax
+        assert pt_stages > prefetch_iters + 1
+
+        ##############################
+        # Tmem tensor allocation
+        ##############################
+        tmem_ptr = cute.arch.retrieve_tmem_ptr(Int32, 16, tmem_ptr_smem_ptr)
+        tmem_offset = 0
+
+        tCtS = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + tmem_offset, dtype=acc_dtype), tCtS.layout
+        )
+        tmem_offset += tcgen05.find_tmem_tensor_col_offset(tCtS)
+
+        tCtL = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + tmem_offset, dtype=acc_dtype), tCtL.layout
+        )
+        tmem_offset += tcgen05.find_tmem_tensor_col_offset(tCtL)
+
+        tCtO = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr + tmem_offset, dtype=acc_dtype), tCtO.layout
+        )
+        tmem_offset += tcgen05.find_tmem_tensor_col_offset(tCtO)
+
+        assert tmem_offset <= tmem_alloc_cols, (
+            f"\t{tmem_offset} tmem cols used, {tmem_alloc_cols} tmem cols allocated"
+        )
+
+        ##############################
+        # Exit early
+        ##############################
+        if exit_early:
+            if warp_idx == mma_vp_warp_id:
+                cute.arch.relinquish_tmem_alloc_permit()
+                cute.arch.dealloc_tmem(tmem_ptr, self.tmem_alloc_cols)
+
+            elif warpgroup_idx == correction_warpgroup_id:
+                sM_final_nbar.arrive()
+                sL_final_nbar.arrive()
+
+        ##############################
+        # TMA QK Dispatch
+        ##############################
+        elif warp_idx == tma_qk_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Slice and partition Q
+            # (TILE_H, TILE_D)
+            gQ = cute.local_tile(
+                mQ,
+                tiler=(blk_tile_hp, blk_tile_d),
+                coord=(coord_hp, 0, coord_hb),
+            )
+            # (MMA_TILE_N, MMA_TILE_K, #TILE_DK)
+            gQ_mma = cute.local_tile(
+                gQ, (mma_tile_n, mma_tile_k), coord=(0, None)
+            )
+            # (MMA, #MMA_N, #MMA_K, #TILE_DK)
+            tBgQ = thrblk_mma_kq.partition_B(gQ_mma)
+            # (TMA, #TILE_DK)
+            tBsQ_tma, tBgQ_tma = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_q,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=cute.group_modes(tBsQ, 0, 3),
+                gmem_tensor=cute.group_modes(tBgQ, 0, 3),
+            )
+
+            # Slice and partition K
+            sK = cute.make_tensor(
+                tAsK.iterator, smem_layout_k_tma.outer
+            )  # ((PAGE, MMA_TILE_K), #PAGE_M, k_stages)
+            gK = cute.local_tile(
+                mK, (page_size, mma_tile_k), coord=(0, None, (coord_hk, None))
+            )  # (PAGE, MMA_TILE_K, #TILE_DK, #PAGE_S)
+            sK_tma, gK_tma = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_k,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=sK,
+                gmem_tensor=cute.group_modes(gK, 0, 2),
+            )  # (TMA, Rest...)
+
+            # Construct page table for this batch
+            gPT = cute.make_tensor(page_table_iter + table_offset, (page_count,))
+            cPT = cute.make_identity_tensor(page_count)
+
+            # Partition page table
+            pt_load = cute.make_tiled_copy(
+                cpasync_atom,
+                # 1 thread per page
+                cute.make_ordered_layout((pages_s, 1), order=(1, 0)),
+                (pages_s,),
+            )
+            lane_load_page = lane_idx < pages_s
+            thr_pt_load = pt_load.get_slice(lane_idx)
+            tPTgPT = thr_pt_load.partition_S(gPT)  # (CPY=1, #CPY=#TILE_S)
+            tPTcPT = thr_pt_load.partition_S(cPT)  # (CPY=1, #CPY=#TILE_S)
+            tPTsPT = thr_pt_load.partition_D(sPT)  # (CPY=1, #CPY=1, pt_stages)
+
+            cute.arch.griddepcontrol_wait()
+
+            # Prefetch page indices for first tile
+            if lane_load_page:
+                logical_page_idx = tPTcPT[0, kv_split_idx]
+                if logical_page_idx < page_count:
+                    cute.copy(cpasync_atom, tPTgPT[None, kv_split_idx], tPTsPT[None, 0, 0])
+                else:
+                    tPTsPT[0] = -1  # load OOB zeros
+            cute.arch.sync_warp()
+            cute.arch.cp_async_commit_group()
+
+            # Load Q
+            cute.copy(tma_atom_q, tBgQ_tma, tBsQ_tma, tma_bar_ptr=q_load_mbar)
+
+            # Sequence loop
+            pt_index = 0
+            for s in cutlass.range(iters_s):
+                # Prefetch page indices for next tile
+                pt_index_next = 0 if pt_index == (pt_stages - 1) else pt_index + 1
+                if s < iters_s - 1 and lane_load_page:
+                    tile_s_next = (s + 1) * kv_splits + kv_split_idx
+                    logical_page_idx = tPTcPT[0, tile_s_next]
+                    virt_page_idx_gmem = tPTgPT[None, tile_s_next]
+                    virt_page_idx_smem = tPTsPT[None, 0, pt_index_next]
+                    if logical_page_idx < page_count:
+                        cute.copy(cpasync_atom, virt_page_idx_gmem, virt_page_idx_smem)
+                    else:
+                        virt_page_idx_smem[0] = -1  # load OOB zeros
+                cute.arch.sync_warp()
+                cute.arch.cp_async_commit_group()
+
+                # Load page indices
+                cute.arch.cp_async_wait_group(1)
+                rPT = sPT[None, pt_index].load().reshape((pages_m, tiles_sm))
+                pt_index = pt_index_next
+
+                # Load K
+                tma_order_v_nbar.arrive_and_wait()
+                kv_token = kv_producer.try_acquire()
+                for sm in cutlass.range_constexpr(tiles_sm):
+                    for dk in cutlass.range_constexpr(tiles_dk):
+                        kv_handle = kv_producer.acquire_and_advance(kv_token)
+                        is_last_iter = sm == tiles_sm - 1 and dk == tiles_dk - 1
+                        if is_last_iter:
+                            tma_order_k_nbar.arrive()
+                        else:
+                            kv_token = kv_producer.try_acquire()
+
+                        for pm in cutlass.range_constexpr(pages_m):
+                            virtual_page_idx = rPT[pm, sm]
+                            cute.copy(
+                                tma_atom_k,
+                                gK_tma[None, dk, virtual_page_idx],
+                                sK_tma[None, pm, kv_handle.index],
+                                tma_bar_ptr=kv_handle.barrier,
+                            )
+
+                # Advance for TMA V
+                if s >= prefetch_iters:
+                    # Load skip predicate
+                    keep_tile = not enable_blasst
+                    if cutlass.const_expr(enable_blasst):
+                        sp_handle = sp_consumer.wait_and_advance()
+                        keep_tile = sSP_i32[sp_handle.index] != 0
+                        sp_handle.release()
+
+                    if keep_tile:
+                        for _ in cutlass.range_constexpr(tiles_dm * tiles_sk):
+                            kv_producer.advance()
+
+            # Tail V loop
+            for s in cutlass.range_constexpr(prefetch_iters):
+                tma_order_v_nbar.arrive_and_wait()
+                tma_order_k_nbar.arrive()
+                if cutlass.const_expr(enable_blasst):
+                    if s < min(prefetch_iters, iters_s):
+                        sp_handle = sp_consumer.wait_and_advance()
+                        sp_handle.release()
+
+        ##############################
+        # TMA VO Dispatch
+        ##############################
+        elif warp_idx == tma_vo_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Slice and partition V
+            sV = cute.make_tensor(
+                tAsV.iterator, smem_layout_v_tma.outer
+            )  # ((MMA_TILE_M, PAGE), #PAGE_K, v_stages)
+            gV = cute.local_tile(
+                mV, (mma_tile_m, page_size), coord=(None, 0, (coord_hk, None))
+            )  # (MMA_TILE_M, PAGE, #TILE_DM, #PAGE_S)
+            sV_tma, gV_tma = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_v,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=sV,
+                gmem_tensor=cute.group_modes(gV, 0, 2),
+            )  # (TMA, Rest...)
+
+            # Prefetch K loop
+            tma_order_v_nbar.arrive()
+            for s in cutlass.range_constexpr(prefetch_iters):
+                if s < iters_s:
+                    for _ in cutlass.range_constexpr(tiles_sm * tiles_dk):
+                        kv_producer.advance()
+                tma_order_k_nbar.arrive_and_wait()
+                tma_order_v_nbar.arrive()
+
+            # Sequence loop
+            pt_index = 0
+            for s in cutlass.range(iters_s):
+                # Advance for TMA K
+                if s < iters_s - prefetch_iters:
+                    for _ in cutlass.range_constexpr(tiles_sm * tiles_dk):
+                        kv_producer.advance()
+
+                # Load skip predicate
+                keep_tile = not enable_blasst
+                if cutlass.const_expr(enable_blasst):
+                    sp_handle = sp_consumer.wait_and_advance()
+                    keep_tile = sSP_i32[sp_handle.index] != 0
+                    sp_handle.release()
+                    if not keep_tile:
+                        tma_order_k_nbar.arrive_and_wait()
+                        tma_order_v_nbar.arrive()
+
+                if keep_tile:
+                    # Load page indices
+                    tma_order_k_nbar.arrive_and_wait()
+                    rPT = sPT[None, pt_index].load().reshape((pages_k, tiles_sk))
+
+                    # Load V
+                    kv_token = kv_producer.try_acquire()
+                    for sk in cutlass.range_constexpr(tiles_sk):
+                        for dm in cutlass.range_constexpr(tiles_dm):
+                            kv_handle = kv_producer.acquire_and_advance(kv_token)
+                            is_last_iter = sk == tiles_sk - 1 and dm == tiles_dm - 1
+                            if is_last_iter:
+                                tma_order_v_nbar.arrive()
+                            else:
+                                kv_token = kv_producer.try_acquire()
+
+                            for pk in cutlass.range_constexpr(pages_k):
+                                virtual_page_idx = rPT[pk, sk]
+                                cute.copy(
+                                    tma_atom_v,
+                                    gV_tma[None, dm, virtual_page_idx],
+                                    sV_tma[None, pk, kv_handle.index],
+                                    tma_bar_ptr=kv_handle.barrier,
+                                )
+                pt_index = 0 if pt_index == (pt_stages - 1) else pt_index + 1
+
+            # Slice and partition O
+            # (TILE_D, TILE_H)
+            coord_b_partial = (coord_b if do_atomic_red
+                               else kv_split_idx * batches + coord_b)
+            gO = cute.local_tile(
+                mO,
+                tiler=(blk_tile_d, blk_tile_hp),
+                coord=(0, coord_hp, (coord_hk, coord_b_partial)),
+            )
+            # (MMA_TILE_M, MMA_TILE_N, #TILE_DM, #TILE_HN=1)
+            gO_mma = cute.flat_divide(gO, (mma_tile_m, mma_tile_n))
+            # (TMA, #TILE_DM, #TILE_HN)
+            sO_tma, gO_tma = cute.nvgpu.cpasync.tma_partition(
+                tma_atom_o,
+                mcast_coord,
+                mcast_layout,
+                smem_tensor=cute.group_modes(sO_mma, 0, 2),
+                gmem_tensor=cute.group_modes(gO_mma, 0, 2),
+            )
+
+            # Store O to gmem
+            sO_final_nbar.arrive_and_wait()
+            cute.copy(tma_atom_o, sO_tma, gO_tma)
+
+        ##############################
+        # MMA KQ (BMM1) Dispatch
+        ##############################
+        elif warp_idx == mma_kq_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Setup mma descriptors
+            tAsK_desc = thrblk_mma_kq.make_fragment_A(tAsK)
+            tBsQ_desc = thrblk_mma_kq.make_fragment_B(tBsQ)
+
+            # Wait for Q
+            cute.arch.mbarrier_wait(q_load_mbar, phase=0)
+
+            # Sequence loop
+            for s in cutlass.range(iters_s):
+                s_token = s_producer.try_acquire()
+
+                mma_order_vp_nbar.arrive_and_wait()
+                k_token = kv_consumer.try_wait()
+
+                s_handle = s_producer.acquire_and_advance(s_token)
+                for sm in cutlass.range_constexpr(tiles_sm):
+                    tiled_mma_kq.set(tcgen05.Field.ACCUMULATE, False)
+                    for dk in cutlass.range_constexpr(tiles_dk):
+                        k_handle = kv_consumer.wait_and_advance(k_token)
+                        is_last_iter = sm == tiles_sm - 1 and dk == tiles_dk - 1
+                        if is_last_iter:
+                            mma_order_kq_nbar.arrive()
+                        else:
+                            k_token = kv_consumer.try_wait()
+
+                        mmas_k = cute.size(tAsK.shape[2])
+                        for mma_k in cutlass.range_constexpr(mmas_k):
+                            cute.gemm(
+                                tiled_mma_kq,
+                                tCtS[mma_dice + (sm, s_handle.index)],
+                                tAsK_desc[None, None, mma_k, k_handle.index],
+                                tBsQ_desc[None, None, mma_k, dk],
+                                tCtS[mma_dice + (sm, s_handle.index)],
+                            )
+                            if dk == 0 and mma_k == 0:
+                                tiled_mma_kq.set(tcgen05.Field.ACCUMULATE, True)
+                        k_handle.release()
+                s_handle.commit()
+
+                # Advance for MMA VP
+                if s >= prefetch_iters:
+                    keep_tile = not enable_blasst
+                    if cutlass.const_expr(enable_blasst):
+                        sp_handle = sp_consumer.wait_and_advance()
+                        keep_tile = sSP_i32[sp_handle.index] != 0
+                        sp_handle.release()
+
+                    if keep_tile:
+                        for _ in cutlass.range_constexpr(tiles_dm * tiles_sk):
+                            kv_consumer.advance()
+
+            # Tail loop
+            for s in cutlass.range_constexpr(prefetch_iters):
+                mma_order_vp_nbar.arrive_and_wait()
+                mma_order_kq_nbar.arrive()
+                if cutlass.const_expr(enable_blasst):
+                    if s < min(prefetch_iters, iters_s):
+                        sp_handle = sp_consumer.wait_and_advance()
+                        sp_handle.release()
+
+        ##############################
+        # MMA VP (BMM2) Dispatch
+        ##############################
+        elif warp_idx == mma_vp_warp_id:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(mma_tma_regs)
+
+            # Setup mma descriptors
+            tiled_mma_vp.set(tcgen05.Field.ACCUMULATE, True)
+            tAsV_desc = thrblk_mma_vp.make_fragment_A(tAsV)
+            tBsP_desc = thrblk_mma_vp.make_fragment_B(tBsP_nk)
+
+            # Prefetch loop
+            mma_order_vp_nbar.arrive()
+            for s in cutlass.range_constexpr(prefetch_iters):
+                if s < iters_s:
+                    for _ in cutlass.range_constexpr(tiles_sm * tiles_dk):
+                        kv_consumer.advance()
+                mma_order_kq_nbar.arrive_and_wait()
+                mma_order_vp_nbar.arrive()
+
+            # Sequence loop
+            for s in cutlass.range(iters_s):
+                # Advance for MMA KQ
+                if s < iters_s - prefetch_iters:
+                    for _ in cutlass.range_constexpr(tiles_sm * tiles_dk):
+                        kv_consumer.advance()
+
+                keep_tile = not enable_blasst
+                if cutlass.const_expr(enable_blasst):
+                    sp_handle = sp_consumer.wait_and_advance()
+                    keep_tile = sSP_i32[sp_handle.index] != 0
+                    sp_handle.release()
+                    if not keep_tile:
+                        mma_order_kq_nbar.arrive_and_wait()
+                        mma_order_vp_nbar.arrive()
+
+                if keep_tile:
+                    p_token = p_consumer.try_wait()
+                    o_token = o_producer.try_acquire()
+
+                    mma_order_kq_nbar.arrive_and_wait()
+                    v_token = kv_consumer.try_wait()
+
+                    p_handle = p_consumer.wait_and_advance(p_token)
+                    o_handle = o_producer.acquire_and_advance(o_token)
+                    for sk in cutlass.range_constexpr(tiles_sk):
+                        for dm in cutlass.range_constexpr(tiles_dm):
+                            v_handle = kv_consumer.wait_and_advance(v_token)
+                            is_last_iter = sk == tiles_sk - 1 and dm == tiles_dm - 1
+                            if is_last_iter:
+                                mma_order_vp_nbar.arrive()
+                            else:
+                                v_token = kv_consumer.try_wait()
+
+                            mmas_k = cute.size(tAsV.shape[2])
+                            for mma_k in cutlass.range_constexpr(mmas_k):
+                                cute.gemm(
+                                    tiled_mma_vp,
+                                    tCtO[mma_dice + (dm, o_handle.index)],
+                                    tAsV_desc[None, None, mma_k, v_handle.index],
+                                    tBsP_desc[None, None, mma_k, sk, p_handle.index],
+                                    tCtO[mma_dice + (dm, o_handle.index)],
+                                )
+                            v_handle.release()
+                    p_handle.release()
+                    o_handle.commit()
+
+            # Wait for signal to dealloc tmem, then dealloc
+            if iters_s == 1:
+                # Epilogue still reads the empty buffer
+                o_producer.commit()
+                o_producer.advance()
+            o_producer.tail()
+            cute.arch.relinquish_tmem_alloc_permit()
+            cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols)
+
+        ##############################
+        # Softmax Dispatch
+        ##############################
+        elif warpgroup_idx in softmax_warpgroup_ids:
+            # Free registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_decrease(softmax_regs)
+
+            # Initialize for dual warpgroups
+            softmax_phase = 0
+            if cutlass.const_expr(softmax_warpgroups == 2):
+                softmax_phase = (warpgroup_idx - 1) % softmax_warpgroups
+                sM_acquire_nbar = with_phase(sM_mutex_nbar, softmax_phase)
+                sM_release_nbar = with_phase(sM_mutex_nbar, softmax_phase ^ 1)
+                if softmax_phase == 1:
+                    s_consumer.advance()
+                    p_producer.advance()
+                    sM_release_nbar.arrive()
+            if iters_s == 1 and softmax_phase == softmax_warpgroups - 1:
+                with_phase(tL_producer_nbar, 1).arrive()
+            assert not (enable_blasst and softmax_warpgroups != 1), "blasst only supports 1 softmax wg"
+
+            # Construct copy atom for S
+            tmem_repeat_op_s = blk_tile_n
+            if cutlass.const_expr(mma_tile_n == blk_tile_n and tiles_sm in (2, 4)):
+                tmem_repeat_op_s *= tiles_sm
+            tmem_repeat_op_s = tcgen05.Repetition(tmem_repeat_op_s)
+            tmem_load_op_s = tcgen05.Ld32x32bOp(tmem_repeat_op_s)
+            tmem_load_atom_s = cute.make_copy_atom(tmem_load_op_s, acc_dtype)
+            # Tile atom and slice
+            tCtS_stage = tCtS[mma_dice + (None, 0)]
+            tmem_load_s = tcgen05.make_tmem_copy(tmem_load_atom_s, tCtS_stage)
+            thr_load_s = tmem_load_s.get_slice(warpgroup_tidx)
+            # Partition S and P
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, #CPY_SM, stages)
+            tStS = thr_load_s.partition_S(tCtS)
+            tSsP = thr_load_s.partition_D(tCsP)
+            # Slice unused modes
+            tStS = tStS[None, 0, 0, 0, None, None]  # (CPY, #CPY_SM, s_stages)
+            tSsP = tSsP[None, 0, 0, 0, None, None]  # (CPY, #CPY_SM, p_stages)
+
+            # Construct copy atom for L
+            tmem_repeat_op_l = tcgen05.Repetition(blk_tile_n)
+            tmem_load_op_l = tcgen05.Ld32x32bOp(tmem_repeat_op_l)
+            tmem_store_op_l = tcgen05.St32x32bOp(tmem_repeat_op_l)
+            tmem_load_atom_l = cute.make_copy_atom(tmem_load_op_l, acc_dtype)
+            tmem_store_atom_l = cute.make_copy_atom(tmem_store_op_l, acc_dtype)
+            # Tile atom and slice
+            tCtL_phase = tCtL[mma_dice + (softmax_phase,)]
+            tmem_load_l = tcgen05.make_tmem_copy(tmem_load_atom_l, tCtL_phase)
+            thr_load_l = tmem_load_l.get_slice(warpgroup_tidx)
+            # Partition L
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, stages)
+            tStL = thr_load_l.partition_S(tCtL)
+            # Slice unused modes
+            # (CPY, stages)
+            tStL = tStL[None, 0, 0, 0, None]
+            tSrL_shape = thr_load_l.partition_D(tCtL_phase).shape[:1]
+
+            # Causal masking for spec decode verification
+            masked_iters_s = masked_start_s = masked_coord_s = 0
+            check_safe_max = False
+            if cutlass.const_expr(not tma_mask):
+                is_last_split = kv_split_idx == (tiles_s - 1) % kv_splits
+                is_prev_split = kv_split_idx == (tiles_s - 2) % kv_splits
+                is_last_phase = softmax_phase == (iters_s - 1) % softmax_warpgroups
+                is_prev_phase = softmax_phase == (iters_s - 2) % softmax_warpgroups
+                # 2 masked tiles
+                if 0 < seqlen % blk_tile_s < prediction:
+                    # 1 split masks 2 tiles
+                    if kv_splits == 1:
+                        masked_start_s = 0 if is_prev_phase else 1
+                        masked_iters_s = 2
+                        masked_coord_s = tiles_s - 2
+                    # 2 splits mask 1 tile each
+                    elif (is_last_split or is_prev_split) and is_last_phase:
+                        masked_start_s = 0
+                        masked_iters_s = 1
+                        masked_coord_s = (tiles_s - 1) if is_last_split else (tiles_s - 2)
+                        # if last split only has 1 tile then some cols will never
+                        # see inbounds values, so P = exp(-inf + inf) -> nan
+                        check_safe_max = is_last_split and iters_s == 1
+                # 1 masked tile
+                elif prediction > 1 or seqlen % blk_tile_s != 0:
+                    # 1 split masks 1 tile
+                    if is_last_split and is_last_phase:
+                        masked_start_s = 0
+                        masked_iters_s = 1
+                        masked_coord_s = tiles_s - 1
+
+            # Tile skip tracking
+            if cutlass.const_expr(enable_blasst):
+                sM_lane_prev = -Float32.inf
+
+            # Sequence loop
+            num_loops = 2 if not tma_mask else 1
+            for loop in cutlass.range_constexpr(num_loops):
+                is_masked_loop = loop == 1
+                for s in cutlass.range(
+                    masked_start_s if is_masked_loop else softmax_phase,
+                    masked_iters_s if is_masked_loop else (iters_s - masked_iters_s),
+                    softmax_warpgroups,
+                ):
+                    # Load S from tmem and notify BMM1
+                    s_token = s_consumer.try_wait()
+                    s_handle = s_consumer.wait_and_advance(s_token)
+                    tStS_s = tStS[None, None, s_handle.index]
+                    tSrS_s = cute.make_rmem_tensor(tSsP.shape[:-1], acc_dtype)
+                    cute.copy(tmem_load_atom_s, tStS_s, tSrS_s)
+                    cute.arch.fence_view_async_tmem_load()
+                    s_handle.release()
+
+                    # Apply causal mask
+                    if cutlass.const_expr(is_masked_loop):
+                        masked = cute.make_rmem_tensor(
+                            (blk_tile_h, blk_tile_p, tiles_sm), acc_dtype
+                        )
+                        masked.store(tSrS_s.load().reshape(masked.shape))
+                        offset_s = (masked_coord_s + s) * blk_tile_s + warpgroup_tidx
+                        offset_p = seqlen - prediction + coord_p * blk_tile_p
+                        for sm in cutlass.range_constexpr(tiles_sm):
+                            for p in cutlass.range_constexpr(blk_tile_p):
+                                masked_p = masked[None, p, sm]
+                                is_oob = offset_s + sm * mma_tile_m > offset_p + p
+                                mask = -Float32.inf if is_oob else Float32(0)
+                                masked_p.store(masked_p.load() + mask)
+                        scores = masked.load().reshape((blk_tile_n, tiles_sm))
+                    else:
+                        scores = tSrS_s.load().reshape((blk_tile_n, tiles_sm))
+
+                    # Reduce colmax in thread RF
+                    rM = cute.make_rmem_tensor_like(sM)
+                    rM.store(scores.reduce(
+                        cute.ReductionOp.MAX,
+                        init_val=-Float32.inf,
+                        reduction_profile=(None, 0)
+                    ))
+
+                    # Reduce colmax in warp RF
+                    rM_lane = Float32(0)
+                    for n in cutlass.range_constexpr(blk_tile_n):
+                        rM[n] = warp_fmax(rM[n])  # warp reduction
+                        # Avoid dynamic register indexing (creates spills)
+                        if n == lane_idx:
+                            rM_lane = rM[n]
+                    rM_lane *= scale_s_log2_e  # apply scale
+
+                    # Compute skip predicate
+                    keep_tile = not enable_blasst
+                    if cutlass.const_expr(enable_blasst):
+                        # warp reduction
+                        lane_keep_tile = rM_lane - sM_lane_prev >= log2_threshold_p
+                        lane_keep_tile &= lane_store_max  # oob lanes skip
+                        lane_keep_tile |= s < o_stages  # correction loop is s-2
+                        warp_keep_tile = warp_or(Int32(lane_keep_tile))
+
+                        # warpgroup reduction
+                        sp_handle = sp_producer.acquire_and_advance()
+                        with cute.arch.elect_one():
+                            sSP_i8[warpgroup_widx, sp_handle.index] = Int8(warp_keep_tile)
+                        sp_handle.commit()
+                        sSP_producer_nbar.sync()
+                        keep_tile = sSP_i32[sp_handle.index] != 0
+
+                    if keep_tile:
+                        p_token = p_producer.try_acquire()
+
+                        # Reduce colmax in smem
+                        if cutlass.const_expr(softmax_warpgroups == 2):
+                            sM_acquire_nbar.arrive_and_wait()
+                        sM_consumer_nbar.arrive_and_wait()
+                        if lane_store_max:
+                            smem_fmax(sM.iterator + sM.layout(lane_idx), rM_lane)
+
+                        # Wait for empty P buffer
+                        # Here so we can interleave ex2 with convert ops
+                        p_handle = p_producer.acquire_and_advance(p_token)
+                        tSsP_s = tSsP[None, None, p_handle.index]
+
+                        # Load colmax
+                        sM_producer_nbar.arrive_and_wait()
+                        colmax = sM.load()
+                        if cutlass.const_expr(enable_blasst):
+                            if lane_store_max:
+                                sM_lane_prev = sM[lane_idx]
+                        if cutlass.const_expr(softmax_warpgroups == 2):
+                            sM_release_nbar.arrive()
+
+                        # Handle if we never saw any in-bounds values
+                        if cutlass.const_expr(is_masked_loop and do_atomic_red):
+                            if check_safe_max:
+                                rM = cute.make_rmem_tensor_like(colmax)
+                                rM.store(colmax)
+                                for n in cutlass.range_constexpr(blk_tile_n):
+                                    if rM[n] == -Float32.inf:
+                                        rM[n] = Float32(0)
+                                colmax = rM.load()
+
+                        # Compute online softmax
+                        probs = exp2(scale_s_log2_e * scores - colmax)
+
+                        # Store P to smem and notify BMM2
+                        tSsP_s.store(probs.to(mma_dtype).reshape(tSsP_s.shape))
+                        cute.arch.fence_view_async_shared()
+                        p_handle.commit()
+
+                        # Accumulate per-thread colsum
+                        colsum = probs[None, 0]
+                        for sm in cutlass.range_constexpr(1, tiles_sm, 1):
+                            colsum += probs[None, sm]
+                        tSrL = cute.make_rmem_tensor(tSrL_shape, acc_dtype)
+                        tSrL.store(colsum.reshape(tSrL.shape))
+
+                        # Store per-thread colsum to tmem
+                        with_phase(tL_consumer_nbar, softmax_phase).arrive_and_wait()
+                        cute.copy(tmem_store_atom_l, tSrL, tStL[None, softmax_phase])
+                        cute.arch.fence_view_async_tmem_store()
+                        with_phase(tL_producer_nbar, softmax_phase).arrive()
+
+                        # Advance state
+                        if cutlass.const_expr(softmax_warpgroups == 2):
+                            s_consumer.advance()
+                            p_producer.advance()
+                        else:
+                            softmax_phase ^= 1
+
+
+        ##############################
+        # Correction Dispatch
+        ##############################
+        elif warpgroup_idx == correction_warpgroup_id:
+            # Alloc registers
+            if cutlass.const_expr(use_reg_reconfig):
+                cute.arch.setmaxregister_increase(correction_regs)
+
+            # Select copy atoms for O and L
+            tmem_repeat_op_o = tcgen05.Repetition(blk_tile_n)
+            tmem_load_op_o = tcgen05.Ld32x32bOp(tmem_repeat_op_o)
+            tmem_store_op_o = tcgen05.St32x32bOp(tmem_repeat_op_o)
+            tmem_load_atom_o = cute.make_copy_atom(tmem_load_op_o, acc_dtype)
+            tmem_store_atom_o = cute.make_copy_atom(tmem_store_op_o, acc_dtype)
+            # Tile atoms and slice
+            tCtO_dm = tCtO[mma_dice + (0, 0)]
+            tmem_load_o = tcgen05.make_tmem_copy(tmem_load_atom_o, tCtO_dm)
+            thr_load_o = tmem_load_o.get_slice(warpgroup_tidx)
+            # Partition O and L
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, #TILE_DM, o_stages)
+            tOtO = thr_load_o.partition_S(tCtO)
+            tOsO = thr_load_o.partition_D(tCsO)
+            # (CPY, #CPY_MMA, #CPY_M, #CPY_N, o_stages)
+            tOtL = thr_load_o.partition_S(tCtL)
+            # Slice unused modes
+            tOtO = tOtO[None, 0, 0, 0, None, None]  # (CPY, #TILE_DM, o_stages)
+            tOsO = tOsO[None, 0, 0, 0, None]  # (CPY, #TILE_DM)
+            tOtL = tOtL[None, 0, 0, 0, None]  # (CPY, o_stages)
+
+            # colsum load helper
+            def colsum_load(
+                phase,
+                blk_tile_n = blk_tile_n,
+                tOtL = tOtL,
+                tOrO_shape = tOsO.shape[:1],
+                tmem_load_atom_o = tmem_load_atom_o,
+                tL_producer_nbar = tL_producer_nbar,
+                tL_consumer_nbar = tL_consumer_nbar,
+            ):
+                with_phase(tL_producer_nbar, phase).arrive_and_wait()
+                tOtL_s = tOtL[None, phase]
+                tOrL_s = cute.make_rmem_tensor(tOrO_shape, Float32)
+                cute.copy(tmem_load_atom_o, tOtL_s, tOrL_s)
+                cute.arch.fence_view_async_tmem_load()
+                with_phase(tL_consumer_nbar, phase).arrive()
+                return tOrL_s.load().reshape(blk_tile_n)
+
+            # Initialize O and colsum in tmem
+            tOrO = cute.make_rmem_tensor(tOsO.shape, acc_dtype)
+            tOrO.fill(Float32(0))
+            for phase in cutlass.range_constexpr(o_stages):
+                cute.copy(tmem_store_atom_o, tOrO, tOtO[None, None, phase])
+            cute.copy(tmem_store_atom_o, tOrO[None, 0], tOtL[None, 1])
+            cute.arch.fence_view_async_tmem_store()
+
+            # Initialize consumer barriers
+            sM_consumer_nbar.arrive()
+            for phase in cutlass.range_constexpr(o_stages):
+                with_phase(tL_consumer_nbar, phase).arrive()
+
+            # Initialize colsum in RF
+            colsum_p = cute.make_rmem_tensor((blk_tile_n, o_stages), Float32)
+            colsum_0, colsum_1 = colsum_p[None, 0], colsum_p[None, 1]
+            colsum_p.fill(Float32(0))
+
+            # Load colmax of s-2, s-1
+            sM_lane_prev_prev = sM_lane_prev = Float32(0)
+            for s in cutlass.range_constexpr(o_stages):
+                sM_lane_prev_prev = sM_lane_prev
+                if not (s == 1 and iters_s == 1):
+                    if cutlass.const_expr(enable_blasst):
+                        sp_handle = sp_consumer.wait_and_advance()
+                        sp_handle.release()
+                    sM_producer_nbar.arrive_and_wait()
+                    if lane_store_max:
+                        sM_lane_prev = sM[lane_idx]
+                    sM_consumer_nbar.arrive()
+
+            # Sequence loop
+            softmax_phase = 0
+            unroll = o_stages if not enable_blasst else 1
+            keep_tile = not enable_blasst
+            for s in cutlass.range(iters_s - o_stages, unroll=unroll):
+                # Load skip predicate
+                if cutlass.const_expr(enable_blasst):
+                    sp_handle = sp_consumer.wait_and_advance()
+                    keep_tile = sSP_i32[sp_handle.index] != 0
+                    sp_handle.release()
+
+                if keep_tile:
+                    # Load colsum of s-2
+                    colsum_s = colsum_load(softmax_phase)
+
+                    # Load colmax of s
+                    sM_producer_nbar.arrive_and_wait()
+                    if s == iters_s - o_stages - 1:
+                        sM_final_nbar.arrive()
+                    sM_lane = Float32(0)
+                    if lane_store_max:
+                        sM_lane = sM[lane_idx]
+                    sM_consumer_nbar.arrive()
+
+                    # Wait for O of s-2
+                    # Here so we can interleave shuffle_sync with correction muls
+                    o_token = o_consumer.try_wait()
+                    o_handle = o_consumer.wait_and_advance(o_token)
+
+                    # Compute correction of s-2
+                    correction_lane = exp2(sM_lane_prev_prev - sM_lane)
+                    correction = cute.make_rmem_tensor_like(sM)
+                    for n in cutlass.range_constexpr(blk_tile_n):
+                        correction[n] = cute.arch.shuffle_sync(correction_lane, n)
+                    correction = correction.load()
+                    sM_lane_prev_prev, sM_lane_prev = sM_lane_prev, sM_lane
+
+                    # Correct O of s-2 and notify MMA VP
+                    correction_o = correction.reshape(tOsO.shape[:1])
+                    for dm in cutlass.range_constexpr(tiles_dm):
+                        tOtO_dm = tOtO[None, dm, softmax_phase]
+                        tOrO_dm = cute.make_rmem_tensor(tOsO.shape[:1], acc_dtype)
+                        cute.copy(tmem_load_atom_o, tOtO_dm, tOrO_dm)
+                        tOrO_dm.store(correction_o * tOrO_dm.load())
+                        cute.copy(tmem_store_atom_o, tOrO_dm, tOtO_dm)
+                    cute.arch.fence_view_async_tmem_store()
+                    o_handle.release()
+
+                    # Correct and accumulate colsum of s-2
+                    colsum_s *= correction
+                    if softmax_phase == 0:
+                        colsum_0.store(correction * colsum_0.load() + colsum_s)
+                    elif softmax_phase == 1:
+                        colsum_1.store(correction * colsum_1.load() + colsum_s)
+
+                    # Next softmax producer phase
+                    softmax_phase ^= 1
+
+            # Notify for final colmax if we didn't already
+            if not keep_tile or iters_s <= o_stages:
+                sM_final_nbar.arrive()
+
+            # Handle if we never saw any in-bounds values
+            if cutlass.const_expr(not tma_mask and do_atomic_red):
+                if sM_lane_prev == -Float32.inf:
+                    sM_lane_prev = Float32(0)
+
+            # Compute correction of s-1
+            correction_lane = exp2(sM_lane_prev_prev - sM_lane_prev)
+            correction = cute.make_rmem_tensor_like(sM)
+            for n in cutlass.range_constexpr(blk_tile_n):
+                correction[n] = cute.arch.shuffle_sync(correction_lane, n)
+            correction = correction.load()
+
+            # Correct and accumulate final colsum
+            tail_phase = softmax_phase if enable_blasst else iters_s % o_stages
+            for phase in cutlass.range_constexpr(o_stages):
+                if tail_phase == phase:
+                    # Accumulate in thread RF
+                    colsum_prev = colsum_load(phase)
+                    colsum_final = colsum_load(phase ^ 1)
+                    colsum_prev += colsum_p[None, phase].load()
+                    colsum_final += colsum_p[None, phase ^ 1].load()
+                    colsum_final += correction * colsum_prev
+                    # Reduce colsum in warp RF
+                    rL_lane = Float32(0.0)
+                    for n in cutlass.range_constexpr(blk_tile_n):
+                        rL_n = cute.arch.warp_reduction_sum(colsum_final[n])
+                        if n == lane_idx:
+                            rL_lane = rL_n
+                    # Store partial colsum in smem and notify
+                    if lane_store_max:
+                        sL[lane_idx, warpgroup_widx] = rL_lane
+                    sL_final_nbar.arrive()
+
+            # Load O of s-1, s
+            tOrO_tail = cute.make_rmem_tensor((*tOsO.shape, o_stages), acc_dtype)
+            for s in cutlass.range_constexpr(o_stages):
+                o_handle = o_consumer.wait_and_advance()
+                tOtO_s = tOtO[None, None, tail_phase ^ s]
+                tOrO_s = tOrO_tail[None, None, s]
+                cute.copy(tmem_load_atom_o, tOtO_s, tOrO_s)
+                cute.arch.fence_view_async_tmem_load()
+                o_handle.release()  # Final release signals tmem dealloc
+            tOrO_prev = tOrO_tail[None, None, 0].load()
+            tOrO_final = tOrO_tail[None, None, 1].load()
+
+            # Correct and accumulate output
+            output_prev = tOrO_prev.reshape((blk_tile_n, tiles_dm))
+            output_final = tOrO_final.reshape((blk_tile_n, tiles_dm))
+            output_final += correction * output_prev
+
+            # Apply final correction
+            if cutlass.const_expr(do_atomic_red):
+                # final correction stored in sM
+                sM_final_nbar.arrive_and_wait()
+                correction = sM.load()
+                output_final *= correction
+
+            # Store O to smem and notify
+            tOsO.store(output_final.to(o_dtype).reshape(tOsO.shape))
+            cute.arch.fence_view_async_shared()
+            sO_final_nbar.arrive()
+
+            # Debug
+            if cutlass.const_expr(enable_blasst and debug_blasst):
+                batches = mQ.shape[-1][1]
+                # Append skip count to page counts
+                tiles_skipped_ptr = seqlens_iter + batches
+                tiles_kept = o_consumer.current_handle().count if iters_s > 1 else 1
+                tiles_skipped = iters_s - tiles_kept
+                if warpgroup_tidx == 0:
+                    gmem_add(tiles_skipped_ptr, Int32(tiles_skipped))
+
+        ##############################
+        # Reduction Dispatch
+        ##############################
+        if warp_idx == reduction_warp_id:
+            if cutlass.const_expr(do_kernel_red):
+                GqaDecode.reduction_epilogue(
+                    blk_tile_hp,
+                    coord_hp,
+                    coord_hb,
+                    kv_split_idx,
+                    lane_idx,
+                    sM_final_nbar,
+                    sL_final_nbar,
+                    sM,
+                    sL,
+                    mM,
+                    mM_partial,
+                    mL_partial,
+                )
+            else:
+                GqaDecode.reduction_cluster(
+                    blk_tile_n,
+                    kv_splits,
+                    kv_split_idx,
+                    lane_idx,
+                    sM_final_nbar,
+                    sL_final_nbar,
+                    reduction_mbars_ptr,
+                    sM,
+                    sL,
+                    sR,
+                )
+            cute.arch.griddepcontrol_launch_dependents()
+
+        return
+
+
+def run(
+    batches: int,
+    prediction: int,
+    seqlen: str,
+    page_size: int,
+    heads_q: int,
+    heads_k: int,
+    headdim: int,
+    kv_splits: int,
+    reduction: str,
+    qkv_dtype: Type[cutlass.Numeric],
+    o_dtype: Type[cutlass.Numeric],
+    acc_dtype: Type[cutlass.Numeric],
+    tolerance: float,
+    scale_s: float,
+    threshold_p: float,
+    warmup_iterations: int = 0,
+    iterations: int = 0,
+    skip_ref_check: bool = False,
+    use_warm_l2: bool = False,
+    quiet: bool = False,
+    **kwargs,
+):
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    seqlens = [int(s) for s in seqlen.split(",")]
+    is_varlen = "," in seqlen
+    if not is_varlen:
+        seqlens = batches * seqlens
+    if batches != len(seqlens):
+        raise ValueError(
+            f"number of seqlens {len(seqlens)} doesn't match batches {batches}"
+        )
+
+    npo2 = lambda x : 2 ** math.ceil(math.log2(x))
+
+    grouped_heads = heads_q // heads_k
+    grouped_head_tile = npo2(grouped_heads)
+    grouped_head_tile = min(32, grouped_head_tile)
+    grouped_head_tiles = math.ceil(grouped_heads / grouped_head_tile)
+
+    prediction_tile = npo2(prediction)
+    prediction_tile = min(32 // grouped_head_tile, prediction_tile)
+    prediction_tiles = math.ceil(prediction / prediction_tile)
+
+    blk_tile_n = grouped_head_tile * prediction_tile
+    if blk_tile_n == 1 and qkv_dtype.width == 8:
+        grouped_head_tile = 2
+
+    # Automatic KV splits
+    if kv_splits == 0:
+        hardware_info = cutlass.utils.HardwareInfo()
+        sm_count = hardware_info.get_device_multiprocessor_count()
+        sm_count = 148 if sm_count <= 0 else sm_count
+        grid_yz = batches * heads_k * grouped_head_tiles * prediction_tiles
+        kv_splits = sm_count // grid_yz  # 1 wave
+        kv_splits = max(1, kv_splits)
+        if sm_count == 148 and grid_yz == 32:
+            kv_splits = 9  # 2 waves
+        # At least 256 tokens per split
+        kv_splits = min(kv_splits, math.ceil(max(seqlens) / 256))
+        # Cluster reduction requires po2 splits
+        if reduction == "atomic":
+            if kv_splits not in (1, 2, 4):
+                kv_splits = 8  # generally performs well
+
+    # Automatic reduction mode
+    if reduction == "auto":
+        if o_dtype in (Float32, Float16, BFloat16) and kv_splits in (1, 2, 4, 8):
+            reduction = "atomic"
+        else:
+            reduction = "kernel"
+    atomic = reduction == "atomic"
+
+    print(f"Command: python {__file__.split("/")[-1]}"
+        f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
+        f" --b {batches} --p {prediction} --s {seqlen}"
+        f" --pg {page_size}"
+        f" --kv_splits {kv_splits} --reduction {reduction}"
+        f" --mma_dtype {qkv_dtype} --out_dtype {o_dtype}"
+        f" --atol {tolerance}{" --skip_ref_check" if skip_ref_check else ""}"
+        f" --scale {scale_s} --threshold {threshold_p}"
+        f" --iterations {iterations} --warmups {warmup_iterations}{" --use_warm_l2" if use_warm_l2 else ""}"
+        f"{" --quiet" if quiet else ""}"
+    )
+
+    seqlen_str = (
+        f"\n\tseqlens: {seqlens}" if is_varlen else f"\tseqlen: {seqlen}"
+    )
+    if not quiet:
+        print(
+            "Running Blackwell SM100 GQA Decode Paged test with:\n"
+            f"\theaddim: {headdim}\theads_q: {heads_q}\theads_k: {heads_k}\n"
+            f"\tbatches: {batches}\tprediction: {prediction}"
+            f"{seqlen_str}\n"
+            f"\tpage_size: {page_size}\n"
+            f"\tkv_splits: {kv_splits}\treduction: {reduction}\n"
+            f"\tqkv: {qkv_dtype}\to: {o_dtype}\t\n"
+            f"\tatol: {tolerance if not skip_ref_check else "skip"}"
+            f"\tscale_s: {f"1 / sqrt({headdim})" if scale_s == 0 else scale_s}"
+            f"\tthreshold_p: {threshold_p}\n"
+            f"\titerations: {iterations}\twarmups: {warmup_iterations}\twarm L2: {use_warm_l2}"
+        )
+
+    # Automatic scale + threshold
+    if scale_s == 0:
+        scale_s = headdim ** -0.5
+    if threshold_p == 0:
+        threshold_p = None  # disable
+    else:
+        threshold_p = Float32(threshold_p)
+    enable_blasst = threshold_p is not None
+
+    #
+    # Config Kernel
+    #
+    fmha = GroupedQueryAttentionDecodePaged(
+        page_size,
+        headdim,
+        grouped_head_tile,
+        prediction_tile=prediction_tile,
+        sequence_tile=128 if enable_blasst else 256,
+        reduction_mode=reduction,
+        softmax_warpgroups=(
+            2 if not enable_blasst
+            and ((qkv_dtype.width <= 8 and blk_tile_n > 8)
+                or (qkv_dtype.width == 16 and blk_tile_n > 16))
+            else 1
+        ),
+        # perf optimization for non-causal
+        tma_mask=(prediction == 1),
+    )
+
+    max_seqlen, min_seqlen = max(seqlens), min(seqlens)
+    qo_shape = (kv_splits, batches, prediction, heads_q, headdim)
+    kv_shape = (batches, min_seqlen, heads_k, headdim)
+
+    fmha.can_implement(
+        qo_shape[0], qo_shape[1:], kv_shape, qkv_dtype, o_dtype, threshold_p
+    )
+
+    #
+    # Allocate Tensors
+    #
+    torch.manual_seed(1111)
+    torch_ref_dtype = torch.float16
+
+    # Convert + copy to device with torch backed cute view
+    cute_tensor_like = partial(
+        cutlass_torch.cute_tensor_like, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Initialize on host and copy to device
+    def create_tensor(shape, dtype, init=None, device=True):
+        init_type = cutlass.torch.TensorInitType.SKIP
+        init_config = None
+        if isinstance(init, int) or isinstance(init, float):
+            init_type = cutlass.torch.TensorInitType.SCALAR
+            init_config = cutlass.torch.ScalarInitConfig(value=init)
+        elif isinstance(init, tuple) or isinstance(init, list):
+            if len(init) == 1:
+                init_type = cutlass.torch.TensorInitType.SCALAR
+                init_config = cutlass.torch.ScalarInitConfig(value=init[0])
+            elif len(init) == 2:
+                init_type = cutlass.torch.TensorInitType.RANDOM
+                init_config = cutlass.torch.RandomInitConfig(
+                    min_val=init[0], max_val=init[1]
+                )
+            elif len(init) == 3:
+                init_type = cutlass.torch.TensorInitType.GAUSSIAN
+                init_config = cutlass.torch.GaussianInitConfig(
+                    mean=init[0], std=init[1], scale=init[2]
+                )
+
+        ref_torch_tensor = cutlass_torch.create_and_permute_torch_tensor(
+            shape,
+            torch_ref_dtype,
+            permute_order=None,
+            init_type=init_type,
+            init_config=init_config,
+        )
+
+        if not device:
+            return ref_torch_tensor
+
+        cute_tensor, torch_tensor = cute_tensor_like(ref_torch_tensor, dtype)
+
+        return (
+            ref_torch_tensor,
+            cute_tensor,
+            torch_tensor,
+        )
+
+    # Initialize QOML tensors
+    q_init = k_init = v_init = [-8, 7]
+    q_ref, q_cute, q_torch = create_tensor(qo_shape[1:], qkv_dtype, init=q_init)
+    _, o_cute, o_torch = create_tensor(
+        qo_shape[1:], o_dtype, init=(0 if atomic else None)
+    )
+    # Workspace tensors
+    m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
+    if not atomic:
+        _, m_cute, m_torch = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
+        _, o_partial_cute, o_partial_torch = create_tensor(qo_shape, acc_dtype)
+        _, m_partial_cute, m_partial_torch = create_tensor(qo_shape[:-1], acc_dtype)
+        _, l_partial_cute, l_partial_torch = create_tensor(qo_shape[:-1], acc_dtype)
+
+    # Initialize reference KV tensors
+    max_pages_per_batch = math.ceil(max_seqlen / page_size)
+    ref_seqlen = max_pages_per_batch * page_size
+    kv_ref_shape = (batches, ref_seqlen, heads_k, headdim)
+    k_ref = create_tensor(kv_ref_shape, qkv_dtype, init=k_init, device=False)
+    v_ref = create_tensor(kv_ref_shape, qkv_dtype, init=v_init, device=False)
+
+    # Fix tiles in KV to given value
+    if debug_blasst:
+        tile_s = fmha.sequence_tile
+        tiles_total = heads_k * sum(math.ceil(seq / tile_s) for seq in seqlens)
+        tiles_fixed = math.ceil(kwargs["fix_ratio"] * tiles_total)
+        fix_value = kwargs["fix_value"]
+        if 0 < tiles_fixed <= tiles_total:
+            tile_indices = []
+            for batch, seq in enumerate(seqlens):
+                for head in range(heads_k):
+                    start_idx = kv_splits * tile_s  # Exclude first tile in a split
+                    tile_indices += [
+                        (batch, head, idx) for idx in range(start_idx, seq, tile_s)
+                    ]
+            random.shuffle(tile_indices)
+            tile_indices = tile_indices[:tiles_fixed]
+            tiles_fixed = len(tile_indices)  # account for excluded tiles
+            for batch, head, idx in tile_indices:
+                start, end = idx, idx + tile_s
+                v_ref[batch, start:end, head, :] = fix_value
+                k_ref[batch, start:end, head, :] = fix_value
+
+    # Partially filled pages must be zero padded
+    for batch, seq in enumerate(seqlens):
+        seq_align = math.ceil(seq / page_size) * page_size
+        k_ref[batch, seq:seq_align, ...] = 0
+        v_ref[batch, seq:seq_align, ...] = 0
+
+    # Calculate page offsets
+    virtual_page_count = batches * max_pages_per_batch  # can be larger
+    logical_page_counts = [math.ceil(seq / page_size) for seq in seqlens]
+    cumsum_page_counts = list(accumulate(logical_page_counts))
+    logical_page_count = cumsum_page_counts[-1]
+    table_offsets = [0] + cumsum_page_counts[:-1]
+    assert logical_page_count <= virtual_page_count
+
+    # Generate page table
+    page_table = list(range(virtual_page_count))
+    random.shuffle(page_table)
+    page_table = page_table[:logical_page_count]
+
+    # Initialize paged KV
+    # Note there is no requirement for K and V to have shared/separate virtual allocations
+    kv_paged_shape = (virtual_page_count, 2, page_size, heads_k, headdim)
+    kv_paged_ref = create_tensor(kv_paged_shape, qkv_dtype, init=None, device=False)
+    k_ref_splits = k_ref.split(page_size, dim=1)
+    v_ref_splits = v_ref.split(page_size, dim=1)
+    assert len(k_ref_splits) == max_pages_per_batch
+
+    for batch, page_count, table_offset in zip(
+        range(batches), logical_page_counts, table_offsets
+    ):
+        for page_idx, k_ref_split, v_ref_split in zip(
+            range(page_count), k_ref_splits, v_ref_splits
+        ):
+            logical_page_idx = table_offset + page_idx
+            virtual_idx = page_table[logical_page_idx]
+            kv_paged_ref[virtual_idx, 0, ...] = k_ref_split[batch, ...]
+            kv_paged_ref[virtual_idx, 1, ...] = v_ref_split[batch, ...]
+
+    # Append skip counter to seqlens for blasst debug
+    seqlens += [0] if debug_blasst else []
+
+    seqlens_cute = Int32(seqlens[0])
+    table_offsets_cute = None
+    if is_varlen:
+        seqlens_cute, seqlens_torch = cute_tensor_like(
+            torch.tensor(seqlens), Int32
+        )
+        table_offsets_cute, table_offsets_torch = cute_tensor_like(
+            torch.tensor(table_offsets), Int32
+        )
+
+    kv_paged_cute, kv_paged_torch = cute_tensor_like(kv_paged_ref, qkv_dtype)
+    page_table_cute, page_table_torch = cute_tensor_like(
+        torch.tensor(page_table), Int32
+    )
+
+    k_paged_cute = cutlass_torch.from_dlpack(
+        kv_paged_torch[:, 0, ...], assumed_align=16).mark_layout_dynamic(-1)
+    v_paged_cute = cutlass_torch.from_dlpack(
+        kv_paged_torch[:, 1, ...], assumed_align=16).mark_layout_dynamic(-1)
+
+    #
+    # Compile
+    #
+    current_stream = cutlass_torch.default_stream()
+    compiled_fmha = cute.compile(
+        fmha,
+        kv_splits,
+        seqlens_cute,
+        table_offsets_cute,
+        page_table_cute,
+        k_paged_cute,
+        v_paged_cute,
+        q_cute,
+        o_cute,
+        m_cute,
+        o_partial_cute,
+        m_partial_cute,
+        l_partial_cute,
+        scale_s,
+        threshold_p,
+        current_stream,
+    )
+    print("Finished Compiling")
+
+    #
+    # Refcheck
+    #
+    def run_torch_fmha(q_bshd, k_bshd, v_bshd, scale_s):
+        with sdpa_kernel(
+            [SDPBackend.FLASH_ATTENTION, SDPBackend.MATH], set_priority=True
+        ):
+            # bottom right causal mask
+            decode_mask = torch.empty(
+                batches, 1, prediction, ref_seqlen,
+                dtype=torch.bool,
+            )
+            for batch, seq in enumerate(seqlens):
+                batch_mask = torch.ones(
+                    prediction, ref_seqlen, dtype=torch.bool
+                ).tril(diagonal=seq-prediction)
+                decode_mask[batch, 0, ...] = (
+                    batch_mask if seq > 0 else False
+                )
+            o_bshd = scaled_dot_product_attention(
+                q_bshd.transpose(1,2),
+                k_bshd.transpose(1,2),
+                v_bshd.transpose(1,2),
+                attn_mask=decode_mask,
+                dropout_p=0.0,
+                scale=scale_s,
+                is_causal=False,  # built-in is upper left causal
+                enable_gqa=(heads_q != heads_k),
+            ).transpose(1,2)
+            return o_bshd
+
+    if not skip_ref_check:
+        # Execute kernel once for reference checking
+        print("Running...")
+        compiled_fmha(
+            kv_splits,
+            seqlens_cute,
+            table_offsets_cute,
+            page_table_cute,
+            k_paged_cute,
+            v_paged_cute,
+            q_cute,
+            o_cute,
+            m_cute,
+            o_partial_cute,
+            m_partial_cute,
+            l_partial_cute,
+            scale_s,
+            threshold_p,
+            current_stream,
+        )
+        if debug_blasst:
+            tiles_skipped = seqlens_torch[batches]
+            if 0 < tiles_fixed <= tiles_total:
+                print(
+                    f"{tiles_fixed} tiles fixed to {fix_value} out of {tiles_total} total ({tiles_fixed / tiles_total})"
+                )
+            print(
+                f"{tiles_skipped} tiles skipped out of {tiles_total} total ({tiles_skipped / tiles_total})"
+            )
+
+        print("Verifying results...")
+        o_ref = run_torch_fmha(q_ref, k_ref, v_ref, scale_s).cuda()
+        torch.testing.assert_close(
+            o_ref, o_torch.to(torch_ref_dtype), atol=tolerance, rtol=1e-05
+        )
+        print("PASS")
+
+    else:
+        print("SKIP")
+
+    #
+    # Profile
+    #
+    if iterations <= 0:
+        return 0.0
+
+    # Create non-default stream for CUDA graph profiling
+    torch_stream = torch.cuda.Stream()
+    profile_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    def workspace_generator():
+        seqlens_cute = Int32(seqlens[0])
+        table_offsets_cute = None
+        if is_varlen:
+            seqlens_cute, _ = cute_tensor_like(seqlens_torch, Int32)
+            table_offsets_cute, _ = cute_tensor_like(table_offsets_torch, Int32)
+
+        page_table_cute, _ = cute_tensor_like(page_table_torch, Int32)
+        kv_paged_cute, kv_paged_torch_ = cute_tensor_like(kv_paged_torch, qkv_dtype)
+
+        k_paged_cute = cutlass_torch.from_dlpack(
+            kv_paged_torch_[:, 0, ...], assumed_align=16).mark_layout_dynamic(-1)
+        v_paged_cute = cutlass_torch.from_dlpack(
+            kv_paged_torch_[:, 1, ...], assumed_align=16).mark_layout_dynamic(-1)
+
+        q_cute, _ = cute_tensor_like(q_torch, qkv_dtype)
+        o_cute, _ = cute_tensor_like(o_torch, o_dtype)
+
+        m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
+        if not atomic:
+            _, m_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
+            _, o_partial_cute, _ = create_tensor(qo_shape, acc_dtype)
+            _, m_partial_cute, _ = create_tensor(qo_shape[:-1], acc_dtype)
+            _, l_partial_cute, _ = create_tensor(qo_shape[:-1], acc_dtype)
+
+        return testing.JitArguments(
+            kv_splits,
+            seqlens_cute,
+            table_offsets_cute,
+            page_table_cute,
+            k_paged_cute,
+            v_paged_cute,
+            q_cute,
+            o_cute,
+            m_cute,
+            o_partial_cute,
+            m_partial_cute,
+            l_partial_cute,
+            scale_s,
+            threshold_p,
+            profile_stream,
+        )
+
+    workspace_count = 1
+    qo_bytes = q_torch.nbytes + o_torch.nbytes
+    if not use_warm_l2:
+        one_workspace_bytes = (
+            page_table_torch.nbytes
+            + kv_paged_torch.nbytes
+            + qo_bytes
+        )
+        if is_varlen:
+            one_workspace_bytes += (
+                seqlens_torch.nbytes
+                + table_offsets_torch.nbytes
+            )
+        if not atomic:
+            one_workspace_bytes += (
+                m_torch.nbytes
+                + o_partial_torch.nbytes
+                + m_partial_torch.nbytes
+                + l_partial_torch.nbytes
+            )
+        workspace_count = testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    runtime_us = testing.benchmark(
+        compiled_fmha,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        stream=profile_stream,
+        workspace_generator=workspace_generator,
+        workspace_count=workspace_count,
+        use_cuda_graphs=True,
+    )
+
+    # Print throughputs
+    total_seqlen = sum(seqlens)
+    kv_bytes = heads_k * total_seqlen * headdim * qkv_dtype.width * 2 // 8
+    terabytes_per_s = (qo_bytes + kv_bytes) / runtime_us * 1.0e-6
+    flops = heads_q * prediction * total_seqlen * headdim * 2 * 2
+    teraflops_per_s = flops / runtime_us * 1.0e-6
+
+    print(
+        f"{runtime_us:.3f} us\n"
+        f"{terabytes_per_s:.3f} TB/s\n"
+        f"{teraflops_per_s:.3f} TFLOPS/s"
+    )
+
+    return (runtime_us, teraflops_per_s, terabytes_per_s)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Example of paged MHA/GQA decode on Blackwell."
+    )
+
+    parser.add_argument(
+        "--batches",
+        "--batch",
+        "--b",
+        type=int,
+        default=1,
+        help="batch size",
+    )
+
+    parser.add_argument(
+        "--prediction",
+        "--p",
+        type=int,
+        default=1,
+        help="number of predicted tokens (without causal masking)",
+    )
+
+    parser.add_argument(
+        "--seqlen",
+        "--seq",
+        "--s",
+        type=str,
+        default="1024",
+        help="comma separated list of key/value sequence lengths for each batch",
+    )
+
+    parser.add_argument(
+        "--page_size",
+        "--pg",
+        type=int,
+        default=32,
+        help="tokens per page",
+    )
+
+    parser.add_argument(
+        "--heads_q",
+        "--h_q",
+        type=int,
+        default=64,
+        help="query heads",
+    )
+
+    parser.add_argument(
+        "--heads_k",
+        "--h_k",
+        type=int,
+        default=8,
+        help="key/value heads",
+    )
+
+    parser.add_argument(
+        "--headdim",
+        "--d",
+        type=int,
+        default=128,
+        help="head dimension",
+    )
+
+    parser.add_argument(
+        "--kv_splits",
+        "--splits",
+        type=int,
+        default=0,
+        help="threadblocks per sequence",
+    )
+
+    parser.add_argument(
+        "--reduction",
+        type=str,
+        default="auto",
+        help="split KV reduction mode, can be kernel, atomic, or auto",
+    )
+
+    parser.add_argument(
+        "--qkv_dtype",
+        "--mma_dtype",
+        type=cutlass.dtype,
+        default=BFloat16,
+        help="query/key/value data type",
+    )
+
+    parser.add_argument(
+        "--o_dtype",
+        "--out_dtype",
+        type=cutlass.dtype,
+        default=BFloat16,
+        help="output data type",
+    )
+
+    parser.add_argument(
+        "--acc_dtype",
+        type=cutlass.dtype,
+        default=Float32,
+        help="accumulator/reduction data type",
+    )
+
+    parser.add_argument(
+        "--tolerance",
+        "--atol",
+        type=float,
+        default=1e-01,
+        help="Absolute tolerance for validation",
+    )
+
+    parser.add_argument(
+        "--scale_s",
+        "--scale",
+        type=float,
+        default=0,
+        help="score (Q*K) scale factor; if zero, defaults to 1/sqrt(D)",
+    )
+
+    parser.add_argument(
+        "--threshold_p",
+        "--threshold",
+        type=float,
+        default=0,
+        help="skips block_pv if exp(block_qk - running_max) < threshold_p",
+    )
+
+    if debug_blasst:
+        parser.add_argument(
+            "--fix_ratio",
+            "--fr",
+            type=float,
+            default=0,
+            help="ratio of tiles to fix in KV reference",
+        )
+
+        parser.add_argument(
+            "--fix_value",
+            "--fv",
+            type=float,
+            default=0,
+            help="value to fix KV reference tiles to",
+        )
+
+    parser.add_argument(
+        "--warmup_iterations",
+        "--warmups",
+        type=int,
+        default=10,
+        help="Number of iterations for warmup",
+    )
+
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=10,
+        help="Number of iterations after warmup",
+    )
+
+    parser.add_argument(
+        "--skip_ref_check",
+        action="store_true",
+        help="Skip reference check",
+    )
+
+    parser.add_argument(
+        "--use_warm_l2",
+        action="store_true",
+        help="dont rotate profiling workspace and dont flush L2 before profiling",
+    )
+
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Less verbose prints",
+    )
+
+    kwargs = vars(parser.parse_args())
+
+    run(**kwargs)

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -25,11 +25,6 @@ from cutlass.cute.typing import (
     Optional, Literal, Union,
 )
 
-# Example-only imports (torch SDPA, cutlass.torch, cutlass.cute.testing,
-# argparse, random, itertools.accumulate) are deferred into run() and
-# __main__ so library users importing GroupedQueryAttentionDecodePaged
-# don't pay for them.
-
 from flashinfer.cute_dsl.attention.gqa_decode import (
     # Kernel invariants
     mma_modes,
@@ -66,6 +61,7 @@ class GroupedQueryAttentionDecodePaged:
         reduction_mode : Literal[  # split-K reduction algorithm
             "kernel", # Deterministic kernel reduction with partial result workspace
             "atomic", # Cluster reduction with atomic adds, no workspace
+            "none", # no split-K, flash decoding disabled
         ] = "kernel",
         softmax_warpgroups=1,
         *,
@@ -81,6 +77,7 @@ class GroupedQueryAttentionDecodePaged:
         self.sequence_tile = sequence_tile
         self.do_kernel_red = reduction_mode == "kernel"
         self.do_atomic_red = reduction_mode == "atomic"
+        self.do_none_red = reduction_mode == "none" or reduction_mode is None
         self.tma_mask = tma_mask
         self.softmax_warpgroups = softmax_warpgroups
         self.threads_per_cta = (2 + softmax_warpgroups) * warpgroup_threads
@@ -90,7 +87,7 @@ class GroupedQueryAttentionDecodePaged:
         assert sequence_tile > 0 and sequence_tile % 128 == 0
         assert page_size in (8, 16, 32, 64)
         assert self.softmax_warpgroups in (1, 2)
-        assert self.do_kernel_red ^ self.do_atomic_red
+        assert self.do_kernel_red ^ self.do_atomic_red ^ self.do_none_red
 
     def can_implement(
         self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype, threshold_scale_factor
@@ -244,7 +241,7 @@ class GroupedQueryAttentionDecodePaged:
         # TMA creation
         ##############################
         h_k = k_bshd.shape[2]
-        o_bshd_ = o_bshd if self.do_atomic_red else o_partial_bshd
+        o_bshd_ = o_partial_bshd if self.do_kernel_red else o_bshd
 
         # Reorder and group modes for GEMM
         # ((h_g, s_q), d, (h_k, b))
@@ -330,12 +327,10 @@ class GroupedQueryAttentionDecodePaged:
             tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
         )
 
-        # GEMM view for LSE output (atomic-reduction path; kernel-reduction
-        # path writes LSE directly from reduction_kernel using the raw bsh).
-        mL_nl = None
-        if cutlass.const_expr(l_bsh is not None and self.do_atomic_red):
-            assert l_bsh.dtype == acc_dtype
-            mL_nl = GqaDecode.gemm_view_bsh(l_bsh, h_k)  # ((h_g, s_q), (h_k, b))
+        # GEMM view for LSE output
+        # ((h_g, s_q), (h_k, b))
+        mL_nl = None if l_bsh is None else GqaDecode.gemm_view_bsh(l_bsh, h_k)
+        assert l_bsh is None or l_bsh.dtype == acc_dtype
 
         # GEMM views for workspace tensors
         mM_nl = mM_partial_nl = mL_partial_nl = None
@@ -363,9 +358,10 @@ class GroupedQueryAttentionDecodePaged:
         )
 
         n_tiles = cute.ceil_div(mQ_nkl.shape[0], (blk_tile_h, blk_tile_p))
-        n_tiles = cute.size(n_tiles)
-        l_tiles = cute.size(mQ_nkl.shape[2])
-        grid = (kv_splits, n_tiles, l_tiles)
+        grid_y = cute.size(n_tiles)
+        grid_z = cute.size(mQ_nkl.shape[2])  # l tiles
+        grid_x = 1 if self.do_none_red else kv_splits
+        grid = (grid_x, grid_y, grid_z)
         cluster_x = kv_splits if self.do_atomic_red else 1
 
         self.decode(
@@ -504,6 +500,8 @@ class GroupedQueryAttentionDecodePaged:
         # Static control flow
         do_kernel_red = self.do_kernel_red
         do_atomic_red = self.do_atomic_red
+        do_none_red = self.do_none_red
+        store_lse = mL is not None
         tma_mask = self.tma_mask
         is_varlen = isinstance(seqlens_iter, cute.Pointer)
         enable_blasst = log2_threshold_scale_factor is not None
@@ -552,6 +550,8 @@ class GroupedQueryAttentionDecodePaged:
         # Read thread indices
         kv_splits, tiles_hp, tiles_hb = cute.arch.grid_dim()
         kv_split_idx, coord_hp, coord_hb = cute.arch.block_idx()
+        if cutlass.const_expr(do_none_red):
+            kv_splits, kv_split_idx = (1, 0)
         tidx, _, _ = cute.arch.thread_idx()
         lane_idx = cute.arch.lane_idx()
         warp_idx = cute.arch.make_warp_uniform(tidx // warp_threads)
@@ -1123,8 +1123,8 @@ class GroupedQueryAttentionDecodePaged:
 
             # Slice and partition O
             # (TILE_D, TILE_H)
-            coord_b_partial = (coord_b if do_atomic_red
-                               else kv_split_idx * batches + coord_b)
+            coord_b_partial = (kv_split_idx * batches + coord_b
+                               if do_kernel_red else coord_b)
             gO = cute.local_tile(
                 mO,
                 tiler=(blk_tile_d, blk_tile_hp),
@@ -1713,12 +1713,12 @@ class GroupedQueryAttentionDecodePaged:
             output_final = tOrO_final.reshape((blk_tile_n, tiles_dm))
             output_final += correction * output_prev
 
-            # Apply final correction
-            if cutlass.const_expr(do_atomic_red):
-                # final correction stored in sM
+            # Apply final normalization
+            if cutlass.const_expr(do_atomic_red or do_none_red):
+                # final normalization stored in sM
                 sM_final_nbar.arrive_and_wait()
-                correction = sM.load()
-                output_final *= correction
+                normalization = sM.load()
+                output_final *= normalization
 
             # Store O to smem and notify
             tOsO.store(output_final.to(o_dtype).reshape(tOsO.shape))
@@ -1754,9 +1754,9 @@ class GroupedQueryAttentionDecodePaged:
                     mM_partial,
                     mL_partial,
                 )
-            else:
+            elif cutlass.const_expr(do_atomic_red):
                 gL = None
-                if cutlass.const_expr(mL is not None):
+                if cutlass.const_expr(store_lse):
                     gL = cute.local_tile(mL, (blk_tile_hp,), (coord_hp, coord_hb))
                 GqaDecode.reduction_cluster(
                     blk_tile_n,
@@ -1769,6 +1769,20 @@ class GroupedQueryAttentionDecodePaged:
                     sM,
                     sL,
                     sR,
+                    gL,
+                    scale_o,
+                )
+            elif cutlass.const_expr(do_none_red):
+                gL = None
+                if cutlass.const_expr(store_lse):
+                    gL = cute.local_tile(mL, (blk_tile_hp,), (coord_hp, coord_hb))
+                GqaDecode.reduction_none(
+                    lane_store_max,
+                    lane_idx,
+                    sM_final_nbar,
+                    sL_final_nbar,
+                    sM,
+                    sL,
                     gL,
                     scale_o,
                 )
@@ -1850,18 +1864,23 @@ def run(
             kv_splits = 9  # 2 waves
         # At least 256 tokens per split
         kv_splits = min(kv_splits, math.ceil(max(seqlens) / 256))
-        # Cluster reduction requires po2 splits
-        if reduction == "atomic":
+        if reduction == "none":
+            kv_splits = 1
+        elif reduction == "atomic":
+            # Cluster reduction requires po2 splits
             if kv_splits not in (1, 2, 4):
                 kv_splits = 8  # generally performs well
 
     # Automatic reduction mode
     if reduction == "auto":
-        if o_dtype in (Float32, Float16, BFloat16) and kv_splits in (1, 2, 4, 8):
+        if kv_splits == 1:
+            reduction = "none"
+        elif o_dtype in (Float32, Float16, BFloat16) and kv_splits in (2, 4, 8):
             reduction = "atomic"
         else:
             reduction = "kernel"
-    atomic = reduction == "atomic"
+    do_atomic_red = reduction == "atomic"
+    do_kernel_red = reduction == "kernel"
 
     print(f"Command: python {__file__.split("/")[-1]}"
         f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
@@ -1987,7 +2006,7 @@ def run(
     q_init = k_init = v_init = [-8, 7]
     q_ref, q_cute, q_torch = create_tensor(qo_shape[1:], qkv_dtype, init=q_init)
     _, o_cute, o_torch = create_tensor(
-        qo_shape[1:], o_dtype, init=(0 if atomic else None)
+        qo_shape[1:], o_dtype, init=(0 if do_atomic_red else None)
     )
     # LSE output (log2 base). Allocated unconditionally for both reduction
     # modes; the kernel only writes here, we don't refcheck — exists solely
@@ -1995,7 +2014,7 @@ def run(
     _, l_cute, l_torch = create_tensor(qo_shape[1:-1], acc_dtype)
     # Workspace tensors
     m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
-    if not atomic:
+    if do_kernel_red:
         _, m_cute, m_torch = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
         _, o_partial_cute, o_partial_torch = create_tensor(qo_shape, acc_dtype)
         _, m_partial_cute, m_partial_torch = create_tensor(qo_shape[:-1], acc_dtype)
@@ -2220,7 +2239,7 @@ def run(
         _, l_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype)
 
         m_cute = o_partial_cute = m_partial_cute = l_partial_cute = None
-        if not atomic:
+        if do_kernel_red:
             _, m_cute, _ = create_tensor(qo_shape[1:-1], acc_dtype, init=-math.inf)
             _, o_partial_cute, _ = create_tensor(qo_shape, acc_dtype)
             _, m_partial_cute, _ = create_tensor(qo_shape[:-1], acc_dtype)
@@ -2259,7 +2278,7 @@ def run(
                 seqlens_torch.nbytes
                 + table_offsets_torch.nbytes
             )
-        if not atomic:
+        if do_kernel_red:
             one_workspace_bytes += (
                 m_torch.nbytes
                 + o_partial_torch.nbytes
@@ -2372,7 +2391,7 @@ if __name__ == "__main__":
         "--reduction",
         type=str,
         default="auto",
-        help="split KV reduction mode, can be kernel, atomic, or auto",
+        help="split KV reduction mode, can be kernel, atomic, none, auto",
     )
 
     parser.add_argument(

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -1,16 +1,9 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import argparse
 import math
-import random
 from typing import Type, Tuple
-from itertools import accumulate
 from functools import partial
-
-import torch
-from torch.nn.functional import scaled_dot_product_attention
-from torch.nn.attention import SDPBackend, sdpa_kernel
 
 import cuda.bindings.driver as cuda
 
@@ -25,14 +18,17 @@ from cutlass.pipeline import (
     NamedBarrier as nbar,
 )
 
-import cutlass.torch as cutlass_torch
 import cutlass.utils.blackwell_helpers as sm100_utils
-import cutlass.cute.testing as testing
 from cutlass.cute.typing import (
     Float32, Float16, BFloat16,
     Int8, Int32, Int64,
     Optional, Literal, Union,
 )
+
+# Example-only imports (torch SDPA, cutlass.torch, cutlass.cute.testing,
+# argparse, random, itertools.accumulate) are deferred into run() and
+# __main__ so library users importing GroupedQueryAttentionDecodePaged
+# don't pay for them.
 
 from flashinfer.cute_dsl.attention.gqa_decode import (
     # Kernel invariants
@@ -1804,6 +1800,17 @@ def run(
     quiet: bool = False,
     **kwargs,
 ):
+    # Example-only imports deferred here so importing the kernel module
+    # doesn't pull in torch SDPA, cutlass.torch, cutlass.cute.testing,
+    # random, or itertools.accumulate.
+    import random
+    from itertools import accumulate
+    import torch
+    from torch.nn.functional import scaled_dot_product_attention
+    from torch.nn.attention import SDPBackend, sdpa_kernel
+    import cutlass.torch as cutlass_torch
+    import cutlass.cute.testing as testing
+
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
 
@@ -2290,6 +2297,7 @@ def run(
 
 
 if __name__ == "__main__":
+    import argparse
     parser = argparse.ArgumentParser(
         description="Example of paged MHA/GQA decode on Blackwell."
     )

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -30,7 +30,7 @@ from cutlass.cute.typing import (
     Union,
 )
 
-from .gqa_decode import (
+from flashinfer.cute_dsl.attention.gqa_decode import (
     # Kernel invariants
     mma_modes,
     mma_dice,
@@ -1898,6 +1898,15 @@ def run(
     do_atomic_red = reduction == "atomic"
     do_kernel_red = reduction == "kernel"
 
+    # Absolute output tolerance for integer-valued inputs
+    if tolerance < 0:
+        if o_dtype.width == 8:
+            tolerance = 0.4
+        elif qkv_dtype.width == 8:
+            tolerance = 0.2
+        else:
+            tolerance = 0.1
+
     print(
         f"Command: python {__file__.split('/')[-1]}"
         f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
@@ -1985,9 +1994,13 @@ def run(
     torch_ref_dtype = torch.float16
 
     # Convert + copy to device with torch backed cute view
-    cute_tensor_like = partial(
-        cutlass_torch.cute_tensor_like, is_dynamic_layout=True, assumed_align=16
-    )
+    def cute_tensor_like(tensor: torch.Tensor, dtype):
+        cute_tensor, torch_tensor = cutlass_torch.cute_tensor_like(
+            tensor, dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        # handle if we casted to int8/uint8 for dlpack
+        torch_tensor = torch_tensor.view(cutlass_torch.dtype(dtype))
+        return cute_tensor, torch_tensor
 
     # Initialize on host and copy to device
     def create_tensor(shape, dtype, init=None, device=True):
@@ -2440,7 +2453,7 @@ if __name__ == "__main__":
         "--tolerance",
         "--atol",
         type=float,
-        default=1e-01,
+        default=-1,
         help="Absolute tolerance for validation",
     )
 

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math
-from typing import Type, Tuple
+from typing import Literal, Type, cast
 from functools import partial
 
 import cuda.bindings.driver as cuda
@@ -20,9 +20,14 @@ from cutlass.pipeline import (
 
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import (
-    Float32, Float16, BFloat16,
-    Int8, Int32, Int64,
-    Optional, Literal, Union,
+    Float32,
+    Float16,
+    BFloat16,
+    Int8,
+    Int32,
+    Int64,
+    Optional,
+    Union,
 )
 
 from .gqa_decode import (
@@ -58,10 +63,10 @@ class GroupedQueryAttentionDecodePaged:
         grouped_head_tile,  # Grouped heads per threadblock (GQA packing factor)
         prediction_tile=1,  # Predicted tokens per threadblock
         sequence_tile=256,  # KV tokens per threadblock per loop iteration
-        reduction_mode : Literal[  # split-K reduction algorithm
-            "kernel", # Deterministic kernel reduction with partial result workspace
-            "atomic", # Cluster reduction with atomic adds, no workspace
-            "none", # no split-K, flash decoding disabled
+        reduction_mode: Literal[  # split-K reduction algorithm
+            "kernel",  # Deterministic kernel reduction with partial result workspace
+            "atomic",  # Cluster reduction with atomic adds, no workspace
+            "none",  # no split-K, flash decoding disabled
         ] = "kernel",
         softmax_warpgroups=1,
         *,
@@ -92,9 +97,7 @@ class GroupedQueryAttentionDecodePaged:
     def can_implement(
         self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype, threshold_scale_factor
     ):
-        GqaDecode.can_implement(
-            self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype
-        )
+        GqaDecode.can_implement(self, kv_splits, qo_shape, kv_shape, qkv_dtype, o_dtype)
 
         if threshold_scale_factor is not None and not threshold_scale_factor > 0:
             raise ValueError(
@@ -110,17 +113,27 @@ class GroupedQueryAttentionDecodePaged:
         self,
         kv_splits: Int32,  # threadblocks per sequence
         seqlens: Union[cute.Tensor, Int32],  # sequence lengths for each batch
-        table_offsets: Optional[cute.Tensor],  # starting offset into page table for each batch
+        table_offsets: Optional[
+            cute.Tensor
+        ],  # starting offset into page table for each batch
         page_table: cute.Tensor,  # logical to virtual page index mappings
         k_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
         v_bshd: cute.Tensor,  # (page_count, page_size, h_k, d)
         q_bshd: cute.Tensor,
         o_bshd: cute.Tensor,  # must be zero initialized for atomic reduction
         l_bsh: Optional[cute.Tensor],  # log-sum-exp output (Float32), log2 base
-        m_bsh: Optional[cute.Tensor],  # colmax_s, must be -inf initialized (kernel-red workspace)
-        o_partial_bshd: Optional[cute.Tensor],  # partial O per kv split (kernel-red workspace)
-        l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split (kernel-red workspace)
-        m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split (kernel-red workspace)
+        m_bsh: Optional[
+            cute.Tensor
+        ],  # colmax_s, must be -inf initialized (kernel-red workspace)
+        o_partial_bshd: Optional[
+            cute.Tensor
+        ],  # partial O per kv split (kernel-red workspace)
+        l_partial_bsh: Optional[
+            cute.Tensor
+        ],  # partial colsum_p per kv split (kernel-red workspace)
+        m_partial_bsh: Optional[
+            cute.Tensor
+        ],  # partial colmax_s per kv split (kernel-red workspace)
         scale_s: Float32,
         scale_o: Float32,
         threshold_scale_factor: Optional[Float32],
@@ -198,7 +211,7 @@ class GroupedQueryAttentionDecodePaged:
         self.s_stages = s_stages = min(max_s_stages, p_stages)
 
         tmem_alloc_cols += tmem_s_stage_cols * s_stages  # S
-        tmem_alloc_cols = 2 ** math.ceil(math.log2(tmem_alloc_cols)) # po2
+        tmem_alloc_cols = 2 ** math.ceil(math.log2(tmem_alloc_cols))  # po2
         self.tmem_alloc_cols = tmem_alloc_cols
         assert tmem_alloc_cols <= tmem_capacity_cols
 
@@ -279,17 +292,13 @@ class GroupedQueryAttentionDecodePaged:
             smem_layout_k_mk, (self.page_size, mma_tile_k)
         )
         # (TMA, #PAGE_M, kv_stages)
-        smem_layout_k_tma = cute.select(
-            smem_layout_k_tma, [0, 1, 3]
-        )
+        smem_layout_k_tma = cute.select(smem_layout_k_tma, [0, 1, 3])
         # ((MMA_TILE_M, PAGE), 1, #PAGE_K, kv_stages)
         smem_layout_v_tma = cute.tiled_divide(
             smem_layout_v_mk, (mma_tile_m, self.page_size)
         )
         # (TMA, #PAGE_K, kv_stages)
-        smem_layout_v_tma = cute.select(
-            smem_layout_v_tma, [0, 2, 3]
-        )
+        smem_layout_v_tma = cute.select(smem_layout_v_tma, [0, 2, 3])
 
         o_smem_dtype = mO_mnl.dtype
         smem_layout_atom_o = tcgen05.make_smem_layout_atom(
@@ -324,7 +333,10 @@ class GroupedQueryAttentionDecodePaged:
             tma_load_op, mV_mkl, smem_layout_v_tma[0], (mma_tile_m, self.page_size)
         )
         tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
-            tma_store_op, mO_mnl, cute.select(smem_layout_o, mode=[0, 1]), tma_tile_mnk[:2]
+            tma_store_op,
+            mO_mnl,
+            cute.select(smem_layout_o, mode=[0, 1]),
+            tma_tile_mnk[:2],
         )
 
         # GEMM view for LSE output
@@ -335,9 +347,13 @@ class GroupedQueryAttentionDecodePaged:
         # GEMM views for workspace tensors
         mM_nl = mM_partial_nl = mL_partial_nl = None
         if cutlass.const_expr(self.do_kernel_red):
-            assert (m_bsh.dtype == m_partial_bsh.dtype
-                    == l_partial_bsh.dtype == o_partial_bshd.dtype
-                    == acc_dtype)
+            assert (
+                m_bsh.dtype
+                == m_partial_bsh.dtype
+                == l_partial_bsh.dtype
+                == o_partial_bshd.dtype
+                == acc_dtype
+            )
 
             # ((h_g, s_q), (h_k, b), kv_splits)
             mM_nl = GqaDecode.gemm_view_bsh(m_bsh, h_k)
@@ -479,7 +495,7 @@ class GroupedQueryAttentionDecodePaged:
         mcast_layout = cute.make_layout((1, 1, 1, 1))  # vmnk
 
         # Alias types
-        q_dtype = k_dtype = v_dtype = mma_dtype
+        q_dtype = k_dtype = mma_dtype
         o_dtype = out_dtype
         acc_dtype = Float32
 
@@ -539,12 +555,10 @@ class GroupedQueryAttentionDecodePaged:
             max_sw_regs_per_wg_thread,
             max_hw_regs_per_wg_thread
             - mma_tma_regs
-            - softmax_regs * softmax_warpgroups
+            - softmax_regs * softmax_warpgroups,
         )
         assert (
-            mma_tma_regs
-            + softmax_regs * softmax_warpgroups
-            + correction_regs
+            mma_tma_regs + softmax_regs * softmax_warpgroups + correction_regs
         ) <= max_hw_regs_per_wg_thread
 
         # Read thread indices
@@ -580,9 +594,7 @@ class GroupedQueryAttentionDecodePaged:
             seqlen_smem = smem.allocate_tensor(Int32, scalar_layout)
             table_offset_smem = smem.allocate_tensor(Int32, scalar_layout)
             if warp_idx == init_warp:
-                seqlen_gmem = cute.make_tensor(
-                    seqlens_iter + coord_b, scalar_layout
-                )
+                seqlen_gmem = cute.make_tensor(seqlens_iter + coord_b, scalar_layout)
                 table_offset_gmem = cute.make_tensor(
                     table_offsets_iter + coord_b, scalar_layout
                 )
@@ -593,7 +605,6 @@ class GroupedQueryAttentionDecodePaged:
                 cute.arch.cp_async_commit_group()
                 cute.arch.cp_async_wait_group(0)
             init_warp += 1
-
 
         ##############################
         # Prefetch TMA descriptor
@@ -642,6 +653,7 @@ class GroupedQueryAttentionDecodePaged:
         # dual softmax and blasst are mutually exclusive
         sSP_producer_nbar = nbar(14, softmax_threads)
         sM_mutex_nbar = nbar(14, softmax_threads * softmax_warpgroups)
+
         # named barrier stage helper
         def with_phase(nbar_, phase):
             return nbar(nbar_.barrier_id + phase, nbar_.num_threads)
@@ -792,9 +804,7 @@ class GroupedQueryAttentionDecodePaged:
 
         # O
         # Reuse KV smem for O TMA store
-        sO_iterator = cute.recast_ptr(
-            tAsK.iterator, smem_layout_o.inner, dtype=o_dtype
-        )
+        sO_iterator = cute.recast_ptr(tAsK.iterator, smem_layout_o.inner, dtype=o_dtype)
         # (MMA_TILE_M, MMA_TILE_N, #TILE_DM, #TILE_HN)
         sO_mma = cute.make_tensor(sO_iterator, smem_layout_o.outer)
         # (MMA, #MMA_M, #MMA_N, #TILE_DM, #TILE_HN=1)
@@ -828,9 +838,7 @@ class GroupedQueryAttentionDecodePaged:
 
         # per-thread colsum
         # (MMA_MN, #MMA_M=1, #MMA_N=1, o_stages)
-        tCtL_shape = tiled_mma_kq.partition_shape_C(
-            (mma_tile_m, mma_tile_n, o_stages)
-        )
+        tCtL_shape = tiled_mma_kq.partition_shape_C((mma_tile_m, mma_tile_n, o_stages))
         tCtL = thrblk_mma_kq.make_fragment_C(tCtL_shape)
 
         # R - cluster reduction buffers for colmax + colsum
@@ -863,7 +871,7 @@ class GroupedQueryAttentionDecodePaged:
         tiles_s = cute.ceil_div(seqlen, blk_tile_s)
         iters_s = cute.ceil_div(tiles_s - kv_split_idx, kv_splits)
         exit_early = kv_split_idx >= tiles_s
-        prefetch_iters = min(2, s_stages - 1) # MMA KQ iters to hide first softmax
+        prefetch_iters = min(2, s_stages - 1)  # MMA KQ iters to hide first softmax
         assert pt_stages > prefetch_iters + 1
 
         ##############################
@@ -919,9 +927,7 @@ class GroupedQueryAttentionDecodePaged:
                 coord=(coord_hp, 0, coord_hb),
             )
             # (MMA_TILE_N, MMA_TILE_K, #TILE_DK)
-            gQ_mma = cute.local_tile(
-                gQ, (mma_tile_n, mma_tile_k), coord=(0, None)
-            )
+            gQ_mma = cute.local_tile(gQ, (mma_tile_n, mma_tile_k), coord=(0, None))
             # (MMA, #MMA_N, #MMA_K, #TILE_DK)
             tBgQ = thrblk_mma_kq.partition_B(gQ_mma)
             # (TMA, #TILE_DK)
@@ -971,7 +977,9 @@ class GroupedQueryAttentionDecodePaged:
             if lane_load_page:
                 logical_page_idx = tPTcPT[0, kv_split_idx]
                 if logical_page_idx < page_count:
-                    cute.copy(cpasync_atom, tPTgPT[None, kv_split_idx], tPTsPT[None, 0, 0])
+                    cute.copy(
+                        cpasync_atom, tPTgPT[None, kv_split_idx], tPTsPT[None, 0, 0]
+                    )
                 else:
                     tPTsPT[0] = -1  # load OOB zeros
             cute.arch.sync_warp()
@@ -1123,8 +1131,9 @@ class GroupedQueryAttentionDecodePaged:
 
             # Slice and partition O
             # (TILE_D, TILE_H)
-            coord_b_partial = (kv_split_idx * batches + coord_b
-                               if do_kernel_red else coord_b)
+            coord_b_partial = (
+                kv_split_idx * batches + coord_b if do_kernel_red else coord_b
+            )
             gO = cute.local_tile(
                 mO,
                 tiler=(blk_tile_d, blk_tile_hp),
@@ -1311,7 +1320,9 @@ class GroupedQueryAttentionDecodePaged:
                     sM_release_nbar.arrive()
             if iters_s == 1 and softmax_phase == softmax_warpgroups - 1:
                 with_phase(tL_producer_nbar, 1).arrive()
-            assert not (enable_blasst and softmax_warpgroups != 1), "blasst only supports 1 softmax wg"
+            assert not (enable_blasst and softmax_warpgroups != 1), (
+                "blasst only supports 1 softmax wg"
+            )
 
             # Construct copy atom for S
             tmem_repeat_op_s = blk_tile_n
@@ -1369,7 +1380,9 @@ class GroupedQueryAttentionDecodePaged:
                     elif (is_last_split or is_prev_split) and is_last_phase:
                         masked_start_s = 0
                         masked_iters_s = 1
-                        masked_coord_s = (tiles_s - 1) if is_last_split else (tiles_s - 2)
+                        masked_coord_s = (
+                            (tiles_s - 1) if is_last_split else (tiles_s - 2)
+                        )
                         # if last split only has 1 tile then some cols will never
                         # see inbounds values, so P = exp(-inf + inf) -> nan
                         check_safe_max = is_last_split and iters_s == 1
@@ -1386,8 +1399,8 @@ class GroupedQueryAttentionDecodePaged:
                 sM_lane_prev = -Float32.inf
                 # Per-batch BLASST threshold, matching trtllm:
                 # effective threshold_p = scale_factor / seqlen
-                log2_threshold_p = (
-                    log2_threshold_scale_factor - cute.math.log2(Float32(seqlen))
+                log2_threshold_p = log2_threshold_scale_factor - cute.math.log2(
+                    Float32(seqlen)
                 )
 
             # Sequence loop
@@ -1428,11 +1441,13 @@ class GroupedQueryAttentionDecodePaged:
 
                     # Reduce colmax in thread RF
                     rM = cute.make_rmem_tensor_like(sM)
-                    rM.store(scores.reduce(
-                        cute.ReductionOp.MAX,
-                        init_val=-Float32.inf,
-                        reduction_profile=(None, 0)
-                    ))
+                    rM.store(
+                        scores.reduce(
+                            cute.ReductionOp.MAX,
+                            init_val=-Float32.inf,
+                            reduction_profile=(None, 0),
+                        )
+                    )
 
                     # Reduce colmax in warp RF
                     rM_lane = Float32(0)
@@ -1455,7 +1470,9 @@ class GroupedQueryAttentionDecodePaged:
                         # warpgroup reduction
                         sp_handle = sp_producer.acquire_and_advance()
                         with cute.arch.elect_one():
-                            sSP_i8[warpgroup_widx, sp_handle.index] = Int8(warp_keep_tile)
+                            sSP_i8[warpgroup_widx, sp_handle.index] = Int8(
+                                warp_keep_tile
+                            )
                         sp_handle.commit()
                         sSP_producer_nbar.sync()
                         keep_tile = sSP_i32[sp_handle.index] != 0
@@ -1522,7 +1539,6 @@ class GroupedQueryAttentionDecodePaged:
                         else:
                             softmax_phase ^= 1
 
-
         ##############################
         # Correction Dispatch
         ##############################
@@ -1555,12 +1571,12 @@ class GroupedQueryAttentionDecodePaged:
             # colsum load helper
             def colsum_load(
                 phase,
-                blk_tile_n = blk_tile_n,
-                tOtL = tOtL,
-                tOrO_shape = tOsO.shape[:1],
-                tmem_load_atom_o = tmem_load_atom_o,
-                tL_producer_nbar = tL_producer_nbar,
-                tL_consumer_nbar = tL_consumer_nbar,
+                blk_tile_n=blk_tile_n,
+                tOtL=tOtL,
+                tOrO_shape=tOsO.shape[:1],
+                tmem_load_atom_o=tmem_load_atom_o,
+                tL_producer_nbar=tL_producer_nbar,
+                tL_consumer_nbar=tL_consumer_nbar,
             ):
                 with_phase(tL_producer_nbar, phase).arrive_and_wait()
                 tOtL_s = tOtL[None, phase]
@@ -1838,7 +1854,7 @@ def run(
             f"number of seqlens {len(seqlens)} doesn't match batches {batches}"
         )
 
-    npo2 = lambda x : 2 ** math.ceil(math.log2(x))
+    npo2 = lambda x: 2 ** math.ceil(math.log2(x))
 
     grouped_heads = heads_q // heads_k
     grouped_head_tile = npo2(grouped_heads)
@@ -1883,21 +1899,20 @@ def run(
     do_atomic_red = reduction == "atomic"
     do_kernel_red = reduction == "kernel"
 
-    print(f"Command: python {__file__.split("/")[-1]}"
+    print(
+        f"Command: python {__file__.split('/')[-1]}"
         f" --d {headdim} --h_q {heads_q} --h_k {heads_k}"
         f" --b {batches} --p {prediction} --s {seqlen}"
         f" --pg {page_size}"
         f" --kv_splits {kv_splits} --reduction {reduction}"
         f" --mma_dtype {qkv_dtype} --out_dtype {o_dtype}"
-        f" --atol {tolerance}{" --skip_ref_check" if skip_ref_check else ""}"
+        f" --atol {tolerance}{' --skip_ref_check' if skip_ref_check else ''}"
         f" --scale {scale_s} --threshold {threshold_scale_factor}"
-        f" --iterations {iterations} --warmups {warmup_iterations}{" --use_warm_l2" if use_warm_l2 else ""}"
-        f"{" --quiet" if quiet else ""}"
+        f" --iterations {iterations} --warmups {warmup_iterations}{' --use_warm_l2' if use_warm_l2 else ''}"
+        f"{' --quiet' if quiet else ''}"
     )
 
-    seqlen_str = (
-        f"\n\tseqlens: {seqlens}" if is_varlen else f"\tseqlen: {seqlen}"
-    )
+    seqlen_str = f"\n\tseqlens: {seqlens}" if is_varlen else f"\tseqlen: {seqlen}"
     if not quiet:
         print(
             "Running Blackwell SM100 GQA Decode Paged test with:\n"
@@ -1907,15 +1922,15 @@ def run(
             f"\tpage_size: {page_size}\n"
             f"\tkv_splits: {kv_splits}\treduction: {reduction}\n"
             f"\tqkv: {qkv_dtype}\to: {o_dtype}\t\n"
-            f"\tatol: {tolerance if not skip_ref_check else "skip"}"
-            f"\tscale_s: {f"1 / sqrt({headdim})" if scale_s == 0 else scale_s}"
+            f"\tatol: {tolerance if not skip_ref_check else 'skip'}"
+            f"\tscale_s: {f'1 / sqrt({headdim})' if scale_s == 0 else scale_s}"
             f"\tthreshold_scale_factor: {threshold_scale_factor}\n"
             f"\titerations: {iterations}\twarmups: {warmup_iterations}\twarm L2: {use_warm_l2}"
         )
 
     # Automatic scale + threshold
     if scale_s == 0:
-        scale_s = headdim ** -0.5
+        scale_s = headdim**-0.5
     if threshold_scale_factor == 0:
         threshold_scale_factor = None  # disable
     else:
@@ -1924,9 +1939,9 @@ def run(
 
     sequence_tile = 256
     if enable_blasst:
-        sequence_tile = 128 # Promote skipping
+        sequence_tile = 128  # Promote skipping
     elif prediction_tile > 1 and blk_tile_n > 8:
-        sequence_tile = 128 # Prevent spills
+        sequence_tile = 128  # Prevent spills
 
     #
     # Config Kernel
@@ -1937,11 +1952,14 @@ def run(
         grouped_head_tile,
         prediction_tile=prediction_tile,
         sequence_tile=sequence_tile,
-        reduction_mode=reduction,
+        reduction_mode=cast(Literal["kernel", "atomic", "none"], reduction),
         softmax_warpgroups=(
-            2 if not enable_blasst
-            and ((qkv_dtype.width <= 8 and blk_tile_n > 8)
-                or (qkv_dtype.width == 16 and blk_tile_n > 16))
+            2
+            if not enable_blasst
+            and (
+                (qkv_dtype.width <= 8 and blk_tile_n > 8)
+                or (qkv_dtype.width == 16 and blk_tile_n > 16)
+            )
             else 1
         ),
         # perf optimization for non-causal
@@ -1953,7 +1971,11 @@ def run(
     kv_shape = (batches, min_seqlen, heads_k, headdim)
 
     fmha.can_implement(
-        qo_shape[0], qo_shape[1:], kv_shape, qkv_dtype, o_dtype,
+        qo_shape[0],
+        qo_shape[1:],
+        kv_shape,
+        qkv_dtype,
+        o_dtype,
         threshold_scale_factor,
     )
 
@@ -1972,10 +1994,10 @@ def run(
     def create_tensor(shape, dtype, init=None, device=True):
         init_type = cutlass.torch.TensorInitType.SKIP
         init_config = None
-        if isinstance(init, int) or isinstance(init, float):
+        if isinstance(init, (int, float)):
             init_type = cutlass.torch.TensorInitType.SCALAR
             init_config = cutlass.torch.ScalarInitConfig(value=init)
-        elif isinstance(init, tuple) or isinstance(init, list):
+        elif isinstance(init, (tuple, list)):
             if len(init) == 1:
                 init_type = cutlass.torch.TensorInitType.SCALAR
                 init_config = cutlass.torch.ScalarInitConfig(value=init[0])
@@ -2084,10 +2106,10 @@ def run(
     assert len(k_ref_splits) == max_pages_per_batch
 
     for batch, page_count, table_offset in zip(
-        range(batches), logical_page_counts, table_offsets
+        range(batches), logical_page_counts, table_offsets, strict=False
     ):
         for page_idx, k_ref_split, v_ref_split in zip(
-            range(page_count), k_ref_splits, v_ref_splits
+            range(page_count), k_ref_splits, v_ref_splits, strict=False
         ):
             logical_page_idx = table_offset + page_idx
             virtual_idx = page_table[logical_page_idx]
@@ -2100,9 +2122,7 @@ def run(
     seqlens_cute = Int32(seqlens[0])
     table_offsets_cute = None
     if is_varlen:
-        seqlens_cute, seqlens_torch = cute_tensor_like(
-            torch.tensor(seqlens), Int32
-        )
+        seqlens_cute, seqlens_torch = cute_tensor_like(torch.tensor(seqlens), Int32)
         table_offsets_cute, table_offsets_torch = cute_tensor_like(
             torch.tensor(table_offsets), Int32
         )
@@ -2113,9 +2133,11 @@ def run(
     )
 
     k_paged_cute = cutlass_torch.from_dlpack(
-        kv_paged_torch[:, 0, ...], assumed_align=16).mark_layout_dynamic(-1)
+        kv_paged_torch[:, 0, ...], assumed_align=16
+    ).mark_layout_dynamic(-1)
     v_paged_cute = cutlass_torch.from_dlpack(
-        kv_paged_torch[:, 1, ...], assumed_align=16).mark_layout_dynamic(-1)
+        kv_paged_torch[:, 1, ...], assumed_align=16
+    ).mark_layout_dynamic(-1)
 
     #
     # Compile
@@ -2152,26 +2174,27 @@ def run(
         ):
             # bottom right causal mask
             decode_mask = torch.empty(
-                batches, 1, prediction, ref_seqlen,
+                batches,
+                1,
+                prediction,
+                ref_seqlen,
                 dtype=torch.bool,
             )
             for batch, seq in enumerate(seqlens):
-                batch_mask = torch.ones(
-                    prediction, ref_seqlen, dtype=torch.bool
-                ).tril(diagonal=seq-prediction)
-                decode_mask[batch, 0, ...] = (
-                    batch_mask if seq > 0 else False
+                batch_mask = torch.ones(prediction, ref_seqlen, dtype=torch.bool).tril(
+                    diagonal=seq - prediction
                 )
+                decode_mask[batch, 0, ...] = batch_mask if seq > 0 else False
             o_bshd = scaled_dot_product_attention(
-                q_bshd.transpose(1,2),
-                k_bshd.transpose(1,2),
-                v_bshd.transpose(1,2),
+                q_bshd.transpose(1, 2),
+                k_bshd.transpose(1, 2),
+                v_bshd.transpose(1, 2),
                 attn_mask=decode_mask,
                 dropout_p=0.0,
                 scale=scale_s,
                 is_causal=False,  # built-in is upper left causal
                 enable_gqa=(heads_q != heads_k),
-            ).transpose(1,2)
+            ).transpose(1, 2)
             return o_bshd
 
     if not skip_ref_check:
@@ -2237,9 +2260,11 @@ def run(
         kv_paged_cute, kv_paged_torch_ = cute_tensor_like(kv_paged_torch, qkv_dtype)
 
         k_paged_cute = cutlass_torch.from_dlpack(
-            kv_paged_torch_[:, 0, ...], assumed_align=16).mark_layout_dynamic(-1)
+            kv_paged_torch_[:, 0, ...], assumed_align=16
+        ).mark_layout_dynamic(-1)
         v_paged_cute = cutlass_torch.from_dlpack(
-            kv_paged_torch_[:, 1, ...], assumed_align=16).mark_layout_dynamic(-1)
+            kv_paged_torch_[:, 1, ...], assumed_align=16
+        ).mark_layout_dynamic(-1)
 
         q_cute, _ = cute_tensor_like(q_torch, qkv_dtype)
         o_cute, _ = cute_tensor_like(o_torch, o_dtype)
@@ -2275,16 +2300,9 @@ def run(
     workspace_count = 1
     qo_bytes = q_torch.nbytes + o_torch.nbytes
     if not use_warm_l2:
-        one_workspace_bytes = (
-            page_table_torch.nbytes
-            + kv_paged_torch.nbytes
-            + qo_bytes
-        )
+        one_workspace_bytes = page_table_torch.nbytes + kv_paged_torch.nbytes + qo_bytes
         if is_varlen:
-            one_workspace_bytes += (
-                seqlens_torch.nbytes
-                + table_offsets_torch.nbytes
-            )
+            one_workspace_bytes += seqlens_torch.nbytes + table_offsets_torch.nbytes
         if do_kernel_red:
             one_workspace_bytes += (
                 m_torch.nbytes
@@ -2324,6 +2342,7 @@ def run(
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(
         description="Example of paged MHA/GQA decode on Blackwell."
     )

--- a/flashinfer/cute_dsl/attention/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/mla_decode_fp8.py
@@ -559,8 +559,8 @@ class BlackwellMultiLatentAttentionForwardFP8:
             # .set(ACCUMULATE) mutations on the same tiled_mma_qk variable.
             compute_tiled_mma_qk = sm100_utils.make_trivial_tiled_mma(
                 self.q_dtype,
-                tcgen05.OperandMajorMode.K,
-                tcgen05.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
                 self.config.acc_dtype,
                 tcgen05.CtaGroup.TWO,
                 self.config.mma_qk_tiler[:2],

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -167,11 +167,11 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
         self.o_layout = utils.LayoutEnum.from_tensor(o)
 
-        if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
+        if cutlass.const_expr(self.q_major_mode != cute.nvgpu.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
-        if cutlass.const_expr(self.k_major_mode != tcgen05.OperandMajorMode.K):
+        if cutlass.const_expr(self.k_major_mode != cute.nvgpu.OperandMajorMode.K):
             raise RuntimeError("The layout of k is not supported")
-        if cutlass.const_expr(self.v_major_mode != tcgen05.OperandMajorMode.MN):
+        if cutlass.const_expr(self.v_major_mode != cute.nvgpu.OperandMajorMode.MN):
             raise RuntimeError("The layout of v is not supported")
 
         # check type consistency

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -5,7 +5,6 @@ from typing import Tuple
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.cute.nvgpu.tcgen05 as tcgen05
 import cutlass.utils as utils
 from cutlass.cute.typing import Int32, Float32
 

--- a/flashinfer/cute_dsl/attention/roles/mla_correction.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_correction.py
@@ -105,8 +105,8 @@ class MLACorrectionRole:
         via .set(ACCUMULATE, ...)).
         """
         cta_group = tcgen05.CtaGroup.TWO
-        p_major_mode = tcgen05.OperandMajorMode.K
-        v_major_mode = tcgen05.OperandMajorMode.MN
+        p_major_mode = cute.nvgpu.OperandMajorMode.K
+        v_major_mode = cute.nvgpu.OperandMajorMode.MN
         return sm100_utils.make_trivial_tiled_mma(
             self.v_dtype,
             p_major_mode,

--- a/flashinfer/cute_dsl/attention/roles/mla_mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma.py
@@ -96,8 +96,8 @@ class MLAMmaRole:
         )
         return sm100_utils.make_trivial_tiled_mma(
             self.q_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_dtype,
             cta_group,
             self.mma_qk_tiler[:2],
@@ -111,8 +111,8 @@ class MLAMmaRole:
         )
         return sm100_utils.make_trivial_tiled_mma(
             self.v_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_dtype,
             cta_group,
             self.mma_pv_tiler[:2],

--- a/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
+++ b/flashinfer/cute_dsl/attention/roles/mla_mma_fp8.py
@@ -91,8 +91,8 @@ class MLAMmaFP8Role:
         )
         return sm100_utils.make_trivial_tiled_mma(
             self.q_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_dtype,
             cta_group,
             self.mma_qk_tiler[:2],
@@ -106,8 +106,8 @@ class MLAMmaFP8Role:
         )
         return sm100_utils.make_trivial_tiled_mma(
             self.v_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_dtype,
             cta_group,
             self.mma_pv_tiler[:2],

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -76,9 +76,9 @@ class MmaRole:
         self,
         q_dtype: Type[cutlass.Numeric],
         v_dtype: Type[cutlass.Numeric],
-        q_major_mode: tcgen05.OperandMajorMode,
-        k_major_mode: tcgen05.OperandMajorMode,
-        v_major_mode: tcgen05.OperandMajorMode,
+        q_major_mode: cute.nvgpu.OperandMajorMode,
+        k_major_mode: cute.nvgpu.OperandMajorMode,
+        v_major_mode: cute.nvgpu.OperandMajorMode,
     ) -> None:
         """Set tensor element types and operand major modes discovered at call time.
 
@@ -87,9 +87,9 @@ class MmaRole:
         """
         self.q_dtype: Type[cutlass.Numeric] = q_dtype
         self.v_dtype: Type[cutlass.Numeric] = v_dtype
-        self.q_major_mode: tcgen05.OperandMajorMode = q_major_mode
-        self.k_major_mode: tcgen05.OperandMajorMode = k_major_mode
-        self.v_major_mode: tcgen05.OperandMajorMode = v_major_mode
+        self.q_major_mode: cute.nvgpu.OperandMajorMode = q_major_mode
+        self.k_major_mode: cute.nvgpu.OperandMajorMode = k_major_mode
+        self.v_major_mode: cute.nvgpu.OperandMajorMode = v_major_mode
 
     @cute.jit
     def _make_local_qk_mma(self) -> cute.TiledMma:
@@ -115,7 +115,7 @@ class MmaRole:
         """
         return sm100_utils.make_trivial_tiled_mma(
             self.v_dtype,
-            tcgen05.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.v_major_mode,
             self.pv_acc_dtype,
             tcgen05.CtaGroup.ONE,

--- a/flashinfer/cute_dsl/attention/wrappers/__init__.py
+++ b/flashinfer/cute_dsl/attention/wrappers/__init__.py
@@ -3,3 +3,7 @@
 
 from .batch_prefill import BatchPrefillCuteDSLWrapper
 from .batch_mla import BatchMLADecodeCuteDSLWrapper, cute_dsl_mla_decode
+from .batch_decode import (
+    BatchDecodeCuteDSLWrapper,
+    BatchDecodePagedCuteDSLWrapper,
+)

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -17,7 +17,6 @@ compilation via :func:`functools.cache` keyed on the static configuration.
 """
 
 import functools
-import math
 from typing import Literal, Optional, Tuple, cast
 
 import torch
@@ -67,7 +66,7 @@ def _pick_tile_shape(
             f"num_qo_heads ({num_qo_heads}) must be a multiple of num_kv_heads "
             f"({num_kv_heads})"
         )
-    npo2 = lambda x: 1 if x <= 1 else 2 ** math.ceil(math.log2(x))
+    npo2 = lambda x: 1 if x <= 1 else 1 << (x - 1).bit_length()
     grouped_heads = num_qo_heads // num_kv_heads
     grouped_head_tile = min(32, npo2(grouped_heads))
     prediction_tile = min(32 // grouped_head_tile, npo2(prediction))
@@ -602,6 +601,7 @@ class BatchDecodeCuteDSLWrapper:
         self._num_qo_heads = num_qo_heads
         self._num_kv_heads = num_kv_heads
         self._head_dim = head_dim
+        self._batch_size = batch_size
         self._q_len_per_req = q_len_per_req
         self._kv_splits = kv_splits
         self._reduction = reduction
@@ -733,7 +733,9 @@ class BatchDecodeCuteDSLWrapper:
 
         m = o_partial = l_partial = m_partial = None
         if self._has_workspace:
-            if s_q <= self._q_len_per_req:
+            # Kernel expects partial + batch stride to be coalescible
+            # So we must reslice workspace if runtime batch doesn't match
+            if b == self._batch_size and s_q <= self._q_len_per_req:
                 # Runtime q_len doesnt exceed plantime q_len, return slice
                 m = self._m[:, :s_q, :]
                 o_partial = self._o_partial[:, :, :s_q, :, :]

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -719,7 +719,7 @@ class BatchDecodePagedCuteDSLWrapper:
         precompile_skip_softmax_kernel : bool
             If True, also compile the BLASST skip-softmax variant of the
             kernel at plan() time, so the first :meth:`run` call that
-            passes ``skip_softmax_threshold`` is fast.  When False (default)
+            passes ``skip_softmax_threshold_scale_factor`` is fast.  When False (default)
             the BLASST variant is lazily compiled on first use, which keeps
             plan() fast at the cost of a one-time compile latency spike on
             that first call.  The standard (no-BLASST) variant is always
@@ -896,7 +896,7 @@ class BatchDecodePagedCuteDSLWrapper:
         out: Optional[torch.Tensor] = None,
         sm_scale: Optional[float] = None,
         o_scale: Optional[float] = None,
-        skip_softmax_threshold: Optional[float] = None,
+        skip_softmax_threshold_scale_factor: Optional[float] = None,
     ) -> torch.Tensor:
         """Run paged GQA decode.
 
@@ -922,12 +922,14 @@ class BatchDecodePagedCuteDSLWrapper:
             Output scale applied to the final O before it is written. The
             cute-dsl kernel folds this in for free in the reduction
             epilogue (no separate post-kernel multiply). Defaults to 1.0.
-        skip_softmax_threshold : Optional[float]
-            BLASST skip-softmax threshold in ``(0, 1]``.  ``None`` (default)
-            dispatches to the standard kernel (no BLASST overhead); a value
-            triggers lazy compile of the BLASST variant on first use, or
-            hits the precompiled cache if ``plan(precompile_skip_softmax_kernel=True)``
-            was used.
+        skip_softmax_threshold_scale_factor : Optional[float]
+            BLASST skip-softmax scale factor. The kernel divides this by
+            each batch's KV seqlen to obtain the per-request effective
+            threshold (matching trtllm-gen semantics). Must be > 0
+            when set. ``None`` (default) dispatches to the standard
+            kernel; a value triggers lazy compile of the BLASST variant
+            on first use, or hits the precompiled cache if
+            ``plan(precompile_skip_softmax_kernel=True)`` was used.
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
@@ -1019,16 +1021,17 @@ class BatchDecodePagedCuteDSLWrapper:
         )
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
-        if skip_softmax_threshold is not None:
-            if not (0.0 < skip_softmax_threshold <= 1.0):
+        if skip_softmax_threshold_scale_factor is not None:
+            if not skip_softmax_threshold_scale_factor > 0:
                 raise ValueError(
-                    f"skip_softmax_threshold must be in (0, 1]; "
-                    f"got {skip_softmax_threshold}"
+                    f"skip_softmax_threshold_scale_factor must be > 0; "
+                    f"got {skip_softmax_threshold_scale_factor}"
                 )
             # Fetch (or first-time compile) the BLASST variant via the
-            # module-level @functools.cache.
+            # module-level @functools.cache. The kernel divides by per-batch
+            # seqlen internally, so pass the raw scale factor.
             fmha = _get_compiled_paged_decode_kernel(*self._compile_args, True)
-            threshold_arg = Float32(skip_softmax_threshold)
+            threshold_arg = Float32(skip_softmax_threshold_scale_factor)
         else:
             fmha = self._compiled_fmha_std
             threshold_arg = None

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -840,7 +840,7 @@ class BatchDecodePagedCuteDSLWrapper:
         self,
         indptr: torch.Tensor,
         indices: torch.Tensor,
-        last_page_len: torch.Tensor,
+        seq_lens: torch.Tensor,
         num_qo_heads: int,
         num_kv_heads: int,
         head_dim: int,
@@ -865,8 +865,10 @@ class BatchDecodePagedCuteDSLWrapper:
             Prefix-sum offsets into ``indices``.
         indices : torch.Tensor (int32, [num_pages_total])
             Flat per-sequence virtual page indices.
-        last_page_len : torch.Tensor (int32, [batch_size])
-            Number of valid tokens on the last page of each sequence.
+        seq_lens : torch.Tensor (int32, [batch_size])
+            Per-sequence KV length in tokens. The kernel reads this
+            directly; callers that have ``last_page_len`` instead should
+            use :func:`flashinfer.page.get_seq_lens` to convert.
         num_qo_heads, num_kv_heads, head_dim, page_size : int
             GQA + paging configuration.  ``page_size`` must be in
             ``{8, 16, 32, 64}`` and ``head_dim`` a positive multiple of 64.
@@ -923,36 +925,32 @@ class BatchDecodePagedCuteDSLWrapper:
             o_data_type = torch.float16 if q_data_type == torch.float8_e4m3fn else q_data_type
         out_dtype = _torch_to_cutlass(o_data_type)
 
-        batch_size = last_page_len.numel()
+        batch_size = seq_lens.numel()
         if indptr.numel() != batch_size + 1:
             raise ValueError(
                 f"indptr length ({indptr.numel()}) must equal batch_size+1 "
                 f"({batch_size + 1})"
             )
+        if seq_lens.dtype != torch.int32 or not seq_lens.is_contiguous():
+            raise ValueError(
+                f"seq_lens must be a contiguous int32 tensor; got "
+                f"dtype={seq_lens.dtype}, is_contiguous={seq_lens.is_contiguous()}"
+            )
+        if seq_lens.device != self.device:
+            raise ValueError(
+                f"seq_lens.device ({seq_lens.device}) must match the wrapper "
+                f"device ({self.device})"
+            )
 
-        # Derive table_offsets and seqlens directly on-device.
         indptr_i32 = indptr.to(torch.int32) if indptr.dtype != torch.int32 else indptr
-        last_page_len_i32 = (
-            last_page_len.to(torch.int32)
-            if last_page_len.dtype != torch.int32
-            else last_page_len
-        )
         if indptr_i32.device != self.device:
             indptr_i32 = indptr_i32.to(self.device, non_blocking=non_blocking)
-        if last_page_len_i32.device != self.device:
-            last_page_len_i32 = last_page_len_i32.to(
-                self.device, non_blocking=non_blocking
-            )
         if indices.device != self.device:
             indices = indices.to(self.device, non_blocking=non_blocking)
         indices_i32 = indices.to(torch.int32) if indices.dtype != torch.int32 else indices
 
         table_offsets = indptr_i32[:-1].contiguous()
-        # Equivalent to flashinfer.page.get_seq_lens (clamps empty sequences to 0).
-        seqlens = (
-            torch.clamp(indptr_i32[1:] - indptr_i32[:-1] - 1, min=0) * page_size
-            + last_page_len_i32
-        ).contiguous()
+        seqlens = seq_lens
         if max_kv_len is None:
             # Forces a GPU→CPU sync; callers that already know max_kv_len on
             # the host (e.g. BatchDecodeWithPagedKVCacheWrapper) should pass it

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -443,6 +443,7 @@ class BatchDecodeCuteDSLWrapper:
         kv_data_type: Optional[torch.dtype] = None,
         o_data_type: Optional[torch.dtype] = None,
         q_len_per_req: int = 1,
+        is_causal: bool = True,
         sm_scale: Optional[float] = None,
         kv_splits: Optional[int] = None,
         reduction: str = "auto",
@@ -465,6 +466,8 @@ class BatchDecodeCuteDSLWrapper:
         q_len_per_req : int
             Predicted tokens per request (1 for plain decode, >1 for
             speculative decode).
+        is_causal : bool
+            Causal masking for speculative decode.
         sm_scale : Optional[float]
             Softmax scale; defaults to ``1 / sqrt(head_dim)``.
         kv_splits : Optional[int]
@@ -540,11 +543,7 @@ class BatchDecodeCuteDSLWrapper:
         # write to o_bshd directly (atomic via atomic_add, none via direct
         # store).
         self._has_workspace = reduction == "kernel"
-        # Always use bottom-right causal masking; for q_len_per_req=1 this
-        # degenerates to "row 0 sees all keys", equivalent to no causal mask.
-        # Keeping a single mask path means the compiled kernel doesn't need
-        # to be re-tuned when the runtime q_len_per_req changes.
-        self._tma_mask = False
+        self._tma_mask = not is_causal
         if sm_scale is None:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
@@ -769,6 +768,7 @@ class BatchDecodePagedCuteDSLWrapper:
         kv_data_type: Optional[torch.dtype] = None,
         o_data_type: Optional[torch.dtype] = None,
         q_len_per_req: int = 1,
+        is_causal: bool = True,
         sm_scale: Optional[float] = None,
         kv_splits: Optional[int] = None,
         reduction: str = "auto",
@@ -793,6 +793,8 @@ class BatchDecodePagedCuteDSLWrapper:
             Q/K/V/O dtypes; ``kv_data_type`` must equal ``q_data_type``.
         q_len_per_req : int
             Predicted tokens per request (1 for plain decode).
+        is_causal : bool
+            Causal masking for speculative decode.
         sm_scale : Optional[float]
             Softmax scale; defaults to ``1 / sqrt(head_dim)``.
         kv_splits : Optional[int]
@@ -918,11 +920,7 @@ class BatchDecodePagedCuteDSLWrapper:
         # Only kernel-reduction uses workspace tensors; atomic and none
         # write to o_bshd directly.
         self._has_workspace = reduction == "kernel"
-        # Always use bottom-right causal masking; for q_len_per_req=1 this
-        # degenerates to "row 0 sees all keys", equivalent to no causal mask.
-        # Keeping a single mask path means the compiled kernel doesn't need
-        # to be re-tuned when the runtime q_len_per_req changes.
-        self._tma_mask = False
+        self._tma_mask = not is_causal
         if sm_scale is None:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -41,6 +41,7 @@ from ..gqa_decode_paged import GroupedQueryAttentionDecodePaged
 _TORCH_TO_CUTLASS_DTYPE = {
     torch.float16: cutlass.Float16,
     torch.bfloat16: cutlass.BFloat16,
+    torch.float8_e5m2: cutlass.Float8E5M2,
     torch.float8_e4m3fn: cutlass.Float8E4M3FN,
 }
 
@@ -52,10 +53,6 @@ def _torch_to_cutlass(dtype: torch.dtype) -> "cutlass.dtype":
             f"supported: {list(_TORCH_TO_CUTLASS_DTYPE)}"
         )
     return _TORCH_TO_CUTLASS_DTYPE[dtype]
-
-
-def _npo2(x: int) -> int:
-    return 1 if x <= 1 else 2 ** math.ceil(math.log2(x))
 
 
 def _pick_tile_shape(
@@ -70,9 +67,10 @@ def _pick_tile_shape(
             f"num_qo_heads ({num_qo_heads}) must be a multiple of num_kv_heads "
             f"({num_kv_heads})"
         )
+    npo2 = lambda x : 1 if x <= 1 else 2 ** math.ceil(math.log2(x))
     grouped_heads = num_qo_heads // num_kv_heads
-    grouped_head_tile = min(32, _npo2(grouped_heads))
-    prediction_tile = min(32 // grouped_head_tile, _npo2(prediction))
+    grouped_head_tile = min(32, npo2(grouped_heads))
+    prediction_tile = min(32 // grouped_head_tile, npo2(prediction))
     if grouped_head_tile == prediction_tile == 1 and qkv_dtype_width == 8:
         # Reproduce the special-case bump applied for fp8 with 1×1 tiles.
         grouped_head_tile = 2
@@ -93,14 +91,17 @@ def _compute_kv_splits(
     """Replicate ``gqa_decode.run`` kv_splits auto-computation."""
     if reduction == "none":
         return 1
-    grouped_head_tiles = math.ceil(grouped_heads / grouped_head_tile)
-    prediction_tiles = math.ceil(prediction / prediction_tile)
-    grid_yz = batch_size * num_kv_heads * grouped_head_tiles * prediction_tiles
+    ceil_div = lambda a, b : (a + b - 1) // b
+    grouped_head_tiles = ceil_div(grouped_heads, grouped_head_tile)
+    prediction_tiles = ceil_div(prediction, prediction_tile)
+    grid_z = batch_size * num_kv_heads
+    grid_y = grouped_head_tiles * prediction_tiles
+    grid_yz = grid_y * grid_z
     sm_count = sm_count if sm_count > 0 else 148
     kv_splits = max(1, sm_count // grid_yz)
     if sm_count == 148 and grid_yz == 32:
         kv_splits = 9  # 2 waves
-    kv_splits = min(kv_splits, max(1, math.ceil(max_kv_len / 256)))
+    kv_splits = min(kv_splits, max(1, ceil_div(max_kv_len, 256)))
     if reduction == "atomic" and kv_splits not in (1, 2, 4):
         kv_splits = 8
     return kv_splits
@@ -122,57 +123,48 @@ def _resolve_reduction(reduction: str, kv_splits: int, o_dtype: "cutlass.dtype")
     return "kernel"
 
 
-# Float32 workspace tensors are 4-byte elements; the kernel's TMA fakes use
-# assumed_align=16 so successive offsets need to be 16-byte-aligned. Each
-# tensor's element count is always a multiple of `num_qo_heads * head_dim`,
-# both of which are >= 8 — so byte sizes are naturally >= 16-aligned.
-_FP32_BYTES = 4
-
-
-def _workspace_layout(
+def _slice_workspace(
+    workspace: torch.Tensor,
     kv_splits: int,
     batch_size: int,
-    q_len_per_req: int,
+    prediction: int,
     num_qo_heads: int,
     head_dim: int,
 ):
-    """Compute (offset, nbytes) for each kernel-reduction workspace tensor.
-
-    Layout order matches the kernel call order: m_bsh, o_partial, m_partial,
-    l_partial. Returns (offsets, sizes, total_bytes).
-    """
-    m_bsh_n = batch_size * q_len_per_req * num_qo_heads
-    o_partial_n = kv_splits * batch_size * q_len_per_req * num_qo_heads * head_dim
-    m_partial_n = kv_splits * batch_size * q_len_per_req * num_qo_heads
-    l_partial_n = m_partial_n
-    sizes = (
-        m_bsh_n * _FP32_BYTES,
-        o_partial_n * _FP32_BYTES,
-        m_partial_n * _FP32_BYTES,
-        l_partial_n * _FP32_BYTES,
+    """Slice pre-allocated workspace into partial result workspace"""
+    o_partial_shape = torch.Size(
+        (kv_splits, batch_size, prediction, num_qo_heads, head_dim)
     )
-    offsets = (
-        0,
-        sizes[0],
-        sizes[0] + sizes[1],
-        sizes[0] + sizes[1] + sizes[2],
-    )
-    total = sum(sizes)
-    return offsets, sizes, total
+    m_partial_shape = l_partial_shape = o_partial_shape[:-1]
+    m_shape = o_partial_shape[1:-1]
 
+    workspace = workspace.view(dtype=torch.float32)
 
-def _slice_fp32(buf_uint8: torch.Tensor, offset: int, shape):
-    """Carve a contiguous float32 tensor of `shape` from a uint8 buffer at
-    `offset` bytes. The resulting view aliases the buffer's storage."""
-    nelem = 1
-    for d in shape:
-        nelem *= d
-    nbytes = nelem * _FP32_BYTES
-    return (
-        buf_uint8[offset : offset + nbytes]
-        .view(torch.float32)
-        .view(*shape)
-    )
+    required_elts = (o_partial_shape.numel()
+                    + m_partial_shape.numel()
+                    + l_partial_shape.numel()
+                    + m_shape.numel())
+    if workspace.numel() < required_elts:
+        raise RuntimeError(
+            f"kernel reduction with kv_splits={kv_splits} "
+            f"batch_size={batch_size} q_len_per_req={prediction} "
+            f"num_qo_heads={num_qo_heads} head_dim={head_dim} "
+            f"requires {required_elts * 4} byte workspace "
+            f"which exceeds provided workspace of {workspace.nbytes} bytes")
+    
+    start, end = 0, o_partial_shape.numel()
+    o_partial = workspace[start:end].view(o_partial_shape)
+
+    start, end = end, end + l_partial_shape.numel()
+    l_partial = workspace[start:end].view(l_partial_shape)
+
+    start, end = end, end + m_partial_shape.numel()
+    m_partial = workspace[start:end].view(m_partial_shape)
+
+    start, end = end, end + m_shape.numel()
+    m = workspace[start:end].view(m_shape)
+
+    return m, o_partial, l_partial, m_partial
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +180,6 @@ def _get_compiled_decode_kernel(
     num_kv_heads: int,
     head_dim: int,
     prediction: int,
-    kv_splits: int,
     reduction: str,
     tma_mask: bool,
     use_lse: bool,
@@ -207,6 +198,7 @@ def _get_compiled_decode_kernel(
     has_workspace = reduction == "kernel"
     acc_dtype = cutlass.Float32
 
+    sym_kv_splits = cute.sym_int()
     sym_batch = cute.sym_int()
     sym_seq_k = cute.sym_int()
     # Symbolic prediction so a single compiled kernel handles varying runtime
@@ -263,19 +255,19 @@ def _get_compiled_decode_kernel(
         )
         o_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, sym_prediction, num_qo_heads, head_dim),
+            (sym_kv_splits, sym_batch, sym_prediction, num_qo_heads, head_dim),
             stride_order=(4, 3, 2, 1, 0),
             assumed_align=16,
         )
         m_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
+            (sym_kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
         l_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
+            (sym_kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
@@ -284,7 +276,7 @@ def _get_compiled_decode_kernel(
 
     return cute.compile(
         fmha,
-        kv_splits,
+        Int32(1),  # kv_splits placeholder
         q_fake,
         k_fake,
         v_fake,
@@ -311,7 +303,6 @@ def _get_compiled_paged_decode_kernel(
     num_kv_heads: int,
     head_dim: int,
     prediction: int,
-    kv_splits: int,
     reduction: str,
     tma_mask: bool,
     use_threshold: bool,
@@ -344,6 +335,7 @@ def _get_compiled_paged_decode_kernel(
     has_workspace = reduction == "kernel"
     acc_dtype = cutlass.Float32
 
+    sym_kv_splits = cute.sym_int()
     sym_batch = cute.sym_int()
     sym_virtual_pages = cute.sym_int()
     sym_total_logical_pages = cute.sym_int()
@@ -414,19 +406,19 @@ def _get_compiled_paged_decode_kernel(
         )
         o_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, sym_prediction, num_qo_heads, head_dim),
+            (sym_kv_splits, sym_batch, sym_prediction, num_qo_heads, head_dim),
             stride_order=(4, 3, 2, 1, 0),
             assumed_align=16,
         )
         m_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
+            (sym_kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
         l_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
+            (sym_kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
@@ -436,7 +428,7 @@ def _get_compiled_paged_decode_kernel(
 
     return cute.compile(
         fmha,
-        kv_splits,
+        Int32(1),  # kv_splits placeholder
         seqlens_fake,
         table_offsets_fake,
         page_table_fake,
@@ -495,11 +487,11 @@ class BatchDecodeCuteDSLWrapper:
         q_data_type: torch.dtype = torch.bfloat16,
         kv_data_type: Optional[torch.dtype] = None,
         o_data_type: Optional[torch.dtype] = None,
-        q_len_per_req: int = 1,
-        is_causal: bool = True,
         sm_scale: Optional[float] = None,
         kv_splits: Optional[int] = None,
         reduction: str = "auto",
+        q_len_per_req: int = 1,
+        is_causal: bool = True,
     ) -> None:
         """Compile the ragged-KV decode kernel for the planned configuration.
 
@@ -516,11 +508,6 @@ class BatchDecodeCuteDSLWrapper:
         q_data_type, kv_data_type, o_data_type : torch.dtype
             Q/K/V/O dtypes. Q and KV must match. ``o_data_type`` defaults to
             ``q_data_type`` (or float16 for fp8 inputs).
-        q_len_per_req : int
-            Predicted tokens per request (1 for plain decode, >1 for
-            speculative decode).
-        is_causal : bool
-            Causal masking for speculative decode.
         sm_scale : Optional[float]
             Softmax scale; defaults to ``1 / sqrt(head_dim)``.
         kv_splits : Optional[int]
@@ -535,6 +522,11 @@ class BatchDecodeCuteDSLWrapper:
             bfloat16}. ``"auto"`` picks ``"none"`` when kv_splits == 1,
             ``"atomic"`` for compatible dtypes and small kv_splits, else
             ``"kernel"``.
+        q_len_per_req : int
+            Predicted tokens per request (1 for plain decode, >1 for
+            speculative decode).
+        is_causal : bool
+            Causal masking for speculative decode.
         """
         if kv_data_type is not None and kv_data_type != q_data_type:
             raise NotImplementedError(
@@ -550,7 +542,7 @@ class BatchDecodeCuteDSLWrapper:
 
         in_dtype = _torch_to_cutlass(q_data_type)
         if o_data_type is None:
-            o_data_type = torch.float16 if q_data_type == torch.float8_e4m3fn else q_data_type
+            o_data_type = q_data_type
         out_dtype = _torch_to_cutlass(o_data_type)
 
         grouped_head_tile, prediction_tile = _pick_tile_shape(
@@ -601,22 +593,20 @@ class BatchDecodeCuteDSLWrapper:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
 
-        # Validate float_workspace_buffer at plan() time. The size is
-        # computed against the planned batch_size (max-batch hint) and the
-        # planned q_len_per_req. Runtime values <= these hints reuse the
-        # same allocation; larger values are re-validated in run().
+        # Carve out workspace tensors
         if self._has_workspace:
-            _, _, total_bytes = _workspace_layout(
-                kv_splits, batch_size, q_len_per_req, num_qo_heads, head_dim
+            m, o_partial, l_partial, m_partial = _slice_workspace(
+                self._float_workspace_buffer,
+                kv_splits,
+                batch_size,
+                q_len_per_req,
+                num_qo_heads,
+                head_dim,
             )
-            if self._float_workspace_buffer.numel() < total_bytes:
-                raise ValueError(
-                    f"float_workspace_buffer too small for kernel-reduction: "
-                    f"{self._float_workspace_buffer.numel()} bytes, need "
-                    f"{total_bytes} bytes (kv_splits={kv_splits}, "
-                    f"batch_size={batch_size}, q_len_per_req={q_len_per_req}, "
-                    f"num_qo_heads={num_qo_heads}, head_dim={head_dim})"
-                )
+            self._m = m
+            self._o_partial = o_partial
+            self._l_partial = l_partial
+            self._m_partial = m_partial
 
         # Always compile the no-LSE variant at plan() time; the LSE variant
         # is lazily fetched at run() time when needed (compile cache hit).
@@ -627,7 +617,6 @@ class BatchDecodeCuteDSLWrapper:
             num_kv_heads,
             head_dim,
             q_len_per_req,
-            kv_splits,
             reduction,
             self._tma_mask,
         )
@@ -635,47 +624,6 @@ class BatchDecodeCuteDSLWrapper:
             *self._compile_args, False
         )
         self._planned = True
-
-    def _allocate_workspace(
-        self, batch_size: int, q_len_per_req: int, device: torch.device
-    ):
-        """Carve kernel-reduction workspace tensors out of float_workspace_buffer."""
-        if not self._has_workspace:
-            return None, None, None, None
-        shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
-        shape_p_o = (
-            self._kv_splits,
-            batch_size,
-            q_len_per_req,
-            self._num_qo_heads,
-            self._head_dim,
-        )
-        shape_p_ml = (
-            self._kv_splits,
-            batch_size,
-            q_len_per_req,
-            self._num_qo_heads,
-        )
-        offsets, _, total_bytes = _workspace_layout(
-            self._kv_splits, batch_size, q_len_per_req,
-            self._num_qo_heads, self._head_dim,
-        )
-        if self._float_workspace_buffer.numel() < total_bytes:
-            raise ValueError(
-                f"float_workspace_buffer too small at run(): "
-                f"{self._float_workspace_buffer.numel()} bytes, need "
-                f"{total_bytes} bytes (batch_size={batch_size}, "
-                f"q_len_per_req={q_len_per_req} — exceeded the plan-time hint)"
-            )
-        buf = self._float_workspace_buffer
-        m_bsh = _slice_fp32(buf, offsets[0], shape_m)
-        o_partial = _slice_fp32(buf, offsets[1], shape_p_o)
-        m_partial = _slice_fp32(buf, offsets[2], shape_p_ml)
-        l_partial = _slice_fp32(buf, offsets[3], shape_p_ml)
-        # m_bsh is read by the kernel as a running colmax accumulator and
-        # must start at -inf. The other three are written from scratch.
-        m_bsh.fill_(float("-inf"))
-        return m_bsh, o_partial, m_partial, l_partial
 
     @flashinfer_api
     def run(
@@ -753,20 +701,32 @@ class BatchDecodeCuteDSLWrapper:
         # zero init; kernel/none modes overwrite via direct store.
         atomic = self._reduction == "atomic"
         if out is None:
-            if atomic:
-                out = torch.zeros(
-                    (b, s_q, h_q, d), dtype=self._o_data_type, device=device
-                )
-            else:
-                out = torch.empty(
-                    (b, s_q, h_q, d), dtype=self._o_data_type, device=device
-                )
+            torch_alloc = torch.zeros if atomic else torch.empty
+            out = torch_alloc(
+                (b, s_q, h_q, d), dtype=self._o_data_type, device=device
+            )
         elif atomic:
             out.zero_()
 
-        m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(
-            b, s_q, device
-        )
+        m = o_partial = l_partial = m_partial = None
+        if self._has_workspace:
+            if s_q <= self._q_len_per_req:
+                # Runtime q_len doesnt exceed plantime q_len, return slice
+                m = self._m[:, :s_q, :]
+                o_partial = self._o_partial[:, :, :s_q, :, :]
+                l_partial = self._l_partial[:, :, :s_q, :]
+                m_partial = self._m_partial[:, :, :s_q, :]
+            else:
+                # Re-validate workspace size and slice
+                m, o_partial, l_partial, m_partial = _slice_workspace(
+                    self._float_workspace_buffer,
+                    self._kv_splits,
+                    b,
+                    s_q,
+                    self._num_qo_heads,
+                    self._head_dim,
+                )
+            m.fill_(float("-inf"))
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
         use_lse = lse is not None
@@ -797,7 +757,7 @@ class BatchDecodeCuteDSLWrapper:
             v,
             out,
             lse,
-            m_bsh,
+            m,
             o_partial,
             l_partial,
             m_partial,
@@ -814,13 +774,7 @@ class BatchDecodeCuteDSLWrapper:
 
 
 class BatchDecodePagedCuteDSLWrapper:
-    """PyTorch-facing wrapper for the paged CuTe DSL GQA decode kernel.
-
-    Designed to back the ``cute-dsl`` backend of
-    :class:`flashinfer.BatchDecodeWithPagedKVCacheWrapper`.  Accepts a
-    flashinfer-style paged KV cache (indptr/indices/last_page_len) and adapts
-    it to the kernel's ``(seqlens, table_offsets, page_table)`` triplet.
-    """
+    """PyTorch-facing wrapper for the paged CuTe DSL GQA decode kernel."""
 
     @flashinfer_api
     def __init__(
@@ -848,14 +802,14 @@ class BatchDecodePagedCuteDSLWrapper:
         q_data_type: torch.dtype = torch.bfloat16,
         kv_data_type: Optional[torch.dtype] = None,
         o_data_type: Optional[torch.dtype] = None,
-        q_len_per_req: int = 1,
-        is_causal: bool = True,
         sm_scale: Optional[float] = None,
         kv_splits: Optional[int] = None,
         reduction: str = "auto",
-        precompile_skip_softmax_kernel: bool = False,
+        q_len_per_req: int = 1,
+        is_causal: bool = True,
         max_kv_len: Optional[int] = None,
         non_blocking: bool = True,
+        precompile_skip_softmax_kernel: bool = False,
     ) -> None:
         """Plan paged GQA decode for the given problem.
 
@@ -874,10 +828,6 @@ class BatchDecodePagedCuteDSLWrapper:
             ``{8, 16, 32, 64}`` and ``head_dim`` a positive multiple of 64.
         q_data_type, kv_data_type, o_data_type : torch.dtype
             Q/K/V/O dtypes; ``kv_data_type`` must equal ``q_data_type``.
-        q_len_per_req : int
-            Predicted tokens per request (1 for plain decode).
-        is_causal : bool
-            Causal masking for speculative decode.
         sm_scale : Optional[float]
             Softmax scale; defaults to ``1 / sqrt(head_dim)``.
         kv_splits : Optional[int]
@@ -889,20 +839,19 @@ class BatchDecodePagedCuteDSLWrapper:
             (no flash-decoding split-K; requires kv_splits == 1), or
             ``"auto"`` (picks ``"none"`` when kv_splits == 1, else atomic
             for compatible dtypes, else kernel).
-        precompile_skip_softmax_kernel : bool
-            If True, also compile the BLASST skip-softmax variant of the
-            kernel at plan() time, so the first :meth:`run` call that
-            passes ``skip_softmax_threshold_scale_factor`` is fast.  When False (default)
-            the BLASST variant is lazily compiled on first use, which keeps
-            plan() fast at the cost of a one-time compile latency spike on
-            that first call.  The standard (no-BLASST) variant is always
-            compiled at plan() time because the BLASST predicate has a
-            real per-tile cost on the standard path.
+        q_len_per_req : int
+            Predicted tokens per request (1 for plain decode).
+        is_causal : bool
+            Causal masking for speculative decode.
         max_kv_len : Optional[int]
             Maximum KV sequence length across the batch.  Used to auto-tune
             ``kv_splits``; pass it explicitly to avoid a GPU→CPU sync.
         non_blocking : bool
             Async device copies for the plan-time integer buffers.
+        precompile_skip_softmax_kernel : bool
+            If True, also compile the BLASST skip-softmax variant of the
+            kernel at plan() time, so the first :meth:`run` call that
+            passes ``skip_softmax_threshold_scale_factor`` is fast.
         """
         if page_size not in (8, 16, 32, 64):
             raise ValueError(
@@ -922,40 +871,33 @@ class BatchDecodePagedCuteDSLWrapper:
 
         in_dtype = _torch_to_cutlass(q_data_type)
         if o_data_type is None:
-            o_data_type = torch.float16 if q_data_type == torch.float8_e4m3fn else q_data_type
+            o_data_type = q_data_type
         out_dtype = _torch_to_cutlass(o_data_type)
 
         batch_size = seq_lens.numel()
-        if indptr.numel() != batch_size + 1:
+        if indptr.numel() < batch_size:
             raise ValueError(
-                f"indptr length ({indptr.numel()}) must equal batch_size+1 "
-                f"({batch_size + 1})"
-            )
-        if seq_lens.dtype != torch.int32 or not seq_lens.is_contiguous():
-            raise ValueError(
-                f"seq_lens must be a contiguous int32 tensor; got "
-                f"dtype={seq_lens.dtype}, is_contiguous={seq_lens.is_contiguous()}"
-            )
-        if seq_lens.device != self.device:
-            raise ValueError(
-                f"seq_lens.device ({seq_lens.device}) must match the wrapper "
-                f"device ({self.device})"
+                f"indptr length ({indptr.numel()}) must be at least batch_size "
+                f"({batch_size})"
             )
 
-        indptr_i32 = indptr.to(torch.int32) if indptr.dtype != torch.int32 else indptr
-        if indptr_i32.device != self.device:
-            indptr_i32 = indptr_i32.to(self.device, non_blocking=non_blocking)
-        if indices.device != self.device:
-            indices = indices.to(self.device, non_blocking=non_blocking)
-        indices_i32 = indices.to(torch.int32) if indices.dtype != torch.int32 else indices
-
-        table_offsets = indptr_i32[:-1].contiguous()
-        seqlens = seq_lens
         if max_kv_len is None:
-            # Forces a GPU→CPU sync; callers that already know max_kv_len on
-            # the host (e.g. BatchDecodeWithPagedKVCacheWrapper) should pass it
-            # in to avoid this.
-            max_kv_len = int(seqlens.max().item()) if seqlens.numel() > 0 else 0
+            if not seq_lens.is_cuda:
+                max_kv_len = int(seq_lens.max().item())
+            else:
+                # Avoid a device sync, just assume largest possible sequence
+                max_kv_len = (2 ** 31) - 1
+
+        def to_int32_device(tensor : torch.Tensor):
+            return tensor.to(
+                dtype=torch.int32,
+                device=self.device,
+                non_blocking=non_blocking,
+            )
+        seq_lens = to_int32_device(seq_lens)
+        indices = to_int32_device(indices)
+        indptr = to_int32_device(indptr)
+
 
         grouped_head_tile, prediction_tile = _pick_tile_shape(
             num_qo_heads, num_kv_heads, q_len_per_req, in_dtype.width
@@ -1005,25 +947,24 @@ class BatchDecodePagedCuteDSLWrapper:
         self._sm_scale = sm_scale
 
         self._batch_size = batch_size
-        self._seqlens = seqlens
-        self._table_offsets = table_offsets
-        self._page_table = indices_i32
+        self._seqlens = seq_lens
+        self._table_offsets = indptr[:batch_size]
+        self._page_table = indices
 
-        # Validate float_workspace_buffer at plan() time. Sized against the
-        # plan-time-fixed batch_size + planned q_len_per_req hint; runtime
-        # q_len_per_req <= hint reuses the same allocation.
+        # Carve out workspace tensors
         if self._has_workspace:
-            _, _, total_bytes = _workspace_layout(
-                kv_splits, batch_size, q_len_per_req, num_qo_heads, head_dim
+            m, o_partial, l_partial, m_partial = _slice_workspace(
+                self._float_workspace_buffer,
+                kv_splits,
+                batch_size,
+                q_len_per_req,
+                num_qo_heads,
+                head_dim,
             )
-            if self._float_workspace_buffer.numel() < total_bytes:
-                raise ValueError(
-                    f"float_workspace_buffer too small for kernel-reduction: "
-                    f"{self._float_workspace_buffer.numel()} bytes, need "
-                    f"{total_bytes} bytes (kv_splits={kv_splits}, "
-                    f"batch_size={batch_size}, q_len_per_req={q_len_per_req}, "
-                    f"num_qo_heads={num_qo_heads}, head_dim={head_dim})"
-                )
+            self._m = m
+            self._o_partial = o_partial
+            self._l_partial = l_partial
+            self._m_partial = m_partial
 
         # Compile args shared by std and BLASST variants. Stashed so run()
         # can lazily fetch the BLASST variant via the @functools.cache.
@@ -1035,7 +976,6 @@ class BatchDecodePagedCuteDSLWrapper:
             num_kv_heads,
             head_dim,
             q_len_per_req,
-            kv_splits,
             reduction,
             self._tma_mask,
         )
@@ -1049,47 +989,6 @@ class BatchDecodePagedCuteDSLWrapper:
             # run() that uses skip_softmax_threshold.
             _get_compiled_paged_decode_kernel(*self._compile_args, True, False)
         self._planned = True
-
-    def _allocate_workspace(
-        self, batch_size: int, q_len_per_req: int, device: torch.device
-    ):
-        """Carve kernel-reduction workspace tensors out of float_workspace_buffer."""
-        if not self._has_workspace:
-            return None, None, None, None
-        shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
-        shape_p_o = (
-            self._kv_splits,
-            batch_size,
-            q_len_per_req,
-            self._num_qo_heads,
-            self._head_dim,
-        )
-        shape_p_ml = (
-            self._kv_splits,
-            batch_size,
-            q_len_per_req,
-            self._num_qo_heads,
-        )
-        offsets, _, total_bytes = _workspace_layout(
-            self._kv_splits, batch_size, q_len_per_req,
-            self._num_qo_heads, self._head_dim,
-        )
-        if self._float_workspace_buffer.numel() < total_bytes:
-            raise ValueError(
-                f"float_workspace_buffer too small at run(): "
-                f"{self._float_workspace_buffer.numel()} bytes, need "
-                f"{total_bytes} bytes (q_len_per_req={q_len_per_req} — "
-                f"exceeded the plan-time hint)"
-            )
-        buf = self._float_workspace_buffer
-        m_bsh = _slice_fp32(buf, offsets[0], shape_m)
-        o_partial = _slice_fp32(buf, offsets[1], shape_p_o)
-        m_partial = _slice_fp32(buf, offsets[2], shape_p_ml)
-        l_partial = _slice_fp32(buf, offsets[3], shape_p_ml)
-        # m_bsh is read by the kernel as a running colmax accumulator and
-        # must start at -inf. The other three are written from scratch.
-        m_bsh.fill_(float("-inf"))
-        return m_bsh, o_partial, m_partial, l_partial
 
     @flashinfer_api
     def run(
@@ -1210,8 +1109,8 @@ class BatchDecodePagedCuteDSLWrapper:
         # zero init; kernel/none modes overwrite via direct store.
         atomic = self._reduction == "atomic"
         if out is None:
-            alloc = torch.zeros if atomic else torch.empty
-            out_4d = alloc(
+            torch_alloc = torch.zeros if atomic else torch.empty
+            out_4d = torch_alloc(
                 (self._batch_size, q_len_per_req, self._num_qo_heads, self._head_dim),
                 dtype=self._o_data_type,
                 device=device,
@@ -1233,9 +1132,25 @@ class BatchDecodePagedCuteDSLWrapper:
             if atomic:
                 out_4d.zero_()
 
-        m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(
-            self._batch_size, q_len_per_req, device
-        )
+        m = o_partial = l_partial = m_partial = None
+        if self._has_workspace:
+            if q_len_per_req <= self._q_len_per_req:
+                # Runtime q_len doesnt exceed plantime q_len, return slice
+                m = self._m[:, :q_len_per_req, :]
+                o_partial = self._o_partial[:, :, :q_len_per_req, :, :]
+                l_partial = self._l_partial[:, :, :q_len_per_req, :]
+                m_partial = self._m_partial[:, :, :q_len_per_req, :]
+            else:
+                # Re-validate workspace size and slice
+                m, o_partial, l_partial, m_partial = _slice_workspace(
+                    self._float_workspace_buffer,
+                    self._kv_splits,
+                    self._batch_size,
+                    q_len_per_req,
+                    self._num_qo_heads,
+                    self._head_dim,
+                )
+            m.fill_(float("-inf"))
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
         use_threshold = skip_softmax_threshold_scale_factor is not None
@@ -1293,7 +1208,7 @@ class BatchDecodePagedCuteDSLWrapper:
             q_view,
             out_4d,
             l_view,
-            m_bsh,
+            m,
             o_partial,
             l_partial,
             m_partial,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -1,0 +1,981 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""BatchDecode CuTe DSL wrappers — PyTorch-facing APIs for GQA decode attention.
+
+Two wrappers are provided, mirroring the structure of
+``flashinfer/cute_dsl/attention/wrappers/batch_prefill.py``:
+
+* :class:`BatchDecodeCuteDSLWrapper`        — ragged contiguous KV cache,
+                                              uses ``gqa_decode.GroupedQueryAttentionDecode``.
+* :class:`BatchDecodePagedCuteDSLWrapper`   — paged KV cache,
+                                              uses ``gqa_decode_paged.GroupedQueryAttentionDecodePaged``.
+
+Both compile their kernels with symbolic dimensions (``cute.sym_int``) so the
+same compiled module can be reused across batches of varying size, and memoize
+compilation via :func:`functools.cache` keyed on the static configuration.
+"""
+
+import functools
+import math
+from typing import Optional, Tuple
+
+import torch
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import Float32, Int32
+
+from flashinfer.api_logging import flashinfer_api
+from flashinfer.cute_dsl.utils import get_num_sm
+
+from ..gqa_decode import GroupedQueryAttentionDecode
+from ..gqa_decode_paged import GroupedQueryAttentionDecodePaged
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+_TORCH_TO_CUTLASS_DTYPE = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+}
+
+
+def _torch_to_cutlass(dtype: torch.dtype) -> "cutlass.dtype":
+    if dtype not in _TORCH_TO_CUTLASS_DTYPE:
+        raise TypeError(
+            f"cute-dsl decode does not support {dtype}; "
+            f"supported: {list(_TORCH_TO_CUTLASS_DTYPE)}"
+        )
+    return _TORCH_TO_CUTLASS_DTYPE[dtype]
+
+
+def _npo2(x: int) -> int:
+    return 1 if x <= 1 else 2 ** math.ceil(math.log2(x))
+
+
+def _pick_tile_shape(
+    num_qo_heads: int,
+    num_kv_heads: int,
+    prediction: int,
+    qkv_dtype_width: int,
+) -> Tuple[int, int]:
+    """Pick (grouped_head_tile, prediction_tile) matching ``gqa_decode.run`` logic."""
+    if num_qo_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_qo_heads ({num_qo_heads}) must be a multiple of num_kv_heads "
+            f"({num_kv_heads})"
+        )
+    grouped_heads = num_qo_heads // num_kv_heads
+    grouped_head_tile = min(32, _npo2(grouped_heads))
+    prediction_tile = min(32 // grouped_head_tile, _npo2(prediction))
+    if grouped_head_tile == prediction_tile == 1 and qkv_dtype_width == 8:
+        # Reproduce the special-case bump applied for fp8 with 1×1 tiles.
+        grouped_head_tile = 2
+    return grouped_head_tile, prediction_tile
+
+
+def _compute_kv_splits(
+    batch_size: int,
+    num_kv_heads: int,
+    grouped_head_tile: int,
+    prediction_tile: int,
+    grouped_heads: int,
+    prediction: int,
+    max_kv_len: int,
+    sm_count: int,
+    reduction: str,
+) -> int:
+    """Replicate ``gqa_decode.run`` kv_splits auto-computation."""
+    grouped_head_tiles = math.ceil(grouped_heads / grouped_head_tile)
+    prediction_tiles = math.ceil(prediction / prediction_tile)
+    grid_yz = batch_size * num_kv_heads * grouped_head_tiles * prediction_tiles
+    sm_count = sm_count if sm_count > 0 else 148
+    kv_splits = max(1, sm_count // grid_yz)
+    if sm_count == 148 and grid_yz == 32:
+        kv_splits = 9  # 2 waves
+    kv_splits = min(kv_splits, max(1, math.ceil(max_kv_len / 256)))
+    if reduction == "atomic" and kv_splits not in (1, 2, 4):
+        kv_splits = 8
+    return kv_splits
+
+
+def _resolve_reduction(reduction: str, kv_splits: int, o_dtype: "cutlass.dtype") -> str:
+    if reduction != "auto":
+        return reduction
+    if o_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16) and kv_splits in (
+        1,
+        2,
+        4,
+        8,
+    ):
+        return "atomic"
+    return "kernel"
+
+
+# ---------------------------------------------------------------------------
+# Compile helpers (memoized)
+# ---------------------------------------------------------------------------
+
+
+@functools.cache
+def _get_compiled_decode_kernel(
+    in_dtype: "cutlass.dtype",
+    out_dtype: "cutlass.dtype",
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    prediction: int,
+    kv_splits: int,
+    reduction: str,
+    tma_mask: bool,
+):
+    """Compile and cache the ragged (contiguous-KV) GQA decode kernel."""
+    grouped_head_tile, prediction_tile = _pick_tile_shape(
+        num_qo_heads, num_kv_heads, prediction, in_dtype.width
+    )
+    fmha = GroupedQueryAttentionDecode(
+        head_dim,
+        grouped_head_tile,
+        prediction_tile=prediction_tile,
+        reduction_mode=reduction,
+        tma_mask=tma_mask,
+    )
+    atomic = reduction == "atomic"
+    acc_dtype = cutlass.Float32
+
+    sym_batch = cute.sym_int()
+    sym_seq_k = cute.sym_int()
+
+    q_fake = cute.runtime.make_fake_compact_tensor(
+        in_dtype,
+        (sym_batch, prediction, num_qo_heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    k_fake = cute.runtime.make_fake_compact_tensor(
+        in_dtype,
+        (sym_batch, sym_seq_k, num_kv_heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    v_fake = cute.runtime.make_fake_compact_tensor(
+        in_dtype,
+        (sym_batch, sym_seq_k, num_kv_heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    o_fake = cute.runtime.make_fake_compact_tensor(
+        out_dtype,
+        (sym_batch, prediction, num_qo_heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    if atomic:
+        m_fake = o_partial_fake = m_partial_fake = l_partial_fake = None
+    else:
+        m_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (sym_batch, prediction, num_qo_heads),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        o_partial_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (kv_splits, sym_batch, prediction, num_qo_heads, head_dim),
+            stride_order=(4, 3, 2, 1, 0),
+            assumed_align=16,
+        )
+        m_partial_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (kv_splits, sym_batch, prediction, num_qo_heads),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+        l_partial_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (kv_splits, sym_batch, prediction, num_qo_heads),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    return cute.compile(
+        fmha,
+        kv_splits,
+        q_fake,
+        k_fake,
+        v_fake,
+        o_fake,
+        m_fake,
+        o_partial_fake,
+        m_partial_fake,
+        l_partial_fake,
+        Float32(1.0),  # scale_s placeholder
+        stream_fake,
+        options="--enable-tvm-ffi --opt-level 2",
+    )
+
+
+@functools.cache
+def _get_compiled_paged_decode_kernel(
+    in_dtype: "cutlass.dtype",
+    out_dtype: "cutlass.dtype",
+    page_size: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    prediction: int,
+    kv_splits: int,
+    reduction: str,
+    tma_mask: bool,
+    use_threshold: bool,
+):
+    """Compile and cache the paged GQA decode kernel."""
+    grouped_head_tile, prediction_tile = _pick_tile_shape(
+        num_qo_heads, num_kv_heads, prediction, in_dtype.width
+    )
+    blk_tile_n = grouped_head_tile * prediction_tile
+    softmax_warpgroups = (
+        2
+        if (not use_threshold)
+        and (
+            (in_dtype.width <= 8 and blk_tile_n > 8)
+            or (in_dtype.width == 16 and blk_tile_n > 16)
+        )
+        else 1
+    )
+    fmha = GroupedQueryAttentionDecodePaged(
+        page_size,
+        head_dim,
+        grouped_head_tile,
+        prediction_tile=prediction_tile,
+        sequence_tile=128 if use_threshold else 256,
+        reduction_mode=reduction,
+        softmax_warpgroups=softmax_warpgroups,
+        tma_mask=tma_mask,
+    )
+    atomic = reduction == "atomic"
+    acc_dtype = cutlass.Float32
+
+    sym_batch = cute.sym_int()
+    sym_virtual_pages = cute.sym_int()
+    sym_total_logical_pages = cute.sym_int()
+
+    seqlens_fake = cute.runtime.make_fake_compact_tensor(
+        Int32, (sym_batch,), assumed_align=16
+    )
+    table_offsets_fake = cute.runtime.make_fake_compact_tensor(
+        Int32, (sym_batch,), assumed_align=16
+    )
+    page_table_fake = cute.runtime.make_fake_compact_tensor(
+        Int32, (sym_total_logical_pages,), assumed_align=16
+    )
+    # K/V cache may come from `unbind(dim=1)` on a combined `[*, 2, *, *, *]`
+    # tensor, in which case the leading-dim stride is doubled. Use a dynamic
+    # outer stride so both compact and unbound layouts are accepted.
+    k_fake = cute.runtime.make_fake_tensor(
+        in_dtype,
+        (sym_virtual_pages, page_size, num_kv_heads, head_dim),
+        stride=(
+            cute.sym_int(),
+            num_kv_heads * head_dim,
+            head_dim,
+            1,
+        ),
+        assumed_align=16,
+    )
+    v_fake = cute.runtime.make_fake_tensor(
+        in_dtype,
+        (sym_virtual_pages, page_size, num_kv_heads, head_dim),
+        stride=(
+            cute.sym_int(),
+            num_kv_heads * head_dim,
+            head_dim,
+            1,
+        ),
+        assumed_align=16,
+    )
+    q_fake = cute.runtime.make_fake_compact_tensor(
+        in_dtype,
+        (sym_batch, prediction, num_qo_heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    o_fake = cute.runtime.make_fake_compact_tensor(
+        out_dtype,
+        (sym_batch, prediction, num_qo_heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    if atomic:
+        m_fake = o_partial_fake = m_partial_fake = l_partial_fake = None
+    else:
+        m_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (sym_batch, prediction, num_qo_heads),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        o_partial_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (kv_splits, sym_batch, prediction, num_qo_heads, head_dim),
+            stride_order=(4, 3, 2, 1, 0),
+            assumed_align=16,
+        )
+        m_partial_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (kv_splits, sym_batch, prediction, num_qo_heads),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+        l_partial_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (kv_splits, sym_batch, prediction, num_qo_heads),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+
+    threshold_p_fake = Float32(0.0) if use_threshold else None
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    return cute.compile(
+        fmha,
+        kv_splits,
+        seqlens_fake,
+        table_offsets_fake,
+        page_table_fake,
+        k_fake,
+        v_fake,
+        q_fake,
+        o_fake,
+        m_fake,
+        o_partial_fake,
+        m_partial_fake,
+        l_partial_fake,
+        Float32(1.0),  # scale_s placeholder
+        threshold_p_fake,
+        stream_fake,
+        options="--enable-tvm-ffi --opt-level 2",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ragged-KV decode wrapper
+# ---------------------------------------------------------------------------
+
+
+class BatchDecodeCuteDSLWrapper:
+    """PyTorch-facing wrapper for the ragged-KV CuTe DSL GQA decode kernel.
+
+    Assumes a contiguous (non-paged) KV cache where all batches have the same
+    KV sequence length.  For paged KV with varying sequence lengths use
+    :class:`BatchDecodePagedCuteDSLWrapper` instead.
+    """
+
+    @flashinfer_api
+    def __init__(
+        self,
+        float_workspace_buffer: torch.Tensor,
+        use_cuda_graph: bool = False,
+    ) -> None:
+        self._float_workspace_buffer = float_workspace_buffer
+        self.device = float_workspace_buffer.device
+        self._use_cuda_graph = use_cuda_graph
+        self._compiled_fmha = None
+        self._planned = False
+
+    @flashinfer_api
+    def plan(
+        self,
+        batch_size: int,
+        max_kv_len: int,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        q_data_type: torch.dtype = torch.bfloat16,
+        kv_data_type: Optional[torch.dtype] = None,
+        o_data_type: Optional[torch.dtype] = None,
+        q_len_per_req: int = 1,
+        sm_scale: Optional[float] = None,
+        kv_splits: Optional[int] = None,
+        reduction: str = "auto",
+    ) -> None:
+        """Compile the ragged-KV decode kernel for the planned configuration.
+
+        Parameters
+        ----------
+        batch_size : int
+            Representative batch size used to auto-tune ``kv_splits``.  Runtime
+            batches may differ.
+        max_kv_len : int
+            Representative KV sequence length used for ``kv_splits`` tuning.
+        num_qo_heads, num_kv_heads, head_dim : int
+            GQA configuration.  ``num_qo_heads`` must be a multiple of
+            ``num_kv_heads`` and ``head_dim`` must be a multiple of 64.
+        q_data_type, kv_data_type, o_data_type : torch.dtype
+            Q/K/V/O dtypes. Q and KV must match. ``o_data_type`` defaults to
+            ``q_data_type`` (or float16 for fp8 inputs).
+        q_len_per_req : int
+            Predicted tokens per request (1 for plain decode, >1 for
+            speculative decode).
+        sm_scale : Optional[float]
+            Softmax scale; defaults to ``1 / sqrt(head_dim)``.
+        kv_splits : Optional[int]
+            Threadblocks per sequence (flash decoding).  ``None`` auto-tunes
+            from the planned shape and the device SM count.
+        reduction : str
+            ``"kernel"``, ``"atomic"``, or ``"auto"`` (default).  Atomic
+            reduction is faster but requires kv_splits ∈ {1, 2, 4, 8, 16} and
+            an output dtype in {float32, float16, bfloat16}.
+        """
+        if kv_data_type is not None and kv_data_type != q_data_type:
+            raise NotImplementedError(
+                "cute-dsl decode requires kv_data_type == q_data_type"
+            )
+        if num_qo_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"num_qo_heads ({num_qo_heads}) must be a multiple of "
+                f"num_kv_heads ({num_kv_heads})"
+            )
+        if head_dim <= 0 or head_dim % 64 != 0:
+            raise ValueError(f"head_dim ({head_dim}) must be a positive multiple of 64")
+
+        in_dtype = _torch_to_cutlass(q_data_type)
+        if o_data_type is None:
+            o_data_type = torch.float16 if q_data_type == torch.float8_e4m3fn else q_data_type
+        out_dtype = _torch_to_cutlass(o_data_type)
+
+        grouped_head_tile, prediction_tile = _pick_tile_shape(
+            num_qo_heads, num_kv_heads, q_len_per_req, in_dtype.width
+        )
+        if kv_splits is None or kv_splits <= 0:
+            kv_splits = _compute_kv_splits(
+                batch_size,
+                num_kv_heads,
+                grouped_head_tile,
+                prediction_tile,
+                num_qo_heads // num_kv_heads,
+                q_len_per_req,
+                max_kv_len,
+                get_num_sm(self.device),
+                reduction,
+            )
+        reduction = _resolve_reduction(reduction, kv_splits, out_dtype)
+        if reduction == "atomic":
+            if kv_splits not in (1, 2, 4, 8, 16):
+                raise ValueError(
+                    f"atomic reduction requires kv_splits ∈ {{1,2,4,8,16}}, got {kv_splits}"
+                )
+            if out_dtype not in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+                raise ValueError(
+                    f"atomic reduction requires output dtype in (float32, float16, "
+                    f"bfloat16); got {o_data_type}"
+                )
+
+        self._q_data_type = q_data_type
+        self._o_data_type = o_data_type
+        self._num_qo_heads = num_qo_heads
+        self._num_kv_heads = num_kv_heads
+        self._head_dim = head_dim
+        self._q_len_per_req = q_len_per_req
+        self._kv_splits = kv_splits
+        self._reduction = reduction
+        self._atomic = reduction == "atomic"
+        self._tma_mask = q_len_per_req == 1
+        if sm_scale is None:
+            sm_scale = head_dim ** -0.5
+        self._sm_scale = sm_scale
+
+        self._compiled_fmha = _get_compiled_decode_kernel(
+            in_dtype,
+            out_dtype,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            q_len_per_req,
+            kv_splits,
+            reduction,
+            self._tma_mask,
+        )
+        self._planned = True
+
+    def _allocate_workspace(self, batch_size: int, device: torch.device):
+        """Allocate kernel-reduction workspace tensors for the current batch."""
+        if self._atomic:
+            return None, None, None, None
+        shape_m = (batch_size, self._q_len_per_req, self._num_qo_heads)
+        shape_p_o = (
+            self._kv_splits,
+            batch_size,
+            self._q_len_per_req,
+            self._num_qo_heads,
+            self._head_dim,
+        )
+        shape_p_ml = (
+            self._kv_splits,
+            batch_size,
+            self._q_len_per_req,
+            self._num_qo_heads,
+        )
+        m_bsh = torch.full(shape_m, float("-inf"), dtype=torch.float32, device=device)
+        o_partial = torch.empty(shape_p_o, dtype=torch.float32, device=device)
+        m_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
+        l_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
+        return m_bsh, o_partial, m_partial, l_partial
+
+    @flashinfer_api
+    def run(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        sm_scale: Optional[float] = None,
+    ) -> torch.Tensor:
+        """Run ragged-KV GQA decode.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            Shape ``[batch_size, q_len_per_req, num_qo_heads, head_dim]``.
+        k, v : torch.Tensor
+            Shape ``[batch_size, seq_len, num_kv_heads, head_dim]``.  Both
+            must have the same seq_len.
+        out : Optional[torch.Tensor]
+            Pre-allocated output buffer.  For atomic reduction it must be
+            zero-initialized before being passed in.
+        sm_scale : Optional[float]
+            Per-call override of the softmax scale set at plan() time.
+        """
+        if not self._planned:
+            raise RuntimeError("Call plan() before run().")
+        if q.dtype != self._q_data_type or k.dtype != self._q_data_type or v.dtype != self._q_data_type:
+            raise ValueError(
+                f"q/k/v dtype mismatch: expected {self._q_data_type}, got "
+                f"q={q.dtype}, k={k.dtype}, v={v.dtype}"
+            )
+        if q.dim() != 4 or k.dim() != 4 or v.dim() != 4:
+            raise ValueError(
+                f"q/k/v must be 4D [b, s, h, d]; got shapes {tuple(q.shape)}, "
+                f"{tuple(k.shape)}, {tuple(v.shape)}"
+            )
+        b, s_q, h_q, d = q.shape
+        b_k, s_k, h_k, d_k = k.shape
+        if (
+            b != b_k
+            or s_q != self._q_len_per_req
+            or h_q != self._num_qo_heads
+            or h_k != self._num_kv_heads
+            or d != d_k
+            or d != self._head_dim
+        ):
+            raise ValueError(
+                f"q/k/v shape mismatch with plan: q={tuple(q.shape)}, k={tuple(k.shape)}, "
+                f"v={tuple(v.shape)}; expected q=[b,{self._q_len_per_req},"
+                f"{self._num_qo_heads},{self._head_dim}], k=[b,*,{self._num_kv_heads},"
+                f"{self._head_dim}]"
+            )
+        if v.shape != k.shape:
+            raise ValueError(f"k.shape={tuple(k.shape)} must equal v.shape={tuple(v.shape)}")
+
+        device = q.device
+        if out is None:
+            out = torch.zeros(
+                (b, s_q, h_q, d), dtype=self._o_data_type, device=device
+            )
+        elif self._atomic:
+            out.zero_()
+
+        m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(b, device)
+
+        scale_s = self._sm_scale if sm_scale is None else sm_scale
+
+        # Stream is bound from the TVM-FFI env stream at runtime
+        # (use_tvm_ffi_env_stream=True at compile), so the stream arg is omitted.
+        self._compiled_fmha(
+            self._kv_splits,
+            q,
+            k,
+            v,
+            out,
+            m_bsh,
+            o_partial,
+            m_partial,
+            l_partial,
+            Float32(scale_s),
+        )
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Paged-KV decode wrapper
+# ---------------------------------------------------------------------------
+
+
+class BatchDecodePagedCuteDSLWrapper:
+    """PyTorch-facing wrapper for the paged CuTe DSL GQA decode kernel.
+
+    Designed to back the ``cute-dsl`` backend of
+    :class:`flashinfer.BatchDecodeWithPagedKVCacheWrapper`.  Accepts a
+    flashinfer-style paged KV cache (indptr/indices/last_page_len) and adapts
+    it to the kernel's ``(seqlens, table_offsets, page_table)`` triplet.
+    """
+
+    @flashinfer_api
+    def __init__(
+        self,
+        float_workspace_buffer: torch.Tensor,
+        use_cuda_graph: bool = False,
+    ) -> None:
+        # ``float_workspace_buffer`` is unused by the kernel itself (its
+        # workspace lives in tmem/smem and in heap-allocated reduction
+        # tensors) but is retained for API parity with the FA2/FA3 paged
+        # decode wrappers.
+        self._float_workspace_buffer = float_workspace_buffer
+        self.device = float_workspace_buffer.device
+        self._use_cuda_graph = use_cuda_graph
+        self._compiled_fmha = None
+        self._planned = False
+
+    @flashinfer_api
+    def plan(
+        self,
+        indptr: torch.Tensor,
+        indices: torch.Tensor,
+        last_page_len: torch.Tensor,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        page_size: int,
+        q_data_type: torch.dtype = torch.bfloat16,
+        kv_data_type: Optional[torch.dtype] = None,
+        o_data_type: Optional[torch.dtype] = None,
+        q_len_per_req: int = 1,
+        sm_scale: Optional[float] = None,
+        kv_splits: Optional[int] = None,
+        reduction: str = "auto",
+        threshold_p: Optional[float] = None,
+        max_kv_len: Optional[int] = None,
+        non_blocking: bool = True,
+    ) -> None:
+        """Plan paged GQA decode for the given problem.
+
+        Parameters
+        ----------
+        indptr : torch.Tensor (int32, [batch_size + 1])
+            Prefix-sum offsets into ``indices``.
+        indices : torch.Tensor (int32, [num_pages_total])
+            Flat per-sequence virtual page indices.
+        last_page_len : torch.Tensor (int32, [batch_size])
+            Number of valid tokens on the last page of each sequence.
+        num_qo_heads, num_kv_heads, head_dim, page_size : int
+            GQA + paging configuration.  ``page_size`` must be in
+            ``{8, 16, 32, 64}`` and ``head_dim`` a positive multiple of 64.
+        q_data_type, kv_data_type, o_data_type : torch.dtype
+            Q/K/V/O dtypes; ``kv_data_type`` must equal ``q_data_type``.
+        q_len_per_req : int
+            Predicted tokens per request (1 for plain decode).
+        sm_scale : Optional[float]
+            Softmax scale; defaults to ``1 / sqrt(head_dim)``.
+        kv_splits : Optional[int]
+            Threadblocks per sequence (flash decoding).  ``None`` auto-tunes
+            from the planned shapes and SM count.
+        reduction : str
+            ``"kernel"`` (deterministic with workspace), ``"atomic"``
+            (cluster reduction, faster but lower precision), or ``"auto"``.
+        threshold_p : Optional[float]
+            BLASST skip threshold; ``None`` (default) disables the
+            optimization.  When set, must be in ``(0, 1]``.
+        non_blocking : bool
+            Async device copies for the plan-time integer buffers.
+        """
+        if page_size not in (8, 16, 32, 64):
+            raise ValueError(
+                f"cute-dsl paged decode supports page_size ∈ {{8,16,32,64}}, got {page_size}"
+            )
+        if num_qo_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"num_qo_heads ({num_qo_heads}) must be a multiple of "
+                f"num_kv_heads ({num_kv_heads})"
+            )
+        if head_dim <= 0 or head_dim % 64 != 0:
+            raise ValueError(f"head_dim ({head_dim}) must be a positive multiple of 64")
+        if kv_data_type is not None and kv_data_type != q_data_type:
+            raise NotImplementedError(
+                "cute-dsl paged decode requires kv_data_type == q_data_type"
+            )
+
+        in_dtype = _torch_to_cutlass(q_data_type)
+        if o_data_type is None:
+            o_data_type = torch.float16 if q_data_type == torch.float8_e4m3fn else q_data_type
+        out_dtype = _torch_to_cutlass(o_data_type)
+
+        batch_size = last_page_len.numel()
+        if indptr.numel() != batch_size + 1:
+            raise ValueError(
+                f"indptr length ({indptr.numel()}) must equal batch_size+1 "
+                f"({batch_size + 1})"
+            )
+
+        # Derive table_offsets and seqlens directly on-device.
+        indptr_i32 = indptr.to(torch.int32) if indptr.dtype != torch.int32 else indptr
+        last_page_len_i32 = (
+            last_page_len.to(torch.int32)
+            if last_page_len.dtype != torch.int32
+            else last_page_len
+        )
+        if indptr_i32.device != self.device:
+            indptr_i32 = indptr_i32.to(self.device, non_blocking=non_blocking)
+        if last_page_len_i32.device != self.device:
+            last_page_len_i32 = last_page_len_i32.to(
+                self.device, non_blocking=non_blocking
+            )
+        if indices.device != self.device:
+            indices = indices.to(self.device, non_blocking=non_blocking)
+        indices_i32 = indices.to(torch.int32) if indices.dtype != torch.int32 else indices
+
+        table_offsets = indptr_i32[:-1].contiguous()
+        # Equivalent to flashinfer.page.get_seq_lens (clamps empty sequences to 0).
+        seqlens = (
+            torch.clamp(indptr_i32[1:] - indptr_i32[:-1] - 1, min=0) * page_size
+            + last_page_len_i32
+        ).contiguous()
+        if max_kv_len is None:
+            # Forces a GPU→CPU sync; callers that already know max_kv_len on
+            # the host (e.g. BatchDecodeWithPagedKVCacheWrapper) should pass it
+            # in to avoid this.
+            max_kv_len = int(seqlens.max().item()) if seqlens.numel() > 0 else 0
+
+        grouped_head_tile, prediction_tile = _pick_tile_shape(
+            num_qo_heads, num_kv_heads, q_len_per_req, in_dtype.width
+        )
+        if kv_splits is None or kv_splits <= 0:
+            kv_splits = _compute_kv_splits(
+                batch_size,
+                num_kv_heads,
+                grouped_head_tile,
+                prediction_tile,
+                num_qo_heads // num_kv_heads,
+                q_len_per_req,
+                max_kv_len,
+                get_num_sm(self.device),
+                reduction,
+            )
+        reduction = _resolve_reduction(reduction, kv_splits, out_dtype)
+        if reduction == "atomic":
+            if kv_splits not in (1, 2, 4, 8, 16):
+                raise ValueError(
+                    f"atomic reduction requires kv_splits ∈ {{1,2,4,8,16}}, got {kv_splits}"
+                )
+            if out_dtype not in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+                raise ValueError(
+                    f"atomic reduction requires output dtype in (float32, float16, "
+                    f"bfloat16); got {o_data_type}"
+                )
+        if threshold_p is not None and not (0.0 < threshold_p <= 1.0):
+            raise ValueError(f"threshold_p must be None or in (0, 1]; got {threshold_p}")
+
+        self._q_data_type = q_data_type
+        self._o_data_type = o_data_type
+        self._num_qo_heads = num_qo_heads
+        self._num_kv_heads = num_kv_heads
+        self._head_dim = head_dim
+        self._page_size = page_size
+        self._q_len_per_req = q_len_per_req
+        self._kv_splits = kv_splits
+        self._reduction = reduction
+        self._atomic = reduction == "atomic"
+        self._tma_mask = q_len_per_req == 1
+        self._threshold_p = threshold_p
+        if sm_scale is None:
+            sm_scale = head_dim ** -0.5
+        self._sm_scale = sm_scale
+
+        self._batch_size = batch_size
+        self._seqlens = seqlens
+        self._table_offsets = table_offsets
+        self._page_table = indices_i32
+
+        self._compiled_fmha = _get_compiled_paged_decode_kernel(
+            in_dtype,
+            out_dtype,
+            page_size,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            q_len_per_req,
+            kv_splits,
+            reduction,
+            self._tma_mask,
+            threshold_p is not None,
+        )
+        self._planned = True
+
+    def _allocate_workspace(self, batch_size: int, device: torch.device):
+        if self._atomic:
+            return None, None, None, None
+        shape_m = (batch_size, self._q_len_per_req, self._num_qo_heads)
+        shape_p_o = (
+            self._kv_splits,
+            batch_size,
+            self._q_len_per_req,
+            self._num_qo_heads,
+            self._head_dim,
+        )
+        shape_p_ml = (
+            self._kv_splits,
+            batch_size,
+            self._q_len_per_req,
+            self._num_qo_heads,
+        )
+        m_bsh = torch.full(shape_m, float("-inf"), dtype=torch.float32, device=device)
+        o_partial = torch.empty(shape_p_o, dtype=torch.float32, device=device)
+        m_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
+        l_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
+        return m_bsh, o_partial, m_partial, l_partial
+
+    @flashinfer_api
+    def run(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        sm_scale: Optional[float] = None,
+    ) -> torch.Tensor:
+        """Run paged GQA decode.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            ``[batch_size * q_len_per_req, num_qo_heads, head_dim]`` or
+            ``[batch_size, q_len_per_req, num_qo_heads, head_dim]``.
+        k_cache, v_cache : torch.Tensor
+            ``[num_pages, page_size, num_kv_heads, head_dim]`` (NHD layout).
+        out : Optional[torch.Tensor]
+            Pre-allocated output of the same logical shape as ``q``.
+            For atomic reduction this is zero-filled on entry.
+        sm_scale : Optional[float]
+            Per-call override of the softmax scale set at plan() time.
+        """
+        if not self._planned:
+            raise RuntimeError("Call plan() before run().")
+        if q.dtype != self._q_data_type:
+            raise ValueError(
+                f"q.dtype={q.dtype} mismatches planned {self._q_data_type}"
+            )
+        if k_cache.dtype != self._q_data_type or v_cache.dtype != self._q_data_type:
+            raise ValueError(
+                f"k_cache/v_cache dtype must equal q.dtype={self._q_data_type}"
+            )
+        if k_cache.shape != v_cache.shape:
+            raise ValueError(
+                f"k_cache.shape={tuple(k_cache.shape)} must equal "
+                f"v_cache.shape={tuple(v_cache.shape)}"
+            )
+        if k_cache.dim() != 4:
+            raise ValueError(
+                f"k_cache must be 4D [num_pages, page_size, num_kv_heads, head_dim]; "
+                f"got {tuple(k_cache.shape)}"
+            )
+        if (
+            k_cache.shape[1] != self._page_size
+            or k_cache.shape[2] != self._num_kv_heads
+            or k_cache.shape[3] != self._head_dim
+        ):
+            raise ValueError(
+                f"k_cache shape {tuple(k_cache.shape)} mismatches plan: "
+                f"expected [*, {self._page_size}, {self._num_kv_heads}, {self._head_dim}]"
+            )
+
+        # Normalize q to [batch_size, q_len_per_req, num_qo_heads, head_dim].
+        q_in = q if q.is_contiguous() else q.contiguous()
+        if q_in.dim() == 3:
+            total_q, h_q, d = q_in.shape
+            expected_total = self._batch_size * self._q_len_per_req
+            if total_q != expected_total:
+                raise ValueError(
+                    f"q.shape[0]={total_q} mismatches batch_size*q_len_per_req="
+                    f"{self._batch_size}*{self._q_len_per_req}={expected_total}"
+                )
+            q_view = q_in.view(self._batch_size, self._q_len_per_req, h_q, d)
+            out_was_3d = True
+        elif q_in.dim() == 4:
+            q_view = q_in
+            out_was_3d = False
+        else:
+            raise ValueError(f"q must be 3D or 4D; got ndim={q_in.dim()}")
+
+        if q_view.shape[2] != self._num_qo_heads or q_view.shape[3] != self._head_dim:
+            raise ValueError(
+                f"q shape {tuple(q_view.shape)} mismatches plan "
+                f"(num_qo_heads={self._num_qo_heads}, head_dim={self._head_dim})"
+            )
+
+        device = q.device
+        if out is None:
+            out_4d = torch.zeros(
+                (self._batch_size, self._q_len_per_req, self._num_qo_heads, self._head_dim),
+                dtype=self._o_data_type,
+                device=device,
+            )
+            user_out = None
+        else:
+            user_out = out
+            if out.dim() == 3:
+                out_4d = out.view(
+                    self._batch_size,
+                    self._q_len_per_req,
+                    self._num_qo_heads,
+                    self._head_dim,
+                )
+            elif out.dim() == 4:
+                out_4d = out
+            else:
+                raise ValueError(f"out must be 3D or 4D; got ndim={out.dim()}")
+            if self._atomic:
+                out_4d.zero_()
+
+        m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(
+            self._batch_size, device
+        )
+
+        scale_s = self._sm_scale if sm_scale is None else sm_scale
+        threshold_arg = (
+            Float32(self._threshold_p) if self._threshold_p is not None else None
+        )
+
+        # Stream is bound from the TVM-FFI env stream at runtime
+        # (use_tvm_ffi_env_stream=True at compile), so the stream arg is omitted.
+        self._compiled_fmha(
+            self._kv_splits,
+            self._seqlens,
+            self._table_offsets,
+            self._page_table,
+            k_cache,
+            v_cache,
+            q_view,
+            out_4d,
+            m_bsh,
+            o_partial,
+            m_partial,
+            l_partial,
+            Float32(scale_s),
+            threshold_arg,
+        )
+
+        if user_out is not None:
+            # Honour the in-place contract: return exactly what the user passed.
+            return user_out
+        # Caller didn't supply out; return shape matching the input rank.
+        if out_was_3d:
+            return out_4d.view(-1, self._num_qo_heads, self._head_dim)
+        return out_4d

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -225,6 +225,7 @@ def _get_compiled_decode_kernel(
         m_partial_fake,
         l_partial_fake,
         Float32(1.0),  # scale_s placeholder
+        Float32(1.0),  # scale_o placeholder
         stream_fake,
         options="--enable-tvm-ffi --opt-level 2",
     )
@@ -366,6 +367,7 @@ def _get_compiled_paged_decode_kernel(
         m_partial_fake,
         l_partial_fake,
         Float32(1.0),  # scale_s placeholder
+        Float32(1.0),  # scale_o placeholder
         threshold_p_fake,
         stream_fake,
         options="--enable-tvm-ffi --opt-level 2",
@@ -550,6 +552,7 @@ class BatchDecodeCuteDSLWrapper:
         v: torch.Tensor,
         out: Optional[torch.Tensor] = None,
         sm_scale: Optional[float] = None,
+        o_scale: Optional[float] = None,
     ) -> torch.Tensor:
         """Run ragged-KV GQA decode.
 
@@ -568,6 +571,10 @@ class BatchDecodeCuteDSLWrapper:
             zero-initialized before being passed in.
         sm_scale : Optional[float]
             Per-call override of the softmax scale set at plan() time.
+        o_scale : Optional[float]
+            Output scale applied to the final O before it is written. The
+            cute-dsl kernel folds this in for free in the reduction
+            epilogue (no separate post-kernel multiply). Defaults to 1.0.
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
@@ -613,6 +620,7 @@ class BatchDecodeCuteDSLWrapper:
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
 
+        scale_o = 1.0 if o_scale is None else o_scale
         # Stream is bound from the TVM-FFI env stream at runtime
         # (use_tvm_ffi_env_stream=True at compile), so the stream arg is omitted.
         self._compiled_fmha(
@@ -626,6 +634,7 @@ class BatchDecodeCuteDSLWrapper:
             m_partial,
             l_partial,
             Float32(scale_s),
+            Float32(scale_o),
         )
         return out
 
@@ -886,6 +895,7 @@ class BatchDecodePagedCuteDSLWrapper:
         v_cache: torch.Tensor,
         out: Optional[torch.Tensor] = None,
         sm_scale: Optional[float] = None,
+        o_scale: Optional[float] = None,
         skip_softmax_threshold: Optional[float] = None,
     ) -> torch.Tensor:
         """Run paged GQA decode.
@@ -908,6 +918,10 @@ class BatchDecodePagedCuteDSLWrapper:
             For atomic reduction this is zero-filled on entry.
         sm_scale : Optional[float]
             Per-call override of the softmax scale set at plan() time.
+        o_scale : Optional[float]
+            Output scale applied to the final O before it is written. The
+            cute-dsl kernel folds this in for free in the reduction
+            epilogue (no separate post-kernel multiply). Defaults to 1.0.
         skip_softmax_threshold : Optional[float]
             BLASST skip-softmax threshold in ``(0, 1]``.  ``None`` (default)
             dispatches to the standard kernel (no BLASST overhead); a value
@@ -1019,6 +1033,7 @@ class BatchDecodePagedCuteDSLWrapper:
             fmha = self._compiled_fmha_std
             threshold_arg = None
 
+        o_scale_val = 1.0 if o_scale is None else o_scale
         # Stream is bound from the TVM-FFI env stream at runtime
         # (use_tvm_ffi_env_stream=True at compile), so the stream arg is omitted.
         fmha(
@@ -1035,6 +1050,7 @@ class BatchDecodePagedCuteDSLWrapper:
             m_partial,
             l_partial,
             Float32(scale_s),
+            Float32(o_scale_val),
             threshold_arg,
         )
 

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -157,16 +157,19 @@ def _get_compiled_decode_kernel(
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
-    k_fake = cute.runtime.make_fake_compact_tensor(
+    # Fully-symbolic outer strides so the same kernel handles both NHD layout
+    # (kernel-native) and HND layout (presented to the kernel via transpose to
+    # a logical NHD view, which has the same shape but different strides).
+    k_fake = cute.runtime.make_fake_tensor(
         in_dtype,
         (sym_batch, sym_seq_k, num_kv_heads, head_dim),
-        stride_order=(3, 2, 1, 0),
+        stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
         assumed_align=16,
     )
-    v_fake = cute.runtime.make_fake_compact_tensor(
+    v_fake = cute.runtime.make_fake_tensor(
         in_dtype,
         (sym_batch, sym_seq_k, num_kv_heads, head_dim),
-        stride_order=(3, 2, 1, 0),
+        stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
         assumed_align=16,
     )
     o_fake = cute.runtime.make_fake_compact_tensor(
@@ -277,29 +280,23 @@ def _get_compiled_paged_decode_kernel(
     page_table_fake = cute.runtime.make_fake_compact_tensor(
         Int32, (sym_total_logical_pages,), assumed_align=16
     )
-    # K/V cache may come from `unbind(dim=1)` on a combined `[*, 2, *, *, *]`
-    # tensor, in which case the leading-dim stride is doubled. Use a dynamic
-    # outer stride so both compact and unbound layouts are accepted.
+    # Fully-symbolic outer strides so the same kernel handles:
+    #   * NHD-contiguous   [num_pages,    page_size,    num_kv_heads, head_dim]
+    #   * NHD post-unbind  (leading-dim stride 2× from the combined kv tensor)
+    #   * HND-transposed   (kernel sees logical NHD, gmem strides reflect the
+    #                       underlying HND layout via .transpose(-3, -2))
+    # Only the innermost (head_dim) stride is fixed at 1, since the kernel's
+    # TMA expects head_dim to be contiguous.
     k_fake = cute.runtime.make_fake_tensor(
         in_dtype,
         (sym_virtual_pages, page_size, num_kv_heads, head_dim),
-        stride=(
-            cute.sym_int(),
-            num_kv_heads * head_dim,
-            head_dim,
-            1,
-        ),
+        stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
         assumed_align=16,
     )
     v_fake = cute.runtime.make_fake_tensor(
         in_dtype,
         (sym_virtual_pages, page_size, num_kv_heads, head_dim),
-        stride=(
-            cute.sym_int(),
-            num_kv_heads * head_dim,
-            head_dim,
-            1,
-        ),
+        stride=(cute.sym_int(), cute.sym_int(), cute.sym_int(), 1),
         assumed_align=16,
     )
     q_fake = cute.runtime.make_fake_compact_tensor(
@@ -642,7 +639,8 @@ class BatchDecodePagedCuteDSLWrapper:
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
         self._use_cuda_graph = use_cuda_graph
-        self._compiled_fmha = None
+        self._compiled_fmha_std = None
+        self._compile_args: Optional[tuple] = None
         self._planned = False
 
     @flashinfer_api
@@ -662,7 +660,7 @@ class BatchDecodePagedCuteDSLWrapper:
         sm_scale: Optional[float] = None,
         kv_splits: Optional[int] = None,
         reduction: str = "auto",
-        threshold_p: Optional[float] = None,
+        precompile_skip_softmax_kernel: bool = False,
         max_kv_len: Optional[int] = None,
         non_blocking: bool = True,
     ) -> None:
@@ -691,9 +689,18 @@ class BatchDecodePagedCuteDSLWrapper:
         reduction : str
             ``"kernel"`` (deterministic with workspace), ``"atomic"``
             (cluster reduction, faster but lower precision), or ``"auto"``.
-        threshold_p : Optional[float]
-            BLASST skip threshold; ``None`` (default) disables the
-            optimization.  When set, must be in ``(0, 1]``.
+        precompile_skip_softmax_kernel : bool
+            If True, also compile the BLASST skip-softmax variant of the
+            kernel at plan() time, so the first :meth:`run` call that
+            passes ``skip_softmax_threshold`` is fast.  When False (default)
+            the BLASST variant is lazily compiled on first use, which keeps
+            plan() fast at the cost of a one-time compile latency spike on
+            that first call.  The standard (no-BLASST) variant is always
+            compiled at plan() time because the BLASST predicate has a
+            real per-tile cost on the standard path.
+        max_kv_len : Optional[int]
+            Maximum KV sequence length across the batch.  Used to auto-tune
+            ``kv_splits``; pass it explicitly to avoid a GPU→CPU sync.
         non_blocking : bool
             Async device copies for the plan-time integer buffers.
         """
@@ -780,9 +787,6 @@ class BatchDecodePagedCuteDSLWrapper:
                     f"atomic reduction requires output dtype in (float32, float16, "
                     f"bfloat16); got {o_data_type}"
                 )
-        if threshold_p is not None and not (0.0 < threshold_p <= 1.0):
-            raise ValueError(f"threshold_p must be None or in (0, 1]; got {threshold_p}")
-
         self._q_data_type = q_data_type
         self._o_data_type = o_data_type
         self._num_qo_heads = num_qo_heads
@@ -794,7 +798,6 @@ class BatchDecodePagedCuteDSLWrapper:
         self._reduction = reduction
         self._atomic = reduction == "atomic"
         self._tma_mask = q_len_per_req == 1
-        self._threshold_p = threshold_p
         if sm_scale is None:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
@@ -804,7 +807,9 @@ class BatchDecodePagedCuteDSLWrapper:
         self._table_offsets = table_offsets
         self._page_table = indices_i32
 
-        self._compiled_fmha = _get_compiled_paged_decode_kernel(
+        # Compile args shared by std and BLASST variants. Stashed so run()
+        # can lazily fetch the BLASST variant via the @functools.cache.
+        self._compile_args = (
             in_dtype,
             out_dtype,
             page_size,
@@ -815,8 +820,15 @@ class BatchDecodePagedCuteDSLWrapper:
             kv_splits,
             reduction,
             self._tma_mask,
-            threshold_p is not None,
         )
+        # Standard (no-BLASST) variant — always compiled at plan() time.
+        self._compiled_fmha_std = _get_compiled_paged_decode_kernel(
+            *self._compile_args, False
+        )
+        if precompile_skip_softmax_kernel:
+            # Warm the cache so the BLASST variant is ready for the first
+            # run() that uses skip_softmax_threshold.
+            _get_compiled_paged_decode_kernel(*self._compile_args, True)
         self._planned = True
 
     def _allocate_workspace(self, batch_size: int, device: torch.device):
@@ -850,6 +862,7 @@ class BatchDecodePagedCuteDSLWrapper:
         v_cache: torch.Tensor,
         out: Optional[torch.Tensor] = None,
         sm_scale: Optional[float] = None,
+        skip_softmax_threshold: Optional[float] = None,
     ) -> torch.Tensor:
         """Run paged GQA decode.
 
@@ -859,12 +872,21 @@ class BatchDecodePagedCuteDSLWrapper:
             ``[batch_size * q_len_per_req, num_qo_heads, head_dim]`` or
             ``[batch_size, q_len_per_req, num_qo_heads, head_dim]``.
         k_cache, v_cache : torch.Tensor
-            ``[num_pages, page_size, num_kv_heads, head_dim]`` (NHD layout).
+            Logical shape ``[num_pages, page_size, num_kv_heads, head_dim]``.
+            Both NHD-contiguous layouts and HND layouts (presented as a
+            transposed view) are accepted; the kernel handles arbitrary
+            strides as long as ``head_dim`` is innermost.
         out : Optional[torch.Tensor]
             Pre-allocated output of the same logical shape as ``q``.
             For atomic reduction this is zero-filled on entry.
         sm_scale : Optional[float]
             Per-call override of the softmax scale set at plan() time.
+        skip_softmax_threshold : Optional[float]
+            BLASST skip-softmax threshold in ``(0, 1]``.  ``None`` (default)
+            dispatches to the standard kernel (no BLASST overhead); a value
+            triggers lazy compile of the BLASST variant on first use, or
+            hits the precompiled cache if ``plan(precompile_skip_softmax_kernel=True)``
+            was used.
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
@@ -949,13 +971,23 @@ class BatchDecodePagedCuteDSLWrapper:
         )
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
-        threshold_arg = (
-            Float32(self._threshold_p) if self._threshold_p is not None else None
-        )
+        if skip_softmax_threshold is not None:
+            if not (0.0 < skip_softmax_threshold <= 1.0):
+                raise ValueError(
+                    f"skip_softmax_threshold must be in (0, 1]; "
+                    f"got {skip_softmax_threshold}"
+                )
+            # Fetch (or first-time compile) the BLASST variant via the
+            # module-level @functools.cache.
+            fmha = _get_compiled_paged_decode_kernel(*self._compile_args, True)
+            threshold_arg = Float32(skip_softmax_threshold)
+        else:
+            fmha = self._compiled_fmha_std
+            threshold_arg = None
 
         # Stream is bound from the TVM-FFI env stream at runtime
         # (use_tvm_ffi_env_stream=True at compile), so the stream arg is omitted.
-        self._compiled_fmha(
+        fmha(
             self._kv_splits,
             self._seqlens,
             self._table_offsets,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -150,10 +150,14 @@ def _get_compiled_decode_kernel(
 
     sym_batch = cute.sym_int()
     sym_seq_k = cute.sym_int()
+    # Symbolic prediction so a single compiled kernel handles varying runtime
+    # q_len_per_req. `prediction` (the Python int) still drives the compile-
+    # time prediction_tile / softmax_warpgroups choices via the kernel ctor.
+    sym_prediction = cute.sym_int()
 
     q_fake = cute.runtime.make_fake_compact_tensor(
         in_dtype,
-        (sym_batch, prediction, num_qo_heads, head_dim),
+        (sym_batch, sym_prediction, num_qo_heads, head_dim),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -174,7 +178,7 @@ def _get_compiled_decode_kernel(
     )
     o_fake = cute.runtime.make_fake_compact_tensor(
         out_dtype,
-        (sym_batch, prediction, num_qo_heads, head_dim),
+        (sym_batch, sym_prediction, num_qo_heads, head_dim),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -184,25 +188,25 @@ def _get_compiled_decode_kernel(
     else:
         m_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (sym_batch, prediction, num_qo_heads),
+            (sym_batch, sym_prediction, num_qo_heads),
             stride_order=(2, 1, 0),
             assumed_align=16,
         )
         o_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, prediction, num_qo_heads, head_dim),
+            (kv_splits, sym_batch, sym_prediction, num_qo_heads, head_dim),
             stride_order=(4, 3, 2, 1, 0),
             assumed_align=16,
         )
         m_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, prediction, num_qo_heads),
+            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
         l_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, prediction, num_qo_heads),
+            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
@@ -270,6 +274,10 @@ def _get_compiled_paged_decode_kernel(
     sym_batch = cute.sym_int()
     sym_virtual_pages = cute.sym_int()
     sym_total_logical_pages = cute.sym_int()
+    # Symbolic prediction so one compiled kernel handles any runtime
+    # q_len_per_req. `prediction` (Python int) still drives the compile-time
+    # prediction_tile / softmax_warpgroups choices via the kernel ctor.
+    sym_prediction = cute.sym_int()
 
     seqlens_fake = cute.runtime.make_fake_compact_tensor(
         Int32, (sym_batch,), assumed_align=16
@@ -301,13 +309,13 @@ def _get_compiled_paged_decode_kernel(
     )
     q_fake = cute.runtime.make_fake_compact_tensor(
         in_dtype,
-        (sym_batch, prediction, num_qo_heads, head_dim),
+        (sym_batch, sym_prediction, num_qo_heads, head_dim),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     o_fake = cute.runtime.make_fake_compact_tensor(
         out_dtype,
-        (sym_batch, prediction, num_qo_heads, head_dim),
+        (sym_batch, sym_prediction, num_qo_heads, head_dim),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -317,25 +325,25 @@ def _get_compiled_paged_decode_kernel(
     else:
         m_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (sym_batch, prediction, num_qo_heads),
+            (sym_batch, sym_prediction, num_qo_heads),
             stride_order=(2, 1, 0),
             assumed_align=16,
         )
         o_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, prediction, num_qo_heads, head_dim),
+            (kv_splits, sym_batch, sym_prediction, num_qo_heads, head_dim),
             stride_order=(4, 3, 2, 1, 0),
             assumed_align=16,
         )
         m_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, prediction, num_qo_heads),
+            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
         l_partial_fake = cute.runtime.make_fake_compact_tensor(
             acc_dtype,
-            (kv_splits, sym_batch, prediction, num_qo_heads),
+            (kv_splits, sym_batch, sym_prediction, num_qo_heads),
             stride_order=(3, 2, 1, 0),
             assumed_align=16,
         )
@@ -486,7 +494,11 @@ class BatchDecodeCuteDSLWrapper:
         self._kv_splits = kv_splits
         self._reduction = reduction
         self._atomic = reduction == "atomic"
-        self._tma_mask = q_len_per_req == 1
+        # Always use bottom-right causal masking; for q_len_per_req=1 this
+        # degenerates to "row 0 sees all keys", equivalent to no causal mask.
+        # Keeping a single mask path means the compiled kernel doesn't need
+        # to be re-tuned when the runtime q_len_per_req changes.
+        self._tma_mask = False
         if sm_scale is None:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
@@ -504,22 +516,24 @@ class BatchDecodeCuteDSLWrapper:
         )
         self._planned = True
 
-    def _allocate_workspace(self, batch_size: int, device: torch.device):
+    def _allocate_workspace(
+        self, batch_size: int, q_len_per_req: int, device: torch.device
+    ):
         """Allocate kernel-reduction workspace tensors for the current batch."""
         if self._atomic:
             return None, None, None, None
-        shape_m = (batch_size, self._q_len_per_req, self._num_qo_heads)
+        shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
         shape_p_o = (
             self._kv_splits,
             batch_size,
-            self._q_len_per_req,
+            q_len_per_req,
             self._num_qo_heads,
             self._head_dim,
         )
         shape_p_ml = (
             self._kv_splits,
             batch_size,
-            self._q_len_per_req,
+            q_len_per_req,
             self._num_qo_heads,
         )
         m_bsh = torch.full(shape_m, float("-inf"), dtype=torch.float32, device=device)
@@ -543,6 +557,9 @@ class BatchDecodeCuteDSLWrapper:
         ----------
         q : torch.Tensor
             Shape ``[batch_size, q_len_per_req, num_qo_heads, head_dim]``.
+            ``q_len_per_req`` is read from ``q.shape[1]`` at run time; it
+            does not have to match the value passed to :meth:`plan` (which
+            is only a compile-time tile-size hint).
         k, v : torch.Tensor
             Shape ``[batch_size, seq_len, num_kv_heads, head_dim]``.  Both
             must have the same seq_len.
@@ -568,7 +585,6 @@ class BatchDecodeCuteDSLWrapper:
         b_k, s_k, h_k, d_k = k.shape
         if (
             b != b_k
-            or s_q != self._q_len_per_req
             or h_q != self._num_qo_heads
             or h_k != self._num_kv_heads
             or d != d_k
@@ -576,8 +592,8 @@ class BatchDecodeCuteDSLWrapper:
         ):
             raise ValueError(
                 f"q/k/v shape mismatch with plan: q={tuple(q.shape)}, k={tuple(k.shape)}, "
-                f"v={tuple(v.shape)}; expected q=[b,{self._q_len_per_req},"
-                f"{self._num_qo_heads},{self._head_dim}], k=[b,*,{self._num_kv_heads},"
+                f"v={tuple(v.shape)}; expected q=[b,*,{self._num_qo_heads},"
+                f"{self._head_dim}], k=[b,*,{self._num_kv_heads},"
                 f"{self._head_dim}]"
             )
         if v.shape != k.shape:
@@ -591,7 +607,9 @@ class BatchDecodeCuteDSLWrapper:
         elif self._atomic:
             out.zero_()
 
-        m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(b, device)
+        m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(
+            b, s_q, device
+        )
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
 
@@ -797,7 +815,11 @@ class BatchDecodePagedCuteDSLWrapper:
         self._kv_splits = kv_splits
         self._reduction = reduction
         self._atomic = reduction == "atomic"
-        self._tma_mask = q_len_per_req == 1
+        # Always use bottom-right causal masking; for q_len_per_req=1 this
+        # degenerates to "row 0 sees all keys", equivalent to no causal mask.
+        # Keeping a single mask path means the compiled kernel doesn't need
+        # to be re-tuned when the runtime q_len_per_req changes.
+        self._tma_mask = False
         if sm_scale is None:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
@@ -831,21 +853,23 @@ class BatchDecodePagedCuteDSLWrapper:
             _get_compiled_paged_decode_kernel(*self._compile_args, True)
         self._planned = True
 
-    def _allocate_workspace(self, batch_size: int, device: torch.device):
+    def _allocate_workspace(
+        self, batch_size: int, q_len_per_req: int, device: torch.device
+    ):
         if self._atomic:
             return None, None, None, None
-        shape_m = (batch_size, self._q_len_per_req, self._num_qo_heads)
+        shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
         shape_p_o = (
             self._kv_splits,
             batch_size,
-            self._q_len_per_req,
+            q_len_per_req,
             self._num_qo_heads,
             self._head_dim,
         )
         shape_p_ml = (
             self._kv_splits,
             batch_size,
-            self._q_len_per_req,
+            q_len_per_req,
             self._num_qo_heads,
         )
         m_bsh = torch.full(shape_m, float("-inf"), dtype=torch.float32, device=device)
@@ -871,6 +895,9 @@ class BatchDecodePagedCuteDSLWrapper:
         q : torch.Tensor
             ``[batch_size * q_len_per_req, num_qo_heads, head_dim]`` or
             ``[batch_size, q_len_per_req, num_qo_heads, head_dim]``.
+            ``q_len_per_req`` is read from ``q.shape`` at run time; it does
+            not have to match the value passed to :meth:`plan` (which is
+            only a compile-time tile-size hint).
         k_cache, v_cache : torch.Tensor
             Logical shape ``[num_pages, page_size, num_kv_heads, head_dim]``.
             Both NHD-contiguous layouts and HND layouts (presented as a
@@ -919,19 +946,26 @@ class BatchDecodePagedCuteDSLWrapper:
             )
 
         # Normalize q to [batch_size, q_len_per_req, num_qo_heads, head_dim].
+        # q_len_per_req is derived from q.shape at run time, not from plan.
         q_in = q if q.is_contiguous() else q.contiguous()
         if q_in.dim() == 3:
             total_q, h_q, d = q_in.shape
-            expected_total = self._batch_size * self._q_len_per_req
-            if total_q != expected_total:
+            if total_q % self._batch_size != 0:
                 raise ValueError(
-                    f"q.shape[0]={total_q} mismatches batch_size*q_len_per_req="
-                    f"{self._batch_size}*{self._q_len_per_req}={expected_total}"
+                    f"q.shape[0]={total_q} not divisible by planned "
+                    f"batch_size={self._batch_size}"
                 )
-            q_view = q_in.view(self._batch_size, self._q_len_per_req, h_q, d)
+            q_len_per_req = total_q // self._batch_size
+            q_view = q_in.view(self._batch_size, q_len_per_req, h_q, d)
             out_was_3d = True
         elif q_in.dim() == 4:
             q_view = q_in
+            q_len_per_req = q_view.shape[1]
+            if q_view.shape[0] != self._batch_size:
+                raise ValueError(
+                    f"q.shape[0]={q_view.shape[0]} mismatches planned "
+                    f"batch_size={self._batch_size}"
+                )
             out_was_3d = False
         else:
             raise ValueError(f"q must be 3D or 4D; got ndim={q_in.dim()}")
@@ -945,7 +979,7 @@ class BatchDecodePagedCuteDSLWrapper:
         device = q.device
         if out is None:
             out_4d = torch.zeros(
-                (self._batch_size, self._q_len_per_req, self._num_qo_heads, self._head_dim),
+                (self._batch_size, q_len_per_req, self._num_qo_heads, self._head_dim),
                 dtype=self._o_data_type,
                 device=device,
             )
@@ -955,7 +989,7 @@ class BatchDecodePagedCuteDSLWrapper:
             if out.dim() == 3:
                 out_4d = out.view(
                     self._batch_size,
-                    self._q_len_per_req,
+                    q_len_per_req,
                     self._num_qo_heads,
                     self._head_dim,
                 )
@@ -967,7 +1001,7 @@ class BatchDecodePagedCuteDSLWrapper:
                 out_4d.zero_()
 
         m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(
-            self._batch_size, device
+            self._batch_size, q_len_per_req, device
         )
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -719,8 +719,6 @@ class BatchDecodeCuteDSLWrapper:
             out = torch_alloc(
                 (b, s_q, h_q, d), dtype=self._o_data_type, device=device
             )
-        elif atomic:
-            out.zero_()
 
         m = o_partial = l_partial = m_partial = None
         if self._has_workspace:
@@ -1033,8 +1031,8 @@ class BatchDecodePagedCuteDSLWrapper:
             transposed view) are accepted; the kernel handles arbitrary
             strides as long as ``head_dim`` is innermost.
         out : Optional[torch.Tensor]
-            Pre-allocated output of the same logical shape as ``q``.
-            For atomic reduction this is zero-filled on entry.
+            Pre-allocated output buffer.  For atomic reduction it must be
+            zero-initialized before being passed in.
         sm_scale : Optional[float]
             Per-call override of the softmax scale set at plan() time.
         o_scale : Optional[float]
@@ -1089,7 +1087,7 @@ class BatchDecodePagedCuteDSLWrapper:
 
         # Normalize q to [batch_size, q_len_per_req, num_qo_heads, head_dim].
         # q_len_per_req is derived from q.shape at run time, not from plan.
-        q_in = q if q.is_contiguous() else q.contiguous()
+        q_in = q
         if q_in.dim() == 3:
             total_q, h_q, d = q_in.shape
             if total_q % self._batch_size != 0:
@@ -1131,6 +1129,7 @@ class BatchDecodePagedCuteDSLWrapper:
             )
             user_out = None
         else:
+            # user out should be zero-init
             user_out = out
             if out.dim() == 3:
                 out_4d = out.view(
@@ -1143,8 +1142,6 @@ class BatchDecodePagedCuteDSLWrapper:
                 out_4d = out
             else:
                 raise ValueError(f"out must be 3D or 4D; got ndim={out.dim()}")
-            if atomic:
-                out_4d.zero_()
 
         m = o_partial = l_partial = m_partial = None
         if self._has_workspace:

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -188,10 +188,17 @@ def _get_compiled_decode_kernel(
     grouped_head_tile, prediction_tile = _pick_tile_shape(
         num_qo_heads, num_kv_heads, prediction, in_dtype.width
     )
+    blk_tile_n = grouped_head_tile * prediction_tile
+
+    sequence_tile = 256
+    if prediction_tile > 1 and blk_tile_n > 8:
+        sequence_tile = 128 # Prevent regspills
+
     fmha = GroupedQueryAttentionDecode(
         head_dim,
         grouped_head_tile,
         prediction_tile=prediction_tile,
+        sequence_tile=sequence_tile,
         reduction_mode=reduction,
         tma_mask=tma_mask,
     )
@@ -313,6 +320,13 @@ def _get_compiled_paged_decode_kernel(
         num_qo_heads, num_kv_heads, prediction, in_dtype.width
     )
     blk_tile_n = grouped_head_tile * prediction_tile
+
+    sequence_tile = 256
+    if use_threshold:
+        sequence_tile = 128 # Promote skipping
+    elif prediction_tile > 1 and blk_tile_n > 8:
+        sequence_tile = 128 # Prevent regspills
+
     softmax_warpgroups = (
         2
         if (not use_threshold)
@@ -327,7 +341,7 @@ def _get_compiled_paged_decode_kernel(
         head_dim,
         grouped_head_tile,
         prediction_tile=prediction_tile,
-        sequence_tile=128 if use_threshold else 256,
+        sequence_tile=sequence_tile,
         reduction_mode=reduction,
         softmax_warpgroups=softmax_warpgroups,
         tma_mask=tma_mask,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -133,6 +133,7 @@ def _get_compiled_decode_kernel(
     kv_splits: int,
     reduction: str,
     tma_mask: bool,
+    use_lse: bool,
 ):
     """Compile and cache the ragged (contiguous-KV) GQA decode kernel."""
     grouped_head_tile, prediction_tile = _pick_tile_shape(
@@ -183,6 +184,15 @@ def _get_compiled_decode_kernel(
         assumed_align=16,
     )
 
+    l_fake = None
+    if use_lse:
+        l_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (sym_batch, sym_prediction, num_qo_heads),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+
     if atomic:
         m_fake = o_partial_fake = m_partial_fake = l_partial_fake = None
     else:
@@ -220,10 +230,11 @@ def _get_compiled_decode_kernel(
         k_fake,
         v_fake,
         o_fake,
+        l_fake,
         m_fake,
         o_partial_fake,
-        m_partial_fake,
         l_partial_fake,
+        m_partial_fake,
         Float32(1.0),  # scale_s placeholder
         Float32(1.0),  # scale_o placeholder
         stream_fake,
@@ -244,6 +255,7 @@ def _get_compiled_paged_decode_kernel(
     reduction: str,
     tma_mask: bool,
     use_threshold: bool,
+    use_lse: bool,
 ):
     """Compile and cache the paged GQA decode kernel."""
     grouped_head_tile, prediction_tile = _pick_tile_shape(
@@ -321,6 +333,15 @@ def _get_compiled_paged_decode_kernel(
         assumed_align=16,
     )
 
+    l_fake = None
+    if use_lse:
+        l_fake = cute.runtime.make_fake_compact_tensor(
+            acc_dtype,
+            (sym_batch, sym_prediction, num_qo_heads),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+
     if atomic:
         m_fake = o_partial_fake = m_partial_fake = l_partial_fake = None
     else:
@@ -362,10 +383,11 @@ def _get_compiled_paged_decode_kernel(
         v_fake,
         q_fake,
         o_fake,
+        l_fake,
         m_fake,
         o_partial_fake,
-        m_partial_fake,
         l_partial_fake,
+        m_partial_fake,
         Float32(1.0),  # scale_s placeholder
         Float32(1.0),  # scale_o placeholder
         threshold_p_fake,
@@ -396,7 +418,8 @@ class BatchDecodeCuteDSLWrapper:
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
         self._use_cuda_graph = use_cuda_graph
-        self._compiled_fmha = None
+        self._compiled_fmha_std = None
+        self._compile_args: Optional[tuple] = None
         self._planned = False
 
     @flashinfer_api
@@ -505,7 +528,9 @@ class BatchDecodeCuteDSLWrapper:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
 
-        self._compiled_fmha = _get_compiled_decode_kernel(
+        # Always compile the no-LSE variant at plan() time; the LSE variant
+        # is lazily fetched at run() time when needed (compile cache hit).
+        self._compile_args = (
             in_dtype,
             out_dtype,
             num_qo_heads,
@@ -515,6 +540,9 @@ class BatchDecodeCuteDSLWrapper:
             kv_splits,
             reduction,
             self._tma_mask,
+        )
+        self._compiled_fmha_std = _get_compiled_decode_kernel(
+            *self._compile_args, False
         )
         self._planned = True
 
@@ -553,6 +581,7 @@ class BatchDecodeCuteDSLWrapper:
         out: Optional[torch.Tensor] = None,
         sm_scale: Optional[float] = None,
         o_scale: Optional[float] = None,
+        lse: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run ragged-KV GQA decode.
 
@@ -575,6 +604,13 @@ class BatchDecodeCuteDSLWrapper:
             Output scale applied to the final O before it is written. The
             cute-dsl kernel folds this in for free in the reduction
             epilogue (no separate post-kernel multiply). Defaults to 1.0.
+        lse : Optional[torch.Tensor]
+            Pre-allocated float32 buffer of shape
+            ``(batch_size, q_len_per_req, num_qo_heads)`` to receive the
+            log-sum-exp (log2 base, matching flashinfer convention). When
+            ``None`` (default) the kernel skips the LSE write entirely;
+            otherwise a log2-base LSE variant is lazily compiled on first
+            use (cache hit afterwards).
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
@@ -619,20 +655,38 @@ class BatchDecodeCuteDSLWrapper:
         )
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
+        use_lse = lse is not None
+        if use_lse:
+            if lse.dtype != torch.float32:
+                raise ValueError(
+                    f"lse must be float32 (LSE is log2-base); got {lse.dtype}"
+                )
+            expected_lse_shape = (b, s_q, h_q)
+            if lse.shape != expected_lse_shape:
+                raise ValueError(
+                    f"lse shape {tuple(lse.shape)} must equal {expected_lse_shape}"
+                )
+
+        fmha = (
+            self._compiled_fmha_std
+            if not use_lse
+            else _get_compiled_decode_kernel(*self._compile_args, True)
+        )
 
         scale_o = 1.0 if o_scale is None else o_scale
         # Stream is bound from the TVM-FFI env stream at runtime
         # (use_tvm_ffi_env_stream=True at compile), so the stream arg is omitted.
-        self._compiled_fmha(
+        fmha(
             self._kv_splits,
             q,
             k,
             v,
             out,
+            lse,
             m_bsh,
             o_partial,
-            m_partial,
             l_partial,
+            m_partial,
             Float32(scale_s),
             Float32(scale_o),
         )
@@ -852,14 +906,15 @@ class BatchDecodePagedCuteDSLWrapper:
             reduction,
             self._tma_mask,
         )
-        # Standard (no-BLASST) variant — always compiled at plan() time.
+        # Standard (no-BLASST, no-LSE) variant — always compiled at plan().
+        # BLASST and LSE variants compile lazily on first use via the cache.
         self._compiled_fmha_std = _get_compiled_paged_decode_kernel(
-            *self._compile_args, False
+            *self._compile_args, False, False
         )
         if precompile_skip_softmax_kernel:
             # Warm the cache so the BLASST variant is ready for the first
             # run() that uses skip_softmax_threshold.
-            _get_compiled_paged_decode_kernel(*self._compile_args, True)
+            _get_compiled_paged_decode_kernel(*self._compile_args, True, False)
         self._planned = True
 
     def _allocate_workspace(
@@ -897,6 +952,7 @@ class BatchDecodePagedCuteDSLWrapper:
         sm_scale: Optional[float] = None,
         o_scale: Optional[float] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
+        lse: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run paged GQA decode.
 
@@ -925,11 +981,18 @@ class BatchDecodePagedCuteDSLWrapper:
         skip_softmax_threshold_scale_factor : Optional[float]
             BLASST skip-softmax scale factor. The kernel divides this by
             each batch's KV seqlen to obtain the per-request effective
-            threshold (matching trtllm-gen semantics). Must be > 0
-            when set. ``None`` (default) dispatches to the standard
-            kernel; a value triggers lazy compile of the BLASST variant
-            on first use, or hits the precompiled cache if
+            threshold. Must be > 0 when set. ``None`` (default) dispatches
+            to the standard kernel; a value triggers lazy compile of the
+            BLASST variant on first use, or hits the precompiled cache if
             ``plan(precompile_skip_softmax_kernel=True)`` was used.
+        lse : Optional[torch.Tensor]
+            Pre-allocated float32 buffer of shape
+            ``(batch_size, q_len_per_req, num_qo_heads)`` (or the flat
+            equivalent ``(batch_size * q_len_per_req, num_qo_heads)``) to
+            receive the log-sum-exp (log2 base, matching flashinfer
+            convention). When ``None`` (default) the kernel skips the LSE
+            write; otherwise an LSE variant is lazily compiled on first
+            use.
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
@@ -1021,20 +1084,47 @@ class BatchDecodePagedCuteDSLWrapper:
         )
 
         scale_s = self._sm_scale if sm_scale is None else sm_scale
-        if skip_softmax_threshold_scale_factor is not None:
+        use_threshold = skip_softmax_threshold_scale_factor is not None
+        use_lse = lse is not None
+        if use_threshold:
             if not skip_softmax_threshold_scale_factor > 0:
                 raise ValueError(
                     f"skip_softmax_threshold_scale_factor must be > 0; "
                     f"got {skip_softmax_threshold_scale_factor}"
                 )
-            # Fetch (or first-time compile) the BLASST variant via the
-            # module-level @functools.cache. The kernel divides by per-batch
-            # seqlen internally, so pass the raw scale factor.
-            fmha = _get_compiled_paged_decode_kernel(*self._compile_args, True)
             threshold_arg = Float32(skip_softmax_threshold_scale_factor)
         else:
-            fmha = self._compiled_fmha_std
             threshold_arg = None
+        if use_lse:
+            if lse.dtype != torch.float32:
+                raise ValueError(
+                    f"lse must be float32 (LSE is log2-base); got {lse.dtype}"
+                )
+            expected_lse_shape = (
+                self._batch_size,
+                q_len_per_req,
+                self._num_qo_heads,
+            )
+            if lse.shape == expected_lse_shape:
+                l_view = lse
+            elif lse.shape == (self._batch_size * q_len_per_req, self._num_qo_heads):
+                l_view = lse.view(*expected_lse_shape)
+            else:
+                raise ValueError(
+                    f"lse shape {tuple(lse.shape)} doesn't match expected "
+                    f"{expected_lse_shape} or its 3D-flat form"
+                )
+        else:
+            l_view = None
+
+        # Pick the variant matching this (use_threshold, use_lse) — std is
+        # always already compiled; the other three are lazy.
+        if use_threshold or use_lse:
+            fmha = _get_compiled_paged_decode_kernel(
+                *self._compile_args, use_threshold, use_lse
+            )
+        else:
+            fmha = self._compiled_fmha_std
 
         o_scale_val = 1.0 if o_scale is None else o_scale
         # Stream is bound from the TVM-FFI env stream at runtime
@@ -1048,10 +1138,11 @@ class BatchDecodePagedCuteDSLWrapper:
             v_cache,
             q_view,
             out_4d,
+            l_view,
             m_bsh,
             o_partial,
-            m_partial,
             l_partial,
+            m_partial,
             Float32(scale_s),
             Float32(o_scale_val),
             threshold_arg,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -91,6 +91,8 @@ def _compute_kv_splits(
     reduction: str,
 ) -> int:
     """Replicate ``gqa_decode.run`` kv_splits auto-computation."""
+    if reduction == "none":
+        return 1
     grouped_head_tiles = math.ceil(grouped_heads / grouped_head_tile)
     prediction_tiles = math.ceil(prediction / prediction_tile)
     grid_yz = batch_size * num_kv_heads * grouped_head_tiles * prediction_tiles
@@ -107,8 +109,11 @@ def _compute_kv_splits(
 def _resolve_reduction(reduction: str, kv_splits: int, o_dtype: "cutlass.dtype") -> str:
     if reduction != "auto":
         return reduction
+    if kv_splits == 1:
+        # No split-K — skip flash-decoding entirely (no reduction kernel,
+        # no cluster atomics).
+        return "none"
     if o_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16) and kv_splits in (
-        1,
         2,
         4,
         8,
@@ -146,7 +151,7 @@ def _get_compiled_decode_kernel(
         reduction_mode=reduction,
         tma_mask=tma_mask,
     )
-    atomic = reduction == "atomic"
+    has_workspace = reduction == "kernel"
     acc_dtype = cutlass.Float32
 
     sym_batch = cute.sym_int()
@@ -193,7 +198,8 @@ def _get_compiled_decode_kernel(
             assumed_align=16,
         )
 
-    if atomic:
+    if not has_workspace:
+        # atomic / none reduction: no per-split workspace tensors.
         m_fake = o_partial_fake = m_partial_fake = l_partial_fake = None
     else:
         m_fake = cute.runtime.make_fake_compact_tensor(
@@ -239,7 +245,7 @@ def _get_compiled_decode_kernel(
         Float32(1.0),  # scale_o placeholder
         stream_fake,
         True,  # enable_pdl placeholder (runtime-dynamic)
-        options="--enable-tvm-ffi --opt-level 2",
+        options="--enable-tvm-ffi --opt-level 3",
     )
 
 
@@ -282,7 +288,7 @@ def _get_compiled_paged_decode_kernel(
         softmax_warpgroups=softmax_warpgroups,
         tma_mask=tma_mask,
     )
-    atomic = reduction == "atomic"
+    has_workspace = reduction == "kernel"
     acc_dtype = cutlass.Float32
 
     sym_batch = cute.sym_int()
@@ -343,7 +349,8 @@ def _get_compiled_paged_decode_kernel(
             assumed_align=16,
         )
 
-    if atomic:
+    if not has_workspace:
+        # atomic / none reduction: no per-split workspace tensors.
         m_fake = o_partial_fake = m_partial_fake = l_partial_fake = None
     else:
         m_fake = cute.runtime.make_fake_compact_tensor(
@@ -394,7 +401,7 @@ def _get_compiled_paged_decode_kernel(
         threshold_p_fake,
         stream_fake,
         True,  # enable_pdl placeholder (runtime-dynamic)
-        options="--enable-tvm-ffi --opt-level 2",
+        options="--enable-tvm-ffi --opt-level 3",
     )
 
 
@@ -464,9 +471,14 @@ class BatchDecodeCuteDSLWrapper:
             Threadblocks per sequence (flash decoding).  ``None`` auto-tunes
             from the planned shape and the device SM count.
         reduction : str
-            ``"kernel"``, ``"atomic"``, or ``"auto"`` (default).  Atomic
-            reduction is faster but requires kv_splits ∈ {1, 2, 4, 8, 16} and
-            an output dtype in {float32, float16, bfloat16}.
+            ``"kernel"``, ``"atomic"``, ``"none"``, or ``"auto"`` (default).
+            ``"none"`` skips flash-decoding entirely (no reduction kernel,
+            no cluster atomics) and requires ``kv_splits == 1``. Atomic
+            reduction is faster than kernel reduction but requires kv_splits
+            ∈ {1, 2, 4, 8, 16} and an output dtype in {float32, float16,
+            bfloat16}. ``"auto"`` picks ``"none"`` when kv_splits == 1,
+            ``"atomic"`` for compatible dtypes and small kv_splits, else
+            ``"kernel"``.
         """
         if kv_data_type is not None and kv_data_type != q_data_type:
             raise NotImplementedError(
@@ -511,6 +523,10 @@ class BatchDecodeCuteDSLWrapper:
                     f"atomic reduction requires output dtype in (float32, float16, "
                     f"bfloat16); got {o_data_type}"
                 )
+        elif reduction == "none" and kv_splits != 1:
+            raise ValueError(
+                f'reduction="none" requires kv_splits == 1, got {kv_splits}'
+            )
 
         self._q_data_type = q_data_type
         self._o_data_type = o_data_type
@@ -520,7 +536,10 @@ class BatchDecodeCuteDSLWrapper:
         self._q_len_per_req = q_len_per_req
         self._kv_splits = kv_splits
         self._reduction = reduction
-        self._atomic = reduction == "atomic"
+        # Only kernel-reduction uses workspace tensors; atomic and none
+        # write to o_bshd directly (atomic via atomic_add, none via direct
+        # store).
+        self._has_workspace = reduction == "kernel"
         # Always use bottom-right causal masking; for q_len_per_req=1 this
         # degenerates to "row 0 sees all keys", equivalent to no causal mask.
         # Keeping a single mask path means the compiled kernel doesn't need
@@ -552,7 +571,7 @@ class BatchDecodeCuteDSLWrapper:
         self, batch_size: int, q_len_per_req: int, device: torch.device
     ):
         """Allocate kernel-reduction workspace tensors for the current batch."""
-        if self._atomic:
+        if not self._has_workspace:
             return None, None, None, None
         shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
         shape_p_o = (
@@ -646,11 +665,19 @@ class BatchDecodeCuteDSLWrapper:
             raise ValueError(f"k.shape={tuple(k.shape)} must equal v.shape={tuple(v.shape)}")
 
         device = q.device
+        # Atomic reduction accumulates into out via atomic_add and requires
+        # zero init; kernel/none modes overwrite via direct store.
+        atomic = self._reduction == "atomic"
         if out is None:
-            out = torch.zeros(
-                (b, s_q, h_q, d), dtype=self._o_data_type, device=device
-            )
-        elif self._atomic:
+            if atomic:
+                out = torch.zeros(
+                    (b, s_q, h_q, d), dtype=self._o_data_type, device=device
+                )
+            else:
+                out = torch.empty(
+                    (b, s_q, h_q, d), dtype=self._o_data_type, device=device
+                )
+        elif atomic:
             out.zero_()
 
         m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(
@@ -773,7 +800,10 @@ class BatchDecodePagedCuteDSLWrapper:
             from the planned shapes and SM count.
         reduction : str
             ``"kernel"`` (deterministic with workspace), ``"atomic"``
-            (cluster reduction, faster but lower precision), or ``"auto"``.
+            (cluster reduction, faster but lower precision), ``"none"``
+            (no flash-decoding split-K; requires kv_splits == 1), or
+            ``"auto"`` (picks ``"none"`` when kv_splits == 1, else atomic
+            for compatible dtypes, else kernel).
         precompile_skip_softmax_kernel : bool
             If True, also compile the BLASST skip-softmax variant of the
             kernel at plan() time, so the first :meth:`run` call that
@@ -872,6 +902,10 @@ class BatchDecodePagedCuteDSLWrapper:
                     f"atomic reduction requires output dtype in (float32, float16, "
                     f"bfloat16); got {o_data_type}"
                 )
+        elif reduction == "none" and kv_splits != 1:
+            raise ValueError(
+                f'reduction="none" requires kv_splits == 1, got {kv_splits}'
+            )
         self._q_data_type = q_data_type
         self._o_data_type = o_data_type
         self._num_qo_heads = num_qo_heads
@@ -881,7 +915,9 @@ class BatchDecodePagedCuteDSLWrapper:
         self._q_len_per_req = q_len_per_req
         self._kv_splits = kv_splits
         self._reduction = reduction
-        self._atomic = reduction == "atomic"
+        # Only kernel-reduction uses workspace tensors; atomic and none
+        # write to o_bshd directly.
+        self._has_workspace = reduction == "kernel"
         # Always use bottom-right causal masking; for q_len_per_req=1 this
         # degenerates to "row 0 sees all keys", equivalent to no causal mask.
         # Keeping a single mask path means the compiled kernel doesn't need
@@ -924,7 +960,7 @@ class BatchDecodePagedCuteDSLWrapper:
     def _allocate_workspace(
         self, batch_size: int, q_len_per_req: int, device: torch.device
     ):
-        if self._atomic:
+        if not self._has_workspace:
             return None, None, None, None
         shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
         shape_p_o = (
@@ -1061,8 +1097,12 @@ class BatchDecodePagedCuteDSLWrapper:
             )
 
         device = q.device
+        # Atomic reduction accumulates into out via atomic_add and requires
+        # zero init; kernel/none modes overwrite via direct store.
+        atomic = self._reduction == "atomic"
         if out is None:
-            out_4d = torch.zeros(
+            alloc = torch.zeros if atomic else torch.empty
+            out_4d = alloc(
                 (self._batch_size, q_len_per_req, self._num_qo_heads, self._head_dim),
                 dtype=self._o_data_type,
                 device=device,
@@ -1081,7 +1121,7 @@ class BatchDecodePagedCuteDSLWrapper:
                 out_4d = out
             else:
                 raise ValueError(f"out must be 3D or 4D; got ndim={out.dim()}")
-            if self._atomic:
+            if atomic:
                 out_4d.zero_()
 
         m_bsh, o_partial, m_partial, l_partial = self._allocate_workspace(

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -238,6 +238,7 @@ def _get_compiled_decode_kernel(
         Float32(1.0),  # scale_s placeholder
         Float32(1.0),  # scale_o placeholder
         stream_fake,
+        True,  # enable_pdl placeholder (runtime-dynamic)
         options="--enable-tvm-ffi --opt-level 2",
     )
 
@@ -392,6 +393,7 @@ def _get_compiled_paged_decode_kernel(
         Float32(1.0),  # scale_o placeholder
         threshold_p_fake,
         stream_fake,
+        True,  # enable_pdl placeholder (runtime-dynamic)
         options="--enable-tvm-ffi --opt-level 2",
     )
 
@@ -582,6 +584,7 @@ class BatchDecodeCuteDSLWrapper:
         sm_scale: Optional[float] = None,
         o_scale: Optional[float] = None,
         lse: Optional[torch.Tensor] = None,
+        enable_pdl: bool = True,
     ) -> torch.Tensor:
         """Run ragged-KV GQA decode.
 
@@ -689,6 +692,7 @@ class BatchDecodeCuteDSLWrapper:
             m_partial,
             Float32(scale_s),
             Float32(scale_o),
+            enable_pdl,
         )
         return out
 
@@ -953,6 +957,7 @@ class BatchDecodePagedCuteDSLWrapper:
         o_scale: Optional[float] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         lse: Optional[torch.Tensor] = None,
+        enable_pdl: bool = True,
     ) -> torch.Tensor:
         """Run paged GQA decode.
 
@@ -1146,6 +1151,7 @@ class BatchDecodePagedCuteDSLWrapper:
             Float32(scale_s),
             Float32(o_scale_val),
             threshold_arg,
+            enable_pdl,
         )
 
         if user_out is not None:

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -122,6 +122,59 @@ def _resolve_reduction(reduction: str, kv_splits: int, o_dtype: "cutlass.dtype")
     return "kernel"
 
 
+# Float32 workspace tensors are 4-byte elements; the kernel's TMA fakes use
+# assumed_align=16 so successive offsets need to be 16-byte-aligned. Each
+# tensor's element count is always a multiple of `num_qo_heads * head_dim`,
+# both of which are >= 8 — so byte sizes are naturally >= 16-aligned.
+_FP32_BYTES = 4
+
+
+def _workspace_layout(
+    kv_splits: int,
+    batch_size: int,
+    q_len_per_req: int,
+    num_qo_heads: int,
+    head_dim: int,
+):
+    """Compute (offset, nbytes) for each kernel-reduction workspace tensor.
+
+    Layout order matches the kernel call order: m_bsh, o_partial, m_partial,
+    l_partial. Returns (offsets, sizes, total_bytes).
+    """
+    m_bsh_n = batch_size * q_len_per_req * num_qo_heads
+    o_partial_n = kv_splits * batch_size * q_len_per_req * num_qo_heads * head_dim
+    m_partial_n = kv_splits * batch_size * q_len_per_req * num_qo_heads
+    l_partial_n = m_partial_n
+    sizes = (
+        m_bsh_n * _FP32_BYTES,
+        o_partial_n * _FP32_BYTES,
+        m_partial_n * _FP32_BYTES,
+        l_partial_n * _FP32_BYTES,
+    )
+    offsets = (
+        0,
+        sizes[0],
+        sizes[0] + sizes[1],
+        sizes[0] + sizes[1] + sizes[2],
+    )
+    total = sum(sizes)
+    return offsets, sizes, total
+
+
+def _slice_fp32(buf_uint8: torch.Tensor, offset: int, shape):
+    """Carve a contiguous float32 tensor of `shape` from a uint8 buffer at
+    `offset` bytes. The resulting view aliases the buffer's storage."""
+    nelem = 1
+    for d in shape:
+        nelem *= d
+    nbytes = nelem * _FP32_BYTES
+    return (
+        buf_uint8[offset : offset + nbytes]
+        .view(torch.float32)
+        .view(*shape)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Compile helpers (memoized)
 # ---------------------------------------------------------------------------
@@ -548,6 +601,23 @@ class BatchDecodeCuteDSLWrapper:
             sm_scale = head_dim ** -0.5
         self._sm_scale = sm_scale
 
+        # Validate float_workspace_buffer at plan() time. The size is
+        # computed against the planned batch_size (max-batch hint) and the
+        # planned q_len_per_req. Runtime values <= these hints reuse the
+        # same allocation; larger values are re-validated in run().
+        if self._has_workspace:
+            _, _, total_bytes = _workspace_layout(
+                kv_splits, batch_size, q_len_per_req, num_qo_heads, head_dim
+            )
+            if self._float_workspace_buffer.numel() < total_bytes:
+                raise ValueError(
+                    f"float_workspace_buffer too small for kernel-reduction: "
+                    f"{self._float_workspace_buffer.numel()} bytes, need "
+                    f"{total_bytes} bytes (kv_splits={kv_splits}, "
+                    f"batch_size={batch_size}, q_len_per_req={q_len_per_req}, "
+                    f"num_qo_heads={num_qo_heads}, head_dim={head_dim})"
+                )
+
         # Always compile the no-LSE variant at plan() time; the LSE variant
         # is lazily fetched at run() time when needed (compile cache hit).
         self._compile_args = (
@@ -569,7 +639,7 @@ class BatchDecodeCuteDSLWrapper:
     def _allocate_workspace(
         self, batch_size: int, q_len_per_req: int, device: torch.device
     ):
-        """Allocate kernel-reduction workspace tensors for the current batch."""
+        """Carve kernel-reduction workspace tensors out of float_workspace_buffer."""
         if not self._has_workspace:
             return None, None, None, None
         shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
@@ -586,10 +656,25 @@ class BatchDecodeCuteDSLWrapper:
             q_len_per_req,
             self._num_qo_heads,
         )
-        m_bsh = torch.full(shape_m, float("-inf"), dtype=torch.float32, device=device)
-        o_partial = torch.empty(shape_p_o, dtype=torch.float32, device=device)
-        m_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
-        l_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
+        offsets, _, total_bytes = _workspace_layout(
+            self._kv_splits, batch_size, q_len_per_req,
+            self._num_qo_heads, self._head_dim,
+        )
+        if self._float_workspace_buffer.numel() < total_bytes:
+            raise ValueError(
+                f"float_workspace_buffer too small at run(): "
+                f"{self._float_workspace_buffer.numel()} bytes, need "
+                f"{total_bytes} bytes (batch_size={batch_size}, "
+                f"q_len_per_req={q_len_per_req} — exceeded the plan-time hint)"
+            )
+        buf = self._float_workspace_buffer
+        m_bsh = _slice_fp32(buf, offsets[0], shape_m)
+        o_partial = _slice_fp32(buf, offsets[1], shape_p_o)
+        m_partial = _slice_fp32(buf, offsets[2], shape_p_ml)
+        l_partial = _slice_fp32(buf, offsets[3], shape_p_ml)
+        # m_bsh is read by the kernel as a running colmax accumulator and
+        # must start at -inf. The other three are written from scratch.
+        m_bsh.fill_(float("-inf"))
         return m_bsh, o_partial, m_partial, l_partial
 
     @flashinfer_api
@@ -743,10 +828,6 @@ class BatchDecodePagedCuteDSLWrapper:
         float_workspace_buffer: torch.Tensor,
         use_cuda_graph: bool = False,
     ) -> None:
-        # ``float_workspace_buffer`` is unused by the kernel itself (its
-        # workspace lives in tmem/smem and in heap-allocated reduction
-        # tensors) but is retained for API parity with the FA2/FA3 paged
-        # decode wrappers.
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
         self._use_cuda_graph = use_cuda_graph
@@ -930,6 +1011,22 @@ class BatchDecodePagedCuteDSLWrapper:
         self._table_offsets = table_offsets
         self._page_table = indices_i32
 
+        # Validate float_workspace_buffer at plan() time. Sized against the
+        # plan-time-fixed batch_size + planned q_len_per_req hint; runtime
+        # q_len_per_req <= hint reuses the same allocation.
+        if self._has_workspace:
+            _, _, total_bytes = _workspace_layout(
+                kv_splits, batch_size, q_len_per_req, num_qo_heads, head_dim
+            )
+            if self._float_workspace_buffer.numel() < total_bytes:
+                raise ValueError(
+                    f"float_workspace_buffer too small for kernel-reduction: "
+                    f"{self._float_workspace_buffer.numel()} bytes, need "
+                    f"{total_bytes} bytes (kv_splits={kv_splits}, "
+                    f"batch_size={batch_size}, q_len_per_req={q_len_per_req}, "
+                    f"num_qo_heads={num_qo_heads}, head_dim={head_dim})"
+                )
+
         # Compile args shared by std and BLASST variants. Stashed so run()
         # can lazily fetch the BLASST variant via the @functools.cache.
         self._compile_args = (
@@ -958,6 +1055,7 @@ class BatchDecodePagedCuteDSLWrapper:
     def _allocate_workspace(
         self, batch_size: int, q_len_per_req: int, device: torch.device
     ):
+        """Carve kernel-reduction workspace tensors out of float_workspace_buffer."""
         if not self._has_workspace:
             return None, None, None, None
         shape_m = (batch_size, q_len_per_req, self._num_qo_heads)
@@ -974,10 +1072,25 @@ class BatchDecodePagedCuteDSLWrapper:
             q_len_per_req,
             self._num_qo_heads,
         )
-        m_bsh = torch.full(shape_m, float("-inf"), dtype=torch.float32, device=device)
-        o_partial = torch.empty(shape_p_o, dtype=torch.float32, device=device)
-        m_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
-        l_partial = torch.empty(shape_p_ml, dtype=torch.float32, device=device)
+        offsets, _, total_bytes = _workspace_layout(
+            self._kv_splits, batch_size, q_len_per_req,
+            self._num_qo_heads, self._head_dim,
+        )
+        if self._float_workspace_buffer.numel() < total_bytes:
+            raise ValueError(
+                f"float_workspace_buffer too small at run(): "
+                f"{self._float_workspace_buffer.numel()} bytes, need "
+                f"{total_bytes} bytes (q_len_per_req={q_len_per_req} — "
+                f"exceeded the plan-time hint)"
+            )
+        buf = self._float_workspace_buffer
+        m_bsh = _slice_fp32(buf, offsets[0], shape_m)
+        o_partial = _slice_fp32(buf, offsets[1], shape_p_o)
+        m_partial = _slice_fp32(buf, offsets[2], shape_p_ml)
+        l_partial = _slice_fp32(buf, offsets[3], shape_p_ml)
+        # m_bsh is read by the kernel as a running colmax accumulator and
+        # must start at -inf. The other three are written from scratch.
+        m_bsh.fill_(float("-inf"))
         return m_bsh, o_partial, m_partial, l_partial
 
     @flashinfer_api

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -18,7 +18,7 @@ compilation via :func:`functools.cache` keyed on the static configuration.
 
 import functools
 import math
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple, cast
 
 import torch
 
@@ -67,7 +67,7 @@ def _pick_tile_shape(
             f"num_qo_heads ({num_qo_heads}) must be a multiple of num_kv_heads "
             f"({num_kv_heads})"
         )
-    npo2 = lambda x : 1 if x <= 1 else 2 ** math.ceil(math.log2(x))
+    npo2 = lambda x: 1 if x <= 1 else 2 ** math.ceil(math.log2(x))
     grouped_heads = num_qo_heads // num_kv_heads
     grouped_head_tile = min(32, npo2(grouped_heads))
     prediction_tile = min(32 // grouped_head_tile, npo2(prediction))
@@ -91,7 +91,7 @@ def _compute_kv_splits(
     """Replicate ``gqa_decode.run`` kv_splits auto-computation."""
     if reduction == "none":
         return 1
-    ceil_div = lambda a, b : (a + b - 1) // b
+    ceil_div = lambda a, b: (a + b - 1) // b
     grouped_head_tiles = ceil_div(grouped_heads, grouped_head_tile)
     prediction_tiles = ceil_div(prediction, prediction_tile)
     grid_z = batch_size * num_kv_heads
@@ -114,7 +114,11 @@ def _resolve_reduction(reduction: str, kv_splits: int, o_dtype: "cutlass.dtype")
         # No split-K — skip flash-decoding entirely (no reduction kernel,
         # no cluster atomics).
         return "none"
-    if o_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16) and kv_splits in (
+    if o_dtype in (
+        cutlass.Float32,
+        cutlass.Float16,
+        cutlass.BFloat16,
+    ) and kv_splits in (
         2,
         4,
         8,
@@ -140,18 +144,21 @@ def _slice_workspace(
 
     workspace = workspace.view(dtype=torch.float32)
 
-    required_elts = (o_partial_shape.numel()
-                    + m_partial_shape.numel()
-                    + l_partial_shape.numel()
-                    + m_shape.numel())
+    required_elts = (
+        o_partial_shape.numel()
+        + m_partial_shape.numel()
+        + l_partial_shape.numel()
+        + m_shape.numel()
+    )
     if workspace.numel() < required_elts:
         raise RuntimeError(
             f"kernel reduction with kv_splits={kv_splits} "
             f"batch_size={batch_size} q_len_per_req={prediction} "
             f"num_qo_heads={num_qo_heads} head_dim={head_dim} "
             f"requires {required_elts * 4} byte workspace "
-            f"which exceeds provided workspace of {workspace.nbytes} bytes")
-    
+            f"which exceeds provided workspace of {workspace.nbytes} bytes"
+        )
+
     start, end = 0, o_partial_shape.numel()
     o_partial = workspace[start:end].view(o_partial_shape)
 
@@ -192,14 +199,14 @@ def _get_compiled_decode_kernel(
 
     sequence_tile = 256
     if prediction_tile > 1 and blk_tile_n > 8:
-        sequence_tile = 128 # Prevent regspills
+        sequence_tile = 128  # Prevent regspills
 
     fmha = GroupedQueryAttentionDecode(
         head_dim,
         grouped_head_tile,
         prediction_tile=prediction_tile,
         sequence_tile=sequence_tile,
-        reduction_mode=reduction,
+        reduction_mode=cast(Literal["kernel", "atomic", "none"], reduction),
         tma_mask=tma_mask,
     )
     has_workspace = reduction == "kernel"
@@ -323,9 +330,9 @@ def _get_compiled_paged_decode_kernel(
 
     sequence_tile = 256
     if use_threshold:
-        sequence_tile = 128 # Promote skipping
+        sequence_tile = 128  # Promote skipping
     elif prediction_tile > 1 and blk_tile_n > 8:
-        sequence_tile = 128 # Prevent regspills
+        sequence_tile = 128  # Prevent regspills
 
     softmax_warpgroups = (
         2
@@ -342,7 +349,7 @@ def _get_compiled_paged_decode_kernel(
         grouped_head_tile,
         prediction_tile=prediction_tile,
         sequence_tile=sequence_tile,
-        reduction_mode=reduction,
+        reduction_mode=cast(Literal["kernel", "atomic", "none"], reduction),
         softmax_warpgroups=softmax_warpgroups,
         tma_mask=tma_mask,
     )
@@ -604,7 +611,7 @@ class BatchDecodeCuteDSLWrapper:
         self._has_workspace = reduction == "kernel"
         self._tma_mask = not is_causal
         if sm_scale is None:
-            sm_scale = head_dim ** -0.5
+            sm_scale = head_dim**-0.5
         self._sm_scale = sm_scale
 
         # Carve out workspace tensors
@@ -682,7 +689,11 @@ class BatchDecodeCuteDSLWrapper:
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
-        if q.dtype != self._q_data_type or k.dtype != self._q_data_type or v.dtype != self._q_data_type:
+        if (
+            q.dtype != self._q_data_type
+            or k.dtype != self._q_data_type
+            or v.dtype != self._q_data_type
+        ):
             raise ValueError(
                 f"q/k/v dtype mismatch: expected {self._q_data_type}, got "
                 f"q={q.dtype}, k={k.dtype}, v={v.dtype}"
@@ -708,7 +719,9 @@ class BatchDecodeCuteDSLWrapper:
                 f"{self._head_dim}]"
             )
         if v.shape != k.shape:
-            raise ValueError(f"k.shape={tuple(k.shape)} must equal v.shape={tuple(v.shape)}")
+            raise ValueError(
+                f"k.shape={tuple(k.shape)} must equal v.shape={tuple(v.shape)}"
+            )
 
         device = q.device
         # Atomic reduction accumulates into out via atomic_add and requires
@@ -716,9 +729,7 @@ class BatchDecodeCuteDSLWrapper:
         atomic = self._reduction == "atomic"
         if out is None:
             torch_alloc = torch.zeros if atomic else torch.empty
-            out = torch_alloc(
-                (b, s_q, h_q, d), dtype=self._o_data_type, device=device
-            )
+            out = torch_alloc((b, s_q, h_q, d), dtype=self._o_data_type, device=device)
 
         m = o_partial = l_partial = m_partial = None
         if self._has_workspace:
@@ -898,18 +909,18 @@ class BatchDecodePagedCuteDSLWrapper:
                 max_kv_len = int(seq_lens.max().item())
             else:
                 # Avoid a device sync, just assume largest possible sequence
-                max_kv_len = (2 ** 31) - 1
+                max_kv_len = (2**31) - 1
 
-        def to_int32_device(tensor : torch.Tensor):
+        def to_int32_device(tensor: torch.Tensor):
             return tensor.to(
                 dtype=torch.int32,
                 device=self.device,
                 non_blocking=non_blocking,
             )
+
         seq_lens = to_int32_device(seq_lens)
         indices = to_int32_device(indices)
         indptr = to_int32_device(indptr)
-
 
         grouped_head_tile, prediction_tile = _pick_tile_shape(
             num_qo_heads, num_kv_heads, q_len_per_req, in_dtype.width
@@ -955,7 +966,7 @@ class BatchDecodePagedCuteDSLWrapper:
         self._has_workspace = reduction == "kernel"
         self._tma_mask = not is_causal
         if sm_scale is None:
-            sm_scale = head_dim ** -0.5
+            sm_scale = head_dim**-0.5
         self._sm_scale = sm_scale
 
         self._batch_size = batch_size

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1494,17 +1494,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
             else:
                 k_cache_view = k_cache
                 v_cache_view = v_cache
-            # Kernel takes one scalar threshold; normalize by max_kv_len so
-            # skipping is conservative across varying-length requests.
-            skip_softmax_threshold = None
-            if skip_softmax_threshold_scale_factor is not None:
-                skip_softmax_threshold = (
-                    skip_softmax_threshold_scale_factor / max(self._max_kv_len, 1)
-                )
             # Fold v_scale into the kernel's o_scale — the cute-dsl kernel
             # applies it in the reduction epilogue for free, replacing the
             # post-kernel `out *= v_scale` that other backends still need.
             o_scale = None if v_scale is None else float(v_scale)
+            # The cute-dsl kernel divides the scale factor by each batch's
+            # seqlen internally (per-batch threshold) — matches trtllm-gen
             self._cute_dsl_wrapper.run(
                 q,
                 k_cache_view,
@@ -1512,7 +1507,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 out=out,
                 sm_scale=sm_scale,
                 o_scale=o_scale,
-                skip_softmax_threshold=skip_softmax_threshold,
+                skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
             )
             return out
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1102,7 +1102,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     dtype=torch.int,
                     device=self.device,
                 )
-                block_id = indptr[0]
+                block_id = int(indptr_host[0].item())
                 for i in range(batch_size):
                     num_blocks_needed = blocks_per_seq[i]
                     self._block_tables[i, :num_blocks_needed] = (

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1475,10 +1475,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
             check_shape_dtype_device(out, q.shape, out_dtype, q.device, "out")
 
         if self._backend == "cute-dsl":
-            if return_lse:
-                raise NotImplementedError(
-                    "cute-dsl decode backend does not support return_lse"
-                )
             if sinks is not None:
                 raise NotImplementedError(
                     "cute-dsl decode backend does not support attention sinks"
@@ -1498,8 +1494,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
             # applies it in the reduction epilogue for free, replacing the
             # post-kernel `out *= v_scale` that other backends still need.
             o_scale = None if v_scale is None else float(v_scale)
-            # The cute-dsl kernel divides the scale factor by each batch's
-            # seqlen internally (per-batch threshold) — matches trtllm-gen
             self._cute_dsl_wrapper.run(
                 q,
                 k_cache_view,
@@ -1508,8 +1502,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 sm_scale=sm_scale,
                 o_scale=o_scale,
                 skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+                lse=lse if return_lse else None,
             )
-            return out
+            return (out, lse) if return_lse else out
 
         if self._backend == "trtllm-gen":
             q = q.view(q.size(0) // q_len_per_req, q_len_per_req, q.size(1), q.size(2))

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1518,7 +1518,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             # applies it in the reduction epilogue for free, replacing the
             # post-kernel `out *= v_scale` that other backends still need.
             o_scale = None if v_scale is None else float(v_scale)
-            self._cute_dsl_wrapper.run(
+            out = self._cute_dsl_wrapper.run(
                 q,
                 k_cache_view,
                 v_cache_view,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1073,10 +1073,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 q_data_type=q_data_type,
                 kv_data_type=kv_data_type,
                 o_data_type=o_data_type,
-                q_len_per_req=q_len_per_req,
                 sm_scale=sm_scale,
                 kv_splits=kv_splits,
                 reduction="none" if disable_split_kv else "auto",
+                q_len_per_req=q_len_per_req,
+                is_causal=True,
                 max_kv_len=self._max_kv_len,
                 non_blocking=non_blocking,
             )
@@ -1321,7 +1322,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         Parameters
         ----------
         q : torch.Tensor
-            The query tensor, shape: ``[batch_size, num_qo_heads, head_dim]``
+            The query tensor, shape: ``[batch_size * q_len_per_req, num_qo_heads, head_dim]``
+            q_len_per_req doesn't need to match the value passed to plan()
         paged_kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
             The paged KV-Cache stored as a tuple of tensors or a single tensor:
 
@@ -1354,8 +1356,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
         q_len_per_req : Optional[int]
             DEPRECATED — pass to :meth:`plan` instead. When provided here, emits
-            a :class:`DeprecationWarning` and uses the run-time value.
-            Scheduled for removal in a future release.
+            a :class:`DeprecationWarning` and is used to validate the run-time value
+            inferred from q.size(0). Scheduled for removal in a future release.
         skip_softmax_threshold_scale_factor: Optional[float] = None
             threshold scale factor for skipping softmax operations.
             Providing a value for this parameter enables skip-softmax sparsity as described in: https://arxiv.org/abs/2512.12087
@@ -1409,9 +1411,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         )
         actual_batch_size = self._paged_kv_last_page_len_buf.size(0)
         # Soft-deprecation: q_len_per_req moved to plan(). Accept it at run()
-        # with a warning and use the run-time value. Backends with symbolic
-        # prediction (e.g. cute-dsl) handle any runtime value; other backends
-        # already accepted varying runtime q_len_per_req under the old API.
+        # with a warning and use to validate q.size(0)
         if q_len_per_req is not None:
             warnings.warn(
                 "Passing `q_len_per_req` to BatchDecodeWithPagedKVCacheWrapper.run() "
@@ -1420,15 +1420,16 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 DeprecationWarning,
                 stacklevel=2,
             )
+            expected_q_len = actual_batch_size * q_len_per_req
+            if q.size(0) != expected_q_len:
+                raise ValueError(
+                    f"q.shape[0] ({q.size(0)}) does not match batch_size * q_len_per_req "
+                    f"({actual_batch_size} * {q_len_per_req} = {expected_q_len}). "
+                    f"For batch decode, q must have shape [batch_size * q_len_per_req, num_heads, head_dim]."
+                )
         else:
-            q_len_per_req = self._q_len_per_req
-        expected_q_len = actual_batch_size * q_len_per_req
-        if q.size(0) != expected_q_len:
-            raise ValueError(
-                f"q.shape[0] ({q.size(0)}) does not match batch_size * q_len_per_req "
-                f"({actual_batch_size} * {q_len_per_req} = {expected_q_len}). "
-                f"For batch decode, q must have shape [batch_size * q_len_per_req, num_heads, head_dim]."
-            )
+            # Infer runtime q_len from q.size(0). Doesn't need to match planned q_len
+            q_len_per_req = q.size(0) // actual_batch_size
 
         # Convert NHD layout to HND for trtllm-gen backend
         if self._backend == "trtllm-gen" and self._kv_layout == "NHD":

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import math
+import warnings
 from types import SimpleNamespace
 from typing import Any, List, Literal, Optional, Tuple, Union, overload
 
@@ -877,6 +878,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         seq_lens: Optional[torch.Tensor] = None,
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
+        q_len_per_req: int = 1,
     ) -> None:
         r"""Plan batch decode for given problem specification.
 
@@ -935,6 +937,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             and lead to a varied number of launched CTAs.
         disable_split_kv : bool,
             Whether to disable the split-kv for determinism in CUDA Graph, defaults to ``False``.
+        q_len_per_req : int
+            The number of query tokens per request. Defaults to ``1``.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -1053,7 +1057,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 q_data_type=q_data_type,
                 kv_data_type=kv_data_type,
                 o_data_type=o_data_type,
-                q_len_per_req=1,
+                q_len_per_req=q_len_per_req,
                 sm_scale=sm_scale,
                 max_kv_len=self._max_kv_len,
                 non_blocking=non_blocking,
@@ -1200,6 +1204,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
+        self._q_len_per_req = q_len_per_req
 
     begin_forward = plan
 
@@ -1243,7 +1248,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         enable_pdl: Optional[bool] = None,
         window_left: Optional[int] = None,
         sinks: Optional[torch.Tensor] = None,
-        q_len_per_req: Optional[int] = 1,
+        q_len_per_req: Optional[int] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -1265,7 +1270,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         enable_pdl: Optional[bool] = None,
         window_left: Optional[int] = None,
         sinks: Optional[torch.Tensor] = None,
-        q_len_per_req: Optional[int] = 1,
+        q_len_per_req: Optional[int] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -1287,7 +1292,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         enable_pdl: Optional[bool] = None,
         window_left: Optional[int] = None,
         sinks: Optional[torch.Tensor] = None,
-        q_len_per_req: Optional[int] = 1,
+        q_len_per_req: Optional[int] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -1329,8 +1334,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
         enable_pdl : bool
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
-        q_len_per_req : int
-            The number of query tokens per request, if not provided, will be set to ``1``.
+        q_len_per_req : Optional[int]
+            DEPRECATED — pass to :meth:`plan` instead. When provided here, emits
+            a :class:`DeprecationWarning` and uses the run-time value.
+            Scheduled for removal in a future release.
         skip_softmax_threshold_scale_factor: Optional[float] = None
             threshold scale factor for skipping softmax operations.
             Providing a value for this parameter enables skip-softmax sparsity as described in: https://arxiv.org/abs/2512.12087
@@ -1383,6 +1390,20 @@ class BatchDecodeWithPagedKVCacheWrapper:
             q, k_cache, self._cached_q_data_type, self._cached_kv_data_type
         )
         actual_batch_size = self._paged_kv_last_page_len_buf.size(0)
+        # Soft-deprecation: q_len_per_req moved to plan(). Accept it at run()
+        # with a warning and use the run-time value. Backends with symbolic
+        # prediction (e.g. cute-dsl) handle any runtime value; other backends
+        # already accepted varying runtime q_len_per_req under the old API.
+        if q_len_per_req is not None:
+            warnings.warn(
+                "Passing `q_len_per_req` to BatchDecodeWithPagedKVCacheWrapper.run() "
+                "is deprecated; pass it to plan() instead. Scheduled for removal "
+                "in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            q_len_per_req = self._q_len_per_req
         expected_q_len = actual_batch_size * q_len_per_req
         if q.size(0) != expected_q_len:
             raise ValueError(
@@ -1469,10 +1490,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
             if kv_cache_sf is not None:
                 raise NotImplementedError(
                     "cute-dsl decode backend does not support NVFP4 KV cache"
-                )
-            if q_len_per_req != 1:
-                raise NotImplementedError(
-                    "cute-dsl decode backend currently supports q_len_per_req=1 only"
                 )
             # Kernel expects logical NHD; HND data is presented via transpose.
             if self._kv_layout == "HND":

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -800,7 +800,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._paged_kv_indptr_buf = paged_kv_indptr_buffer
         self._paged_kv_indices_buf = paged_kv_indices_buffer
         self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buffer
-        self._use_tensor_cores = use_tensor_cores or backend in ("trtllm-gen", "cute-dsl")
+        self._use_tensor_cores = use_tensor_cores or backend in (
+            "trtllm-gen",
+            "cute-dsl",
+        )
         self._use_cuda_graph = use_cuda_graph
 
         if use_tensor_cores:

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1346,7 +1346,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         v_scale : Optional[float]
             The calibration scale of value for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
         out : Optional[torch.Tensor]
-            The output tensor, if not provided, will be allocated internally.
+            The output tensor, if not provided, will be allocated internally. Must be zero-init for cute-dsl backend.
         lse : Optional[torch.Tensor]
             The log-sum-exp of attention logits, if not provided, will be allocated internally.
         return_lse : bool
@@ -1481,7 +1481,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
 
-        if out is None:
+        if self._backend == "cute-dsl" and out is None:
+            out = None  # Let cute-dsl wrapper handle the alloc
+        elif out is None:
             out_dtype = getattr(self, "_cached_o_data_type", None) or q.dtype
             # For NVFP4 KV (uint8 packed), v_cache last dim is head_dim//2;
             # use q's head_dim for output instead

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -800,7 +800,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._paged_kv_indptr_buf = paged_kv_indptr_buffer
         self._paged_kv_indices_buf = paged_kv_indices_buffer
         self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buffer
-        self._use_tensor_cores = use_tensor_cores or backend == "trtllm-gen"
+        self._use_tensor_cores = use_tensor_cores or backend in ("trtllm-gen", "cute-dsl")
         self._use_cuda_graph = use_cuda_graph
 
         if use_tensor_cores:
@@ -930,8 +930,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
         block_tables: Optional[torch.Tensor]
             A uint32 2D tensor indicating the block table of each prompt. shape: ``[batch_size, max_num_blocks_per_seq]``.
         fixed_split_size : Optional[int],
-            The fixed split size for FA2 split-kv decode, in pages. Only supported by tensor core decode for now. Recommend setting to the average sequence length of your workload.
-            When enabled, will lead to deterministic softmax score reduction in the merge_states kernel, and therefore
+            The fixed split size for FA2 split-kv decode, in pages. Only supported by tensor core decode for now.
+            Recommend setting to the average sequence length of your workload.
+            When enabled for FA2, will lead to deterministic softmax score reduction in the merge_states kernel, and therefore
             batch-size invariant outputs. See https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/
             Note that compatibility with CUDA graph is NOT guaranteed, as even when bs is fixed, kv seq len can change
             and lead to a varied number of launched CTAs.
@@ -1046,6 +1047,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     f"pos_encoding_mode={pos_encoding_mode!r}"
                 )
             self._max_kv_len = int(max(kv_lens_arr_host).item())
+            kv_splits = None
+            if fixed_split_size > 0:
+                fixed_split_len = fixed_split_size * page_size
+                kv_splits = (self._max_kv_len + fixed_split_len - 1) // fixed_split_len
             self._cute_dsl_wrapper.plan(
                 self._paged_kv_indptr_buf,
                 self._paged_kv_indices_buf,
@@ -1059,6 +1064,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 o_data_type=o_data_type,
                 q_len_per_req=q_len_per_req,
                 sm_scale=sm_scale,
+                kv_splits=kv_splits,
+                reduction="none" if disable_split_kv else "auto",
                 max_kv_len=self._max_kv_len,
                 non_blocking=non_blocking,
             )
@@ -1429,7 +1436,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         pos_encoding_mode = self._pos_encoding_mode
         window_left = self._window_left if window_left is None else window_left
-        if self._backend not in ("trtllm-gen", "cute-dsl"):
+        if self._backend not in ("trtllm-gen",):
             # NOTE(Siyuan): since window_left is appeared in the plan function, we need to make sure it is the same as the one in the plan function.
             # Remove this check if the backend supports dynamic window_left.
             assert window_left == self._window_left

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -720,9 +720,13 @@ class BatchDecodeWithPagedKVCacheWrapper:
             Only needed when ``use_cuda_graph`` is ``True``.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2``/``fa3`` or ``trtllm-gen``. Defaults to ``auto``.
+            The implementation backend, could be ``auto``/``fa2``/``fa3``/``trtllm-gen``
+            or ``cute-dsl``. Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
+            The ``cute-dsl`` backend uses the CuTe DSL GQA decode kernel for Blackwell
+            (SM100+) and only supports a subset of features (NHD layout, equal
+            head_dim_qk/vo, no RoPE/ALiBi/soft-cap/sliding window).
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -730,6 +734,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
         """
         _check_kv_layout(kv_layout)
 
+        if backend == "cute-dsl" and jit_args is not None:
+            raise NotImplementedError(
+                "cute-dsl backend does not support jit_args customization"
+            )
         if jit_args is not None:
             if use_tensor_cores:
                 self._jit_module = get_batch_prefill_jit_module(
@@ -803,6 +811,18 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     device=float_workspace_buffer.device,
                 )
         self._backend = backend
+
+        self._cute_dsl_wrapper = None
+        if backend == "cute-dsl":
+            if kv_layout != "NHD":
+                raise NotImplementedError(
+                    "cute-dsl decode backend only supports NHD layout"
+                )
+            from .cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
+
+            self._cute_dsl_wrapper = BatchDecodePagedCuteDSLWrapper(
+                float_workspace_buffer, use_cuda_graph=use_cuda_graph
+            )
 
     @property
     def use_tensor_cores(self) -> bool:
@@ -1011,7 +1031,38 @@ class BatchDecodeWithPagedKVCacheWrapper:
             kv_lens_arr_host = get_seq_lens(indptr_host, last_page_len_host, page_size)
         else:
             kv_lens_arr_host = seq_lens.cpu()
-        if self._backend == "trtllm-gen":
+        if self._backend == "cute-dsl":
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support logits_soft_cap"
+                )
+            if window_left >= 0:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support sliding window"
+                )
+            if pos_encoding_mode != "NONE":
+                raise NotImplementedError(
+                    f"cute-dsl decode backend does not support "
+                    f"pos_encoding_mode={pos_encoding_mode!r}"
+                )
+            self._max_kv_len = int(max(kv_lens_arr_host).item())
+            self._cute_dsl_wrapper.plan(
+                self._paged_kv_indptr_buf,
+                self._paged_kv_indices_buf,
+                self._paged_kv_last_page_len_buf,
+                num_qo_heads=num_qo_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                page_size=page_size,
+                q_data_type=q_data_type,
+                kv_data_type=kv_data_type,
+                o_data_type=o_data_type,
+                q_len_per_req=1,
+                sm_scale=sm_scale,
+                max_kv_len=self._max_kv_len,
+                non_blocking=non_blocking,
+            )
+        elif self._backend == "trtllm-gen":
             assert logits_soft_cap == 0.0
             self._max_kv_len = max(kv_lens_arr_host).item()
             required_size = len(kv_lens_arr_host)
@@ -1361,7 +1412,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         pos_encoding_mode = self._pos_encoding_mode
         window_left = self._window_left if window_left is None else window_left
-        if self._backend != "trtllm-gen":
+        if self._backend not in ("trtllm-gen", "cute-dsl"):
             # NOTE(Siyuan): since window_left is appeared in the plan function, we need to make sure it is the same as the one in the plan function.
             # Remove this check if the backend supports dynamic window_left.
             assert window_left == self._window_left
@@ -1405,6 +1456,40 @@ class BatchDecodeWithPagedKVCacheWrapper:
         else:
             out_dtype = getattr(self, "_cached_o_data_type", None) or q.dtype
             check_shape_dtype_device(out, q.shape, out_dtype, q.device, "out")
+
+        if self._backend == "cute-dsl":
+            if return_lse:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support return_lse"
+                )
+            if any(s is not None for s in (q_scale, k_scale)):
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support FP8 scale parameters"
+                )
+            if sinks is not None:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support attention sinks"
+                )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support NVFP4 KV cache"
+                )
+            if skip_softmax_threshold_scale_factor is not None:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support "
+                    "skip_softmax_threshold_scale_factor"
+                )
+            if q_len_per_req != 1:
+                raise NotImplementedError(
+                    "cute-dsl decode backend currently supports q_len_per_req=1 only"
+                )
+            self._cute_dsl_wrapper.run(
+                q, k_cache, v_cache, out=out, sm_scale=sm_scale
+            )
+            is_float_one = isinstance(v_scale, float) and v_scale == 1.0
+            if v_scale is not None and not is_float_one:
+                out *= v_scale
+            return out
 
         if self._backend == "trtllm-gen":
             q = q.view(q.size(0) // q_len_per_req, q_len_per_req, q.size(1), q.size(2))

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -814,10 +814,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
-            if kv_layout != "NHD":
-                raise NotImplementedError(
-                    "cute-dsl decode backend only supports NHD layout"
-                )
             from .cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
 
             self._cute_dsl_wrapper = BatchDecodePagedCuteDSLWrapper(
@@ -1474,17 +1470,31 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 raise NotImplementedError(
                     "cute-dsl decode backend does not support NVFP4 KV cache"
                 )
-            if skip_softmax_threshold_scale_factor is not None:
-                raise NotImplementedError(
-                    "cute-dsl decode backend does not support "
-                    "skip_softmax_threshold_scale_factor"
-                )
             if q_len_per_req != 1:
                 raise NotImplementedError(
                     "cute-dsl decode backend currently supports q_len_per_req=1 only"
                 )
+            # Kernel expects logical NHD; HND data is presented via transpose.
+            if self._kv_layout == "HND":
+                k_cache_view = k_cache.transpose(-3, -2)
+                v_cache_view = v_cache.transpose(-3, -2)
+            else:
+                k_cache_view = k_cache
+                v_cache_view = v_cache
+            # Kernel takes one scalar threshold; normalize by max_kv_len so
+            # skipping is conservative across varying-length requests.
+            skip_softmax_threshold = None
+            if skip_softmax_threshold_scale_factor is not None:
+                skip_softmax_threshold = (
+                    skip_softmax_threshold_scale_factor / max(self._max_kv_len, 1)
+                )
             self._cute_dsl_wrapper.run(
-                q, k_cache, v_cache, out=out, sm_scale=sm_scale
+                q,
+                k_cache_view,
+                v_cache_view,
+                out=out,
+                sm_scale=sm_scale,
+                skip_softmax_threshold=skip_softmax_threshold,
             )
             is_float_one = isinstance(v_scale, float) and v_scale == 1.0
             if v_scale is not None and not is_float_one:

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -726,8 +726,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
             The ``cute-dsl`` backend uses the CuTe DSL GQA decode kernel for Blackwell
-            (SM100+) and only supports a subset of features (NHD layout, equal
-            head_dim_qk/vo, no RoPE/ALiBi/soft-cap/sliding window).
+            (SM100+) and only supports a subset of features (equal head_dim_qk/vo,
+            no RoPE/ALiBi/soft-cap/sliding window).
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -1503,6 +1503,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 o_scale=o_scale,
                 skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
                 lse=lse if return_lse else None,
+                enable_pdl=enable_pdl,
             )
             return (out, lse) if return_lse else out
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1479,10 +1479,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 raise NotImplementedError(
                     "cute-dsl decode backend does not support return_lse"
                 )
-            if any(s is not None for s in (q_scale, k_scale)):
-                raise NotImplementedError(
-                    "cute-dsl decode backend does not support FP8 scale parameters"
-                )
             if sinks is not None:
                 raise NotImplementedError(
                     "cute-dsl decode backend does not support attention sinks"
@@ -1505,17 +1501,19 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 skip_softmax_threshold = (
                     skip_softmax_threshold_scale_factor / max(self._max_kv_len, 1)
                 )
+            # Fold v_scale into the kernel's o_scale — the cute-dsl kernel
+            # applies it in the reduction epilogue for free, replacing the
+            # post-kernel `out *= v_scale` that other backends still need.
+            o_scale = None if v_scale is None else float(v_scale)
             self._cute_dsl_wrapper.run(
                 q,
                 k_cache_view,
                 v_cache_view,
                 out=out,
                 sm_scale=sm_scale,
+                o_scale=o_scale,
                 skip_softmax_threshold=skip_softmax_threshold,
             )
-            is_float_one = isinstance(v_scale, float) and v_scale == 1.0
-            if v_scale is not None and not is_float_one:
-                out *= v_scale
             return out
 
         if self._backend == "trtllm-gen":

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -771,7 +771,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             device="cpu",
         )
         self._kv_lens_buffer: Optional[torch.Tensor] = None
-        if backend == "trtllm-gen":
+        if backend in ("trtllm-gen", "cute-dsl"):
             self._kv_lens_buffer = torch.empty(
                 (32768,), dtype=torch.int32, device=self.device
             )
@@ -1051,10 +1051,21 @@ class BatchDecodeWithPagedKVCacheWrapper:
             if fixed_split_size > 0:
                 fixed_split_len = fixed_split_size * page_size
                 kv_splits = (self._max_kv_len + fixed_split_len - 1) // fixed_split_len
+            # Stage the per-request KV lengths in the reusable device buffer
+            # (same pattern as trtllm-gen) so the wrapper consumes them
+            # directly without re-deriving from last_page_len.
+            required_size = len(kv_lens_arr_host)
+            if required_size > self._kv_lens_buffer.shape[0]:
+                self._kv_lens_buffer = torch.empty(
+                    (required_size,), dtype=torch.int32, device=self.device
+                )
+            self._kv_lens_buffer[:required_size].copy_(
+                kv_lens_arr_host, non_blocking=non_blocking
+            )
             self._cute_dsl_wrapper.plan(
                 self._paged_kv_indptr_buf,
                 self._paged_kv_indices_buf,
-                self._paged_kv_last_page_len_buf,
+                self._kv_lens_buffer[:required_size],
                 num_qo_heads=num_qo_heads,
                 num_kv_heads=num_kv_heads,
                 head_dim=head_dim,

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -95,8 +95,7 @@ import cutlass.utils as utils
 from cutlass.utils import TensorMapManager, TensorMapUpdateMode
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
-from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
+from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.cute.testing as testing
 

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
@@ -1718,9 +1718,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         tiled_mma: cute.TiledMma,
         mma_tiler_mnk: Tuple[int, int, int],
         a_dtype: Type[cutlass.Numeric],
-        a_major_mode: tcgen05.OperandMajorMode,
+        a_major_mode: cute.nvgpu.OperandMajorMode,
         b_dtype: Type[cutlass.Numeric],
-        b_major_mode: tcgen05.OperandMajorMode,
+        b_major_mode: cute.nvgpu.OperandMajorMode,
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
         c_layout: utils.LayoutEnum,
@@ -1740,9 +1740,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             mma_tiler_mnk (Tuple[int, int, int]): The shape (M, N, K) of the
                 MMA tiler.
             a_dtype (Type[cutlass.Numeric]): Data type of operand A.
-            a_major_mode (tcgen05.OperandMajorMode): Layout of operand A.
+            a_major_mode (cute.nvgpu.OperandMajorMode): Layout of operand A.
             b_dtype (Type[cutlass.Numeric]): Data type of operand B.
-            b_major_mode (tcgen05.OperandMajorMode): Layout of operand B.
+            b_major_mode (cute.nvgpu.OperandMajorMode): Layout of operand B.
             epi_tile (cute.Tile): The epilogue tile shape.
             c_dtype (Type[cutlass.Numeric]): Data type of operand C.
             c_layout (utils.LayoutEnum): Layout of operand C.

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
@@ -1765,7 +1765,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         :return: SMEM layout for operand A
         :rtype: cute.Layout
         """
-        is_k_major = tiled_mma.op.a_major_mode == tcgen05.OperandMajorMode.K
+        is_k_major = tiled_mma.op.a_major_mode == cute.nvgpu.OperandMajorMode.K
         a_smem_layout_staged = tcgen05.tile_to_mma_shape(
             tcgen05.make_smem_layout_atom(
                 tcgen05.SmemLayoutAtomKind.K_SW128, cutlass.Uint8
@@ -1808,7 +1808,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         :return: SMEM layout for operand B
         :rtype: cute.Layout
         """
-        is_k_major = tiled_mma.op.b_major_mode == tcgen05.OperandMajorMode.K
+        is_k_major = tiled_mma.op.b_major_mode == cute.nvgpu.OperandMajorMode.K
         b_smem_layout_staged = tcgen05.tile_to_mma_shape(
             tcgen05.make_smem_layout_atom(
                 tcgen05.SmemLayoutAtomKind.K_SW128, cutlass.Uint8
@@ -1832,11 +1832,11 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         """
 
         sf_vec_size: int
-        major_mode: tcgen05.OperandMajorMode = tcgen05.OperandMajorMode.K
+        major_mode: cute.nvgpu.OperandMajorMode = cute.nvgpu.OperandMajorMode.K
         _layout: cute.Layout = field(init=False, repr=False)
 
         def __post_init__(self) -> None:
-            if self.major_mode == tcgen05.OperandMajorMode.K:
+            if self.major_mode == cute.nvgpu.OperandMajorMode.K:
                 atom_shape = ((8, 4, 4), (self.sf_vec_size, 4))
                 atom_stride = ((16, 128, 4), (0, 1))
             else:

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -2380,9 +2380,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         tiled_mma: cute.TiledMma,
         mma_tiler_mnk: Tuple[int, int, int],
         a_dtype: Type[cutlass.Numeric],
-        a_major_mode: tcgen05.OperandMajorMode,
+        a_major_mode: cute.nvgpu.OperandMajorMode,
         b_dtype: Type[cutlass.Numeric],
-        b_major_mode: tcgen05.OperandMajorMode,
+        b_major_mode: cute.nvgpu.OperandMajorMode,
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
         c_layout: utils.LayoutEnum,
@@ -2401,11 +2401,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :param a_dtype: Data type of operand A.
         :type a_dtype: type[cutlass.Numeric]
         :param a_major_mode: Major mode of operand A.
-        :type a_major_mode: tcgen05.OperandMajorMode
+        :type a_major_mode: cute.nvgpu.OperandMajorMode
         :param b_dtype: Data type of operand B.
         :type b_dtype: type[cutlass.Numeric]
         :param b_major_mode: Major mode of operand B.
-        :type b_major_mode: tcgen05.OperandMajorMode
+        :type b_major_mode: cute.nvgpu.OperandMajorMode
         :param epi_tile: The epilogue tile shape.
         :type epi_tile: cute.Tile
         :param c_dtype: Data type of operand C (output).

--- a/flashinfer/mamba/ssd_kernel.py
+++ b/flashinfer/mamba/ssd_kernel.py
@@ -3362,8 +3362,8 @@ class SSDKernel:
     ):
         tiled_mma_intra1 = sm100_utils.make_trivial_tiled_mma(
             io_dtype,
-            tcgen05.OperandMajorMode("k"),  # A operand (C) is K-major (N-contiguous)
-            tcgen05.OperandMajorMode("k"),  # B operand (B) is K-major (N-contiguous)
+            cute.nvgpu.OperandMajorMode("k"),  # A operand (C) is K-major (N-contiguous)
+            cute.nvgpu.OperandMajorMode("k"),  # B operand (B) is K-major (N-contiguous)
             acc_dtype,
             cta_group,
             tile_shape_mnk_intra1[:2],
@@ -3371,8 +3371,8 @@ class SSDKernel:
         )
         tiled_mma_intra2 = sm100_utils.make_trivial_tiled_mma(
             io_dtype,
-            tcgen05.OperandMajorMode("k"),
-            tcgen05.OperandMajorMode("mn"),  # B operand (x) is N-major (D-contiguous)
+            cute.nvgpu.OperandMajorMode("k"),
+            cute.nvgpu.OperandMajorMode("mn"),  # B operand (x) is N-major (D-contiguous)
             acc_dtype,
             cta_group,
             tile_shape_mnk_intra2[:2],
@@ -3380,8 +3380,8 @@ class SSDKernel:
         )
         tiled_mma_inter1 = sm100_utils.make_trivial_tiled_mma(
             io_dtype,
-            tcgen05.OperandMajorMode("k"),
-            tcgen05.OperandMajorMode("mn"),  # B operand (x) is N-major (D-contiguous)
+            cute.nvgpu.OperandMajorMode("k"),
+            cute.nvgpu.OperandMajorMode("mn"),  # B operand (x) is N-major (D-contiguous)
             acc_dtype,
             cta_group,
             tile_shape_mnk_inter1[:2],
@@ -3389,8 +3389,8 @@ class SSDKernel:
         )
         tiled_mma_inter2 = sm100_utils.make_trivial_tiled_mma(
             io_dtype,
-            tcgen05.OperandMajorMode("k"),  # A operand (C) is K-major (N-contiguous)
-            tcgen05.OperandMajorMode("k"),
+            cute.nvgpu.OperandMajorMode("k"),  # A operand (C) is K-major (N-contiguous)
+            cute.nvgpu.OperandMajorMode("k"),
             acc_dtype,
             cta_group,
             tile_shape_mnk_inter2[:2],

--- a/flashinfer/mamba/ssd_kernel.py
+++ b/flashinfer/mamba/ssd_kernel.py
@@ -3372,7 +3372,9 @@ class SSDKernel:
         tiled_mma_intra2 = sm100_utils.make_trivial_tiled_mma(
             io_dtype,
             cute.nvgpu.OperandMajorMode("k"),
-            cute.nvgpu.OperandMajorMode("mn"),  # B operand (x) is N-major (D-contiguous)
+            cute.nvgpu.OperandMajorMode(
+                "mn"
+            ),  # B operand (x) is N-major (D-contiguous)
             acc_dtype,
             cta_group,
             tile_shape_mnk_intra2[:2],
@@ -3381,7 +3383,9 @@ class SSDKernel:
         tiled_mma_inter1 = sm100_utils.make_trivial_tiled_mma(
             io_dtype,
             cute.nvgpu.OperandMajorMode("k"),
-            cute.nvgpu.OperandMajorMode("mn"),  # B operand (x) is N-major (D-contiguous)
+            cute.nvgpu.OperandMajorMode(
+                "mn"
+            ),  # B operand (x) is N-major (D-contiguous)
             acc_dtype,
             cta_group,
             tile_shape_mnk_inter1[:2],

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -647,5 +647,115 @@ def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
         q_data_type=dtype,
         kv_data_type=dtype,
     )
-    with pytest.raises(NotImplementedError, match="return_lse"):
-        wrapper.run(q, kv, return_lse=True)
+    # (return_lse is now supported — covered by dedicated LSE tests below.)
+
+
+# ---------------------------------------------------------------------------
+# 4. LSE return
+# ---------------------------------------------------------------------------
+
+
+def _lse_reference_paged(
+    q: torch.Tensor,  # [batch_size, num_qo_heads, head_dim]
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """LSE reference in log2 base, shape [batch_size, num_qo_heads]."""
+    batch_size = kv_indptr.numel() - 1
+    page_size = k_cache.shape[1]
+    num_kv_heads = k_cache.shape[2]
+    head_dim = k_cache.shape[3]
+    num_qo_heads = q.shape[1]
+    group = num_qo_heads // num_kv_heads
+    out = torch.empty(batch_size, num_qo_heads, dtype=torch.float32, device=q.device)
+    for b in range(batch_size):
+        pages_b = kv_indices[kv_indptr[b] : kv_indptr[b + 1]]
+        num_pages = pages_b.numel()
+        if num_pages == 0:
+            out[b] = -float("inf")
+            continue
+        last = int(kv_last_page_len[b].item())
+        valid_len = (num_pages - 1) * page_size + last
+        keys = k_cache[pages_b].float().reshape(
+            num_pages * page_size, num_kv_heads, head_dim
+        )[:valid_len]
+        keys = keys.repeat_interleave(group, dim=1)
+        logits = torch.einsum("hd,nhd->hn", q[b].float(), keys) * sm_scale
+        # natural-log logsumexp, converted to log2
+        out[b] = torch.logsumexp(logits, dim=-1) * math.log2(math.e)
+    return out
+
+
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("kv_len", [129, 1024])
+@pytest.mark.parametrize("page_size", [16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_return_lse(batch_size, kv_len, page_size, dtype):
+    """LSE values from cute-dsl backend must match the torch reference (log2-base)."""
+    torch.manual_seed(0)
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    cd.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype, sm_scale=sm_scale,
+    )
+    out, lse = cd.run(q, kv, return_lse=True)
+
+    k_cache, v_cache = kv.unbind(dim=1)
+    lse_ref = _lse_reference_paged(
+        q, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+    torch.testing.assert_close(lse, lse_ref, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
+    """Both reduction modes ("kernel" and "atomic") must write the same LSE."""
+    batch_size, page_size = 4, 16
+    # Pick a kv_len that lands in "atomic" mode for auto by default, then
+    # also force "kernel" reduction in a separate plan.
+    kv_len = 1024
+    torch.manual_seed(0)
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    lse_ref = _lse_reference_paged(
+        q, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+
+    for reduction in ("kernel", "atomic"):
+        wrapper = BatchDecodePagedCuteDSLWrapper(
+            torch.empty(1, dtype=torch.uint8, device=DEVICE),
+        )
+        wrapper.plan(
+            kv_indptr, kv_indices, kv_last_page_len,
+            num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+            head_dim=HEAD_DIM, page_size=page_size,
+            q_data_type=dtype, sm_scale=sm_scale,
+            reduction=reduction,
+        )
+        lse_buf = torch.empty(
+            batch_size, 1, NUM_QO_HEADS, dtype=torch.float32, device=DEVICE
+        )
+        wrapper.run(q, k_cache, v_cache, lse=lse_buf)
+        # squeeze q_len_per_req=1 axis to compare against (batch, h_q) ref
+        torch.testing.assert_close(
+            lse_buf.squeeze(1), lse_ref, rtol=5e-3, atol=5e-3,
+            msg=f"reduction={reduction}",
+        )

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -385,7 +385,6 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
         kv_data_type=dtype,
         q_len_per_req=q_len_per_req,
     )
-    out = cd.run(q, kv)
 
     trt = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
         workspace, kv_layout="NHD", backend="trtllm-gen"
@@ -402,15 +401,72 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
         kv_data_type=dtype,
         q_len_per_req=q_len_per_req,
     )
-    ref = trt.run(q, kv)
-    assert out.shape == ref.shape
 
+    out = cd.run(q, kv)
+    ref = trt.run(q, kv)
+
+    assert out.shape == ref.shape
     torch.testing.assert_close(
         out,
         ref,
         rtol=5e-3,
         atol=5e-3,
     )
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_cute_dsl_decode_paged_wrapper_speculative_runtime(dtype):
+    """Runtime q_len doesnt match plan time q_len"""
+    batch_size, page_size = 4, 16
+    kv_len = 1024
+    torch.manual_seed(0)
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+
+    cd = BatchDecodePagedCuteDSLWrapper(workspace)
+    cd.plan(
+        kv_indptr, kv_indices, seq_lens,
+        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM, page_size=page_size,
+        q_data_type=dtype, sm_scale=sm_scale,
+        reduction="kernel",
+        q_len_per_req=2,
+        max_kv_len=kv_len,
+    )
+
+    trt = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="trtllm-gen"
+    )
+    trt.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS,
+        HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype,
+        sm_scale=sm_scale,
+        q_len_per_req=2,
+        seq_lens=seq_lens,
+    )
+
+    for q_len_per_req in (1, 2, 4):
+        q = torch.randn(
+            batch_size * q_len_per_req,
+            NUM_QO_HEADS, HEAD_DIM,
+            device=DEVICE, dtype=dtype
+        )
+        out = cd.run(q, k_cache, v_cache)
+        ref = trt.run(q, kv)
+
+        assert out.shape == ref.shape
+        torch.testing.assert_close(
+            out,
+            ref,
+            rtol=5e-3,
+            atol=5e-3,
+        )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -850,7 +906,7 @@ def test_cute_dsl_decode_paged_wrapper_workspace_too_small():
     wrapper = BatchDecodePagedCuteDSLWrapper(
         torch.empty(1024, dtype=torch.uint8, device=DEVICE),  # 1 KiB — way too small
     )
-    with pytest.raises(ValueError, match="float_workspace_buffer too small"):
+    with pytest.raises(RuntimeError, match="exceeds provided workspace"):
         wrapper.plan(
             kv_indptr, kv_indices, seq_lens,
             num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -140,7 +140,7 @@ def test_cute_dsl_decode_ragged(batch_size, kv_len, dtype):
     v = torch.randn_like(k)
 
     wrapper = BatchDecodeCuteDSLWrapper(
-        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     sm_scale = 1.0 / math.sqrt(HEAD_DIM)
     wrapper.plan(
@@ -209,7 +209,7 @@ def test_cute_dsl_decode_paged_wrapper(batch_size, kv_len, page_size, dtype):
     sm_scale = 1.0 / math.sqrt(HEAD_DIM)
 
     wrapper = BatchDecodePagedCuteDSLWrapper(
-        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
         kv_indptr,
@@ -368,7 +368,7 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
 
-    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
     cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
         workspace, kv_layout="NHD", backend="cute-dsl"
     )
@@ -386,7 +386,6 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
     )
     out = cd.run(q, kv)
 
-    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
     trt = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
         workspace, kv_layout="NHD", backend="trtllm-gen"
     )
@@ -454,7 +453,7 @@ def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
     )
     k_cache, v_cache = kv.unbind(dim=1)
     wrapper = BatchDecodePagedCuteDSLWrapper(
-        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
         kv_indptr, kv_indices, kv_last_page_len,
@@ -704,7 +703,7 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
 
     for reduction in ("kernel", "atomic", "none"):
         wrapper = BatchDecodePagedCuteDSLWrapper(
-            torch.empty(1, dtype=torch.uint8, device=DEVICE),
+            torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
         )
         plan_kwargs = dict(
             num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
@@ -749,7 +748,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none(
     sm_scale = 1.0 / math.sqrt(HEAD_DIM)
 
     wrapper = BatchDecodePagedCuteDSLWrapper(
-        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
         kv_indptr, kv_indices, kv_last_page_len,
@@ -778,7 +777,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none_rejects_split():
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     wrapper = BatchDecodePagedCuteDSLWrapper(
-        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     with pytest.raises(ValueError, match='kv_splits == 1'):
         wrapper.plan(
@@ -788,3 +787,98 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none_rejects_split():
             q_data_type=dtype,
             reduction="none", kv_splits=4,
         )
+
+
+# ---------------------------------------------------------------------------
+# 5. float_workspace_buffer reuse / sizing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_cute_dsl_decode_paged_wrapper_reuses_workspace(dtype):
+    """Workspace tensors come from `float_workspace_buffer`, not fresh allocs.
+    A second run() with different inputs must still produce correct output —
+    confirms m_bsh is re-`-inf`-initialized each call (a missed re-init would
+    corrupt the second run's softmax)."""
+    batch_size, page_size, kv_len = 8, 16, 1024
+    torch.manual_seed(0)
+    q1 = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    q2 = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
+    )
+    wrapper.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM, page_size=page_size,
+        q_data_type=dtype, sm_scale=sm_scale,
+        reduction="kernel",
+    )
+    out1 = wrapper.run(q1, k_cache, v_cache)
+    out2 = wrapper.run(q2, k_cache, v_cache)
+
+    ref1 = _decode_reference_paged(
+        q1, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+    ref2 = _decode_reference_paged(
+        q2, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+    torch.testing.assert_close(
+        out1.reshape(batch_size, NUM_QO_HEADS, HEAD_DIM),
+        ref1, rtol=5e-3, atol=5e-3,
+    )
+    torch.testing.assert_close(
+        out2.reshape(batch_size, NUM_QO_HEADS, HEAD_DIM),
+        ref2, rtol=5e-3, atol=5e-3,
+    )
+
+
+def test_cute_dsl_decode_paged_wrapper_workspace_too_small():
+    """plan() with kernel-reduction must reject undersized float_workspace_buffer."""
+    batch_size, page_size, kv_len = 4, 16, 2048
+    dtype = torch.bfloat16
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(1024, dtype=torch.uint8, device=DEVICE),  # 1 KiB — way too small
+    )
+    with pytest.raises(ValueError, match="float_workspace_buffer too small"):
+        wrapper.plan(
+            kv_indptr, kv_indices, kv_last_page_len,
+            num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+            head_dim=HEAD_DIM, page_size=page_size,
+            q_data_type=dtype,
+            reduction="kernel", kv_splits=8,
+        )
+
+
+def test_cute_dsl_decode_paged_wrapper_workspace_unused_for_none():
+    """`reduction="none"` (and atomic) don't need workspace — a 1-byte buffer
+    must be accepted."""
+    batch_size, page_size, kv_len = 4, 16, 1024
+    dtype = torch.bfloat16
+    torch.manual_seed(0)
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+    )
+    wrapper.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM, page_size=page_size,
+        q_data_type=dtype,
+        reduction="none", kv_splits=1,
+    )
+    # No exception expected; just verify output runs.
+    wrapper.run(q, k_cache, v_cache)

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -297,6 +297,84 @@ def test_batch_decode_wrapper_cute_dsl_backend(batch_size, kv_len, page_size, dt
     torch.testing.assert_close(out_buf, ref, rtol=5e-3, atol=5e-3)
 
 
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("kv_len", [1024])
+@pytest.mark.parametrize("page_size", [16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_hnd(batch_size, kv_len, page_size, dtype):
+    """HND layout is presented as a transposed view; output must match NHD."""
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_pages = pages_per_seq * batch_size
+    # HND-laid-out combined KV tensor.
+    kv_hnd = torch.randn(
+        total_pages, 2, NUM_KV_HEADS, page_size, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv_nhd = kv_hnd.transpose(-3, -2).contiguous()  # NHD copy for the reference
+    kv_indptr = (
+        torch.arange(batch_size + 1, device=DEVICE, dtype=torch.int32) * pages_per_seq
+    )
+    kv_indices = torch.arange(total_pages, device=DEVICE, dtype=torch.int32)
+    last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, device=DEVICE, dtype=torch.int32
+    )
+
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="HND", backend="cute-dsl"
+    )
+    cd.plan(
+        kv_indptr, kv_indices, last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype,
+    )
+    out_hnd = cd.run(q, kv_hnd)
+
+    # NHD reference via fa2.
+    ref_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
+        kv_layout="NHD", backend="fa2",
+    )
+    ref_wrapper.plan(
+        kv_indptr, kv_indices, last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype,
+    )
+    ref = ref_wrapper.run(q, kv_nhd)
+    torch.testing.assert_close(out_hnd, ref, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
+    """skip_softmax_threshold_scale_factor=0 must match the standard path."""
+    batch_size, page_size, kv_len = 4, 16, 1024
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    cd.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype,
+    )
+    out_std = cd.run(q, kv)
+    # threshold = small positive ⇒ BLASST path runs but nothing should be
+    # skipped at this magnitude; output should match the standard path.
+    out_skip = cd.run(q, kv, skip_softmax_threshold_scale_factor=1e-6)
+    torch.testing.assert_close(out_skip, out_std, rtol=5e-3, atol=5e-3)
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
     """The cute-dsl decode backend should reject features it doesn't support."""

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -723,10 +723,10 @@ def test_batch_decode_wrapper_cute_dsl_return_lse(batch_size, kv_len, page_size,
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
-    """Both reduction modes ("kernel" and "atomic") must write the same LSE."""
+    """All three reduction modes must write the same LSE."""
     batch_size, page_size = 4, 16
     # Pick a kv_len that lands in "atomic" mode for auto by default, then
-    # also force "kernel" reduction in a separate plan.
+    # also force "kernel" / "none" reduction in separate plans.
     kv_len = 1024
     torch.manual_seed(0)
     q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
@@ -739,16 +739,21 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
         q, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
     )
 
-    for reduction in ("kernel", "atomic"):
+    for reduction in ("kernel", "atomic", "none"):
         wrapper = BatchDecodePagedCuteDSLWrapper(
             torch.empty(1, dtype=torch.uint8, device=DEVICE),
         )
-        wrapper.plan(
-            kv_indptr, kv_indices, kv_last_page_len,
+        plan_kwargs = dict(
             num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
             head_dim=HEAD_DIM, page_size=page_size,
             q_data_type=dtype, sm_scale=sm_scale,
             reduction=reduction,
+        )
+        if reduction == "none":
+            # "none" only supports kv_splits == 1.
+            plan_kwargs["kv_splits"] = 1
+        wrapper.plan(
+            kv_indptr, kv_indices, kv_last_page_len, **plan_kwargs,
         )
         lse_buf = torch.empty(
             batch_size, 1, NUM_QO_HEADS, dtype=torch.float32, device=DEVICE
@@ -758,4 +763,65 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
         torch.testing.assert_close(
             lse_buf.squeeze(1), lse_ref, rtol=5e-3, atol=5e-3,
             msg=f"reduction={reduction}",
+        )
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("kv_len", [129, 1024])
+@pytest.mark.parametrize("page_size", [16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cute_dsl_decode_paged_wrapper_reduction_none(
+    batch_size, kv_len, page_size, dtype
+):
+    """`reduction="none"` (no flash-decoding split-K): direct write to o_bshd,
+    no reduction kernel / workspace. Output must match the standard reference."""
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+    )
+    wrapper.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM, page_size=page_size,
+        q_data_type=dtype, sm_scale=sm_scale,
+        reduction="none", kv_splits=1,
+    )
+    out = wrapper.run(q, k_cache, v_cache)
+    ref = _decode_reference_paged(
+        q, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+    torch.testing.assert_close(
+        out.reshape(batch_size, NUM_QO_HEADS, HEAD_DIM),
+        ref,
+        rtol=5e-3,
+        atol=5e-3,
+    )
+
+
+def test_cute_dsl_decode_paged_wrapper_reduction_none_rejects_split():
+    """`reduction="none"` requires `kv_splits == 1`."""
+    batch_size, page_size, kv_len = 4, 16, 1024
+    dtype = torch.bfloat16
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+    )
+    with pytest.raises(ValueError, match='kv_splits == 1'):
+        wrapper.plan(
+            kv_indptr, kv_indices, kv_last_page_len,
+            num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+            head_dim=HEAD_DIM, page_size=page_size,
+            q_data_type=dtype,
+            reduction="none", kv_splits=4,
         )

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -506,6 +506,54 @@ def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_skip_softmax_per_cta(dtype):
+    """Per-batch threshold normalization: with a varying-seqlen batch and a
+    sub-threshold scale factor (no actual skipping), the BLASST path's
+    output must still match the standard kernel exactly — verifying that
+    the kernel-side divide by per-CTA seqlen runs cleanly and that no
+    spurious tiles get skipped."""
+    page_size = 16
+    # Distinct per-batch seqlens to exercise per-CTA normalization
+    # (constant-seqlen batches would coincide with the old behavior).
+    seqlens = [128, 512, 1024, 2048]
+    batch_size = len(seqlens)
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    pages_per_seq = [(s + page_size - 1) // page_size for s in seqlens]
+    kv_indptr = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(pages_per_seq), 0).tolist()),
+        device=DEVICE, dtype=torch.int32,
+    )
+    total_pages = int(kv_indptr[-1].item())
+    kv = torch.randn(
+        total_pages, 2, page_size, NUM_KV_HEADS, HEAD_DIM,
+        device=DEVICE, dtype=dtype,
+    )
+    kv_indices = torch.arange(total_pages, device=DEVICE, dtype=torch.int32)
+    kv_last_page_len = torch.tensor(
+        [((s - 1) % page_size + 1) for s in seqlens],
+        device=DEVICE, dtype=torch.int32,
+    )
+
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    cd.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype,
+    )
+    out_std = cd.run(q, kv)
+    # Per-CTA effective threshold = 1e-6 / seqlen_i, all far below any
+    # softmax probability — output must match the standard path.
+    out_skip = cd.run(q, kv, skip_softmax_threshold_scale_factor=1e-6)
+    torch.testing.assert_close(out_skip, out_std, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
     """skip_softmax_threshold_scale_factor=0 must match the standard path."""
     batch_size, page_size, kv_len = 4, 16, 1024

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -155,7 +155,7 @@ def test_cute_dsl_decode_ragged(batch_size, kv_len, dtype):
     torch.testing.assert_close(out, ref, rtol=5e-3, atol=5e-3)
 
     # out= path
-    out_buf = torch.empty_like(out)
+    out_buf = torch.zeros_like(out)
     ret = wrapper.run(q, k, v, out=out_buf)
     assert ret.data_ptr() == out_buf.data_ptr()
     torch.testing.assert_close(out_buf, ref, rtol=5e-3, atol=5e-3)
@@ -286,7 +286,7 @@ def test_batch_decode_wrapper_cute_dsl_backend(batch_size, kv_len, page_size, dt
     torch.testing.assert_close(out, ref, rtol=5e-3, atol=5e-3)
 
     # user-allocated output
-    out_buf = torch.empty_like(out)
+    out_buf = torch.zeros_like(out)
     cd_wrapper.run(q, kv, out=out_buf)
     torch.testing.assert_close(out_buf, ref, rtol=5e-3, atol=5e-3)
 

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -451,6 +451,61 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_v_scale(dtype):
+    """v_scale must be folded into the cute-dsl kernel's o_scale: the output
+    of run(v_scale=k) should equal k * run() (within fp tolerance)."""
+    batch_size, page_size, kv_len = 4, 16, 1024
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    cd.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
+        q_data_type=dtype, kv_data_type=dtype,
+    )
+    out_unit = cd.run(q, kv)
+    k = 2.5
+    out_scaled = cd.run(q, kv, v_scale=k)
+    torch.testing.assert_close(out_scaled, k * out_unit, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
+    """Standalone BatchDecodePagedCuteDSLWrapper.run(o_scale=k) is equivalent
+    to multiplying the unscaled output by k."""
+    batch_size, page_size, kv_len = 4, 16, 1024
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+    )
+    wrapper.plan(
+        kv_indptr, kv_indices, kv_last_page_len,
+        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM, page_size=page_size,
+        q_data_type=dtype,
+    )
+    out_unit = wrapper.run(q, k_cache, v_cache)
+    k = 0.375
+    out_scaled = wrapper.run(q, k_cache, v_cache, o_scale=k)
+    torch.testing.assert_close(out_scaled, k * out_unit, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
     """skip_softmax_threshold_scale_factor=0 must match the standard path."""
     batch_size, page_size, kv_len = 4, 16, 1024

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the cute-dsl GQA decode integration.
+
+Covers both the standalone CuTe DSL wrappers
+(``BatchDecodeCuteDSLWrapper``/``BatchDecodePagedCuteDSLWrapper``) and the
+``backend="cute-dsl"`` path of
+:class:`flashinfer.BatchDecodeWithPagedKVCacheWrapper`.
+
+Each unique (head_dim, num_qo_heads, num_kv_heads, dtype) combination
+triggers a fresh kernel compilation (a few seconds). Test matrices are kept
+small so the full suite compiles a handful of kernels.
+"""
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.utils import is_sm100a_supported
+
+
+if not is_cute_dsl_available():
+    pytest.skip("CuTe DSL not available", allow_module_level=True)
+
+
+from flashinfer.cute_dsl.attention import (  # noqa: E402
+    BatchDecodeCuteDSLWrapper,
+    BatchDecodePagedCuteDSLWrapper,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
+    reason="cute-dsl GQA decode requires Blackwell (SM100a)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _decode_reference_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    sm_scale: float,
+):
+    """Single-token GQA decode reference using a paged KV cache (NHD layout)."""
+    batch_size = kv_indptr.numel() - 1
+    page_size = k_cache.shape[1]
+    num_kv_heads = k_cache.shape[2]
+    head_dim = k_cache.shape[3]
+    num_qo_heads = q.shape[1]
+    assert num_qo_heads % num_kv_heads == 0
+    group = num_qo_heads // num_kv_heads
+
+    out = torch.empty_like(q, dtype=torch.float32)
+    k_f32 = k_cache.float()
+    v_f32 = v_cache.float()
+    q_f32 = q.float()
+    for b in range(batch_size):
+        pages_b = kv_indices[kv_indptr[b] : kv_indptr[b + 1]]
+        num_pages = pages_b.numel()
+        if num_pages == 0:
+            out[b] = 0
+            continue
+        last_len = int(kv_last_page_len[b].item())
+        keys = k_f32[pages_b]  # [num_pages, page_size, num_kv_heads, head_dim]
+        values = v_f32[pages_b]
+        keys = keys.reshape(num_pages * page_size, num_kv_heads, head_dim)
+        values = values.reshape(num_pages * page_size, num_kv_heads, head_dim)
+        valid_len = (num_pages - 1) * page_size + last_len
+        keys = keys[:valid_len]
+        values = values[:valid_len]
+        # broadcast KV heads to QO heads for GQA
+        keys = keys.repeat_interleave(group, dim=1)
+        values = values.repeat_interleave(group, dim=1)
+        # logits: [num_qo_heads, valid_len]
+        logits = torch.einsum("hd,nhd->hn", q_f32[b], keys) * sm_scale
+        probs = torch.softmax(logits, dim=-1)
+        out[b] = torch.einsum("hn,nhd->hd", probs, values)
+    return out.to(q.dtype)
+
+
+def _decode_reference_contiguous(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sm_scale: float,
+):
+    """Ragged (contiguous KV) GQA decode reference; q has shape [b, 1, h_q, d]."""
+    batch_size, q_len, num_qo_heads, head_dim = q.shape
+    assert q_len == 1
+    num_kv_heads = k.shape[2]
+    group = num_qo_heads // num_kv_heads
+    keys = k.repeat_interleave(group, dim=2).float()  # [b, s, h_q, d]
+    values = v.repeat_interleave(group, dim=2).float()
+    q_f32 = q.float()
+    logits = torch.einsum("bqhd,bnhd->bhqn", q_f32, keys) * sm_scale
+    probs = torch.softmax(logits, dim=-1)
+    out = torch.einsum("bhqn,bnhd->bqhd", probs, values)
+    return out.to(q.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / common params
+# ---------------------------------------------------------------------------
+
+
+HEAD_DIM = 128
+NUM_QO_HEADS = 32
+NUM_KV_HEADS = 4
+DEVICE = torch.device("cuda")
+
+
+# ---------------------------------------------------------------------------
+# 1. Standalone ragged wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 17])
+@pytest.mark.parametrize("kv_len", [128, 1024])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cute_dsl_decode_ragged(batch_size, kv_len, dtype):
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, 1, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    k = torch.randn(
+        batch_size, kv_len, NUM_KV_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    v = torch.randn_like(k)
+
+    wrapper = BatchDecodeCuteDSLWrapper(
+        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+    )
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    wrapper.plan(
+        batch_size=batch_size,
+        max_kv_len=kv_len,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+    )
+    out = wrapper.run(q, k, v)
+    ref = _decode_reference_contiguous(q, k, v, sm_scale)
+    torch.testing.assert_close(out, ref, rtol=5e-3, atol=5e-3)
+
+    # out= path
+    out_buf = torch.empty_like(out)
+    ret = wrapper.run(q, k, v, out=out_buf)
+    assert ret.data_ptr() == out_buf.data_ptr()
+    torch.testing.assert_close(out_buf, ref, rtol=5e-3, atol=5e-3)
+
+
+# ---------------------------------------------------------------------------
+# 2. Standalone paged wrapper
+# ---------------------------------------------------------------------------
+
+
+def _make_paged_kv(
+    batch_size: int,
+    kv_len: int,
+    page_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+):
+    pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_pages = pages_per_seq * batch_size
+    kv = torch.randn(
+        total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_pages, device=device, dtype=torch.int32)
+    last = (kv_len - 1) % page_size + 1
+    kv_last_page_len = torch.full(
+        (batch_size,), last, device=device, dtype=torch.int32
+    )
+    return kv, kv_indptr, kv_indices, kv_last_page_len
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 17])
+@pytest.mark.parametrize("kv_len", [129, 1024])
+@pytest.mark.parametrize("page_size", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cute_dsl_decode_paged_wrapper(batch_size, kv_len, page_size, dtype):
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(1, dtype=torch.uint8, device=DEVICE),
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+    )
+    out = wrapper.run(q, k_cache, v_cache)
+    ref = _decode_reference_paged(
+        q, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+    torch.testing.assert_close(
+        out.reshape(batch_size, NUM_QO_HEADS, HEAD_DIM),
+        ref,
+        rtol=5e-3,
+        atol=5e-3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. BatchDecodeWithPagedKVCacheWrapper(backend="cute-dsl")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 17])
+@pytest.mark.parametrize("kv_len", [129, 1024])
+@pytest.mark.parametrize("page_size", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_batch_decode_wrapper_cute_dsl_backend(batch_size, kv_len, page_size, dtype):
+    """Integration test via the standard BatchDecodeWithPagedKVCacheWrapper API."""
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+
+    cd_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    cd_wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    out = cd_wrapper.run(q, kv)
+
+    # Reference via FA2 backend.
+    ref_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
+        kv_layout="NHD",
+        backend="fa2",
+    )
+    ref_wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    ref = ref_wrapper.run(q, kv)
+    torch.testing.assert_close(out, ref, rtol=5e-3, atol=5e-3)
+
+    # user-allocated output
+    out_buf = torch.empty_like(out)
+    cd_wrapper.run(q, kv, out=out_buf)
+    torch.testing.assert_close(out_buf, ref, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
+    """The cute-dsl decode backend should reject features it doesn't support."""
+    batch_size, page_size, kv_len = 4, 16, 256
+    q = torch.randn(
+        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    with pytest.raises(NotImplementedError, match="sliding window"):
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            page_size,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            window_left=64,
+        )
+    with pytest.raises(NotImplementedError, match="logits_soft_cap"):
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            page_size,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            logits_soft_cap=2.0,
+        )
+    with pytest.raises(NotImplementedError, match="pos_encoding_mode"):
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            page_size,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            pos_encoding_mode="ROPE_LLAMA",
+        )
+
+    # Successful plan; verify run-time rejections.
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    with pytest.raises(NotImplementedError, match="return_lse"):
+        wrapper.run(q, kv, return_lse=True)

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -90,6 +90,56 @@ def _decode_reference_paged(
     return out.to(q.dtype)
 
 
+def _decode_reference_paged_speculative(
+    q: torch.Tensor,  # [batch_size, q_len_per_req, num_qo_heads, head_dim]
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    sm_scale: float,
+):
+    """Speculative-decode GQA reference: q_len_per_req predicted tokens per
+    request with bottom-right causal masking. Predicted token i (0-indexed
+    within the prediction window) sits at sequence position
+    ``seq - q_len_per_req + i`` and can attend to keys ``0 .. seq - q_len_per_req + i``.
+    """
+    batch_size, q_len_per_req, num_qo_heads, head_dim = q.shape
+    page_size = k_cache.shape[1]
+    num_kv_heads = k_cache.shape[2]
+    assert num_qo_heads % num_kv_heads == 0
+    group = num_qo_heads // num_kv_heads
+
+    out = torch.empty_like(q, dtype=torch.float32)
+    k_f32 = k_cache.float()
+    v_f32 = v_cache.float()
+    q_f32 = q.float()
+    for b in range(batch_size):
+        pages_b = kv_indices[kv_indptr[b] : kv_indptr[b + 1]]
+        num_pages = pages_b.numel()
+        if num_pages == 0:
+            out[b] = 0
+            continue
+        last_len = int(kv_last_page_len[b].item())
+        seq = (num_pages - 1) * page_size + last_len
+        keys = k_f32[pages_b].reshape(num_pages * page_size, num_kv_heads, head_dim)[:seq]
+        values = v_f32[pages_b].reshape(num_pages * page_size, num_kv_heads, head_dim)[:seq]
+        keys = keys.repeat_interleave(group, dim=1)
+        values = values.repeat_interleave(group, dim=1)
+        # logits: [q_len_per_req, num_qo_heads, seq]
+        logits = torch.einsum("qhd,nhd->qhn", q_f32[b], keys) * sm_scale
+        # bottom-right causal: row i sees cols [0, seq - q_len_per_req + i]
+        mask = torch.zeros(q_len_per_req, seq, dtype=torch.bool, device=q.device)
+        for i in range(q_len_per_req):
+            allowed = max(0, min(seq, seq - q_len_per_req + i + 1))
+            if allowed > 0:
+                mask[i, :allowed] = True
+        logits.masked_fill_(~mask.unsqueeze(1), float("-inf"))
+        probs = torch.softmax(logits, dim=-1)
+        out[b] = torch.einsum("qhn,nhd->qhd", probs, values)
+    return out.to(q.dtype)
+
+
 def _decode_reference_contiguous(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -345,6 +395,59 @@ def test_batch_decode_wrapper_cute_dsl_hnd(batch_size, kv_len, page_size, dtype)
     )
     ref = ref_wrapper.run(q, kv_nhd)
     torch.testing.assert_close(out_hnd, ref, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("kv_len", [1024])
+@pytest.mark.parametrize("page_size", [16])
+@pytest.mark.parametrize("q_len_per_req", [2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batch_decode_wrapper_cute_dsl_speculative(
+    batch_size, kv_len, page_size, q_len_per_req, dtype
+):
+    """Speculative decode: q_len_per_req > 1 with bottom-right causal mask."""
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size * q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        device=DEVICE,
+        dtype=dtype,
+    )
+    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+        batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="cute-dsl"
+    )
+    cd.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        q_len_per_req=q_len_per_req,
+    )
+    out = cd.run(q, kv)
+
+    q_4d = q.view(batch_size, q_len_per_req, NUM_QO_HEADS, HEAD_DIM)
+    ref = _decode_reference_paged_speculative(
+        q_4d, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    )
+    torch.testing.assert_close(
+        out.view(batch_size, q_len_per_req, NUM_QO_HEADS, HEAD_DIM),
+        ref,
+        rtol=5e-3,
+        atol=5e-3,
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -131,9 +131,7 @@ DEVICE = torch.device("cuda")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_cute_dsl_decode_ragged(batch_size, kv_len, dtype):
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, 1, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, 1, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     k = torch.randn(
         batch_size, kv_len, NUM_KV_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
@@ -183,13 +181,12 @@ def _make_paged_kv(
         total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=dtype
     )
     kv_indptr = (
-        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * pages_per_seq
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        * pages_per_seq
     )
     kv_indices = torch.arange(0, total_pages, device=device, dtype=torch.int32)
     last = (kv_len - 1) % page_size + 1
-    kv_last_page_len = torch.full(
-        (batch_size,), last, device=device, dtype=torch.int32
-    )
+    kv_last_page_len = torch.full((batch_size,), last, device=device, dtype=torch.int32)
     seq_lens = torch.full((batch_size,), kv_len, device=device, dtype=torch.int32)
     return kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens
 
@@ -200,9 +197,7 @@ def _make_paged_kv(
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_cute_dsl_decode_paged_wrapper(batch_size, kv_len, page_size, dtype):
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -247,9 +242,7 @@ def test_cute_dsl_decode_paged_wrapper(batch_size, kv_len, page_size, dtype):
 def test_batch_decode_wrapper_cute_dsl_backend(batch_size, kv_len, page_size, dtype):
     """Integration test via the standard BatchDecodeWithPagedKVCacheWrapper API."""
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -305,9 +298,7 @@ def test_batch_decode_wrapper_cute_dsl_backend(batch_size, kv_len, page_size, dt
 def test_batch_decode_wrapper_cute_dsl_hnd(batch_size, kv_len, page_size, dtype):
     """HND layout is presented as a transposed view; output must match NHD."""
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     pages_per_seq = (kv_len + page_size - 1) // page_size
     total_pages = pages_per_seq * batch_size
     # HND-laid-out combined KV tensor.
@@ -328,21 +319,34 @@ def test_batch_decode_wrapper_cute_dsl_hnd(batch_size, kv_len, page_size, dtype)
         workspace, kv_layout="HND", backend="cute-dsl"
     )
     cd.plan(
-        kv_indptr, kv_indices, last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype,
+        kv_indptr,
+        kv_indices,
+        last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
     )
     out_hnd = cd.run(q, kv_hnd)
 
     # NHD reference via fa2.
     ref_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
         torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
-        kv_layout="NHD", backend="fa2",
+        kv_layout="NHD",
+        backend="fa2",
     )
     ref_wrapper.plan(
-        kv_indptr, kv_indices, last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype,
+        kv_indptr,
+        kv_indices,
+        last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
     )
     ref = ref_wrapper.run(q, kv_nhd)
     torch.testing.assert_close(out_hnd, ref, rtol=5e-3, atol=5e-3)
@@ -413,6 +417,7 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
         atol=5e-3,
     )
 
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_cute_dsl_decode_paged_wrapper_speculative_runtime(dtype):
     """Runtime q_len doesnt match plan time q_len"""
@@ -429,10 +434,15 @@ def test_cute_dsl_decode_paged_wrapper_speculative_runtime(dtype):
 
     cd = BatchDecodePagedCuteDSLWrapper(workspace)
     cd.plan(
-        kv_indptr, kv_indices, seq_lens,
-        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-        head_dim=HEAD_DIM, page_size=page_size,
-        q_data_type=dtype, sm_scale=sm_scale,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
         reduction="kernel",
         q_len_per_req=2,
         max_kv_len=kv_len,
@@ -442,10 +452,15 @@ def test_cute_dsl_decode_paged_wrapper_speculative_runtime(dtype):
         workspace, kv_layout="NHD", backend="trtllm-gen"
     )
     trt.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS,
-        HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
         sm_scale=sm_scale,
         q_len_per_req=2,
         seq_lens=seq_lens,
@@ -454,8 +469,10 @@ def test_cute_dsl_decode_paged_wrapper_speculative_runtime(dtype):
     for q_len_per_req in (1, 2, 4):
         q = torch.randn(
             batch_size * q_len_per_req,
-            NUM_QO_HEADS, HEAD_DIM,
-            device=DEVICE, dtype=dtype
+            NUM_QO_HEADS,
+            HEAD_DIM,
+            device=DEVICE,
+            dtype=dtype,
         )
         out = cd.run(q, k_cache, v_cache)
         ref = trt.run(q, kv)
@@ -475,9 +492,7 @@ def test_batch_decode_wrapper_cute_dsl_v_scale(dtype):
     of run(v_scale=k) should equal k * run() (within fp tolerance)."""
     batch_size, page_size, kv_len = 4, 16, 1024
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -486,9 +501,15 @@ def test_batch_decode_wrapper_cute_dsl_v_scale(dtype):
         workspace, kv_layout="NHD", backend="cute-dsl"
     )
     cd.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
     )
     out_unit = cd.run(q, kv)
     k = 2.5
@@ -502,9 +523,7 @@ def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
     to multiplying the unscaled output by k."""
     batch_size, page_size, kv_len = 4, 16, 1024
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -513,9 +532,13 @@ def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, seq_lens,
-        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-        head_dim=HEAD_DIM, page_size=page_size,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
         q_data_type=dtype,
     )
     out_unit = wrapper.run(q, k_cache, v_cache)
@@ -537,23 +560,28 @@ def test_batch_decode_wrapper_cute_dsl_skip_softmax_per_cta(dtype):
     seqlens = [128, 512, 1024, 2048]
     batch_size = len(seqlens)
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     pages_per_seq = [(s + page_size - 1) // page_size for s in seqlens]
     kv_indptr = torch.tensor(
         [0] + list(torch.cumsum(torch.tensor(pages_per_seq), 0).tolist()),
-        device=DEVICE, dtype=torch.int32,
+        device=DEVICE,
+        dtype=torch.int32,
     )
     total_pages = int(kv_indptr[-1].item())
     kv = torch.randn(
-        total_pages, 2, page_size, NUM_KV_HEADS, HEAD_DIM,
-        device=DEVICE, dtype=dtype,
+        total_pages,
+        2,
+        page_size,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        device=DEVICE,
+        dtype=dtype,
     )
     kv_indices = torch.arange(total_pages, device=DEVICE, dtype=torch.int32)
     kv_last_page_len = torch.tensor(
         [((s - 1) % page_size + 1) for s in seqlens],
-        device=DEVICE, dtype=torch.int32,
+        device=DEVICE,
+        dtype=torch.int32,
     )
 
     workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
@@ -561,9 +589,15 @@ def test_batch_decode_wrapper_cute_dsl_skip_softmax_per_cta(dtype):
         workspace, kv_layout="NHD", backend="cute-dsl"
     )
     cd.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
     )
     out_std = cd.run(q, kv)
     # Per-CTA effective threshold = 1e-6 / seqlen_i, all far below any
@@ -577,9 +611,7 @@ def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
     """skip_softmax_threshold_scale_factor=0 must match the standard path."""
     batch_size, page_size, kv_len = 4, 16, 1024
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -589,9 +621,15 @@ def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
         workspace, kv_layout="NHD", backend="cute-dsl"
     )
     cd.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
     )
     out_std = cd.run(q, kv)
     # threshold = small positive ⇒ BLASST path runs but nothing should be
@@ -604,9 +642,6 @@ def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
 def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
     """The cute-dsl decode backend should reject features it doesn't support."""
     batch_size, page_size, kv_len = 4, 16, 256
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -699,9 +734,11 @@ def _lse_reference_paged(
             continue
         last = int(kv_last_page_len[b].item())
         valid_len = (num_pages - 1) * page_size + last
-        keys = k_cache[pages_b].float().reshape(
-            num_pages * page_size, num_kv_heads, head_dim
-        )[:valid_len]
+        keys = (
+            k_cache[pages_b]
+            .float()
+            .reshape(num_pages * page_size, num_kv_heads, head_dim)[:valid_len]
+        )
         keys = keys.repeat_interleave(group, dim=1)
         logits = torch.einsum("hd,nhd->hn", q[b].float(), keys) * sm_scale
         # natural-log logsumexp, converted to log2
@@ -727,9 +764,16 @@ def test_batch_decode_wrapper_cute_dsl_return_lse(batch_size, kv_len, page_size,
         workspace, kv_layout="NHD", backend="cute-dsl"
     )
     cd.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
-        NUM_QO_HEADS, NUM_KV_HEADS, HEAD_DIM, page_size,
-        q_data_type=dtype, kv_data_type=dtype, sm_scale=sm_scale,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        sm_scale=sm_scale,
     )
     out, lse = cd.run(q, kv, return_lse=True)
 
@@ -763,16 +807,22 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
             torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
         )
         plan_kwargs = dict(
-            num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-            head_dim=HEAD_DIM, page_size=page_size,
-            q_data_type=dtype, sm_scale=sm_scale,
+            num_qo_heads=NUM_QO_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim=HEAD_DIM,
+            page_size=page_size,
+            q_data_type=dtype,
+            sm_scale=sm_scale,
             reduction=reduction,
         )
         if reduction == "none":
             # "none" only supports kv_splits == 1.
             plan_kwargs["kv_splits"] = 1
         wrapper.plan(
-            kv_indptr, kv_indices, seq_lens, **plan_kwargs,
+            kv_indptr,
+            kv_indices,
+            seq_lens,
+            **plan_kwargs,
         )
         lse_buf = torch.empty(
             batch_size, 1, NUM_QO_HEADS, dtype=torch.float32, device=DEVICE
@@ -780,7 +830,10 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
         wrapper.run(q, k_cache, v_cache, lse=lse_buf)
         # squeeze q_len_per_req=1 axis to compare against (batch, h_q) ref
         torch.testing.assert_close(
-            lse_buf.squeeze(1), lse_ref, rtol=5e-3, atol=5e-3,
+            lse_buf.squeeze(1),
+            lse_ref,
+            rtol=5e-3,
+            atol=5e-3,
             msg=f"reduction={reduction}",
         )
 
@@ -795,9 +848,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none(
     """`reduction="none"` (no flash-decoding split-K): direct write to o_bshd,
     no reduction kernel / workspace. Output must match the standard reference."""
     torch.manual_seed(0)
-    q = torch.randn(
-        batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
-    )
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
@@ -808,11 +859,17 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none(
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, seq_lens,
-        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-        head_dim=HEAD_DIM, page_size=page_size,
-        q_data_type=dtype, sm_scale=sm_scale,
-        reduction="none", kv_splits=1,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+        reduction="none",
+        kv_splits=1,
     )
     out = wrapper.run(q, k_cache, v_cache)
     ref = _decode_reference_paged(
@@ -836,13 +893,18 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none_rejects_split():
     wrapper = BatchDecodePagedCuteDSLWrapper(
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
-    with pytest.raises(ValueError, match='kv_splits == 1'):
+    with pytest.raises(ValueError, match="kv_splits == 1"):
         wrapper.plan(
-            kv_indptr, kv_indices, seq_lens,
-            num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-            head_dim=HEAD_DIM, page_size=page_size,
+            kv_indptr,
+            kv_indices,
+            seq_lens,
+            num_qo_heads=NUM_QO_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim=HEAD_DIM,
+            page_size=page_size,
             q_data_type=dtype,
-            reduction="none", kv_splits=4,
+            reduction="none",
+            kv_splits=4,
         )
 
 
@@ -871,10 +933,15 @@ def test_cute_dsl_decode_paged_wrapper_reuses_workspace(dtype):
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, seq_lens,
-        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-        head_dim=HEAD_DIM, page_size=page_size,
-        q_data_type=dtype, sm_scale=sm_scale,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
         reduction="kernel",
     )
     out1 = wrapper.run(q1, k_cache, v_cache)
@@ -888,11 +955,15 @@ def test_cute_dsl_decode_paged_wrapper_reuses_workspace(dtype):
     )
     torch.testing.assert_close(
         out1.reshape(batch_size, NUM_QO_HEADS, HEAD_DIM),
-        ref1, rtol=5e-3, atol=5e-3,
+        ref1,
+        rtol=5e-3,
+        atol=5e-3,
     )
     torch.testing.assert_close(
         out2.reshape(batch_size, NUM_QO_HEADS, HEAD_DIM),
-        ref2, rtol=5e-3, atol=5e-3,
+        ref2,
+        rtol=5e-3,
+        atol=5e-3,
     )
 
 
@@ -908,11 +979,16 @@ def test_cute_dsl_decode_paged_wrapper_workspace_too_small():
     )
     with pytest.raises(RuntimeError, match="exceeds provided workspace"):
         wrapper.plan(
-            kv_indptr, kv_indices, seq_lens,
-            num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-            head_dim=HEAD_DIM, page_size=page_size,
+            kv_indptr,
+            kv_indices,
+            seq_lens,
+            num_qo_heads=NUM_QO_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim=HEAD_DIM,
+            page_size=page_size,
             q_data_type=dtype,
-            reduction="kernel", kv_splits=8,
+            reduction="kernel",
+            kv_splits=8,
         )
 
 
@@ -931,11 +1007,16 @@ def test_cute_dsl_decode_paged_wrapper_workspace_unused_for_none():
         torch.empty(1, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, seq_lens,
-        num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
-        head_dim=HEAD_DIM, page_size=page_size,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
         q_data_type=dtype,
-        reduction="none", kv_splits=1,
+        reduction="none",
+        kv_splits=1,
     )
     # No exception expected; just verify output runs.
     wrapper.run(q, k_cache, v_cache)

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -190,7 +190,8 @@ def _make_paged_kv(
     kv_last_page_len = torch.full(
         (batch_size,), last, device=device, dtype=torch.int32
     )
-    return kv, kv_indptr, kv_indices, kv_last_page_len
+    seq_lens = torch.full((batch_size,), kv_len, device=device, dtype=torch.int32)
+    return kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens
 
 
 @pytest.mark.parametrize("batch_size", [1, 4, 17])
@@ -202,7 +203,7 @@ def test_cute_dsl_decode_paged_wrapper(batch_size, kv_len, page_size, dtype):
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
@@ -214,7 +215,7 @@ def test_cute_dsl_decode_paged_wrapper(batch_size, kv_len, page_size, dtype):
     wrapper.plan(
         kv_indptr,
         kv_indices,
-        kv_last_page_len,
+        seq_lens,
         num_qo_heads=NUM_QO_HEADS,
         num_kv_heads=NUM_KV_HEADS,
         head_dim=HEAD_DIM,
@@ -249,7 +250,7 @@ def test_batch_decode_wrapper_cute_dsl_backend(batch_size, kv_len, page_size, dt
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
 
@@ -364,7 +365,7 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
         device=DEVICE,
         dtype=dtype,
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
 
@@ -421,7 +422,7 @@ def test_batch_decode_wrapper_cute_dsl_v_scale(dtype):
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
@@ -448,7 +449,7 @@ def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
@@ -456,7 +457,7 @@ def test_cute_dsl_decode_paged_wrapper_o_scale(dtype):
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
+        kv_indptr, kv_indices, seq_lens,
         num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
         head_dim=HEAD_DIM, page_size=page_size,
         q_data_type=dtype,
@@ -523,7 +524,7 @@ def test_batch_decode_wrapper_cute_dsl_skip_softmax(dtype):
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
 
@@ -550,7 +551,7 @@ def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
@@ -561,7 +562,7 @@ def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
         wrapper.plan(
             kv_indptr,
             kv_indices,
-            kv_last_page_len,
+            seq_lens,
             NUM_QO_HEADS,
             NUM_KV_HEADS,
             HEAD_DIM,
@@ -574,7 +575,7 @@ def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
         wrapper.plan(
             kv_indptr,
             kv_indices,
-            kv_last_page_len,
+            seq_lens,
             NUM_QO_HEADS,
             NUM_KV_HEADS,
             HEAD_DIM,
@@ -587,7 +588,7 @@ def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
         wrapper.plan(
             kv_indptr,
             kv_indices,
-            kv_last_page_len,
+            seq_lens,
             NUM_QO_HEADS,
             NUM_KV_HEADS,
             HEAD_DIM,
@@ -601,7 +602,7 @@ def test_batch_decode_wrapper_cute_dsl_rejects_unsupported(dtype):
     wrapper.plan(
         kv_indptr,
         kv_indices,
-        kv_last_page_len,
+        seq_lens,
         NUM_QO_HEADS,
         NUM_KV_HEADS,
         HEAD_DIM,
@@ -660,7 +661,7 @@ def test_batch_decode_wrapper_cute_dsl_return_lse(batch_size, kv_len, page_size,
     """LSE values from cute-dsl backend must match the torch reference (log2-base)."""
     torch.manual_seed(0)
     q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     sm_scale = 1.0 / math.sqrt(HEAD_DIM)
@@ -692,7 +693,7 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
     kv_len = 1024
     torch.manual_seed(0)
     q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
@@ -715,7 +716,7 @@ def test_cute_dsl_decode_paged_wrapper_lse_both_reductions(dtype):
             # "none" only supports kv_splits == 1.
             plan_kwargs["kv_splits"] = 1
         wrapper.plan(
-            kv_indptr, kv_indices, kv_last_page_len, **plan_kwargs,
+            kv_indptr, kv_indices, seq_lens, **plan_kwargs,
         )
         lse_buf = torch.empty(
             batch_size, 1, NUM_QO_HEADS, dtype=torch.float32, device=DEVICE
@@ -741,7 +742,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none(
     q = torch.randn(
         batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype
     )
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
@@ -751,7 +752,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none(
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
+        kv_indptr, kv_indices, seq_lens,
         num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
         head_dim=HEAD_DIM, page_size=page_size,
         q_data_type=dtype, sm_scale=sm_scale,
@@ -773,7 +774,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none_rejects_split():
     """`reduction="none"` requires `kv_splits == 1`."""
     batch_size, page_size, kv_len = 4, 16, 1024
     dtype = torch.bfloat16
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     wrapper = BatchDecodePagedCuteDSLWrapper(
@@ -781,7 +782,7 @@ def test_cute_dsl_decode_paged_wrapper_reduction_none_rejects_split():
     )
     with pytest.raises(ValueError, match='kv_splits == 1'):
         wrapper.plan(
-            kv_indptr, kv_indices, kv_last_page_len,
+            kv_indptr, kv_indices, seq_lens,
             num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
             head_dim=HEAD_DIM, page_size=page_size,
             q_data_type=dtype,
@@ -804,7 +805,7 @@ def test_cute_dsl_decode_paged_wrapper_reuses_workspace(dtype):
     torch.manual_seed(0)
     q1 = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
     q2 = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
@@ -814,7 +815,7 @@ def test_cute_dsl_decode_paged_wrapper_reuses_workspace(dtype):
         torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
+        kv_indptr, kv_indices, seq_lens,
         num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
         head_dim=HEAD_DIM, page_size=page_size,
         q_data_type=dtype, sm_scale=sm_scale,
@@ -843,7 +844,7 @@ def test_cute_dsl_decode_paged_wrapper_workspace_too_small():
     """plan() with kernel-reduction must reject undersized float_workspace_buffer."""
     batch_size, page_size, kv_len = 4, 16, 2048
     dtype = torch.bfloat16
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     wrapper = BatchDecodePagedCuteDSLWrapper(
@@ -851,7 +852,7 @@ def test_cute_dsl_decode_paged_wrapper_workspace_too_small():
     )
     with pytest.raises(ValueError, match="float_workspace_buffer too small"):
         wrapper.plan(
-            kv_indptr, kv_indices, kv_last_page_len,
+            kv_indptr, kv_indices, seq_lens,
             num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
             head_dim=HEAD_DIM, page_size=page_size,
             q_data_type=dtype,
@@ -866,7 +867,7 @@ def test_cute_dsl_decode_paged_wrapper_workspace_unused_for_none():
     dtype = torch.bfloat16
     torch.manual_seed(0)
     q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
-    kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
+    kv, kv_indptr, kv_indices, kv_last_page_len, seq_lens = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
@@ -874,7 +875,7 @@ def test_cute_dsl_decode_paged_wrapper_workspace_unused_for_none():
         torch.empty(1, dtype=torch.uint8, device=DEVICE),
     )
     wrapper.plan(
-        kv_indptr, kv_indices, kv_last_page_len,
+        kv_indptr, kv_indices, seq_lens,
         num_qo_heads=NUM_QO_HEADS, num_kv_heads=NUM_KV_HEADS,
         head_dim=HEAD_DIM, page_size=page_size,
         q_data_type=dtype,

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -90,56 +90,6 @@ def _decode_reference_paged(
     return out.to(q.dtype)
 
 
-def _decode_reference_paged_speculative(
-    q: torch.Tensor,  # [batch_size, q_len_per_req, num_qo_heads, head_dim]
-    k_cache: torch.Tensor,
-    v_cache: torch.Tensor,
-    kv_indptr: torch.Tensor,
-    kv_indices: torch.Tensor,
-    kv_last_page_len: torch.Tensor,
-    sm_scale: float,
-):
-    """Speculative-decode GQA reference: q_len_per_req predicted tokens per
-    request with bottom-right causal masking. Predicted token i (0-indexed
-    within the prediction window) sits at sequence position
-    ``seq - q_len_per_req + i`` and can attend to keys ``0 .. seq - q_len_per_req + i``.
-    """
-    batch_size, q_len_per_req, num_qo_heads, head_dim = q.shape
-    page_size = k_cache.shape[1]
-    num_kv_heads = k_cache.shape[2]
-    assert num_qo_heads % num_kv_heads == 0
-    group = num_qo_heads // num_kv_heads
-
-    out = torch.empty_like(q, dtype=torch.float32)
-    k_f32 = k_cache.float()
-    v_f32 = v_cache.float()
-    q_f32 = q.float()
-    for b in range(batch_size):
-        pages_b = kv_indices[kv_indptr[b] : kv_indptr[b + 1]]
-        num_pages = pages_b.numel()
-        if num_pages == 0:
-            out[b] = 0
-            continue
-        last_len = int(kv_last_page_len[b].item())
-        seq = (num_pages - 1) * page_size + last_len
-        keys = k_f32[pages_b].reshape(num_pages * page_size, num_kv_heads, head_dim)[:seq]
-        values = v_f32[pages_b].reshape(num_pages * page_size, num_kv_heads, head_dim)[:seq]
-        keys = keys.repeat_interleave(group, dim=1)
-        values = values.repeat_interleave(group, dim=1)
-        # logits: [q_len_per_req, num_qo_heads, seq]
-        logits = torch.einsum("qhd,nhd->qhn", q_f32[b], keys) * sm_scale
-        # bottom-right causal: row i sees cols [0, seq - q_len_per_req + i]
-        mask = torch.zeros(q_len_per_req, seq, dtype=torch.bool, device=q.device)
-        for i in range(q_len_per_req):
-            allowed = max(0, min(seq, seq - q_len_per_req + i + 1))
-            if allowed > 0:
-                mask[i, :allowed] = True
-        logits.masked_fill_(~mask.unsqueeze(1), float("-inf"))
-        probs = torch.softmax(logits, dim=-1)
-        out[b] = torch.einsum("qhn,nhd->qhd", probs, values)
-    return out.to(q.dtype)
-
-
 def _decode_reference_contiguous(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -417,10 +367,8 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
     kv, kv_indptr, kv_indices, kv_last_page_len = _make_paged_kv(
         batch_size, kv_len, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
-    k_cache, v_cache = kv.unbind(dim=1)
-    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
 
-    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
     cd = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
         workspace, kv_layout="NHD", backend="cute-dsl"
     )
@@ -438,12 +386,27 @@ def test_batch_decode_wrapper_cute_dsl_speculative(
     )
     out = cd.run(q, kv)
 
-    q_4d = q.view(batch_size, q_len_per_req, NUM_QO_HEADS, HEAD_DIM)
-    ref = _decode_reference_paged_speculative(
-        q_4d, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    trt = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="trtllm-gen"
     )
+    trt.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        q_len_per_req=q_len_per_req,
+    )
+    ref = trt.run(q, kv)
+    assert out.shape == ref.shape
+
     torch.testing.assert_close(
-        out.view(batch_size, q_len_per_req, NUM_QO_HEADS, HEAD_DIM),
+        out,
         ref,
         rtol=5e-3,
         atol=5e-3,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
- Adds a new `cute-dsl` backend to `BatchDecodeWithPagedKVCacheWrapper` powered by the cute-dsl Blackwell (SM100a) GQA decode kernel, supporting
    - NHD + HND paged + non-paged KV layout
    - fp8/bf16 QKVO
    - headdim multiple of 64 (large headdims supported)
    - speculative-decode (q_len_per_req > 1 + causal mask)
    - runtime PDL
    - skip softmax with threshold scale factor matching trtllm behavior
    - per-tensor scale factors (folded into softmax scale and output scale)
    - LSE return
    - three reduction modes:`kernel` (deterministic split-K + reduction kernel), `atomic` (cluster reduction + L2 atomic adds), and `none` (kv_splits == 1, no flash-decoding).
- Wraps the kernel in two PyTorch-facing classes (`BatchDecodeCuteDSLWrapper`, `BatchDecodePagedCuteDSLWrapper`) modeled on the prefill cute-dsl pattern. Compile is memoized via `@functools.cache`; symbolic dims (`cute.sym_int`) cover runtime variation in batch_size, seq_len, and prediction.
- Bug fix in trtllm-gen `plan()`: `block_id = indptr[0]` was a 0-dim view, and `block_id += ...` did an in-place add that mutated `indptr[0]`. Switched to a Python int read from the host-side indptr to avoid corrupting shared buffers.
- Replace references to deprecated `cute.nvgpu.tcgen05.OperandMajorMode` with `cute.nvgpu.OperandMajorMode` introduced in cute-dsl 4.5.0
- `BatchDecodeWithPagedKVCacheWrapper` API change: `q_len_per_req` is now accepted in `plan` instead of `run`, to provide a tile size hint to the `cute-dsl` compilation. Passing to `run` emits deprecation notice and is used to validate the expected shape of `q`. Otherwise `q_len_per_req` is inferred from the shape of `q` at runtime.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
- [x] `pytest tests/attention/test_cute_dsl_decode.py` on Blackwell — covers
      both reduction modes, paged + ragged wrappers, LSE, speculative decode,
      v_scale, HND vs NHD layout, and runtime-q_len mismatch.
- [x] `python benchmarks/bench_cute_dsl_decode.py` — sanity-check throughput
      against fa2 / trtllm-gen.

## Perf results B200
```
b= 1 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:   12.243 us      0.3 TB/s
   trtllm-gen:    6.301 us      0.7 TB/s
     cute-dsl:    4.862 us      0.9 TB/s
b= 1 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:   18.184 us      0.9 TB/s
   trtllm-gen:    8.128 us      2.1 TB/s
     cute-dsl:   11.002 us      1.5 TB/s
b= 1 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:   44.368 us      1.5 TB/s
   trtllm-gen:   17.782 us      3.8 TB/s
     cute-dsl:   18.137 us      3.7 TB/s
b= 8 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:   28.691 us      1.2 TB/s
   trtllm-gen:   10.577 us      3.2 TB/s
     cute-dsl:    8.952 us      3.8 TB/s
b= 8 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:   85.133 us      1.6 TB/s
   trtllm-gen:   24.139 us      5.6 TB/s
     cute-dsl:   22.920 us      5.9 TB/s
b= 8 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:  300.016 us      1.8 TB/s
   trtllm-gen:   78.230 us      6.9 TB/s
     cute-dsl:   77.682 us      6.9 TB/s
b=64 mtp=0 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:  159.955 us      1.7 TB/s
   trtllm-gen:   43.420 us      6.2 TB/s
     cute-dsl:   45.634 us      5.9 TB/s
b=64 mtp=0 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2:  589.830 us      1.8 TB/s
   trtllm-gen:  156.094 us      6.9 TB/s
     cute-dsl:  152.400 us      7.1 TB/s
b=64 mtp=0 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
          fa2: 2314.402 us      1.9 TB/s
   trtllm-gen:  606.548 us      7.1 TB/s
     cute-dsl:  598.255 us      7.2 TB/s
b= 1 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:    6.703 us      0.6 TB/s
     cute-dsl:    6.693 us      0.6 TB/s
b= 1 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:   10.593 us      1.6 TB/s
     cute-dsl:   11.871 us      1.4 TB/s
b= 1 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:   19.029 us      3.5 TB/s
     cute-dsl:   21.917 us      3.1 TB/s
b= 8 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:   11.857 us      2.9 TB/s
     cute-dsl:   11.616 us      3.0 TB/s
b= 8 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:   25.721 us      5.3 TB/s
     cute-dsl:   29.520 us      4.6 TB/s
b= 8 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:   80.154 us      6.7 TB/s
     cute-dsl:   90.475 us      5.9 TB/s
b=64 mtp=3 s= 1024 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:   49.531 us      5.6 TB/s
     cute-dsl:   63.087 us      4.4 TB/s
b=64 mtp=3 s= 4096 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:  162.000 us      6.7 TB/s
     cute-dsl:  180.057 us      6.0 TB/s
b=64 mtp=3 s=16384 pg=16 h_q=64 h_kv=8 d=128 dtype=torch.bfloat16
   trtllm-gen:  621.074 us      6.9 TB/s
     cute-dsl:  690.734 us      6.2 TB/s
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "cute-dsl" decode backend for Blackwell GPUs with high-performance grouped-query attention decoding, plus two user-facing wrappers for ragged and paged KV-cache decoding; supports LSE output, kernel/atomic/none reductions, speculative multi-token decode, softmax-skip tuning, workspace reuse, and optional user-provided outputs.

* **Benchmarks**
  * Added a CUDA-gated paged-batch GQA decode benchmark exercising multiple backends, dtypes, batch/seq sizes and reporting latency/bandwidth.

* **Tests**
  * Added comprehensive integration and correctness tests covering decode paths, LSE, reduction modes, softmax-skip behavior, and workspace handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->