### PR TITLE
sched: apply LPT scheduling in TwoStageHolisticPlan

### DIFF
--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -1211,10 +1211,21 @@ inline cudaError_t TwoStageHolisticPlan(void* float_buffer, size_t float_workspa
         cluster_kv_head_idx(num_clusters, std::vector<IdType>()),
         cluster_partial_indptr(num_clusters, std::vector<IdType>());
 
+    // LPT scheduling: collect work items in qo order (for correct partial_o offset assignment
+    // and merge_indptr construction), then sort descending by cost before cluster assignment.
+    struct WorkItem {
+      IdType q_indptr, kv_indptr;
+      int partial_indptr;
+      int q_len, kv_len, q_start, kv_start, kv_end;
+      float cost;
+    };
+    std::vector<WorkItem> work_items;
+    work_items.reserve(max_total_num_works);
+
     for (auto& [i, qo_len, kv_len] : idx_qo_kv_len_vec[task]) {
       int packed_qo_len = qo_len * gqa_group_size;
       int num_qo_tiles = ceil_div(packed_qo_len, cluster_tile_q);
-      // NOTE (Yilong): this ordering correspoinds to the layout of reduction kernel
+      // NOTE (Yilong): this ordering corresponds to the layout of reduction kernel
       for (int qo_tile_idx = 0; qo_tile_idx < num_qo_tiles; ++qo_tile_idx) {
         int remaining_len = causal
                                 ? packed_causal_kv_end(qo_len, kv_len, qo_tile_idx, cluster_tile_q,
@@ -1227,23 +1238,10 @@ inline cudaError_t TwoStageHolisticPlan(void* float_buffer, size_t float_workspa
         bool zero_kv_len = (remaining_len == 0);
         while (remaining_len > 0 || zero_kv_len) {
           int actual_len = std::min(remaining_len, kv_len_limit);
-          for (uint32_t kv_head_idx = 0; kv_head_idx < num_kv_heads; ++kv_head_idx) {
-            auto [cluster_idx, accum_cost] = cluster_cost_heap.pop();
-            cluster_cost_heap.insert(
-                {cluster_idx, accum_cost + cost_function(cluster_tile_q, actual_len)});
-            cluster_q_len[cluster_idx].push_back(qo_len);
-            cluster_kv_len[cluster_idx].push_back(kv_len);
-            cluster_q_indptr[cluster_idx].push_back(qo_indptr_h[i]);
-            cluster_kv_indptr[cluster_idx].push_back(kv_indptr_h[i]);
-
-            // use kv_chunk to rematerize num_kv_tiles and kv_tile_idx
-            cluster_partial_indptr[cluster_idx].push_back(partial_o_nnz);
-
-            cluster_q_start[cluster_idx].push_back(qo_tile_idx * cluster_tile_q);
-            cluster_kv_start[cluster_idx].push_back(kv_start);
-            cluster_kv_end[cluster_idx].push_back(kv_start + actual_len);
-            cluster_kv_head_idx[cluster_idx].push_back(kv_head_idx);
-          }
+          // use kv_chunk to rematerialize num_kv_tiles and kv_tile_idx
+          work_items.push_back({qo_indptr_h[i], kv_indptr_h[i], partial_o_nnz, qo_len, kv_len,
+                                qo_tile_idx * cluster_tile_q, kv_start, kv_start + actual_len,
+                                cost_function(cluster_tile_q, actual_len)});
           remaining_len -= actual_len;
           zero_kv_len = (remaining_len == 0);
           kv_start += actual_len;
@@ -1263,6 +1261,27 @@ inline cudaError_t TwoStageHolisticPlan(void* float_buffer, size_t float_workspa
           }
           partial_o_nnz += row_tile_size * num_kv_tiles;
         }
+      }
+    }
+
+    // LPT: sort work items by descending cost so the heaviest tiles are scheduled first,
+    // giving the min-heap a better chance to balance load across clusters.
+    std::sort(work_items.begin(), work_items.end(),
+              [](const WorkItem& a, const WorkItem& b) { return a.cost > b.cost; });
+
+    for (const auto& item : work_items) {
+      for (uint32_t kv_head_idx = 0; kv_head_idx < num_kv_heads; ++kv_head_idx) {
+        auto [cluster_idx, accum_cost] = cluster_cost_heap.pop();
+        cluster_cost_heap.insert({cluster_idx, accum_cost + item.cost});
+        cluster_q_indptr[cluster_idx].push_back(item.q_indptr);
+        cluster_kv_indptr[cluster_idx].push_back(item.kv_indptr);
+        cluster_partial_indptr[cluster_idx].push_back(item.partial_indptr);
+        cluster_q_len[cluster_idx].push_back(item.q_len);
+        cluster_kv_len[cluster_idx].push_back(item.kv_len);
+        cluster_q_start[cluster_idx].push_back(item.q_start);
+        cluster_kv_start[cluster_idx].push_back(item.kv_start);
+        cluster_kv_end[cluster_idx].push_back(item.kv_end);
+        cluster_kv_head_idx[cluster_idx].push_back(kv_head_idx);
       }
     }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR improves load balancing in `TwoStageHolisticPlan` by applying **LPT (Longest Processing Time)** scheduling.

**Problem:** When requests arrive with varying KV lengths, which is a common production pattern, the original scheduler assigns work tiles in batch order. As a result, cheap tiles can be assigned to several clusters before expensive tiles are processed, leaving the min-heap with limited room to rebalance.

**Solution:** LPT scheduling uses a two-phase approach:

1. **Collect** all work items in QO order. This preserves correct `partial_o` offset assignment and `merge_indptr` construction.
2. **Sort** items by descending cost before cluster assignment. This ensures the heaviest tiles are distributed first, and cheaper tiles then fill the remaining gaps.

The cost of each item is computed once during collection and stored in the `WorkItem` struct. Therefore, the sort comparator only performs a simple float comparison, without redundant `cost_function` calls.

This PR also fixes a typo in a comment: `correspoinds` -> `corresponds`.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
- The scheduling behavior change is localized to `TwoStageHolisticPlan`; other schedulers are untouched.
- No API surface changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned the attention scheduling to a two-phase assignment: tasks are now collected, prioritized, and then assigned to processing clusters. This improves task ordering and load balancing across clusters, reducing scheduling overhead and enabling more consistent, efficient execution of attention workloads. May yield better performance and resource utilization on supported hardware.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->