### PR TITLE
feat: batch splitting with LUT optimization for TRTLLM-GEN MLA

### DIFF
--- a/benchmarks/evaluate_trtllm_gen_mla_batch_split.py
+++ b/benchmarks/evaluate_trtllm_gen_mla_batch_split.py
@@ -1,0 +1,239 @@
+import argparse
+import os
+
+import numpy as np
+import torch
+
+
+LUT_ENV = "FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT"
+
+
+def dtype_from_str(dtype_str: str) -> torch.dtype:
+    if dtype_str in ("bf16", "bfloat16"):
+        return torch.bfloat16
+    if dtype_str in ("fp8_e4m3", "fp8", "e4m3"):
+        return torch.float8_e4m3fn
+    raise ValueError(f"Unsupported dtype: {dtype_str}")
+
+
+def make_benchmark_case(
+    batch_size,
+    q_len_per_request,
+    seq_len,
+    page_size,
+    dtype,
+    num_q_heads,
+    kv_lora_rank,
+    qk_rope_head_dim,
+    workspace_mib,
+    fixed_seq_len,
+):
+    torch.manual_seed(42)
+    device = "cuda:0"
+    head_dim_qk = kv_lora_rank + qk_rope_head_dim
+
+    query = torch.randn(
+        batch_size,
+        q_len_per_request,
+        num_q_heads,
+        head_dim_qk,
+        device=device,
+    ).to(dtype)
+
+    if fixed_seq_len:
+        seq_lens = [seq_len] * batch_size
+    else:
+        seq_lens = [torch.randint(1, seq_len, (1,)).item() for _ in range(batch_size)]
+        seq_lens[-1] = seq_len
+    max_seq_len = max(seq_lens)
+    seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.int32, device=device)
+
+    blocks_per_seq = (seq_lens_tensor + page_size - 1) // page_size
+    max_num_blocks_per_seq = int(blocks_per_seq.max().item())
+    total_blocks_needed = int(blocks_per_seq.sum().item())
+    block_ids = torch.randperm(total_blocks_needed, device=device)
+    block_tables = torch.zeros(
+        (batch_size, max_num_blocks_per_seq), dtype=torch.int32, device=device
+    )
+
+    block_offset = 0
+    for batch_idx in range(batch_size):
+        num_blocks = int(blocks_per_seq[batch_idx].item())
+        block_tables[batch_idx, :num_blocks] = block_ids[
+            block_offset : block_offset + num_blocks
+        ]
+        block_offset += num_blocks
+
+    kv_cache = torch.randn(
+        total_blocks_needed,
+        1,
+        page_size,
+        head_dim_qk,
+        device=device,
+    ).to(dtype)
+    workspace_buffer = torch.zeros(
+        workspace_mib * 1024 * 1024, dtype=torch.int8, device=device
+    )
+    out = torch.empty(
+        batch_size,
+        q_len_per_request,
+        num_q_heads,
+        kv_lora_rank,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    return (
+        query,
+        kv_cache,
+        workspace_buffer,
+        block_tables,
+        seq_lens_tensor,
+        max_seq_len,
+        out,
+    )
+
+
+def run_decode(
+    query,
+    kv_cache,
+    workspace_buffer,
+    block_tables,
+    seq_lens,
+    max_seq_len,
+    out,
+    flashinfer_module,
+    backend,
+    qk_nope_head_dim,
+    kv_lora_rank,
+    qk_rope_head_dim,
+    sm_scale,
+):
+    flashinfer_module.decode.trtllm_batch_decode_with_kv_cache_mla(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace_buffer,
+        qk_nope_head_dim=qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=max_seq_len,
+        out=out,
+        bmm1_scale=sm_scale,
+        bmm2_scale=1.0,
+        backend=backend,
+    )
+
+
+def calculate_metrics(case, args, execution_time_ms):
+    query, _, _, _, seq_lens, _, _ = case
+    elem_size = query.element_size()
+    actual_kv_tokens = int(seq_lens.sum().item())
+    query_bytes = query.numel() * elem_size
+    kv_bytes = (
+        actual_kv_tokens * (args.kv_lora_rank + args.qk_rope_head_dim) * elem_size
+    )
+    output_bytes = (
+        args.batch_size
+        * args.q_len_per_request
+        * args.num_qo_heads
+        * args.kv_lora_rank
+        * elem_size
+    )
+    total_bytes = query_bytes + kv_bytes + output_bytes
+    flops = (
+        2
+        * args.num_qo_heads
+        * (2 * args.kv_lora_rank + args.qk_rope_head_dim)
+        * actual_kv_tokens
+        * args.q_len_per_request
+    )
+    return total_bytes / execution_time_ms / 1e6, flops / execution_time_ms / 1e9
+
+
+def evaluate_trtllm_mla(args):
+    import flashinfer as flashinfer_module
+    from flashinfer.testing.utils import bench_gpu_time
+
+    dtype = dtype_from_str(args.dtype)
+    head_dim_qk = args.kv_lora_rank + args.qk_rope_head_dim
+    sm_scale = 1.0 / (head_dim_qk**0.5)
+    case = make_benchmark_case(
+        args.batch_size,
+        args.q_len_per_request,
+        args.seq_len,
+        args.page_size,
+        dtype,
+        args.num_qo_heads,
+        args.kv_lora_rank,
+        args.qk_rope_head_dim,
+        args.workspace_mib,
+        args.fixed_seq_len,
+    )
+    input_args = (
+        *case,
+        flashinfer_module,
+        args.backend,
+        args.qk_nope_head_dim,
+        args.kv_lora_rank,
+        args.qk_rope_head_dim,
+        sm_scale,
+    )
+    measurements = bench_gpu_time(
+        run_decode,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.num_iters,
+        enable_cupti=False,
+        use_cuda_graph=True,
+        input_args=input_args,
+        cold_l2_cache=True,
+    )
+    execution_time_ms = float(np.median(measurements))
+    bandwidth_gbps, tflops = calculate_metrics(case, args, execution_time_ms)
+
+    print(
+        f"backend={args.backend}, batch_size={args.batch_size}, "
+        f"q_len_per_request={args.q_len_per_request}, seq_len={args.seq_len}, "
+        f"fixed_seq_len={args.fixed_seq_len}, num_q_heads={args.num_qo_heads}, "
+        f"qk_nope_head_dim={args.qk_nope_head_dim}, "
+        f"qk_rope_head_dim={args.qk_rope_head_dim}, "
+        f"kv_lora_rank={args.kv_lora_rank}, page_size={args.page_size}, "
+        f"dtype={args.dtype}, workspace_mib={args.workspace_mib}, "
+        f"{LUT_ENV}={os.getenv(LUT_ENV, '')}"
+    )
+    print(f"execution time: {execution_time_ms:.4f} ms")
+    print(f"memory bandwidth: {bandwidth_gbps:.2f} GB/s")
+    print(f"FLOPs: {tflops:.2f} TFLOPs/s")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Evaluate TRTLLM-GEN MLA decode with an optional batch-split LUT"
+    )
+    parser.add_argument("--backend", type=str, default="trtllm-gen")
+    parser.add_argument("--batch_size", type=int, default=40)
+    parser.add_argument("--q_len_per_request", type=int, default=2)
+    parser.add_argument("--seq_len", type=int, default=20480)
+    parser.add_argument("--page_size", type=int, default=32, choices=[32, 64])
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="fp8_e4m3",
+        choices=["bf16", "bfloat16", "fp8_e4m3", "fp8", "e4m3"],
+    )
+    parser.add_argument("--num_iters", type=int, default=30)
+    parser.add_argument("--dry_run_iters", type=int, default=5)
+    parser.add_argument("--fixed_seq_len", action="store_true")
+    parser.add_argument("--num_qo_heads", type=int, default=64)
+    parser.add_argument("--head_dim_ckv", type=int, default=512)
+    parser.add_argument("--head_dim_kpe", type=int, default=64)
+    parser.add_argument("--qk_nope_head_dim", type=int, default=128)
+    parser.add_argument("--workspace_mib", type=int, default=256)
+    args = parser.parse_args()
+    args.kv_lora_rank = args.head_dim_ckv
+    args.qk_rope_head_dim = args.head_dim_kpe
+    return args
+
+
+if __name__ == "__main__":
+    evaluate_trtllm_mla(parse_args())

