### PR TITLE
[docs] Backfill missing docstrings and decorators across kernels

### DIFF
--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -1006,6 +1006,14 @@ def trtllm_allreduce_fusion(
     - metadata: optional workspace metadata dict from create_ipc_workspace_for_all_reduce_fusion.
                 If provided, validates that token_num <= max_token_num, world_size == tp_size,
                 and hidden_dim == workspace hidden_dim. Raises ValueError if validation fails.
+    - block_quant_group_size: group size (in elements along hidden_dim) for per-token-group
+                              block-wise FP8 quantization patterns
+                              (e.g. ``kPerTokenGroupFP8Packed`` / DeepSeek-style FP8 with
+                              UE8M0 packed scales). Number of consecutive elements that
+                              share a single scale factor. Must be > 0 and divide
+                              ``hidden_dim`` when the pattern requires it; ignored
+                              (treated as 0 / unused) for patterns that do not perform
+                              block-quantization.
     - weight_bias: bias added to rms_gamma before scaling.
                    None or 0.0 -> standard RMSNorm (out = gamma * x * rsqrt(...)).
                    1.0          -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).

--- a/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
@@ -1139,6 +1139,12 @@ def add_rmsnorm_fp4quant(
         Dtype should be ``torch.float8_e4m3fn`` for E4M3 format or ``torch.uint8``
         for UE8M0 format. If ``None``, will be allocated automatically when
         ``output_both_sf_layouts=True``.
+    enable_pdl : bool, optional
+        Whether to launch with Programmatic Dependent Launch (PDL). When
+        ``None`` (default) or ``True``, PDL is enabled only if the current
+        device supports it (probed via :func:`device_support_pdl`). Pass
+        ``False`` to force-disable. See
+        https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
 
     Returns
     -------

--- a/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_decode.py
@@ -489,6 +489,22 @@ class BatchDecodeCuteDSLWrapper:
         float_workspace_buffer: torch.Tensor,
         use_cuda_graph: bool = False,
     ) -> None:
+        r"""Construct a ragged-KV CuTe DSL decode wrapper.
+
+        Parameters
+        ----------
+        float_workspace_buffer : torch.Tensor
+            Pre-allocated float32 workspace buffer used by the underlying
+            CuTe DSL kernel for split-K partial reductions. The wrapper
+            does not resize this buffer; the caller is responsible for
+            sizing it for the largest expected batch (see :meth:`plan`).
+            The buffer's device determines the device of subsequent
+            kernel launches.
+        use_cuda_graph : bool
+            If ``True``, prepare the wrapper for capture in a CUDA graph
+            so that subsequent :meth:`run` calls are graph-safe (no host
+            sync, stable workspace pointers). Defaults to ``False``.
+        """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
         self._use_cuda_graph = use_cuda_graph
@@ -686,6 +702,11 @@ class BatchDecodeCuteDSLWrapper:
             ``None`` (default) the kernel skips the LSE write entirely;
             otherwise a log2-base LSE variant is lazily compiled on first
             use (cache hit afterwards).
+        enable_pdl : bool
+            Whether to launch with Programmatic Dependent Launch (PDL).
+            Default ``True``. Set to ``False`` to disable PDL when the
+            target device does not support it. See
+            https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")
@@ -807,6 +828,22 @@ class BatchDecodePagedCuteDSLWrapper:
         float_workspace_buffer: torch.Tensor,
         use_cuda_graph: bool = False,
     ) -> None:
+        r"""Construct a paged-KV CuTe DSL decode wrapper.
+
+        Parameters
+        ----------
+        float_workspace_buffer : torch.Tensor
+            Pre-allocated float32 workspace buffer used by the underlying
+            CuTe DSL kernel for split-K partial reductions. The wrapper
+            does not resize this buffer; the caller is responsible for
+            sizing it for the largest expected batch and page table (see
+            :meth:`plan`). The buffer's device determines the device of
+            subsequent kernel launches.
+        use_cuda_graph : bool
+            If ``True``, prepare the wrapper for capture in a CUDA graph
+            so that subsequent :meth:`run` calls are graph-safe (no host
+            sync, stable workspace pointers). Defaults to ``False``.
+        """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
         self._use_cuda_graph = use_cuda_graph
@@ -1067,6 +1104,11 @@ class BatchDecodePagedCuteDSLWrapper:
             convention). When ``None`` (default) the kernel skips the LSE
             write; otherwise an LSE variant is lazily compiled on first
             use.
