### PR TITLE
fix: use explicit .ptr on scalar struct fields in monolithic MLA decode to get cleaner logs

### DIFF
--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -945,11 +945,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
 
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_warp_id,
             is_two_cta=self.use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
         )
 
         load_q_pipeline = self.make_and_init_load_qkv_pipeline(

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -1061,11 +1061,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # allocate + free on W11 avoids the race where W8 frees TMEM while
         # W11 still has in-flight mma_pv. See OPT#14.
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_pv_warp_id,
             is_two_cta=self.use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
         )
 
         load_q_pipeline = self.make_and_init_load_qkv_pipeline(


### PR DESCRIPTION
Accessing a cute.struct scalar field directly (e.g. storage.tmem_holding_buf) implicitly extracts the underlying MLIR value via the now-deprecated _ScalarData.value property, producing a noisy DeprecationWarning from cutlass DSL. The replacement is the explicit .ptr accessor, which is already the convention everywhere else in flashinfer.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory buffer handling in multi-head latent attention decode kernels (FP16/FP8) by correcting allocator references, improving allocation consistency, cross-thread/CTA synchronization reliability, and runtime stability of attention operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->