### PR TITLE
bench: Unify PDL behavior, add missing norm routines, and misc improvements

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,6 +38,9 @@ Currently supports testing attention, gemm, fused MOE, normalization, quantizati
     - `allreduce_fusion` - AllReduce fusion benchmark for multi-GPU inference. Requires `mpirun` for multi-GPU execution. Supports TRTLLM and TRTLLM MNNVL backends with multiple fusion patterns (plain allreduce, allreduce + residual + RMSNorm).
 - Norm:
     - `rmsnorm` - Root Mean Square Layer Normalization.
+    - `fused_add_rmsnorm` - Fused residual add + RMSNorm.
+    - `gemma_rmsnorm` - Gemma-style RMSNorm using `(weight + 1)`.
+    - `gemma_fused_add_rmsnorm` - Gemma-style fused residual add + RMSNorm.
     - `rmsnorm_quant` - RMSNorm with FP8 quantized output.
     - `fused_add_rmsnorm_quant` - Fused residual add + RMSNorm with FP8 quantized output.
     - `rmsnorm_fp4quant` - RMSNorm with FP4 quantized output (CuTe-DSL, Blackwell SM10.0+).
@@ -369,7 +372,7 @@ mpirun -np 8 python benchmarks/flashinfer_benchmark.py \
 | `--out_dtype`            | Output dtype: `fp8_e4m3`, `fp8_e5m2` (for FP8 quant); `nvfp4`, `mxfp4` (for FP4 quant). Default: `fp8_e4m3`|
 | `--use_global_scale`     | Use global scale factor for NVFP4 format (FP4 routines only)                                               |
 | `--is_sf_swizzled_layout`| Use swizzled scale factor layout for tensor core GEMM (FP4 routines only)                                  |
-| `--backends`             | Backend to test: `cuda` (default) or `cute-dsl` (for FP4 routines)                                         |
+| `--backends`             | Backend to test. Defaults to `cute-dsl` for rmsnorm/rmsnorm_quant/fused_add_rmsnorm/fused_add_rmsnorm_quant/gemma_rmsnorm/gemma_fused_add_rmsnorm/rmsnorm_fp4quant/add_rmsnorm_fp4quant (CuTe-DSL kernels) and `cuda` otherwise. Pass `--backends cuda` to force the CUDA JIT fallback (set `FLASHINFER_USE_CUDA_NORM=1` to actually run the CUDA path). |
 
 ### Quantization Flags
 | Flag                     | Description                                                                                                 |
@@ -477,9 +480,12 @@ Legend:
 | **cutlass_fused_moe** |  |  |  |  |  | cutlass | cutlass |  |
 | **moe_a2a_dispatch_combine** |  |  |  |  |  | moe_a2a | moe_a2a |  |
 | **allreduce_fusion** |  |  |  |  |  | allreduce | allreduce |  |
-| **rmsnorm** | cuda | cuda | cuda | cuda | cuda | cuda | cuda | cuda |
-| **rmsnorm_quant** | cuda | cuda | cuda | cuda | cuda | cuda | cuda | cuda |
-| **fused_add_rmsnorm_quant** | cuda | cuda | cuda | cuda | cuda | cuda | cuda | cuda |
+| **rmsnorm** | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl |
+| **fused_add_rmsnorm** | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl |
+| **gemma_rmsnorm** | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl |
+| **gemma_fused_add_rmsnorm** | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl |
+| **rmsnorm_quant** | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl |
+| **fused_add_rmsnorm_quant** | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl | cute-dsl |
 | **rmsnorm_fp4quant** |  |  |  |  |  | cute-dsl | cute-dsl |  |
 | **add_rmsnorm_fp4quant** |  |  |  |  |  | cute-dsl | cute-dsl |  |
 | **mxfp8_quantize** |  |  |  |  |  | cuda | cuda |  |

--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -210,6 +210,16 @@ def parse_args(line=sys.argv[1:]):
         default="",
         help="Placeholder for generated reproducer command for the test case. Not to be used directly.",
     )
+    parser.add_argument(
+        "--enable_pdl",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable Programmatic Dependent Launch (PDL) for routines whose backing "
+            "API accepts it. When omitted, PDL is forced off for every routine. "
+            "Routines whose API does not accept PDL emit a warning and ignore the flag."
+        ),
+    )
 
     ## Check routine and pass on to routine-specific argument parser
     ## Imports are done lazily to avoid loading unnecessary dependencies

--- a/benchmarks/routines/allreduce_comm.py
+++ b/benchmarks/routines/allreduce_comm.py
@@ -75,11 +75,13 @@ try:
     from .flashinfer_benchmark_utils import (
         dtype_str_to_torch_dtype,
         print_perf_metrics,
+        warn_if_pdl_unsupported,
     )
 except ImportError:
     from flashinfer_benchmark_utils import (
         dtype_str_to_torch_dtype,
         print_perf_metrics,
+        warn_if_pdl_unsupported,
     )
 
 PATTERN_NAME_TO_CODE = {
@@ -456,6 +458,7 @@ def parse_allreduce_comm_args(line, parser):
 
 def test_allreduce_fusion(args):
     """Benchmark allreduce fusion across shapes, backends, and patterns."""
+    warn_if_pdl_unsupported(args, args.routine)
     comm, rank, world_size, local_rank = _setup_mpi_and_device()
     gpus_per_node = torch.cuda.device_count()
 

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -642,6 +642,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 v_scale=v_scale,
                 q_len_per_req=s_qo,
                 kv_cache_sf=kv_cache_sf,
+                enable_pdl=args.enable_pdl,
             )
         elif backend == "cudnn":
             return flashinfer.decode.cudnn_batch_decode_with_kv_cache(
@@ -673,6 +674,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 q_len_per_req=s_qo,
                 mask=speculative_mask,
                 kv_cache_sf=kv_cache_sf,
+                enable_pdl=args.enable_pdl,
             )
         else:
             print(f"[ERROR] Backend {backend} not supported")
@@ -1285,6 +1287,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 k_scale=k_scale,
                 v_scale=v_scale,
                 kv_cache_sf=kv_cache_sf,
+                enable_pdl=args.enable_pdl,
             )
         elif backend == "cudnn":
             # cuDNN uses wrapper API with tensor scales for FP8
@@ -1294,6 +1297,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 q_scale=q_scale_tensor,
                 k_scale=k_scale_tensor,
                 v_scale=v_scale_tensor,
+                enable_pdl=args.enable_pdl,
             )
         elif backend == "trtllm-native":
             # Compute combined bmm1_scale: q_scale * k_scale * sm_scale
@@ -1318,6 +1322,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 cum_seq_lens_kv=kv_indptr,
                 causal=causal,
                 kv_cache_sf=kv_cache_sf,
+                enable_pdl=args.enable_pdl,
             )
         elif backend == "cudnn-native":
             # Direct cudnn_batch_prefill_with_kv_cache call (similar to trtllm-native)
@@ -1962,7 +1967,9 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
         kv_indptr,
     ):
         if backend in ["cutlass", "fa2", "fa3", "trtllm-gen"]:
-            return backend_wrappers[backend].run_return_lse(q, k, v)[0]
+            return backend_wrappers[backend].run_return_lse(
+                q, k, v, enable_pdl=args.enable_pdl
+            )[0]
         elif backend == "cute-dsl":
             _q_scale = q_scale if q_scale is not None else 1.0
             _k_scale = k_scale if k_scale is not None else 1.0
@@ -1982,7 +1989,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 window_left=-1,
                 cum_seq_lens_q=qo_indptr,
                 cum_seq_lens_kv=kv_indptr,
-                enable_pdl=False,
+                enable_pdl=args.enable_pdl,
                 is_causal=causal,
                 return_lse=True,
                 out=trtllm_out,
@@ -1990,7 +1997,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
             )[0]
         elif backend == "cudnn":
             # cuDNN uses wrapper API
