### PR TITLE
Remove excessive CuteDslMoEWrapper memory allocation

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -27,7 +27,8 @@ Two APIs are provided:
    Best for: simple use cases, experimenting, auto-tuning.
 
 2. **Wrapper API** (`CuteDslMoEWrapper`):
-   Class-based API with pre-allocated buffers for CUDA graph compatibility.
+   Class-based API that holds persistent CUDA stream/event resources for
+   async-memset overlap and CUDA graph compatibility.
    Best for: production inference with CUDA graphs, fine-grained control.
 
 Both APIs share the same core implementation and support auto-tuning.
@@ -60,11 +61,9 @@ from ...trace.templates.moe import (
     cute_dsl_fused_moe_nvfp4_trace,
     cute_dsl_moe_wrapper_run_trace,
 )
-from ...autotuner import AutoTuner, is_in_profile_measurement
+from ...autotuner import AutoTuner
 from ...utils import supported_compute_capability
 from .moe_utils import (
-    allocate_moe_sort_buffers,
-    get_max_num_permuted_tokens,
     moe_output_memset_inplace,
     moe_sort,
 )
@@ -77,7 +76,6 @@ from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
 from .tuner import (
     ALL_MOE_TACTICS,
     CuteDslFusedMoENvfp4Runner,
-    VALID_TILE_SIZES,
 )
 
 
@@ -315,9 +313,10 @@ def _moe_core_impl(
 class CuteDslMoEWrapper:
     """Wrapper class for CuteDSL MoE with CUDA graph and auto-tuning support.
 
-    This wrapper pre-allocates all necessary buffers when `use_cuda_graph=True`,
-    enabling CUDA graph capture and replay. It also supports auto-tuning via
-    the `tactic` parameter or by calling inside `autotune()` context.
+    With `use_cuda_graph=True`, the wrapper creates persistent CUDA stream
+    and event resources outside graph capture, enabling async-memset / GEMM1
+    overlap during capture and replay. Auto-tuning is supported via the `tactic`
+    parameter or `autotune()` context.
 
     Supported architectures: SM100, SM103.
 
@@ -326,14 +325,16 @@ class CuteDslMoEWrapper:
         top_k: Number of experts per token.
         hidden_size: Hidden dimension size.
         intermediate_size: Intermediate dimension size.
-        use_cuda_graph: Whether to pre-allocate buffers for CUDA graph.
-        max_num_tokens: Maximum tokens (only used with use_cuda_graph=True).
+        use_cuda_graph: Whether the wrapper holds persistent stream/event
+            resources for CUDA graph capture.
+        max_num_tokens: Deprecated; accepted for backwards compatibility
+            but ignored.
 
     Example (CUDA Graph):
         >>> moe = CuteDslMoEWrapper(
         ...     num_experts=256, top_k=8,
         ...     hidden_size=7168, intermediate_size=2048,
-        ...     use_cuda_graph=True, max_num_tokens=4096,
+        ...     use_cuda_graph=True,
         ... )
         >>> # Warmup
         >>> for _ in range(3):
@@ -361,7 +362,7 @@ class CuteDslMoEWrapper:
         hidden_size: int,
         intermediate_size: int,
         use_cuda_graph: bool = False,
-        max_num_tokens: int = 4096,
+        max_num_tokens: Optional[int] = None,
         num_local_experts: Optional[int] = None,
         local_expert_offset: int = 0,
         tile_size: int = 128,
@@ -383,12 +384,11 @@ class CuteDslMoEWrapper:
         intermediate_size : int
             Intermediate dimension size (after SwiGLU reduction).
         use_cuda_graph : bool
-            If ``True``, pre-allocate workspace buffers sized for
-            ``max_num_tokens`` so the wrapper can be captured into a CUDA
-            graph.  Defaults to ``False``.
-        max_num_tokens : int
-            Maximum batch size, used when ``use_cuda_graph=True``.  Defaults
-            to ``4096``.
+            Create persistent CUDA stream/events for async-memset overlap.
+            Required for CUDA graph capture, since streams and events must be
+            created outside graph capture.  Defaults to ``False``.
+        max_num_tokens : Optional[int]
+            Deprecated; accepted for backwards compatibility but ignored.
         num_local_experts : Optional[int]
             Local experts for expert parallelism.  Defaults to
             ``num_experts``.
@@ -402,8 +402,7 @@ class CuteDslMoEWrapper:
         output_dtype : torch.dtype
             Output dtype.  Defaults to ``torch.bfloat16``.
         device : str
-            Device on which to allocate workspace buffers.  Defaults to
-            ``"cuda"``.
+            Device on which to allocate buffers.  Defaults to ``"cuda"``.
         enable_pdl : bool
             Enable Programmatic Dependent Launch.  Defaults to ``True``.
         """
@@ -412,7 +411,6 @@ class CuteDslMoEWrapper:
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
         self.use_cuda_graph = use_cuda_graph
-        self.max_num_tokens = max_num_tokens
         self.num_local_experts = num_local_experts or num_experts
         self.local_expert_offset = local_expert_offset
         self.tile_size = tile_size
@@ -421,11 +419,10 @@ class CuteDslMoEWrapper:
         self.device = device
         self.enable_pdl = enable_pdl
 
-        # Pre-allocated buffers
-        self._moe_sort_buffers: Optional[Dict[str, torch.Tensor]] = None
-        self._gemm1_output: Optional[torch.Tensor] = None
-        self._gemm1_output_scale: Optional[torch.Tensor] = None
-        self._moe_output: Optional[torch.Tensor] = None
+        # Persistent CUDA resources for async-memset / GEMM1 overlap. These
+        # are created outside graph capture (so they can be reused inside it)
+        # when ``use_cuda_graph=True``. When None, ``_moe_core_impl`` falls
+        # back to module-level resources via ``_get_cuda_graph_resources``.
         self._aux_stream: Optional[torch.cuda.Stream] = None
         self._main_event: Optional[torch.cuda.Event] = None
         self._memset_event: Optional[torch.cuda.Event] = None
@@ -455,85 +452,9 @@ class CuteDslMoEWrapper:
         )
 
         if use_cuda_graph:
