### PR TITLE
feat(comm): Support per-token LoRA Info in MoE a2a comm payloads

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -298,6 +298,7 @@ The `moe_a2a_dispatch_combine` routine benchmarks MoE All-to-All communication f
 | `--validate`             | Run correctness validation before benchmarking using deterministic fake MoE                                |
 | `--per_phase_timing`     | Enable per-phase timing (dispatch/combine/moe_kernel). Adds slight overhead from CUDA events               |
 | `--nvtx`                 | Enable NVTX markers for Nsight Systems profiling                                                           |
+| `--use_lora`             | Carry a per-token int32 LoRA adapter ID through dispatch as an extra payload.                                                                                                                  |
 
 **Launch Examples:**
 ```bash
@@ -323,6 +324,12 @@ mpirun -np 8 python benchmarks/flashinfer_benchmark.py \
     --routine moe_a2a_dispatch_combine \
     --num_tokens 1024 --hidden_size 7168 --num_experts 256 --top_k 8 \
     --validate --per_phase_timing
+
+# Multi-tenant LoRA: carry per-token adapter ID through dispatch
+mpirun -np 8 python benchmarks/flashinfer_benchmark.py \
+    --routine moe_a2a_dispatch_combine \
+    --num_tokens 2048 --hidden_size 7168 --num_experts 256 --top_k 8 \
+    --use_lora --validate
 ```
 
 ### AllReduce Communication Flags (allreduce_fusion)

--- a/benchmarks/routines/moe_comm.py
+++ b/benchmarks/routines/moe_comm.py
@@ -109,6 +109,10 @@ from .moe_utils import (
     quantize_and_pack_nvfp4,
 )
 
+# Number of distinct LoRA adapter IDs when --use_lora is enabled.
+# Matches issue #3109's "up to 8 concurrent adapter IDs" target.
+NUM_LORA_ADAPTERS = 8
+
 
 @contextmanager
 def cuda_event_timer(events_list: list, enabled: bool = True):
@@ -242,6 +246,11 @@ def parse_moe_comm_args(line, parser):
         "--per_phase_timing",
         action="store_true",
         help="Enable per-phase timing (dispatch/combine). Adds slight overhead from CUDA events.",
+    )
+    parser.add_argument(
+        "--use_lora",
+        action="store_true",
+        help="Enable per-token LoRA adapter ID payload.",
     )
 
     args = parser.parse_args(line)
