### PR TITLE
Fixes flashinfer memleak issue when using the latency backend for fused_moe

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1113,8 +1113,53 @@ def get_trtllm_moe_sm100_module():
                 tune_max_num_tokens: Upper bound for the num_tokens tuning buckets.
                 **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
             """
-            num_experts = self.num_experts
+            # Validate hidden_states_scale layout at call time (asserts must run
+            # every call), but resolve the dynamic dim to a hashable int so the
+            # actual TuningConfig can be cached. Without caching, every MoE
+            # forward allocates a fresh TuningConfig + DynamicTensorSpec +
+            # ~5 lambdas + bucket tuple, which leaks ~25 MB Own Memory across
+            # the trtllm autotuner family (see PR #2942 regression).
+            hidden_states_scale_dim: Optional[int] = None
+            if moe_inputs.hidden_states_scale is not None:
+                num_tokens = moe_inputs.hidden_states.shape[0]
+                t = moe_inputs.hidden_states_scale
+                if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
+                    assert t.shape == (self.hidden_size // 128, num_tokens), (
+                        f"hidden_states_scale shape {tuple(t.shape)} does not match "
+                        f"expected DeepSeekFp8 layout "
+                        f"(hidden_size//128={self.hidden_size // 128}, num_tokens={num_tokens})"
+                    )
+                    hidden_states_scale_dim = 1
+                else:
+                    assert t.shape[0] == num_tokens, (
+                        f"hidden_states_scale shape {tuple(t.shape)} does not match "
+                        f"expected layout (num_tokens={num_tokens}, ...)"
+                    )
+                    hidden_states_scale_dim = 0
 
+            return self._build_tuning_config(
+                num_experts=self.num_experts,
+                num_local_experts=self.num_local_experts,
+                has_routing_logits=moe_inputs.routing_logits is not None,
+                has_topk_ids=moe_inputs.topk_ids is not None,
+                has_expert_weights=moe_inputs.expert_weights is not None,
+                hidden_states_scale_dim=hidden_states_scale_dim,
+                tune_max_num_tokens=tune_max_num_tokens,
+                extra_kwargs=tuple(sorted(kwargs.items())),
+            )
+
+        @staticmethod
+        @functools.lru_cache(maxsize=None)
+        def _build_tuning_config(
+            num_experts: int,
+            num_local_experts: int,
+            has_routing_logits: bool,
+            has_topk_ids: bool,
+            has_expert_weights: bool,
+            hidden_states_scale_dim: Optional[int],
+            tune_max_num_tokens: int,
+            extra_kwargs: Tuple[Tuple[str, Any], ...],
+        ) -> TuningConfig:
             def _init_packed_topk_ids(shapes, dtype, device):
                 expert_ids = torch.randint(
                     0, num_experts, shapes, dtype=torch.int32, device=device
@@ -1132,17 +1177,17 @@ def get_trtllm_moe_sm100_module():
                     shapes, device=device
                 ).to(dtype),
             }
-            if moe_inputs.routing_logits is not None:
+            if has_routing_logits:
                 spec["routing_logits"] = lambda shapes, dtype, device: torch.rand(
                     shapes, dtype=dtype, device=device
                 )
-            if moe_inputs.topk_ids is not None:
+            if has_topk_ids:
                 spec["topk_ids"] = _init_packed_topk_ids
-            if moe_inputs.expert_weights is not None:
+            if has_expert_weights:
                 spec["expert_weights"] = lambda shapes, dtype, device: torch.ones(
                     shapes, dtype=dtype, device=device
                 )
-            if moe_inputs.hidden_states_scale is not None:
+            if hidden_states_scale_dim is not None:
                 spec["hidden_states_scale"] = lambda shapes, dtype, device: torch.ones(
                     shapes, device=device
                 ).to(dtype)
@@ -1156,28 +1201,12 @@ def get_trtllm_moe_sm100_module():
             )
             input_idx = tuple(i for i, _, _ in sorted_inputs)
 
-            num_tokens = moe_inputs.hidden_states.shape[0]
-
-            def _dynamic_dim(name: str) -> int:
+            def _dim_for(name: str) -> int:
                 if name == "hidden_states_scale":
-                    # DeepSeekFp8 uses [hidden_size//128, num_tokens];
-                    # all others (MxFp8, fp4, …) use [num_tokens, ...].
-                    t = moe_inputs.hidden_states_scale
-                    if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
-                        assert t.shape == (self.hidden_size // 128, num_tokens), (
-                            f"hidden_states_scale shape {tuple(t.shape)} does not match "
-                            f"expected DeepSeekFp8 layout "
-                            f"(hidden_size//128={self.hidden_size // 128}, num_tokens={num_tokens})"
-                        )
-                        return 1
-                    assert t.shape[0] == num_tokens, (
-                        f"hidden_states_scale shape {tuple(t.shape)} does not match "
-                        f"expected layout (num_tokens={num_tokens}, ...)"
-                    )
-                    return 0
+                    return hidden_states_scale_dim
                 return MoEInputs._DYNAMIC_DIM[name]
 
-            dim_idx = tuple(_dynamic_dim(name) for _, name, _ in sorted_inputs)
+            dim_idx = tuple(_dim_for(name) for _, name, _ in sorted_inputs)
             initializers = [init for _, _, init in sorted_inputs]
 
             return TuningConfig(
@@ -1190,7 +1219,7 @@ def get_trtllm_moe_sm100_module():
                         initializers,
                     ),
                 ),
-                **kwargs,
+                **dict(extra_kwargs),
             )
 
         def get_valid_tactics(

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -220,6 +220,12 @@ def _ceil_to_step(x: int, step: int) -> int:
     return ((x + step - 1) // step) * step
 
 
+# Manual cache: keep this a real function so call sites that pass it as a
+# `gen_tuning_buckets` reference (autotuner checks `inspect.isfunction(...)`)
+# still work. `functools.lru_cache` would wrap it as a C class instance.
+_hybrid_num_tokens_buckets_cache: Dict[Tuple[int, int], Tuple[int, ...]] = {}
+
+
 def get_hybrid_num_tokens_buckets(
     max_num_tokens: int, min_num_tokens: int = 1
 ) -> Tuple[int, ...]:
@@ -238,6 +244,11 @@ def get_hybrid_num_tokens_buckets(
         Phase 3:  (2048 .. 4096] — linear step 512
         Phase 4:  (4096 .. max]  — power-of-2    (step ×2)
     """
