### PR TITLE
fix(autotuner): differentiate file cache entries by runner specific kernel parameters

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -753,7 +753,7 @@ def load_from_file(key):
     except (ImportError, AttributeError):
         best_configs = None
     if best_configs is not None:
-        k = str((key[0], key[1], key[3]))
+        k = str((key[0], key[1], key[3], key[4]))
         if k in best_configs:
             logger.info(f"[Autotuner]: Loading configs for {k} from file.")
             return True, best_configs[k][0], best_configs[k][1], None
@@ -937,8 +937,10 @@ class AutoTuner:
                 if cache_key in self.profiling_cache:
                     return True, *self.profiling_cache[cache_key]
 
-                # Build the hash-free file key used by both user configs and bundled configs
-                file_key = str((cache_key[0], cache_key[1], cache_key[3]))
+                # Build the hash-free file key used by both user configs and bundled configs.
+                # Include extras (index 4) so that runner specific parameters
+                # are not lost on disk.
+                file_key = str((cache_key[0], cache_key[1], cache_key[3], cache_key[4]))
 
                 # 2. User-loaded configs (from load_configs or autotune(cache=...))
                 #    Always consulted, even during tuning mode — loaded configs take priority
@@ -1682,8 +1684,9 @@ class AutoTuner:
                 custom_op, runner_class_name, _runner_hash, profile, _extras = cache_key
                 runner_id, tactic, _opt_profile = cache_value
 
-                # Use hash-free key: (custom_op, runner_class_name, profile)
-                file_key = str((custom_op, runner_class_name, profile))
+                # Use hash-free key including extras so runner specific parameters
+                # are preserved across save or load.
+                file_key = str((custom_op, runner_class_name, profile, _extras))
 
                 # Store runner class name (not positional index) for robustness
                 tactic_json = _tactic_to_json(tactic)

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6438,6 +6438,9 @@ def get_trtllm_gemm_module():
             self._input_dtype = input_dtype
             self._output_dtype = output_dtype
 
