### PR TITLE
perf: replace moe_static_kernel compact topk spin-wait with histogram-based reduction

### DIFF
--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -251,7 +251,6 @@ def parse_moe_args(line, parser):
             "eliminates per-call allocation overhead."
         ),
     )
-
     # CUTLASS fused MoE specific
     parser.add_argument(
         "--cutlass_variant",

--- a/flashinfer/cute_dsl/fp4_common.py
+++ b/flashinfer/cute_dsl/fp4_common.py
@@ -1564,6 +1564,72 @@ def atomic_add_global_i32(addr: Int64, val: Int32, *, loc=None, ip=None) -> Int3
 
 
 @dsl_user_op
+def atomic_add_shared_i32(addr: Int32, val: Int32, *, loc=None, ip=None) -> Int32:
+    """Shared memory int32 atomic add. addr is a 32-bit smem byte address."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Int32(val).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared.add.s32 $0, [$1], $2;",
+            "=r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def warp_inclusive_prefix_sum_i32(val: Int32, *, loc=None, ip=None) -> Int32:
+    """Inclusive warp prefix sum over all 32 lanes using shfl.sync.up.
+
+    Returns the inclusive prefix sum of `val` across lanes 0..lane_id within
+    the calling warp.  All 32 lanes must participate (full-warp mask).
+    The five rounds run entirely in registers — no shared memory, no barrier.
+
+    PTX: five rounds of shfl.sync.up.b32 with predicated add.  The built-in
+    predicate from shfl.up is true iff the source lane was within the warp,
+    so @p add only accumulates when valid (no explicit lane_id comparison
+    needed).
+    """
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(val).ir_value(loc=loc, ip=ip)],
+            (
+                "{\n\t"
+                ".reg .b32 r, t;\n\t"
+                ".reg .pred p;\n\t"
+                "mov.b32 r, $1;\n\t"
+                "shfl.sync.up.b32 t|p, r, 1, 0, 0xffffffff;\n\t"
+                "@p add.s32 r, r, t;\n\t"
+                "shfl.sync.up.b32 t|p, r, 2, 0, 0xffffffff;\n\t"
+                "@p add.s32 r, r, t;\n\t"
+                "shfl.sync.up.b32 t|p, r, 4, 0, 0xffffffff;\n\t"
+                "@p add.s32 r, r, t;\n\t"
+                "shfl.sync.up.b32 t|p, r, 8, 0, 0xffffffff;\n\t"
+                "@p add.s32 r, r, t;\n\t"
+                "shfl.sync.up.b32 t|p, r, 16, 0, 0xffffffff;\n\t"
+                "@p add.s32 r, r, t;\n\t"
+                "mov.b32 $0, r;\n\t"
+                "}"
+            ),
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
 def atomic_cas_global_i32(
     addr: Int64, compare: Int32, value: Int32, *, loc=None, ip=None
 ) -> Int32:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -1100,7 +1100,9 @@ def launch_sm120_static_moe(
             activation=activation,
             activation_precision=activation_precision,
         )
-        launch_ids = flat_ids
+        compact_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+        compact_ids.copy_(flat_ids)
+        launch_ids = compact_ids
 
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
     runtime_args: Tuple[Any, ...] = (

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -111,6 +111,8 @@ from flashinfer.cute_dsl.fp4_common import (
     atomic_add_global_i32,
     fabs_f32,
     fmax_f32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
@@ -120,7 +122,7 @@ from flashinfer.cute_dsl.fp4_common import (
     shared_ptr_to_u32,
     st_shared_u8,
     st_global_u64,
-    scatter_add_bf16x2,
+    scatter_add_v4_bf16x2,
 )
 from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
     Sm120B12xBlockScaledDenseGemmKernel as DenseGemmKernel,
@@ -2123,15 +2125,13 @@ class MoEMicroKernel:
                         if warp_epi_rows < Int32(0):
                             warp_epi_rows = Int32(0)
 
-                        pair_idx = lane_id
-                        while pair_idx < warp_epi_rows * Int32(32):
-                            local_row = pair_idx >> Int32(5)  # / 32
-                            local_pair_col = pair_idx & Int32(31)  # % 32
-                            global_col = (
-                                tile_n_base_cur
-                                + warp_n_base
-                                + local_pair_col * Int32(2)
-                            )
+                        tile_vec_cols = Int32(64) // Int32(8)
+                        vec_idx = lane_id
+                        while vec_idx < warp_epi_rows * tile_vec_cols:
+                            local_row = vec_idx // tile_vec_cols
+                            local_vec_col = vec_idx - local_row * tile_vec_cols
+                            local_col = warp_n_base + local_vec_col * Int32(8)
+                            global_col = tile_n_base_cur + local_col
                             cached_row = rows_offset + warp_m_base + local_row
                             tok = Int32(0)
                             wv = cutlass.Float32(0.0)
@@ -2139,38 +2139,50 @@ class MoEMicroKernel:
                                 tok = unique_tok
                                 wv = unique_wv
                             else:
-                                # Only lane 0 loads tok/wv from smem; broadcast via shuffle.
-                                if lane_id == Int32(0):
-                                    tok = _ld_shared_i32(
-                                        scatter_tok_base_addr + cached_row * Int32(4)
-                                    )
-                                    wv = _ld_shared_f32(
-                                        scatter_weight_base_addr + cached_row * Int32(4)
-                                    )
-                                tok = cute.arch.shuffle_sync(tok, Int32(0))
-                                wv = cute.arch.shuffle_sync(wv, Int32(0))
+                                tok = ld_shared_i32_relaxed(
+                                    scatter_tok_base_addr + cached_row * Int32(4)
+                                )
+                                wv = ld_shared_f32(
+                                    scatter_weight_base_addr + cached_row * Int32(4)
+                                )
                             sc_v0 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    warp_n_base + local_pair_col * Int32(2),
-                                    epi_buffer,
-                                ]
+                                sC[warp_m_base + local_row, local_col, epi_buffer]
                             )
                             sc_v1 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    warp_n_base + local_pair_col * Int32(2) + Int32(1),
-                                    epi_buffer,
-                                ]
+                                sC[warp_m_base + local_row, local_col + Int32(1), epi_buffer]
                             )
-                            scatter_add_bf16x2(
+                            sc_v2 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(2), epi_buffer]
+                            )
+                            sc_v3 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(3), epi_buffer]
+                            )
+                            sc_v4 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(4), epi_buffer]
+                            )
+                            sc_v5 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(5), epi_buffer]
+                            )
+                            sc_v6 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(6), epi_buffer]
+                            )
+                            sc_v7 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(7), epi_buffer]
+                            )
+                            scatter_add_v4_bf16x2(
                                 get_ptr_as_int64(
                                     scatter_output, tok * scatter_N + global_col
                                 ),
                                 wv * sc_v0,
                                 wv * sc_v1,
+                                wv * sc_v2,
+                                wv * sc_v3,
+                                wv * sc_v4,
+                                wv * sc_v5,
+                                wv * sc_v6,
+                                wv * sc_v7,
                             )
-                            pair_idx += Int32(self.num_threads_per_warp)
+                            vec_idx += Int32(self.num_threads_per_warp)
 
                         # Post-scatter barrier: needed to ensure all warps
                         # finish scatter before next output tile's pipeline ops

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -2149,25 +2149,53 @@ class MoEMicroKernel:
                                 sC[warp_m_base + local_row, local_col, epi_buffer]
                             )
                             sc_v1 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(1), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(1),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v2 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(2), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(2),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v3 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(3), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(3),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v4 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(4), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(4),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v5 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(5), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(5),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v6 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(6), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(6),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v7 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(7), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(7),
+                                    epi_buffer,
+                                ]
                             )
                             scatter_add_v4_bf16x2(
                                 get_ptr_as_int64(

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -978,7 +978,6 @@ class MoEStaticKernel:
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
         num_k_tiles = (cols + Int32(63)) // Int32(64)
 
-
         if bidz == Int32(0):
             k0 = Int32(tidx)
             while k0 < num_global_experts:
@@ -1001,37 +1000,54 @@ class MoEStaticKernel:
             expert_idx = Int32(tidx)
             while expert_idx < num_global_experts:
                 active_expert_cnt = active_expert_cnt + (
-                    Int32(1) if ld_shared_i32_relaxed(
-                        smem_hist_base + expert_idx * Int32(4)
-                    ) > Int32(0) else Int32(0)
+                    Int32(1)
+                    if ld_shared_i32_relaxed(smem_hist_base + expert_idx * Int32(4))
+                    > Int32(0)
+                    else Int32(0)
                 )
                 expert_idx = expert_idx + Int32(self.threads_per_cta)
 
             warp_active_expert_prefix = warp_inclusive_prefix_sum_i32(active_expert_cnt)
 
             if lane_id == Int32(31):
-                st_shared_i32(smem_warp_base + warp_id * Int32(4), warp_active_expert_prefix)
+                st_shared_i32(
+                    smem_warp_base + warp_id * Int32(4), warp_active_expert_prefix
+                )
             cute.arch.sync_threads()
 
             if is_cta_leader > Int32(0):
                 total_active_expert = Int32(0)
                 warp_scan_idx = Int32(0)
                 while warp_scan_idx < Int32(self.threads_per_cta // 32):
-                    warp_active_cnt = ld_shared_i32_relaxed(smem_warp_base + warp_scan_idx * Int32(4))
-                    st_shared_i32(smem_warp_base + warp_scan_idx * Int32(4), total_active_expert)
+                    warp_active_cnt = ld_shared_i32_relaxed(
+                        smem_warp_base + warp_scan_idx * Int32(4)
+                    )
+                    st_shared_i32(
+                        smem_warp_base + warp_scan_idx * Int32(4), total_active_expert
+                    )
                     total_active_expert = total_active_expert + warp_active_cnt
                     warp_scan_idx = warp_scan_idx + Int32(1)
                 active_expert_count[Int32(0)] = total_active_expert
             cute.arch.sync_threads()
 
-            warp_active_expert_offset = ld_shared_i32_relaxed(smem_warp_base + warp_id * Int32(4))
-            local_expert_idx = warp_active_expert_offset + warp_active_expert_prefix - active_expert_cnt
+            warp_active_expert_offset = ld_shared_i32_relaxed(
+                smem_warp_base + warp_id * Int32(4)
+            )
+            local_expert_idx = (
+                warp_active_expert_offset
+                + warp_active_expert_prefix
+                - active_expert_cnt
+            )
 
             expert_idx = Int32(tidx)
             while expert_idx < num_global_experts:
-                token_cnt = ld_shared_i32_relaxed(smem_hist_base + expert_idx * Int32(4))
+                token_cnt = ld_shared_i32_relaxed(
+                    smem_hist_base + expert_idx * Int32(4)
+                )
                 if token_cnt > Int32(0):
-                    st_shared_i32(smem_hist_base + expert_idx * Int32(4), local_expert_idx)
+                    st_shared_i32(
+                        smem_hist_base + expert_idx * Int32(4), local_expert_idx
+                    )
                     weight_expert_ids[local_expert_idx] = expert_idx
                     local_expert_idx = local_expert_idx + Int32(1)
                 else:
@@ -2100,25 +2116,53 @@ class MoEStaticKernel:
                                 sC[warp_m_base + local_row, local_col, epi_buffer]
                             )
                             sc_v1 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(1), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(1),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v2 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(2), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(2),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v3 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(3), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(3),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v4 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(4), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(4),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v5 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(5), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(5),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v6 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(6), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(6),
+                                    epi_buffer,
+                                ]
                             )
                             sc_v7 = cutlass.Float32(
-                                sC[warp_m_base + local_row, local_col + Int32(7), epi_buffer]
+                                sC[
+                                    warp_m_base + local_row,
+                                    local_col + Int32(7),
+                                    epi_buffer,
+                                ]
                             )
                             scatter_add_v4_bf16x2(
                                 get_ptr_as_int64(

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -107,8 +107,11 @@ from flashinfer.cute_dsl.utils import (
 )
 from flashinfer.cute_dsl.fp4_common import (
     atomic_add_global_i32,
+    atomic_add_shared_i32,
     fabs_f32,
     fmax_f32,
+    ld_shared_f32,
+    ld_shared_i32_relaxed,
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
@@ -116,9 +119,11 @@ from flashinfer.cute_dsl.fp4_common import (
     st_global_f32,
     st_global_i32,
     shared_ptr_to_u32,
+    st_shared_i32,
     st_shared_u8,
     st_global_u64,
-    scatter_add_bf16x2,
+    scatter_add_v4_bf16x2,
+    warp_inclusive_prefix_sum_i32,
 )
 from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
     Sm120B12xBlockScaledDenseGemmKernel as DenseGemmKernel,
@@ -818,7 +823,7 @@ class MoEStaticKernel:
 
         @cute.struct
         class StorageGated:
-            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            ctrl: cute.struct.MemRange[cutlass.Int32, 3]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             phase2_pipeline_array: cute.struct.MemRange[
@@ -861,7 +866,7 @@ class MoEStaticKernel:
 
         @cute.struct
         class StorageRelu2:
-            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            ctrl: cute.struct.MemRange[cutlass.Int32, 3]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             phase2_pipeline_array: cute.struct.MemRange[
                 cutlass.Int64, self.ab_stage * 2
@@ -951,6 +956,7 @@ class MoEStaticKernel:
             epi_smem_staged.outer,
             swizzle=epi_smem_staged.inner,
         )
+        smem_hist_base = shared_ptr_to_u32(storage.sA.data_ptr())
         sfa_base_addr = shared_ptr_to_u32(storage.sSFA.data_ptr())
         ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
         scatter_tok_base_addr = shared_ptr_to_u32(storage.scatter_tok_cache.data_ptr())
@@ -972,17 +978,79 @@ class MoEStaticKernel:
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
         num_k_tiles = (cols + Int32(63)) // Int32(64)
 
+
+        if bidz == Int32(0):
+            k0 = Int32(tidx)
+            while k0 < num_global_experts:
+                st_shared_i32(smem_hist_base + k0 * Int32(4), Int32(0))
+                k0 += Int32(self.threads_per_cta)
+            cute.arch.sync_threads()
+
+            p0 = Int32(tidx)
+            while p0 < total_pairs:
+                gid = topk_ids[p0].to(Int32)
+                atomic_add_shared_i32(smem_hist_base + gid * Int32(4), Int32(1))
+                p0 += Int32(self.threads_per_cta)
+            cute.arch.sync_threads()
+
+            smem_warp_base = smem_hist_base + num_global_experts * Int32(4)
+            lane_id = Int32(tidx) & Int32(31)
+            warp_id = Int32(tidx) >> Int32(5)
+
+            active_expert_cnt = Int32(0)
+            expert_idx = Int32(tidx)
+            while expert_idx < num_global_experts:
+                active_expert_cnt = active_expert_cnt + (
+                    Int32(1) if ld_shared_i32_relaxed(
+                        smem_hist_base + expert_idx * Int32(4)
+                    ) > Int32(0) else Int32(0)
+                )
+                expert_idx = expert_idx + Int32(self.threads_per_cta)
+
+            warp_active_expert_prefix = warp_inclusive_prefix_sum_i32(active_expert_cnt)
+
+            if lane_id == Int32(31):
+                st_shared_i32(smem_warp_base + warp_id * Int32(4), warp_active_expert_prefix)
+            cute.arch.sync_threads()
+
+            if is_cta_leader > Int32(0):
+                total_active_expert = Int32(0)
+                warp_scan_idx = Int32(0)
+                while warp_scan_idx < Int32(self.threads_per_cta // 32):
+                    warp_active_cnt = ld_shared_i32_relaxed(smem_warp_base + warp_scan_idx * Int32(4))
+                    st_shared_i32(smem_warp_base + warp_scan_idx * Int32(4), total_active_expert)
+                    total_active_expert = total_active_expert + warp_active_cnt
+                    warp_scan_idx = warp_scan_idx + Int32(1)
+                active_expert_count[Int32(0)] = total_active_expert
+            cute.arch.sync_threads()
+
+            warp_active_expert_offset = ld_shared_i32_relaxed(smem_warp_base + warp_id * Int32(4))
+            local_expert_idx = warp_active_expert_offset + warp_active_expert_prefix - active_expert_cnt
+
+            expert_idx = Int32(tidx)
+            while expert_idx < num_global_experts:
+                token_cnt = ld_shared_i32_relaxed(smem_hist_base + expert_idx * Int32(4))
+                if token_cnt > Int32(0):
+                    st_shared_i32(smem_hist_base + expert_idx * Int32(4), local_expert_idx)
+                    weight_expert_ids[local_expert_idx] = expert_idx
+                    local_expert_idx = local_expert_idx + Int32(1)
+                else:
+                    st_shared_i32(smem_hist_base + expert_idx * Int32(4), Int32(-1))
+                expert_idx = expert_idx + Int32(self.threads_per_cta)
+            cute.arch.sync_threads()
+
+            p1 = Int32(tidx)
+            while p1 < total_pairs:
+                gid = topk_ids[p1].to(Int32)
+                topk_ids[p1] = ld_shared_i32_relaxed(smem_hist_base + gid * Int32(4))
+                p1 += Int32(self.threads_per_cta)
+            cute.arch.sync_threads()
+
         # Phase 0: cooperative init — zero row_counts and scatter_output
         i = flat_tid
         while i < num_experts:
             row_counts[i] = Int32(0)
             i += flat_stride
-        i = flat_tid
-        while i < num_global_experts:
-            global_to_local_expert[i] = Int32(-1)
-            i += flat_stride
-        if flat_tid == Int32(0):
-            active_expert_count[Int32(0)] = Int32(0)
         scatter_total = num_tokens * cols
         j = flat_tid
         while j < scatter_total:
@@ -998,40 +1066,12 @@ class MoEStaticKernel:
 
         pair_idx = Int32(bidz)
         while pair_idx < total_pairs:
-            expert_id = topk_ids[pair_idx].to(Int32)
+            local_expert_id = topk_ids[pair_idx].to(Int32)
+            expert_id = weight_expert_ids[local_expert_id].to(Int32)
             token_idx = pair_idx // num_topk
             weight = topk_weights[pair_idx].to(cutlass.Float32)
-            local_expert_id = Int32(0)
             row = Int32(0)
             if is_cta_leader > Int32(0):
-                prior_local_expert_id = _atomic_cas_global_i32(
-                    get_ptr_as_int64(global_to_local_expert, expert_id),
-                    Int32(-1),
-                    Int32(-2),
-                )
-                if prior_local_expert_id == Int32(-1):
-                    local_expert_id = atomic_add_global_i32(
-                        get_ptr_as_int64(active_expert_count, Int32(0)),
-                        Int32(1),
-                    )
-                    weight_expert_ids[local_expert_id] = expert_id
-                    _st_global_release_i32(
-                        get_ptr_as_int64(global_to_local_expert, expert_id),
-                        local_expert_id,
-                    )
-                else:
-                    if prior_local_expert_id == Int32(-2):
-                        # TODO: revisit whether we can replace this with a
-                        # weaker ordering path once the compact publish
-                        # sequence is better characterized.
-                        _spin_wait_global_eq_i32(
-                            get_ptr_as_int64(global_to_local_expert, expert_id),
-                            Int32(-2),
-                        )
-                        prior_local_expert_id = _ld_global_acquire_i32(
-                            get_ptr_as_int64(global_to_local_expert, expert_id),
-                        )
-                    local_expert_id = prior_local_expert_id
                 row = atomic_add_global_i32(
                     get_ptr_as_int64(row_counts, local_expert_id),
                     Int32(1),
@@ -1041,9 +1081,11 @@ class MoEStaticKernel:
                 st_global_f32(get_ptr_as_int64(token_weights, map_idx), weight)
                 _st_shared_i32(ctrl_base_addr + Int32(0), local_expert_id)
                 _st_shared_i32(ctrl_base_addr + Int32(4), row)
+                _st_shared_i32(ctrl_base_addr + Int32(8), expert_id)
             cute.arch.sync_threads()
             local_expert_id = _ld_shared_i32(ctrl_base_addr + Int32(0))
             row = _ld_shared_i32(ctrl_base_addr + Int32(4))
+            expert_id = _ld_shared_i32(ctrl_base_addr + Int32(8))
 
             # Distribute quantization across ALL CTA threads, not just leader.
             # Each FP4 block (16 elements) is independent — perfect parallelism.
@@ -2040,50 +2082,58 @@ class MoEStaticKernel:
                         if warp_epi_rows < Int32(0):
                             warp_epi_rows = Int32(0)
 
-                        pair_idx = lane_id
-                        while pair_idx < warp_epi_rows * Int32(32):
-                            local_row = pair_idx >> Int32(5)  # / 32
-                            local_pair_col = pair_idx & Int32(31)  # % 32
-                            global_col = (
-                                tile_n_base_cur
-                                + warp_n_base
-                                + local_pair_col * Int32(2)
-                            )
+                        tile_vec_cols = Int32(64) // Int32(8)
+                        vec_idx = lane_id
+                        while vec_idx < warp_epi_rows * tile_vec_cols:
+                            local_row = vec_idx // tile_vec_cols
+                            local_vec_col = vec_idx - local_row * tile_vec_cols
+                            local_col = warp_n_base + local_vec_col * Int32(8)
+                            global_col = tile_n_base_cur + local_col
                             cached_row = rows_offset + warp_m_base + local_row
-                            # Only lane 0 loads tok/wv from gmem; broadcast via shuffle.
-                            tok = Int32(0)
-                            wv = cutlass.Float32(0.0)
-                            if lane_id == Int32(0):
-                                tok = _ld_shared_i32(
-                                    scatter_tok_base_addr + cached_row * Int32(4)
-                                )
-                                wv = _ld_shared_f32(
-                                    scatter_weight_base_addr + cached_row * Int32(4)
-                                )
-                            tok = cute.arch.shuffle_sync(tok, Int32(0))
-                            wv = cute.arch.shuffle_sync(wv, Int32(0))
+                            tok = ld_shared_i32_relaxed(
+                                scatter_tok_base_addr + cached_row * Int32(4)
+                            )
+                            wv = ld_shared_f32(
+                                scatter_weight_base_addr + cached_row * Int32(4)
+                            )
                             sc_v0 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    warp_n_base + local_pair_col * Int32(2),
-                                    epi_buffer,
-                                ]
+                                sC[warp_m_base + local_row, local_col, epi_buffer]
                             )
                             sc_v1 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    warp_n_base + local_pair_col * Int32(2) + Int32(1),
-                                    epi_buffer,
-                                ]
+                                sC[warp_m_base + local_row, local_col + Int32(1), epi_buffer]
                             )
-                            scatter_add_bf16x2(
+                            sc_v2 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(2), epi_buffer]
+                            )
+                            sc_v3 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(3), epi_buffer]
+                            )
+                            sc_v4 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(4), epi_buffer]
+                            )
+                            sc_v5 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(5), epi_buffer]
+                            )
+                            sc_v6 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(6), epi_buffer]
+                            )
+                            sc_v7 = cutlass.Float32(
+                                sC[warp_m_base + local_row, local_col + Int32(7), epi_buffer]
+                            )
+                            scatter_add_v4_bf16x2(
                                 get_ptr_as_int64(
                                     scatter_output, tok * scatter_N + global_col
                                 ),
                                 wv * sc_v0,
                                 wv * sc_v1,
+                                wv * sc_v2,
+                                wv * sc_v3,
+                                wv * sc_v4,
+                                wv * sc_v5,
+                                wv * sc_v6,
+                                wv * sc_v7,
                             )
-                            pair_idx += Int32(self.num_threads_per_warp)
+                            vec_idx += Int32(self.num_threads_per_warp)
 
                         # Post-scatter barrier: needed to ensure all warps
                         # finish scatter before next output tile's pipeline ops


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

For static kernel, we can use a simplified histogram-base mechanism used in dynamic kernel. The routed rows is no larger than 640 in moe_static_kernel
1. the histogram can be stored and reduced purely on shared memory. The shared memory instructions like `atom.shared.add.s32` are cheaper than original global memory instructions like `atom.global.cas.b32`.
2. spin-wait procedure in global-local mapping is replaced with a two-phase warp-level prefix sum.

Another side optimization is that the previous loop `while pair_idx < warp_epi_rows * Int32(32)` starts pair_idx from tidx, which produces `.pragma nounroll` in the result ptx instructions, preventing potential compiler optimization.
Also, when the threads in a warp is loading the same address, it will automatically broadcast, so there is no need to only let thread 0 read cached_row and then manually broadcast.
My initial solution was to start the loop in zero and let the compiler do the unrolling, but then I find similar optimization has already been introduced in dynamic kernel in #3271. Although that PR seems not designed for performance optimization, but it did fix the unrolling issue in dynamic kernel with manual unrolling, so I just keep the implementation and migrated it to micro kernel as well.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

b12x moe related pytests passed.

The optimization is more obvious when num_experts is small, perhaps in a large EP scenario, but not quite obvious when num_experts is large because that way each expert only gets a small portion of tokens.


num_tokens | hidden_size | intermediate_size | num_experts | topk | median time (ms) wo. | median time (ms) w. | TFLOPs wo. | TFLOPs w. | Bandwidth (TB/s) wo. | Bandwidth (TB/s) w
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
4 | 2048 | 512 | 256 | 8 | 0.052 | 0.051 | 3.905 | 3.922 | 0.996 | 1.001
80 | 2048 | 512 | 256 | 8 | 0.328 | **0.326** | 12.284 | **12.343** | 1.287 | **1.293**
4 | 4096 | 768 | 32 | 8 | 0.106 | 0.106 | 5.706 | 5.722 | 1.154 | 1.157
80 | 4096 | 768 | 32 | 8 | 0.238 | **0.188** | 50.704 | **64.156** | 0.719 | **0.909**
4 | 1024 | 256 | 32 | 4 | 0.024 | 0.023 | 1.070 | 1.080 | 0.283 | 0.286
80 | 1024 | 256 | 32 | 4 | 0.034 | **0.029** | 14.591 | **17.332** | 0.420 | **0.499**

<span citadel-meta="{&quot;isCut&quot;:false,&quot;dataset&quot;:{&quot;from-citadel&quot;:true}}"></span>

## Reviewer Notes

Part of the credits gives to sonnet 4.6
<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized shared-memory operations and vectorized data loading for improved MoE kernel throughput
  * Enhanced scatter operations with improved vectorization strategy
  * Refactored token routing and expert assignment logic for reduced latency and better resource utilization

* **Chores**
  * Updated internal kernel utility functions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->