+        enable_pdl : bool
+            Whether to launch with Programmatic Dependent Launch (PDL).
+            Default ``True``. Set to ``False`` to disable PDL when the
+            target device does not support it. See
+            https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
         """
         if not self._planned:
             raise RuntimeError("Call plan() before run().")

--- a/flashinfer/cute_dsl/rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/rmsnorm_fp4quant.py
@@ -839,6 +839,12 @@ def rmsnorm_fp4quant(
         ``[m_tile_idx * k_tiles * 512 + k_tile_idx * 512 + outer_m * 16 + inner_m * 4 + inner_k]``
         where ``outer_m = row % 32``, ``inner_m = (row % 128) // 32``, etc.
         Default is ``False`` (row-major layout).
+    enable_pdl : bool, optional
+        Whether to launch with Programmatic Dependent Launch (PDL). When
+        ``None`` (default) or ``True``, PDL is enabled only if the current
+        device supports it (probed via :func:`device_support_pdl`). Pass
+        ``False`` to force-disable. See
+        https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
 
     Returns
     -------

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -28,15 +28,12 @@ from cutlass._mlir import ir
 from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.cute.typing import AddressSpace, Numeric, Pointer, Type
 
-from ..api_logging import flashinfer_api
-
 
 def ceil_div(a: int, b: int) -> int:
     """Ceiling division."""
     return (a + b - 1) // b
 
 
-@flashinfer_api
 def is_cute_dsl_available() -> bool:
     r"""Return ``True`` when the optional CuTe DSL stack is importable.
 

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -28,13 +28,30 @@ from cutlass._mlir import ir
 from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.cute.typing import AddressSpace, Numeric, Pointer, Type
 
+from ..api_logging import flashinfer_api
+
 
 def ceil_div(a: int, b: int) -> int:
     """Ceiling division."""
     return (a + b - 1) // b
 
 
+@flashinfer_api
 def is_cute_dsl_available() -> bool:
+    r"""Return ``True`` when the optional CuTe DSL stack is importable.
+
+    Probes for ``cutlass`` and ``cutlass.cute`` via :func:`importlib.util.find_spec`.
+    Used by higher-level wrappers to decide whether to dispatch to a CuTe-DSL
+    backend (e.g. :func:`flashinfer.quantization.mxfp4_quantize`,
+    :class:`flashinfer.cute_dsl.attention.wrappers.BatchDecodeCuteDSLWrapper`)
+    or fall back to a plain-CUDA implementation.
+
+    Returns
+    -------
+    bool
+        ``True`` if both ``cutlass`` and ``cutlass.cute`` are importable in the
+        current Python environment.
+    """
     return (
         importlib.util.find_spec("cutlass") is not None
         and importlib.util.find_spec("cutlass.cute") is not None

--- a/flashinfer/green_ctx.py
+++ b/flashinfer/green_ctx.py
@@ -27,7 +27,6 @@ except ImportError as e:
         "Please install cuda-python that matches your CUDA version."
     ) from e
 
-from .api_logging import flashinfer_api
 from .cuda_utils import checkCudaErrors
 from .utils import get_compute_capability, round_up
 
