### PR TITLE
docs(attention): backfill missing/stale Attention/POD/cuDNN/CuteDSL APIs; restore single_prefill_with_kv_cache_return_lse

### DIFF
--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -16,6 +16,7 @@ Single Request Decoding
     :toctree: ../generated
 
     single_decode_with_kv_cache
+    single_decode_with_kv_cache_with_jit_module
 
 Batch Decoding
 --------------
@@ -25,8 +26,15 @@ Batch Decoding
 
     cudnn_batch_decode_with_kv_cache
     trtllm_batch_decode_with_kv_cache
+    xqa_batch_decode_with_kv_cache
 
 .. autoclass:: BatchDecodeWithPagedKVCacheWrapper
+    :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
+
+    .. automethod:: __init__
+
+.. autoclass:: BatchDecodeMlaWithPagedKVCacheWrapper
     :members:
     :exclude-members: begin_forward, end_forward, forward, forward_return_lse
 
@@ -64,6 +72,7 @@ Single Request Prefill/Append Attention
 
     single_prefill_with_kv_cache
     single_prefill_with_kv_cache_return_lse
+    single_prefill_with_kv_cache_with_jit_module
 
 Batch Prefill/Append Attention
 ------------------------------
@@ -73,6 +82,9 @@ Batch Prefill/Append Attention
 
     cudnn_batch_prefill_with_kv_cache
     trtllm_batch_context_with_kv_cache
+    trtllm_ragged_attention_deepseek
+    fmha_v2_prefill_deepseek
+    trtllm_fmha_v2_prefill
 
 .. autoclass:: BatchPrefillWithPagedKVCacheWrapper
     :members:
@@ -83,6 +95,27 @@ Batch Prefill/Append Attention
 .. autoclass:: BatchPrefillWithRaggedKVCacheWrapper
     :members:
     :exclude-members: begin_forward, end_forward, forward, forward_return_lse
+
+    .. automethod:: __init__
+
+
+Unified BatchAttention
+----------------------
+
+.. currentmodule:: flashinfer.attention
+
+The ``BatchAttention`` class provides a holistic attention wrapper that automatically dispatches
+between paged-prefill and paged-decode based on per-request sequence lengths. It is the
+recommended entry point for serving stacks that batch mixed prefill/decode requests in a
+single kernel launch.
+
+.. autoclass:: BatchAttention
+    :members:
+
+    .. automethod:: __init__
+
+.. autoclass:: BatchAttentionWithAttentionSinkWrapper
+    :members:
 
     .. automethod:: __init__
 
@@ -103,6 +136,7 @@ PageAttention for MLA
     :toctree: ../generated
 
     trtllm_batch_decode_with_kv_cache_mla
+    xqa_batch_decode_with_kv_cache_mla
 
 .. autoclass:: BatchMLAPagedAttentionWrapper
     :members:

--- a/docs/api/cudnn.rst
+++ b/docs/api/cudnn.rst
@@ -1,0 +1,17 @@
+.. _apicudnn:
+
+flashinfer.cudnn
+================
+
+cuDNN-backed attention kernels. These wrappers call into NVIDIA's cuDNN runtime
+for batch prefill and batch decode, and are typically used as an alternative
+backend for ``BatchPrefillWithPagedKVCacheWrapper`` /
+``BatchDecodeWithPagedKVCacheWrapper`` when cuDNN is available on the host GPU.
+
+.. currentmodule:: flashinfer.cudnn
+
+.. autosummary::
+    :toctree: ../generated
+
+    cudnn_batch_decode_with_kv_cache
+    cudnn_batch_prefill_with_kv_cache

--- a/docs/api/cute_dsl.rst
+++ b/docs/api/cute_dsl.rst
@@ -1,0 +1,65 @@
+.. _apicute_dsl:
+
+flashinfer.cute_dsl
+===================
+
+CuTe-DSL implementations of selected FlashInfer kernels. These symbols are
+available only when the ``nvidia-cutlass-dsl`` package is installed and the
+host has a supported NVIDIA GPU; the module guards its imports with
+``is_cute_dsl_available()``.
+
+.. note::
+
+    A handful of GEMM symbols (``grouped_gemm_nt_masked``,
+    ``Sm100BlockScaledPersistentDenseGemmKernel``,
+    ``create_scale_factor_tensor``) used to live in ``flashinfer.cute_dsl`` and
+    are still re-exported for backwards compatibility, but their canonical
+    home is :doc:`gemm`. New code should import from ``flashinfer.gemm``.
+
+.. currentmodule:: flashinfer.cute_dsl
+
+Availability
+------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    is_cute_dsl_available
+
+RMSNorm + FP4 Quantization
+--------------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    rmsnorm_fp4quant
+    add_rmsnorm_fp4quant
+
+.. autoclass:: RMSNormFP4QuantKernel
+    :members:
+
+    .. automethod:: __init__
+
+.. autoclass:: AddRMSNormFP4QuantKernel
+    :members:
+
+    .. automethod:: __init__
+
+Attention Wrappers
+------------------
+
+CuTe-DSL implementations of the batch attention wrappers.
+
+.. currentmodule:: flashinfer.cute_dsl.attention.wrappers.batch_mla
+
+.. autoclass:: BatchMLADecodeCuteDSLWrapper
+    :members:
+
+    .. automethod:: __init__
+
+.. currentmodule:: flashinfer.cute_dsl.attention.wrappers.batch_prefill
+
+.. autoclass:: BatchPrefillCuteDSLWrapper
+    :members:
+
+    .. automethod:: __init__

--- a/docs/api/pod.rst
+++ b/docs/api/pod.rst
@@ -1,0 +1,22 @@
+.. _apipod:
+
+flashinfer.pod
+==============
+
+POD (Prefill-On-Decode) attention executes a single-request prefill kernel and
+a batch-decode kernel concurrently in one launch, which is useful for serving
+stacks that overlap a chunked prefill with ongoing decode requests.
+
+.. currentmodule:: flashinfer.pod
+
+.. autoclass:: PODWithPagedKVCacheWrapper
+    :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
+
+    .. automethod:: __init__
+
+.. autoclass:: BatchPODWithPagedKVCacheWrapper
+    :members:
+    :exclude-members: begin_forward, end_forward, forward, forward_return_lse
+
+    .. automethod:: __init__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,9 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/cascade
    api/comm
    api/sparse
+   api/pod
+   api/cudnn
+   api/cute_dsl
    api/page
    api/sampling
    api/topk

--- a/flashinfer/attention/_core.py
+++ b/flashinfer/attention/_core.py
@@ -42,12 +42,35 @@ def get_holistic_attention_module(*args):
 
 
 class BatchAttention:
+    r"""Holistic batched attention wrapper that fuses paged-prefill and paged-decode requests
+    into a single kernel launch.
+
+    ``BatchAttention`` dispatches between prefill-style and decode-style execution per
+    request based on the ``qo_indptr`` / ``kv_indptr`` ranges supplied to :meth:`plan`, so a
+    serving stack can submit a mixed batch (e.g. some prompts in prefill, others in decode)
+    without splitting it into two separate wrappers.  Workspace buffers are owned by the
+    instance and reused across :meth:`plan` / :meth:`run` calls.
+
+    Parameters
+    ----------
+    kv_layout : str
+        Layout of the paged KV-cache tensors, either ``"NHD"`` (token-major) or
+        ``"HND"`` (head-major).  Defaults to ``"NHD"``.
+    device : str
+        CUDA device that owns the internal workspace buffers, e.g. ``"cuda"`` or
+        ``"cuda:0"``.  Defaults to ``"cuda"``.
+    """
+
     @flashinfer_api
     def __init__(
         self,
         kv_layout: str = "NHD",
         device: str = "cuda",
     ):
+        r"""Allocate workspace buffers and bind the wrapper to a CUDA device.
+
+        See :class:`BatchAttention` for the meaning of each parameter.
+        """
         _check_kv_layout(kv_layout)
         self._kv_layout = kv_layout
 
@@ -87,6 +110,49 @@ class BatchAttention:
         kv_data_type: torch.dtype = torch.bfloat16,
         use_profiler: bool = False,
     ) -> None:
