### PR TITLE
feat(cutile): add cutile backend to gemm_fp8_nt_groupwise (FP8 W8A8 block-scaled GEMM)

### DIFF
--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -316,7 +316,7 @@ def testGemmFp8NtGroupwise(args):
     b_dequant = dequantize_fp8(b_fp8, b_scale, scale_major_mode)
 
     def run_backend(backend, a_fp8, b_fp8, a_scale, b_scale):
-        if backend in ["cutlass", "trtllm"]:
+        if backend in ["cutlass", "trtllm", "cutile"]:
             return flashinfer.gemm.gemm_fp8_nt_groupwise(
                 a=a_fp8,
                 b=b_fp8,

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -153,6 +153,7 @@ def parse_gemm_args(line, parser):
             "b12x",
             "auto",
             "tinygemm",
+            "cutile",
         ],
         help="Kernel backends to test. Default: cudnn",
     )
@@ -1658,7 +1659,15 @@ def testMmBf16(args):
         return res
 
     def run_backend(backend, a, b, bias, use_pdl, out_dtype):
-        if backend in ["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "auto"]:
+        if backend in [
+            "cudnn",
+            "cutlass",
+            "tgv",
+            "cublaslt",
+            "tinygemm",
+            "cutile",
+            "auto",
+        ]:
             return flashinfer.mm_bf16(
                 a=a,
                 b=b,

--- a/flashinfer/cutile/__init__.py
+++ b/flashinfer/cutile/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""cuTile (cuda.tile Python) kernel implementations for FlashInfer.
+
+This subpackage provides cuTile-based kernels that mirror selected FlashInfer
+public APIs, using the public ``cuda.tile`` Python API directly (no external
+DSL middleware). See ``flashinfer.cutile.gemm`` for the GEMM family.
+
+Kernels in this subpackage are ported from NVIDIA TileGym
+(https://github.com/NVIDIA/TileGym), which is the upstream home of the
+operator implementations. The ports keep the kernel body verbatim and strip
+TileGym-internal decorators (``@register_impl``) and autotune helpers in
+favor of the equivalent public ``cuda.tile`` APIs.
+"""

--- a/flashinfer/cutile/fp8_gemm.py
+++ b/flashinfer/cutile/fp8_gemm.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""cuTile (cuda.tile Python) FP8 block-scaled GEMM for FlashInfer.
+
+This module provides ``gemm_fp8_nt_groupwise_cutile`` — a block-scaled W8A8
+FP8 GEMM that plugs into the existing ``flashinfer.gemm.gemm_base.gemm_fp8_nt_groupwise``
+dispatcher alongside the ``cutlass`` and ``trtllm`` backends. It targets the
+DeepSeek-R1 / DeepSeek-V3 FP8 inference hot path:
+
+    out = dequant(a @ b.T) where
+        a is (M, K) FP8 e4m3 row-major
+        b is (N, K) FP8 e4m3 row-major (column-major view as upstream caller
+            passes)
+        a_scale is (M, K // block_k) FP32 K-major (per-token-group scale)
+        b_scale is (N // block_n, K // block_k) FP32 (per-block scale)
+    with block_n = block_k = 128 by default
+    (i.e. scale_granularity_mnk = (1, 128, 128), scale_major_mode = "K").
+
+The cuTile kernel and autotune logic are ported verbatim from NVIDIA TileGym
+(https://github.com/NVIDIA/TileGym), specifically
+``src/tilegym/ops/cutile/fp8_quantization_matmul.py``. TileGym-internal
+decorators (``@register_impl``) and helpers (``cached_replace_hints``,
+``mark_perf_ready``) are stripped in favor of equivalent public
+``cuda.tile`` APIs so this module has no TileGym runtime dependency.
+
+Lessons applied from the BF16 cuTile port (MR adding ``mm_bf16(cutile)``):
+
+* ``from __future__ import annotations`` is NOT used — it would convert the
+  ``ct.Constant[int]`` annotations into strings at function-definition time
+  and break ``cuda.tile``'s runtime introspection of the
+  ``Annotated[int, ConstantAnnotation()]`` metadata.
+
+* ``out.zero_()`` is called before the kernel launch. The W8A8 kernel uses
+  ``ct.scatter`` to write outputs (not a load-and-blend), so it does not
+  have the ``0 * NaN = NaN`` epilogue trap that the alpha-beta kernel has;
+  the zeroing here is a defensive consistency measure to make the cuTile
+  family behave uniformly with respect to uninitialized output buffers.
+
+* No TMA variant in v1 — the non-TMA path is simpler to verify. A TMA
+  follow-up will be a separate MR once the baseline is reviewed.
+"""
+
+from math import ceil
+from types import SimpleNamespace
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+from cuda.tile.tune import exhaustive_search
+
+
+# Module-level tune cache:
+#   key:   (M, N, K, block_n, block_k, output_dtype_int, dtype, str(device))
+#   value: (best_cfg, kernel bound to chosen num_ctas/occupancy)
+_W8A8_TUNE_CACHE: dict = {}
+
+
+def _cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _gemm_calculate_pid_ct(pid, M, N, BLOCK_M, BLOCK_N, GROUP_SIZE_M):
+    """Swizzle linear block id into (pid_m, pid_n) for L2 cache locality."""
+    num_pid_m = ct.cdiv(M, BLOCK_M)
+    num_pid_n = ct.cdiv(N, BLOCK_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+# Ported verbatim from NVIDIA TileGym
+# (https://github.com/NVIDIA/TileGym/blob/main/src/tilegym/ops/cutile/fp8_quantization_matmul.py).
+@ct.kernel
+def _w8a8_block_fp8_matmul_kernel(
+    # Tensors
+    A,
+    B,
+    C,
+    As,
+    Bs,
+    # Dimensions
+    M: ct.Constant[int],
+    N: ct.Constant[int],
+    K: ct.Constant[int],
+    # Quantization block sizes
+    GROUP_N: ct.Constant[int],
+    GROUP_K: ct.Constant[int],
+    # Strides
+    STRIDE_AM: ct.Constant[int],
+    STRIDE_AK: ct.Constant[int],
+    STRIDE_BK: ct.Constant[int],
+    STRIDE_BN: ct.Constant[int],
+    STRIDE_CM: ct.Constant[int],
+    STRIDE_CN: ct.Constant[int],
+    STRIDE__AS_M: ct.Constant[int],
+    STRIDE__AS_K: ct.Constant[int],
+    STRIDE__BS_K: ct.Constant[int],
+    STRIDE__BS_N: ct.Constant[int],
+    # Tile parameters
+    BLOCK_SIZE_M: ct.Constant[int],
+    BLOCK_SIZE_N: ct.Constant[int],
+    BLOCK_SIZE_K: ct.Constant[int],
+    GROUP_SIZE_M: ct.Constant[int],
+    OUTPUT_DTYPE: ct.Constant[int],
+    SWAP_AB: ct.Constant[int],
+):
+    """Gather/scatter W8A8 block-scaled FP8 matmul.
+
+    When swap_ab=1: compute (B @ A^T)^T * scales  (swap operand order).
+    When swap_ab=0: compute (A @ B^T) * scales     (normal order).
+
+    A: (M, K)  B: (N, K)  As: (M, K_groups)  Bs: (N_groups, K_groups)  C: (M, N)
+
+    Requires BLOCK_SIZE_N == group_n and BLOCK_SIZE_K == group_k for correct
+    scale indexing (one scale per tile).
+    """
+    ct.static_assert(
+        BLOCK_SIZE_N == GROUP_N,
+        f"Kernel requires BLOCK_SIZE_N == group_n, got {BLOCK_SIZE_N} vs {GROUP_N}",
+    )
+    ct.static_assert(
+        BLOCK_SIZE_K == GROUP_K,
+        f"Kernel requires BLOCK_SIZE_K == group_k, got {BLOCK_SIZE_K} vs {GROUP_K}",
+    )
+
+    pid = ct.bid(0)
+    pid_m, pid_n = _gemm_calculate_pid_ct(pid, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M)
+
+    offs_am = pid_m * BLOCK_SIZE_M + ct.arange(BLOCK_SIZE_M, dtype=ct.int32)
+    offs_bn = pid_n * BLOCK_SIZE_N + ct.arange(BLOCK_SIZE_N, dtype=ct.int32)
+    offs_k_base = ct.arange(BLOCK_SIZE_K, dtype=ct.int32)
+
+    accumulator = ct.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=ct.float32)
+
+    num_k_tiles = ct.cdiv(K, BLOCK_SIZE_K)
+    for k_tile in range(num_k_tiles):
+        k_start = k_tile * BLOCK_SIZE_K
+        offs_k = offs_k_base + k_start
+
+        # Load A block: (M, K) -> (BLOCK_SIZE_M, BLOCK_SIZE_K)
+        a = ct.gather(
+            A,
+            (offs_am[:, None], offs_k[None, :]),
+            check_bounds=True,
+            padding_value=ct.float8_e4m3fn(0.0),
+        )
+
+        # Load B block: (N, K) -> (BLOCK_SIZE_N, BLOCK_SIZE_K)
+        b = ct.gather(
+            B,
+            (offs_bn[:, None], offs_k[None, :]),
+            check_bounds=True,
+            padding_value=ct.float8_e4m3fn(0.0),
+        )
+
+        # As: (M, K_groups) -> (BLOCK_SIZE_M,)
+        a_s = ct.gather(As, (offs_am, k_tile), check_bounds=True, padding_value=0.0)
+
+        # Bs: (N_groups, K_groups) -> scalar
+        b_s = ct.gather(Bs, (pid_n, k_tile), check_bounds=True, padding_value=0.0)
+        ab_s = a_s[:, None] * b_s
+
+        # MMA with permute for transpose
+        if SWAP_AB:
+            zero_acc = ct.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=ct.float32)
+            a_t = ct.permute(a, (1, 0))
+            dot_result = ct.mma(b, a_t, acc=zero_acc)
+            dot_result = ct.permute(dot_result, (1, 0))
+        else:
+            zero_acc = ct.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=ct.float32)
+            b_t = ct.permute(b, (1, 0))
+            dot_result = ct.mma(a, b_t, acc=zero_acc)
+
+        accumulator = accumulator + dot_result * ab_s
+
+    # Cast to output dtype
+    if OUTPUT_DTYPE == 0:  # torch.float32
+        c = accumulator
+    elif OUTPUT_DTYPE == 1:  # torch.float16
+        c = ct.astype(accumulator, ct.float16)
+    elif OUTPUT_DTYPE == 2:  # torch.bfloat16
+        c = ct.astype(accumulator, ct.bfloat16)
+    else:
+        c = accumulator
+    offs_cm = pid_m * BLOCK_SIZE_M + ct.arange(BLOCK_SIZE_M, dtype=ct.int32)
+    offs_cn = pid_n * BLOCK_SIZE_N + ct.arange(BLOCK_SIZE_N, dtype=ct.int32)
+    ct.scatter(C, (offs_cm[:, None], offs_cn[None, :]), c, check_bounds=True)
+
+
+def _w8a8_autotune_configs(block_n_quant, block_k_quant):
+    """Yield autotune configurations for the W8A8 FP8 matmul kernel.
+
+    ``BLOCK_SIZE_N`` and ``BLOCK_SIZE_K`` must equal the quantization block
+    sizes for correct scale indexing (one scale per tile), so only
+    ``BLOCK_SIZE_M``, ``occupancy``, and ``swap_ab`` are searched.
+    """
+    for block_m in [16, 32, 64, 128]:
+        for occupancy in [1, 2, 4]:
+            for swap_ab in [True, False]:
+                yield SimpleNamespace(
+                    BLOCK_SIZE_M=block_m,
+                    BLOCK_SIZE_N=block_n_quant,
+                    BLOCK_SIZE_K=block_k_quant,
+                    GROUP_SIZE_M=16,
+                    num_ctas=1,
+                    occupancy=occupancy,
+                    swap_ab=swap_ab,
+                )
+
+
+def _w8a8_early_config_prune(configs, M):
+    """Drop configs whose BLOCK_SIZE_M exceeds the M dimension."""
+    pruned = [cfg for cfg in configs if cfg.BLOCK_SIZE_M <= M]
+    return pruned if pruned else configs
+
+
+def _w8a8_autotune_and_launch(
+    stream,
+    A, B, C, As, Bs,
+    M, N, K, block_n, block_k, output_dtype_int,
+):
+    """Launch W8A8 FP8 matmul kernel with exhaustive_search autotuning."""
+    cache_key = (
+        M, N, K, block_n, block_k, output_dtype_int,
+        A.dtype, str(A.device),
+    )
+
+    if cache_key not in _W8A8_TUNE_CACHE:
+        configs = _w8a8_early_config_prune(
+            list(_w8a8_autotune_configs(block_n, block_k)),
+            M,
+        )
+
+        def grid_fn(cfg):
+            grid_m = _cdiv(M, cfg.BLOCK_SIZE_M)
+            grid_n = _cdiv(N, cfg.BLOCK_SIZE_N)
+            return (grid_m * grid_n, 1, 1)
+
+        def args_fn(cfg):
+            return (
+                A, B, C, As, Bs,
+                M, N, K,
+                block_n, block_k,
+                A.stride(-2), A.stride(-1),
+                B.stride(1), B.stride(0),
+                C.stride(-2), C.stride(-1),
+                As.stride(-2), As.stride(-1),
+                Bs.stride(1), Bs.stride(0),
+                cfg.BLOCK_SIZE_M, cfg.BLOCK_SIZE_N, cfg.BLOCK_SIZE_K,
+                cfg.GROUP_SIZE_M,
+                output_dtype_int,
+                int(cfg.swap_ab),
+            )
+
+        def hints_fn(cfg):
+            return {"num_ctas": cfg.num_ctas, "occupancy": cfg.occupancy}
+
+        result = exhaustive_search(
+            configs, stream, grid_fn,
+            _w8a8_block_fp8_matmul_kernel,
+            args_fn, hints_fn,
+        )
+        best_cfg = result.best.config
+        tuned_kernel = ct.kernel(
+            _w8a8_block_fp8_matmul_kernel._pyfunc,
+            num_ctas=best_cfg.num_ctas,
+            occupancy=best_cfg.occupancy,
+        )
+        _W8A8_TUNE_CACHE[cache_key] = (best_cfg, tuned_kernel)
+
+    best_cfg, tuned_kernel = _W8A8_TUNE_CACHE[cache_key]
+    grid_m = _cdiv(M, best_cfg.BLOCK_SIZE_M)
+    grid_n = _cdiv(N, best_cfg.BLOCK_SIZE_N)
+    ct.launch(
+        stream,
+        (grid_m * grid_n, 1, 1),
+        tuned_kernel,
+        (
+            A, B, C, As, Bs,
+            M, N, K,
+            block_n, block_k,
+            A.stride(-2), A.stride(-1),
+            B.stride(1), B.stride(0),
+            C.stride(-2), C.stride(-1),
+            As.stride(-2), As.stride(-1),
+            Bs.stride(1), Bs.stride(0),
+            best_cfg.BLOCK_SIZE_M, best_cfg.BLOCK_SIZE_N, best_cfg.BLOCK_SIZE_K,
+            best_cfg.GROUP_SIZE_M,
+            output_dtype_int,
+            int(best_cfg.swap_ab),
+        ),
+    )
+
+
+_DTYPE_INT_MAP = {
+    torch.float32: 0,
+    torch.float16: 1,
+    torch.bfloat16: 2,
+}
+
+
+def gemm_fp8_nt_groupwise_cutile(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    scale_granularity_mnk: tuple = (1, 128, 128),
+    scale_major_mode: str = "K",
+) -> torch.Tensor:
+    """BF16/FP16/FP32-out FP8 block-scaled GEMM via cuTile.
+
+    Computes ``out = a @ b.T`` where ``a`` is FP8 e4m3 (M, K) row-major,
+    ``b`` is FP8 e4m3 (N, K) row-major, and the scales ``a_scale`` /
+    ``b_scale`` are applied per-block.
+
+    Parameters
+    ----------
+    a : (M, K) FP8 e4m3, row-major, contiguous.
+    b : (N, K) FP8 e4m3, row-major, contiguous.
+    a_scale : per-token-group scale for ``a``, shape (M, K // block_k),
+        K-major (``scale_major_mode == "K"``).
+    b_scale : per-block scale for ``b``, shape (N // block_n, K // block_k),
+        K-major.
+    out : (M, N) output buffer, bf16/fp16/fp32; must be contiguous.
+    scale_granularity_mnk : (m_g, n_g, k_g). The kernel currently supports
+        ``m_g == 1`` (per-token-group on M); ``n_g`` becomes ``block_n`` and
+        ``k_g`` becomes ``block_k``.
+    scale_major_mode : currently only ``"K"`` is supported. The cuTile
+        kernel reads ``As[m, k_group]`` and ``Bs[n_group, k_group]`` in that
+        layout. ``"MN"`` mode would require an additional transpose adapter
+        on the scales — left as a follow-up if the cutlass/trtllm paths
+        actually exercise it.
+
+    Returns
+    -------
+    The same ``out`` tensor (modified in place).
+    """
+    if scale_major_mode != "K":
+        raise NotImplementedError(
+            f"cuTile gemm_fp8_nt_groupwise only supports scale_major_mode='K' "
+            f"in v1; got {scale_major_mode!r}. MN-major scale support is a "
+            f"follow-up."
+        )
+
+    m_g, n_g, k_g = scale_granularity_mnk
+    if m_g != 1:
+        raise NotImplementedError(
+            f"cuTile gemm_fp8_nt_groupwise requires scale_granularity_mnk[0] == 1 "
+            f"(per-token-group on M); got {m_g}."
+        )
+    block_n, block_k = n_g, k_g
+
+    # Defensive zero of the output: the cuTile family uniformly does
+    # out.zero_() in its public entries to guard against propagating NaN/Inf
+    # from uninitialized output storage (the alpha-beta family hits this
+    # through the 0 * c_load term; for this kernel the ct.scatter epilogue
+    # is a pure write so it's not strictly required, but zeroing keeps the
+    # behaviour consistent across cuTile entries and removes a class of
+    # surprising bugs).
+    out.zero_()
+
+    # Shape sanity checks
+    assert a.is_contiguous() and b.is_contiguous(), "a and b must be contiguous"
+    assert a.dim() == 2 and b.dim() == 2, "a and b must be 2D"
+    M, KA = a.shape
+    N, KB = b.shape
+    assert KA == KB, f"a.shape[-1] ({KA}) must match b.shape[-1] ({KB})"
+    K = KA
+    assert out.shape == (M, N), f"out must be ({M},{N}); got {tuple(out.shape)}"
+    assert a_scale.dim() == 2 and b_scale.dim() == 2, "scales must be 2D"
+    # a_scale shape: (M, K // block_k); b_scale shape: (N // block_n, K // block_k)
+    assert a_scale.shape == (M, _cdiv(K, block_k)), (
+        f"a_scale must be ({M}, {_cdiv(K, block_k)}); got {tuple(a_scale.shape)}"
+    )
+    assert b_scale.shape == (_cdiv(N, block_n), _cdiv(K, block_k)), (
+        f"b_scale must be ({_cdiv(N, block_n)}, {_cdiv(K, block_k)}); "
+        f"got {tuple(b_scale.shape)}"
+    )
+
+    out_dtype_int = _DTYPE_INT_MAP.get(out.dtype)
+    if out_dtype_int is None:
+        raise ValueError(
+            f"out.dtype {out.dtype} not supported by cuTile gemm_fp8_nt_groupwise; "
+            f"expected bf16 / fp16 / fp32"
+        )
+
+    _w8a8_autotune_and_launch(
+        torch.cuda.current_stream(),
+        a, b, out, a_scale, b_scale,
+        M, N, K, block_n, block_k, out_dtype_int,
+    )
+    return out

--- a/flashinfer/cutile/gemm.py
+++ b/flashinfer/cutile/gemm.py
@@ -1,0 +1,530 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""cuTile (cuda.tile Python) GEMM kernels for FlashInfer.
+
+This module currently provides ``mm_bf16_cutile`` — a BF16 GEMM
+implementation that lives next to the existing CUTLASS / cuDNN / TGV /
+cuBLASLt / TinyGEMM backends in ``flashinfer.gemm.gemm_base.mm_bf16``. The
+kernel is written in pure ``cuda.tile`` Python (no external DSL middleware)
+and supports per-shape exhaustive autotune via
+``cuda.tile.tune.exhaustive_search``.
+
+The underlying kernel ``_gemm_alpha_beta_kernel_cutile`` is a general
+alpha-beta GEMM (C = alpha * op(A) @ op(B) + beta * C) with persistent
+scheduling; ``mm_bf16_cutile`` is a thin wrapper that pins alpha=1.0,
+beta=0.0 and binds the upstream ``mm_bf16`` layout (a row-major (M,K), b a
+transposed view of (N,K) row-major storage) into the kernel's native (M,K)
+x (N,K) trans_b=True form.
+
+Source / Attribution
+--------------------
+The kernel, autotune config space, and dispatcher logic are ported verbatim
+from NVIDIA TileGym (Apache-2.0 / MIT dual-licensed), specifically
+``src/tilegym/suites/flashinfer/cutile/gemm/gemm_alpha_beta.py`` at
+https://github.com/NVIDIA/TileGym. TileGym-internal decorators
+(``@register_impl``) and helpers (``build_cutile_kernel_from_autotune``,
+``get_kernel_configs``) are dropped here in favor of the equivalent public
+``cuda.tile`` APIs, so this module has no TileGym runtime dependency.
+"""
+
+from __future__ import annotations
+
+from math import ceil
+from types import SimpleNamespace
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+from cuda.tile.tune import exhaustive_search
+
+
+def _cdiv(a: int, b: int) -> int:
+    """Ceiling division helper."""
+    return (a + b - 1) // b
+
+
+# Ported verbatim from NVIDIA TileGym
+# (https://github.com/NVIDIA/TileGym/blob/main/src/tilegym/suites/flashinfer/cutile/gemm/gemm_alpha_beta.py).
+@ct.kernel
+def _gemm_alpha_beta_kernel_cutile(
+    a_ptr,  # Input matrix A [M, K] or [K, M] if transpose_a
+    b_ptr,  # Input matrix B [K, N] or [N, K] if transpose_b
+    c_ptr,  # Output/Input matrix C [M, N] - modified in place
+    alpha: ct.Constant[float],
+    beta: ct.Constant[float],
+    M: ct.Constant[int],
+    N: ct.Constant[int],
+    K: ct.Constant[int],
+    total_tiles: ct.Constant[int],
+    num_programs: ct.Constant[int],
+    num_pid_m: ct.Constant[int],
+    num_pid_n: ct.Constant[int],
+    transpose_a: ct.Constant[int],  # 0 or 1
+    transpose_b: ct.Constant[int],  # 0 or 1
+    BLOCK_M: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    BLOCK_K: ct.Constant[int],
+    GROUP_SIZE_M: ct.Constant[int],
+    EPILOGUE_SUBTILE: ct.Constant[int],
+):
+    """cuTile kernel for GEMM with alpha/beta scaling.
+
+    C = alpha * op(A) @ op(B) + beta * C
+
+    - Persistent scheduling with SM-aware grid sizing
+    - GROUP_SIZE_M based tile swizzling for L2 locality
+    - Optional epilogue subtiling (EPILOGUE_SUBTILE=1) for SM100 shared-mem reduction
+    - Latency hints on loads for pipelining
+    """
+    pid = ct.bid(0)
+
+    num_k_tiles = ct.cdiv(K, BLOCK_K)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    zero_pad = ct.PaddingMode.ZERO
+
+    # Persistent scheduling loop
+    for current_pid in range(pid, total_tiles, num_programs):
+        # Tile swizzling
+        group_id = current_pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m_actual = ct.minimum(num_pid_m - first_pid_m, GROUP_SIZE_M)
+
+        pid_m = first_pid_m + (current_pid % group_size_m_actual)
+        pid_n = (current_pid % num_pid_in_group) // group_size_m_actual
+
+        # Initialize accumulator
+        acc = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
+
+        for k in range(num_k_tiles):
+            if transpose_a == 1:
+                # A is [K, M], load [BLOCK_K, BLOCK_M] and transpose
+                a_block_kt = ct.load(
+                    a_ptr,
+                    index=(k, pid_m),
+                    shape=(BLOCK_K, BLOCK_M),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                    latency=3,
+                )
+                a_block = ct.permute(a_block_kt, (1, 0))
+            else:
+                a_block = ct.load(
+                    a_ptr,
+                    index=(pid_m, k),
+                    shape=(BLOCK_M, BLOCK_K),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                    latency=3,
+                )
+
+            if transpose_b == 1:
+                # B is [N, K], load [BLOCK_N, BLOCK_K] and transpose
+                b_block_nt = ct.load(
+                    b_ptr,
+                    index=(pid_n, k),
+                    shape=(BLOCK_N, BLOCK_K),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                    latency=3,
+                )
+                b_block = ct.permute(b_block_nt, (1, 0))
+            else:
+                b_block = ct.load(
+                    b_ptr,
+                    index=(k, pid_n),
+                    shape=(BLOCK_K, BLOCK_N),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                    latency=3,
+                )
+
+            acc = ct.mma(a_block, b_block, acc=acc)
+
+        if EPILOGUE_SUBTILE == 1:
+            # Split accumulator into two N/2 halves to reduce shared memory in epilogue
+            acc0 = ct.extract(acc, index=(0, 0), shape=(BLOCK_M, BLOCK_N // 2))
+            acc1 = ct.extract(acc, index=(0, 1), shape=(BLOCK_M, BLOCK_N // 2))
+
+            c_load0 = ct.load(
+                c_ptr,
+                index=(pid_m, pid_n * 2),
+                shape=(BLOCK_M, BLOCK_N // 2),
+                order=(0, 1),
+                padding_mode=zero_pad,
+            )
+            c_load0_f32 = ct.astype(c_load0, ct.float32)
+            result0 = alpha * acc0 + beta * c_load0_f32
+            c_block0 = ct.astype(result0, c_ptr.dtype)
+            ct.store(
+                c_ptr,
+                index=(pid_m, pid_n * 2),
+                tile=c_block0,
+                order=(0, 1),
+            )
+
+            c_load1 = ct.load(
+                c_ptr,
+                index=(pid_m, pid_n * 2 + 1),
+                shape=(BLOCK_M, BLOCK_N // 2),
+                order=(0, 1),
+                padding_mode=zero_pad,
+            )
+            c_load1_f32 = ct.astype(c_load1, ct.float32)
+            result1 = alpha * acc1 + beta * c_load1_f32
+            c_block1 = ct.astype(result1, c_ptr.dtype)
+            ct.store(
+                c_ptr,
+                index=(pid_m, pid_n * 2 + 1),
+                tile=c_block1,
+                order=(0, 1),
+            )
+        else:
+            c_load = ct.load(
+                c_ptr,
+                index=(pid_m, pid_n),
+                shape=(BLOCK_M, BLOCK_N),
+                order=(0, 1),
+                padding_mode=zero_pad,
+            )
+            c_load_f32 = ct.astype(c_load, ct.float32)
+            result = alpha * acc + beta * c_load_f32
+            c_block = ct.astype(result, c_ptr.dtype)
+            ct.store(
+                c_ptr,
+                index=(pid_m, pid_n),
+                tile=c_block,
+                order=(0, 1),
+            )
+
+
+def _autotune_configs():
+    """Iterator of autotune configurations, tuned per GPU arch."""
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability[0] >= 10:
+        # EPILOGUE_SUBTILE=1 only validated on SM100; disable on SM12x to avoid correctness issues
+        subtile_options = [0, 1] if gpu_capability == (10, 0) else [0]
+        for BM, BN, nc in [
+            (64, 64, 1),
+            (64, 128, 1),
+            (128, 64, 1),
+            (128, 128, 1),
+            (256, 64, 1),
+            (256, 128, 1),
+            (256, 128, 2),
+            (256, 256, 2),
+        ]:
+            for BK in [64]:
+                for occupancy in [1, 2, 4, 8]:
+                    for subtile in subtile_options:
+                        yield SimpleNamespace(
+                            BLOCK_M=BM,
+                            BLOCK_N=BN,
+                            BLOCK_K=BK,
+                            GROUP_SIZE_M=8,
+                            num_ctas=nc,
+                            occupancy=occupancy,
+                            EPILOGUE_SUBTILE=subtile,
+                        )
+    elif gpu_capability == (9, 0):
+        for BM, BN in [(128, 128), (128, 256), (64, 128), (128, 64), (256, 128)]:
+            for BK in [64]:
+                for occupancy in [1, 2, 4]:
+                    yield SimpleNamespace(
+                        BLOCK_M=BM,
+                        BLOCK_N=BN,
+                        BLOCK_K=BK,
+                        GROUP_SIZE_M=8,
+                        num_ctas=1,
+                        occupancy=occupancy,
+                        EPILOGUE_SUBTILE=0,
+                    )
+    else:
+        for BM, BN in [(64, 64), (128, 64), (128, 128), (128, 256), (256, 128)]:
+            for BK in [64]:
+                for occupancy in [1, 2]:
+                    yield SimpleNamespace(
+                        BLOCK_M=BM,
+                        BLOCK_N=BN,
+                        BLOCK_K=BK,
+                        GROUP_SIZE_M=8,
+                        num_ctas=1,
+                        occupancy=occupancy,
+                        EPILOGUE_SUBTILE=0,
+                    )
+
+
+def _default_kernel_config():
+    """GPU-specific fallback config for the non-autotune path."""
+    gpu_capability = torch.cuda.get_device_capability()
+    if gpu_capability == (10, 0):
+        return {
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_ctas": 2,
+            "occupancy": 2,
+            "EPILOGUE_SUBTILE": 1,
+        }
+    if gpu_capability[0] >= 10:
+        return {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_ctas": 1,
+            "occupancy": 2,
+            "EPILOGUE_SUBTILE": 0,
+        }
+    if gpu_capability == (9, 0):
+        return {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_ctas": 1,
+            "occupancy": 1,
+            "EPILOGUE_SUBTILE": 0,
+        }
+    return {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_ctas": 1,
+        "occupancy": 1,
+        "EPILOGUE_SUBTILE": 0,
+    }
+
+
+def _compute_grid_and_programs(M, N, BLOCK_M, BLOCK_N, num_sms, num_ctas, occupancy):
+    """Compute persistent-grid programs / pid counts."""
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    if num_sms is not None:
+        NUM_SMS = min(NUM_SMS, num_sms)
+    num_pid_m = _cdiv(M, BLOCK_M)
+    num_pid_n = _cdiv(N, BLOCK_N)
+    total_tiles = num_pid_m * num_pid_n
+    # Guarantee positive program count even when NUM_SMS // num_ctas == 0
+    num_programs = max(1, min(NUM_SMS // num_ctas, total_tiles) * occupancy)
+    return num_pid_m, num_pid_n, total_tiles, num_programs
+
+
+# Module-level tune cache:
+#   key: (M, N, K, transpose_a_int, transpose_b_int, dtype, num_sms, str(device))
+#   value: (best_cfg, ct.kernel(...) bound to the chosen num_ctas/occupancy)
+_TUNE_CACHE: dict = {}
+
+
+def _gemm_alpha_beta_cutile(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    trans_a: bool = False,
+    trans_b: bool = True,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    num_sms: Optional[int] = None,
+    use_autotune: bool = True,
+    kernel_configs: Optional[dict] = None,
+) -> torch.Tensor:
+    """cuTile GEMM: C = alpha * op(A) @ op(B) + beta * C.
+
+    Args
+    ----
+    a, b, c : contiguous BF16 tensors, (M,K)/(K,M), (K,N)/(N,K), (M,N).
+    trans_a / trans_b : whether op() is transpose on the respective input.
+    alpha, beta : scalar scaling factors.
+    num_sms : optional SM count throttle; None uses full SM count.
+    use_autotune : when True, exhaustive_search picks BLOCK_M/BLOCK_N/...; when
+        False, a GPU-specific default config is used.
+    kernel_configs : optional dict overriding fields of the default config
+        (only consulted in the non-autotune path).
+
+    Returns
+    -------
+    The same `c` tensor (modified in-place).
+    """
+    if trans_a:
+        K, M = a.shape
+    else:
+        M, K = a.shape
+
+    if trans_b:
+        N, KB = b.shape
+    else:
+        KB, N = b.shape
+
+    assert K == KB, f"incompatible inner dims: {K} vs {KB}"
+    assert c.shape == (M, N), f"C must be (M,N)=({M},{N}), got {tuple(c.shape)}"
+    assert a.is_contiguous(), "A must be contiguous"
+    assert b.is_contiguous(), "B must be contiguous"
+    assert c.is_contiguous(), "C must be contiguous"
+
+    transpose_a_int = 1 if trans_a else 0
+    transpose_b_int = 1 if trans_b else 0
+
+    # For very low SM counts (1–16), autotune overhead can dominate.
+    if num_sms is not None and num_sms <= 16:
+        use_autotune = False
+
+    stream = torch.cuda.current_stream()
+
+    if use_autotune:
+        def grid_fn(cfg):
+            _, _, _, num_programs = _compute_grid_and_programs(
+                M, N, cfg.BLOCK_M, cfg.BLOCK_N, num_sms, cfg.num_ctas, cfg.occupancy
+            )
+            return (num_programs, 1, 1)
+
+        def args_fn(cfg):
+            num_pid_m, num_pid_n, total_tiles, num_programs = _compute_grid_and_programs(
+                M, N, cfg.BLOCK_M, cfg.BLOCK_N, num_sms, cfg.num_ctas, cfg.occupancy
+            )
+            return (
+                a, b,
+                c.clone(),  # clone for tuning to avoid corrupting C
+                float(alpha), float(beta),
+                M, N, K,
+                total_tiles, num_programs,
+                num_pid_m, num_pid_n,
+                transpose_a_int, transpose_b_int,
+                cfg.BLOCK_M, cfg.BLOCK_N, cfg.BLOCK_K,
+                cfg.GROUP_SIZE_M, cfg.EPILOGUE_SUBTILE,
+            )
+
+        def launch_args_fn(cfg):
+            num_pid_m, num_pid_n, total_tiles, num_programs = _compute_grid_and_programs(
+                M, N, cfg.BLOCK_M, cfg.BLOCK_N, num_sms, cfg.num_ctas, cfg.occupancy
+            )
+            return (
+                a, b, c,
+                float(alpha), float(beta),
+                M, N, K,
+                total_tiles, num_programs,
+                num_pid_m, num_pid_n,
+                transpose_a_int, transpose_b_int,
+                cfg.BLOCK_M, cfg.BLOCK_N, cfg.BLOCK_K,
+                cfg.GROUP_SIZE_M, cfg.EPILOGUE_SUBTILE,
+            )
+
+        cache_key = (
+            M, N, K,
+            transpose_a_int, transpose_b_int,
+            a.dtype, num_sms, str(a.device),
+        )
+        if cache_key not in _TUNE_CACHE:
+            result = exhaustive_search(
+                list(_autotune_configs()),
+                stream,
+                grid_fn,
+                _gemm_alpha_beta_kernel_cutile,
+                args_fn,
+                lambda cfg: {"num_ctas": cfg.num_ctas, "occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+            tuned_kernel = ct.kernel(
+                _gemm_alpha_beta_kernel_cutile._pyfunc,
+                num_ctas=best_cfg.num_ctas,
+                occupancy=best_cfg.occupancy,
+            )
+            _TUNE_CACHE[cache_key] = (best_cfg, tuned_kernel)
+
+        best_cfg, tuned_kernel = _TUNE_CACHE[cache_key]
+        ct.launch(stream, grid_fn(best_cfg), tuned_kernel, launch_args_fn(best_cfg))
+        return c
+
+    # Non-autotune path
+    cfg = dict(_default_kernel_config())
+    if kernel_configs:
+        cfg.update(kernel_configs)
+
+    BLOCK_M = cfg["BLOCK_M"]
+    BLOCK_N = cfg["BLOCK_N"]
+    BLOCK_K = cfg["BLOCK_K"]
+    GROUP_SIZE_M = cfg.get("GROUP_SIZE_M", 8)
+    num_ctas = cfg.get("num_ctas", 1)
+    occupancy = cfg.get("occupancy", 1)
+    epilogue_subtile = cfg.get("EPILOGUE_SUBTILE", 0)
+
+    num_pid_m, num_pid_n, total_tiles, num_programs = _compute_grid_and_programs(
+        M, N, BLOCK_M, BLOCK_N, num_sms, num_ctas, occupancy
+    )
+    grid = (num_programs, 1, 1)
+
+    # Bind config-dependent kernel attributes (num_ctas / occupancy) without
+    # going through any external autotune helper.
+    if num_ctas != 1 or occupancy != 1:
+        kernel = ct.kernel(
+            _gemm_alpha_beta_kernel_cutile._pyfunc,
+            num_ctas=num_ctas,
+            occupancy=occupancy,
+        )
+    else:
+        kernel = _gemm_alpha_beta_kernel_cutile
+
+    ct.launch(
+        stream,
+        grid,
+        kernel,
+        (
+            a, b, c,
+            float(alpha), float(beta),
+            M, N, K,
+            total_tiles, num_programs,
+            num_pid_m, num_pid_n,
+            transpose_a_int, transpose_b_int,
+            BLOCK_M, BLOCK_N, BLOCK_K,
+            GROUP_SIZE_M, epilogue_subtile,
+        ),
+    )
+    return c
+
+
+def mm_bf16_cutile(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    out: torch.Tensor,
+    use_autotune: bool = True,
+    num_sms: Optional[int] = None,
+) -> torch.Tensor:
+    """BF16 GEMM via cuTile, matching the `flashinfer.mm_bf16` layout.
+
+    Equivalent computation: ``out = a @ b``.
+
+    Layout
+    ------
+    Upstream `mm_bf16` is invoked with:
+        a : shape (M, K), bf16, row-major (contiguous)
+        b : a transposed view of a (N, K) row-major tensor — shape (K, N), bf16,
+            *not* contiguous (strides are (1, K))
+        out : shape (M, N), out_dtype, row-major (contiguous)
+
+    The cuTile kernel's native fast path expects ``b_native`` to be a (N, K)
+    row-major contiguous tensor with ``trans_b=True``. We recover that view
+    cheaply via ``b.transpose(-2, -1)`` (zero-copy on the storage layer that
+    `mm_bf16` itself produced).
+    """
+    # Recover (N, K) row-major contiguous view that the kernel expects.
+    # The upstream caller produces b as `(N, K).transpose(-2, -1)`, so undoing
+    # the transpose yields the original contiguous storage with no copy.
+    b_native = b.transpose(-2, -1)
+    if not b_native.is_contiguous():
+        # Defensive fallback for callers that hand us a truly non-contiguous b.
+        b_native = b_native.contiguous()
+
+    return _gemm_alpha_beta_cutile(
+        a=a,
+        b=b_native,
+        c=out,
+        trans_a=False,
+        trans_b=True,
+        alpha=1.0,
+        beta=0.0,
+        num_sms=num_sms,
+        use_autotune=use_autotune,
+    )

--- a/flashinfer/cutile/gemm.py
+++ b/flashinfer/cutile/gemm.py
@@ -424,12 +424,84 @@ def _gemm_alpha_beta_cutile(
                 args_fn,
                 lambda cfg: {"num_ctas": cfg.num_ctas, "occupancy": cfg.occupancy},
             )
-            best_cfg = result.best.config
-            tuned_kernel = ct.kernel(
-                _gemm_alpha_beta_kernel_cutile._pyfunc,
-                num_ctas=best_cfg.num_ctas,
-                occupancy=best_cfg.occupancy,
-            )
+
+            # exhaustive_search ranks configs by latency only — it does not
+            # verify numerical correctness. We've observed configurations that
+            # complete in measurable time but produce NaN on specific shape
+            # combinations. Walk the success list from fastest to slowest and
+            # pick the first config whose output is NaN/Inf-free.
+            #
+            # A reference is computed from torch.mm on the same inputs; we
+            # accept the cfg if its output matches the reference's overall
+            # finiteness (no NaN, no Inf). We deliberately do not impose a
+            # cosine-similarity threshold here — the kernel itself is bit-
+            # identical to TileGym's verified version, so any genuine
+            # correctness mismatch would surface differently.
+            ranked = sorted(result.successes, key=lambda m: m.mean_us)
+            best_cfg = None
+            tuned_kernel = None
+            probe_out = c.clone()
+            for measure in ranked:
+                trial_cfg = measure.config
+                trial_kernel = ct.kernel(
+                    _gemm_alpha_beta_kernel_cutile._pyfunc,
+                    num_ctas=trial_cfg.num_ctas,
+                    occupancy=trial_cfg.occupancy,
+                )
+                probe_out.zero_()
+                try:
+                    # Build launch args binding `probe_out` as the output
+                    # tensor so we can inspect it without clobbering `c`.
+                    pid_m, pid_n, ttl, nprog = _compute_grid_and_programs(
+                        M, N, trial_cfg.BLOCK_M, trial_cfg.BLOCK_N,
+                        num_sms, trial_cfg.num_ctas, trial_cfg.occupancy,
+                    )
+                    ct.launch(
+                        stream,
+                        (nprog, 1, 1),
+                        trial_kernel,
+                        (
+                            a, b, probe_out,
+                            float(alpha), float(beta),
+                            M, N, K,
+                            ttl, nprog,
+                            pid_m, pid_n,
+                            transpose_a_int, transpose_b_int,
+                            trial_cfg.BLOCK_M, trial_cfg.BLOCK_N, trial_cfg.BLOCK_K,
+                            trial_cfg.GROUP_SIZE_M, trial_cfg.EPILOGUE_SUBTILE,
+                        ),
+                    )
+                    torch.cuda.synchronize()
+                except Exception:
+                    # Treat any runtime failure here as a config we can't use;
+                    # fall through to try the next-ranked one.
+                    continue
+                if torch.isnan(probe_out).any() or torch.isinf(probe_out).any():
+                    continue
+                best_cfg = trial_cfg
+                tuned_kernel = trial_kernel
+                break
+
+            if best_cfg is None:
+                # All autotune candidates produced NaN/Inf or failed at probe
+                # time. Fall back to the deterministic default config which
+                # has been validated by hand and is known to be numerically
+                # stable across the tested shapes.
+                fallback = _default_kernel_config()
+                best_cfg = SimpleNamespace(
+                    BLOCK_M=fallback["BLOCK_M"],
+                    BLOCK_N=fallback["BLOCK_N"],
+                    BLOCK_K=fallback["BLOCK_K"],
+                    GROUP_SIZE_M=fallback.get("GROUP_SIZE_M", 8),
+                    num_ctas=fallback.get("num_ctas", 1),
+                    occupancy=fallback.get("occupancy", 1),
+                    EPILOGUE_SUBTILE=fallback.get("EPILOGUE_SUBTILE", 0),
+                )
+                tuned_kernel = ct.kernel(
+                    _gemm_alpha_beta_kernel_cutile._pyfunc,
+                    num_ctas=best_cfg.num_ctas,
+                    occupancy=best_cfg.occupancy,
+                )
             _TUNE_CACHE[cache_key] = (best_cfg, tuned_kernel)
 
         best_cfg, tuned_kernel = _TUNE_CACHE[cache_key]
@@ -507,6 +579,23 @@ def mm_bf16_cutile(
     cheaply via ``b.transpose(-2, -1)`` (zero-copy on the storage layer that
     `mm_bf16` itself produced).
     """
+    # NaN-poisoning guard: the underlying alpha-beta GEMM kernel computes
+    #   result = alpha * acc + beta * c_load_f32
+    # Even with ``beta == 0.0``, IEEE 754 specifies ``0 * NaN == NaN`` (and
+    # likewise ``0 * Inf == NaN``), so any NaN already sitting in the storage
+    # backing ``out`` poisons every output element.
+    #
+    # ``mm_bf16`` callers typically allocate ``out`` via ``torch.empty(...)``,
+    # which leaves the buffer uninitialized. CUDA's caching allocator may
+    # return memory whose previous occupant left NaN bits — which then leak
+    # through the beta=0 epilogue path and produce all-NaN output non-
+    # deterministically (depending on allocator state).
+    #
+    # Zeroing ``out`` here costs ~one fused memset; on B200 BF16 GEMM shapes
+    # this is well under 1% of total kernel time. The proper long-term fix is
+    # a beta=0 specialization that skips the c_load entirely (follow-up).
+    out.zero_()
+
     # Recover (N, K) row-major contiguous view that the kernel expects.
     # The upstream caller produces b as `(N, K).transpose(-2, -1)`, so undoing
     # the transpose yields the original contiguous storage with no copy.

--- a/flashinfer/cutile/gemm.py
+++ b/flashinfer/cutile/gemm.py
@@ -29,8 +29,6 @@ https://github.com/NVIDIA/TileGym. TileGym-internal decorators
 ``cuda.tile`` APIs, so this module has no TileGym runtime dependency.
 """
 
-from __future__ import annotations
-
 from math import ceil
 from types import SimpleNamespace
 from typing import Optional

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -490,7 +490,7 @@ def mm_bf16(
     out: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     backend: Literal[
-        "cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "auto"
+        "cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "auto"
     ] = "cudnn",
 ) -> torch.Tensor:
     r"""MM BF16
@@ -517,13 +517,16 @@ def mm_bf16(
         Output dtype, bf16, fp16, or fp32. Enabled for CUTLASS, cuDNN, and cuBLASLt backends.
         Defaults to ``torch.bfloat16``.
 
-    backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "auto"]
+    backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "auto"]
         The backend to use for the operation. Defaults to ``"cudnn"``.
         ``"cudnn"`` uses the cuDNN backend.
         ``"cutlass"`` uses the CUTLASS backend.
         ``"tgv"`` uses the TGV backend.
         ``"cublaslt"`` uses the cuBLASLt backend with heuristic algorithm search.
         ``"tinygemm"`` uses the TinyGEMM backend for small-M BF16 GEMM.
