### PR TITLE
[ci feat] Support /bot run tests/<dir> to scope CI test runs 

### DIFF
--- a/scripts/task_run_unit_tests.sh
+++ b/scripts/task_run_unit_tests.sh
@@ -16,6 +16,13 @@ pip install nvshmem4py-cu12
 
 # Find and filter test files based on pytest.ini exclusions
 find_test_files() {
+    SEARCH_DIR="${TEST_PATH:-tests/}"
+
+    if [ -n "$TEST_PATH" ]; then
+        echo "🎯 TEST_PATH set: scoping test discovery to ${SEARCH_DIR}"
+        echo ""
+    fi
+
     echo "Reading pytest.ini for excluded directories..."
     EXCLUDED_DIRS=""
     if [ -f "./pytest.ini" ]; then
@@ -28,10 +35,10 @@ find_test_files() {
         fi
     fi
 
-    echo "Finding all test_*.py files in tests/ directory..."
+    echo "Finding all test_*.py files in ${SEARCH_DIR} directory..."
 
     # Find all test_*.py files
-    ALL_TEST_FILES=$(find tests/ -name "test_*.py" -type f | sort)
+    ALL_TEST_FILES=$(find "${SEARCH_DIR}" -name "test_*.py" -type f | sort)
 
     # Filter out excluded files based on directory exclusions
     TEST_FILES=""
@@ -59,7 +66,7 @@ find_test_files() {
     TEST_FILES=$(echo "$TEST_FILES" | xargs)
 
     if [ -z "$TEST_FILES" ]; then
-        echo "No test files found in tests/ directory (after exclusions)"
+        echo "No test files found in ${SEARCH_DIR} directory (after exclusions)"
         exit 1
     fi
 

--- a/scripts/task_run_unit_tests.sh
+++ b/scripts/task_run_unit_tests.sh
@@ -19,6 +19,12 @@ find_test_files() {
     SEARCH_DIR="${TEST_PATH:-tests/}"
 
     if [ -n "$TEST_PATH" ]; then
+        if [ ! -d "${SEARCH_DIR}" ]; then
+            echo "ERROR: TEST_PATH '${SEARCH_DIR}' does not exist or is not a directory."
+            echo "Available test directories:"
+            find tests/ -maxdepth 1 -type d | sort | tail -n +2 | sed 's/^/  /'
+            exit 1
+        fi
         echo "🎯 TEST_PATH set: scoping test discovery to ${SEARCH_DIR}"
         echo ""
     fi

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -63,7 +63,7 @@ EXIT_CODE=0
 parse_args() {
     DRY_RUN=false
     SANITY_TEST=false
-    TEST_PATH=""
+    TEST_PATH="${TEST_PATH:-}"
     while [[ $# -gt 0 ]]; do
         case $1 in
             --dry-run)

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -71,6 +71,10 @@ parse_args() {
                 shift
                 ;;
             --test-path)
+                if [[ $# -lt 2 ]]; then
+                    echo "ERROR: --test-path requires an argument." >&2
+                    exit 1
+                fi
                 TEST_PATH="$2"
                 shift 2
                 ;;

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -63,10 +63,20 @@ EXIT_CODE=0
 parse_args() {
     DRY_RUN=false
     SANITY_TEST=false
-    for arg in "$@"; do
-        case $arg in
+    TEST_PATH=""
+    while [[ $# -gt 0 ]]; do
+        case $1 in
             --dry-run)
                 DRY_RUN=true
+                shift
+                ;;
+            --test-path)
+                TEST_PATH="$2"
+                shift 2
+                ;;
+            --test-path=*)
+                TEST_PATH="${1#*=}"
+                shift
                 ;;
             --sanity-test)
                 if [ "$DISABLE_SANITY_TEST" = "true" ]; then
@@ -76,6 +86,10 @@ parse_args() {
                 else
                     SANITY_TEST=true
                 fi
+                shift
+                ;;
+            *)
+                shift
                 ;;
         esac
     done
@@ -83,6 +97,11 @@ parse_args() {
 
 # Print test mode banner
 print_test_mode_banner() {
+    if [ -n "$TEST_PATH" ]; then
+        echo "🎯 SCOPED TEST MODE - Only running tests under: ${TEST_PATH}"
+        echo ""
+    fi
+
     if [ "$DRY_RUN" = "true" ]; then
         echo "🔍 DRY RUN MODE - No tests will be executed"
         echo ""


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Note
Relies on upstream internal gitlab changes being merged first.

### Summary
- Add --test-path argument to parse_args() in test_utils.sh and honor TEST_PATH env var (set by GitLab CI pipeline variable)
- Scope find in task_run_unit_tests.sh to the specified subdirectory instead of all of tests/
- Validate the path exists upfront and list available directories on failure

### Motivation
The full test suite (attn + moe + gdn + ...) exceeds the 4-hour CI timeout. This allows running a single test subdirectory via /bot run tests/moe, keeping each scoped run well within the window while we work on pruning the full suite.

### Usage
When TEST_PATH is set (via env var or --test-path flag), only tests under that directory are discovered. Without it, behavior is unchanged.
```
/bot run tests/moe       # only MOE tests
/bot run tests/attention # only attention tests
/bot run                 # all tests (unchanged)
```

### Test plan

- [ ] Verify /bot run without a path still runs the full test suite
 - [ ]  Verify /bot run tests/moe scopes discovery to tests/moe/ only
 - [ ] Verify an invalid path (e.g. tests/nonexistent) fails early with a helpful error
 - [ ] Verify --test-path flag works for local runs: bash scripts/task_run_unit_tests.sh --test-path tests/nor

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test discovery is now configurable via the TEST_PATH environment variable or --test-path CLI argument, enabling scoped test execution.
  * Log messages now reflect the selected search directory; overall test execution behavior remains unchanged.
* **Bug Fixes / UX**
  * Added validation and clearer error messages when the configured test directory doesn't exist, including listing available top-level test directories.
* **Style**
  * Displays a “SCOPED TEST MODE” banner when a test path is set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->