### PR TITLE
docs(gemm): document GEMM + grouped_mm public surface; canonicalize aliases

### DIFF
--- a/docs/api/gemm.rst
+++ b/docs/api/gemm.rst
@@ -39,11 +39,14 @@ FP8 GEMM
 .. autosummary::
     :toctree: ../generated
 
+    mm_fp8
     bmm_fp8
+    gemm_fp8_nt_blockscaled
     gemm_fp8_nt_groupwise
     group_gemm_fp8_nt_groupwise
     group_deepgemm_fp8_nt_groupwise
     batch_deepgemm_fp8_nt_groupwise
+    fp8_blockscale_gemm_sm90
 
 Mixed Precision GEMM (fp8 x fp4)
 --------------------------------
@@ -51,7 +54,35 @@ Mixed Precision GEMM (fp8 x fp4)
 .. autosummary::
     :toctree: ../generated
 
-    group_gemm_mxfp4_nt_groupwise
+    group_gemm_mxfp8_mxfp4_nt_groupwise
+    group_gemm_nvfp4_nt_groupwise
+
+Router GEMM (DeepSeek-V3 / Mistral / GLM)
+-----------------------------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    mm_M1_16_K7168_N128
+    mm_M1_16_K7168_N256
+    mm_M1_16_K6144_N256
+    tinygemm_bf16
+
+Blackwell SM100 GEMM
+--------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    tgv_gemm_sm100
+
+Grouped GEMM (CuTe-DSL, Blackwell)
+----------------------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    grouped_gemm_nt_masked
 
 Grouped GEMM (Ampere/Hopper)
 ----------------------------

--- a/docs/api/grouped_mm.rst
+++ b/docs/api/grouped_mm.rst
@@ -1,0 +1,45 @@
+.. _api-grouped-mm:
+
+flashinfer.grouped_mm
+=====================
+
+.. currentmodule:: flashinfer.grouped_mm
+
+Grouped matrix multiplication APIs for Mixture-of-Experts (MoE) layers,
+where each expert holds its own weight matrix and tokens are routed to
+experts via an ``m_indptr`` cumulative-count tensor.
+
+The functions in this module mirror the dense ``flashinfer.gemm.mm_*``
+APIs and currently dispatch to the cuDNN MoE backend.
+
+BF16 / FP16
+-----------
+
+.. autosummary::
+    :toctree: ../generated
+
+    grouped_mm_bf16
+
+FP8
+---
+
+.. autosummary::
+    :toctree: ../generated
+
+    grouped_mm_fp8
+
+MXFP8
+-----
+
+.. autosummary::
+    :toctree: ../generated
+
+    grouped_mm_mxfp8
+
+FP4 (NVFP4 / MXFP4)
+-------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    grouped_mm_fp4

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
 
    api/attention
    api/gemm
+   api/grouped_mm
    api/fused_moe
    api/cascade
    api/comm

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -8,6 +8,9 @@ from .gemm_base import mm_fp8 as mm_fp8
 from .gemm_base import mm_mxfp8 as mm_mxfp8
 from .gemm_base import tgv_gemm_sm100 as tgv_gemm_sm100
 from .gemm_base import group_gemm_mxfp4_nt_groupwise as group_gemm_mxfp4_nt_groupwise
