### PR TITLE
Unify B12x Decode with CUTLASS Prefill under a single API

### DIFF
--- a/benchmarks/b12x_vs_cutlass_moe_sweep.py
+++ b/benchmarks/b12x_vs_cutlass_moe_sweep.py
@@ -1,0 +1,347 @@
+"""
+Sweep benchmark: B12xMoEWrapper vs cutlass_fused_moe (NVFP4) on SM120/121.
+
+Charts the prefill/decode crossover so we can pin a default
+``cutlass_prefill_threshold`` inside ``B12xMoEWrapper``.
+
+For each ``num_tokens`` in the sweep we run both backends with their native
+weight packings (built from independent BF16 baselines — perf is the only
+metric, so we don't need bit-equal weights) and record median GPU time via
+CUPTI.
+
+Usage:
+    python benchmarks/b12x_vs_cutlass_moe_sweep.py \\
+        --hidden 6144 --intermediate 3072 --num_experts 128 --top_k 8 \\
+        --activation relu2 \\
+        --num_tokens 1 4 8 16 32 64 128 256 512 1024 2048 4096 8192 \\
+        --out sweep.csv
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from routines.moe import _create_nvfp4_moe_test_data, _activation_kwarg
+from routines.moe_utils import (
+    FLOAT4_E2M1_MAX,
+    FLOAT8_E4M3_MAX,
+    compute_routing,
+)
+
+import flashinfer  # noqa: F401
+from flashinfer import (
+    ActivationType,
+    B12xMoEWrapper,
+    cutlass_fused_moe,
+    fp4_quantize,
+)
+from flashinfer.testing.utils import bench_gpu_time
+
+
+def _round_up(x: int, y: int) -> int:
+    return (x + y - 1) // y * y
+
+
+def build_cutlass_nvfp4_weights(
+    *, num_experts: int, hidden: int, intermediate: int, is_gated: bool, device
+):
+    """Build CUTLASS-NVFP4-format weights from a fresh bf16 baseline.
+
+    Mirrors the inline path in benchmarks/routines/moe.py::testCutlassFusedMoe
+    (variant="nvfp4"). Returns the tensors that ``cutlass_fused_moe`` expects.
+    """
+    e = num_experts
+    n = intermediate
+    k = hidden
+    w1_n = (2 if is_gated else 1) * n
+    quant_blocksize = 16
+
+    w31_bf16 = (
+        torch.randn(e, w1_n, k, dtype=torch.bfloat16, device=device) / 10
+    ).contiguous()
+    w2_bf16 = (
+        torch.randn(e, k, n, dtype=torch.bfloat16, device=device) / 10
+    ).contiguous()
+
+    w1_q = torch.empty((e, w1_n, k // 2), device=device, dtype=torch.uint8)
+    w2_q = torch.empty((e, k, n // 2), device=device, dtype=torch.uint8)
+    w1_blockscale = torch.empty(
+        (e, _round_up(w1_n, 128), _round_up(k // quant_blocksize, 4)),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    w2_blockscale = torch.empty(
+        (e, _round_up(k, 128), _round_up(n // quant_blocksize, 4)),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    w1_gs = torch.empty((e,), device=device, dtype=torch.float32)
+    w2_gs = torch.empty((e,), device=device, dtype=torch.float32)
+
+    for ex in range(e):
+        w1_amax = torch.abs(w31_bf16[ex]).max().to(torch.float32)
+        w2_amax = torch.abs(w2_bf16[ex]).max().to(torch.float32)
+        w1_gs[ex] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w1_amax
+        w2_gs[ex] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w2_amax
+        w1_q[ex], w1_blockscale[ex] = fp4_quantize(w31_bf16[ex], w1_gs[ex])
+        w2_q[ex], w2_blockscale[ex] = fp4_quantize(w2_bf16[ex], w2_gs[ex])
+
+    a1_gs = torch.ones((), device=device, dtype=torch.float32)
+    a2_gs = torch.ones((), device=device, dtype=torch.float32)
+
+    quant_scales = [
+        a1_gs,
+        w1_blockscale.view(torch.int32),
+        1.0 / (a1_gs * w1_gs),
+        a2_gs,
+        w2_blockscale.view(torch.int32),
+        1.0 / (a2_gs * w2_gs),
+    ]
+    return {
+        "w1_q": w1_q,
+        "w2_q": w2_q,
+        "quant_scales": quant_scales,
+        "a1_gs": a1_gs,
+    }
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--hidden", type=int, required=True)
+    p.add_argument("--intermediate", type=int, required=True)
+    p.add_argument("--num_experts", type=int, required=True)
+    p.add_argument("--top_k", type=int, required=True)
+    p.add_argument(
+        "--activation",
+        choices=["silu", "relu2"],
+        default="relu2",
+        help="silu = SwiGLU (gated), relu2 = ReLU2 (non-gated, e.g. Nemotron-Super)",
+    )
+    p.add_argument(
+        "--num_tokens",
+        nargs="+",
+        type=int,
+        default=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+    )
+    p.add_argument("--dry_run_iters", type=int, default=5)
+    p.add_argument("--repeat_iters", type=int, default=30)
+    p.add_argument("--no_cuda_graph", action="store_true")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--out", default=None, help="Output CSV path")
+    p.add_argument("--skip_cutlass", action="store_true")
+    p.add_argument("--skip_b12x", action="store_true")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA device required")
+
+    device = torch.device("cuda")
+    use_cuda_graph = not args.no_cuda_graph
+    is_gated = args.activation == "silu"
+    activation_type = ActivationType.Swiglu if is_gated else ActivationType.Relu2
+
+    cc_major, cc_minor = torch.cuda.get_device_capability(device)
+    if (cc_major, cc_minor) not in ((12, 0), (12, 1)):
+        print(
+            f"[WARN] Detected SM{cc_major}{cc_minor}; b12x kernels target SM120/121.",
+            file=sys.stderr,
+        )
+
+    print(
+        f"[INFO] device={torch.cuda.get_device_name(device)} "
+        f"(SM{cc_major}{cc_minor})  hidden={args.hidden}  intermediate={args.intermediate}  "
+        f"num_experts={args.num_experts}  top_k={args.top_k}  activation={args.activation}"
+    )
+
+    max_m = max(args.num_tokens)
+
+    # --- b12x weight packing (also gives us bf16 input shape; we'll re-roll x per m) ---
+    torch.manual_seed(args.seed)
+    b12x_data = _create_nvfp4_moe_test_data(
+        num_tokens=max_m,
+        hidden_size=args.hidden,
+        intermediate_size=args.intermediate,
+        num_experts=args.num_experts,
+        num_local_experts=args.num_experts,
+        top_k=args.top_k,
+        device=device,
+        backend="b12x",
+        is_gated=is_gated,
+    )
+
+    # --- CUTLASS NVFP4 weight packing (independent bf16 baseline; perf-only) ---
+    torch.manual_seed(args.seed + 1)
+    cutlass_w = build_cutlass_nvfp4_weights(
+        num_experts=args.num_experts,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        is_gated=is_gated,
+        device=device,
+    )
+
+    # --- Single B12xMoEWrapper covers all m ≤ max_m via internal slicing ---
+    moe = (
+        None
+        if args.skip_b12x
+        else B12xMoEWrapper(
+            num_experts=args.num_experts,
+            top_k=args.top_k,
+            hidden_size=args.hidden,
+            intermediate_size=args.intermediate,
+            use_cuda_graph=use_cuda_graph,
+            max_num_tokens=max_m,
+            activation=args.activation,
+        )
+    )
+
+    rows = []
+    print(
+        f"{'m':>7} {'b12x_us':>10} {'cutlass_us':>11} {'cutlass_speedup':>16} {'winner':>8}"
+    )
+    for m in args.num_tokens:
+        torch.manual_seed(args.seed + 100 + m)
+        x_bf16 = (
+            torch.randn(m, args.hidden, dtype=torch.bfloat16, device=device) / 10
+        )
+        routing_logits = torch.randn(m, args.num_experts, device=device)
+        routing_weights, selected_experts = compute_routing(routing_logits, args.top_k)
+        selected_experts = selected_experts.to(torch.int32)
+
+        # ----- b12x -----
+        b12x_us = float("nan")
+        if moe is not None:
+            b12x_args = (
+                x_bf16,
+                b12x_data["w1_weight"],
+                b12x_data["w1_weight_sf"],
+                b12x_data["w1_alpha"],
+                b12x_data["fc2_input_scale"],
+                b12x_data["w2_weight"],
+                b12x_data["w2_weight_sf"],
+                b12x_data["w2_alpha"],
+                selected_experts,
+                routing_weights,
+            )
+
+            def run_b12x(x, w1, w1sf, w1a, fc2s, w2, w2sf, w2a, te, tfs):
+                return moe.run(
+                    x=x,
+                    w1_weight=w1,
+                    w1_weight_sf=w1sf,
+                    w1_alpha=w1a,
+                    fc2_input_scale=fc2s,
+                    w2_weight=w2,
+                    w2_weight_sf=w2sf,
+                    w2_alpha=w2a,
+                    token_selected_experts=te,
+                    token_final_scales=tfs,
+                )
+
+            b12x_times = bench_gpu_time(
+                fn=run_b12x,
+                dry_run_iters=args.dry_run_iters,
+                repeat_iters=args.repeat_iters,
+                sleep_after_run=False,
+                enable_cupti=True,
+                use_cuda_graph=use_cuda_graph,
+                cold_l2_cache=True,
+                input_args=b12x_args,
+            )
+            b12x_us = float(np.median(b12x_times))
+
+        # ----- CUTLASS NVFP4 -----
+        cutlass_us = float("nan")
+        if not args.skip_cutlass:
+            out = torch.empty(m, args.hidden, dtype=torch.bfloat16, device=device)
+            x_q, x_sf = fp4_quantize(x_bf16, cutlass_w["a1_gs"])
+
+            def run_cutlass(x, te, rw, w1q, w2q, o):
+                return cutlass_fused_moe(
+                    x,
+                    te.to(torch.int),
+                    rw,
+                    w1q.contiguous().view(torch.long),
+                    w2q.contiguous().view(torch.long),
+                    torch.bfloat16,
+                    quant_scales=cutlass_w["quant_scales"],
+                    input_sf=x_sf,
+                    output=o,
+                    **_activation_kwarg(cutlass_fused_moe, activation_type),
+                )
+
+            cutlass_args = (
+                x_q,
+                selected_experts,
+                routing_weights,
+                cutlass_w["w1_q"],
+                cutlass_w["w2_q"],
+                out,
+            )
+            cutlass_times = bench_gpu_time(
+                fn=run_cutlass,
+                dry_run_iters=args.dry_run_iters,
+                repeat_iters=args.repeat_iters,
+                sleep_after_run=False,
+                enable_cupti=True,
+                use_cuda_graph=use_cuda_graph,
+                cold_l2_cache=True,
+                input_args=cutlass_args,
+            )
+            cutlass_us = float(np.median(cutlass_times))
+
+        if np.isnan(b12x_us) or np.isnan(cutlass_us):
+            speedup = float("nan")
+            winner = "?"
+        else:
+            speedup = b12x_us / cutlass_us  # >1 ⇒ cutlass faster
+            winner = "cutlass" if cutlass_us < b12x_us else "b12x"
+        print(
+            f"{m:>7d} {b12x_us:>10.2f} {cutlass_us:>11.2f} {speedup:>16.2f} {winner:>8}"
+        )
+        rows.append(
+            {
+                "num_tokens": m,
+                "b12x_us": b12x_us,
+                "cutlass_us": cutlass_us,
+                "cutlass_speedup_over_b12x": speedup,
+                "winner": winner,
+                "hidden": args.hidden,
+                "intermediate": args.intermediate,
+                "num_experts": args.num_experts,
+                "top_k": args.top_k,
+                "activation": args.activation,
+            }
+        )
+
+    if args.out:
+        with open(args.out, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            w.writeheader()
+            w.writerows(rows)
+        print(f"[INFO] Wrote {args.out}")
+
+    # Highlight crossover
+    crossovers = []
+    for i in range(1, len(rows)):
+        prev, cur = rows[i - 1], rows[i]
+        if prev["winner"] != cur["winner"] and "?" not in (prev["winner"], cur["winner"]):
+            crossovers.append((prev["num_tokens"], cur["num_tokens"], cur["winner"]))
+    if crossovers:
+        print("[INFO] Crossover(s):")
+        for lo, hi, w in crossovers:
+            print(f"        {lo} → {hi}: switch to {w}")
+    else:
+        print("[INFO] No crossover observed in the swept range.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/b12x_vs_cutlass_moe_sweep.py
+++ b/benchmarks/b12x_vs_cutlass_moe_sweep.py
@@ -43,6 +43,12 @@ from flashinfer import (
 from flashinfer.testing.utils import bench_gpu_time
 
 
+ACTIVATION_TYPES = {
+    "silu": ActivationType.Swiglu,
+    "relu2": ActivationType.Relu2,
+}
+
+
 def _round_up(x: int, y: int) -> int:
     return (x + y - 1) // y * y
 
@@ -147,7 +153,13 @@ def main():
     device = torch.device("cuda")
     use_cuda_graph = not args.no_cuda_graph
     is_gated = args.activation == "silu"
-    activation_type = ActivationType.Swiglu if is_gated else ActivationType.Relu2
+    try:
+        activation_type = ACTIVATION_TYPES[args.activation]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported activation {args.activation!r}; "
+            f"expected one of {tuple(ACTIVATION_TYPES)}."
+        ) from err
 
     cc_major, cc_minor = torch.cuda.get_device_capability(device)
     if (cc_major, cc_minor) not in ((12, 0), (12, 1)):
@@ -187,6 +199,8 @@ def main():
         is_gated=is_gated,
         device=device,
     )
+    cutlass_w1_long = cutlass_w["w1_q"].contiguous().view(torch.long)
+    cutlass_w2_long = cutlass_w["w2_q"].contiguous().view(torch.long)
 
     # --- Single B12xMoEWrapper covers all m ≤ max_m via internal slicing ---
     moe = (
@@ -209,9 +223,7 @@ def main():
     )
     for m in args.num_tokens:
         torch.manual_seed(args.seed + 100 + m)
-        x_bf16 = (
-            torch.randn(m, args.hidden, dtype=torch.bfloat16, device=device) / 10
-        )
+        x_bf16 = torch.randn(m, args.hidden, dtype=torch.bfloat16, device=device) / 10
         routing_logits = torch.randn(m, args.num_experts, device=device)
         routing_weights, selected_experts = compute_routing(routing_logits, args.top_k)
         selected_experts = selected_experts.to(torch.int32)
@@ -263,27 +275,29 @@ def main():
         if not args.skip_cutlass:
             out = torch.empty(m, args.hidden, dtype=torch.bfloat16, device=device)
             x_q, x_sf = fp4_quantize(x_bf16, cutlass_w["a1_gs"])
+            selected_experts_i32 = selected_experts.to(torch.int)
 
-            def run_cutlass(x, te, rw, w1q, w2q, o):
+            def run_cutlass(x, x_scale, te, rw, w1q, w2q, o):
                 return cutlass_fused_moe(
                     x,
-                    te.to(torch.int),
+                    te,
                     rw,
-                    w1q.contiguous().view(torch.long),
-                    w2q.contiguous().view(torch.long),
+                    w1q,
+                    w2q,
                     torch.bfloat16,
                     quant_scales=cutlass_w["quant_scales"],
-                    input_sf=x_sf,
+                    input_sf=x_scale,
                     output=o,
                     **_activation_kwarg(cutlass_fused_moe, activation_type),
                 )
 
             cutlass_args = (
                 x_q,
-                selected_experts,
+                x_sf,
+                selected_experts_i32,
                 routing_weights,
-                cutlass_w["w1_q"],
-                cutlass_w["w2_q"],
+                cutlass_w1_long,
+                cutlass_w2_long,
                 out,
             )
             cutlass_times = bench_gpu_time(
@@ -333,7 +347,10 @@ def main():
     crossovers = []
     for i in range(1, len(rows)):
         prev, cur = rows[i - 1], rows[i]
-        if prev["winner"] != cur["winner"] and "?" not in (prev["winner"], cur["winner"]):
+        if prev["winner"] != cur["winner"] and "?" not in (
+            prev["winner"],
+            cur["winner"],
+        ):
             crossovers.append((prev["num_tokens"], cur["num_tokens"], cur["winner"]))
     if crossovers:
         print("[INFO] Crossover(s):")

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -38,6 +38,7 @@ Example (Wrapper API with CUDA Graph):
 """
 
 import os
