### PR TITLE
fix: One sided MOE A2A warp token policy hangs in some cases, disable…

### DIFF
--- a/csrc/nv_internal/cpp/common/envUtils.cpp
+++ b/csrc/nv_internal/cpp/common/envUtils.cpp
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <exception>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -324,19 +325,6 @@ uint16_t getEnvNixlPort() {
 
 bool getEnvDisaggBenchmarkGenOnly() { return getBoolEnv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY"); }
 
-bool getEnvMoeA2AOneBlockPerToken() {
-  static bool const enabled = []() {
-    std::optional<int32_t> const val = getIntEnv("TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN");
-    if (val.has_value()) {
-      TLLM_LOG_WARNING(
-          "Changing A2A block scheduling mode via TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN is no longer "
-          "supported. Flashinfer only supports one-block-per-token mode.");
-    }
-    return true;
-  }();
-  return enabled;
-}
-
 static int sanitizeBlockSize(std::optional<int32_t> const& val) {
   // Default 256 when not set or invalid
   int block = val.value_or(256);
@@ -349,13 +337,23 @@ static int sanitizeBlockSize(std::optional<int32_t> const& val) {
   return block;
 }
 
+// Treat malformed values as unset so debug block-size knobs never become hard failures.
+static int getSanitizedBlockSizeFromEnv(char const* name) {
+  try {
+    return sanitizeBlockSize(getIntEnv(name));
+  } catch (std::exception const&) {
+    TLLM_LOG_WARNING("Invalid value for %s. Falling back to default block size.", name);
+    return sanitizeBlockSize(std::nullopt);
+  }
+}
+
 int getEnvMoeA2ADispatchBlockSize() {
-  static int const kBlock = sanitizeBlockSize(getIntEnv("TLLM_MOE_A2A_DISPATCH_BLOCK_SIZE"));
+  static int const kBlock = getSanitizedBlockSizeFromEnv("TLLM_MOE_A2A_DISPATCH_BLOCK_SIZE");
   return kBlock;
 }
 
 int getEnvMoeA2ACombineBlockSize() {
-  static int const kBlock = sanitizeBlockSize(getIntEnv("TLLM_MOE_A2A_COMBINE_BLOCK_SIZE"));
+  static int const kBlock = getSanitizedBlockSizeFromEnv("TLLM_MOE_A2A_COMBINE_BLOCK_SIZE");
   return kBlock;
 }
 

--- a/csrc/nv_internal/cpp/common/envUtils.cpp
+++ b/csrc/nv_internal/cpp/common/envUtils.cpp
@@ -325,12 +325,16 @@ uint16_t getEnvNixlPort() {
 bool getEnvDisaggBenchmarkGenOnly() { return getBoolEnv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY"); }
 
 bool getEnvMoeA2AOneBlockPerToken() {
-  // Default true; return false only if env set to "0"
-  static std::optional<int32_t> const val = getIntEnv("TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN");
-  if (!val.has_value()) {
+  static bool const enabled = []() {
+    std::optional<int32_t> const val = getIntEnv("TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN");
+    if (val.has_value()) {
+      TLLM_LOG_WARNING(
+          "Changing A2A block scheduling mode via TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN is no longer "
+          "supported. Flashinfer only supports one-block-per-token mode.");
+    }
     return true;
-  }
-  return val.value() != 0;
+  }();
+  return enabled;
 }
 
 static int sanitizeBlockSize(std::optional<int32_t> const& val) {

--- a/csrc/nv_internal/tensorrt_llm/common/envUtils.h
+++ b/csrc/nv_internal/tensorrt_llm/common/envUtils.h
@@ -94,7 +94,7 @@ size_t getEnvKVCacheSendMaxConcurrenceNum();
 
 size_t getEnvMemSizeForKVCacheTransferBuffer();
 
-// MoE A2A always uses one block per token; TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN=0 is ignored.
+// Deprecated. Always returns true.
 bool getEnvMoeA2AOneBlockPerToken();
 
 // TODO: For DEV purpose temporarily.

--- a/csrc/nv_internal/tensorrt_llm/common/envUtils.h
+++ b/csrc/nv_internal/tensorrt_llm/common/envUtils.h
@@ -94,9 +94,6 @@ size_t getEnvKVCacheSendMaxConcurrenceNum();
 
 size_t getEnvMemSizeForKVCacheTransferBuffer();
 
-// Deprecated. Always returns true.
-bool getEnvMoeA2AOneBlockPerToken();
-
 // TODO: For DEV purpose temporarily.
 // Block size (threads per block) for MoE A2A Dispatch kernels (default 256 if unset or invalid)
 int getEnvMoeA2ADispatchBlockSize();

--- a/csrc/nv_internal/tensorrt_llm/common/envUtils.h
+++ b/csrc/nv_internal/tensorrt_llm/common/envUtils.h
@@ -94,7 +94,7 @@ size_t getEnvKVCacheSendMaxConcurrenceNum();
 
 size_t getEnvMemSizeForKVCacheTransferBuffer();
 
-// Whether to use one block per token for MoE A2A kernels (default true).
+// MoE A2A always uses one block per token; TLLM_MOE_A2A_ONE_BLOCK_PER_TOKEN=0 is ignored.
 bool getEnvMoeA2AOneBlockPerToken();
 
 // TODO: For DEV purpose temporarily.

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -432,7 +432,6 @@ void moe_a2a_prepare_dispatch_launch(MoeA2ADispatchParams const& params) {
 
 void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   // Validate parameters
-  TLLM_CHECK(params.one_block_per_token);
   TLLM_CHECK(params.top_k > 0 && params.top_k <= kMaxTopK);
   TLLM_CHECK(params.ep_size > 0 && params.ep_size <= kMaxRanks);
   TLLM_CHECK(params.local_num_tokens >= 0);
@@ -838,7 +837,6 @@ __global__ void moeA2ACombineKernel(
 }
 
 void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
-  TLLM_CHECK(params.one_block_per_token);
   constexpr int kBlockSize = 256;
 
   // Calculate bytes per token based on dtype
@@ -874,7 +872,6 @@ void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
 
 void moe_a2a_combine_launch(MoeA2ACombineParams const& params) {
   // Validate parameters
-  TLLM_CHECK(params.one_block_per_token);
   TLLM_CHECK(params.top_k > 0 && params.top_k <= kMaxTopK);
   TLLM_CHECK(params.ep_size > 0 && params.ep_size <= kMaxRanks);
   TLLM_CHECK(params.local_num_tokens >= 0);

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -119,14 +119,6 @@ __host__ __device__ inline T ceilDiv(T m, T n) {
     }                                                                   \
   }
 
-#define SWITCH_POLICY(one_block_per_token, POLICY, ...)                       \
-  if (one_block_per_token) {                                                  \
-    using POLICY = BlockPolicy;                                               \
-    __VA_ARGS__                                                               \
-  } else {                                                                    \
-    FLASHINFER_CHECK(false, "WarpPolicy is no longer supported for moe A2A"); \
-  }
-
 #if DISABLE_TIMEOUT
 #define check_timeout(s) false
 #else
@@ -156,49 +148,38 @@ __device__ int compute_target_rank_id(int expert_id, int num_experts_per_rank) {
 // Helper Functions for Vectorized Memory Operations
 // ============================================================================
 
-struct BlockPolicy {
-  __device__ static int stride() { return blockDim.x; }
-
-  __device__ static int offset() { return threadIdx.x; }
-
-  __device__ static int token_idx() { return blockIdx.x; }
-
-  __device__ static void sync() { __syncthreads(); }
-};
-
-template <int VEC_SIZE, typename ThreadingPolicy>
+template <int VEC_SIZE>
 __device__ void vectorized_copy_impl(void* dst, void const* src, int size) {
   using flashinfer::vec_t;
 
   uint8_t* dst_ptr = static_cast<uint8_t*>(dst);
   uint8_t const* src_ptr = static_cast<uint8_t const*>(src);
 
-  int const stride = ThreadingPolicy::stride() * VEC_SIZE;
+  int const stride = blockDim.x * VEC_SIZE;
 
-  for (int offset = ThreadingPolicy::offset() * VEC_SIZE; offset < size; offset += stride) {
+  for (int offset = threadIdx.x * VEC_SIZE; offset < size; offset += stride) {
     vec_t<uint8_t, VEC_SIZE> v;
     v.load(src_ptr + offset);
     v.store(dst_ptr + offset);
   }
 }
 
-template <typename ThreadingPolicy>
 __device__ void vectorized_copy(void* dst, void const* src, int size) {
   if (size % 16 == 0) {
-    vectorized_copy_impl<16, ThreadingPolicy>(dst, src, size);
+    vectorized_copy_impl<16>(dst, src, size);
   } else if (size % 8 == 0) {
-    vectorized_copy_impl<8, ThreadingPolicy>(dst, src, size);
+    vectorized_copy_impl<8>(dst, src, size);
   } else if (size % 4 == 0) {
-    vectorized_copy_impl<4, ThreadingPolicy>(dst, src, size);
+    vectorized_copy_impl<4>(dst, src, size);
   } else if (size % 2 == 0) {
-    vectorized_copy_impl<2, ThreadingPolicy>(dst, src, size);
+    vectorized_copy_impl<2>(dst, src, size);
   } else {
-    vectorized_copy_impl<1, ThreadingPolicy>(dst, src, size);
+    vectorized_copy_impl<1>(dst, src, size);
   }
 }
 
 // Vectorized dispatch: load one vec from source and write to up to TOP_K destinations
-template <int VEC_SIZE, int TOP_K, typename ThreadingPolicy>
+template <int VEC_SIZE, int TOP_K>
 __device__ void vectorized_dispatch_impl(uint8_t const* src_ptr, int bytes_per_token, int rank_id,
                                          int max_tokens_per_rank, int payload_idx,
                                          DispatchKernelPointers const& ptrs,
@@ -225,9 +206,8 @@ __device__ void vectorized_dispatch_impl(uint8_t const* src_ptr, int bytes_per_t
   }
 
   // TODO: process all payloads. index could be reused.
-  int const stride = ThreadingPolicy::stride() * VEC_SIZE;
-  for (int offset = ThreadingPolicy::offset() * VEC_SIZE; offset < bytes_per_token;
-       offset += stride) {
+  int const stride = blockDim.x * VEC_SIZE;
+  for (int offset = threadIdx.x * VEC_SIZE; offset < bytes_per_token; offset += stride) {
     vec_t<uint8_t, VEC_SIZE> v;
     v.load(src_ptr + offset);
 
@@ -242,31 +222,26 @@ __device__ void vectorized_dispatch_impl(uint8_t const* src_ptr, int bytes_per_t
   }
 }
 
-template <int TOP_K, typename ThreadingPolicy>
+template <int TOP_K>
 __device__ void vectorized_dispatch(uint8_t const* src_ptr, int bytes_per_token, int rank_id,
                                     int max_tokens_per_rank, int payload_idx,
                                     DispatchKernelPointers const& ptrs,
                                     int const* topk_target_ranks, int const* topk_send_indices) {
   if (bytes_per_token % 16 == 0) {
-    vectorized_dispatch_impl<16, TOP_K, ThreadingPolicy>(src_ptr, bytes_per_token, rank_id,
-                                                         max_tokens_per_rank, payload_idx, ptrs,
-                                                         topk_target_ranks, topk_send_indices);
+    vectorized_dispatch_impl<16, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                        payload_idx, ptrs, topk_target_ranks, topk_send_indices);
   } else if (bytes_per_token % 8 == 0) {
-    vectorized_dispatch_impl<8, TOP_K, ThreadingPolicy>(src_ptr, bytes_per_token, rank_id,
-                                                        max_tokens_per_rank, payload_idx, ptrs,
-                                                        topk_target_ranks, topk_send_indices);
+    vectorized_dispatch_impl<8, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
   } else if (bytes_per_token % 4 == 0) {
-    vectorized_dispatch_impl<4, TOP_K, ThreadingPolicy>(src_ptr, bytes_per_token, rank_id,
-                                                        max_tokens_per_rank, payload_idx, ptrs,
-                                                        topk_target_ranks, topk_send_indices);
+    vectorized_dispatch_impl<4, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
   } else if (bytes_per_token % 2 == 0) {
-    vectorized_dispatch_impl<2, TOP_K, ThreadingPolicy>(src_ptr, bytes_per_token, rank_id,
-                                                        max_tokens_per_rank, payload_idx, ptrs,
-                                                        topk_target_ranks, topk_send_indices);
+    vectorized_dispatch_impl<2, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
   } else {
-    vectorized_dispatch_impl<1, TOP_K, ThreadingPolicy>(src_ptr, bytes_per_token, rank_id,
-                                                        max_tokens_per_rank, payload_idx, ptrs,
-                                                        topk_target_ranks, topk_send_indices);
+    vectorized_dispatch_impl<1, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
   }
 }
 
@@ -293,15 +268,15 @@ __global__ void moeA2APrepareDispatchKernel(int* send_counters, int* local_token
 // - Better GPU utilization and reduced synchronization overhead
 // ============================================================================
 
-template <typename ThreadingPolicy, int TOP_K>
+template <int TOP_K>
 __global__ void moeA2ADispatchKernel(
     int32_t const* token_selected_experts,  // [local_num_tokens, TOP_K]
     const DispatchKernelPointers ptrs,      // Struct containing all kernel pointers
     int num_payloads,                       // Number of payloads
     int max_tokens_per_rank,                // Maximum tokens per rank
     int local_num_tokens, int rank_id, int ep_size, int num_experts_per_rank) {
-  int thread_idx = ThreadingPolicy::offset();
-  int local_token_idx = ThreadingPolicy::token_idx();
+  int thread_idx = threadIdx.x;
+  int local_token_idx = blockIdx.x;
 
   if (local_num_tokens == 0) {
     // Special case: If local_num_tokens == 0,
@@ -348,7 +323,7 @@ __global__ void moeA2ADispatchKernel(
       already_copied |= 1ULL << target_rank;
     }
     // Sync before dispatching data
-    ThreadingPolicy::sync();
+    __syncthreads();
 
     // Read staged routing once into registers per thread
     int topk_target_ranks[TOP_K];
@@ -365,12 +340,11 @@ __global__ void moeA2ADispatchKernel(
       int bytes_per_token = ptrs.payload_bytes_per_token[payload_idx];
       uint8_t const* src_ptr = src_data + local_token_idx * bytes_per_token;
 
-      vectorized_dispatch<TOP_K, ThreadingPolicy>(src_ptr, bytes_per_token, rank_id,
-                                                  max_tokens_per_rank, payload_idx, ptrs,
-                                                  topk_target_ranks, topk_send_indices);
+      vectorized_dispatch<TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                 payload_idx, ptrs, topk_target_ranks, topk_send_indices);
     }
 
-    ThreadingPolicy::sync();
+    __syncthreads();
   }
 
   bool is_first_warp = threadIdx.x / warpSize == 0;
@@ -458,6 +432,7 @@ void moe_a2a_prepare_dispatch_launch(MoeA2ADispatchParams const& params) {
 
 void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   // Validate parameters
+  TLLM_CHECK(params.one_block_per_token);
   TLLM_CHECK(params.top_k > 0 && params.top_k <= kMaxTopK);
   TLLM_CHECK(params.ep_size > 0 && params.ep_size <= kMaxRanks);
   TLLM_CHECK(params.local_num_tokens >= 0);
@@ -494,27 +469,20 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   kernel_ptrs.topk_send_indices = params.topk_send_indices;
 
   int const kBlockSize = tensorrt_llm::common::getEnvMoeA2ADispatchBlockSize();
-  constexpr int kWarpSize = 32;
-  int const kWarpsPerBlock = kBlockSize / kWarpSize;
 
-  // Configure kernel launch
-  if (params.one_block_per_token) {
-    int grid_size = params.local_num_tokens;
-    // If local_num_tokens is 0, we still need to launch a minimal kernel to participate in the
-    // synchronization.
-    if (grid_size == 0) {
-      grid_size = 1;
-    }
-    int shared_bytes = 2 * params.top_k * (int)sizeof(int);
-    SWITCH_TOP_K(params.top_k, TOP_K,
-                 moeA2ADispatchKernel<BlockPolicy, TOP_K>
-                 <<<grid_size, kBlockSize, shared_bytes, params.stream>>>(
-                     params.token_selected_experts, kernel_ptrs, params.num_payloads,
-                     params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
-                     params.ep_size, params.num_experts_per_rank))
-  } else {
-    FLASHINFER_CHECK(false, "WarpPolicy is no longer supported for moe A2A");
+  // Configure kernel launch: one block per token
+  int grid_size = params.local_num_tokens;
+  // If local_num_tokens is 0, we still need to launch a minimal kernel to participate in the
+  // synchronization.
+  if (grid_size == 0) {
+    grid_size = 1;
   }
+  int shared_bytes = 2 * params.top_k * (int)sizeof(int);
+  SWITCH_TOP_K(params.top_k, TOP_K,
+               moeA2ADispatchKernel<TOP_K><<<grid_size, kBlockSize, shared_bytes, params.stream>>>(
+                   params.token_selected_experts, kernel_ptrs, params.num_payloads,
+                   params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
+                   params.ep_size, params.num_experts_per_rank))
 }
 
 // ============================================================================
@@ -530,7 +498,7 @@ __device__ __forceinline__ void accumulate_vec(T* dst, T const* src) {
 }
 
 // Accumulate across all valid ranks into registers, then store once per segment
-template <int VEC_SIZE, int TOP_K, typename ThreadingPolicy, typename T>
+template <int VEC_SIZE, int TOP_K, typename T>
 __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, int rank_id,
                                         int max_tokens_per_rank,
                                         CombineKernelPointers const& ptrs) {
@@ -539,11 +507,10 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
 
   uint8_t* dst_bytes = reinterpret_cast<uint8_t*>(dst_typed_base);
 
-  int const stride = ThreadingPolicy::stride() * VEC_SIZE;
-  int const local_token_idx = ThreadingPolicy::token_idx();
+  int const stride = blockDim.x * VEC_SIZE;
+  int const local_token_idx = blockIdx.x;
 
-  for (int offset = ThreadingPolicy::offset() * VEC_SIZE; offset < size_per_token;
-       offset += stride) {
+  for (int offset = threadIdx.x * VEC_SIZE; offset < size_per_token; offset += stride) {
     vec_t<uint8_t, VEC_SIZE> acc[TOP_K];
 
 // Unrolled K accumulation using compact top-k lists
@@ -728,29 +695,28 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
 }
 
 // Wrapper that selects vector width based on size_per_token alignment
-template <int TOP_K, typename ThreadingPolicy, typename T>
+template <int TOP_K, typename T>
 __device__ void vectorized_combine(T* dst_typed_base, int size_per_token, int rank_id,
                                    int max_tokens_per_rank, CombineKernelPointers const& ptrs) {
   if (size_per_token % 16 == 0) {
-    vectorized_combine_impl<16, TOP_K, ThreadingPolicy, T>(dst_typed_base, size_per_token, rank_id,
-                                                           max_tokens_per_rank, ptrs);
+    vectorized_combine_impl<16, TOP_K, T>(dst_typed_base, size_per_token, rank_id,
+                                          max_tokens_per_rank, ptrs);
   } else if (size_per_token % 8 == 0) {
-    vectorized_combine_impl<8, TOP_K, ThreadingPolicy, T>(dst_typed_base, size_per_token, rank_id,
-                                                          max_tokens_per_rank, ptrs);
+    vectorized_combine_impl<8, TOP_K, T>(dst_typed_base, size_per_token, rank_id,
+                                         max_tokens_per_rank, ptrs);
   } else if (size_per_token % 4 == 0) {
-    vectorized_combine_impl<4, TOP_K, ThreadingPolicy, T>(dst_typed_base, size_per_token, rank_id,
-                                                          max_tokens_per_rank, ptrs);
+    vectorized_combine_impl<4, TOP_K, T>(dst_typed_base, size_per_token, rank_id,
+                                         max_tokens_per_rank, ptrs);
   } else if (size_per_token % 2 == 0) {
-    vectorized_combine_impl<2, TOP_K, ThreadingPolicy, T>(dst_typed_base, size_per_token, rank_id,
-                                                          max_tokens_per_rank, ptrs);
+    vectorized_combine_impl<2, TOP_K, T>(dst_typed_base, size_per_token, rank_id,
+                                         max_tokens_per_rank, ptrs);
   } else {
-    vectorized_combine_impl<1, TOP_K, ThreadingPolicy, T>(dst_typed_base, size_per_token, rank_id,
-                                                          max_tokens_per_rank, ptrs);
+    vectorized_combine_impl<1, TOP_K, T>(dst_typed_base, size_per_token, rank_id,
+                                         max_tokens_per_rank, ptrs);
   }
 }
 
-// Copy payload to recv buffer using vectorized copy; supports warp/block token mapping
-template <typename ThreadingPolicy>
+// Copy payload to recv buffer using vectorized copy; one block per token
 __global__ void moeA2APrepareCombineKernel(uint8_t* recv_buffer_bytes, uint8_t const* payload_bytes,
                                            int bytes_per_token, int ep_size,
                                            int max_tokens_per_rank, uint32_t* flag_val_ptr,
@@ -762,7 +728,7 @@ __global__ void moeA2APrepareCombineKernel(uint8_t* recv_buffer_bytes, uint8_t c
 
   if (payload_bytes == nullptr) return;
 
-  int slot_idx = ThreadingPolicy::token_idx();
+  int slot_idx = blockIdx.x;
 
   int total_slots = ep_size * max_tokens_per_rank;
   if (slot_idx >= total_slots) return;
@@ -779,20 +745,20 @@ __global__ void moeA2APrepareCombineKernel(uint8_t* recv_buffer_bytes, uint8_t c
   uint8_t* dst_ptr = recv_buffer_bytes + slot_offset;
   uint8_t const* src_ptr = payload_bytes + slot_offset;
 
-  // Copy one token's data using vectorized copy with policy
-  vectorized_copy<ThreadingPolicy>(dst_ptr, src_ptr, bytes_per_token);
+  // Copy one token's data using vectorized copy
+  vectorized_copy(dst_ptr, src_ptr, bytes_per_token);
 }
 
 // ============================================================================
 // Generic Combine Kernel Implementation (Templated by data type)
 // ============================================================================
 
-template <typename T, typename ThreadingPolicy, int TOP_K>
+template <typename T, int TOP_K>
 __global__ void moeA2ACombineKernel(
     const CombineKernelPointers ptrs,  // Combine-specific struct, src_data_ptrs[0] is output
     int max_tokens_per_rank, int elements_per_token, int local_num_tokens, int rank_id,
     int ep_size) {
-  int local_token_idx = ThreadingPolicy::token_idx();
+  int local_token_idx = blockIdx.x;
   int const size_per_token = elements_per_token * sizeof(T);
 
   if (local_num_tokens == 0) {
@@ -868,13 +834,12 @@ __global__ void moeA2ACombineKernel(
   T* token_output = static_cast<T*>(ptrs.src_data_ptrs[0]) + local_token_idx * elements_per_token;
 
   // Accumulate across ranks in registers, then store once per segment
-  vectorized_combine<TOP_K, ThreadingPolicy, T>(token_output, size_per_token, rank_id,
-                                                max_tokens_per_rank, ptrs);
+  vectorized_combine<TOP_K, T>(token_output, size_per_token, rank_id, max_tokens_per_rank, ptrs);
 }
 
 void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
+  TLLM_CHECK(params.one_block_per_token);
   constexpr int kBlockSize = 256;
-  constexpr int kWarpsPerBlock = kBlockSize / 32;  // 8 warps per block
 
   // Calculate bytes per token based on dtype
   int element_size;
@@ -894,19 +859,13 @@ void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
   }
 
   int bytes_per_token = params.elements_per_token * element_size;
-  int total_slots =
+  int grid_size_block =
       params.prepare_payload == nullptr ? 1 : params.ep_size * params.max_tokens_per_rank;
-  int grid_size_warp = ceilDiv(total_slots, kWarpsPerBlock);
-  int grid_size_block = total_slots;  // one block per token
 
-  if (params.one_block_per_token) {
-    moeA2APrepareCombineKernel<BlockPolicy><<<grid_size_block, kBlockSize, 0, params.stream>>>(
-        static_cast<uint8_t*>(const_cast<void*>(params.recv_buffers[params.ep_rank])),
-        static_cast<uint8_t const*>(params.prepare_payload), bytes_per_token, params.ep_size,
-        params.max_tokens_per_rank, params.flag_val, params.recv_counters);
-  } else {
-    FLASHINFER_CHECK(false, "WarpPolicy is no longer supported for moe A2A");
-  }
+  moeA2APrepareCombineKernel<<<grid_size_block, kBlockSize, 0, params.stream>>>(
+      static_cast<uint8_t*>(const_cast<void*>(params.recv_buffers[params.ep_rank])),
+      static_cast<uint8_t const*>(params.prepare_payload), bytes_per_token, params.ep_size,
+      params.max_tokens_per_rank, params.flag_val, params.recv_counters);
 }
 
 // ============================================================================
@@ -915,21 +874,17 @@ void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
 
 void moe_a2a_combine_launch(MoeA2ACombineParams const& params) {
   // Validate parameters
+  TLLM_CHECK(params.one_block_per_token);
   TLLM_CHECK(params.top_k > 0 && params.top_k <= kMaxTopK);
   TLLM_CHECK(params.ep_size > 0 && params.ep_size <= kMaxRanks);
   TLLM_CHECK(params.local_num_tokens >= 0);
   TLLM_CHECK(params.elements_per_token > 0);
 
-  // Configure kernel launch
+  // Configure kernel launch: one block per token
   int const kBlockSize = tensorrt_llm::common::getEnvMoeA2ACombineBlockSize();
-  int const kWarpsPerBlock = kBlockSize / 32;  // warpSize
-  int grid_size_warp = ceilDiv(params.local_num_tokens, kWarpsPerBlock);
   int grid_size_block = params.local_num_tokens;
   // If local_num_tokens is 0, we still need to launch a minimal kernel to participate in the
   // synchronization.
-  if (grid_size_warp == 0) {
-    grid_size_warp = 1;
-  }
   if (grid_size_block == 0) {
     grid_size_block = 1;
   }
@@ -957,18 +912,10 @@ void moe_a2a_combine_launch(MoeA2ACombineParams const& params) {
 
   // Launch appropriate kernel with compact macros
   SWITCH_DTYPE(params.dtype, TKernelType, {
-    SWITCH_POLICY(params.one_block_per_token, Policy, {
-      SWITCH_TOP_K(params.top_k, TOP_K, {
-        auto launch = [&](int grid_blocks, int block_threads) {
-          moeA2ACombineKernel<TKernelType, Policy, TOP_K>
-              <<<grid_blocks, block_threads, 0, params.stream>>>(
-                  kernel_ptrs, params.max_tokens_per_rank, params.elements_per_token,
-                  params.local_num_tokens, params.ep_rank, params.ep_size);
-        };
-        int grid = params.one_block_per_token ? grid_size_block : grid_size_warp;
-        int cta = kBlockSize;
-        launch(grid, cta);
-      });
+    SWITCH_TOP_K(params.top_k, TOP_K, {
+      moeA2ACombineKernel<TKernelType, TOP_K><<<grid_size_block, kBlockSize, 0, params.stream>>>(
+          kernel_ptrs, params.max_tokens_per_rank, params.elements_per_token,
+          params.local_num_tokens, params.ep_rank, params.ep_size);
     });
   });
 }

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -119,13 +119,12 @@ __host__ __device__ inline T ceilDiv(T m, T n) {
     }                                                                   \
   }
 
-#define SWITCH_POLICY(one_block_per_token, POLICY, ...) \
-  if (one_block_per_token) {                            \
-    using POLICY = BlockPolicy;                         \
-    __VA_ARGS__                                         \
-  } else {                                              \
-    using POLICY = WarpPolicy;                          \
-    __VA_ARGS__                                         \
+#define SWITCH_POLICY(one_block_per_token, POLICY, ...)                       \
+  if (one_block_per_token) {                                                  \
+    using POLICY = BlockPolicy;                                               \
+    __VA_ARGS__                                                               \
+  } else {                                                                    \
+    FLASHINFER_CHECK(false, "WarpPolicy is no longer supported for moe A2A"); \
   }
 
 #if DISABLE_TIMEOUT
@@ -156,16 +155,6 @@ __device__ int compute_target_rank_id(int expert_id, int num_experts_per_rank) {
 // ============================================================================
 // Helper Functions for Vectorized Memory Operations
 // ============================================================================
-
-struct WarpPolicy {
-  __device__ static int stride() { return warpSize; }
-
-  __device__ static int offset() { return (threadIdx.x % warpSize); }
-
-  __device__ static int token_idx() { return (blockIdx.x * blockDim.x + threadIdx.x) / warpSize; }
-
-  __device__ static void sync() { __syncwarp(); }
-};
 
 struct BlockPolicy {
   __device__ static int stride() { return blockDim.x; }
@@ -325,17 +314,8 @@ __global__ void moeA2ADispatchKernel(
 
     // Prepare per-policy shared-memory tiles for this token
     extern __shared__ int smem[];
-    int* smem_topk_target_ranks;
-    int* smem_topk_send_indices;
-    int warps_per_block = blockDim.x / warpSize;
-    if constexpr (std::is_same<ThreadingPolicy, WarpPolicy>::value) {
-      int lane_id = threadIdx.x / warpSize;
-      smem_topk_target_ranks = smem + lane_id * TOP_K;
-      smem_topk_send_indices = smem + warps_per_block * TOP_K + lane_id * TOP_K;
-    } else {
-      smem_topk_target_ranks = smem;
-      smem_topk_send_indices = smem + TOP_K;
-    }
+    int* smem_topk_target_ranks = smem;
+    int* smem_topk_send_indices = smem + TOP_K;
 
     uint64_t already_copied = 0;
     for (int k = 0; k < TOP_K; k++) {
@@ -533,19 +513,7 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
                      params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
                      params.ep_size, params.num_experts_per_rank))
   } else {
-    int grid_size = ceilDiv(params.local_num_tokens, kWarpsPerBlock);
-    // If local_num_tokens is 0, we still need to launch a minimal kernel to participate in the
-    // synchronization.
-    if (grid_size == 0) {
-      grid_size = 1;
-    }
-    int shared_bytes = 2 * kWarpsPerBlock * params.top_k * (int)sizeof(int);
-    SWITCH_TOP_K(params.top_k, TOP_K,
-                 moeA2ADispatchKernel<WarpPolicy, TOP_K>
-                 <<<grid_size, kBlockSize, shared_bytes, params.stream>>>(
-                     params.token_selected_experts, kernel_ptrs, params.num_payloads,
-                     params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
-                     params.ep_size, params.num_experts_per_rank))
+    FLASHINFER_CHECK(false, "WarpPolicy is no longer supported for moe A2A");
   }
 }
 
@@ -937,10 +905,7 @@ void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
         static_cast<uint8_t const*>(params.prepare_payload), bytes_per_token, params.ep_size,
         params.max_tokens_per_rank, params.flag_val, params.recv_counters);
   } else {
-    moeA2APrepareCombineKernel<WarpPolicy><<<grid_size_warp, kBlockSize, 0, params.stream>>>(
-        static_cast<uint8_t*>(const_cast<void*>(params.recv_buffers[params.ep_rank])),
-        static_cast<uint8_t const*>(params.prepare_payload), bytes_per_token, params.ep_size,
-        params.max_tokens_per_rank, params.flag_val, params.recv_counters);
+    FLASHINFER_CHECK(false, "WarpPolicy is no longer supported for moe A2A");
   }
 }
 

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
@@ -76,9 +76,6 @@ struct CombineKernelPointers {
 
 // Dispatch phase parameters
 struct MoeA2ADispatchParams {
-  bool one_block_per_token;  // True: one block per token, False: one warp per token
-
-  // Threading policy
   // EP configuration
   int ep_size;               // Number of EP ranks
   int ep_rank;               // Current EP rank
@@ -125,8 +122,6 @@ void moe_a2a_prepare_dispatch_launch(MoeA2ADispatchParams const& params);
 
 // Combine phase parameters
 struct MoeA2ACombineParams {
-  bool one_block_per_token;  // True: one block per token, False: one warp per token
-
   // EP configuration
   int ep_size;  // Number of EP ranks
   int ep_rank;  // Current EP rank

--- a/csrc/trtllm_moe_alltoall.cu
+++ b/csrc/trtllm_moe_alltoall.cu
@@ -26,7 +26,6 @@
 
 #include "flashinfer/utils.cuh"
 #include "tensorrt_llm/common/dataType.h"
-#include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h"
 #include "tensorrt_llm/thop/moeAlltoAllMeta.h"
 #include "tvm_ffi_utils.h"
@@ -196,7 +195,6 @@ Tuple<Array<int64_t>, Array<int64_t>, int64_t> moeA2ADispatchOp(
                                               << requiredSize << " bytes but has " << sizePerRank;
 
   tl_throughput::MoeA2ADispatchParams params{};
-  params.one_block_per_token = tensorrt_llm::common::getEnvMoeA2AOneBlockPerToken();
   params.ep_size = static_cast<int>(epSize);
   params.ep_rank = static_cast<int>(epRank);
   params.num_experts_per_rank = static_cast<int>(numExperts / epSize);
@@ -317,7 +315,6 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
       alloc_tensor({localNumTokens, elementsPerToken}, payload.dtype(), payload.device());
 
   MoeA2ACombineParams params{};
-  params.one_block_per_token = tensorrt_llm::common::getEnvMoeA2AOneBlockPerToken();
   params.ep_size = static_cast<int>(epSize);
   params.ep_rank = static_cast<int>(epRank);
   params.local_num_tokens = static_cast<int>(localNumTokens);


### PR DESCRIPTION
… this option as it is never beneficial

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

See TRT-LLM corresponding PR https://github.com/NVIDIA/TensorRT-LLM/pull/14550

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MoE all-to-all now always uses one-block-per-token scheduling across the system.
  * Attempts to disable this mode via configuration are ignored and will emit a warning informing users the legacy option is no longer supported.
  * Selecting the legacy (warp-level) scheduling now produces an explicit error instead of silently falling back.
  * Documentation and comments updated to reflect the always-on behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->