+        r"""Plan the holistic attention kernel for a specific batch shape.
+
+        Should be called before any :meth:`run` call.  The plan is cached on the
+        instance and reused across subsequent :meth:`run` invocations with the same
+        layout.
+
+        Parameters
+        ----------
+        qo_indptr : torch.Tensor
+            CSR-style query offsets, shape ``[batch_size + 1]``, dtype ``int32``.
+        kv_indptr : torch.Tensor
+            CSR-style page offsets into ``kv_indices``, shape ``[batch_size + 1]``,
+            dtype ``int32``.
+        kv_indices : torch.Tensor
+            Page indices into the paged KV-cache, shape ``[kv_indptr[-1]]``,
+            dtype ``int32``.
+        kv_len_arr : torch.Tensor
+            Per-request KV-cache lengths in tokens, shape ``[batch_size]``,
+            dtype ``int32``.
+        num_qo_heads : int
+            Number of query / output heads.
+        num_kv_heads : int
+            Number of key / value heads.  Must divide ``num_qo_heads``.
+        head_dim_qk : int
+            Per-head dimension of the query / key tensors.
+        head_dim_vo : int
+            Per-head dimension of the value / output tensors.
+        page_size : int
+            Page size of the paged KV-cache.
+        causal : bool
+            Whether to apply a causal mask.  Defaults to ``False``.
+        sm_scale : float
+            Softmax scale.  If ``None``, defaults to ``1/sqrt(head_dim_qk)``.
+        logits_soft_cap : Optional[float]
+            Logits soft-cap value.  ``None`` or ``0`` disables capping.
+        q_data_type : torch.dtype
+            Dtype of the query tensor.  Defaults to ``torch.bfloat16``.
+        kv_data_type : torch.dtype
+            Dtype of the key / value tensors.  Defaults to ``torch.bfloat16``.
+        use_profiler : bool
+            Whether to compile the profiler-enabled variant of the kernel.  Defaults
+            to ``False``.
+        """
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
         self._logits_soft_cap = logits_soft_cap
@@ -151,6 +217,42 @@ class BatchAttention:
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         ] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""Run the planned holistic attention kernel.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            Query tensor, shape ``[total_qo_tokens, num_qo_heads, head_dim_qk]``.
+        kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            Either a single packed paged KV-cache tensor (when K and V share storage) or a
+            ``(k_cache, v_cache)`` pair.  Layout must match the ``kv_layout`` passed to
+            :meth:`__init__`.
+        out : Optional[torch.Tensor]
+            Optional output buffer.  If ``None``, a new tensor is allocated with the same
+            shape as ``q``.
+        lse : Optional[torch.Tensor]
+            Optional log-sum-exp buffer, shape ``[total_qo_tokens, num_qo_heads]``, dtype
+            ``float32``.  Allocated if ``None``.
+        k_scale : Optional[torch.Tensor]
+            FP8 dequantization scale for ``k``.  Pre-multiplied into ``sm_scale``.
+        v_scale : Optional[torch.Tensor]
+            FP8 dequantization scale for ``v``.  Applied to the output.
+        logits_soft_cap : float
+            Logits soft-cap value.  Must be consistent with the ``logits_soft_cap``
+            passed to :meth:`plan` (a non-zero value here requires a non-zero plan-time
+            value too).
+        profiler_buffer : Optional[torch.Tensor]
+            Profiler buffer.  Required if the wrapper was planned with
+            ``use_profiler=True``.
+        kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
+            Optional scale tensors for NVFP4 KV-cache (one tensor or a ``(k_sf, v_sf)``
+            pair, mirroring the structure of ``kv_cache``).
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            ``(out, lse)`` — the attention output and its log-sum-exp.
+        """
         if profiler_buffer is None:
             if self._use_profiler:
                 raise ValueError(

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -646,6 +646,17 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
     def __init__(
         self, float_workspace_buffer: torch.Tensor, kv_layout: str = "NHD"
     ) -> None:
+        r"""Allocate workspace for shared-prefix batch decode attention.
+
+        Parameters
+        ----------
+        float_workspace_buffer : torch.Tensor
+            User-provided float workspace buffer (e.g. 128 MiB) on the same CUDA device as
+            the inputs.  Shared with the underlying :class:`BatchDecodeWithPagedKVCacheWrapper`.
+        kv_layout : str
+            Layout of the KV-cache tensors, either ``"NHD"`` or ``"HND"``.  Defaults to
+            ``"NHD"``.
+        """
         self._batch_decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
             float_workspace_buffer, kv_layout
         )
@@ -686,13 +697,16 @@ class BatchDecodeWithSharedPrefixPagedKVCacheWrapper:
 
         Parameters
         ----------
-        indptr : torch.Tensor
-            The indptr of the paged kv cache, shape: ``[batch_size + 1]``
-        indices : torch.Tensor
-            The page indices of the paged kv cache, shape: ``[qo_indptr[-1]]``
-        last_page_len : torch.Tensor
-            The number of entries in the last page of each request in the paged kv
-            cache, shape: ``[batch_size]``
+        unique_kv_indptr : torch.Tensor
+            CSR-style page offsets into ``unique_kv_indices`` for the *per-request*
+            (non-shared) suffix of each KV cache, shape ``[batch_size + 1]``, dtype
+            ``int32``.
+        unique_kv_indices : torch.Tensor
+            Page indices of the non-shared suffix of the paged KV cache,
+            shape ``[unique_kv_indptr[-1]]``, dtype ``int32``.
+        unique_kv_last_page_len : torch.Tensor
+            Number of valid entries on the last page of each request's unique
+            suffix, shape ``[batch_size]``, dtype ``int32``.
         num_qo_heads : int
             The number of query/output heads
         num_kv_heads : int
@@ -1013,7 +1027,7 @@ class BatchPrefillWithSharedPrefixPagedKVCacheWrapper:
             ``[shared_prefix_len, num_kv_heads, head_dim]`` if :attr:`kv_layout` is
             ``NHD``, or ``[num_kv_heads, shared_prefix_len, head_dim]`` if
             :attr:`kv_layout` is ``HND``.
-        v_shared ; torch.Tensor
+        v_shared : torch.Tensor
             The shared prefix value tensor, shape:
             ``[shared_prefix_len, num_kv_heads, head_dim]`` if :attr:`kv_layout` is
             ``NHD``, or ``[num_kv_heads, shared_prefix_len, head_dim]`` if

--- a/flashinfer/cudnn/decode.py
+++ b/flashinfer/cudnn/decode.py
@@ -290,7 +290,10 @@ def cudnn_batch_decode_with_kv_cache(
     max_sequence_kv : int
         Maximum number of tokens per KV sequence in the batch (``s_kv_max``).
     actual_seq_lens_kv : Optional[torch.Tensor]
-        Per-request KV lengths, shape ``(batch_size,)``, on CPU.
+        Per-request KV lengths, shape ``(batch_size,)``.  When cuDNN is
+        available (the default backend) this tensor must reside on the
+        same CUDA device as ``q``.  Only the fallback non-cuDNN path
+        accepts (and internally copies) a CPU tensor.
     block_tables : Optional[torch.Tensor]
         Page-table mapping for the paged KV cache, shape
         ``(batch_size, num_pages_per_seq)`` on GPU.

--- a/flashinfer/cudnn/decode.py
+++ b/flashinfer/cudnn/decode.py
@@ -272,32 +272,52 @@ def cudnn_batch_decode_with_kv_cache(
     batch_offsets_v: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Performs batched decode attention with paged KV cache using cuDNN.
+    r"""Batched decode attention with paged KV cache, backed by cuDNN SDPA.
 
-    Args:
-        q: Query tensor of shape (batch_size, num_heads_qo, head_dim), seq_len_q is the maximum sequence length of queries in the batch
-        k_cache: Key cache tensor of shape   (total_num_pages, num_heads_kv, page_size, head_dim)
-        v_cache: Value cache tensor of shape (total_num_pages, num_heads_kv, page_size, head_dim)
-        scale: Scaling factor for attention scores, typically 1/sqrt(head_dim)
-        workspace_buffer: Workspace buffer for cuDNN operations. Scales with batch size. 128 MB should be sufficient for most cases
-        max_sequence_kv: Maximum number of tokens per key/value sequence (s_kv_max)
-        actual_seq_lens_kv: Actual sequence lengths for key/values per batch, shape (batch_size,) on CPU
-        block_tables: Page table mapping for KV cache, shape (batch_size, num_pages_per_seq) on GPU
-        is_cuda_graph_compatible: Whether the decode operation is compatible with CUDA graph
-        batch_offsets: Optional batch offsets tensor of shape (batch_size,) on GPU
-        out: Optional pre-allocated output tensor
-        batch_offsets_q: Optional batch offsets for query tensor of shape (batch_size,) on GPU
-        batch_offsets_o: Optional batch offsets for output tensor of shape (batch_size,) on GPU
-        batch_offsets_k: Optional batch offsets for key tensor of shape (batch_size,) on GPU
-        batch_offsets_v: Optional batch offsets for value tensor of shape (batch_size,) on GPU
+    Parameters
+    ----------
+    q : torch.Tensor
+        Query tensor of shape ``(batch_size, num_heads_qo, head_dim)``.
+    k_cache : torch.Tensor
+        Key cache, shape ``(total_num_pages, num_heads_kv, page_size, head_dim)``.
+    v_cache : torch.Tensor
+        Value cache, shape ``(total_num_pages, num_heads_kv, page_size, head_dim)``.
+    scale : float
+        Softmax scaling factor, typically ``1 / sqrt(head_dim)``.
+    workspace_buffer : torch.Tensor
+        Workspace buffer for cuDNN.  Scales with batch size; 128 MB is sufficient
+        for typical decode workloads.
+    max_sequence_kv : int
+        Maximum number of tokens per KV sequence in the batch (``s_kv_max``).
+    actual_seq_lens_kv : Optional[torch.Tensor]
+        Per-request KV lengths, shape ``(batch_size,)``, on CPU.
+    block_tables : Optional[torch.Tensor]
+        Page-table mapping for the paged KV cache, shape
+        ``(batch_size, num_pages_per_seq)`` on GPU.
+    is_cuda_graph_compatible : bool
+        Whether to plan the operation in a CUDA-graph-capture-safe mode.
+    batch_offsets_q : Optional[torch.Tensor]
+        Per-request offsets into the query tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_o : Optional[torch.Tensor]
+        Per-request offsets into the output tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_k : Optional[torch.Tensor]
+        Per-request offsets into the key tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_v : Optional[torch.Tensor]
+        Per-request offsets into the value tensor, shape ``(batch_size,)`` on GPU.
+    out : Optional[torch.Tensor]
+        Pre-allocated output tensor, shape ``(batch_size, num_heads_qo, head_dim)``;
+        allocated internally when ``None``.
 
