### PR TITLE
Fix and benchmark mxfp8 async-fence

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
+++ b/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
@@ -575,6 +575,18 @@ quantize_with_block_size_tma(
       }
     }
   }
+  // Async-proxy fence: make our generic-proxy stores to `out` and `SFout`
+  // visible to the next kernel's async-proxy reads (e.g. TMA loads in the
+  // subsequent GEMM). Without this, PDL allows the dependent kernel to
+  // start before our writes have drained across the proxy boundary, and
+  // the consumer reads stale/partial data, producing NaN output.
+  // The `fence` then `__syncthreads` ordering
+  // is mandated by the CUDA async-proxy memory model: the fence applies
+  // only to the calling thread's memory ops, and __syncthreads is what
+  // makes those orderings observable to the leader thread issuing the
+  // dependent-grid launch.
+  asm volatile("fence.proxy.async.global;");
+  __syncthreads();
   asm volatile("griddepcontrol.launch_dependents;");
 #endif
 }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The quantize_with_block_size kernel in flashinfer is missing an fence.proxy.async.global + __syncthreads() before griddepcontrol.launch_dependents. With PDL enabled, the dependent GEMM kernel (mm_mxfp8) can begin TMA loads while the quantize kernel's generic-proxy stores are still draining, causing NaN output and bimodal performance.

This repro demonstrates both issues using only torch + flashinfer:

Correctness (compile mode): torch.compile puts quantize and GEMM back-to-back with zero barriers, exposing the race. Without the fence fix, ~9% of iterations produce NaN at M=4096.

Performance (piecewise mode): Piecewise compiled CUDA graphs with eager attention between pieces (matching the vLLM production execution pattern). Without the fence, the racy PDL overlap makes each iteration ~2-3% faster, but produces NaN in 94% of iterations.

Results on GB200

Without fence fix:
- Piecewise: median 942.8ms, 373/400 NaN
- Compile: median 60.4ms, 17/400 NaN

With fence fix:
- Piecewise: median 974.9ms, 0/400 NaN
- Compile: median 60.6ms, 0/400 NaN

This PR is designed for exploring the following questions:
- Should launch_dependents guarantee async-proxy store visibility?
- Is there a lighter synchronization mechanism that avoids the ~3% perf regression in piecewise cuda graph mode while ensuring correctness?

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [✅] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [✅] I have installed the hooks with `pre-commit install`.
- [✅] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [✅] Tests have been added or updated as needed. See the standalone benchmark below.
[mxfp8_pdl_repro.py](https://github.com/user-attachments/files/28021238/mxfp8_pdl_repro.py)
- [✅] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory ordering issue in GPU quantization kernels to ensure proper synchronization between dependent operations, preventing potential data visibility problems during tensor processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->