### PR TITLE
feat(moe): write routing_replay_out from custom routing kernels

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -121,6 +121,12 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
           params.mPtrTopKWeights[warpIdx * params.mTopK + laneIdx] =
               OutputT{warpTopKScore[laneIdx]};
         }
+        // Routing replay: record selected expert IDs. Layout: [num_tokens, topK]
+        // -- same indexing as mPtrTopKPacked / mPtrTopKWeights.
+        if (params.mPtrRoutingReplayOut != nullptr) {
+          params.mPtrRoutingReplayOut[warpIdx * params.mTopK + laneIdx] =
+              static_cast<int16_t>(warpTopKExpertIdx[laneIdx]);
+        }
       }
     }  // end if (validToken)
   } else if (params.mPtrTopKPacked != nullptr) {
@@ -436,6 +442,12 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
           params.mPtrTopKWeights[tokenIdx * params.mTopK + laneIdx] =
               OutputT{warpTopKScore[laneIdx]};
         }
+        // Routing replay: record selected expert IDs. Layout: [num_tokens, topK]
+        // -- same indexing as mPtrTopKWeights.
+        if (params.mPtrRoutingReplayOut != nullptr) {
+          params.mPtrRoutingReplayOut[tokenIdx * params.mTopK + laneIdx] =
+              static_cast<int16_t>(warpTopKExpertIdx[laneIdx]);
+        }
       }
     } else if (params.mPtrTopKPacked != nullptr) {
       if (laneIdx < params.mTopK) {
@@ -667,6 +679,12 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
       if (laneIdx < params.mTopK) {
         smemPackedScoreIdx[warpIdx * params.mTopK + laneIdx] =
             TypePacked{warpTopKScore[laneIdx], static_cast<int16_t>(warpTopKExpertIdx[laneIdx])};
+        // Routing replay: record selected expert IDs. Layout: [num_tokens, topK]
+        // -- warpTokenIdx is the global token index for this warp.
+        if (params.mPtrRoutingReplayOut != nullptr) {
+          params.mPtrRoutingReplayOut[warpTokenIdx * params.mTopK + laneIdx] =
+              static_cast<int16_t>(warpTopKExpertIdx[laneIdx]);
+        }
       }
     }
   }
@@ -755,6 +773,12 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
       PackedScoreIdx<OutputT> packedScore{static_cast<OutputT>(warpTopKScore[laneIdx]),
                                           static_cast<int16_t>(warpTopKExpertIdx[laneIdx])};
       params.mPtrTopKPacked[tokenIdx * params.mTopK + laneIdx] = packedScore;
+      // Routing replay: record selected expert IDs. Layout: [num_tokens, topK]
+      // -- same indexing as mPtrTopKPacked.
+      if (params.mPtrRoutingReplayOut != nullptr) {
+        params.mPtrRoutingReplayOut[tokenIdx * params.mTopK + laneIdx] =
+            static_cast<int16_t>(warpTopKExpertIdx[laneIdx]);
+      }
     }
   }
 
@@ -947,6 +971,12 @@ __global__ void __launch_bounds__(kBlockScoresKernelBlockDim)
       PackedScoreIdx<OutputT> packedScore{static_cast<OutputT>(topScores[laneIdx]),
                                           static_cast<int16_t>(expertIdx)};
       params.mPtrTopKPacked[int64_t{tokenIdx} * int64_t{params.mTopK} + laneIdx] = packedScore;