-    Returns:
-        Output tensor of shape (batch_size, num_heads_qo, head_dim)
+    Returns
+    -------
+    torch.Tensor
+        Output tensor of shape ``(batch_size, num_heads_qo, head_dim)``.
 
-    Note:
-        Currently only supports causal attention (causal must be True)
-        All tensors must be contiguous and on the same CUDA device
-        Query and KV heads can have different sizes (num_heads_qo >= num_heads_kv)
+    Note
+    ----
+    Currently only supports causal attention; all tensors must be contiguous and
+    on the same CUDA device.  Query and KV heads may differ
+    (``num_heads_qo >= num_heads_kv``, multi-query / grouped-query attention).
     """
 
     bs = q.shape[0]

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -612,9 +612,12 @@ def cudnn_batch_prefill_with_kv_cache(
     max_sequence_kv : int
         Maximum number of tokens per KV sequence (``s_kv_max``).
     actual_seq_lens_q : torch.Tensor
-        Per-request query lengths, shape ``(batch_size,)``.  Must be on CPU when
-        ``is_cuda_graph_compatible`` is ``False``, otherwise on the same device as
-        ``q``.
+        Per-request query lengths, shape ``(batch_size,)``.  When cuDNN is
+        available (the default backend) this tensor must reside on the same
+        CUDA device as ``q``.  Only the fallback non-cuDNN path accepts (and
+        internally copies) a CPU tensor; that fallback is also the only path
+        that requires a CPU tensor when ``is_cuda_graph_compatible`` is
+        ``False``.
     actual_seq_lens_kv : torch.Tensor
         Per-request KV lengths, shape ``(batch_size,)``.  Same device rules as
         ``actual_seq_lens_q``.

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -588,41 +588,90 @@ def cudnn_batch_prefill_with_kv_cache(
     backend: Optional[str] = None,
     o_data_type: Optional[torch.dtype] = None,
 ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-    """Performs batched prefill attention with paged KV cache using cuDNN.
+    r"""Batched prefill attention with paged KV cache, backed by cuDNN SDPA.
 
-    Args:
-        q: Query tensor of shape (Total number of tokens, num_heads_qo, head_dim)
-        k_cache: Key cache tensor of shape   (total_num_pages, num_heads_kv, page_size, head_dim) if paged kv cache is enabled else (Total sequence length of kv, num_heads_kv, d_qk)
-        v_cache: Value cache tensor of shape (total_num_pages, num_heads_kv, page_size, head_dim) if paged kv cache is enabled else (Total sequence length of kv, num_heads_kv, d_vo)
-        scale: Scaling factor for attention scores, typically 1/sqrt(head_dim)
-        workspace_buffer: Workspace buffer for cuDNN operations. Scales with batch size. 128 MB should be sufficient for most cases
-        max_token_per_sequence: Maximum number of tokens per query sequence (s_qo_max)
-        max_sequence_kv: Maximum number of tokens per key/value sequence (s_kv_max)
-        actual_seq_lens_q:  Actual number of tokens per query sequence shape (batch_size,) on cpu or device (cpu if cuda_graph is False)
-        actual_seq_lens_kv: Actual sequence lengths for key/values per batch, shape (batch_size,) on CPU or device (cpu if cuda_graph is False)
-        block_tables: Page table mapping for KV cache, shape (batch_size, num_pages_per_seq) on GPU
-        causal: Whether to apply causal masking
-        return_lse: Whether to return log-sum-exp values (must be True)
-        out: Optional pre-allocated output tensor
-        lse: Optional pre-allocated tensor for log-sum-exp values if return_lse is True else returns None
-        is_cuda_graph_compatible: Whether the prefill operation is compatible with CUDA graph
-        q_scale: Optional scale tensor for query tensor of shape (1, 1, 1, 1) on GPU
-        k_scale: Optional scale tensor for key tensor of shape (1, 1, 1, 1) on GPU
-        v_scale: Optional scale tensor for value tensor of shape (1, 1, 1, 1) on GPU
-        batch_offsets_q: Optional batch offsets for query tensor of shape (batch_size,) on GPU
-        batch_offsets_o: Optional batch offsets for output tensor of shape (batch_size,) on GPU
-        batch_offsets_k: Optional batch offsets for key tensor of shape (batch_size,) on GPU
-        batch_offsets_v: Optional batch offsets for value tensor of shape (batch_size,) on GPU
-        o_data_type: Optional data type for output tensor
-    Returns:
-        Output tensor of shape (batch_size * seq_len_q, num_heads_qo, head_dim)
-        If return_lse is True, also returns log-sum-exp tensor of shape (batch_size, seq_len_q, num_heads_qo)
+    Parameters
+    ----------
+    q : torch.Tensor
+        Packed query tensor with shape ``(total_qo_tokens, num_heads_qo, head_dim_qk)``.
+    k_cache : torch.Tensor
+        Key cache.  If paged:
+        ``(total_num_pages, num_heads_kv, page_size, head_dim_qk)``; otherwise
+        ``(total_kv_tokens, num_heads_kv, head_dim_qk)``.
+    v_cache : torch.Tensor
+        Value cache.  If paged:
+        ``(total_num_pages, num_heads_kv, page_size, head_dim_vo)``; otherwise
+        ``(total_kv_tokens, num_heads_kv, head_dim_vo)``.
+    scale : float
+        Softmax scaling factor, typically ``1 / sqrt(head_dim_qk)``.
+    workspace_buffer : torch.Tensor
+        Workspace buffer for cuDNN.  Scales with batch size; 128 MB is sufficient
+        for typical prefill workloads.
+    max_token_per_sequence : int
+        Maximum number of tokens per query sequence (``s_qo_max``).
+    max_sequence_kv : int
+        Maximum number of tokens per KV sequence (``s_kv_max``).
+    actual_seq_lens_q : torch.Tensor
+        Per-request query lengths, shape ``(batch_size,)``.  Must be on CPU when
+        ``is_cuda_graph_compatible`` is ``False``, otherwise on the same device as
+        ``q``.
+    actual_seq_lens_kv : torch.Tensor
+        Per-request KV lengths, shape ``(batch_size,)``.  Same device rules as
+        ``actual_seq_lens_q``.
+    block_tables : Optional[torch.Tensor]
+        Paged KV block table, shape ``(batch_size, num_pages_per_seq)`` on GPU.
+        Pass ``None`` for non-paged KV layouts.
+    causal : bool
+        Whether to apply a causal mask.
+    return_lse : bool
+        Whether to return the log-sum-exp tensor (currently must be ``True`` in the
+        cubin backend).
+    q_scale : Optional[torch.Tensor]
+        FP8 dequantization scale for the query, shape ``(1, 1, 1, 1)`` on GPU.
+    k_scale : Optional[torch.Tensor]
+        FP8 dequantization scale for the key, shape ``(1, 1, 1, 1)`` on GPU.
+    v_scale : Optional[torch.Tensor]
+        FP8 dequantization scale for the value, shape ``(1, 1, 1, 1)`` on GPU.
+    batch_offsets_q : Optional[torch.Tensor]
+        Per-request offsets into the query tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_o : Optional[torch.Tensor]
+        Per-request offsets into the output tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_k : Optional[torch.Tensor]
+        Per-request offsets into the key tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_v : Optional[torch.Tensor]
+        Per-request offsets into the value tensor, shape ``(batch_size,)`` on GPU.
+    batch_offsets_stats : Optional[torch.Tensor]
+        Per-request offsets into the LSE / stats tensor, shape ``(batch_size,)``.
+    out : Optional[torch.Tensor]
+        Pre-allocated output tensor, shape
+        ``(total_qo_tokens, num_heads_qo, head_dim_vo)``.  Allocated internally
+        when ``None``.
+    lse : Optional[torch.Tensor]
+        Pre-allocated LSE tensor, shape
+        ``(batch_size, max_token_per_sequence, num_heads_qo)``.  Allocated
+        internally when ``None`` and ``return_lse`` is ``True``.
+    is_cuda_graph_compatible : bool
+        Whether to plan the operation in a CUDA-graph-capture-safe mode.
+    backend : Optional[str]
+        Optional cuDNN backend selector (e.g. ``"cubin"``).  When ``None``,
+        autodetects based on cuDNN availability.
+    o_data_type : Optional[torch.dtype]
+        Optional output dtype; defaults to ``q.dtype``.
 
-    Note:
-        Query and KV heads can have different sizes (num_heads_qo >= num_heads_kv)
-        When using cuda graph, actual_seq_lens_q and actual_seq_lens_kv must be on the same device as q
-        Head dimension of query and key must be 128 or 192
-        Head dimension of value and output must be 128
+    Returns
+    -------
+    Tuple[torch.Tensor, Optional[torch.Tensor]]
+        ``(output, lse)`` where ``output`` has shape
+        ``(total_qo_tokens, num_heads_qo, head_dim_vo)``; ``lse`` has shape
+        ``(batch_size, max_token_per_sequence, num_heads_qo)`` when
+        ``return_lse=True``, else ``None``.
+
+    Note
+    ----
+    Query and KV heads may differ (``num_heads_qo >= num_heads_kv``, MQA / GQA).
+    When using CUDA graph capture, ``actual_seq_lens_q`` and ``actual_seq_lens_kv``
+    must reside on the same device as ``q``.  ``head_dim_qk`` must be 128 or 192,
+    and ``head_dim_vo`` must be 128.
     """
 
     num_tokens = q.shape[0]