+from contextlib import suppress
 from typing import Any, List, Optional, Tuple
 
 import torch
@@ -253,9 +254,17 @@ class B12xMoEWrapper:
             kernels. Use to keep b12x's micro/static decode path while routing
             prefill chunks (where b12x's dynamic kernel underperforms) to
             CUTLASS. Requires :meth:`register_cutlass_prefill_weights` to be
-            called before the first prefill call. Default ``0`` disables
-            hybrid dispatch (pure b12x). The env var
-            ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD`` overrides this if set.
+            called before the first prefill call. An explicit value, including
+            ``0``, takes precedence over the environment. When omitted, the
+            value is read from ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD``;
+            the effective default is ``0`` (pure b12x).
+
+            Hybrid dispatch is available only for NVFP4. It keeps both b12x-
+            and CUTLASS-format FP4 weights resident, roughly doubling weight
+            memory. Backend selection is a host-side decision, so a CUDA graph
+            captures only the path selected by that graph's token shape; use
+            separate graphs for shape buckets on opposite sides of the
+            threshold.
 
     Example:
         >>> moe = B12xMoEWrapper(num_experts=256, top_k=8, ...)
@@ -291,7 +300,7 @@ class B12xMoEWrapper:
         activation_precision: str = "fp4",
         quant_mode: Optional[str] = None,
         source_format: str = "modelopt",
-        cutlass_prefill_threshold: int = 0,
+        cutlass_prefill_threshold: Optional[int] = None,
     ):
         r"""Configure the b12x fused-MoE wrapper.
 
@@ -336,6 +345,12 @@ class B12xMoEWrapper:
         source_format : str
             Source weight format for ``quant_mode="w4a16"`` —
             ``"modelopt"`` (default) or ``"compressed_tensors"``.
+        cutlass_prefill_threshold : Optional[int]
+            Route calls with at least this many tokens to CUTLASS. Explicit
+            values take precedence over
+            ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD``; when both are
+            omitted, the effective default is ``0`` (disabled). Hybrid mode is
+            NVFP4-only and requires separately registered CUTLASS weights.
         """
         from ...jit.cpp_ext import get_cuda_version
         from .blackwell_sm12x.moe_dispatch import (
@@ -383,13 +398,19 @@ class B12xMoEWrapper:
         )
         self.source_format = source_format
 
-        env_override = os.environ.get("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD")
-        if env_override is not None:
-            try:
-                cutlass_prefill_threshold = int(env_override)
-            except ValueError:
-                pass
+        if cutlass_prefill_threshold is None:
+            cutlass_prefill_threshold = 0
+            env_override = os.environ.get("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD")
+            if env_override is not None:
+                with suppress(ValueError):
+                    cutlass_prefill_threshold = int(env_override)
         self.cutlass_prefill_threshold = cutlass_prefill_threshold
+        if self.cutlass_prefill_threshold > 0 and self.quant_mode != "nvfp4":
+            raise NotImplementedError(
+                "B12xMoEWrapper hybrid CUTLASS prefill dispatch supports only "
+                f"quant_mode='nvfp4', got {self.quant_mode!r}. Set "
+                "cutlass_prefill_threshold=0 to use pure b12x W4A16."
+            )
 
         # Pre-allocated objects. Both workspace slots may be populated so
         # run() can pick per-call; without this, the backend would be locked
@@ -404,11 +425,14 @@ class B12xMoEWrapper:
 
         # CUTLASS-format prefill weights, registered post-construction via
         # register_cutlass_prefill_weights(). Held alongside the b12x weights
-        # the caller passes to run() — same FP4 numeric values, different
-        # physical layout (gate/up interleave + non-MMA SF for CUTLASS).
+        # the caller passes to run() — the same logical weights quantized into
+        # different physical layouts and scale-factor conventions.
         self._cutlass_w1: Optional[torch.Tensor] = None
         self._cutlass_w2: Optional[torch.Tensor] = None
         self._cutlass_quant_scales: Optional[List[torch.Tensor]] = None
+        self._cutlass_swiglu_alpha: Optional[torch.Tensor] = None
+        self._cutlass_swiglu_beta: Optional[torch.Tensor] = None
+        self._cutlass_swiglu_limit: Optional[torch.Tensor] = None
 
         if use_cuda_graph:
             self._allocate_buffers()
@@ -513,9 +537,9 @@ class B12xMoEWrapper:
 
         Required when ``cutlass_prefill_threshold > 0``. The b12x decode path
         (un-normalized SF + MMA-swizzled layout) and the CUTLASS prefill path