--- a/benchmarks/generate_trtllm_gen_mla_batch_split_lut.py
+++ b/benchmarks/generate_trtllm_gen_mla_batch_split_lut.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+import argparse
+import datetime
+import itertools
+import json
+import math
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV = "FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a TRTLLM-GEN MLA decode batch-split LUT by benchmarking "
+            "multi-launch splits."
+        )
+    )
+    parser.add_argument(
+        "--output", type=Path, default=None, help="Output JSON LUT path"
+    )
+    parser.add_argument("--device", type=int, default=0, help="CUDA device index")
+    parser.add_argument(
+        "--max-batch-size",
+        type=int,
+        default=None,
+        help="Largest batch size to benchmark; defaults to the device SM count",
+    )
+    parser.add_argument(
+        "--seq-len", type=int, default=20480, help="Maximum KV sequence length"
+    )
+    parser.add_argument(
+        "--fixed-seq-len",
+        action="store_true",
+        default=True,
+        help="Use the same KV sequence length for every request",
+    )
+    parser.add_argument(
+        "--var-seq-len",
+        action="store_false",
+        dest="fixed_seq_len",
+        help="Use random per-request KV sequence lengths up to seq-len",
+    )
+    parser.add_argument(
+        "--q-len-per-request", type=int, default=2, help="Query length per request"
+    )
+    parser.add_argument("--page-size", type=int, default=64, choices=(32, 64))
+    parser.add_argument(
+        "--dtype", type=str, default="bfloat16", choices=("bfloat16", "float8_e4m3fn")
+    )
+    parser.add_argument("--num-q-heads", type=int, default=128)
+    parser.add_argument("--qk-nope-head-dim", type=int, default=128)
+    parser.add_argument("--qk-rope-head-dim", type=int, default=64)
+    parser.add_argument("--kv-lora-rank", type=int, default=512)
+    parser.add_argument("--workspace-mib", type=int, default=256)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--dry-run-iters", type=int, default=5)
+    parser.add_argument("--repeat-iters", type=int, default=30)
+    parser.add_argument(
+        "--min-speedup",
+        type=float,
+        default=1.02,
+        help="Only keep splits at least this much faster than baseline",
+    )
+    parser.add_argument(
+        "--max-num-splits",
+        type=int,
+        default=3,
+        help="Maximum number of sub-batches to benchmark per batch size",
+    )
+    return parser.parse_args()
+
+
+def torch_dtype(dtype_name):
+    if dtype_name == "bfloat16":
+        return torch.bfloat16
+    if dtype_name == "float8_e4m3fn":
+        return torch.float8_e4m3fn
+    raise ValueError(f"Unsupported dtype: {dtype_name}")
+
+
+def make_benchmark_case(batch_size, args, device, dtype):
+    generator = torch.Generator(device=device)
+    generator.manual_seed(args.seed + batch_size)
+
+    head_dim = args.kv_lora_rank + args.qk_rope_head_dim
+    query = torch.randn(
+        batch_size,
+        args.q_len_per_request,
+        args.num_q_heads,
+        head_dim,
+        device=device,
+        generator=generator,
+    ).to(dtype)
+
+    if args.fixed_seq_len:
+        seq_lens = torch.full(
+            (batch_size,), args.seq_len, dtype=torch.int32, device=device
+        )
+    else:
+        seq_lens = torch.randint(
+            1,
+            args.seq_len + 1,
+            (batch_size,),
+            dtype=torch.int32,
+            device=device,
+            generator=generator,
+        )
+        seq_lens[-1] = args.seq_len
+    max_seq_len = int(seq_lens.max().item())
+
+    blocks_per_seq = (seq_lens + args.page_size - 1) // args.page_size
+    max_num_blocks_per_seq = int(blocks_per_seq.max().item())
+    total_blocks_needed = int(blocks_per_seq.sum().item())
+    block_ids = torch.randperm(total_blocks_needed, device=device, generator=generator)
+    block_tables = torch.zeros(
+        (batch_size, max_num_blocks_per_seq), dtype=torch.int32, device=device
+    )
+
+    block_offset = 0
+    for batch_idx in range(batch_size):
+        num_blocks = int(blocks_per_seq[batch_idx].item())
+        block_tables[batch_idx, :num_blocks] = block_ids[
+            block_offset : block_offset + num_blocks
+        ]
+        block_offset += num_blocks
+
+    kv_cache = torch.randn(
+        total_blocks_needed,
+        1,
+        args.page_size,
+        head_dim,
+        device=device,
+        generator=generator,
+    ).to(dtype)
+    workspace_buffer = torch.zeros(
+        args.workspace_mib * 1024 * 1024, dtype=torch.int8, device=device
+    )
+    out = torch.empty(
+        batch_size,
+        args.q_len_per_request,
+        args.num_q_heads,
+        args.kv_lora_rank,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    return query, kv_cache, workspace_buffer, block_tables, seq_lens, max_seq_len, out
+
+
+def run_decode_tensors(
+    query,
+    kv_cache,
+    workspace_buffer,
+    block_tables,
+    seq_lens,
+    max_seq_len,
+    out,
+    flashinfer_module,
+    args,
+    start_batch,
+    end_batch,
+):
+    flashinfer_module.decode.trtllm_batch_decode_with_kv_cache_mla(
+        query=query[start_batch:end_batch],
+        kv_cache=kv_cache,
+        workspace_buffer=workspace_buffer,
+        qk_nope_head_dim=args.qk_nope_head_dim,
+        kv_lora_rank=args.kv_lora_rank,
+        qk_rope_head_dim=args.qk_rope_head_dim,
+        block_tables=block_tables[start_batch:end_batch],
+        seq_lens=seq_lens[start_batch:end_batch],
+        max_seq_len=max_seq_len,
+        out=out[start_batch:end_batch],
+        bmm1_scale=1.0 / ((args.qk_nope_head_dim + args.qk_rope_head_dim) ** 0.5),
+        bmm2_scale=1.0,
+        backend="trtllm-gen",
+    )
+
+
+def run_decode(case, args, start_batch, end_batch):
+    import flashinfer as flashinfer_module
+
+    run_decode_tensors(*case, flashinfer_module, args, start_batch, end_batch)
+
+
+def iter_splits(batch_size, max_num_splits):
+    max_num_splits = min(max_num_splits, batch_size)
+    for num_splits in range(2, max_num_splits + 1):
+        for split_points in itertools.combinations(
+            range(1, batch_size), num_splits - 1
+        ):
+            previous_split_point = 0
+            split = []
+            for split_point in split_points:
+                split.append(split_point - previous_split_point)
+                previous_split_point = split_point
+            split.append(batch_size - previous_split_point)
+            yield tuple(split)
+
+
+def count_splits(batch_size, max_num_splits):
+    max_num_splits = min(max_num_splits, batch_size)
+    return sum(
+        math.comb(batch_size - 1, num_splits - 1)
+        for num_splits in range(2, max_num_splits + 1)
+    )
+
+
+def split_count_breakdown(batch_size, max_num_splits):
+    max_num_splits = min(max_num_splits, batch_size)
+    return ", ".join(
+        f"{num_splits} parts: {math.comb(batch_size - 1, num_splits - 1)}"
+        for num_splits in range(2, max_num_splits + 1)
+    )
+
+
+def median_ms(fn, bench_gpu_time_fn, args, input_args):
+    measurements = bench_gpu_time_fn(
+        fn,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.repeat_iters,
+        enable_cupti=False,
+        use_cuda_graph=True,
+        input_args=input_args,
+        cold_l2_cache=True,
+    )
+    return float(np.median(measurements))
+
+
+def calculate_decode_metrics(case, args, execution_time_ms):
+    query, _, _, _, seq_lens, _, _ = case
+    elem_size = query.element_size()
+    actual_kv_tokens = int(seq_lens.sum().item())
+    query_bytes = query.numel() * elem_size
+    kv_bytes = (
+        actual_kv_tokens * (args.kv_lora_rank + args.qk_rope_head_dim) * elem_size
+    )
+    output_bytes = (
+        query.size(0)
+        * args.q_len_per_request
+        * args.num_q_heads
+        * args.kv_lora_rank
+        * elem_size
+    )
+    total_bytes = query_bytes + kv_bytes + output_bytes
+    flops = (
+        2
+        * args.num_q_heads
+        * (2 * args.kv_lora_rank + args.qk_rope_head_dim)
+        * actual_kv_tokens
+        * args.q_len_per_request
+    )
+    return {
+        "actual_kv_tokens": actual_kv_tokens,
+        "memory_bandwidth_gbps": total_bytes / execution_time_ms / 1e6,
+        "tflops": flops / execution_time_ms / 1e9,
+    }
+
+
+def benchmark_single_batch(
+    batch_size,
+    max_batch_size,
+    flashinfer_module,
+    bench_gpu_time_fn,
+    args,
+    device,
+    dtype,
+):
+    case = make_benchmark_case(batch_size, args, device, dtype)
+    print(
+        f"[{batch_size}/1..{max_batch_size}] measuring single-launch latency",
+        flush=True,
+    )
+    single_launch_ms = median_ms(
+        run_decode_tensors,
+        bench_gpu_time_fn,
+        args,
+        (*case, flashinfer_module, args, 0, batch_size),
+    )
+    metrics = calculate_decode_metrics(case, args, single_launch_ms)
+    print(
+        f"[{batch_size}/1..{max_batch_size}] execution time: {single_launch_ms:.4f} ms, "
+        f"memory bandwidth: {metrics['memory_bandwidth_gbps']:.2f} GB/s, "
+        f"FLOPs: {metrics['tflops']:.2f} TFLOPs/s",
+        flush=True,
+    )
+    return {"batch_size": batch_size, "single_launch_ms": single_launch_ms, **metrics}
+
+
+def find_best_split_from_table(
+    batch_size, max_batch_size, args, single_launch_ms_by_batch
+):
+    baseline_ms = single_launch_ms_by_batch[batch_size]
+    best_split = None
+    best_split_ms = baseline_ms
+    split_count = count_splits(batch_size, args.max_num_splits)
+    print(
+        f"[{batch_size}/1..{max_batch_size}] searching {split_count} "
+        f"split candidates up to {args.max_num_splits} parts "
+        f"({split_count_breakdown(batch_size, args.max_num_splits)}, "
+        f"baseline={baseline_ms:.4f}ms) from measured single-launch table",
+        flush=True,
+    )
+    for split_idx, split in enumerate(
+        iter_splits(batch_size, args.max_num_splits), start=1
+    ):
+        split_ms = sum(
+            single_launch_ms_by_batch[split_batch_size] for split_batch_size in split
+        )
+        if split_ms < best_split_ms:
+            best_split_ms = split_ms
+            best_split = split
+            split_label = "+".join(str(value) for value in split)
+            speedup = baseline_ms / split_ms
+            print(
+                f"[{batch_size}/1..{max_batch_size}] found new best "
+                f"split {split_label} at candidate {split_idx}/{split_count}: "
+                f"{split_ms:.4f}ms speedup={speedup:.4f}",
+                flush=True,
+            )
+
+    speedup = baseline_ms / best_split_ms if best_split is not None else 1.0
+    if best_split is None or speedup < args.min_speedup:
+        best_split = None
+
+    return {
+        "batch_size": batch_size,
+        "baseline_ms": baseline_ms,
+        "best_split": list(best_split) if best_split is not None else None,
+        "best_split_ms": best_split_ms,
+        "speedup": speedup,
+    }
+
+
+def print_run_config(args, device, sm_count, max_batch_size, dtype):
+    config = {
+        "device": str(device),
+        "device_name": torch.cuda.get_device_name(device),
+        "sm_count": sm_count,
+        "max_batch_size": max_batch_size,
+        "seq_len": args.seq_len,
+        "fixed_seq_len": args.fixed_seq_len,
+        "q_len_per_request": args.q_len_per_request,
+        "page_size": args.page_size,
+        "dtype": str(dtype).removeprefix("torch."),
+        "num_q_heads": args.num_q_heads,
+        "qk_nope_head_dim": args.qk_nope_head_dim,
+        "qk_rope_head_dim": args.qk_rope_head_dim,
+        "kv_lora_rank": args.kv_lora_rank,
+        "workspace_mib": args.workspace_mib,
+        "seed": args.seed,
+        "dry_run_iters": args.dry_run_iters,
+        "repeat_iters": args.repeat_iters,
+        "min_speedup": args.min_speedup,
+        "max_num_splits": args.max_num_splits,
+        "use_cuda_graph": True,
+    }
+    print("TRTLLM-GEN MLA batch-split LUT generation config:", flush=True)
+    print(json.dumps(config, indent=2, sort_keys=True), flush=True)
+
+
+def main():
+    args = parse_args()
+    os.environ.pop(TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV, None)
+    if args.max_num_splits < 2:
+        raise ValueError("--max-num-splits must be at least 2")
+
+    import flashinfer as flashinfer_module
+    from flashinfer.testing.utils import bench_gpu_time as bench_gpu_time_fn
+
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA is required to generate a TRTLLM-GEN MLA batch-split LUT"
+        )
+
+    device = torch.device(f"cuda:{args.device}")
+    torch.cuda.set_device(device)
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    max_batch_size = args.max_batch_size or sm_count
+    dtype = torch_dtype(args.dtype)
+    print_run_config(args, device, sm_count, max_batch_size, dtype)
+
+    output_path = args.output or Path(
+        f"trtllm_gen_mla_batch_split_lut_sm{sm_count}.json"
+    )
+    measurements = []
+    single_launch_measurements = []
+    single_launch_ms_by_batch = {}
+    splits = {}
+
+    print(
+        f"Precomputing single-launch latencies for batch sizes 1..{max_batch_size}",
+        flush=True,
+    )
+    for batch_size in range(1, max_batch_size + 1):
+        single_launch_result = benchmark_single_batch(
+            batch_size,
+            max_batch_size,
+            flashinfer_module,
+            bench_gpu_time_fn,
+            args,
+            device,
+            dtype,
+        )
+        single_launch_ms = single_launch_result["single_launch_ms"]
+        single_launch_ms_by_batch[batch_size] = single_launch_ms
+        single_launch_measurements.append(single_launch_result)
+
+    print(
+        f"Searching LUT splits for batch sizes 1..{max_batch_size}",
+        flush=True,
+    )
+    for batch_size in range(1, max_batch_size + 1):
+        result = find_best_split_from_table(
+            batch_size, max_batch_size, args, single_launch_ms_by_batch
+        )
+        measurements.append(result)
+        if result["best_split"] is not None:
+            splits[str(batch_size)] = result["best_split"]
+            split_label = "+".join(str(value) for value in result["best_split"])
+        else:
+            split_label = "none"
+        print(
+            f"batch_size={batch_size:4d} baseline={result['baseline_ms']:.4f}ms "
+            f"best={result['best_split_ms']:.4f}ms speedup={result['speedup']:.4f} "
+            f"split={split_label}",
+            flush=True,
+        )
+
+    lut = {
+        "format_version": 1,
+        "backend": "trtllm-gen",
+        "kernel": "mla_decode",
+        "sm_count": sm_count,
+        "device_name": torch.cuda.get_device_name(device),
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "config": {
+            "max_batch_size": max_batch_size,
+            "seq_len": args.seq_len,
+            "fixed_seq_len": args.fixed_seq_len,
+            "q_len_per_request": args.q_len_per_request,
+            "page_size": args.page_size,
+            "dtype": args.dtype,
+            "num_q_heads": args.num_q_heads,
+            "qk_nope_head_dim": args.qk_nope_head_dim,
+            "qk_rope_head_dim": args.qk_rope_head_dim,
+            "kv_lora_rank": args.kv_lora_rank,
+            "dry_run_iters": args.dry_run_iters,
+            "repeat_iters": args.repeat_iters,
+            "min_speedup": args.min_speedup,
+            "max_num_splits": args.max_num_splits,
+            "use_cuda_graph": True,
+        },
+        "splits": splits,
+    }
+    lut["single_launch_measurements"] = single_launch_measurements
+    lut["measurements"] = measurements
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(lut, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote {len(splits)} splits to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/plot_trtllm_gen_mla_batch_split.py
+++ b/benchmarks/plot_trtllm_gen_mla_batch_split.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+FLOPS_RE = re.compile(r"FLOPs:\s*([0-9.]+)\s*TFLOPs/s")
+TIME_RE = re.compile(r"execution time:\s*([0-9.]+)\s*ms")
+BW_RE = re.compile(r"memory bandwidth:\s*([0-9.]+)\s*GB/s")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run TRTLLM-GEN MLA batch-split A/B benchmarks and plot TFLOPs/s"
+    )
+    parser.add_argument("--fixed-lut", type=Path, default=Path("fixed_data.json"))
+    parser.add_argument("--varlen-lut", type=Path, default=Path("varlen_data.json"))
+    parser.add_argument("--out-dir", type=Path, default=Path("batch_split_plots"))
+    parser.add_argument("--batch-sizes", type=str, default="38")
+    parser.add_argument(
+        "--all-lut-batches",
+        action="store_true",
+        help="Benchmark all batch sizes present in each LUT's splits object",
+    )
+    parser.add_argument("--seq-len", type=int, default=None)
+    parser.add_argument("--q-len-per-request", type=int, default=None)
+    parser.add_argument("--num-iters", type=int, default=None)
+    parser.add_argument("--dry-run-iters", type=int, default=None)
+    return parser.parse_args()
+
+
+def load_lut(path):
+    with open(path, encoding="utf-8") as file:
+        return json.load(file)
+
+
+def normalize_dtype(dtype):
+    return {
+        "float8_e4m3fn": "fp8_e4m3",
+        "bfloat16": "bfloat16",
+    }.get(dtype, dtype)
+
+
+def batch_sizes_from_arg(value):
+    result = []
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start, end = part.split("-", 1)
+            result.extend(range(int(start), int(end) + 1))
+        else:
+            result.append(int(part))
+    return sorted(dict.fromkeys(result))
+
+
+def batch_sizes_for_lut(lut, args):
+    if not args.all_lut_batches:
+        return batch_sizes_from_arg(args.batch_sizes)
+    splits = lut.get("splits", {})
+    return sorted(int(batch_size) for batch_size in splits)
+
+
+def env_from_lut(lut, fixed_seq_len, batch_size, lut_path, optimized, args):
+    config = lut.get("config", {})
+    env = os.environ.copy()
+    env.update(
+        {
+            "BACKEND": "trtllm-gen",
+            "BATCH_SIZE": str(batch_size),
+            "Q_LEN_PER_REQUEST": str(
+                args.q_len_per_request or config.get("q_len_per_request", 2)
+            ),
+            "SEQ_LEN": str(args.seq_len or config.get("seq_len", 20480)),
+            "FIXED_SEQ_LEN": "1" if fixed_seq_len else "0",
+            "PAGE_SIZE": str(config.get("page_size", 32)),
+            "NUM_QO_HEADS": str(config.get("num_q_heads", 64)),
+            "HEAD_DIM_CKV": str(config.get("kv_lora_rank", 512)),
+            "HEAD_DIM_KPE": str(config.get("qk_rope_head_dim", 64)),
+            "QK_NOPE_HEAD_DIM": str(config.get("qk_nope_head_dim", 128)),
+            "DTYPE": normalize_dtype(config.get("dtype", "fp8_e4m3")),
+        }
+    )
+    if args.num_iters is not None:
+        env["NUM_ITERS"] = str(args.num_iters)
+    elif "repeat_iters" in config:
+        env["NUM_ITERS"] = str(config["repeat_iters"])
+    if args.dry_run_iters is not None:
+        env["DRY_RUN_ITERS"] = str(args.dry_run_iters)
+    elif "dry_run_iters" in config:
+        env["DRY_RUN_ITERS"] = str(config["dry_run_iters"])
+    if optimized:
+        env["LUT_CONFIG_ENV_VAL"] = str(lut_path)
+    else:
+        env.pop("LUT_CONFIG_ENV_VAL", None)
+        env.pop("FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT", None)
+    return env
+
+
+def parse_metric(pattern, stdout, name):
+    match = pattern.search(stdout)
+    if match is None:
+        raise RuntimeError(f"Could not parse {name} from output:\n{stdout}")
+    return float(match.group(1))
+
+
+def run_case(repo_root, out_dir, dataset, lut, lut_path, fixed_seq_len, batch_size, optimized, args):
+    label = "optimized" if optimized else "baseline"
+    env = env_from_lut(lut, fixed_seq_len, batch_size, lut_path, optimized, args)
+    print(f"[{dataset}] batch={batch_size} {label}", flush=True)
+    completed = subprocess.run(
+        ["./benchmarks/run_trtllm_gen_mla_batch_split.sh"],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Command failed for {dataset} batch={batch_size} {label}:\n"
+            f"{completed.stdout}"
+        )
+    return {
+        "dataset": dataset,
+        "batch_size": batch_size,
+        "optimized": int(optimized),
+        "mode": label,
+        "lut_path": str(lut_path if optimized else ""),
+        "fixed_seq_len": int(fixed_seq_len),
+        "tflops": parse_metric(FLOPS_RE, completed.stdout, "TFLOPs/s"),
+        "execution_time_ms": parse_metric(TIME_RE, completed.stdout, "execution time"),
+        "memory_bandwidth_gbps": parse_metric(BW_RE, completed.stdout, "memory bandwidth"),
+    }
+
+
+def write_csv(path, rows):
+    fieldnames = [
+        "dataset",
+        "batch_size",
+        "optimized",
+        "mode",
+        "lut_path",
+        "fixed_seq_len",
+        "tflops",
+        "execution_time_ms",
+        "memory_bandwidth_gbps",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def plot_bar_dataset(path, dataset, rows):
+    import matplotlib.pyplot as plt
+
+    batch_sizes = sorted({row["batch_size"] for row in rows})
+    baseline = {
+        row["batch_size"]: row["tflops"] for row in rows if row["mode"] == "baseline"
+    }
+    optimized = {
+        row["batch_size"]: row["tflops"] for row in rows if row["mode"] == "optimized"
+    }
+
+    x = list(range(len(batch_sizes)))
+    width = 0.38
+    fig, axis = plt.subplots(figsize=(max(7, len(batch_sizes) * 0.45), 4.5))
+    axis.bar([value - width / 2 for value in x], [baseline[b] for b in batch_sizes], width, label="without LUT")
+    axis.bar([value + width / 2 for value in x], [optimized[b] for b in batch_sizes], width, label="with LUT")
+    axis.set_title(f"TRTLLM-GEN MLA batch split: {dataset}")
+    axis.set_xlabel("batch size")
+    axis.set_ylabel("TFLOPs/s")
+    axis.set_xticks(x, [str(batch_size) for batch_size in batch_sizes], rotation=45)
+    axis.grid(axis="y", alpha=0.25)
+    axis.legend()
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)
+
+
+def plot_line_dataset(path, dataset, rows):
+    import matplotlib.pyplot as plt
+
+    batch_sizes = sorted({row["batch_size"] for row in rows})
+    baseline = {
+        row["batch_size"]: row["tflops"] for row in rows if row["mode"] == "baseline"
+    }
+    optimized = {
+        row["batch_size"]: row["tflops"] for row in rows if row["mode"] == "optimized"
+    }
+
+    fig, axis = plt.subplots(figsize=(max(7, len(batch_sizes) * 0.45), 4.5))
+    axis.plot(
+        batch_sizes,
+        [baseline[batch_size] for batch_size in batch_sizes],
+        marker="o",
+        linewidth=1.8,
+        label="without LUT",
+    )
+    axis.plot(
+        batch_sizes,
+        [optimized[batch_size] for batch_size in batch_sizes],
+        marker="o",
+        linewidth=1.8,
+        label="with LUT",
+    )
+    axis.set_title(f"TRTLLM-GEN MLA batch split: {dataset}")
+    axis.set_xlabel("batch size")
+    axis.set_ylabel("TFLOPs/s")
+    axis.grid(alpha=0.25)
+    axis.legend()
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)
+
+
+def main():
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    datasets = [
+        ("fixed", args.fixed_lut, True),
+        ("varlen", args.varlen_lut, False),
+    ]
+    all_rows = []
+    for dataset, lut_path, fixed_seq_len in datasets:
+        lut_path = lut_path.resolve()
+        lut = load_lut(lut_path)
+        rows = []
+        for batch_size in batch_sizes_for_lut(lut, args):
+            rows.append(
+                run_case(repo_root, args.out_dir, dataset, lut, lut_path, fixed_seq_len, batch_size, False, args)
+            )
+            rows.append(
+                run_case(repo_root, args.out_dir, dataset, lut, lut_path, fixed_seq_len, batch_size, True, args)
+            )
+        csv_path = args.out_dir / f"{dataset}_batch_split.csv"
+        write_csv(csv_path, rows)
+        bar_plot_path = args.out_dir / f"{dataset}_batch_split_bar.png"
+        line_plot_path = args.out_dir / f"{dataset}_batch_split_line.png"
+        plot_bar_dataset(bar_plot_path, dataset, rows)
+        plot_line_dataset(line_plot_path, dataset, rows)
+        print(f"wrote {csv_path}")
+        print(f"wrote {bar_plot_path}")
+        print(f"wrote {line_plot_path}")
+        all_rows.extend(rows)
+
+    combined_csv_path = args.out_dir / "batch_split_summary.csv"
+    write_csv(combined_csv_path, all_rows)
+    print(f"wrote {combined_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_trtllm_gen_mla_batch_split.sh
+++ b/benchmarks/run_trtllm_gen_mla_batch_split.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Evaluate TRTLLM-GEN MLA decode with an optional batch-split LUT.
+#
+# Example:
+#   LUT_CONFIG_ENV_VAL=/path/to/lut.json \
+#   Q_LEN_PER_REQUEST=2 BATCH_SIZE=9 SEQ_LEN=20480 FIXED_SEQ_LEN=1 \
+#   ./benchmarks/run_trtllm_gen_mla_batch_split.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BACKEND="${BACKEND:-trtllm-gen}"
+BATCH_SIZE="${BATCH_SIZE:-40}"
+Q_LEN_PER_REQUEST="${Q_LEN_PER_REQUEST:-2}"
+SEQ_LEN="${SEQ_LEN:-20480}"
+PAGE_SIZE="${PAGE_SIZE:-32}"
+NUM_QO_HEADS="${NUM_QO_HEADS:-64}"
+HEAD_DIM_CKV="${HEAD_DIM_CKV:-512}"
+HEAD_DIM_KPE="${HEAD_DIM_KPE:-64}"
+QK_NOPE_HEAD_DIM="${QK_NOPE_HEAD_DIM:-128}"
+DTYPE="${DTYPE:-fp8_e4m3}"
+NUM_ITERS="${NUM_ITERS:-30}"
+DRY_RUN_ITERS="${DRY_RUN_ITERS:-5}"
+FIXED_SEQ_LEN="${FIXED_SEQ_LEN:-1}"
+WORKSPACE_MIB="${WORKSPACE_MIB:-256}"
+FLASHINFER_LOG_LEVEL="${FLASHINFER_LOG_LEVEL:-INFO}"
+
+cd "${REPO_ROOT}"
+
+export FLASHINFER_LOG_LEVEL
+if [[ -n "${LUT_CONFIG_ENV_VAL:-}" ]]; then
+  export FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT="${LUT_CONFIG_ENV_VAL}"
+fi
+
+EXTRA_ARGS=()
+if [[ "${FIXED_SEQ_LEN}" == "1" ]]; then
+  EXTRA_ARGS+=(--fixed_seq_len)
+fi
+
+echo "TRTLLM-GEN MLA batch-split evaluation config:"
+echo "  BACKEND=${BACKEND}"
+echo "  BATCH_SIZE=${BATCH_SIZE}"
+echo "  Q_LEN_PER_REQUEST=${Q_LEN_PER_REQUEST}"
+echo "  SEQ_LEN=${SEQ_LEN}"
+echo "  FIXED_SEQ_LEN=${FIXED_SEQ_LEN}"
+echo "  PAGE_SIZE=${PAGE_SIZE}"
+echo "  NUM_QO_HEADS=${NUM_QO_HEADS}"
+echo "  HEAD_DIM_CKV=${HEAD_DIM_CKV}"
+echo "  HEAD_DIM_KPE=${HEAD_DIM_KPE}"
+echo "  QK_NOPE_HEAD_DIM=${QK_NOPE_HEAD_DIM}"
+echo "  DTYPE=${DTYPE}"
+echo "  WORKSPACE_MIB=${WORKSPACE_MIB}"
+echo "  FLASHINFER_LOG_LEVEL=${FLASHINFER_LOG_LEVEL}"
+echo "  FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT=${FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT:-}"
+
+python benchmarks/evaluate_trtllm_gen_mla_batch_split.py \
+  --backend "${BACKEND}" \
+  --batch_size "${BATCH_SIZE}" \
+  --q_len_per_request "${Q_LEN_PER_REQUEST}" \
+  --seq_len "${SEQ_LEN}" \
+  --page_size "${PAGE_SIZE}" \
+  --num_qo_heads "${NUM_QO_HEADS}" \
+  --head_dim_ckv "${HEAD_DIM_CKV}" \
+  --head_dim_kpe "${HEAD_DIM_KPE}" \
+  --qk_nope_head_dim "${QK_NOPE_HEAD_DIM}" \
+  --dtype "${DTYPE}" \
+  --num_iters "${NUM_ITERS}" \
+  --dry_run_iters "${DRY_RUN_ITERS}" \
+  --workspace_mib "${WORKSPACE_MIB}" \
+  "${EXTRA_ARGS[@]}"

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from dataclasses import dataclass
 import functools
+import json
 import math
 import os
 from typing import List, Literal, Optional, Tuple, Union, overload
@@ -1394,6 +1395,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             else "bmm2_float",
             sinks_key,
             self.skip_softmax_threshold_scale_factor,
+            _trtllm_gen_mla_batch_split(q.size(0), self.sm_count),
             self.return_lse,
         )
 