+      // Routing replay: record selected expert IDs. Layout: [num_tokens, topK]
+      // -- same indexing as mPtrTopKPacked.
+      if (params.mPtrRoutingReplayOut != nullptr) {
+        params.mPtrRoutingReplayOut[int64_t{tokenIdx} * int64_t{params.mTopK} + laneIdx] =
+            static_cast<int16_t>(expertIdx);
+      }
     }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -972,3 +972,196 @@ def test_fp8_block_scale_moe_routing_replay(
     assert (routing_replay_out[num_tokens:] == -1).all(), (
         "Kernel should not write beyond active token rows"
     )
+
+
+# Each (num_tokens, num_experts) entry is chosen to land in exactly one of the
+# five top-K kernels in `routing_custom.cu`. See the dispatch logic comment in
+# `trtllm_fused_moe_routing_custom.cu` (around the `useSplitTopKPath` block):
+#
+#   * BlockKernel             : num_tokens <= 4
+#   * DynBlockKernel          : 5 <= num_tokens <= 16  (num_experts <= 512)
+#   * ClusterKernel           : 17 <= num_tokens <= 256, num_experts < 160 (SM90+)
+#   * BlockScoresKernel       : 17 <= num_tokens <= 256, num_experts >= 160
+#                               (split-topK path; also requires policy opt-in)
+#   * HistogramScoresKernel   : num_tokens > 256  (warp-per-token fallback)
+_REPLAY_KERNEL_TIERS = [
+    (4, 16, "BlockKernel"),
+    (16, 16, "DynBlockKernel"),
+    (32, 16, "ClusterKernel"),
+    (32, 256, "BlockScoresKernel"),
+    (512, 16, "HistogramScoresKernel"),
+]
+
+
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, kernel_tier",
+    _REPLAY_KERNEL_TIERS,
+    ids=[t[2] for t in _REPLAY_KERNEL_TIERS],
+)
+@pytest.mark.parametrize("hidden_size", [1024])
+@pytest.mark.parametrize("intermediate_size", [1024])
+@pytest.mark.parametrize("top_k", [2, 4])
+@pytest.mark.parametrize(
+    "routing_method_type",
+    [
+        RoutingMethodType.Renormalize,
+        RoutingMethodType.RenormalizeNaive,
+        RoutingMethodType.TopK,
+    ],
+)
+def test_fp8_block_scale_moe_routing_replay_custom_routing(
+    num_tokens: int,
+    num_experts: int,
+    kernel_tier: str,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    routing_method_type: RoutingMethodType,
+):
+    """Test that ``routing_replay_out`` in ``trtllm_fp8_block_scale_moe`` records
+    correct expert IDs for the routing methods that dispatch through
+    ``routingCustom`` (Renormalize / RenormalizeNaive / TopK).
+
+    Companion to ``test_fp8_block_scale_moe_routing_replay`` (which only
+    exercises the DeepSeekV3 routing kernel). The parametrize grid is chosen
+    so that each ``(num_tokens, num_experts)`` row lands in exactly one of
+    the five custom-routing top-K kernels — together they cover every kernel
+    that writes ``mPtrRoutingReplayOut`` on the non-DSV3 path.
+
+    Mirrors the DSV3 test's verification structure:
+      1. MoE output is identical with/without replay (replay is a side
+         channel with no observable effect on the GEMM result).
+      2. Replay buffer contains valid expert IDs in ``[0, num_experts)``.
+      3. Each active row picks ``top_k`` distinct experts (TopK over raw
+         scores cannot select the same expert twice within one token).
+      4. Tail rows beyond ``num_tokens`` remain at the sentinel ``-1``
+         (CUDA-graph pre-allocation contract).
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] not in [10]:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    enable_pdl = device_support_pdl(device)
+
+    routing_logits = torch.rand(
+        num_tokens, num_experts, device=device, dtype=torch.float32
+    )
+
+    hidden_states_bf16 = (
+        torch.randn(num_tokens, hidden_size, device=device).to(torch.bfloat16) * 0.1
+    )
+    hidden_states = hidden_states_bf16.to(torch.float8_e4m3fn)
+
+    hidden_states_scale = torch.ones(
+        hidden_size // 128, num_tokens, device=device, dtype=torch.float32
+    )
+
+    gemm1_weights = torch.randn(
+        num_experts, 2 * intermediate_size, hidden_size, device=device
+    ).to(torch.float8_e4m3fn)
+    gemm2_weights = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device
+    ).to(torch.float8_e4m3fn)
+
+    gemm1_weights_scale = torch.ones(
+        num_experts,
+        2 * intermediate_size // 128,
+        hidden_size // 128,
+        device=device,
+        dtype=torch.float32,
+    )
+    gemm2_weights_scale = torch.ones(
+        num_experts,
+        hidden_size // 128,
+        intermediate_size // 128,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    # Oversized buffer + sentinel: validates the CUDA-graph pre-allocation
+    # contract that the kernel writes only the [0, num_tokens) prefix.
+    replay_capacity = num_tokens + 5
+    routing_replay_out = torch.full(
+        (replay_capacity, top_k), -1, device=device, dtype=torch.int16
+    )
+
+    output_with_replay = trtllm_fp8_block_scale_moe(
+        routing_logits,
+        None,  # routing_bias (DSV3-only)
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        num_experts,
+        top_k,
+        None,  # n_group (DSV3-only)
+        None,  # topk_group (DSV3-only)
+        intermediate_size,
+        0,  # local_expert_offset
+        num_experts,
+        None,  # routed_scaling_factor
+        routing_method_type.value,
+        False,  # use_shuffled_weight
+        0,  # weight_layout
+        enable_pdl,
+        routing_replay_out=routing_replay_out,
+    )
+
+    output_without_replay = trtllm_fp8_block_scale_moe(
+        routing_logits,
+        None,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        num_experts,
+        top_k,
+        None,
+        None,
+        intermediate_size,
+        0,
+        num_experts,
+        None,
+        routing_method_type.value,
+        False,
+        0,
+        enable_pdl,
+        routing_replay_out=None,
+    )
+
+    # 1. MoE output is unaffected by the replay side channel.
+    torch.testing.assert_close(
+        output_with_replay.to(torch.float),
+        output_without_replay.to(torch.float),
+        rtol=0,
+        atol=0,
+    )
+
+    active_replay = routing_replay_out[:num_tokens]
+
+    # 2. All recorded IDs are valid expert indices.
+    assert (active_replay >= 0).all() and (active_replay < num_experts).all(), (
+        f"Replay contains out-of-range expert IDs (kernel={kernel_tier}, "
+        f"routing={routing_method_type.name}): "
+        f"min={active_replay.min().item()}, max={active_replay.max().item()}"
+    )
+
+    # 3. Each token's top_k selections are distinct.
+    for t in range(num_tokens):
+        unique_experts = active_replay[t].unique()
+        assert unique_experts.numel() == top_k, (
+            f"Token {t}: expected {top_k} unique experts, got "
+            f"{unique_experts.numel()} ({active_replay[t].tolist()}) "
+            f"(kernel={kernel_tier}, routing={routing_method_type.name})"
+        )
+
+    # 4. Tail rows untouched.
+    assert (routing_replay_out[num_tokens:] == -1).all(), (
+        f"Kernel wrote beyond active token rows "
+        f"(kernel={kernel_tier}, routing={routing_method_type.name})"
+    )


### PR DESCRIPTION
The custom routing dispatch in trtllm_fused_moe_runner.cu already plumbs mPtrRoutingReplayOut to routingCustom::Data for all routing methods (Default, Renormalize, RenormalizeNaive, TopK, SigmoidRenorm, Sigmoid, MiniMax2), but the kernels themselves only set the pointer and skip the write -- only the DeepSeekV3 path (in trtllm_fused_moe_routing_deepseek.cu) actually records the selected expert IDs. Callers that allocate a replay buffer for any non-DSV3 routing therefore observe uninitialized memory.

Mirror the DeepSeek write site in each of the five kernels that compute top-K from raw scores in routingIndicesCustom:

  * routingIndicesBlockKernel        (<= 4 tokens)
  * routingIndicesDynBlockKernel     (<= 16 tokens)
  * routingIndicesClusterKernel      (<= 256 tokens, SM90+)
  * routingIndicesHistogramScoresKernel (warp-per-token, large BS)
  * routingIndicesBlockScoresKernel  (block-per-token, split path)

Each addition is a conditional int16 write next to the existing mPtrTopKPacked / smemPackedScoreIdx / smemKIdx write, using the same [num_tokens, topK] layout as the DeepSeek path. The pre-computed-topK branches (mPtrTopKIds / mPtrTopKPacked input) are intentionally untouched since the caller already knows the IDs.

Validated on B200 with bf16 trtllm_bf16_moe across Renormalize and RenormalizeNaive at num_tokens in {2, 8, 64, 512} and top_k in {2, 4}, exercising each of the four main dispatch paths; captured buffer contained valid expert IDs and top_k distinct experts per token.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added routing replay output across multiple routing kernel paths to record selected expert IDs per token/top-K position, without changing inference behavior.

* **Tests**
  * Added tests covering multiple routing methods and kernel tiers; validate replay buffer contents are in-range, per-token selections are distinct, rows beyond active tokens keep the sentinel value, and outputs match with/without replay enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->