-            return backend_wrappers[backend].run(q, k, v)
+            return backend_wrappers[backend].run(q, k, v, enable_pdl=args.enable_pdl)
         elif backend == "cudnn-native":
             # Direct cudnn_batch_prefill_with_kv_cache call
             return flashinfer.prefill.cudnn_batch_prefill_with_kv_cache(
@@ -2033,7 +2040,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 window_left=-1,
                 cum_seq_lens_q=qo_indptr,
                 cum_seq_lens_kv=kv_indptr,
-                enable_pdl=False,
+                enable_pdl=args.enable_pdl,
                 is_causal=causal,
                 return_lse=True,
                 out=trtllm_out,
@@ -2477,6 +2484,9 @@ def testBatchMLAPagedAttentionWrapper(args):
         actual_seq_lens_kv,
     ):
         if backend in ["fa2", "fa3"]:
+            # BatchMLAPagedAttentionWrapper.run() does not accept enable_pdl;
+            # the fa2/fa3 MLA wrapper has no PDL support. trtllm-native/auto/
+            # cute-dsl branches below pass args.enable_pdl to the direct API.
             return backend_wrappers[backend].run(
                 q_nope,
                 q_pe,
@@ -2486,6 +2496,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 return_lse=False,
             )
         elif backend == "cutlass":
+            # BatchMLAPagedAttentionWrapper.run() does not accept enable_pdl.
             return backend_wrappers[backend].run(
                 q_nope,
                 q_pe,
@@ -2509,6 +2520,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm1_scale=sm_scale,
                 bmm2_scale=1.0,
                 backend="trtllm-gen",
+                enable_pdl=args.enable_pdl,
             ).squeeze(1)
         elif backend == "auto":
             # Autotune dispatcher: picks between trtllm-gen and cute-dsl per
@@ -2527,6 +2539,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm1_scale=sm_scale,
                 bmm2_scale=1.0,
                 backend="auto",
+                enable_pdl=args.enable_pdl,
             ).squeeze(1)
         elif backend == "cute-dsl":
             return flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla(
@@ -2542,6 +2555,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm1_scale=sm_scale,
                 bmm2_scale=1.0,
                 backend="cute-dsl",
+                enable_pdl=args.enable_pdl,
             ).squeeze(1)
         else:
             print(f"[ERROR] Unsupported backend: {backend}")

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -212,6 +212,9 @@ benchmark_apis = {
     ],
     "norm": [
         "rmsnorm",
+        "fused_add_rmsnorm",
+        "gemma_rmsnorm",
+        "gemma_fused_add_rmsnorm",
         "rmsnorm_quant",
         "fused_add_rmsnorm_quant",
         "rmsnorm_fp4quant",
@@ -264,6 +267,18 @@ def print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec):
     print(
         f"[PERF] {backend.ljust(output_backend_width)}:: median time {median_time:.3f} ms; std {std_time:.3f} ms; achieved tflops {tflops:.3f} TFLOPs/sec; achieved tb_per_sec {tb_per_sec:.3f} TB/sec"
     )
+
+
+def warn_if_pdl_unsupported(args, routine_name):
+    """Emit a one-shot warning if --enable_pdl is set but the routine's API does
+    not accept enable_pdl. Call from the top of test functions whose underlying
+    flashinfer API takes no enable_pdl parameter, so users get clear feedback
+    that the flag is a no-op instead of silently being ignored.
+    """
+    if getattr(args, "enable_pdl", False):
+        print(
+            f"[WARNING] --enable_pdl provided but routine {routine_name} does not support PDL; flag is ignored."
+        )
 
 
 def get_device(args):
@@ -402,17 +417,6 @@ routine_cc_to_supported_backends = {
         "12.0": [],
         "12.1": [],
     },
