### PR TITLE
Fix silent no-op autotuning for cuBLAS `bmm_fp8` and cuDNN `bmm_fp8`/`mm_fp4`

### DIFF
--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -630,6 +630,8 @@ def testBmmFp8(args):
     run_refcheck = args.refcheck
     autotune_supported_backends = [
         "cutlass",
+        "cudnn",
+        "cublas",
     ]
     res = []
 

--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -632,6 +632,7 @@ def testBmmFp8(args):
         "cutlass",
         "cudnn",
         "cublas",
+        "auto",
     ]
     res = []
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -138,12 +138,22 @@ def get_gemm_module():
                 self._algo_cache: dict = {}
 
             def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+                # Must be synthesis-invariant: including a.shape (dynamic M)
+                # makes the runtime key miss the bucketed profile key, so the
+                # tuned tactic is dropped for tactic=-1. Shapes are already in
+                # the autotuner's input_shapes; add only dtypes.
+                a, b, _, _, out, _ = inputs
+                return (a.dtype, b.dtype, out.dtype)
+
+            def _algo_cache_key(self, inputs: List[torch.Tensor]) -> tuple:
+                # Internal cuBLASLt algo-enumeration cache: this one is
+                # shape-specific, so key on full shapes (incl. M).
                 a, b, _, _, out, _ = inputs
                 return (a.shape, b.shape, a.dtype, b.dtype, out.dtype)
 
             def _get_algos(self, inputs):
                 a, b, scale_a, scale_b, out, workspace_buffer = inputs
-                key = self.get_cache_key_extras(inputs)
+                key = self._algo_cache_key(inputs)
                 cached = self._algo_cache.get(key)
                 if cached is not None:
                     return cached
@@ -3193,6 +3203,9 @@ def _cudnn_gemm_fp8_runner():
             if self._use_override_shape:
                 graph = self._get_override_graph(a, b, out)
             else:
+                # ALL exposes every heuristic plan to the autotuner;
+                # HEURISTICS_CHOICE would collapse to a single plan. Graph
+                # is @lru_cache'd, so all plans are built once per shape.
                 graph = build_cudnn_gemm_fp8_graph(
                     a_shape=a.shape,
                     a_stride=a.stride(),
@@ -3202,7 +3215,7 @@ def _cudnn_gemm_fp8_runner():
                     b_type=_torch_data_type_to_cudnn_data_type(b.dtype),
                     o_type=_torch_data_type_to_cudnn_data_type(out.dtype),
                     device=a.device,
-                    policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
+                    policy=cudnn.build_plan_policy.ALL,
                 )
 
             return list(range(graph.get_execution_plan_count()))
@@ -3228,6 +3241,8 @@ def _cudnn_gemm_fp8_runner():
                     tactic=max(tactic, 0),
                 )
             else:
+                # Apply the tuned tactic. tactic>=0 -> specific plan
+                # (policy=ALL); tactic==-1 -> cheap HEURISTICS_CHOICE default.
                 _cudnn_gemm_fp8(
                     workspace_buffer,
                     a,
@@ -3236,7 +3251,7 @@ def _cudnn_gemm_fp8_runner():
                     scale_b,
                     out,
                     out.dtype,
-                    tactic=-1,
+                    tactic=tactic,
                 )
             return out
 
@@ -4960,6 +4975,9 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     _expand_block_scale_tensor_shape(b_descale, batch)
                 )
 
+                # ALL exposes every heuristic plan (heur_mode A+B) to the
+                # autotuner; HEURISTICS_CHOICE would collapse to a single
+                # plan. Graph is @lru_cache'd, so all plans built once/shape.
                 graph = build_cudnn_gemm_fp4_graph(
                     real_a_shape,
                     real_a_stride,
@@ -4975,7 +4993,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     a.device,
                     alpha is not None,
                     use_nvfp4,
-                    policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
+                    policy=cudnn.build_plan_policy.ALL,
                 )
 
             return list(range(graph.get_execution_plan_count()))
@@ -5017,6 +5035,8 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     tactic=max(tactic, 0),
                 )
             else:
+                # Apply the tuned tactic. tactic>=0 -> specific plan
+                # (policy=ALL); tactic==-1 -> cheap HEURISTICS_CHOICE default.
                 _cudnn_gemm_fp4(
                     a,
                     b,
@@ -5028,7 +5048,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     block_size,
                     use_nvfp4,
                     workspace_buffer,
-                    tactic=-1,
+                    tactic=tactic,
                 )
 
             return out

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1010,6 +1010,11 @@ _FP8_GEMM_SM100_TUNING_CONFIG = TuningConfig(
             -2,
             lambda shapes: shapes[0][-2],
         ),
+        ConstraintSpec(
+            5,  # workspace_buffer index: scratch buffer that a backend may
+            0,  # resize during profiling. Wildcard its size out of the cache
+            lambda shapes: shapes[5][0],  # key so a mid-tune resize never
+        ),  # changes the key (would otherwise cause a silent cache miss).
     ),
 )
 
@@ -5832,6 +5837,11 @@ _MM_FP4_TUNING_CONFIG_8x4 = TuningConfig(
             0,
             lambda shapes: shapes[0][0],
         ),
+        ConstraintSpec(
+            9,  # workspace_buffer index: scratch; exclude its (resizable)
+            0,  # size from the cache key so a mid-tune resize never causes
+            lambda shapes: shapes[9][0],  # a silent cache miss.
+        ),
     ),
 )
 
@@ -5855,6 +5865,11 @@ _MM_FP4_TUNING_CONFIG_128x4 = TuningConfig(
             6,  # out_tensor_index
             0,
             lambda shapes: shapes[0][0],
+        ),
+        ConstraintSpec(
+            9,  # workspace_buffer index: scratch; exclude its (resizable)
+            0,  # size from the cache key so a mid-tune resize never causes
+            lambda shapes: shapes[9][0],  # a silent cache miss.
         ),
     ),
 )

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -196,33 +196,28 @@ def get_gemm_module():
                 a, b, scale_a, scale_b, out, workspace_buffer = inputs
                 with torch.cuda.device(a.device):
                     cublas_handle = torch.cuda.current_blas_handle()
+                # The cuBLASLt algo list is enumerated per-shape, so a tactic
+                # tuned at a different (bucketed) M may be out of range here.
+                # Fall back to the heuristic default (the tactic==-1 path) on an
+                # out-of-range or empty algo list rather than raising.
                 if tactic >= 0:
                     algo_buf, count = self._get_algos(inputs)
