### PR TITLE
feat: GPU preparation kernel for fmha_v2 prefill (fixes #3254) 

### DIFF
--- a/csrc/fmha_v2_jit_binding.cu
+++ b/csrc/fmha_v2_jit_binding.cu
@@ -15,7 +15,7 @@
  */
 
 // FMHAv2 JIT Binding
-// This file exports the fmha_v2_run function via TVM FFI
+// This file exports fmha_v2 functions via TVM FFI
 
 #include <fused_multihead_attention.h>
 
@@ -24,6 +24,7 @@
 using tvm::ffi::Optional;
 using Attention_input_layout = fmha::Attention_input_layout;
 
+// Original run (backward compatible)
 void fmha_v2_run(ffi::TensorView q, ffi::TensorView k, ffi::TensorView v, ffi::TensorView o,
                  ffi::TensorView workspace_buffer, size_t workspace_buffer_size_in_bytes,
                  Optional<ffi::TensorView> maybe_block_tables, int page_size,
@@ -35,5 +36,33 @@ void fmha_v2_run(ffi::TensorView q, ffi::TensorView k, ffi::TensorView v, ffi::T
                  float skip_softmax_threshold_scale_factor, Optional<ffi::TensorView> softmax_stats,
                  Optional<ffi::TensorView> sinks);
 
-// FMHAv2 attention operator
+// GPU preparation kernel
+void fmha_v2_prepare(ffi::TensorView qo_indptr, ffi::TensorView paged_kv_indptr,
+                      ffi::TensorView paged_kv_last_page_len, ffi::TensorView paged_kv_indices,
+                      ffi::TensorView kv_lens_out, ffi::TensorView block_tables_out,
+                      ffi::TensorView metadata_out, int page_size, int batch_size,
+                      int max_blocks_per_seq);
+
+// Plan: pre-compute static config (SM, launch params, warps, grid)
+void fmha_v2_plan(ffi::TensorView q, ffi::TensorView k, ffi::TensorView v,
+                   const std::string& input_layout_str, const std::string& mask_mode_str,
+                   int max_kv_len, int batch_size, int window_left, int chunked_attention_size,
+                   bool has_alibi, float skip_softmax_threshold_scale_factor,
+                   ffi::TensorView plan_info_out);
+
+// Run with pre-computed plan (skips SM detection, string parsing, launch param computation)
+void fmha_v2_run_with_plan(
+    ffi::TensorView plan_info, ffi::TensorView q, ffi::TensorView k, ffi::TensorView v,
+    ffi::TensorView o, ffi::TensorView workspace_buffer, size_t workspace_buffer_size_in_bytes,
+    Optional<ffi::TensorView> maybe_block_tables, int page_size, ffi::TensorView seq_lens,
+    ffi::TensorView cum_seq_lens_q, ffi::TensorView cum_seq_lens_kv, int max_q_len, int max_kv_len,
+    int batch_size, float scale_softmax, float scale_bmm1, float scale_bmm2, int window_left,
+    int chunked_attention_size, bool has_alibi, float softcapping_scale,
+    float skip_softmax_threshold_scale_factor, Optional<ffi::TensorView> softmax_stats,
+    Optional<ffi::TensorView> sinks);
+
+// FMHAv2 FFI exports
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, fmha_v2_run);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(prepare, fmha_v2_prepare);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, fmha_v2_plan);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_with_plan, fmha_v2_run_with_plan);

