### PR TITLE
fix(moe): add shared memory capacity guard to dynamic MoE kernel

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -328,6 +328,43 @@ class MoEDynamicKernel:
     def _get_layoutSFB_TV(self, tiled_mma):
         return self._dense_cls._get_layoutSFB_TV(self, tiled_mma)  # type: ignore[arg-type]
 
+    def _shared_storage_size_bytes(
+        self,
+        a_smem_staged,
+        b_smem_staged,
+        sfa_smem_staged,
+        sfb_smem_staged,
+        epi_smem_staged,
+    ) -> int:
+        def _align_up(value: int, align: int) -> int:
+            return ((value + align - 1) // align) * align
+
+        pipeline_count = 3 if self.is_gated else 2
+        offset = (
+            8 * 4  # ctrl
+            + (self.num_mma_warps + 1) * 32 * 4  # route_phys_rows
+            + (self.num_mma_warps + 1) * 32 * 4  # route_expert_ids
+            + pipeline_count * (self.ab_stage * 2 * 8)  # pipeline arrays
+            + self.tile_shape_mnk[0] * 4  # scatter_tok_cache
+            + self.tile_shape_mnk[0] * 4  # scatter_weight_cache
+        )
+        buffers = [
+            cute.size_in_bytes(self.a_dtype, a_smem_staged),
+            cute.size_in_bytes(self.b_dtype, b_smem_staged),
+            cute.size_in_bytes(self.sf_dtype, sfa_smem_staged),
+            cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
+            cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
+        ]
+        if self.is_gated:
+            buffers.insert(2, cute.size_in_bytes(self.b_dtype, b_smem_staged))
+            buffers.insert(5, cute.size_in_bytes(self.sf_dtype, sfb_smem_staged))
+        offset = _align_up(offset, self.buffer_align_bytes)
+        for idx, size in enumerate(buffers):
+            offset += size
+            if idx + 1 != len(buffers):
+                offset = _align_up(offset, self.buffer_align_bytes)
+        return offset
+
     def _setup_attributes(self, hidden_size: int):
         import cutlass.utils.blackwell_helpers as sm120_utils
 
@@ -387,26 +424,42 @@ class MoEDynamicKernel:
         while self.ab_stage > 1 and k_tile_cnt % self.ab_stage != 0:
             self.ab_stage -= 1
         self.epi_stage = 1
-        (
-            self.a_smem_layout_staged,
-            self.b_smem_layout_staged,
-            self.sfa_smem_layout_staged,
-            self.sfb_smem_layout_staged,
-            self.epi_smem_layout_staged,
-        ) = self._dense_cls._make_smem_layouts(
-            self.tile_shape_mnk,
-            self.epi_tile,
-            self.a_dtype,
-            self.a_layout,
-            self.b_dtype,
-            self.b_layout,
-            self.ab_stage,
-            cutlass.BFloat16,
-            self.c_layout,
-            self.epi_stage,
-            self.sf_vec_size,
-            self.tiled_mma,
-        )
+        while True:
+            (
+                self.a_smem_layout_staged,
+                self.b_smem_layout_staged,
+                self.sfa_smem_layout_staged,
+                self.sfb_smem_layout_staged,
+                self.epi_smem_layout_staged,
+            ) = self._dense_cls._make_smem_layouts(
+                self.tile_shape_mnk,
+                self.epi_tile,
+                self.a_dtype,
+                self.a_layout,
+                self.b_dtype,
+                self.b_layout,
+                self.ab_stage,
+                cutlass.BFloat16,
+                self.c_layout,
+                self.epi_stage,
+                self.sf_vec_size,
+                self.tiled_mma,
+            )
+            if (
+                self._shared_storage_size_bytes(
+                    self.a_smem_layout_staged,
+                    self.b_smem_layout_staged,
+                    self.sfa_smem_layout_staged,
+                    self.sfb_smem_layout_staged,
+                    self.epi_smem_layout_staged,
+                )
+                <= self.smem_capacity
+                or self.ab_stage <= 1
+            ):
+                break
+            self.ab_stage -= 1
+            while self.ab_stage > 1 and k_tile_cnt % self.ab_stage != 0:
+                self.ab_stage -= 1
 
     @cute.jit
     def _resident_grid_barrier(


### PR DESCRIPTION
## Summary

The dynamic MoE kernel (`MoEDynamicKernel`) crashes with `cudaErrorInvalidValue` on SM 12.0/12.1 (DGX Spark, RTX 5090) when serving gated MoE models (e.g. MiniMax M2.7 with SiLU activation).

**Root cause:** `_compute_stages()` estimates `ab_stage` based on a single GEMM footprint, but `StorageGated` includes duplicate weight buffers (`sB_up`, `sSFB_up`) for the up-projection that push total shared memory to ~118 KB, exceeding the 99 KB hardware limit.

**Fix:** Add `_shared_storage_size_bytes()` and a fallback loop to `_setup_attributes()` that reduces `ab_stage` until the allocation fits within `smem_capacity`. This matches the existing pattern in `moe_static_kernel.py` (lines 451-484, 546-568) and `moe_micro_kernel.py` (lines 580-597).

## References
- Fixes: https://github.com/lukealonso/b12x/issues/5
- Related: #3383 (SM121 b12x failures with EP>1)

## Test plan
- [x] Tested on 2x ASUS GX10 (NVIDIA GB10, SM 12.1) with MiniMax M2.7 NVFP4 (230B MoE, gated SiLU)
- [x] vLLM v0.21.1 + `--moe-backend flashinfer_b12x` — model loads and serves without crash
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] CI: needs `@flashinfer-bot run` from a ci-users team member

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared memory management for mixture-of-experts kernels on Blackwell GPUs, with adaptive configuration adjustments to better accommodate hardware memory constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->