-                    if count == 0:
-                        raise RuntimeError(
-                            "cuBLASLt heuristic returned zero FP8 algorithms for "
-                            f"A={tuple(a.shape)}, B={tuple(b.shape)}, out={tuple(out.shape)}."
+                    if 0 <= tactic < count:
+                        module.bmm_fp8_run_with_algo(
+                            a,
+                            b,
+                            out,
+                            scale_a,
+                            scale_b,
+                            workspace_buffer,
+                            cublas_handle,
+                            algo_buf,
+                            tactic,
                         )
-                    if tactic >= count:
-                        raise ValueError(
-                            f"Requested tactic {tactic} but only {count} algorithms "
-                            f"available for A={tuple(a.shape)}, B={tuple(b.shape)}."
-                        )
-                    module.bmm_fp8_run_with_algo(
-                        a,
-                        b,
-                        out,
-                        scale_a,
-                        scale_b,
-                        workspace_buffer,
-                        cublas_handle,
-                        algo_buf,
-                        tactic,
-                    )
-                else:
-                    module.bmm_fp8(
-                        a, b, out, scale_a, scale_b, workspace_buffer, cublas_handle
-                    )
+                        return out
+                module.bmm_fp8(
+                    a, b, out, scale_a, scale_b, workspace_buffer, cublas_handle
+                )
                 return out
 
         return CublasFp8GemmRunner()
@@ -2385,6 +2380,13 @@ def execute_cudnn_gemm_fp4_graph(
     if alpha is not None:
         variant_pack[UIDs.ALPHA_UID.value] = alpha.view(torch.float)
 
+    # This (non-override) graph is built at the real shape, whereas the tactic
+    # was tuned against a possibly different (bucketed) M whose plan list can
+    # differ in length. If the index is out of range, fall back to the
+    # heuristic default rather than letting execute_plan_at_index raise.
+    if tactic >= graph.get_execution_plan_count():
+        tactic = -1
+
     workspace_size = _get_cudnn_workspace_size(graph, tactic)
     if workspace_buffer.numel() < workspace_size:
         workspace_buffer.resize_(workspace_size)
@@ -2963,6 +2965,13 @@ def execute_cudnn_gemm_fp8_graph(
 
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
+
+    # This (non-override) graph is built at the real shape, whereas the tactic
+    # was tuned against a possibly different (bucketed) M whose plan list can
+    # differ in length. If the index is out of range, fall back to the
+    # heuristic default rather than letting execute_plan_at_index raise.
+    if tactic >= graph.get_execution_plan_count():
+        tactic = -1
 
     workspace_size = _get_cudnn_workspace_size(graph, tactic)
     if workspace.numel() < workspace_size:

--- a/tests/autotuner/test_autotuner_bmm_fp8.py
+++ b/tests/autotuner/test_autotuner_bmm_fp8.py
@@ -7,6 +7,7 @@ from flashinfer.gemm.gemm_base import (
     _FP8_GEMM_SM100_TUNING_CONFIG,
     _cudnn_gemm_fp8_runner,
     _get_cache_buf,
+    get_gemm_module,
     DEFAULT_WORKSPACE_SIZE,
 )
 from flashinfer.utils import get_compute_capability
@@ -124,3 +125,79 @@ def test_autotuner_gemm(pre_tune, tune_mode, expected_cache_hit, m, n, k):
         # mean the fallback path was chosen (no hit), which contradicts the hit.
         assert tactic >= 0
         assert stored_profile is not None
+
+
+@pytest.mark.parametrize("backend", ["cudnn", "cublas"])
+def test_autotuner_gemm_cross_bucket_m(backend):
+    """Tune at one M bucket, then run inference at a non-bucket M.
+
+    The non-override cuDNN graph (and the cuBLASLt algo list) is enumerated at
+    the *real* shape, so a tactic tuned against a different (bucketed) M may be
+    out of range for the runtime plan/algo list. This must NOT raise (the
+    runner clamps an out-of-range index back to the heuristic default), and the
+    autotuner must still reuse the tuned bucket entry for the non-bucket M
+    (i.e. the workspace scratch size does not leak into the cache key).
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    cc = compute_capability[0] * 10 + compute_capability[1]
+    if not bmm_fp8.is_compute_capability_supported(cc):
+        pytest.skip(f"bmm_fp8 not supported on sm{cc}.")
+    if not bmm_fp8.is_backend_supported(backend, cc):
+        pytest.skip(f"{backend} backend not supported on sm{cc}.")
+
+    autotuner = AutoTuner.get()
+    autotuner.clear_cache()
+
+    input_dtype = torch.float8_e4m3fn
+    res_dtype = torch.bfloat16
+    b, n, k = 1, 64, 256
+    # Tuning at M=256 profiles all buckets up to 256 (incl. 128). A runtime
+    # M=100 rounds up to bucket 128, so real-M (100) != bucket-M (128).
+    tune_m, run_m = 256, 100
+
+    def make(m):
+        inp = torch.randn([b, m, k], device="cuda", dtype=torch.bfloat16)
+        inp_fp8, inp_s = to_float8(inp, dtype=input_dtype)
+        mat2 = torch.randn([b, n, k], device="cuda", dtype=torch.bfloat16).transpose(
+            -2, -1
+        )
+        mat2_fp8, mat2_s = to_float8(mat2, dtype=input_dtype)
+        return inp_fp8, mat2_fp8, inp_s, mat2_s
+
+    # 1) Tune over the bucket range.
+    a8, b8, a_s, b_s = make(tune_m)
+    with autotune(tune_mode=True):
+        bmm_fp8(a8, b8, a_s, b_s, res_dtype, backend=backend)
+
+    # 2) Run at a non-bucket M. Must not raise (out-of-range tactic is clamped)
+    #    and must produce finite output.
+    a8, b8, a_s, b_s = make(run_m)
+    res = bmm_fp8(a8, b8, a_s, b_s, res_dtype, backend=backend)
+    assert res.isfinite().all()
+
+    # 3) The tuned bucket entry must be reused for the non-bucket M.
+    runner = (
+        _cudnn_gemm_fp8_runner()
+        if backend == "cudnn"
+        else get_gemm_module().cublas_fp8_gemm_runner()
+    )
+    workspace_buffer = _get_cache_buf(
+        "bmm_fp8_workspace", DEFAULT_WORKSPACE_SIZE, a8.device
+    )
+    is_cache_hit, runner_id, tactic, stored_profile = autotuner.search_cache(
+        "fp8_gemm",
+        [runner],
+        (
+            a8.shape,
+            b8.shape,
+            a_s.shape,
+            b_s.shape,
+            res.shape,
+            workspace_buffer.shape,
+        ),
+        _FP8_GEMM_SM100_TUNING_CONFIG,
+        inputs=[a8, b8, a_s, b_s, res, workspace_buffer],
+    )
+    assert is_cache_hit
+    assert tactic >= 0
+    assert stored_profile is not None

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -27,8 +27,10 @@ def test_bmm_fp8(b, m, n, k, input_dtype, mat2_dtype, res_dtype, backend, auto_t
     if input_dtype == torch.float8_e5m2 or mat2_dtype == torch.float8_e5m2:
         if backend == "cutlass":
             pytest.skip("Invalid combination: cutlass does not support e5m2")
-    if auto_tuning and backend != "cutlass":
-        pytest.skip("Invalid combination: auto_tuning only supported for cutlass")
+    if auto_tuning and backend not in ["cutlass", "cudnn", "cublas"]:
+        pytest.skip(
+            "Invalid combination: auto_tuning only supported for cutlass, cudnn, and cublas"
+        )
     if compute_capability[0] == 11 and (
         input_dtype == torch.float8_e5m2 or mat2_dtype == torch.float8_e5m2
     ):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

### Summary 
Autotuning the `cuBLAS`/`cuDNN` backends of `bmm_fp8` (and `cuDNN` for `mm_fp4`) silently selected the default heuristic tactic instead of a tuned one in several common configurations as reported in #3436. This PR makes the tuned tactic actually get enumerated and applied, and enables these backends in the benchmark/tests.

### Changes
- **cuBLAS `bmm_fp8` cache key** (`CublasFp8GemmRunner`): `get_cache_key_extras` included `a.shape` (dynamic `M`), violating the autotuner's synthesis-invariant contract — the runtime key missed the bucketed profile key and fell back to `tactic=-1`. Now returns dtypes only; added `_algo_cache_key` (full shapes) for the internal cuBLASLt algo cache.
- **cuDNN `bmm_fp8` / `mm_fp4` non-override path** (`_cudnn_gemm_fp8_runner`, `CudnnFp4GemmRunner`): built with `HEURISTICS_CHOICE` (one plan) and hardcoded `tactic=-1`. Now uses `build_plan_policy.ALL` and passes the selected tactic through. 
  - Override path requires cuDNN 9.21 and autotuning works as expected. No changes for override path.
  - Non-override path now mirrors the override path with this PR.
- **Benchmark/tests**: add `cudnn`/`cublas` to `testBmmFp8`'s autotune allowlist and relax the `test_bmm_fp8` autotune guard.

## 🔍 Related Issues

<!-- Link any related issues here -->

- #3436

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FP8 GEMM caching to avoid collisions and ensure correct tuned parameters are applied during execution.
  * Improved runtime fallback when tuned tactics are out-of-range to use a safe heuristic.

* **Performance**
  * Autotuning now supports the cuBLAS backend in addition to existing backends.
  * Autotuner includes workspace sizing in tuning keys and evaluates a fuller set of plans for more reliable results.

* **Tests**
  * Added tests to validate autotuner cache reuse across shape bucket boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->