### PR TITLE
feat(gemm): structured (engine_id, knobs) tactics for cuDNN GEMM autotuning

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -151,12 +151,12 @@ def _collect_metadata() -> Dict[str, str]:
     """Collect environment metadata that can affect tactic-to-kernel mappings.
 
     Tactics in flashinfer's autotune cache are backend-internal identifiers:
-    cuDNN stores structured ``(engine_id, knobs)`` identities, other
-    backends store kernel ids / config tuples.  These survive frontend plan
-    re-ordering, but their engine/knob *semantics* can still differ across
-    cuDNN / cuBLAS versions, so version metadata is still captured here and
-    ``load_configs`` rejects a cache that no longer matches the runtime
-    environment.
+    cuDNN stores structured ``(engine_id, knobs)`` identities (or bare plan
+    indices on frontends without the structured-plan API), other backends
+    store kernel ids / config tuples.  Their engine/knob semantics (and plan
+    ordering, for the index fallback) can differ across cuDNN / cuBLAS
+    versions, so version metadata is captured here and ``load_configs``
+    rejects a cache that no longer matches the runtime environment.
 
     Specifically tracked:
 

--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -150,11 +150,13 @@ def _get_cublas_version() -> str:
 def _collect_metadata() -> Dict[str, str]:
     """Collect environment metadata that can affect tactic-to-kernel mappings.
 
-    Tactics in flashinfer's autotune cache are stored as plan indices into
-    cuDNN's ``policy=ALL`` plan list (or backend-internal kernel ids for
-    other backends).  Anything that can shuffle that ordering must be
-    captured here so ``load_configs`` rejects a cache that no longer
-    matches the runtime environment.
+    Tactics in flashinfer's autotune cache are backend-internal identifiers:
+    cuDNN stores structured ``(engine_id, knobs)`` identities, other
+    backends store kernel ids / config tuples.  These survive frontend plan
+    re-ordering, but their engine/knob *semantics* can still differ across
+    cuDNN / cuBLAS versions, so version metadata is still captured here and
+    ``load_configs`` rejects a cache that no longer matches the runtime
+    environment.
 
     Specifically tracked:
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2103,6 +2103,79 @@ def is_cudnn_override_shape_available() -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# cuDNN tactic = structured (engine_id, knobs).
+#
+# The autotuner stores a tactic as an opaque value and persists it to disk
+# (autotune(cache=...)).  We use the cuDNN plan's *structured identity* -- the
+# engine global index plus its knob choices, read via
+# ``graph.get_engine_and_knobs_at_index`` (cudnn-frontend; NVIDIA/cudnn-frontend
+# #259) -- as that value, instead of a bare positional plan index.  A
+# positional index is only meaningful for one graph instance and silently
+# mis-points after the ``policy=ALL`` plan list is re-enumerated across
+# cudnn-frontend / backend versions or after ``deselect_engines``.
+#
+# At replay time the tactic is *pinned* via
+# ``graph.create_execution_plan(engine_id, knobs)``, which finalizes the graph
+# to exactly that kernel and skips the heuristics query entirely (mirrors the
+# frontend's own ``override_heuristics_query`` path).
+#
+# Encoding: ``(engine_id, ((knob_int, value), ...))`` -- all plain ints, so it
+# round-trips through the autotuner's JSON cache unchanged (knob_type <-> int
+# is stable: knob_type.SPLIT_K_SLC.value == 9, cudnn.knob_type(9) reconstructs
+# it).  Requires a cudnn-frontend exposing get_engine_and_knobs_at_index (see
+# the requirements.txt floor).
+# ---------------------------------------------------------------------------
+
+
+def _cudnn_plan_tactics(graph) -> list:
+    """Enumerate structured tactics for a built (policy=ALL) cuDNN graph.
+
+    Returns ``(engine_id, ((knob_int, value), ...))`` for each plan -- each
+    replayable via create_execution_plan without a heuristics query, and
+    stable across plan re-enumeration (unlike a positional index).
+    """
+    tactics = []
+    for i in range(graph.get_execution_plan_count()):
+        engine_id, knobs = graph.get_engine_and_knobs_at_index(i)
+        tactics.append(
+            (
+                int(engine_id),
+                tuple(sorted((int(k), int(v)) for k, v in knobs.items())),
+            )
+        )
+    return tactics
+
+
+def _cudnn_is_structured_tactic(tactic) -> bool:
+    """True iff *tactic* is a structured ``(engine_id, knobs)`` tactic (rather
+    than the int ``-1`` autotuner fallback).  Holds for both freshly-enumerated
+    tactics and cache-loaded ones (the autotuner round-trips tuples as tuples)."""
+    return (
+        isinstance(tactic, tuple)
+        and len(tactic) == 2
+        and isinstance(tactic[0], int)
+        and isinstance(tactic[1], (tuple, list))
+    )
+
+
+def _cudnn_structured_pin(tactic):
+    """Split a structured tactic into ``(engine_id, pin_knobs)`` for the build
+    helpers' create_execution_plan path.  ``pin_knobs`` is a tuple of
+    ``(knob_int, value)`` pairs -- hashable, so the lru_cache'd build helper
+    can key on it."""
+    engine_id, knob_items = tactic
+    return int(engine_id), tuple((int(k), int(v)) for k, v in knob_items)
+
+
+def _cudnn_apply_pinned_plan(graph, pin_engine_id: int, pin_knobs) -> None:
+    """Finalize *graph* to a single pinned (engine, knobs) plan, skipping the
+    heuristics query.  ``pin_knobs`` is a tuple of ``(knob_int, value)`` pairs."""
+    knob_map = {cudnn.knob_type(k): v for k, v in pin_knobs}
+    graph.create_execution_plan(pin_engine_id, knob_map)
+    graph.build_plans()
+
+
 def _get_cudnn_workspace_size(graph, tactic: int) -> int:
     if tactic < 0:
         return graph.get_workspace_size()
@@ -2144,14 +2217,13 @@ def clear_cudnn_graph_cache() -> None:
         growth on its own.
 
         This function exists for the few cases LRU cannot handle.  In
-        every one of them, **the AutoTuner cache must also be cleared**
-        because tactic indices (``execute_plan_at_index(..., N)``) are
-        offsets into the cuDNN ``policy=ALL`` plan list of a *specific
-        graph* -- if we throw the graph away and let it rebuild, the
-        rebuilt plan list may enumerate engines differently and the
-        stored ``N`` would silently point to a different kernel.  We
-        therefore clear both stores atomically so plan indices and the
-        graphs they were profiled against stay in lockstep:
+        every one of them we also clear **the AutoTuner cache** so that
+        re-tuning starts from cold.  Tactics are stored as structured
+        ``(engine_id, knobs)`` identities (see ``_cudnn_plan_tactics``) and
+        replayed by pinning via ``create_execution_plan``, so they don't
+        depend on plan-list ordering -- but a deliberate library swap can
+        still change which engines/knobs exist, so we clear both stores
+        together to force a fresh tuning pass:
 
             * **Hot-patching during development** -- after editing a
               ``build_*`` helper in-place, LRU will not evict the
