### PR TITLE
Support LSE buffers in TRTLLM API

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2572,8 +2572,9 @@ def trtllm_batch_decode_with_kv_cache(
     lse : Optional[torch.Tensor] = None
         Optional pre-allocated buffer for the Log-Sum-Exp (LSE) output, only supported
         by the ``trtllm-gen`` backend. Must have shape ``[num_tokens, num_qo_heads]``
-        and dtype ``torch.float32``. If ``return_lse`` is True and this is None, a
-        buffer will be allocated internally. Ignored when ``return_lse`` is False.
+        and dtype ``torch.float32``. If provided, the tensor is filled regardless of
+        :attr:`return_lse`. If ``return_lse`` is True and this is None, a buffer will
+        be allocated internally.
 
     return_lse : bool = False
         Whether to return the Log-Sum-Exp (LSE) values. Only supported by the
@@ -2788,18 +2789,16 @@ def trtllm_batch_decode_with_kv_cache(
         _check_block_tables_shape(block_tables, uses_shared_paged_kv_idx)
 
         num_qo_heads = query.size(1)
-        if return_lse:
-            lse_shape = (query.size(0), num_qo_heads)
-            if lse is None:
-                lse = torch.empty(lse_shape, dtype=torch.float32, device=query.device)
-            else:
-                check_shape_dtype_device(
-                    lse, lse_shape, torch.float32, query.device, "lse"
-                )
+        lse_shape = (query.size(0), num_qo_heads)
+        if lse is not None:
+            check_shape_dtype_device(lse, lse_shape, torch.float32, query.device, "lse")
+            lse_stride_tokens = lse.stride(0)
+            lse_stride_heads = lse.stride(1)
+        elif return_lse:
+            lse = torch.empty(lse_shape, dtype=torch.float32, device=query.device)
             lse_stride_tokens = lse.stride(0)
             lse_stride_heads = lse.stride(1)
         else:
-            lse = None
             lse_stride_tokens = 0
             lse_stride_heads = 0
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4137,8 +4137,9 @@ def trtllm_batch_context_with_kv_cache(
         ``window_left == -1``.
     lse : Optional[torch.Tensor] = None
         Optional pre-allocated buffer for Log-Sum-Exp values. Must have shape
-        ``[num_tokens, num_qo_heads]`` with dtype ``torch.float32``.
-        If ``return_lse`` is True and this is None, a buffer will be allocated.
+        ``[num_tokens, num_qo_heads]`` with dtype ``torch.float32``. If provided,
+        the tensor is filled regardless of :attr:`return_lse`. If ``return_lse`` is
+        True and this is None, a buffer will be allocated.
     return_lse : bool = False
         Whether to return Log-Sum-Exp values. When True, returns ``(out, lse)``.
     Returns

--- a/tests/attention/test_trtllm_gen_attention.py
+++ b/tests/attention/test_trtllm_gen_attention.py
@@ -645,6 +645,8 @@ def _test_trtllm_batch_prefill(
     non_contiguous_query: bool = False,
     skips_softmax: bool = False,
     uses_shared_paged_kv_idx: bool = True,
+    return_lse: bool | None = None,
+    provide_lse: bool = False,
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] != 10:
@@ -812,16 +814,25 @@ def _test_trtllm_batch_prefill(
         and kv_dtype != "nvfp4"
         and q_dtype != "fp8"
     )
+    if (return_lse or provide_lse) and not check_lse:
+        pytest.skip("LSE contract validation requires a reliable LSE reference")
+    effective_return_lse = check_lse if return_lse is None else return_lse
+    expects_lse = check_lse and (effective_return_lse or provide_lse)
 
     max_q_len_val = torch.max(q_lens).item()
-    if check_lse:
+    provided_lse = None
+    if expects_lse:
         # Allocate LSE on the caller side so we can pre-populate it with NaNs
         # and catch missed writes. Shape is [total_qo_tokens, num_qo_heads].
-        provided_lse = torch.full(
-            (ref_q.shape[0], num_qo_heads),
-            float("nan"),
-            device=GPU_DEVICE,
-            dtype=torch.float32,
+        provided_lse = (
+            torch.full(
+                (ref_q.shape[0], num_qo_heads),
+                float("nan"),
+                device=GPU_DEVICE,
+                dtype=torch.float32,
+            )
+            if provide_lse
+            else None
         )
         # Zero out the guard region that sits immediately after the softmax
         # slab. If the kernel writes out of bounds we'll notice it flip to
@@ -831,8 +842,6 @@ def _test_trtllm_batch_prefill(
         )
         guard_end = min(softmax_end + TRTLLM_GEN_WORKSPACE_CHECK_BYTES, workspace_size)
         workspace_buffer[softmax_end:guard_end].zero_()
-    else:
-        provided_lse = None
 
     output_and_lse = flashinfer.prefill.trtllm_batch_context_with_kv_cache(
         q_input,
@@ -860,11 +869,17 @@ def _test_trtllm_batch_prefill(
         skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
         lse=provided_lse,
-        return_lse=check_lse,
+        return_lse=effective_return_lse,
     )
-    if check_lse:
-        output, lse_out = output_and_lse
-        assert lse_out is provided_lse
+    if expects_lse:
+        if effective_return_lse:
+            output, lse_out = output_and_lse
+            if provide_lse:
+                assert lse_out is provided_lse
+        else:
+            output = output_and_lse
+            lse_out = provided_lse
+            assert lse_out is not None
         assert lse_out.dtype == torch.float32
         assert lse_out.shape == (ref_q.shape[0], num_qo_heads)
         assert torch.isfinite(lse_out).all(), (
@@ -1056,6 +1071,32 @@ def test_trtllm_batch_prefill(
     )
 
 
+@pytest.mark.parametrize("return_lse", [False, True])
+@pytest.mark.parametrize("provide_lse", [False, True])
+def test_trtllm_batch_prefill_lse_contract(return_lse, provide_lse):
+    _test_trtllm_batch_prefill(
+        "HND",
+        2,
+        16,
+        2,
+        2,
+        True,
+        -1,
+        "fp16",
+        "fp16",
+        "fp16",
+        False,
+        False,
+        64,
+        128,
+        False,
+        128,
+        uses_shared_paged_kv_idx=True,
+        return_lse=return_lse,
+        provide_lse=provide_lse,
+    )
+
+
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize(
     "batch_size,page_size,num_kv_heads,head_grp_size",
@@ -1166,6 +1207,8 @@ def _test_trtllm_batch_decode(
     non_contiguous_query: bool = False,
     skips_softmax: bool = False,
     uses_shared_paged_kv_idx: bool = True,
+    return_lse: bool | None = None,
+    provide_lse: bool = False,
 ) -> None:
     """
     Common function for testing trtllm-gen decode.
@@ -1384,6 +1427,10 @@ def _test_trtllm_batch_decode(
         and kv_dtype != "nvfp4"
         and q_dtype != "fp8"
     )
+    if (return_lse or provide_lse) and not check_lse:
+        pytest.skip("LSE contract validation requires a reliable LSE reference")
+    effective_return_lse = check_lse if return_lse is None else return_lse
+    expects_lse = check_lse and (effective_return_lse or provide_lse)
 
     if max_q_len is not None:
         max_q_len_val = max_q_len
@@ -1392,20 +1439,23 @@ def _test_trtllm_batch_decode(
     else:
         max_q_len_val = torch.max(q_lens).item()
 
-    if check_lse:
-        provided_lse = torch.full(
-            (q.shape[0], num_qo_heads),
-            float("nan"),
-            device=GPU_DEVICE,
-            dtype=torch.float32,
+    provided_lse = None
+    if expects_lse:
+        provided_lse = (
+            torch.full(
+                (q.shape[0], num_qo_heads),
+                float("nan"),
+                device=GPU_DEVICE,
+                dtype=torch.float32,
+            )
+            if provide_lse
+            else None
         )
         softmax_end = trtllm_gen_workspace_softmax_end_bytes_decode(
             num_qo_heads, batch_size, max_q_len_val
         )
         guard_end = min(softmax_end + TRTLLM_GEN_WORKSPACE_CHECK_BYTES, workspace_size)
         workspace_buffer[softmax_end:guard_end].zero_()
-    else:
-        provided_lse = None
 
     output_and_lse = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
         q_input,
@@ -1434,11 +1484,17 @@ def _test_trtllm_batch_decode(
         kv_cache_sf=kv_cache_sf_kernel,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
         lse=provided_lse,
-        return_lse=check_lse,
+        return_lse=effective_return_lse,
     )
-    if check_lse:
-        output, lse_out = output_and_lse
-        assert lse_out is provided_lse
+    if expects_lse:
+        if effective_return_lse:
+            output, lse_out = output_and_lse
+            if provide_lse:
+                assert lse_out is provided_lse
+        else:
+            output = output_and_lse
+            lse_out = provided_lse
+            assert lse_out is not None
         assert lse_out.dtype == torch.float32
         assert lse_out.shape == (q.shape[0], num_qo_heads)
         assert torch.isfinite(lse_out).all(), (
@@ -1461,6 +1517,7 @@ def _test_trtllm_batch_decode(
         )
     else:
         output = output_and_lse
+
     if backend == "trtllm-gen":
         # check if the first 8192 * 256 * 4 bytes of workspace_buffer is zero
         # note(Yingyi): the first 8192 * 256 * 4 bytes of workspace_buffer is the counter workspace, size might change in the future
@@ -1679,6 +1736,32 @@ def test_trtllm_batch_decode(
         non_contiguous_query=non_contiguous_query,
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
+
+
+@pytest.mark.parametrize("return_lse", [False, True])
+@pytest.mark.parametrize("provide_lse", [False, True])
+def test_trtllm_batch_decode_lse_contract(return_lse, provide_lse):
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        2,
+        1,
+        16,
+        2,
+        2,
+        -1,
+        "fp16",
+        "fp16",
+        "fp16",
+        False,
+        False,
+        128,
+        128,
+        device_scale=False,
+        uses_shared_paged_kv_idx=True,
+        return_lse=return_lse,
+        provide_lse=provide_lse,
     )
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR updates the direct TRTLLM-Gen paged attention APIs so a caller-provided `lse` buffer is honored independently from `return_lse`.

- `flashinfer.decode.trtllm_batch_decode_with_kv_cache` now validates and passes a provided `lse` buffer to the TRTLLM-Gen kernel even when `return_lse=False`.
- Direct decode/context API docs now state that a provided `lse` buffer is filled regardless of `return_lse`.
- `tests/attention/test_trtllm_gen_attention.py` adds focused direct TRTLLM-Gen coverage for the `return_lse` x caller-provided `lse` matrix.

The wrapper API scope is intentionally unchanged; this PR only covers the direct TRTLLM APIs.

## 🔍 Related Issues

Fixes #2755

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation run:

- `uv run python -m py_compile tests/attention/test_trtllm_gen_attention.py`
- `git diff --check`
- pre-commit hooks during commit: passed

Focused pytest collection/runtime was not rerun locally because the worktree venv lacks `pytest`.

## Reviewer Notes

The direct test helper uses `return_lse=None` as an internal auto mode so existing broad tests keep their previous `return_lse=check_lse` behavior. The focused LSE contract tests pass explicit booleans to cover all four direct API cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure provided LSE buffers are always filled; allocate a new LSE buffer only when LSE return is requested.

* **Documentation**
  * Clarified LSE parameter behavior in batch prefill and decode operations.

* **Tests**
  * Added parametrized LSE contract tests for prefill and decode, with conditional validation depending on reference availability and backend support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->