-            self._allocate_buffers()
-
-    def _allocate_buffers(self) -> None:
-        """Pre-allocate all buffers for CUDA graph compatibility.
-
-        Buffers are sized to fit *any* ``tile_size in VALID_TILE_SIZES``,
-        not just ``self.tile_size``.  Two distinct buffer-shape concerns:
-
-        - ``max_num_permuted_tokens`` is monotonically *increasing* in
-          ``tile_size`` (the ``(tile - 1) * num_local_experts`` padding
-          term grows faster than ``max_num_tiles`` shrinks), so
-          permuted-token-indexed buffers (``_gemm1_output``,
-          ``_gemm1_output_scale``,
-          ``out_permuted_idx_to_expanded_idx``) must be sized using
-          ``max(VALID_TILE_SIZES)``.
-        - ``max_num_tiles`` is monotonically *decreasing* in
-          ``tile_size``, so the tile-count-indexed moe_sort buffers
-          (``out_tile_idx_to_expert_idx``,
-          ``out_tile_idx_to_mn_limit``) must be sized using
-          ``min(VALID_TILE_SIZES)``.
-
-        Sizing this way means the ``use_prealloc`` gate at
-        ``_forward_with_tactic`` doesn't need a ``tile_size ==
-        self.tile_size`` check at runtime: whichever tactic the
-        autotuner picked, the prealloc fits.  This preserves the
-        wrapper's CUDA-graph contract (``run()`` is graph-safe with
-        ``use_cuda_graph=True``) regardless of which ``tile_size`` the
-        autotuner ends up choosing.
-        """
-        smallest_tile = min(VALID_TILE_SIZES)
-        largest_tile = max(VALID_TILE_SIZES)
-        max_permuted_across_tiles = get_max_num_permuted_tokens(
-            self.max_num_tokens, self.top_k, self.num_local_experts, largest_tile
-        )
-
-        # moe_sort buffers — allocate using smallest_tile so the
-        # tile-count-indexed buffers (out_tile_idx_to_expert_idx,
-        # out_tile_idx_to_mn_limit) are large enough for any tile_size,
-        # then override out_permuted_idx_to_expanded_idx (which scales
-        # with tile_size in the opposite direction) to fit the largest
-        # tile_size's max_num_permuted_tokens.
-        self._moe_sort_buffers = allocate_moe_sort_buffers(
-            num_tokens=self.max_num_tokens,
-            num_experts=self.num_experts,
-            top_k=self.top_k,
-            num_local_experts=self.num_local_experts,
-            tile_tokens_dim=smallest_tile,
-            device=self.device,
-        )
-        self._moe_sort_buffers["out_permuted_idx_to_expanded_idx"] = torch.empty(
-            (max_permuted_across_tiles,), dtype=torch.int32, device=self.device
-        )
-
-        # GEMM1 output (FP4 quantized)
-        self._gemm1_output = torch.empty(
-            (max_permuted_across_tiles, self.intermediate_size // 2),
-            dtype=torch.uint8,
-            device=self.device,
-        )
-
-        # GEMM1 output scale
-        scale_size = max_permuted_across_tiles * (
-            self.intermediate_size // self.sf_vec_size
-        )
-        self._gemm1_output_scale = torch.empty(
-            (scale_size,), dtype=torch.uint8, device=self.device
-        )
-
-        # Final output
-        self._moe_output = torch.empty(
-            (self.max_num_tokens, self.hidden_size),
-            dtype=self.output_dtype,
-            device=self.device,
-        )
-
-        # CUDA resources
-        self._aux_stream = torch.cuda.Stream(device=self.device)
-        self._main_event = torch.cuda.Event()
-        self._memset_event = torch.cuda.Event()
+            self._aux_stream = torch.cuda.Stream(device=self.device)
+            self._main_event = torch.cuda.Event()
+            self._memset_event = torch.cuda.Event()
 
     def _forward_with_tactic(
         self,
@@ -564,30 +485,6 @@ class CuteDslMoEWrapper:
         **kwargs,
     ) -> torch.Tensor:
         """Forward implementation called by auto-tuner."""
-        # Pre-allocated buffers are sized to fit any ``tile_size in
-        # VALID_TILE_SIZES`` (see ``_allocate_buffers``).  Fall back to
-        # dynamic allocation when:
-        #
-        # - the autotuner is in its per-tactic measurement window
-        #   (``is_in_profile_measurement()``): every probed tactic must
-        #   see the same allocation overhead so the comparison is
-        #   unbiased.  Note: this is intentionally narrower than
-        #   ``is_tuning_mode`` -- it excludes cache lookups,
-        #   ``do_preparation`` calls, the final invocation after
-        #   ``choose_one`` returns, and other threads' inference, which
-        #   all benefit from prealloc.
-        # - the tactic's ``tile_size`` is somehow outside the canonical
-        #   enumeration (defensive; should never fire for tactics from
-        #   ``ALL_MOE_TACTICS``).
-        # - the batch exceeds what the buffers were sized for (e.g.
-        #   autotuner probing larger buckets than ``max_num_tokens``).
-        num_tokens = x.shape[0]
-        use_prealloc = (
-            self.use_cuda_graph
-            and not is_in_profile_measurement()
-            and tile_size in VALID_TILE_SIZES
-            and num_tokens <= self.max_num_tokens
-        )
         return _moe_core_impl(
             x=x,
             x_sf=x_sf,
@@ -609,13 +506,10 @@ class CuteDslMoEWrapper:
             gemm1_cluster_shape_mn=gemm1_cluster_shape_mn,
             gemm2_mma_tiler_mn=gemm2_mma_tiler_mn,
             gemm2_cluster_shape_mn=gemm2_cluster_shape_mn,
-            moe_sort_buffers=self._moe_sort_buffers if use_prealloc else None,
-            gemm1_out=self._gemm1_output if use_prealloc else None,
-            gemm1_out_scale=self._gemm1_output_scale if use_prealloc else None,
-            moe_output=moe_output
-            if moe_output is not None
-            # Slice the CUDA-graph buffer to the active batch.
-            else (self._moe_output[: x.shape[0]] if use_prealloc else None),
+            moe_sort_buffers=None,
+            gemm1_out=None,
+            gemm1_out_scale=None,
+            moe_output=moe_output,
             aux_stream=self._aux_stream,
             main_event=self._main_event,
             memset_event=self._memset_event,
@@ -681,21 +575,11 @@ class CuteDslMoEWrapper:
         """
         num_tokens = token_selected_experts.size(0)
 
-        if self.use_cuda_graph and num_tokens > self.max_num_tokens:
-            raise ValueError(
-                f"num_tokens ({num_tokens}) exceeds max_num_tokens ({self.max_num_tokens})"
-            )
-
-        # Slice the pre-allocated buffer to the active batch so that
-        # _moe_core_impl only zeros num_tokens rows, not max_num_tokens.
-        if self.use_cuda_graph:
-            moe_output = self._moe_output[:num_tokens]
-        else:
-            moe_output = torch.empty(
-                (num_tokens, self.hidden_size),
-                dtype=self.output_dtype,
-                device=x.device,
-            )
+        moe_output = torch.empty(
+            (num_tokens, self.hidden_size),
+            dtype=self.output_dtype,
+            device=x.device,
+        )
 
         # Use auto-tuner for tactic selection
         tuner = AutoTuner.get()

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -154,11 +154,7 @@ def get_gemm2_valid_tactics(tile_size: int) -> List[Tuple]:
 
 
 # Canonical list of tile_sizes the autotuner is allowed to pick.  Used by
-# ``get_moe_valid_tactics`` for tactic enumeration AND by
-# ``CuteDslMoEWrapper`` to size its preallocated kernel-output buffers so
-# every tactic in this list can reuse the prealloc, regardless of which
-# tile_size the autotuner picks at runtime.  Adding a new tile_size here
-# automatically widens the prealloc.
+# ``get_moe_valid_tactics`` for tactic enumeration.
 VALID_TILE_SIZES: Tuple[int, ...] = (128, 256)
 
 

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1756,8 +1756,8 @@ class TestExpertParallelism:
 class TestMoeSortBufferInitPoisoned:
     """Validate the invariant that the routing kernel writes every
     output entry that downstream code reads, by pre-poisoning the
-    wrapper's preallocated ``moe_sort`` output buffers with a sentinel
-    value before the first call.
+    ``moe_sort`` output buffers with a sentinel value before invoking
+    the MoE pipeline.
 
     The ``moe_sort`` wrapper in ``moe_utils.py`` allocates its output
     buffers via ``torch.empty(...)`` and relies on the routing kernel
@@ -1778,11 +1778,11 @@ class TestMoeSortBufferInitPoisoned:
     written as ``-1`` by the kernel. If the kernel ever stops writing
     masked slots, this test catches it.
 
-    These tests use ``use_cuda_graph=True`` so the wrapper preallocates
-    buffers (the path where stale state from prior calls / poisoning is
-    actually retained between calls). The default ``use_cuda_graph=False``
-    path allocates fresh buffers per call and doesn't exercise the
-    same scenario.
+    ``_moe_core_impl`` accepts an external ``moe_sort_buffers`` dict
+    for callers who want to manage their own routing-output buffers.
+    The test allocates the dict via ``allocate_moe_sort_buffers``,
+    fills it with the poison sentinel, and drives the full
+    routing+gemm pipeline through ``_moe_core_impl`` directly.
     """
 
     @pytest.mark.parametrize(
@@ -1806,7 +1806,7 @@ class TestMoeSortBufferInitPoisoned:
         self, ep_size: int, num_tokens: int
     ):
         """Pre-poison all six moe_sort output buffers with a sentinel
-        before the wrapper's first call; verify output is well-formed
+        before invoking the MoE pipeline; verify output is well-formed
         and (at low N) matches the eager reference within tolerance.
 
         The high-N case (``num_tokens > 1024``) skips the
@@ -1817,7 +1817,10 @@ class TestMoeSortBufferInitPoisoned:
         what the poisoning-detection logic actually relies on; the
         reference comparison is supplementary.
         """
-        from flashinfer import CuteDslMoEWrapper
+        from flashinfer.fused_moe.cute_dsl.fused_moe import _moe_core_impl
+        from flashinfer.fused_moe.cute_dsl.moe_utils import (
+            allocate_moe_sort_buffers,
+        )
 
         hidden_size, intermediate_size = 256, 512
         num_experts, top_k = 256, 8
@@ -1833,33 +1836,29 @@ class TestMoeSortBufferInitPoisoned:
             top_k=top_k,
         )
 
-        # use_cuda_graph=True so the wrapper preallocates _moe_sort_buffers
-        # (the path that retains stale state between calls — exactly what
-        # we want to stress here).
-        moe = CuteDslMoEWrapper(
+        # Allocate the moe_sort outputs externally so we can poison them
+        # before invoking the kernel. ``_moe_core_impl`` accepts a
+        # ``moe_sort_buffers`` dict that flows through to ``moe_sort`` via
+        # **kwargs, taking the place of its internal ``torch.empty`` calls.
+        tile_size = 128  # default tactic for _moe_core_impl
+        moe_sort_buffers = allocate_moe_sort_buffers(
+            num_tokens=num_tokens,
             num_experts=num_experts,
             top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
             num_local_experts=num_local_experts,
-            local_expert_offset=local_expert_offset,
-            use_cuda_graph=True,
-            max_num_tokens=num_tokens,
+            tile_tokens_dim=tile_size,
+            device="cuda",
         )
 
-        # Defensive guard: if a future refactor renames or restructures
-        # ``_moe_sort_buffers``, the poisoning loop below would silently
-        # iterate over zero items and the test would pass without
-        # actually exercising the kernel-write invariant. Fail loudly
-        # in that case so the test must be updated rather than silently
-        # rotting.
-        assert (
-            getattr(moe, "_moe_sort_buffers", None) is not None
-            and len(moe._moe_sort_buffers) > 0
-        ), (
-            "Wrapper no longer exposes a non-empty ``_moe_sort_buffers`` "
-            "dict; the poisoning loop would be a no-op. Update this "
-            "test to target the new preallocation attribute."
+        # Defensive guard: if a future refactor renames or restructures the
+        # buffer dict returned by ``allocate_moe_sort_buffers``, the
+        # poisoning loop below would silently iterate over zero items and
+        # the test would pass without exercising the kernel-write
+        # invariant. Fail loudly in that case.
+        assert moe_sort_buffers and len(moe_sort_buffers) > 0, (
+            "``allocate_moe_sort_buffers`` no longer returns a non-empty "
+            "dict; the poisoning loop would be a no-op. Update this test "
+            "to target the new buffer-allocation API."
         )
 
         # Sentinel: a non-zero, non-(-1), out-of-valid-index-range int32.
@@ -1868,10 +1867,10 @@ class TestMoeSortBufferInitPoisoned:
         # atomic-add will scatter into wildly wrong output rows, producing
         # NaN/Inf or massive numerical divergence.
         POISON = 0x7FFFFFFE
-        for buf in moe._moe_sort_buffers.values():
+        for buf in moe_sort_buffers.values():
             buf.fill_(POISON)
 
-        result = moe.run(
+        result = _moe_core_impl(
             x=tensors["x"],
             x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
@@ -1883,6 +1882,13 @@ class TestMoeSortBufferInitPoisoned:
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+            num_local_experts=num_local_experts,
+            local_expert_offset=local_expert_offset,
+            tile_size=tile_size,
+            moe_sort_buffers=moe_sort_buffers,
+            output_dtype=torch.bfloat16,
         )
 
         assert result.shape == (num_tokens, hidden_size)
@@ -2084,338 +2090,6 @@ class TestAllValidTactics:
             f"(tokens={num_tokens}, hidden={hidden_size}, "
             f"intermediate={intermediate_size}, experts={num_experts}, top_k={top_k})"
         )
-
-
-# =============================================================================
-# Test Class: CuteDslMoEWrapper prealloc static invariants (no GPU required)
-# =============================================================================
-
-
-@cute_dsl_available
-class TestPreallocStaticInvariants:
-    """No-GPU structural invariants on ``VALID_TILE_SIZES``.
-
-    The empirical buffer-shape and prealloc-gate behavior is covered
-    by ``TestPreallocBuffersIntegration`` and
-    ``TestPreallocGateUnderTuning`` (GPU-required).  This class catches
-    the orthogonal failure mode where ``VALID_TILE_SIZES`` is
-    accidentally reduced to a single entry — in that case the GPU
-    integration tests pass trivially (no max/min divergence in
-    ``_allocate_buffers``, only one tile_size to gate-check) and the
-    bias-prevention silently disappears.
-    """
-
-    def test_valid_tile_sizes_has_multiple_entries(self):
-        """``VALID_TILE_SIZES`` must enumerate more than one tile_size.
-        With a single entry, the bias-prevention is moot — the
-        autotuner only ever profiles one tile_size class, defeating
-        the whole point of widening the prealloc.
-        """
-        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
-
-        assert len(VALID_TILE_SIZES) >= 2, (
-            f"VALID_TILE_SIZES has only {len(VALID_TILE_SIZES)} entry; "
-            f"need >= 2 for the prealloc-bias fix to be meaningful."
-        )
-        assert all(isinstance(t, int) and t > 0 for t in VALID_TILE_SIZES), (
-            f"VALID_TILE_SIZES entries must be positive ints; got {VALID_TILE_SIZES}"
-        )
-
-
-# =============================================================================
-# Test Class: CuteDslMoEWrapper prealloc-buffer integration (GPU required)
-# =============================================================================
-
-
-@cute_dsl_available
-@sm100_required
-class TestPreallocBuffersIntegration:
-    """Verify the wrapper's prealloc'd buffers fit the workload at
-    *every* ``tile_size in VALID_TILE_SIZES``, not just the
-    constructor-time ``self.tile_size``.
-
-    Load-bearing property: when the autotuner picks a tactic with
-    ``tile_size != self.tile_size`` (the common case at large N where
-    ``tile_size=256`` wins on intrinsic kernel time), the wrapper's
-    ``use_prealloc`` gate still resolves True and inference uses the
-    prealloc.  This requires the buffers to fit the *largest* possible
-    workload across all valid tile_sizes; if they were sized only for
-    ``self.tile_size``, picking a different tactic at runtime would
-    OOB-write the prealloc -- forcing the gate to fall through to
-    per-call ``torch.empty()`` calls, which violates the wrapper's
-    CUDA-graph contract.
-    """
-
-    def test_prealloc_buffers_fit_all_valid_tile_sizes(self):
-        from flashinfer import CuteDslMoEWrapper
-        from flashinfer.fused_moe.cute_dsl.moe_utils import (
-            get_max_num_permuted_tokens,
-            get_max_num_tiles,
-        )
-        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
-
-        wrapper = CuteDslMoEWrapper(
-            num_experts=256,
-            top_k=8,
-            hidden_size=256,
-            intermediate_size=512,
-            num_local_experts=256,
-            local_expert_offset=0,
-            use_cuda_graph=True,
-            max_num_tokens=256,
-        )
-
-        gemm1_capacity = wrapper._gemm1_output.shape[0]
-        gemm1_scale_capacity = wrapper._gemm1_output_scale.shape[0]
-        permuted_idx_capacity = wrapper._moe_sort_buffers[
-            "out_permuted_idx_to_expanded_idx"
-        ].shape[0]
-        tile_expert_capacity = wrapper._moe_sort_buffers[
-            "out_tile_idx_to_expert_idx"
-        ].shape[0]
-        tile_mn_limit_capacity = wrapper._moe_sort_buffers[
-            "out_tile_idx_to_mn_limit"
-        ].shape[0]
-
-        # Scale buffer is sized in scale-factor elements (one per
-        # (permuted_token, scale_vec_group) pair), not in permuted
-        # tokens directly.
-        scale_factor_per_token = wrapper.intermediate_size // wrapper.sf_vec_size
-
-        for tile_size in VALID_TILE_SIZES:
-            required_permuted = get_max_num_permuted_tokens(
-                wrapper.max_num_tokens,
-                wrapper.top_k,
-                wrapper.num_local_experts,
-                tile_size,
-            )
-            required_scale_size = required_permuted * scale_factor_per_token
-            required_tiles = get_max_num_tiles(
-                wrapper.max_num_tokens,
-                wrapper.top_k,
-                wrapper.num_local_experts,
-                tile_size,
-            )
-
-            assert gemm1_capacity >= required_permuted, (
-                f"_gemm1_output rows ({gemm1_capacity}) < required "
-                f"({required_permuted}) at tile_size={tile_size}"
-            )
-            assert gemm1_scale_capacity >= required_scale_size, (
-                f"_gemm1_output_scale capacity ({gemm1_scale_capacity}) "
-                f"< required ({required_scale_size} = {required_permuted} "
-                f"permuted * {scale_factor_per_token} scales/token) at "
-                f"tile_size={tile_size}"
-            )
-            assert permuted_idx_capacity >= required_permuted, (
-                f"out_permuted_idx_to_expanded_idx capacity "
-                f"({permuted_idx_capacity}) < required ({required_permuted}) "
-                f"at tile_size={tile_size}"
-            )
-            assert tile_expert_capacity >= required_tiles, (
-                f"out_tile_idx_to_expert_idx capacity "
-                f"({tile_expert_capacity}) < required ({required_tiles}) "
-                f"at tile_size={tile_size}"
-            )
-            assert tile_mn_limit_capacity >= required_tiles, (
-                f"out_tile_idx_to_mn_limit capacity "
-                f"({tile_mn_limit_capacity}) < required ({required_tiles}) "
-                f"at tile_size={tile_size}"
-            )
-
-
-# =============================================================================
-# Test Class: CuteDslMoEWrapper autotune-profiling prealloc gate (GPU required)
-# =============================================================================
-
-
-@cute_dsl_available
-@sm100_required
-class TestPreallocGateUnderTuning:
-    """Validate that ``_forward_with_tactic``'s ``use_prealloc`` gate
-    is on during normal inference (any valid tile_size) but off during
-    the autotuner's per-tactic measurement window.
-
-    Behavioral contract:
-
-    1. **Inside the per-tactic measurement window** (i.e. while
-       ``is_in_profile_measurement()`` is True): the gate must return
-       ``False`` for every tactic, regardless of whether the tactic's
-       ``tile_size`` matches ``self.tile_size``.  All tactics see the
-       same per-call ``torch.empty()`` allocation overhead and the
-       autotuner's tactic comparison is unbiased.
-
-    2. **Inside ``autotune(True)`` but outside the measurement window**
-       (cache lookups, ``do_preparation`` calls, the post-``choose_one``
-       final invocation, concurrent threads): the gate must use
-       prealloc for *any* ``tile_size in VALID_TILE_SIZES``.  This is
-       the property that ``is_in_profile_measurement()`` adds over the
-       broader ``is_tuning_mode`` flag: the gate doesn't leak into
-       these adjacent code paths.
-
-    3. **Outside any tuning context** (plain inference): same as case
-       2 — prealloc for any ``tile_size in VALID_TILE_SIZES``.  This is
-       the property that the expanded ``_allocate_buffers`` adds: the
-       gate doesn't depend on ``tile_size == self.tile_size``, so
-       whichever tactic the autotuner picks, the wrapper's CUDA-graph
-       prealloc is still used and the wrapper's graph-safety contract
-       is preserved.
-
-    Implementation: monkey-patch the module-level ``_moe_core_impl``
-    to capture the ``moe_sort_buffers`` argument without launching
-    kernels, then call ``_forward_with_tactic`` from each of the three
-    contexts × {``self.tile_size``, other valid tile_size}
-    configurations.
-    """
-
-    def test_gate_decouples_self_tile_size_only_during_measurement_window(
-        self, monkeypatch
-    ):
-        from flashinfer import CuteDslMoEWrapper, autotune
-        from flashinfer.autotuner import _profile_measurement_scope
-        from flashinfer.fused_moe.cute_dsl import fused_moe as fused_moe_module
-        from flashinfer.fused_moe.cute_dsl.tuner import VALID_TILE_SIZES
-
-        wrapper = CuteDslMoEWrapper(
-            num_experts=256,
-            top_k=8,
-            hidden_size=256,
-            intermediate_size=512,
-            num_local_experts=256,
-            local_expert_offset=0,
-            use_cuda_graph=True,
-            max_num_tokens=128,
-        )
-
-        # (context, tile_size) -> bool (prealloc'd buffers passed)
-        captured: dict = {}
-        # The mode under which the next call is made; updated by the
-        # caller before each ``call(tile_size, mode)`` so the mock can
-        # tag the captured row correctly.
-        current_mode = {"name": "inference"}
-
-        def mock_moe_core_impl(*args, **kwargs):
-            captured[(current_mode["name"], kwargs["tile_size"])] = (
-                kwargs["moe_sort_buffers"] is wrapper._moe_sort_buffers
-            )
-            n = args[0].shape[0] if args else kwargs["x"].shape[0]
-            return torch.zeros(
-                (n, wrapper.hidden_size), dtype=torch.bfloat16, device="cuda"
-            )
-
-        monkeypatch.setattr(fused_moe_module, "_moe_core_impl", mock_moe_core_impl)
-
-        # Build minimal placeholder tensors: _forward_with_tactic only
-        # reads x.shape[0]; everything else is passed through to the
-        # (mocked) inner function untouched.
-        n = 64  # < max_num_tokens=128 so the batch check passes
-        x = torch.empty((n, wrapper.hidden_size // 2), dtype=torch.uint8, device="cuda")
-        x_sf = torch.empty((n, 1), dtype=torch.uint8, device="cuda")
-        token_selected_experts = torch.zeros(
-            (n, wrapper.top_k), dtype=torch.int32, device="cuda"
-        )
-        token_final_scales = torch.zeros(
-            (n, wrapper.top_k), dtype=torch.float32, device="cuda"
-        )
-        dummy_w = torch.empty((1,), dtype=torch.uint8, device="cuda")
-        dummy_alpha = torch.empty((1,), dtype=torch.float32, device="cuda")
-
-        def call(tile_size: int) -> None:
-            wrapper._forward_with_tactic(
-                x=x,
-                x_sf=x_sf,
-                token_selected_experts=token_selected_experts,
-                token_final_scales=token_final_scales,
-                w1_weight=dummy_w,
-                w1_weight_sf=dummy_w,
-                w1_alpha=dummy_alpha,
-                fc2_input_scale=dummy_alpha,
-                w2_weight=dummy_w,
-                w2_weight_sf=dummy_w,
-                w2_alpha=dummy_alpha,
-                num_experts=wrapper.num_experts,
-                top_k=wrapper.top_k,
-                num_local_experts=wrapper.num_local_experts,
-                tile_size=tile_size,
-            )
-
-        matching = wrapper.tile_size  # the tile_size the prealloc was sized for
-        # Exercise every tile_size in VALID_TILE_SIZES so adding a new
-        # entry doesn't silently leave the gate untested for that tile.
-        others = [t for t in VALID_TILE_SIZES if t != matching]
-        assert others, (
-            f"Test requires >= 2 distinct VALID_TILE_SIZES entries; "
-            f"got {VALID_TILE_SIZES}"
-        )
-        all_tiles = (matching, *others)
-
-        # Context 1: inside autotune(True) AND inside the measurement
-        # window — what _profile_single_kernel does for each tactic
-        # invocation.  The gate must skip prealloc for every tactic.
-        with autotune(True):
-            with _profile_measurement_scope():
-                current_mode["name"] = "measurement"
-                for tile_size in all_tiles:
-                    call(tile_size)
-
-            # Context 2: inside autotune(True) but OUTSIDE the
-            # measurement window — analogous to a cache hit, the
-            # do_preparation call, or the runner invocation immediately
-            # after choose_one returns. The gate should behave like
-            # plain inference here.
-            current_mode["name"] = "in_tuning_context_outside_measurement"
-            for tile_size in all_tiles:
-                call(tile_size)
-
-        # Context 3: outside any tuning context — plain inference.
-        current_mode["name"] = "inference"
-        for tile_size in all_tiles:
-            call(tile_size)
-
-        # Context 1 contract: skip prealloc unconditionally.
-        for tile_size in all_tiles:
-            assert not captured[("measurement", tile_size)], (
-                f"In the per-tactic measurement window, gate passed "
-                f"prealloc'd buffers for tile_size={tile_size} "
-                f"(self.tile_size={matching}). This re-introduces the "
-                f"autotune-profiling bias the gate is designed to prevent."
-            )
-
-        # Context 2 contract: prealloc for ANY valid tile_size.  This
-        # is the property that distinguishes
-        # ``is_in_profile_measurement()`` from the broader
-        # ``is_tuning_mode``: cache lookups, do_preparation calls,
-        # post-choose_one runs, and concurrent threads should NOT lose
-        # prealloc just because some other thread/operation is inside
-        # an ``autotune(True)`` context.  Combined with the expanded
-        # buffer sizing in ``_allocate_buffers``, the prealloc is also
-        # used regardless of whether ``tile_size == self.tile_size``.
-        for tile_size in all_tiles:
-            assert captured[("in_tuning_context_outside_measurement", tile_size)], (
-                f"Inside autotune(True) but outside the measurement "
-                f"window at tile_size={tile_size}, gate did not pass "
-                f"prealloc'd buffers (self.tile_size={matching}). "
-                f"Either the narrower is_in_profile_measurement() "
-                f"signal is leaking back into is_tuning_mode breadth, "
-                f"or the gate is incorrectly checking tile_size == "
-                f"self.tile_size -- both regress the wrapper's "
-                f"CUDA-graph contract."
-            )
-
-        # Context 3 contract: same as Context 2 -- gate uses prealloc
-        # for ANY valid tile_size.  This preserves the wrapper's
-        # CUDA-graph contract regardless of which tactic the autotuner
-        # picks at runtime.
-        for tile_size in all_tiles:
-            assert captured[("inference", tile_size)], (
-                f"In inference mode at tile_size={tile_size}, gate "
-                f"did not pass prealloc'd buffers "
-                f"(self.tile_size={matching}). The wrapper loses its "
-                f"CUDA-graph prealloc benefit -- with use_cuda_graph="
-                f"True, captured graphs would record per-call "
-                f"torch.empty() calls instead of using the prealloc, "
-                f"violating the wrapper's run() graph-safety contract."
-            )
 
 
 # ============================================================================


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Resolves https://github.com/flashinfer-ai/flashinfer/issues/3308.
Previously, `max_num_tokens` were only checked in cuda graph path, but now deprecated and unused.
Dropped tests that test for pre-allocated buffers.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * `max_num_tokens` is now optional/deprecated (ignored at runtime); existing calls remain compatible.

* **Performance Improvements**
  * Persistent CUDA stream/event handling improves CUDA-graph compatibility and enables better async-memset overlap, reducing memory overhead.

* **Tests**
  * Tests updated to validate routing/buffer write-completeness via the core execution path using poisoned-buffer checks.

* **Documentation**
  * Docstrings updated to reflect the new persistent CUDA resource model and deprecated `max_num_tokens`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->