### PR TITLE
fix(trace): repair TGV and XQA MLA reference tests

### DIFF
--- a/flashinfer/trace/templates/page.py
+++ b/flashinfer/trace/templates/page.py
@@ -904,7 +904,7 @@ def _tgv_gemm_sm100_init(
     """Build inputs for TGV GEMM (SM100). ``b`` is column-major [K, N]."""
     torch.manual_seed(seed)
     a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
-    b = torch.randn(K, N, dtype=torch.bfloat16, device=device)
+    b = torch.randn(N, K, dtype=torch.bfloat16, device=device).t()
     bias = torch.randn(N, dtype=torch.bfloat16, device=device)
     return {"a": a, "b": b, "bias": bias}
 

--- a/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
+++ b/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
@@ -32,11 +32,13 @@ def test_tgv_gemm_sm100_reference_correctness(shape_kwargs):
     from flashinfer.trace.templates.page import tgv_gemm_sm100_trace
 
     inputs = tgv_gemm_sm100_trace.init(**shape_kwargs)
+    assert inputs["b"].shape == (shape_kwargs["K"], shape_kwargs["N"])
+    assert inputs["b"].stride(0) == 1, "tgv_gemm_sm100 expects column-major b"
     try:
         api_out = tgv_gemm_sm100(inputs["a"], inputs["b"], inputs["bias"])
-        torch.cuda.synchronize()
     except Exception as exc:
         pytest.skip(f"tgv_gemm_sm100 unavailable: {exc}")
+    torch.cuda.synchronize()
     ref_out = tgv_gemm_sm100_trace.reference(inputs["a"], inputs["b"], inputs["bias"])
     # Matches tests/gemm/test_tgv_gemm.py: bf16 * K=1024 accumulation makes
     # element-wise tolerance unreliable; cosine similarity is the repo

--- a/tests/trace/test_xqa_mla_reference_correctness.py
+++ b/tests/trace/test_xqa_mla_reference_correctness.py
@@ -29,7 +29,7 @@ from tests.trace.reference_utils import (
             beam_width=1,
             num_pages=2,
             max_pages_per_seq=2,
-            num_heads_qo=64,
+            num_heads_qo=128,
             head_dim_ckv=512,
             head_dim_qk=576,
             page_size=16,
@@ -58,10 +58,10 @@ def test_xqa_mla_reference_correctness(shape_kwargs):
         sm_count=sm_count,
     )
     # Reference uses dequantized API inputs for a clean comparison.
-    q_ref = inputs["q"].float().squeeze(1)  # [B, Hq, QK]
+    q_ref = inputs["q"].float()
     k_ref = inputs["k_cache"].float().squeeze(-2)
     v_ref = inputs["v_cache"].float().squeeze(-2)
-    seq_lens_ref = inputs["seq_lens"].squeeze(1).to(torch.int32)
+    seq_lens_ref = inputs["seq_lens"].to(torch.int32)
     ref_buffer = torch.empty_like(inputs["output"])
     ref_out = xqa_mla_trace.reference(
         q_ref,
@@ -77,7 +77,7 @@ def test_xqa_mla_reference_correctness(shape_kwargs):
     # metric the existing tests/attention/test_xqa.py uses for the same op:
     # >=95% of elements within (atol=0.05, rtol=0.05).
     _close_pass_ratio(
-        inputs["output"].squeeze(1).float(),
+        inputs["output"].float(),
         ref_out.float(),
         atol=0.05,
         rtol=0.05,


### PR DESCRIPTION
## Summary
- construct `tgv_gemm_sm100` trace `b` with column-major strides, matching the kernel contract
- add a TGV test layout assertion and avoid converting CUDA sync failures into skips
- keep the XQA MLA beam dimension in the reference path and remove the invalid 64-query-head positive case

Fixes #3352
Fixes #3353

## Testing
- reproduced the old TGV bad-layout failure on B200 with `torch 2.9.1+cu129`: `GPUassert: an illegal instruction was encountered`
- `python -m compileall flashinfer/trace/templates/page.py tests/trace/test_tgv_gemm_sm100_reference_correctness.py tests/trace/test_xqa_mla_reference_correctness.py`
- `FLASHINFER_WORKSPACE_BASE=/tmp/flashinfer-pr-cache /tmp/flashinfer-cu129/bin/python -m pytest tests/trace/test_tgv_gemm_sm100_reference_correctness.py -q -rs` -> 2 passed
- on SM120, reproduced `upstream/main` XQA MLA failure: `output with shape [2, 1, 128, 512]` does not match broadcast shape `[2, 2, 128, 512]`
- on SM120, fix branch: `CUDA_VISIBLE_DEVICES=0 FLASHINFER_WORKSPACE_BASE=/tmp/flashinfer-sm120-fix-cache python -m pytest tests/trace/test_xqa_mla_reference_correctness.py -q -rs --tb=short` -> 2 passed