### PR TITLE
fix: headDim=512 GQA decode (#3343)

### DIFF
--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -65,9 +65,10 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   // The warpGrpThreadIdx.
   int32_t const warpGrpThreadIdx{static_cast<int32_t>(threadIdx.x)};
 
-  // The seqOffsetQ.
-  int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr ? batchIdx * params.mMaxNumCtasQ
-                                                            : params.ptrCumSeqLensQ[batchIdx]};
+  // The seqOffsetQ in token units (cumSeqLensQ is already token-relative).
+  int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr
+                               ? batchIdx * params.mMaxNumCtasQ * params.mNumTokensPerCtaQ
+                               : params.ptrCumSeqLensQ[batchIdx]};
   // The seqLenQ.
   int32_t const seqLenQ{params.ptrCumSeqLensQ == nullptr
                             ? params.mMaxSeqLenQ
@@ -126,8 +127,9 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   // Whether to store the softmax stats.
   bool const storesSoftmaxStats{params.ptrSoftmaxStats != nullptr};
 
-  // The softmaxScaleLog2.
-  float const softmaxScaleLog2 = params.mScaleSoftmaxLog2;
+  // The softmaxScaleLog2. Prefer the device-side scale when supplied.
+  float const softmaxScaleLog2 = params.ptrScaleSoftmaxLog2 != nullptr ? *params.ptrScaleSoftmaxLog2
+                                                                       : params.mScaleSoftmaxLog2;
 
   int32_t constexpr NumBytesPerPartialElt{sizeof(DtypePartialO)};
   static_assert(NumBytesPerPartialElt == 2,

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -710,6 +710,28 @@ class TllmGenFmhaKernel {
     }
   }
 
+  void syncGqaGenerationTraitsForKernelHash(RunnerParams const& params,
+                                            SelectKernelParams& selectKernelParams) const {
+    bool const multiCtasKvEnabled = isMultiCtasKvEnabled(selectKernelParams.mMultiCtasKvMode);
+    if (selectKernelParams.mKernelType == FmhaKernelType::KeepsMmaAbForGeneration &&
+        params.mHeadDimV > 256) {
+      // Current GQA keepsMmaAb H512 cubins are registered in the split-V
+      // headDimPerCtaV=256 form; full-V H512 is a cubin coverage follow-up.
+      selectKernelParams.mHeadDimPerCtaV = 256;
+      if (multiCtasKvEnabled) {
+        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReductionWithSeparateKernel;
+      }
+    } else {
+      // SwapsMmaAb hashes the full-V form; undo a previous keepsMmaAb separate-reduction upgrade
+      // when the tile-size cost model walks back to swapsMmaAb.
+      selectKernelParams.mHeadDimPerCtaV = params.mHeadDimV;
+      if (multiCtasKvEnabled &&
+          selectKernelParams.mMultiCtasKvMode == MultiCtasKvMode::GmemReductionWithSeparateKernel) {
+        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReduction;
+      }
+    }
+  }
+
   // Selects a heuristic tileSizeQ if groupsTokensHeadsQ is true.
   void selectTileSizeQForGqaGeneration(RunnerParams const& params,
                                        SelectKernelParams& selectKernelParams) const {
@@ -778,23 +800,8 @@ class TllmGenFmhaKernel {
         selectKernelParamsCopy.mKernelType = FmhaKernelType::SwapsMmaAbForGeneration;
       }
       // Keep headDimPerCtaV and multiCtasKvMode in sync with the candidate kernelType so
-      // loadKernel hashes a registered kernel; reverse the multiCtasKvMode upgrade when
-      // the cost model walks back from keepsMmaAb to swapsMmaAb.
-      bool const multiCtasKvEnabled = isMultiCtasKvEnabled(selectKernelParamsCopy.mMultiCtasKvMode);
-      if (selectKernelParamsCopy.mKernelType == FmhaKernelType::KeepsMmaAbForGeneration &&
-          params.mHeadDimV > 256) {
-        selectKernelParamsCopy.mHeadDimPerCtaV = 256;
-        if (multiCtasKvEnabled) {
-          selectKernelParamsCopy.mMultiCtasKvMode =
-              MultiCtasKvMode::GmemReductionWithSeparateKernel;
-        }
-      } else {
-        selectKernelParamsCopy.mHeadDimPerCtaV = params.mHeadDimV;
-        if (multiCtasKvEnabled && selectKernelParamsCopy.mMultiCtasKvMode ==
-                                      MultiCtasKvMode::GmemReductionWithSeparateKernel) {
-          selectKernelParamsCopy.mMultiCtasKvMode = MultiCtasKvMode::GmemReduction;
-        }
-      }
+      // loadKernel hashes a registered kernel.
+      syncGqaGenerationTraitsForKernelHash(params, selectKernelParamsCopy);
 
       // Load the kernel.
       std::tie(func, kernelMeta) = loadKernel(params, selectKernelParamsCopy);
@@ -837,20 +844,7 @@ class TllmGenFmhaKernel {
       selectKernelParams.mKernelType = FmhaKernelType::SwapsMmaAbForGeneration;
     }
     // Apply the same sync to the committed kernelType; the probe above mutated only the copy.
-    bool const multiCtasKvEnabled = isMultiCtasKvEnabled(selectKernelParams.mMultiCtasKvMode);
-    if (selectKernelParams.mKernelType == FmhaKernelType::KeepsMmaAbForGeneration &&
-        params.mHeadDimV > 256) {
-      selectKernelParams.mHeadDimPerCtaV = 256;
-      if (multiCtasKvEnabled) {
-        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReductionWithSeparateKernel;
-      }
-    } else {
-      selectKernelParams.mHeadDimPerCtaV = params.mHeadDimV;
-      if (multiCtasKvEnabled &&
-          selectKernelParams.mMultiCtasKvMode == MultiCtasKvMode::GmemReductionWithSeparateKernel) {
-        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReduction;
-      }
-    }
+    syncGqaGenerationTraitsForKernelHash(params, selectKernelParams);
   }
 
   // Selects a heuristic kernel for GQA generation.
@@ -888,15 +882,8 @@ class TllmGenFmhaKernel {
       kernelType = FmhaKernelType::KeepsMmaAbForGeneration;
     }
 
-    // At headDimV > 256 keepsMmaAb is only registered with the V-split headDimPerCtaV=256
-    // form, which requires GmemReductionWithSeparateKernel. Apply the clamp/upgrade here so
-    // the cost-model probe below hashes a registered kernel.
-    if (kernelType == FmhaKernelType::KeepsMmaAbForGeneration && params.mHeadDimV > 256) {
-      selectKernelParams.mHeadDimPerCtaV = 256;
-      if (isGmemReduction(selectKernelParams.mMultiCtasKvMode)) {
-        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReductionWithSeparateKernel;
-      }
-    }
+    // Normalize traits before the cost-model probe calls loadKernel().
+    syncGqaGenerationTraitsForKernelHash(params, selectKernelParams);
 
     // When maxSeqLenQ > 1, use an experimental kernel-timing model to select the best kernel that
     // groups both tokensQ and headsQ into one CTA.

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -777,6 +777,24 @@ class TllmGenFmhaKernel {
       } else {
         selectKernelParamsCopy.mKernelType = FmhaKernelType::SwapsMmaAbForGeneration;
       }
+      // Keep headDimPerCtaV and multiCtasKvMode in sync with the candidate kernelType so
+      // loadKernel hashes a registered kernel; reverse the multiCtasKvMode upgrade when
+      // the cost model walks back from keepsMmaAb to swapsMmaAb.
+      bool const multiCtasKvEnabled = isMultiCtasKvEnabled(selectKernelParamsCopy.mMultiCtasKvMode);
+      if (selectKernelParamsCopy.mKernelType == FmhaKernelType::KeepsMmaAbForGeneration &&
+          params.mHeadDimV > 256) {
+        selectKernelParamsCopy.mHeadDimPerCtaV = 256;
+        if (multiCtasKvEnabled) {
+          selectKernelParamsCopy.mMultiCtasKvMode =
+              MultiCtasKvMode::GmemReductionWithSeparateKernel;
+        }
+      } else {
+        selectKernelParamsCopy.mHeadDimPerCtaV = params.mHeadDimV;
+        if (multiCtasKvEnabled && selectKernelParamsCopy.mMultiCtasKvMode ==
+                                      MultiCtasKvMode::GmemReductionWithSeparateKernel) {
+          selectKernelParamsCopy.mMultiCtasKvMode = MultiCtasKvMode::GmemReduction;
+        }
+      }
 
       // Load the kernel.
       std::tie(func, kernelMeta) = loadKernel(params, selectKernelParamsCopy);
@@ -818,6 +836,21 @@ class TllmGenFmhaKernel {
     } else {
       selectKernelParams.mKernelType = FmhaKernelType::SwapsMmaAbForGeneration;
     }
+    // Apply the same sync to the committed kernelType; the probe above mutated only the copy.
+    bool const multiCtasKvEnabled = isMultiCtasKvEnabled(selectKernelParams.mMultiCtasKvMode);
+    if (selectKernelParams.mKernelType == FmhaKernelType::KeepsMmaAbForGeneration &&
+        params.mHeadDimV > 256) {
+      selectKernelParams.mHeadDimPerCtaV = 256;
+      if (multiCtasKvEnabled) {
+        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReductionWithSeparateKernel;
+      }
+    } else {
+      selectKernelParams.mHeadDimPerCtaV = params.mHeadDimV;
+      if (multiCtasKvEnabled &&
+          selectKernelParams.mMultiCtasKvMode == MultiCtasKvMode::GmemReductionWithSeparateKernel) {
+        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReduction;
+      }
+    }
   }
 
   // Selects a heuristic kernel for GQA generation.