@@ -1426,6 +1428,47 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             lse_stride_tokens = 0
             lse_stride_heads = 0
 
+        def run_trtllm_gen(
+            split_out,
+            split_query,
+            split_block_tables,
+            split_seq_lens,
+            split_batch_size,
+            split_lse,
+        ):
+            self._run(
+                split_out,
+                None,  # fp4 output (unsupported by wrapper)
+                split_query,
+                self.kv_cache,
+                self.kv_cache,  # kv passed twice (K/V views over the same buffer)
+                self.workspace_buffer,
+                split_block_tables,
+                split_seq_lens,
+                max_q_len,
+                self.max_seq_len,
+                self.bmm1_scale,
+                self.bmm2_scale,
+                -1,  # o_sf_scale
+                -1,  # o_sf_vec_size
+                0,  # o_sf_start_index
+                split_batch_size,
+                -1,  # window_left
+                self.sparse_mla_top_k,
+                self.sm_count,
+                self.enable_pdl,
+                self.workspace_buffer.numel() * self.workspace_buffer.element_size(),
+                self.sinks,
+                None,  # cum_seq_lens_q
+                None,  # key_block_scales
+                None,  # value_block_scales
+                self.skip_softmax_threshold_scale_factor,
+                self.uses_shared_paged_kv_idx,
+                split_lse,
+                lse_stride_tokens,
+                lse_stride_heads,
+            )
+
         # Zero the counter region on every call. Other runners (cute-dsl)
         # may share this workspace_buffer and write scratch into the first
         # bytes, which would leave non-zero values in trtllm-gen's
