### PR TITLE
Fix cross-warp race in checkpointing SSU kernel (mamba)

### DIFF
--- a/include/flashinfer/mamba/kernel_checkpointing_ssu.cuh
+++ b/include/flashinfer/mamba/kernel_checkpointing_ssu.cuh
@@ -890,11 +890,10 @@ __device__ __forceinline__ void ssu_nocheckpoint(SmemT& smem, CheckpointingSsuPa
                                                  int warp, int lane, int prev_k, int d_tile,
                                                  int64_t out_seq_base, int head, int64_t cache_slot,
                                                  float D_val, int seq_len) {
-  // Sync makes warps 0,1's CB_scaled writes and warps 2,3's CB_old writes
-  // visible to all warps before matmul-4 reads CB_scaled + CB_old.  Also
-  // covers smem.x (warp 2-loaded) and smem.z (warp 3-loaded) for Phase 2.
-  __syncthreads();
-
+  // Caller's responsibility to __syncthreads() before this call — see the
+  // dispatch site in checkpointing_ssu_kernel.  The sync covers (a) load_data
+  // cross-warp loads (state, B/C/x/z), (b) compute_CB_scaled_2warp writes
+  // from warps 0,1, and (c) compute_CB_old_2warp writes from warps 2,3.
   compute_no_write_output<input_t, state_t, NPREDICTED, MAX_WINDOW, DIM, D_PER_CTA, DSTATE,
                           NUM_WARPS>(smem, params, warp, lane, prev_k, d_tile, out_seq_base, head,
                                      cache_slot, D_val, seq_len);
@@ -1070,8 +1069,23 @@ __global__ void checkpointing_ssu_kernel(CheckpointingSsuParams params) {
   //                 reads s_0 directly from smem.state, matmul-4 extends with
   //                 the CB_old @ old_x contribution over [0, prev_k)).
   // must_checkpoint is uniform across the CTA (derived from broadcast prev_k
-  // + compile-time NPREDICTED + MAX_WINDOW), so both branches contain a
-  // __syncthreads and divergence is balanced.
+  // + compile-time NPREDICTED + MAX_WINDOW), so both branches start from
+  // the same barrier and divergence is balanced.
+  //
+  // This single barrier covers cross-warp visibility for everything written
+  // in Phase 0/1a that either downstream branch needs to read:
+  //   (a) load_data's per-warp-partitioned smem.state (load_state_per_warp
+  //       splits M across warps; replay_state_mma in the checkpoint path
+  //       reads full M per warp).  Symptom of missing sync: per-launch
+  //       non-deterministic state writes (state_diff up to ~13 in fp16 at
+  //       batch=99 with must_checkpoint=True).
+  //   (b) smem.x (warp-2-loaded) and smem.z (warp-3-loaded) — both paths read.
+  //   (c) compute_CB_scaled_2warp writes (warps 0,1) — both paths read.
+  //   (d) compute_CB_old_2warp writes (warps 2,3) — no-checkpoint path reads.
+  // The per-warp `__syncwarp()` at the tail of load_data only establishes
+  // visibility within a single warp; this is the cross-warp barrier.
+  __syncthreads();
+
   if (must_checkpoint) {
     ssu_checkpoint<input_t, state_t, NPREDICTED, DIM, D_PER_CTA, DSTATE, NUM_WARPS, PHILOX_ROUNDS>(
         smem, params, warp, lane, prev_k, d_tile, out_seq_base, head, cache_slot, D_val, seq_len);

--- a/tests/mamba/test_checkpointing_ssu.py
+++ b/tests/mamba/test_checkpointing_ssu.py
@@ -4593,3 +4593,176 @@ def test_checkpointing_ssu_noncontig(state_dtype, varlen):
         atol=0,
         msg=f"old_cumAdt mismatch (varlen={varlen})",
     )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Determinism regression test (issue: cross-warp race in must_checkpoint=True)
+# ────────────────────────────────────────────────────────────────────────────
+#
+# Repro for a cross-warp race that lived between `load_state_per_warp` (which
+# partitions M=DIM across warps) and `replay_state_mma` (where each warp reads
+# the FULL M=DIM extent of `smem.state` to form `frag_h`).  `load_data` ended
+# with `__syncwarp()` only, so warp 0's replay reads rows that warps 1/2/3
+# may not yet have cp.async-committed → per-launch non-deterministic state.
+#
+# Fix: `__syncthreads()` at the `ssu_checkpoint` / `ssu_nocheckpoint` dispatch
+# site, replacing the per-branch barrier that previously lived inside
+# `ssu_nocheckpoint` only.
+#
+# The bug only manifested in the must_checkpoint=True path (the
+# must_checkpoint=False path always had its own __syncthreads inside
+# ssu_nocheckpoint), but we test both paths for both quantized (fp8) and
+# non-quantized (fp16) state to guard against regression in either branch.
+# All parametrizations share `(heads_per_group=64, head_dim=64, d_state=128,
+# max_window=16, npredicted=8)` — one JIT entry per state dtype.
+@pytest.mark.parametrize(
+    "state_dtype,prev_k,must_checkpoint,tag",
+    [
+        (torch.float16, 4, False, "fp16-no_checkpoint"),
+        (torch.float16, 12, True, "fp16-checkpoint"),
+        (torch.float8_e4m3fn, 4, False, "fp8-no_checkpoint"),
+        (torch.float8_e4m3fn, 12, True, "fp8-checkpoint"),
+    ],
+)
+def test_checkpointing_ssu_determinism_across_launches(
+    state_dtype, prev_k, must_checkpoint, tag
+):
+    """Run the kernel 5× with bit-identical inputs and assert that state,
+    state_scale (quantized only), and output are bit-exact across launches.
+    """
+    import hashlib
+
+    nheads = 64
+    head_dim = 64
+    d_state = 128
+    ngroups = 1
+    max_window = 16
+    npredicted = 8
+    batch = 16
+    dtype = torch.bfloat16
+    device = "cuda"
+    cache_size = batch
+    assert (prev_k + npredicted > max_window) == must_checkpoint, (
+        f"test bug: parametrize disagrees with must_checkpoint formula "
+        f"(prev_k={prev_k}, npredicted={npredicted}, max_window={max_window})"
+    )
+
+    def _hash(t):
+        t = t.detach().cpu().contiguous()
+        # numpy can't view bf16/fp8 directly — promote losslessly to f32.
+        if t.dtype in (torch.bfloat16, torch.float8_e4m3fn):
+            t = t.float()
+        return hashlib.sha1(t.numpy().tobytes()).hexdigest()
+
+    torch.manual_seed(42)
+    A_base = -torch.rand(nheads, device=device) - 0.5
+    A = repeat(A_base, "h -> h p n", p=head_dim, n=d_state)
+    dt_bias_base = torch.randn(nheads, device=device, dtype=dtype)
+    dt_bias = repeat(dt_bias_base, "h -> h p", p=head_dim)
+    D_base = torch.randn(nheads, device=device, dtype=dtype)
+    D = repeat(D_base, "h -> h p", p=head_dim)
+
+    # State + (optional) decode scale for the quantized path.
+    is_quantized = state_dtype == torch.float8_e4m3fn
+    state_fp32 = torch.randn(
+        cache_size, nheads, head_dim, d_state, device=device, dtype=torch.float32
+    )
+    if is_quantized:
+        quant_max = 448.0  # fp8_e4m3fn
+        amax = state_fp32.abs().amax(dim=-1).clamp(min=1e-30)
+        encode_scale = quant_max / amax
+        state_scale0 = (1.0 / encode_scale).to(torch.float32)
+        state0 = (
+            (state_fp32 * encode_scale.unsqueeze(-1))
+            .clamp(-quant_max, quant_max)
+            .to(state_dtype)
+        )
+    else:
+        state0 = state_fp32.to(state_dtype)
+        state_scale0 = None
+
+    # Step-1 cache fill — `old_dt`/`old_cumAdt` must be self-consistent so the
+    # replay branch doesn't trip on physically-nonsensical values.
+    x1 = torch.randn(batch, max_window, nheads, head_dim, device=device, dtype=dtype)
+    dt1_base = torch.randn(batch, max_window, nheads, device=device, dtype=dtype)
+    B1 = torch.randn(batch, max_window, ngroups, d_state, device=device, dtype=dtype)
+    dt1_proc = F.softplus(dt1_base.float() + dt_bias_base.float()[None, None, :])
+    cumAdt1 = torch.cumsum(A_base.float()[None, None, :] * dt1_proc, dim=1)
+
+    old_x0 = torch.zeros(
+        cache_size, max_window, nheads, head_dim, device=device, dtype=dtype
+    )
+    old_B0 = torch.randn(
+        cache_size, 2, max_window, ngroups, d_state, device=device, dtype=dtype
+    )
+    old_dt0 = torch.randn(
+        cache_size, 2, nheads, max_window, device=device, dtype=torch.float32
+    )
+    old_cumAdt0 = torch.randn(
+        cache_size, 2, nheads, max_window, device=device, dtype=torch.float32
+    )
+    cache_buf_idx0 = torch.randint(
+        0, 2, (cache_size,), device=device, dtype=torch.int32
+    )
+    old_x0[:] = x1
+    for i in range(cache_size):
+        buf = cache_buf_idx0[i].item()
+        old_B0[i, buf] = B1[i]
+        old_dt0[i, buf] = dt1_proc[i].permute(1, 0)
+        old_cumAdt0[i, buf] = cumAdt1[i].permute(1, 0)
+
+    # New-token inputs (deterministic w.r.t. prev_k).
+    torch.manual_seed(prev_k + 100)
+    x2 = torch.randn(batch, npredicted, nheads, head_dim, device=device, dtype=dtype)
+    dt2_base = torch.randn(batch, npredicted, nheads, device=device, dtype=dtype)
+    dt2 = repeat(dt2_base, "b t h -> b t h p", p=head_dim)
+    B2 = torch.randn(batch, npredicted, ngroups, d_state, device=device, dtype=dtype)
+    C2 = torch.randn(batch, npredicted, ngroups, d_state, device=device, dtype=dtype)
+
+    state_hashes = set()
+    out_hashes = set()
+    scale_hashes = set()
+    for _ in range(5):
+        state_w = state0.clone()
+        scale_w = state_scale0.clone() if state_scale0 is not None else None
+        prev = torch.full((cache_size,), prev_k, device=device, dtype=torch.int32)
+        out = torch.zeros(
+            batch, npredicted, nheads, head_dim, device=device, dtype=dtype
+        )
+        checkpointing_ssu(
+            state_w,
+            old_x0.clone(),
+            old_B0.clone(),
+            old_dt0.clone(),
+            old_cumAdt0.clone(),
+            cache_buf_idx0.clone(),
+            prev,
+            x=x2,
+            dt=dt2,
+            A=A,
+            B=B2,
+            C=C2,
+            out=out,
+            D=D,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            state_scale=scale_w,
+        )
+        state_hashes.add(_hash(state_w))
+        out_hashes.add(_hash(out))
+        if scale_w is not None:
+            scale_hashes.add(_hash(scale_w))
+
+    assert len(state_hashes) == 1, (
+        f"[{tag}] state non-deterministic across 5 launches "
+        f"(got {len(state_hashes)} unique hashes)"
+    )
+    assert len(out_hashes) == 1, (
+        f"[{tag}] output non-deterministic across 5 launches "
+        f"(got {len(out_hashes)} unique hashes)"
+    )
+    if scale_hashes:
+        assert len(scale_hashes) == 1, (
+            f"[{tag}] state_scale non-deterministic across 5 launches "
+            f"(got {len(scale_hashes)} unique hashes)"
+        )

--- a/tests/mamba/test_checkpointing_ssu.py
+++ b/tests/mamba/test_checkpointing_ssu.py
@@ -4630,6 +4630,9 @@ def test_checkpointing_ssu_determinism_across_launches(
     """Run the kernel 5× with bit-identical inputs and assert that state,
     state_scale (quantized only), and output are bit-exact across launches.
     """
+    # fp8_e4m3fn requires SM89+ (Ada / Hopper / Blackwell).  No stochastic
+    # rounding is used in this test, so use_sr=False.
+    _maybe_skip_dtype(state_dtype, use_sr=False)
     import hashlib
 
     nheads = 64

--- a/tests/mamba/test_checkpointing_ssu.py
+++ b/tests/mamba/test_checkpointing_ssu.py
@@ -4655,7 +4655,7 @@ def test_checkpointing_ssu_determinism_across_launches(
         # numpy can't view bf16/fp8 directly — promote losslessly to f32.
         if t.dtype in (torch.bfloat16, torch.float8_e4m3fn):
             t = t.float()
-        return hashlib.sha1(t.numpy().tobytes()).hexdigest()
+        return hashlib.sha256(t.numpy().tobytes()).hexdigest()
 
     torch.manual_seed(42)
     A_base = -torch.rand(nheads, device=device) - 0.5


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fixes a per-launch non-determinism bug in the CUDA `checkpointing_ssu` kernel's `must_checkpoint=True` code path, caused by a missing cross-warp barrier between `load_state_per_warp` (Phase 0) and `replay_state_mma` (Phase 1).

**Root cause.** `load_state_per_warp` partitions M=DIM across warps — warp W loads rows `[W*D_PER_CTA/4, (W+1)*D_PER_CTA/4)` of `smem.state` via cp.async. `replay_state_mma` uses a `Layout<_1, _4>` tiled MMA (1 warp on M, 4 warps on N), so every warp reads the **full M=DIM extent** of `smem.state` when forming its `frag_h` initial value. The `load_data` tail used only `__syncwarp()` + `__pipeline_wait_prior(0)`, which establishes visibility *within* a single warp but not *across* warps. Result: warp 0's replay reads rows that warps 1/2/3 may not have committed yet, picking up partial/stale smem and producing different output every launch.

**Symptom (pre-fix).** Hashing the post-kernel `state`, `state_scale`, and `out` across 5 launches with bit-identical inputs gave 5 distinct hashes per config. `state_diff` (max abs delta between launches) up to ~13 in fp16 at `batch=99`, scaling roughly with how much `smem.state` each warp's MMA touched. Sub-ULP for small batches/heads where the race rarely fires before the consumer thread arrives — i.e. genuine race timing, not arithmetic noise.

**Fix.** Hoist a single `__syncthreads()` from inside `ssu_nocheckpoint` to the dispatch site in `checkpointing_ssu_kernel`, right before the `if (must_checkpoint)` branch. One barrier now covers cross-warp visibility for everything both branches consume:
- (a) load_data's per-warp-partitioned `smem.state`
- (b) `smem.x` (warp 2-loaded), `smem.z` (warp 3-loaded)
- (c) `compute_CB_scaled_2warp` writes (warps 0,1)
- (d) `compute_CB_old_2warp` writes (warps 2,3, no-checkpoint path)

Net barrier-count delta is **zero** — the `__syncthreads()` previously inside `ssu_nocheckpoint` is just relocated, and `ssu_checkpoint` was missing one. No new compilation flags, no smem layout changes, no perf-relevant code path touched.

**Scope.** Only the generic kernel (`kernel_checkpointing_ssu.cuh`) is affected. The 8-bit kernel (`kernel_checkpointing_ssu_8bit.cuh`, used for `int8`/`fp8_e4m3fn` state) goes through a separate code path and was already deterministic — verified empirically across `mw ∈ {8, 16}, np ∈ {8, 16}`, `philox ∈ {0, 5}`, all `prev_k` values.

## 🔍 Related Issues

Discovered while investigating intermittent failures in the batch-sweep parity test added in #3431. The race is in the existing kernel — not introduced by that PR — but the new sweep stresses it across enough `(batch, heads_per_group)` configurations to expose it reliably. Landing this hotfix should let #3431's CUDA-vs-Triton parity test go green.

Adjacent prior art: NVIDIA/TensorRT-LLM#14203 fixes a structurally similar (but mechanically distinct) bug in the Triton replay kernel — Triton alias analysis reordering writes ahead of reads on a single-buffered `old_x`. Our CUDA kernel doesn't have that issue because cp.async + explicit barriers preserve in-thread ordering; our bug is purely cross-warp visibility.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added: `tests/mamba/test_checkpointing_ssu.py::test_checkpointing_ssu_determinism_across_launches` — runs the kernel 5× with bit-identical inputs and asserts that the `state`, `state_scale` (quantized path only), and `out` tensors hash to a single value across all launches. Four parametrizations:
  - `fp16-no_checkpoint` (`prev_k=4`, no state write)
  - `fp16-checkpoint` (`prev_k=12`, state writeback)
  - `fp8-no_checkpoint`
  - `fp8-checkpoint`
- [x] All tests are passing (`unittest`, etc.). *(Local: full `tests/mamba/test_checkpointing_ssu.py` — please trigger CI.)*

## Reviewer Notes

- **Why hash-equality instead of `assert_close(rtol, atol)`?** For *self*-determinism (one kernel against itself, same inputs, same compiled binary) there should be zero numerical noise — any difference indicates a real race / uninitialized read / nondeterministic atomic. A tolerance-based check would silently swallow sub-ULP variance that still represents a correctness bug (some pre-fix configs had `state_diff ≈ 1e-3` — small in magnitude but the symptom of the same race). See the test docstring for details.
- **Performance impact**: a single extra `__syncthreads()` per CTA on the dispatch path. Branch divergence is unchanged — `must_checkpoint` is CTA-uniform (derived from broadcast `prev_k` + compile-time `NPREDICTED` + `MAX_WINDOW`).
- **Follow-up opportunity (not in this PR)**: the redundant per-warp cp.async loads of `old_x` / `old_B` / scalar `old_dt` / `old_cumAdt` in `load_data` were a defensive measure for the missing-sync regime. With the dispatch-site barrier in place, these could be partitioned across all 128 threads to reclaim the 3× redundant cp.async issue cost. Out of scope for the hotfix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified GPU kernel synchronization to ensure correct cross-warp shared-memory visibility, preventing inconsistent outcomes between checkpointing and non-checkpointing executions.

* **Tests**
  * Added a determinism regression test that validates bit-exact, launch-to-launch consistency across multiple runs, data types, and checkpointing configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->