### PR TITLE
Enable SM100 FP4 swap_ab for non-8 M

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4240,6 +4240,10 @@ def _get_approximate_cta_nums(m, n, tile_mn, cluster_shape_mn):
     return ctas_m * ctas_n
 
 
+def _get_16b_contiguous_alignment(dtype):
+    return 16 * 8 // dtype.width
+
+
 def _get_sm100_block_scaled_tactics(
     m,
     n,
@@ -4260,18 +4264,15 @@ def _get_sm100_block_scaled_tactics(
     )
 
     batch_size = 1
-    m_aligned = m % 8 == 0
-    n_aligned = n % 8 == 0
+    n_alignment = _get_16b_contiguous_alignment(c_cutlass_dtype)
+    n_aligned = n % n_alignment == 0
+    if not n_aligned:
+        return []
 
     valid_tactics = []
     for mma_tiler_mn in _SM100_MMA_TILER_MN_CANDIDATES:
         for cluster_shape_mn in _SM100_CLUSTER_SHAPE_MN_CANDIDATES:
             for swap_ab in (False, True):
-                if not swap_ab and not n_aligned:
-                    continue
-                if swap_ab and not m_aligned:
-                    continue
-
                 if swap_ab:
                     c_major = "m"
                     kernel_m, kernel_n = n, m
@@ -5349,8 +5350,10 @@ def _cute_dsl_gemm_fp4_runner(
             # --- SM103 tactics (only on SM103) ---
             if sm_version == 103 and Sm103Kernel is not None:
                 batch_size = 1
-                m_aligned = m % 8 == 0
-                n_aligned = n % 8 == 0
+                n_alignment = _get_16b_contiguous_alignment(c_cutlass_dtype)
+                n_aligned = n % n_alignment == 0
+                if not n_aligned:
+                    return valid_tactics
 
                 sm103_mma_tiler_candidates = [
                     (128, 128),
@@ -5362,11 +5365,6 @@ def _cute_dsl_gemm_fp4_runner(
                 for mma_tiler_mn in sm103_mma_tiler_candidates:
                     for cluster_shape_mn in _SM100_CLUSTER_SHAPE_MN_CANDIDATES:
                         for swap_ab in (False, True):
-                            if not swap_ab and not n_aligned:
-                                continue
-                            if swap_ab and not m_aligned:
-                                continue
-
                             if swap_ab:
                                 c_major = "m"
                                 kernel_m, kernel_n = n, m
@@ -5426,6 +5424,12 @@ def _cute_dsl_gemm_fp4_runner(
             if tactic is None or tactic == -1:
                 # Use analytical heuristic to pick the best tactic based on
                 # tile and wave quantization efficiency.
+                n_alignment = _get_16b_contiguous_alignment(c_cutlass_dtype)
+                if n % n_alignment != 0:
+                    raise ValueError(
+                        "CuTe-DSL SM100 FP4 GEMM requires N to be a multiple of "
+                        f"{n_alignment}, got n={n}"
+                    )
                 tactic = _select_sm100_mm_fp4_cute_dsl_tactic(
                     m, n, real_k, get_device_sm_count(a.device)
                 )

--- a/flashinfer/gemm/kernels/utils.py
+++ b/flashinfer/gemm/kernels/utils.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from ...fused_moe.utils import last_positive_power_of_2
+from ...fused_moe.utils import next_positive_power_of_2
 
 _SM100_MMA_TILER_MN_CANDIDATES = [
     (128, 8),
@@ -30,26 +30,22 @@ _SM100_MMA_TILER_MN_CANDIDATES = [
     (256, 256),
 ]
 
-# Tactic cache: (n, real_k, sm_count) -> dict[(m_bucket, is_8_aligned) -> tactic_tuple]
+# Tactic cache: (n, real_k, sm_count) -> dict[m_bucket -> tactic_tuple]
 # Bounded by the number of unique (N, K) pairs in the model (typically < 50).
 _SM100_MM_FP4_TACTIC_CACHE: dict[tuple, dict] = {}
 
-# M bucket boundaries — powers of 2 for fast bucketing via
-# last_positive_power_of_2 (imported from flashinfer.fused_moe.utils).
-# Each bucket is precomputed for both 8-aligned and non-8-aligned M,
-# keyed as (bucket, is_8_aligned).
+# M bucket boundaries - powers of 2 for fast bucketing.  M values round up to
+# the next bucket so a swapped tactic's tile_n always covers the real M.
 _M_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096)
 
 
-def _compute_tactic_for_m(rep_m, n, real_k, sm_count, m_aligned):
+def _compute_tactic_for_m(m, n, real_k, sm_count):
     """Compute the best tactic for a specific (M, N, K) on a GPU with sm_count SMs.
 
     Selects swap_ab, tile shape, and cluster shape sequentially:
 
-    1. **swap_ab**: Swap A and B operands when M is small (8-16) and
-       8-aligned, putting the larger N dimension on the M-axis to increase
-       the number of CTAs.  Also swaps when N is not 8-aligned (required
-       for memory alignment).
+    1. **swap_ab**: Swap A and B operands when M is small and N is larger,
+       putting the larger N dimension on the M-axis to increase CTA count.
 
     2. **Tile shape**: Scores all 8 candidates from _SM100_MMA_TILER_MN_CANDIDATES.
        The score balances three factors:
@@ -68,16 +64,12 @@ def _compute_tactic_for_m(rep_m, n, real_k, sm_count, m_aligned):
 
     4. **Prefetch**: Disabled.
     """
-    n_aligned = n % 8 == 0
-
     swap_ab = False
-    if m_aligned and 8 <= rep_m <= 16 and n > rep_m:
-        swap_ab = True
-    if not swap_ab and not n_aligned and m_aligned:
+    if m <= 32 and n > m:
         swap_ab = True
 
-    prob_m = n if swap_ab else rep_m
-    prob_n = rep_m if swap_ab else n
+    prob_m = n if swap_ab else m
+    prob_n = m if swap_ab else n
 
     # Small-K penalty factor (loop-invariant).
     if real_k <= 1024:
@@ -145,9 +137,8 @@ def _compute_tactic_for_m(rep_m, n, real_k, sm_count, m_aligned):
 def _select_sm100_mm_fp4_cute_dsl_tactic(m, n, real_k, sm_count):
     """Select the best tactic for mm_fp4(backend='cute-dsl').
 
-    On the first call for a given (N, K), precomputes the optimal tactic
-    for each M bucket (~13 buckets, ~55-86 usec).  Subsequent calls with
-    any M just look up the bucket — runs in ~0.2 usec.
+    Computes and caches the optimal tactic for M rounded up to a power-of-two
+    bucket. Rounding up keeps small swapped tile_n choices valid for the real M.
 
     Args:
         m: M dimension of the GEMM problem.
@@ -160,15 +151,10 @@ def _select_sm100_mm_fp4_cute_dsl_tactic(m, n, real_k, sm_count):
                         kernel_type, use_tma_store)
     """
     cache_key = (n, real_k, sm_count)
-    bucket_tactics = _SM100_MM_FP4_TACTIC_CACHE.get(cache_key)
-    if bucket_tactics is None:
-        bucket_tactics = {}
-        for rep_m in _M_BUCKETS:
-            for aligned in (True, False):
-                bucket_tactics[(rep_m, aligned)] = _compute_tactic_for_m(
-                    rep_m, n, real_k, sm_count, aligned
-                )
-        _SM100_MM_FP4_TACTIC_CACHE[cache_key] = bucket_tactics
-
-    bucket = min(last_positive_power_of_2(m), _M_BUCKETS[-1])
-    return bucket_tactics[(bucket, m % 8 == 0)]
+    cached_tactics = _SM100_MM_FP4_TACTIC_CACHE.setdefault(cache_key, {})
+    m_bucket = min(next_positive_power_of_2(m), _M_BUCKETS[-1])
+    tactic = cached_tactics.get(m_bucket)
+    if tactic is None:
+        tactic = _compute_tactic_for_m(m_bucket, n, real_k, sm_count)
+        cached_tactics[m_bucket] = tactic
+    return tactic


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

This PR removes the guard against using swap AB for the CuTe DSL mm_fp4 backend when M is not divisible by 8. This guard was unnecessary and limiting available tactics. See [#3402](https://github.com/flashinfer-ai/flashinfer/issues/3402).

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of FP4 matrix operations to detect invalid configurations earlier with clearer error messages.

* **Performance**
  * Streamlined tactic selection logic for matrix computations for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->