+    cache_key = (max_num_tokens, min_num_tokens)
+    cached = _hybrid_num_tokens_buckets_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     buckets: List[int] = []
 
     # Phase 1: power-of-2 up to _PHASE1_END
@@ -267,7 +278,9 @@ def get_hybrid_num_tokens_buckets(
     if not buckets or buckets[-1] != max_num_tokens:
         buckets.append(max_num_tokens)
 
-    return tuple(sorted(set(buckets)))
+    result = tuple(sorted(set(buckets)))
+    _hybrid_num_tokens_buckets_cache[cache_key] = result
+    return result
 
 
 def map_to_hybrid_bucket(x: int, max_num_tokens: int) -> int:


### PR DESCRIPTION
Hi @wzhao18 @aleozlx  we found a host memory leak caused by the missing cache introduced in this PR: https://github.com/flashinfer-ai/flashinfer/pull/2942. After running for about 12 hours run, it will cause about 100GB host memory leak.

We have drafted a patch but not sure if it is applicable, could you folks help to check and consider if it worth merge?

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Enhancements**
  * Improved Mixture of Experts (MoE) tuning configuration caching with enhanced validation logic and support for special hardware configurations.
  * Optimized hybrid token bucket computation by introducing intelligent caching mechanisms to prevent redundant calculations.
  * Refined tensor dimension handling for greater stability and improved performance in configuration management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->