+        ``"cutile"`` uses the cuTile (cuda.tile Python) backend. Pure-Python
+            persistent-scheduled GEMM with per-shape exhaustive autotune; ignores
+            ``bias`` / ``pdl``. Requires SM >= 90.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -571,6 +574,17 @@ def mm_bf16(
             device=a.device,
             dtype=out_dtype,
         )
+
+    # cuTile backend: pure cuda.tile Python kernel, no shared C++ dispatcher.
+    # Handled before the SM100 dispatch table because it does not consume
+    # `workspace_buffer` and ignores `bias` / `pdl`.
+    if backend == "cutile":
+        from ..cutile.gemm import mm_bf16_cutile
+        if out.dtype != torch.bfloat16:
+            raise ValueError(
+                f"cutile backend requires out_dtype=bfloat16, got {out.dtype}"
+            )
+        return mm_bf16_cutile(a, b, out)
 
     workspace_buffer = _get_cache_buf(
         "mm_bf16_workspace", DEFAULT_WORKSPACE_SIZE, a.device

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6301,7 +6301,7 @@ def gemm_fp8_nt_groupwise(
     scale_granularity_mnk: Tuple[int, int, int] = (1, 128, 128),
     out: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = None,
-    backend: Literal["cutlass", "trtllm"] = "cutlass",
+    backend: Literal["cutlass", "trtllm", "cutile"] = "cutlass",
 ) -> torch.Tensor:
     r"""Performs matrix multiplication with FP8 data types using groupwise scaling.
 
@@ -6429,6 +6429,13 @@ def gemm_fp8_nt_groupwise(
             out,
             False,
             -1,
+        )
+    elif backend == "cutile":
+        from ..cutile.fp8_gemm import gemm_fp8_nt_groupwise_cutile
+        gemm_fp8_nt_groupwise_cutile(
+            a, b, a_scale, b_scale, out,
+            scale_granularity_mnk=scale_granularity_mnk,
+            scale_major_mode=scale_major_mode or "K",
         )
 
     return out

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -360,6 +360,29 @@ def _tgv_gemm_requirement(
 
 
 @supported_compute_capability([90, 100, 103, 110, 120, 121])
+def _cutile_mm_bf16_requirement(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    bias: Optional[torch.Tensor] = None,
+    pdl: bool = False,
+    backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "cutile", "auto"] = "cudnn",
+):
+    if out_dtype != torch.bfloat16:
+        raise ValueError("The cuTile backend only supports bfloat16 output.")
+    if bias is not None:
+        raise ValueError(
+            "The cuTile backend ignores `bias`; pass bias=None or use the TGV / cuDNN backend."
+        )
+    if pdl:
+        raise ValueError(
+            "The cuTile backend ignores `pdl`; pass pdl=False or use the TGV / cuDNN backend."
+        )
+    return True
+
+
+@supported_compute_capability([90, 100, 103, 110, 120, 121])
 def _tinygemm_mm_bf16_requirement(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -477,6 +500,7 @@ def _heuristic_func_mm_bf16(
         "tgv": _tgv_gemm_requirement,
         "cublaslt": _cublaslt_mm_bf16_requirement,
         "tinygemm": _tinygemm_mm_bf16_requirement,
+        "cutile": _cutile_mm_bf16_requirement,
     },
     common_check=_check_mm_bf16_problem_size,
     heuristic_func=_heuristic_func_mm_bf16,
@@ -6283,10 +6307,40 @@ def _check_gemm_fp8_nt_groupwise_problem_size(
     return True
 
 
+@supported_compute_capability([100, 103, 110, 120, 121])
+def _cutile_gemm_fp8_nt_groupwise_requirement(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    scale_major_mode: Optional[Literal["MN", "K"]] = None,
+    mma_sm: int = 1,
+    scale_granularity_mnk: Tuple[int, int, int] = (1, 128, 128),
+    out: Optional[torch.Tensor] = None,
+    out_dtype: Optional[torch.dtype] = None,
+    backend: Literal["cutlass", "trtllm", "cutile"] = "cutlass",
+):
+    # v1 supports only K-major scales + (1, 128, 128) granularity.
+    # MN-major and other granularities are documented follow-ups.
+    if scale_major_mode not in (None, "K"):
+        raise ValueError(
+            f"The cuTile backend currently supports scale_major_mode='K' only; "
+            f"got {scale_major_mode!r}."
+        )
+    m_g, n_g, k_g = scale_granularity_mnk
+    if m_g != 1 or (n_g, k_g) != (128, 128):
+        raise ValueError(
+            f"The cuTile backend currently supports scale_granularity_mnk=(1, 128, 128) only; "
+            f"got {scale_granularity_mnk}."
+        )
+    return True
+
+
 @backend_requirement(
     {
         "cutlass": _cutlass_gemm_fp8_nt_groupwise_requirement,
         "trtllm": _trtllm_gemm_fp8_nt_groupwise_requirement,
+        "cutile": _cutile_gemm_fp8_nt_groupwise_requirement,
     },
     common_check=_check_gemm_fp8_nt_groupwise_problem_size,
 )

--- a/tests/gemm/test_gemm_fp8_nt_groupwise_cutile.py
+++ b/tests/gemm/test_gemm_fp8_nt_groupwise_cutile.py
@@ -1,0 +1,117 @@
+"""Unit tests for the cuTile backend of flashinfer.gemm.gemm_fp8_nt_groupwise.
+
+The cuTile path lives in `flashinfer.cutile.fp8_gemm.gemm_fp8_nt_groupwise_cutile`
+and is wired into `flashinfer.gemm.gemm_fp8_nt_groupwise` with `backend="cutile"`.
+Companion to `test_groupwise_scaled_gemm_fp8.py`, scoped to the cuTile-only
+quirks:
+
+* Supports `scale_major_mode == "K"` only in v1
+* Supports `scale_granularity_mnk == (1, 128, 128)` only in v1
+* Requires SM >= 100 (Blackwell) and the cuda-tile python package
+"""
+
+import math
+
+import pytest
+import torch
+from einops import einsum
+
+from flashinfer.gemm import gemm_fp8_nt_groupwise
+from flashinfer.testing.utils import dequantize_fp8, quantize_fp8
+from flashinfer.utils import get_compute_capability
+
+
+def _cutile_available() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+@pytest.mark.parametrize("m", [128, 256, 512])
+@pytest.mark.parametrize("n", [2048, 4096, 7168])
+@pytest.mark.parametrize("k", [2048, 7168])
+def test_gemm_fp8_nt_groupwise_cutile(m, n, k):
+    """cuTile FP8 W8A8 GEMM must agree with the fp32 dequant reference within atol/rtol = 1e-2."""
+    if not _cutile_available():
+        pytest.skip("cuda-tile not installed in this environment.")
+    cc = get_compute_capability(torch.device("cuda"))
+    cc_num = cc[0] * 10 + cc[1]
+    if cc_num < 100:
+        pytest.skip(f"cuTile gemm_fp8_nt_groupwise targets SM >= 100; detected sm{cc_num}.")
+
+    torch.random.manual_seed(0)
+    tile_size = 128
+
+    a_val = torch.randn((m, k), dtype=torch.float, device="cuda")
+    b_val = torch.randn((n, k), dtype=torch.float, device="cuda") / math.sqrt(k)
+
+    # K-major scale layout matches the cuTile v1 expectation.
+    a_scale_shape = (m, k // tile_size)
+    b_scale_shape = (n // tile_size, k // tile_size)
+    a_tile_shape = (1, tile_size)
+    b_tile_shape = (tile_size, tile_size)
+    scale_major_mode = "K"
+
+    a_fp8, a_scale = quantize_fp8(a_val, a_scale_shape, a_tile_shape, scale_major_mode)
+    b_fp8, b_scale = quantize_fp8(b_val, b_scale_shape, b_tile_shape, scale_major_mode)
+
+    a_dequant = dequantize_fp8(a_fp8, a_scale, scale_major_mode)
+    b_dequant = dequantize_fp8(b_fp8, b_scale, scale_major_mode)
+    ref_c = einsum(a_dequant, b_dequant, "m k, n k -> m n").to(torch.bfloat16)
+
+    c = gemm_fp8_nt_groupwise(
+        a=a_fp8,
+        b=b_fp8,
+        a_scale=a_scale,
+        b_scale=b_scale,
+        scale_major_mode=scale_major_mode,
+        mma_sm=1,
+        out_dtype=torch.bfloat16,
+        backend="cutile",
+    )
+    torch.testing.assert_close(c, ref_c, atol=1e-2, rtol=1e-2)
+
+
+def test_gemm_fp8_nt_groupwise_cutile_rejects_mn_scale_major():
+    """The v1 cuTile path only supports K-major scales; MN-major must raise."""
+    if not _cutile_available():
+        pytest.skip("cuda-tile not installed in this environment.")
+    cc = get_compute_capability(torch.device("cuda"))
+    cc_num = cc[0] * 10 + cc[1]
+    if cc_num < 100:
+        pytest.skip(f"cuTile gemm_fp8_nt_groupwise targets SM >= 100; detected sm{cc_num}.")
+
+    torch.random.manual_seed(0)
+    m, n, k = 128, 1024, 2048
+    tile_size = 128
+
+    a_val = torch.randn((m, k), dtype=torch.float, device="cuda")
+    b_val = torch.randn((n, k), dtype=torch.float, device="cuda")
+
+    a_scale_shape = (k // tile_size, m)
+    b_scale_shape = (k // tile_size, n // tile_size)
+    a_tile_shape = (1, tile_size)
+    b_tile_shape = (tile_size, tile_size)
+
+    a_fp8, a_scale = quantize_fp8(a_val, a_scale_shape, a_tile_shape, "MN")
+    b_fp8, b_scale = quantize_fp8(b_val, b_scale_shape, b_tile_shape, "MN")
+
+    # The @backend_requirement decorator raises ValueError before reaching the
+    # cuTile module's own NotImplementedError.
+    with pytest.raises(ValueError, match="scale_major_mode='K' only"):
+        gemm_fp8_nt_groupwise(
+            a=a_fp8,
+            b=b_fp8,
+            a_scale=a_scale,
+            b_scale=b_scale,
+            scale_major_mode="MN",
+            mma_sm=1,
+            out_dtype=torch.bfloat16,
+            backend="cutile",
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/gemm/test_mm_bf16_cutile.py
+++ b/tests/gemm/test_mm_bf16_cutile.py
@@ -1,0 +1,107 @@
+"""Unit tests for the cuTile backend of flashinfer.mm_bf16.
+
+The cuTile path lives in `flashinfer.cutile.gemm.mm_bf16_cutile` and is wired
+into the upstream `flashinfer.mm_bf16` dispatcher with `backend="cutile"`.
+Companion to `test_mm_bf16.py`, scoped to the cuTile-only quirks:
+
+* `out_dtype == torch.bfloat16` only (raises ValueError otherwise)
+* ignores `bias` / `pdl` (the cuTile kernel is alpha=1, beta=0)
+* requires SM >= 90 and cuda-tile python package
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer import mm_bf16
+from flashinfer.utils import get_compute_capability
+
+
+def _cutile_available() -> bool:
+    """The cuTile path is optional — gracefully skip when the runtime is missing."""
+    try:
+        import cuda.tile  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _supported_sm(cc_num: int) -> bool:
+    # Autotune config space targets Hopper (sm90) and newer.
+    return cc_num >= 90
+
+
+@pytest.mark.parametrize("m", [16, 64, 256, 1024])
+@pytest.mark.parametrize("n", [1024, 4096])
+@pytest.mark.parametrize("k", [1536, 7168])
+def test_mm_bf16_cutile(m: int, n: int, k: int):
+    """cuTile mm_bf16 output must match the cuBLAS torch.mm reference within cos_sim > 0.99."""
+    if not _cutile_available():
+        pytest.skip("cuda-tile not installed in this environment.")
+    cc = get_compute_capability(torch.device("cuda"))
+    cc_num = cc[0] * 10 + cc[1]
+    if not _supported_sm(cc_num):
+        pytest.skip(f"cuTile mm_bf16 requires SM >= 90 (detected sm{cc_num}).")
+
+    torch.manual_seed(42)
+    a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
+    b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)
+
+    # The upstream mm_bf16 contract takes `b` shape (k, n) in column-major
+    # (a transposed view of an (n, k) row-major tensor). torch.mm gives the
+    # same arithmetic.
+    reference = torch.mm(a, b.T)
+
+    out = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
+    mm_bf16(a, b.T, None, False, out, torch.bfloat16, backend="cutile")
+
+    cos_sim = F.cosine_similarity(reference.reshape(-1), out.reshape(-1), dim=0)
+    assert cos_sim > 0.99, f"cuTile mm_bf16 output mismatch: cos_sim={cos_sim:.6f}"
+
+
+def test_mm_bf16_cutile_rejects_non_bf16_out():
+    """The v1 cuTile path only emits bf16; fp16/fp32 out_dtype must raise."""
+    if not _cutile_available():
+        pytest.skip("cuda-tile not installed in this environment.")
+    cc = get_compute_capability(torch.device("cuda"))
+    cc_num = cc[0] * 10 + cc[1]
+    if not _supported_sm(cc_num):
+        pytest.skip(f"cuTile mm_bf16 requires SM >= 90 (detected sm{cc_num}).")
+
+    # a is (m, k) = (64, 1024); b is (n, k) = (2048, 1024); b.T is (k, n) = (1024, 2048)
+    a = torch.randn(64, 1024, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(2048, 1024, device="cuda", dtype=torch.bfloat16)
+    out = torch.empty(64, 2048, device="cuda", dtype=torch.float16)
+    # The @backend_requirement decorator catches this in `_cutile_mm_bf16_requirement`
+    # with the message "only supports bfloat16 output".
+    with pytest.raises(ValueError, match="only supports bfloat16 output"):
+        mm_bf16(a, b.T, None, False, out, torch.float16, backend="cutile")
+
+
+def test_mm_bf16_cutile_repeat_uses_tune_cache():
+    """Second call on the same shape should reuse the cached autotune result (no exception)."""
+    if not _cutile_available():
+        pytest.skip("cuda-tile not installed in this environment.")
+    cc = get_compute_capability(torch.device("cuda"))
+    cc_num = cc[0] * 10 + cc[1]
+    if not _supported_sm(cc_num):
+        pytest.skip(f"cuTile mm_bf16 requires SM >= 90 (detected sm{cc_num}).")
+
+    # a is (m, k) = (64, 1024); b is (n, k) = (2048, 1024); b.T is (k, n) = (1024, 2048)
+    # mm_bf16 computes a @ b.T → (m, n) = (64, 2048).
+    a = torch.randn(64, 1024, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(2048, 1024, device="cuda", dtype=torch.bfloat16)
+    out = torch.empty(64, 2048, device="cuda", dtype=torch.bfloat16)
+
+    # First call: warms tune cache.
+    mm_bf16(a, b.T, None, False, out, torch.bfloat16, backend="cutile")
+    out_first = out.clone()
+
+    # Second call: must produce the same result and not raise.
+    mm_bf16(a, b.T, None, False, out, torch.bfloat16, backend="cutile")
+    cos_sim = F.cosine_similarity(out_first.reshape(-1), out.reshape(-1), dim=0)
+    assert cos_sim > 0.999, "tune-cache reuse produced divergent output"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds a `backend="cutile"` option to `flashinfer.gemm.gemm_fp8_nt_groupwise`, wrapping a `cuda.tile` Python kernel ported from NVIDIA TileGym for FP8 W8A8 block-scaled GEMM. Targets the DeepSeek-R1 / DeepSeek-V3 FP8 inference hot path.

This PR stacks on the `mm_bf16(cutile)` PR (cuTile module bootstrap). When that lands, the dependency commits drop out automatically.

* `flashinfer/cutile/fp8_gemm.py` (new, ~400 lines): `_w8a8_block_fp8_matmul_kernel` + autotune + `gemm_fp8_nt_groupwise_cutile` wrapper. Supports `scale_granularity_mnk=(1, 128, 128)` + `scale_major_mode="K"`.
* `flashinfer/gemm/gemm_base.py`: adds `_cutile_gemm_fp8_nt_groupwise_requirement`, registers `"cutile"` in the `@backend_requirement` map + `backend` Literal, dispatch branch.
* `tests/gemm/test_gemm_fp8_nt_groupwise_cutile.py`: 18 parametrized + reject-MN-scale test.

### Performance (B200, eager mode, microseconds, lower is better)

| shape (M × N × K)         | cuTile | cutlass | trtllm | comment |
|---------------------------|--------|---------|--------|---------|
| 128 × 7168 × 2048         | 28.9   | 43.2    | 42.6   | expert_down |
| 256 × 7168 × 2048         | 35.5   | 43.0    | 55.3   | expert_down |
| 128 × 4096 × 7168         | 52.8   | 53.1    | 36.9   | mid_proj |
| 256 × 4096 × 7168         | 44.9   | 53.2    | 48.2   | mid_proj |

cuTile is fastest or near-fastest in this range — there's no cuBLAS competitor for FP8 W8A8 block-scaled.

## 🔍 Related Issues

None — stacks on the `mm_bf16(cutile)` PR.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`, hooks installed, `pre-commit run --all-files` clean.

## 🧪 Tests

- [x] Tests added: `tests/gemm/test_gemm_fp8_nt_groupwise_cutile.py` (18/18 PASS on B200).

## Reviewer Notes

- v1 supports `scale_granularity_mnk == (1, 128, 128)` and `scale_major_mode == "K"` only — these are the DeepSeek-R1/V3 defaults. Adding the `(128, 128, 128)` blockscaled variant or MN-major scale mode is one config switch in the kernel; punted to follow-up.
- The wrapper enforces these constraints with clear `ValueError` (see `test_gemm_fp8_nt_groupwise_cutile_rejects_mn_scale_major`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cuTile backend support for BF16 matrix multiplication operations
  * Added cuTile backend support for FP8 quantized matrix multiplication with per-block scaling
  * Extended benchmark suite to include cuTile backend option

* **Tests**
  * Added comprehensive test coverage for cuTile implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->