### PR TITLE
fix(prefill): support multi-item scoring on BatchPrefillWithRaggedKVCacheWrapper

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3462,6 +3462,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             else:
                 mask_mode = MaskMode.NON_CAUSAL.value
 
+        # Mirror BatchPrefillWithPagedKVCacheWrapper.run (prefill.py earlier):
+        # when MIS params are planned, override mask_mode so the kernel takes
+        # the multi-item-scoring template branch.
+        if self._prefix_len_ptr is not None:
+            mask_mode = MaskMode.MULTIITEMSCORING.value
+
         run_args = [
             self._float_workspace_buffer,
             self._int_workspace_buffer,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2381,6 +2381,17 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 mask_mode = MaskMode.NON_CAUSAL.value
 
         if self._prefix_len_ptr is not None:
+            # MIS requires the full param set; the kernel dereferences
+            # token_pos_in_items_ptr and max_item_len_ptr unconditionally inside
+            # the MULTIITEMSCORING template branch. Partial input would read
+            # invalid memory.
+            assert (
+                self._token_pos_in_items_ptr is not None
+                and self._max_item_len_ptr is not None
+            ), (
+                "Multi-item scoring requires prefix_len_ptr, "
+                "token_pos_in_items_ptr, and max_item_len_ptr to be planned together."
+            )
             mask_mode = MaskMode.MULTIITEMSCORING.value
 
         if self._backend == "cudnn":
@@ -3466,6 +3477,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         # when MIS params are planned, override mask_mode so the kernel takes
         # the multi-item-scoring template branch.
         if self._prefix_len_ptr is not None:
+            # MIS requires the full param set; the kernel dereferences
+            # token_pos_in_items_ptr and max_item_len_ptr unconditionally inside
+            # the MULTIITEMSCORING template branch. Partial input would read
+            # invalid memory.
+            assert (
+                self._token_pos_in_items_ptr is not None
+                and self._max_item_len_ptr is not None
+            ), (
+                "Multi-item scoring requires prefix_len_ptr, "
+                "token_pos_in_items_ptr, and max_item_len_ptr to be planned together."
+            )
             mask_mode = MaskMode.MULTIITEMSCORING.value
 
         run_args = [

--- a/include/flashinfer/attention/hopper/mainloop.cuh
+++ b/include/flashinfer/attention/hopper/mainloop.cuh
@@ -26,6 +26,12 @@ using namespace cute;
 
 template <typename AdditionalParams, typename Ktraits, bool CAUSAL, bool MULTIITEMSCORING = false>
 struct CollectiveMainloop {
+  // The ragged mainloop does not yet implement MIS-aware K/V tile skipping
+  // (see SparseCollectiveMainloop's kv_tile_idx_decrement). The kernel uses
+  // this flag to skip computing skip-window args and pass neutral 0/0 to
+  // mma_f16 instead, keeping producer and consumer in lockstep.
+  static constexpr bool kSupportsMISAwareLoad = false;
+
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
   using TileShape_QKD = typename Ktraits::TileShape_QKD;
@@ -153,27 +159,6 @@ struct CollectiveMainloop {
     }
 
     return num_kv_tiles;
-  }
-
-  // MIS-call-compat overload: the PrefillWithKVCacheKernel passes two extra MIS
-  // params to load() when MULTIITEMSCORING is true (see prefill_sm90.cuh ~line 191).
-  // We don't yet do MIS-aware K/V tile skipping in the ragged path (an optimization
-  // mirroring sparse_mainloop's kv_tile_idx_decrement lambda); we just load all K/V
-  // tiles and let mma_f16's MIS mask handle correctness. Future optimization: port
-  // the skip-window logic from sparse_mainloop.cuh:261-268.
-  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
-            typename SharedStorage>
-  CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
-                           MainloopPipeline pipeline_v, PipelineState& smem_pipe_write_k,
-                           PipelineState& smem_pipe_write_v, SharedStorage& shared_storage,
-                           Scheduler& scheduler, typename Scheduler::Params const& scheduler_params,
-                           typename Scheduler::WorkTileInfo& work_tile_info,
-                           BlockCoord const& block_coord, int work_idx,
-                           const int /*num_kv_tiles_outside_items_window*/,
-                           const int /*num_kv_tiles_prefix*/) {
-    load<LEFT_SLIDING_WINDOW>(mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k,
-                              smem_pipe_write_v, shared_storage, scheduler, scheduler_params,
-                              work_tile_info, block_coord, work_idx);
   }
 
   template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,

--- a/include/flashinfer/attention/hopper/mainloop.cuh
+++ b/include/flashinfer/attention/hopper/mainloop.cuh
@@ -24,7 +24,7 @@ namespace flashinfer {
 
 using namespace cute;
 
-template <typename AdditionalParams, typename Ktraits, bool CAUSAL>
+template <typename AdditionalParams, typename Ktraits, bool CAUSAL, bool MULTIITEMSCORING = false>
 struct CollectiveMainloop {
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
@@ -147,8 +147,33 @@ struct CollectiveMainloop {
       num_kv_tiles = std::min(num_kv_tiles,
                               cute::ceil_div((q_tile_idx + 1) * CTA_Q + kv_len - qo_len, CTA_KV));
     }
+    if constexpr (MULTIITEMSCORING) {
+      num_kv_tiles = std::min(num_kv_tiles,
+                              cute::ceil_div((q_tile_idx + 1) * CTA_Q + kv_len - qo_len, CTA_KV));
+    }
 
     return num_kv_tiles;
+  }
+
+  // MIS-call-compat overload: the PrefillWithKVCacheKernel passes two extra MIS
+  // params to load() when MULTIITEMSCORING is true (see prefill_sm90.cuh ~line 191).
+  // We don't yet do MIS-aware K/V tile skipping in the ragged path (an optimization
+  // mirroring sparse_mainloop's kv_tile_idx_decrement lambda); we just load all K/V
+  // tiles and let mma_f16's MIS mask handle correctness. Future optimization: port
+  // the skip-window logic from sparse_mainloop.cuh:261-268.
+  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
+            typename SharedStorage>
+  CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
+                           MainloopPipeline pipeline_v, PipelineState& smem_pipe_write_k,
+                           PipelineState& smem_pipe_write_v, SharedStorage& shared_storage,
+                           Scheduler& scheduler, typename Scheduler::Params const& scheduler_params,
+                           typename Scheduler::WorkTileInfo& work_tile_info,
+                           BlockCoord const& block_coord, int work_idx,
+                           const int /*num_kv_tiles_outside_items_window*/,
+                           const int /*num_kv_tiles_prefix*/) {
+    load<LEFT_SLIDING_WINDOW>(mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k,
+                              smem_pipe_write_v, shared_storage, scheduler, scheduler_params,
+                              work_tile_info, block_coord, work_idx);
   }
 
   template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -180,7 +180,11 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
         }
         int num_kv_tiles_outside_items_window = 0;
         int num_kv_tiles_prefix = 0;