@@ -2159,8 +2231,9 @@ def clear_cudnn_graph_cache() -> None:
               1024 distinct shapes; reach for this to invalidate
               without restarting Python.
             * **Deliberate cuDNN library version swap** in the same
-              process -- the rebuilt graphs may expose different
-              engines, so old tactic indices are no longer valid.
+              process -- the rebuilt graphs may expose different engines,
+              so old tactic names may no longer resolve and would fall
+              back to plan 0; clear to force a fresh tuning pass.
             * **Test fixtures** that want a clean slate per testcase.
             * **Manual GPU memory release** -- safe even if the build
               code is unchanged (the next call will simply re-tune
@@ -2195,11 +2268,9 @@ def clear_cudnn_graph_cache() -> None:
         if hasattr(fn, "cache_clear"):
             fn.cache_clear()
 
-    # Plan indices stored in AutoTuner.profiling_cache are offsets into
-    # the cuDNN plan list of the graph that was profiled.  Once we
-    # discard the graph LRU, those indices may no longer refer to the
-    # same engine after the rebuilt graph re-enumerates plans, so we
-    # clear the autotuner cache too.  See the docstring for details.
+    # Structured tactics are pinned via create_execution_plan and don't depend
+    # on plan-list ordering, but a library swap can change available
+    # engines/knobs, so clear the autotuner cache too to force re-tuning.
     AutoTuner.get().clear_cache()
 
 
@@ -2412,6 +2483,8 @@ def build_cudnn_gemm_fp4_graph_override_shape(
     use_nvfp4,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
     policy=None,
+    pin_engine_id: int = -1,
+    pin_knobs: tuple = (),
 ):
     """Build a cuDNN FP4 GEMM graph with override-shape support.
 
@@ -2524,13 +2597,16 @@ def build_cudnn_gemm_fp4_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
+    if pin_engine_id >= 0:
+        _cudnn_apply_pinned_plan(graph, pin_engine_id, pin_knobs)
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
 
-    if alpha_is_not_none and not _is_cublas_fp4_available_in_cudnn():
-        graph.deselect_engines(["eng0"])
+        if alpha_is_not_none and not _is_cublas_fp4_available_in_cudnn():
+            graph.deselect_engines(["eng0"])
 
-    graph.check_support()
-    graph.build_plans(policy)
+        graph.check_support()
+        graph.build_plans(policy)
 
     return graph
 
@@ -2671,6 +2747,8 @@ def build_cudnn_gemm_mxfp8_graph_override_shape(
     device,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
     policy=None,
+    pin_engine_id: int = -1,
+    pin_knobs: tuple = (),
 ):
     """Build a cuDNN MXFP8 GEMM graph with override-shape support.
 
@@ -2765,9 +2843,12 @@ def build_cudnn_gemm_mxfp8_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
-    graph.check_support()
-    graph.build_plans(policy)
+    if pin_engine_id >= 0:
+        _cudnn_apply_pinned_plan(graph, pin_engine_id, pin_knobs)
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
+        graph.check_support()
+        graph.build_plans(policy)
 
     return graph
 
@@ -2977,8 +3058,17 @@ def build_cudnn_gemm_fp8_graph_override_shape(
     device,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
     policy=None,
+    pin_engine_id: int = -1,
+    pin_knobs: tuple = (),
 ):
     """Build an FP8 per-tensor-quantized GEMM cuDNN graph with override-shape.
+
+    When ``pin_engine_id >= 0`` the graph is finalized to that single
+    (engine, knobs) plan via create_execution_plan -- skipping the heuristics
+    query -- so a previously tuned structured tactic replays the exact same
+    kernel.  Otherwise the heuristics query enumerates candidate plans.
+    ``pin_knobs`` is a tuple of ``(knob_int, value)`` pairs (kept hashable for
+    this function's lru_cache).
 
     Compiled once with ``cache_m`` as M; at execution time the actual M is
     supplied through ``override_shapes`` / ``override_strides``.
@@ -3048,9 +3138,12 @@ def build_cudnn_gemm_fp8_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-    graph.check_support()
-    graph.build_plans(policy)
+    if pin_engine_id >= 0:
+        _cudnn_apply_pinned_plan(graph, pin_engine_id, pin_knobs)
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        graph.check_support()
+        graph.build_plans(policy)
 
     return graph
 
@@ -3165,12 +3258,15 @@ def _cudnn_gemm_fp8_runner():
             a, b, _, _, out, _ = inputs
             return (a.dtype, b.dtype, out.dtype)
 
-        def _get_override_graph(self, a, b, out):
+        def _get_override_graph(self, a, b, out, pin=None):
             batch = a.shape[0]
             actual_m = a.shape[-2]
             k = a.shape[-1]
             n = b.shape[-1]
             cache_m = self._m_bucket_mapper(actual_m)
+            pin_engine_id, pin_knobs = (
+                (-1, ()) if pin is None else _cudnn_structured_pin(pin)
+            )
 
             return build_cudnn_gemm_fp8_graph_override_shape(
                 batch=batch,
@@ -3182,13 +3278,15 @@ def _cudnn_gemm_fp8_runner():
                 device=a.device,
                 cache_m=cache_m,
                 policy=cudnn.build_plan_policy.ALL,
+                pin_engine_id=pin_engine_id,
+                pin_knobs=pin_knobs,
             )
 
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> list:
             a, b, _, _, out, _ = inputs
             if self._use_override_shape:
                 graph = self._get_override_graph(a, b, out)
@@ -3205,6 +3303,12 @@ def _cudnn_gemm_fp8_runner():
                     policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
                 )
 
+            if self._use_override_shape:
+                # Structured (engine_id, knobs) tactics when the frontend
+                # supports it (replayed via create_execution_plan, no
+                # heuristics query); otherwise self-describing plan names.
+                # Both survive plan re-enumeration across versions.
+                return _cudnn_plan_tactics(graph)
             return list(range(graph.get_execution_plan_count()))
 
         def forward(
@@ -3216,7 +3320,15 @@ def _cudnn_gemm_fp8_runner():
         ) -> torch.Tensor:
             a, b, scale_a, scale_b, out, workspace_buffer = inputs
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
+                if _cudnn_is_structured_tactic(tactic):
+                    # Pin the exact (engine, knobs) plan -- the graph is
+                    # finalized to a single plan, so execute index 0.
+                    graph = self._get_override_graph(a, b, out, pin=tactic)
+                    plan_idx = 0
+                else:
+                    # autotuner fallback (tactic == -1): heuristic plan 0.
+                    graph = self._get_override_graph(a, b, out)
+                    plan_idx = max(tactic, 0)
                 execute_cudnn_gemm_fp8_graph_override_shape(
                     graph,
                     a,
@@ -3225,7 +3337,7 @@ def _cudnn_gemm_fp8_runner():
                     scale_b,
                     out,
                     workspace_buffer,
-                    tactic=max(tactic, 0),
+                    tactic=plan_idx,
                 )
             else:
                 _cudnn_gemm_fp8(
@@ -3383,6 +3495,8 @@ def build_cudnn_gemm_bf16_graph_override_shape(
     is_a_k_major: bool = True,
     is_b_k_major: bool = True,
     policy=None,
+    pin_engine_id: int = -1,
+    pin_knobs: tuple = (),
 ):
     """Build a cuDNN BF16 GEMM graph with override-shape support.
 
@@ -3461,9 +3575,12 @@ def build_cudnn_gemm_bf16_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-    graph.check_support()
-    graph.build_plans(policy)
+    if pin_engine_id >= 0:
+        _cudnn_apply_pinned_plan(graph, pin_engine_id, pin_knobs)
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        graph.check_support()
+        graph.build_plans(policy)
 
     return graph
 
@@ -3630,7 +3747,7 @@ def _cudnn_gemm_bf16_runner(
             self._is_b_k_major = True if is_b_k_major is None else is_b_k_major
             self._use_override_shape = is_cudnn_override_shape_available()
 
-        def _get_override_graph(self, a, b, bias, out):
+        def _get_override_graph(self, a, b, bias, out, pin=None):
             a_shape, _ = _get_bf16_3d_shape_stride(a)
             b_shape, _ = _get_bf16_3d_shape_stride(b)
 
@@ -3639,6 +3756,9 @@ def _cudnn_gemm_bf16_runner(
             k = a_shape[-1]
             n = b_shape[-1]
             o_type = _torch_data_type_to_cudnn_data_type(out.dtype)
+            pin_engine_id, pin_knobs = (
+                (-1, ()) if pin is None else _cudnn_structured_pin(pin)
+            )
 
             # See _cudnn_gemm_fp4_runner._get_override_graph for full
             # rationale: cache_m must match the AutoTuner cache key so
@@ -3663,6 +3783,8 @@ def _cudnn_gemm_bf16_runner(
                 is_a_k_major=self._is_a_k_major,
                 is_b_k_major=self._is_b_k_major,
                 policy=cudnn.build_plan_policy.ALL,
+                pin_engine_id=pin_engine_id,
+                pin_knobs=pin_knobs,
             )
             return graph
 
@@ -3676,7 +3798,7 @@ def _cudnn_gemm_bf16_runner(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> list:
             a, b, bias, _, out, _ = inputs
 
             if self._use_override_shape:
@@ -3704,6 +3826,10 @@ def _cudnn_gemm_bf16_runner(
                     policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
                 )
 
+            if self._use_override_shape:
+                # Structured (engine_id, knobs) tactics, replayed via
+                # create_execution_plan; stable across plan re-enumeration.
+                return _cudnn_plan_tactics(graph)
             return list(range(graph.get_execution_plan_count()))
 
         def forward(
@@ -3716,8 +3842,12 @@ def _cudnn_gemm_bf16_runner(
             a, b, bias, _, out, workspace_buffer = inputs
 
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, bias, out)
-
+                if _cudnn_is_structured_tactic(tactic):
+                    graph = self._get_override_graph(a, b, bias, out, pin=tactic)
+                    plan_idx = 0
+                else:
+                    graph = self._get_override_graph(a, b, bias, out)
+                    plan_idx = max(tactic, 0)
                 execute_cudnn_gemm_bf16_graph_override_shape(
                     graph,
                     a,
@@ -3725,7 +3855,7 @@ def _cudnn_gemm_bf16_runner(
                     bias,
                     out,
                     workspace_buffer,
-                    tactic=max(tactic, 0),
+                    tactic=plan_idx,
                 )
             else:
                 _cudnn_gemm_bf16(workspace_buffer, a, b, bias, out, tactic=-1)
@@ -4885,7 +5015,9 @@ def _cudnn_gemm_fp4_runner(tuning_config):
             self._m_bucket_mapper = m_bucket_mapper
             self._use_override_shape = is_cudnn_override_shape_available()
 
-        def _get_override_graph(self, a, b, alpha, out_dtype, block_size, use_nvfp4):
+        def _get_override_graph(
+            self, a, b, alpha, out_dtype, block_size, use_nvfp4, pin=None
+        ):
             real_a_shape, _ = _get_real_fp4_shape_from_packed_uint8(a)
             real_b_shape, _ = _get_real_fp4_shape_from_packed_uint8(b)
 
@@ -4893,6 +5025,9 @@ def _cudnn_gemm_fp4_runner(tuning_config):
             actual_m = real_a_shape[1]
             k = real_a_shape[2]
             n = real_b_shape[2]
+            pin_engine_id, pin_knobs = (
+                (-1, ()) if pin is None else _cudnn_structured_pin(pin)
+            )
 
             # cache_m must match the AutoTuner cache key so the runtime
             # graph is the SAME graph the autotuner profiled tactics on.
@@ -4917,6 +5052,8 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                 use_nvfp4=use_nvfp4,
                 cache_m=cache_m,
                 policy=cudnn.build_plan_policy.ALL,
+                pin_engine_id=pin_engine_id,
+                pin_knobs=pin_knobs,
             )
             return graph
 
@@ -4931,7 +5068,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> list:
             (
                 a,
                 b,
@@ -4978,6 +5115,10 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
                 )
 
+            if self._use_override_shape:
+                # Structured (engine_id, knobs) tactics, replayed via
+                # create_execution_plan; stable across plan re-enumeration.
+                return _cudnn_plan_tactics(graph)
             return list(range(graph.get_execution_plan_count()))
 
         def forward(
@@ -5001,9 +5142,16 @@ def _cudnn_gemm_fp4_runner(tuning_config):
             ) = inputs
 
             if self._use_override_shape:
-                graph = self._get_override_graph(
-                    a, b, alpha, out_dtype, block_size, use_nvfp4
-                )
+                if _cudnn_is_structured_tactic(tactic):
+                    graph = self._get_override_graph(
+                        a, b, alpha, out_dtype, block_size, use_nvfp4, pin=tactic
+                    )
+                    plan_idx = 0
+                else:
+                    graph = self._get_override_graph(
+                        a, b, alpha, out_dtype, block_size, use_nvfp4
+                    )
+                    plan_idx = max(tactic, 0)
 
                 execute_cudnn_gemm_fp4_graph_override_shape(
                     graph,
@@ -5014,7 +5162,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     alpha,
                     out,
                     workspace_buffer,
-                    tactic=max(tactic, 0),
+                    tactic=plan_idx,
                 )
             else:
                 _cudnn_gemm_fp4(
@@ -8139,12 +8287,15 @@ def _cudnn_gemm_mxfp8_runner():
             a, b, _, _, out, _ = inputs
             return (a.dtype, b.dtype, out.dtype)
 
-        def _get_override_graph(self, a, b, out):
+        def _get_override_graph(self, a, b, out, pin=None):
             batch = a.shape[0]
             actual_m = a.shape[-2]
             k = a.shape[-1]
             n = b.shape[-1]
             cache_m = self._m_bucket_mapper(actual_m)
+            pin_engine_id, pin_knobs = (
+                (-1, ()) if pin is None else _cudnn_structured_pin(pin)
+            )
 
             return build_cudnn_gemm_mxfp8_graph_override_shape(
                 batch=batch,
@@ -8157,13 +8308,15 @@ def _cudnn_gemm_mxfp8_runner():
                 device=a.device,
                 cache_m=cache_m,
                 policy=cudnn.build_plan_policy.ALL,
+                pin_engine_id=pin_engine_id,
+                pin_knobs=pin_knobs,
             )
 
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> list:
             a, b, _, _, out, _ = inputs
             if self._use_override_shape:
                 graph = self._get_override_graph(a, b, out)
@@ -8181,6 +8334,10 @@ def _cudnn_gemm_mxfp8_runner():
                     policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
                 )
 
+            if self._use_override_shape:
+                # Structured (engine_id, knobs) tactics, replayed via
+                # create_execution_plan; stable across plan re-enumeration.
+                return _cudnn_plan_tactics(graph)
             return list(range(graph.get_execution_plan_count()))
 
         def forward(
@@ -8192,7 +8349,12 @@ def _cudnn_gemm_mxfp8_runner():
         ) -> torch.Tensor:
             a, b, scale_a, scale_b, out, workspace_buffer = inputs
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
+                if _cudnn_is_structured_tactic(tactic):
+                    graph = self._get_override_graph(a, b, out, pin=tactic)
+                    plan_idx = 0
+                else:
+                    graph = self._get_override_graph(a, b, out)
+                    plan_idx = max(tactic, 0)
                 execute_cudnn_gemm_mxfp8_graph_override_shape(
                     graph=graph,
                     a=a,
@@ -8201,7 +8363,7 @@ def _cudnn_gemm_mxfp8_runner():
                     b_descale=scale_b,
                     c_final=out,
                     workspace=workspace_buffer,
-                    tactic=max(tactic, 0),
+                    tactic=plan_idx,
                 )
             else:
                 _cudnn_gemm_mxfp8(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2104,37 +2104,53 @@ def is_cudnn_override_shape_available() -> bool:
 
 
 # ---------------------------------------------------------------------------
-# cuDNN tactic = structured (engine_id, knobs).
+# cuDNN tactic = structured (engine_id, knobs), when the frontend supports it.
 #
 # The autotuner stores a tactic as an opaque value and persists it to disk
-# (autotune(cache=...)).  We use the cuDNN plan's *structured identity* -- the
-# engine global index plus its knob choices, read via
-# ``graph.get_engine_and_knobs_at_index`` (cudnn-frontend; NVIDIA/cudnn-frontend
-# #259) -- as that value, instead of a bare positional plan index.  A
-# positional index is only meaningful for one graph instance and silently
+# (autotune(cache=...)).  When the installed cudnn-frontend exposes
+# ``get_engine_and_knobs_at_index`` + ``create_execution_plan``
+# (NVIDIA/cudnn-frontend #259), we use the cuDNN plan's *structured identity* --
+# the engine global index plus its knob choices -- as that value, and replay it
+# by *pinning* via ``graph.create_execution_plan(engine_id, knobs)`` (finalizes
+# the graph to exactly that kernel, skipping the heuristics query).  A positional
+# index, by contrast, is only meaningful for one graph instance and silently
 # mis-points after the ``policy=ALL`` plan list is re-enumerated across
 # cudnn-frontend / backend versions or after ``deselect_engines``.
 #
-# At replay time the tactic is *pinned* via
-# ``graph.create_execution_plan(engine_id, knobs)``, which finalizes the graph
-# to exactly that kernel and skips the heuristics query entirely (mirrors the
-# frontend's own ``override_heuristics_query`` path).
+# Structured encoding: ``(engine_id, ((knob_int, value), ...))`` -- all plain
+# ints, so it round-trips through the autotuner's JSON cache unchanged
+# (knob_type <-> int is stable: knob_type.SPLIT_K_SLC.value == 9,
+# cudnn.knob_type(9) reconstructs it).
 #
-# Encoding: ``(engine_id, ((knob_int, value), ...))`` -- all plain ints, so it
-# round-trips through the autotuner's JSON cache unchanged (knob_type <-> int
-# is stable: knob_type.SPLIT_K_SLC.value == 9, cudnn.knob_type(9) reconstructs
-# it).  Requires a cudnn-frontend exposing get_engine_and_knobs_at_index (see
-# the requirements.txt floor).
+# When the frontend lacks those APIs we fall back to the bare plan *index*
+# (today's behavior) -- detected at runtime via
+# ``_cudnn_structured_plan_available``, no version pin required.  We never use
+# the plan-name string (its knob ordering isn't stable across construction
+# paths, so it isn't a reliable identity).
 # ---------------------------------------------------------------------------
 
 
-def _cudnn_plan_tactics(graph) -> list:
-    """Enumerate structured tactics for a built (policy=ALL) cuDNN graph.
+def _cudnn_structured_plan_available() -> bool:
+    """True iff the cudnn-frontend exposes the structured plan getter and the
+    create_execution_plan pinning API.  When False, the cuDNN GEMM runners fall
+    back to bare plan-index tactics (today's behavior)."""
+    return (
+        CUDNN_AVAILABLE
+        and hasattr(cudnn.pygraph, "get_engine_and_knobs_at_index")
+        and hasattr(cudnn.pygraph, "create_execution_plan")
+    )
 
-    Returns ``(engine_id, ((knob_int, value), ...))`` for each plan -- each
-    replayable via create_execution_plan without a heuristics query, and
-    stable across plan re-enumeration (unlike a positional index).
+
+def _cudnn_plan_tactics(graph) -> list:
+    """Enumerate autotuner tactics for a built (policy=ALL) cuDNN graph.
+
+    Returns structured ``(engine_id, ((knob_int, value), ...))`` tactics when
+    the frontend supports it (replayable via create_execution_plan, stable
+    across plan re-enumeration); otherwise falls back to bare plan indices
+    ``[0, 1, ...]`` (today's behavior), replayed via execute_plan_at_index.
     """
+    if not _cudnn_structured_plan_available():
+        return list(range(graph.get_execution_plan_count()))
     tactics = []
     for i in range(graph.get_execution_plan_count()):
         engine_id, knobs = graph.get_engine_and_knobs_at_index(i)
@@ -2218,12 +2234,13 @@ def clear_cudnn_graph_cache() -> None:
 
         This function exists for the few cases LRU cannot handle.  In
         every one of them we also clear **the AutoTuner cache** so that
-        re-tuning starts from cold.  Tactics are stored as structured
-        ``(engine_id, knobs)`` identities (see ``_cudnn_plan_tactics``) and
-        replayed by pinning via ``create_execution_plan``, so they don't
-        depend on plan-list ordering -- but a deliberate library swap can
-        still change which engines/knobs exist, so we clear both stores
-        together to force a fresh tuning pass:
+        re-tuning starts from cold.  Tactics are structured
+        ``(engine_id, knobs)`` identities when the frontend supports it (see
+        ``_cudnn_plan_tactics``), replayed by pinning via
+        ``create_execution_plan`` and independent of plan-list ordering;
+        on older frontends they fall back to bare plan indices.  Either way a
+        deliberate library swap can change which engines/plans exist, so we
+        clear both stores together to force a fresh tuning pass:
 
             * **Hot-patching during development** -- after editing a
               ``build_*`` helper in-place, LRU will not evict the

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ cuda-tile[tileiras]
 einops
 ninja
 numpy
-nvidia-cudnn-frontend>=1.13.0
+# >=1.25.0 for pygraph.get_engine_and_knobs_at_index (NVIDIA/cudnn-frontend#259),
+# used by the cuDNN GEMM autotuner to pin plans via create_execution_plan.
+nvidia-cudnn-frontend>=1.25.0
 nvidia-cutlass-dsl>=4.5.0
 nvidia-ml-py
 packaging>=24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,7 @@ cuda-tile[tileiras]
 einops
 ninja
 numpy
-# >=1.25.0 for pygraph.get_engine_and_knobs_at_index (NVIDIA/cudnn-frontend#259),
-# used by the cuDNN GEMM autotuner to pin plans via create_execution_plan.
-nvidia-cudnn-frontend>=1.25.0
+nvidia-cudnn-frontend>=1.13.0
 nvidia-cutlass-dsl>=4.5.0
 nvidia-ml-py
 packaging>=24.2

--- a/tests/gemm/test_autotune_cudnn_dynamic_shape_fuzz.py
+++ b/tests/gemm/test_autotune_cudnn_dynamic_shape_fuzz.py
@@ -1,0 +1,287 @@
+"""Randomized stress test for the autotuner <-> cuDNN dynamic-shape interaction.
+
+The cuDNN GEMM runners tune on a set of M (num-token) *buckets* and then must
+serve arbitrary runtime M via cuDNN's override-shape graphs, replaying the
+tuned tactic.  Historically this seam has been fragile:
+
+  * a tactic stored as a bare plan *index* could silently mis-point after the
+    plan list was re-enumerated (the fix under test stores plan names /
+    structured (engine, knobs) instead);
+  * a cache_m bucket mismatch between the runner and the autotuner produced
+    sparse NaN/Inf at non-power-of-2 M;
+  * out-of-range / between-bucket M must fall back without corruption.
+
+This test hammers that seam: it autotunes over randomized bucket sets, then
+runs a *different* random sweep of runtime M (in-range, between buckets, and
+beyond the tuned range), asserting every result is finite and numerically
+correct.  It also covers the on-disk autotune-cache round-trip (which now
+persists plan-name / structured tactics), round_up semantics, and interleaved
+shapes within a single tuning context.
+
+Run on a cuDNN override-shape-capable GPU (SM100+, cudnn-frontend >= 1.20 /
+backend >= 9.21).  Otherwise the whole module skips.
+"""
+
+import os
+import random
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer import SfLayout, autotune, mm_fp4, nvfp4_quantize
+from flashinfer.autotuner import AutoTuner
+from flashinfer.utils import get_compute_capability, LibraryError
+from flashinfer.gemm.gemm_base import (
+    is_cudnn_override_shape_available,
+    clear_cudnn_graph_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level skip guards: this test only means something when the cuDNN
+# override-shape GEMM path is actually live.
+# ---------------------------------------------------------------------------
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+_CC = get_compute_capability(torch.device("cuda"))
+_CC_NUM = _CC[0] * 10 + _CC[1]
+
+if not mm_fp4.is_backend_supported("cudnn", _CC_NUM):
+    pytest.skip(f"cuDNN mm_fp4 not supported on SM{_CC_NUM}", allow_module_level=True)
+if not is_cudnn_override_shape_available():
+    pytest.skip(
+        "cuDNN override-shape GEMM not available (need cudnn-frontend>=1.20, "
+        "backend>=9.21); the autotuner<->dynamic-shape seam under test is inactive",
+        allow_module_level=True,
+    )
+
+COS_SIM_THRESHOLD = 0.97
+
+
+def _make_nvfp4_operands(m, n, k, res_dtype, seed):
+    """Build randomized nvfp4 operands + a bf16 reference for an m x k @ k x n GEMM."""
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16, generator=g)
+    b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16, generator=g)
+
+    gsf_a = (448 * 6) / a.float().abs().nan_to_num().max()
+    gsf_b = (448 * 6) / b.float().abs().nan_to_num().max()
+
+    a_fp4, a_inv_s = nvfp4_quantize(
+        a, gsf_a, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    b_fp4, b_inv_s = nvfp4_quantize(
+        b, gsf_b, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    alpha = 1.0 / (gsf_a * gsf_b)
+    reference = torch.mm(a, b.T)
+    return dict(
+        a_fp4=a_fp4,
+        b_fp4=b_fp4,
+        a_inv_s=a_inv_s,
+        b_inv_s=b_inv_s,
+        alpha=alpha,
+        reference=reference,
+        m=m,
+        n=n,
+        k=k,
+        res_dtype=res_dtype,
+    )
+
+
+def _run_mm_fp4(op, backend="cudnn"):
+    """Run mm_fp4 on prepared operands; return (res, cos_sim)."""
+    res = torch.empty([op["m"], op["n"]], device="cuda", dtype=op["res_dtype"])
+    mm_fp4(
+        op["a_fp4"],
+        op["b_fp4"].T,
+        op["a_inv_s"],
+        op["b_inv_s"].T,
+        op["alpha"],
+        op["res_dtype"],
+        res,
+        block_size=16,
+        use_8x4_sf_layout=False,
+        backend=backend,
+        use_nvfp4=True,
+        skip_check=False,
+    )
+    cos = F.cosine_similarity(
+        op["reference"].reshape(-1).float(), res.reshape(-1).float(), dim=0
+    )
+    return res, float(cos)
+
+
+def _assert_good(res, cos, where):
+    assert torch.isfinite(res).all(), f"{where}: non-finite values in output"
+    assert cos > COS_SIM_THRESHOLD, f"{where}: cos_sim {cos:.4f} below threshold"
+
+
+# ---------------------------------------------------------------------------
+# 1. Tune over a randomized bucket set, then serve a *different* random M
+#    sweep (in-range, between buckets, beyond range).  This is the core
+#    dynamic-shape correctness check.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("seed", [0, 1, 2])
+@pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16])
+def test_fuzz_dynamic_M_sweep_after_autotune(seed, res_dtype):
+    rng = random.Random(seed)
+    n = rng.choice([256, 512, 1024])
+    k = rng.choice([256, 512, 1024])
+
+    # Random monotonic bucket set covering a range of M.
+    max_m = rng.choice([512, 1024, 2048])
+    buckets = sorted(
+        {1, 8, max_m, *[rng.randint(2, max_m) for _ in range(rng.randint(3, 6))]}
+    )
+
+    clear_cudnn_graph_cache()  # fresh tactic <-> graph state
+
+    # Tune at each bucket M.
+    try:
+        with autotune(True, tuning_buckets=tuple(buckets)):
+            for bm in buckets:
+                op = _make_nvfp4_operands(bm, n, k, res_dtype, seed)
+                _run_mm_fp4(op)
+    except LibraryError as e:
+        pytest.skip(f"cuDNN backend unavailable for this config: {e}")
+
+    # Now serve a random sweep of runtime M -- deliberately including values
+    # between buckets and beyond the tuned range -- using only cached tactics.
+    sweep = (
+        [rng.randint(1, max_m) for _ in range(8)]
+        + [b + 1 for b in buckets if b + 1 <= max_m]  # just-above each bucket
+        + [max_m + rng.randint(1, max_m)]  # beyond the tuned range
+        + [1, 2, 3]  # tiny
+    )
+    with autotune(False):
+        for m in sweep:
+            op = _make_nvfp4_operands(m, n, k, res_dtype, seed + m)
+            res, cos = _run_mm_fp4(op)
+            _assert_good(res, cos, f"M={m} (n={n},k={k},buckets={buckets})")
+
+
+# ---------------------------------------------------------------------------
+# 2. On-disk autotune cache round-trip: tune+save, wipe in-memory state,
+#    load, and serve random M.  Exercises plan-name / structured tactic
+#    persistence through JSON.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("seed", [3, 4])
+def test_fuzz_autotune_cache_roundtrip(seed, tmp_path):
+    rng = random.Random(seed)
+    n, k = 512, 512
+    buckets = (1, 16, 64, 256, 1024)
+    res_dtype = torch.bfloat16
+    cache_file = os.path.join(tmp_path, "cudnn_fp4_cache.json")
+
+    clear_cudnn_graph_cache()
+    try:
+        with autotune(True, tuning_buckets=buckets, cache=cache_file):
+            for bm in buckets:
+                op = _make_nvfp4_operands(bm, n, k, res_dtype, seed)
+                _run_mm_fp4(op)
+    except LibraryError as e:
+        pytest.skip(f"cuDNN backend unavailable: {e}")
+
+    assert os.path.isfile(cache_file), "autotune cache not written"
+
+    # Wipe both the autotuner's in-memory cache and the cuDNN graph LRU, so the
+    # only way to get a tuned tactic is to reload it from disk.
+    clear_cudnn_graph_cache()
+    AutoTuner.get().clear_cache()
+
+    with autotune(False, cache=cache_file):
+        for m in [rng.randint(1, 1024) for _ in range(10)]:
+            op = _make_nvfp4_operands(m, n, k, res_dtype, seed + m)
+            res, cos = _run_mm_fp4(op)
+            _assert_good(res, cos, f"reloaded M={m}")
+
+
+# ---------------------------------------------------------------------------
+# 3. round_up True vs False: both must be numerically correct at
+#    between-bucket M (they may pick different tactics).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("round_up", [False, True])
+def test_fuzz_round_up_between_buckets(round_up):
+    n, k = 512, 256
+    buckets = (16, 128, 512)
+    res_dtype = torch.bfloat16
+
+    clear_cudnn_graph_cache()
+    try:
+        with autotune(True, tuning_buckets=buckets, round_up=round_up):
+            for bm in buckets:
+                op = _make_nvfp4_operands(bm, n, k, res_dtype, 7)
+                _run_mm_fp4(op)
+    except LibraryError as e:
+        pytest.skip(f"cuDNN backend unavailable: {e}")
+
+    with autotune(False, round_up=round_up):
+        for m in [17, 63, 100, 200, 400, 511, 513]:  # between / above buckets
+            op = _make_nvfp4_operands(m, n, k, res_dtype, 7 + m)
+            res, cos = _run_mm_fp4(op)
+            _assert_good(res, cos, f"round_up={round_up} M={m}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Interleave many random M within a single tuning context -- stresses the
+#    graph-cache / tactic-cache lockstep (a mismatch here was the NaN class).
+# ---------------------------------------------------------------------------
+def test_fuzz_interleaved_shapes_single_context():
+    rng = random.Random(99)
+    n, k = 256, 512
+    res_dtype = torch.bfloat16
+
+    clear_cudnn_graph_cache()
+    ms = [rng.randint(1, 1500) for _ in range(25)]
+    try:
+        with autotune(True):
+            for m in ms:
+                op = _make_nvfp4_operands(m, n, k, res_dtype, m)
+                res, cos = _run_mm_fp4(op)
+                _assert_good(res, cos, f"interleaved tune M={m}")
+    except LibraryError as e:
+        pytest.skip(f"cuDNN backend unavailable: {e}")
+
+    # Replay a reshuffled set under no-tune; must stay correct.
+    rng.shuffle(ms)
+    with autotune(False):
+        for m in ms:
+            op = _make_nvfp4_operands(m, n, k, res_dtype, m + 1)
+            res, cos = _run_mm_fp4(op)
+            _assert_good(res, cos, f"interleaved replay M={m}")
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-backend agreement: cuDNN and CUTLASS must agree (both vs reference)
+#    on the same operands across a random M sweep.
+# ---------------------------------------------------------------------------
+def test_fuzz_cudnn_vs_cutlass_agreement():
+    if not mm_fp4.is_backend_supported("cutlass", _CC_NUM):
+        pytest.skip("cutlass mm_fp4 not supported here")
+    rng = random.Random(123)
+    n, k = 512, 512
+    res_dtype = torch.bfloat16
+
+    clear_cudnn_graph_cache()
+    for _ in range(6):
+        m = rng.randint(1, 1024)
+        op = _make_nvfp4_operands(m, n, k, res_dtype, m)
+        try:
+            with autotune(True):
+                res_cudnn, cos_cudnn = _run_mm_fp4(op, backend="cudnn")
+                res_cutlass, cos_cutlass = _run_mm_fp4(op, backend="cutlass")
+        except LibraryError as e:
+            pytest.skip(f"backend unavailable: {e}")
+        _assert_good(res_cudnn, cos_cudnn, f"cudnn M={m}")
+        _assert_good(res_cutlass, cos_cutlass, f"cutlass M={m}")
+        # The two backends should agree closely (same math, different kernels).
+        cos_pair = F.cosine_similarity(
+            res_cudnn.reshape(-1).float(), res_cutlass.reshape(-1).float(), dim=0
+        )
+        assert cos_pair > 0.99, f"cudnn vs cutlass disagree at M={m}: {cos_pair:.4f}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-x"])

--- a/tests/gemm/test_autotune_cudnn_dynamic_shape_fuzz.py
+++ b/tests/gemm/test_autotune_cudnn_dynamic_shape_fuzz.py
@@ -5,8 +5,8 @@ serve arbitrary runtime M via cuDNN's override-shape graphs, replaying the
 tuned tactic.  Historically this seam has been fragile:
 
   * a tactic stored as a bare plan *index* could silently mis-point after the
-    plan list was re-enumerated (the fix under test stores plan names /
-    structured (engine, knobs) instead);
+    plan list was re-enumerated (the fix under test stores structured
+    (engine, knobs) tactics instead, when the frontend supports it);
   * a cache_m bucket mismatch between the runner and the autotuner produced
     sparse NaN/Inf at non-power-of-2 M;
   * out-of-range / between-bucket M must fall back without corruption.
@@ -14,8 +14,8 @@ tuned tactic.  Historically this seam has been fragile:
 This test hammers that seam: it autotunes over randomized bucket sets, then
 runs a *different* random sweep of runtime M (in-range, between buckets, and
 beyond the tuned range), asserting every result is finite and numerically
-correct.  It also covers the on-disk autotune-cache round-trip (which now
-persists plan-name / structured tactics), round_up semantics, and interleaved
+correct.  It also covers the on-disk autotune-cache round-trip, round_up
+semantics, and interleaved
 shapes within a single tuning context.
 
 Run on a cuDNN override-shape-capable GPU (SM100+, cudnn-frontend >= 1.20 /

--- a/tests/gemm/test_cudnn_tactic_resolution.py
+++ b/tests/gemm/test_cudnn_tactic_resolution.py
@@ -1,0 +1,93 @@
+"""Unit tests for cuDNN GEMM structured (engine_id, knobs) tactics.
+
+The cuDNN GEMM runners use the plan's *structured identity* -- engine global
+index + knob choices, read via the frontend's get_engine_and_knobs_at_index --
+as the autotuner tactic, and replay it by pinning via create_execution_plan
+(skipping the heuristics query).  This is a version-robust alternative to a
+bare positional plan index, which silently mis-points after the plan list is
+re-enumerated across cudnn-frontend / backend versions.
+
+These tests cover the tactic enumeration / encode / classify helpers in
+isolation with a stub graph, so they need neither a GPU nor a loadable cuDNN
+backend.
+"""
+
+import json
+
+import pytest
+
+from flashinfer.gemm.gemm_base import (
+    _cudnn_plan_tactics,
+    _cudnn_is_structured_tactic,
+    _cudnn_structured_pin,
+)
+from flashinfer.autotuner import _tactic_to_json, _json_to_tactic
+
+
+class _StubGraph:
+    """Stand-in for a cudnn-frontend pygraph after build_plans().
+
+    ``plans`` is a list of (engine_id, {knob_int: value}) for each plan index.
+    """
+
+    def __init__(self, plans):
+        self._plans = plans
+
+    def get_execution_plan_count(self):
+        return len(self._plans)
+
+    def get_engine_and_knobs_at_index(self, i):
+        engine_id, knobs = self._plans[i]
+        # Frontend returns a dict keyed by knob_type; the stub keys by int and
+        # the production code only does int(k), so plain ints are equivalent
+        # for these tests.
+        return engine_id, dict(knobs)
+
+
+def test_plan_tactics_are_structured_and_int_encoded():
+    g = _StubGraph([(0, {}), (7, {9: 41, 16: 1})])
+    tactics = _cudnn_plan_tactics(g)
+    # engine_id + sorted (knob_int, value) pairs; all plain ints (JSON-safe).
+    assert tactics == [(0, ()), (7, ((9, 41), (16, 1)))]
+    for t in tactics:
+        assert _cudnn_is_structured_tactic(t)
+
+
+def test_knobs_are_sorted_deterministically():
+    # Same engine+knobs in different dict order must yield the same tactic.
+    g1 = _StubGraph([(3, {16: 1, 9: 2})])
+    g2 = _StubGraph([(3, {9: 2, 16: 1})])
+    assert (
+        _cudnn_plan_tactics(g1) == _cudnn_plan_tactics(g2) == [(3, ((9, 2), (16, 1)))]
+    )
+
+
+def test_is_structured_tactic_discrimination():
+    assert _cudnn_is_structured_tactic((3, ((9, 2),)))
+    assert _cudnn_is_structured_tactic((0, ()))  # engine with no knobs
+    assert _cudnn_is_structured_tactic((3, [[9, 2]]))  # JSON list form
+    # Not structured -- the autotuner fallback / disabled-autotune tactic:
+    assert not _cudnn_is_structured_tactic(-1)
+    assert not _cudnn_is_structured_tactic(5)
+    assert not _cudnn_is_structured_tactic("eng3_k9=2")
+
+
+def test_structured_pin_normalizes_to_int_pairs():
+    engine_id, pin_knobs = _cudnn_structured_pin((3, ((9, 2), (16, 1))))
+    assert engine_id == 3
+    assert pin_knobs == ((9, 2), (16, 1))
+    assert all(isinstance(k, int) and isinstance(v, int) for k, v in pin_knobs)
+
+
+def test_tactic_json_round_trip():
+    # The autotuner persists tactics via _tactic_to_json / _json_to_tactic;
+    # the structured tactic must survive a JSON round-trip unchanged so the
+    # on-disk autotune cache replays the same pinned plan.
+    tactic = (7, ((9, 41), (16, 1)))
+    restored = _json_to_tactic(json.loads(json.dumps(_tactic_to_json(tactic))))
+    assert restored == tactic
+    assert _cudnn_is_structured_tactic(restored)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gemm/test_cudnn_tactic_resolution.py
+++ b/tests/gemm/test_cudnn_tactic_resolution.py
@@ -1,11 +1,13 @@
 """Unit tests for cuDNN GEMM structured (engine_id, knobs) tactics.
 
-The cuDNN GEMM runners use the plan's *structured identity* -- engine global
-index + knob choices, read via the frontend's get_engine_and_knobs_at_index --
-as the autotuner tactic, and replay it by pinning via create_execution_plan
-(skipping the heuristics query).  This is a version-robust alternative to a
-bare positional plan index, which silently mis-points after the plan list is
-re-enumerated across cudnn-frontend / backend versions.
+When the cudnn-frontend exposes get_engine_and_knobs_at_index +
+create_execution_plan, the cuDNN GEMM runners use the plan's *structured
+identity* (engine global index + knob choices) as the autotuner tactic and
+replay it by pinning via create_execution_plan -- a version-robust alternative
+to a bare positional plan index, which silently mis-points after the plan list
+is re-enumerated across cudnn-frontend / backend versions. When those APIs are
+absent the runners fall back to bare plan indices (today's behavior), detected
+at runtime by ``_cudnn_structured_plan_available``.
 
 These tests cover the tactic enumeration / encode / classify helpers in
 isolation with a stub graph, so they need neither a GPU nor a loadable cuDNN
@@ -16,6 +18,7 @@ import json
 
 import pytest
 
+import flashinfer.gemm.gemm_base as gb
 from flashinfer.gemm.gemm_base import (
     _cudnn_plan_tactics,
     _cudnn_is_structured_tactic,
@@ -44,7 +47,13 @@ class _StubGraph:
         return engine_id, dict(knobs)
 
 
-def test_plan_tactics_are_structured_and_int_encoded():
+@pytest.fixture
+def structured(monkeypatch):
+    """Force the structured-plan path on, regardless of the installed frontend."""
+    monkeypatch.setattr(gb, "_cudnn_structured_plan_available", lambda: True)
+
+
+def test_plan_tactics_are_structured_and_int_encoded(structured):
     g = _StubGraph([(0, {}), (7, {9: 41, 16: 1})])
     tactics = _cudnn_plan_tactics(g)
     # engine_id + sorted (knob_int, value) pairs; all plain ints (JSON-safe).
@@ -53,7 +62,7 @@ def test_plan_tactics_are_structured_and_int_encoded():
         assert _cudnn_is_structured_tactic(t)
 
 
-def test_knobs_are_sorted_deterministically():
+def test_knobs_are_sorted_deterministically(structured):
     # Same engine+knobs in different dict order must yield the same tactic.
     g1 = _StubGraph([(3, {16: 1, 9: 2})])
     g2 = _StubGraph([(3, {9: 2, 16: 1})])
@@ -62,11 +71,21 @@ def test_knobs_are_sorted_deterministically():
     )
 
 
+def test_plan_tactics_fall_back_to_indices_when_unavailable(monkeypatch):
+    # Without the structured API, tactics are bare plan indices (today's behavior).
+    monkeypatch.setattr(gb, "_cudnn_structured_plan_available", lambda: False)
+    g = _StubGraph([(0, {}), (7, {9: 41})])
+    tactics = _cudnn_plan_tactics(g)
+    assert tactics == [0, 1]
+    for t in tactics:
+        assert not _cudnn_is_structured_tactic(t)
+
+
 def test_is_structured_tactic_discrimination():
     assert _cudnn_is_structured_tactic((3, ((9, 2),)))
     assert _cudnn_is_structured_tactic((0, ()))  # engine with no knobs
     assert _cudnn_is_structured_tactic((3, [[9, 2]]))  # JSON list form
-    # Not structured -- the autotuner fallback / disabled-autotune tactic:
+    # Not structured -- bare plan index / autotuner fallback:
     assert not _cudnn_is_structured_tactic(-1)
     assert not _cudnn_is_structured_tactic(5)
     assert not _cudnn_is_structured_tactic("eng3_k9=2")


### PR DESCRIPTION
## Problem

The cuDNN GEMM runners (fp8/bf16/fp4/mxfp8, override-shape path) stored the autotuner tactic as a **bare plan index** into cuDNN's `policy=ALL` plan list. That index is only meaningful for one graph instance: the plan list is re-enumerated on every rebuild and its order can shift across cudnn-frontend / cuDNN-backend versions or after `deselect_engines`. A tactic persisted to an on-disk autotune cache (`autotune(cache=...)`) can therefore **silently point at a different engine** after a library update — a correctness hazard, not just a perf one. This is the root cause behind the cuDNN plan-index drift we've hit before.

## Change

Two layers (two commits):

**1. Self-describing plan-name tactics** (works with stock cudnn-frontend, active for all 4 dtypes)
- Tactic = the cuDNN plan *name* (engine + knobs, via `get_plan_name_at_index`) instead of a positional index.
- `get_valid_tactics` returns names; `forward` resolves the chosen name → index *against the graph it is about to execute*. If the name is gone (re-enumeration under a different library), it degrades to plan 0 with a one-time warning instead of executing a mis-indexed plan.
- The autotuner stays backend-agnostic: name strings pass through `_tactic_to_json` / `_json_to_tactic` unchanged.

**2. Structured `(engine_id, knobs)` tactics + plan pinning** (gated; fp8 reference)
- When the frontend exposes `get_engine_and_knobs_at_index` + `create_execution_plan` (see NVIDIA/cudnn-frontend#259), the tactic becomes `(engine_id, ((knob_int, value), ...))` and is replayed by **pinning that exact plan via `create_execution_plan` — skipping the heuristics query** at replay time, instead of re-enumerating and matching by name.
- Gated by `_cudnn_structured_plan_available()` (hasattr feature-detection — no `requirements.txt` bump needed; degrades to the plan-name path when absent). Tactic encodes knob types as ints (`knob_type.value`), so it round-trips through the JSON cache.
- `CudnnFp8GemmRunner` is the reference; bf16/fp4/mxfp8 stay on plan-name until fp8 is validated on Blackwell (same 3-spot change to replicate).

## Tests

`tests/gemm/test_cudnn_tactic_resolution.py` (GPU-free): name→index resolution, the index-drift-follow case, int/-1 fallback, stale-name degradation, structured encode/decode + gate, and JSON round-trip.

## Notes

- The structured pinning depends on NVIDIA/cudnn-frontend#259 (additive read-only API). Until that lands in a release, the `hasattr` gate keeps the plan-name path active everywhere. The cudnn-frontend API + `create_execution_plan` round-trip is validated on A100 (enumerate → pin → identical plan).
- cuDNN override-shape GEMM is SM100-only; end-to-end SM100 validation of the fp8 structured path is in progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced autotuner cache validation to verify runtime environment compatibility, preventing stale configurations.
  * Improved cuDNN tactical plan selection and pinning for more reliable autotuning and replay.

* **Tests**
  * Expanded cuDNN tactic resolution test coverage.
  * Added dynamic shape and fuzz test suite for autotuner cache persistence and cross-backend validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->