### PR TITLE
[bugfix] TorchDistBackend.bcast uses global rank instead of local rank

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -267,9 +267,17 @@ class TorchDistBackend(CommBackend):
         return output_list
 
     def bcast(self, data: Any, root: int) -> Any:
-        """Broadcast a Python object from root to all ranks."""
+        """Broadcast a Python object from root to all ranks.
+
+        Args:
+            data: object to broadcast (only used on the root rank).
+            root: group-local rank of the sender (consistent with MPI).
+        """
         object_list = [data]
-        self._dist.broadcast_object_list(object_list, src=root, group=self._group)
+        global_root = self._dist.get_global_rank(self._group, root)
+        self._dist.broadcast_object_list(
+            object_list, src=global_root, group=self._group
+        )
         return object_list[0]
 
     def barrier(self) -> None:

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -274,7 +274,11 @@ class TorchDistBackend(CommBackend):
             root: group-local rank of the sender (consistent with MPI).
         """
         object_list = [data]
-        global_root = self._dist.get_global_rank(self._group, root)
+        global_root = (
+            self._dist.get_global_rank(self._group, root)
+            if self._group is not None
+            else root
+        )
         self._dist.broadcast_object_list(
             object_list, src=global_root, group=self._group
         )

--- a/tests/comm/test_trtllm_allreduce_fusion_subgroup.py
+++ b/tests/comm/test_trtllm_allreduce_fusion_subgroup.py
@@ -18,7 +18,6 @@ from flashinfer.comm.mnnvl import TorchDistBackend
 
 
 def _worker_subgroup(tp_size: int, hidden_dim: int, use_unified_api: bool):
-    """Worker function launched via elastic_launch (torchrun semantics)."""
     dist.init_process_group(backend="nccl")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
@@ -65,7 +64,7 @@ def _worker_subgroup(tp_size: int, hidden_dim: int, use_unified_api: bool):
 
 
 def _launch_subgroup_test(tp_size: int, hidden_dim: int, use_unified_api: bool):
-    """Launch 4 workers via elastic_launch (same as torchrun)."""
+    """Launch 4 workers via elastic_launch, same as torchrun."""
     from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 
     config = LaunchConfig(
@@ -84,12 +83,6 @@ def _launch_subgroup_test(tp_size: int, hidden_dim: int, use_unified_api: bool):
 @pytest.mark.parametrize("hidden_dim", [1024, 7168])
 @pytest.mark.parametrize("use_unified_api", [False, True])
 def test_trtllm_allreduce_fusion_subgroup(tp_size, hidden_dim, use_unified_api):
-    """Test allreduce fusion with TP sub-groups (not WORLD group).
-
-    Simulates a TP=2/DP=2 deployment where 4 GPUs form 2 independent TP groups.
-    Both workspace creation and allreduce execution must work for ALL sub-groups,
-    not just the one containing global rank 0.
-    """
     available_gpus = torch.cuda.device_count()
     if available_gpus < 4:
         pytest.skip(f"Test requires 4 GPUs, only {available_gpus} available")

--- a/tests/comm/test_trtllm_allreduce_fusion_subgroup.py
+++ b/tests/comm/test_trtllm_allreduce_fusion_subgroup.py
@@ -1,0 +1,97 @@
+"""
+Test allreduce fusion workspace creation with TP sub-groups.
+
+Requires: 4 GPUs (2 TP groups of size 2).
+
+Uses torch.distributed.launcher to spawn workers the same way
+torchrun does. This is necessary because the bug only manifests under
+torchrun-style initialization, where broadcast_object_list interprets `src` as
+a global rank. With mp.Process-style init the bug does not reproduce.
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import flashinfer.comm as comm
+from flashinfer.comm.mnnvl import TorchDistBackend
+
+
+def _worker_subgroup(tp_size: int, hidden_dim: int, use_unified_api: bool):
+    """Worker function launched via elastic_launch (torchrun semantics)."""
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.cuda.set_device(rank)
+
+    assert world_size == 4, f"Requires 4 GPUs, got {world_size}"
+
+    my_tp_group = None
+    for start in range(0, world_size, tp_size):
+        ranks = list(range(start, start + tp_size))
+        group = dist.new_group(ranks)
+        if rank in ranks:
+            my_tp_group = group
+
+    assert my_tp_group is not None
+    tp_rank = dist.get_rank(group=my_tp_group)
+
+    comm_backend = TorchDistBackend(group=my_tp_group)
+
+    if use_unified_api:
+        workspace = comm.create_allreduce_fusion_workspace(
+            backend="trtllm",
+            world_size=tp_size,
+            rank=tp_rank,
+            max_token_num=1024,
+            hidden_dim=hidden_dim,
+            dtype=torch.bfloat16,
+            comm_backend=comm_backend,
+        )
+    else:
+        comm.trtllm_create_ipc_workspace_for_all_reduce_fusion(
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            max_token_num=1024,
+            hidden_dim=hidden_dim,
+            group=my_tp_group,
+        )
+        workspace = None
+
+    if workspace is not None:
+        workspace.destroy()
+
+    dist.destroy_process_group()
+
+
+def _launch_subgroup_test(tp_size: int, hidden_dim: int, use_unified_api: bool):
+    """Launch 4 workers via elastic_launch (same as torchrun)."""
+    from torch.distributed.launcher.api import LaunchConfig, elastic_launch
+
+    config = LaunchConfig(
+        min_nodes=1,
+        max_nodes=1,
+        nproc_per_node=4,
+        rdzv_backend="c10d",
+        rdzv_endpoint="localhost:0",
+        max_restarts=0,
+        start_method="spawn",
+    )
+    elastic_launch(config, _worker_subgroup)(tp_size, hidden_dim, use_unified_api)
+
+
+@pytest.mark.parametrize("tp_size", [2])
+@pytest.mark.parametrize("hidden_dim", [1024, 7168])
+@pytest.mark.parametrize("use_unified_api", [False, True])
+def test_trtllm_allreduce_fusion_subgroup(tp_size, hidden_dim, use_unified_api):
+    """Test allreduce fusion with TP sub-groups (not WORLD group).
+
+    Simulates a TP=2/DP=2 deployment where 4 GPUs form 2 independent TP groups.
+    Both workspace creation and allreduce execution must work for ALL sub-groups,
+    not just the one containing global rank 0.
+    """
+    available_gpus = torch.cuda.device_count()
+    if available_gpus < 4:
+        pytest.skip(f"Test requires 4 GPUs, only {available_gpus} available")
+
+    _launch_subgroup_test(tp_size, hidden_dim, use_unified_api)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Introduced in https://github.com/flashinfer-ai/flashinfer/pull/2955 `TorchDistBackend.bcast()` in `flashinfer/comm/mnnvl.py` passes the `root` parameter directly to `torch.distributed.broadcast_object_list(src=root)`. The `root` parameter is intended to be a **group-local rank**, but `broadcast_object_list` interprets `src` as a **global rank** when using torchrun initialized NCCL backends. This causes `create_allreduce_fusion_workspace(backend="trtllm", ...)` to crash for any TP sub-group that does not contain global rank 0.

In vLLM, the `AllReduceFusionPass` (fused allreduce + RMSNorm, auto-enabled at optimization level O2+ with TP > 1 on Hopper/Blackwell) calls `create_allreduce_fusion_workspace` for the TP sub-group. The workspace creation failure is caught by a try/except, resulting in a `None` workspace. When the fused allreduce kernel runs during CUDA graph capture, it silently hangs because the workspace is missing.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadcast now correctly interprets sender rank within distributed sub-groups, improving group-local broadcast behavior and documentation.

* **Tests**
  * Added distributed tests validating allreduce fusion workspace creation with tensor-parallel sub-groups across multiple GPU configurations and hidden-dimension scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->