@@ -454,11 +463,13 @@ def _create_moe_inputs(
     quant_dtype: Optional[str],
     device: torch.device,
     comm: MPI.Comm,
+    use_lora: bool = False,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
+    Optional[torch.Tensor],
     Optional[torch.Tensor],
     Optional[torch.Tensor],
     List[torch.Tensor],
@@ -475,15 +486,17 @@ def _create_moe_inputs(
         quant_dtype: None, "fp8", "nvfp4", or "fp8_block_scale"
         device: CUDA device
         comm: MPI communicator for syncing global scale
+        use_lora: If True, append per-token LoRA adapter ID as an extra dispatch payload
 
     Returns:
-        Tuple of (hidden_states, hidden_states_original, token_selected_experts, token_final_scales, scale_factor, global_scale, input_payloads)
+        Tuple of (hidden_states, hidden_states_original, token_selected_experts, token_final_scales, scale_factor, global_scale, lora_ids, input_payloads)
         - hidden_states: The tensor to communicate (may be quantized)
         - hidden_states_original: The original unquantized hidden states for validation purpose
         - token_selected_experts: Expert indices
         - token_final_scales: Routing weights
         - scale_factor: Block scale factor tensor for NVFP4 (in A2A payloads), None otherwise
         - global_scale: Global/per-tensor scale factor for quantized dtype (synced via MPI max, same across ranks), None otherwise
+        - lora_ids: [num_tokens] int32 per-token LoRA adapter IDs when use_lora=True, None otherwise
         - input_payloads: List of all payloads for dispatch
     """
     # Generate original hidden states in input_dtype
@@ -554,6 +567,15 @@ def _create_moe_inputs(
     if scale_factor is not None:
         input_payloads.append(scale_factor)
 
+    # Per-token LoRA adapter IDs
+    lora_ids = None
+    if use_lora:
+        lora_ids = torch.randint(
+            0, NUM_LORA_ADAPTERS, (num_tokens,), dtype=torch.int32, device=device
+        )
+        # Dispatch kernel requires 2D payloads [num_tokens, elements_per_token]
+        input_payloads.append(lora_ids.unsqueeze(-1))
+
     return (
         hidden_states,
         hidden_states_original,
@@ -561,6 +583,7 @@ def _create_moe_inputs(
         token_final_scales,
         scale_factor,
         global_scale,
+        lora_ids,
         input_payloads,
     )
 
@@ -572,6 +595,7 @@ def _calculate_exact_comm_traffic(
     hidden_size: int,
     input_dtype: torch.dtype,
     quant_dtype: Optional[str] = None,
+    use_lora: bool = False,
 ) -> Tuple[int, int]:
     """
     Calculate exact inter-rank traffic from actual expert assignments.
@@ -589,6 +613,7 @@ def _calculate_exact_comm_traffic(
         hidden_size: Hidden dimension size
         input_dtype: Data type of hidden states (before quantization)
         quant_dtype: None, "fp8", or "nvfp4"
+        use_lora: If True, include per-token int32 LoRA ID bytes in dispatch traffic
 
     Returns:
         Tuple of (dispatch_bytes, combine_bytes) for actual inter-rank traffic
@@ -609,6 +634,9 @@ def _calculate_exact_comm_traffic(
         element_size = torch.tensor([], dtype=input_dtype).element_size()
         hidden_bytes_per_token = hidden_size * element_size
         scale_bytes_per_token = 0
+
+    # Per-token LoRA adapter ID (int32) travels alongside hidden states (once per src→dst pair)
+    lora_bytes_per_token = 4 if use_lora else 0
 
     # Activation dtype element size for combine phase
     combine_element_bytes = torch.tensor([], dtype=input_dtype).element_size()
@@ -647,6 +675,7 @@ def _calculate_exact_comm_traffic(
                 total_dispatch_bytes += (
                     hidden_bytes_per_token
                     + scale_bytes_per_token
+                    + lora_bytes_per_token
                     + num_experts_to_dst * token_topk_id_and_weight_bytes
                 )
                 # Combine: one output per token per dst_rank
@@ -665,6 +694,7 @@ def _calculate_comm_bandwidth(
     quant_dtype: Optional[str] = None,
     phase: str = "dispatch_combine",
     actual_traffic: Optional[Tuple[int, int]] = None,
+    use_lora: bool = False,
 ) -> float:
     """
     Calculate memory bandwidth for MoE A2A communication in TB/sec.
@@ -721,6 +751,7 @@ def _calculate_comm_bandwidth(
             + num_tokens * top_k * 4  # token_selected_experts (int32)
             + num_tokens * top_k * 4  # token_final_scales (float32)
             + scale_bytes
+            + (num_tokens * 4 if use_lora else 0)  # LoRA adapter ID payload
         )
 
         # Combine phase: receive processed hidden_states back
@@ -750,13 +781,16 @@ def fake_moe(
     is_ep: bool = False,
     ep_rank: Optional[int] = None,
     num_experts_per_rank: Optional[int] = None,
+    lora_ids: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Apply a deterministic fake MoE transformation for validation.
 
     Each expert applies a predictable scale: (expert_id + 1.0) / num_experts + 0.5
+    When lora_ids is provided, the LoRA adapter ID adds an integer step: scale += lora_id + 1.0
     This allows verifying that communication correctly routes tokens to experts
     and combines results.
+
 
     Args:
         hidden_states: Input tensor [num_tokens, hidden_size] or [world_size, num_tokens, hidden_size]
@@ -765,6 +799,7 @@ def fake_moe(
         is_ep: If True, only process experts assigned to this rank
         ep_rank: Rank for expert parallel filtering
         num_experts_per_rank: Number of experts per rank
+        lora_ids: Per-token LoRA adapter IDs [num_tokens] int32, or None
 
     Returns:
         Processed tensor with same shape as hidden_states
@@ -795,6 +830,8 @@ def fake_moe(
 
             # Deterministic scale based on expert_id
             scale = (expert_id + 1.0) / num_experts + 0.5
+            if lora_ids is not None:
+                scale += lora_ids[token_idx].item() + 1.0
             results.append(hidden_states[token_idx].to(torch.float32) * scale)
 
         # Sum results with higher precision to match actual implementation
@@ -823,6 +860,7 @@ def _validate_moe_a2a(
     rank: int,
     comm,
     verbose: int = 0,
+    lora_ids: Optional[torch.Tensor] = None,
 ) -> bool:
     """
     Validate MoE A2A communication correctness with a round-trip test.
@@ -872,7 +910,13 @@ def _validate_moe_a2a(
     recv_hidden = recv_tensors[0]
     recv_experts = recv_tensors[1]
     _ = recv_tensors[2]  # recv_token_final_scales
-    recv_scale_factor = recv_tensors[3] if len(recv_tensors) > 3 else None
+    # When use_lora, the LoRA ID payload is appended after the scale_factor (or directly
+    # after the 3 base payloads when there is no quant scale factor).
+    use_lora = lora_ids is not None
+    has_scale_factor = quant_dtype in ("nvfp4", "fp8_block_scale")
+    recv_scale_factor = recv_tensors[3] if has_scale_factor else None
+    lora_id_payload_index = (4 if has_scale_factor else 3) if use_lora else None
+    recv_lora_ids = recv_tensors[lora_id_payload_index].flatten() if use_lora else None
 
     # Note: For quantized dispatch, recv_tensors[0] is quantized.
     # Per-tensor scale factor is part of model ckpts, not in A2A payloads.
@@ -925,6 +969,7 @@ def _validate_moe_a2a(
         is_ep=True,
         ep_rank=rank,
         num_experts_per_rank=num_experts_per_rank,
+        lora_ids=recv_lora_ids,
     )
 
     # Get combine payload workspace
@@ -964,12 +1009,20 @@ def _validate_moe_a2a(
         np.concatenate(all_token_selected_experts, axis=0)
     ).to(token_selected_experts.device)
 
+    global_lora_ids = None
+    if use_lora:
+        all_lora_ids = comm.allgather(lora_ids.cpu().numpy())
+        global_lora_ids = torch.from_numpy(np.concatenate(all_lora_ids, axis=0)).to(
+            lora_ids.device
+        )
+
     # Compute expected result locally
     expected = fake_moe(
         global_hidden_states,
         global_token_selected_experts,
         num_experts,
         is_ep=False,
+        lora_ids=global_lora_ids,
     )
 
     # Extract this rank's portion
@@ -1063,6 +1116,7 @@ def test_moe_a2a_dispatch_combine(args):
     max_num_tokens = args.max_num_tokens
     input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
     quant_dtype = args.quant_dtype
+    use_lora = getattr(args, "use_lora", False)
 
     res = []
 
@@ -1082,13 +1136,22 @@ def test_moe_a2a_dispatch_combine(args):
         world_size=world_size,
     )
 
-    # Create MoeAlltoAll instance
+    # Create MoeAlltoAll instance — when use_lora, size workspace with an extra
+    # int32 per token for the LoRA ID payload.
+    extra_payload_bytes = 4 if use_lora else 0
+    workspace_size_per_rank = MoeAlltoAll.get_moe_workspace_size_per_rank(
+        ep_size,
+        top_k,
+        max_num_tokens,
+        hidden_size,
+        extra_payload_bytes_per_token=extra_payload_bytes,
+    )
     moe_a2a = MoeAlltoAll(
         mapping=mapping,
         max_num_tokens=max_num_tokens,
         top_k=top_k,
         num_experts=num_experts,
-        hidden_size=hidden_size,
+        workspace_size_per_rank=workspace_size_per_rank,
     )
 
     # Synchronize all_num_tokens across ranks
@@ -1105,6 +1168,7 @@ def test_moe_a2a_dispatch_combine(args):
         token_final_scales,
         scale_factor,
         global_scale,
+        lora_ids,
         input_payloads,
     ) = _create_moe_inputs(
         num_tokens,
@@ -1115,6 +1179,7 @@ def test_moe_a2a_dispatch_combine(args):
         quant_dtype,
         device,
         comm,
+        use_lora=use_lora,
     )
 
     # Run validation if requested
@@ -1139,6 +1204,7 @@ def test_moe_a2a_dispatch_combine(args):
             rank=rank,
             comm=comm,
             verbose=args.verbose,
+            lora_ids=lora_ids,
         )
         if not validation_passed:
             if rank == 0:
@@ -1154,6 +1220,7 @@ def test_moe_a2a_dispatch_combine(args):
         hidden_size,
         input_dtype,
         quant_dtype,
+        use_lora=use_lora,
     )
     # Compute total active experts across all ranks
     total_active_experts = int(

--- a/tests/comm/test_mnnvl_moe_alltoall.py
+++ b/tests/comm/test_mnnvl_moe_alltoall.py
@@ -129,6 +129,8 @@ def fake_moe(
     is_ep=False,
     ep_rank=None,
     num_experts_per_rank=None,
+    lora_ids=None,
+    lora_weights=None,
 ):
     """
     Emulate MoE computation by scaling tokens based on which experts belong to this rank.
@@ -141,6 +143,8 @@ def fake_moe(
         is_ep: If true, emulate MoE on a EP rank; otherwise, emulate MoE with all experts
         ep_rank: EP rank ID
         num_experts_per_rank: Number of experts per rank
+        lora_ids: [num_tokens] int32 per-token LoRA adapter IDs, or None
+        lora_weights: [num_adapters, hidden_size, hidden_size] shared LoRA weights, or None
 
     Returns:
         processed_states: [num_tokens, hidden_size] - processed hidden states
@@ -173,7 +177,13 @@ def fake_moe(
                 expert = experts[expert_id]
 
             scale = token_final_scales[token_idx, k]
-            results.append(hidden_states[token_idx] @ expert * scale)
+            expert_out = hidden_states[token_idx] @ expert * scale
+            if lora_ids is not None and lora_weights is not None:
+                lora_id = lora_ids[token_idx].item()
+                expert_out = (
+                    expert_out + hidden_states[token_idx] @ lora_weights[lora_id]
+                )
+            results.append(expert_out)
 
         # Summing the results after is closer to the actual implementation as we do a tree reduction.
         if results:
@@ -184,14 +194,21 @@ def fake_moe(
     return processed_states
 
 
+# Number of distinct LoRA adapter IDs in tests.  Used by both
+# test_moe_a2a_dispatch and test_moe_a2a_dispatch_moe_combine.
+NUM_LORA_ADAPTERS = 4
+
+
 def make_nvfp4_payloads(
     local_num_tokens: int,
     hidden_size: int,
     top_k: int,
     rank: int,
     token_selected_experts: torch.Tensor,
+    lora_ids: torch.Tensor | None = None,
 ) -> tuple[list, int]:
-    """Create the four NV FP4 payloads exactly as in single-GPU test."""
+    """Create the four NV FP4 payloads exactly as in single-GPU test, with an
+    optional 5th LoRA adapter ID payload."""
     payloads = []
     # Payload 0: Packed FP4 tokens (uint8)
     packed_hidden_size = hidden_size // 2
@@ -222,6 +239,12 @@ def make_nvfp4_payloads(
     # token_final_scales[:, 1] = torch.linspace(0, local_num_tokens - 1, local_num_tokens, dtype=torch.bfloat16, device='cuda')
 
     payloads.append(token_final_scales)
+
+    # Payload 4 (optional): LoRA adapter IDs
+    if lora_ids is not None:
+        # Dispatch kernel requires 2D payloads [num_tokens, elements_per_token]
+        payloads.append(lora_ids.unsqueeze(-1))
+
     return payloads, 2
 
 
@@ -231,6 +254,7 @@ def make_bfloat16_payloads(
     top_k: int,
     rank: int,
     token_selected_experts: torch.Tensor,
+    lora_ids: torch.Tensor | None = None,
 ) -> tuple[list, int]:
     """Create bfloat16 test payloads matching nvfp4 structure but without scaling factors."""
     payloads = []
@@ -257,6 +281,12 @@ def make_bfloat16_payloads(
 
     payloads.append(token_final_scales)
 
+    # Payload 3 (optional): LoRA adapter IDs
+    if lora_ids is not None:
+        payloads.append(
+            lora_ids.unsqueeze(-1)
+        )  # [num_tokens, 1] for 2D dispatch requirement
+
     return payloads, 1
 
 
@@ -267,6 +297,7 @@ def run_moe_a2a_dispatch_single_rank(
     num_experts_per_rank,
     hidden_size,
     invalid_token_expert_id,
+    use_lora=False,
 ):
     """Worker function for MPI testing."""
     comm = MPI.COMM_WORLD
@@ -292,12 +323,21 @@ def run_moe_a2a_dispatch_single_rank(
     # Create MoeAlltoAll manager
     max_num_tokens = max(all_num_tokens)
 
+    # When use_lora is True, account for the extra int32 LoRA ID payload (4 bytes/token).
+    extra_payload_bytes = 4 if use_lora else 0
+    workspace_size_per_rank = MoeAlltoAll.get_moe_workspace_size_per_rank(
+        ep_size,
+        top_k,
+        max_num_tokens,
+        hidden_size,
+        extra_payload_bytes_per_token=extra_payload_bytes,
+    )
     moe_a2a = MoeAlltoAll(
         mapping,
         max_num_tokens,
         top_k,
         ep_size * num_experts_per_rank,
-        hidden_size=hidden_size,
+        workspace_size_per_rank=workspace_size_per_rank,
     )
 
     # Get the number of tokens for this specific rank (same as single-GPU)
@@ -307,8 +347,22 @@ def run_moe_a2a_dispatch_single_rank(
     token_selected_experts = generate_token_selected_experts(
         rank_local_tokens, ep_size, num_experts_per_rank, top_k
     )
+    lora_ids = None
+    if use_lora:
+        lora_ids = torch.randint(
+            0,
+            NUM_LORA_ADAPTERS,
+            (rank_local_tokens,),
+            dtype=torch.int32,
+            device="cuda",
+        )
     payloads, expert_id_payload_index = make_nvfp4_payloads(
-        rank_local_tokens, hidden_size, top_k, rank, token_selected_experts
+        rank_local_tokens,
+        hidden_size,
+        top_k,
+        rank,
+        token_selected_experts,
+        lora_ids=lora_ids,
     )
 
     check_any_rank_failed()
@@ -555,7 +609,7 @@ def verify_dispatch(
                     assert torch.all(token_expert_ids == invalid_token_expert_id)
 
 
-def moe_a2a_dispatch_test_impl(distribution, top_k):
+def moe_a2a_dispatch_test_impl(distribution, top_k, use_lora=False):
     """Test MoE A2A dispatch operation."""
     comm = MPI.COMM_WORLD
     world_size = comm.Get_size()
@@ -598,6 +652,7 @@ def moe_a2a_dispatch_test_impl(distribution, top_k):
         num_experts_per_rank,
         hidden_size,
         invalid_token_expert_id,
+        use_lora=use_lora,
     )
 
     check_any_rank_failed()
@@ -639,22 +694,40 @@ def moe_a2a_dispatch_test_impl(distribution, top_k):
 
 
 @pytest.mark.parametrize(
-    "distribution,top_k",
+    "distribution,top_k,use_lora",
     [
-        ("random", 1),  # topk=1 with random distribution
-        ("uniform", 1),  # topk=1 with uniform distribution
-        ("random", 2),  # topk=2 with random distribution
-        ("uniform", 2),  # topk=2 with uniform distribution
-        ("random", 8),  # topk=8 with random distribution
-        ("uniform", 8),  # topk=8 with uniform distribution
+        ("random", 1, False),
+        ("uniform", 1, False),
+        ("random", 2, False),
+        ("uniform", 2, False),
+        ("random", 8, False),
+        ("uniform", 8, False),
+        ("random", 8, True),  # LoRA + nvfp4 payloads
+        ("uniform", 8, True),
     ],
 )
-def test_moe_a2a_dispatch(distribution, top_k):
+def test_moe_a2a_dispatch(distribution, top_k, use_lora):
     """Test MoE A2A dispatch operation."""
-    safe_run(moe_a2a_dispatch_test_impl, distribution, top_k)
+    safe_run(moe_a2a_dispatch_test_impl, distribution, top_k, use_lora)
 
 
-def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
+def create_lora_weights(num_adapters, hidden_size, device, dtype=torch.bfloat16):
+    """Create shared LoRA weights deterministically (same on all ranks).
+
+    Uses fork_rng to avoid disturbing the caller's RNG state while ensuring
+    all ranks produce identical weights from a fixed seed.
+    """
+    lora_weights = torch.empty(
+        (num_adapters, hidden_size, hidden_size), dtype=dtype, device=device
+    )
+    with torch.random.fork_rng(devices=[device]):
+        torch.manual_seed(9999)
+        for i in range(num_adapters):
+            torch.nn.init.xavier_uniform_(lora_weights[i])
+    return lora_weights
+
+
+def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k, use_lora=False):
     """Test full MoE A2A dispatch + expert processing + combine cycle."""
 
     comm = MPI.COMM_WORLD
@@ -709,8 +782,27 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
         local_num_tokens, ep_size, num_experts_per_rank, top_k
     )
 
+    lora_ids = None
+    lora_weights = None
+    if use_lora:
+        lora_ids = torch.randint(
+            0,
+            NUM_LORA_ADAPTERS,
+            (local_num_tokens,),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        lora_weights = create_lora_weights(
+            NUM_LORA_ADAPTERS, hidden_size, "cuda", dtype=torch.bfloat16
+        )
+
     payloads, expert_id_payload_index = make_bfloat16_payloads(
-        local_num_tokens, hidden_size, top_k, rank, token_selected_experts
+        local_num_tokens,
+        hidden_size,
+        top_k,
+        rank,
+        token_selected_experts,
+        lora_ids=lora_ids,
     )
 
     hidden_states = payloads[0]
@@ -737,15 +829,25 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
         token_final_scales,
         all_experts,
         is_ep=False,
+        lora_ids=lora_ids,
+        lora_weights=lora_weights,
     )
 
-    # Initialize MoeAlltoAll
+    # Initialize MoeAlltoAll — extra_payload_bytes_per_token accounts for LoRA ID
+    extra_payload_bytes = 4 if use_lora else 0
+    workspace_size_per_rank = MoeAlltoAll.get_moe_workspace_size_per_rank(
+        ep_size,
+        top_k,
+        max_num_tokens,
+        hidden_size,
+        extra_payload_bytes_per_token=extra_payload_bytes,
+    )
     moe_a2a = MoeAlltoAll(
         mapping=mapping,
         max_num_tokens=max_num_tokens,
         top_k=top_k,
         num_experts=ep_size * num_experts_per_rank,
-        hidden_size=hidden_size,
+        workspace_size_per_rank=workspace_size_per_rank,
     )
 
     check_any_rank_failed()
@@ -761,6 +863,10 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
     hidden_states_recv = recv_tensors[0]  # [ep_size, max_tokens, hidden_size]
     token_selected_experts_recv = recv_tensors[1]  # [ep_size, max_tokens, top_k]
     token_final_scales_recv = recv_tensors[2]  # [ep_size, max_tokens, top_k]
+
+    recv_lora_ids = None
+    if use_lora:
+        recv_lora_ids = recv_tensors[3].flatten()  # [ep_size * max_tokens]
 
     # Get workspace-backed tensor for output
     moe_output = moe_a2a.get_combine_payload_tensor_in_workspace(
@@ -782,10 +888,12 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
             token_final_scales_recv.view(
                 ep_size * max_num_tokens, token_final_scales_recv.shape[-1]
             ),
-            rank_experts,  # experts for current rank
+            rank_experts,
             is_ep=True,
             ep_rank=rank,
             num_experts_per_rank=num_experts_per_rank,
+            lora_ids=recv_lora_ids,
+            lora_weights=lora_weights,
         ).view(ep_size, max_num_tokens, hidden_size)
     )
 
@@ -819,19 +927,21 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k):
 
 
 @pytest.mark.parametrize(
-    "distribution,top_k",
+    "distribution,top_k,use_lora",
     [
-        ("random", 1),  # topk=1 with random distribution
-        ("uniform", 1),  # topk=1 with uniform distribution
-        ("random", 2),  # topk=2 with random distribution
-        ("uniform", 2),  # topk=2 with uniform distribution
-        ("random", 8),  # topk=8 with random distribution
-        ("uniform", 8),  # topk=8 with uniform distribution
+        ("random", 1, False),
+        ("uniform", 1, False),
+        ("random", 2, False),
+        ("uniform", 2, False),
+        ("random", 8, False),
+        ("uniform", 8, False),
+        ("random", 2, True),  # LoRA with topk=2
+        ("uniform", 8, True),  # LoRA with topk=8
     ],
 )
-def test_moe_a2a_dispatch_moe_combine(distribution, top_k):
+def test_moe_a2a_dispatch_moe_combine(distribution, top_k, use_lora):
     """Test full MoE A2A dispatch + expert processing + combine cycle."""
-    safe_run(moe_a2a_dispatch_moe_combine_test_impl, distribution, top_k)
+    safe_run(moe_a2a_dispatch_moe_combine_test_impl, distribution, top_k, use_lora)
 
 
 if __name__ == "__main__":

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -42,6 +42,8 @@ def setup_test_environment():
     yield
 
 
+NUM_LORA_ADAPTERS = 8
+
 # Single GPU test parameters
 SINGLE_GPU_PARAMS = [
     (902, 7168, 256, 8),  # Large data
@@ -96,6 +98,44 @@ QUANT_PARAMS = [
     (CombineQuantMode.MXFP8, SfLayout.layout_8x4),
     (CombineQuantMode.MXFP4, SfLayout.layout_128x4),
     (CombineQuantMode.NVFP4, SfLayout.layout_128x4),
+]
+
+
+LORA_COMBINE_PARAMS = [
+    # (world_size, num_tokens, vector_dim, top_k, dtype, payload_in_workspace, quant_mode, sf_layout, use_lora)
+    (
+        8,
+        16,
+        7168,
+        8,
+        torch.bfloat16,
+        True,
+        CombineQuantMode.NONE,
+        SfLayout.layout_linear,
+        True,
+    ),  # DeepSeek-V3 with LoRA
+    (
+        4,
+        16,
+        4096,
+        2,
+        torch.bfloat16,
+        True,
+        CombineQuantMode.NONE,
+        SfLayout.layout_linear,
+        True,
+    ),  # Mixtral-8x7B with LoRA
+    (
+        8,
+        16,
+        4096,
+        8,
+        torch.bfloat16,
+        False,
+        CombineQuantMode.NONE,
+        SfLayout.layout_linear,
+        True,
+    ),  # LoRA + payload not in workspace
 ]
 
 
@@ -166,7 +206,7 @@ def test_moe_alltoall_single_gpu(num_tokens, vector_dim, num_experts, top_k):
     """Test MOE alltoall communication on single GPU."""
     torch.cuda.set_device(0)
     # Create a random input tensor
-    dtypes = [torch.bfloat16, torch.float16, torch.int32, torch.uint8]
+    dtypes = [torch.bfloat16, torch.float16, torch.int32, torch.uint8, torch.int32]
     hidden_state_index = 0
     input_tensors = [
         make_payload(num_tokens, vector_dim * (i + 1), dtype)
@@ -393,7 +433,8 @@ def test_moe_alltoall_multi_rank_single_gpu(world_size, num_tokens, vector_dim):
         f"should run with world_size at most {max_world_size}"
     )
 
-    dtypes = [torch.float16, torch.bfloat16, torch.int32, torch.uint8]
+    # 5 payloads (max): the trailing int32 represents the LoRA adapter ID slot.
+    dtypes = [torch.float16, torch.bfloat16, torch.int32, torch.uint8, torch.int32]
     # Create a random input tensor
     input_tensors = [
         make_payload(num_tokens * world_size, vector_dim * (i + 1), dtype)
@@ -529,13 +570,13 @@ def fake_moe(
     is_ep: bool = False,
     ep_rank: int | None = None,
     num_experts_per_rank: int | None = None,
+    lora_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Apply a deterministic fake MoE transformation for validation.
 
     Each expert applies a predictable scale: (expert_id + 1.0) / num_experts + 0.5
-    This allows verifying that communication correctly routes tokens to experts
-    and combines results.
+    When lora_ids is provided, the LoRA adapter ID adds an integer step: scale += lora_id + 1.0
 
     Args:
         hidden_states: Input tensor [num_tokens, hidden_size] or [world_size, num_tokens, hidden_size]
@@ -544,6 +585,7 @@ def fake_moe(
         is_ep: If True, only process experts assigned to this rank
         ep_rank: Rank for expert parallel filtering
         num_experts_per_rank: Number of experts per rank
+        lora_ids: Per-token LoRA adapter IDs [num_tokens] int32, or None
 
     Returns:
         Processed tensor with same shape as hidden_states
@@ -573,6 +615,8 @@ def fake_moe(
                 continue
 
             scale = (expert_id + 1.0) / num_experts + 0.5
+            if lora_ids is not None:
+                scale += lora_ids[token_idx].item() + 1.0
             results.append(hidden_states[token_idx] * scale)
 
         # Summing the results after is closer to the actual implementation as we do a tree reduction.
@@ -584,8 +628,9 @@ def fake_moe(
 
 
 @pytest.mark.parametrize(
-    "world_size,num_tokens,vector_dim,top_k,dtype,payload_in_workspace,quant_mode,sf_layout",
-    [(*x, *y) for x, y in itertools.product(COMBINE_PARAMS, QUANT_PARAMS)],
+    "world_size,num_tokens,vector_dim,top_k,dtype,payload_in_workspace,quant_mode,sf_layout,use_lora",
+    [(*x, *y, False) for x, y in itertools.product(COMBINE_PARAMS, QUANT_PARAMS)]
+    + LORA_COMBINE_PARAMS,
 )
 def test_moe_combine_multi_rank_single_gpu(
     world_size,
@@ -596,6 +641,7 @@ def test_moe_combine_multi_rank_single_gpu(
     payload_in_workspace,
     quant_mode,
     sf_layout,
+    use_lora,
 ):
     torch.cuda.set_device(0)
     compute_capability = get_compute_capability(torch.device("cuda"))
@@ -612,15 +658,16 @@ def test_moe_combine_multi_rank_single_gpu(
     )
 
     num_experts = world_size * top_k
+    total_tokens = num_tokens * world_size
 
     token_selected_experts_index = 0
     hidden_state_index = 1
 
     token_selected_experts = torch.empty(
-        num_tokens * world_size, top_k, dtype=torch.int32, device=torch.device("cuda")
+        total_tokens, top_k, dtype=torch.int32, device=torch.device("cuda")
     )
 
-    for i in range(num_tokens * world_size):
+    for i in range(total_tokens):
         # Include one extra expert to represent invalid expert IDs
         token_selected_experts[i] = torch.randperm(
             num_experts, dtype=torch.int32, device=torch.device("cuda")
@@ -628,14 +675,28 @@ def test_moe_combine_multi_rank_single_gpu(
     token_selected_experts = token_selected_experts.contiguous()
 
     # Create a random input tensor
-    reference_tensor = make_payload(num_tokens * world_size, vector_dim, dtype)
+    reference_tensor = make_payload(total_tokens, vector_dim, dtype)
     input_tensors = [
         token_selected_experts,
         reference_tensor,
         make_payload(
-            num_tokens * world_size, 1, torch.uint8
+            total_tokens, 1, torch.uint8
         ),  # Some extra payload to test combine alignment logic
     ]
+
+    lora_ids = None
+    lora_id_payload_index = None
+    if use_lora:
+        lora_ids = torch.randint(
+            0,
+            NUM_LORA_ADAPTERS,
+            (total_tokens,),
+            dtype=torch.int32,
+            device=torch.device("cuda"),
+        )
+        lora_id_payload_index = len(input_tensors)
+        # Dispatch kernel requires 2D payloads [num_tokens, elements_per_token]
+        input_tensors.append(lora_ids.unsqueeze(-1))
 
     output_tensors, all_workspaces, metainfo, combine_payload_offsets = (
         dispatch_from_single_rank(
@@ -683,6 +744,9 @@ def test_moe_combine_multi_rank_single_gpu(
             )
 
     for rank in range(world_size):
+        recv_lora_ids = None
+        if use_lora:
+            recv_lora_ids = output_tensors[rank][lora_id_payload_index].flatten()
         inplace_combine_tensors[rank].copy_(
             fake_moe(
                 output_tensors[rank][hidden_state_index],
@@ -691,6 +755,7 @@ def test_moe_combine_multi_rank_single_gpu(
                 is_ep=True,
                 ep_rank=rank,
                 num_experts_per_rank=num_experts // world_size,
+                lora_ids=recv_lora_ids,
             )
         )
 
@@ -750,7 +815,10 @@ def test_moe_combine_multi_rank_single_gpu(
 
     if quant_mode == CombineQuantMode.NONE:
         reference_result = fake_moe(
-            input_tensors[hidden_state_index], token_selected_experts, num_experts
+            input_tensors[hidden_state_index],
+            token_selected_experts,
+            num_experts,
+            lora_ids=lora_ids,
         )
         for rank in range(world_size):
             torch.testing.assert_close(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

  - Bump `kMaxPayloads` from 4 → 5 so the dispatch can carry additional per-token LoRA adapter ID with blocked scale dtypes
  - LoRA support in single node / MNNVL Tests and benchmarks

cc: @djns99 
  
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues
- implement #3109 
- Umbrella #3107 
- Related #3108 
- Prev. #3153 

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.). **Only tested on single node multi GPUs**

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-token LoRA adapter IDs added to MoE all-to-all dispatch/combine as an extra int32 payload; payload capacity increased to accommodate them.
* **Documentation**
  * Benchmark docs updated with a multi-tenant LoRA launch example and a new flag to enable LoRA.
* **Tests**
  * Unit and integration tests extended and re-parameterized to cover LoRA-enabled dispatch and combine scenarios.
* **Chores**
  * Workspace sizing and communication accounting updated to include the extra LoRA payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->