### PR TITLE
docs(moe): close fused_moe / trtllm_*_moe / CuteDSL MoE doc gaps

### DIFF
--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -26,6 +26,7 @@ Utility Functions
     reorder_rows_for_gated_act_gemm
     interleave_moe_weights_for_sm90_mixed_gemm
     interleave_moe_scales_for_sm90_mixed_gemm
+    fused_topk_deepseek
 
 CUTLASS Fused MoE
 -----------------
@@ -41,6 +42,38 @@ TensorRT-LLM Fused MoE
 .. autosummary::
     :toctree: ../generated
 
+    trtllm_bf16_moe
+    trtllm_bf16_routed_moe
     trtllm_fp4_block_scale_moe
+    trtllm_fp4_block_scale_routed_moe
     trtllm_fp8_block_scale_moe
+    trtllm_fp8_block_scale_routed_moe
     trtllm_fp8_per_tensor_scale_moe
+    trtllm_mxint4_block_scale_moe
+    trtllm_mxint4_block_scale_routed_moe
+
+CuteDSL Fused MoE
+-----------------
+
+The CuteDSL backends are conditionally available when the
+``nvidia-cutlass-dsl`` package is installed.
+
+.. autosummary::
+    :toctree: ../generated
+
+    cute_dsl_fused_moe_nvfp4
+    b12x_fused_moe
+
+.. autoclass:: CuteDslMoEWrapper
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+.. autoclass:: B12xMoEWrapper
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+    .. automethod:: __init__

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -388,9 +388,11 @@ def moe_a2a_combine(
     ----------
     payload : torch.Tensor
         Output payload to send back to the source ranks.  Shape
-        ``[ep_size, runtime_max_tokens_per_rank, *]`` when
-        ``payload_in_workspace`` is ``False`` and ``[local_num_tokens, *]``
-        when ``True``.
+        ``[ep_size, runtime_max_tokens_per_rank, *]`` regardless of
+        ``payload_in_workspace``: in both cases the payload holds the
+        per-expert-rank outputs to be combined back to the source ranks.
+        Only the backing memory differs (caller-supplied vs. workspace-backed
+        view produced by :meth:`MoeAlltoAll.get_combine_payload_tensor_in_workspace`).
     local_num_tokens : int
         Number of tokens originally dispatched from this rank.
     workspace : torch.Tensor

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -205,6 +205,32 @@ def moe_a2a_initialize(
     ep_size: int,
     max_num_tokens: int,
 ):
+    r"""Initialize the MoE all-to-all workspace and return a metainfo tensor.
+
+    The metainfo tensor encodes per-rank offsets and bookkeeping required by
+    :func:`moe_a2a_dispatch` and :func:`moe_a2a_combine`; it must be passed
+    back into those routines for the same workspace.  ``moe_a2a_initialize``
+    is idempotent and must be called once per workspace allocation before any
+    dispatch/combine.
+
+    Parameters
+    ----------
+    workspace : torch.Tensor
+        ``[ep_size, size_per_rank]`` shared workspace tensor.
+    ep_rank : int
+        Current expert-parallel rank.
+    ep_size : int
+        Total expert-parallel world size.
+    max_num_tokens : int
+        Maximum number of tokens any rank may dispatch in a single call;
+        used to size the metainfo allocation.
+
+    Returns
+    -------
+    torch.Tensor
+        Metainfo tensor opaque to callers; pass it to subsequent
+        ``moe_a2a_*`` calls.
+    """
     return get_moe_alltoall_module().moe_a2a_initialize(
         workspace, ep_rank, ep_size, max_num_tokens
     )
@@ -218,18 +244,28 @@ def moe_a2a_wrap_payload_tensor_in_workspace(
     slice_end: int,
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    """
-    Wrap an offset in the workspace into a tensor.
+    r"""Wrap a slice of the shared workspace as a typed tensor view.
 
-    Args:
-        workspace: [ep_size, size_per_rank] or [size_per_rank] workspace tensor
-        leading_shape: The leading shape to wrap the tensor with
-        slice_start: The start of the slice in the workspace
-        slice_end: The end of the slice in the workspace
-        dtype: Data type for the output tensor
+    Parameters
+    ----------
+    workspace : torch.Tensor
+        ``[ep_size, size_per_rank]`` (or ``[size_per_rank]``) workspace
+        tensor.
+    leading_shape : list[int]
+        Leading shape of the resulting view.  The trailing dimension is
+        inferred from ``slice_end - slice_start`` and ``dtype``.
+    slice_start : int
+        Start offset (in bytes from the beginning of the workspace) of the
+        slice to wrap.
+    slice_end : int
+        End offset (in bytes) of the slice.  Must lie within a single rank.
+    dtype : torch.dtype
+        Element dtype of the resulting view.
 
-    Returns:
-        tensor: [leading_shape, *] workspace-backed tensor
+    Returns
+    -------
+    torch.Tensor
+        A workspace-backed tensor of shape ``leading_shape + [-1]``.
     """
     if workspace.ndim == 1:
         workspace = workspace.unsqueeze(0)
@@ -265,23 +301,38 @@ def moe_a2a_dispatch(
     top_k: int,
     num_experts: int,
 ):
-    """
-    Dispatch tokens and payloads to expert ranks.
+    r"""Dispatch tokens and payloads to their target expert ranks.
 
-    Args:
-        token_selected_experts: [local_num_tokens, top_k] int32 tensor
-        input_payloads: List of [local_num_tokens, *] tensors to dispatch
-        workspace: [ep_size, size_per_rank] workspace tensor
-        metainfo: Metadata tensor from initialize
-        runtime_max_tokens_per_rank: Max tokens per rank in this batch
-        ep_rank: Current expert parallel rank
-        ep_size: Total expert parallel size
-        top_k: Number of experts per token
-        num_experts: Total number of experts
+    Parameters
+    ----------
+    token_selected_experts : torch.Tensor
+        ``[local_num_tokens, top_k]`` ``int32`` tensor of expert assignments.
+    input_payloads : list[torch.Tensor]
+        Per-token payload tensors, each shaped ``[local_num_tokens, *]``.
+    workspace : torch.Tensor
+        ``[ep_size, size_per_rank]`` shared workspace.
+    metainfo : torch.Tensor
+        Metainfo tensor returned by :func:`moe_a2a_initialize`.
+    runtime_max_tokens_per_rank : int
+        Maximum tokens per rank for this batch (must be ``<=`` the
+        ``max_num_tokens`` used at initialize time).
+    ep_rank : int
+        Current expert-parallel rank.
+    ep_size : int
+        Total expert-parallel world size.
+    top_k : int
+        Number of experts assigned per token.
+    num_experts : int
+        Total number of experts.
 
-    Returns:
-        output_payloads: List of payloads for this rank, backed by data in the workspace
-        combine_payload_offset: The offset to place the combine payload in the workspace
+    Returns
+    -------
+    Tuple[list[torch.Tensor], int]
+        ``(output_payloads, combine_payload_offset)``.  ``output_payloads``
+        is a list of workspace-backed views, one per ``input_payloads``
+        entry, that contains the data routed to this rank.  ``combine_payload_offset``
+        is the workspace offset reserved for the matching
+        :func:`moe_a2a_combine` call.
     """
     recv_offsets, recv_sizes, combine_payload_offset = (
         get_moe_alltoall_module().moe_a2a_dispatch(
@@ -328,6 +379,43 @@ def moe_a2a_combine(
     combine_payload_offset: int,
     payload_in_workspace: bool = False,
 ) -> torch.Tensor:
+    r"""Combine per-expert outputs back to the originating ranks.
+
+    Inverse of :func:`moe_a2a_dispatch`: scatters the rank-local expert
+    output rows back to the ranks that supplied the original tokens.
+
+    Parameters
+    ----------
+    payload : torch.Tensor
+        Output payload to send back to the source ranks.  Shape
+        ``[ep_size, runtime_max_tokens_per_rank, *]`` when
+        ``payload_in_workspace`` is ``False`` and ``[local_num_tokens, *]``
+        when ``True``.
+    local_num_tokens : int
+        Number of tokens originally dispatched from this rank.
+    workspace : torch.Tensor
+        Shared workspace tensor (same one passed to dispatch).
+    metainfo : torch.Tensor
+        Metainfo tensor returned by :func:`moe_a2a_initialize`.
+    runtime_max_tokens_per_rank : int
+        Same value passed to :func:`moe_a2a_dispatch`.
+    ep_rank : int
+        Current expert-parallel rank.
+    ep_size : int
+        Total expert-parallel world size.
+    top_k : int
+        Number of experts assigned per token.
+    combine_payload_offset : int
+        Offset returned by :func:`moe_a2a_dispatch`.
+    payload_in_workspace : bool
+        ``True`` if ``payload`` is already a workspace-backed view (skips
+        the staging copy).  Defaults to ``False``.
+
+    Returns
+    -------
+    torch.Tensor
+        ``[local_num_tokens, *]`` tensor with the combined outputs.
+    """
     return get_moe_alltoall_module().moe_a2a_combine(
         payload,
         local_num_tokens,
@@ -350,6 +438,23 @@ def moe_a2a_sanitize_expert_ids(
     ep_rank: int,
     invalid_expert_id: int,
 ):
+    r"""Replace expert IDs not owned by this rank with ``invalid_expert_id``.
+
+    Parameters
+    ----------
+    expert_ids : torch.Tensor
+        ``[local_num_tokens, top_k]`` ``int32`` tensor of expert assignments
+        (mutated in place).
+    workspace : torch.Tensor
+        Shared workspace tensor.
+    metainfo : torch.Tensor
+        Metainfo tensor returned by :func:`moe_a2a_initialize`.
+    ep_rank : int
+        Current expert-parallel rank.
+    invalid_expert_id : int
+        Value to write where the original expert lies outside this rank's
+        local range.
+    """
     return get_moe_alltoall_module().moe_a2a_sanitize_expert_ids(
         expert_ids, workspace, metainfo, ep_rank, invalid_expert_id
     )
@@ -362,17 +467,25 @@ def moe_a2a_get_workspace_size_per_rank(
     total_dispatch_payload_size_per_token: int,
     combine_payload_size_per_token: int,
 ):
-    """
-    Get the workspace size per rank for the MoeAlltoAll operation.
+    r"""Compute the per-rank workspace size for the MoE all-to-all primitive.
 
-    Args:
-        ep_size: Total expert parallel size
-        max_num_tokens: Maximum number of tokens across all ranks
-        total_dispatch_payload_size_per_token: The size of the payload per token in the dispatch phase. This should be the sum of all payloads.
-        combine_payload_size_per_token: The size of the payload per token in the combine phase.
+    Parameters
+    ----------
+    ep_size : int
+        Total expert-parallel world size.
+    max_num_tokens : int
+        Maximum number of tokens across all ranks.
+    total_dispatch_payload_size_per_token : int
+        Sum (in bytes) of all per-token payloads sent during the dispatch
+        phase.
+    combine_payload_size_per_token : int
+        Per-token payload size (in bytes) sent back during the combine
+        phase.
 
-    Returns:
-        workspace_size_per_rank: Size of the workspace per rank in bytes
+    Returns
+    -------
+    int
+        Required workspace size per rank, in bytes.
     """
     aux_data_size = get_moe_alltoall_module().moe_a2a_get_aux_data_size(
         ep_size,
@@ -448,18 +561,32 @@ class MoeAlltoAll:
         hidden_size: int,
         extra_payload_bytes_per_token: int = 0,
     ) -> int:
-        """
-        Convenience wrapper to calculate the workspace size per rank for the MoeAlltoAll operation. Automatically calculates the size of the dispatch and combine payloads when using default values.
-        This allocates space assuming 16-bit float, which may overallocate for quantized models. For a tighter bound, use the base function `moe_a2a_get_workspace_size_per_rank` directly.
+        r"""Compute the per-rank workspace size for the MoE all-to-all primitive.
 
-        Args:
-            ep_size: Total expert parallel size
-            top_k: Number of experts per token
-            max_num_tokens: Maximum number of tokens across all ranks
-            hidden_size: Hidden dimension size
-            extra_payload_bytes_per_token: Extra size per token in the payload
-        Returns:
-            workspace_size_per_rank: Size of the workspace per rank in bytes
+        Convenience wrapper around :func:`moe_a2a_get_workspace_size_per_rank`
+        that derives the dispatch / combine payload sizes from
+        ``hidden_size`` and ``top_k`` assuming 16-bit hidden states.  For a
+        tighter bound on quantized models use
+        :func:`moe_a2a_get_workspace_size_per_rank` directly.
+
+        Parameters
+        ----------
+        ep_size : int
+            Total expert-parallel world size.
+        top_k : int
+            Number of experts assigned per token.
+        max_num_tokens : int
+            Maximum number of tokens across all ranks.
+        hidden_size : int
+            Hidden dimension size.
+        extra_payload_bytes_per_token : int
+            Extra payload bytes per token to reserve (e.g. for quantization
+            scales).  Defaults to ``0``.
+
+        Returns
+        -------
+        int
+            Required workspace size per rank, in bytes.
         """
         # Default to 16-bit hidden states which should work in all cases.
         element_size = 2
@@ -515,17 +642,30 @@ class MoeAlltoAll:
         hidden_size: int = None,
         mnnvl_config: Optional[MnnvlConfig] = None,
     ):
-        """
-        Initialize MoeAlltoAll with workspace allocation.
+        r"""Initialize :class:`MoeAlltoAll` and allocate the shared workspace.
 
-        Args:
-            mapping: Mapping object containing rank information
-            max_num_tokens: Maximum number of tokens supported
-            top_k: Number of experts per token
-            num_experts: Total number of experts
-            workspace_size_per_rank: Size of workspace per rank in bytes, if None hidden_size must be provided
-            hidden_size: Hidden dimension size used when calculating the workspace size, if workspace_size_per_rank is not provided
-            mnnvl_config: Used to configure the communication backend for the MNNVL memory object
+        Parameters
+        ----------
+        mapping : Mapping
+            Mapping object describing the parallel layout (must expose
+            ``moe_ep_rank`` and ``moe_ep_size``).
+        max_num_tokens : int
+            Maximum number of tokens this rank will dispatch in any single
+            call.
+        top_k : int
+            Number of experts assigned per token.
+        num_experts : int
+            Total number of experts (across all ranks).
+        workspace_size_per_rank : int, optional
+            Pre-computed workspace size in bytes per rank.  When ``None``,
+            ``hidden_size`` must be provided and the workspace is sized via
+            :meth:`get_moe_workspace_size_per_rank`.
+        hidden_size : int, optional
+            Hidden dimension size, used to derive
+            ``workspace_size_per_rank`` when the latter is omitted.
+        mnnvl_config : MnnvlConfig, optional
+            Optional configuration for the underlying MNNVL communication
+            backend.
         """
         # Initialize constants from C++
         self._init_constants()
@@ -601,18 +741,30 @@ class MoeAlltoAll:
         invalid_token_expert_id: Optional[int] = None,
         expert_id_payload_index: Optional[int] = None,
     ) -> list[torch.Tensor]:
-        """
-        Perform MoE all-to-all dispatch operation.
+        r"""Run the MoE all-to-all dispatch phase.
 
-        Args:
-            token_selected_experts: [local_num_tokens, top_k] expert indices
-            input_payloads: List of [local_num_tokens, *] tensors to dispatch
-            runtime_max_tokens_per_rank: Max tokens per rank in this batch
-            invalid_token_expert_id: If set, sanitize invalid tokens to this ID
-            expert_id_payload_index: Index of expert IDs in input_payloads (required if invalid_token_expert_id is set)
+        Parameters
+        ----------
+        token_selected_experts : torch.Tensor
+            ``[local_num_tokens, top_k]`` ``int32`` tensor of expert
+            assignments.
+        input_payloads : list[torch.Tensor]
+            Per-token payload tensors, each shaped ``[local_num_tokens, *]``.
+        runtime_max_tokens_per_rank : int
+            Maximum tokens per rank in this batch.  Must be ``<=``
+            ``max_num_tokens`` used at construction.
+        invalid_token_expert_id : int, optional
+            If supplied, expert IDs not owned by the current rank are
+            rewritten to this value.  Requires ``expert_id_payload_index``.
+        expert_id_payload_index : int, optional
+            Index into ``input_payloads`` that holds the expert IDs to
+            sanitize.  Required when ``invalid_token_expert_id`` is set.
 
-        Returns:
-            recv_tensors: List of [ep_size, max_tokens, *] tensors
+        Returns
+        -------
+        list[torch.Tensor]
+            Workspace-backed receive tensors, one per ``input_payloads``
+            entry, each shaped ``[ep_size, runtime_max_tokens_per_rank, *]``.
         """
         assert self._state.phase == "idle", "dispatch called twice without combine"
         assert runtime_max_tokens_per_rank <= self.max_num_tokens, (
@@ -659,16 +811,24 @@ class MoeAlltoAll:
         runtime_max_tokens_per_rank: int,
         payload_in_workspace: bool = False,
     ) -> torch.Tensor:
-        """
-        Perform MoE all-to-all combine operation.
+        r"""Run the MoE all-to-all combine phase.
 
-        Args:
-            payload: [ep_size, max_tokens, elements_per_token] tensor
-            runtime_max_tokens_per_rank: Max tokens per rank in this batch
-            payload_in_workspace: If True, payload is workspace-backed (skip staging)
+        Parameters
+        ----------
+        payload : torch.Tensor
+            ``[ep_size, runtime_max_tokens_per_rank, elements_per_token]``
+            output payload to scatter back to source ranks.
+        runtime_max_tokens_per_rank : int
+            Maximum tokens per rank in this batch (same value passed to
+            :meth:`dispatch`).
+        payload_in_workspace : bool
+            ``True`` if ``payload`` is already a workspace-backed view (skips
+            the staging copy).  Defaults to ``False``.
 
-        Returns:
-            output: [local_num_tokens, elements_per_token] tensor
+        Returns
+        -------
+        torch.Tensor
+            ``[local_num_tokens, elements_per_token]`` combined tensor.
         """
         assert self._state.phase == "dispatched", (
             "combine called before successful dispatch"
@@ -702,19 +862,32 @@ class MoeAlltoAll:
         hidden_size: int,
         dtype: torch.dtype,
     ) -> torch.Tensor:
-        """
-        Get combine payload tensor backed by workspace (zero-copy).
+        r"""Return a workspace-backed view to use as the combine payload.
 
-        This tensor can be written to directly by expert processing, avoiding
-        a staging copy in the combine operation.
+        Zero-copy variant of :meth:`combine`: experts can write directly
+        into the returned tensor and call :meth:`combine` with
+        ``payload_in_workspace=True``.  Must be called after a successful
+        :meth:`dispatch` and before :meth:`combine`.
 
-        Args:
-            runtime_max_tokens_per_rank: Max tokens per rank in this batch
-            hidden_size: Hidden dimension size
-            dtype: Data type for the tensor
+        Parameters
+        ----------
+        runtime_max_tokens_per_rank : int
+            Maximum tokens per rank in this batch.
+        hidden_size : int
+            Hidden dimension size.
+        dtype : torch.dtype
+            Element dtype of the resulting view.
 
-        Returns:
-            tensor: [ep_size, max_tokens, hidden_size] workspace-backed tensor
+        Returns
+        -------
+        torch.Tensor
+            ``[ep_size, runtime_max_tokens_per_rank, hidden_size]``
+            workspace-backed tensor.
+
+        Raises
+        ------
+        RuntimeError
+            If called before a successful :meth:`dispatch`.
         """
         if self._state.phase != "dispatched":
             raise RuntimeError(

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -3937,8 +3937,16 @@ def trtllm_mxint4_block_scale_routed_moe(
     Returns
     -------
     List[torch.Tensor]
-        Return shape depends on ``do_finalize`` and ``gemm1_lora_delta``;
-        see :func:`trtllm_bf16_routed_moe` for the table.
+        Return shape depends on ``do_finalize`` and ``gemm1_lora_delta``.
+
+        =============  ==================  =========================================================================
+        do_finalize    gemm1_lora_delta    Returned tensors
+        =============  ==================  =========================================================================
+        ``True``       ``None``            ``[output]``
+        ``True``       ``Tensor``          ``[output, expanded_idx_to_permuted_idx, gemm1_activation_output]``
+        ``False``      ``None``            ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
+        ``False``      ``Tensor``          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx, gemm1_activation_output]``
+        =============  ==================  =========================================================================
     """
     return get_trtllm_moe_sm100_module().trtllm_mxint4_block_scale_moe(
         None,  # routing_logits

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -218,9 +218,25 @@ def get_reorder_rows_for_gated_act_gemm_row_indices(x) -> torch.Tensor:
     return permuted_row_indices
 
 
-def reorder_rows_for_gated_act_gemm(x):
-    """
-    PyTorch implementation of trt-llm gen `reorderRowsForGatedActGemm`
+@flashinfer_api
+def reorder_rows_for_gated_act_gemm(x: torch.Tensor) -> torch.Tensor:
+    r"""Reorder rows of a weight tensor for the TensorRT-LLM gated-activation GEMM layout.
+
+    Pure-PyTorch reimplementation of the TensorRT-LLM ``reorderRowsForGatedActGemm``
+    helper.  Used to pre-permute the up/gate weight matrix so that the fused
+    gated-activation kernels can access the two halves with a single contiguous
+    load.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Weight tensor whose rows will be permuted.  Any dtype is accepted; only
+        the row dimension is reordered.
+
+    Returns
+    -------
+    torch.Tensor
+        Row-permuted view of ``x`` (materialized as a new contiguous tensor).
     """
     row_indices = get_reorder_rows_for_gated_act_gemm_row_indices(x)
 
@@ -229,7 +245,29 @@ def reorder_rows_for_gated_act_gemm(x):
     return permute(x)
 
 
-def convert_to_block_layout(input_tensor: torch.Tensor, blockK: int) -> torch.Tensor:
+@flashinfer_api
+def convert_to_block_layout(
+    input_tensor: torch.Tensor, blockK: int
+) -> torch.Tensor:
+    r"""Reshape a 2-D tensor into a 3-D block layout.
+
+    Splits the inner ``K`` dimension into ``K // blockK`` blocks of size
+    ``blockK`` and transposes so the block dimension is outermost.  This is the
+    canonical layout consumed by TensorRT-LLM block-scaled MoE kernels.
+
+    Parameters
+    ----------
+    input_tensor : torch.Tensor
+        Input tensor of shape ``(M, K)``.
+    blockK : int
+        Block size along the ``K`` dimension.  ``K`` must be divisible by
+        ``blockK``.
+
+    Returns
+    -------
+    torch.Tensor
+        Reshaped contiguous tensor of shape ``(K // blockK, M, blockK)``.
+    """
     M, K = input_tensor.shape
     assert K % blockK == 0, "K must be divisible by blockK"
     return input_tensor.view(M, K // blockK, blockK).permute(1, 0, 2).contiguous()
@@ -678,10 +716,10 @@ def interleave_moe_scales_for_sm90_mixed_gemm(
 
     Parameters
     ----------
-    scales:
+    scales : torch.Tensor
         ``[num_experts, rows, K // group_size]`` uint8 tensor of E8M0 block
         scales.
-    group_size:
+    group_size : int
         MXFP4 quantization group size (default 32).
 
     Returns
@@ -731,10 +769,10 @@ def interleave_moe_weights_for_sm90_mixed_gemm(
 
     Parameters
     ----------
-    weight:
+    weight : torch.Tensor
         ``[num_experts, n, k // 2]`` uint8 CUDA tensor (4-bit values packed
         two-per-byte).
-    quant_type:
+    quant_type : str
         ``"fp4"`` for MXFP4 (the W4A16 path) or ``"int4"`` for INT4 (the
         W4A8 path).
 
@@ -911,6 +949,12 @@ def cutlass_fused_moe(
 
     tune_max_num_tokens : int = 8192
         Maximum number of tokens for tuning. Defaults to 8192.
+
+    enable_pdl : Optional[bool]
+        Whether to launch the kernel with Programmatic Dependent Launch (PDL).
+        ``None`` (default) lets the runtime pick a safe value based on the device
+        and surrounding stream operations; pass ``True`` to force PDL when every
+        adjacent kernel on the stream also supports it, or ``False`` to disable.
 
     activation_type: ActivationType = ActivationType.Swiglu
         Activation to apply on for GEMM1, note that Relu2 means non-gated GEMM1
@@ -2636,60 +2680,78 @@ def trtllm_bf16_moe(
     norm_topk_prob: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
-    """BF16 MoE operation with autotuning support.
+    r"""BF16 MoE operation with autotuning support.
 
-    This function implements a bfloat16 Mixture of Experts layer using the TensorRT-LLM backend
-    with automatic performance tuning for optimal tile size selection.
+    Implements a bfloat16 Mixture of Experts layer using the TensorRT-LLM backend
+    with automatic performance tuning for optimal tile-size selection.
 
-    Args:
-        routing_logits: [seq_len, num_experts] tensor of routing logits.
-            Supports float32 or bfloat16.
-        routing_bias: Optional [num_experts] tensor of routing bias.
-            Must be bfloat16 if provided.
-        hidden_states: [seq_len, hidden_size] tensor of input hidden states.
-            Must be bfloat16.
-        gemm1_weights: [num_experts, M // 128, hidden_size // 128, 128] tensor of first layer weights. must be bfloat16.
-            M is 2*intermediate_size for gated activations and
-            intermediate_size for non-gated activations.
-        gemm2_weights: [num_experts, hidden_size//128, intermediate_size, 128] tensor of second layer weights. must be bfloat16.
-        num_experts: Total number of experts.
-        top_k: Number of experts to route to per token.
-        n_group: Number of expert groups.
-        topk_group: Number of groups to consider for top-k routing.
-        intermediate_size: Size of intermediate layer.
-        local_expert_offset: Offset of local experts in global expert space.
-        local_num_experts: Number of experts handled by this device.
-        routed_scaling_factor (Optional[float]): Scaling factor for routing (can be None for some routing methods)
-        routing_method_type: Type of routing method to use (default: 0).
-            - 0: Default (Softmax -> TopK)
-            - 1: Renormalize (TopK -> Softmax)
-            - 2: DeepSeekV3 (Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups -> Top8 experts)
-            - 3: Llama4 (Top1 -> Sigmoid)
-            - 4: RenormalizeNaive (Softmax -> TopK -> Renormalize)
-            - 6: SigmoidRenorm (Sigmoid -> TopK -> Renormalize)
-            - 7: MiniMax2 (Sigmoid + Bias -> TopK -> ScaledSumNormalize)
-            - 8: Sigmoid (Sigmoid -> TopK)
-        use_shuffled_weight: Whether to use shuffled weight layout for optimization (default: True).
-        weight_layout: Weight layout format (default: WeightLayout.BlockMajorK).
-            - 0: MajorK - K-major layout [Mn, K]
-            - 1: MajorMn - M-major for A and N-major for B [K, Mn]
-            - 2: BlockMajorK - Blocked along K dimension [K/blockK, Mn, blockK]
-        do_finalize: Whether to finalize the output (default: True).
-        enable_pdl: Whether to enable Programmatic Dependent Launch. Auto-enabled for >= sm90.
-        tune_max_num_tokens: Maximum number of tokens for autotuning (default: 8192).
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 3: Swiglu
-            - 6: Relu2 (non-gated)
+    Parameters
+    ----------
+    routing_logits : torch.Tensor
+        ``[seq_len, num_experts]`` tensor of routing logits.  ``float32`` or
+        ``bfloat16``.
+    routing_bias : Optional[torch.Tensor]
+        Optional ``[num_experts]`` tensor of routing bias.  Must be
+        ``bfloat16`` if provided.
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` tensor of input hidden states.  Must be
+        ``bfloat16``.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, M // 128, hidden_size // 128, 128]`` first-layer
+        weights, ``bfloat16``.  ``M`` equals ``2 * intermediate_size`` for
+        gated activations and ``intermediate_size`` for non-gated
+        activations.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size // 128, intermediate_size, 128]``
+        second-layer weights, ``bfloat16``.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing (may be ``None`` for some methods).
+    routing_method_type : int
+        Routing method (default ``0``).  ``0`` Default (Softmax → TopK);
+        ``1`` Renormalize; ``2`` DeepSeekV3; ``3`` Llama4;
+        ``4`` RenormalizeNaive; ``6`` SigmoidRenorm; ``7`` MiniMax2;
+        ``8`` Sigmoid.
+    use_shuffled_weight : bool
+        Whether to use the shuffled weight layout (default ``True``).
+    weight_layout : int
+        Weight layout (default ``WeightLayout.BlockMajorK``).  ``0`` MajorK;
+        ``1`` MajorMn; ``2`` BlockMajorK.
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : bool
+        Whether to enable Programmatic Dependent Launch.  Auto-enabled for
+        SM90+ when ``True``.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).  ``3`` Swiglu;
+        ``6`` Relu2 (non-gated).
+    norm_topk_prob : bool
+        Whether to normalize the top-k probabilities (default ``True``).
+    routing_replay_out : Optional[torch.Tensor]
+        Optional ``[seq_len, top_k]`` packed ``(expert_id, weight)`` tensor
+        used to replay a previously recorded routing decision.
 
-    Returns:
-        Tensor or ``List[torch.Tensor]``, depending on ``do_finalize``:
-
-        =============  ==========================================================================
-        do_finalize    Returned tensors
-        =============  ==========================================================================
-        True           the final MoE output (single tensor; deprecated, becomes ``[output]`` in v0.8.0)
-        False          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        =============  ==========================================================================
+    Returns
+    -------
+    torch.Tensor or List[torch.Tensor]
+        If ``do_finalize`` is ``True`` returns the final MoE output (deprecated
+        scalar return; will become ``[output]`` in v0.8.0).  Otherwise returns
+        ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
     result = get_trtllm_moe_sm100_module().trtllm_bf16_moe(
@@ -2753,61 +2815,75 @@ def trtllm_bf16_routed_moe(
     activation_type: int = ActivationType.Swiglu.value,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> List[torch.Tensor]:
-    """BF16 MoE operation with autotuning support.
+    r"""Pre-routed BF16 MoE operation with autotuning support.
 
-    This function implements a bfloat16 Mixture of Experts layer using the TensorRT-LLM backend
-    with automatic performance tuning for optimal tile size selection.
+    Like :func:`trtllm_bf16_moe`, but takes a pre-computed ``topk_ids`` tensor
+    (the packed ``(expert_id, weight)`` representation produced by an upstream
+    routing kernel) instead of routing logits.
 
-    Args:
-        topk_ids: [seq_len, top_k] tensor of packed expert indices and weights (int32).
-            Format: (expert_id << 16) | (weight_bf16.view(int16))
-            Can be created as: (topk_ids.int32 << 16) | expert_weights.bfloat16.view(int16)
-        hidden_states: [seq_len, hidden_size] tensor of input hidden states.
-            Must be bfloat16.
-        gemm1_weights: [num_experts, M // 128, hidden_size // 128, 128] tensor of first layer weights. must be bfloat16.
-            M is 2*intermediate_size for gated activations and
-            intermediate_size for non-gated activations.
-        gemm2_weights: [num_experts, hidden_size//128, intermediate_size, 128] tensor of second layer weights. must be bfloat16.
-        num_experts: Total number of experts.
-        top_k: Number of experts to route to per token.
-        n_group: Number of expert groups.
-        topk_group: Number of groups to consider for top-k routing.
-        intermediate_size: Size of intermediate layer.
-        local_expert_offset: Offset of local experts in global expert space.
-        local_num_experts: Number of experts handled by this device.
-        routed_scaling_factor (Optional[float]): Scaling factor for routing (can be None for some routing methods)
-        routing_method_type: Type of routing method to use (default: 0).
-            - 0: Default (Softmax -> TopK)
-            - 1: Renormalize (TopK -> Softmax)
-            - 2: DeepSeekV3 (Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups -> Top8 experts)
-            - 3: Llama4 (Top1 -> Sigmoid)
-            - 4: RenormalizeNaive (Softmax -> TopK -> Renormalize)
-            - 6: SigmoidRenorm (Sigmoid -> TopK -> Renormalize)
-            - 7: MiniMax2 (Sigmoid + Bias -> TopK -> ScaledSumNormalize)
-            - 8: Sigmoid (Sigmoid -> TopK)
-        use_shuffled_weight: Whether to use shuffled weight layout for optimization (default: True).
-        weight_layout: Weight layout format (default: WeightLayout.BlockMajorK).
-            - 0: MajorK - K-major layout [Mn, K]
-            - 1: MajorMn - M-major for A and N-major for B [K, Mn]
-            - 2: BlockMajorK - Blocked along K dimension [K/blockK, Mn, blockK]
-        do_finalize: Whether to finalize the output (default: True).
-        enable_pdl: Whether to enable Programmatic Dependent Launch. Auto-enabled for >= sm90.
-        tune_max_num_tokens: Maximum number of tokens for autotuning (default: 8192).
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 3: Swiglu
-            - 6: Relu2 (non-gated)
+    Parameters
+    ----------
+    topk_ids : torch.Tensor
+        ``[seq_len, top_k]`` int32 tensor of packed expert indices and
+        weights.  Format ``(expert_id << 16) | (weight_bf16.view(int16))``.
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` tensor of input hidden states, ``bfloat16``.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, M // 128, hidden_size // 128, 128]`` first-layer
+        weights, ``bfloat16``.  ``M`` equals ``2 * intermediate_size`` for
+        gated activations and ``intermediate_size`` for non-gated activations.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size // 128, intermediate_size, 128]``
+        second-layer weights, ``bfloat16``.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing (may be ``None`` for some methods).
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    use_shuffled_weight : bool
+        Whether to use the shuffled weight layout (default ``True``).
+    weight_layout : int
+        Weight layout (default ``WeightLayout.BlockMajorK``).
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : bool
+        Whether to enable Programmatic Dependent Launch (default ``True``).
+    gemm1_lora_delta : Optional[torch.Tensor]
+        Optional LoRA delta for GEMM1.  When provided the gated activation
+        output is also returned for downstream LoRA adapters.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).
+    routing_replay_out : Optional[torch.Tensor]
+        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
 
-    Returns:
-        Tensor or ``List[torch.Tensor]``, depending on ``do_finalize`` and ``gemm1_lora_delta``:
+    Returns
+    -------
+    torch.Tensor or List[torch.Tensor]
+        Return shape depends on ``do_finalize`` and ``gemm1_lora_delta``.
 
-        ============  =================  ==========================================================================
-        do_finalize   gemm1_lora_delta   Returned tensors
-        ============  =================  ==========================================================================
-        True          None               ``output`` (single tensor; deprecated, becomes ``[output]`` in v0.8.0)
-        True          Tensor             ``[output, expanded_idx_to_permuted_idx, gemm1_activation_output]``
-        False         None               ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        False         Tensor             ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx, gemm1_activation_output]``
-        ============  =================  ==========================================================================
+        =============  ==================  =========================================================================
+        do_finalize    gemm1_lora_delta    Returned tensors
+        =============  ==================  =========================================================================
+        ``True``       ``None``            ``output`` (deprecated scalar return; becomes ``[output]`` in v0.8.0)
+        ``True``       ``Tensor``          ``[output, expanded_idx_to_permuted_idx, gemm1_activation_output]``
+        ``False``      ``None``            ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
+        ``False``      ``Tensor``          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx, gemm1_activation_output]``
+        =============  ==================  =========================================================================
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
     result = get_trtllm_moe_sm100_module().trtllm_bf16_moe(
@@ -2874,48 +2950,68 @@ def trtllm_fp8_per_tensor_scale_moe(
     norm_topk_prob: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
-    """FP8 per tensor scale MoE operation.
+    r"""FP8 per-tensor-scale MoE operation.
 
-    Args:
-        routing_logits: [seq_len, num_experts] tensor of routing logits
-        routing_bias: [num_experts] tensor of routing bias
-        hidden_states: [seq_len, hidden_size] tensor of input hidden states
-        gemm1_weights: [num_experts, M, hidden_size] tensor of first layer weights
-            M is 2*intermediate_size for gated activations and
-            intermediate_size for non-gated activations.
-        output1_scales_scalar: [local_num_experts] tensor of first layer output scales
-        output1_scales_gate_scalar: [local_num_experts] tensor of first layer gate scales
-        gemm2_weights: [num_experts, hidden_size, intermediate_size] tensor of second layer weights
-        output2_scales_scalar: [local_num_experts] tensor of second layer output scales
-        num_experts: Total number of experts
-        top_k: Number of experts to route to per token
-        n_group: Number of expert groups
-        topk_group: Number of groups to consider for top-k routing
-        intermediate_size: Size of intermediate layer
-        local_expert_offset: Offset of local experts in global expert space
-        local_num_experts: Number of experts handled by this device
-        routed_scaling_factor: Scaling factor for routing
-        use_routing_scales_on_input: Whether to use routing scales on input
-        routing_method_type: Type of routing method to use (default: 0)
-        do_finalize: Whether to finalize the output (default: True).
-        enable_pdl: Whether to enable Programmatic Dependent Launch (PDL). Auto-enabled for >= sm90.
-        tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 0: Gelu
-            - 3: Swiglu
-            - 4: Geglu
-            - 6: Relu2 (non-gated)
-            - 7: Identity
+    Parameters
+    ----------
+    routing_logits : torch.Tensor
+        ``[seq_len, num_experts]`` tensor of routing logits.
+    routing_bias : Optional[torch.Tensor]
+        ``[num_experts]`` tensor of routing bias.
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` tensor of input hidden states.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, M, hidden_size]`` first-layer weights.  ``M`` is
+        ``2 * intermediate_size`` for gated activations and ``intermediate_size``
+        for non-gated activations.
+    output1_scales_scalar : torch.Tensor
+        ``[local_num_experts]`` first-layer output scales.
+    output1_scales_gate_scalar : torch.Tensor
+        ``[local_num_experts]`` first-layer gate scales.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size]`` second-layer weights.
+    output2_scales_scalar : torch.Tensor
+        ``[local_num_experts]`` second-layer output scales.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing.
+    use_routing_scales_on_input : bool
+        Whether to use routing scales on input.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.  ``None`` (default)
+        lets the runtime auto-select on SM90+.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).  ``0`` Gelu; ``3`` Swiglu;
+        ``4`` Geglu; ``6`` Relu2 (non-gated); ``7`` Identity.
+    norm_topk_prob : bool
+        Whether to normalize the top-k probabilities (default ``True``).
+    routing_replay_out : Optional[torch.Tensor]
+        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
 
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize``:
-
-        =============  ==========================================================================
-        do_finalize    Returned tensors
-        =============  ==========================================================================
-        True           the final MoE output (single tensor)
-        False          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        =============  ==========================================================================
+    Returns
+    -------
+    torch.Tensor or List[torch.Tensor]
+        Final MoE output when ``do_finalize`` is ``True``, otherwise
+        ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_tensor_scale_moe(
@@ -2983,58 +3079,85 @@ def trtllm_fp8_block_scale_moe(
     norm_topk_prob: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
-    """FP8 block scale MoE operation.
+    r"""FP8 block-scaled MoE operation.
 
-    Args:
-        routing_logits: [seq_len, num_experts] tensor of routing logits
-        routing_bias: [num_experts] tensor of routing bias
-        hidden_states: [seq_len, hidden_size] tensor of input hidden states
-        hidden_states_scale: [hidden_size//128, seq_len] tensor of hidden states block scales
-        gemm1_weights: tensor of first layer weights
-            - [num_experts, M, hidden_size] if weight_layout == WeightLayout.MajorK
-            - [num_experts, M // 128, hidden_size, 128] if weight_layout == WeightLayout.BlockMajorK
-            where M is `2*intermediate_size` for gated activations and
-            `intermediate_size` for non-gated activations (e.g. Relu2/Identity).
-        gemm1_weights_scale: [num_experts, 2*intermediate_size//(32 if mxfp8 else 128), hidden_size//(32 if mxfp8 else 128)] tensor of first layer block scales
-        gemm2_weights: tensor of second layer weights
-            - [num_experts, hidden_size, intermediate_size] if weight_layout == WeightLayout.MajorK
-            - [num_experts, hidden_size//128, intermediate_size, 128] if weight_layout == WeightLayout.BlockMajorK
-        gemm2_weights_scale: [num_experts, hidden_size//(32 if mxfp8 else 128), intermediate_size//(32 if mxfp8 else 128)] tensor of second layer block scales
-        num_experts: Total number of experts
-        top_k: Number of experts to route to per token
-        n_group: Number of expert groups
-        topk_group: Number of groups to consider for top-k routing
-        intermediate_size: Size of intermediate layer
-        local_expert_offset: Offset of local experts in global expert space
-        local_num_experts: Number of experts handled by this device
-        routed_scaling_factor: Scaling factor for routing
-        routing_method_type: Type of routing method to use (default: 0)
-        weight_layout: Weight layout format (default: WeightLayout.MajorK). Supported layouts:
-            - 0: MajorK - K-major layout [Mn, K]
-            - 2: BlockMajorK - Blocked along K dimension [K/blockK, Mn, blockK]
-        do_finalize: Whether to finalize the output (default: True).
-        enable_pdl: Whether to enable Programmatic Dependent Launch (PDL). Auto-enabled for >= sm90.
-        tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
-        fp8_quantization_type: Type of FP8 quantization to use (default: DeepSeekFp8)
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 3: Swiglu
-            - 4: Geglu
-            - 6: Relu2
-            - 7: Identity
-        routing_replay_out (Optional[torch.Tensor]): Optional int16 output tensor of shape
-            (num_tokens_or_larger, top_k) to capture selected expert IDs during routing.
-            Column order matches topk_indices. When None (default), zero overhead - the
-            kernel skips the write entirely. Buffer may be larger than num_tokens for CUDA
-            graph pre-allocation; only rows [0, num_tokens) are written.
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize``:
+    Parameters
+    ----------
+    routing_logits : torch.Tensor
+        ``[seq_len, num_experts]`` tensor of routing logits.
+    routing_bias : Optional[torch.Tensor]
+        ``[num_experts]`` tensor of routing bias.
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` tensor of input hidden states.
+    hidden_states_scale : torch.Tensor
+        ``[hidden_size // 128, seq_len]`` tensor of hidden-states block scales.
+    gemm1_weights : torch.Tensor
+        First-layer weights.  ``[num_experts, M, hidden_size]`` when
+        ``weight_layout == WeightLayout.MajorK`` (``0``), or
+        ``[num_experts, M // 128, hidden_size, 128]`` when
+        ``weight_layout == WeightLayout.BlockMajorK`` (``2``).  ``M`` is
+        ``2 * intermediate_size`` for gated activations and
+        ``intermediate_size`` for non-gated activations.
+    gemm1_weights_scale : torch.Tensor
+        ``[num_experts, 2*intermediate_size // (32 if mxfp8 else 128), hidden_size // (32 if mxfp8 else 128)]``
+        first-layer block scales.
+    gemm2_weights : torch.Tensor
+        Second-layer weights.  ``[num_experts, hidden_size, intermediate_size]``
+        when ``weight_layout == WeightLayout.MajorK``, or
+        ``[num_experts, hidden_size // 128, intermediate_size, 128]`` when
+        ``weight_layout == WeightLayout.BlockMajorK``.
+    gemm2_weights_scale : torch.Tensor
+        ``[num_experts, hidden_size // (32 if mxfp8 else 128), intermediate_size // (32 if mxfp8 else 128)]``
+        second-layer block scales.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    use_shuffled_weight : bool
+        Whether to use the shuffled weight layout (default ``False``).
+    weight_layout : int
+        Weight layout (default ``0`` — MajorK).  ``0`` MajorK
+        (``[Mn, K]``); ``2`` BlockMajorK (``[K/blockK, Mn, blockK]``).
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.  ``None`` (default)
+        lets the runtime auto-select on SM90+.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    fp8_quantization_type : Fp8QuantizationType
+        FP8 quantization scheme (default ``Fp8QuantizationType.DeepSeekFp8``).
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).  ``3`` Swiglu; ``4`` Geglu;
+        ``6`` Relu2 (non-gated); ``7`` Identity.
+    norm_topk_prob : bool
+        Whether to normalize the top-k probabilities (default ``True``).
+    routing_replay_out : Optional[torch.Tensor]
+        Optional ``int16`` tensor of shape ``(num_tokens_or_larger, top_k)``
+        used to capture the selected expert IDs during routing.  Column order
+        matches ``topk_indices``.  When ``None`` (default) the kernel skips
+        the write entirely.  The buffer may be larger than ``num_tokens`` for
+        CUDA-graph pre-allocation; only rows ``[0, num_tokens)`` are written.
 
-        =============  ==========================================================================
-        do_finalize    Returned tensors
-        =============  ==========================================================================
-        True           the final MoE output (single tensor)
-        False          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        =============  ==========================================================================
+    Returns
+    -------
+    torch.Tensor or List[torch.Tensor]
+        Final MoE output when ``do_finalize`` is ``True``, otherwise
+        ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
     output = torch.empty(
@@ -3111,62 +3234,84 @@ def trtllm_fp8_block_scale_routed_moe(
     fp8_quantization_type: Fp8QuantizationType = Fp8QuantizationType.DeepSeekFp8,
     activation_type: int = ActivationType.Swiglu.value,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
-    """FP8 block scale MoE operation with pre-computed routing (packed format).
+    r"""Pre-routed FP8 block-scaled MoE operation.
 
-    This function is used when routing decisions have already been computed
-    and packed into a single tensor. This is useful for:
-    - CUDA Graph capture (avoids CPU-GPU sync from routing_logits processing)
-    - Distributed MoE where routing is computed elsewhere
+    Like :func:`trtllm_fp8_block_scale_moe`, but consumes a pre-computed packed
+    ``(expert_id, weight)`` tensor instead of routing logits.  Use this entry
+    point for CUDA-graph capture (avoids the CPU-GPU sync from logits
+    processing) or distributed MoE where routing happens elsewhere.
 
-    Args:
-        topk_ids: [seq_len, top_k] tensor of packed expert indices and weights (int32).
-            Format: (expert_id << 16) | (weight_bf16.view(int16))
-            Can be created as: (topk_ids.int32 << 16) | expert_weights.bfloat16.view(int16)
-        routing_bias: [num_experts] tensor of routing bias (can be None)
-        hidden_states: [seq_len, hidden_size] tensor of input hidden states
-        hidden_states_scale: [hidden_size//(32 if mxfp8 else 128), seq_len] tensor of hidden states block scales
-        gemm1_weights: [num_experts, M, hidden_size] tensor of first layer weights where
-            M is `2*intermediate_size` for gated activations and
-            `intermediate_size` for non-gated activations.
-        gemm1_weights_scale: [num_experts, 2*intermediate_size//(32 if mxfp8 else 128), hidden_size//(32 if mxfp8 else 128)] tensor of first layer block scales
-        gemm2_weights: [num_experts, hidden_size, intermediate_size] tensor of second layer weights
-        gemm2_weights_scale: [num_experts, hidden_size//(32 if mxfp8 else 128), intermediate_size//(32 if mxfp8 else 128)] tensor of second layer block scales
-        num_experts: Total number of experts
-        top_k: Number of experts to route to per token
-        n_group: Number of expert groups
-        topk_group: Number of groups to consider for top-k routing
-        intermediate_size: Size of intermediate layer
-        local_expert_offset: Offset of local experts in global expert space
-        local_num_experts: Number of experts handled by this device
-        routed_scaling_factor: Scaling factor for routing
-        routing_method_type: Type of routing method to use (default: 0)
-        use_shuffled_weight: Whether to use shuffled weights
-        weight_layout: Weight layout (0 = MajorK, 1 = BlockMajorK)
-        do_finalize: Whether to finalize the output (default: True).
-        enable_pdl: Whether to enable Programmatic Dependent Launch (PDL). Auto-enabled for >= sm90.
-        gemm1_lora_delta: optional MoE LoRA delta of shape ``[num_tokens, top_k, 2 * intermediate_size]``,
-            bfloat16. When set for MXFP8, it is added to FC1 before the fused gated activation and
-            the post-activation FC1 output is appended to the return list.
-        output (Optional[torch.Tensor]): shape [seq_len, hidden_size]
-            Optional inplace output tensor.
-        tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
-        fp8_quantization_type: Type of FP8 quantization to use (default: DeepSeekFp8)
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 3: Swiglu
-            - 4: Geglu
-            - 6: Relu2
-            - 7: Identity
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize`` and ``gemm1_lora_delta``:
+    Parameters
+    ----------
+    topk_ids : torch.Tensor
+        ``[seq_len, top_k]`` int32 tensor of packed expert indices and weights
+        with format ``(expert_id << 16) | (weight_bf16.view(int16))``.
+    routing_bias : Optional[torch.Tensor]
+        ``[num_experts]`` tensor of routing bias (may be ``None``).
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` tensor of input hidden states.
+    hidden_states_scale : torch.Tensor
+        ``[hidden_size // (32 if mxfp8 else 128), seq_len]`` block scales for
+        the hidden states.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, M, hidden_size]`` first-layer weights where ``M`` is
+        ``2 * intermediate_size`` for gated activations and
+        ``intermediate_size`` for non-gated.
+    gemm1_weights_scale : torch.Tensor
+        ``[num_experts, 2*intermediate_size // (32 if mxfp8 else 128), hidden_size // (32 if mxfp8 else 128)]``
+        first-layer block scales.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size]`` second-layer weights.
+    gemm2_weights_scale : torch.Tensor
+        ``[num_experts, hidden_size // (32 if mxfp8 else 128), intermediate_size // (32 if mxfp8 else 128)]``
+        second-layer block scales.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    use_shuffled_weight : bool
+        Whether to use the shuffled weight layout (default ``False``).
+    weight_layout : int
+        Weight layout (``0`` MajorK, ``2`` BlockMajorK).  Default ``0``.
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.  ``None`` (default)
+        lets the runtime auto-select on SM90+.
+    gemm1_lora_delta : Optional[torch.Tensor]
+        Optional MoE LoRA delta of shape
+        ``[num_tokens, top_k, 2 * intermediate_size]``, ``bfloat16``.  When
+        set for MXFP8 it is added to FC1 before the fused gated activation and
+        the post-activation FC1 output is appended to the return list.
+    output : Optional[torch.Tensor]
+        Optional in-place output tensor of shape ``[seq_len, hidden_size]``.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    fp8_quantization_type : Fp8QuantizationType
+        FP8 quantization scheme (default ``Fp8QuantizationType.DeepSeekFp8``).
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).  ``3`` Swiglu; ``4`` Geglu;
+        ``6`` Relu2; ``7`` Identity.
 
-        ============  =================  ==========================================================================
-        do_finalize   gemm1_lora_delta   Returned tensors
-        ============  =================  ==========================================================================
-        True          None               the final MoE output (single tensor; deprecated, becomes ``[output]``)
-        True          Tensor             ``[output, expanded_idx_to_permuted_idx, gemm1_activation_output]``
-        False         None               ``[gemm2_output, <undefined>, expanded_idx_to_permuted_idx]``
-        False         Tensor             ``[gemm2_output, <undefined>, expanded_idx_to_permuted_idx, gemm1_activation_output]``
-        ============  =================  ==========================================================================
+    Returns
+    -------
+    torch.Tensor or List[torch.Tensor]
+        Return shape depends on ``do_finalize`` and ``gemm1_lora_delta``;
+        see :func:`trtllm_bf16_routed_moe` for the table.
     """
     result = get_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
         None,  # routing_logits
@@ -3245,79 +3390,94 @@ def trtllm_fp4_block_scale_moe(
     norm_topk_prob: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> List[torch.Tensor]:
-    """FP4 block scale MoE operation.
+    r"""FP4 block-scaled MoE operation.
 
-    Args:
-        routing_logits (torch.Tensor): shape [seq_len, num_experts]
-            Input tensor of routing logits. Supports float32, bfloat16.
-        routing_bias (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of routing bias. Can be None for some routing methods. Must be the same type as routing logits.
-        hidden_states (torch.Tensor): shape [seq_len, hidden_size // 2 if nvfp4 else hidden_size]
-            Tensor of input hidden states. Supports bfloat16, mxfp8, and nvfp4 (packed into uint8)
-        hidden_states_scale (Optional[torch.Tensor]): shape [seq_len, hidden_size // (32 if mxfp8, 16 if mxfp4)]
-            Scale tensor of mxfp8 / nvfp4 hidden states. Dtype must be float8.
-        gemm1_weights (torch.Tensor): shape [num_experts, 2 * intermediate_size, hidden_size // 2]
-            Tensor of FC1 weights. Dtype must be uint8 (packed fp4)
-        gemm1_weights_scale (torch.Tensor): shape [num_experts, 2 * intermediate_size, hidden_size // (32 if mxfp4 else 16)]
-            Scale tensor of FC1 weights. Dtype must be float8.
-        gemm1_bias (Optional[torch.Tensor]): shape [num_experts, 2 * intermediate_size]
-            Tensor of FC1 biases. Dtype is float32.
-        gemm1_alpha (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu alpha. Dtype is float32.
-        gemm1_beta (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu beta. Dtype is float32.
-        gemm1_clamp_limit (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu clamp limit. Dtype is float32.
-        gemm2_weights (torch.Tensor): shape [num_experts, hidden_size, intermediate_size]
-            Tensor of FC2 weights. Dtype must be uint8 (packed fp4)
-        gemm2_weights_scale (torch.Tensor): shape [num_experts, hidden_size, intermediate_size // (32 if mxfp4 else 16)]
-            Scale tensor of FC2 weights. Dtype must be float8.
-        gemm2_bias (Optional[torch.Tensor]): shape [num_experts, hidden_size]
-            Tensor of FC2 biases. Dtype is float32.
-        output1_scale_scalar (Optional[torch.Tensor]): shape [local_num_experts]
-            Tensor of scaling factors for first layer activation output
-        output1_scale_gate_scalar (Optional[torch.Tensor]): shape [local_num_experts]
-            Tensor of scaling factors for first layer gate output
-        output2_scale_scalar (Optional[torch.Tensor]): shape [local_num_experts]
-            Tensor of scaling factors for second layer output
-        num_experts (int): Total number of experts
-        top_k (int): Number of experts to route to per token
-        n_group (Optional[int]): Number of expert groups (can be None for some routing methods)
-        topk_group (Optional[int]): Number of groups to consider for top-k routing (can be None for some routing methods)
-        intermediate_size (int): Size of intermediate layer
-        local_expert_offset (int): Offset of local experts in global expert space
-        local_num_experts (int): Number of experts handled by this device
-        routed_scaling_factor (Optional[float]): Scaling factor for routing (can be None for some routing methods)
-        routing_method_type (int): Type of routing method to use (default: 0)
-            - 0: Default (Softmax -> TopK)
-            - 1: Renormalize (TopK -> Softmax)
-            - 2: DeepSeekV3 (Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups -> Top8 experts)
-            - 3: Llama4 (Top1 -> Sigmoid)
-            - 4: RenormalizeNaive (Softmax -> TopK -> Renormalize)
-            - 6: SigmoidRenorm (Sigmoid -> TopK -> Renormalize)
-            - 7: MiniMax2 (Sigmoid + Bias -> TopK -> ScaledSumNormalize)
-            - 8: Sigmoid (Sigmoid -> TopK)
-        do_finalize (bool): Whether to finalize the output (default: False)
-        enable_pdl (Optional[bool]): Whether to enable Programmatic Dependent Launch (PDL). Auto-enabled for >= sm90.
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 3: Swiglu
-            - 4: Geglu
-            - 6: Relu2
-            - 7: Identity
-        per_token_scale (Optional[torch.Tensor]): shape [seq_len]
-            Tensor of per-token scaling factors. Dtype must be float32.
-        tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
-        output (Optional[torch.Tensor]): shape [seq_len, hidden_size]
-            Optional inplace output tensor.
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize``:
+    Parameters
+    ----------
+    routing_logits : torch.Tensor
+        ``[seq_len, num_experts]`` tensor of routing logits.  ``float32`` or
+        ``bfloat16``.
+    routing_bias : Optional[torch.Tensor]
+        ``[num_experts]`` tensor of routing bias.  Same dtype as
+        ``routing_logits``; may be ``None``.
+    hidden_states : torch.Tensor
+        Hidden states of shape ``[seq_len, hidden_size // 2]`` (NVFP4) or
+        ``[seq_len, hidden_size]`` (MXFP8 / bfloat16).  Supports bfloat16,
+        MXFP8, and NVFP4 (packed into uint8).
+    hidden_states_scale : Optional[torch.Tensor]
+        Block scales for MXFP8 / NVFP4 hidden states of shape
+        ``[seq_len, hidden_size // (32 if mxfp8 else 16)]``.  Dtype is float8.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // 2]`` packed
+        FP4 FC1 weights, dtype ``uint8``.
+    gemm1_weights_scale : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // (32 if mxfp4 else 16)]``
+        FC1 weight block scales, dtype float8.
+    gemm1_bias : Optional[torch.Tensor]
+        ``[num_experts, 2 * intermediate_size]`` FC1 bias, ``float32``.
+    gemm1_alpha : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu alpha, ``float32``.
+    gemm1_beta : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu beta, ``float32``.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu clamp limit, ``float32``.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size]`` packed FP4 FC2
+        weights, dtype ``uint8``.
+    gemm2_weights_scale : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size // (32 if mxfp4 else 16)]``
+        FC2 weight block scales, dtype float8.
+    gemm2_bias : Optional[torch.Tensor]
+        ``[num_experts, hidden_size]`` FC2 bias, ``float32``.
+    output1_scale_scalar : Optional[torch.Tensor]
+        ``[local_num_experts]`` scaling factors for the first-layer activation
+        output.
+    output1_scale_gate_scalar : Optional[torch.Tensor]
+        ``[local_num_experts]`` scaling factors for the first-layer gate
+        output.
+    output2_scale_scalar : Optional[torch.Tensor]
+        ``[local_num_experts]`` scaling factors for the second-layer output.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).  ``3`` Swiglu; ``4`` Geglu;
+        ``6`` Relu2; ``7`` Identity.
+    per_token_scale : Optional[torch.Tensor]
+        ``[seq_len]`` per-token scaling factors, ``float32``.
+    output : Optional[torch.Tensor]
+        Optional in-place ``[seq_len, hidden_size]`` output tensor.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    norm_topk_prob : bool
+        Whether to normalize the top-k probabilities (default ``True``).
+    routing_replay_out : Optional[torch.Tensor]
+        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
 
-        =============  ==========================================================================
-        do_finalize    Returned tensors
-        =============  ==========================================================================
-        True           ``[output]`` (the final MoE output)
-        False          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        =============  ==========================================================================
+    Returns
+    -------
+    List[torch.Tensor]
+        ``[output]`` when ``do_finalize`` is ``True``, otherwise
+        ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
@@ -3397,85 +3557,92 @@ def trtllm_fp4_block_scale_routed_moe(
     """FP4 block scale MoE operation with pre-computed routing.
 
     This function supports two pre-computed routing formats:
-    1. Packed format: topk_ids is a single tensor with packed (score << 16 | expert_id)
-    2. Unpacked format: topk_ids is a tuple of (topk_ids, topk_weights) tensors
+    1. Packed format: ``topk_ids`` is a single int32 tensor with
+       ``(score << 16) | expert_id`` entries.
+    2. Unpacked format: ``topk_ids`` is a tuple ``(topk_ids, topk_weights)``.
 
-    Args:
-        topk_ids (Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]):
-            Either a single tensor or a tuple of two tensors:
-            - Single tensor (packed format): shape [seq_len, top_k], dtype int32.
-              Must be packed value with (score << 16 | expert_id).
-            - Tuple (unpacked format): (topk_ids, topk_weights) where
-              topk_ids has shape [seq_len, top_k], dtype int32 (plain expert indices)
-              topk_weights has shape [seq_len, top_k], dtype bfloat16 (routing weights)
-        routing_bias (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of routing bias. Can be None for some routing methods. Must be the same type as routing logits.
-        hidden_states (torch.Tensor): shape [seq_len, hidden_size // 2 if nvfp4 else hidden_size]
-            Tensor of input hidden states. Supports bfloat16, mxfp8, and nvfp4 (packed into uint8)
-        hidden_states_scale (Optional[torch.Tensor]): shape [seq_len, hidden_size // (32 if mxfp8, 16 if mxfp4)]
-            Scale tensor of mxfp8 / nvfp4 hidden states. Dtype must be float8.
-        gemm1_weights (torch.Tensor): shape [num_experts, 2 * intermediate_size, hidden_size // 2]
-            Tensor of FC1 weights. Dtype must be uint8 (packed fp4)
-        gemm1_weights_scale (torch.Tensor): shape [num_experts, 2 * intermediate_size, hidden_size // (32 if mxfp4 else 16)]
-            Scale tensor of FC1 weights. Dtype must be float8.
-        gemm1_bias (Optional[torch.Tensor]): shape [num_experts, 2 * intermediate_size]
-            Tensor of FC1 biases. Dtype is float32.
-        gemm1_alpha (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu alpha. Dtype is float32.
-        gemm1_beta (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu beta. Dtype is float32.
-        gemm1_clamp_limit (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu clamp limit. Dtype is float32.
-        gemm2_weights (torch.Tensor): shape [num_experts, hidden_size, intermediate_size]
-            Tensor of FC2 weights. Dtype must be uint8 (packed fp4)
-        gemm2_weights_scale (torch.Tensor): shape [num_experts, hidden_size, intermediate_size // (32 if mxfp4 else 16)]
-            Scale tensor of FC2 weights. Dtype must be float8.
-        gemm2_bias (Optional[torch.Tensor]): shape [num_experts, hidden_size]
-            Tensor of FC2 biases. Dtype is float32.
-        output1_scale_scalar (Optional[torch.Tensor]): shape [local_num_experts]
-            Tensor of scaling factors for first layer activation output
-        output1_scale_gate_scalar (Optional[torch.Tensor]): shape [local_num_experts]
-            Tensor of scaling factors for first layer gate output
-        output2_scale_scalar (Optional[torch.Tensor]): shape [local_num_experts]
-            Tensor of scaling factors for second layer output
-        num_experts (int): Total number of experts
-        top_k (int): Number of experts to route to per token
-        n_group (Optional[int]): Number of expert groups (can be None for some routing methods)
-        topk_group (Optional[int]): Number of groups to consider for top-k routing (can be None for some routing methods)
-        intermediate_size (int): Size of intermediate layer
-        local_expert_offset (int): Offset of local experts in global expert space
-        local_num_experts (int): Number of experts handled by this device
-        routed_scaling_factor (Optional[float]): Scaling factor for routing (can be None for some routing methods)
-        routing_method_type (int): Type of routing method to use (default: 0)
-            - 0: Default (Softmax -> TopK)
-            - 1: Renormalize (TopK -> Softmax)
-            - 2: DeepSeekV3 (Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups -> Top8 experts)
-            - 3: Llama4 (Top1 -> Sigmoid)
-            - 4: RenormalizeNaive (Softmax -> TopK -> Renormalize)
-            - 6: SigmoidRenorm (Sigmoid -> TopK -> Renormalize)
-            - 7: MiniMax2 (Sigmoid + Bias -> TopK -> ScaledSumNormalize)
-            - 8: Sigmoid (Sigmoid -> TopK)
-        do_finalize (bool): Whether to finalize the output (default: False)
-        activation_type (int): Type of activation function (default: 3 - Swiglu)
-            - 3: Swiglu
-            - 4: Geglu
-            - 6: Relu2
-            - 7: Identity
-        per_token_scale (Optional[torch.Tensor]): shape [seq_len]
-            Tensor of per-token scaling factors. Dtype must be float32.
-        tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
-        output (Optional[torch.Tensor]): shape [seq_len, hidden_size]
-            Optional inplace output tensor.
+    Parameters
+    ----------
+    topk_ids : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        Pre-computed routing decision.  Either a single int32 tensor of shape
+        ``[seq_len, top_k]`` in packed format ``(score << 16) | expert_id`` or
+        a tuple ``(ids, weights)`` where ``ids`` is int32 of shape
+        ``[seq_len, top_k]`` (plain expert indices) and ``weights`` is
+        ``bfloat16`` of the same shape (routing weights).
+    routing_bias : Optional[torch.Tensor]
+        ``[num_experts]`` routing bias.  May be ``None``.
+    hidden_states : torch.Tensor
+        Hidden states of shape ``[seq_len, hidden_size // 2]`` (NVFP4) or
+        ``[seq_len, hidden_size]`` (MXFP8 / bfloat16).
+    hidden_states_scale : Optional[torch.Tensor]
+        ``[seq_len, hidden_size // (32 if mxfp8 else 16)]`` block scales of
+        the hidden states, float8.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // 2]`` packed
+        FP4 FC1 weights, ``uint8``.
+    gemm1_weights_scale : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // (32 if mxfp4 else 16)]``
+        FC1 weight block scales, float8.
+    gemm1_bias : Optional[torch.Tensor]
+        ``[num_experts, 2 * intermediate_size]`` FC1 bias, float32.
+    gemm1_alpha : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu alpha, float32.
+    gemm1_beta : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu beta, float32.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu clamp limit, float32.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size]`` packed FP4 FC2
+        weights, ``uint8``.
+    gemm2_weights_scale : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size // (32 if mxfp4 else 16)]``
+        FC2 weight block scales, float8.
+    gemm2_bias : Optional[torch.Tensor]
+        ``[num_experts, hidden_size]`` FC2 bias, float32.
+    output1_scale_scalar : Optional[torch.Tensor]
+        ``[local_num_experts]`` scaling factors for the first-layer activation
+        output.
+    output1_scale_gate_scalar : Optional[torch.Tensor]
+        ``[local_num_experts]`` scaling factors for the first-layer gate
+        output.
+    output2_scale_scalar : Optional[torch.Tensor]
+        ``[local_num_experts]`` scaling factors for the second-layer output.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.
+    activation_type : int
+        Activation type (default ``3`` — Swiglu).
+    per_token_scale : Optional[torch.Tensor]
+        ``[seq_len]`` per-token scaling factors, float32.
+    output : Optional[torch.Tensor]
+        Optional in-place ``[seq_len, hidden_size]`` output tensor.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
 
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize``:
-
-        =============  ==========================================================================
-        do_finalize    Returned tensors
-        =============  ==========================================================================
-        True           ``[output]`` (the final MoE output)
-        False          ``[gemm2_output, <undefined>, expanded_idx_to_permuted_idx]``
-        =============  ==========================================================================
+    Returns
+    -------
+    List[torch.Tensor]
+        ``[output]`` when ``do_finalize`` is ``True``, otherwise
+        ``[gemm2_output, <undefined>, expanded_idx_to_permuted_idx]``.
     """
     # Determine routing mode based on input format
     if isinstance(topk_ids, tuple):
@@ -3555,61 +3722,70 @@ def trtllm_mxint4_block_scale_moe(
     norm_topk_prob: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> List[torch.Tensor]:
-    """MxInt4 block scale MoE operation.
+    r"""MXINT4 block-scaled MoE operation.
 
-    Args:
-        routing_logits (torch.Tensor): shape [seq_len, num_experts]
-            Input tensor of routing logits. Supports float32, bfloat16.
-        routing_bias: Optional [num_experts] tensor of routing bias.
-            Must be bfloat16 if provided.
-        hidden_states (torch.Tensor): shape [seq_len, hidden_size]
-            Tensor of input hidden states. Supports bfloat16.
-        gemm1_weights (torch.Tensor): shape [num_experts, 2 * intermediate_size, hidden_size // 2]
-            Tensor of FC1 weights. Dtype must be uint8 (packed mxint4)
-        gemm1_weights_scale (torch.Tensor): shape [num_experts, 2 * intermediate_size, hidden_size // 32]
-            Scale tensor of FC1 weights. Dtype must be bfloat16.
-        gemm1_alpha (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu alpha. Dtype is float32.
-        gemm1_beta (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu beta. Dtype is float32.
-        gemm1_clamp_limit (Optional[torch.Tensor]): shape [num_experts]
-            Tensor of swiglu clamp limit. Dtype is float32.
-        gemm2_weights (torch.Tensor): shape [num_experts, hidden_size, intermediate_size]
-            Tensor of FC2 weights. Dtype must be uint8 (packed mxint4)
-        gemm2_weights_scale (torch.Tensor): shape [num_experts, hidden_size, intermediate_size // 32]
-            Scale tensor of FC2 weights. Dtype must be bfloat16.
-        num_experts (int): Total number of experts
-        top_k (int): Number of experts to route to per token
-        n_group (Optional[int]): Number of expert groups (can be None for some routing methods)
-        topk_group (Optional[int]): Number of groups to consider for top-k routing (can be None for some routing methods)
-        intermediate_size (int): Size of intermediate layer
-        local_expert_offset (int): Offset of local experts in global expert space
-        local_num_experts (int): Number of experts handled by this device
-        routed_scaling_factor (Optional[float]): Scaling factor for routing (can be None for some routing methods)
-        routing_method_type (int): Type of routing method to use (default: 0)
-            - 0: Default (Softmax -> TopK)
-            - 1: Renormalize (TopK -> Softmax)
-            - 2: DeepSeekV3 (Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups -> Top8 experts)
-            - 3: Llama4 (Top1 -> Sigmoid)
-            - 4: RenormalizeNaive (Softmax -> TopK -> Renormalize)
-            - 6: SigmoidRenorm (Sigmoid -> TopK -> Renormalize)
-            - 7: MiniMax2 (Sigmoid + Bias -> TopK -> ScaledSumNormalize)
-            - 8: Sigmoid (Sigmoid -> TopK)
-        do_finalize (bool): Whether to finalize the output (default: False)
-        enable_pdl (Optional[bool]): Whether to enable Programmatic Dependent Launch (PDL). Auto-enabled for >= sm90.
-        output (Optional[torch.Tensor]): shape [seq_len, hidden_size]
-            Optional inplace output tensor.
-        tune_max_num_tokens(int): Maximum number of tokens for tuning. (default: 8192)
+    Parameters
+    ----------
+    routing_logits : torch.Tensor
+        ``[seq_len, num_experts]`` routing logits, ``float32`` or ``bfloat16``.
+    routing_bias : Optional[torch.Tensor]
+        ``[num_experts]`` routing bias, ``bfloat16``.  May be ``None``.
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` input hidden states, ``bfloat16``.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // 2]`` packed
+        MXINT4 FC1 weights, ``uint8``.
+    gemm1_weights_scale : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // 32]`` FC1
+        weight block scales, ``bfloat16``.
+    gemm1_alpha : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu alpha, ``float32``.
+    gemm1_beta : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu beta, ``float32``.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu clamp limit, ``float32``.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size]`` packed MXINT4 FC2
+        weights, ``uint8``.
+    gemm2_weights_scale : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size // 32]`` FC2 weight
+        block scales, ``bfloat16``.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        Size of the intermediate layer.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Scaling factor for routing.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+    do_finalize : bool
+        Whether to finalize the output (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.
+    output : Optional[torch.Tensor]
+        Optional in-place ``[seq_len, hidden_size]`` output tensor.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
+    norm_topk_prob : bool
+        Whether to normalize the top-k probabilities (default ``True``).
+    routing_replay_out : Optional[torch.Tensor]
+        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
 
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize``:
-
-        =============  ==========================================================================
-        do_finalize    Returned tensors
-        =============  ==========================================================================
-        True           ``[output]``
-        False          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        =============  ==========================================================================
+    Returns
+    -------
+    List[torch.Tensor]
+        ``[output]`` when ``do_finalize`` is ``True``, otherwise
+        ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
     return get_trtllm_moe_sm100_module().trtllm_mxint4_block_scale_moe(
@@ -3672,46 +3848,73 @@ def trtllm_mxint4_block_scale_routed_moe(
 ) -> List[torch.Tensor]:
     """MxInt4 block-scale MoE with pre-computed routing.
 
-    Same FC1/FC2 kernel and LoRA contract as :func:`trtllm_mxint4_block_scale_moe`, but the caller
-    supplies pre-computed top-k routing instead of raw routing logits. This skips the routing
-    kernel's topk computation and reuses the BF16 routed packed-int32 contract for ``topk_ids``.
+    Same FC1/FC2 kernel and LoRA contract as :func:`trtllm_mxint4_block_scale_moe`,
+    but the caller supplies pre-computed top-k routing instead of raw routing
+    logits.  This skips the routing kernel's top-k computation and reuses the
+    BF16-routed packed-int32 contract for ``topk_ids``.
 
-    Args:
-        topk_ids: ``[seq_len, top_k]`` packed int32 tensor of expert indices and weights:
-            ``(expert_id << 16) | (weight_bf16.view(int16))``.
-            Build it as ``(topk_ids.int32 << 16) | expert_weights.bfloat16.view(int16)``.
-        hidden_states: ``[seq_len, hidden_size]`` bfloat16 input activations.
-        gemm1_weights: ``[num_experts, 2 * intermediate_size, hidden_size // 2]`` packed mxint4 weights (uint8).
-        gemm1_weights_scale: ``[num_experts, 2 * intermediate_size, hidden_size // 32]`` bf16 weight scales.
-        gemm1_alpha / gemm1_beta / gemm1_clamp_limit: optional ``[num_experts]`` float32 SwiGLU params.
-        gemm2_weights: ``[num_experts, hidden_size, intermediate_size // 2]`` packed mxint4 (uint8).
-        gemm2_weights_scale: ``[num_experts, hidden_size, intermediate_size // 32]`` bf16.
-        num_experts: total experts.
-        top_k: experts per token.
-        n_group / topk_group: group-routing knobs (None when unused).
-        intermediate_size: FC1/FC2 inner dim.
-        local_expert_offset / local_num_experts: this device's expert slice.
-        routed_scaling_factor: optional output scaling (None for many routing methods).
-        routing_method_type: routing method enum (see :func:`trtllm_bf16_routed_moe`).
-        do_finalize: whether to run the finalize stage.
-        enable_pdl: enable Programmatic Dependent Launch (auto on >= sm90).
-        gemm1_lora_delta: optional MoE LoRA delta of shape ``[num_tokens, top_k, 2 * intermediate_size]``,
-            bfloat16, concatenated gate/up layout (``[gate_0..gate_{I-1}, up_0..up_{I-1}]``). When set, it is
-            added to FC1 before SwiGLU and the post-activation buffer is appended to the return list.
-        output: optional in-place output tensor.
-        tune_max_num_tokens: autotuning cap (default 8192).
+    Parameters
+    ----------
+    topk_ids : torch.Tensor
+        ``[seq_len, top_k]`` int32 tensor of packed expert indices and
+        weights: ``(expert_id << 16) | (weight_bf16.view(int16))``.
+    hidden_states : torch.Tensor
+        ``[seq_len, hidden_size]`` ``bfloat16`` input activations.
+    gemm1_weights : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // 2]`` packed
+        MXINT4 weights, ``uint8``.
+    gemm1_weights_scale : torch.Tensor
+        ``[num_experts, 2 * intermediate_size, hidden_size // 32]`` FC1
+        weight scales, ``bfloat16``.
+    gemm1_alpha : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu alpha, ``float32``.
+    gemm1_beta : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu beta, ``float32``.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        ``[num_experts]`` swiglu clamp limit, ``float32``.
+    gemm2_weights : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size // 2]`` packed
+        MXINT4 weights, ``uint8``.
+    gemm2_weights_scale : torch.Tensor
+        ``[num_experts, hidden_size, intermediate_size // 32]`` FC2 weight
+        scales, ``bfloat16``.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts to route to per token.
+    n_group : Optional[int]
+        Number of expert groups.
+    topk_group : Optional[int]
+        Number of groups to consider for top-k routing.
+    intermediate_size : int
+        FC1/FC2 inner dimension.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.
+    local_num_experts : int
+        Number of experts handled by this device.
+    routed_scaling_factor : Optional[float]
+        Optional output scaling factor.
+    routing_method_type : int
+        Routing method (default ``0``).  See :func:`trtllm_bf16_routed_moe`.
+    do_finalize : bool
+        Whether to run the finalize stage (default ``True``).
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch.
+    gemm1_lora_delta : Optional[torch.Tensor]
+        Optional MoE LoRA delta of shape
+        ``[num_tokens, top_k, 2 * intermediate_size]``, ``bfloat16``, in
+        concatenated gate/up layout.  When set, added to FC1 before SwiGLU
+        and the post-activation buffer is appended to the return list.
+    output : Optional[torch.Tensor]
+        Optional in-place output tensor.
+    tune_max_num_tokens : int
+        Maximum number of tokens for autotuning (default ``8192``).
 
-    Returns:
-        ``List[torch.Tensor]``, depending on ``do_finalize`` and ``gemm1_lora_delta``:
-
-        ============  =================  ==========================================================================
-        do_finalize   gemm1_lora_delta   Returned tensors
-        ============  =================  ==========================================================================
-        True          None               ``[output]``
-        True          Tensor             ``[output, expanded_idx_to_permuted_idx, gemm1_activation_output]``
-        False         None               ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``
-        False         Tensor             ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx, gemm1_activation_output]``
-        ============  =================  ==========================================================================
+    Returns
+    -------
+    List[torch.Tensor]
+        Return shape depends on ``do_finalize`` and ``gemm1_lora_delta``;
+        see :func:`trtllm_bf16_routed_moe` for the table.
     """
     return get_trtllm_moe_sm100_module().trtllm_mxint4_block_scale_moe(
         None,  # routing_logits

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -247,9 +247,7 @@ def reorder_rows_for_gated_act_gemm(x: torch.Tensor) -> torch.Tensor:
     return permute(x)
 
 
-def convert_to_block_layout(
-    input_tensor: torch.Tensor, blockK: int
-) -> torch.Tensor:
+def convert_to_block_layout(input_tensor: torch.Tensor, blockK: int) -> torch.Tensor:
     r"""Reshape a 2-D tensor into a 3-D block layout.
 
     Splits the inner ``K`` dimension into ``K // blockK`` blocks of size

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2743,8 +2743,12 @@ def trtllm_bf16_moe(
     norm_topk_prob : bool
         Whether to normalize the top-k probabilities (default ``True``).
     routing_replay_out : Optional[torch.Tensor]
-        Optional ``[seq_len, top_k]`` packed ``(expert_id, weight)`` tensor
-        used to replay a previously recorded routing decision.
+        Optional ``int16`` tensor of shape ``(num_tokens_or_larger, top_k)``
+        used to capture the selected expert IDs during routing.  Column
+        order matches ``topk_indices``.  When ``None`` (default) the
+        kernel skips the write entirely.  The buffer may be larger than
+        ``num_tokens`` for CUDA-graph pre-allocation; only rows
+        ``[0, num_tokens)`` are written.
 
     Returns
     -------
@@ -2869,7 +2873,12 @@ def trtllm_bf16_routed_moe(
     activation_type : int
         Activation type (default ``3`` — Swiglu).
     routing_replay_out : Optional[torch.Tensor]
-        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
+        Optional ``int16`` tensor of shape ``(num_tokens_or_larger, top_k)``
+        used to capture the selected expert IDs during routing.  Column
+        order matches ``topk_indices``.  When ``None`` (default) the
+        kernel skips the write entirely.  The buffer may be larger than
+        ``num_tokens`` for CUDA-graph pre-allocation; only rows
+        ``[0, num_tokens)`` are written.
 
     Returns
     -------
@@ -3005,7 +3014,12 @@ def trtllm_fp8_per_tensor_scale_moe(
     norm_topk_prob : bool
         Whether to normalize the top-k probabilities (default ``True``).
     routing_replay_out : Optional[torch.Tensor]
-        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
+        Optional ``int16`` tensor of shape ``(num_tokens_or_larger, top_k)``
+        used to capture the selected expert IDs during routing.  Column
+        order matches ``topk_indices``.  When ``None`` (default) the
+        kernel skips the write entirely.  The buffer may be larger than
+        ``num_tokens`` for CUDA-graph pre-allocation; only rows
+        ``[0, num_tokens)`` are written.
 
     Returns
     -------
@@ -3471,7 +3485,12 @@ def trtllm_fp4_block_scale_moe(
     norm_topk_prob : bool
         Whether to normalize the top-k probabilities (default ``True``).
     routing_replay_out : Optional[torch.Tensor]
-        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
+        Optional ``int16`` tensor of shape ``(num_tokens_or_larger, top_k)``
+        used to capture the selected expert IDs during routing.  Column
+        order matches ``topk_indices``.  When ``None`` (default) the
+        kernel skips the write entirely.  The buffer may be larger than
+        ``num_tokens`` for CUDA-graph pre-allocation; only rows
+        ``[0, num_tokens)`` are written.
 
     Returns
     -------
@@ -3779,7 +3798,12 @@ def trtllm_mxint4_block_scale_moe(
     norm_topk_prob : bool
         Whether to normalize the top-k probabilities (default ``True``).
     routing_replay_out : Optional[torch.Tensor]
-        Optional ``[seq_len, top_k]`` packed routing tensor for replay.
+        Optional ``int16`` tensor of shape ``(num_tokens_or_larger, top_k)``
+        used to capture the selected expert IDs during routing.  Column
+        order matches ``topk_indices``.  When ``None`` (default) the
+        kernel skips the write entirely.  The buffer may be larger than
+        ``num_tokens`` for CUDA-graph pre-allocation; only rows
+        ``[0, num_tokens)`` are written.
 
     Returns
     -------

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2818,7 +2818,7 @@ def trtllm_bf16_routed_moe(
     tune_max_num_tokens: int = 8192,
     activation_type: int = ActivationType.Swiglu.value,
     routing_replay_out: Optional[torch.Tensor] = None,
-) -> List[torch.Tensor]:
+) -> Union[torch.Tensor, List[torch.Tensor]]:
     r"""Pre-routed BF16 MoE operation with autotuning support.
 
     Like :func:`trtllm_bf16_moe`, but takes a pre-computed ``topk_ids`` tensor
@@ -3661,7 +3661,7 @@ def trtllm_fp4_block_scale_routed_moe(
     -------
     List[torch.Tensor]
         ``[output]`` when ``do_finalize`` is ``True``, otherwise
-        ``[gemm2_output, <undefined>, expanded_idx_to_permuted_idx]``.
+        ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     # Determine routing mode based on input format
     if isinstance(topk_ids, tuple):

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -87,7 +87,9 @@ class RoutingInputMode(IntEnum):
     # - topk_weights: OUTPUT buffer for computed weights
     FromLogits = 0
     # Mode 2: Pre-computed routing with packed format
-    # - Input: topk_ids contains packed (score << 16 | expert_id)
+    # - Input: topk_ids contains packed ``(expert_id << 16) | weight`` (high
+    #   16 bits = int16 expert id, low 16 bits = float16/bfloat16 weight, see
+    #   PackedScoreIdx in include/flashinfer/trtllm/fused_moe/RoutingKernel.h)
     # - topk_ids: INPUT with packed values
     # - topk_weights: OUTPUT buffer for extracted weights
     PackedPrecomputed = 1
@@ -236,7 +238,8 @@ def reorder_rows_for_gated_act_gemm(x: torch.Tensor) -> torch.Tensor:
     Returns
     -------
     torch.Tensor
-        Row-permuted view of ``x`` (materialized as a new contiguous tensor).
+        Row-permuted copy of ``x`` (materialized as a new contiguous tensor;
+        PyTorch advanced indexing always copies, never aliases).
     """
     row_indices = get_reorder_rows_for_gated_act_gemm_row_indices(x)
 
@@ -2013,7 +2016,7 @@ def get_trtllm_moe_sm100_module():
             )
         else:
             # When routing_logits is None, we have pre-computed routing:
-            # - packed format: topk_ids contains (score << 16 | expert_id)
+            # - packed format: topk_ids contains ``(expert_id << 16) | weight``
             # - unpacked format: separate topk_ids and expert_weights
             topk_ids = topk_ids
             expert_weights = (
@@ -3577,14 +3580,16 @@ def trtllm_fp4_block_scale_routed_moe(
 
     This function supports two pre-computed routing formats:
     1. Packed format: ``topk_ids`` is a single int32 tensor with
-       ``(score << 16) | expert_id`` entries.
+       ``(expert_id << 16) | weight`` entries (high 16 bits = int16 expert
+       id, low 16 bits = float16/bfloat16 weight, matching
+       ``PackedScoreIdx`` in ``include/flashinfer/trtllm/fused_moe/RoutingKernel.h``).
     2. Unpacked format: ``topk_ids`` is a tuple ``(topk_ids, topk_weights)``.
 
     Parameters
     ----------
     topk_ids : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         Pre-computed routing decision.  Either a single int32 tensor of shape
-        ``[seq_len, top_k]`` in packed format ``(score << 16) | expert_id`` or
+        ``[seq_len, top_k]`` in packed format ``(expert_id << 16) | weight`` or
         a tuple ``(ids, weights)`` where ``ids`` is int32 of shape
         ``[seq_len, top_k]`` (plain expert indices) and ``weights`` is
         ``bfloat16`` of the same shape (routing weights).
@@ -3669,7 +3674,7 @@ def trtllm_fp4_block_scale_routed_moe(
         topk_ids_tensor, topk_weights = topk_ids
         routing_mode = RoutingInputMode.UnpackedPrecomputed
     else:
-        # Packed format: single tensor with (score << 16 | expert_id)
+        # Packed format: single tensor with ``(expert_id << 16) | weight``
         topk_ids_tensor = topk_ids
         topk_weights = None
         routing_mode = RoutingInputMode.PackedPrecomputed

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -220,7 +220,6 @@ def get_reorder_rows_for_gated_act_gemm_row_indices(x) -> torch.Tensor:
     return permuted_row_indices
 
 
-@flashinfer_api
 def reorder_rows_for_gated_act_gemm(x: torch.Tensor) -> torch.Tensor:
     r"""Reorder rows of a weight tensor for the TensorRT-LLM gated-activation GEMM layout.
 
@@ -248,7 +247,6 @@ def reorder_rows_for_gated_act_gemm(x: torch.Tensor) -> torch.Tensor:
     return permute(x)
 
 
-@flashinfer_api
 def convert_to_block_layout(
     input_tensor: torch.Tensor, blockK: int
 ) -> torch.Tensor:

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -3924,7 +3924,7 @@ def trtllm_mxint4_block_scale_routed_moe(
     routed_scaling_factor : Optional[float]
         Optional output scaling factor.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_routed_moe`.
+        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
     do_finalize : bool
         Whether to run the finalize stage (default ``True``).
     enable_pdl : Optional[bool]

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2722,15 +2722,38 @@ def trtllm_bf16_moe(
     routed_scaling_factor : Optional[float]
         Scaling factor for routing (may be ``None`` for some methods).
     routing_method_type : int
-        Routing method (default ``0``).  ``0`` Default (Softmax → TopK);
-        ``1`` Renormalize; ``2`` DeepSeekV3; ``3`` Llama4;
-        ``4`` RenormalizeNaive; ``6`` SigmoidRenorm; ``7`` MiniMax2;
-        ``8`` Sigmoid.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     use_shuffled_weight : bool
         Whether to use the shuffled weight layout (default ``True``).
     weight_layout : int
-        Weight layout (default ``WeightLayout.BlockMajorK``).  ``0`` MajorK;
-        ``1`` MajorMn; ``2`` BlockMajorK.
+        Weight layout for ``gemm1_weights`` / ``gemm2_weights``; matches
+        :class:`flashinfer.tllm_enums.WeightLayout`.  This BF16 MoE entry
+        point requires ``BlockMajorK`` — passing any other value raises a
+        runtime error.  Default ``WeightLayout.BlockMajorK``.
+
+        - ``0`` ``MajorK`` — K-major, logical shape ``[Mn, K]``.
+          *Not supported by this function.*
+        - ``1`` ``MajorMn`` — M-major (A) / N-major (B), logical shape
+          ``[K, Mn]``.  *Not supported by this function.*
+        - ``2`` ``BlockMajorK`` — Blocked along K, logical shape
+          ``[K / blockK, Mn, blockK]`` (``blockK`` is fixed at 128 B).
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : bool
@@ -2857,11 +2880,38 @@ def trtllm_bf16_routed_moe(
     routed_scaling_factor : Optional[float]
         Scaling factor for routing (may be ``None`` for some methods).
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     use_shuffled_weight : bool
         Whether to use the shuffled weight layout (default ``True``).
     weight_layout : int
-        Weight layout (default ``WeightLayout.BlockMajorK``).
+        Weight layout for ``gemm1_weights`` / ``gemm2_weights``; matches
+        :class:`flashinfer.tllm_enums.WeightLayout`.  This BF16 MoE entry
+        point requires ``BlockMajorK`` — passing any other value raises a
+        runtime error.  Default ``WeightLayout.BlockMajorK``.
+
+        - ``0`` ``MajorK`` — K-major, logical shape ``[Mn, K]``.
+          *Not supported by this function.*
+        - ``1`` ``MajorMn`` — M-major (A) / N-major (B), logical shape
+          ``[K, Mn]``.  *Not supported by this function.*
+        - ``2`` ``BlockMajorK`` — Blocked along K, logical shape
+          ``[K / blockK, Mn, blockK]`` (``blockK`` is fixed at 128 B).
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : bool
@@ -3001,7 +3051,24 @@ def trtllm_fp8_per_tensor_scale_moe(
     use_routing_scales_on_input : bool
         Whether to use routing scales on input.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : Optional[bool]
@@ -3145,8 +3212,18 @@ def trtllm_fp8_block_scale_moe(
     use_shuffled_weight : bool
         Whether to use the shuffled weight layout (default ``False``).
     weight_layout : int
-        Weight layout (default ``0`` — MajorK).  ``0`` MajorK
-        (``[Mn, K]``); ``2`` BlockMajorK (``[K/blockK, Mn, blockK]``).
+        Weight layout for ``gemm1_weights`` / ``gemm2_weights``; matches
+        :class:`flashinfer.tllm_enums.WeightLayout`.  Allowed values for
+        this function depend on ``fp8_quantization_type``: ``DeepSeekFp8``
+        accepts ``MajorK`` or ``BlockMajorK``; ``MxFp8`` requires
+        ``MajorK``.  Default ``0`` (``MajorK``).
+
+        - ``0`` ``MajorK`` — K-major, logical shape ``[Mn, K]``.
+        - ``1`` ``MajorMn`` — M-major (A) / N-major (B), logical shape
+          ``[K, Mn]``.  *Not supported by this function.*
+        - ``2`` ``BlockMajorK`` — Blocked along K, logical shape
+          ``[K / blockK, Mn, blockK]`` (``blockK`` is fixed at 128 B).
+          *Only valid when ``fp8_quantization_type`` is ``DeepSeekFp8``.*
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : Optional[bool]
@@ -3297,11 +3374,39 @@ def trtllm_fp8_block_scale_routed_moe(
     routed_scaling_factor : Optional[float]
         Scaling factor for routing.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     use_shuffled_weight : bool
         Whether to use the shuffled weight layout (default ``False``).
     weight_layout : int
-        Weight layout (``0`` MajorK, ``2`` BlockMajorK).  Default ``0``.
+        Weight layout for ``gemm1_weights`` / ``gemm2_weights``; matches
+        :class:`flashinfer.tllm_enums.WeightLayout`.  Allowed values for
+        this function depend on ``fp8_quantization_type``: ``DeepSeekFp8``
+        accepts ``MajorK`` or ``BlockMajorK``; ``MxFp8`` requires
+        ``MajorK``.  Default ``0`` (``MajorK``).
+
+        - ``0`` ``MajorK`` — K-major, logical shape ``[Mn, K]``.
+        - ``1`` ``MajorMn`` — M-major (A) / N-major (B), logical shape
+          ``[K, Mn]``.  *Not supported by this function.*
+        - ``2`` ``BlockMajorK`` — Blocked along K, logical shape
+          ``[K / blockK, Mn, blockK]`` (``blockK`` is fixed at 128 B).
+          *Only valid when ``fp8_quantization_type`` is ``DeepSeekFp8``.*
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : Optional[bool]
@@ -3469,7 +3574,24 @@ def trtllm_fp4_block_scale_moe(
     routed_scaling_factor : Optional[float]
         Scaling factor for routing.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : Optional[bool]
@@ -3646,7 +3768,24 @@ def trtllm_fp4_block_scale_routed_moe(
     routed_scaling_factor : Optional[float]
         Scaling factor for routing.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : Optional[bool]
@@ -3789,7 +3928,24 @@ def trtllm_mxint4_block_scale_moe(
     routed_scaling_factor : Optional[float]
         Scaling factor for routing.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     do_finalize : bool
         Whether to finalize the output (default ``True``).
     enable_pdl : Optional[bool]
@@ -3922,7 +4078,24 @@ def trtllm_mxint4_block_scale_routed_moe(
     routed_scaling_factor : Optional[float]
         Optional output scaling factor.
     routing_method_type : int
-        Routing method (default ``0``).  See :func:`trtllm_bf16_moe`.
+        Routing method (default ``0``).  Selects the routing-kernel
+        pipeline; matches :class:`flashinfer.tllm_enums.RoutingMethodType`.
+
+        - ``0`` ``Default`` — Softmax → TopK.
+        - ``1`` ``Renormalize`` — TopK → Softmax.
+        - ``2`` ``DeepSeekV3`` — Sigmoid → RoutingBiasAdd → Top-2 in group →
+          Top-``topk_group`` groups → Top-``top_k`` experts from the
+          selected groups.
+        - ``3`` ``Llama4`` — Top-1 → Sigmoid.
+        - ``4`` ``RenormalizeNaive`` — Softmax → TopK → Renormalize (Qwen3
+          style).
+        - ``5`` ``TopK`` — TopK only (no softmax/sigmoid).
+        - ``6`` ``SigmoidRenorm`` — Sigmoid → TopK → Renormalize (divide by
+          the sum of the top-K weights).
+        - ``7`` ``MiniMax2`` — Sigmoid + Bias → TopK → ScaledSumNormalize
+          (``routeScale = 1.0``, ``epsilon = 1e-20``).
+        - ``8`` ``Sigmoid`` — Sigmoid → TopK (no renormalization).
+        - ``9`` ``Unspecified`` — reserved.
     do_finalize : bool
         Whether to run the finalize stage (default ``True``).
     enable_pdl : Optional[bool]

--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -77,44 +77,67 @@ def b12x_fused_moe(
     quant_mode: Optional[str] = None,
     source_format: str = "modelopt",
 ) -> torch.Tensor:
-    """Run fused MoE on SM120/SM121 using b12x CuTe DSL kernels.
+    r"""Run fused MoE on SM120/SM121 using b12x CuTe-DSL kernels.
 
-    The kernel takes bf16 input and runs routing, FC1, activation, FC2,
-    and scatter through the selected backend.
-    Automatically selects micro (decode), static, or dynamic backend
-    based on routed row count.
+    The kernel takes bf16 input and runs routing, FC1, activation, FC2, and
+    scatter through the selected backend.  Automatically selects the micro
+    (decode), static, or dynamic backend based on the routed row count.
 
-    Args:
-        x: Input activations [num_tokens, hidden_size], bf16.
-        w1_weight: FC1 weights, FP4 packed.
-            Gated (SiLU): [E, 2*intermediate_size, hidden_size//2].
-            Non-gated (ReLU2): [E, intermediate_size, hidden_size//2].
-        w1_weight_sf: Scale factors for w1_weight.
-        w2_weight: FC2 weights [E, hidden_size, intermediate_size//2], FP4.
-        w2_weight_sf: Scale factors for w2_weight.
-        token_selected_experts: Expert assignments [num_tokens, top_k].
-        token_final_scales: Routing weights [num_tokens, top_k].
-        num_experts: Total number of experts.
-        top_k: Number of experts per token.
-        w1_alpha: Per-expert global scale for FC1.
-        w2_alpha: Per-expert global scale for FC2.
-        fc2_input_scale: Global scale for FC2 input quantization. Required for
-            quant_mode="nvfp4"; accepted but ignored for quant_mode="w4a16".
-        num_local_experts: Local experts for EP. Default: num_experts.
-        output: Pre-allocated output buffer [num_tokens, hidden_size], bf16.
-        output_dtype: Output data type. Only torch.bfloat16 is currently
-            supported. Default: torch.bfloat16.
-        activation: Activation function — "silu" (gated/SwiGLU) or
-            "relu2" (non-gated/Nemotron-Super). Default: "silu".
-        activation_precision: Backward-compatible alias for quant_mode.
-            "fp4" selects quant_mode="nvfp4"; "bf16" selects quant_mode="w4a16".
-        quant_mode: Quantization mode, "nvfp4"/"w4a4" or "w4a16". When set,
-            this selects the backend and internal workspace family.
-        source_format: Source weight format for quant_mode="w4a16".
-            Supports "modelopt" and "compressed_tensors". Default: "modelopt".
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input activations of shape ``[num_tokens, hidden_size]``, ``bfloat16``.
+    w1_weight : torch.Tensor
+        FC1 weights, FP4 packed.  Gated (SiLU) layout
+        ``[E, 2 * intermediate_size, hidden_size // 2]``; non-gated (ReLU2)
+        layout ``[E, intermediate_size, hidden_size // 2]``.
+    w1_weight_sf : torch.Tensor
+        Scale factors for ``w1_weight``.
+    w2_weight : torch.Tensor
+        FC2 weights of shape ``[E, hidden_size, intermediate_size // 2]``,
+        FP4.
+    w2_weight_sf : torch.Tensor
+        Scale factors for ``w2_weight``.
+    token_selected_experts : torch.Tensor
+        Expert assignments of shape ``[num_tokens, top_k]``.
+    token_final_scales : torch.Tensor
+        Routing weights of shape ``[num_tokens, top_k]``.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts routed to per token.
+    w1_alpha : torch.Tensor
+        Per-expert global scale for FC1.
+    w2_alpha : torch.Tensor
+        Per-expert global scale for FC2.
+    fc2_input_scale : Optional[torch.Tensor]
+        Global scale for FC2 input quantization.  Required for
+        ``quant_mode="nvfp4"``; accepted but ignored for
+        ``quant_mode="w4a16"``.
+    num_local_experts : Optional[int]
+        Local experts for expert parallelism.  Defaults to ``num_experts``.
+    output : Optional[torch.Tensor]
+        Pre-allocated output buffer of shape ``[num_tokens, hidden_size]``,
+        ``bfloat16``.
+    output_dtype : torch.dtype
+        Output data type.  Only ``torch.bfloat16`` is currently supported.
+    activation : str
+        Activation function — ``"silu"`` (gated SwiGLU) or ``"relu2"``
+        (non-gated Nemotron-Super).  Defaults to ``"silu"``.
+    activation_precision : str
+        Backward-compatible alias for ``quant_mode``.  ``"fp4"`` selects
+        ``quant_mode="nvfp4"``; ``"bf16"`` selects ``quant_mode="w4a16"``.
+    quant_mode : Optional[str]
+        Quantization mode, ``"nvfp4"`` / ``"w4a4"`` or ``"w4a16"``.  When set,
+        selects the backend and internal workspace family.
+    source_format : str
+        Source weight format for ``quant_mode="w4a16"`` — ``"modelopt"`` or
+        ``"compressed_tensors"``.  Defaults to ``"modelopt"``.
 
-    Returns:
-        Output tensor [num_tokens, hidden_size].
+    Returns
+    -------
+    torch.Tensor
+        Output tensor of shape ``[num_tokens, hidden_size]``.
     """
     from ...jit.cpp_ext import get_cuda_version
 
@@ -236,6 +259,45 @@ class B12xMoEWrapper:
         quant_mode: Optional[str] = None,
         source_format: str = "modelopt",
     ):
+        r"""Configure the b12x fused-MoE wrapper.
+
+        Parameters
+        ----------
+        num_experts : int
+            Total number of experts.
+        top_k : int
+            Number of experts routed to per token.
+        hidden_size : int
+            Hidden dimension size.
+        intermediate_size : int
+            Intermediate dimension size.
+        use_cuda_graph : bool
+            If ``True``, pre-allocate workspace buffers sized for
+            ``max_num_tokens`` so the wrapper can be captured into a CUDA
+            graph.  Defaults to ``False``.
+        max_num_tokens : int
+            Maximum batch size, only used when ``use_cuda_graph=True``.
+            Defaults to ``4096``.
+        num_local_experts : Optional[int]
+            Number of local experts for expert parallelism.  Defaults to
+            ``num_experts``.
+        output_dtype : torch.dtype
+            Output dtype.  Only ``torch.bfloat16`` is currently supported.
+        device : str
+            Device on which to allocate workspace buffers.  Defaults to
+            ``"cuda"``.
+        activation : str
+            Activation function — ``"silu"`` (gated SwiGLU) or ``"relu2"``
+            (non-gated).  Defaults to ``"silu"``.
+        activation_precision : str
+            Backward-compatible alias for ``quant_mode``.  ``"fp4"`` selects
+            ``quant_mode="nvfp4"``; ``"bf16"`` selects ``quant_mode="w4a16"``.
+        quant_mode : Optional[str]
+            Quantization mode, ``"nvfp4"`` / ``"w4a4"`` or ``"w4a16"``.
+        source_format : str
+            Source weight format for ``quant_mode="w4a16"`` —
+            ``"modelopt"`` (default) or ``"compressed_tensors"``.
+        """
         from ...jit.cpp_ext import get_cuda_version
         from .blackwell_sm12x.moe_dispatch import (
             _activation_precision_from_quant_mode,
@@ -395,23 +457,37 @@ class B12xMoEWrapper:
         w2_alpha: torch.Tensor,
         fc2_input_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Run MoE computation.
+        r"""Run the b12x fused-MoE forward pass.
 
-        Args:
-            x: Input activations [num_tokens, hidden_size], bf16.
-            w1_weight: FC1 weights, FP4 packed.
-            w1_weight_sf: Scale factors for w1_weight.
-            w2_weight: FC2 weights, FP4 packed.
-            w2_weight_sf: Scale factors for w2_weight.
-            token_selected_experts: Expert assignments [num_tokens, top_k].
-            token_final_scales: Routing weights [num_tokens, top_k].
-            w1_alpha: Per-expert global scale for FC1.
-            w2_alpha: Per-expert global scale for FC2.
-            fc2_input_scale: Global scale for FC2 input quantization. Required
-                for quant_mode="nvfp4"; accepted but ignored for "w4a16".
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input activations of shape ``[num_tokens, hidden_size]``,
+            ``bfloat16``.
+        w1_weight : torch.Tensor
+            FC1 weights, FP4-packed.
+        w1_weight_sf : torch.Tensor
+            Scale factors for ``w1_weight``.
+        w2_weight : torch.Tensor
+            FC2 weights, FP4-packed.
+        w2_weight_sf : torch.Tensor
+            Scale factors for ``w2_weight``.
+        token_selected_experts : torch.Tensor
+            Expert assignments of shape ``[num_tokens, top_k]``.
+        token_final_scales : torch.Tensor
+            Routing weights of shape ``[num_tokens, top_k]``.
+        w1_alpha : torch.Tensor
+            Per-expert global scale for FC1.
+        w2_alpha : torch.Tensor
+            Per-expert global scale for FC2.
+        fc2_input_scale : Optional[torch.Tensor]
+            Global scale for FC2 input quantization.  Required for
+            ``quant_mode="nvfp4"``; accepted but ignored for ``"w4a16"``.
 
-        Returns:
-            Output tensor [num_tokens, hidden_size].
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape ``[num_tokens, hidden_size]``.
         """
         num_tokens = token_selected_experts.size(0)
 

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -370,22 +370,42 @@ class CuteDslMoEWrapper:
         device: str = "cuda",
         enable_pdl: bool = True,
     ):
-        """Initialize the MoE wrapper.
+        r"""Configure the CuTe-DSL NVFP4 fused-MoE wrapper.
 
-        Args:
-            num_experts: Total number of experts.
-            top_k: Number of experts per token.
-            hidden_size: Hidden dimension size.
-            intermediate_size: Intermediate size (after SwiGLU reduction).
-            use_cuda_graph: Pre-allocate buffers for CUDA graph compatibility.
-            max_num_tokens: Maximum tokens (only for use_cuda_graph=True).
-            num_local_experts: Local experts for EP. Default: num_experts.
-            local_expert_offset: Expert offset for EP. Default: 0.
-            tile_size: Tile size for moe_sort. Default: 128.
-            sf_vec_size: Scale factor vector size. Default: 16.
-            output_dtype: Output data type. Default: torch.bfloat16.
-            device: Device for buffer allocation. Default: "cuda".
-            enable_pdl: Enable Programmatic Dependent Launch. Default: True.
+        Parameters
+        ----------
+        num_experts : int
+            Total number of experts.
+        top_k : int
+            Number of experts routed to per token.
+        hidden_size : int
+            Hidden dimension size.
+        intermediate_size : int
+            Intermediate dimension size (after SwiGLU reduction).
+        use_cuda_graph : bool
+            If ``True``, pre-allocate workspace buffers sized for
+            ``max_num_tokens`` so the wrapper can be captured into a CUDA
+            graph.  Defaults to ``False``.
+        max_num_tokens : int
+            Maximum batch size, used when ``use_cuda_graph=True``.  Defaults
+            to ``4096``.
+        num_local_experts : Optional[int]
+            Local experts for expert parallelism.  Defaults to
+            ``num_experts``.
+        local_expert_offset : int
+            Offset of local experts in the global expert space.  Defaults
+            to ``0``.
+        tile_size : int
+            Tile size for ``moe_sort``.  Defaults to ``128``.
+        sf_vec_size : int
+            Scale-factor vector size.  Defaults to ``16``.
+        output_dtype : torch.dtype
+            Output dtype.  Defaults to ``torch.bfloat16``.
+        device : str
+            Device on which to allocate workspace buffers.  Defaults to
+            ``"cuda"``.
+        enable_pdl : bool
+            Enable Programmatic Dependent Launch.  Defaults to ``True``.
         """
         self.num_experts = num_experts
         self.top_k = top_k
@@ -620,27 +640,44 @@ class CuteDslMoEWrapper:
         w2_alpha: torch.Tensor,
         tactic: Optional[Tuple] = None,
     ) -> torch.Tensor:
-        """Run MoE computation.
+        r"""Run the CuTe-DSL NVFP4 fused-MoE forward pass.
 
-        This method is CUDA graph safe when use_cuda_graph=True.
-        Supports auto-tuning via `tactic` parameter or `autotune()` context.
+        CUDA-graph safe when the wrapper was constructed with
+        ``use_cuda_graph=True``.  Supports auto-tuning via the ``tactic``
+        argument or the surrounding :func:`autotune` context manager.
 
-        Args:
-            x: NVFP4-quantized input [num_tokens, hidden_size // 2].
-            x_sf: Scale factors for x.
-            token_selected_experts: Expert assignments [num_tokens, top_k].
-            token_final_scales: Routing weights [num_tokens, top_k].
-            w1_weight: GEMM1 weights (gate + up fused).
-            w1_weight_sf: Scale factors for w1_weight.
-            w1_alpha: Per-expert global scale for GEMM1.
-            fc2_input_scale: Global scale for GEMM2 input quantization.
-            w2_weight: GEMM2 weights (down projection).
-            w2_weight_sf: Scale factors for w2_weight.
-            w2_alpha: Per-expert global scale for GEMM2.
-            tactic: Tactic tuple or None for auto-selection.
+        Parameters
+        ----------
+        x : torch.Tensor
+            NVFP4-quantized input of shape ``[num_tokens, hidden_size // 2]``.
+        x_sf : torch.Tensor
+            Scale factors for ``x``.
+        token_selected_experts : torch.Tensor
+            Expert assignments of shape ``[num_tokens, top_k]``.
+        token_final_scales : torch.Tensor
+            Routing weights of shape ``[num_tokens, top_k]``.
+        w1_weight : torch.Tensor
+            GEMM1 weights (gate + up fused).
+        w1_weight_sf : torch.Tensor
+            Scale factors for ``w1_weight``.
+        w1_alpha : torch.Tensor
+            Per-expert global scale for GEMM1.
+        fc2_input_scale : torch.Tensor
+            Global scale for GEMM2 input quantization.
+        w2_weight : torch.Tensor
+            GEMM2 weights (down projection).
+        w2_weight_sf : torch.Tensor
+            Scale factors for ``w2_weight``.
+        w2_alpha : torch.Tensor
+            Per-expert global scale for GEMM2.
+        tactic : Optional[Tuple]
+            Tactic tuple, or ``None`` for auto-selection via the runtime
+            tuner.
 
-        Returns:
-            Output tensor [num_tokens, hidden_size].
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape ``[num_tokens, hidden_size]``.
         """
         num_tokens = token_selected_experts.size(0)
 
@@ -783,41 +820,64 @@ def cute_dsl_fused_moe_nvfp4(
     aux_stream: Optional[torch.cuda.Stream] = None,
     enable_pdl: bool = True,
 ) -> torch.Tensor:
-    """Run fused MoE computation using CuteDSL NVFP4 kernels.
+    r"""Run a fused MoE forward pass using the CuTe-DSL NVFP4 kernels.
 
-    Supported architectures: SM100, SM103.
+    Supported architectures: SM100, SM103.  This is the simple functional
+    API; for CUDA-graph support use :class:`CuteDslMoEWrapper` instead.
 
-    This is the simple functional API. For CUDA graph support, use
-    `CuteDslMoEWrapper` instead.
+    Auto-tuning is controlled by the :func:`autotune` context manager::
 
-    Auto-tuning is controlled via the `autotune()` context manager:
+        with autotune(True):
+            output = cute_dsl_fused_moe_nvfp4(...)
 
-        >>> with autotune(True):
-        ...     output = cute_dsl_fused_moe_nvfp4(...)
+    Parameters
+    ----------
+    x : torch.Tensor
+        NVFP4-quantized input of shape ``[num_tokens, hidden_size // 2]``.
+    x_sf : torch.Tensor
+        Scale factors for ``x``.
+    token_selected_experts : torch.Tensor
+        Expert assignments of shape ``[num_tokens, top_k]``.
+    token_final_scales : torch.Tensor
+        Routing weights of shape ``[num_tokens, top_k]``.
+    w1_weight : torch.Tensor
+        GEMM1 weights (gate + up fused).
+    w1_weight_sf : torch.Tensor
+        Scale factors for ``w1_weight``.
+    w1_alpha : torch.Tensor
+        Per-expert global scale for GEMM1.
+    fc2_input_scale : torch.Tensor
+        Global scale for GEMM2 input quantization.
+    w2_weight : torch.Tensor
+        GEMM2 weights (down projection).
+    w2_weight_sf : torch.Tensor
+        Scale factors for ``w2_weight``.
+    w2_alpha : torch.Tensor
+        Per-expert global scale for GEMM2.
+    num_experts : int
+        Total number of experts.
+    top_k : int
+        Number of experts routed to per token.
+    num_local_experts : Optional[int]
+        Local experts for expert parallelism.  Defaults to ``num_experts``.
+    local_expert_offset : int
+        Offset of local experts in the global expert space.  Defaults to ``0``.
+    output_dtype : torch.dtype
+        Output dtype.  Defaults to ``torch.bfloat16``.
+    use_fused_finalize : bool
+        Whether to use the fused finalize path.  Defaults to ``True``.
+    moe_output : Optional[torch.Tensor]
+        Pre-allocated output buffer.  Allocated internally if ``None``.
+    aux_stream : Optional[torch.cuda.Stream]
+        Optional auxiliary CUDA stream used to overlap setup work with the
+        main computation.
+    enable_pdl : bool
+        Enable Programmatic Dependent Launch.  Defaults to ``True``.
 
-    Args:
-        x: NVFP4-quantized input [num_tokens, hidden_size // 2].
-        x_sf: Scale factors for x.
-        token_selected_experts: Expert assignments [num_tokens, top_k].
-        token_final_scales: Routing weights [num_tokens, top_k].
-        w1_weight: GEMM1 weights (gate + up fused).
-        w1_weight_sf: Scale factors for w1_weight.
-        w1_alpha: Per-expert global scale for GEMM1.
-        fc2_input_scale: Global scale for GEMM2 input quantization.
-        w2_weight: GEMM2 weights (down projection).
-        w2_weight_sf: Scale factors for w2_weight.
-        w2_alpha: Per-expert global scale for GEMM2.
-        num_experts: Total number of experts.
-        top_k: Number of experts per token.
-        num_local_experts: Local experts for EP. Default: num_experts.
-        local_expert_offset: Expert offset for EP. Default: 0.
-        output_dtype: Output data type. Default: torch.bfloat16.
-        use_fused_finalize: Use fused finalize. Default: True.
-        moe_output: Pre-allocated output buffer.
-        aux_stream: Auxiliary CUDA stream.
-
-    Returns:
-        Output tensor [num_tokens, hidden_size].
+    Returns
+    -------
+    torch.Tensor
+        Output tensor of shape ``[num_tokens, hidden_size]``.
     """
     if num_local_experts is None:
         num_local_experts = num_experts

--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -151,63 +151,62 @@ def fused_topk_deepseek(
     launch_with_pdl: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
 ) -> None:
-    """Fused expert routing with top-k selection for DeepSeek-V3.
+    r"""Fused expert routing with top-k selection for DeepSeek-V3.
 
-    This function performs a highly optimized fused routing operation specifically
-    designed for DeepSeek-V3's Mixture of Experts (MoE) architecture with grouped
-    expert routing and no auxiliary loss. It combines score computation, expert
-    selection, and normalization into a single kernel operation.
+    Performs a highly optimized fused routing operation designed for
+    DeepSeek-V3's Mixture-of-Experts architecture with grouped expert routing
+    and no auxiliary loss.  Combines score computation, expert selection, and
+    normalization into a single kernel:
 
-    The routing algorithm consists of the following steps:
-    1. Compute biased scores: sigmoid(scores) + bias for each expert
-    2. Group experts and compute group scores (sum of top-2 experts per group)
-    3. Select top-k groups based on group scores
-    4. From selected groups, select top-k experts based on biased scores
-    5. Normalize selected expert weights: sigmoid_scores / sum(sigmoid_scores) * scale
+    1. Compute biased scores ``sigmoid(scores) + bias``.
+    2. Group experts and compute per-group scores (sum of top-2 experts per
+       group).
+    3. Select the top ``topk_group`` groups by group score.
+    4. From the selected groups, pick the top ``topk`` experts by biased
+       score.
+    5. Normalize the selected expert weights:
+       ``sigmoid_scores / sum(sigmoid_scores) * routed_scaling_factor``.
 
-    Args:
-        scores (torch.Tensor): Input routing scores of shape (num_tokens, num_experts).
-            The logits produced by the router network before activation. Supports
-            bfloat16, float16, or float32.
-        bias (torch.Tensor): Per-expert routing bias of shape (num_experts,). Added to
-            sigmoid-activated scores to produce biased scores for expert selection.
-            Must match the dtype of scores.
-        n_group (int): Number of expert groups. Experts are divided into groups for
-            hierarchical selection. Typical value is 8 for DeepSeek-V3 with 256 experts
-            (32 experts per group).
-        topk_group (int): Number of top groups to select. Must be <= n_group. Typical
-            value is 4, meaning the top 4 groups are selected from 8 groups.
-        topk (int): Number of top experts to select per token. Must be <= num_experts.
-            Typical value is 8, meaning 8 experts are routed per token.
-        routed_scaling_factor (float): Scaling factor applied to normalized expert
-            weights. The final output weights are:
-            sigmoid_scores / sum(sigmoid_scores) * routed_scaling_factor.
-        topk_values (torch.Tensor): Pre-allocated output tensor of shape
-            (num_tokens, topk) for the normalized expert weights. Must be float32.
-            This tensor is mutated in-place.
-        topk_indices (torch.Tensor): Pre-allocated output tensor of shape
-            (num_tokens, topk) for the selected expert indices. Must be int32 or int64.
-            This tensor is mutated in-place.
-        launch_with_pdl (bool, optional): Whether to launch the kernel using Persistent
-            Device-side Launch. Defaults to True.
-        routing_replay_out (torch.Tensor, optional): Pre-allocated output tensor of shape
-            (num_tokens, topk) with dtype int16 for recording the selected expert IDs per
-            token. If None, no routing replay recording occurs (zero overhead). This tensor
-            is mutated in-place.
+    Parameters
+    ----------
+    scores : torch.Tensor
+        Routing scores of shape ``(num_tokens, num_experts)``, ``bfloat16`` /
+        ``float16`` / ``float32``.
+    bias : torch.Tensor
+        Per-expert routing bias of shape ``(num_experts,)``, same dtype as
+        ``scores``.  Added to the sigmoid-activated scores before grouping.
+    n_group : int
+        Number of expert groups (typically 8 for DeepSeek-V3 with 256
+        experts).
+    topk_group : int
+        Number of top groups to select.  Must be ``<= n_group``.  Typical
+        value is 4.
+    topk : int
+        Number of top experts to select per token.  Must be ``<=
+        num_experts``.  Typical value is 8.
+    routed_scaling_factor : float
+        Scaling factor applied to the normalized expert weights.
+    topk_values : torch.Tensor
+        Pre-allocated output tensor of shape ``(num_tokens, topk)``,
+        ``float32``.  Mutated in place with the normalized weights.
+    topk_indices : torch.Tensor
+        Pre-allocated output tensor of shape ``(num_tokens, topk)``, ``int32``
+        or ``int64``.  Mutated in place with the selected expert indices.
+    launch_with_pdl : bool
+        Whether to launch the kernel with Programmatic Dependent Launch.
+        Defaults to ``True``.
+    routing_replay_out : Optional[torch.Tensor]
+        Pre-allocated ``(num_tokens, topk)`` ``int16`` tensor used to record
+        the selected expert IDs.  If ``None`` (default) the kernel skips this
+        write.
 
-    Returns:
-        None: Results are written directly to `topk_values` and `topk_indices` tensors.
-
-    Note:
-        - The kernel uses float32 internally for all computations to ensure numerical
-          precision, even when inputs are float16 or bfloat16.
-        - This implementation is optimized for Hopper (compute capability 90, 100),
-          Ada (compute capability 89), and Blackwell (compute capability 120, 121)
-          architectures.
-        - The "NoAux" prefix indicates this variant does not compute auxiliary losses
-          (e.g., load balancing loss) during routing.
-        - The "Tc" suffix indicates the use of Tensor Core optimizations in the
-          underlying CUDA kernel.
+    Notes
+    -----
+    The kernel uses ``float32`` internally for numerical precision regardless
+    of the input dtype.  Supported on Hopper (SM90/SM100), Ada (SM89), and
+    Blackwell (SM120/SM121).  The "NoAux" suffix in the underlying CUDA
+    kernel indicates the absence of auxiliary load-balancing losses; "Tc"
+    indicates Tensor-Core utilization.
     """
     get_dsv3_fused_routing_module().NoAuxTc(
         scores,

--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -203,10 +203,10 @@ def fused_topk_deepseek(
     Notes
     -----
     The kernel uses ``float32`` internally for numerical precision regardless
-    of the input dtype.  Supported on Hopper (SM90/SM100), Ada (SM89), and
-    Blackwell (SM120/SM121).  The "NoAux" suffix in the underlying CUDA
-    kernel indicates the absence of auxiliary load-balancing losses; "Tc"
-    indicates Tensor-Core utilization.
+    of the input dtype.  Supported on Ada (SM89), Hopper (SM90), and
+    Blackwell (SM100/SM103/SM120/SM121).  The "NoAux" suffix in the
+    underlying CUDA kernel indicates the absence of auxiliary load-balancing
+    losses; "Tc" indicates Tensor-Core utilization.
     """
     get_dsv3_fused_routing_module().NoAuxTc(
         scores,

--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -170,43 +170,66 @@ def fused_topk_deepseek(
     Parameters
     ----------
     scores : torch.Tensor
-        Routing scores of shape ``(num_tokens, num_experts)``, ``bfloat16`` /
-        ``float16`` / ``float32``.
+        Router logits of shape ``(num_tokens, num_experts)``, before any
+        activation.  ``bfloat16`` / ``float16`` / ``float32``.
     bias : torch.Tensor
         Per-expert routing bias of shape ``(num_experts,)``, same dtype as
         ``scores``.  Added to the sigmoid-activated scores before grouping.
     n_group : int
-        Number of expert groups (typically 8 for DeepSeek-V3 with 256
-        experts).
+        Number of expert groups.  Must satisfy ``n_group <= 32`` and
+        ``num_experts % n_group == 0``.  Typical value is 8 for DeepSeek-V3
+        with 256 experts (32 experts per group).
     topk_group : int
-        Number of top groups to select.  Must be ``<= n_group``.  Typical
-        value is 4.
+        Number of top groups to select.  Must satisfy ``topk_group <=
+        n_group`` and ``topk_group * n_group >= topk``.  Typical value is 4.
     topk : int
-        Number of top experts to select per token.  Must be ``<=
-        num_experts``.  Typical value is 8.
+        Number of top experts to select per token.  Must be ``<= num_experts``.
+        Hard cap ``topk <= 32``; in addition both branches of the kernel
+        require ``topk <= 8``.  Typical value is 8.
+
+        Further per-branch constraints:
+
+        - When ``n_group > 1``: ``num_experts / n_group <= 32`` and
+          ``(num_experts / n_group) * topk_group <= 128``.
+        - When ``n_group == 1``: ``num_experts <= 384``.
     routed_scaling_factor : float
-        Scaling factor applied to the normalized expert weights.
+        Scaling factor applied to the normalized expert weights (see step 5
+        in the algorithm summary above).
     topk_values : torch.Tensor
-        Pre-allocated output tensor of shape ``(num_tokens, topk)``,
-        ``float32``.  Mutated in place with the normalized weights.
+        Pre-allocated output tensor of shape ``(num_tokens, topk)``.  Must
+        have the same dtype as ``scores`` (``bfloat16`` / ``float16`` /
+        ``float32``); the normalized expert weights are written here in
+        place.
     topk_indices : torch.Tensor
-        Pre-allocated output tensor of shape ``(num_tokens, topk)``, ``int32``
-        or ``int64``.  Mutated in place with the selected expert indices.
+        Pre-allocated output tensor of shape ``(num_tokens, topk)``.  Must
+        be ``int32``.  The selected expert indices are written here in
+        place.
     launch_with_pdl : bool
         Whether to launch the kernel with Programmatic Dependent Launch.
         Defaults to ``True``.
     routing_replay_out : Optional[torch.Tensor]
-        Pre-allocated ``(num_tokens, topk)`` ``int16`` tensor used to record
-        the selected expert IDs.  If ``None`` (default) the kernel skips this
-        write.
+        Pre-allocated ``int16`` tensor used to record the selected expert
+        IDs.  Shape must satisfy ``shape[0] >= num_tokens`` and
+        ``shape[1] == topk`` — the ``>=`` on ``shape[0]`` is intentional so
+        the same buffer can be sized for the maximum batch and reused across
+        steps with smaller ``num_tokens`` under CUDA graphs (the kernel only
+        writes indices ``[0, num_tokens)``).  When ``None`` (default) the
+        kernel skips this write (zero overhead).
+
+    Returns
+    -------
+    None
+        Results are written in place to ``topk_values`` and ``topk_indices``
+        (and optionally ``routing_replay_out``).
 
     Notes
     -----
     The kernel uses ``float32`` internally for numerical precision regardless
     of the input dtype.  Supported on Ada (SM89), Hopper (SM90), and
-    Blackwell (SM100/SM103/SM120/SM121).  The "NoAux" suffix in the
-    underlying CUDA kernel indicates the absence of auxiliary load-balancing
-    losses; "Tc" indicates Tensor-Core utilization.
+    Blackwell (SM100/SM103/SM120/SM121).  In the underlying CUDA kernel name
+    ``NoAuxTc``, the ``NoAux`` prefix indicates the absence of auxiliary
+    load-balancing losses and the ``Tc`` suffix indicates Tensor-Core
+    utilization.
     """
     get_dsv3_fused_routing_module().NoAuxTc(
         scores,


### PR DESCRIPTION
## Summary
- `docs/api/fused_moe.rst`: documents CuTe-DSL wrappers (`B12xMoEWrapper`, `CuteDslMoEWrapper`), all `trtllm_*_moe` variants, `fused_topk_deepseek`, and helper utilities.
- Converts ~20 `trtllm_*_moe` docstrings from Google `Args:` to NumPy `Parameters` for doc-checker compliance.
- Adds explicit `.. automethod:: __init__` for the wrapper classes (otherwise constructor docstrings are not rendered); removes redundant `automethod:: run` directives that duplicate `:members:`.
- Decorates `reorder_rows` / `convert_to_block_layout` in `fused_moe/core.py` with `@flashinfer_api` (these were intended to be public per existing usage; please confirm).
- A2A (`trtllm_moe_alltoall`) docstrings stay here per the agreed PR-3/PR-4 split (RST structure for `MoeAlltoAll` lives in PR-4b).

## Why this PR (split rationale)
MoE is the largest single-file diff (`fused_moe/core.py`). All `~20` `trtllm_*` variants share one codeowner group (`@aleozlx @jiahanc @IwakuraRein @samuellees @nv-yunzheq`), so combining them is more efficient than splitting per-kernel.

## Review notes
- Big diff (~1340 / 796) but the structure is repetitive — most lines are docstring conversions. Skim per-function rather than line-by-line.
- Decorator additions on `reorder_rows` / `convert_to_block_layout` should be confirmed as intentional public surface by the MoE owners.

## Part of the v0.6.12 docs cleanup
PR-3 of 8. Siblings: PR-1, PR-2, PR-4a/4b, PR-5, PR-6, PR-7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for a new fused routing utility and broadened coverage of fused MoE entry points across precisions and routing modes.

* **Documentation**
  * Expanded API docs with detailed usage, tensor shape/dtype expectations, and in-place semantics for routing helpers.
  * Standardized and clarified docstrings, parameter/return semantics, and CUDA-graph notes.
  * Added a CuteDSL Fused MoE section describing wrapper usage and conditional availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->