@@ -1434,37 +1477,32 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         # that autotune profile-loop invocations are also protected.
         # The 8 MB memset is ~5us on B200, negligible vs kernel time.
         self.workspace_buffer[:_TRTLLM_GEN_MLA_COUNTER_REGION_BYTES].zero_()
-        self._run(
+        batch_split = _trtllm_gen_mla_batch_split(batch_size, self.sm_count)
+        if batch_split is not None:
+            start_batch = 0
+            for split_batch_size in batch_split:
+                end_batch = start_batch + split_batch_size
+                start_token = start_batch * max_q_len
+                end_token = end_batch * max_q_len
+                split_lse = lse[start_token:end_token] if lse is not None else None
+                run_trtllm_gen(
+                    out[start_batch:end_batch],
+                    query_flat[start_token:end_token],
+                    block_tables[start_batch:end_batch],
+                    seq_lens[start_batch:end_batch],
+                    split_batch_size,
+                    split_lse,
+                )
+                start_batch = end_batch
+            return out
+
+        run_trtllm_gen(
             out,
-            None,  # fp4 output (unsupported by wrapper)
             query_flat,
-            self.kv_cache,
-            self.kv_cache,  # kv passed twice (K/V views over the same buffer)
-            self.workspace_buffer,
             block_tables,
             seq_lens,
-            max_q_len,
-            self.max_seq_len,
-            self.bmm1_scale,
-            self.bmm2_scale,
-            -1,  # o_sf_scale
-            -1,  # o_sf_vec_size
-            0,  # o_sf_start_index
             batch_size,
-            -1,  # window_left
-            self.sparse_mla_top_k,
-            self.sm_count,
-            self.enable_pdl,
-            self.workspace_buffer.numel() * self.workspace_buffer.element_size(),
-            self.sinks,
-            None,  # cum_seq_lens_q
-            None,  # key_block_scales
-            None,  # value_block_scales
-            self.skip_softmax_threshold_scale_factor,
-            self.uses_shared_paged_kv_idx,
             lse,
-            lse_stride_tokens,
-            lse_stride_heads,
         )
         return out
 
@@ -1601,6 +1639,70 @@ class CuteDslMlaDecodeRunner(TunableRunner):
             sinks=self.sinks,
             cute_dsl_impl=self.cute_dsl_impl,
         )