@@ -853,6 +886,16 @@ class TllmGenFmhaKernel {
     } else {
       tileSizeQ = 128;
       kernelType = FmhaKernelType::KeepsMmaAbForGeneration;
+    }
+
+    // At headDimV > 256 keepsMmaAb is only registered with the V-split headDimPerCtaV=256
+    // form, which requires GmemReductionWithSeparateKernel. Apply the clamp/upgrade here so
+    // the cost-model probe below hashes a registered kernel.
+    if (kernelType == FmhaKernelType::KeepsMmaAbForGeneration && params.mHeadDimV > 256) {
+      selectKernelParams.mHeadDimPerCtaV = 256;
+      if (isGmemReduction(selectKernelParams.mMultiCtasKvMode)) {
+        selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReductionWithSeparateKernel;
+      }
     }
 
     // When maxSeqLenQ > 1, use an experimental kernel-timing model to select the best kernel that

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -840,27 +840,11 @@ struct KernelParams {
     // Attention sink
     params.ptrAttentionSinks = options.ptrAttentionSinks;
 
-    // The partial buffers' pointers when the multiCtasKv mode is enabled. partialStats and
-    // partialO share the scratch slab; size the partialStats region to the full layout so
-    // partialO writes don't clobber partialStats when batch * numHeadCtas > 1.
-    {
-      int32_t const numHeadsPerCta =
-          kernelMeta.mGroupsHeadsQ
-              ? std::min(options.mNumHeadsQPerKv, static_cast<int32_t>(kernelMeta.mTileSizeQ))
-              : 1;
-      int32_t const numCtasForAllHeadsQ = options.mNumHeadsQ / numHeadsPerCta;
-      int32_t const headDimPerCtaVAfter2Cta =
-          kernelMeta.m2CtaMma ? kernelMeta.mHeadDimPerCtaV * 2 : kernelMeta.mHeadDimPerCtaV;
-      int32_t const numHeadDimCtasV = std::max(1, kernelMeta.mHeadDimV / headDimPerCtaVAfter2Cta);
-      int32_t const numHeadCtas = numCtasForAllHeadsQ * numHeadDimCtasV;
-      int64_t const partialStatsBufferSize =
-          static_cast<int64_t>(options.mBatchSize) * static_cast<int64_t>(numHeadCtas) *
-          static_cast<int64_t>(maxNumCtasQ) * static_cast<int64_t>(maxNumCtasKv) *
-          static_cast<int64_t>(kernelMeta.mTileSizeQ);
-      params.ptrMultiCtasKvCounter = options.multiCtasKvCounterPtr;
-      params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
-      params.ptrPartialO = params.ptrPartialStats + partialStatsBufferSize;
-    }
+    // The partial buffers' pointers when the multiCtasKv mode is enabled.
+    int64_t partialStatsBufferSize = options.mMultiProcessorCount * kernelMeta.mStepQ;
+    params.ptrMultiCtasKvCounter = options.multiCtasKvCounterPtr;
+    params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
+    params.ptrPartialO = params.ptrPartialStats + partialStatsBufferSize;
 
     params.ptrPageIdxKv = options.kvPageIdxPtr;
     params.ptrScaleSoftmaxLog2 = options.scaleSoftmaxLog2Ptr;

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -840,11 +840,27 @@ struct KernelParams {
     // Attention sink
     params.ptrAttentionSinks = options.ptrAttentionSinks;
 
-    // The partial buffers' pointers when the multiCtasKv mode is enabled.
-    int64_t partialStatsBufferSize = options.mMultiProcessorCount * kernelMeta.mStepQ;
-    params.ptrMultiCtasKvCounter = options.multiCtasKvCounterPtr;
-    params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
-    params.ptrPartialO = params.ptrPartialStats + partialStatsBufferSize;
+    // The partial buffers' pointers when the multiCtasKv mode is enabled. partialStats and
+    // partialO share the scratch slab; size the partialStats region to the full layout so
+    // partialO writes don't clobber partialStats when batch * numHeadCtas > 1.
+    {
+      int32_t const numHeadsPerCta =
+          kernelMeta.mGroupsHeadsQ
+              ? std::min(options.mNumHeadsQPerKv, static_cast<int32_t>(kernelMeta.mTileSizeQ))
+              : 1;
+      int32_t const numCtasForAllHeadsQ = options.mNumHeadsQ / numHeadsPerCta;
+      int32_t const headDimPerCtaVAfter2Cta =
+          kernelMeta.m2CtaMma ? kernelMeta.mHeadDimPerCtaV * 2 : kernelMeta.mHeadDimPerCtaV;
+      int32_t const numHeadDimCtasV = std::max(1, kernelMeta.mHeadDimV / headDimPerCtaVAfter2Cta);
+      int32_t const numHeadCtas = numCtasForAllHeadsQ * numHeadDimCtasV;
+      int64_t const partialStatsBufferSize =
+          static_cast<int64_t>(options.mBatchSize) * static_cast<int64_t>(numHeadCtas) *
+          static_cast<int64_t>(maxNumCtasQ) * static_cast<int64_t>(maxNumCtasKv) *
+          static_cast<int64_t>(kernelMeta.mTileSizeQ);
+      params.ptrMultiCtasKvCounter = options.multiCtasKvCounterPtr;
+      params.ptrPartialStats = reinterpret_cast<float2*>(options.multiCtasKvScratchPtr);
+      params.ptrPartialO = params.ptrPartialStats + partialStatsBufferSize;
+    }
 
     params.ptrPageIdxKv = options.kvPageIdxPtr;
     params.ptrScaleSoftmaxLog2 = options.scaleSoftmaxLog2Ptr;

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1447,6 +1447,8 @@ def test_trtllm_batch_decode_dynamic_page_size_gqa(
         (4, 1, 32, 2, 5),
         (4, 3, 64, 4, 1),
         (128, 3, 16, 4, 8),
+        (1, 6, 64, 2, 8),
+        (4, 8, 64, 2, 8),
     ],
 )
 @pytest.mark.parametrize("window_left", [-1])


### PR DESCRIPTION
Closes #3343.

`trtllm_batch_decode_with_kv_cache` raised `Trtllm kernels not found` on
headDim=512 GQA (`numHeadsQPerKv=8`) when `q_len_per_req in [5, 8]`.

The host selector hashed a kernel shape that isn't registered. At
`headDimV > 256` the keepsMmaAb generation kernels are only registered
with `headDimPerCtaV=256` (the 1-CTA `headDimPerCtaV=512` variant
overflows Blackwell smem at `tileSizeQ >= 32`). The V-split form must be
paired with `multiCtasKvMode = GmemReductionWithSeparateKernel`.

Routing to the registered kernel exposed two latent bugs in the separate-
reduction launcher that were unreachable before. This PR addresses all
three:

1. **`fmhaKernels.cuh`**: in `selectGqGenerationKernel` and
   `selectTileSizeQForGqaGeneration`, clamp `mHeadDimPerCtaV=256` and
   upgrade `mMultiCtasKvMode` to `GmemReductionWithSeparateKernel` when
   `KeepsMmaAb` is picked at `headDimV > 256`; reverse the upgrade per
   candidate when the cost model walks back to `SwapsMmaAb`.
2. **`csrc/fmhaReduction.cu`**: `softmaxScaleLog2` now reads
   `ptrScaleSoftmaxLog2` when present (host fallback was wrong when
   `bmm1_scale` is a device tensor); `seqOffsetQ` is in token units
   (`* mNumTokensPerCtaQ`), not CTA units, so spec-decode batches don't
   collide on the same `softmaxStats` rows.
3. **`kernelParams.h`**: `partialStatsBufferSize` now matches the actual
   `[batch, numHeadCtas, maxNumCtasQ, maxNumCtasKv, mTileSizeQ]` layout
   instead of the `mMultiProcessorCount * mStepQ` placeholder; otherwise
   `ptrPartialO` clobbers partialStats when `batch * numHeadCtas > 1`.

## Test plan

- [x] `test_trtllm_batch_decode_head_dim_512` parametrize extended with
  `(1, 6, 64, 2, 8)` and `(4, 8, 64, 2, 8)`. Full cross-product passes
  (576/576) on B200.
- [x] Without the fix, `q_len_per_req in {5..8}` reproduces the original
  error.
- [x] `pre-commit run` clean on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention mechanism accuracy through optimized softmax scaling computations.
  * Enhanced kernel selection and matching for multi-CTA attention operations on complex model configurations.

* **Tests**
  * Expanded test coverage for large head dimension inference scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->