@@ -124,7 +123,6 @@ def create_green_ctx_streams(
     return streams
 
 
-@flashinfer_api
 def split_device_green_ctx(
     dev: torch.device, num_groups: int, min_count: int
 ) -> Tuple[List[torch.Stream], List[CUdevResource]]:
@@ -195,7 +193,6 @@ def split_device_green_ctx(
         raise
 
 
-@flashinfer_api
 def split_device_green_ctx_by_sm_count(
     dev: torch.device, sm_counts: List[int]
 ) -> Tuple[List[torch.Stream], List[CUdevResource]]:

--- a/flashinfer/green_ctx.py
+++ b/flashinfer/green_ctx.py
@@ -27,6 +27,7 @@ except ImportError as e:
         "Please install cuda-python that matches your CUDA version."
     ) from e
 
+from .api_logging import flashinfer_api
 from .cuda_utils import checkCudaErrors
 from .utils import get_compute_capability, round_up
 
@@ -123,6 +124,7 @@ def create_green_ctx_streams(
     return streams
 
 
+@flashinfer_api
 def split_device_green_ctx(
     dev: torch.device, num_groups: int, min_count: int
 ) -> Tuple[List[torch.Stream], List[CUdevResource]]:
@@ -193,6 +195,7 @@ def split_device_green_ctx(
         raise
 
 
+@flashinfer_api
 def split_device_green_ctx_by_sm_count(
     dev: torch.device, sm_counts: List[int]
 ) -> Tuple[List[torch.Stream], List[CUdevResource]]:

--- a/flashinfer/kda_decode.py
+++ b/flashinfer/kda_decode.py
@@ -64,6 +64,68 @@ def recurrent_kda(
     ``flashinfer.kda_kernels.recurrent_kda``. It supports single-token decode,
     fused speculative decode, GQA, optional cu_seqlens packing, and the same
     gate modes as the backend implementation.
+
+    Args:
+        q (torch.Tensor):
+            Current query of shape ``[B, 1, H, K]``, or ``[1, total_tokens, H, K]``
+            when using ``cu_seqlens``. Must be bfloat16.
+        k (torch.Tensor):
+            Current key of shape ``[B, 1, H, K]``. Must be bfloat16.
+        v (torch.Tensor):
+            Current value of shape ``[B, 1, HV, V]``. Must be bfloat16.
+            GQA is applied when ``HV != H``.
+        g (torch.Tensor):
+            Per-K-dimension gate of shape ``[B, 1, HV, K]``. Must be bfloat16.
+            Log-space if pre-computed, raw input if ``use_gate_in_kernel=True``.
+        beta (torch.Tensor):
+            Delta-rule learning rate of shape ``[B, 1, HV]``. Must be bfloat16.
+            Pre-sigmoided.
+        A_log (Optional[torch.Tensor]):
+            Log decay parameter of shape ``[H]``. Must be float32.
+            Required when ``use_gate_in_kernel=True``.
+        dt_bias (Optional[torch.Tensor]):
+            Per-head-K decay bias of shape ``[H*K]``. Must be float32.
+        scale (Optional[float]):
+            Scale factor for queries. If ``None``, defaults to ``1 / sqrt(K)``.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape ``[N, HV, V, K]``. Must be bfloat16.
+            If ``None``, zero-initialized. Updated in-place. For batched spec
+            decode without ``cu_seqlens``, ``N`` is the packed checkpoint-slot
+            count ``B * (1 + num_spec_tokens)`` when ``ssm_state_indices`` is
+            omitted.
+        output_final_state (bool):
+            Whether to return the final state. Default: ``False``.
+        use_qk_l2norm_in_kernel (bool):
+            Whether to apply L2 normalization to Q and K. Default: ``True``.
+        use_gate_in_kernel (bool):
+            Whether to compute the gate inside the kernel from ``A_log`` and
+            ``g``. Default: ``False``.
+        lower_bound (Optional[float]):
+            If set, uses ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``
+            gate formula instead of softplus. Must be negative.
+        cu_seqlens (Optional[torch.Tensor]):
+            Cumulative sequence lengths of shape ``[N+1]``. Must be int32.
+        ssm_state_indices (Optional[torch.Tensor]):
+            State cache indices. Shape ``[N]`` int32 for standard decode, or
+            ``[N, 1+S]`` int32 for spec decode (``num_spec_tokens`` must also
+            be set).
+        num_spec_tokens (Optional[int]):
+            Number of speculative tokens (S). When set, processes 1+S tokens in
+            a single fused kernel launch. Must be >= 1.
+        num_accepted_tokens (Optional[torch.Tensor]):
+            Per-sequence accepted token count from the previous spec decode
+            round. Shape ``[N]`` int32. If ``None``, initial state is loaded
+            from ``ssm_state_indices[n, 0]``.
+        output (Optional[torch.Tensor]):
+            Pre-allocated output tensor. Shape ``[B, 1, HV, V]`` for standard
+            decode, ``[1, N*(1+S), HV, V]`` for spec decode with
+            ``cu_seqlens``. If ``None``, a new tensor is allocated.
+
+    Returns:
+        Tuple of ``(output, final_state)`` where ``final_state`` is ``None``
+        when ``output_final_state=False``. See
+        :func:`flashinfer.kda_kernels.recurrent_kda.run_recurrent_kda` for the
+        backend implementation.
     """
     if _run_recurrent_kda is None:
         raise NotImplementedError("recurrent KDA backend is unavailable")

--- a/flashinfer/mhc.py
+++ b/flashinfer/mhc.py
@@ -83,6 +83,33 @@ def mhc_post(
 
     ``out[..., new_hc, h] = x[..., h] * post_layer_mix[..., new_hc]
     + sum_old residual[..., old_hc, h] * comb_res_mix[..., old_hc, new_hc]``
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Layer output tensor, shape ``[..., H]`` (matches ``residual``'s
+        outer dimensions and ``H = residual.shape[-1]``).
+    residual : torch.Tensor
+        Multi-head residual tensor, shape ``[..., HC=4, H]``. The
+        ``HC=4`` axis must equal 4 (mHC is currently hard-wired to 4 sub-heads).
+    post_layer_mix : torch.Tensor
+        Layer-output mixing weights, shape ``[..., HC=4]`` or
+        ``[..., HC=4, 1]`` (both accepted). Provides the per-new-head
+        coefficient applied to ``x`` (the ``post_layer_mix`` factor in the
+        formula above). See mHC paper / reference implementation for the
+        exact training-time derivation.
+    comb_res_mix : torch.Tensor
+        Residual combination matrix, shape ``[..., HC=4, HC=4]``. Each
+        ``[old_hc, new_hc]`` entry is the coefficient mixing
+        ``residual[..., old_hc, :]`` into the new head ``new_hc`` (the
+        ``comb_res_mix`` factor above). See mHC paper / reference
+        implementation for the training-time derivation.
+
+    Returns
+    -------
+    torch.Tensor
+        Output tensor with the same shape as ``residual``
+        (``[..., HC=4, H]``).
     """
 
     hc, hidden_size, _ = _check_mhc_post_inputs(
@@ -168,6 +195,65 @@ def mhc_pre_big_fuse(
     residual-square sums used for RMS normalization. When ``num_splits > 1``,
     both inputs have a leading split dimension that is reduced inside the CUDA
     kernel.
+
+    Parameters
+    ----------
+    dot_mix : torch.Tensor
+        Raw projection logits, shape ``[..., 24]`` when ``num_splits=1`` or
+        ``[num_splits, ..., 24]`` when ``num_splits > 1``. The trailing
+        ``24 = 4 (pre) + 4 (post) + 16 (comb)`` slots are partitioned and
+        re-shaped to per-head ``pre / post / comb`` factors inside the kernel.
+        See mHC paper / reference implementation for the projection
+        derivation.
+    sqrsum : torch.Tensor
+        Pre-computed per-token residual square-sum used for RMS
+        normalization. Shape ``[...]`` matching ``dot_mix`` outer dims, or
+        ``[num_splits, ...]`` when ``num_splits > 1`` (the kernel reduces
+        the split axis internally). dtype is implementation-defined.
+    residual : torch.Tensor
+        Multi-head residual tensor, shape ``[..., HC=4, H]`` (bfloat16).
+        Same layout as :func:`mhc_post`'s ``residual``.
+    mhc_scale : torch.Tensor
+        mHC scaling tensor consumed by the Sinkhorn / mix step. Shape and
+        dtype are implementation-defined; see mHC paper / reference
+        implementation for the exact semantics.
+    mhc_base : torch.Tensor
+        mHC bias / base tensor consumed by the Sinkhorn / mix step. Shape
+        and dtype are implementation-defined; see mHC paper / reference
+        implementation for the exact semantics.
+    k : int
+        mHC algorithm parameter ``k`` passed to the CUDA kernel. See mHC
+        paper / reference implementation for the precise semantics.
+    rms_eps : float
+        RMSNorm epsilon for numerical stability. Default ``1e-6``. Must be
+        strictly positive.
+    mhc_pre_eps : float
+        Numerical-stability epsilon used in the mHC pre-map step.
+        Default ``1e-6``. Must be strictly positive.
+    mhc_sinkhorn_eps : float
+        Numerical-stability epsilon used in the Sinkhorn iteration step.
+        Default ``1e-6``. Must be strictly positive.
+    mhc_post_mult_value : float
+        Post-mix multiplicative factor applied to the mHC post outputs.
+        Default ``1.0``.
+    sinkhorn_repeat : int
+        Number of Sinkhorn iterations. Default ``20``.
+    num_splits : int
+        Split factor along the leading dimension. Must be one of
+        ``{1, 2, 4, 8, 16}``. When > 1, ``dot_mix`` and ``sqrsum`` carry a
+        leading split axis that is reduced inside the kernel. Default
+        ``1``.
+    block_size : int
+        CUDA block-size hint forwarded to the kernel (``0`` selects the
+        kernel's default). Default ``0``.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        ``(post_mix, comb_mix, layer_input)`` tensors with shapes
+        ``[..., HC=4, 1]``, ``[..., HC=4, HC=4]`` and ``[..., H]``
+        respectively. See mHC paper / reference implementation for how
+        downstream layers consume them.
     """
 
     if num_splits not in (1, 2, 4, 8, 16):
@@ -262,6 +348,52 @@ def mhc_pre_big_fuse_with_prenorm(
     This matches the Agentic ``mhc_pre_finalize`` boundary when no precomputed
     ``sqrsum`` is supplied. ``dot_mix`` may be shaped ``[..., 24]`` or
     ``[1, ..., 24]``.
+
+    Parameters
+    ----------
+    dot_mix : torch.Tensor
+        Raw projection logits, shape ``[..., 24]`` or ``[1, ..., 24]``. The
+        trailing ``24 = 4 (pre) + 4 (post) + 16 (comb)`` slots are
+        partitioned and re-shaped to per-head factors inside the kernel.
+        See mHC paper / reference implementation for the projection
+        derivation.
+    residual : torch.Tensor
+        Multi-head residual tensor, shape ``[..., HC=4, H]`` (bfloat16).
+        ``sqrsum`` is computed from this tensor inside the kernel; same
+        layout as :func:`mhc_post`'s ``residual``.
+    mhc_scale : torch.Tensor
+        mHC scaling tensor consumed by the Sinkhorn / mix step. Shape and
+        dtype are implementation-defined; see mHC paper / reference
+        implementation for the exact semantics.
+    mhc_base : torch.Tensor
+        mHC bias / base tensor consumed by the Sinkhorn / mix step. Shape
+        and dtype are implementation-defined; see mHC paper / reference
+        implementation for the exact semantics.
+    rms_eps : float
+        RMSNorm epsilon for numerical stability. Default ``1e-6``. Must be
+        strictly positive.
+    mhc_pre_eps : float
+        Numerical-stability epsilon used in the mHC pre-map step.
+        Default ``1e-6``. Must be strictly positive.
+    mhc_sinkhorn_eps : float
+        Numerical-stability epsilon used in the Sinkhorn iteration step.
+        Default ``1e-6``. Must be strictly positive.
+    mhc_post_mult_value : float
+        Post-mix multiplicative factor applied to the mHC post outputs.
+        Default ``1.0``.
+    sinkhorn_repeat : int
+        Number of Sinkhorn iterations. Default ``20``.
+    block_size : int
+        CUDA block-size hint forwarded to the kernel (``0`` selects the
+        kernel's default). Default ``0``.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        ``(post_mix, comb_mix, layer_input)`` tensors with shapes
+        ``[..., HC=4, 1]``, ``[..., HC=4, HC=4]`` and ``[..., H]``
+        respectively. See mHC paper / reference implementation for how
+        downstream layers consume them.
     """
 
     _check_positive_eps("rms_eps", rms_eps)

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -1176,6 +1176,11 @@ def apply_rope_with_cos_sin_cache(
         Query tensor, shape: ``(nnz, num_q_heads * head_size)``.
     key : torch.Tensor
         Key tensor, shape: ``(nnz, num_k_heads * head_size)``.
+    head_size : int
+        Per-head feature dimension. ``query`` and ``key`` are reshaped to
+        ``(nnz, num_q_heads, head_size)`` and ``(nnz, num_k_heads, head_size)``
+        respectively before applying RoPE. Must divide the trailing dimension
+        of ``query`` and ``key``.
     cos_sin_cache : torch.Tensor
         Cosine and Sine cache tensor, shape: ``(max_seq_len, rotary_dim)``.
         Cosine is the first half and Sine is the second half on rotary_dim.
@@ -1241,6 +1246,11 @@ def apply_rope_with_cos_sin_cache_inplace(
         Query tensor, shape: ``(nnz, num_q_heads * head_size)``.
     key : torch.Tensor
         Key tensor, shape: ``(nnz, num_k_heads * head_size)``.
+    head_size : int
+        Per-head feature dimension. ``query`` and ``key`` are reshaped to
+        ``(nnz, num_q_heads, head_size)`` and ``(nnz, num_k_heads, head_size)``
+        respectively before applying RoPE. Must divide the trailing dimension
+        of ``query`` and ``key``.
     cos_sin_cache : torch.Tensor
         Cosine and Sine cache tensor, shape: ``(max_seq_len, rotary_dim)``.
         Cosine is the first half and Sine is the second half on rotary_dim.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the 0.6.12 doc-PR sweep (#3440–#3447).
Fixes 14 pre-existing doc-check failures that surfaced after running the
internal `flashinfer_document_check` tools against `main`. **No kernel
logic is modified.**

### What's fixed

**`@flashinfer_api` decorator added (3 public APIs that were previously
plain functions but listed in `.rst`):**

- `flashinfer.cute_dsl.utils.is_cute_dsl_available`
- `flashinfer.green_ctx.split_device_green_ctx`
- `flashinfer.green_ctx.split_device_green_ctx_by_sm_count`

**Args Consistency — undocumented signature parameters added (7
fixes):**

| Function | Missing parameter(s) |
| --- | --- |
| `flashinfer.cute_dsl.add_rmsnorm_fp4quant.add_rmsnorm_fp4quant` | `enable_pdl` |
| `flashinfer.cute_dsl.rmsnorm_fp4quant.rmsnorm_fp4quant` | `enable_pdl` |
| `flashinfer.cute_dsl.attention.wrappers.batch_decode.BatchDecodeCuteDSLWrapper.run` | `enable_pdl` |
| `flashinfer.cute_dsl.attention.wrappers.batch_decode.BatchDecodePagedCuteDSLWrapper.run` | `enable_pdl` |
| `flashinfer.rope.apply_rope_with_cos_sin_cache` | `head_size` |
| `flashinfer.rope.apply_rope_with_cos_sin_cache_inplace` | `head_size` |
| `flashinfer.comm.trtllm_ar.trtllm_allreduce_fusion` | `block_quant_group_size` |

**Docstring Completeness — added missing Parameters / Args sections (6
fixes):**

- `BatchDecodeCuteDSLWrapper.__init__`
- `BatchDecodePagedCuteDSLWrapper.__init__`
- `flashinfer.kda_decode.recurrent_kda` (mirrors backend
  `kda_kernels.recurrent_kda.run_recurrent_kda`)
- `flashinfer.mhc.mhc_post`
- `flashinfer.mhc.mhc_pre_big_fuse`
- `flashinfer.mhc.mhc_pre_big_fuse_with_prenorm`

### A note on mHC docs

The mHC Parameters sections describe shapes and dtypes accurately but
intentionally defer algorithm-specific semantics
(`mhc_scale` / `mhc_base` / Sinkhorn parameters) to the mHC paper /
reference implementation, since the in-tree code does not document those
semantics. The doc-check checker is now satisfied; refining the prose
can be done as a follow-up by someone with mHC domain knowledge.

### Verification

Ran the FlashInfer internal `flashinfer_document_check` tools against
this branch (`FLASHINFER_SRC` pointing to this tree):

| Metric | `main` baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| STALE | 30 | 28 | **-2** |
| MISSING | 45 | 46 | +1 (transient, see below) |
| Docstring Completeness fail | 24 | 18 | **-6** |
| Args Consistency fail | 73 | 67 | **-6** |

Net 14 doc-check failures fixed. The single new MISSING
(`flashinfer.gemm.is_cute_dsl_available`) is a transient artifact of
the checker's cross-module collection: `flashinfer.gemm.__init__`
re-imports `is_cute_dsl_available`, so once it is decorated it also
shows up in the `gemm` namespace. The 0.6.12 doc sweep (#3440) already
introduces `docs/api/cute_dsl.rst` with `is_cute_dsl_available` in its
"Availability" section, which causes the checker's prefix match to
resolve. **No action needed here once #3440 lands.**

## Test plan

- [x] `flashinfer_document_check/flashinfer_doc_test.py` — STALE
      decreases by 2, no regression beyond the transient MISSING noted
      above.
- [x] `flashinfer_document_check/doc_check_extended.py` — Docstring
      Completeness 24→18 and Args Consistency 73→67.
- [ ] `pre-commit run -a` (reviewer to confirm in CI).

Co-developed with Cursor AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced parameter documentation for quantization and attention operators, providing clear specifications of tensor shapes, data types, device requirements, and configuration patterns.
  * Improved API documentation across multiple functions with detailed descriptions of behavior, return values, supported layouts, and usage requirements for better developer understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->