-    "bmm_fp8": {
-        "7.5": [],
-        "8.0": [],
-        "8.6": [],
-        "8.9": ["cudnn", "cublas"],
-        "9.0": ["cudnn", "cublas"],
-        "10.0": ["cudnn", "cublas", "cutlass"],
-        "10.3": ["cudnn", "cublas", "cutlass"],
-        "12.0": ["cudnn", "cublas"],
-        "12.1": ["cudnn", "cublas"],
-    },
     "bmm_mxfp8": {
         "7.5": [],
         "8.0": [],
@@ -448,7 +452,7 @@ routine_cc_to_supported_backends = {
         "12.0": ["tinygemm"],
         "12.1": ["tinygemm"],
     },
-    # Note: mm_fp4, mm_bf16, and bmm_bf16 use support checkers to filter backends, so they are not listed here
+    # Note: bmm_fp8, mm_fp4, mm_bf16, and bmm_bf16 use support checkers to filter backends, so they are not listed here
     # MOE
     "trtllm_fp4_block_scale_moe": {
         "7.5": [],
@@ -518,37 +522,70 @@ routine_cc_to_supported_backends = {
     },
     # NORM
     "rmsnorm": {
-        "7.5": ["cuda"],
-        "8.0": ["cuda"],
-        "8.6": ["cuda"],
-        "8.9": ["cuda"],
-        "9.0": ["cuda"],
-        "10.0": ["cuda"],
-        "10.3": ["cuda"],
-        "12.0": ["cuda"],
-        "12.1": ["cuda"],
+        "7.5": ["cute-dsl"],
+        "8.0": ["cute-dsl"],
+        "8.6": ["cute-dsl"],
+        "8.9": ["cute-dsl"],
+        "9.0": ["cute-dsl"],
+        "10.0": ["cute-dsl"],
+        "10.3": ["cute-dsl"],
+        "12.0": ["cute-dsl"],
+        "12.1": ["cute-dsl"],
+    },
+    "fused_add_rmsnorm": {
+        "7.5": ["cute-dsl"],
+        "8.0": ["cute-dsl"],
+        "8.6": ["cute-dsl"],
+        "8.9": ["cute-dsl"],
+        "9.0": ["cute-dsl"],
+        "10.0": ["cute-dsl"],
+        "10.3": ["cute-dsl"],
+        "12.0": ["cute-dsl"],
+        "12.1": ["cute-dsl"],
+    },
+    "gemma_rmsnorm": {
+        "7.5": ["cute-dsl"],
+        "8.0": ["cute-dsl"],
+        "8.6": ["cute-dsl"],
+        "8.9": ["cute-dsl"],
+        "9.0": ["cute-dsl"],
+        "10.0": ["cute-dsl"],
+        "10.3": ["cute-dsl"],
+        "12.0": ["cute-dsl"],
+        "12.1": ["cute-dsl"],
+    },
+    "gemma_fused_add_rmsnorm": {
+        "7.5": ["cute-dsl"],
+        "8.0": ["cute-dsl"],
+        "8.6": ["cute-dsl"],
+        "8.9": ["cute-dsl"],
+        "9.0": ["cute-dsl"],
+        "10.0": ["cute-dsl"],
+        "10.3": ["cute-dsl"],
+        "12.0": ["cute-dsl"],
+        "12.1": ["cute-dsl"],
     },
     "rmsnorm_quant": {
-        "7.5": ["cuda"],
-        "8.0": ["cuda"],
-        "8.6": ["cuda"],
-        "8.9": ["cuda"],
-        "9.0": ["cuda"],
-        "10.0": ["cuda"],
-        "10.3": ["cuda"],
-        "12.0": ["cuda"],
-        "12.1": ["cuda"],
+        "7.5": ["cute-dsl"],
+        "8.0": ["cute-dsl"],
+        "8.6": ["cute-dsl"],
+        "8.9": ["cute-dsl"],
+        "9.0": ["cute-dsl"],
+        "10.0": ["cute-dsl"],
+        "10.3": ["cute-dsl"],
+        "12.0": ["cute-dsl"],
+        "12.1": ["cute-dsl"],
     },
     "fused_add_rmsnorm_quant": {
-        "7.5": ["cuda"],
-        "8.0": ["cuda"],
-        "8.6": ["cuda"],
-        "8.9": ["cuda"],
-        "9.0": ["cuda"],
-        "10.0": ["cuda"],
-        "10.3": ["cuda"],
-        "12.0": ["cuda"],
-        "12.1": ["cuda"],
+        "7.5": ["cute-dsl"],
+        "8.0": ["cute-dsl"],
+        "8.6": ["cute-dsl"],
+        "8.9": ["cute-dsl"],
+        "9.0": ["cute-dsl"],
+        "10.0": ["cute-dsl"],
+        "10.3": ["cute-dsl"],
+        "12.0": ["cute-dsl"],
+        "12.1": ["cute-dsl"],
     },
     # NORM - FP4 Quantization (Blackwell SM100+ only, CuTe-DSL kernels)
     "rmsnorm_fp4quant": {

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -20,6 +20,7 @@ from .flashinfer_benchmark_utils import (
     print_perf_metrics,
     is_close_stats,
     filter_backends_by_compute_capability,
+    warn_if_pdl_unsupported,
 )
 
 
@@ -180,12 +181,6 @@ def parse_gemm_args(line, parser):
         default=False,
         help="Use bias (enabled for mm_bf16 with TGV and TinyGEMM backends)",
     )
-    parser.add_argument(
-        "--enable_pdl",
-        action="store_true",
-        default=False,
-        help="Enable programmatic dependent launch.",
-    )
 
     args = parser.parse_args(line)
     has_backends_arg = any(
@@ -235,6 +230,7 @@ def testGemmFp8NtGroupwise(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testGemmFp8NtGroupwise")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -424,6 +420,7 @@ def testGroupGemmFp8NtGroupwise(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testGroupGemmFp8NtGroupwise")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -608,6 +605,7 @@ def testBmmFp8(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testBmmFp8")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -635,11 +633,6 @@ def testBmmFp8(args):
     ]
     res = []
 
-    backends = filter_backends_by_compute_capability(backends, args.routine, device)
-    if len(backends) == 0:
-        print("[ERROR] No backends to test. Exiting.")
-        return res
-
     input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
     if input_dtype not in [torch.float8_e4m3fn, torch.float8_e5m2]:
         raise ValueError(
@@ -658,19 +651,6 @@ def testBmmFp8(args):
             f"Unsupported res dtype: {res_dtype}. Supported dtypes are bfloat16 and float16."
         )
     ## Done parsing input arguments
-
-    if getattr(args, "autotune", False):
-        backends_to_remove = []
-        for cur_backend in backends:
-            if cur_backend not in autotune_supported_backends:
-                print(f"[INFO] {cur_backend} backend does not support autotune")
-                backends_to_remove.append(cur_backend)
-        for cur_backend in backends_to_remove:
-            backends.remove(cur_backend)
-
-    if len(backends) == 0:
-        print("[ERROR] No backends to test. Exiting.")
-        return
 
     ## Prepare input tensors
     input = torch.randn([batch_size, m, k], device=device, dtype=torch.bfloat16)
@@ -691,9 +671,21 @@ def testBmmFp8(args):
         print(f"[VVERBOSE] {mat2_inv_s = }")
         print(f"[VVERBOSE] {mat2_inv_s.dtype = }")
 
-    def run_backend(backend, input_fp8, mat2_fp8, input_inv_s, mat2_inv_s):
-        if backend in ["cudnn", "cublas", "cutlass"]:
-            return flashinfer.gemm.bmm_fp8(
+    # Programmatically filter backends: rely on bmm_fp8's @backend_requirement
+    # support checks (instead of a hard-coded compute-capability table) by
+    # probing each backend with a trial call.
+    backends_to_remove = []
+    for backend in backends:
+        if (
+            getattr(args, "autotune", False)
+            and backend not in autotune_supported_backends
+        ):
+            print(f"[INFO] {backend} backend does not support autotune")
+            backends_to_remove.append(backend)
+            continue
+
+        try:
+            flashinfer.gemm.bmm_fp8(
                 A=input_fp8,
                 B=mat2_fp8,
                 A_scale=input_inv_s,
@@ -701,8 +693,28 @@ def testBmmFp8(args):
                 dtype=res_dtype,
                 backend=backend,
             )
-        else:
-            raise ValueError(f"Unsupported backend: {backend}")
+        except Exception as e:
+            print(
+                f"[INFO] {backend} backend does not support this configuration: {type(e).__name__}: {e}"
+            )
+            backends_to_remove.append(backend)
+
+    for backend in backends_to_remove:
+        backends.remove(backend)
+
+    if len(backends) == 0:
+        print("[ERROR] No backends passed validation. Exiting.")
+        return res
+
+    def run_backend(backend, input_fp8, mat2_fp8, input_inv_s, mat2_inv_s):
+        return flashinfer.gemm.bmm_fp8(
+            A=input_fp8,
+            B=mat2_fp8,
+            A_scale=input_inv_s,
+            B_scale=mat2_inv_s,
+            dtype=res_dtype,
+            backend=backend,
+        )
 
     has_reference_output = False
     if run_refcheck:
@@ -830,6 +842,7 @@ def testBmmMxfp8(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testBmmMxfp8")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1150,6 +1163,7 @@ def testMmFp4(args):
                 use_8x4_sf_layout=not use_128x4_sf_layout,
                 backend=backend,
                 use_nvfp4=use_nvfp4,
+                enable_pdl=args.enable_pdl,
             )
         except Exception as e:
             print(
@@ -1185,6 +1199,7 @@ def testMmFp4(args):
             use_8x4_sf_layout=not use_128x4_sf_layout,
             backend=backend,
             use_nvfp4=use_nvfp4,
+            enable_pdl=args.enable_pdl,
         )
 
     has_reference_output = False
@@ -1323,6 +1338,7 @@ def testMmMxfp8(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testMmMxfp8")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1981,6 +1997,7 @@ def testBmmBf16(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testBmmBf16")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")

--- a/benchmarks/routines/mamba.py
+++ b/benchmarks/routines/mamba.py
@@ -38,6 +38,7 @@ from .flashinfer_benchmark_utils import (
     is_close_stats,
     print_perf_metrics,
     filter_backends_by_compute_capability,
+    warn_if_pdl_unsupported,
 )
 
 from triton_reference.selective_state_update import (
@@ -253,6 +254,7 @@ def testSelectiveStateUpdate(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testSelectiveStateUpdate")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")

--- a/benchmarks/routines/mixed_comm.py
+++ b/benchmarks/routines/mixed_comm.py
@@ -49,9 +49,15 @@ from flashinfer.comm.mixed_comm import (
 from flashinfer.testing.utils import bench_gpu_time
 
 try:
-    from .flashinfer_benchmark_utils import dtype_str_to_torch_dtype
+    from .flashinfer_benchmark_utils import (
+        dtype_str_to_torch_dtype,
+        warn_if_pdl_unsupported,
+    )
 except ImportError:
-    from flashinfer_benchmark_utils import dtype_str_to_torch_dtype
+    from flashinfer_benchmark_utils import (
+        dtype_str_to_torch_dtype,
+        warn_if_pdl_unsupported,
+    )
 
 
 @torch.inference_mode()
@@ -239,6 +245,7 @@ def test_mixed_comm(args):
     Spawns one process per local GPU, each running torch.distributed.
     Rank 0 collects and returns benchmark results via a queue.
     """
+    warn_if_pdl_unsupported(args, args.routine)
     num_local_gpus = torch.cuda.device_count()
     local_size = args.local_tp_size * args.local_dp_size
     assert local_size > 1, "local_size must be greater than 1"

--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -33,6 +33,7 @@ from .flashinfer_benchmark_utils import (
     get_device,
     print_perf_metrics,
     filter_backends_by_compute_capability,
+    warn_if_pdl_unsupported,
 )
 from .moe_utils import (
     calculate_fp4_global_scale,
@@ -678,6 +679,7 @@ def testTrtllmFp4BlockScaleMoe(args):
             routed_scaling_factor=routed_scaling_factor,
             routing_method_type=routing_method_type,
             do_finalize=True,
+            enable_pdl=args.enable_pdl,
             **_activation_kwarg(trtllm_fp4_block_scale_moe, activation_type),
         )
 
@@ -928,6 +930,7 @@ def testCutlassFusedMoe(args):
                 ep_rank=ep_rank,
                 quant_scales=None,
                 output=out,
+                enable_pdl=args.enable_pdl,
                 **_activation_kwarg(cutlass_fused_moe, activation_type),
             )
 
@@ -996,6 +999,7 @@ def testCutlassFusedMoe(args):
                 ep_rank=ep_rank,
                 quant_scales=quant_scales,
                 output=out,
+                enable_pdl=args.enable_pdl,
                 **_activation_kwarg(cutlass_fused_moe, activation_type),
             )
 
@@ -1082,6 +1086,7 @@ def testCutlassFusedMoe(args):
                 quant_scales=quant_scales,
                 input_sf=input_sf,
                 output=out,
+                enable_pdl=args.enable_pdl,
                 **_activation_kwarg(cutlass_fused_moe, activation_type),
             )
 
@@ -1432,6 +1437,7 @@ def testCuteDslFp4BlockScaleMoe(args):
             num_local_experts=local_num_experts,
             local_expert_offset=local_expert_offset,
             moe_output=moe_output,
+            enable_pdl=args.enable_pdl,
         )
 
         # Warmup call to populate workspace cache before timed region
@@ -1458,6 +1464,7 @@ def testCuteDslFp4BlockScaleMoe(args):
             max_num_tokens=num_tokens,
             num_local_experts=local_num_experts,
             local_expert_offset=local_expert_offset,
+            enable_pdl=args.enable_pdl,
         )
         runner = moe.run
 
@@ -1613,6 +1620,7 @@ def testB12xFusedMoe(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testB12xFusedMoe")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -2038,7 +2046,7 @@ def testTrtllmFp8BlockScaleMoe(args):
             routing_method_type=routing_method_type,
             use_shuffled_weight=use_shuffled_weight,
             weight_layout=weight_layout,
-            enable_pdl=True,
+            enable_pdl=args.enable_pdl,
         )
 
     # Benchmark timing
@@ -2272,6 +2280,7 @@ def testTrtllmFp8PerTensorScaleMoe(args):
             routed_scaling_factor=routed_scaling_factor,
             use_routing_scales_on_input=use_routing_scales_on_input,
             routing_method_type=routing_method_type,
+            enable_pdl=args.enable_pdl,
             **_activation_kwarg(trtllm_fp8_per_tensor_scale_moe, activation_type),
         )
 

--- a/benchmarks/routines/moe_comm.py
+++ b/benchmarks/routines/moe_comm.py
@@ -1339,7 +1339,7 @@ def test_moe_a2a_dispatch_combine(args):
                             routing_method_type=1,  # Renormalize: TopK -> Softmax
                             use_shuffled_weight=False,
                             weight_layout=int(WeightLayout.MajorK),
-                            enable_pdl=True,
+                            enable_pdl=args.enable_pdl,
                             output=combine_payload.view(total_tokens, hidden_size),
                         )
 

--- a/benchmarks/routines/norm.py
+++ b/benchmarks/routines/norm.py
@@ -43,6 +43,12 @@ def run_norm_test(args):
     """
     if args.routine == "rmsnorm":
         return testRmsnorm(args)
+    elif args.routine == "fused_add_rmsnorm":
+        return testFusedAddRmsnorm(args)
+    elif args.routine == "gemma_rmsnorm":
+        return testGemmaRmsnorm(args)
+    elif args.routine == "gemma_fused_add_rmsnorm":
+        return testGemmaFusedAddRmsnorm(args)
     elif args.routine == "rmsnorm_quant":
         return testRmsnormQuant(args)
     elif args.routine == "fused_add_rmsnorm_quant":
@@ -104,12 +110,6 @@ def parse_norm_args(line, parser):
         required=False,
         default=1e-6,
         help="Epsilon for numerical stability.",
-    )
-    parser.add_argument(
-        "--enable_pdl",
-        action="store_true",
-        default=False,
-        help="Enable programmatic dependent launch.",
     )
     parser.add_argument(
         "--scale",
@@ -227,6 +227,11 @@ def testRmsnorm(args):
 
     ## Parse input arguments
     backends = args.backends[:]  # Make a copy to avoid modifying the original
+
+    # Default backend to cute-dsl for rmsnorm variants (CuTe-DSL kernels by default)
+    if backends == ["cuda"]:
+        backends = ["cute-dsl"]
+
     batch_size = args.batch_size
     hidden_size = args.hidden_size
     num_heads = args.num_heads
@@ -263,7 +268,7 @@ def testRmsnorm(args):
         print(f"[VVERBOSE] {weight.shape = }")
 
     def run_backend(backend, input_tensor, weight):
-        if backend == "cuda":
+        if backend == "cute-dsl":
             return flashinfer.rmsnorm(
                 input_tensor, weight, eps=eps, enable_pdl=enable_pdl
             )
@@ -358,6 +363,469 @@ def testRmsnorm(args):
     return res
 
 
+def testFusedAddRmsnorm(args):
+    """
+    Test fused_add_rmsnorm API.
+
+    This test benchmarks residual += input followed by RMSNorm, with the
+    normalized output written back to input and residual updated in-place.
+    """
+    if args.verbose >= 1:
+        print("[INFO] Running testFusedAddRmsnorm")
+        print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
+
+    device = get_device(args)
+    if args.generate_repro_command:
+        print(
+            f"[INFO] To reproduce this test case, run the following command: {args.repro_command}"
+        )
+
+    backends = args.backends[:]
+
+    # Default backend to cute-dsl for rmsnorm variants (CuTe-DSL kernels by default)
+    if backends == ["cuda"]:
+        backends = ["cute-dsl"]
+
+    batch_size = args.batch_size
+    hidden_size = args.hidden_size
+    eps = args.eps
+    enable_pdl = args.enable_pdl
+    is_cuda_graph_compatible = not args.no_cuda_graph
+    run_refcheck = args.refcheck
+    res = []
+
+    backends = filter_backends_by_compute_capability(backends, args.routine, device)
+    if len(backends) == 0:
+        print("[ERROR] No backends to test. Exiting.")
+        return res
+
+    input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
+    if input_dtype not in [torch.bfloat16, torch.float16]:
+        raise ValueError(
+            f"Unsupported input dtype: {args.input_dtype}. Supported dtypes are bfloat16, float16."
+        )
+
+    input_shape = (batch_size, hidden_size)
+    input_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
+    residual_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
+    weight = torch.randn(hidden_size, dtype=input_dtype, device=device)
+
+    if args.verbose >= 2:
+        print(f"[VVERBOSE] {input_tensor.shape = }")
+        print(f"[VVERBOSE] {input_tensor.dtype = }")
+        print(f"[VVERBOSE] {residual_tensor.shape = }")
+        print(f"[VVERBOSE] {weight.shape = }")
+
+    def run_backend(backend, input_tensor, residual_tensor, weight):
+        if backend == "cute-dsl":
+            flashinfer.fused_add_rmsnorm(
+                input_tensor,
+                residual_tensor,
+                weight,
+                eps=eps,
+                enable_pdl=enable_pdl,
+            )
+            return input_tensor, residual_tensor
+        else:
+            raise ValueError(f"Unsupported backend: {backend}")
+
+    has_reference_output = False
+    if run_refcheck:
+        reference_residual = residual_tensor.float() + input_tensor.float()
+        rms = torch.sqrt(torch.mean(reference_residual**2, dim=-1, keepdim=True) + eps)
+        reference_output = (reference_residual / rms * weight.float()).to(input_dtype)
+        reference_residual = reference_residual.to(input_dtype)
+        has_reference_output = True
+
+    backend_times = {backend: [] for backend in backends}
+    outputs = {}
+    residual_outputs = {}
+    for cur_backend in backends:
+        if run_refcheck:
+            cur_input = input_tensor.clone()
+            cur_residual = residual_tensor.clone()
+            out, residual_out = run_backend(
+                cur_backend, cur_input, cur_residual, weight
+            )
+            outputs[cur_backend] = out.detach().clone()
+            residual_outputs[cur_backend] = residual_out.detach().clone()
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=run_backend,
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+            input_args=(
+                cur_backend,
+                input_tensor.clone(),
+                residual_tensor.clone(),
+                weight,
+            ),
+        )
+
+    tested_backends = list(outputs.keys())
+    if len(tested_backends) > 0 and run_refcheck and has_reference_output:
+        for backend in tested_backends:
+            for name, ref, out in (
+                ("output", reference_output, outputs[backend]),
+                ("residual", reference_residual, residual_outputs[backend]),
+            ):
+                (
+                    num_different_elements,
+                    num_elements,
+                    num_different_elements_percentage,
+                ) = is_close_stats(ref, out, rtol=1e-2, atol=1e-2)
+                if num_different_elements > 0:
+                    print(
+                        f"[ERROR] {name} tensor mismatch from backend {backend}: "
+                        f"{num_different_elements}/{num_elements} ({num_different_elements_percentage:.2f}%) elements differ"
+                    )
+                    if not args.allow_output_mismatch:
+                        raise AssertionError(
+                            f"[ERROR] Backend {backend} {name} mismatch with {num_different_elements} elements"
+                        )
+
+    for backend in backends:
+        if len(backend_times[backend]) > 0:
+            median_time = np.median(backend_times[backend])
+            std_time = np.std(backend_times[backend])
+
+            # Memory bandwidth: read input + residual + weight; write residual + normalized input
+            num_elements = np.prod(input_shape)
+            problem_bytes = (
+                num_elements * input_dtype.itemsize  # input read
+                + num_elements * input_dtype.itemsize  # residual read
+                + hidden_size * input_dtype.itemsize  # weight read
+                + num_elements * input_dtype.itemsize  # residual write
+                + num_elements * input_dtype.itemsize  # normalized input write
+            )
+            problem_flops = num_elements * 6
+            tflops = problem_flops / (10**9 * median_time)
+            tb_per_sec = problem_bytes / (10**9 * median_time)
+
+            print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
+
+            if args.output_path is not None:
+                cur_res = defaultdict(str)
+                cur_res["routine"] = args.routine
+                cur_res["median_time"] = median_time
+                cur_res["std_time"] = std_time
+                cur_res["tflops"] = tflops
+                cur_res["tb_per_sec"] = tb_per_sec
+                cur_res["input_dtype"] = str(input_dtype)
+                cur_res["eps"] = eps
+                cur_res["enable_pdl"] = enable_pdl
+                cur_res["backend"] = backend
+                cur_res["case_tag"] = args.case_tag
+                res.append(cur_res)
+    return res
+
+
+def testGemmaRmsnorm(args):
+    """
+    Test gemma_rmsnorm API.
+
+    Gemma RMSNorm uses (weight + 1) instead of weight.
+    """
+    if args.verbose >= 1:
+        print("[INFO] Running testGemmaRmsnorm")
+        print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
+
+    device = get_device(args)
+    if args.generate_repro_command:
+        print(
+            f"[INFO] To reproduce this test case, run the following command: {args.repro_command}"
+        )
+
+    backends = args.backends[:]
+
+    # Default backend to cute-dsl for rmsnorm variants (CuTe-DSL kernels by default)
+    if backends == ["cuda"]:
+        backends = ["cute-dsl"]
+
+    batch_size = args.batch_size
+    hidden_size = args.hidden_size
+    num_heads = args.num_heads
+    eps = args.eps
+    enable_pdl = args.enable_pdl
+    is_cuda_graph_compatible = not args.no_cuda_graph
+    run_refcheck = args.refcheck
+    res = []
+
+    backends = filter_backends_by_compute_capability(backends, args.routine, device)
+    if len(backends) == 0:
+        print("[ERROR] No backends to test. Exiting.")
+        return res
+
+    input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
+    if input_dtype not in [torch.bfloat16, torch.float16]:
+        raise ValueError(
+            f"Unsupported input dtype: {args.input_dtype}. Supported dtypes are bfloat16, float16."
+        )
+
+    if num_heads is not None:
+        input_shape = (batch_size, num_heads, hidden_size)
+    else:
+        input_shape = (batch_size, hidden_size)
+
+    input_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
+    weight = torch.randn(hidden_size, dtype=input_dtype, device=device)
+
+    if args.verbose >= 2:
+        print(f"[VVERBOSE] {input_tensor.shape = }")
+        print(f"[VVERBOSE] {input_tensor.dtype = }")
+        print(f"[VVERBOSE] {weight.shape = }")
+
+    def run_backend(backend, input_tensor, weight):
+        if backend == "cute-dsl":
+            return flashinfer.gemma_rmsnorm(
+                input_tensor, weight, eps=eps, enable_pdl=enable_pdl
+            )
+        else:
+            raise ValueError(f"Unsupported backend: {backend}")
+
+    has_reference_output = False
+    if run_refcheck:
+        rms = torch.sqrt(
+            torch.mean(input_tensor.float() ** 2, dim=-1, keepdim=True) + eps
+        )
+        reference_output = (input_tensor.float() / rms * (weight.float() + 1.0)).to(
+            input_dtype
+        )
+        has_reference_output = True
+
+    backend_times = {backend: [] for backend in backends}
+    outputs = {}
+    for cur_backend in backends:
+        if run_refcheck:
+            outputs[cur_backend] = run_backend(
+                cur_backend, input_tensor, weight
+            ).detach()
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=run_backend,
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+            input_args=(cur_backend, input_tensor, weight),
+        )
+
+    tested_backends = list(outputs.keys())
+    tested_outputs = list(outputs.values())
+    if len(tested_backends) > 0:
+        if run_refcheck and has_reference_output:
+            for i in range(len(tested_backends)):
+                (
+                    num_different_elements,
+                    num_elements,
+                    num_different_elements_percentage,
+                ) = is_close_stats(
+                    reference_output, tested_outputs[i], rtol=1e-2, atol=1e-2
+                )
+                if num_different_elements > 0:
+                    print(
+                        f"[ERROR] Output tensor mismatch from backend {tested_backends[i]}: "
+                        f"{num_different_elements}/{num_elements} ({num_different_elements_percentage:.2f}%) elements differ"
+                    )
+                    if not args.allow_output_mismatch:
+                        raise AssertionError(
+                            f"[ERROR] Backend {tested_backends[i]} output mismatch with {num_different_elements} elements"
+                        )
+
+    for backend in backends:
+        if len(backend_times[backend]) > 0:
+            median_time = np.median(backend_times[backend])
+            std_time = np.std(backend_times[backend])
+
+            # Memory bandwidth: read input + weight; write output
+            num_elements = np.prod(input_shape)
+            problem_bytes = (
+                num_elements * input_dtype.itemsize  # input read
+                + hidden_size * input_dtype.itemsize  # weight read
+                + num_elements * input_dtype.itemsize  # output write
+            )
+            problem_flops = num_elements * 5
+            tflops = problem_flops / (10**9 * median_time)
+            tb_per_sec = problem_bytes / (10**9 * median_time)
+
+            print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
+
+            if args.output_path is not None:
+                cur_res = defaultdict(str)
+                cur_res["routine"] = args.routine
+                cur_res["median_time"] = median_time
+                cur_res["std_time"] = std_time
+                cur_res["tflops"] = tflops
+                cur_res["tb_per_sec"] = tb_per_sec
+                cur_res["num_heads"] = num_heads if num_heads else ""
+                cur_res["input_dtype"] = str(input_dtype)
+                cur_res["eps"] = eps
+                cur_res["enable_pdl"] = enable_pdl
+                cur_res["backend"] = backend
+                cur_res["case_tag"] = args.case_tag
+                res.append(cur_res)
+    return res
+
+
+def testGemmaFusedAddRmsnorm(args):
+    """
+    Test gemma_fused_add_rmsnorm API.
+
+    This is fused_add_rmsnorm with Gemma-style (weight + 1) scaling.
+    """
+    if args.verbose >= 1:
+        print("[INFO] Running testGemmaFusedAddRmsnorm")
+        print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
+
+    device = get_device(args)
+    if args.generate_repro_command:
+        print(
+            f"[INFO] To reproduce this test case, run the following command: {args.repro_command}"
+        )
+
+    backends = args.backends[:]
+
+    # Default backend to cute-dsl for rmsnorm variants (CuTe-DSL kernels by default)
+    if backends == ["cuda"]:
+        backends = ["cute-dsl"]
+
+    batch_size = args.batch_size
+    hidden_size = args.hidden_size
+    eps = args.eps
+    enable_pdl = args.enable_pdl
+    is_cuda_graph_compatible = not args.no_cuda_graph
+    run_refcheck = args.refcheck
+    res = []
+
+    backends = filter_backends_by_compute_capability(backends, args.routine, device)
+    if len(backends) == 0:
+        print("[ERROR] No backends to test. Exiting.")
+        return res
+
+    input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
+    if input_dtype not in [torch.bfloat16, torch.float16]:
+        raise ValueError(
+            f"Unsupported input dtype: {args.input_dtype}. Supported dtypes are bfloat16, float16."
+        )
+
+    input_shape = (batch_size, hidden_size)
+    input_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
+    residual_tensor = torch.randn(input_shape, dtype=input_dtype, device=device)
+    weight = torch.randn(hidden_size, dtype=input_dtype, device=device)
+
+    if args.verbose >= 2:
+        print(f"[VVERBOSE] {input_tensor.shape = }")
+        print(f"[VVERBOSE] {input_tensor.dtype = }")
+        print(f"[VVERBOSE] {residual_tensor.shape = }")
+        print(f"[VVERBOSE] {weight.shape = }")
+
+    def run_backend(backend, input_tensor, residual_tensor, weight):
+        if backend == "cute-dsl":
+            flashinfer.gemma_fused_add_rmsnorm(
+                input_tensor,
+                residual_tensor,
+                weight,
+                eps=eps,
+                enable_pdl=enable_pdl,
+            )
+            return input_tensor, residual_tensor
+        else:
+            raise ValueError(f"Unsupported backend: {backend}")
+
+    has_reference_output = False
+    if run_refcheck:
+        reference_residual = residual_tensor.float() + input_tensor.float()
+        rms = torch.sqrt(torch.mean(reference_residual**2, dim=-1, keepdim=True) + eps)
+        reference_output = (reference_residual / rms * (weight.float() + 1.0)).to(
+            input_dtype
+        )
+        reference_residual = reference_residual.to(input_dtype)
+        has_reference_output = True
+
+    backend_times = {backend: [] for backend in backends}
+    outputs = {}
+    residual_outputs = {}
+    for cur_backend in backends:
+        if run_refcheck:
+            cur_input = input_tensor.clone()
+            cur_residual = residual_tensor.clone()
+            out, residual_out = run_backend(
+                cur_backend, cur_input, cur_residual, weight
+            )
+            outputs[cur_backend] = out.detach().clone()
+            residual_outputs[cur_backend] = residual_out.detach().clone()
+        backend_times[cur_backend] = bench_gpu_time(
+            fn=run_backend,
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            enable_cupti=args.use_cupti,
+            use_cuda_graph=is_cuda_graph_compatible,
+            input_args=(
+                cur_backend,
+                input_tensor.clone(),
+                residual_tensor.clone(),
+                weight,
+            ),
+        )
+
+    tested_backends = list(outputs.keys())
+    if len(tested_backends) > 0 and run_refcheck and has_reference_output:
+        for backend in tested_backends:
+            for name, ref, out in (
+                ("output", reference_output, outputs[backend]),
+                ("residual", reference_residual, residual_outputs[backend]),
+            ):
+                (
+                    num_different_elements,
+                    num_elements,
+                    num_different_elements_percentage,
+                ) = is_close_stats(ref, out, rtol=1e-2, atol=1e-2)
+                if num_different_elements > 0:
+                    print(
+                        f"[ERROR] {name} tensor mismatch from backend {backend}: "
+                        f"{num_different_elements}/{num_elements} ({num_different_elements_percentage:.2f}%) elements differ"
+                    )
+                    if not args.allow_output_mismatch:
+                        raise AssertionError(
+                            f"[ERROR] Backend {backend} {name} mismatch with {num_different_elements} elements"
+                        )
+
+    for backend in backends:
+        if len(backend_times[backend]) > 0:
+            median_time = np.median(backend_times[backend])
+            std_time = np.std(backend_times[backend])
+
+            # Memory bandwidth: read input + residual + weight; write residual + normalized input
+            num_elements = np.prod(input_shape)
+            problem_bytes = (
+                num_elements * input_dtype.itemsize  # input read
+                + num_elements * input_dtype.itemsize  # residual read
+                + hidden_size * input_dtype.itemsize  # weight read
+                + num_elements * input_dtype.itemsize  # residual write
+                + num_elements * input_dtype.itemsize  # normalized input write
+            )
+            problem_flops = num_elements * 6
+            tflops = problem_flops / (10**9 * median_time)
+            tb_per_sec = problem_bytes / (10**9 * median_time)
+
+            print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
+
+            if args.output_path is not None:
+                cur_res = defaultdict(str)
+                cur_res["routine"] = args.routine
+                cur_res["median_time"] = median_time
+                cur_res["std_time"] = std_time
+                cur_res["tflops"] = tflops
+                cur_res["tb_per_sec"] = tb_per_sec
+                cur_res["input_dtype"] = str(input_dtype)
+                cur_res["eps"] = eps
+                cur_res["enable_pdl"] = enable_pdl
+                cur_res["backend"] = backend
+                cur_res["case_tag"] = args.case_tag
+                res.append(cur_res)
+    return res
+
+
 def testRmsnormQuant(args):
     """
     Test rmsnorm_quant API.
@@ -388,9 +856,18 @@ def testRmsnormQuant(args):
 
     ## Parse input arguments
     backends = args.backends[:]  # Make a copy to avoid modifying the original
+
+    # Default backend to cute-dsl for rmsnorm variants (CuTe-DSL kernels by default)
+    if backends == ["cuda"]:
+        backends = ["cute-dsl"]
+
     batch_size = args.batch_size
     hidden_size = args.hidden_size
-    scale = args.scale
+    # Pre-allocate scale on device once. Passing a Python float forces flashinfer's
+    # _normalize_scale_tensor to create a tensor on each call, which triggers a
+    # host->device copy that is illegal under CUDA graph capture (and emits a
+    # FutureWarning about the deprecated float form).
+    scale = torch.tensor([args.scale], dtype=torch.float32, device=device)
     eps = args.eps
     enable_pdl = args.enable_pdl
     is_cuda_graph_compatible = not args.no_cuda_graph
@@ -430,7 +907,7 @@ def testRmsnormQuant(args):
         print(f"[VVERBOSE] {scale = }")
 
     def run_backend(backend, out_tensor, input_tensor, weight):
-        if backend == "cuda":
+        if backend == "cute-dsl":
             flashinfer.norm.rmsnorm_quant(
                 out_tensor,
                 input_tensor,
@@ -529,7 +1006,7 @@ def testRmsnormQuant(args):
                 cur_res["tb_per_sec"] = tb_per_sec
                 cur_res["input_dtype"] = str(input_dtype)
                 cur_res["out_dtype"] = str(out_dtype)
-                cur_res["scale"] = scale
+                cur_res["scale"] = scale.item()
                 cur_res["eps"] = eps
                 cur_res["enable_pdl"] = enable_pdl
                 cur_res["backend"] = backend
@@ -568,9 +1045,18 @@ def testFusedAddRmsnormQuant(args):
 
     ## Parse input arguments
     backends = args.backends[:]  # Make a copy to avoid modifying the original
+
+    # Default backend to cute-dsl for rmsnorm variants (CuTe-DSL kernels by default)
+    if backends == ["cuda"]:
+        backends = ["cute-dsl"]
+
     batch_size = args.batch_size
     hidden_size = args.hidden_size
-    scale = args.scale
+    # Pre-allocate scale on device once. Passing a Python float forces flashinfer's
+    # _normalize_scale_tensor to create a tensor on each call, which triggers a
+    # host->device copy that is illegal under CUDA graph capture (and emits a
+    # FutureWarning about the deprecated float form).
+    scale = torch.tensor([args.scale], dtype=torch.float32, device=device)
     eps = args.eps
     enable_pdl = args.enable_pdl
     is_cuda_graph_compatible = not args.no_cuda_graph
@@ -612,7 +1098,7 @@ def testFusedAddRmsnormQuant(args):
         print(f"[VVERBOSE] {scale = }")
 
     def run_backend(backend, out_tensor, input_tensor, residual_tensor, weight):
-        if backend == "cuda":
+        if backend == "cute-dsl":
             flashinfer.norm.fused_add_rmsnorm_quant(
                 out_tensor,
                 input_tensor,
@@ -729,7 +1215,7 @@ def testFusedAddRmsnormQuant(args):
                 cur_res["tb_per_sec"] = tb_per_sec
                 cur_res["input_dtype"] = str(input_dtype)
                 cur_res["out_dtype"] = str(out_dtype)
-                cur_res["scale"] = scale
+                cur_res["scale"] = scale.item()
                 cur_res["eps"] = eps
                 cur_res["enable_pdl"] = enable_pdl
                 cur_res["backend"] = backend

--- a/benchmarks/routines/quantization.py
+++ b/benchmarks/routines/quantization.py
@@ -28,6 +28,7 @@ from .flashinfer_benchmark_utils import (
     print_perf_metrics,
     is_close_stats,
     filter_backends_by_compute_capability,
+    warn_if_pdl_unsupported,
 )
 
 
@@ -103,12 +104,6 @@ def parse_quantization_args(line, parser):
         required=False,
         default=32,
         help="sfVecSize for quantization. Default: 32",
-    )
-    parser.add_argument(
-        "--enable_pdl",
-        action="store_true",
-        default=False,
-        help="Enable programmatic dependent launch.",
     )
     parser.add_argument(
         "--backends",
@@ -733,6 +728,7 @@ def testNvfp4BatchedQuantize(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testNvfp4BatchedQuantize")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")

--- a/benchmarks/routines/rope.py
+++ b/benchmarks/routines/rope.py
@@ -27,6 +27,7 @@ from .flashinfer_benchmark_utils import (
     get_device,
     print_perf_metrics,
     filter_backends_by_compute_capability,
+    warn_if_pdl_unsupported,
 )
 
 
@@ -222,6 +223,7 @@ def testApplyRope(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testApplyRope")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -372,6 +374,7 @@ def testApplyRopePosIds(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testApplyRopePosIds")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -516,6 +519,7 @@ def testApplyLlama31Rope(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testApplyLlama31Rope")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -675,6 +679,7 @@ def testApplyLlama31RopePosIds(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testApplyLlama31RopePosIds")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -830,6 +835,7 @@ def testApplyRopeWithCosSinCache(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testApplyRopeWithCosSinCache")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1077,6 +1083,7 @@ def testMlaRopeQuantizeFp8(args):
                 pos_ids,
                 is_neox=is_neox,
                 quantize_dtype=quant_dtype,
+                enable_pdl=args.enable_pdl,
             )
         else:
             raise ValueError(f"Unsupported backend: {backend}")
@@ -1287,6 +1294,7 @@ def testRopeQuantizeFp8(args):
                 pos_ids,
                 is_neox=is_neox,
                 quantize_dtype=quant_dtype,
+                enable_pdl=args.enable_pdl,
             )
         else:
             raise ValueError(f"Unsupported backend: {backend}")
@@ -1602,6 +1610,7 @@ def testRopeQuantizeFp8AppendPagedKvCache(args):
                 quantize_dtype=quant_dtype,
                 page_size=page_size,
                 kv_layout=kv_layout,
+                enable_pdl=args.enable_pdl,
             )
         else:
             raise ValueError(f"Unsupported backend: {backend}")

--- a/benchmarks/routines/sampling.py
+++ b/benchmarks/routines/sampling.py
@@ -28,6 +28,7 @@ from .flashinfer_benchmark_utils import (
     is_close_stats,
     print_perf_metrics,
     filter_backends_by_compute_capability,
+    warn_if_pdl_unsupported,
 )
 
 
@@ -245,7 +246,9 @@ def testSoftmax(args):
 
     def run_backend(backend, logits):
         if backend == "cuda":
-            return flashinfer.sampling.softmax(logits, temperature=temperature)
+            return flashinfer.sampling.softmax(
+                logits, temperature=temperature, enable_pdl=args.enable_pdl
+            )
         else:
             raise ValueError(f"Unsupported backend: {backend}")
 
@@ -328,6 +331,7 @@ def testSamplingFromProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testSamplingFromProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -427,6 +431,7 @@ def testSamplingFromLogits(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testSamplingFromLogits")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -527,6 +532,7 @@ def testTopKSamplingFromProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKSamplingFromProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -629,6 +635,7 @@ def testTopPSamplingFromProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopPSamplingFromProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -731,6 +738,7 @@ def testTopKTopPSamplingFromProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKTopPSamplingFromProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -844,6 +852,7 @@ def testTopKTopPSamplingFromLogits(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKTopPSamplingFromLogits")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -958,6 +967,7 @@ def testMinPSamplingFromProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testMinPSamplingFromProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1060,6 +1070,7 @@ def testTopKRenormProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKRenormProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1193,6 +1204,7 @@ def testTopPRenormProbs(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopPRenormProbs")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1330,6 +1342,7 @@ def testTopKMaskLogits(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKMaskLogits")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1477,6 +1490,7 @@ def testChainSpeculativeSampling(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testChainSpeculativeSampling")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1599,6 +1613,7 @@ def testTopK(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopK")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1744,6 +1759,7 @@ def testTopKPageTableTransform(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKPageTableTransform")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
@@ -1894,6 +1910,7 @@ def testTopKRaggedTransform(args):
     Returns:
         dict: List of dictionaries containing performance results
     """
+    warn_if_pdl_unsupported(args, args.routine)
     if args.verbose >= 1:
         print("[INFO] Running testTopKRaggedTransform")
         print(f"[INFO] FlashInfer version: {flashinfer.__version__}")

--- a/benchmarks/samples/sample_testlist.txt
+++ b/benchmarks/samples/sample_testlist.txt
@@ -77,13 +77,28 @@
 # RMSNorm with PDL enabled
 --routine rmsnorm --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --enable_pdl --refcheck -vv --generate_repro_command --case_tag "rmsnorm_pdl"
 
+## Fused Add + RMSNorm
+# Fused residual add + RMSNorm (in-place); residual is updated, normalized output written back to input
+--routine fused_add_rmsnorm --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "fused_add_rmsnorm_llama_hidden"
+--routine fused_add_rmsnorm --batch_size 64 --hidden_size 8192 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "fused_add_rmsnorm_large_hidden"
+--routine fused_add_rmsnorm --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --enable_pdl --refcheck -vv --generate_repro_command --case_tag "fused_add_rmsnorm_pdl"
+
+## Gemma RMSNorm
+# Gemma-style RMSNorm using (weight + 1)
+--routine gemma_rmsnorm --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "gemma_rmsnorm_llama_hidden"
+--routine gemma_rmsnorm --batch_size 64 --hidden_size 8192 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "gemma_rmsnorm_large_hidden"
+--routine gemma_rmsnorm --batch_size 32 --num_heads 32 --hidden_size 128 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "gemma_rmsnorm_3d_gqa"
+
+## Gemma Fused Add + RMSNorm
+# Gemma-style fused residual add + RMSNorm using (weight + 1)
+--routine gemma_fused_add_rmsnorm --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "gemma_fused_add_rmsnorm_llama_hidden"
+--routine gemma_fused_add_rmsnorm --batch_size 64 --hidden_size 8192 --input_dtype bfloat16 --refcheck -vv --generate_repro_command --case_tag "gemma_fused_add_rmsnorm_large_hidden"
+--routine gemma_fused_add_rmsnorm --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --enable_pdl --refcheck -vv --generate_repro_command --case_tag "gemma_fused_add_rmsnorm_pdl"
+
 ## RMSNorm with Quantized Output
 # RMSNorm with FP8 e4m3 output
 --routine rmsnorm_quant --batch_size 32 --hidden_size 4096 --input_dtype bfloat16 --out_dtype fp8_e4m3 --scale 1.0 --refcheck -vv --generate_repro_command --case_tag "rmsnorm_quant_fp8_e4m3"
 --routine rmsnorm_quant --batch_size 64 --hidden_size 8192 --input_dtype bfloat16 --out_dtype fp8_e4m3 --scale 1.0 --refcheck -vv --generate_repro_command --case_tag "rmsnorm_quant_large"
-
-# RMSNorm with FP8 e5m2 output
---routine rmsnorm_quant --batch_size 32 --hidden_size 4096 --input_dtype float16 --out_dtype fp8_e5m2 --scale 1.0 --refcheck -vv --generate_repro_command --case_tag "rmsnorm_quant_fp8_e5m2"
 
 ## Fused Add + RMSNorm with Quantized Output
 # Fused add + RMSNorm with FP8 e4m3 output


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Reshapes `flashinfer_benchmark.py` to (a) make `--enable_pdl` behave uniformly across every routine, (b) add three previously-missing norm benchmarks, and (c) fix a few backend-label / API-routing bugs surfaced along the way.

#### `--enable_pdl` uniform semantics

A single rule across all 50+ routines: **`--enable_pdl` omitted → PDL off; `--enable_pdl` set → PDL on; routines whose API can't accept PDL emit a one-shot `[WARNING]` and ignore the flag.**

- Hoisted `--enable_pdl` to the shared parser in `flashinfer_benchmark.py`; removed three duplicate declarations in `parse_norm_args` / `parse_gemm_args` / `parse_quantization_args`.
- Added `warn_if_pdl_unsupported(args, routine)` helper in `flashinfer_benchmark_utils.py`.
- **Fixed silent-ON bugs** (APIs default `enable_pdl=None` → auto-enable on H100/B200, but benchmark wasn't passing it): all 4 attention wrappers (decode / prefill paged / prefill ragged / MLA) + 4 direct
trtllm/MLA call sites, `mm_fp4` (API default was `True`!), `softmax`, plus 4 MoE routines (`trtllm_fp4_block_scale_moe`, `trtllm_fp8_per_tensor_scale_moe`, `cutlass_fused_moe`, `cute_dsl_fp4_block_scale_moe`).
- **Fixed hardcoded `enable_pdl=True`**: `moe.py` (`trtllm_fp8_block_scale_moe`) and `moe_comm.py` (`trtllm_fp8_block_scale_routed_moe` in a2a dispatch).
- **Fixed hardcoded `enable_pdl=False` blocking opt-in**: two `trtllm_ragged_attention_deepseek` call sites in `attention.py` (cute-dsl and trtllm-native branches).
- **Wired CLI control for off-by-default APIs**: 3 rope quant variants (`mla_rope_quantize_fp8`, `rope_quantize_fp8`, `rope_quantize_fp8_append_paged_kv_cache`).
- **Added 30 `warn_if_pdl_unsupported` calls** to routines whose APIs don't accept `enable_pdl`: 6 gemm, 5 rope, 14 sampling, 1 quantization (nvfp4_batched_quantize), 1 mamba, 1 moe (b12x_fused_moe), 
allreduce_fusion, mixed_comm.
- Net: ~50 call-site changes; verified with on/off pairs that produce measurable perf deltas (e.g. attention prefill paged fa2: 71→49 μs with `--enable_pdl`).

#### New norm benchmarks

Three rmsnorm-family routines added to `benchmarks/routines/norm.py`, ported from a side branch and stripped of unrelated tooling:

- `fused_add_rmsnorm`
- `gemma_rmsnorm`
- `gemma_fused_add_rmsnorm`

Registered in `flashinfer_benchmark_utils.py` (`benchmark_apis`, `routine_cc_to_supported_backends`), documented in `benchmarks/README.md` (bullets + support matrix), and exercised by new 
`samples/sample_testlist.txt` entries.

#### Backend label corrections (cuda → cute-dsl)

Six rmsnorm-family routines (`rmsnorm`, `rmsnorm_quant`, `fused_add_rmsnorm`, `fused_add_rmsnorm_quant`, `gemma_rmsnorm`, `gemma_fused_add_rmsnorm`) actually route to CuTe-DSL kernels by default in flashinfer 
(env-var fallback to CUDA JIT via `FLASHINFER_USE_CUDA_NORM=1`), but the benchmark was labeling them as `cuda`. Updated the cc-support map and `run_backend` dispatch to use `cute-dsl`, with a `cuda → cute-dsl`
 auto-remap matching the existing FP4 routine pattern so sample lines don't need explicit `--backends`. README support matrix updated.

#### `rmsnorm_quant` CUDA-graph capture fix

`testRmsnormQuant` / `testFusedAddRmsnormQuant` were constructing `scale` as a Python `float`, which forced flashinfer's `_normalize_scale_tensor` to allocate a host tensor on every call — illegal under 
CUDA-graph capture (and explicitly deprecated by a `FutureWarning`). Now pre-allocate `scale` as a shape-`(1,)` GPU `float32` tensor once in the test function; CSV `scale` column unchanged thanks to `.item()` 
on emit.

#### `testBmmFp8` refactor (programmatic backend probing)

`bmm_fp8` test has been checking hard-coded backend support, leading to gaps (e.g. cutlass is supported on SM120 but was not runnable) Aligned with `testMmFp4`: removed the hard-coded `routine_cc_to_supported_backends["bmm_fp8"]` table and the `if backend in [...]` whitelist inside `run_backend`. The test now probes each backend with a trial 
`flashinfer.gemm.bmm_fp8(...)` call and relies on the `@backend_requirement` decorator to raise `BackendSupportedError` for unsupported (routine, backend, cc) combos. Future SM/backend additions no longer need
 to touch the benchmark utils.

#### Misc

- `samples/sample_testlist.txt`: added 9 new norm-variant sample lines (3 routines × 3 configs each); removed the `rmsnorm_quant_fp8_e5m2` line (cute-dsl path is missing the dtype-string entry upstream — 
separate bug, not introduced here).
  


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmarking support for fused residual add + RMSNorm and Gemma RMSNorm variants.
  * Introduced `--enable_pdl` flag to enable Programmatic Dependent Launch optimization in benchmarks.

* **Documentation**
  * Updated benchmark support matrix: norm routines now default to CuTe-DSL backend instead of CUDA.
  * Added PDL compatibility warnings across multiple benchmark routines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->