### PR TITLE
docs(misc): expose DiT/RoPE norms; new RSTs for GDN decode/prefill/Mamba

### DIFF
--- a/docs/api/gdn_decode.rst
+++ b/docs/api/gdn_decode.rst
@@ -1,0 +1,17 @@
+.. _apigdn_decode:
+
+flashinfer.gdn_decode
+=====================
+
+Gated Delta-Rule decode-side kernels used in Mamba-2 / GDN-style sequence
+models. These functions consume a pre-built KV / state cache and run the
+recurrent gated delta-rule update for the current decode step.
+
+.. currentmodule:: flashinfer.gdn_decode
+
+.. autosummary::
+    :toctree: ../generated
+
+    gated_delta_rule_decode
+    gated_delta_rule_decode_pretranspose
+    gated_delta_rule_mtp

--- a/docs/api/gdn_prefill.rst
+++ b/docs/api/gdn_prefill.rst
@@ -1,0 +1,15 @@
+.. _apigdn_prefill:
+
+flashinfer.gdn_prefill
+======================
+
+Gated Delta-Rule prefill-side kernels. ``chunk_gated_delta_rule`` is the
+chunked GDN scan that initializes the recurrent state from a full prompt
+before the decode loop takes over.
+
+.. currentmodule:: flashinfer.gdn_prefill
+
+.. autosummary::
+    :toctree: ../generated
+
+    chunk_gated_delta_rule

--- a/docs/api/mamba.rst
+++ b/docs/api/mamba.rst
@@ -1,0 +1,15 @@
+.. _apimamba:
+
+flashinfer.mamba
+================
+
+Mamba / Mamba-2 state-space-model kernels. These wrap the selective scan and
+state-update primitives used in SSM blocks.
+
+.. currentmodule:: flashinfer.mamba
+
+.. autosummary::
+    :toctree: ../generated
+
+    selective_state_update
+    checkpointing_ssu

--- a/docs/api/norm.rst
+++ b/docs/api/norm.rst
@@ -18,3 +18,7 @@ Kernels for normalization layers.
     gemma_fused_add_rmsnorm
     layernorm
     fused_rmsnorm_silu
+    fused_qk_rmsnorm_rope
+    fused_dit_residual_layernorm_scale_shift
+    fused_dit_gate_residual_layernorm_scale_shift
+    fused_dit_gate_residual_layernorm_gamma_beta

--- a/docs/api/rope.rst
+++ b/docs/api/rope.rst
@@ -20,3 +20,6 @@ Kernels for applying rotary embeddings.
     apply_llama31_rope_pos_ids_inplace
     apply_rope_with_cos_sin_cache
     apply_rope_with_cos_sin_cache_inplace
+    rope_quantize_fp8
+    rope_quantize_fp8_append_paged_kv_cache
+    mla_rope_quantize_fp8

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,9 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/norm
    api/rope
    api/activation
+   api/gdn_decode
+   api/gdn_prefill
+   api/mamba
    api/quantization
    api/green_ctx
    api/fp4_quantization

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -123,6 +123,16 @@ from .norm import gemma_rmsnorm as gemma_rmsnorm
 from .norm import rmsnorm as rmsnorm
 from .norm import rmsnorm_quant as rmsnorm_quant
 from .norm import fused_rmsnorm_silu as fused_rmsnorm_silu
+from .norm import fused_qk_rmsnorm_rope as fused_qk_rmsnorm_rope
+from .norm import (
+    fused_dit_residual_layernorm_scale_shift as fused_dit_residual_layernorm_scale_shift,
+)
+from .norm import (
+    fused_dit_gate_residual_layernorm_scale_shift as fused_dit_gate_residual_layernorm_scale_shift,
+)
+from .norm import (
+    fused_dit_gate_residual_layernorm_gamma_beta as fused_dit_gate_residual_layernorm_gamma_beta,
+)
 
 try:
     from .norm import rmsnorm_fp4quant as rmsnorm_fp4quant

