### PR TITLE
docs(comm): NumPy-style docstrings + Deprecated leads for 21 STALE comm APIs (no decorator changes)

### DIFF
--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -197,9 +197,25 @@ cudart = CudaRTLibrary()
 def create_shared_buffer(
     size_in_bytes: int, group: Optional[ProcessGroup] = None
 ) -> List[int]:
-    """
-    Creates a shared buffer and returns a list of pointers
-    representing the buffer on all processes in the group.
+    r"""Allocate a buffer and share it across the process group via CUDA IPC.
+
+    The local rank performs ``cudaMalloc`` followed by
+    ``cudaIpcGetMemHandle``; other ranks open the resulting handle to obtain
+    a pointer mapped into their address space.
+
+    Parameters
+    ----------
+    size_in_bytes : int
+        Size of the buffer to allocate per rank.
+    group : torch.distributed.ProcessGroup, optional
+        Process group to exchange IPC handles across.  Defaults to
+        ``dist.group.WORLD``.
+
+    Returns
+    -------
+    list[int]
+        Per-rank device pointers (rank-local at position ``rank``, IPC-mapped
+        for the others).
     """
     pointer = cudart.cudaMalloc(size_in_bytes)
     handle = cudart.cudaIpcGetMemHandle(pointer)
@@ -226,8 +242,18 @@ def create_shared_buffer(
 def free_shared_buffer(
     pointers: List[int], group: Optional[ProcessGroup] = None
 ) -> None:
-    """
-    Frees a shared buffer.
+    r"""Free a shared buffer previously created by :func:`create_shared_buffer`.
+
+    Each rank releases only its rank-local allocation; the IPC-mapped peer
+    pointers must not be freed here.
+
+    Parameters
+    ----------
+    pointers : list[int]
+        Per-rank pointer list returned by :func:`create_shared_buffer`.
+    group : torch.distributed.ProcessGroup, optional
+        Process group used during allocation.  Defaults to
+        ``dist.group.WORLD``.
     """
     if group is None:
         group = dist.group.WORLD

--- a/flashinfer/comm/dlpack_utils.py
+++ b/flashinfer/comm/dlpack_utils.py
@@ -194,25 +194,32 @@ def pack_strided_memory(
     segment_stride: int,
     num_segments: int,
     dtype: torch.dtype,
-    dev_id,
-):
-    """
-    Pack GPU memory into a PyTorch tensor with specified stride.
+    dev_id: int,
+) -> torch.Tensor:
+    r"""Pack a strided device allocation as a PyTorch tensor view.
 
-    Parameters:
-        ptr: GPU memory address obtained from cudaMalloc
-        segment_size: Memory size of each segment in bytes
-        segment_stride: Memory stride size between segments in bytes
-        num_segments: Number of segments
-        dtype: PyTorch data type for the resulting tensor
-        dev_id: CUDA device ID
+    A fresh DLPack capsule is created on every call, so each tensor returned
+    by this function consumes its own capsule.
 
-    Returns:
-        PyTorch tensor that references the provided memory
+    Parameters
+    ----------
+    ptr : int
+        Device pointer (e.g. one returned by ``cudaMalloc``).
+    segment_size : int
+        Size of each segment in bytes.
+    segment_stride : int
+        Stride between consecutive segments in bytes.
+    num_segments : int
+        Number of segments to expose.
+    dtype : torch.dtype
+        Element dtype of the resulting tensor.
+    dev_id : int
+        CUDA device ID hosting ``ptr``.
 
-    Note:
-        This function creates a new DLPack capsule each time it's called,
-        even with the same pointer. Each capsule is consumed only once.
+    Returns
+    -------
+    torch.Tensor
+        A tensor that views the provided device memory.
     """
     # Create a new capsule each time
     capsule_wrapper = create_dlpack_capsule(

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -68,17 +68,23 @@ def round_up(val: int, gran: int) -> int:
 def create_tensor_from_cuda_memory(
     ptr: int, shape: tuple, dtype: torch.dtype, device_id: int
 ) -> torch.Tensor:
-    """
-    Create a PyTorch tensor from a CUDA memory pointer using DLPack.
+    r"""Wrap a CUDA memory allocation as a PyTorch tensor via DLPack.
 
-    Args:
-        ptr: CUDA memory pointer address as integer
-        shape: Desired tensor shape
-        dtype: PyTorch data type
-        device_id: CUDA device ID
+    Parameters
+    ----------
+    ptr : int
+        CUDA memory pointer (device address) as an integer.
+    shape : tuple
+        Desired tensor shape.
+    dtype : torch.dtype
+        Element dtype of the resulting tensor.
+    device_id : int
+        CUDA device ID hosting ``ptr``.
 
-    Returns:
-        PyTorch tensor that wraps the CUDA memory
+    Returns
+    -------
+    torch.Tensor
+        A tensor that views the provided device memory.
     """
     # Calculate total size in elements
     numel = 1
