### PR TITLE
fix(gemm): cuDNN mxfp8 override-shape block-scale descale shape (broken on cuDNN >=9.21)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -8427,6 +8427,28 @@ def bmm_mxfp8(
     if resolved_backend == "cudnn":
         if not CUDNN_AVAILABLE:
             raise ValueError("cudnn is not available")
+        # The cuDNN mxfp8 graph requires the F8_128x4-swizzled scale layout.
+        # Non-swizzled / linear scales are not supported -- the graph's
+        # reordering + 128-padding only matched a linear scale at 128-aligned M
+        # by coincidence, and silently produced wrong results otherwise.
+        # mxfp8_quantize returns a 1D buffer for *both* layouts, so we can't
+        # distinguish by rank; the swizzled (128x4) buffer has a specific length
+        # (M/N padded to 128, K grouped by 4), which differs from the linear
+        # length at non-128-aligned M.  Reject on length mismatch.
+        exp_a = _mxfp8_swizzled_scale_len(
+            A.shape[0] * A.shape[1], A.shape[2], SfLayout.layout_128x4
+        )
+        exp_b = _mxfp8_swizzled_scale_len(
+            B.shape[0] * B.shape[2], B.shape[1], SfLayout.layout_128x4
+        )
+        if A_scale.numel() != exp_a or B_scale.numel() != exp_b:
+            raise ValueError(
+                "bmm_mxfp8(backend='cudnn') requires swizzled (F8_128x4) scale "
+                "factors (mxfp8_quantize(..., is_sf_swizzled_layout=True)); got "
+                f"A_scale.numel()={A_scale.numel()} (expected {exp_a}), "
+                f"B_scale.numel()={B_scale.numel()} (expected {exp_b}). "
+                "Use the cutlass backend for non-swizzled scales."
+            )
         mxfp8_gemm_sm100(
             A,
             B,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2800,18 +2800,35 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         UIDs.BLOCK_DESCALE_B_UID.value,
         UIDs.O_UID.value,
     ]
+
+    # The block-scale tensors are declared in the graph as 3D
+    # ``[batch, block_scale_dim_m, block_scale_dim_k]`` (F8_128x4 reordered),
+    # but the runtime scale buffer is 1D-flat.  Describe it with the same 3D
+    # shape/stride the graph was built with, recomputed for the *actual* M,
+    # rather than passing the flat ``.shape`` (which the backend rejects with
+    # CUDNN_STATUS_NOT_SUPPORTED_INVALID_DYNAMIC_SHAPE).  Mirrors the FP4 path.
+    batch, actual_m, k = a.shape[0], a.shape[1], a.shape[2]
+    n = b.shape[2]
+    block_scale_dim_m, block_scale_dim_n, block_scale_dim_k = (
+        _calculate_block_scale_dims(actual_m, n, k, 32)
+    )
+    a_descale_shape = [batch, block_scale_dim_m, block_scale_dim_k]
+    a_descale_stride = [block_scale_dim_m * block_scale_dim_k, block_scale_dim_k, 1]
+    b_descale_shape = [batch, block_scale_dim_k, block_scale_dim_n]
+    b_descale_stride = [block_scale_dim_n * block_scale_dim_k, 1, block_scale_dim_k]
+
     override_shapes = [
         list(a.shape),
         list(b.shape),
-        list(a_descale.shape),
-        list(b_descale.shape),
+        a_descale_shape,
+        b_descale_shape,
         list(c_final.shape),
     ]
     override_strides = [
         list(a.stride()),
         list(b.stride()),
-        list(a_descale.stride()),
-        list(b_descale.stride()),
+        a_descale_stride,
+        b_descale_stride,
         list(c_final.stride()),
     ]
 

--- a/tests/gemm/test_bmm_mxfp8.py
+++ b/tests/gemm/test_bmm_mxfp8.py
@@ -27,6 +27,11 @@ def test_bmm_mxfp8(
         pytest.skip("bmm_mxfp8 cutlass backend requires SM12x.")
     if backend == "cutlass" and not is_sf_swizzled_layout:
         pytest.skip("bmm_mxfp8 cutlass backend on SM12x only supports swizzled layout.")
+    if backend == "cudnn" and not is_sf_swizzled_layout:
+        pytest.skip(
+            "bmm_mxfp8 cudnn backend requires swizzled (F8_128x4) scales; "
+            "non-swizzled/linear scales are not supported."
+        )
 
     # Create inputs and quantize them to MXFP8 format
     input_mat = torch.randn([b, m, k], device="cuda", dtype=input_dtype)

--- a/tests/gemm/test_bmm_mxfp8.py
+++ b/tests/gemm/test_bmm_mxfp8.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 from flashinfer import autotune, bmm_mxfp8
 from flashinfer.fp8_quantization import mxfp8_quantize
 from flashinfer.utils import get_compute_capability
+from flashinfer.gemm.gemm_base import is_cudnn_override_shape_available
 
 
 @pytest.mark.parametrize("b", [1, 16])
@@ -74,6 +75,48 @@ def test_bmm_mxfp8(
     assert cos_sim > min_cos_sim, (
         f"Cosine similarity {cos_sim:.4f} is too low (expected > {min_cos_sim})"
     )
+
+
+@pytest.mark.parametrize("m", [130, 200, 257, 384, 1000])
+def test_bmm_mxfp8_cudnn_dynamic_m(m):
+    """cuDNN mxfp8 must work for M that is not a multiple of 128.
+
+    Regression for the override-shape path: the block-scale descale tensor is
+    declared 3D ``[batch, dim_m, dim_k]`` in the graph, but the runtime scale
+    buffer is 1D-flat.  Passing the flat ``.shape`` as the override made cuDNN
+    reject every call (CUDNN_STATUS_NOT_SUPPORTED_INVALID_DYNAMIC_SHAPE) on
+    cuDNN >= 9.21 -- even for 128-aligned M.  Existing tests only used
+    128-aligned M on older cuDNN (non-override path), so this was masked.
+
+    Uses the swizzled (128x4) scale layout, which is what the cuDNN graph's
+    F8_128x4 reordering requires.  (Separate follow-ups: non-swizzled/linear SF
+    is layout-incompatible with this graph at non-128-aligned M, and batched
+    b>1 needs per-batch SF padding in mxfp8_quantize.)
+    """
+    is_sf_swizzled_layout = True
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip("bmm_mxfp8 cudnn backend requires SM10x.")
+    if not is_cudnn_override_shape_available():
+        pytest.skip("dynamic-M cuDNN mxfp8 requires the override-shape path.")
+
+    b, n, k = 1, 256, 256  # b=1: batched (b>1) non-aligned-M is a separate fix.
+    a = torch.randn([b, m, k], device="cuda", dtype=torch.bfloat16)
+    mat2 = (
+        torch.randn([b, n, k], device="cuda", dtype=torch.bfloat16)
+        .transpose(-2, -1)
+        .contiguous()
+    )
+    aq, asf = mxfp8_quantize(a, is_sf_swizzled_layout)
+    bq, bsf = mxfp8_quantize(mat2, is_sf_swizzled_layout)
+    res = torch.empty([b, m, n], device="cuda", dtype=torch.bfloat16)
+    with autotune(False):
+        bmm_mxfp8(aq, bq, asf, bsf, torch.bfloat16, res, backend="cudnn")
+    assert torch.isfinite(res).all(), f"non-finite output at M={m}"
+    cos = F.cosine_similarity(
+        torch.bmm(a, mat2).reshape(-1).float(), res.reshape(-1).float(), dim=0
+    )
+    assert cos > 0.9, f"cos_sim {cos:.4f} too low at M={m}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes `bmm_mxfp8(backend="cudnn")`, which is **broken for every shape on cuDNN ≥ 9.21** (`CUDNN_STATUS_NOT_SUPPORTED_INVALID_DYNAMIC_SHAPE`), and hardens the scale-layout contract. Two commits:

### 1. Correct the override-shape block-scale descale shape
`execute_cudnn_gemm_mxfp8_graph_override_shape` passed the runtime scale buffer's **flat 1D** shape (`list(a_descale.shape)`) as the override for a tensor the graph declares **3D** (`[batch, dim_m, dim_k]`, `F8_128x4` reordered) → cuDNN rejects the mismatch. Masked because existing tests only use 128-aligned M, and on cuDNN < 9.21 the non-override path runs instead. Present since override-shape was introduced (#2790): FP4 used `_expand_block_scale_tensor_shape`, mxfp8 was handed the flat `.shape`.

**Fix:** describe the descale override with the same 3D `[batch, dim_m, dim_k]` shape/stride the graph was built with, recomputed for the actual M via `_calculate_block_scale_dims` (mirrors FP4). Pure shape/stride metadata — no data movement, no quantizer change, cuDNN-path only.

Root of the asymmetry: **`nvfp4_quantize` returns a 2D scale, `mxfp8_quantize` returns a 1D-flat scale** — so `_expand` (which assumes 2D/3D) handled FP4 but not mxfp8.

### 2. Reject non-swizzled scales on the cuDNN mxfp8 path
The cuDNN graph hardwires `F8_128x4` (128-padded) scales — there is no linear/non-swizzled path; a linear scale only matched at 128-aligned M by coincidence and silently produced wrong results otherwise. Since `mxfp8_quantize` returns 1D for *both* layouts (rank can't disambiguate), validate the scale **length** against `_mxfp8_swizzled_scale_len` and raise a clear error on mismatch. Also skips the `(cudnn, non-swizzled)` combo in `test_bmm_mxfp8` (it tested an unsupported layout). Downstream check: vllm/sglang use linear scales but never via `bmm_mxfp8`, and the cutlass non-swizzled path is untouched — so this is safe.

### Tests / validation (Blackwell SM100 + cuDNN 9.30)
- New `test_bmm_mxfp8_cudnn_dynamic_m`: non-128-aligned M (130/200/257/384/1000), swizzled — 5/5.
- Full aligned-M `test_bmm_mxfp8[cudnn]` matrix goes green (was 288/288 failing on cuDNN 9.30).
- Non-aligned linear → clear `ValueError`; swizzled → correct.

### Known separate follow-ups (not this PR)
- **Batched b>1 at non-128-aligned M** still NaNs: `mxfp8_quantize` flattens `[b,m,k]→[b*m,k]` and pads the combined dim, so the swizzled scale isn't per-batch-padded the way the cuDNN bmm graph expects. Needs per-batch SF padding (quantizer-side).
- flashinfer CI should add a **cuDNN ≥9.21** leg — this whole path was untested there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block-scale tensor dimension handling for MXFP8 cuDNN graph execution to respect actual runtime shapes.
  * Added input validation to reject non-swizzled MXFP8 scale tensors for the cuDNN backend with guidance to use the alternate backend.

* **Tests**
  * Tightened cuDNN test coverage and added a regression test for MXFP8 matrix multiply with variable M sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->