-        if constexpr (MULTIITEMSCORING) {
+        // Only compute real MIS skip-window args when the mainloop's load()
+        // actually honors them. The ragged mainloop falls through to the
+        // non-MIS loader; passing real values would desync producer/consumer
+        // tile order (load walks descending, mma jumps via kv_tile_idx_decrement).
+        if constexpr (MULTIITEMSCORING && CollectiveMainloop::kSupportsMISAwareLoad) {
           auto prefix_len = __ldg(maybe_prefix_len_ptr + batch_idx);
           auto max_item_len = __ldg(maybe_max_item_len_ptr + batch_idx);
           auto valid_items_window_len =
@@ -188,7 +192,7 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           num_kv_tiles_outside_items_window = valid_items_window_len / CTA_KV;
           num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
         }
-        if constexpr (MULTIITEMSCORING) {
+        if constexpr (MULTIITEMSCORING && CollectiveMainloop::kSupportsMISAwareLoad) {
           collective_mainloop.load<LEFT_SLIDING_WINDOW>(
               mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
               shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx,
@@ -265,7 +269,12 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
       }
       int num_kv_tiles_outside_items_window = 0;
       int num_kv_tiles_prefix = 0;
-      if constexpr (MULTIITEMSCORING) {
+      // Mirror the producer-side gate. When the mainloop doesn't support MIS-aware
+      // loading we leave both at 0 so mma_f16's kv_tile_idx_decrement never jumps
+      // (condition fires only at kv_tile_idx == 0, where natural decrement to -1
+      // is the same result as num_kv_tiles_prefix - 1 = -1). The MIS mask logic
+      // inside mma_f16 still applies because MULTIITEMSCORING stays true.
+      if constexpr (MULTIITEMSCORING && CollectiveMainloop::kSupportsMISAwareLoad) {
         auto prefix_len = __ldg(maybe_prefix_len_ptr + batch_idx);
         auto max_item_len = __ldg(maybe_max_item_len_ptr + batch_idx);
         auto valid_items_window_len =

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -429,7 +429,7 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
 }
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool MULTIITEMSCORING = false>
 cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
                                                                 cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -438,7 +438,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
   using IdType = typename KernelTraits::IdType;
 
   using CollectiveMainloop =
-      CollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>;
+      CollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL, MULTIITEMSCORING>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler =
       std::conditional_t<SAME_SCHEDULE_FOR_ALL_HEADS, BatchPrefillTileScheduler<IdType>,
@@ -484,7 +484,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
   // Get the ptr to kernel function.
   auto kernel =
       (void*)PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
-                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler>;
+                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler, MULTIITEMSCORING>;
   int smem_size = sizeof(typename KernelTraits::SharedStorage);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -553,6 +553,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_
     return cudaErrorNotSupported;  // Not supported yet.
   }
   constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
+  constexpr bool MULTIITEMSCORING = MASK_MODE == MaskMode::kMultiItemScoring;
   constexpr auto CTA_TILE_SIZE = getCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO, CAUSAL>();
   BatchPrefillWithRaggedKVCacheKernelTraitsDispatched<
       AttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
@@ -560,7 +561,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_
                             /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
                             /*NUM_STAGES_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
                             typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
-      LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+      LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(params, stream);
   cudaError_t status = cudaGetLastError();
   return status;
 }

--- a/include/flashinfer/attention/hopper/sparse_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/sparse_mainloop.cuh
@@ -35,6 +35,11 @@ using namespace cute;
 
 template <typename AdditionalParams, typename Ktraits, bool CAUSAL, bool MULTIITEMSCORING = false>
 struct SparseCollectiveMainloop {
+  // The paged mainloop implements the MIS-aware K/V tile skip optimization
+  // (kv_tile_idx_decrement). The kernel reads this flag to decide whether
+  // to compute real skip-window args and call the 13-arg load() overload.
+  static constexpr bool kSupportsMISAwareLoad = true;
+
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
   using IdType = typename Ktraits::IdType;


### PR DESCRIPTION
# PR1 — flashinfer-ai/flashinfer

**Title:** `fix(prefill): support multi-item scoring on BatchPrefillWithRaggedKVCacheWrapper`

**Branch:** `jiaguo/ragged-mis`

---

## Summary

`BatchPrefillWithRaggedKVCacheWrapper.plan()` already accepts the full multi-item-scoring (MIS) parameter surface — `prefix_len_ptr`, `token_pos_in_items_ptr`, `token_pos_in_items_len`, `max_item_len_ptr` — and they are forwarded to the kernel binding's `run_args` (see `prefill.py:3178-3186`). But three downstream gaps cause MIS to silently produce wrong outputs on the ragged path:

1. **Python `run()` never picks `MaskMode.MULTIITEMSCORING`.** `BatchPrefillWithPagedKVCacheWrapper.run()` has the override at `prefill.py:2370-2371`:
   ```python
   if self._prefix_len_ptr is not None:
       mask_mode = MaskMode.MULTIITEMSCORING.value
   ```
   The ragged wrapper's `run()` is missing this — so the kernel runs with `mask_mode=CAUSAL` and the planned MIS pointers are ignored at the mask-mode dispatch.
2. **Hopper kernel dispatch chain drops `MULTIITEMSCORING`.** `BatchPrefillWithRaggedKVCacheDispatched` (prefill_sm90.cuh:549) never derives `MULTIITEMSCORING` from `MASK_MODE` and `BatchPrefillWithRaggedKVCacheKernelTraitsDispatched` (prefill_sm90.cuh:430) has no `MULTIITEMSCORING` template parameter. The kernel is launched as `PrefillWithKVCacheKernel<..., Scheduler>` instead of `PrefillWithKVCacheKernel<..., Scheduler, MULTIITEMSCORING>`, so it always instantiates with the default `MULTIITEMSCORING=false`. Contrast with the paged dispatcher at `prefill_sm90.cuh:577, 411-412`, which derives and forwards correctly.
3. **Ragged `CollectiveMainloop` (mainloop.cuh) has no `MULTIITEMSCORING` template parameter at all.** Its `get_num_kv_tiles()` doesn't have the MIS bound, and its `load()` doesn't accept the extra `num_kv_tiles_outside_items_window` / `num_kv_tiles_prefix` arguments that the kernel passes when `MULTIITEMSCORING=true`. Without these, even if (2) were fixed, the kernel wouldn't compile against the ragged mainloop.

The paged path through `SparseCollectiveMainloop` (sparse_mainloop.cuh) has all of this wired up correctly; this PR brings the ragged path to parity.

## What this PR does

**Python side (`flashinfer/prefill.py`):**

- `BatchPrefillWithRaggedKVCacheWrapper.run()` — add the `MULTIITEMSCORING` mask_mode override, mirror of paged at line 2370-2371:
  ```python
  if self._prefix_len_ptr is not None:
      mask_mode = MaskMode.MULTIITEMSCORING.value
  ```

**Hopper kernel side (`include/flashinfer/attention/hopper/prefill_sm90.cuh`):**

- `BatchPrefillWithRaggedKVCacheKernelTraitsDispatched` — add `bool MULTIITEMSCORING = false` template parameter.
- `CollectiveMainloop` instantiation inside `KernelTraitsDispatched` — pass `MULTIITEMSCORING`.
- `PrefillWithKVCacheKernel` launch — add `MULTIITEMSCORING` as the 7th template argument.
- `BatchPrefillWithRaggedKVCacheDispatched` — `constexpr bool MULTIITEMSCORING = MASK_MODE == MaskMode::kMultiItemScoring;` and forward to `KernelTraitsDispatched`.

**Hopper mainloop (`include/flashinfer/attention/hopper/mainloop.cuh`):**

- `CollectiveMainloop` — add `bool MULTIITEMSCORING = false` template parameter.
- `get_num_kv_tiles()` — add MIS branch (verbatim mirror of `sparse_mainloop.cuh:168-172`).
- `load()` — add a 13-arg overload that accepts `num_kv_tiles_outside_items_window` / `num_kv_tiles_prefix` (the extra params the kernel passes when MIS is on). For now this overload dispatches to the existing 11-arg `load()` body — i.e., we don't yet implement the MIS-aware K/V tile skip optimization from `SparseCollectiveMainloop`. Correctness comes from `mma_f16`'s own MIS-aware mask path, which is already shared between paged and ragged at the MMA level.

## Out of scope (deferred to follow-up PRs)

- **MIS-aware K/V tile skip optimization** in `CollectiveMainloop::load()` — port of the `kv_tile_idx_decrement` lambda from `sparse_mainloop.cuh:259-268`. This is a performance optimization, not a correctness one; the current PR loads all K/V tiles but the MMA mask drops cross-item attention, so outputs are correct. Worth a follow-up to claw back some of the load bandwidth.
- **SM80 / FA2 ragged-MIS support** — the analogous fix in `include/flashinfer/attention/prefill.cuh`. The SM80 dispatch chain has the same structural asymmetry. This PR focuses on Hopper because that's where MIS is being deployed; the SM80 fix follows the same template.
- **`fmha_varlen` cutlass / cudnn MIS support** — those ragged backends still drop the MIS pointers in `run()` at `prefill.py:3082-3134`. Out of scope; this PR targets the default FA2/FA3 ragged path that was already partially wired.

## Test plan

Tested on H200 + Qwen3-0.6B against the paged-MIS baseline (which is what production deployments use today). Engine config mirrors the prod overlay: `dtype=float16`, `attention_backend=flashinfer`, `enable_mis=True`, `chunked_prefill_size=-1`, `disable_radix_cache=True`, `disable_cuda_graph=True`, `mem_fraction_static=0.5`, `max_prefill_tokens=30000`.

**Test 1 — `test_mis_basic` prompts verbatim (`test/registered/prefill_only/test_multi_item_scoring.py:78-94`):**

| item | paged baseline (pre-PR) | ragged + this PR |
|---|---|---|
| "Option A" | 0.3478 | 0.3469 |
| "Option B" | 0.1993 | 0.1999 |
| "Option C" | 0.1750 | 0.1738 |

**Test 2 — five items of varied length (1 char → 139 chars):**

| item char-len | paged baseline | ragged + this PR | abs diff |
|---|---|---|---|
| 1 | 0.9478 | 0.9478 | 0.0000 |
| 25 | 0.7909 | 0.7915 | 0.0006 |
| 124 | 0.9297 | 0.9291 | 0.0006 |
| 9 | 0.8650 | 0.8641 | 0.0009 |
| 139 | 0.5660 | 0.5675 | 0.0015 |

**Test 3 — sjs-ranking-like 4-item prompt (LinkedIn production traffic shape):**

| item | paged baseline | ragged + this PR | abs diff |
|---|---|---|---|
| 0 | 0.9194 | 0.9198 | 0.0004 |
| 1 | 0.6680 | 0.6715 | 0.0035 |
| 2 | 0.9835 | 0.9835 | 0.0000 |
| 3 | 0.7645 | 0.7631 | 0.0014 |

All differences are within FP16 reduction-order noise across the two kernels.

**Without this PR**, the same three tests on the ragged path produce items collapsed to bit-identical outputs (e.g., test 3 items 1 and 2 produce identical `[0.952, 0.048]`; test 2 items 2 and 4 produce identical `[0.078, 0.922]` despite being 100+ chars apart in length). The kernel runs at `mask_mode=CAUSAL` and ignores the MIS pointers entirely.

## Notes for reviewers

- The fix is structural — it's enabling a code path that was already half-wired up, not introducing new MIS semantics. The existing `mma_f16` already has `MULTIITEMSCORING` template parameter handling (`mainloop_mma.cuh:138, 155, 178, 207, 254`), the kernel template `PrefillWithKVCacheKernel` already has `MULTIITEMSCORING` parameter (`prefill_sm90.cuh:45`), the JIT codegen already instantiates ragged kernels for all 4 mask modes including 3=MULTIITEMSCORING (`flashinfer/jit/attention/modules.py:1606-1610, 1678-1682`).
- No existing test in the flashinfer or sglang test suites covers ragged+MIS, which is presumably why this regression wasn't caught — sglang's `test_multi_item_scoring.py` pins `attention_backend="flashinfer"` and routes everything through paged.
- Recommend adding a CI test that runs MIS through ragged once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compile-time support for multi-item scoring in batched prefill operations.

* **Bug Fixes**
  * Ensures the correct attention variant is chosen when prefix-length info is present so multi-item scoring runs reliably.
  * Adds runtime checks requiring token-position and item-length parameters when prefix-length is provided, surfacing misconfiguration earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->