--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -219,8 +219,9 @@ def gated_delta_rule_decode_pretranspose(
       supported on both the bf16 fast path (K=V=128) and the float32 legacy
       path (T=1).  Both paths support ``-1`` padding indices (see
       ``initial_state_indices`` above for per-backend semantics).
-    - Legacy path (float32 state, T=1): ``K`` and ``V`` must be multiples
-      of 4.
+    - Legacy path (float32 state, T=1): ``K`` and ``V`` must each be
+      ``>= 128``, and ``V`` must be a multiple of 8 (the pretranspose tile
+      size ``TILE_V``).
     """
     # Validate input shapes
     B, T, H, K = q.shape
@@ -491,7 +492,11 @@ def gated_delta_rule_decode(
     -----
     - Requires SM90 (Hopper) architecture.
     - State is updated in-place.
-    - ``K`` and ``V`` must be multiples of 4 for vectorized loads.
+    - ``K`` and ``V`` must each be ``>= 128``.  ``V`` must be a multiple
+      of 32 (``TILE_V_NT``): the launcher conservatively asserts the
+      large-batch tile size to cover both code paths, even though the
+      small-batch kernel could in principle accept ``V % 16 == 0``
+      (``TILE_V_SMALL_NT``).
     - State layout is k-major: ``[B, HV, K, V]`` (no transpose needed).
     """
     # Validate input shapes
@@ -610,7 +615,10 @@ def gated_delta_rule_mtp(
         Value tensor of shape ``[B, T, HV, V]``.
     initial_state : torch.Tensor
         Initial state tensor of shape ``[pool_size, HV, V, K]`` (K-last
-        layout).
+        layout). **Must be float32** — this standalone MTP entry point
+        does not support the BF16 fast path; for a BF16 K=V=128 state
+        pool, call :func:`gated_delta_rule_decode_pretranspose` instead
+        (which dispatches into the BF16 MTP kernel when ``T > 1``).
     initial_state_indices : torch.Tensor
         Indices mapping each batch to its initial state, shape ``[B]``.
     A_log : torch.Tensor

--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -133,84 +133,94 @@ def gated_delta_rule_decode_pretranspose(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Gated Delta Rule Decode kernel for single-token generation.
 
-    This implements the decode phase of gated delta rule linear attention,
+    Implements the decode phase of gated delta rule linear attention,
     processing one token at a time and updating the recurrent state.
 
-    Args:
-        q (torch.Tensor):
-            Current query of shape ``[B, 1, H, K]``. Must be float16/bfloat16.
-        k (torch.Tensor):
-            Current key of shape ``[B, 1, H, K]``. Must be float16/bfloat16.
-        v (torch.Tensor):
-            Current value of shape ``[B, 1, HV, V]``. Must be float16/bfloat16.
-        state (Optional[torch.Tensor]):
-            Current state of shape ``[B, HV, V, K]`` (v-major / K-last layout).
-            Float32: legacy kernel (T=1 only). Bfloat16: BF16 state backend
-            (T=1 or MTP for T>1) when K=V=128. Will be updated in-place.
-            Pass ``None`` when using ``initial_state`` / ``initial_state_indices`` instead.
-        A_log (torch.Tensor):
-            Log decay parameter of shape ``[HV]``. Must be float32.
-        a (torch.Tensor):
-            Input-dependent decay of shape ``[B, 1, HV]``. Must be float16/bfloat16.
-        dt_bias (torch.Tensor):
-            Decay bias of shape ``[HV]``. Must be bfloat16 or float32.
-        b (torch.Tensor):
-            Update gate (beta) input of shape ``[B, 1, HV]``. Must be float16/bfloat16.
-        scale (Optional[float]):
-            Scale factor for queries. If None, defaults to ``1 / sqrt(K)``.
-        output (Optional[torch.Tensor]):
-            Pre-allocated output tensor of shape ``[B, 1, HV, V]``.
-            If None, will be allocated automatically.
-        use_qk_l2norm (bool):
-            Whether to apply L2 normalization to q and k. Default: ``True``.
-        initial_state (Optional[torch.Tensor]):
-            State pool of shape ``[pool_size, HV, V, K]`` (K-last / K-contiguous,
-            same layout as the per-batch ``state`` argument).
-            When provided, the kernel gathers directly from the pool using
-            ``initial_state_indices`` and writes updates back in-place — eliminating
-            the caller-side gather/scatter overhead.
-            Requires bfloat16 state with K=V=128 (bf16 fast path).
-        initial_state_indices (Optional[torch.Tensor]):
-            Per-batch indices of shape ``[B]`` (int32 or int64) mapping each batch
-            entry to its slot in ``initial_state``.  Required when ``initial_state``
-            is provided.
-        output_state_indices (Optional[torch.Tensor]):
-            Per-batch indices of shape ``[B]`` (int32 or int64) specifying where to write the updated state for each batch entry in the pool.
-            Requires ``initial_state`` to be provided.
-            If None, the kernel will write the updated state back to the same slot it read from (i.e., ``initial_state_indices``).
+    Parameters
+    ----------
+    q : torch.Tensor
+        Current query of shape ``[B, 1, H, K]``.  Must be float16/bfloat16.
+    k : torch.Tensor
+        Current key of shape ``[B, 1, H, K]``.  Must be float16/bfloat16.
+    v : torch.Tensor
+        Current value of shape ``[B, 1, HV, V]``.  Must be float16/bfloat16.
+    state : torch.Tensor, optional
+        Current state of shape ``[B, HV, V, K]`` (v-major / K-last layout).
+        Float32: legacy kernel (T=1 only).  Bfloat16: BF16 state backend
+        (T=1 or MTP for T>1) when K=V=128.  Updated in-place.  Pass ``None``
+        when using ``initial_state`` / ``initial_state_indices`` instead.
+    A_log : torch.Tensor
+        Log decay parameter of shape ``[HV]``.  Must be float32.
+    a : torch.Tensor
+        Input-dependent decay of shape ``[B, 1, HV]``.  Must be
+        float16/bfloat16.
+    dt_bias : torch.Tensor
+        Decay bias of shape ``[HV]``.  Must be bfloat16 or float32.
+    b : torch.Tensor
+        Update gate (beta) input of shape ``[B, 1, HV]``.  Must be
+        float16/bfloat16.
+    scale : float, optional
+        Scale factor for queries.  If ``None``, defaults to
+        ``1 / sqrt(K)``.
+    output : torch.Tensor, optional
+        Pre-allocated output tensor of shape ``[B, 1, HV, V]``.  Allocated
+        automatically when ``None``.
+    use_qk_l2norm : bool
+        Whether to apply L2 normalization to q and k.  Default: ``True``.
+    initial_state : torch.Tensor, optional
+        State pool of shape ``[pool_size, HV, V, K]`` (K-last /
+        K-contiguous, same layout as the per-batch ``state`` argument).
+        When provided, the kernel gathers directly from the pool using
+        ``initial_state_indices`` and writes updates back in-place,
+        eliminating the caller-side gather/scatter overhead.  Requires
+        bfloat16 state with K=V=128 (bf16 fast path).
+    initial_state_indices : torch.Tensor, optional
+        Per-batch indices of shape ``[B]`` (int32 or int64) mapping each
+        batch entry to its slot in ``initial_state``.  Required when
+        ``initial_state`` is provided.
+    output_state_indices : torch.Tensor, optional
+        Per-batch indices of shape ``[B]`` (int32 or int64) specifying
+        where to write the updated state for each batch entry in the pool.
+        Requires ``initial_state`` to be provided.  If ``None``, the kernel
+        writes the updated state back to the same slot it read from (i.e.
+        ``initial_state_indices``).
 
-            **Padding / inactive sequences**: set the index to ``-1`` for any batch
-            entry that should be treated as padding.  The two backends handle ``-1``
-            differently:
+        **Padding / inactive sequences**: set the index to ``-1`` for any
+        batch entry that should be treated as padding.  The two backends
+        handle ``-1`` differently:
 
-            - **bf16 fast path** (bfloat16 state, K=V=128): ``-1`` is redirected
-              to ``initial_state[0]``, which acts as a sacrificial *null buffer*.
-              The kernel reads from and writes back to slot 0; the output for that
-              batch entry is computed but **undefined** (caller should not use it).
-              The caller must therefore allocate the pool with an extra leading slot
-              (``pool_size = num_real_slots + 1``) and keep real slots at indices
-              ``1..pool_size-1``.
-            - **float32 legacy path** (T=1): ``-1`` entries are skipped entirely —
-              neither the state pool nor the output are touched for that batch entry;
-              the output slot is written as **zero**.
+        - **bf16 fast path** (bfloat16 state, K=V=128): ``-1`` is redirected
+          to ``initial_state[0]``, which acts as a sacrificial *null
+          buffer*.  The kernel reads from and writes back to slot 0; the
+          output for that batch entry is computed but **undefined** (caller
+          should not use it).  The caller must therefore allocate the pool
+          with an extra leading slot (``pool_size = num_real_slots + 1``)
+          and keep real slots at indices ``1..pool_size-1``.
+        - **float32 legacy path** (T=1): ``-1`` entries are skipped
+          entirely; neither the state pool nor the output are touched for
+          that batch entry; the output slot is written as **zero**.
 
-    Returns:
-        Tuple[torch.Tensor, torch.Tensor]:
-            - output: Output tensor of shape ``[B, 1, HV, V]``
-            - state or initial_state: Updated state (in-place).
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(output, state_or_initial_state)`` where ``output`` has shape
+        ``[B, 1, HV, V]`` and the second element is the updated state
+        (mutated in place).
 
-    Note:
-        - Requires SM90+ (Hopper, Blackwell, etc.)
-        - State is always updated in-place; the pool path writes directly into
-          ``initial_state`` memory (no separate scatter step needed)
-        - State layout is v-major (K-last): [B, HV, V, K]. When state is bfloat16
-          and K=V=128, the BF16 state kernel is used (T=1 or MTP for T>1).
-          The pool+indices path routes through the MTP kernel.
-        - pool+indices (``initial_state``/``initial_state_indices``) supported on
-          both the bf16 fast path (K=V=128) and the float32 legacy path (T=1).
-          Both paths support ``-1`` padding indices (see ``initial_state_indices``
-          above for per-backend semantics).
-        - Legacy path (float32 state, T=1): K and V must be multiples of 4.
+    Notes
+    -----
+    - Requires SM90+ (Hopper, Blackwell, etc.).
+    - State is always updated in-place; the pool path writes directly into
+      ``initial_state`` memory (no separate scatter step needed).
+    - State layout is v-major (K-last): ``[B, HV, V, K]``.  When state is
+      bfloat16 and ``K = V = 128``, the BF16 state kernel is used (T=1 or
+      MTP for T>1); the pool+indices path routes through the MTP kernel.
+    - Pool+indices (``initial_state`` / ``initial_state_indices``) are
+      supported on both the bf16 fast path (K=V=128) and the float32 legacy
+      path (T=1).  Both paths support ``-1`` padding indices (see
+      ``initial_state_indices`` above for per-backend semantics).
+    - Legacy path (float32 state, T=1): ``K`` and ``V`` must be multiples
+      of 4.
     """
     # Validate input shapes
     B, T, H, K = q.shape
@@ -437,47 +447,52 @@ def gated_delta_rule_decode(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Gated Delta Rule Decode kernel (K-major layout, no transpose needed).
 
-    This implements the decode phase of gated delta rule linear attention,
-    processing one token at a time and updating the recurrent state.
-    This version uses K-major state layout [B, HV, K, V] which is more natural
-    and doesn't require transposition.
+    Implements the decode phase of gated delta rule linear attention,
+    processing one token at a time and updating the recurrent state.  This
+    variant uses K-major state layout ``[B, HV, K, V]`` (no transposition).
 
-    Args:
-        q (torch.Tensor):
-            Current query of shape ``[B, 1, H, K]``. Must be float16/bfloat16.
-        k (torch.Tensor):
-            Current key of shape ``[B, 1, H, K]``. Must be float16/bfloat16.
-        v (torch.Tensor):
-            Current value of shape ``[B, 1, HV, V]``. Must be float16/bfloat16.
-        state (torch.Tensor):
-            Current state of shape ``[B, HV, K, V]`` (k-major layout).
-            Must be float32. Will be updated in-place.
-        A_log (torch.Tensor):
-            Log decay parameter of shape ``[HV]``. Must be float32.
-        a (torch.Tensor):
-            Input-dependent decay of shape ``[B, 1, HV]``. Must be float16/bfloat16.
-        dt_bias (torch.Tensor):
-            Decay bias of shape ``[HV]``. Must be bfloat16 or float32.
-        b (torch.Tensor):
-            Update gate (beta) input of shape ``[B, 1, HV]``. Must be float16/bfloat16.
-        scale (Optional[float]):
-            Scale factor for queries. If None, defaults to ``1 / sqrt(K)``.
-        output (Optional[torch.Tensor]):
-            Pre-allocated output tensor of shape ``[B, 1, HV, V]``.
-            If None, will be allocated automatically.
-        use_qk_l2norm (bool):
-            Whether to apply L2 normalization to q and k. Default: ``True``.
+    Parameters
+    ----------
+    q : torch.Tensor
+        Current query of shape ``[B, 1, H, K]``.  Must be float16/bfloat16.
+    k : torch.Tensor
+        Current key of shape ``[B, 1, H, K]``.  Must be float16/bfloat16.
+    v : torch.Tensor
+        Current value of shape ``[B, 1, HV, V]``.  Must be float16/bfloat16.
+    state : torch.Tensor
+        Current state of shape ``[B, HV, K, V]`` (k-major layout).  Must be
+        float32.  Updated in-place.
+    A_log : torch.Tensor
+        Log decay parameter of shape ``[HV]``.  Must be float32.
+    a : torch.Tensor
+        Input-dependent decay of shape ``[B, 1, HV]``.  Must be
+        float16/bfloat16.
+    dt_bias : torch.Tensor
+        Decay bias of shape ``[HV]``.  Must be bfloat16 or float32.
+    b : torch.Tensor
+        Update gate (beta) input of shape ``[B, 1, HV]``.  Must be
+        float16/bfloat16.
+    scale : float, optional
+        Scale factor for queries.  If ``None``, defaults to ``1 /
+        sqrt(K)``.
+    output : torch.Tensor, optional
+        Pre-allocated output tensor of shape ``[B, 1, HV, V]``.  Allocated
+        automatically when ``None``.
+    use_qk_l2norm : bool
+        Whether to apply L2 normalization to q and k.  Default: ``True``.
 
-    Returns:
-        Tuple[torch.Tensor, torch.Tensor]:
-            - output: Output tensor of shape ``[B, 1, HV, V]``
-            - state: Updated state tensor of shape ``[B, HV, K, V]``
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(output, state)`` where ``output`` has shape ``[B, 1, HV, V]``
+        and ``state`` has shape ``[B, HV, K, V]`` (updated in-place).
 
-    Note:
-        - Requires SM90 (Hopper) architecture
-        - State is updated in-place
-        - K and V must be multiples of 4 for vectorized loads
-        - State layout is k-major: [B, HV, K, V] (no transpose needed)
+    Notes
+    -----
+    - Requires SM90 (Hopper) architecture.
+    - State is updated in-place.
+    - ``K`` and ``V`` must be multiples of 4 for vectorized loads.
+    - State layout is k-major: ``[B, HV, K, V]`` (no transpose needed).
     """
     # Validate input shapes
     B, T, H, K = q.shape
@@ -579,61 +594,67 @@ def gated_delta_rule_mtp(
     disable_state_update: Optional[bool] = None,
     use_qk_l2norm: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Gated Delta Rule MTP Kernel (Multiple Token Processing).
+    r"""Gated Delta Rule MTP kernel (Multiple Token Processing).
 
-    This function processes multiple tokens (T > 1) in sequence, typically used for
-    speculative decoding verification. It supports intermediate state caching for
-    potential rollback scenarios.
+    Processes multiple tokens (``T > 1``) per call, typically used for
+    speculative decoding verification.  Supports intermediate state caching
+    for potential rollback scenarios.
 
-    Args:
-        q (torch.Tensor):
-            Query tensor of shape ``[B, T, H, K]``.
-        k (torch.Tensor):
-            Key tensor of shape ``[B, T, H, K]``.
-        v (torch.Tensor):
-            Value tensor of shape ``[B, T, HV, V]``.
-        initial_state (torch.Tensor):
-            Initial state tensor of shape ``[pool_size, HV, V, K]`` (K-last layout).
-        initial_state_indices (torch.Tensor):
-            Indices mapping each batch to its initial state, shape ``[B]``.
-        A_log (torch.Tensor):
-            Log decay parameter of shape ``[HV]``.
-        a (torch.Tensor):
-            Input-dependent decay of shape ``[B, T, HV]``.
-        dt_bias (torch.Tensor):
-            Decay bias of shape ``[HV]``.
-        b (torch.Tensor):
-            Update gate input of shape ``[B, T, HV]``.
-        scale (Optional[float]):
-            Scaling factor for queries. If None, uses ``1/sqrt(K)``.
-        output (Optional[torch.Tensor]):
-            Pre-allocated output tensor of shape ``[B, T, HV, V]``.
-        intermediate_states_buffer (Optional[torch.Tensor]):
-            Buffer for caching intermediate states, shape ``[pool_size, T, HV, V, K]``.
-            If None, intermediate states are not cached.
-        disable_state_update (Optional[bool]):
-            If True, the initial state is not updated. Currently defaults to ``True``.
-            Please pass this argument explicitly — the default will change to ``False``
-            in FlashInfer 0.7.0.
+    Parameters
+    ----------
+    q : torch.Tensor
+        Query tensor of shape ``[B, T, H, K]``.
+    k : torch.Tensor
+        Key tensor of shape ``[B, T, H, K]``.
+    v : torch.Tensor
+        Value tensor of shape ``[B, T, HV, V]``.
+    initial_state : torch.Tensor
+        Initial state tensor of shape ``[pool_size, HV, V, K]`` (K-last
+        layout).
+    initial_state_indices : torch.Tensor
+        Indices mapping each batch to its initial state, shape ``[B]``.
+    A_log : torch.Tensor
+        Log decay parameter of shape ``[HV]``.
+    a : torch.Tensor
+        Input-dependent decay of shape ``[B, T, HV]``.
+    dt_bias : torch.Tensor
+        Decay bias of shape ``[HV]``.
+    b : torch.Tensor
+        Update gate input of shape ``[B, T, HV]``.
+    scale : float, optional
+        Scaling factor for queries.  If ``None``, uses ``1 / sqrt(K)``.
+    output : torch.Tensor, optional
+        Pre-allocated output tensor of shape ``[B, T, HV, V]``.
+    intermediate_states_buffer : torch.Tensor, optional
+        Buffer for caching intermediate states, shape ``[pool_size, T, HV,
+        V, K]``.  When ``None``, intermediate states are not cached.
+    disable_state_update : bool, optional
+        If ``True``, the initial state is not updated.  Currently defaults
+        to ``True``; pass this argument explicitly to silence the
+        deprecation warning - the default will change to ``False`` in
+        FlashInfer 0.7.0.
 
-            .. deprecated::
-                The implicit default of ``True`` is deprecated and will change to
-                ``False`` in version 0.7.0. Pass ``disable_state_update=True`` or
-                ``disable_state_update=False`` explicitly to silence the warning.
-        use_qk_l2norm (bool):
-            Whether to apply L2 normalization to q and k. Default: ``True``.
+        .. deprecated::
+            The implicit default of ``True`` is deprecated and will change
+            to ``False`` in version 0.7.0.  Pass
+            ``disable_state_update=True`` or ``disable_state_update=False``
+            explicitly to silence the warning.
+    use_qk_l2norm : bool
+        Whether to apply L2 normalization to q and k.  Default: ``True``.
 
-    Returns:
-        Tuple[torch.Tensor, torch.Tensor]:
-            - output: Output tensor of shape ``[B, T, HV, V]``
-            - initial_state: Updated state tensor (unchanged if disable_state_update=True)
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(output, initial_state)`` where ``output`` has shape
+        ``[B, T, HV, V]`` and ``initial_state`` is the updated state
+        (unchanged when ``disable_state_update=True``).
 
-    Note:
-        - Requires SM90 (Hopper) architecture
-        - Supports T > 1 (multiple token processing)
-        - State layout is K-last: [pool_size, HV, V, K]
-        - Optimized for speculative decoding verification scenarios
+    Notes
+    -----
+    - Requires SM90 (Hopper) architecture.
+    - Supports ``T > 1`` (multiple token processing).
+    - State layout is K-last: ``[pool_size, HV, V, K]``.
+    - Optimized for speculative decoding verification scenarios.
     """
     # Handle deprecation of disable_state_update default value
     if disable_state_update is None:

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -116,78 +116,82 @@ def chunk_gated_delta_rule(
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated Delta Rule (GDN) attention for prefill.
 
-    This implements the gated delta rule linear attention mechanism for efficient
-    training and inference. Supports both GQA (grouped query attention) and GVA
-    (grouped value attention) configurations.
+    Implements the gated delta rule linear attention mechanism for efficient
+    training and inference.  Supports both GQA (grouped query attention)
+    and GVA (grouped value attention) configurations.
 
-    Args:
-        q (torch.Tensor):
-            Queries of shape ``[total_seq_len, num_q_heads, head_size]``.
-            Must be contiguous and on CUDA.
-        k (torch.Tensor):
-            Keys of shape ``[total_seq_len, num_k_heads, head_size]``.
-            Must be contiguous and on CUDA.
-        v (torch.Tensor):
-            Values of shape ``[total_seq_len, num_v_heads, head_size]``.
-            Must be contiguous and on CUDA.
-        g (Optional[torch.Tensor]):
-            Forget gate (alpha) of shape ``[total_seq_len, num_sab_heads]`` where
-            ``num_sab_heads = max(num_q_heads, num_v_heads)``. Must be float32.
-            If None, defaults to all ones. Default: ``None``.
-        beta (Optional[torch.Tensor]):
-            Update gate (beta) of shape ``[total_seq_len, num_sab_heads]``.
-            Must be float32. If None, defaults to all ones. Default: ``None``.
-        scale (Optional[float]):
-            Scale factor for the attention scores.
-            If not provided, defaults to ``1 / sqrt(head_size)``. Default: ``None``.
-        initial_state (Optional[torch.Tensor]):
-            Initial KV state of shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
-            Must be float32. If None, starts from zero state. Default: ``None``.
-        output_final_state (bool):
-            Whether to output the final state. Default: ``False``.
-        cu_seqlens (torch.Tensor):
-            Cumulative sequence lengths of shape ``[num_seqs + 1]``, int64.
-            Required for variable-length sequences (varlen mode).
-        use_qk_l2norm_in_kernel (bool):
-            Whether to use QK L2 normalization in kernel. Default: ``False``.
-        output (Optional[torch.Tensor]):
-            Pre-allocated output tensor of shape ``[total_seq_len, num_o_heads, head_size]``
-            where ``num_o_heads = max(num_q_heads, num_v_heads)``.
-            If None, will be allocated automatically. Default: ``None``.
-        output_state (Optional[torch.Tensor]):
-            Pre-allocated output state tensor of shape
-            ``[num_seqs, num_sab_heads, head_size, head_size]``, float32.
-            Required if ``output_final_state=True``. Default: ``None``.
-        state_checkpoints (Optional[torch.Tensor]):
-            Pre-allocated checkpoint tensor of shape
-            ``[total_checkpoints, num_sab_heads, head_size, head_size]``, float32.
-            Must be provided when ``checkpoint_every_n_tokens > 0``.
-            Default: ``None``.
-        checkpoint_cu_starts (Optional[torch.Tensor]):
-            Cumulative checkpoint counts of shape ``[num_seqs + 1]``, int64.
-            ``checkpoint_cu_starts[i+1] - checkpoint_cu_starts[i]`` is the number
-            of checkpoints for sequence *i* (= ``seq_len_i // checkpoint_every_n_tokens``).
-            Must be provided when ``checkpoint_every_n_tokens > 0``.
-            Default: ``None``.
-        checkpoint_every_n_tokens (int):
-            Store intermediate state every N tokens. Must be a multiple of
-            the chunk size (64). 0 means disabled (default).
+    Parameters
+    ----------
+    q : torch.Tensor
+        Queries of shape ``[total_seq_len, num_q_heads, head_size]``.  Must
+        be contiguous and on CUDA.
+    k : torch.Tensor
+        Keys of shape ``[total_seq_len, num_k_heads, head_size]``.  Must be
+        contiguous and on CUDA.
+    v : torch.Tensor
+        Values of shape ``[total_seq_len, num_v_heads, head_size]``.  Must
+        be contiguous and on CUDA.
+    g : torch.Tensor, optional
+        Forget gate (alpha) of shape ``[total_seq_len, num_sab_heads]``
+        where ``num_sab_heads = max(num_q_heads, num_v_heads)``.  Must be
+        float32.  Defaults to all ones when ``None``.
+    beta : torch.Tensor, optional
+        Update gate (beta) of shape ``[total_seq_len, num_sab_heads]``.
+        Must be float32.  Defaults to all ones when ``None``.
+    scale : float, optional
+        Scale factor for the attention scores.  Defaults to
+        ``1 / sqrt(head_size)`` when ``None``.
+    initial_state : torch.Tensor, optional
+        Initial KV state of shape
+        ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be
+        float32.  Starts from zero state when ``None``.
+    output_final_state : bool
+        Whether to output the final state.  Default: ``False``.
+    cu_seqlens : torch.Tensor, optional
+        Cumulative sequence lengths of shape ``[num_seqs + 1]``, int64.
+        Required for variable-length sequences (varlen mode).
+    use_qk_l2norm_in_kernel : bool
+        Whether to use QK L2 normalization in kernel.  Default: ``False``.
+    output : torch.Tensor, optional
+        Pre-allocated output tensor of shape
+        ``[total_seq_len, num_o_heads, head_size]`` where ``num_o_heads =
+        max(num_q_heads, num_v_heads)``.  Allocated automatically when
+        ``None``.
+    output_state : torch.Tensor, optional
+        Pre-allocated output state tensor of shape ``[num_seqs,
+        num_sab_heads, head_size, head_size]``, float32.  Required when
+        ``output_final_state=True``.
+    state_checkpoints : torch.Tensor, optional
+        Pre-allocated checkpoint tensor of shape ``[total_checkpoints,
+        num_sab_heads, head_size, head_size]``, float32.  Required when
+        ``checkpoint_every_n_tokens > 0``.
+    checkpoint_cu_starts : torch.Tensor, optional
+        Cumulative checkpoint counts of shape ``[num_seqs + 1]``, int64.
+        ``checkpoint_cu_starts[i+1] - checkpoint_cu_starts[i]`` is the
+        number of checkpoints for sequence ``i`` (= ``seq_len_i //
+        checkpoint_every_n_tokens``).  Required when
+        ``checkpoint_every_n_tokens > 0``.
+    checkpoint_every_n_tokens : int
+        Store intermediate state every N tokens.  Must be a multiple of the
+        chunk size (64).  ``0`` disables checkpointing (default).
 
-    Returns:
-        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-            - If ``output_final_state=False``: Returns output tensor of shape
-              ``[total_seq_len, num_o_heads, head_size]``.
-            - If ``output_final_state=True``: Returns tuple of (output, final_state) where
-              final_state has shape ``[num_seqs, num_sab_heads, head_size, head_size]``.
+    Returns
+    -------
+    torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
+        When ``output_final_state=False``, the output tensor of shape
+        ``[total_seq_len, num_o_heads, head_size]``.  Otherwise a tuple
+        ``(output, final_state)`` where ``final_state`` has shape
+        ``[num_seqs, num_sab_heads, head_size, head_size]``.
 
-    Note:
-        - Supports GQA: ``num_q_heads > num_k_heads = num_v_heads``
-        - Supports GVA: ``num_v_heads > num_q_heads = num_k_heads``
-        - The final state layout is ``[N, H, V, K]``.
-        - Requires SM90 (Hopper) or SM100 (Blackwell) architecture.
-        - SM100 path requires head_size == 128.
-        - SM100 path requires ``nvidia-cutlass-dsl[cu13]>=4.4.2``
-          (install via ``pip install flashinfer-python[cu13]``).
+    Notes
+    -----
+    - Supports GQA (``num_q_heads > num_k_heads = num_v_heads``) and GVA
+      (``num_v_heads > num_q_heads = num_k_heads``).
+    - The final state layout is ``[N, H, V, K]``.
+    - Requires SM90 (Hopper) or SM100 (Blackwell) architecture.  The SM100
+      path requires ``head_size == 128`` and
+      ``nvidia-cutlass-dsl[cu13]>=4.4.2`` (``pip install
+      flashinfer-python[cu13]``).
     """
     if checkpoint_every_n_tokens < 0:
         raise ValueError(

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -148,9 +148,13 @@ def chunk_gated_delta_rule(
     output_final_state : bool
         Whether to output the final state.  Default: ``False``.
     cu_seqlens : torch.Tensor
-        Cumulative sequence lengths of shape ``[num_seqs + 1]``, int64.
-        Required for variable-length sequences (varlen mode); must not be
-        ``None`` (the kernel asserts this).
+        Cumulative sequence lengths of shape ``[num_seqs + 1]``, integer
+        dtype on the same CUDA device as ``q``.  Required for
+        variable-length sequences (varlen mode); must not be ``None``
+        (asserted at the top of the function body).  Internally cast to
+        ``int32`` for the SM100/Blackwell CuTe-DSL kernel and to ``int64``
+        for the SM90/Hopper C++ kernel, so the caller can pass either
+        dtype.
     use_qk_l2norm_in_kernel : bool
         Whether to use QK L2 normalization in kernel.  Default: ``False``.
     output : torch.Tensor, optional

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -147,9 +147,10 @@ def chunk_gated_delta_rule(
         float32.  Starts from zero state when ``None``.
     output_final_state : bool
         Whether to output the final state.  Default: ``False``.
-    cu_seqlens : torch.Tensor, optional
+    cu_seqlens : torch.Tensor
         Cumulative sequence lengths of shape ``[num_seqs + 1]``, int64.
-        Required for variable-length sequences (varlen mode).
+        Required for variable-length sequences (varlen mode); must not be
+        ``None`` (the kernel asserts this).
     use_qk_l2norm_in_kernel : bool
         Whether to use QK L2 normalization in kernel.  Default: ``False``.
     output : torch.Tensor, optional

--- a/flashinfer/mamba/checkpointing_ssu.py
+++ b/flashinfer/mamba/checkpointing_ssu.py
@@ -277,6 +277,15 @@ def checkpointing_ssu(
     d_split : Optional[int]
         Per-head DIM split factor.  This is only exposed for benchmarking.
         Do not use it cause it will make things slow.
+    cu_seqlens : Optional[torch.Tensor]
+        Cumulative sequence lengths with shape ``(N + 1,)``. When provided, the
+        new-token inputs (``x``, ``dt``, ``B``, ``C``, ``out``, optionally ``z``)
+        are interpreted in varlen layout (tokens flattened into the batch
+        dimension) instead of the default ``(batch, T, ...)`` layout.
+    max_seqlen : Optional[int]
+        Maximum sequence length present in ``cu_seqlens``. Required when
+        ``cu_seqlens`` is provided so the kernel can size its per-sequence
+        work tiles; ignored otherwise.
     enable_pdl : bool
         When True the kernel is launched with
         `cudaLaunchAttributeProgrammaticStreamSerialization`, enabling the

--- a/flashinfer/mamba/checkpointing_ssu.py
+++ b/flashinfer/mamba/checkpointing_ssu.py
@@ -283,9 +283,11 @@ def checkpointing_ssu(
         are interpreted in varlen layout (tokens flattened into the batch
         dimension) instead of the default ``(batch, T, ...)`` layout.
     max_seqlen : Optional[int]
-        Maximum sequence length present in ``cu_seqlens``. Required when
-        ``cu_seqlens`` is provided so the kernel can size its per-sequence
-        work tiles; ignored otherwise.
+        Maximum sequence length present in ``cu_seqlens``, used by the kernel
+        to size its per-sequence work tiles. Only meaningful in varlen mode
+        (``cu_seqlens is not None``); falls back to ``max_window`` when
+        omitted (wider smem than strictly needed but always safe). Must be
+        ``None`` in non-varlen mode (the JIT key is taken from ``x.size(1)``).
     enable_pdl : bool
         When True the kernel is launched with
         `cudaLaunchAttributeProgrammaticStreamSerialization`, enabling the

--- a/flashinfer/mamba/checkpointing_ssu.py
+++ b/flashinfer/mamba/checkpointing_ssu.py
@@ -278,10 +278,14 @@ def checkpointing_ssu(
         Per-head DIM split factor.  This is only exposed for benchmarking.
         Do not use it cause it will make things slow.
     cu_seqlens : Optional[torch.Tensor]
-        Cumulative sequence lengths with shape ``(N + 1,)``. When provided, the
-        new-token inputs (``x``, ``dt``, ``B``, ``C``, ``out``, optionally ``z``)
-        are interpreted in varlen layout (tokens flattened into the batch
-        dimension) instead of the default ``(batch, T, ...)`` layout.
+        Cumulative sequence lengths with shape ``(N + 1,)``, dtype
+        ``torch.int32``, on the same CUDA device as ``x`` (the kernel
+        asserts both). When provided, the new-token inputs (``x``, ``dt``,
+        ``B``, ``C``, ``out``, optionally ``z``) are interpreted in varlen
+        layout where tokens are packed along the **time** axis with batch
+        fixed to 1 — i.e. ``x`` is 4-D with shape
+        ``(1, total_tokens, nheads, dim)`` — instead of the default
+        ``(batch, T, ...)`` layout.
     max_seqlen : Optional[int]
         Maximum sequence length present in ``cu_seqlens``, used by the kernel
         to size its per-sequence work tiles. Only meaningful in varlen mode
@@ -300,6 +304,18 @@ def checkpointing_ssu(
     -------
     out : torch.Tensor
         Output tensor, shape (batch, T, nheads, dim).
+
+    Notes
+    -----
+    **In-place updates.** The custom op declares ``mutates_args =
+    ("state", "out", "old_x", "old_B", "old_dt", "old_cumAdt",
+    "state_scale")`` — the four ``old_*`` cache tensors are double-buffered
+    and the kernel writes the *current* step's x / B / dt / cumulative-A·dt
+    back into the slot selected by ``cache_buf_idx`` so the next call can
+    replay them. ``state_scale`` is also written when ``state`` is
+    quantized (int8 / fp8_e4m3fn): the kernel computes new per-block
+    decode scales and stores them here for the caller to dequantize
+    against on read-back.
     """
     # Validate quantized state ↔ state_scale combo.
     # int8 and fp8_e4m3fn use a per-(cache, head, dim) decode-scale tensor

--- a/flashinfer/mamba/selective_state_update.py
+++ b/flashinfer/mamba/selective_state_update.py
@@ -178,6 +178,11 @@ def selective_state_update(
     intermediate_state_indices : Optional[torch.Tensor]
         Optional indices mapping batch elements to intermediate state buffer positions
         with shape (batch,)
+    intermediate_state_scales : Optional[torch.Tensor]
+        Optional per-block float32 scale tensor matching ``intermediate_states_buffer``.
+        When provided alongside an int16 ``intermediate_states_buffer``, the caller is
+        responsible for quantizing intermediate states with these scales (mirrors the
+        ``state_scale`` layout but for the speculative-decoding intermediate buffer).
     rand_seed : Optional[torch.Tensor]
         Optional single-element int64 CUDA tensor for stochastic rounding seed.
     philox_rounds : int

--- a/flashinfer/mamba/selective_state_update.py
+++ b/flashinfer/mamba/selective_state_update.py
@@ -180,9 +180,12 @@ def selective_state_update(
         with shape (batch,)
     intermediate_state_scales : Optional[torch.Tensor]
         Optional per-block float32 scale tensor matching ``intermediate_states_buffer``.
-        When provided alongside an int16 ``intermediate_states_buffer``, the caller is
-        responsible for quantizing intermediate states with these scales (mirrors the
-        ``state_scale`` layout but for the speculative-decoding intermediate buffer).
+        When provided alongside an int16 ``intermediate_states_buffer``, the kernel
+        writes the computed scales into this tensor (it is listed in the custom
+        op's ``mutates_args``), and the caller is responsible for *dequantizing*
+        the intermediate states using these scales when reading them back.
+        Mirrors the ``state_scale`` layout but for the speculative-decoding
+        intermediate buffer.
     rand_seed : Optional[torch.Tensor]
         Optional single-element int64 CUDA tensor for stochastic rounding seed.
     philox_rounds : int

--- a/flashinfer/mamba/selective_state_update.py
+++ b/flashinfer/mamba/selective_state_update.py
@@ -167,14 +167,20 @@ def selective_state_update(
         Sentinel value for padded entries in state_batch_indices
     state_scale : Optional[torch.Tensor]
         Optional float32 scale tensor with shape (state_cache_size, nheads, dim)
-        for int16 state quantization with block scaling
+        for int16 state quantization with block scaling. Listed in the custom
+        op's ``mutates_args``: when ``state`` is quantized (int16), the kernel
+        writes the new per-block scales here in place — the caller dequantizes
+        ``state`` against this tensor on read-back (mirrors the
+        ``intermediate_state_scales`` contract below).
     out : Optional[torch.Tensor]
         Optional output tensor (same shape as x)
     disable_state_update : bool
         If True, skip updating the state tensor (useful for speculative decoding verification)
     intermediate_states_buffer : Optional[torch.Tensor]
         Optional buffer for caching intermediate states during speculative decoding
-        with shape (batch, cache_steps, nheads, dim, dstate)
+        with shape (batch, cache_steps, nheads, dim, dstate). Also listed in
+        ``mutates_args`` — the kernel writes intermediate states into it
+        in place.
     intermediate_state_indices : Optional[torch.Tensor]
         Optional indices mapping batch elements to intermediate state buffer positions
         with shape (batch,)
@@ -194,8 +200,13 @@ def selective_state_update(
         Number of steps/tokens to cache for speculative decoding.
         For varlen mode (cu_seqlens provided), this specifies max_seqlen.
     cu_seqlens : Optional[torch.Tensor]
-        Cumulative sequence lengths with shape (N + 1,).
-        When provided, inputs are in varlen format (tokens flattened into batch dim).
+        Cumulative sequence lengths with shape (N + 1,), integer dtype
+        (the JIT specializes on the actual dtype, so int32 or int64 is fine;
+        int32 is the default when omitted). When provided, inputs are in
+        packed-token varlen format: ``x`` / ``dt`` are 3-D
+        ``(total_tokens, nheads, dim)``, ``B`` / ``C`` are 3-D
+        ``(total_tokens, ngroups, dstate)``, with sequence boundaries given
+        by ``cu_seqlens``.
     num_accepted_tokens : Optional[torch.Tensor]
         Number of accepted tokens per sequence with shape (N,).
         Determines which state to read as initial state for each sequence.

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -1290,6 +1290,47 @@ def mla_rope_quantize_fp8(
     k_nope_out: Optional[torch.Tensor] = None,
     enable_pdl: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""Apply RoPE and quantize to FP8 for MLA attention.
+
+    Thin wrapper that forwards to :func:`rope_quantize_fp8` with the MLA
+    tensor layout: ``k_rope`` / ``k_nope`` are 2-D (no KV-head axis).  All
+    other parameters and behavior match :func:`rope_quantize_fp8`; see that
+    function for full parameter documentation.
+
+    Parameters
+    ----------
+    q_rope : torch.Tensor
+        Query rotary portion, ``(nnz, num_qo_heads, rope_dim)``, fp16/bf16.
+    k_rope : torch.Tensor
+        Key rotary portion in MLA layout, ``(nnz, rope_dim)``, fp16/bf16.
+    q_nope : torch.Tensor
+        Query non-rotary portion, ``(nnz, num_qo_heads, no_rope_dim)``.
+    k_nope : torch.Tensor
+        Key non-rotary portion in MLA layout, ``(nnz, no_rope_dim)``.
+    cos_sin_cache : torch.Tensor
+        ``(max_seq_len, rope_dim)`` precomputed cos/sin cache (fp32).
+    pos_ids : torch.Tensor
+        Per-token position indices, ``(nnz,)``.
+    is_neox : bool
+        ``True`` for NeoX (split-half) layout, ``False`` for interleaved.
+    quantize_dtype : torch.dtype, optional
+        Target quantization dtype (``float8_e4m3fn`` or ``float8_e5m2``).
+        Inferred from ``*_out`` tensors when ``None``.
+    quant_scale_q : float
+        Quantization scale applied to queries.
+    quant_scale_kv : float
+        Quantization scale applied to keys.
+    q_rope_out, k_rope_out, q_nope_out, k_nope_out : torch.Tensor, optional
+        Pre-allocated output tensors.  Allocated automatically when
+        ``None``.
+    enable_pdl : bool
+        Whether to enable Programmatic Dependent Launch.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+        ``(q_rope_out, k_rope_out, q_nope_out, k_nope_out)``.
+    """
     return rope_quantize_fp8(
         q_rope,
         k_rope,


### PR DESCRIPTION
## Summary
- New RST files: `docs/api/gdn_decode.rst`, `docs/api/gdn_prefill.rst`, `docs/api/mamba.rst` (wired into `docs/index.rst`).
- Re-exports 4 DiT / QK-RoPE norm helpers at `flashinfer.__init__` package root (`fused_qk_rmsnorm_rope`, `fused_dit_residual_layernorm_scale_shift`, `fused_dit_gate_residual_layernorm_scale_shift`, `fused_dit_gate_residual_layernorm_gamma_beta`).
- Adds missing argument documentation to Mamba kernels: `intermediate_state_scales` (in `selective_state_update.py`), `cu_seqlens` + `max_seqlen` (in `checkpointing_ssu.py`).
- Converts the rest of the GDN/Mamba public docstrings to NumPy `Parameters` style.

## Why this PR (split rationale)
All changes share the misc-op codeowner group (`@kahyunnam @ishovkun` plus `@yongwww` for GDN). GDN and Mamba have overlapping ownership and were originally planned as separate RSTs — kept in one PR to avoid bikeshedding the boundary.

## Review notes
- The 4 norm re-exports are the only non-doc change. Please confirm package-root visibility is desired (they are already importable via `flashinfer.norm.*`).

## Part of the v0.6.12 docs cleanup
PR-5 of 8. Siblings: PR-1, PR-2, PR-3, PR-4a/4b, PR-6, PR-7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new API pages and expanded docs covering gated-delta-rule decode/prefill, Mamba routines, RoPE quantization, and related normalization helpers; improved parameter, shape and usage notes across several functions.
* **New Features**
  * Exposed additional fused normalization/RoPE-related kernels via package exports for use in downstream code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->