### PR TITLE
Use the ninja version associated with the python env

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -351,6 +351,8 @@ def _get_num_workers() -> Optional[int]:
 def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:
     workdir.mkdir(parents=True, exist_ok=True)
     command = [
+        sys.executable,
+        "-m",
         "ninja",
         "-v",
         "-C",

--- a/tests/test_jit_cpp_ext.py
+++ b/tests/test_jit_cpp_ext.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from flashinfer.jit import core, cpp_ext
 
@@ -105,6 +106,8 @@ def test_run_ninja_uses_max_jobs(monkeypatch, tmp_path):
 
     assert commands == [
         [
+            sys.executable,
+            "-m",
             "ninja",
             "-v",
             "-C",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Ran into an issue when running vllm with an virtual environment that is not active / added to path. Flashinfer is unable to find `ninja` because it is not in the local path, even though the environment that vllm/flashinfer is running in includes ninja.

This pr fixes the issue by calling `ninja` as a python module which resolves the path to the ninja value is the local venv. 

<details>
<summary> Partial stacktrace of issue</summary>

```
(EngineCore pid=3931639)     next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
(EngineCore pid=3931639)   File "/home/fynnsu/repos/vllm-project/speculators/vllm_venv/lib/python3.10/site-packages/flashinfer/sampling.py", line 1400, in top_k_top_p_sampling_from_logits
(EngineCore pid=3931639)     masked_logits = top_k_mask_logits(logits, top_k)
(EngineCore pid=3931639)   File "/home/fynnsu/repos/vllm-project/speculators/vllm_venv/lib/python3.10/site-packages/flashinfer/sampling.py", line 1806, in top_k_mask_logits
(EngineCore pid=3931639)     return get_sampling_module().top_k_mask_logits(
(EngineCore pid=3931639)   File "/home/fynnsu/repos/vllm-project/speculators/vllm_venv/lib/python3.10/site-packages/flashinfer/sampling.py", line 54, in get_sampling_module
(EngineCore pid=3931639)     module = gen_sampling_module().build_and_load()
(EngineCore pid=3931639)   File "/home/fynnsu/repos/vllm-project/speculators/vllm_venv/lib/python3.10/site-packages/flashinfer/jit/core.py", line 318, in build_and_load
(EngineCore pid=3931639)     self.build(verbose, need_lock=False)
(EngineCore pid=3931639)   File "/home/fynnsu/repos/vllm-project/speculators/vllm_venv/lib/python3.10/site-packages/flashinfer/jit/core.py", line 304, in build
(EngineCore pid=3931639)     run_ninja(self.build_dir, self.ninja_path, verbose)
(EngineCore pid=3931639)   File "/home/fynnsu/repos/vllm-project/speculators/vllm_venv/lib/python3.10/site-packages/flashinfer/jit/cpp_ext.py", line 332, in run_ninja
(EngineCore pid=3931639)     subprocess.run(
(EngineCore pid=3931639)   File "/home/fynnsu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/subprocess.py", line 503, in run
(EngineCore pid=3931639)     with Popen(*popenargs, **kwargs) as process:
(EngineCore pid=3931639)   File "/home/fynnsu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/subprocess.py", line 971, in __init__
(EngineCore pid=3931639)     self._execute_child(args, executable, preexec_fn, close_fds,
(EngineCore pid=3931639)   File "/home/fynnsu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/subprocess.py", line 1863, in _execute_child
(EngineCore pid=3931639)     raise child_exception_type(errno_num, err_msg, err_filename)
(EngineCore pid=3931639) FileNotFoundError: [Errno 2] No such file or directory: 'ninja'
```


</details>

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

Validated that this change fixes the issue I observed. 

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ninja build tool invocation during JIT compilation for more reliable behavior across environments.

* **Tests**
  * Updated test expectations to align with the revised build invocation method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->