+
+
+_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV = "FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT"
+
+
+def _trtllm_gen_mla_lut_path() -> Optional[str]:
+    path = os.getenv(_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV)
+    if not path:
+        return None
+    return os.path.abspath(os.path.expanduser(path))
+
+
+@functools.cache
+def _load_trtllm_gen_mla_batch_split_lut(
+    path: str, sm_count: int
+) -> Tuple[Tuple[int, Tuple[int, ...]], ...]:
+    with open(path, encoding="utf-8") as file:
+        lut_config = json.load(file)
+    if not isinstance(lut_config, dict):
+        raise ValueError(
+            f"{_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV} must point to a JSON object"
+        )
+
+    config_sm_count = lut_config.get("sm_count")
+    if config_sm_count is not None and int(config_sm_count) != sm_count:
+        return ()
+
+    splits = lut_config.get("splits")
+    if not isinstance(splits, dict):
+        raise ValueError(
+            f"{_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV} must point to a JSON file with a 'splits' object"
+        )
+
+    parsed_splits = []
+    for batch_size_str, split in splits.items():
+        batch_size = int(batch_size_str)
+        if (
+            not isinstance(split, list)
+            or len(split) < 2
+            or not all(isinstance(split_size, int) for split_size in split)
+        ):
+            raise ValueError(
+                f"Invalid TRTLLM-GEN MLA batch split for batch_size={batch_size}: {split}"
+            )
+        if any(split_size <= 0 for split_size in split) or sum(split) != batch_size:
+            raise ValueError(
+                f"Invalid TRTLLM-GEN MLA batch split for batch_size={batch_size}: {split}"
+            )
+        parsed_splits.append((batch_size, tuple(split)))
+
+    return tuple(parsed_splits)
+
+
+def _trtllm_gen_mla_batch_split(
+    batch_size: int, sm_count: int
+) -> Optional[Tuple[int, ...]]:
+    path = _trtllm_gen_mla_lut_path()
+    if path is None:
+        return None
+    try:
+        lut = dict(_load_trtllm_gen_mla_batch_split_lut(path, sm_count))
+    except FileNotFoundError:
+        return None
+    return lut.get(batch_size)
 
 
 @flashinfer_api(trace=trtllm_batch_decode_mla_trace)

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1644,6 +1644,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
 _TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV = "FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT"
 
 