-        (normalized FP8 SF + non-interleave-aware layout) share FP4 numeric
-        values but use different physical packings. The wrapper holds both
-        alive — the caller must FP4-quantize weights twice at load time
+        (normalized FP8 SF + non-interleave-aware layout) represent the same
+        logical weights with different physical packings. The wrapper holds
+        both alive — the caller must FP4-quantize weights twice at load time
         (mirroring TRT-LLM's ``FlashInferFusedMoE.post_load_weights``).
 
         Args:
@@ -536,6 +560,21 @@ class B12xMoEWrapper:
         self._cutlass_w1 = w1_q.contiguous().view(torch.long)
         self._cutlass_w2 = w2_q.contiguous().view(torch.long)
         self._cutlass_quant_scales = quant_scales
+        if self.activation == "swigluoai_uninterleave":
+            param_options = {
+                "device": w1_q.device,
+                "dtype": torch.float32,
+            }
+            self._cutlass_swiglu_alpha = torch.full(
+                (self.num_experts,), self.swiglu_alpha, **param_options
+            )
+            self._cutlass_swiglu_beta = torch.full(
+                (self.num_experts,), self.swiglu_beta, **param_options
+            )
+            if self.swiglu_limit is not None:
+                self._cutlass_swiglu_limit = torch.full(
+                    (self.num_experts,), self.swiglu_limit, **param_options
+                )
 
     def _should_route_to_cutlass(self, num_tokens: int) -> bool:
         return (
@@ -562,13 +601,25 @@ class B12xMoEWrapper:
                 "or set cutlass_prefill_threshold=0 to disable hybrid dispatch."
             )
 
-        activation_type = (
-            ActivationType.Swiglu if self.activation == "silu" else ActivationType.Relu2
-        )
+        activation_types = {
+            "silu": ActivationType.Swiglu,
+            "gelu_tanh": ActivationType.GegluTanh,
+            "swigluoai_uninterleave": ActivationType.Swiglu,
+            "relu2": ActivationType.Relu2,
+        }
+        try:
+            activation_type = activation_types[self.activation]
+        except KeyError as err:
+            raise ValueError(
+                "CUTLASS prefill dispatch does not support activation "
+                f"{self.activation!r}; expected one of {tuple(activation_types)}."
+            ) from err
         # cutlass_fused_moe returns a list (carryover from min-latency mode's
         # multi-output case); it writes into the pre-allocated `output` buffer
         # we pass, so we return that directly to keep our run() contract a
         # single Tensor.
+        # In NVFP4 mode a BF16 input with input_sf=None is quantized internally
+        # using quant_scales[0] as the FC1 activation global scale.
         cutlass_fused_moe(
             input=x,
             token_selected_experts=token_selected_experts.to(torch.int),
@@ -578,6 +629,9 @@ class B12xMoEWrapper:
             output_dtype=self.output_dtype,
             quant_scales=self._cutlass_quant_scales,
             input_sf=None,
+            swiglu_alpha=self._cutlass_swiglu_alpha,
+            swiglu_beta=self._cutlass_swiglu_beta,
+            swiglu_limit=self._cutlass_swiglu_limit,
             output=output,
             activation_type=activation_type,
         )

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -565,7 +565,11 @@ class B12xMoEWrapper:
         activation_type = (
             ActivationType.Swiglu if self.activation == "silu" else ActivationType.Relu2
         )
-        return cutlass_fused_moe(
+        # cutlass_fused_moe returns a list (carryover from min-latency mode's
+        # multi-output case); it writes into the pre-allocated `output` buffer
+        # we pass, so we return that directly to keep our run() contract a
+        # single Tensor.
+        cutlass_fused_moe(
             input=x,
             token_selected_experts=token_selected_experts.to(torch.int),
             token_final_scales=token_final_scales,
@@ -577,6 +581,7 @@ class B12xMoEWrapper:
             output=output,
             activation_type=activation_type,
         )
+        return output
 
     @flashinfer_api(trace=b12x_moe_wrapper_run_trace)
     def run(

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -259,12 +259,17 @@ class B12xMoEWrapper:
             value is read from ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD``;
             the effective default is ``0`` (pure b12x).
 
-            Hybrid dispatch is available only for NVFP4. It keeps both b12x-
-            and CUTLASS-format FP4 weights resident, roughly doubling weight
-            memory. Backend selection is a host-side decision, so a CUDA graph
-            captures only the path selected by that graph's token shape; use
-            separate graphs for shape buckets on opposite sides of the
-            threshold.
+            Hybrid dispatch is available only for NVFP4. The decode and
+            prefill paths can share the same contiguous packed-FP4 W1/W2
+            tensors; this wrapper stores CUTLASS long views of the registered
+            uint8 tensors. The paths use different scale-factor conventions,
+            so an integration normally retains both B12x and CUTLASS FP8
+            block-scale representations. This adds one scale set, not another
+            packed-FP4 weight set. Supplying distinct packed tensors instead
+            deliberately adds a full weight copy. Backend selection is a
+            host-side decision, so a CUDA graph captures only the path selected
+            by that graph's token shape; use separate graphs for shape buckets
+            on opposite sides of the threshold.
 
     Example:
         >>> moe = B12xMoEWrapper(num_experts=256, top_k=8, ...)
@@ -424,9 +429,9 @@ class B12xMoEWrapper:
         self._moe_output: Optional[torch.Tensor] = None
 
         # CUTLASS-format prefill weights, registered post-construction via
-        # register_cutlass_prefill_weights(). Held alongside the b12x weights
-        # the caller passes to run() — the same logical weights quantized into
-        # different physical layouts and scale-factor conventions.
+        # register_cutlass_prefill_weights(). The decode and prefill paths can
+        # share the same packed FP4 payload; their scale-factor conventions can
+        # require separate scale representations.
         self._cutlass_w1: Optional[torch.Tensor] = None
         self._cutlass_w2: Optional[torch.Tensor] = None
         self._cutlass_quant_scales: Optional[List[torch.Tensor]] = None
@@ -536,11 +541,13 @@ class B12xMoEWrapper:
         """Register CUTLASS-format NVFP4 weights for the prefill dispatch.
 
         Required when ``cutlass_prefill_threshold > 0``. The b12x decode path
-        (un-normalized SF + MMA-swizzled layout) and the CUTLASS prefill path
-        (normalized FP8 SF + non-interleave-aware layout) represent the same
-        logical weights with different physical packings. The wrapper holds
-        both alive — the caller must FP4-quantize weights twice at load time
-        (mirroring TRT-LLM's ``FlashInferFusedMoE.post_load_weights``).
+        uses un-normalized scale factors in an MMA view, while the CUTLASS
+        prefill path uses normalized FP8 scale factors. Both paths can use the
+        same packed FP4 W1/W2 payload: pass the tensors supplied to :meth:`run`
+        here when they are contiguous. The wrapper stores long views of those
+        tensors without copying their data. Retain separate B12x and CUTLASS
+        scale representations when their values differ; do not FP4-quantize
+        the weights twice unless distinct packed tensors are required.
 
         Args:
             w1_q: FC1 FP4 weights, uint8 packed.

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -37,7 +37,8 @@ Example (Wrapper API with CUDA Graph):
     >>> output = moe.run(x=hidden_states_bf16, ...)
 """
 
-from typing import Any, Optional, Tuple
+import os
+from typing import Any, List, Optional, Tuple
 
 import torch
 
@@ -247,10 +248,26 @@ class B12xMoEWrapper:
             this selects the backend and internal workspace family.
         source_format: Source weight format for quant_mode="w4a16".
             Supports "modelopt" and "compressed_tensors". Default: "modelopt".
+        cutlass_prefill_threshold: When ``> 0`` and ``x.shape[0] >= threshold``,
+            ``run()`` forwards to ``cutlass_fused_moe`` instead of the b12x
+            kernels. Use to keep b12x's micro/static decode path while routing
+            prefill chunks (where b12x's dynamic kernel underperforms) to
+            CUTLASS. Requires :meth:`register_cutlass_prefill_weights` to be
+            called before the first prefill call. Default ``0`` disables
+            hybrid dispatch (pure b12x). The env var
+            ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD`` overrides this if set.
 
     Example:
         >>> moe = B12xMoEWrapper(num_experts=256, top_k=8, ...)
         >>> output = moe.run(x=hidden_states_bf16, ...)
+
+    Hybrid prefill example::
+
+        >>> moe = B12xMoEWrapper(..., cutlass_prefill_threshold=9)
+        >>> moe.register_cutlass_prefill_weights(
+        ...     w1_q=w1_cutlass, w2_q=w2_cutlass, quant_scales=[...]
+        ... )
+        >>> moe.run(x=hidden_states_bf16, ...)  # routes per call
     """
 
     @supported_compute_capability([120, 121])
@@ -274,6 +291,7 @@ class B12xMoEWrapper:
         activation_precision: str = "fp4",
         quant_mode: Optional[str] = None,
         source_format: str = "modelopt",
+        cutlass_prefill_threshold: int = 0,
     ):
         r"""Configure the b12x fused-MoE wrapper.
 
@@ -365,6 +383,14 @@ class B12xMoEWrapper:
         )
         self.source_format = source_format
 
+        env_override = os.environ.get("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD")
+        if env_override is not None:
+            try:
+                cutlass_prefill_threshold = int(env_override)
+            except ValueError:
+                pass
+        self.cutlass_prefill_threshold = cutlass_prefill_threshold
+
         # Pre-allocated objects. Both workspace slots may be populated so
         # run() can pick per-call; without this, the backend would be locked
         # to whichever workspace was allocated at init time.
@@ -375,6 +401,14 @@ class B12xMoEWrapper:
         self._padded_weights: Any = None
         self._padded_weight_key: Optional[Tuple] = None
         self._moe_output: Optional[torch.Tensor] = None
+
+        # CUTLASS-format prefill weights, registered post-construction via
+        # register_cutlass_prefill_weights(). Held alongside the b12x weights
+        # the caller passes to run() — same FP4 numeric values, different
+        # physical layout (gate/up interleave + non-MMA SF for CUTLASS).
+        self._cutlass_w1: Optional[torch.Tensor] = None
+        self._cutlass_w2: Optional[torch.Tensor] = None
+        self._cutlass_quant_scales: Optional[List[torch.Tensor]] = None
 
         if use_cuda_graph:
             self._allocate_buffers()
@@ -468,6 +502,82 @@ class B12xMoEWrapper:
             device=self.device,
         )
 
+    def register_cutlass_prefill_weights(
+        self,
+        *,
+        w1_q: torch.Tensor,
+        w2_q: torch.Tensor,
+        quant_scales: List[torch.Tensor],
+    ) -> None:
+        """Register CUTLASS-format NVFP4 weights for the prefill dispatch.
+
+        Required when ``cutlass_prefill_threshold > 0``. The b12x decode path
+        (un-normalized SF + MMA-swizzled layout) and the CUTLASS prefill path
+        (normalized FP8 SF + non-interleave-aware layout) share FP4 numeric
+        values but use different physical packings. The wrapper holds both
+        alive — the caller must FP4-quantize weights twice at load time
+        (mirroring TRT-LLM's ``FlashInferFusedMoE.post_load_weights``).
+
+        Args:
+            w1_q: FC1 FP4 weights, uint8 packed.
+                ``[E, 2*intermediate_size, hidden_size//2]`` for SwiGLU,
+                ``[E, intermediate_size, hidden_size//2]`` for ReLU2.
+            w2_q: FC2 FP4 weights, uint8 packed
+                ``[E, hidden_size, intermediate_size//2]``.
+            quant_scales: 6-element list expected by ``cutlass_fused_moe``
+                NVFP4 mode: ``[a1_gs, w1_blockscale_int32, 1/(a1_gs*w1_gs),
+                a2_gs, w2_blockscale_int32, 1/(a2_gs*w2_gs)]``. Build with
+                the same recipe as the cutlass NVFP4 benchmark variant
+                (``benchmarks/routines/moe.py::testCutlassFusedMoe``).
+        """
+        # Pre-view to long once; the b12x decode path won't touch these
+        # tensors, so the view is stable for the lifetime of the wrapper
+        # (or until the caller re-registers).
+        self._cutlass_w1 = w1_q.contiguous().view(torch.long)
+        self._cutlass_w2 = w2_q.contiguous().view(torch.long)
+        self._cutlass_quant_scales = quant_scales
+
+    def _should_route_to_cutlass(self, num_tokens: int) -> bool:
+        return (
+            self.cutlass_prefill_threshold > 0
+            and num_tokens >= self.cutlass_prefill_threshold
+        )
+
+    def _run_cutlass_prefill(
+        self,
+        *,
+        x: torch.Tensor,
+        token_selected_experts: torch.Tensor,
+        token_final_scales: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        from ..core import ActivationType, cutlass_fused_moe
+
+        if self._cutlass_w1 is None:
+            raise RuntimeError(
+                f"B12xMoEWrapper: x.shape[0]={x.shape[0]} >= "
+                f"cutlass_prefill_threshold={self.cutlass_prefill_threshold} "
+                "but CUTLASS prefill weights have not been registered. Call "
+                "register_cutlass_prefill_weights(...) after weight loading, "
+                "or set cutlass_prefill_threshold=0 to disable hybrid dispatch."
+            )
+
+        activation_type = (
+            ActivationType.Swiglu if self.activation == "silu" else ActivationType.Relu2
+        )
+        return cutlass_fused_moe(
+            input=x,
+            token_selected_experts=token_selected_experts.to(torch.int),
+            token_final_scales=token_final_scales,
+            fc1_expert_weights=self._cutlass_w1,
+            fc2_expert_weights=self._cutlass_w2,
+            output_dtype=self.output_dtype,
+            quant_scales=self._cutlass_quant_scales,
+            input_sf=None,
+            output=output,
+            activation_type=activation_type,
+        )
+
     @flashinfer_api(trace=b12x_moe_wrapper_run_trace)
     def run(
         self,
@@ -535,6 +645,14 @@ class B12xMoEWrapper:
                 (num_tokens, self.hidden_size),
                 dtype=self.output_dtype,
                 device=x.device,
+            )
+
+        if self._should_route_to_cutlass(num_tokens):
+            return self._run_cutlass_prefill(
+                x=x,
+                token_selected_experts=token_selected_experts,
+                token_final_scales=token_final_scales,
+                output=moe_output,
             )
 
         from .blackwell_sm12x.moe_dispatch import (

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -553,7 +553,40 @@ class B12xMoEWrapper:
                 a2_gs, w2_blockscale_int32, 1/(a2_gs*w2_gs)]``. Build with
                 the same recipe as the cutlass NVFP4 benchmark variant
                 (``benchmarks/routines/moe.py::testCutlassFusedMoe``).
+
+                Keep these normalized CUTLASS scales independent from the
+                b12x scales passed to :meth:`run`. For the same packed FP4
+                values, the corresponding unnormalized b12x weight scales are
+                ``cutlass_w1_sf * quant_scales[2] * quant_scales[0]`` and
+                ``cutlass_w2_sf * quant_scales[5] * quant_scales[3]`` before
+                conversion to the MMA layout. The b12x ``w1_alpha`` and both
+                ``fc2_input_scale``/``w2_alpha`` are respectively
+                ``1 / quant_scales[0]`` and ``1 / quant_scales[3]``. In
+                particular, do not leave the activation scale folded into a
+                b12x weight scale or pass CUTLASS's large activation global
+                scale as a b12x alpha: b12x consumes the reciprocal, small
+                activation scale during both input quantization and the GEMM
+                epilogue.
         """
+        if w1_q.dtype != torch.uint8 or w2_q.dtype != torch.uint8:
+            raise TypeError(
+                "CUTLASS NVFP4 weights must be uint8-packed tensors, got "
+                f"w1_q.dtype={w1_q.dtype}, w2_q.dtype={w2_q.dtype}."
+            )
+        if w1_q.device != w2_q.device:
+            raise ValueError(
+                "CUTLASS prefill weights must be on the same device, got "
+                f"w1_q.device={w1_q.device}, w2_q.device={w2_q.device}."
+            )
+        if len(quant_scales) != 6:
+            raise ValueError(
+                "CUTLASS NVFP4 quant_scales must contain exactly 6 tensors, "
+                f"got {len(quant_scales)}."
+            )
+        if any(scale.device != w1_q.device for scale in quant_scales):
+            raise ValueError(
+                "CUTLASS weights and all quant_scales must be on the same device."
+            )
         # Pre-view to long once; the b12x decode path won't touch these
         # tensors, so the view is stable for the lifetime of the wrapper
         # (or until the caller re-registers).

--- a/tests/moe/test_b12x_cutlass_hybrid.py
+++ b/tests/moe/test_b12x_cutlass_hybrid.py
@@ -65,7 +65,7 @@ def _round_up(x: int, y: int) -> int:
 
 
 def _make_b12x_weights(
-    *, num_local_experts, hidden, intermediate, is_gated, device, seed=0
+    *, num_experts, hidden, intermediate, is_gated, device, seed=0
 ):
     """B12x-format NVFP4 weights (non-interleaved gate/up, MMA-swizzled SF)."""
     torch.manual_seed(seed)
@@ -73,56 +73,56 @@ def _make_b12x_weights(
 
     w1_bf16 = (
         torch.randn(
-            num_local_experts, w1_rows, hidden, dtype=torch.bfloat16, device=device
+            num_experts, w1_rows, hidden, dtype=torch.bfloat16, device=device
         )
         / 10
     )
     w2_bf16 = (
         torch.randn(
-            num_local_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
+            num_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
         )
         / 10
     )
 
     w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
     w1_q_flat, w1_sf_flat = fp4_quantize(
-        w1_bf16.view(num_local_experts * w1_rows, hidden),
+        w1_bf16.view(num_experts * w1_rows, hidden),
         global_scale=w1_gs,
         sf_vec_size=SF_VEC_SIZE,
         is_sf_swizzled_layout=True,
     )
-    w1_q = w1_q_flat.view(num_local_experts, w1_rows, hidden // 2)
+    w1_q = w1_q_flat.view(num_experts, w1_rows, hidden // 2)
     w1_sf = convert_sf_to_mma_layout(
         w1_sf_flat,
         m=w1_rows,
         k=hidden,
-        num_groups=num_local_experts,
+        num_groups=num_experts,
         sf_vec_size=SF_VEC_SIZE,
     )
 
     w2_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
     w2_q_flat, w2_sf_flat = fp4_quantize(
-        w2_bf16.view(num_local_experts * hidden, intermediate),
+        w2_bf16.view(num_experts * hidden, intermediate),
         global_scale=w2_gs,
         sf_vec_size=SF_VEC_SIZE,
         is_sf_swizzled_layout=True,
     )
-    w2_q = w2_q_flat.view(num_local_experts, hidden, intermediate // 2)
+    w2_q = w2_q_flat.view(num_experts, hidden, intermediate // 2)
     w2_sf = convert_sf_to_mma_layout(
         w2_sf_flat,
         m=hidden,
         k=intermediate,
-        num_groups=num_local_experts,
+        num_groups=num_experts,
         sf_vec_size=SF_VEC_SIZE,
     )
 
     return {
         "w1_weight": w1_q,
         "w1_weight_sf": w1_sf,
-        "w1_alpha": torch.ones(num_local_experts, device=device, dtype=torch.float32),
+        "w1_alpha": torch.ones(num_experts, device=device, dtype=torch.float32),
         "w2_weight": w2_q,
         "w2_weight_sf": w2_sf,
-        "w2_alpha": torch.ones(num_local_experts, device=device, dtype=torch.float32),
+        "w2_alpha": torch.ones(num_experts, device=device, dtype=torch.float32),
         "fc2_input_scale": torch.tensor([1.0], device=device, dtype=torch.float32),
     }
 
@@ -222,7 +222,6 @@ def _run(moe, x, b12x_weights, num_experts, top_k, device):
 # Realistic-but-small Nemotron-Super-shaped config: ReLU2 (non-gated), small E.
 _CFG = dict(
     num_experts=8,
-    num_local_experts=8,
     top_k=2,
     hidden=2048,
     intermediate=1024,
@@ -243,7 +242,13 @@ def setup():
     device = torch.device("cuda")
     return {
         "device": device,
-        "b12x": _make_b12x_weights(device=device, **_CFG),
+        "b12x": _make_b12x_weights(
+            num_experts=_CFG["num_experts"],
+            hidden=_CFG["hidden"],
+            intermediate=_CFG["intermediate"],
+            is_gated=_CFG["is_gated"],
+            device=device,
+        ),
         "cutlass": _make_cutlass_weights(
             num_experts=_CFG["num_experts"],
             hidden=_CFG["hidden"],
@@ -275,7 +280,6 @@ def _build_wrapper(*, threshold: int) -> B12xMoEWrapper:
         top_k=_CFG["top_k"],
         hidden_size=_CFG["hidden"],
         intermediate_size=_CFG["intermediate"],
-        num_local_experts=_CFG["num_local_experts"],
         activation=_ACTIVATION,
         use_cuda_graph=False,
         cutlass_prefill_threshold=threshold,

--- a/tests/moe/test_b12x_cutlass_hybrid.py
+++ b/tests/moe/test_b12x_cutlass_hybrid.py
@@ -1,0 +1,395 @@
+"""
+Tests for the hybrid CUTLASS-prefill / b12x-decode dispatch in
+``B12xMoEWrapper`` (the ``cutlass_prefill_threshold`` knob).
+
+Verifies:
+  - Default ``cutlass_prefill_threshold=0`` keeps pure b12x behavior.
+  - Threshold > 0: ``num_tokens < threshold`` routes to b12x;
+    ``num_tokens >= threshold`` routes to ``cutlass_fused_moe``.
+  - Calling without registered cutlass weights raises a clear error.
+  - ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD`` overrides the kwarg.
+  - Both paths produce bf16 output of the expected shape.
+
+The dispatch decision is verified by monkey-patching
+``flashinfer.fused_moe.core.cutlass_fused_moe`` with a counting spy — the
+underlying b12x kernels still run (or not) for real, so the tests also
+cover the wiring end-to-end.
+"""
+
+import pytest
+import torch
+from torch.nn import functional as F
+
+from flashinfer import B12xMoEWrapper
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.fp4_quantization import fp4_quantize
+from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+
+
+SF_VEC_SIZE = 16
+FLOAT8_E4M3_MAX = 448.0
+FLOAT4_E2M1_MAX = 6.0
+
+
+def _is_sm12x_supported() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from flashinfer.utils import is_sm120a_supported, is_sm121a_supported
+
+    device = torch.device("cuda")
+    return is_sm120a_supported(device) or is_sm121a_supported(device)
+
+
+def _cuda_13_or_newer() -> bool:
+    try:
+        from flashinfer.jit.cpp_ext import get_cuda_version
+
+        return get_cuda_version().major >= 13
+    except Exception:
+        return False
+
+
+cute_dsl_available = pytest.mark.skipif(
+    not is_cute_dsl_available(), reason="CuteDSL not available"
+)
+sm120_required = pytest.mark.skipif(
+    not _is_sm12x_supported(), reason="Requires SM120/SM121 GPU"
+)
+cuda_13_required = pytest.mark.skipif(
+    not _cuda_13_or_newer(), reason="b12x fused MoE requires CUDA 13 or later"
+)
+
+
+def _round_up(x: int, y: int) -> int:
+    return (x + y - 1) // y * y
+
+
+def _make_b12x_weights(
+    *, num_local_experts, hidden, intermediate, is_gated, device, seed=0
+):
+    """B12x-format NVFP4 weights (non-interleaved gate/up, MMA-swizzled SF)."""
+    torch.manual_seed(seed)
+    w1_rows = (2 if is_gated else 1) * intermediate
+
+    w1_bf16 = (
+        torch.randn(
+            num_local_experts, w1_rows, hidden, dtype=torch.bfloat16, device=device
+        )
+        / 10
+    )
+    w2_bf16 = (
+        torch.randn(
+            num_local_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
+        )
+        / 10
+    )
+
+    w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    w1_q_flat, w1_sf_flat = fp4_quantize(
+        w1_bf16.view(num_local_experts * w1_rows, hidden),
+        global_scale=w1_gs,
+        sf_vec_size=SF_VEC_SIZE,
+        is_sf_swizzled_layout=True,
+    )
+    w1_q = w1_q_flat.view(num_local_experts, w1_rows, hidden // 2)
+    w1_sf = convert_sf_to_mma_layout(
+        w1_sf_flat,
+        m=w1_rows,
+        k=hidden,
+        num_groups=num_local_experts,
+        sf_vec_size=SF_VEC_SIZE,
+    )
+
+    w2_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    w2_q_flat, w2_sf_flat = fp4_quantize(
+        w2_bf16.view(num_local_experts * hidden, intermediate),
+        global_scale=w2_gs,
+        sf_vec_size=SF_VEC_SIZE,
+        is_sf_swizzled_layout=True,
+    )
+    w2_q = w2_q_flat.view(num_local_experts, hidden, intermediate // 2)
+    w2_sf = convert_sf_to_mma_layout(
+        w2_sf_flat,
+        m=hidden,
+        k=intermediate,
+        num_groups=num_local_experts,
+        sf_vec_size=SF_VEC_SIZE,
+    )
+
+    return {
+        "w1_weight": w1_q,
+        "w1_weight_sf": w1_sf,
+        "w1_alpha": torch.ones(num_local_experts, device=device, dtype=torch.float32),
+        "w2_weight": w2_q,
+        "w2_weight_sf": w2_sf,
+        "w2_alpha": torch.ones(num_local_experts, device=device, dtype=torch.float32),
+        "fc2_input_scale": torch.tensor([1.0], device=device, dtype=torch.float32),
+    }
+
+
+def _make_cutlass_weights(
+    *, num_experts, hidden, intermediate, is_gated, device, seed=1
+):
+    """CUTLASS NVFP4-format weights (per-expert global scales + blockscale tensors)."""
+    torch.manual_seed(seed)
+    w1_n = (2 if is_gated else 1) * intermediate
+
+    w1_bf16 = (
+        torch.randn(
+            num_experts, w1_n, hidden, dtype=torch.bfloat16, device=device
+        )
+        / 10
+    ).contiguous()
+    w2_bf16 = (
+        torch.randn(
+            num_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
+        )
+        / 10
+    ).contiguous()
+
+    w1_q = torch.empty(
+        (num_experts, w1_n, hidden // 2), device=device, dtype=torch.uint8
+    )
+    w2_q = torch.empty(
+        (num_experts, hidden, intermediate // 2), device=device, dtype=torch.uint8
+    )
+    w1_blockscale = torch.empty(
+        (
+            num_experts,
+            _round_up(w1_n, 128),
+            _round_up(hidden // SF_VEC_SIZE, 4),
+        ),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    w2_blockscale = torch.empty(
+        (
+            num_experts,
+            _round_up(hidden, 128),
+            _round_up(intermediate // SF_VEC_SIZE, 4),
+        ),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    w1_gs = torch.empty((num_experts,), device=device, dtype=torch.float32)
+    w2_gs = torch.empty((num_experts,), device=device, dtype=torch.float32)
+
+    for ex in range(num_experts):
+        w1_amax = torch.abs(w1_bf16[ex]).max().to(torch.float32)
+        w2_amax = torch.abs(w2_bf16[ex]).max().to(torch.float32)
+        w1_gs[ex] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w1_amax
+        w2_gs[ex] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w2_amax
+        w1_q[ex], w1_blockscale[ex] = fp4_quantize(w1_bf16[ex], w1_gs[ex])
+        w2_q[ex], w2_blockscale[ex] = fp4_quantize(w2_bf16[ex], w2_gs[ex])
+
+    a1_gs = torch.ones((), device=device, dtype=torch.float32)
+    a2_gs = torch.ones((), device=device, dtype=torch.float32)
+    quant_scales = [
+        a1_gs,
+        w1_blockscale.view(torch.int32),
+        1.0 / (a1_gs * w1_gs),
+        a2_gs,
+        w2_blockscale.view(torch.int32),
+        1.0 / (a2_gs * w2_gs),
+    ]
+    return {"w1_q": w1_q, "w2_q": w2_q, "quant_scales": quant_scales}
+
+
+def _routing(num_tokens, num_experts, top_k, device):
+    logits = torch.randn(num_tokens, num_experts, device=device)
+    weights = F.softmax(logits, dim=1, dtype=torch.float)
+    weights, ids = torch.topk(weights, top_k, dim=-1)
+    weights = (weights / weights.sum(dim=-1, keepdim=True)).float()
+    return weights, ids.to(torch.int32)
+
+
+def _run(moe, x, b12x_weights, num_experts, top_k, device):
+    weights, ids = _routing(x.size(0), num_experts, top_k, device)
+    return moe.run(
+        x=x,
+        w1_weight=b12x_weights["w1_weight"],
+        w1_weight_sf=b12x_weights["w1_weight_sf"],
+        w1_alpha=b12x_weights["w1_alpha"],
+        fc2_input_scale=b12x_weights["fc2_input_scale"],
+        w2_weight=b12x_weights["w2_weight"],
+        w2_weight_sf=b12x_weights["w2_weight_sf"],
+        w2_alpha=b12x_weights["w2_alpha"],
+        token_selected_experts=ids,
+        token_final_scales=weights,
+    )
+
+
+# Realistic-but-small Nemotron-Super-shaped config: ReLU2 (non-gated), small E.
+_CFG = dict(
+    num_experts=8,
+    num_local_experts=8,
+    top_k=2,
+    hidden=2048,
+    intermediate=1024,
+    is_gated=False,
+)
+_ACTIVATION = "relu2"
+
+
+@pytest.fixture(scope="module")
+def setup():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if not _is_sm12x_supported():
+        pytest.skip("SM120/SM121 required")
+    if not _cuda_13_or_newer():
+        pytest.skip("CUDA 13+ required")
+
+    device = torch.device("cuda")
+    return {
+        "device": device,
+        "b12x": _make_b12x_weights(device=device, **_CFG),
+        "cutlass": _make_cutlass_weights(
+            num_experts=_CFG["num_experts"],
+            hidden=_CFG["hidden"],
+            intermediate=_CFG["intermediate"],
+            is_gated=_CFG["is_gated"],
+            device=device,
+        ),
+    }
+
+
+def _spy_cutlass(monkeypatch):
+    """Replace cutlass_fused_moe with a counting spy that delegates to the real impl."""
+    import flashinfer.fused_moe.core as core
+
+    real = core.cutlass_fused_moe
+    calls = {"n": 0}
+
+    def spy(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr("flashinfer.fused_moe.core.cutlass_fused_moe", spy)
+    return calls
+
+
+def _build_wrapper(*, threshold: int) -> B12xMoEWrapper:
+    return B12xMoEWrapper(
+        num_experts=_CFG["num_experts"],
+        top_k=_CFG["top_k"],
+        hidden_size=_CFG["hidden"],
+        intermediate_size=_CFG["intermediate"],
+        num_local_experts=_CFG["num_local_experts"],
+        activation=_ACTIVATION,
+        use_cuda_graph=False,
+        cutlass_prefill_threshold=threshold,
+    )
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_threshold_zero_disables_hybrid(setup, monkeypatch):
+    """Default threshold=0 → cutlass_fused_moe is never called for any m."""
+    moe = _build_wrapper(threshold=0)
+    calls = _spy_cutlass(monkeypatch)
+
+    for m in (1, 32, 256):
+        x = (
+            torch.randn(m, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
+            / 10
+        )
+        out = _run(
+            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
+        )
+        assert out.shape == (m, _CFG["hidden"])
+        assert out.dtype == torch.bfloat16
+    assert calls["n"] == 0
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_decode_below_threshold_uses_b12x(setup, monkeypatch):
+    """num_tokens < threshold → b12x kernels run, cutlass_fused_moe is not called."""
+    moe = _build_wrapper(threshold=64)
+    moe.register_cutlass_prefill_weights(**setup["cutlass"])
+    calls = _spy_cutlass(monkeypatch)
+
+    for m in (1, 4, 32, 63):
+        x = (
+            torch.randn(m, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
+            / 10
+        )
+        out = _run(
+            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
+        )
+        assert out.shape == (m, _CFG["hidden"])
+        assert torch.isfinite(out).all()
+    assert calls["n"] == 0
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_prefill_above_threshold_uses_cutlass(setup, monkeypatch):
+    """num_tokens >= threshold → cutlass_fused_moe is invoked once per call."""
+    moe = _build_wrapper(threshold=64)
+    moe.register_cutlass_prefill_weights(**setup["cutlass"])
+    calls = _spy_cutlass(monkeypatch)
+
+    sizes = (64, 128, 256)
+    for m in sizes:
+        x = (
+            torch.randn(m, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
+            / 10
+        )
+        out = _run(
+            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
+        )
+        assert out.shape == (m, _CFG["hidden"])
+        assert torch.isfinite(out).all()
+    assert calls["n"] == len(sizes)
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_prefill_without_registered_weights_raises(setup):
+    """Threshold > 0 + prefill call without registered cutlass weights → RuntimeError."""
+    moe = _build_wrapper(threshold=64)
+    # Intentionally do NOT call register_cutlass_prefill_weights.
+
+    x = (
+        torch.randn(64, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
+        / 10
+    )
+    with pytest.raises(RuntimeError, match="register_cutlass_prefill_weights"):
+        _run(
+            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
+        )
+
+    # Decode call must still work even without cutlass weights registered.
+    x_dec = (
+        torch.randn(1, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"]) / 10
+    )
+    out = _run(
+        moe, x_dec, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
+    )
+    assert out.shape == (1, _CFG["hidden"])
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_env_var_overrides_kwarg(setup, monkeypatch):
+    """FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD takes precedence over the kwarg."""
+    monkeypatch.setenv("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", "32")
+    moe = _build_wrapper(threshold=0)  # would be disabled without the env override
+    assert moe.cutlass_prefill_threshold == 32
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_invalid_env_var_falls_back_to_kwarg(setup, monkeypatch):
+    """Non-integer env var is ignored (the kwarg value is kept)."""
+    monkeypatch.setenv("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", "garbage")
+    moe = _build_wrapper(threshold=16)
+    assert moe.cutlass_prefill_threshold == 16

--- a/tests/moe/test_b12x_cutlass_hybrid.py
+++ b/tests/moe/test_b12x_cutlass_hybrid.py
@@ -1,29 +1,18 @@
-"""
-Tests for the hybrid CUTLASS-prefill / b12x-decode dispatch in
-``B12xMoEWrapper`` (the ``cutlass_prefill_threshold`` knob).
+"""Tests for hybrid CUTLASS-prefill / b12x-decode dispatch.
 
-Verifies:
-  - Default ``cutlass_prefill_threshold=0`` keeps pure b12x behavior.
-  - Threshold > 0: ``num_tokens < threshold`` routes to b12x;
-    ``num_tokens >= threshold`` routes to ``cutlass_fused_moe``.
-  - Calling without registered cutlass weights raises a clear error.
-  - ``FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD`` overrides the kwarg.
-  - Both paths produce bf16 output of the expected shape.
-
-The dispatch decision is verified by monkey-patching
-``flashinfer.fused_moe.core.cutlass_fused_moe`` with a counting spy — the
-underlying b12x kernels still run (or not) for real, so the tests also
-cover the wiring end-to-end.
+The tests exercise dispatch at the threshold, verify numerical parity between
+the two physical FP4 weight layouts, and confirm CUTLASS's BF16-input NVFP4
+quantization convention.
 """
 
 import pytest
 import torch
 from torch.nn import functional as F
 
-from flashinfer import B12xMoEWrapper
+from flashinfer import ActivationType, B12xMoEWrapper, cutlass_fused_moe
 from flashinfer.cute_dsl import is_cute_dsl_available
-from flashinfer.fp4_quantization import fp4_quantize
 from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+from flashinfer.fp4_quantization import fp4_quantize
 
 
 SF_VEC_SIZE = 16
@@ -32,6 +21,7 @@ FLOAT4_E2M1_MAX = 6.0
 
 
 def _is_sm12x_supported() -> bool:
+    """Return whether the active CUDA device supports b12x kernels."""
     if not torch.cuda.is_available():
         return False
     from flashinfer.utils import is_sm120a_supported, is_sm121a_supported
@@ -41,6 +31,7 @@ def _is_sm12x_supported() -> bool:
 
 
 def _cuda_13_or_newer() -> bool:
+    """Return whether FlashInfer is using CUDA 13 or newer."""
     try:
         from flashinfer.jit.cpp_ext import get_cuda_version
 
@@ -61,33 +52,36 @@ cuda_13_required = pytest.mark.skipif(
 
 
 def _round_up(x: int, y: int) -> int:
+    """Round ``x`` up to a multiple of ``y``."""
     return (x + y - 1) // y * y
 
 
-def _make_b12x_weights(
-    *, num_experts, hidden, intermediate, is_gated, device, seed=0
-):
-    """B12x-format NVFP4 weights (non-interleaved gate/up, MMA-swizzled SF)."""
+def _make_bf16_weights(*, num_experts, hidden, intermediate, is_gated, device, seed=0):
+    """Create one BF16 baseline shared by both FP4 physical layouts."""
     torch.manual_seed(seed)
     w1_rows = (2 if is_gated else 1) * intermediate
-
     w1_bf16 = (
-        torch.randn(
-            num_experts, w1_rows, hidden, dtype=torch.bfloat16, device=device
-        )
+        torch.randn(num_experts, w1_rows, hidden, dtype=torch.bfloat16, device=device)
         / 10
-    )
+    ).contiguous()
     w2_bf16 = (
         torch.randn(
             num_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
         )
         / 10
-    )
+    ).contiguous()
+    return w1_bf16, w2_bf16
 
-    w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+
+def _make_b12x_weights(w1_bf16, w2_bf16):
+    """Pack a shared BF16 baseline into b12x's MMA scale-factor layout."""
+    num_experts, w1_rows, hidden = w1_bf16.shape
+    intermediate = w2_bf16.shape[2]
+    global_scale = torch.ones((), device=w1_bf16.device, dtype=torch.float32)
+
     w1_q_flat, w1_sf_flat = fp4_quantize(
         w1_bf16.view(num_experts * w1_rows, hidden),
-        global_scale=w1_gs,
+        global_scale=global_scale,
         sf_vec_size=SF_VEC_SIZE,
         is_sf_swizzled_layout=True,
     )
@@ -100,10 +94,9 @@ def _make_b12x_weights(
         sf_vec_size=SF_VEC_SIZE,
     )
 
-    w2_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
     w2_q_flat, w2_sf_flat = fp4_quantize(
         w2_bf16.view(num_experts * hidden, intermediate),
-        global_scale=w2_gs,
+        global_scale=global_scale,
         sf_vec_size=SF_VEC_SIZE,
         is_sf_swizzled_layout=True,
     )
@@ -119,44 +112,32 @@ def _make_b12x_weights(
     return {
         "w1_weight": w1_q,
         "w1_weight_sf": w1_sf,
-        "w1_alpha": torch.ones(num_experts, device=device, dtype=torch.float32),
+        "w1_alpha": torch.ones(num_experts, device=w1_bf16.device, dtype=torch.float32),
         "w2_weight": w2_q,
         "w2_weight_sf": w2_sf,
-        "w2_alpha": torch.ones(num_experts, device=device, dtype=torch.float32),
-        "fc2_input_scale": torch.tensor([1.0], device=device, dtype=torch.float32),
+        "w2_alpha": torch.ones(num_experts, device=w1_bf16.device, dtype=torch.float32),
+        "fc2_input_scale": global_scale.reshape(1),
     }
 
 
-def _make_cutlass_weights(
-    *, num_experts, hidden, intermediate, is_gated, device, seed=1
-):
-    """CUTLASS NVFP4-format weights (per-expert global scales + blockscale tensors)."""
-    torch.manual_seed(seed)
-    w1_n = (2 if is_gated else 1) * intermediate
-
-    w1_bf16 = (
-        torch.randn(
-            num_experts, w1_n, hidden, dtype=torch.bfloat16, device=device
-        )
-        / 10
-    ).contiguous()
-    w2_bf16 = (
-        torch.randn(
-            num_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
-        )
-        / 10
-    ).contiguous()
+def _make_cutlass_weights(w1_bf16, w2_bf16):
+    """Pack the shared BF16 baseline into CUTLASS's NVFP4 layout."""
+    num_experts, w1_rows, hidden = w1_bf16.shape
+    intermediate = w2_bf16.shape[2]
+    device = w1_bf16.device
 
     w1_q = torch.empty(
-        (num_experts, w1_n, hidden // 2), device=device, dtype=torch.uint8
+        (num_experts, w1_rows, hidden // 2), device=device, dtype=torch.uint8
     )
     w2_q = torch.empty(
-        (num_experts, hidden, intermediate // 2), device=device, dtype=torch.uint8
+        (num_experts, hidden, intermediate // 2),
+        device=device,
+        dtype=torch.uint8,
     )
     w1_blockscale = torch.empty(
         (
             num_experts,
-            _round_up(w1_n, 128),
+            _round_up(w1_rows, 128),
             _round_up(hidden // SF_VEC_SIZE, 4),
         ),
         device=device,
@@ -171,16 +152,22 @@ def _make_cutlass_weights(
         device=device,
         dtype=torch.float8_e4m3fn,
     )
-    w1_gs = torch.empty((num_experts,), device=device, dtype=torch.float32)
-    w2_gs = torch.empty((num_experts,), device=device, dtype=torch.float32)
+    w1_gs = torch.empty(num_experts, device=device, dtype=torch.float32)
+    w2_gs = torch.empty(num_experts, device=device, dtype=torch.float32)
 
-    for ex in range(num_experts):
-        w1_amax = torch.abs(w1_bf16[ex]).max().to(torch.float32)
-        w2_amax = torch.abs(w2_bf16[ex]).max().to(torch.float32)
-        w1_gs[ex] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w1_amax
-        w2_gs[ex] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w2_amax
-        w1_q[ex], w1_blockscale[ex] = fp4_quantize(w1_bf16[ex], w1_gs[ex])
-        w2_q[ex], w2_blockscale[ex] = fp4_quantize(w2_bf16[ex], w2_gs[ex])
+    for expert in range(num_experts):
+        w1_gs[expert] = (
+            FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w1_bf16[expert].abs().max().float()
+        )
+        w2_gs[expert] = (
+            FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w2_bf16[expert].abs().max().float()
+        )
+        w1_q[expert], w1_blockscale[expert] = fp4_quantize(
+            w1_bf16[expert], w1_gs[expert]
+        )
+        w2_q[expert], w2_blockscale[expert] = fp4_quantize(
+            w2_bf16[expert], w2_gs[expert]
+        )
 
     a1_gs = torch.ones((), device=device, dtype=torch.float32)
     a2_gs = torch.ones((), device=device, dtype=torch.float32)
@@ -192,10 +179,16 @@ def _make_cutlass_weights(
         w2_blockscale.view(torch.int32),
         1.0 / (a2_gs * w2_gs),
     ]
-    return {"w1_q": w1_q, "w2_q": w2_q, "quant_scales": quant_scales}
+    return {
+        "w1_q": w1_q,
+        "w2_q": w2_q,
+        "quant_scales": quant_scales,
+        "a1_gs": a1_gs,
+    }
 
 
 def _routing(num_tokens, num_experts, top_k, device):
+    """Create normalized top-k routing weights and int32 expert IDs."""
     logits = torch.randn(num_tokens, num_experts, device=device)
     weights = F.softmax(logits, dim=1, dtype=torch.float)
     weights, ids = torch.topk(weights, top_k, dim=-1)
@@ -203,8 +196,11 @@ def _routing(num_tokens, num_experts, top_k, device):
     return weights, ids.to(torch.int32)
 
 
-def _run(moe, x, b12x_weights, num_experts, top_k, device):
-    weights, ids = _routing(x.size(0), num_experts, top_k, device)
+def _run(moe, x, b12x_weights, routing=None):
+    """Run a wrapper with shared b12x weights and optionally fixed routing."""
+    if routing is None:
+        routing = _routing(x.size(0), _CFG["num_experts"], _CFG["top_k"], x.device)
+    weights, ids = routing
     return moe.run(
         x=x,
         w1_weight=b12x_weights["w1_weight"],
@@ -219,19 +215,36 @@ def _run(moe, x, b12x_weights, num_experts, top_k, device):
     )
 
 
+def _assert_moe_close(actual, expected, percent_threshold=0.97):
+    """Apply the percentage-based FP4 tolerance used by b12x accuracy tests."""
+    actual = actual.float()
+    expected = expected.float()
+    output_scale = max(expected.std().item(), 0.01)
+    atol = max(0.05, 1.5 * output_scale)
+    abs_diff = torch.abs(actual - expected)
+    rel_diff = abs_diff / (torch.abs(expected) + 1e-8)
+    percent_within = ((abs_diff < atol) | (rel_diff < 0.5)).float().mean().item()
+    assert percent_within >= percent_threshold, (
+        f"only {percent_within:.2%} of values are within FP4 tolerance "
+        f"(required {percent_threshold:.2%}, atol={atol:.5f})"
+    )
+
+
 # Realistic-but-small Nemotron-Super-shaped config: ReLU2 (non-gated), small E.
-_CFG = dict(
-    num_experts=8,
-    top_k=2,
-    hidden=2048,
-    intermediate=1024,
-    is_gated=False,
-)
+_CFG = {
+    "num_experts": 8,
+    "top_k": 2,
+    "hidden": 2048,
+    "intermediate": 1024,
+    "is_gated": False,
+}
 _ACTIVATION = "relu2"
+_UNSET = object()
 
 
 @pytest.fixture(scope="module")
 def setup():
+    """Build matching b12x and CUTLASS weights on a supported device."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
     if not _is_sm12x_supported():
@@ -240,27 +253,23 @@ def setup():
         pytest.skip("CUDA 13+ required")
 
     device = torch.device("cuda")
-    return {
-        "device": device,
-        "b12x": _make_b12x_weights(
-            num_experts=_CFG["num_experts"],
-            hidden=_CFG["hidden"],
-            intermediate=_CFG["intermediate"],
-            is_gated=_CFG["is_gated"],
-            device=device,
-        ),
-        "cutlass": _make_cutlass_weights(
-            num_experts=_CFG["num_experts"],
-            hidden=_CFG["hidden"],
-            intermediate=_CFG["intermediate"],
-            is_gated=_CFG["is_gated"],
-            device=device,
-        ),
-    }
+    baseline = _make_bf16_weights(
+        num_experts=_CFG["num_experts"],
+        hidden=_CFG["hidden"],
+        intermediate=_CFG["intermediate"],
+        is_gated=_CFG["is_gated"],
+        device=device,
+    )
+    b12x = _make_b12x_weights(*baseline)
+    cutlass = _make_cutlass_weights(*baseline)
+
+    # Both native packers consume the exact same BF16 baseline. Their E4M3
+    # scale normalization differs, so the packed FP4 bytes need not be equal.
+    return {"device": device, "b12x": b12x, "cutlass": cutlass}
 
 
 def _spy_cutlass(monkeypatch):
-    """Replace cutlass_fused_moe with a counting spy that delegates to the real impl."""
+    """Replace CUTLASS MoE with a counting spy that delegates to the kernel."""
     import flashinfer.fused_moe.core as core
 
     real = core.cutlass_fused_moe
@@ -274,34 +283,56 @@ def _spy_cutlass(monkeypatch):
     return calls
 
 
-def _build_wrapper(*, threshold: int) -> B12xMoEWrapper:
+def _register_cutlass(moe, weights):
+    """Register only the three tensors accepted by the public wrapper API."""
+    moe.register_cutlass_prefill_weights(
+        w1_q=weights["w1_q"],
+        w2_q=weights["w2_q"],
+        quant_scales=weights["quant_scales"],
+    )
+
+
+def _build_wrapper(
+    *,
+    threshold=_UNSET,
+    activation=_ACTIVATION,
+    quant_mode=None,
+    swiglu_limit=None,
+):
+    """Build a wrapper while preserving omitted-threshold semantics."""
+    kwargs = {}
+    if threshold is not _UNSET:
+        kwargs["cutlass_prefill_threshold"] = threshold
+    if quant_mode is not None:
+        kwargs["quant_mode"] = quant_mode
     return B12xMoEWrapper(
         num_experts=_CFG["num_experts"],
         top_k=_CFG["top_k"],
         hidden_size=_CFG["hidden"],
         intermediate_size=_CFG["intermediate"],
-        activation=_ACTIVATION,
+        activation=activation,
+        swiglu_limit=swiglu_limit,
         use_cuda_graph=False,
-        cutlass_prefill_threshold=threshold,
+        **kwargs,
     )
 
 
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-def test_threshold_zero_disables_hybrid(setup, monkeypatch):
-    """Default threshold=0 → cutlass_fused_moe is never called for any m."""
-    moe = _build_wrapper(threshold=0)
+def test_default_threshold_disables_hybrid(setup, monkeypatch):
+    """An omitted threshold defaults to pure b12x behavior."""
+    monkeypatch.delenv("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", raising=False)
+    moe = _build_wrapper()
     calls = _spy_cutlass(monkeypatch)
+    assert moe.cutlass_prefill_threshold == 0
 
     for m in (1, 32, 256):
         x = (
             torch.randn(m, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
             / 10
         )
-        out = _run(
-            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
-        )
+        out = _run(moe, x, setup["b12x"])
         assert out.shape == (m, _CFG["hidden"])
         assert out.dtype == torch.bfloat16
     assert calls["n"] == 0
@@ -311,9 +342,9 @@ def test_threshold_zero_disables_hybrid(setup, monkeypatch):
 @sm120_required
 @cuda_13_required
 def test_decode_below_threshold_uses_b12x(setup, monkeypatch):
-    """num_tokens < threshold → b12x kernels run, cutlass_fused_moe is not called."""
+    """Token counts below the threshold stay on b12x."""
     moe = _build_wrapper(threshold=64)
-    moe.register_cutlass_prefill_weights(**setup["cutlass"])
+    _register_cutlass(moe, setup["cutlass"])
     calls = _spy_cutlass(monkeypatch)
 
     for m in (1, 4, 32, 63):
@@ -321,9 +352,7 @@ def test_decode_below_threshold_uses_b12x(setup, monkeypatch):
             torch.randn(m, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
             / 10
         )
-        out = _run(
-            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
-        )
+        out = _run(moe, x, setup["b12x"])
         assert out.shape == (m, _CFG["hidden"])
         assert torch.isfinite(out).all()
     assert calls["n"] == 0
@@ -332,10 +361,10 @@ def test_decode_below_threshold_uses_b12x(setup, monkeypatch):
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-def test_prefill_above_threshold_uses_cutlass(setup, monkeypatch):
-    """num_tokens >= threshold → cutlass_fused_moe is invoked once per call."""
+def test_prefill_at_or_above_threshold_uses_cutlass(setup, monkeypatch):
+    """Token counts at or above the threshold run CUTLASS once per call."""
     moe = _build_wrapper(threshold=64)
-    moe.register_cutlass_prefill_weights(**setup["cutlass"])
+    _register_cutlass(moe, setup["cutlass"])
     calls = _spy_cutlass(monkeypatch)
 
     sizes = (64, 128, 256)
@@ -344,9 +373,7 @@ def test_prefill_above_threshold_uses_cutlass(setup, monkeypatch):
             torch.randn(m, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
             / 10
         )
-        out = _run(
-            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
-        )
+        out = _run(moe, x, setup["b12x"])
         assert out.shape == (m, _CFG["hidden"])
         assert torch.isfinite(out).all()
     assert calls["n"] == len(sizes)
@@ -356,44 +383,199 @@ def test_prefill_above_threshold_uses_cutlass(setup, monkeypatch):
 @sm120_required
 @cuda_13_required
 def test_prefill_without_registered_weights_raises(setup):
-    """Threshold > 0 + prefill call without registered cutlass weights → RuntimeError."""
+    """Hybrid prefill requires separately registered CUTLASS weights."""
     moe = _build_wrapper(threshold=64)
-    # Intentionally do NOT call register_cutlass_prefill_weights.
-
     x = (
         torch.randn(64, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
         / 10
     )
     with pytest.raises(RuntimeError, match="register_cutlass_prefill_weights"):
-        _run(
-            moe, x, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
+        _run(moe, x, setup["b12x"])
+
+    x_decode = (
+        torch.randn(1, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"])
+        / 10
+    )
+    assert _run(moe, x_decode, setup["b12x"]).shape == (1, _CFG["hidden"])
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_hybrid_matches_pure_b12x_at_threshold(setup):
+    """Hybrid CUTLASS output matches pure b12x at the dispatch boundary."""
+    threshold = 64
+    torch.manual_seed(123)
+    x = (
+        torch.randn(
+            threshold,
+            _CFG["hidden"],
+            dtype=torch.bfloat16,
+            device=setup["device"],
+        )
+        / 10
+    )
+    routing = _routing(threshold, _CFG["num_experts"], _CFG["top_k"], setup["device"])
+
+    pure_b12x = _build_wrapper(threshold=0)
+    hybrid = _build_wrapper(threshold=threshold)
+    _register_cutlass(hybrid, setup["cutlass"])
+
+    expected = _run(pure_b12x, x, setup["b12x"], routing)
+    actual = _run(hybrid, x, setup["b12x"], routing)
+    # The backends independently round their native E4M3 scale conventions;
+    # use a slightly lower percentage than single-backend reference tests.
+    _assert_moe_close(actual, expected, percent_threshold=0.95)
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_cutlass_bf16_input_matches_explicit_fp4_quantization(setup):
+    """BF16 input with no input_sf matches explicit NVFP4 input quantization."""
+    num_tokens = 64
+    torch.manual_seed(321)
+    x_bf16 = (
+        torch.randn(
+            num_tokens,
+            _CFG["hidden"],
+            dtype=torch.bfloat16,
+            device=setup["device"],
+        )
+        / 10
+    )
+    routing_weights, selected_experts = _routing(
+        num_tokens, _CFG["num_experts"], _CFG["top_k"], setup["device"]
+    )
+    x_fp4, x_sf = fp4_quantize(x_bf16, setup["cutlass"]["a1_gs"])
+    w1 = setup["cutlass"]["w1_q"].contiguous().view(torch.long)
+    w2 = setup["cutlass"]["w2_q"].contiguous().view(torch.long)
+    bf16_output = torch.empty_like(x_bf16)
+    fp4_output = torch.empty_like(x_bf16)
+
+    common = {
+        "token_selected_experts": selected_experts,
+        "token_final_scales": routing_weights,
+        "fc1_expert_weights": w1,
+        "fc2_expert_weights": w2,
+        "output_dtype": torch.bfloat16,
+        "quant_scales": setup["cutlass"]["quant_scales"],
+        "activation_type": ActivationType.Relu2,
+    }
+    cutlass_fused_moe(
+        input=x_bf16,
+        input_sf=None,
+        output=bf16_output,
+        **common,
+    )
+    cutlass_fused_moe(
+        input=x_fp4,
+        input_sf=x_sf,
+        output=fp4_output,
+        **common,
+    )
+    _assert_moe_close(bf16_output, fp4_output)
+
+
+@pytest.mark.parametrize(
+    ("activation", "expected"),
+    [
+        ("silu", ActivationType.Swiglu),
+        ("gelu_tanh", ActivationType.GegluTanh),
+        ("swigluoai_uninterleave", ActivationType.Swiglu),
+        ("relu2", ActivationType.Relu2),
+    ],
+)
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_cutlass_activation_mapping(setup, monkeypatch, activation, expected):
+    """Every current B12x activation maps explicitly to CUTLASS."""
+    import flashinfer.fused_moe.core as core
+
+    captured = {}
+
+    def fake_cutlass(**kwargs):
+        captured.update(kwargs)
+        return [kwargs["output"]]
+
+    monkeypatch.setattr(core, "cutlass_fused_moe", fake_cutlass)
+    limit = 7.0 if activation == "swigluoai_uninterleave" else None
+    moe = _build_wrapper(threshold=1, activation=activation, swiglu_limit=limit)
+    _register_cutlass(moe, setup["cutlass"])
+    routing_weights, selected_experts = _routing(
+        1, _CFG["num_experts"], _CFG["top_k"], setup["device"]
+    )
+    output = torch.empty(
+        1, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"]
+    )
+    result = moe._run_cutlass_prefill(
+        x=torch.zeros_like(output),
+        token_selected_experts=selected_experts,
+        token_final_scales=routing_weights,
+        output=output,
+    )
+
+    assert result is output
+    assert captured["activation_type"] == expected
+    if activation == "swigluoai_uninterleave":
+        assert torch.all(captured["swiglu_alpha"] == moe.swiglu_alpha)
+        assert torch.all(captured["swiglu_beta"] == moe.swiglu_beta)
+        assert torch.all(captured["swiglu_limit"] == moe.swiglu_limit)
+    else:
+        assert captured["swiglu_alpha"] is None
+        assert captured["swiglu_beta"] is None
+        assert captured["swiglu_limit"] is None
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_unsupported_cutlass_activation_raises(setup):
+    """Hybrid dispatch never silently falls through to another activation."""
+    moe = _build_wrapper(threshold=1, activation="unsupported")
+    _register_cutlass(moe, setup["cutlass"])
+    routing_weights, selected_experts = _routing(
+        1, _CFG["num_experts"], _CFG["top_k"], setup["device"]
+    )
+    output = torch.empty(
+        1, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"]
+    )
+    with pytest.raises(ValueError, match="does not support activation"):
+        moe._run_cutlass_prefill(
+            x=torch.zeros_like(output),
+            token_selected_experts=selected_experts,
+            token_final_scales=routing_weights,
+            output=output,
         )
 
-    # Decode call must still work even without cutlass weights registered.
-    x_dec = (
-        torch.randn(1, _CFG["hidden"], dtype=torch.bfloat16, device=setup["device"]) / 10
-    )
-    out = _run(
-        moe, x_dec, setup["b12x"], _CFG["num_experts"], _CFG["top_k"], setup["device"]
-    )
-    assert out.shape == (1, _CFG["hidden"])
-
 
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-def test_env_var_overrides_kwarg(setup, monkeypatch):
-    """FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD takes precedence over the kwarg."""
+def test_env_var_is_used_only_when_threshold_is_omitted(monkeypatch):
+    """The environment supplies the threshold only when the kwarg is omitted."""
     monkeypatch.setenv("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", "32")
-    moe = _build_wrapper(threshold=0)  # would be disabled without the env override
-    assert moe.cutlass_prefill_threshold == 32
+    assert _build_wrapper().cutlass_prefill_threshold == 32
+    assert _build_wrapper(threshold=0).cutlass_prefill_threshold == 0
+    assert _build_wrapper(threshold=16).cutlass_prefill_threshold == 16
 
 
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-def test_invalid_env_var_falls_back_to_kwarg(setup, monkeypatch):
-    """Non-integer env var is ignored (the kwarg value is kept)."""
+def test_invalid_env_var_uses_effective_default(monkeypatch):
+    """An invalid environment value leaves the effective default at zero."""
     monkeypatch.setenv("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", "garbage")
-    moe = _build_wrapper(threshold=16)
-    assert moe.cutlass_prefill_threshold == 16
+    assert _build_wrapper().cutlass_prefill_threshold == 0
+    assert _build_wrapper(threshold=16).cutlass_prefill_threshold == 16
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_hybrid_dispatch_rejects_w4a16(monkeypatch):
+    """Hybrid CUTLASS dispatch is restricted to NVFP4 weights."""
+    monkeypatch.delenv("FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", raising=False)
+    with pytest.raises(NotImplementedError, match="supports only.*nvfp4"):
+        _build_wrapper(threshold=1, quant_mode="w4a16")

--- a/tests/moe/test_b12x_cutlass_hybrid.py
+++ b/tests/moe/test_b12x_cutlass_hybrid.py
@@ -16,8 +16,6 @@ from flashinfer.fp4_quantization import fp4_quantize
 
 
 SF_VEC_SIZE = 16
-FLOAT8_E4M3_MAX = 448.0
-FLOAT4_E2M1_MAX = 6.0
 
 
 def _is_sm12x_supported() -> bool:
@@ -73,117 +71,89 @@ def _make_bf16_weights(*, num_experts, hidden, intermediate, is_gated, device, s
     return w1_bf16, w2_bf16
 
 
-def _make_b12x_weights(w1_bf16, w2_bf16):
-    """Pack a shared BF16 baseline into b12x's MMA scale-factor layout."""
-    num_experts, w1_rows, hidden = w1_bf16.shape
-    intermediate = w2_bf16.shape[2]
-    global_scale = torch.ones((), device=w1_bf16.device, dtype=torch.float32)
+def _make_matching_fp4_weights(w1_bf16, w2_bf16):
+    """Build both backend views from one quantization of each BF16 weight.
 
-    w1_q_flat, w1_sf_flat = fp4_quantize(
-        w1_bf16.view(num_experts * w1_rows, hidden),
-        global_scale=global_scale,
-        sf_vec_size=SF_VEC_SIZE,
-        is_sf_swizzled_layout=True,
-    )
-    w1_q = w1_q_flat.view(num_experts, w1_rows, hidden // 2)
-    w1_sf = convert_sf_to_mma_layout(
-        w1_sf_flat,
-        m=w1_rows,
-        k=hidden,
-        num_groups=num_experts,
-        sf_vec_size=SF_VEC_SIZE,
-    )
-
-    w2_q_flat, w2_sf_flat = fp4_quantize(
-        w2_bf16.view(num_experts * hidden, intermediate),
-        global_scale=global_scale,
-        sf_vec_size=SF_VEC_SIZE,
-        is_sf_swizzled_layout=True,
-    )
-    w2_q = w2_q_flat.view(num_experts, hidden, intermediate // 2)
-    w2_sf = convert_sf_to_mma_layout(
-        w2_sf_flat,
-        m=hidden,
-        k=intermediate,
-        num_groups=num_experts,
-        sf_vec_size=SF_VEC_SIZE,
-    )
-
-    return {
-        "w1_weight": w1_q,
-        "w1_weight_sf": w1_sf,
-        "w1_alpha": torch.ones(num_experts, device=w1_bf16.device, dtype=torch.float32),
-        "w2_weight": w2_q,
-        "w2_weight_sf": w2_sf,
-        "w2_alpha": torch.ones(num_experts, device=w1_bf16.device, dtype=torch.float32),
-        "fc2_input_scale": global_scale.reshape(1),
-    }
-
-
-def _make_cutlass_weights(w1_bf16, w2_bf16):
-    """Pack the shared BF16 baseline into CUTLASS's NVFP4 layout."""
+    The packed FP4 values and E4M3 scale-factor samples are shared. CUTLASS
+    consumes the normalized 2D SF storage directly, while b12x consumes an MMA
+    view of that same storage. Non-unit activation global scales make this
+    fixture sensitive to accidentally folding an activation scale into the
+    b12x weight scales.
+    """
     num_experts, w1_rows, hidden = w1_bf16.shape
     intermediate = w2_bf16.shape[2]
     device = w1_bf16.device
 
-    w1_q = torch.empty(
-        (num_experts, w1_rows, hidden // 2), device=device, dtype=torch.uint8
+    weight_gs = torch.ones((), device=device, dtype=torch.float32)
+    w1_q_flat, w1_sf_flat = fp4_quantize(
+        w1_bf16.view(num_experts * w1_rows, hidden),
+        global_scale=weight_gs,
+        sf_vec_size=SF_VEC_SIZE,
+        is_sf_swizzled_layout=True,
     )
-    w2_q = torch.empty(
-        (num_experts, hidden, intermediate // 2),
-        device=device,
-        dtype=torch.uint8,
+    w2_q_flat, w2_sf_flat = fp4_quantize(
+        w2_bf16.view(num_experts * hidden, intermediate),
+        global_scale=weight_gs,
+        sf_vec_size=SF_VEC_SIZE,
+        is_sf_swizzled_layout=True,
     )
-    w1_blockscale = torch.empty(
-        (
-            num_experts,
-            _round_up(w1_rows, 128),
-            _round_up(hidden // SF_VEC_SIZE, 4),
-        ),
-        device=device,
-        dtype=torch.float8_e4m3fn,
+    w1_q = w1_q_flat.view(num_experts, w1_rows, hidden // 2)
+    w2_q = w2_q_flat.view(num_experts, hidden, intermediate // 2)
+    w1_blockscale = w1_sf_flat.view(
+        num_experts,
+        _round_up(w1_rows, 128),
+        _round_up(hidden // SF_VEC_SIZE, 4),
     )
-    w2_blockscale = torch.empty(
-        (
-            num_experts,
-            _round_up(hidden, 128),
-            _round_up(intermediate // SF_VEC_SIZE, 4),
-        ),
-        device=device,
-        dtype=torch.float8_e4m3fn,
+    w2_blockscale = w2_sf_flat.view(
+        num_experts,
+        _round_up(hidden, 128),
+        _round_up(intermediate // SF_VEC_SIZE, 4),
     )
-    w1_gs = torch.empty(num_experts, device=device, dtype=torch.float32)
-    w2_gs = torch.empty(num_experts, device=device, dtype=torch.float32)
 
-    for expert in range(num_experts):
-        w1_gs[expert] = (
-            FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w1_bf16[expert].abs().max().float()
-        )
-        w2_gs[expert] = (
-            FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w2_bf16[expert].abs().max().float()
-        )
-        w1_q[expert], w1_blockscale[expert] = fp4_quantize(
-            w1_bf16[expert], w1_gs[expert]
-        )
-        w2_q[expert], w2_blockscale[expert] = fp4_quantize(
-            w2_bf16[expert], w2_gs[expert]
-        )
-
-    a1_gs = torch.ones((), device=device, dtype=torch.float32)
-    a2_gs = torch.ones((), device=device, dtype=torch.float32)
-    quant_scales = [
-        a1_gs,
-        w1_blockscale.view(torch.int32),
-        1.0 / (a1_gs * w1_gs),
-        a2_gs,
-        w2_blockscale.view(torch.int32),
-        1.0 / (a2_gs * w2_gs),
-    ]
-    return {
+    # These are deliberately far from one. CUTLASS consumes the large global
+    # scales; b12x consumes their reciprocals (the small activation scales).
+    # Both kernels must cancel them in their respective quant/dequant paths.
+    a1_gs = torch.tensor(16.0, device=device, dtype=torch.float32)
+    a2_gs = torch.tensor(8.0, device=device, dtype=torch.float32)
+    w1_alpha = (1.0 / a1_gs).expand(num_experts).contiguous()
+    w2_alpha = (1.0 / a2_gs).expand(num_experts).contiguous()
+    b12x = {
+        "w1_weight": w1_q,
+        "w1_weight_sf": convert_sf_to_mma_layout(
+            w1_sf_flat,
+            m=w1_rows,
+            k=hidden,
+            num_groups=num_experts,
+            sf_vec_size=SF_VEC_SIZE,
+        ),
+        "w1_alpha": w1_alpha,
+        "w2_weight": w2_q,
+        "w2_weight_sf": convert_sf_to_mma_layout(
+            w2_sf_flat,
+            m=hidden,
+            k=intermediate,
+            num_groups=num_experts,
+            sf_vec_size=SF_VEC_SIZE,
+        ),
+        "w2_alpha": w2_alpha,
+        "fc2_input_scale": w2_alpha,
+    }
+    cutlass = {
         "w1_q": w1_q,
         "w2_q": w2_q,
-        "quant_scales": quant_scales,
+        "quant_scales": [
+            a1_gs,
+            w1_blockscale.view(torch.int32),
+            w1_alpha.clone(),
+            a2_gs,
+            w2_blockscale.view(torch.int32),
+            w2_alpha.clone(),
+        ],
         "a1_gs": a1_gs,
+    }
+    return {
+        "b12x": b12x,
+        "cutlass": cutlass,
     }
 
 
@@ -215,19 +185,51 @@ def _run(moe, x, b12x_weights, routing=None):
     )
 
 
-def _assert_moe_close(actual, expected, percent_threshold=0.97):
-    """Apply the percentage-based FP4 tolerance used by b12x accuracy tests."""
+def _run_cutlass(x, cutlass_weights, routing):
+    """Run standalone CUTLASS with the exact tensors registered by hybrid."""
+    weights, ids = routing
+    output = torch.empty_like(x)
+    cutlass_fused_moe(
+        input=x,
+        token_selected_experts=ids,
+        token_final_scales=weights,
+        fc1_expert_weights=cutlass_weights["w1_q"].contiguous().view(torch.long),
+        fc2_expert_weights=cutlass_weights["w2_q"].contiguous().view(torch.long),
+        output_dtype=torch.bfloat16,
+        quant_scales=cutlass_weights["quant_scales"],
+        input_sf=None,
+        output=output,
+        activation_type=ActivationType.Relu2,
+    )
+    return output
+
+
+def _assert_cross_backend_close(actual, expected):
+    """Require scale-sensitive agreement between independent FP4 kernels."""
     actual = actual.float()
     expected = expected.float()
-    output_scale = max(expected.std().item(), 0.01)
-    atol = max(0.05, 1.5 * output_scale)
-    abs_diff = torch.abs(actual - expected)
-    rel_diff = abs_diff / (torch.abs(expected) + 1e-8)
-    percent_within = ((abs_diff < atol) | (rel_diff < 0.5)).float().mean().item()
-    assert percent_within >= percent_threshold, (
-        f"only {percent_within:.2%} of values are within FP4 tolerance "
-        f"(required {percent_threshold:.2%}, atol={atol:.5f})"
+    assert torch.isfinite(actual).all()
+    assert torch.isfinite(expected).all()
+    reference_rms = expected.square().mean().sqrt().clamp_min(1e-6)
+    nrmse = ((actual - expected).square().mean().sqrt() / reference_rms).item()
+    cosine = F.cosine_similarity(actual.flatten(), expected.flatten(), dim=0).item()
+    assert nrmse < 0.05, (
+        f"normalized RMSE {nrmse:.5f} exceeds the FP4 parity limit 0.05"
     )
+    assert cosine > 0.999, (
+        f"cosine similarity {cosine:.6f} is below the FP4 parity limit 0.999"
+    )
+
+
+def _assert_b12x_repeatability(actual, expected):
+    """Bound atomic accumulation-order noise between two B12x launches."""
+    actual = actual.float()
+    expected = expected.float()
+    reference_rms = expected.square().mean().sqrt().clamp_min(1e-6)
+    nrmse = ((actual - expected).square().mean().sqrt() / reference_rms).item()
+    cosine = F.cosine_similarity(actual.flatten(), expected.flatten(), dim=0).item()
+    assert nrmse < 0.02, f"B12x repeatability NRMSE {nrmse:.6f} exceeds 0.02"
+    assert cosine > 0.9998, f"B12x repeatability cosine {cosine:.6f} is below 0.9998"
 
 
 # Realistic-but-small Nemotron-Super-shaped config: ReLU2 (non-gated), small E.
@@ -260,12 +262,13 @@ def setup():
         is_gated=_CFG["is_gated"],
         device=device,
     )
-    b12x = _make_b12x_weights(*baseline)
-    cutlass = _make_cutlass_weights(*baseline)
+    packed = _make_matching_fp4_weights(*baseline)
 
-    # Both native packers consume the exact same BF16 baseline. Their E4M3
-    # scale normalization differs, so the packed FP4 bytes need not be equal.
-    return {"device": device, "b12x": b12x, "cutlass": cutlass}
+    # The two paths consume identical packed FP4 bytes and identical E4M3 SF
+    # samples; only the required scale-factor view and alpha contract differ.
+    assert torch.equal(packed["b12x"]["w1_weight"], packed["cutlass"]["w1_q"])
+    assert torch.equal(packed["b12x"]["w2_weight"], packed["cutlass"]["w2_q"])
+    return {"device": device, **packed}
 
 
 def _spy_cutlass(monkeypatch):
@@ -399,33 +402,66 @@ def test_prefill_without_registered_weights_raises(setup):
     assert _run(moe, x_decode, setup["b12x"]).shape == (1, _CFG["hidden"])
 
 
+@pytest.mark.parametrize("num_tokens", [63, 64, 65])
 @cute_dsl_available
 @sm120_required
 @cuda_13_required
-def test_hybrid_matches_pure_b12x_at_threshold(setup):
-    """Hybrid CUTLASS output matches pure b12x at the dispatch boundary."""
+def test_hybrid_branch_matches_corresponding_standalone(setup, num_tokens):
+    """Each hybrid branch numerically matches its standalone backend."""
     threshold = 64
     torch.manual_seed(123)
     x = (
         torch.randn(
-            threshold,
+            num_tokens,
             _CFG["hidden"],
             dtype=torch.bfloat16,
             device=setup["device"],
         )
         / 10
     )
-    routing = _routing(threshold, _CFG["num_experts"], _CFG["top_k"], setup["device"])
+    routing = _routing(num_tokens, _CFG["num_experts"], _CFG["top_k"], setup["device"])
 
-    pure_b12x = _build_wrapper(threshold=0)
     hybrid = _build_wrapper(threshold=threshold)
     _register_cutlass(hybrid, setup["cutlass"])
-
-    expected = _run(pure_b12x, x, setup["b12x"], routing)
     actual = _run(hybrid, x, setup["b12x"], routing)
-    # The backends independently round their native E4M3 scale conventions;
-    # use a slightly lower percentage than single-backend reference tests.
-    _assert_moe_close(actual, expected, percent_threshold=0.95)
+
+    if num_tokens < threshold:
+        standalone = _build_wrapper(threshold=0)
+        expected = _run(standalone, x, setup["b12x"], routing)
+    else:
+        expected = _run_cutlass(x, setup["cutlass"], routing)
+
+    if num_tokens < threshold:
+        # B12x scatters top-k contributions with atomics; independent launches
+        # can differ by a small BF16 accumulation-order error.
+        _assert_b12x_repeatability(actual, expected)
+    else:
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+def test_cutlass_and_b12x_match_for_identical_quantized_weights(setup):
+    """Standalone kernels agree on one FP4 tensor with non-unit scales."""
+    num_tokens = 64
+    torch.manual_seed(456)
+    x = (
+        torch.randn(
+            num_tokens,
+            _CFG["hidden"],
+            dtype=torch.bfloat16,
+            device=setup["device"],
+        )
+        / 10
+    )
+    routing = _routing(num_tokens, _CFG["num_experts"], _CFG["top_k"], setup["device"])
+
+    b12x = _build_wrapper(threshold=0)
+    b12x_output = _run(b12x, x, setup["b12x"], routing)
+    cutlass_output = _run_cutlass(x, setup["cutlass"], routing)
+
+    _assert_cross_backend_close(cutlass_output, b12x_output)
 
 
 @cute_dsl_available
@@ -474,7 +510,7 @@ def test_cutlass_bf16_input_matches_explicit_fp4_quantization(setup):
         output=fp4_output,
         **common,
     )
-    _assert_moe_close(bf16_output, fp4_output)
+    torch.testing.assert_close(bf16_output, fp4_output, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable hybrid MoE dispatch in `B12xMoEWrapper`: prefill can route to a CUTLASS-based path and fall back to b12x decoding using a `cutlass_prefill_threshold` (or an environment-variable override) for NVFP4.
  * Added support for registering CUTLASS-format prefill weights (including activation-specific parameters when needed).

* **Benchmarks**
  * Added a token-sweep benchmark to compare B12x vs CUTLASS fused-MoE performance, with optional CSV output.

* **Tests**
  * Added CUDA/SM120/SM121-gated tests covering threshold behavior, weight registration requirements, environment-variable handling, activation mapping, and cross-backend numerical parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->