--- a/flashinfer/cute_dsl/attention/wrappers/batch_mla.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_mla.py
@@ -373,6 +373,15 @@ class BatchMLADecodeCuteDSLWrapper:
 
     @flashinfer_api
     def __init__(self, workspace_buffer: torch.Tensor) -> None:
+        r"""Bind the wrapper to a user-provided workspace buffer.
+
+        Parameters
+        ----------
+        workspace_buffer : torch.Tensor
+            Pre-allocated workspace buffer on the target CUDA device.  Must have
+            dtype ``torch.int8``; the size determines the maximum batch this
+            wrapper can handle without re-allocation.
+        """
         assert workspace_buffer.dtype == torch.int8, (
             f"workspace_buffer must be torch.int8, got {workspace_buffer.dtype}"
         )

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -150,15 +150,43 @@ def _get_compiled_prefill_kernel(
 
 
 class BatchPrefillCuteDSLWrapper:
+    r"""PyTorch-facing wrapper for the CuTe-DSL ragged-KV batch prefill kernel.
+
+    This wrapper exposes a ``plan`` + ``run`` API compatible with
+    :class:`flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper`, but compiles a
+    CuTe-DSL kernel under the hood instead of the C++ FA2/FA3 path.
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        wrapper = BatchPrefillCuteDSLWrapper(workspace_buffer)
+        wrapper.plan(qo_indptr, kv_indptr,
+                     num_qo_heads=32, num_kv_heads=8, head_dim_qk=128)
+        out = wrapper.run(q, k, v)
+    """
+
     @flashinfer_api
     def __init__(
         self,
         float_workspace_buffer: torch.Tensor,
         use_cuda_graph: bool = False,
     ) -> None:
-        # Named float_workspace_buffer for compatibility with the parent
-        # BatchPrefillWithRaggedKVCacheWrapper API. Callers typically pass
-        # torch.uint8; the CuTe DSL kernel does not use this buffer.
+        r"""Initialise the wrapper and bind it to a workspace buffer.
+
+        Parameters
+        ----------
+        float_workspace_buffer : torch.Tensor
+            Pre-allocated workspace buffer on the target CUDA device.  Named for
+            API parity with :class:`BatchPrefillWithRaggedKVCacheWrapper`; callers
+            typically pass ``torch.uint8``.  The CuTe-DSL kernel itself does not
+            consume this buffer, but it is retained so the wrapper can mirror the
+            parent API.
+        use_cuda_graph : bool
+            Whether the wrapper will be used inside a CUDA graph capture.  Defaults
+            to ``False``.
+        """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -369,12 +369,18 @@ def single_decode_with_kv_cache_with_jit_module(
     window_left : int
         Left window size for sliding-window attention; ``-1`` disables it.
     return_lse : bool
-        Whether to allocate and return the log-sum-exp tensor.  Defaults to ``False``.
+        If ``True``, allocate an LSE buffer (shape ``(num_qo_heads,)``,
+        ``float32``) for the kernel to write into.  Defaults to ``False``.
+        **Note: the buffer is allocated and filled by the kernel but is not
+        currently returned to the caller** -- this function always returns
+        just ``o``.  Callers who need the LSE should use
+        :func:`single_decode_with_kv_cache` instead.
 
     Returns
     -------
     torch.Tensor
-        Output tensor with shape matching ``q``.
+        Output tensor with shape matching ``q``.  The LSE buffer (when
+        ``return_lse=True``) is discarded; see the parameter note.
     """
     device = q.device
     tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device=device)

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -342,6 +342,40 @@ def single_decode_with_kv_cache_with_jit_module(
     window_left: int = -1,
     return_lse: bool = False,
 ):
+    r"""Single-request decode using a pre-compiled JIT module.
+
+    This is the low-level entry point used by :func:`single_decode_with_kv_cache` after
+    backend dispatch; user code should normally call ``single_decode_with_kv_cache``
+    directly.  This function is exposed for advanced users who already hold a compiled
+    JIT module (for example to customize the attention variant via extra kernel
+    arguments).
+
+    Parameters
+    ----------
+    jit_module : Any
+        Compiled JIT module returned by one of the ``gen_*_module`` factories.
+    q : torch.Tensor
+        Query tensor, shape ``[num_qo_heads, head_dim]``.
+    k : torch.Tensor
+        Key tensor, shape ``[kv_len, num_kv_heads, head_dim]`` (``NHD``) or
+        ``[num_kv_heads, kv_len, head_dim]`` (``HND``).
+    v : torch.Tensor
+        Value tensor, layout matches ``k``.
+    *args
+        Extra positional arguments forwarded to the JIT module's ``run`` symbol
+        (e.g. soft-cap or sliding-window parameters required by the chosen variant).
+    kv_layout : str
+        Layout of ``k`` and ``v``, either ``"NHD"`` or ``"HND"``.  Defaults to ``"NHD"``.
+    window_left : int
+        Left window size for sliding-window attention; ``-1`` disables it.
+    return_lse : bool
+        Whether to allocate and return the log-sum-exp tensor.  Defaults to ``False``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output tensor with shape matching ``q``.
+    """
     device = q.device
     tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device=device)
     o = torch.empty_like(q)
@@ -927,6 +961,15 @@ class BatchDecodeWithPagedKVCacheWrapper:
         data_type: Optional[Union[str, torch.dtype]]
             The data type of both the query and key/value tensors. Defaults to torch.float16.
             data_type is deprecated, please use q_data_type and kv_data_type instead.
+        sm_scale : Optional[float]
+            Softmax scale.  If ``None``, defaults to ``1 / sqrt(head_dim)``.  Cached on
+            the wrapper and reused at :meth:`run` time.
+        rope_scale : Optional[float]
+            Scale factor applied during RoPE interpolation.  Only consulted when
+            ``pos_encoding_mode != "NONE"``.  Defaults to ``1.0`` when ``None``.
+        rope_theta : Optional[float]
+            Base value for the RoPE frequencies.  Only consulted when
+            ``pos_encoding_mode != "NONE"``.  Defaults to ``1e4`` when ``None``.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
         seq_lens: Optional[torch.Tensor]
@@ -1971,6 +2014,12 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         q_data_type : Optional[Union[str, torch.dtype]]
             The data type of the query tensor. If None, will be set to
             ``data_type``. Defaults to ``None``.
+        rope_scale : Optional[float]
+            Scale factor applied during RoPE interpolation for the rope-portion of
+            the MLA query.  Defaults to ``1.0`` when ``None``.
+        rope_theta : Optional[float]
+            Base value for the RoPE frequencies of the rope-portion of the MLA
+            query.  Defaults to ``1e4`` when ``None``.
 
         Note
         ----
@@ -2528,6 +2577,12 @@ def trtllm_batch_decode_with_kv_cache(
         For sm_100 and sm_103 (blackwell architecture), ``auto`` will choose ``trtllm-gen`` backend.
         For sm_90 (hopper architecture) and sm_120/sm_121 (blackwell architecture), ``auto`` will choose ``xqa`` backend.
 
+    q_len_per_req : Optional[int] = 1
+        Number of query tokens per request (i.e. speculative-decoding / MTP depth).
+        ``query`` is expected to have ``batch_size * q_len_per_req`` rows along its
+        leading dimension when ``cum_seq_lens_q`` / ``max_q_len`` are ``None``.
+        Defaults to ``1``.
+
     o_scale : Optional[float] = 1.0
         output scale factor for xqa fp8 output.
 
@@ -2917,6 +2972,11 @@ def xqa_batch_decode_with_kv_cache(
     enable_pdl : bool
         Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
         Only supported for >= sm90, and currently only for FA2, CUDA core, and trtllm-gen decode.
+
+    q_len_per_req : Optional[int] = 1
+        Number of query tokens per request (i.e. speculative-decoding / MTP depth).
+        ``query`` is expected to have ``batch_size * q_len_per_req`` rows along its
+        leading dimension.  Defaults to ``1``.
 
     o_scale : Optional[float] = 1.0
         output scale factor for fp8 output.

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1407,6 +1407,18 @@ class BatchDecodeWithPagedKVCacheWrapper:
         enable_pdl : bool
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+        window_left : Optional[int]
+            Per-call sliding-window bound. Must either be ``None`` (default,
+            inherit the value from :meth:`plan`) or equal the value passed to
+            :meth:`plan` (the kernel asserts this). Passing ``-1`` to
+            :meth:`plan` disables the sliding window for the entire batch.
+        sinks : Optional[torch.Tensor]
+            Per-head attention sink logits, shape ``[num_qo_heads]``. When
+            provided, ``sinks[head_idx]`` is appended to each row of the
+            softmax denominator (Streaming-LLM / Attention-Sinks). The dtype
+            requirement is backend-specific and validated by the underlying
+            kernel; pass ``None`` to disable. Not supported by the
+            ``cute-dsl`` backend.
         q_len_per_req : Optional[int]
             DEPRECATED — pass to :meth:`plan` instead. When provided here, emits
             a :class:`DeprecationWarning` and is used to validate the run-time value

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -729,21 +729,21 @@ class BatchMLAPagedAttentionWrapper:
             Whether to enable CUDA graph capture for the prefill kernels, if enabled, the
             auxiliary data structures will be stored in provided buffers. The ``batch_size``
             cannot change during the lifecycle of this wrapper when CUDAGraph is enabled.
-        qo_indptr_buf : Optional[torch.Tensor]
-            The user reserved buffer to store the ``qo_indptr`` array, the size of the buffer
-            should be ``[batch_size + 1]``.
-            This argument is only effective when ``use_cuda_graph`` is ``True``.
-        kv_indptr_buf : Optional[torch.Tensor]
-            The user reserved buffer to store the ``kv_indptr`` array, the size of the buffer
-            should be ``[batch_size + 1]``.
-            This argument is only effective when ``use_cuda_graph`` is ``True``.
-        kv_indices_buf : Optional[torch.Tensor]
-            The user reserved buffer to store the ``kv_indices`` array.
-            This argument is only effective when ``use_cuda_graph`` is ``True``.
-        kv_len_arr_buf : Optional[torch.Tensor]
-            The user reserved buffer to store the ``kv_len_arr`` array, the size of the buffer
-            should be ``[batch_size]``.
-            This argument is only effective when ``use_cuda_graph`` is ``True``.
+        qo_indptr : Optional[torch.Tensor]
+            User-reserved buffer to back the ``qo_indptr`` array, shape ``[batch_size + 1]``,
+            dtype ``int32``.  Only consulted when ``use_cuda_graph=True``.  The wrapper
+            copies into this buffer at :meth:`plan` time so capture-time pointers remain
+            stable.
+        kv_indptr : Optional[torch.Tensor]
+            User-reserved buffer to back the ``kv_indptr`` array, shape ``[batch_size + 1]``,
+            dtype ``int32``.  Only consulted when ``use_cuda_graph=True``.
+        kv_indices : Optional[torch.Tensor]
+            User-reserved buffer to back the ``kv_indices`` array, sized to the maximum
+            expected number of pages, dtype ``int32``.  Only consulted when
+            ``use_cuda_graph=True``.
+        kv_len_arr : Optional[torch.Tensor]
+            User-reserved buffer to back the ``kv_len_arr`` array, shape ``[batch_size]``,
+            dtype ``int32``.  Only consulted when ``use_cuda_graph=True``.
         backend : str
             The implementation backend, could be ``auto``/``fa2`` or ``fa3``. Defaults to ``auto``.
             If set to ``auto``, the function will automatically choose the backend based on the
@@ -945,6 +945,12 @@ class BatchMLAPagedAttentionWrapper:
             The query length of each request, shape: ``[batch_size]``. Required when ``backend`` is ``cutlass``.
         page_table : Optional[torch.Tensor]
             The page table of the paged kv-cache, shape: ``[batch_size, num_pages]``. Required when ``backend`` is ``cutlass``.
+        return_lse_base_on_e : bool, optional
+            Controls the base of the returned LSE values when ``return_lse=True``.
+            If ``False`` (default), the LSE is returned in base-2
+            (``log2(sum(exp2(...)))``) to match the kernel's internal log-base.
+            If ``True``, the LSE is converted to natural-log base (``log(sum(exp(...)))``)
+            for compatibility with cascade-merging APIs that expect base-e LSEs.
         o_scale : Optional[float]
             FP8 output dequantization scale (``real = quantized * o_scale``).
             When provided, ``out`` must be an FP8 tensor. Only supported with
@@ -1671,6 +1677,10 @@ def trtllm_batch_decode_with_kv_cache_mla(
         If no value is provided, then standard attention is used.
         Setting the threshold to a higher value generally increases kernel performance at the cost of accuracy degradation.
         The actual threshold value equals the provided threshold_scale_factor divided by the context length.
+    enable_pdl : Optional[bool]
+        Programmatic Dependent Launch toggle.  When ``None`` (default), auto-detects
+        support from the query device.  Honoured by the ``trtllm-gen`` and ``xqa``
+        backends; ignored by ``cute-dsl``.
     backend : str = "auto"
         The implementation backend, could be ``auto``/``xqa``, ``trtllm-gen``, or ``cute-dsl``. Defaults to ``auto``.
         When set to ``auto``, the backend will be chosen based on the device architecture and kernel availability.
@@ -2008,36 +2018,75 @@ def xqa_batch_decode_with_kv_cache_mla(
     sinks: Optional[List[torch.Tensor]] = None,
     enable_pdl: bool | None = None,
 ) -> torch.Tensor:
-    """
-    Parameters:
-    query: [batch_size, q_len_per_request, num_heads, head_dim_qk], head_dim_qk = qk_nope_head_dim (kv_lora_rank) + qk_rope_head_dim, should be concated q_nope + q_rope; q_len_per_request is the MTP query length.
-    kv_cache: [num_pages, page_size, head_dim_ckv + head_dim_kpe] or [num_pages, 1, page_size, head_dim_ckv + head_dim_kpe], should be concated ckv_cache + kpe_cache. Both 3D and 4D formats are supported for backward compatibility.
-    workspace_buffer: torch.Tensor. Must be initialized to 0 for its first use.
-    qk_nope_head_dim: qk_nope_head_dim, must be 128
-    kv_lora_rank: kv_lora_rank, must be 512
-    qk_rope_head_dim: qk_rope_head_dim, must be 64
-    block_tables: page_table of kv cache, [batch_size, num_pages]
-    seq_lens: query_len
-    max_seq_len: max sequence length for kv_cache
-    out: output tensor, if not provided, will be allocated internally
-    bmm1_scale: fused scale for mla bmm1 input. Can be a float or a torch.Tensor.
-    bmm2_scale: fused scale for mla bmm2 input. Can be a float or a torch.Tensor.
-    sinks: additional value per head in the denominator of the softmax.
+    r"""XQA-backend batched MLA decode.
 
-    Note:
-    In MLA, the actual BMM1 and BMM2 scales applied would be fused as:
-    bmm1_scale = q_scale * k_scale * sm_scale / (head_dim_qk ** 0.5)
-    bmm2_scale = v_scale * o_scale
+    Single-query (MTP-aware) MLA decode kernel optimized for SM120a / SM121a tensor cores.
+    Accepts the concatenated ``(q_nope || q_rope)`` query and ``(ckv || kpe)`` paged KV
+    cache layout used by DeepSeek-V3 / R1 inference.
 
-    The two scale factors should be static constant for cuda graph capture.
-    Either (bmm1_scale, bmm2_scale) or (bmm1_scale_log2_tensor, bmm2_scale_tensor) should be provided.
+    Parameters
+    ----------
+    query : torch.Tensor
+        Query tensor with shape
+        ``[batch_size, q_len_per_request, num_heads, head_dim_qk]`` where
+        ``head_dim_qk = kv_lora_rank + qk_rope_head_dim``.  Must be the concatenation
+        ``[q_nope, q_rope]``.  ``q_len_per_request`` is the MTP query length and is
+        currently required to be ``1``.
+    kv_cache : torch.Tensor
+        Paged KV cache, either 3-D
+        ``[num_pages, page_size, kv_lora_rank + qk_rope_head_dim]`` or 4-D
+        ``[num_pages, 1, page_size, kv_lora_rank + qk_rope_head_dim]``.  The last
+        dimension is the concatenation ``[ckv_cache, kpe_cache]``.  Both shapes are
+        accepted for backward compatibility.
+    workspace_buffer : torch.Tensor
+        Pre-allocated workspace buffer.  Must be zero-initialized on first use.
+    qk_nope_head_dim : int
+        Non-RoPE head dimension.  Must be ``128``.  Will be removed in 1.0; pass
+        ``kv_lora_rank`` instead going forward.
+    kv_lora_rank : int
+        Rank of the latent KV projection.  Must be ``512``.
+    qk_rope_head_dim : int
+        RoPE head dimension appended to the latent projection.  Must be ``64``.
+    block_tables : torch.Tensor
+        Per-request paged KV block table, shape ``[batch_size, num_pages]``.
+    seq_lens : torch.Tensor
+        Per-request KV sequence length, shape ``[batch_size]``.
+    max_seq_len : int
+        Maximum KV sequence length used for kernel scheduling.  Will be removed in
+        1.0; the kernel reads the per-request lengths from ``seq_lens``.
+    out : Optional[torch.Tensor]
+        Optional output tensor of shape ``[batch_size, num_heads, kv_lora_rank]``
+        and dtype ``torch.bfloat16``.  If ``None``, it is allocated internally.
+    bmm1_scale : Union[float, torch.Tensor]
+        Fused scale for MLA BMM1 (see Note).  ``float`` for static (CUDA-graph
+        safe) scales; ``torch.Tensor`` for on-device dynamic scales (FP8 only).
+    bmm2_scale : Union[float, torch.Tensor]
+        Fused scale for MLA BMM2 (see Note).  Same typing rules as ``bmm1_scale``.
+    sinks : Optional[List[torch.Tensor]]
+        Attention-sink tensors.  Currently unsupported and must be ``None``.
+    enable_pdl : Optional[bool]
+        Programmatic Dependent Launch toggle.  When ``None``, auto-detects support
+        from the device.
 
-    For static constant scale factors, the scale factors should be provided as float.
-        - (bmm1_scale, bmm2_scale)
-    For on-device fused scale tensors, which could dynamically change, the scale factors should be provided as torch.Tensor.
-        - (bmm1_scale_log2_tensor, bmm2_scale_tensor)
-        - Currently, only fp8 tensor core operation supports this mode.
-    When both are provided, the dynamic scale factor tensors will be used.
+    Returns
+    -------
+    torch.Tensor
+        Attention output, shape ``[batch_size, num_heads, kv_lora_rank]``, dtype
+        ``torch.bfloat16``.
+
+    Note
+    ----
+    In MLA, the BMM1 and BMM2 scales are fused as:
+
+    .. code-block:: text
+
+        bmm1_scale = q_scale * k_scale * sm_scale / sqrt(head_dim_qk)
+        bmm2_scale = v_scale * o_scale
+
+    The scale factors must be static constants for CUDA graph capture.  Either the
+    ``(bmm1_scale, bmm2_scale)`` (float) pair or the on-device
+    ``(bmm1_scale_log2_tensor, bmm2_scale_tensor)`` tensor pair may be passed.
+    When tensor inputs are supplied, the on-device path is taken (FP8 only).
     """
     enable_pdl = device_support_pdl(query.device) if enable_pdl is None else enable_pdl
     sm_count = get_device_sm_count(query.device)

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -525,30 +525,42 @@ class PODWithPagedKVCacheWrapper:
         rope_scale_p, rope_theta_p : Optional[float]
             RoPE scale / theta for the prefill side.  Defaults to ``1.0`` / ``1e4``.
         return_lse_p : bool
-            Whether to return the prefill LSE.  Defaults to ``False``.
+            If ``True``, allocate an LSE buffer for the prefill kernel to write
+            into.  Defaults to ``False``.  **Note: the buffer is allocated and
+            filled by the kernel but is not currently returned to the caller**
+            -- ``run`` always returns just ``(out_p, out_d)``.  This is a known
+            limitation of the current POD wrapper (kernel API exists, Python
+            wrapper does not yet plumb LSE through the return value).
         custom_mask_d, packed_custom_mask_d : Optional[torch.Tensor]
             Optional dense / bit-packed custom mask for the decode side.
         causal_d : bool
             Whether to apply a causal mask to the decode side.  Defaults to
             ``False``.
         kv_layout_d : str
-            Layout of the decode KV cache; should match the wrapper's
-            ``kv_layout`` set in :meth:`__init__`.
+            **Currently ignored**: the decode KV layout is always taken from
+            the wrapper's ``kv_layout`` (set in :meth:`__init__`); this
+            argument is accepted for signature symmetry with ``kv_layout_p``
+            but the value is not consulted by the kernel.
         pos_encoding_mode_d : str
-            Position-encoding mode for the decode side.  Defaults to ``"NONE"``.
+            **Currently ignored**: overridden by ``self._pos_encoding_mode``
+            from :meth:`plan`.
         sm_scale_d : Optional[float]
-            Softmax scale for the decode side.  When ``None``, uses the value
-            cached at :meth:`plan` time.
+            **Currently ignored**: overridden by ``self._sm_scale`` from
+            :meth:`plan` (which itself defaults to ``1 / sqrt(head_dim)``).
         window_left_d : int
-            Left window size for sliding-window decode.
+            **Currently ignored**: overridden by ``self._window_left`` from
+            :meth:`plan`.
         rope_scale_d, rope_theta_d : Optional[float]
-            RoPE scale / theta for the decode side.
+            **Currently ignored**: overridden by ``self._rope_scale`` /
+            ``self._rope_theta`` from :meth:`plan`.
         q_scale, k_scale, v_scale : Optional[float]
             FP8 calibration scales applied to the decode side.  Folded into the
             decode ``sm_scale`` (``q_scale``, ``k_scale``) or the kernel output
             (``v_scale``).
         return_lse_d : bool
-            Whether to return the decode LSE.  Defaults to ``False``.
+            If ``True``, allocate an LSE buffer for the decode kernel to write
+            into.  Defaults to ``False``.  See ``return_lse_p`` -- same
+            caveat: allocated but not returned.
         use_fp16_qk_reduction : bool
             Whether to accumulate ``QK`` in FP16 (lower precision, higher
             throughput).  Defaults to ``False``.
@@ -560,12 +572,12 @@ class PODWithPagedKVCacheWrapper:
 
         Returns
         -------
-        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
-            By default ``(out_p, out_d)``: the prefill output (shape
+        Tuple[torch.Tensor, torch.Tensor]
+            ``(out_p, out_d)``: the prefill output (shape
             ``[qo_len, num_qo_heads, head_dim]``) and the decode output (shape
-            ``[batch_size, num_qo_heads, head_dim]``).  When ``return_lse_p`` or
-            ``return_lse_d`` is ``True`` the corresponding LSE tensor is
-            appended.
+            ``[batch_size, num_qo_heads, head_dim]``).  LSE tensors are
+            **not** part of the return value even when ``return_lse_p`` /
+            ``return_lse_d`` is ``True`` (see those parameter notes).
         """
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q_p.device)

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -152,18 +152,18 @@ class PODWithPagedKVCacheWrapper:
             auxiliary data structures will be stored as the provided buffers. The ``batch_size``
             cannot change during the lifecycle of this wrapper when CUDAGraph is enabled.
 
-        indptr_buffer : Optional[torch.Tensor]
+        paged_kv_indptr_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
             of the buffer should be ``[batch_size + 1]``.
             Only needed when ``use_cuda_graph`` is ``True``.
 
-        indices_buffer : Optional[torch.Tensor]
+        paged_kv_indices_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the page indices of the paged kv cache,
             should be large enough to store the maximum number of page indices
             (``max_num_pages``) during the lifecycle of this wrapper.
             Only needed when ``use_cuda_graph`` is ``True``.
 
-        last_page_len_buffer : Optional[torch.Tensor]
+        paged_kv_last_page_len_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the number of entries in the last page, the
             size of the buffer should be ``[batch_size]``.
             Only needed when ``use_cuda_graph`` is ``True``.
@@ -319,6 +319,15 @@ class PODWithPagedKVCacheWrapper:
         data_type: Optional[Union[str, torch.dtype]]
             The data type of both the query and key/value tensors. Defaults to torch.float16.
             data_type is deprecated, please use q_data_type and kv_data_type instead.
+        sm_scale : Optional[float]
+            Softmax scale.  If ``None``, defaults to ``1 / sqrt(head_dim)``.  Cached on
+            the wrapper and reused at :meth:`run` time.
+        rope_scale : Optional[float]
+            Scale factor applied during RoPE interpolation.  Only consulted when
+            ``pos_encoding_mode != "NONE"``.  Defaults to ``1.0`` when ``None``.
+        rope_theta : Optional[float]
+            Base value for the RoPE frequencies.  Only consulted when
+            ``pos_encoding_mode != "NONE"``.  Defaults to ``1e4`` when ``None``.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
 
@@ -477,7 +486,87 @@ class PODWithPagedKVCacheWrapper:
         enable_pdl: Optional[bool] = None,
         *args,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        r"""Compute POD-attention for a batch of requests."""
+        r"""Compute POD (Prefill-On-Decode) fused attention for a batch of requests.
+
+        Single-shot fused attention that simultaneously runs single-request
+        prefill (``q_p`` against ``k_p``/``v_p``) and batch-decode
+        (``q_d`` against ``paged_kv_cache_d``) so prefill and decode tokens of a
+        chunked-prefill / continuous-batching iteration share kernel launch and
+        scheduling resources.
+
+        Parameters
+        ----------
+        q_p : torch.Tensor
+            Prefill query tensor, shape ``[qo_len, num_qo_heads, head_dim]``.
+        k_p : torch.Tensor
+            Prefill key tensor.  Layout matches ``kv_layout_p``.
+        v_p : torch.Tensor
+            Prefill value tensor.  Layout matches ``kv_layout_p``.
+        q_d : torch.Tensor
+            Decode query tensor, shape ``[batch_size, num_qo_heads, head_dim]``.
+        paged_kv_cache_d : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            Paged KV cache for the decode requests.  Layout matches the wrapper's
+            ``kv_layout`` set in :meth:`__init__`.
+        custom_mask_p, packed_custom_mask_p : Optional[torch.Tensor]
+            Optional dense / bit-packed custom mask for the prefill side.  See
+            :func:`flashinfer.single_prefill_with_kv_cache` for the layout.
+        causal_p : bool
+            Whether to apply a causal mask to the prefill side.  Defaults to
+            ``False``.
+        kv_layout_p : str
+            Layout of ``k_p`` and ``v_p``, either ``"NHD"`` or ``"HND"``.
+        pos_encoding_mode_p : str
+            Position-encoding mode for the prefill side.  Defaults to ``"NONE"``.
+        sm_scale_p : Optional[float]
+            Softmax scale for the prefill side.  Defaults to
+            ``1 / sqrt(head_dim)``.
+        window_left_p : int
+            Left window size for sliding-window prefill; ``-1`` disables it.
+        rope_scale_p, rope_theta_p : Optional[float]
+            RoPE scale / theta for the prefill side.  Defaults to ``1.0`` / ``1e4``.
+        return_lse_p : bool
+            Whether to return the prefill LSE.  Defaults to ``False``.
+        custom_mask_d, packed_custom_mask_d : Optional[torch.Tensor]
+            Optional dense / bit-packed custom mask for the decode side.
+        causal_d : bool
+            Whether to apply a causal mask to the decode side.  Defaults to
+            ``False``.
+        kv_layout_d : str
+            Layout of the decode KV cache; should match the wrapper's
+            ``kv_layout`` set in :meth:`__init__`.
+        pos_encoding_mode_d : str
+            Position-encoding mode for the decode side.  Defaults to ``"NONE"``.
+        sm_scale_d : Optional[float]
+            Softmax scale for the decode side.  When ``None``, uses the value
+            cached at :meth:`plan` time.
+        window_left_d : int
+            Left window size for sliding-window decode.
+        rope_scale_d, rope_theta_d : Optional[float]
+            RoPE scale / theta for the decode side.
+        q_scale, k_scale, v_scale : Optional[float]
+            FP8 calibration scales applied to the decode side.  Folded into the
+            decode ``sm_scale`` (``q_scale``, ``k_scale``) or the kernel output
+            (``v_scale``).
+        return_lse_d : bool
+            Whether to return the decode LSE.  Defaults to ``False``.
+        use_fp16_qk_reduction : bool
+            Whether to accumulate ``QK`` in FP16 (lower precision, higher
+            throughput).  Defaults to ``False``.
+        enable_pdl : Optional[bool]
+            Programmatic Dependent Launch toggle.  When ``None`` (default), the
+            wrapper auto-detects support from the query device.
+        *args
+            Reserved for forward-compat with future kernel parameters.
+
+        Returns
+        -------
+        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            By default ``(out_p, out_d)``: the prefill output (shape
+            ``[qo_len, num_qo_heads, head_dim]``) and the decode output (shape
+            ``[batch_size, num_qo_heads, head_dim]``).  When ``return_lse_p`` or
+            ``return_lse_d`` is ``True`` the corresponding LSE tensor is
+            appended.
+        """
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q_p.device)
 
@@ -1043,7 +1132,56 @@ class BatchPODWithPagedKVCacheWrapper:
         Tuple[torch.Tensor, torch.Tensor],
         Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]],
     ]:
-        r"""Compute POD-attention for a batch of requests."""
+        r"""Compute batched POD (Prefill-On-Decode) fused attention.
+
+        Fused single-shot attention that runs batched paged prefill (``q_p`` against
+        ``paged_kv_cache_p``) and batched paged decode (``q_d`` against
+        ``paged_kv_cache_d``) in the same kernel launch, sharing scheduling and
+        execution resources.  All prefill / decode shape and policy parameters
+        (pos-encoding, sliding window, sm_scale, RoPE, etc.) are taken from the
+        cached values supplied to :meth:`plan`.
+
+        Parameters
+        ----------
+        q_p : torch.Tensor
+            Prefill query tensor, shape ``[qo_indptr_p[-1], num_qo_heads, head_dim]``.
+        paged_kv_cache_p : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            Paged KV cache for the prefill requests.  Layout matches
+            ``kv_layout`` set in :meth:`__init__`.
+        q_d : torch.Tensor
+            Decode query tensor, shape ``[batch_size_d, num_qo_heads, head_dim]``.
+        paged_kv_cache_d : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            Paged KV cache for the decode requests.  Layout matches
+            ``kv_layout`` set in :meth:`__init__`.
+        custom_mask_p : Optional[torch.Tensor]
+            Optional dense custom mask for the prefill side (auto-packed when
+            ``packed_custom_mask_p`` is ``None``).
+        packed_custom_mask_p : Optional[torch.Tensor]
+            Optional bit-packed custom mask for the prefill side.
+        causal_p : bool
+            Whether to apply a causal mask to the prefill side.  Defaults to
+            ``False``.
+        q_scale, k_scale, v_scale : Optional[float]
+            FP8 calibration scales applied to the decode side.  Folded into the
+            decode ``sm_scale`` (``q_scale``, ``k_scale``) or the kernel output
+            (``v_scale``).
+        return_lse : bool
+            Whether to return the LSE tensors for both prefill and decode.
+            Defaults to ``False``.
+        use_fp16_qk_reduction : bool
+            Whether to accumulate ``QK`` in FP16 (lower precision, higher
+            throughput).  Defaults to ``False``.
+        enable_pdl : Optional[bool]
+            Programmatic Dependent Launch toggle.  When ``None`` (default), the
+            wrapper auto-detects support from the query device.
+
+        Returns
+        -------
+        Union[Tuple[torch.Tensor, torch.Tensor], Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]]
+            By default ``(out_p, out_d)``: the prefill output and the decode
+            output.  When ``return_lse`` is ``True`` the return becomes
+            ``((out_p, lse_p), (out_d, lse_d))``.
+        """
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q_p.device)
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1423,8 +1423,7 @@ def single_prefill_with_kv_cache(
 single_prefill_with_kv_cache_return_lse = functools.partial(
     single_prefill_with_kv_cache, return_lse=True
 )
-single_prefill_with_kv_cache_return_lse.__doc__ = (
-    """Convenience wrapper for :func:`single_prefill_with_kv_cache` that always returns LSE.
+single_prefill_with_kv_cache_return_lse.__doc__ = """Convenience wrapper for :func:`single_prefill_with_kv_cache` that always returns LSE.
 
     Equivalent to calling
     :func:`single_prefill_with_kv_cache` with ``return_lse=True``; accepts the
@@ -1439,7 +1438,6 @@ single_prefill_with_kv_cache_return_lse.__doc__ = (
         A pair ``(output, lse)`` where ``output`` is the attention output and
         ``lse`` is the log-sum-exp tensor used for cascade merging.
     """
-)
 
 
 def _compute_page_mask_indptr(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1030,6 +1030,45 @@ def single_prefill_with_kv_cache_with_jit_module(
     window_left: int = -1,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Single-request prefill / append attention using a pre-compiled JIT module.
+
+    Low-level entry point used by :func:`single_prefill_with_kv_cache` after backend
+    dispatch; user code should normally call ``single_prefill_with_kv_cache`` directly.
+    Exposed for advanced users who already hold a compiled JIT module (for example to
+    customize the attention variant via extra kernel arguments).
+
+    Parameters
+    ----------
+    jit_module : Any
+        Compiled JIT module returned by one of the ``gen_*_module`` factories.
+    q : torch.Tensor
+        Query tensor, shape ``[qo_len, num_qo_heads, head_dim_qk]``.
+    k : torch.Tensor
+        Key tensor, shape ``[kv_len, num_kv_heads, head_dim_qk]`` (``NHD``) or
+        ``[num_kv_heads, kv_len, head_dim_qk]`` (``HND``).
+    v : torch.Tensor
+        Value tensor, layout matches ``k``; last dimension may differ when
+        ``head_dim_vo != head_dim_qk``.
+    *args
+        Extra positional arguments forwarded to the JIT module's ``run`` symbol
+        (e.g. soft-cap, sink, or custom-mask buffers required by the chosen variant).
+    kv_layout : str
+        Layout of ``k`` and ``v``, either ``"NHD"`` or ``"HND"``.  Defaults to ``"NHD"``.
+    mask_mode : int
+        Mask mode, one of the values defined by :class:`~flashinfer.utils.MaskMode`.
+        Defaults to ``MaskMode.NON_CAUSAL.value``.
+    window_left : int
+        Left window size for sliding-window attention; ``-1`` disables it.
+    return_lse : bool
+        Whether to allocate and return the log-sum-exp tensor.  Defaults to ``False``.
+
+    Returns
+    -------
+    Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        If ``return_lse`` is ``False``, the attention output tensor.  Otherwise the
+        ``(output, lse)`` pair, where ``lse`` has shape
+        ``[qo_len, num_qo_heads]`` and dtype ``float32``.
+    """
     device = q.device
     tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device=device)
     o = torch.empty(q.shape[:-1] + v.shape[-1:], dtype=q.dtype, device=device)
@@ -1383,6 +1422,23 @@ def single_prefill_with_kv_cache(
 
 single_prefill_with_kv_cache_return_lse = functools.partial(
     single_prefill_with_kv_cache, return_lse=True
+)
+single_prefill_with_kv_cache_return_lse.__doc__ = (
+    """Convenience wrapper for :func:`single_prefill_with_kv_cache` that always returns LSE.
+
+    Equivalent to calling
+    :func:`single_prefill_with_kv_cache` with ``return_lse=True``; accepts the
+    same arguments and forwards them unchanged. See
+    :func:`single_prefill_with_kv_cache` for the full parameter list (including
+    FP8 / NVFP4 quantization scales such as ``scale_q``, ``scale_k``,
+    ``scale_v``, ``o_dtype``, ``kv_cache_sf``, ``k_scale``, and ``v_scale``).
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        A pair ``(output, lse)`` where ``output`` is the attention output and
+        ``lse`` is the log-sum-exp tensor used for cascade merging.
+    """
 )
 
 
@@ -2237,6 +2293,15 @@ class BatchPrefillWithPagedKVCacheWrapper:
         enable_pdl : bool
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+        window_left : Optional[int]
+            Per-call override for the left (inclusive) sliding-window size.  When
+            ``None``, the value supplied to :meth:`plan` is used.  Pass ``-1`` to
+            disable the sliding window for this call.
+        sinks : Optional[torch.Tensor]
+            Per-head attention-sink logits.  When provided, the kernel applies the
+            attention-with-sink variant: an additional virtual token whose logit is
+            ``sinks[head_idx]`` is appended to each row of the softmax denominator.
+            Shape: ``[num_qo_heads]``, dtype ``float32``.
         kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
             Per-block scale factors for NVFP4 KV cache. Accepts the same formats as
             ``paged_kv_cache``:
@@ -2259,6 +2324,13 @@ class BatchPrefillWithPagedKVCacheWrapper:
             to HND internally (incurring a copy). Use ``HND`` for better performance.
 
             Currently, NVFP4 KV supports `fa2` and `trtllm-gen` backend.
+        skip_softmax_threshold_scale_factor : Optional[float]
+            Threshold scale factor for skipping softmax operations.  Providing a
+            value enables skip-softmax sparsity as described in
+            https://arxiv.org/abs/2512.12087.  Defaults to ``None`` (standard
+            attention).  Higher values yield faster kernels at the cost of accuracy;
+            the effective threshold equals the supplied factor divided by the
+            context length.
         Returns
         -------
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -3291,6 +3363,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         enable_pdl : bool
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+        kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
+            Per-block scale factors for NVFP4 KV input.  Accepts either a single
+            packed scale tensor or a ``(k_scales, v_scales)`` tuple matching the
+            structure expected by the chosen backend.  When ``None`` (default), the
+            kernel runs without NVFP4 KV scaling.  See
+            :func:`flashinfer.fp4_quantization.nvfp4_quantize` for layout details.
         Returns
         -------
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -3821,6 +3899,10 @@ def trtllm_ragged_attention_deepseek(
         enable pdl
     is_causal : bool
         is causal
+    return_lse : bool
+        Whether to allocate and return the log-sum-exp tensor in addition to the
+        attention output.  When ``True`` the function returns
+        ``(out, lse)``; when ``False`` only ``out`` is returned.
     attention_sinks : Optional[torch.Tensor]
         attention sinks
     skip_softmax_threshold_scale_factor : Optional[float]
@@ -3833,6 +3915,16 @@ def trtllm_ragged_attention_deepseek(
         output tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1], value.shape[2]]
     lse : Optional[torch.Tensor]
         lse tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1]]
+    sage_attn_sfs : Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]
+        SageAttention scale-factor tensors for the four sub-blocks
+        ``(q_sf, k_sf, v_block_sum, p_block_sum)``.  Defaults to ``(None, None,
+        None, None)`` which disables SageAttention.  Currently only consulted by
+        the ``trtllm-gen`` backend.
+    num_elts_per_sage_attn_blk : Tuple[int, int, int, int]
+        Per-block element counts for the SageAttention scale-factor tensors,
+        matching the order of ``sage_attn_sfs``.  Defaults to ``(0, 0, 0, 0)``,
+        which disables SageAttention.  Only consulted when ``sage_attn_sfs``
+        contains non-``None`` tensors.
     backend : str
         Attention backend to use. "trtllm-gen" (default) or "cute-dsl".
 

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -823,6 +823,12 @@ class VariableBlockSparseAttentionWrapper:
             The theta used in RoPE, if not provided, will be set to ``1e4``.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
+        q_data_type : Union[str, torch.dtype]
+            Dtype of the query tensor.  Used to specialize the JIT-compiled kernel.
+            Defaults to ``"float16"``.
+        kv_data_type : Optional[Union[str, torch.dtype]]
+            Dtype of the key/value tensors.  When ``None``, defaults to
+            ``q_data_type``.
 
 
         The :meth:`plan` method should be called before any :meth:`run` or


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Backfills missing/stale Attention API documentation against the v0.6.12 doc-check report, and restores a silent FP8 regression in `single_prefill_with_kv_cache_return_lse`.

- New RST pages: `docs/api/pod.rst`, `docs/api/cudnn.rst`, `docs/api/cute_dsl.rst` (wired into `docs/index.rst`).
- Removes redundant `automethod` directives for `plan` / `run` / `begin_forward` / `end_forward` / `forward` across `attention.rst`, `cascade.rst`, `sparse.rst` (already covered by `:members:`); keeps only the explicit `.. automethod:: __init__` since `autoclass_content` does not surface constructors by default.
- Adds docstrings / NumPy-style `Parameters` to `BatchDecodeWithPagedKVCacheWrapper.plan`, `BatchDecodeMlaWithPagedKVCacheWrapper.plan`, `trtllm_batch_decode_with_kv_cache`, `xqa_batch_decode_with_kv_cache`, `single_decode_with_kv_cache_with_jit_module`, and the POD / cuDNN / CuTe-DSL wrappers.
- Restores `single_prefill_with_kv_cache_return_lse` to `functools.partial` (was accidentally rewritten as a standalone function, which dropped `scale_q` / `scale_k` / `scale_v` / `o_dtype` / `kv_cache_sf` / `k_scale` / `v_scale` — a silent FP8 prefill regression). Docstring attached via `__doc__`.

Part of the v0.6.12 docs cleanup, PR-1 of 8 codeowner-aligned PRs.
Siblings: PR-2 GEMM (#3442), PR-3 fused_moe (#3443), PR-4a/4b comm (#3444, #3445), PR-5 misc DiT/RoPE/GDN/Mamba (#3446), PR-6 quant (#3447), PR-7 infra (#3440), PR-8 others (#3456).

## 🔍 Related Issues

v0.6.12 docs cleanup tracking (no separate issue filed).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed. *(docs-only PR; no behavior change other than the `functools.partial` restore.)*
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- The `functools.partial` revert is the only non-doc change in the PR — please double-check that signature is intact.
- `pod.rst` / `cudnn.rst` / `cute_dsl.rst` are new; build locally with `python -m sphinx -W -b html docs docs/_build` to confirm no orphan / duplicate-object warnings.
- All new `.. automethod:: __init__` directives are intentional (constructor docstrings are not auto-included).
- Last commit (`fixup! ... PR-1`) is a `ruff-format` fix for the `single_prefill_with_kv_cache_return_lse.__doc__` block — safe to squash on merge.

Suggested reviewers (attention codeowners): @saltyminty @nv-yunzheq @bkryu @qsang-nv @yzh119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API pages for POD attention, cuDNN-backed kernels, and CuTe-DSL implementations
  * Expanded and clarified docstrings across attention, prefill, decode, MLA, POD, and sparse modules (parameters, shapes, device/return semantics, examples)
  * Reorganized API reference with additional kernel entries and a unified BatchAttention documentation section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->