### PR TITLE
fix nightly update-wheel-index disk exhaustion

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -398,10 +398,13 @@ jobs:
       - name: Checkout flashinfer repo
         uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download wheel and sdist artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts/
+          # Only fetch wheel/sdist artifacts; skip the multi-GB jit-cache
+          # artifacts this job does not need (avoids running out of disk).
+          pattern: 'flashinfer-*'
 
       - name: Collect wheels and sdist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,10 +406,13 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - name: Download all artifacts
+      - name: Download wheel and sdist artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts/
+          # Only fetch wheel/sdist artifacts; skip the multi-GB jit-cache
+          # artifacts this job does not need (avoids running out of disk).
+          pattern: 'flashinfer-*'
 
       - name: Collect wheels and sdist
         run: |


### PR DESCRIPTION
The update-wheel-index job runs on ubuntu-latest and downloaded all artifacts (~11.4GB including jit-cache), causing "No space left on device". Add pattern: 'flashinfer-*' to download only the wheel/sdist artifacts (~449MB) that this job actually needs. Applied to both nightly-release.yml and release.yml.

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow processes to reduce unnecessary artifact downloads, improving build efficiency and minimizing disk usage during the release pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->