+@functools.cache
 def _trtllm_gen_mla_lut_path() -> Optional[str]:
     path = os.getenv(_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV)
     if not path:
@@ -1654,7 +1655,7 @@ def _trtllm_gen_mla_lut_path() -> Optional[str]:
 @functools.cache
 def _load_trtllm_gen_mla_batch_split_lut(
     path: str, sm_count: int
-) -> Tuple[Tuple[int, Tuple[int, ...]], ...]:
+) -> dict[int, Tuple[int, ...]]:
     with open(path, encoding="utf-8") as file:
         lut_config = json.load(file)
     if not isinstance(lut_config, dict):
@@ -1664,7 +1665,7 @@ def _load_trtllm_gen_mla_batch_split_lut(
 
     config_sm_count = lut_config.get("sm_count")
     if config_sm_count is not None and int(config_sm_count) != sm_count:
-        return ()
+        return {}
 
     splits = lut_config.get("splits")
     if not isinstance(splits, dict):
@@ -1672,7 +1673,7 @@ def _load_trtllm_gen_mla_batch_split_lut(
             f"{_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT_ENV} must point to a JSON file with a 'splits' object"
         )
 
-    parsed_splits = []
+    parsed_splits = {}
     for batch_size_str, split in splits.items():
         batch_size = int(batch_size_str)
         if (
@@ -1687,9 +1688,9 @@ def _load_trtllm_gen_mla_batch_split_lut(
             raise ValueError(
                 f"Invalid TRTLLM-GEN MLA batch split for batch_size={batch_size}: {split}"
             )
-        parsed_splits.append((batch_size, tuple(split)))
+        parsed_splits[batch_size] = tuple(split)
 
-    return tuple(parsed_splits)
+    return parsed_splits
 
 
 def _trtllm_gen_mla_batch_split(
@@ -1699,7 +1700,7 @@ def _trtllm_gen_mla_batch_split(
     if path is None:
         return None
     try:
-        lut = dict(_load_trtllm_gen_mla_batch_split_lut(path, sm_count))
+        lut = _load_trtllm_gen_mla_batch_split_lut(path, sm_count)
     except FileNotFoundError:
         return None
     return lut.get(batch_size)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

**Motivation of optimization**

On NVIDIA B200gpu , the TRTLLM-GEN MLA decode path can show poor SM utilization for certain batch sizes because the generated CTA count does not always fill complete SM waves. For the common DeepSeek-style MLA configuration, the launch effectively produces about 4 * batch_size CTAs; on a 148-SM B200 this means batch sizes around 37, 74, 111, etc. map well to full waves, while nearby sizes such as 38 create an almost empty tail wave. 

For example, batch_size=38 launches roughly 152 CTAs: one full 148-CTA wave plus a tiny second wave with only 4 CTAs, which adds latency with very low parallel occupancy. This PR adds an opt-in batch-splitting mechanism for TRTLLM-GEN MLA decode: a JSON LUT can specify that problematic batch sizes should be executed as several smaller launches, e.g. 38 -> 14 + 24, when the measured sum of split-launch latencies is lower than the original single launch. The LUT is generated offline by first benchmarking single-launch latency for all batch sizes in the target range, then searching split candidates using only this latency table.


**Example of LUT file generation**

```
python benchmarks/generate_trtllm_gen_mla_batch_split_lut.py  --max-batch-size 148 --max-num-splits 2 --fixed-seq-len --min-speedup 1.05
```

Generates the following LUT file: trtllm_gen_mla_batch_split_lut_sm148.json

**Run MLA with and without LUT table**

w/o LUT:
```
Q_LEN_PER_REQUEST=2 \
BATCH_SIZE=38 \
SEQ_LEN=20480 \
FIXED_SEQ_LEN=1 \
./benchmarks/run_trtllm_gen_mla_batch_split.sh
```

```
execution time: 0.2680 ms
memory bandwidth: 1692.40 GB/s
FLOPs: 808.82 TFLOPs/s
```

with LUT:
```
LUT_CONFIG_ENV_VAL=trtllm_gen_mla_batch_split_lut_sm148.json \
Q_LEN_PER_REQUEST=2 \
BATCH_SIZE=38 \
SEQ_LEN=20480 \
FIXED_SEQ_LEN=1 \
./benchmarks/run_trtllm_gen_mla_batch_split.sh
```

```
execution time: 0.1828 ms
memory bandwidth: 2481.02 GB/s
FLOPs: 1185.71 TFLOPs/s
```

**Overall optimization effect depending on batch size**

fixed seq len:
<img width="9216" height="720" alt="fixed_batch_split_bar" src="https://github.com/user-attachments/assets/1e162bb9-5153-477f-b32c-ae8b648dc2a3" />
<img width="9216" height="720" alt="fixed_batch_split_line" src="https://github.com/user-attachments/assets/c672908a-1f68-477f-95ed-baf02500201b" />






**SGLANG decode inference effects**

1500 -> 2000 output TPS based on the following distribution of batch sizes

```
Counter({'70': 52, '74': 50, '69': 48, '75': 47, '71': 46, '72': 43, '78': 41, '68': 41, '73': 40, '66': 39, '77': 34, '76': 33, '67': 32, '65': 27, '64': 22, '79': 20, '63': 20, '1': 20, '80': 17, '3': 16, '2': 16, '62': 15, '60': 14, '81': 13, '61': 13, '6': 10, '5': 8, '57': 7, '89': 6, '58': 6, '8': 6, '83': 5, '11': 5, '82': 4, '56': 4, '59': 4, '12': 4, '14': 4, '7': 4, '10': 4, '4': 4, '84': 3, '55': 3, '27': 3, '28': 3, '19': 3, '37': 3, '15': 3, '9': 3, '87': 2, '88': 2, '42': 2, '40': 2, '34': 2, '48': 2, '20': 2, '23': 2, '21': 2, '16': 2, '91': 1, '85': 1, '86': 1, '90': 1, '49': 1, '51': 1, '38': 1, '30': 1, '17': 1, '18': 1, '29': 1, '13': 1, '25': 1, '54': 1, '53': 1, '47': 1, '46': 1, '44': 1, '43': 1, '39': 1, '36': 1, '32': 1, '22': 1, '24': 1})
```

SGLANG version: 0.5.11

SGLANG command:

```
SGLANG_DISAGGREGATION_NIXL_BACKEND=UCX SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=1 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python3 -m sglang.launch_server --model-path /home/ivafanasev/models/700b/hf --tp 8 --dp 8 --ep 8 --enable-dp-attention --enable-dp-lm-head --disaggregation-mode decode --disaggregation-transfer-backend nixl --cuda-graph-max-bs 128 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.91 --stream-interval 30 --fp8-gemm-backend auto --attention-backend trtllm_mla --moe-runner-backend auto --moe-a2a-backend deepep --deepep-mode normal --host 0.0.0.0 --port 8003 --max-running-requests 1024 --context-length 131072 --trust-remote-code --page-size 64 --ep-dispatch-algorithm fake --tokenizer-worker-num 16
```

AIPerf command:
```
 aiperf profile -m ultra --url http://127.0.0.1:8003 --endpoint-type chat --streaming --tokenizer /home/ivafanasev/models/700b/hf --tokenizer-trust-remote-code --input-file ./decode_all.jsonl --custom-dataset-type mooncake_trace --concurrency 1024 --use-server-token-count --no-server-metrics --no-gpu-telemetry --artifact-dir ./decode_trace_1024_bs --extra-inputs '{"bootstrap_host":"2.2.2.2","bootstrap_room":123456789}'
```

Model: https://huggingface.co/ai-sage/GigaChat3.1-702B-A36B

SGLang results:

<img width="874" height="751" alt="Снимок экрана 2026-05-26 в 13 58 02" src="https://github.com/user-attachments/assets/4af4ab39-9bee-4026-b62f-d02b9bdececc" />
<img width="909" height="865" alt="Снимок экрана 2026-05-26 в 15 10 00" src="https://github.com/user-attachments/assets/bb9a12cf-4483-4b6e-971d-1b3e97f2fbaf" />


## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

I have executed the following tests:
```
export FLASHINFER_TRTLLM_GEN_MLA_BATCH_SPLIT_LUT=~/varlen_data.json
pytest -v \
  tests/attention/test_trtllm_gen_mla.py \
  tests/autotuner/test_autotuner_mla_decode.py \
  tests/trace/test_trtllm_batch_decode_mla_reference_correctness.py
```

Results:
```
8039 passed, 12322 skipped, 516 warnings in 345.66s (0:05:45)
```

## Reviewer Notes

N/A

CC @akhoroshev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional lookup-table driven batch-splitting for TRTLLM-GEN MLA decode path to improve multi-launch handling and performance.

* **Chores**
  * Added end-to-end benchmarking, LUT-generation, runner, and plotting tools to measure, search, and visualize batch-split performance and throughput.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->