@@ -131,9 +137,22 @@ def test_cuda_memory_access(ptr: int, size: int, device_id: int) -> bool:
         return False
 
 
-def alloc_and_copy_to_cuda(host_ptr_array: List[int]) -> int:
-    """
-    A helper function that allocates memory on cuda and copies the data from the host to the device.
+def alloc_and_copy_to_cuda(host_ptr_array: List[int]) -> Optional[int]:
+    r"""Allocate a device buffer holding the supplied host pointer array.
+
+    The host pointers are packed into a ``uint64`` array, copied to device,
+    and the resulting device pointer is returned.
+
+    Parameters
+    ----------
+    host_ptr_array : list[int]
+        Sequence of host-side pointer values (interpreted as ``uint64``).
+
+    Returns
+    -------
+    Optional[int]
+        Device pointer to the packed array, or ``None`` if
+        ``host_ptr_array`` is empty.
     """
     if not host_ptr_array:
         return None

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -765,13 +765,20 @@ def trtllm_destroy_ipc_workspace_for_all_reduce_fusion(
 
 
 # allReduce fused quant utils
-def compute_fp4_swizzled_layout_sf_size(total_row, total_column):
-    """
-    Helper function to compute the padded size of the fp4 swizzled layout.
+def compute_fp4_swizzled_layout_sf_size(total_row: int, total_column: int) -> int:
+    r"""Compute the padded size (rows times columns) of the FP4 swizzled layout.
 
-    Parameters:
-    - total_row: the total number of rows.
-    - total_column: the total number of columns.
+    Parameters
+    ----------
+    total_row : int
+        Logical row count of the un-padded layout.
+    total_column : int
+        Logical column count of the un-padded layout.
+
+    Returns
+    -------
+    int
+        ``padded_row * padded_column`` for the swizzled layout.
     """
 
     def pad_up(x, y):
@@ -783,6 +790,17 @@ def compute_fp4_swizzled_layout_sf_size(total_row, total_column):
 
 
 def trtllm_lamport_initialize(buffer_ptr: int, size: int, dtype: torch.dtype) -> None:
+    r"""Initialize a single Lamport-style buffer to negative zero.
+
+    Parameters
+    ----------
+    buffer_ptr : int
+        Device pointer to the buffer.
+    size : int
+        Number of elements in the buffer.
+    dtype : torch.dtype
+        Element dtype of the buffer.
+    """
     get_trtllm_comm_module().trtllm_lamport_initialize(buffer_ptr, size, dtype)
 
 
@@ -793,15 +811,20 @@ def trtllm_lamport_initialize_all(
     size: int,
     dtype: torch.dtype,
 ) -> None:
-    """
-    Initialize 3 lamport buffers by negative zero.
+    r"""Initialize three Lamport buffers to negative zero.
 
-    Parameters:
-    - buffer_0_ptr: the pointer to the first buffer.
-    - buffer_1_ptr: the pointer to the second buffer.
-    - buffer_2_ptr: the pointer to the third buffer.
-    - size: the size of the buffer.
-    - dtype: the data type of the buffer.
+    Parameters
+    ----------
+    buffer_0_ptr : int
+        Device pointer to the first buffer.
+    buffer_1_ptr : int
+        Device pointer to the second buffer.
+    buffer_2_ptr : int
+        Device pointer to the third buffer.
+    size : int
+        Number of elements in each buffer.
+    dtype : torch.dtype
+        Element dtype of each buffer.
     """
 
     get_trtllm_comm_module().trtllm_lamport_initialize_all(

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -797,6 +797,10 @@ def get_allreduce_mnnvl_workspace(
 ) -> Tuple[MNNVLAllReduceFusionWorkspace, torch.Tensor, int]:
     """Get workspace buffers needed for multi-node NVLink all-reduce operation.
 
+    Deprecated: use :class:`MNNVLAllReduceFusionWorkspace` to manage the
+    workspace instead. This legacy helper is kept for backward compatibility
+    and may be removed in a future release.
+
     Args:
         mapping: Tensor parallel mapping configuration containing rank info
         dtype: Data type of the tensors being reduced
