### PR TITLE
Make cubin symlink setup idempotent under concurrent startup

### DIFF
--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -261,7 +261,12 @@ def ensure_symlink(
                 link.unlink()
             else:
                 shutil.rmtree(link)
-        link.symlink_to(target)
+        try:
+            link.symlink_to(target)
+        except FileExistsError:
+            if link.is_symlink() and link.resolve() == target.resolve():
+                return
+            raise
 
 
 def verify_symlinked_headers(

--- a/tests/utils/test_cubin_loader.py
+++ b/tests/utils/test_cubin_loader.py
@@ -1,0 +1,57 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pathlib
+
+import pytest
+
+from flashinfer.jit.cubin_loader import ensure_symlink
+
+
+def test_ensure_symlink_tolerates_concurrent_same_target(monkeypatch, tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "include" / "target"
+    original_symlink_to = pathlib.Path.symlink_to
+
+    def create_link_then_raise(self, symlink_target, *args, **kwargs):
+        original_symlink_to(self, symlink_target, *args, **kwargs)
+        raise FileExistsError
+
+    monkeypatch.setattr(pathlib.Path, "symlink_to", create_link_then_raise)
+
+    ensure_symlink(link, target)
+
+    assert link.is_symlink()
+    assert link.resolve() == target.resolve()
+
+
+def test_ensure_symlink_reraises_concurrent_different_target(monkeypatch, tmp_path):
+    target = tmp_path / "target"
+    other_target = tmp_path / "other_target"
+    target.mkdir()
+    other_target.mkdir()
+    link = tmp_path / "include" / "target"
+    original_symlink_to = pathlib.Path.symlink_to
+
+    def create_wrong_link_then_raise(self, symlink_target, *args, **kwargs):
+        original_symlink_to(self, other_target, *args, **kwargs)
+        raise FileExistsError
+
+    monkeypatch.setattr(pathlib.Path, "symlink_to", create_wrong_link_then_raise)
+
+    with pytest.raises(FileExistsError):
+        ensure_symlink(link, target)


### PR DESCRIPTION
## Summary

Make `ensure_symlink()` tolerate a concurrent startup race where another process creates the intended cubin symlink after the pre-check but before `symlink_to()`.

## Root Cause

During multi-rank SGLang startup, multiple ranks can set up the same FlashInfer cubin include symlink concurrently. If one rank creates the symlink after another rank checks `link.exists()` / `link.is_symlink()` but before it calls `link.symlink_to(target)`, the second rank can fail with:

```text
FileExistsError: [Errno 17] File exists
```

This is harmless when the symlink now points to the same intended target, so treat that case as success. Stale links, files, directories, or links to a different target still follow the existing behavior and raise/remove as before.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/pycache-flashinfer python3 -m py_compile flashinfer/jit/cubin_loader.py tests/utils/test_cubin_loader.py`
- Manual focused race simulation for:
  - same-target concurrent symlink creation returns successfully
  - different-target concurrent symlink creation still raises `FileExistsError`

Note: local `pytest` could not collect the repo test directly on this machine because the lightweight local environment lacks FlashInfer test dependencies such as `torch` / `tvm_ffi`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced symlink creation error handling to gracefully handle cases where symlinks already exist with the correct target, improving system robustness.

* **Tests**
  * Added test coverage for concurrent symlink creation scenarios, verifying correct behavior when conflicts occur and ensuring proper error handling when symlinks point to different targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->