--- a/csrc/fmha_v2_prepare.cu
+++ b/csrc/fmha_v2_prepare.cu
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023-2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// GPU preparation kernel for fmha_v2.
+// Replaces CPU-side D2H transfers, get_seq_lens(), Python for-loop block table
+// construction, and H2D copies with a single GPU kernel + one 16-byte D2H.
+
+#include <cuda_runtime.h>
+
+#include "tvm_ffi_utils.h"
+
+namespace ffi = tvm::ffi;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// fmha_v2_prepare_kernel
+//
+// Each thread handles one request in the batch.
+// Computes:
+//   1. kv_lens[i] = max(num_pages_i - 1, 0) * page_size + last_page_len[i]
+//   2. q_len[i] for max reduction
+//   3. block_tables[i, 0..num_pages_i)
+//   4. metadata: [max_q_len, max_kv_len, total_num_rows, max_blocks_per_seq]
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+__global__ void fmha_v2_prepare_kernel(
+    const int32_t* __restrict__ qo_indptr,              // [B+1]
+    const int32_t* __restrict__ paged_kv_indptr,         // [B+1]
+    const int32_t* __restrict__ paged_kv_last_page_len,  // [B]
+    const int32_t* __restrict__ paged_kv_indices,        // [total_pages]
+    int32_t* __restrict__ kv_lens,                       // [B] output
+    int32_t* __restrict__ block_tables,                  // [B * max_blocks_per_seq] output
+    int32_t* __restrict__ metadata,                      // [4] output
+    int page_size, int batch_size, int max_blocks_per_seq) {
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  if (i >= batch_size) return;
+
+  // 1. Compute kv_lens
+  int num_pages_i = paged_kv_indptr[i + 1] - paged_kv_indptr[i];
+  int kv_len_i = max(num_pages_i - 1, 0) * page_size + paged_kv_last_page_len[i];
+  kv_lens[i] = kv_len_i;
+
+  // 2. Compute q_len for max reduction
+  int q_len_i = qo_indptr[i + 1] - qo_indptr[i];
+
+  // 3. Fill block_tables row i
+  int block_start = paged_kv_indptr[i];
+  for (int j = 0; j < num_pages_i && j < max_blocks_per_seq; j++) {
+    block_tables[i * max_blocks_per_seq + j] = paged_kv_indices[block_start + j];
+  }
+
+  // 4. Atomically reduce max_q_len, max_kv_len
+  atomicMax(&metadata[0], q_len_i);
+  atomicMax(&metadata[1], kv_len_i);
+
+  // Thread 0 writes total_num_rows and max_blocks_per_seq
+  if (i == 0) {
+    metadata[2] = qo_indptr[batch_size];
+    metadata[3] = max_blocks_per_seq;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// TVM FFI wrapper
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void fmha_v2_prepare(ffi::TensorView qo_indptr, ffi::TensorView paged_kv_indptr,
+                      ffi::TensorView paged_kv_last_page_len, ffi::TensorView paged_kv_indices,
+                      ffi::TensorView kv_lens_out, ffi::TensorView block_tables_out,
+                      ffi::TensorView metadata_out, int page_size, int batch_size,
+                      int max_blocks_per_seq) {
+  cudaStream_t stream = static_cast<cudaStream_t>(get_stream(qo_indptr.device()));
+
+  // Zero metadata before atomicMax
+  cudaMemsetAsync(metadata_out.data_ptr(), 0, 4 * sizeof(int32_t), stream);
+
+  int threads = min(batch_size, 1024);
+  int blocks = (batch_size + threads - 1) / threads;
+
+  fmha_v2_prepare_kernel<<<blocks, threads, 0, stream>>>(
+      static_cast<const int32_t*>(qo_indptr.data_ptr()),
+      static_cast<const int32_t*>(paged_kv_indptr.data_ptr()),
+      static_cast<const int32_t*>(paged_kv_last_page_len.data_ptr()),
+      static_cast<const int32_t*>(paged_kv_indices.data_ptr()),
+      static_cast<int32_t*>(kv_lens_out.data_ptr()),
+      static_cast<int32_t*>(block_tables_out.data_ptr()),
+      static_cast<int32_t*>(metadata_out.data_ptr()), page_size, batch_size, max_blocks_per_seq);
+}

--- a/csrc/fmha_v2_run.cu
+++ b/csrc/fmha_v2_run.cu
@@ -676,3 +676,344 @@ void fmha_v2_run(
   // Run the V2 kernel with runtime dispatch based on dtype and head dimensions
   run_fmha_v2(params_v2, launch_params, data_type, output_dtype, sm, stream);
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// fmha_v2_plan / fmha_v2_run_with_plan
+//
+// Splits the one-shot fmha_v2_run into a plan phase (expensive string parsing,
+// SM detection, launch param / warp / grid computation) and a run phase that
+// only fills params_v2 and dispatches the kernel.
+//
+// Plan info is encoded as a flat int64 array so it can cross the TVM FFI
+// boundary without special types.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Plan info layout (int64 elements):
+//   [0]  sm
+//   [1]  data_type (enum)
+//   [2]  acc_type (enum)
+//   [3]  input_layout (enum)
+//   [4]  is_paged_hnd
+//   [5]  attention_mask_type (enum)
+//   [6]  force_fp32_acc
+//   [7]  warps_m
+//   [8]  warps_n
+//   [9]  warps_k
+//   [10] heads_per_wave
+//   [11] ctas_per_head
+//   [12] flash_attention
+//   [13] warp_specialization
+//   [14] use_tma
+//   [15] use_granular_tiling
+//   [16] enable_skip_softmax
+//   [17] multi_processor_count
+//   [18] device_l2_cache_size
+static constexpr int PLAN_INFO_SIZE = 19;
+
+void fmha_v2_plan(ffi::TensorView q, ffi::TensorView k, ffi::TensorView v,
+                   const std::string& input_layout_str, const std::string& mask_mode_str,
+                   int max_kv_len, int batch_size, int window_left, int chunked_attention_size,
+                   bool has_alibi, float skip_softmax_threshold_scale_factor,
+                   ffi::TensorView plan_info_out  // [PLAN_INFO_SIZE] int64 on CPU
+) {
+  bool is_paged_hnd;
+  Attention_input_layout input_layout = string_to_input_layout(input_layout_str, is_paged_hnd);
+  Attention_mask_type attention_mask_type = string_to_mask_type(mask_mode_str);
+
+  CudaDevice device;
+  int sm = device.sm;
+  if (sm > 120 && sm < 130) {
+    sm = 120;
+  }
+  cudaDeviceProp props = device.props;
+
+  size_t h, h_kv, d, dv;
+  if (input_layout == Attention_input_layout::PACKED_QKV) {
+    h = q.shape()[2];
+    h_kv = q.shape()[2];
+    d = q.shape()[3];
+    dv = q.shape()[3];
+  } else if (input_layout == Attention_input_layout::Q_PAGED_KV) {
+    h = q.shape()[1];
+    h_kv = k.shape()[is_paged_hnd ? 1 : 2];
+    d = q.shape()[2];
+    dv = v.shape()[3];
+  } else if (input_layout == Attention_input_layout::CONTIGUOUS_Q_KV) {
+    h = q.shape()[1];
+    h_kv = k.shape()[2];
+    d = q.shape()[2];
+    dv = k.shape()[3];
+  } else {
+    h = q.shape()[1];
+    h_kv = k.shape()[1];
+    d = q.shape()[2];
+    dv = v.shape()[2];
+  }
+
+  const size_t b = batch_size;
+  const size_t s = max_kv_len;
+
+  Data_type data_type = dltype_to_data_type(q.dtype());
+  Data_type acc_type =
+      (data_type == DATA_TYPE_BF16 || data_type == DATA_TYPE_E4M3) ? DATA_TYPE_FP32 : data_type;
+  bool force_fp32_acc = (data_type == DATA_TYPE_BF16 || data_type == DATA_TYPE_E4M3);
+
+  if (window_left > 0 && window_left < static_cast<int>(s)) {
+    attention_mask_type = Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL;
+  }
+  if (chunked_attention_size > 0) {
+    attention_mask_type = Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL;
+  }
+  if (has_alibi && attention_mask_type == Attention_mask_type::PADDING) {
+    attention_mask_type = Attention_mask_type::CAUSAL;
+  }
+
+  Launch_params launch_params;
+  determine_launch_params(launch_params, data_type, sm, s, d, attention_mask_type, input_layout,
+                          false, false, false, false, false, false, false, force_fp32_acc,
+                          skip_softmax_threshold_scale_factor, props);
+
+  size_t warps_m, warps_n, warps_k;
+  std::tie(warps_m, warps_n, warps_k) = get_warps(launch_params, sm, data_type, s, b, d, 2);
+
+  int heads_per_wave, ctas_per_head;
+  get_grid_size(heads_per_wave, ctas_per_head, sm, data_type, b, s, h, d, false, 2);
+
+  // Write plan info
+  int64_t* info = static_cast<int64_t*>(plan_info_out.data_ptr());
+  info[0] = sm;
+  info[1] = static_cast<int64_t>(data_type);
+  info[2] = static_cast<int64_t>(acc_type);
+  info[3] = static_cast<int64_t>(input_layout);
+  info[4] = is_paged_hnd ? 1 : 0;
+  info[5] = static_cast<int64_t>(attention_mask_type);
+  info[6] = force_fp32_acc ? 1 : 0;
+  info[7] = static_cast<int64_t>(warps_m);
+  info[8] = static_cast<int64_t>(warps_n);
+  info[9] = static_cast<int64_t>(warps_k);
+  info[10] = heads_per_wave;
+  info[11] = ctas_per_head;
+  info[12] = launch_params.flash_attention ? 1 : 0;
+  info[13] = launch_params.warp_specialization ? 1 : 0;
+  info[14] = launch_params.use_tma ? 1 : 0;
+  info[15] = launch_params.use_granular_tiling ? 1 : 0;
+  info[16] = launch_params.enable_skip_softmax ? 1 : 0;
+  info[17] = props.multiProcessorCount;
+  info[18] = props.l2CacheSize;
+}
+
+void fmha_v2_run_with_plan(
+    ffi::TensorView plan_info,  // [PLAN_INFO_SIZE] int64 on CPU
+    ffi::TensorView q, ffi::TensorView k, ffi::TensorView v, ffi::TensorView o,
+    ffi::TensorView workspace_buffer, size_t workspace_buffer_size_in_bytes,
+    Optional<ffi::TensorView> maybe_block_tables, int page_size,
+    ffi::TensorView seq_lens, ffi::TensorView cum_seq_lens_q, ffi::TensorView cum_seq_lens_kv,
+    int max_q_len, int max_kv_len, int batch_size, float scale_softmax, float scale_bmm1,
+    float scale_bmm2, int window_left, int chunked_attention_size, bool has_alibi,
+    float softcapping_scale, float skip_softmax_threshold_scale_factor,
+    Optional<ffi::TensorView> softmax_stats, Optional<ffi::TensorView> sinks) {
+  // Decode plan info
+  const int64_t* info = static_cast<const int64_t*>(plan_info.data_ptr());
+  int sm = static_cast<int>(info[0]);
+  Data_type data_type = static_cast<Data_type>(info[1]);
+  Data_type acc_type = static_cast<Data_type>(info[2]);
+  Attention_input_layout input_layout = static_cast<Attention_input_layout>(info[3]);
+  bool is_paged_hnd = info[4] != 0;
+  Attention_mask_type attention_mask_type = static_cast<Attention_mask_type>(info[5]);
+  // bool force_fp32_acc = info[6] != 0;  // encoded in launch_params already
+  size_t warps_m = static_cast<size_t>(info[7]);
+  size_t warps_n = static_cast<size_t>(info[8]);
+  size_t warps_k = static_cast<size_t>(info[9]);
+  int heads_per_wave = static_cast<int>(info[10]);
+  int ctas_per_head = static_cast<int>(info[11]);
+
+  Data_type output_dtype = dltype_to_data_type(o.dtype());
+
+  // Reconstruct launch_params from plan info (no SM detection or string parsing)
+  Launch_params launch_params;
+  launch_params.ignore_b1opt = false;
+  launch_params.force_unroll = false;
+  launch_params.force_fp32_acc = info[6] != 0;
+  launch_params.interleaved = false;
+  launch_params.attention_mask_type = attention_mask_type;
+  launch_params.attention_input_layout = input_layout;
+  launch_params.multi_processor_count = static_cast<int>(info[17]);
+  launch_params.device_l2_cache_size = static_cast<int>(info[18]);
+  launch_params.flash_attention = info[12] != 0;
+  launch_params.warp_specialization = info[13] != 0;
+  launch_params.use_tma = info[14] != 0;
+  launch_params.use_granular_tiling = info[15] != 0;
+  launch_params.enable_skip_softmax = info[16] != 0;
+
+  cudaStream_t stream = static_cast<cudaStream_t>(get_stream(q.device()));
+
+  // Extract dimensions (fast path — no string parsing needed)
+  const size_t b = batch_size;
+  size_t h, h_kv, d, dv;
+  if (input_layout == Attention_input_layout::PACKED_QKV) {
+    h = q.shape()[2];
+    h_kv = q.shape()[2];
+    d = q.shape()[3];
+    dv = q.shape()[3];
+  } else if (input_layout == Attention_input_layout::Q_PAGED_KV) {
+    h = q.shape()[1];
+    h_kv = k.shape()[is_paged_hnd ? 1 : 2];
+    d = q.shape()[2];
+    dv = v.shape()[3];
+  } else if (input_layout == Attention_input_layout::CONTIGUOUS_Q_KV) {
+    h = q.shape()[1];
+    h_kv = k.shape()[2];
+    d = q.shape()[2];
+    dv = k.shape()[3];
+  } else {
+    h = q.shape()[1];
+    h_kv = k.shape()[1];
+    d = q.shape()[2];
+    dv = v.shape()[2];
+  }
+
+  const size_t s_q = max_q_len;
+  const size_t s_kv = max_kv_len;
+  const size_t s = s_kv;
+
+  int tokens_per_block = page_size;
+  float softcapping_scale_bmm1 = softcapping_scale;
+
+  size_t sliding_window_size = size_t(INT_MAX);
+  if (attention_mask_type == Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL) {
+    if (window_left != -1) {
+      sliding_window_size = size_t(window_left + 1);
+    }
+  }
+
+  uint32_t total_q_tokens = static_cast<uint32_t>(q.shape()[0]);
+  uint32_t total = total_q_tokens;
+
+  AlignedAllocator allocator(workspace_buffer.data_ptr(), workspace_buffer_size_in_bytes);
+
+  if (scale_bmm1 == 0.f) {
+    scale_bmm1 = 1.f / sqrtf(static_cast<float>(d));
+  }
+  if (data_type == DATA_TYPE_FP16 && scale_softmax == 0.f) {
+    scale_softmax = 1.f;
+  } else if (data_type == DATA_TYPE_INT8 && scale_softmax == 0.f) {
+    scale_softmax = std::max(512.f, static_cast<float>(s));
+  } else if (data_type == DATA_TYPE_E4M3 && scale_softmax == 0.f) {
+    scale_softmax = 1.f;
+  }
+
+  const size_t threads_per_cta = warps_m * warps_n * warps_k * 32;
+  size_t mmas_m = (s + 16 * warps_m - 1) / (16 * warps_m);
+  size_t mmas_n = (s + 16 * warps_n - 1) / (16 * warps_n);
+  size_t packed_mask_size = b * mmas_m * threads_per_cta;
+
+  if (attention_mask_type == Attention_mask_type::CUSTOM_MASK) {
+    size_t rounded_q_s = align_to(s, size_t(fmha::FLASH_ATTEN_MASK_M_ALIGNMENT));
+    size_t rounded_k_s = align_to(s, size_t(fmha::FLASH_ATTEN_MASK_N_ALIGNMENT));
+    mmas_m = rounded_q_s / fmha::FLASH_ATTEN_MASK_MMA_M;
+    mmas_n = rounded_k_s / fmha::FLASH_ATTEN_MASK_MMA_N;
+    packed_mask_size = b * mmas_m * mmas_n * threads_per_cta;
+  }
+  const size_t packed_mask_size_in_bytes = packed_mask_size * sizeof(uint32_t);
+
+  void* packed_mask_d =
+      (attention_mask_type == Attention_mask_type::CUSTOM_MASK)
+          ? allocator.aligned_alloc<void>(packed_mask_size_in_bytes, 128, "packed_mask_d")
+          : nullptr;
+
+  void* softmax_stats_ptr = nullptr;
+  if (softmax_stats.has_value()) {
+    softmax_stats_ptr = softmax_stats.value().data_ptr();
+  }
+  void* attention_sinks_d = sinks.has_value() ? sinks.value().data_ptr() : nullptr;
+
+  void* qkv_packed_d = nullptr;
+  void* q_d = nullptr;
+  void* k_d = nullptr;
+  void* v_d = nullptr;
+  void* contiguous_kv_d = nullptr;
+  void* kv_cache_pool_ptr = nullptr;
+  int32_t* kv_cache_block_offsets_d = nullptr;
+  int block_table_max_blocks = 0;
+
+  switch (input_layout) {
+    case Attention_input_layout::PACKED_QKV:
+      qkv_packed_d = q.data_ptr();
+      break;
+    case Attention_input_layout::CONTIGUOUS_Q_KV:
+      q_d = q.data_ptr();
+      contiguous_kv_d = k.data_ptr();
+      break;
+    case Attention_input_layout::SEPARATE_Q_K_V:
+      q_d = q.data_ptr();
+      k_d = k.data_ptr();
+      v_d = v.data_ptr();
+      break;
+    case Attention_input_layout::Q_PAGED_KV: {
+      q_d = q.data_ptr();
+      kv_cache_pool_ptr = k.data_ptr();
+      if (maybe_block_tables.has_value()) {
+        ffi::TensorView block_tables = maybe_block_tables.value();
+        block_table_max_blocks = block_tables.shape()[1];
+        kv_cache_block_offsets_d = static_cast<int32_t*>(block_tables.data_ptr());
+      }
+    } break;
+    default:
+      assert(false && "Invalid input layout");
+      break;
+  }
+
+  bert::Fused_multihead_attention_params_v2 params_v2;
+  set_params(
+      params_v2, launch_params, data_type, acc_type, output_dtype, input_layout, is_paged_hnd, b,
+      s_q, s, h, h_kv, d, dv, total, 1, sliding_window_size, chunked_attention_size,
+      tokens_per_block, qkv_packed_d, q_d, k_d, v_d, contiguous_kv_d, kv_cache_pool_ptr,
+      kv_cache_block_offsets_d, packed_mask_d, nullptr, attention_sinks_d,
+      static_cast<void*>(cum_seq_lens_kv.data_ptr()), static_cast<void*>(cum_seq_lens_q.data_ptr()),
+      o.data_ptr(), nullptr, nullptr, softmax_stats_ptr, nullptr, scale_bmm1, scale_softmax,
+      scale_bmm2, softcapping_scale_bmm1, false, false, false, has_alibi,
+      skip_softmax_threshold_scale_factor);
+
+  if (input_layout == Attention_input_layout::Q_PAGED_KV && block_table_max_blocks > 0) {
+    params_v2.paged_kv_cache.mMaxBlocksPerSeq = block_table_max_blocks;
+    params_v2.paged_kv_cache.mUsesSharedPagedKvIdx = true;
+  }
+
+  launch_params.total_q_seqlen = total_q_tokens;
+  launch_params.enable_attn_logit_softcapping = softcapping_scale_bmm1 != 0.f;
+
+  // Workspace allocations
+  size_t counters_sz = (ctas_per_head > 1) ? heads_per_wave * sizeof(int) : 0;
+  size_t softmax_scratch_sz =
+      (ctas_per_head > 1) ? heads_per_wave * ctas_per_head * threads_per_cta * sizeof(float) : 0;
+  size_t o_scratch_sz = (ctas_per_head > 1 && data_type != DATA_TYPE_FP16)
+                            ? heads_per_wave * threads_per_cta * MAX_STGS_PER_LOOP * sizeof(uint4)
+                            : 0;
+
+  void* counters_d = (counters_sz > 0)
+                         ? allocator.aligned_alloc<void>(3 * counters_sz, 16, "counters_d")
+                         : nullptr;
+  void* max_scratch_d = (softmax_scratch_sz > 0)
+                            ? allocator.aligned_alloc<void>(softmax_scratch_sz, 128, "max_scratch_d")
+                            : nullptr;
+  void* sum_scratch_d = (softmax_scratch_sz > 0)
+                            ? allocator.aligned_alloc<void>(softmax_scratch_sz, 128, "sum_scratch_d")
+                            : nullptr;
+  void* o_scratch_d = (o_scratch_sz > 0)
+                          ? allocator.aligned_alloc<void>(o_scratch_sz, 128, "o_scratch_d")
+                          : nullptr;
+  void* tile_id_counter_d =
+      allocator.aligned_alloc<void>(sizeof(uint32_t), 16, "tile_id_counter_d");
+
+  params_v2.heads_per_wave = heads_per_wave;
+  params_v2.counters = (int*)counters_d + 0 * heads_per_wave;
+  params_v2.max_barriers = (int*)counters_d + 0 * heads_per_wave;
+  params_v2.sum_barriers = (int*)counters_d + 1 * heads_per_wave;
+  params_v2.locks = (int*)counters_d + 2 * heads_per_wave;
+  params_v2.max_scratch_ptr = (float*)max_scratch_d;
+  params_v2.sum_scratch_ptr = (float*)sum_scratch_d;
+  params_v2.o_scratch_ptr = (int*)o_scratch_d;
+  params_v2.tile_id_counter_ptr = (uint32_t*)tile_id_counter_d;
+
+  run_fmha_v2(params_v2, launch_params, data_type, output_dtype, sm, stream);
+}

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -144,6 +144,8 @@ from .prefill import (
     single_prefill_with_kv_cache_return_lse as single_prefill_with_kv_cache_return_lse,
 )
 from .prefill import trtllm_fmha_v2_prefill as trtllm_fmha_v2_prefill
+from .prefill import trtllm_fmha_v2_prepare as trtllm_fmha_v2_prepare
+from .prefill import trtllm_fmha_v2_plan as trtllm_fmha_v2_plan
 from .quantization import packbits as packbits
 from .quantization import segment_packbits as segment_packbits
 from .rope import apply_llama31_rope as apply_llama31_rope

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1992,6 +1992,13 @@ def gen_fmha_v2_module(
         compilation_context=current_compilation_context,
     )
 
+    # copy static fmha_v2_prepare.cu
+    static_prepare_path = csrc_dir / "fmha_v2_prepare.cu"
+    prepare_path = gen_directory / "fmha_v2_prepare.cu"
+    with open(static_prepare_path, "r") as f:
+        write_if_different(prepare_path, f.read())
+    source_paths.append(prepare_path)
+
     # copy static fmha_v2_run.cu
     static_run_path = csrc_dir / "fmha_v2_run.cu"
     run_path = gen_directory / "fmha_v2_run.cu"

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2040,26 +2040,80 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     "Use window_left=-1 for dense bidirectional attention."
                 )
             if self._block_tables is None:
-                blocks_per_seq = [
-                    (seq_len + page_size - 1) // page_size
-                    for seq_len in kv_lens_arr_host
-                ]
-                max_num_blocks_per_seq = max(blocks_per_seq)
-                self._block_tables = torch.zeros(
-                    (batch_size, max_num_blocks_per_seq),
-                    dtype=torch.int,
-                    device=self.device,
-                )
-                block_id = paged_kv_indptr_host[0]
-                for i in range(batch_size):
-                    num_blocks_needed = blocks_per_seq[i]
-                    assert self._block_tables is not None, (
-                        "block_tables is not initialized"
+                # Try GPU preparation path: compute kv_lens, block_tables, and
+                # metadata entirely on the GPU, avoiding the Python for-loop and
+                # extra D2H/H2D transfers.
+                _fmha_v2_mod = None
+                try:
+                    _fmha_v2_mod = get_trtllm_fmha_v2_module(
+                        "q_paged_kv_hnd", q_data_type
                     )
-                    self._block_tables[i, :num_blocks_needed] = paged_kv_indices[
-                        block_id : block_id + num_blocks_needed
+                except Exception:
+                    pass
+
+                if (
+                    _fmha_v2_mod is not None
+                    and hasattr(_fmha_v2_mod, "prepare")
+                    and qo_indptr.is_cuda
+                ):
+                    # GPU prepare path
+                    max_blocks_per_seq = (
+                        len(paged_kv_indices) + batch_size - 1
+                    ) // max(batch_size, 1)
+                    if batch_size > self._kv_lens_buffer.shape[0]:
+                        self._kv_lens_buffer = torch.empty(
+                            (batch_size,), dtype=torch.int32, device=self.device
+                        )
+                    self._block_tables = torch.zeros(
+                        (batch_size, max_blocks_per_seq),
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    metadata = torch.zeros(
+                        4, dtype=torch.int32, device=self.device
+                    )
+                    _fmha_v2_mod.prepare(
+                        qo_indptr,
+                        paged_kv_indptr,
+                        paged_kv_last_page_len,
+                        paged_kv_indices,
+                        self._kv_lens_buffer,
+                        self._block_tables,
+                        metadata,
+                        page_size,
+                        batch_size,
+                        max_blocks_per_seq,
+                    )
+                    # Single 16-byte D2H for metadata
+                    metadata_host = metadata.cpu()
+                    if max_token_per_sequence is None:
+                        self._max_q_len = metadata_host[0].item()
+                    if max_sequence_kv is None:
+                        self._max_kv_len = metadata_host[1].item()
+                    self._qo_indptr_last = metadata_host[2].item()
+                    total_num_rows = self._qo_indptr_last
+                else:
+                    # CPU fallback path
+                    blocks_per_seq = [
+                        (seq_len + page_size - 1) // page_size
+                        for seq_len in kv_lens_arr_host
                     ]
-                    block_id += num_blocks_needed
+                    max_num_blocks_per_seq = max(blocks_per_seq)
+                    self._block_tables = torch.zeros(
+                        (batch_size, max_num_blocks_per_seq),
+                        dtype=torch.int,
+                        device=self.device,
+                    )
+                    block_id = paged_kv_indptr_host[0]
+                    for i in range(batch_size):
+                        num_blocks_needed = blocks_per_seq[i]
+                        assert self._block_tables is not None, (
+                            "block_tables is not initialized"
+                        )
+                        self._block_tables[i, :num_blocks_needed] = paged_kv_indices[
+                            block_id : block_id + num_blocks_needed
+                        ]
+                        block_id += num_blocks_needed
 
         if self._cached_module is not None:
             args = [
@@ -4384,6 +4438,141 @@ def get_trtllm_fmha_v2_module(
     return gen_fmha_v2_module(input_layout, input_dtype, output_dtype).build_and_load()
 
 
+def trtllm_fmha_v2_prepare(
+    qo_indptr: torch.Tensor,
+    paged_kv_indptr: torch.Tensor,
+    paged_kv_last_page_len: torch.Tensor,
+    paged_kv_indices: torch.Tensor,
+    kv_lens_out: torch.Tensor,
+    block_tables_out: torch.Tensor,
+    metadata_out: torch.Tensor,
+    page_size: int,
+    batch_size: int,
+    max_blocks_per_seq: int,
+    input_layout: str = "q_paged_kv_hnd",
+    input_dtype: torch.dtype = torch.float16,
+) -> None:
+    r"""Run the GPU preparation kernel for FMHAv2.
+
+    Computes kv_lens, block_tables, and metadata (max_q_len, max_kv_len,
+    total_num_rows, max_blocks_per_seq) entirely on GPU, replacing CPU-side
+    D2H + computation + H2D transfers.
+
+    Parameters
+    ----------
+    qo_indptr : torch.Tensor
+        Cumulative query token counts, shape ``[batch_size + 1]``, int32, device.
+    paged_kv_indptr : torch.Tensor
+        Cumulative page counts, shape ``[batch_size + 1]``, int32, device.
+    paged_kv_last_page_len : torch.Tensor
+        Number of valid tokens in the last page per request, shape ``[batch_size]``, int32, device.
+    paged_kv_indices : torch.Tensor
+        Flat page indices, shape ``[total_pages]``, int32, device.
+    kv_lens_out : torch.Tensor
+        Output KV sequence lengths, shape ``[batch_size]``, int32, device.
+    block_tables_out : torch.Tensor
+        Output block table, shape ``[batch_size, max_blocks_per_seq]``, int32, device.
+    metadata_out : torch.Tensor
+        Output metadata ``[max_q_len, max_kv_len, total_rows, max_blocks]``, shape ``[4]``, int32, device.
+    page_size : int
+        Page size.
+    batch_size : int
+        Batch size.
+    max_blocks_per_seq : int
+        Maximum number of blocks per sequence (stride of block_tables_out).
+    input_layout : str
+        Input layout string for module selection. Default ``"q_paged_kv_hnd"``.
+    input_dtype : torch.dtype
+        Input data type for module selection. Default ``torch.float16``.
+    """
+    module = get_trtllm_fmha_v2_module(input_layout, input_dtype)
+    module.prepare(
+        qo_indptr,
+        paged_kv_indptr,
+        paged_kv_last_page_len,
+        paged_kv_indices,
+        kv_lens_out,
+        block_tables_out,
+        metadata_out,
+        page_size,
+        batch_size,
+        max_blocks_per_seq,
+    )
+
+
+def trtllm_fmha_v2_plan(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    input_layout: str,
+    mask_mode: str,
+    max_kv_len: int,
+    batch_size: int,
+    window_left: int = -1,
+    chunked_attention_size: int = 0,
+    has_alibi: bool = False,
+    skip_softmax_threshold_scale_factor: float = 0.0,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    r"""Pre-compute static configuration for FMHAv2.
+
+    Returns a plan_info tensor that can be passed to
+    :func:`trtllm_fmha_v2_prefill` to skip SM detection, string parsing,
+    and launch parameter computation on subsequent calls.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Query tensor (used to infer shapes and dtype).
+    k : torch.Tensor
+        Key tensor (used to infer shapes).
+    v : torch.Tensor
+        Value tensor (used to infer shapes).
+    input_layout : str
+        Input layout string (e.g. ``"q_paged_kv_hnd"``).
+    mask_mode : str
+        Mask mode string (e.g. ``"causal"``).
+    max_kv_len : int
+        Maximum KV sequence length.
+    batch_size : int
+        Batch size.
+    window_left : int
+        Left window size, default ``-1``.
+    chunked_attention_size : int
+        Chunked attention size, default ``0``.
+    has_alibi : bool
+        Whether ALiBi is enabled.
+    skip_softmax_threshold_scale_factor : float
+        Skip-softmax threshold factor.
+    output_dtype : Optional[torch.dtype]
+        Output dtype; if None, same as query dtype.
+
+    Returns
+    -------
+    torch.Tensor
+        Plan info tensor, shape ``[19]``, dtype int64, on CPU.
+    """
+    module = get_trtllm_fmha_v2_module(
+        input_layout, q.dtype, output_dtype
+    )
+    plan_info_out = torch.zeros(19, dtype=torch.int64)
+    module.plan(
+        q,
+        k,
+        v,
+        input_layout.lower(),
+        mask_mode.lower(),
+        max_kv_len,
+        batch_size,
+        window_left,
+        chunked_attention_size,
+        has_alibi,
+        skip_softmax_threshold_scale_factor,
+        plan_info_out,
+    )
+    return plan_info_out
+
+
 @flashinfer_api(trace=trtllm_fmha_v2_prefill_trace)
 def trtllm_fmha_v2_prefill(
     qkv: Union[
@@ -4412,6 +4601,7 @@ def trtllm_fmha_v2_prefill(
     chunked_attention_size: int = 0,
     save_softmax_stats: bool = False,
     skip_softmax_threshold_scale_factor: float = 0,
+    plan_info: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""TRT-LLM FMHAv2 prefill attention.
 
@@ -4653,36 +4843,69 @@ def trtllm_fmha_v2_prefill(
             device=query.device,
         )
 
-    module.run(
-        query,  # Q tensor
-        k_cache,  # K tensor
-        v_cache,  # V tensor
-        out,  # Output tensor
-        workspace_buffer,  # Workspace buffer
-        workspace_buffer.numel()
-        * workspace_buffer.element_size(),  # Workspace buffer size in bytes
-        block_tables,
-        page_size,
-        seq_lens,  # Sequence length for kv_cache
-        cum_seq_lens_q,  # Cumulative sequence length for query
-        cum_seq_lens_kv,  # Cumulative sequence length for kv_cache
-        input_layout.lower(),  # Input layout
-        max_q_len,  # Max sequence length for query
-        max_kv_len,  # Max sequence length for kv_cache
-        batch_size,  # Batch size
-        mask_mode.lower(),  # Attention mask type
-        scale_softmax,  # Softmax scale
-        bmm1_scale,  # BMM1 scale
-        bmm2_scale,  # BMM2 scale (host float; encoded by C++ set_alpha)
-        window_left,  # Window left
-        chunked_attention_size,  # Chunked attention size
-        pos_encoding_mode is not None
-        and pos_encoding_mode.lower() == "alibi",  # Alibi mode
-        softcapping_scale,  # Softcapping scale (0.0 = disabled)
-        skip_softmax_threshold_scale_factor,  # threshold_scale_factor for skip-softmax (0.0 = disable)
-        lse,  # Optional LSE tensor (None if not saving softmax stats)
-        sinks,  # Optional sinks tensor
-    )
+    if plan_info is not None:
+        # Use pre-computed plan: skips SM detection, string parsing, launch param computation
+        module.run_with_plan(
+            plan_info,
+            query,  # Q tensor
+            k_cache,  # K tensor
+            v_cache,  # V tensor
+            out,  # Output tensor
+            workspace_buffer,  # Workspace buffer
+            workspace_buffer.numel()
+            * workspace_buffer.element_size(),  # Workspace buffer size in bytes
+            block_tables,
+            page_size,
+            seq_lens,  # Sequence length for kv_cache
+            cum_seq_lens_q,  # Cumulative sequence length for query
+            cum_seq_lens_kv,  # Cumulative sequence length for kv_cache
+            max_q_len,  # Max sequence length for query
+            max_kv_len,  # Max sequence length for kv_cache
+            batch_size,  # Batch size
+            scale_softmax,  # Softmax scale
+            bmm1_scale,  # BMM1 scale
+            bmm2_scale,  # BMM2 scale
+            window_left,  # Window left
+            chunked_attention_size,  # Chunked attention size
+            pos_encoding_mode is not None
+            and pos_encoding_mode.lower() == "alibi",  # Alibi mode
+            softcapping_scale,  # Softcapping scale (0.0 = disabled)
+            skip_softmax_threshold_scale_factor,
+            lse,  # Optional LSE tensor
+            sinks,  # Optional sinks tensor
+        )
+    else:
+        # Backward compatible: full run with string parsing, SM detection, etc.
+        module.run(
+            query,  # Q tensor
+            k_cache,  # K tensor
+            v_cache,  # V tensor
+            out,  # Output tensor
+            workspace_buffer,  # Workspace buffer
+            workspace_buffer.numel()
+            * workspace_buffer.element_size(),  # Workspace buffer size in bytes
+            block_tables,
+            page_size,
+            seq_lens,  # Sequence length for kv_cache
+            cum_seq_lens_q,  # Cumulative sequence length for query
+            cum_seq_lens_kv,  # Cumulative sequence length for kv_cache
+            input_layout.lower(),  # Input layout
+            max_q_len,  # Max sequence length for query
+            max_kv_len,  # Max sequence length for kv_cache
+            batch_size,  # Batch size
+            mask_mode.lower(),  # Attention mask type
+            scale_softmax,  # Softmax scale
+            bmm1_scale,  # BMM1 scale
+            bmm2_scale,  # BMM2 scale (host float; encoded by C++ set_alpha)
+            window_left,  # Window left
+            chunked_attention_size,  # Chunked attention size
+            pos_encoding_mode is not None
+            and pos_encoding_mode.lower() == "alibi",  # Alibi mode
+            softcapping_scale,  # Softcapping scale (0.0 = disabled)
+            skip_softmax_threshold_scale_factor,  # threshold_scale_factor for skip-softmax (0.0 = disable)
+            lse,  # Optional LSE tensor (None if not saving softmax stats)
+            sinks,  # Optional sinks tensor
+        )
 
     if save_softmax_stats:
         return out, lse

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -1327,3 +1327,207 @@ def test_trtllm_fmha_v2_chunked_prefill_chunked_attention(
 
     rtol, atol = 1e-2, 1e-2
     torch.testing.assert_close(output.float(), output_ref.float(), rtol=rtol, atol=atol)
+
+
+####################################################################################################
+# Tests for GPU prepare + plan + run_with_plan path
+####################################################################################################
+
+
+def test_fmha_v2_prepare_kernel():
+    """Test that the GPU prepare kernel produces the same kv_lens, block_tables,
+    and metadata as the CPU-side Python computation."""
+    from flashinfer.prefill import trtllm_fmha_v2_prepare
+    from flashinfer.utils import is_sm90a_supported
+
+    if not is_sm90a_supported(torch.device("cuda")) and not is_sm120a_supported(
+        torch.device("cuda")
+    ):
+        pytest.skip("FMHA v2 requires SM90+ (Hopper) or SM12x GPUs.")
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    batch_size = 4
+    page_size = 16
+
+    # Create variable-length KV sequences
+    kv_seq_lens = torch.tensor([48, 32, 64, 16], dtype=torch.int32, device=device)
+    q_seq_lens = torch.tensor([8, 4, 16, 2], dtype=torch.int32, device=device)
+
+    # Build paged KV indptr and indices
+    num_pages_per_seq = (kv_seq_lens + page_size - 1) // page_size  # [3, 2, 4, 1]
+    total_pages = num_pages_per_seq.sum().item()
+    paged_kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    paged_kv_indptr[1:] = torch.cumsum(num_pages_per_seq, dim=0)
+    paged_kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    paged_kv_last_page_len = ((kv_seq_lens - 1) % page_size) + 1
+
+    # Build qo_indptr
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(q_seq_lens, dim=0)
+
+    max_blocks_per_seq = num_pages_per_seq.max().item()
+
+    # Outputs
+    kv_lens_out = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    block_tables_out = torch.zeros(
+        batch_size, max_blocks_per_seq, dtype=torch.int32, device=device
+    )
+    metadata_out = torch.zeros(4, dtype=torch.int32, device=device)
+
+    trtllm_fmha_v2_prepare(
+        qo_indptr,
+        paged_kv_indptr,
+        paged_kv_last_page_len,
+        paged_kv_indices,
+        kv_lens_out,
+        block_tables_out,
+        metadata_out,
+        page_size,
+        batch_size,
+        max_blocks_per_seq,
+    )
+
+    # Verify kv_lens
+    expected_kv_lens = kv_seq_lens.cpu()
+    torch.testing.assert_close(kv_lens_out.cpu(), expected_kv_lens)
+
+    # Verify metadata
+    meta = metadata_out.cpu()
+    assert meta[0].item() == q_seq_lens.max().item(), "max_q_len mismatch"
+    assert meta[1].item() == kv_seq_lens.max().item(), "max_kv_len mismatch"
+    assert meta[2].item() == qo_indptr[-1].item(), "total_num_rows mismatch"
+    assert meta[3].item() == max_blocks_per_seq, "max_blocks_per_seq mismatch"
+
+    # Verify block_tables
+    indptr_cpu = paged_kv_indptr.cpu()
+    indices_cpu = paged_kv_indices.cpu()
+    bt_cpu = block_tables_out.cpu()
+    for i in range(batch_size):
+        n_pages = num_pages_per_seq[i].item()
+        start = indptr_cpu[i].item()
+        expected_row = indices_cpu[start : start + n_pages]
+        torch.testing.assert_close(bt_cpu[i, :n_pages], expected_row)
+
+
+@pytest.mark.parametrize("input_layout", ["Q_PAGED_KV_HND", "Q_PAGED_KV_NHD"])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fmha_v2_prefill_with_plan(
+    input_layout: str,
+    batch_size: int,
+    dtype: torch.dtype,
+) -> None:
+    """Test that prepare + plan + run_with_plan produces the same result as
+    the original one-shot run path."""
+    from flashinfer.prefill import (
+        trtllm_fmha_v2_prefill,
+        trtllm_fmha_v2_plan,
+    )
+    from flashinfer.utils import is_sm90a_supported
+
+    if not is_sm90a_supported(torch.device("cuda")) and not is_sm120a_supported(
+        torch.device("cuda")
+    ):
+        pytest.skip("FMHA v2 requires SM90+ (Hopper) or SM12x GPUs.")
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    num_qo_heads = 8
+    num_kv_heads = 4
+    head_dim = 128
+    page_size = 16
+    max_seq_len = 256
+
+    is_nhd = input_layout == "Q_PAGED_KV_NHD"
+
+    # Create sequences
+    seq_lens = torch.randint(
+        max_seq_len // 2, max_seq_len + 1, (batch_size,),
+        dtype=torch.int32, device=device,
+    )
+    max_kv_len = seq_lens.max().item()
+    max_q_len = max_kv_len  # prefill: q_len == kv_len
+    cum_seq_lens = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    cum_seq_lens[1:] = torch.cumsum(seq_lens, dim=0)
+    total_tokens = cum_seq_lens[-1].item()
+
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    # Create paged KV cache
+    max_num_blocks = (max_kv_len + page_size - 1) // page_size
+    num_pages = batch_size * max_num_blocks
+    paged_shape = (
+        (num_pages, 2, page_size, num_kv_heads, head_dim)
+        if is_nhd
+        else (num_pages, 2, num_kv_heads, page_size, head_dim)
+    )
+    paged_kv_cache = torch.randn(*paged_shape, dtype=dtype, device=device)
+    q = torch.randn(total_tokens, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    # Build block tables
+    block_tables = torch.zeros(batch_size, max_num_blocks, dtype=torch.int32, device=device)
+    for i in range(batch_size):
+        num_blocks_needed = (seq_lens[i].item() + page_size - 1) // page_size
+        block_tables[i, :num_blocks_needed] = torch.arange(
+            i * max_num_blocks, i * max_num_blocks + num_blocks_needed, device=device,
+        )
+
+    qkv_arg = (q, paged_kv_cache)
+    workspace_buffer = _get_workspace_buffer()
+
+    # --- Original one-shot path ---
+    o_ref = torch.zeros(total_tokens, num_qo_heads, head_dim, dtype=dtype, device=device)
+    trtllm_fmha_v2_prefill(
+        qkv_arg,
+        input_layout,
+        workspace_buffer=workspace_buffer,
+        seq_lens=seq_lens,
+        max_q_len=max_q_len,
+        max_kv_len=max_kv_len,
+        bmm1_scale=sm_scale,
+        bmm2_scale=1.0,
+        batch_size=batch_size,
+        cum_seq_lens_q=cum_seq_lens,
+        cum_seq_lens_kv=cum_seq_lens,
+        block_tables=block_tables,
+        out=o_ref,
+        out_dtype=dtype,
+        mask_mode="causal",
+    )
+
+    # --- Plan + run_with_plan path ---
+    k_cache, v_cache = paged_kv_cache.unbind(dim=1)
+    plan_info = trtllm_fmha_v2_plan(
+        q,
+        k_cache,
+        v_cache,
+        input_layout,
+        mask_mode="causal",
+        max_kv_len=max_kv_len,
+        batch_size=batch_size,
+    )
+
+    workspace_buffer2 = _get_workspace_buffer()
+    o_plan = torch.zeros(total_tokens, num_qo_heads, head_dim, dtype=dtype, device=device)
+    trtllm_fmha_v2_prefill(
+        qkv_arg,
+        input_layout,
+        workspace_buffer=workspace_buffer2,
+        seq_lens=seq_lens,
+        max_q_len=max_q_len,
+        max_kv_len=max_kv_len,
+        bmm1_scale=sm_scale,
+        bmm2_scale=1.0,
+        batch_size=batch_size,
+        cum_seq_lens_q=cum_seq_lens,
+        cum_seq_lens_kv=cum_seq_lens,
+        block_tables=block_tables,
+        out=o_plan,
+        out_dtype=dtype,
+        mask_mode="causal",
+        plan_info=plan_info,
+    )
+
+    # The two outputs should be bitwise identical since they run the same kernel
+    torch.testing.assert_close(o_plan.float(), o_ref.float(), rtol=0, atol=0)

--- a/tests/test_fmha_v2_prepare_standalone.py
+++ b/tests/test_fmha_v2_prepare_standalone.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Standalone verification for fmha_v2_prepare_kernel.
+Compiles and runs the kernel directly via PyTorch's CUDA extension,
+bypassing FlashInfer's import chain.
+
+Requirements: torch (with CUDA), Python 3.8+
+Works on any NVIDIA GPU (SM86 included).
+"""
+import torch
+import torch.utils.cpp_extension
+import tempfile
+import os
+
+KERNEL_SOURCE = r"""
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+
+__global__ void fmha_v2_prepare_kernel(
+    const int32_t* __restrict__ qo_indptr,
+    const int32_t* __restrict__ paged_kv_indptr,
+    const int32_t* __restrict__ paged_kv_last_page_len,
+    const int32_t* __restrict__ paged_kv_indices,
+    int32_t* __restrict__ kv_lens,
+    int32_t* __restrict__ block_tables,
+    int32_t* __restrict__ metadata,
+    int page_size, int batch_size, int max_blocks_per_seq) {
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  if (i >= batch_size) return;
+
+  int num_pages_i = paged_kv_indptr[i + 1] - paged_kv_indptr[i];
+  int kv_len_i = max(num_pages_i - 1, 0) * page_size + paged_kv_last_page_len[i];
+  kv_lens[i] = kv_len_i;
+
+  int q_len_i = qo_indptr[i + 1] - qo_indptr[i];
+
+  int block_start = paged_kv_indptr[i];
+  for (int j = 0; j < num_pages_i && j < max_blocks_per_seq; j++) {
+    block_tables[i * max_blocks_per_seq + j] = paged_kv_indices[block_start + j];
+  }
+
+  atomicMax(&metadata[0], q_len_i);
+  atomicMax(&metadata[1], kv_len_i);
+
+  if (i == 0) {
+    metadata[2] = qo_indptr[batch_size];
+    metadata[3] = max_blocks_per_seq;
+  }
+}
+
+void launch_prepare(
+    torch::Tensor qo_indptr,
+    torch::Tensor paged_kv_indptr,
+    torch::Tensor paged_kv_last_page_len,
+    torch::Tensor paged_kv_indices,
+    torch::Tensor kv_lens_out,
+    torch::Tensor block_tables_out,
+    torch::Tensor metadata_out,
+    int page_size, int batch_size, int max_blocks_per_seq) {
+
+  cudaMemsetAsync(metadata_out.data_ptr(), 0, 4 * sizeof(int32_t),
+                  at::cuda::getCurrentCUDAStream());
+
+  int threads = min(batch_size, 1024);
+  int blocks = (batch_size + threads - 1) / threads;
+
+  fmha_v2_prepare_kernel<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+      qo_indptr.data_ptr<int32_t>(),
+      paged_kv_indptr.data_ptr<int32_t>(),
+      paged_kv_last_page_len.data_ptr<int32_t>(),
+      paged_kv_indices.data_ptr<int32_t>(),
+      kv_lens_out.data_ptr<int32_t>(),
+      block_tables_out.data_ptr<int32_t>(),
+      metadata_out.data_ptr<int32_t>(),
+      page_size, batch_size, max_blocks_per_seq);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("launch_prepare", &launch_prepare, "FMHAv2 GPU prepare kernel");
+}
+"""
+
+
+def test_prepare_kernel():
+    # JIT compile
+    print("Compiling prepare kernel...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, "fmha_v2_prepare_test.cu")
+        with open(src_path, "w") as f:
+            f.write(KERNEL_SOURCE)
+
+        mod = torch.utils.cpp_extension.load(
+            name="fmha_v2_prepare_test",
+            sources=[src_path],
+            verbose=True,
+        )
+
+    print("Compilation OK! Running test...")
+
+    device = torch.device("cuda")
+    batch_size = 4
+    page_size = 16
+
+    # Variable-length sequences
+    kv_seq_lens = torch.tensor([48, 32, 64, 16], dtype=torch.int32, device=device)
+    q_seq_lens = torch.tensor([8, 4, 16, 2], dtype=torch.int32, device=device)
+
+    # Build paged KV structures
+    num_pages_per_seq = (kv_seq_lens + page_size - 1) // page_size  # [3, 2, 4, 1]
+    total_pages = num_pages_per_seq.sum().item()
+
+    paged_kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    paged_kv_indptr[1:] = torch.cumsum(num_pages_per_seq, dim=0)
+
+    paged_kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    paged_kv_last_page_len = ((kv_seq_lens - 1) % page_size) + 1
+
+    # Build qo_indptr
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(q_seq_lens, dim=0)
+
+    max_blocks_per_seq = num_pages_per_seq.max().item()
+
+    # Outputs
+    kv_lens_out = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    block_tables_out = torch.zeros(batch_size, max_blocks_per_seq, dtype=torch.int32, device=device)
+    metadata_out = torch.zeros(4, dtype=torch.int32, device=device)
+
+    # Run GPU kernel
+    mod.launch_prepare(
+        qo_indptr, paged_kv_indptr, paged_kv_last_page_len, paged_kv_indices,
+        kv_lens_out, block_tables_out, metadata_out,
+        page_size, batch_size, max_blocks_per_seq,
+    )
+    torch.cuda.synchronize()
+
+    # ===== Verify =====
+    print("\n--- Results ---")
+
+    # 1. kv_lens
+    expected_kv_lens = kv_seq_lens.cpu()
+    actual_kv_lens = kv_lens_out.cpu()
+    assert torch.equal(actual_kv_lens, expected_kv_lens), \
+        f"kv_lens mismatch:\n  expected: {expected_kv_lens}\n  got: {actual_kv_lens}"
+    print(f"[PASS] kv_lens: {actual_kv_lens.tolist()}")
+
+    # 2. metadata
+    meta = metadata_out.cpu()
+    assert meta[0].item() == q_seq_lens.max().item(), f"max_q_len: expected {q_seq_lens.max().item()}, got {meta[0].item()}"
+    assert meta[1].item() == kv_seq_lens.max().item(), f"max_kv_len: expected {kv_seq_lens.max().item()}, got {meta[1].item()}"
+    assert meta[2].item() == qo_indptr[-1].item(), f"total_rows: expected {qo_indptr[-1].item()}, got {meta[2].item()}"
+    assert meta[3].item() == max_blocks_per_seq, f"max_blocks: expected {max_blocks_per_seq}, got {meta[3].item()}"
+    print(f"[PASS] metadata: max_q_len={meta[0]}, max_kv_len={meta[1]}, total_rows={meta[2]}, max_blocks={meta[3]}")
+
+    # 3. block_tables
+    indptr_cpu = paged_kv_indptr.cpu()
+    indices_cpu = paged_kv_indices.cpu()
+    bt_cpu = block_tables_out.cpu()
+    for i in range(batch_size):
+        n_pages = num_pages_per_seq[i].item()
+        start = indptr_cpu[i].item()
+        expected_row = indices_cpu[start: start + n_pages]
+        actual_row = bt_cpu[i, :n_pages]
+        assert torch.equal(actual_row, expected_row), \
+            f"block_tables[{i}] mismatch:\n  expected: {expected_row}\n  got: {actual_row}"
+    print(f"[PASS] block_tables: all {batch_size} rows correct")
+
+    print("\n=== ALL TESTS PASSED ===")
+
+
+if __name__ == "__main__":
+    test_prepare_kernel()


### PR DESCRIPTION

  ## Summary

  Addresses #3254 — fuses the preparation phase of `trtllm_fmha_v2_prefill` into a single GPU kernel, eliminating multiple D2H/H2D transfers and CPU-side computation.

  ### Before
  - 3x D2H transfers (qo_indptr, paged_kv_indptr, paged_kv_last_page_len)
  - CPU-side `get_seq_lens` computation
  - Python for-loop to build block_tables
  - 1x H2D transfer (kv_lens_buffer)

  ### After
  - 1x GPU kernel (`fmha_v2_prepare_kernel`) computes kv_lens, block_tables, metadata
  - 1x 16-byte D2H (metadata: max_q_len, max_kv_len, total_rows, max_blocks)

  ## Changes

  | File | Description |
  |------|-------------|
  | `csrc/fmha_v2_prepare.cu` | **New** — GPU prep kernel + TVM FFI wrapper |
  | `csrc/fmha_v2_run.cu` | Add `fmha_v2_plan()` and `fmha_v2_run_with_plan()` |
  | `csrc/fmha_v2_jit_binding.cu` | FFI exports for prepare/plan/run_with_plan |
  | `flashinfer/jit/attention/modules.py` | Include new source in JIT module |
  | `flashinfer/prefill.py` | GPU prepare path in `plan()` + standalone APIs |
  | `flashinfer/__init__.py` | Export `trtllm_fmha_v2_prepare`, `trtllm_fmha_v2_plan` |
  | `tests/attention/test_fmha_v2_prefill.py` | Tests for prepare + plan/run_with_plan path |
  | `tests/test_fmha_v2_prepare_standalone.py` | Standalone kernel test (SM86 compatible) |

  ## API additions

  ```python
  # GPU prepare — replaces D2H + CPU + H2D in plan()
  flashinfer.trtllm_fmha_v2_prepare(qo_indptr, paged_kv_indptr, ...)

  # Pre-compute static launch config (call once)
  plan_info = flashinfer.trtllm_fmha_v2_plan(...)

  # Execute with pre-computed plan (skip redundant computation)
  flashinfer.trtllm_fmha_v2_prefill(..., plan_info=plan_info)

  Test plan

  - Standalone prepare kernel test passed on SM86 (RTX 3080)
  - Full attention e2e test (test_fmha_v2_prefill_with_plan) — requires SM90+ GPU
  - pytest tests/attention/test_fmha_v2_prefill.py — backward compat on SM90+
  - nsys profile to confirm timeline improvement

  Notes

  - Backward compatible: existing trtllm_fmha_v2_prefill() without plan_info works unchanged
  - The prepare kernel itself only requires SM86+; the attention kernels still require SM90/SM120
  - fmha_v2_plan() caches SM detection, launch params, warps/grid into a flat int64 array (19 elements) that crosses the FFI boundary efficiently

  ---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-side KV metadata preparation for paged KV cache
  * One-time FMHA v2 execution plan generation and a planned-run execution path
  * Prefill API accepts optional pre-generated plan info; new convenience helpers exposed

* **Integration**
  * JIT build now includes the GPU preparation source so it's compiled into FMHA v2 modules

* **Tests**
  * Added GPU tests and a standalone test validating preparation, planning, and planned prefill outputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->