+from .gemm_base import (
+    group_gemm_mxfp8_mxfp4_nt_groupwise as group_gemm_mxfp8_mxfp4_nt_groupwise,
+)
 from .gemm_base import group_gemm_nvfp4_nt_groupwise as group_gemm_nvfp4_nt_groupwise
 from .gemm_base import (
     batch_deepgemm_fp8_nt_groupwise as batch_deepgemm_fp8_nt_groupwise,
@@ -70,6 +73,7 @@ __all__ = [
     "mm_mxfp8",
     "tgv_gemm_sm100",
     "group_gemm_mxfp4_nt_groupwise",
+    "group_gemm_mxfp8_mxfp4_nt_groupwise",
     "group_gemm_nvfp4_nt_groupwise",
     "batch_deepgemm_fp8_nt_groupwise",
     "group_deepgemm_fp8_nt_groupwise",

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1477,7 +1477,7 @@ def tgv_gemm_sm100(
 
     Notes
     -----
-    Requires SM100, SM103, or SM110 architecture.  Supported dtypes are
+    Requires SM100 or SM103 architecture.  Supported dtypes are
     ``torch.bfloat16`` and ``torch.float16``.
     """
     # Verify SM100 architecture support

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1450,29 +1450,35 @@ def tgv_gemm_sm100(
     pdl: bool = False,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """
-    Perform TGV GEMM on SM100 architecture with automatic dtype detection.
+    r"""Perform TGV GEMM on SM100 architecture with automatic dtype detection.
 
-    Computes: A @ B + bias
+    Computes ``out = a @ b + bias``.  Both ``a`` and ``b`` must share the same
+    floating-point dtype (``torch.bfloat16`` or ``torch.float16``).
 
-    Args:
-        a: First input tensor of shape (M, K) in row-major layout
-        b: Second input tensor of shape (K, N) in column-major layout
-        bias: Bias tensor of shape (N,)
-        pdl: Whether to use PDL (persistent data loader), defaults to False
-        out: Optional output tensor, shape (M, N), defaults to None.
+    Parameters
+    ----------
+    a : torch.Tensor
+        First input tensor of shape ``(M, K)`` in row-major layout.
+    b : torch.Tensor
+        Second input tensor of shape ``(K, N)`` in column-major layout
+        (transposed from the typical PyTorch row-major convention).
+    bias : torch.Tensor
+        Bias tensor of shape ``(N,)`` to add to each row of ``a @ b``.
+    pdl : bool
+        Whether to use PDL (Programmatic Dependent Launch).  Defaults to ``False``.
+    out : Optional[torch.Tensor]
+        Pre-allocated output tensor of shape ``(M, N)``.  If ``None``, a new
+        tensor is allocated.
 
-    Returns:
-        Output tensor of shape (M, N) in row-major layout
+    Returns
+    -------
+    torch.Tensor
+        Output tensor of shape ``(M, N)`` in row-major layout.
 
-    Supported dtypes:
-        - torch.bfloat16
-        - torch.float16
-
-    Note:
-        - Requires SM100, SM103, or SM110 architecture
-        - Input tensors a and b must have the same dtype
-        - Tensor b is expected to be in column-major layout (transposed from typical PyTorch row-major)
+    Notes
+    -----
+    Requires SM100, SM103, or SM110 architecture.  Supported dtypes are
+    ``torch.bfloat16`` and ``torch.float16``.
     """
     # Verify SM100 architecture support
     if not _match_sm_version(a.device, ["100", "103"]):
@@ -1793,8 +1799,13 @@ class SegmentGEMMWrapper:
         Parameters
         ----------
         float_workspace_buffer : torch.Tensor
-            The workspace buffer for the kernels, we use it for storing intermediate results in cutlass
-            segment GEMM kernels. Encouraged size is 128MB.
+            The workspace buffer for the kernels, we use it for storing intermediate
+            results in cutlass segment GEMM kernels.  Encouraged size is 128 MiB.
+        backend : str
+            Backend selector.  ``"auto"`` (default) lets the runtime pick the best
+            available implementation (CUTLASS Hopper if available, otherwise the
+            Ampere-compatible kernel).  Explicit values are ``"cutlass"`` for the
+            CUTLASS path and ``"sm90"`` for the SM90 specialization.
         """
         self._int_workspace_buffer = torch.empty(
             (1024 * 1024,), dtype=torch.int8, device=float_workspace_buffer.device
@@ -6668,8 +6679,36 @@ def gemm_fp8_nt_blockscaled(
 ) -> torch.Tensor:
     r"""Performs matrix multiplication with FP8 data types using block-scaled scaling.
 
-    Block-scaled scaling is a special case of groupwise scaling where the scale granularity
-    is (128, 128, 128).
+    Block-scaled scaling is a special case of groupwise scaling where the scale
+    granularity is ``(128, 128, 128)``.  See :func:`gemm_fp8_nt_groupwise` for the
+    semantics of each parameter.
+
+    Parameters
+    ----------
+    a : torch.Tensor
+        FP8 input tensor.  Shape ``(M, K)``.
+    b : torch.Tensor
+        FP8 input tensor (transposed weight).  Shape ``(N, K)``.
+    a_scale : torch.Tensor
+        FP32 block-scale tensor for ``a``, layout determined by ``scale_major_mode``.
+    b_scale : torch.Tensor
+        FP32 block-scale tensor for ``b``, layout determined by ``scale_major_mode``.
+    scale_major_mode : Optional[Literal["MN", "K"]]
+        Storage order for the scale tensors.  ``"MN"`` (default) places the
+        non-contracted dimension in the major direction; ``"K"`` places the
+        contracted dimension in the major direction.
+    mma_sm : int
+        Number of SMs to fuse per MMA (``1`` or ``2``).  Defaults to ``1``.
+    out : Optional[torch.Tensor]
+        Pre-allocated output tensor of shape ``(M, N)``.  If ``None``, a new tensor
+        is allocated.
+    out_dtype : Optional[torch.dtype]
+        Output data type.  Defaults to ``torch.bfloat16``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output tensor of shape ``(M, N)`` with dtype ``out_dtype``.
     """
     return gemm_fp8_nt_groupwise(
         a,
@@ -7281,8 +7320,9 @@ def group_gemm_nvfp4_nt_groupwise(
     tile_k: int
         The tile size for the K dimension, must be 128 or 256.
 
-    swap_ab:
-        Whether to compute ``Output^T = Weight^T Activation^T`` instead of ``Output = Activation Weight``.
+    swap_ab : bool
+        Whether to compute ``Output^T = Weight^T Activation^T`` instead of
+        ``Output = Activation Weight``.  Defaults to ``True``.
 
     out: Optional[torch.Tensor]
         The output tensor, shape ``(cum_m, n)``. If not specified, we will create an output tensor explicitly.

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1804,8 +1804,10 @@ class SegmentGEMMWrapper:
         backend : str
             Backend selector.  ``"auto"`` (default) lets the runtime pick the best
             available implementation (CUTLASS Hopper if available, otherwise the
-            Ampere-compatible kernel).  Explicit values are ``"cutlass"`` for the
-            CUTLASS path and ``"sm90"`` for the SM90 specialization.
+            Ampere-compatible kernel).  Explicit values are ``"sm80"`` for the
+            SM80/Ampere CUTLASS path and ``"sm90"`` for the SM90 Hopper
+            specialization (see :func:`run` dispatch in
+            ``flashinfer/gemm/gemm_base.py``).
         """
         self._int_workspace_buffer = torch.empty(
             (1024 * 1024,), dtype=torch.int8, device=float_workspace_buffer.device

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -3596,7 +3596,15 @@ def grouped_gemm_nt_masked(
         If ``True``, swap the ``lhs``/``rhs`` input tensors.  Defaults to
         ``False``.
     **kwargs
-        Reserved for forward-compatible kernel options (currently unused).
+        Additional keyword arguments.  Currently recognized:
+
+        * ``alpha`` (``Optional[torch.Tensor]``): per-batch scaling factor
+          tensor applied to the accumulated output before writing back.
+        * ``alpha_dtype`` (``Optional[str]``): elemental dtype for the
+          ``alpha`` tensor, used when the kernel needs to interpret it
+          (defaults to inferring from ``alpha.dtype``).
+
+        Other entries are reserved for forward-compatible kernel options.
 
     Notes
     -----

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -3544,7 +3544,8 @@ def grouped_gemm_nt_masked(
         tensor.  ``B`` has logical shape ``(n, k, l)``
         (physically ``(l, n, k)``; FP4 with 8-bit storage is
         ``(n, k/2, l)``).  ``SFB`` has logical shape
-        ``(n32, n4, rn, k4, rk, l)``.
+        ``(n32, n4, rn, k4, rk, l)``
+        (physically ``(l, rn, rk, n32, n4, k4)``).
     out : torch.Tensor
         Output tensor of shape ``(l, m, n)``.  Mutated in place.
     masked_m : torch.Tensor
@@ -3598,11 +3599,19 @@ def grouped_gemm_nt_masked(
     **kwargs
         Additional keyword arguments.  Currently recognized:
 
-        * ``alpha`` (``Optional[torch.Tensor]``): per-batch scaling factor
-          tensor applied to the accumulated output before writing back.
-        * ``alpha_dtype`` (``Optional[str]``): elemental dtype for the
-          ``alpha`` tensor, used when the kernel needs to interpret it
-          (defaults to inferring from ``alpha.dtype``).
+        * ``mma_tiler_mn`` (``Tuple[int, int]``): shape of the MMA tiler
+          ``(M, N)``.  Defaults to ``(128, 128)``.  ``mma_tiler_mn[0] == 256``
+          enables the 2-CTA MMA path.  Must be ``(128, 128)`` when
+          ``is_combine_fusion=True``.
+        * ``cluster_shape_mn`` (``Tuple[int, int]``): shape of the CTA
+          cluster ``(ClusterM, ClusterN)``.  Defaults to ``(1, 1)``.
+        * ``alpha`` (``Optional[torch.Tensor]``): optional 1-D tensor of
+          shape ``(l,)`` containing per-batch scaling factors.  When
+          provided, each batch output is multiplied by its corresponding
+          alpha value: ``out = alpha * (A @ B)``.
+        * ``alpha_dtype`` (``str``): elemental dtype string for the
+          ``alpha`` tensor (e.g. ``"float32"``).  Required when ``alpha``
+          is provided.
 
         Other entries are reserved for forward-compatible kernel options.
 
@@ -3621,9 +3630,9 @@ def grouped_gemm_nt_masked(
     * ``k4 * rk`` equals ``K``, where ``K`` is ``k / sf_vec_size`` padded up to
       the nearest multiple of 4.
 
-    Masking is applied per batch via ``masked_m``.  If ``alpha`` is bound by
-    the kernel registry, each batch output is multiplied by its corresponding
-    alpha value: ``out = alpha * (A @ B)``.
+    Masking is applied per batch via ``masked_m``.  When ``alpha`` is
+    provided (see ``**kwargs``), each batch output is multiplied by its
+    corresponding alpha value: ``out = alpha * (A @ B)``.
     """
 
     if is_swap_ab:

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -3524,48 +3524,98 @@ def grouped_gemm_nt_masked(
     is_swap_ab: bool = False,
     **kwargs,
 ):
-    """
-    Executes a masked, batched matrix multiplication (GEMM) with scale factors and optional alpha scaling at output.
+    r"""Masked, batched, block-scaled GEMM on Blackwell SM100.
 
-    Args:
-        lhs (Tuple[torch.Tensor, torch.Tensor]): Tuple containing the left-hand side input tensor (A) and its scale factor tensor (SFA).
-            - A should be in (m, k, l) order, but physically (l, m, k). For fp4 tensor with 8-bit storage, we expect the shape to be (m, k/2, l).
-            - SFA should be in (m32, m4, rm, k4, rk, l) order, but physically (l, rm, rk, m32, m4, k4)
-        rhs (Tuple[torch.Tensor, torch.Tensor]): Tuple containing the right-hand side input tensor (B) and its scale factor tensor (SFB).
-            - B should be in (n, k, l) order, but physically (l, n, k). For fp4 tensor with 8-bit storage, we expect the shape to be (n, k/2, l).
-            - SFB should be in (n32, n4, rn, k4, rk, l) order, but physically (l, rn, rk, n32, n4, k4)
-        out (torch.Tensor): Output tensor to store the result, with shape (l, m, n).
-        masked_m (torch.Tensor): 1D tensor of shape (l,) specifying the valid row count for each batch (used for masking).
-        ab_dtype (str): Data type for A and B matrices. Supported: "float4_e2m1fn", "float8_e4m3fn", "float8_e5m2".
-        topk_weights (torch.Tensor, optional): 2D tensor of shape (l, m) containing top-k weights (float32). Default: None.
-        idx_src_info (torch.Tensor, optional): 2D tensor of shape (l, m) containing source index info (int32). Default: None.
-        rank_src_info (torch.Tensor, optional): 2D tensor of shape (l, m) containing rank source info (int32). Default: None.
-        out_ptrs (torch.Tensor, optional): 1D tensor of shape (num_ranks,) containing output pointers (int64). Default: None.
-        num_ranks (int, optional): Number of ranks. Default: 0.
-        sf_dtype (str): Data type for scale factors. Supported: "float8_e8m0fnu", "float8_e4m3fn".
-        c_dtype (str): Data type for output matrix C. Supported: "float16", "bfloat16", "float32", "float8_e4m3fn", "float8_e5m2".
-        sf_vec_size (int): Vector size for scale factors. Typically 16 or 32.
-        sm_count (int, optional): Number of SMs to use. Default: max available SMs under the CTA configuration.
-        mma_tiler_mn (Tuple[int, int], optional): Shape of the MMA tiler (M, N). Default: (128, 128).
-        cluster_shape_mn (Tuple[int, int], optional): Shape of the CTA cluster (ClusterM, ClusterN). Default: (1, 1).
-        alpha_dtype (str, optional): Data type for alpha scaling factors.
-        alpha (torch.Tensor, optional): Optional 1D tensor of shape (l,) containing per-batch scaling factors. Perform per-batch scaling out = alpha * out.
-        barrier_flag_local (torch.Tensor, optional): 1D tensor of shape (sm_count,) containing int32 flags for local barrier synchronization.
-            Used for spin-lock wait in multi-rank distributed operations. Default: None.
-        barrier_flag_multicast (torch.Tensor, optional): 1D tensor of shape (sm_count,) containing int32 flags for multicast barrier synchronization.
-            Used to release barrier flags across ranks in distributed operations. Default: None.
-        is_combine_fusion (bool): If True, enables fused gemm+combine operation mode. Default: False.
-        is_swap_ab (bool): If True, swaps the AB input tensors. Default: False.
-    Notes:
-        - Legends of the input tensors:
-            * `l` is the batch size, `m/n` is the number of rows, and `k` is the number of columns.
-            * `m/n32`, `m/n4`, `k4` are constant values 32, 4, 4 respectively.
-            * `m32 * m4 * rm` should be same as `M`, which is `m` padded up to the nearest multiple of 128.
-            * `n32 * n4 * rn` should be same as `N`, which is `n` padded up to the nearest multiple of 128.
-            * `k4 * rk` should be same as `K`, which is `k / sf_vec_size` padded up to the nearest multiple of 4.
-        - The function applies masking per batch using masked_m.
-        - If alpha is provided, each batch output is multiplied by its corresponding alpha value. out = alpha * (A @ B).
-        - The result is written to c_tensor.
+    Executes a masked, batched matrix multiplication with scale factors and
+    optional per-batch alpha scaling on the output.  ``alpha`` is currently
+    applied internally by the kernel; see Notes for the canonical tensor
+    layouts.
+
+    Parameters
+    ----------
+    lhs : Tuple[torch.Tensor, torch.Tensor]
+        ``(A, SFA)`` — left-hand-side input tensor and its scale-factor tensor.
+        ``A`` has logical shape ``(m, k, l)`` (physically ``(l, m, k)``);
+        for FP4 with 8-bit storage the physical shape is ``(m, k/2, l)``.
+        ``SFA`` has logical shape ``(m32, m4, rm, k4, rk, l)``
+        (physically ``(l, rm, rk, m32, m4, k4)``).
+    rhs : Tuple[torch.Tensor, torch.Tensor]
+        ``(B, SFB)`` — right-hand-side input tensor and its scale-factor
+        tensor.  ``B`` has logical shape ``(n, k, l)``
+        (physically ``(l, n, k)``; FP4 with 8-bit storage is
+        ``(n, k/2, l)``).  ``SFB`` has logical shape
+        ``(n32, n4, rn, k4, rk, l)``.
+    out : torch.Tensor
+        Output tensor of shape ``(l, m, n)``.  Mutated in place.
+    masked_m : torch.Tensor
+        1-D ``int32`` tensor of shape ``(l,)`` giving the valid row count of
+        each batch.  Rows above ``masked_m[batch]`` are ignored.
+    ab_dtype : str
+        Data type for ``A`` and ``B``.  One of ``"float4_e2m1fn"``,
+        ``"float8_e4m3fn"``, ``"float8_e5m2"``.
+    sf_dtype : str
+        Data type for the scale factors.  One of ``"float8_e8m0fnu"`` or
+        ``"float8_e4m3fn"``.
+    c_dtype : str
+        Data type for output matrix ``C``.  One of ``"float16"``,
+        ``"bfloat16"``, ``"float32"``, ``"float8_e4m3fn"``, ``"float8_e5m2"``.
+    sf_vec_size : int
+        Vector size for scale factors (typically 16 or 32).
+    topk_weights : Optional[torch.Tensor]
+        2-D ``float32`` tensor of shape ``(l, m)`` containing top-k routing
+        weights.  Defaults to ``None``.
+    idx_src_info : Optional[torch.Tensor]
+        2-D ``int32`` tensor of shape ``(l, m)`` carrying source-index metadata
+        for the combine fusion path.  Defaults to ``None``.
+    rank_src_info : Optional[torch.Tensor]
+        2-D ``int32`` tensor of shape ``(l, m)`` carrying rank-source metadata
+        for the combine fusion path.  Defaults to ``None``.
+    out_ptrs : Optional[torch.Tensor]
+        1-D ``int64`` tensor of shape ``(num_ranks,)`` containing remote output
+        pointers for multi-rank combine.  Defaults to ``None``.
+    num_ranks : int
+        Number of ranks participating in the combine path.  Defaults to ``0``.
+    dst_signals : Optional[torch.Tensor]
+        Optional 1-D signal tensor used by the combine-fusion path to notify
+        consumers.  Defaults to ``None``.
+    sm_count : Optional[int]
+        Number of SMs to use.  If ``None``, the runtime picks the max available
+        under the CTA configuration.
+    barrier_flag_local : Optional[torch.Tensor]
+        1-D ``int32`` tensor of shape ``(sm_count,)`` containing flags for
+        local barrier synchronization (spin-lock wait in multi-rank ops).
+        Defaults to ``None``.
+    barrier_flag_multicast : Optional[torch.Tensor]
+        1-D ``int32`` tensor of shape ``(sm_count,)`` containing flags for
+        multicast barrier synchronization (release across ranks).  Defaults to
+        ``None``.
+    is_combine_fusion : bool
+        If ``True``, enable the fused GEMM + combine operation mode.  Defaults
+        to ``False``.
+    is_swap_ab : bool
+        If ``True``, swap the ``lhs``/``rhs`` input tensors.  Defaults to
+        ``False``.
+    **kwargs
+        Reserved for forward-compatible kernel options (currently unused).
+
+    Notes
+    -----
+    Tensor-layout conventions:
+
+    * ``l`` is the batch size, ``m``/``n`` are the row/column counts, and
+      ``k`` is the contraction dimension.
+    * ``m/n32``, ``m/n4``, ``k4`` are the constants ``32``, ``4``, ``4``
+      respectively.
+    * ``m32 * m4 * rm`` equals ``M``, where ``M`` is ``m`` padded up to the
+      nearest multiple of 128.
+    * ``n32 * n4 * rn`` equals ``N``, where ``N`` is ``n`` padded up to the
+      nearest multiple of 128.
+    * ``k4 * rk`` equals ``K``, where ``K`` is ``k / sf_vec_size`` padded up to
+      the nearest multiple of 4.
+
+    Masking is applied per batch via ``masked_m``.  If ``alpha`` is bound by
+    the kernel registry, each batch output is multiplied by its corresponding
+    alpha value: ``out = alpha * (A @ B)``.
     """
 
     if is_swap_ab:

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -174,10 +174,12 @@ def mm_M1_16_K7168_N128(
 ) -> None:
     r"""Optimized GEMM for the router operation in Mistral Large 3.
 
-    Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a small batch of token
-    embeddings (1-16 rows) and ``mat_b`` is the expert routing weight matrix.
-    Specialized for the dimensions used in Mistral Large 3 MoE
-    (``K = 7168``, ``N = 128``).
+    Performs a highly optimized matrix multiplication specifically tailored
+    for the expert routing GEMM in Mistral Large 3's Mixture-of-Experts
+    (MoE) architecture.  Computes ``out = mat_a @ mat_b`` where ``mat_a``
+    is a small batch of token embeddings (1-16 rows) and ``mat_b`` is the
+    expert routing weight matrix.  Specialized for the dimensions used in
+    Mistral Large 3 MoE (``K = 7168``, ``N = 128``).
 
     Parameters
     ----------
@@ -218,10 +220,12 @@ def mm_M1_16_K7168_N256(
 ) -> None:
     r"""Optimized GEMM for the router operation in DeepSeek-V3.
 
-    Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a small batch of token
-    embeddings (1-16 rows) and ``mat_b`` is the expert routing weight matrix.
-    Specialized for the dimensions used in DeepSeek-V3 MoE
-    (``K = 7168``, ``N = 256``).
+    Performs a highly optimized matrix multiplication specifically tailored
+    for the expert routing GEMM in DeepSeek-V3's Mixture-of-Experts (MoE)
+    architecture.  Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a
+    small batch of token embeddings (1-16 rows) and ``mat_b`` is the expert
+    routing weight matrix.  Specialized for the dimensions used in
+    DeepSeek-V3 MoE (``K = 7168``, ``N = 256``).
 
     Parameters
     ----------
@@ -241,9 +245,11 @@ def mm_M1_16_K7168_N256(
 
     Notes
     -----
-    Requires Blackwell SM100/SM103 architecture.  Raises ``ValueError`` if tensor
-    dimensions, strides, or dtypes do not match the expected DeepSeek-V3 router
-    configuration.
+    Requires Blackwell SM100/SM103 architecture.  The specialized
+    problem-size optimization makes this significantly faster than
+    general-purpose GEMM implementations for the router op.  Raises
+    ``ValueError`` if tensor dimensions, strides, or dtypes do not match the
+    expected DeepSeek-V3 router configuration.
     """
     get_dsv3_router_gemm_module().mm_M1_16_K7168_N256(
         mat_a, mat_b, out, launch_with_pdl
@@ -260,10 +266,12 @@ def mm_M1_16_K6144_N256(
 ) -> None:
     r"""Optimized GEMM for the router operation in GLM-MoE-DSA.
 
-    Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a small batch of token
-    embeddings (1-16 rows) and ``mat_b`` is the expert routing weight matrix.
-    Specialized for the dimensions used in GLM-MoE-DSA
-    (``K = 6144``, ``N = 256``).
+    Performs a highly optimized matrix multiplication specifically tailored
+    for the expert routing GEMM in GLM-MoE-DSA's Mixture-of-Experts (MoE)
+    architecture.  Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a
+    small batch of token embeddings (1-16 rows) and ``mat_b`` is the expert
+    routing weight matrix.  Specialized for the dimensions used in
+    GLM-MoE-DSA (``K = 6144``, ``N = 256``).
 
     Parameters
     ----------
@@ -283,9 +291,11 @@ def mm_M1_16_K6144_N256(
 
     Notes
     -----
-    Requires Blackwell SM100/SM103 architecture.  Raises ``ValueError`` if tensor
-    dimensions, strides, or dtypes do not match the expected GLM-MoE-DSA
-    configuration.
+    Requires Blackwell SM100/SM103 architecture.  The specialized
+    problem-size optimization makes this significantly faster than
+    general-purpose GEMM implementations for the router op.  Raises
+    ``ValueError`` if tensor dimensions, strides, or dtypes do not match the
+    expected GLM-MoE-DSA configuration.
     """
     get_dsv3_router_gemm_module().mm_M1_16_K6144_N256(
         mat_a, mat_b, out, launch_with_pdl
@@ -403,11 +413,12 @@ def tinygemm_bf16(
 
     A latency-optimized, warp-specialized GEMM designed for tiny batch sizes
     (ideally 1-8 rows, where a single ``TILE_N=8`` tile covers the entire batch
-    dimension).  Uses TMA for async bulk data loads and ``mma.sync.aligned.m16n8k16``
-    tensor-core instructions with BF16 input/weight/bias/output and FP32 internal
-    accumulation.  The warp-specialized design (384 threads: 4 compute + 8 DMA
-    warps) with 16 pipeline stages and 4x stage unroll trades off peak throughput
-    in favor of minimal latency.  Adapted from the TensorRT-LLM ``tinygemm2`` kernel.
+    dimension) using Ampere-style HMMA instructions.  Uses TMA for async bulk
+    data loads and ``mma.sync.aligned.m16n8k16`` tensor-core instructions with
+    BF16 input/weight/bias/output and FP32 internal accumulation.  The
+    warp-specialized design (384 threads: 4 compute + 8 DMA warps) with 16
+    pipeline stages and 4x stage unroll trades off peak throughput in favor of
+    minimal latency.  Adapted from the TensorRT-LLM ``tinygemm2`` kernel.
 
     Parameters
     ----------

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -172,42 +172,36 @@ def mm_M1_16_K7168_N128(
     out: torch.Tensor,
     launch_with_pdl: bool = True,
 ) -> None:
-    """Optimized GEMM for the router operation in Mistral Large 3.
+    r"""Optimized GEMM for the router operation in Mistral Large 3.
 
-    This function performs a highly optimized matrix multiplication specifically tailored
-    for the expert routing GEMM in Mistral Large 3's Mixture of Experts (MoE) architecture.
-    It computes out = mat_a @ mat_b where mat_a contains token embeddings and mat_b
-    contains expert routing weights.
+    Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a small batch of token
+    embeddings (1-16 rows) and ``mat_b`` is the expert routing weight matrix.
+    Specialized for the dimensions used in Mistral Large 3 MoE
+    (``K = 7168``, ``N = 128``).
 
-    The implementation is optimized for the specific problem dimensions used in Mistral Large 3:
-    - Hidden dimension (K): 7168
-    - Number of experts (N): 128
-    - Number of tokens (M): 1-16
+    Parameters
+    ----------
+    mat_a : torch.Tensor
+        Input token embeddings of shape ``(M, K)`` where ``M`` is the number of
+        tokens (1-16) and ``K`` is the hidden dimension (7168).  Must be bfloat16,
+        row-major (contiguous).
+    mat_b : torch.Tensor
+        Expert routing weights of shape ``(K, N)`` where ``N`` is the number of
+        experts (128).  Must be bfloat16, column-major (transposed layout).
+    out : torch.Tensor
+        Pre-allocated output tensor of shape ``(M, N)`` containing the routing
+        scores.  Must be bfloat16, row-major (contiguous).  Mutated in place.
+    launch_with_pdl : bool
+        Whether to launch the kernel using Programmatic Dependent Launch.
+        Defaults to ``True``.
 
-    Args:
-        mat_a (torch.Tensor): Input token embeddings of shape (M, K) where M is the number
-            of tokens (1-16) and K is the hidden dimension (7168). Must be bfloat16,
-            row-major (contiguous).
-        mat_b (torch.Tensor): Expert routing weights of shape (K, N) where K is the hidden
-            dimension (7168) and N is the number of experts (128). Must be bfloat16,
-            column-major (transposed layout).
-        out (torch.Tensor): Pre-allocated output tensor of shape (M, N) containing the
-            routing scores. Must be bfloat16, row-major (contiguous). This tensor is
-            mutated in-place.
-        launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to True.
-
-    Returns:
-        None: The result is written directly to the `out` tensor.
-
-    Raises:
-        ValueError: If tensor dimensions, strides, or data types do not match the
-            expected Mistral Large 3 router configuration.
-
-    Note:
-        This kernel is specialized for compute capability 10.0 (Blackwell architecture).
-        The specific problem size optimization makes this significantly faster than
-        general-purpose GEMM implementations for the router operation.
+    Notes
+    -----
+    Requires Blackwell SM100/SM103 architecture.  The specialized problem-size
+    optimization makes this significantly faster than general-purpose GEMM
+    implementations for the router op.  Raises ``ValueError`` if tensor
+    dimensions, strides, or dtypes do not match the expected Mistral Large 3
+    configuration.
     """
     get_dsv3_router_gemm_module().mm_M1_16_K7168_N128(
         mat_a, mat_b, out, launch_with_pdl
@@ -222,42 +216,34 @@ def mm_M1_16_K7168_N256(
     out: torch.Tensor,
     launch_with_pdl: bool = True,
 ) -> None:
-    """Optimized GEMM for the router operation in DeepSeek-V3.
+    r"""Optimized GEMM for the router operation in DeepSeek-V3.
 
-    This function performs a highly optimized matrix multiplication specifically tailored
-    for the expert routing GEMM in DeepSeek-V3's Mixture of Experts (MoE) architecture.
-    It computes out = mat_a @ mat_b where mat_a contains token embeddings and mat_b
-    contains expert routing weights.
+    Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a small batch of token
+    embeddings (1-16 rows) and ``mat_b`` is the expert routing weight matrix.
+    Specialized for the dimensions used in DeepSeek-V3 MoE
+    (``K = 7168``, ``N = 256``).
 
-    The implementation is optimized for the specific problem dimensions used in DeepSeek-V3:
-    - Hidden dimension (K): 7168
-    - Number of experts (N): 256
-    - Number of tokens (M): 1-16
+    Parameters
+    ----------
+    mat_a : torch.Tensor
+        Input token embeddings of shape ``(M, K)`` where ``M`` is the number of
+        tokens (1-16) and ``K`` is the hidden dimension (7168).  Must be bfloat16,
+        row-major (contiguous).
+    mat_b : torch.Tensor
+        Expert routing weights of shape ``(K, N)`` where ``N`` is the number of
+        experts (256).  Must be bfloat16, column-major (transposed layout).
+    out : torch.Tensor
+        Pre-allocated output tensor of shape ``(M, N)`` containing the routing
+        scores.  Must be float32, row-major (contiguous).  Mutated in place.
+    launch_with_pdl : bool
+        Whether to launch the kernel using Programmatic Dependent Launch.
+        Defaults to ``True``.
 
-    Args:
-        mat_a (torch.Tensor): Input token embeddings of shape (M, K) where M is the number
-            of tokens (1-16) and K is the hidden dimension (7168). Must be bfloat16,
-            row-major (contiguous).
-        mat_b (torch.Tensor): Expert routing weights of shape (K, N) where K is the hidden
-            dimension (7168) and N is the number of experts (256). Must be bfloat16,
-            column-major (transposed layout).
-        out (torch.Tensor): Pre-allocated output tensor of shape (M, N) containing the
-            routing scores. Must be float32, row-major (contiguous). This tensor is
-            mutated in-place.
-        launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to True.
-
-    Returns:
-        None: The result is written directly to the `out` tensor.
-
-    Raises:
-        ValueError: If tensor dimensions, strides, or data types do not match the
-            expected DeepSeek-V3 router configuration.
-
-    Note:
-        This kernel is specialized for compute capability 10.0 (Blackwell architecture).
-        The specific problem size optimization makes this significantly faster than
-        general-purpose GEMM implementations for the router operation.
+    Notes
+    -----
+    Requires Blackwell SM100/SM103 architecture.  Raises ``ValueError`` if tensor
+    dimensions, strides, or dtypes do not match the expected DeepSeek-V3 router
+    configuration.
     """
     get_dsv3_router_gemm_module().mm_M1_16_K7168_N256(
         mat_a, mat_b, out, launch_with_pdl
@@ -272,40 +258,34 @@ def mm_M1_16_K6144_N256(
     out: torch.Tensor,
     launch_with_pdl: bool = True,
 ) -> None:
-    """Optimized GEMM for the router operation in GLM-MoE-DSA.
+    r"""Optimized GEMM for the router operation in GLM-MoE-DSA.
 
-    This function performs a highly optimized matrix multiplication specifically tailored
-    for the expert routing GEMM in GLM-MoE-DSA's Mixture of Experts (MoE) architecture.
-    It computes out = mat_a @ mat_b where mat_a contains token embeddings and mat_b
-    contains expert routing weights.
+    Computes ``out = mat_a @ mat_b`` where ``mat_a`` is a small batch of token
+    embeddings (1-16 rows) and ``mat_b`` is the expert routing weight matrix.
+    Specialized for the dimensions used in GLM-MoE-DSA
+    (``K = 6144``, ``N = 256``).
 
-    The implementation is optimized for the specific problem dimensions used in GLM-MoE-DSA:
-    - Hidden dimension (K): 6144
-    - Number of experts (N): 256
-    - Number of tokens (M): 1-16
+    Parameters
+    ----------
+    mat_a : torch.Tensor
+        Input token embeddings of shape ``(M, K)`` where ``M`` is the number of
+        tokens (1-16) and ``K`` is the hidden dimension (6144).  Must be bfloat16,
+        row-major (contiguous).
+    mat_b : torch.Tensor
+        Expert routing weights of shape ``(K, N)`` where ``N`` is the number of
+        experts (256).  Must be bfloat16, column-major (transposed layout).
+    out : torch.Tensor
+        Pre-allocated output tensor of shape ``(M, N)`` containing the routing
+        scores.  Must be float32, row-major (contiguous).  Mutated in place.
+    launch_with_pdl : bool
+        Whether to launch the kernel using Programmatic Dependent Launch.
+        Defaults to ``True``.
 
-    Args:
-        mat_a (torch.Tensor): Input token embeddings of shape (M, K) where M is the number
-            of tokens (1-16) and K is the hidden dimension (6144). Must be bfloat16,
-            row-major (contiguous).
-        mat_b (torch.Tensor): Expert routing weights of shape (K, N) where K is the hidden
-            dimension (6144) and N is the number of experts (256). Must be bfloat16,
-            column-major (transposed layout).
-        out (torch.Tensor): Pre-allocated output tensor of shape (M, N) containing the
-            routing scores. Must be float32, row-major (contiguous). This tensor is
-            mutated in-place.
-        launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to True.
-
-    Returns:
-        None: The result is written directly to the `out` tensor.
-
-    Raises:
-        ValueError: If tensor dimensions, strides, or data types do not match the
-            expected GLM-MoE-DSA router configuration.
-
-    Note:
-        This kernel is specialized for compute capability 10.0 (Blackwell architecture).
+    Notes
+    -----
+    Requires Blackwell SM100/SM103 architecture.  Raises ``ValueError`` if tensor
+    dimensions, strides, or dtypes do not match the expected GLM-MoE-DSA
+    configuration.
     """
     get_dsv3_router_gemm_module().mm_M1_16_K6144_N256(
         mat_a, mat_b, out, launch_with_pdl
@@ -419,38 +399,42 @@ def tinygemm_bf16(
     bias: Optional[torch.Tensor] = None,
     use_pdl: bool = False,
 ) -> None:
-    """SM90+ optimized small GEMM: out = input @ weight.T + bias (equivalent to F.linear).
+    r"""SM90+ optimized small GEMM: ``out = input @ weight.T + bias`` (equivalent to F.linear).
 
-    A latency-optimized, warp-specialized GEMM designed for tiny batch sizes (ideally
-    1-8 rows, where a single TILE_N=8 tile covers the entire batch dimension) using
-    Ampere-style HMMA instructions. Uses TMA for async bulk data loads and
-    mma.sync.aligned.m16n8k16 tensor core instructions with BF16 input/weight/bias/output
-    and FP32 internal accumulation. The warp-specialized design (384 threads: 4 compute +
-    8 DMA warps) with 16 pipeline stages and 4x stage unroll trades off peak throughput
-    in favor of minimal latency.
+    A latency-optimized, warp-specialized GEMM designed for tiny batch sizes
+    (ideally 1-8 rows, where a single ``TILE_N=8`` tile covers the entire batch
+    dimension).  Uses TMA for async bulk data loads and ``mma.sync.aligned.m16n8k16``
+    tensor-core instructions with BF16 input/weight/bias/output and FP32 internal
+    accumulation.  The warp-specialized design (384 threads: 4 compute + 8 DMA
+    warps) with 16 pipeline stages and 4x stage unroll trades off peak throughput
+    in favor of minimal latency.  Adapted from the TensorRT-LLM ``tinygemm2`` kernel.
 
-    From TensorRT-LLM tinygemm2 kernel.
+    Parameters
+    ----------
+    input : torch.Tensor
+        Input activations of shape ``(batch_size, input_features)``.  Must be
+        bfloat16, contiguous.  ``input_features`` must be a multiple of 64.
+    weight : torch.Tensor
+        Weight matrix of shape ``(output_features, input_features)``.  Must be
+        bfloat16, contiguous (row-major).  ``output_features`` must be a multiple
+        of 16.
+    out : torch.Tensor
+        Pre-allocated output tensor of shape ``(batch_size, output_features)``.
+        Must be bfloat16, contiguous.  Mutated in place.
+    bias : Optional[torch.Tensor]
+        Optional bias vector of shape ``(output_features,)``.  Must be bfloat16,
+        contiguous.  If ``None``, zero bias is used.
+    use_pdl : bool
+        Enable Programmatic Dependent Launch (stream serialization).  When
+        ``True``, the kernel uses ``cudaGridDependencySynchronize()`` to overlap
+        DMA with the preceding kernel's compute.  Only enable when ALL preceding
+        stream operations also use PDL, otherwise the kernel hangs.  Defaults to
+        ``False``.
 
-    Args:
-        input: Input activations of shape (batch_size, input_features). Must be
-            bfloat16, contiguous. input_features must be a multiple of 64.
-        weight: Weight matrix of shape (output_features, input_features). Must be
-            bfloat16, contiguous (row-major). output_features must be a multiple of 16.
-        out: Pre-allocated output tensor of shape (batch_size, output_features).
-            Must be bfloat16, contiguous. Mutated in-place.
-        bias: Optional bias vector of shape (output_features,). Must be bfloat16,
-            contiguous. If None, zero bias is used.
-        use_pdl: Enable Programmatic Dependent Launch (stream serialization).
-            When True, the kernel uses cudaGridDependencySynchronize() to overlap
-            DMA with the preceding kernel's compute. Only enable when ALL preceding
-            stream operations also use PDL, otherwise the kernel hangs. Defaults
-            to False.
-
-    Raises:
-        ValueError: If tensor dimensions, dtypes, or alignment constraints are violated.
-
-    Note:
-        This kernel requires SM90+ (Hopper or newer).
+    Notes
+    -----
+    Requires SM90+ (Hopper or newer).  Raises ``ValueError`` if tensor
+    dimensions, dtypes, or alignment constraints are violated.
     """
     if bias is None:
         get_tinygemm2_module().tinygemm2_nobias_op(input, weight, out, use_pdl)

--- a/flashinfer/grouped_mm/core.py
+++ b/flashinfer/grouped_mm/core.py
@@ -115,6 +115,9 @@ def grouped_mm_bf16(
         Output data type.  ``torch.bfloat16`` (default) or ``torch.float16``, ``torch.float32``.
     backend : str
         Backend selector.  Currently only ``"cudnn"`` is supported.
+    tactic : int
+        cuDNN execution-plan index.  ``-1`` (default) uses the heuristic-best
+        plan; non-negative values select a specific plan.
 
     Returns
     -------
@@ -389,6 +392,9 @@ def grouped_mm_mxfp8(
         Output data type.  ``torch.bfloat16`` (default) or ``torch.float16``, ``torch.float32``.
     backend : str
         Backend selector.  Currently only ``"cudnn"`` is supported.
+    tactic : int
+        cuDNN execution-plan index.  ``-1`` (default) uses the heuristic-best
+        plan; non-negative values select a specific plan.
 
     Returns
     -------
@@ -548,8 +554,15 @@ def grouped_mm_fp4(
         Pre-allocated output ``(m_out, n)``.
     out_dtype : torch.dtype
         Output data type.  ``torch.bfloat16`` (default) or ``torch.float16``, ``torch.float32``.
+    block_size : int
+        Block size used for the FP4 scale layout.  ``16`` selects NVFP4 (with
+        ``float8_e4m3fn`` scales) and ``32`` selects MXFP4 (with ``uint8``
+        scales).  Defaults to ``16``.
     backend : str
         Backend selector.  Currently only ``"cudnn"`` is supported.
+    tactic : int
+        cuDNN execution-plan index.  ``-1`` (default) uses the heuristic-best
+        plan; non-negative values select a specific plan.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- `docs/api/gemm.rst`: documents `mm_fp8`, `tgv_gemm_sm100`, router gemm, masked grouped GEMM, and the canonical `SegmentGEMMWrapper`/`mm_fp4` entry points.
- New `docs/api/grouped_mm.rst` for the grouped GEMM module (wired into `docs/index.rst`).
- Canonicalizes the public name for `group_gemm_mxfp8_mxfp4` (alias `group_gemm_mxfp4_nt_groupwise` kept for back-compat; only the canonical name is autosummarized to avoid `sphinx -W` duplicate-object warnings).
- Removes redundant `.. automethod:: run` from `SegmentGEMMWrapper` (covered by `:members:`).
- Adds NumPy-style `Parameters` sections where docstrings were Google-style or missing.

## Why this PR (split rationale)
GEMM and grouped_mm have overlapping but distinct codeowners (`@dhiraj113 @aleozlx @bkryu` core, `@jiahanc @IwakuraRein @samuellees @nv-yunzheq` for grouped). Keeping them in one PR lets a single review pass cover both directories without diff-skipping.

## Review notes
- Zero behavior changes; this is doc + autosummary curation only.
- The `group_gemm_mxfp8_mxfp4` canonical name was already the recommended import path — confirm the alias is still exported for back-compat.

## Part of the v0.6.12 docs cleanup
PR-2 of 8. See PR-1 attention, PR-3 fused_moe, PR-4a/4b comm, PR-5 misc, PR-6 quant, PR-7 infra.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API reference for GEMM with new sections for FP8/FP4 mixed precision, Router GEMM variants, Blackwell SM100, and grouped GEMM; updated index to include grouped_mm.
  * Enhanced and reformatted docstrings across GEMM and grouped-MM APIs for clearer parameters, notes, and usage guidance.

* **New Features**
  * Added grouped matrix multiplication API docs and publicly exported a new grouped GEMM kernel for mixed-precision workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->