### PR TITLE
feat(quantize): opt-in rank_preserving scale-factor convention (mxfp8 + nvfp4 batched)

### DIFF
--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -1176,6 +1176,12 @@ def nvfp4_quantize(
           When `per_token_activation=True`, returns a third tensor containing
           per-token FP32 scales.
 
+    Note:
+        This is the 2D-matrix quantizer; a batched ``[B, M, K]`` input has its batch
+        folded into M (the scale factor is collapsed to 2D ``[-1, sf_cols]``). For batched
+        (bmm) use, prefer :func:`nvfp4_batched_quantize`, which pads each batch's M
+        independently and supports ``rank_preserving=True`` for a per-batch 3D scale.
+
     Warning:
         The "cute-dsl" backend is **experimental** and not part of the stable API.
         It may change or be removed in future versions without notice.
@@ -1395,19 +1401,32 @@ def nvfp4_batched_quantize(
     a,
     a_global_sf,
     sf_vec_size=16,
+    rank_preserving=False,
 ):
     """
     Quantize batched input tensor to NVFP4 format.
+
+    The scale factors are padded **per batch** (each batch's M is padded to the swizzle
+    block size independently), so this is the correct quantizer for batched (bmm)
+    consumers -- unlike folding a 3D input through :func:`nvfp4_quantize`.
 
     Parameters:
         a (torch.Tensor): Input tensor of shape [B, M, K] with dtype fp16/bf16.
         a_global_sf (torch.Tensor): Global scale factor of shape [1] with dtype float32.
         sf_vec_size (int, optional): Scale factor vector size. Defaults to 16.
+        rank_preserving (bool, optional): Scale-factor output shape convention. Defaults to False.
+            - ``False`` (default, legacy): per-batch scale factor returned flattened as
+              ``[B, M_pad * sf_cols]``.
+            - ``True``: per-batch scale factor returned as 3D ``[B, M_pad, sf_cols]``.
+              This matches the ``rank_preserving=True`` convention of :func:`mxfp8_quantize`
+              (rank mirrors the input, per-batch padding), so batched fp8/fp4 consumers
+              share one scale-factor layout. This is the recommended form going forward.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
             - Quantized tensor of shape [B, M, K/2] with dtype FLOAT4_E2M1X2
-            - Scale factors tensor with shape determined by layout and sf_vec_size
+            - Scale factors tensor of shape ``[B, M_pad * sf_cols]`` (default) or
+              ``[B, M_pad, sf_cols]`` (``rank_preserving=True``)
     """
     major, minor = get_compute_capability(a.device)
     device_arch = f"{major * 10 + minor}"
@@ -1417,6 +1436,13 @@ def nvfp4_batched_quantize(
         sf_vec_size,
         False,
     )
+    if rank_preserving:
+        # The native batched kernel already pads each batch's M independently; the SF is
+        # just flattened per batch (swizzled 128x4 layout). Reshape to the per-batch 3D
+        # form so it matches mxfp8_quantize(rank_preserving=True). Pure view, no recompute.
+        b = a.shape[0]
+        sf_cols = round_up(a.shape[-1] // sf_vec_size, 4)
+        a_sf = a_sf.reshape(b, -1, sf_cols)
     return a_fp4, a_sf
 
 

--- a/flashinfer/quantization/fp8_quantization.py
+++ b/flashinfer/quantization/fp8_quantization.py
@@ -1,4 +1,5 @@
 import functools
+import math
 from types import SimpleNamespace
 from typing import Literal, Optional, Tuple
 
@@ -19,6 +20,24 @@ def _compute_swizzled_layout_sf_size(total_row, total_column, row_size=128):
     padded_row = (total_row + row_size - 1) // row_size * row_size
     padded_column = (total_column + 3) // 4 * 4
     return padded_row * padded_column
+
+
+def _mxfp8_sf_shape_2d(m, k, sf_swizzle_layout, alignment=32):
+    """Rank-preserving 2D shape of the scale-factor buffer for one ``[m, k]`` matrix.
+
+    Mirrors the (row, column) padding the kernel applies to the flat 1D buffer, so
+    reshaping the 1D output to this shape is a pure view.  For the swizzled layouts
+    the row dim is padded to the swizzle block size and the column dim to a multiple
+    of 4 (matching ``_compute_swizzled_layout_sf_size``); ``layout_linear`` is
+    unpadded.  This is the 2D scale convention ``nvfp4_quantize`` already returns.
+    """
+    padded_k = (k + alignment - 1) // alignment * alignment
+    cols = padded_k // 32
+    if sf_swizzle_layout == SfLayout.layout_128x4:
+        return ((m + 127) // 128 * 128, (cols + 3) // 4 * 4)
+    if sf_swizzle_layout == SfLayout.layout_8x4:
+        return ((m + 7) // 8 * 8, (cols + 3) // 4 * 4)
+    return (m, cols)  # layout_linear
 
 
 @functools.cache
@@ -167,6 +186,7 @@ def mxfp8_quantize(
     enable_pdl: Optional[bool] = None,
     backend: Literal["cuda", "cute-dsl"] = "cuda",
     sf_swizzle_layout: Optional[SfLayout] = None,
+    rank_preserving: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Quantize input tensor to MxFP8 format.
 
@@ -184,11 +204,25 @@ def mxfp8_quantize(
             - "cute-dsl": Use CuTe-DSL kernel (requires SM100+, **experimental**)
         sf_swizzle_layout (Optional[SfLayout], optional): Swizzle layout for scale factors.
             If provided,it overrides is_sf_swizzled_layout. Defaults to None.
+        rank_preserving (bool, optional): Scale-factor output shape convention. Defaults to False.
+            - ``False`` (default, legacy): the scale factor is returned as a flat 1D
+              buffer regardless of input rank; for batched ``[B, M, K]`` input the batch
+              is folded into M (``B*M``) and the swizzle padding is applied to the
+              combined ``B*M`` dimension.
+            - ``True`` (opt-in, recommended): the scale factor's rank mirrors the input.
+              A 2D ``[M, K]`` input returns a 2D ``[M_pad, K_blocks_pad]`` scale (the same
+              convention :func:`nvfp4_quantize` uses), and a 3D ``[B, M, K]`` input returns
+              a 3D ``[B, M_pad, K_blocks_pad]`` scale that is padded **per batch** (each
+              batch's M padded to the swizzle block size independently). The per-batch form
+              is what batched consumers such as the cuDNN ``bmm`` path require. This is the
+              transition path toward unifying the mxfp8 (1D) and nvfp4 (2D) scale
+              conventions; the default will flip to ``True`` in a future release.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
             - Quantized tensor of shape [M, K] with dtype FLOAT8_E4M3
-            - Scale factors tensor with shape determined by layout and sf_vec_size
+            - Scale factors tensor with shape determined by layout, sf_vec_size and
+              ``rank_preserving`` (see above)
 
     Warning:
         The "cute-dsl" backend is **experimental** and not part of the stable API.
@@ -206,6 +240,40 @@ def mxfp8_quantize(
         sf_swizzle_layout = (
             SfLayout.layout_128x4 if is_sf_swizzled_layout else SfLayout.layout_linear
         )
+
+    if rank_preserving and backend != "cuda":
+        raise NotImplementedError(
+            "rank_preserving=True is currently only supported with backend='cuda'."
+        )
+
+    # Batched (>=3D) swizzled input with rank_preserving must be quantized per batch:
+    # the default kernel folds the batch into M and pads the combined B*M, so the
+    # per-batch padding rows simply don't exist in that flat buffer and cannot be
+    # recovered by a reshape. (2D input and the linear layout need no per-batch padding
+    # and are handled by the reshape at the end.)
+    if (
+        rank_preserving
+        and input.dim() >= 3
+        and sf_swizzle_layout != SfLayout.layout_linear
+    ):
+        if enable_pdl is None:
+            enable_pdl = device_support_pdl(input.device)
+        *batch_dims, m, k = input.shape
+        bsz = math.prod(batch_dims)
+        flat_in = input.reshape(bsz, m, k)
+        module = get_mxfp8_quantization_sm100_module()
+        qs, sfs = [], []
+        for i in range(bsz):
+            q_i, sf_i = module.mxfp8_quantize_sm100(
+                flat_in[i].contiguous(), sf_swizzle_layout, alignment, enable_pdl
+            )
+            qs.append(q_i)
+            sfs.append(sf_i)
+        padded_k = (k + alignment - 1) // alignment * alignment
+        m_pad, cols = _mxfp8_sf_shape_2d(m, k, sf_swizzle_layout, alignment)
+        x_q = torch.stack(qs, 0).reshape(*batch_dims, m, padded_k)
+        sf = torch.stack(sfs, 0).reshape(*batch_dims, m_pad, cols)
+        return x_q, sf
 
     if backend == "cute-dsl":
         from ..cute_dsl import is_cute_dsl_available
@@ -237,6 +305,17 @@ def mxfp8_quantize(
             alignment,
             enable_pdl,
         )
+        if rank_preserving:
+            # 2D input -> 2D [M_pad, K_blocks_pad]; 3D+ here is necessarily the linear
+            # layout (swizzled 3D returned above), which needs no per-batch padding so a
+            # plain reshape mirroring the input rank is exact.
+            *batch_dims, m, k = input.shape
+            m_pad, cols = _mxfp8_sf_shape_2d(m, k, sf_swizzle_layout, alignment)
+            sf = (
+                sf.reshape(*batch_dims, m, cols)
+                if batch_dims
+                else sf.reshape(m_pad, cols)
+            )
         return x_q, sf
 
 

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1398,6 +1398,49 @@ def test_nvfp4_batched_quantize(
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @torch.inference_mode()
+def test_nvfp4_batched_quantize_rank_preserving(
+    dtype: torch.dtype,
+    batch_shape: tuple[int, int, int],
+    seed: int,
+    device: str,
+) -> None:
+    """rank_preserving=True returns the per-batch SF as 3D [B, M_pad, sf_cols].
+
+    A pure reshape of the default [B, M_pad*sf_cols] output, matching the
+    mxfp8_quantize(rank_preserving=True) convention so batched fp8/fp4 consumers
+    share one scale-factor layout.
+    """
+    if not _is_fp4_supported(torch.device(device)):
+        pytest.skip("Nvfp4 Requires compute capability of 10 or above")
+    torch.set_default_device(device)
+    torch.manual_seed(seed)
+
+    b, m, n = batch_shape
+    sf_vec_size = 16
+    sf_cols = ((n // sf_vec_size + 3) // 4) * 4  # round_up(n // sf_vec_size, 4)
+    x = torch.randn(batch_shape, dtype=dtype)
+    tensor_amax = torch.abs(x).max().to(torch.float32)
+    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
+
+    out_flat, sf_flat = nvfp4_batched_quantize(x, global_scale)
+    out_rp, sf_rp = nvfp4_batched_quantize(x, global_scale, rank_preserving=True)
+
+    assert sf_rp.dim() == 3
+    assert sf_rp.shape[0] == b and sf_rp.shape[2] == sf_cols
+    # Pure reshape of the flat per-batch SF; quantized values unaffected.
+    assert torch.equal(sf_rp.reshape(b, -1), sf_flat)
+    assert torch.equal(out_rp, out_flat)
+    # Each batch's SF equals an independent 2D quantization of that batch.
+    for i in range(b):
+        _, single_scale = fp4_quantize(x[i], global_scale, sf_vec_size, False, True)
+        assert torch.equal(sf_rp[i].reshape(-1), single_scale.flatten())
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("batch_shape", BATCH_SHAPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
 def test_scaled_fp4_grouped_quantize(
     dtype: torch.dtype,
     batch_shape: tuple[int, int, int],

--- a/tests/utils/test_fp8_quantize.py
+++ b/tests/utils/test_fp8_quantize.py
@@ -573,5 +573,103 @@ def test_cute_dsl_compilation_cache_dtype_specific(is_sf_swizzled_layout):
     cache_fn.cache_clear()
 
 
+# =============================================================================
+# rank_preserving scale-factor convention (opt-in 2D/3D output)
+# =============================================================================
+
+
+def _skip_if_not_sm100():
+    major, _ = get_compute_capability(torch.device("cuda:0"))
+    if major < 10:
+        pytest.skip("mxfp8 quantization is not supported on compute capability < 10")
+
+
+@pytest.mark.parametrize("m", [3, 64, 130, 256])
+@pytest.mark.parametrize("k", [128, 1024])
+@pytest.mark.parametrize("sf_layout", MXFP8_SF_LAYOUTS)
+def test_mxfp8_rank_preserving_2d_is_reshape_of_1d(m, k, sf_layout):
+    """For 2D input, rank_preserving=True must be a pure reshape of the flat buffer.
+
+    Same bytes, just shaped to the [M_pad, K_blocks_pad] 2D convention that
+    nvfp4_quantize already uses -- nothing recomputed, quantized values identical.
+    """
+    _skip_if_not_sm100()
+    from flashinfer.quantization.fp8_quantization import _mxfp8_sf_shape_2d
+
+    torch.random.manual_seed(0)
+    a = (torch.randn([m, k], dtype=torch.float) * 16).bfloat16().cuda().contiguous()
+
+    q_flat, sf_flat = mxfp8_quantize(
+        a, sf_swizzle_layout=sf_layout, rank_preserving=False
+    )
+    q_2d, sf_2d = mxfp8_quantize(a, sf_swizzle_layout=sf_layout, rank_preserving=True)
+
+    assert sf_2d.shape == _mxfp8_sf_shape_2d(m, k, sf_layout)
+    assert torch.equal(sf_2d.reshape(-1), sf_flat)
+    assert torch.equal(q_2d, q_flat)  # quantized values unaffected by the SF shape
+
+
+@pytest.mark.parametrize("b", [2, 4])
+@pytest.mark.parametrize("m", [130, 200, 256])
+@pytest.mark.parametrize("k", [128, 256])
+def test_mxfp8_rank_preserving_3d_swizzled_per_batch(b, m, k):
+    """3D swizzled rank_preserving must pad each batch's M independently.
+
+    The legacy (flat) path folds B*M and pads the combined dim, so at non-128
+    aligned M the per-batch padding rows are missing.  rank_preserving must
+    produce ``[B, round_up(M,128), K_blocks_pad]`` equal to quantizing each
+    batch slice on its own.
+    """
+    _skip_if_not_sm100()
+    from flashinfer.quantization.fp8_quantization import _mxfp8_sf_shape_2d
+
+    layout = SfLayout.layout_128x4
+    torch.random.manual_seed(0)
+    a = (torch.randn([b, m, k], dtype=torch.float) * 16).bfloat16().cuda().contiguous()
+
+    q_rp, sf_rp = mxfp8_quantize(a, sf_swizzle_layout=layout, rank_preserving=True)
+
+    m_pad, cols = _mxfp8_sf_shape_2d(m, k, layout)
+    assert sf_rp.shape == (b, m_pad, cols)
+    # The whole point: per-batch padding has MORE elements than the B*M-flattened
+    # buffer whenever M is not 128-aligned.
+    assert sf_rp.numel() == b * m_pad * cols
+
+    # Each batch slice must equal an independent 2D rank_preserving quantization.
+    for i in range(b):
+        q_i, sf_i = mxfp8_quantize(
+            a[i].contiguous(), sf_swizzle_layout=layout, rank_preserving=True
+        )
+        assert torch.equal(sf_rp[i], sf_i)
+        assert torch.equal(q_rp[i], q_i)
+
+
+@pytest.mark.parametrize("b", [2, 4])
+@pytest.mark.parametrize("m", [130, 256])
+@pytest.mark.parametrize("k", [128, 256])
+def test_mxfp8_rank_preserving_3d_linear_is_reshape(b, m, k):
+    """3D linear needs no per-batch padding -> a plain rank-mirroring reshape."""
+    _skip_if_not_sm100()
+
+    layout = SfLayout.layout_linear
+    torch.random.manual_seed(0)
+    a = (torch.randn([b, m, k], dtype=torch.float) * 16).bfloat16().cuda().contiguous()
+
+    q_flat, sf_flat = mxfp8_quantize(a, sf_swizzle_layout=layout, rank_preserving=False)
+    q_rp, sf_rp = mxfp8_quantize(a, sf_swizzle_layout=layout, rank_preserving=True)
+
+    assert sf_rp.shape == (b, m, k // 32)
+    assert torch.equal(sf_rp.reshape(-1), sf_flat)
+    assert torch.equal(q_rp, q_flat)
+
+
+def test_mxfp8_rank_preserving_rejects_cute_dsl():
+    """rank_preserving is only implemented for the CUDA backend for now."""
+    _skip_if_not_sm100()
+    a = torch.randn([128, 128], dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(NotImplementedError):
+        mxfp8_quantize(a, backend="cute-dsl", rank_preserving=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## The mess today

The block-scale quantizers return scale factors (SF) with **inconsistent rank conventions**, for historical reasons (they were added in separate feature PRs):

| quantizer | SF shape today |
|---|---|
| `nvfp4_quantize` (2D matmul) | **2D** `[M_pad, sf_cols]`; a 3D input is folded into M and collapsed to 2D |
| `nvfp4_batched_quantize` (bmm) | per-batch correct, but SF **flattened** to `[B, M_pad*sf_cols]` |
| `mxfp8_quantize` | **1D flat**, regardless of input rank; a 3D input folds the batch into `M` and pads the combined `B*M` |

For a batched `[B, M, K]` input, folding the batch into `M` and padding the *combined* dim is fine at 128-aligned `M`, but at non-aligned `M` the **per-batch padding rows don't exist** in the flat buffer — so batched consumers (notably the cuDNN `bmm` path) can't be made correct downstream. The 1D-vs-2D-vs-flattened divergence is also a recurring footgun in the GEMM↔cuDNN integration.

We can't just change the default shapes: vLLM and SGLang consume the flat `mxfp8_quantize` buffer and reshape it themselves, so flipping the default would break them.

## What this PR adds

An **opt-in** `rank_preserving: bool = False` on the two quantizers a batched GEMM would call, with **one shared convention**: rank mirrors the input, padding is per batch.

**`mxfp8_quantize`:**
- `False` (default, unchanged): flat 1D buffer, exactly as today.
- `True`: 2D `[M,K]` → **2D `[M_pad, K_blocks_pad]`** (a reshape); 3D `[B,M,K]` → **3D `[B, M_pad, K_blocks_pad]`**, padded per batch (swizzled 3D is quantized per batch since the rows can't be recovered from the `B*M`-flattened buffer; linear 3D is reshaped).

**`nvfp4_batched_quantize`:**
- `False` (default, unchanged): per-batch SF flattened as `[B, M_pad*sf_cols]`.
- `True`: per-batch SF as **3D `[B, M_pad, sf_cols]`** — a pure reshape of the already-per-batch buffer (the native batched kernel already pads each batch independently).

So `mxfp8_quantize(rank_preserving=True)` and `nvfp4_batched_quantize(rank_preserving=True)` produce the **same `[B, M_pad, *]` layout**, which is exactly what the cuDNN `bmm` descale tensor expects — unblocking batched mxfp8 `bmm` at non-128-aligned `M`, and giving a future `bmm_fp4` the same convention out of the box.

Notes:
- `rank_preserving` was deliberately **not** added to `nvfp4_quantize` (the 2D matmul quantizer): fp4 already has the dedicated `nvfp4_batched_quantize` for batched use, so adding a per-batch loop there would be a redundant third path. A docstring note now points batched fp4 callers at `nvfp4_batched_quantize`.
- `mxfp8_quantize` + `backend="cute-dsl"` + `rank_preserving=True` raises `NotImplementedError` (CUDA backend only).

## How to transition

1. Today: nothing changes — default is `False` everywhere.
2. Batched consumers (incl. the upcoming bmm paths) pass `rank_preserving=True` and get the unified `[B, M_pad, *]` layout; non-batched callers can pass it on 2D input to get the nvfp4-style 2D scale.
3. Once vLLM/SGLang and other consumers migrate, flip the defaults to `True` and deprecate the flat forms — converging mxfp8 and nvfp4 onto one rank-preserving scale convention.

## Testing (Blackwell SM100)

- **mxfp8:** 2D output is a byte-exact reshape of the 1D buffer; 3D swizzled equals per-batch independent quantization and carries the larger per-batch element count (the actual fix); 3D linear is a plain reshape; cute-dsl opt-in is rejected. Default path unchanged — 418 existing quantize tests pass.
- **nvfp4 batched:** rank_preserving output is a byte-exact reshape of the flat per-batch SF and each batch equals an independent `fp4_quantize`.

Separate from #3455 (cuDNN mxfp8 override-shape fix); this is the quantizer-side groundwork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in rank-preserving mode for FP8 and FP4 quantization to preserve per-batch/2D scale-factor shapes for batched inputs.

* **Documentation**
  * Clarified docstrings on how batched inputs fold to 2D and pointed to batched APIs for per-batch behavior.

* **Tests**
  * Added tests validating rank-preserving shapes and equivalence to non-ranked outputs across 2D/3D, swizzled/linear layouts, and backend behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flashinfer-ai/flashinfer/pull/3457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->