@@ -938,6 +942,10 @@ def trtllm_mnnvl_fused_allreduce_rmsnorm(
     launch_with_pdl: bool,
 ) -> None:
     """Performs MNNVL TwoShot Allreduce + RMSNorm.
+
+    Deprecated: use :func:`trtllm_mnnvl_fused_allreduce_add_rmsnorm` instead.
+    This legacy function is kept for backward compatibility and may be removed
+    in a future release.
 
     This function performs a multi-node all-reduce (sum) operation by first calling trtllm_mnnvl_all_reduce on the shard_input.
     After this, it performs RMSNorm on the all-reduced result, reading it directly from the multicast buffer.

--- a/flashinfer/comm/vllm_ar.py
+++ b/flashinfer/comm/vllm_ar.py
@@ -94,12 +94,38 @@ def get_vllm_comm_module():
 def init_custom_ar(
     ipc_tensors: List[int], rank_data: torch.Tensor, rank: int, full_nvlink: bool
 ) -> int:
+    r"""Initialize the vLLM custom all-reduce backend.
+
+    Parameters
+    ----------
+    ipc_tensors : list[int]
+        IPC pointers to the per-rank communication buffers.
+    rank_data : torch.Tensor
+        Scratch tensor (one per rank) used for metadata exchange.
+    rank : int
+        Current rank within the all-reduce world.
+    full_nvlink : bool
+        ``True`` when every pair of ranks is connected via NVLink (enables
+        the fully-NVLink-optimized kernel path).
+
+    Returns
+    -------
+    int
+        Opaque handle (``fa``) to be passed to subsequent ``vllm_ar`` calls.
+    """
     return get_vllm_comm_module().init_custom_ar(
         ipc_tensors, rank_data, rank, full_nvlink
     )
 
 
 def dispose(fa: int) -> None:
+    r"""Release the resources held by a vLLM custom all-reduce handle.
+
+    Parameters
+    ----------
+    fa : int
+        Handle returned by :func:`init_custom_ar`.
+    """
     get_vllm_comm_module().dispose(fa)
 
 
@@ -111,35 +137,76 @@ def all_reduce(
     reg_buffer_sz_bytes: int,
     num_ctas: int,
 ) -> None:
-    """Performs an out-of-place all reduce.
+    r"""Perform an out-of-place all-reduce via the vLLM custom kernel.
 
-    Args:
-        fa: The handle to the custom all reduce.
-        inp: The input tensor to all reduce.
-        out: The output tensor to all reduce.
-        reg_buffer: The register buffer to all reduce.
-        reg_buffer_sz_bytes: The size of the register buffer.
-        num_ctas: The number of CTAs to use for the all reduce.
-        CTA upper bounds: 36. Generally, we can saturate the bandwidth even with small amount the SMs.
+    Parameters
+    ----------
+    fa : int
+        Handle returned by :func:`init_custom_ar`.
+    inp : torch.Tensor
+        Input tensor (rank-local contribution).
+    out : torch.Tensor
+        Pre-allocated output tensor (receives the reduced result).
+    reg_buffer : int
+        Device pointer to the registered buffer used by the kernel.
+    reg_buffer_sz_bytes : int
+        Size of ``reg_buffer`` in bytes.
+    num_ctas : int
+        Number of CTAs to launch.  Upper bound is 36; small values are
+        usually enough to saturate NVLink bandwidth.
     """
     get_vllm_comm_module().all_reduce(
         fa, inp, out, reg_buffer, reg_buffer_sz_bytes, num_ctas
     )
 
 
-def get_graph_buffer_ipc_meta(fa) -> Tuple[List[int], List[int]]:
+def get_graph_buffer_ipc_meta(fa: int) -> Tuple[List[int], List[int]]:
+    r"""Return IPC metadata for graph-capture buffers.
+
+    Parameters
+    ----------
+    fa : int
+        Handle returned by :func:`init_custom_ar`.
+
+    Returns
+    -------
+    Tuple[list[int], list[int]]
+        ``(output_bytes, output_offsets)`` describing the registered
+        graph-capture buffers.  Used to publish IPC handles to peer ranks.
+    """
     return get_vllm_comm_module().get_graph_buffer_ipc_meta(fa)
 
 
 def register_buffer(fa: int, fake_ipc_ptrs: List[int]) -> None:
+    r"""Register a peer's IPC-shared buffer with the local all-reduce handle.
+
+    Parameters
+    ----------
+    fa : int
+        Handle returned by :func:`init_custom_ar`.
+    fake_ipc_ptrs : list[int]
+        Per-rank IPC pointers obtained from each peer.
+    """
     return get_vllm_comm_module().register_buffer(fa, fake_ipc_ptrs)
 
 
 def register_graph_buffers(
     fa: int, handles: List[List[int]], offsets: List[List[int]]
 ) -> None:
+    r"""Register graph-capture buffers across the all-reduce world.
+
+    Parameters
+    ----------
+    fa : int
+        Handle returned by :func:`init_custom_ar`.
+    handles : list[list[int]]
+        Per-rank IPC handles published via :func:`get_graph_buffer_ipc_meta`.
+    offsets : list[list[int]]
+        Per-rank offsets matching ``handles``.
+    """
     get_vllm_comm_module().register_graph_buffers(fa, handles, offsets)
 
 
 def meta_size() -> int:
+    r"""Return the size of the vLLM all-reduce metadata structure in bytes."""
     return get_vllm_comm_module().meta_size()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Pure-docstring follow-up to the v0.6.12 doc-check report. Touches **only** docstrings, type annotations, and `Deprecated:` leads on 21 STALE comm APIs — **no behavior change, no decorator additions**.

The `@flashinfer_api` re-decoration of these same APIs has been split into a separate follow-up PR per reviewer request, so this PR can be approved on doc content alone.

Per-file scope:
- `cuda_ipc.py`: NumPy docstrings for `create_shared_buffer`, `free_shared_buffer`.
- `dlpack_utils.py`: NumPy docstring + `dev_id: int` / `-> torch.Tensor` for `pack_strided_memory`.
- `mnnvl.py`: NumPy docstrings for `create_tensor_from_cuda_memory`, `alloc_and_copy_to_cuda`; fix `alloc_and_copy_to_cuda` return type to `Optional[int]` (the `host_ptr_array == []` branch returns `None` — CodeRabbit catch).
- `trtllm_ar.py`: NumPy docstrings + type annotations for `compute_fp4_swizzled_layout_sf_size`, `trtllm_lamport_initialize`, `trtllm_lamport_initialize_all`.
- `trtllm_mnnvl_ar.py`: add `Deprecated:` leads to `get_allreduce_mnnvl_workspace` and `trtllm_mnnvl_fused_allreduce_rmsnorm` (already-`@deprecated` functions whose docstrings did not advertise the deprecation, so static doc checkers flagged them as STALE).
- `vllm_ar.py`: NumPy docstrings + `fa: int` annotation for `init_custom_ar`, `dispose`, `all_reduce`, `get_graph_buffer_ipc_meta`, `register_buffer`, `register_graph_buffers`, `meta_size`.

## 🔍 Related Issues

v0.6.12 docs cleanup tracking. Split from the original combined PR per @aleozlx review feedback: `let's approve the doc content changes here first`.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed. *(Docs-only PR; the only non-doc change is the `Optional[int]` return-type fix on `alloc_and_copy_to_cuda`, which matches existing runtime behavior — type-checker fix, not a behavior change.)*
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- **Force-pushed** from the previous head (`0d5cd770`) to drop all `@flashinfer_api` decorator additions; those now live in a follow-up PR.
- `grep -nE "@flashinfer_api|api_logging" flashinfer/comm/{cuda_ipc,dlpack_utils,mnnvl,trtllm_ar,trtllm_mnnvl_ar,vllm_ar}.py` returns no matches in the diff — confirmed decorator-free.
- `mnnvl.py`'s `alloc_and_copy_to_cuda` return-type fix (`int` → `Optional[int]`) is the only signature change. Verified by reading the `if not host_ptr_array: return None` early-out at the top of the function.

## Part of the v0.6.12 docs cleanup

PR-4a of 8 (split). Siblings: PR-1 attention (#3441), PR-2 GEMM (#3442), PR-3 fused_moe (#3443), **PR-4a' decorator follow-up (to be filed)**, PR-4b comm structural (#3445), PR-5 misc (#3446), PR-6 quant (#3447), PR-7 infra (#3440), PR-8 others (#3456).

Suggested reviewers (comm codeowners): @aleozlx @jimmyzho @bkryu @nv-yunzheq @yzh119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and restructured docstrings across communication utilities to clarify parameters, return values, allocation/ownership semantics, and deprecation guidance.

* **Chores**
  * Added and tightened type annotations and return hints for several public APIs to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->