+        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            return (self._use_8x4_sf_layout,)
+
         def unpack_inputs(
             self,
             inputs: List[torch.Tensor],

--- a/tests/autotuner/test_autotuner_configs.py
+++ b/tests/autotuner/test_autotuner_configs.py
@@ -278,7 +278,7 @@ class TestSearchCacheFallbackChain:
         _populate_cache(self.tuner, runner, "op1", profile, tactic=99)
 
         cache_key = AutoTuner._get_cache_key("op1", runner, profile, _TUNING_CONFIG)
-        file_key = str((cache_key[0], cache_key[1], cache_key[3]))
+        file_key = str((cache_key[0], cache_key[1], cache_key[3], cache_key[4]))
         self.tuner._file_configs[file_key] = ("FakeRunnerA", 55)
 
         is_hit, runner_id, tactic, _ = self.tuner.search_cache(
@@ -293,7 +293,7 @@ class TestSearchCacheFallbackChain:
         profile = ((10, 20),)
 
         cache_key = AutoTuner._get_cache_key("op1", runner, profile, _TUNING_CONFIG)
-        file_key = str((cache_key[0], cache_key[1], cache_key[3]))
+        file_key = str((cache_key[0], cache_key[1], cache_key[3], cache_key[4]))
         self.tuner._file_configs[file_key] = ("FakeRunnerA", 42)
 
         is_hit, runner_id, tactic, _ = self.tuner.search_cache(
@@ -311,7 +311,7 @@ class TestSearchCacheFallbackChain:
 
         # File config says FakeRunnerB won
         cache_key = AutoTuner._get_cache_key("op1", runner_b, profile, _TUNING_CONFIG)
-        file_key = str((cache_key[0], cache_key[1], cache_key[3]))
+        file_key = str((cache_key[0], cache_key[1], cache_key[3], cache_key[4]))
         self.tuner._file_configs[file_key] = ("FakeRunnerB", 11)
 
         # Pass runners in order [A, B] — B is at index 1
@@ -393,7 +393,7 @@ class TestEndToEnd:
         runner_b = FakeRunnerB(value=2)
 
         # Simulate loaded file configs
-        self.tuner._file_configs["('old_op', 'FakeRunnerA', ((1, 2),))"] = (
+        self.tuner._file_configs["('old_op', 'FakeRunnerA', ((1, 2),), ())"] = (
             "FakeRunnerA",
             10,
         )
@@ -414,8 +414,8 @@ class TestEndToEnd:
             assert len(_config_entries(data)) == 2
 
             # Verify old loaded config is included
-            assert "('old_op', 'FakeRunnerA', ((1, 2),))" in data
-            old_entry = data["('old_op', 'FakeRunnerA', ((1, 2),))"]
+            assert "('old_op', 'FakeRunnerA', ((1, 2),), ())" in data
+            old_entry = data["('old_op', 'FakeRunnerA', ((1, 2),), ())"]
             assert old_entry == ["FakeRunnerA", 10]
         finally:
             os.unlink(tmp_path)
@@ -427,7 +427,7 @@ class TestEndToEnd:
 
         # Simulate a loaded config for this key
         cache_key = AutoTuner._get_cache_key("op1", runner, profile, _TUNING_CONFIG)
-        file_key = str((cache_key[0], cache_key[1], cache_key[3]))
+        file_key = str((cache_key[0], cache_key[1], cache_key[3], cache_key[4]))
         self.tuner._file_configs[file_key] = ("FakeRunnerA", 99)
 
         # Add a newer in-memory result for the same op/runner/profile
@@ -452,6 +452,93 @@ class TestEndToEnd:
 
 
 # ---------------------------------------------------------------------------
+# Tests: file cache key collision (reproduces GitHub issue #3363)
+# ---------------------------------------------------------------------------
+
+
+class TestFileCacheKeyCollision:
+    """Verify that runners differing only in extras do not collide in file cache.
+
+    This reproduces the bug where TrtllmGemmRunner with use_8x4_sf_layout=True
+    and use_8x4_sf_layout=False produce the same file cache key, causing the
+    wrong tactic to be loaded from a persistent cache file.
+    """
+
+    def setup_method(self):
+        AutoTuner._instance = None
+        self.tuner = AutoTuner.get()
+
+    def teardown_method(self):
+        AutoTuner._instance = None
+
+    def test_different_extras_produce_different_file_keys(self):
+        """Two entries with same op/runner/profile but different extras must not collide."""
+        runner = FakeRunnerA(value=1)
+        profile = ((128, 3584), (3584, 7168))
+
+        # Simulate two cache entries that differ only in extras
+        # (e.g. use_8x4_sf_layout=True vs False)
+        cache_key_a = AutoTuner._get_cache_key(
+            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(True,)
+        )
+        cache_key_b = AutoTuner._get_cache_key(
+            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(False,)
+        )
+        self.tuner.profiling_cache[cache_key_a] = (0, 42, None)
+        self.tuner.profiling_cache[cache_key_b] = (0, 17, None)
+        self.tuner._dirty = True
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            tmp_path = f.name
+
+        try:
+            self.tuner.save_configs(tmp_path)
+
+            with open(tmp_path, "r") as f:
+                data = json.load(f)
+
+            configs = _config_entries(data)
+            # BUG: without fix, only 1 entry (collision). With fix, 2 entries.
+            assert len(configs) == 2, (
+                f"Expected 2 distinct file cache entries but got {len(configs)}. "
+                f"Entries with different extras collided in the file key."
+            )
+        finally:
+            os.unlink(tmp_path)
+
+    def test_save_load_roundtrip_with_extras(self):
+        """Save two entries with different extras, load them back, verify both are found."""
+        runner = FakeRunnerA(value=1)
+        profile = ((128, 3584), (3584, 7168))
+
+        cache_key_a = AutoTuner._get_cache_key(
+            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(True,)
+        )
+        cache_key_b = AutoTuner._get_cache_key(
+            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(False,)
+        )
+        self.tuner.profiling_cache[cache_key_a] = (0, 42, None)
+        self.tuner.profiling_cache[cache_key_b] = (0, 17, None)
+        self.tuner._dirty = True
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            tmp_path = f.name
+
+        try:
+            self.tuner.save_configs(tmp_path)
+            self.tuner.clear_cache()
+            self.tuner.load_configs(tmp_path)
+
+            # Both entries should be in _file_configs, not just one
+            assert len(self.tuner._file_configs) == 2, (
+                f"Expected 2 file_configs entries but got {len(self.tuner._file_configs)}. "
+                f"One entry was overwritten due to key collision."
+            )
+        finally:
+            os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
 # Tests: autotune(cache=...) context manager
 # ---------------------------------------------------------------------------
 
@@ -466,7 +553,7 @@ class TestAutotuneCache:
     def test_autotune_cache_loads_on_entry(self):
         """autotune(cache=path) should load configs from the file on entry."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump({"('op1', 'FakeRunnerA', ((1, 2),))": ["FakeRunnerA", 7]}, f)
+            json.dump({"('op1', 'FakeRunnerA', ((1, 2),), ())": ["FakeRunnerA", 7]}, f)
             tmp_path = f.name
 
         try:

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -99,7 +99,7 @@ def _force_tactic_in_autotuner_cache(
     tactic: list[int] | None,
     custom_op: str,
 ) -> None:
-    file_key = str((custom_op, _TEST_RUNNER, profile_shapes))
+    file_key = str((custom_op, _TEST_RUNNER, profile_shapes, ()))
     tuner = AutoTuner.get()
     tuner.profiling_cache.clear()
     tuner._file_configs.clear()


### PR DESCRIPTION
## 📌 Description

The persistent autotune file cache key was constructed as a 3-tuple `(custom_op, runner_class, profile)`, intentionally dropping `hash(runner)` for cross-process stability, but **unintentionally also dropping `extras`**, which carries runnerspecific parameters like `use_8x4_sf_layout`, which caused `TrtllmGemmRunner` instances with `use_8x4_sf_layout=True` and `use_8x4_sf_layout=False` to collide in the file cache. When vLLM or other frameworks persists and reloads autotune results, the wrong tactic gets applied, producing:
```
RuntimeError: Check failed: (config.mOptions.mSfLayoutB == mOptions.sfLayoutB)
             is false: Invalid sf layout in run
```

**Updates:**

1. **`flashinfer/autotuner.py`**, extend file key from 3-tuple to 4-tuple in `search_cache`, `save_configs`, `load_from_file`.
2. **`flashinfer/gemm/gemm_base.py`**, implement `get_cache_key_extras()` to return `(self._use_8x4_sf_layout,)`.
3. **`tests/autotuner/test_autotuner_configs.py`**, add `TestFileCacheKeyCollision` with two tests reproducing and update existing tests for the new 4-tuple key format.

## 🔍 Related Issues

- Fixes flashinfer-ai/flashinfer#3363
- Related to vllm-project/vllm#42537

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
  - `test_autotuner_configs.py` — **37 passed**
  - `test_autotuner_core.py` — **78 passed**

## Reviewer Notes

The bug is latent until autotune results are persisted to disk and reloaded. It was exposed by vllm-project/vllm#42537 which added persistent caching for FlashInfer autotuning in vLLM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache key mismatch between memory and disk so runner-specific parameters (extras/layout) are preserved when saving/loading autotuner results.
  * Resolved collisions where configurations that differed only by layout-related parameters were treated as the same.

* **Tests**
  * Added and updated tests to verify distinct file-cache entries and loading for entries differing by extras/layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->